### PR TITLE
feat: add env-gated cloud runtime launcher (MUL-2453)

### DIFF
--- a/apps/web/app/[workspaceSlug]/(dashboard)/runtimes/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/runtimes/page.tsx
@@ -1,1 +1,8 @@
-export { RuntimesPage as default } from "@multica/views/runtimes";
+import { RuntimesPage } from "@multica/views/runtimes";
+
+const cloudRuntimeEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_CLOUD_RUNTIME === "true";
+
+export default function RuntimesRoute() {
+  return <RuntimesPage cloudRuntimeEnabled={cloudRuntimeEnabled} />;
+}

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -152,6 +152,66 @@ describe("ApiClient", () => {
     expect(headers["X-Client-OS"]).toBeUndefined();
   });
 
+  it("uses the Cloud Runtime node API contract and forwards bootstrap PAT on create", async () => {
+    const node = {
+      id: "node-1",
+      owner_id: "user-1",
+      instance_id: "i-0123456789abcdef0",
+      region: "us-west-2",
+      instance_type: "g5.xlarge",
+      image_id: "ami-1",
+      subnet_id: "subnet-1",
+      name: "gpu-dev-01",
+      status: "launching",
+      tags: {},
+      metadata: {},
+      created_at: "2026-05-21T08:30:00Z",
+      updated_at: "2026-05-21T08:30:00Z",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(node), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+    await client.listCloudRuntimeNodes({ limit: 20, offset: 5 });
+    await client.createCloudRuntimeNode(
+      { instance_type: "g5.xlarge", name: "gpu-dev-01" },
+      { userPAT: "mul_cloud_bootstrap_pat" },
+    );
+
+    const listCall = fetchMock.mock.calls[0]!;
+    const createCall = fetchMock.mock.calls[1]!;
+    expect(listCall[0]).toBe(
+      "https://api.example.test/api/cloud-runtime/nodes?limit=20&offset=5",
+    );
+    expect((listCall[1]!.headers as Record<string, string>)["X-User-PAT"]).toBeUndefined();
+    expect(createCall[0]).toBe(
+      "https://api.example.test/api/cloud-runtime/nodes",
+    );
+    expect(createCall[1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        instance_type: "g5.xlarge",
+        name: "gpu-dev-01",
+      }),
+    });
+    expect((createCall[1]!.headers as Record<string, string>)["X-User-PAT"]).toBe(
+      "mul_cloud_bootstrap_pat",
+    );
+  });
+
   describe("getAttachment", () => {
     it("returns the parsed attachment for a well-formed response", async () => {
       vi.stubGlobal(

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -212,6 +212,31 @@ describe("ApiClient", () => {
     );
   });
 
+  it("falls back when Cloud Runtime node responses drift", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ id: 123 }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 123 }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+
+    await expect(client.listCloudRuntimeNodes()).resolves.toEqual([]);
+    await expect(
+      client.createCloudRuntimeNode({ instance_type: "g5.xlarge" }),
+    ).resolves.toMatchObject({ id: "", status: "" });
+  });
+
   describe("getAttachment", () => {
     it("returns the parsed attachment for a well-formed response", async () => {
       vi.stubGlobal(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -101,6 +101,12 @@ import type {
   SquadMemberStatusListResponse,
 } from "../types";
 import type { OnboardingCompletionPath } from "../onboarding/types";
+import type {
+  CloudRuntimeNode,
+  CreateCloudRuntimeNodeOptions,
+  CreateCloudRuntimeNodeRequest,
+  ListCloudRuntimeNodesParams,
+} from "../runtimes/cloud-runtime";
 import { type Logger, noopLogger } from "../logger";
 import { createRequestId } from "../utils";
 import { getCurrentSlug } from "../platform/workspace-storage";
@@ -804,6 +810,33 @@ export class ApiClient {
     if (params?.workspace_id) search.set("workspace_id", params.workspace_id);
     if (params?.owner) search.set("owner", params.owner);
     return this.fetch(`/api/runtimes?${search}`);
+  }
+
+  async listCloudRuntimeNodes(
+    params?: ListCloudRuntimeNodesParams,
+  ): Promise<CloudRuntimeNode[]> {
+    const search = new URLSearchParams();
+    if (params?.limit !== undefined) search.set("limit", String(params.limit));
+    if (params?.offset !== undefined) search.set("offset", String(params.offset));
+    const query = search.toString();
+    return this.fetch(`/api/cloud-runtime/nodes${query ? `?${query}` : ""}`);
+  }
+
+  async createCloudRuntimeNode(
+    data: CreateCloudRuntimeNodeRequest,
+    options?: CreateCloudRuntimeNodeOptions,
+  ): Promise<CloudRuntimeNode> {
+    const extraHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const userPAT = options?.userPAT?.trim();
+    if (userPAT) extraHeaders["X-User-PAT"] = userPAT;
+    const res = await this.fetchRaw("/api/cloud-runtime/nodes", {
+      method: "POST",
+      body: JSON.stringify(data),
+      extraHeaders,
+    });
+    return res.json() as Promise<CloudRuntimeNode>;
   }
 
   async deleteRuntime(runtimeId: string): Promise<void> {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -117,6 +117,8 @@ import {
   AttachmentResponseSchema,
   ChildIssuesResponseSchema,
   CommentsListSchema,
+  CloudRuntimeNodeListSchema,
+  CloudRuntimeNodeSchema,
   CreateAgentFromTemplateResponseSchema,
   DashboardAgentRunTimeListSchema,
   DashboardRunTimeDailyListSchema,
@@ -125,6 +127,8 @@ import {
   EMPTY_AGENT_TEMPLATE_DETAIL,
   EMPTY_AGENT_TEMPLATE_SUMMARY_LIST,
   EMPTY_ATTACHMENT,
+  EMPTY_CLOUD_RUNTIME_NODE,
+  EMPTY_CLOUD_RUNTIME_NODE_LIST,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
   EMPTY_GROUPED_ISSUES_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
@@ -819,7 +823,15 @@ export class ApiClient {
     if (params?.limit !== undefined) search.set("limit", String(params.limit));
     if (params?.offset !== undefined) search.set("offset", String(params.offset));
     const query = search.toString();
-    return this.fetch(`/api/cloud-runtime/nodes${query ? `?${query}` : ""}`);
+    const raw = await this.fetch<unknown>(
+      `/api/cloud-runtime/nodes${query ? `?${query}` : ""}`,
+    );
+    return parseWithFallback(
+      raw,
+      CloudRuntimeNodeListSchema,
+      EMPTY_CLOUD_RUNTIME_NODE_LIST,
+      { endpoint: "GET /api/cloud-runtime/nodes" },
+    );
   }
 
   async createCloudRuntimeNode(
@@ -836,7 +848,13 @@ export class ApiClient {
       body: JSON.stringify(data),
       extraHeaders,
     });
-    return res.json() as Promise<CloudRuntimeNode>;
+    const raw = await res.json() as unknown;
+    return parseWithFallback(
+      raw,
+      CloudRuntimeNodeSchema,
+      EMPTY_CLOUD_RUNTIME_NODE,
+      { endpoint: "POST /api/cloud-runtime/nodes" },
+    );
   }
 
   async deleteRuntime(runtimeId: string): Promise<void> {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -12,6 +12,7 @@ import type {
   User,
   WebhookDelivery,
 } from "../types";
+import type { CloudRuntimeNode } from "../runtimes/cloud-runtime";
 
 // ---------------------------------------------------------------------------
 // Schemas for the highest-risk API endpoints — those whose responses drive
@@ -209,6 +210,42 @@ export const OnboardingNoRuntimeBootstrapResponseSchema = z.object({
   workspace_id: z.string(),
   issue_id: z.string(),
 }).loose();
+
+export const CloudRuntimeNodeSchema = z.object({
+  id: z.string(),
+  owner_id: z.string(),
+  instance_id: z.string(),
+  region: z.string(),
+  instance_type: z.string(),
+  image_id: z.string(),
+  subnet_id: z.string(),
+  name: z.string(),
+  status: z.string(),
+  tags: z.record(z.string(), z.string()).default({}),
+  metadata: z.record(z.string(), z.unknown()).default({}),
+  created_at: z.string(),
+  updated_at: z.string(),
+}).loose();
+
+export const CloudRuntimeNodeListSchema = z.array(CloudRuntimeNodeSchema);
+
+export const EMPTY_CLOUD_RUNTIME_NODE_LIST: CloudRuntimeNode[] = [];
+
+export const EMPTY_CLOUD_RUNTIME_NODE: CloudRuntimeNode = {
+  id: "",
+  owner_id: "",
+  instance_id: "",
+  region: "",
+  instance_type: "",
+  image_id: "",
+  subnet_id: "",
+  name: "",
+  status: "",
+  tags: {},
+  metadata: {},
+  created_at: "",
+  updated_at: "",
+};
 
 // ---------------------------------------------------------------------------
 // Workspace dashboard schemas

--- a/packages/core/runtimes/cloud-runtime.ts
+++ b/packages/core/runtimes/cloud-runtime.ts
@@ -1,6 +1,5 @@
 import { queryOptions, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
-import { runtimeKeys } from "./queries";
 
 export interface CloudRuntimeNode {
   id: string;
@@ -44,6 +43,19 @@ export const cloudRuntimeKeys = {
   nodes: (wsId: string) => [...cloudRuntimeKeys.all(wsId), "nodes"] as const,
 };
 
+const PENDING_NODE_STATUSES = new Set([
+  "launching",
+  "pending",
+  "starting",
+  "stopping",
+  "rebooting",
+  "terminating",
+]);
+
+export function isCloudRuntimeNodePending(status: string): boolean {
+  return PENDING_NODE_STATUSES.has(status.toLowerCase());
+}
+
 export function cloudRuntimeNodeListOptions(
   wsId: string,
   params?: ListCloudRuntimeNodesParams,
@@ -53,6 +65,10 @@ export function cloudRuntimeNodeListOptions(
   return queryOptions({
     queryKey: [...cloudRuntimeKeys.nodes(wsId), { limit, offset }] as const,
     queryFn: () => api.listCloudRuntimeNodes({ limit, offset }),
+    refetchInterval: (query) =>
+      query.state.data?.some((node) => isCloudRuntimeNodePending(node.status))
+        ? 5000
+        : false,
     staleTime: 15 * 1000,
   });
 }
@@ -69,7 +85,6 @@ export function useCreateCloudRuntimeNode(wsId: string) {
     }) => api.createCloudRuntimeNode(data, { userPAT }),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: cloudRuntimeKeys.all(wsId) });
-      qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });
     },
   });
 }

--- a/packages/core/runtimes/cloud-runtime.ts
+++ b/packages/core/runtimes/cloud-runtime.ts
@@ -1,0 +1,75 @@
+import { queryOptions, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api";
+import { runtimeKeys } from "./queries";
+
+export interface CloudRuntimeNode {
+  id: string;
+  owner_id: string;
+  instance_id: string;
+  region: string;
+  instance_type: string;
+  image_id: string;
+  subnet_id: string;
+  name: string;
+  status: string;
+  tags: Record<string, string>;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListCloudRuntimeNodesParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateCloudRuntimeNodeRequest {
+  instance_type: string;
+  name?: string;
+  region?: string;
+  image_id?: string;
+  subnet_id?: string;
+  key_name?: string;
+  iam_instance_profile?: string;
+  disk_size_gb?: number;
+  tags?: Record<string, string>;
+}
+
+export interface CreateCloudRuntimeNodeOptions {
+  userPAT?: string;
+}
+
+export const cloudRuntimeKeys = {
+  all: (wsId: string) => ["cloud-runtime", wsId] as const,
+  nodes: (wsId: string) => [...cloudRuntimeKeys.all(wsId), "nodes"] as const,
+};
+
+export function cloudRuntimeNodeListOptions(
+  wsId: string,
+  params?: ListCloudRuntimeNodesParams,
+) {
+  const limit = params?.limit ?? 20;
+  const offset = params?.offset ?? 0;
+  return queryOptions({
+    queryKey: [...cloudRuntimeKeys.nodes(wsId), { limit, offset }] as const,
+    queryFn: () => api.listCloudRuntimeNodes({ limit, offset }),
+    staleTime: 15 * 1000,
+  });
+}
+
+export function useCreateCloudRuntimeNode(wsId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      data,
+      userPAT,
+    }: {
+      data: CreateCloudRuntimeNodeRequest;
+      userPAT?: string;
+    }) => api.createCloudRuntimeNode(data, { userPAT }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: cloudRuntimeKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });
+    },
+  });
+}

