### PR TITLE
MUL-2510 fix(api): use instance_id in deleteCloudRuntimeNode body

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -241,14 +241,14 @@ describe("ApiClient", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new ApiClient("https://api.example.test");
-    await client.deleteCloudRuntimeNode("node-abc-123");
+    await client.deleteCloudRuntimeNode("i-0123456789abcdef0");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0]!;
     expect(url).toBe("https://api.example.test/api/cloud-runtime/nodes");
     expect(opts).toMatchObject({
       method: "DELETE",
-      body: JSON.stringify({ instance_id: "node-abc-123" }),
+      body: JSON.stringify({ instance_id: "i-0123456789abcdef0" }),
     });
     expect((opts.headers as Record<string, string>)["Content-Type"]).toBe(
       "application/json",

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -248,7 +248,7 @@ describe("ApiClient", () => {
     expect(url).toBe("https://api.example.test/api/cloud-runtime/nodes");
     expect(opts).toMatchObject({
       method: "DELETE",
-      body: JSON.stringify({ id: "node-abc-123" }),
+      body: JSON.stringify({ instance_id: "node-abc-123" }),
     });
     expect((opts.headers as Record<string, string>)["Content-Type"]).toBe(
       "application/json",

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -234,7 +234,7 @@ describe("ApiClient", () => {
     ).resolves.toMatchObject({ id: "", status: "" });
   });
 
-  it("deleteCloudRuntimeNode sends DELETE with JSON body containing node id", async () => {
+  it("deleteCloudRuntimeNode sends DELETE with JSON body containing instance id", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(null, { status: 204 }),
     );

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -869,10 +869,10 @@ export class ApiClient {
     );
   }
 
-  async deleteCloudRuntimeNode(nodeId: string): Promise<void> {
+  async deleteCloudRuntimeNode(instanceId: string): Promise<void> {
     await this.fetchRaw("/api/cloud-runtime/nodes", {
       method: "DELETE",
-      body: JSON.stringify({ instance_id: nodeId }),
+      body: JSON.stringify({ instance_id: instanceId }),
       extraHeaders: { "Content-Type": "application/json" },
     });
   }

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -872,7 +872,7 @@ export class ApiClient {
   async deleteCloudRuntimeNode(nodeId: string): Promise<void> {
     await this.fetchRaw("/api/cloud-runtime/nodes", {
       method: "DELETE",
-      body: JSON.stringify({ id: nodeId }),
+      body: JSON.stringify({ instance_id: nodeId }),
       extraHeaders: { "Content-Type": "application/json" },
     });
   }

--- a/packages/core/runtimes/cloud-runtime.ts
+++ b/packages/core/runtimes/cloud-runtime.ts
@@ -83,7 +83,7 @@ export function useCreateCloudRuntimeNode(wsId: string) {
 export function useDeleteCloudRuntimeNode(wsId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (nodeId: string) => api.deleteCloudRuntimeNode(nodeId),
+    mutationFn: (instanceId: string) => api.deleteCloudRuntimeNode(instanceId),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: cloudRuntimeKeys.all(wsId) });
     },

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -327,7 +327,7 @@ function CloudRuntimeNodeRow({ node, wsId }: { node: CloudRuntimeNode; wsId: str
           disabled={deleteNode.isPending}
           onClick={() => {
             if (!confirm(t(($) => $.cloud_runtime.delete_confirm))) return;
-            deleteNode.mutate(node.id, {
+            deleteNode.mutate(node.instance_id, {
               onSuccess: () => toast.success(t(($) => $.cloud_runtime.toast_deleted)),
               onError: (err) =>
                 toast.error(


### PR DESCRIPTION
Fleet API requires `instance_id` field, not `id`. The previous body `{ id: nodeId }` caused "instance_id is required" error on delete.

**Changes:**
- `client.ts`: body changed from `{ id: nodeId }` to `{ instance_id: nodeId }`
- `client.test.ts`: contract test updated to match

**Tested:** 42 test files, 378 tests pass.

MUL-2510