### PR TITLE
test(core): add unit tests for reserved-slugs

### DIFF
--- a/packages/core/paths/reserved-slugs.test.ts
+++ b/packages/core/paths/reserved-slugs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { RESERVED_SLUGS, isReservedSlug } from "./reserved-slugs";
+
+describe("reserved slugs", () => {
+  it("returns true for a known reserved slug", () => {
+    expect(isReservedSlug("login")).toBe(true);
+  });
+
+  it("returns false for an unreserved slug", () => {
+    expect(isReservedSlug("my-cool-workspace")).toBe(false);
+  });
+
+  it("returns false for an empty slug", () => {
+    expect(isReservedSlug("")).toBe(false);
+  });
+
+  it("exposes a non-empty reserved slug set", () => {
+    expect(RESERVED_SLUGS.size).toBeGreaterThan(0);
+  });
+
+  it("keeps the set and predicate consistent", () => {
+    for (const slug of RESERVED_SLUGS) {
+      expect(isReservedSlug(slug)).toBe(true);
+    }
+  });
+
+  it("matches slugs case-sensitively", () => {
+    expect(isReservedSlug("Login")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds `packages/core/paths/reserved-slugs.test.ts` to cover `RESERVED_SLUGS` and `isReservedSlug`. Sibling files (`paths.ts`, `resolve.ts`, `consistency.ts`) all already have tests; this one was missed.

## Related Issue

Closes #2983

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `packages/core/paths/reserved-slugs.test.ts` (new): known reserved / unreserved slug, empty input, non-empty set, internal consistency (`forEach` in set → predicate true).

## How to Test

```
pnpm --filter @multica/core exec vitest run paths/reserved-slugs.test.ts
```

All cases pass locally; typecheck clean.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Surveyed `packages/core/paths/` for files without sibling tests. `reserved-slugs.ts` stood out because it's auto-generated and the only file in that directory without explicit tests — adding a tripwire-style test guards against future regressions in the generator pipeline. The auto-generated source file itself was not modified.