### PR TITLE
fix(timezone): harden hourly-rollup rollout against straight-through migrate MUL-2488

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG COMMIT=unknown
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o bin/server ./cmd/server
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o bin/multica ./cmd/multica
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/migrate ./cmd/migrate
+RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/backfill_task_usage_hourly ./cmd/backfill_task_usage_hourly
 
 # --- Runtime stage ---
 FROM alpine:3.21
@@ -29,6 +30,7 @@ WORKDIR /app
 COPY --from=builder /src/server/bin/server .
 COPY --from=builder /src/server/bin/multica .
 COPY --from=builder /src/server/bin/migrate .
+COPY --from=builder /src/server/bin/backfill_task_usage_hourly .
 COPY server/migrations/ ./migrations/
 COPY docker/entrypoint.sh .
 RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh

--- a/server/migrations/103_drop_legacy_daily_rollups.up.sql
+++ b/server/migrations/103_drop_legacy_daily_rollups.up.sql
@@ -21,6 +21,32 @@
 -- (same guard pattern as migration 076).
 
 -- ---------------------------------------------------------------------------
+-- Fail-closed guard: refuse to drop the legacy daily pipelines while the
+-- new hourly rollup is empty on a database that already has token-event
+-- history. `migrate up` runs the migration set straight through (no
+-- per-version stop), so a self-host operator who skips the documented
+-- backfill step would otherwise silently land in a state where dashboards
+-- show zeros (see SELF-HOST UPGRADE ORDER in
+-- cmd/backfill_task_usage_hourly/main.go and
+-- docs/timezone-architecture-rfc.md §6 / §7.1). Failing loud here is the
+-- only thing that turns an undetected outage into a clear migration error.
+--
+-- A fresh database (no rows in task_usage) is exempt — there is nothing to
+-- backfill, and the new triggers installed in 102 will populate
+-- task_usage_hourly on the first event.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM task_usage LIMIT 1)
+       AND NOT EXISTS (SELECT 1 FROM task_usage_hourly LIMIT 1) THEN
+        RAISE EXCEPTION
+            'refusing to drop legacy daily rollups: task_usage_hourly is empty but task_usage has data — apply migrations 100-102 first, then run cmd/backfill_task_usage_hourly, then re-run migrate (see SELF-HOST UPGRADE ORDER in cmd/backfill_task_usage_hourly/main.go)';
+    END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
 -- Unschedule the legacy pg_cron jobs first (no-op when pg_cron is absent
 -- or the job was never registered).
 -- ---------------------------------------------------------------------------

--- a/server/migrations/103_drop_legacy_daily_rollups.up.sql
+++ b/server/migrations/103_drop_legacy_daily_rollups.up.sql
@@ -21,8 +21,8 @@
 -- (same guard pattern as migration 076).
 
 -- ---------------------------------------------------------------------------
--- Fail-closed guard: refuse to drop the legacy daily pipelines while the
--- new hourly rollup is empty on a database that already has token-event
+-- Fail-closed guard: refuse to drop the legacy daily pipelines unless the
+-- hourly rollup has actually been seeded across the existing `task_usage`
 -- history. `migrate up` runs the migration set straight through (no
 -- per-version stop), so a self-host operator who skips the documented
 -- backfill step would otherwise silently land in a state where dashboards
@@ -31,17 +31,66 @@
 -- docs/timezone-architecture-rfc.md §6 / §7.1). Failing loud here is the
 -- only thing that turns an undetected outage into a clear migration error.
 --
--- A fresh database (no rows in task_usage) is exempt — there is nothing to
--- backfill, and the new triggers installed in 102 will populate
--- task_usage_hourly on the first event.
+-- The completion signal we trust is task_usage_hourly_rollup_state.watermark_at:
+--
+--   * cmd/backfill_task_usage_hourly stamps it to `now() - 5 minutes` only
+--     after every monthly slice succeeded (server/cmd/backfill_task_usage_hourly/main.go).
+--   * rollup_task_usage_hourly() (the pg_cron entry) advances it on every
+--     tick (102_task_usage_hourly_pipeline.up.sql).
+--   * The default after migration 101 is `1970-01-01`, so an unrun or
+--     interrupted backfill is trivially detected.
+--
+-- A non-empty `task_usage_hourly` is NOT a safe proxy for "backfill done":
+-- the triggers in 102 only enqueue dirty keys on agent_task_queue /
+-- issue / task_usage DELETE — they do not write hourly rows themselves,
+-- and they fire only on writes since 102 landed. A backfill that
+-- crashed mid-run, or a manual `rollup_task_usage_hourly_window` call,
+-- both leave the hourly table non-empty but with a stale watermark and
+-- partial history; the legacy rollups would still be the only complete
+-- read path.
+--
+-- A fresh database (no rows in task_usage) is exempt — there is no
+-- history to backfill, and rollup_task_usage_hourly() (registered as a
+-- pg_cron job by the operator) will populate task_usage_hourly from the
+-- first event forward via its updated_at watermark window.
 -- ---------------------------------------------------------------------------
 
 DO $$
+DECLARE
+    v_watermark TIMESTAMPTZ;
+    v_max_event TIMESTAMPTZ;
+    v_lag       INTERVAL := INTERVAL '1 hour';
 BEGIN
-    IF EXISTS (SELECT 1 FROM task_usage LIMIT 1)
-       AND NOT EXISTS (SELECT 1 FROM task_usage_hourly LIMIT 1) THEN
+    IF NOT EXISTS (SELECT 1 FROM task_usage LIMIT 1) THEN
+        RETURN;
+    END IF;
+
+    SELECT watermark_at INTO v_watermark
+      FROM task_usage_hourly_rollup_state
+     WHERE id = 1;
+
+    IF v_watermark IS NULL THEN
         RAISE EXCEPTION