--- a/packages/core/runtimes/index.ts
+++ b/packages/core/runtimes/index.ts
@@ -8,3 +8,4 @@ export * from "./derive-health";
 export * from "./use-runtime-health";
 export * from "./cli-version";
 export * from "./custom-pricing-store";
+export * from "./cloud-runtime";

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -160,6 +160,42 @@
     "view_runtime": "View runtime",
     "create_agent": "Create an agent"
   },
+  "cloud_runtime": {
+    "action": "Cloud Runtime",
+    "title": "Cloud Runtime",
+    "description": "Launch a managed cloud node and watch its Fleet status.",
+    "create_title": "New node",
+    "create_hint": "Defaults target the shared us-west-2 Fleet configuration.",
+    "nodes_title": "Fleet nodes",
+    "refresh": "Refresh",
+    "nodes_empty": "No cloud nodes",
+    "nodes_failed": "Cloud Runtime unavailable",
+    "nodes_failed_hint": "Fleet did not return a node list.",
+    "node_fallback_name": "Cloud node",
+    "create": "Create node",
+    "creating": "Creating...",
+    "cancel": "Cancel",
+    "toast_created": "Cloud Runtime node created",
+    "toast_create_failed": "Failed to create Cloud Runtime node",
+    "fields": {
+      "name": "Name",
+      "instance_type": "Instance type",
+      "region": "Region",
+      "disk_size": "Disk size GiB",
+      "image_id": "AMI ID",
+      "subnet_id": "Subnet ID",
+      "key_name": "Key pair",
+      "bootstrap_pat": "Bootstrap PAT"
+    },
+    "placeholders": {
+      "name": "gpu-dev-01",
+      "key_name": "dev-key"
+    },
+    "validation": {
+      "instance_type_required": "Instance type is required",
+      "disk_size_invalid": "Disk size must be a positive integer"
+    }
+  },
   "update": {
     "cli_version_label": "CLI Version:",
     "version_unknown": "unknown",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -151,6 +151,42 @@
     "view_runtime": "查看运行时",
     "create_agent": "创建智能体"
   },
