### PR TITLE
feat(desktop): support macOS swipe navigation

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { setupDaemonManager } from "./daemon-manager";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
+import { installNavigationGestures } from "./navigation-gestures";
 import { getAppVersion } from "./app-version";
 import { loadRuntimeConfig } from "./runtime-config-loader";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
@@ -252,6 +253,7 @@ function createWindow(): void {
   }
 
   installContextMenu(mainWindow.webContents);
+  installNavigationGestures(mainWindow);
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
     mainWindow.loadURL(process.env["ELECTRON_RENDERER_URL"]);

--- a/apps/desktop/src/main/navigation-gestures.test.ts
+++ b/apps/desktop/src/main/navigation-gestures.test.ts
@@ -1,0 +1,60 @@
+import type { BrowserWindow } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import { NAVIGATION_GESTURE_CHANNEL } from "../shared/navigation-gestures";
+import { installNavigationGestures } from "./navigation-gestures";
+
+function makeWindow() {
+  let swipeHandler:
+    | ((event: unknown, direction: string) => void)
+    | undefined;
+
+  const win = {
+    on: vi.fn(
+      (event: string, handler: (event: unknown, direction: string) => void) => {
+        if (event === "swipe") swipeHandler = handler;
+        return win;
+      },
+    ),
+    webContents: {
+      send: vi.fn(),
+    },
+  };
+
+  return {
+    win: win as unknown as BrowserWindow,
+    send: win.webContents.send,
+    emitSwipe: (direction: string) => swipeHandler?.({}, direction),
+  };
+}
+
+describe("installNavigationGestures", () => {
+  it("registers macOS swipe navigation", () => {
+    const { win, send, emitSwipe } = makeWindow();
+
+    installNavigationGestures(win, "darwin");
+
+    emitSwipe("right");
+    expect(send).toHaveBeenCalledWith(NAVIGATION_GESTURE_CHANNEL, "back");
+
+    emitSwipe("left");
+    expect(send).toHaveBeenCalledWith(NAVIGATION_GESTURE_CHANNEL, "forward");
+  });
+
+  it("ignores non-horizontal swipe directions", () => {
+    const { win, send, emitSwipe } = makeWindow();
+
+    installNavigationGestures(win, "darwin");
+    emitSwipe("up");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not register on non-mac platforms", () => {
+    const { win, send, emitSwipe } = makeWindow();
+
+    installNavigationGestures(win, "linux");
+    emitSwipe("right");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/navigation-gestures.ts
+++ b/apps/desktop/src/main/navigation-gestures.ts
@@ -1,0 +1,18 @@
+import type { BrowserWindow } from "electron";
+import {
+  NAVIGATION_GESTURE_CHANNEL,
+  navigationGestureFromSwipe,
+} from "../shared/navigation-gestures";
+
+export function installNavigationGestures(
+  win: BrowserWindow,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "darwin") return;
+
+  win.on("swipe", (_event, direction) => {
+    const gesture = navigationGestureFromSwipe(direction);
+    if (!gesture) return;
+    win.webContents.send(NAVIGATION_GESTURE_CHANNEL, gesture);
+  });
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,5 +1,6 @@
 import { ElectronAPI } from "@electron-toolkit/preload";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
+import type { NavigationGesture } from "../shared/navigation-gestures";
 
 interface DesktopAPI {
   /** App version + normalized OS, captured synchronously at preload time. */
@@ -42,6 +43,8 @@ interface DesktopAPI {
       issueKey: string;
     }) => void,
   ) => () => void;
+  /** Listen for native macOS back/forward swipe gestures. Returns an unsubscribe function. */
+  onNavigationGesture: (callback: (gesture: NavigationGesture) => void) => () => void;
 }
 
 interface DaemonStatus {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,11 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
+import {
+  isNavigationGesture,
+  NAVIGATION_GESTURE_CHANNEL,
+  type NavigationGesture,
+} from "../shared/navigation-gestures";
 
 // Synchronously fetch app metadata from main at preload time so the renderer
 // can pass it into CoreProvider during the initial render — the alternative
@@ -139,6 +144,16 @@ const desktopAPI = {
     ipcRenderer.on("inbox:open", handler);
     return () => {
       ipcRenderer.removeListener("inbox:open", handler);
+    };
+  },
+  /** Listen for native macOS back/forward swipe gestures. */
+  onNavigationGesture: (callback: (gesture: NavigationGesture) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, gesture: unknown) => {
+      if (isNavigationGesture(gesture)) callback(gesture);
+    };
+    ipcRenderer.on(NAVIGATION_GESTURE_CHANNEL, handler);
+    return () => {
+      ipcRenderer.removeListener(NAVIGATION_GESTURE_CHANNEL, handler);
     };
   },
 };

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -54,6 +54,20 @@ function SidebarTopBar() {
   );
 }
 