-            'refusing to drop legacy daily rollups: task_usage_hourly is empty but task_usage has data — apply migrations 100-102 first, then run cmd/backfill_task_usage_hourly, then re-run migrate (see SELF-HOST UPGRADE ORDER in cmd/backfill_task_usage_hourly/main.go)';
+            'refusing to drop legacy daily rollups: task_usage_hourly_rollup_state row is missing — apply migrations 100-102 first, then run cmd/backfill_task_usage_hourly';
+    END IF;
+
+    SELECT MAX(COALESCE(updated_at, created_at)) INTO v_max_event FROM task_usage;
+
+    -- A successful cmd/backfill_task_usage_hourly stamps watermark_at to
+    -- `now() - 5 min`; once pg_cron is registered the worker keeps it
+    -- within a similar window. If the watermark trails the latest event
+    -- by more than v_lag, one of these went wrong:
+    --   * the backfill was never run (watermark stuck at 1970-01-01),
+    --   * the backfill was interrupted before stampWatermark ran,
+    --   * someone hand-seeded task_usage_hourly without stamping,
+    --   * pg_cron has been off long enough to drift past the cap.
+    -- In every case, dropping the legacy rollups now would remove the
+    -- only read path for buckets the hourly pipeline has not proven it
+    -- owns yet.
+    IF v_watermark < v_max_event - v_lag THEN
+        RAISE EXCEPTION
+            'refusing to drop legacy daily rollups: task_usage_hourly_rollup_state.watermark_at (%) trails task_usage latest event (%) by more than % — backfill is incomplete or pg_cron is not running. Run cmd/backfill_task_usage_hourly (and let pg_cron catch up) before re-running migrate (see SELF-HOST UPGRADE ORDER in cmd/backfill_task_usage_hourly/main.go).',
+            v_watermark, v_max_event, v_lag;
     END IF;
 END
 $$;


### PR DESCRIPTION
MUL-2488 follow-up to #2968.

## Summary

PR #2968 introduced the new `task_usage_hourly` rollup but the playbook for
rolling it out only existed in code comments and the RFC. The actual deploy
pipeline (`entrypoint.sh` → `migrate up`) ignores that playbook and runs all
migrations through to 104, so operators who skipped the one-shot backfill
between 102 and 103 silently end up with empty `task_usage_hourly` and
zeroed dashboards.

This PR makes the rollout safe-by-default:

- **`Dockerfile`** — build `cmd/backfill_task_usage_hourly` into the runtime
  image alongside `server` / `multica` / `migrate`, so a deployed container
  can run the backfill directly (`docker exec ... ./backfill_task_usage_hourly`)
  without a source checkout.
- **`server/migrations/103_drop_legacy_daily_rollups.up.sql`** — fail-closed
  plpgsql guard at the top: refuses to drop the legacy daily pipelines until
  `task_usage_hourly_rollup_state.watermark_at` proves the backfill actually
  finished. The check is `watermark_at >= max(COALESCE(updated_at, created_at)) - 1h`
  on `task_usage`. A successful `cmd/backfill_task_usage_hourly` stamps the
  watermark to `now() - 5 min` only after every monthly slice succeeded; an
  interrupted backfill, a manual `rollup_task_usage_hourly_window` call, or
  pg_cron being off all leave the gap above the threshold. Fresh installs
  (no `task_usage` rows) are exempt.

Together these turn the "skipped the backfill" scenario from a silent zero
into a loud migration error, and give operators a binary in the image to
recover with.

## Why `watermark_at` and not "is the hourly table non-empty"

`task_usage_hourly` can be non-empty after a crashed backfill or a hand
re-run of `rollup_task_usage_hourly_window`, but in both cases the table
covers only a slice of history while `watermark_at` stays at its default
(`1970-01-01`). Trusting non-empty would pass those scenarios. `watermark_at`
is the only signal that backfill ran to completion *and* the cron worker
is keeping it fresh.

The triggers added in migration 102 don't fill the hourly table directly —
they only enqueue dirty keys for re-attribution events (atq / issue updates,
`task_usage` DELETE). INSERT / UPDATE on `task_usage` are picked up by the
`updated_at` watermark window inside `rollup_task_usage_hourly()`, which
only runs when the operator has registered it as a pg_cron job. That is
why fresh installs are exempt: there is no history to backfill, and the
cron entry will catch new events from the first tick.

## What this does *not* change

- Already-applied databases (anything past migration 103) are unaffected.
  `schema_migrations` tracks by version only, so 103 is not re-run.
- pg_cron registration is intentionally still out of migrations — self-host
  environments without pg_cron should not have migrations fail.

## Test plan

- [x] `go build ./cmd/backfill_task_usage_hourly` succeeds locally.
- [ ] Build the Docker image and confirm `./backfill_task_usage_hourly --help`
      is reachable inside the runtime container.
- [ ] On a database with `task_usage` rows and `watermark_at = 1970-01-01`,
      `migrate up` aborts at 103 with the documented error message.
- [ ] On a fresh database (no `task_usage` rows), `migrate up` runs through
      100→104 with no change in behavior.
- [ ] After running the backfill (watermark stamped to `now() - 5m`),
      `migrate up` proceeds past 103 normally.
- [ ] Partial / interrupted backfill: kill the backfill mid-slice, confirm
      `task_usage_hourly` has rows but `watermark_at` is still 1970, then
      verify `migrate up` aborts at 103.