+  "cloud_runtime": {
+    "action": "Cloud Runtime",
+    "title": "Cloud Runtime",
+    "description": "创建托管云端节点，并查看它的 Fleet 状态。",
+    "create_title": "新节点",
+    "create_hint": "默认使用共享的 us-west-2 Fleet 配置。",
+    "nodes_title": "Fleet 节点",
+    "refresh": "刷新",
+    "nodes_empty": "还没有云端节点",
+    "nodes_failed": "Cloud Runtime 不可用",
+    "nodes_failed_hint": "Fleet 未返回节点列表。",
+    "node_fallback_name": "云端节点",
+    "create": "创建节点",
+    "creating": "创建中...",
+    "cancel": "取消",
+    "toast_created": "Cloud Runtime 节点已创建",
+    "toast_create_failed": "创建 Cloud Runtime 节点失败",
+    "fields": {
+      "name": "名称",
+      "instance_type": "实例规格",
+      "region": "Region",
+      "disk_size": "磁盘 GiB",
+      "image_id": "AMI ID",
+      "subnet_id": "Subnet ID",
+      "key_name": "Key pair",
+      "bootstrap_pat": "Bootstrap PAT"
+    },
+    "placeholders": {
+      "name": "gpu-dev-01",
+      "key_name": "dev-key"
+    },
+    "validation": {
+      "instance_type_required": "实例规格不能为空",
+      "disk_size_invalid": "磁盘大小必须是正整数"
+    }
+  },
   "update": {
     "cli_version_label": "CLI 版本：",
     "version_unknown": "未知",

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { FormEvent, HTMLAttributes } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Cloud, Loader2, RefreshCw, Rocket } from "lucide-react";
+import { toast } from "sonner";
+import type { CloudRuntimeNode } from "@multica/core/runtimes";
+import {
+  cloudRuntimeNodeListOptions,
+  useCreateCloudRuntimeNode,
+} from "@multica/core/runtimes";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { Badge } from "@multica/ui/components/ui/badge";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Input } from "@multica/ui/components/ui/input";
+import { Label } from "@multica/ui/components/ui/label";
+import { cn } from "@multica/ui/lib/utils";
+import { useT } from "../../i18n";
+
+const DEFAULT_REGION = "us-west-2";
+const DEFAULT_INSTANCE_TYPE = "g5.xlarge";
+
+export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
+  const { t } = useT("runtimes");
+  const wsId = useWorkspaceId();
+  const [name, setName] = useState("");
+  const [instanceType, setInstanceType] = useState(DEFAULT_INSTANCE_TYPE);
+  const [region, setRegion] = useState(DEFAULT_REGION);
+  const [diskSizeGB, setDiskSizeGB] = useState("");
+  const [imageId, setImageId] = useState("");
+  const [subnetId, setSubnetId] = useState("");
+  const [keyName, setKeyName] = useState("");
+  const [bootstrapPAT, setBootstrapPAT] = useState("");
+
+  const nodesQuery = useQuery(
+    cloudRuntimeNodeListOptions(wsId, { limit: 20, offset: 0 }),
+  );
+  const createNode = useCreateCloudRuntimeNode(wsId);
+
+  const sortedNodes = useMemo(
+    () =>
+      [...(nodesQuery.data ?? [])].sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      ),
+    [nodesQuery.data],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const instance_type = instanceType.trim();
+    if (!instance_type) {
+      toast.error(t(($) => $.cloud_runtime.validation.instance_type_required));
+      return;
+    }
+
+    const diskSize = diskSizeGB.trim() ? Number(diskSizeGB.trim()) : undefined;
+    if (
+      diskSize !== undefined &&
+      (!Number.isInteger(diskSize) || diskSize <= 0)
+    ) {
+      toast.error(t(($) => $.cloud_runtime.validation.disk_size_invalid));
+      return;
+    }
+
+    try {
+      await createNode.mutateAsync({
+        data: {
+          instance_type,
+          name: valueOrUndefined(name),
+          region: valueOrUndefined(region),
+          disk_size_gb: diskSize,
+          image_id: valueOrUndefined(imageId),
+          subnet_id: valueOrUndefined(subnetId),
+          key_name: valueOrUndefined(keyName),
+        },
+        userPAT: valueOrUndefined(bootstrapPAT),
+      });
+      toast.success(t(($) => $.cloud_runtime.toast_created));
+      setName("");
+      setBootstrapPAT("");
+      void nodesQuery.refetch();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t(($) => $.cloud_runtime.toast_create_failed),
+      );
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[88vh] flex-col gap-0 p-0 sm:max-w-3xl">
+        <DialogHeader className="border-b px-6 py-5">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Cloud className="h-4 w-4 text-muted-foreground" />
+            {t(($) => $.cloud_runtime.title)}
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            {t(($) => $.cloud_runtime.description)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.82fr)]">
+            <form id="cloud-runtime-form" onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <h3 className="text-sm font-medium">
+                  {t(($) => $.cloud_runtime.create_title)}
+                </h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t(($) => $.cloud_runtime.create_hint)}
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <LabeledInput
+                  id="cloud-runtime-name"
+                  label={t(($) => $.cloud_runtime.fields.name)}
+                  value={name}
+                  onChange={setName}
+                  placeholder={t(($) => $.cloud_runtime.placeholders.name)}
+                />
+                <LabeledInput
+                  id="cloud-runtime-instance-type"
+                  label={t(($) => $.cloud_runtime.fields.instance_type)}
+                  value={instanceType}
+                  onChange={setInstanceType}
+                  placeholder={DEFAULT_INSTANCE_TYPE}
+                  required
+                />
+                <LabeledInput
+                  id="cloud-runtime-region"
+                  label={t(($) => $.cloud_runtime.fields.region)}
+                  value={region}
+                  onChange={setRegion}
+                  placeholder={DEFAULT_REGION}
+                />
+                <LabeledInput
+                  id="cloud-runtime-disk-size"
+                  label={t(($) => $.cloud_runtime.fields.disk_size)}
+                  value={diskSizeGB}
+                  onChange={setDiskSizeGB}
+                  placeholder="200"
+                  inputMode="numeric"
+                />
+                <LabeledInput
+                  id="cloud-runtime-image-id"
+                  label={t(($) => $.cloud_runtime.fields.image_id)}
+                  value={imageId}
+                  onChange={setImageId}
+                  placeholder="ami-..."
+                />
+                <LabeledInput
+                  id="cloud-runtime-subnet-id"
+                  label={t(($) => $.cloud_runtime.fields.subnet_id)}
+                  value={subnetId}
+                  onChange={setSubnetId}
+                  placeholder="subnet-..."
+                />
+                <LabeledInput
+                  id="cloud-runtime-key-name"
+                  label={t(($) => $.cloud_runtime.fields.key_name)}
+                  value={keyName}
+                  onChange={setKeyName}
+                  placeholder={t(($) => $.cloud_runtime.placeholders.key_name)}
+                />
+                <LabeledInput
+                  id="cloud-runtime-bootstrap-pat"
+                  label={t(($) => $.cloud_runtime.fields.bootstrap_pat)}
+                  value={bootstrapPAT}
+                  onChange={setBootstrapPAT}
+                  placeholder="mul_..."
+                  type="password"
+                />
+              </div>
+            </form>
+
+            <section className="min-h-0 rounded-md border bg-muted/20">
+              <div className="flex items-center justify-between border-b bg-background px-3 py-2.5">
+                <h3 className="text-sm font-medium">
+                  {t(($) => $.cloud_runtime.nodes_title)}
+                </h3>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void nodesQuery.refetch()}
+                  disabled={nodesQuery.isFetching}
+                  className="h-7 px-2"
+                >
+                  <RefreshCw
+                    className={cn(
+                      "h-3.5 w-3.5",
+                      nodesQuery.isFetching && "animate-spin",
+                    )}
+                  />
+                  {t(($) => $.cloud_runtime.refresh)}
+                </Button>
+              </div>
+
+              {nodesQuery.isLoading ? (
+                <div className="flex h-40 items-center justify-center">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : nodesQuery.isError ? (
+                <div className="flex h-40 flex-col items-center justify-center px-5 text-center">
+                  <p className="text-sm font-medium">
+                    {t(($) => $.cloud_runtime.nodes_failed)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {nodesQuery.error instanceof Error
+                      ? nodesQuery.error.message
+                      : t(($) => $.cloud_runtime.nodes_failed_hint)}
+                  </p>
+                </div>
+              ) : sortedNodes.length === 0 ? (
+                <div className="flex h-40 flex-col items-center justify-center px-5 text-center">
+                  <Cloud className="h-7 w-7 text-muted-foreground/50" />
+                  <p className="mt-3 text-sm font-medium">
+                    {t(($) => $.cloud_runtime.nodes_empty)}
+                  </p>
+                </div>
+              ) : (
+                <div className="max-h-[410px] overflow-y-auto p-2">
+                  <div className="space-y-2">
+                    {sortedNodes.map((node) => (
+                      <CloudRuntimeNodeRow key={node.id} node={node} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
+        </div>
+
+        <DialogFooter className="m-0 border-t bg-muted/30 px-6 py-3">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            {t(($) => $.cloud_runtime.cancel)}
+          </Button>
+          <Button
+            type="submit"
+            size="sm"
+            form="cloud-runtime-form"
+            disabled={createNode.isPending}
+          >
+            {createNode.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Rocket className="h-3.5 w-3.5" />
+            )}
+            {createNode.isPending
+              ? t(($) => $.cloud_runtime.creating)
+              : t(($) => $.cloud_runtime.create)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LabeledInput({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  required,
+  type = "text",
+  inputMode,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  required?: boolean;
+  type?: string;
+  inputMode?: HTMLAttributes<HTMLInputElement>["inputMode"];
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-xs text-muted-foreground">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+        type={type}
+        inputMode={inputMode}
+        className="h-9 text-sm"
+      />
+    </div>
+  );
+}
+
+function CloudRuntimeNodeRow({ node }: { node: CloudRuntimeNode }) {
+  const { t } = useT("runtimes");
+  const title =
+    node.name.trim() ||
+    node.instance_id.trim() ||
+    t(($) => $.cloud_runtime.node_fallback_name);
+  const created = formatDateTime(node.created_at);
+  return (
+    <div className="rounded-md border bg-background px-3 py-2.5">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-medium">{title}</span>
+            <CloudRuntimeStatusBadge status={node.status} />
+          </div>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            <span>{node.instance_type}</span>
+            <span className="text-muted-foreground/40">/</span>
+            <span>{node.region}</span>
+            {created && (
+              <>
+                <span className="text-muted-foreground/40">/</span>
+                <span>{created}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      {node.instance_id && (
+        <div className="mt-2 truncate font-mono text-[11px] text-muted-foreground/80">
+          {node.instance_id}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CloudRuntimeStatusBadge({ status }: { status: string }) {
+  const normalized = status.toLowerCase();
+  const active = new Set(["running", "success"]);
+  const pending = new Set([
+    "launching",
+    "pending",
+    "starting",
+    "stopping",
+    "rebooting",
+    "terminating",
+  ]);
+  const failed = new Set(["failed", "terminated", "error"]);
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "h-5 rounded-md px-1.5 font-mono text-[10px]",
+        active.has(normalized) && "bg-success/10 text-success",
+        pending.has(normalized) && "bg-warning/10 text-warning",
+        failed.has(normalized) && "bg-destructive/10 text-destructive",
+      )}
+    >
+      {status || "unknown"}
+    </Badge>
+  );
+}
+
+function valueOrUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function formatDateTime(value: string): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import type { FormEvent, HTMLAttributes } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Cloud, Loader2, RefreshCw, Rocket } from "lucide-react";
@@ -32,6 +32,8 @@ const DEFAULT_INSTANCE_TYPE = "g5.xlarge";
 export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
   const { t } = useT("runtimes");
   const wsId = useWorkspaceId();
+  const idPrefix = `cloud-runtime-${useId().replace(/:/g, "")}`;
+  const formId = `${idPrefix}-form`;
   const [name, setName] = useState("");
   const [instanceType, setInstanceType] = useState(DEFAULT_INSTANCE_TYPE);
   const [region, setRegion] = useState(DEFAULT_REGION);
@@ -88,7 +90,6 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
       toast.success(t(($) => $.cloud_runtime.toast_created));
       setName("");
       setBootstrapPAT("");
-      void nodesQuery.refetch();
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -113,7 +114,7 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
           <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.82fr)]">
-            <form id="cloud-runtime-form" onSubmit={handleSubmit} className="space-y-4">
+            <form id={formId} onSubmit={handleSubmit} className="space-y-4">
               <div>
                 <h3 className="text-sm font-medium">
                   {t(($) => $.cloud_runtime.create_title)}
@@ -125,14 +126,14 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
 
               <div className="grid gap-3 sm:grid-cols-2">
                 <LabeledInput
-                  id="cloud-runtime-name"
+                  id={`${idPrefix}-name`}
                   label={t(($) => $.cloud_runtime.fields.name)}
                   value={name}
                   onChange={setName}
                   placeholder={t(($) => $.cloud_runtime.placeholders.name)}
                 />
                 <LabeledInput
-                  id="cloud-runtime-instance-type"
+                  id={`${idPrefix}-instance-type`}
                   label={t(($) => $.cloud_runtime.fields.instance_type)}
                   value={instanceType}
                   onChange={setInstanceType}
@@ -140,14 +141,14 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
                   required
                 />
                 <LabeledInput
-                  id="cloud-runtime-region"
+                  id={`${idPrefix}-region`}
                   label={t(($) => $.cloud_runtime.fields.region)}
                   value={region}
                   onChange={setRegion}
                   placeholder={DEFAULT_REGION}
                 />
                 <LabeledInput
-                  id="cloud-runtime-disk-size"
+                  id={`${idPrefix}-disk-size`}
                   label={t(($) => $.cloud_runtime.fields.disk_size)}
                   value={diskSizeGB}
                   onChange={setDiskSizeGB}
@@ -155,28 +156,28 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
                   inputMode="numeric"
                 />
                 <LabeledInput
-                  id="cloud-runtime-image-id"
+                  id={`${idPrefix}-image-id`}
                   label={t(($) => $.cloud_runtime.fields.image_id)}
                   value={imageId}
                   onChange={setImageId}
                   placeholder="ami-..."
                 />
                 <LabeledInput
-                  id="cloud-runtime-subnet-id"
+                  id={`${idPrefix}-subnet-id`}
                   label={t(($) => $.cloud_runtime.fields.subnet_id)}
                   value={subnetId}
                   onChange={setSubnetId}
                   placeholder="subnet-..."
                 />
                 <LabeledInput
-                  id="cloud-runtime-key-name"
+                  id={`${idPrefix}-key-name`}
                   label={t(($) => $.cloud_runtime.fields.key_name)}
                   value={keyName}
                   onChange={setKeyName}
                   placeholder={t(($) => $.cloud_runtime.placeholders.key_name)}
                 />
                 <LabeledInput
-                  id="cloud-runtime-bootstrap-pat"
+                  id={`${idPrefix}-bootstrap-pat`}
                   label={t(($) => $.cloud_runtime.fields.bootstrap_pat)}
                   value={bootstrapPAT}
                   onChange={setBootstrapPAT}
@@ -251,7 +252,7 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
           <Button
             type="submit"
             size="sm"
-            form="cloud-runtime-form"
+            form={formId}
             disabled={createNode.isPending}
           >
             {createNode.isPending ? (

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -29,6 +29,7 @@ import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { cn } from "@multica/ui/lib/utils";
 import { PageHeader } from "../../layout/page-header";
 import { ConnectRemoteDialog } from "./connect-remote-dialog";
+import { CloudRuntimeDialog } from "./cloud-runtime-dialog";
 import { ProviderLogo } from "./provider-logo";
 import { RuntimeList, buildWorkloadIndex } from "./runtime-list";
 import {
@@ -65,6 +66,8 @@ interface RuntimesPageProps {
    * during the boot window. Web omits this.
    */
   bootstrapping?: boolean;
+  /** Web SaaS-only Cloud Runtime entrypoint. Defaults off for self-hosted builds. */
+  cloudRuntimeEnabled?: boolean;
 }
 
 // Re-render every 30s so derived health (recently_lost → offline transitions)
@@ -84,6 +87,7 @@ export function RuntimesPage({
   localMachineActions,
   hasLocalMachine,
   bootstrapping,
+  cloudRuntimeEnabled = false,
 }: RuntimesPageProps = {}) {
   const isLoading = useAuthStore((s) => s.isLoading);
   const wsId = useWorkspaceId();
@@ -103,6 +107,7 @@ export function RuntimesPage({
     setSelectedMachineId(id);
   }, []);
   const [showConnectDialog, setShowConnectDialog] = useState(false);
+  const [showCloudRuntimeDialog, setShowCloudRuntimeDialog] = useState(false);
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_runtimes_layout",
   });
@@ -187,6 +192,8 @@ export function RuntimesPage({
       <PageHeaderBar
         totalCount={totalCount}
         onConnectRemote={() => setShowConnectDialog(true)}
+        cloudRuntimeEnabled={cloudRuntimeEnabled}
+        onOpenCloudRuntime={() => setShowCloudRuntimeDialog(true)}
       />
 
       {showEmpty ? (
@@ -263,6 +270,9 @@ export function RuntimesPage({
       {showConnectDialog && (
         <ConnectRemoteDialog onClose={() => setShowConnectDialog(false)} />
       )}
+      {cloudRuntimeEnabled && showCloudRuntimeDialog && (
+        <CloudRuntimeDialog onClose={() => setShowCloudRuntimeDialog(false)} />
+      )}
     </div>
   );
 }
@@ -275,9 +285,13 @@ export function RuntimesPage({
 function PageHeaderBar({
   totalCount,
   onConnectRemote,
+  cloudRuntimeEnabled,
+  onOpenCloudRuntime,
 }: {
   totalCount: number;
   onConnectRemote: () => void;
+  cloudRuntimeEnabled: boolean;
+  onOpenCloudRuntime: () => void;
 }) {
   const { t } = useT("runtimes");
   return (
@@ -291,10 +305,23 @@ function PageHeaderBar({
           </span>
         )}
       </div>
-      <Button type="button" size="sm" onClick={onConnectRemote}>
-        <Plus className="h-3 w-3" />
-        {t(($) => $.page.connect_remote)}
-      </Button>
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+        {cloudRuntimeEnabled && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onOpenCloudRuntime}
+          >
+            <Cloud className="h-3 w-3" />
+            {t(($) => $.cloud_runtime.action)}
+          </Button>
+        )}
+        <Button type="button" size="sm" onClick={onConnectRemote}>
+          <Plus className="h-3 w-3" />
+          {t(($) => $.page.connect_remote)}
+        </Button>
+      </div>
     </PageHeader>
   );
 }


### PR DESCRIPTION
## Summary
- add a `NEXT_PUBLIC_ENABLE_CLOUD_RUNTIME=true` web env gate for the Runtime page Cloud Runtime entrypoint
- add typed Cloud Runtime node list/create API client methods, including optional `X-User-PAT` forwarding for Fleet bootstrap
- add a Runtime page Cloud Runtime dialog for launching Fleet nodes and viewing recent node status

## Verification
- `pnpm --filter @multica/core test -- api/client.test.ts`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/web typecheck`
- `pnpm --filter @multica/views test -- runtimes locales/parity.test.ts`
- `pnpm --filter @multica/core lint` (passes with one pre-existing warning in `platform/auth-initializer.tsx`)
- `pnpm --filter @multica/views lint` (passes with pre-existing warnings outside this change)
- `pnpm --filter @multica/web lint` (passes with one pre-existing warning in `app/(auth)/login/page.tsx`)
