### PR TITLE
fix(ws): truncate unparseable frame payload in client warn log

### DIFF
--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -73,6 +73,27 @@ describe("WSClient", () => {
     expect(url.searchParams.has("client_os")).toBe(false);
   });
 
+  it("truncates the logged payload when an unparseable frame is large", () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const ws = new WSClient("ws://example.test/ws", { logger });
+    ws.connect();
+
+    const huge = "x".repeat(5000);
+    FakeWebSocket.lastInstance!.onmessage?.({ data: huge });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [, summary] = logger.warn.mock.calls[0] as [string, string];
+    expect(summary.length).toBeLessThan(huge.length);
+    expect(summary).toContain("truncated");
+    expect(summary).toContain("5000");
+    expect(summary.startsWith("x".repeat(200))).toBe(true);
+  });
+
   it("logs and skips malformed frames without breaking later messages", () => {
     const logger = {
       debug: vi.fn(),

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -3,6 +3,17 @@ import { type Logger, noopLogger } from "../logger";
 
 type EventHandler = (payload: unknown, actorId?: string, actorType?: string) => void;
 
+// Cap how much of an unparseable frame we put into the log. A malformed or
+// rogue server can stream arbitrarily large garbage, and the warn handler may
+// be a console / IPC bridge whose buffers we don't want to blow.
+const UNPARSEABLE_LOG_MAX_CHARS = 200;
+
+function summarizeUnparseable(data: unknown): string {
+  const text = typeof data === "string" ? data : String(data);
+  if (text.length <= UNPARSEABLE_LOG_MAX_CHARS) return text;
+  return `${text.slice(0, UNPARSEABLE_LOG_MAX_CHARS)}… (truncated, ${text.length} chars total)`;
+}
+
 /** Identifies the WS client to the server. Sent as `client_platform`,
  *  `client_version`, and `client_os` query parameters on the upgrade URL —
  *  browsers cannot set custom headers on WebSocket handshakes, so query
@@ -79,7 +90,10 @@ export class WSClient {
       try {
         msg = JSON.parse(event.data as string) as WSMessage;
       } catch {
-        this.logger.warn("ws: received unparseable message", event.data);
+        this.logger.warn(
+          "ws: received unparseable message",
+          summarizeUnparseable(event.data),
+        );
         return;
       }
       if ((msg as any).type === "auth_ack") {


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2946.

When `WSClient.onmessage` cannot parse an incoming frame, the existing guard logs the raw `event.data` alongside the warning to help debug malformed frames. A malformed or rogue server can stream arbitrarily large garbage on this channel, and the warn handler is wired through console / IPC / log files whose buffers we don't want to blow.

Cap the logged payload at 200 characters and append a `(truncated, N chars total)` suffix when truncation actually occurs. Short frames are unchanged — the existing diagnostic value is preserved.

## Related Issue

Follow-up to #2946 (closes #2933 + #2934). No new issue.

MUL-2490

## Type of Change

- [x] Refactor / code improvement (no behavior change for short frames)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `summarizeUnparseable(data)` helper in `packages/core/api/ws-client.ts`. Coerces non-string `event.data` to string, returns it unchanged if `<= 200` chars, otherwise returns `"<first 200 chars>… (truncated, N chars total)"`.
- `onmessage` now passes `event.data` through the helper before handing it to `logger.warn`.
- Added a vitest case that injects a 5000-char garbage frame and asserts the logged summary is shorter than the input, starts with the first 200 chars, and contains the total-length marker.
- Existing "logs and skips malformed frames without breaking later messages" test continues to assert that short frames are logged verbatim (no regression).

## How to Test

1. Inject a 5000-char string into `onmessage` — the warn handler receives a ~230-char summary, not the full payload.
2. Inject a short malformed frame — warn handler receives the original string unchanged.

## Verification

- `pnpm --filter @multica/core exec vitest run api/ws-client.test.ts` — all 5 tests pass.
- `pnpm --filter @multica/core typecheck` — clean.
- `pnpm --filter @multica/core lint` — clean (1 pre-existing warning in `auth-initializer.tsx`, unrelated).

## AI Disclosure

**AI tool used:** Claude (multica agent J)

**Prompt / approach:** Follow-up requested after merging #2946. The two reviewing agents both flagged unbounded `event.data` in the warn log as a non-blocking nit; the maintainer asked for a truncation follow-up. Kept the helper module-private and the test focused on the truncation invariant.