+function useNativeNavigationGestures() {
+  const { goBack, goForward } = useTabHistory();
+
+  useEffect(() => {
+    return window.desktopAPI.onNavigationGesture((gesture) => {
+      if (gesture === "back") {
+        goBack();
+      } else {
+        goForward();
+      }
+    });
+  }, [goBack, goForward]);
+}
+
 // The main area's top bar doubles as a window drag region. When the sidebar
 // is not occupying main-flow width — either user-collapsed (offcanvas) or
 // auto-hidden in mobile mode (<768px, becomes a sheet drawer) — we pad the
@@ -132,6 +146,7 @@ function DesktopInboxBridge() {
 export function DesktopShell() {
   useInternalLinkHandler();
   useActiveTitleSync();
+  useNativeNavigationGestures();
 
   // Reactive read of current workspace slug from the platform singleton.
   // On first mount, slug is null until WorkspaceRouteLayout (inside the tab

--- a/apps/desktop/src/shared/navigation-gestures.test.ts
+++ b/apps/desktop/src/shared/navigation-gestures.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNavigationGesture,
+  navigationGestureFromSwipe,
+} from "./navigation-gestures";
+
+describe("navigationGestureFromSwipe", () => {
+  it("maps horizontal macOS swipe directions to browser-style history", () => {
+    expect(navigationGestureFromSwipe("right")).toBe("back");
+    expect(navigationGestureFromSwipe("left")).toBe("forward");
+  });
+
+  it("ignores vertical and unknown directions", () => {
+    expect(navigationGestureFromSwipe("up")).toBeNull();
+    expect(navigationGestureFromSwipe("down")).toBeNull();
+    expect(navigationGestureFromSwipe("sideways")).toBeNull();
+  });
+});
+
+describe("isNavigationGesture", () => {
+  it("accepts only the renderer navigation gestures", () => {
+    expect(isNavigationGesture("back")).toBe(true);
+    expect(isNavigationGesture("forward")).toBe(true);
+    expect(isNavigationGesture("right")).toBe(false);
+    expect(isNavigationGesture(null)).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/navigation-gestures.ts
+++ b/apps/desktop/src/shared/navigation-gestures.ts
@@ -1,0 +1,15 @@
+export const NAVIGATION_GESTURE_CHANNEL = "navigation:gesture";
+
+export type NavigationGesture = "back" | "forward";
+
+export function isNavigationGesture(value: unknown): value is NavigationGesture {
+  return value === "back" || value === "forward";
+}
+
+export function navigationGestureFromSwipe(
+  direction: string,
+): NavigationGesture | null {
+  if (direction === "right") return "back";
+  if (direction === "left") return "forward";
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add a macOS BrowserWindow swipe bridge for Desktop back/forward navigation.
- Expose a typed preload listener and reuse the existing per-tab history handlers in the renderer.
- Add focused unit coverage for swipe mapping and main-process IPC dispatch.

## Verification
- corepack pnpm --filter @multica/desktop exec vitest run src/shared/navigation-gestures.test.ts src/main/navigation-gestures.test.ts
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.web.json --composite false
- corepack pnpm --filter @multica/desktop exec vitest run
- corepack pnpm --filter @multica/desktop exec eslint . (passes with existing warnings in tab-content.tsx and tab-store.ts)