### PR TITLE
fix(settings): i18n the desktop Updates tab (MUL-2515)

### DIFF
--- a/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { AlertCircle, ArrowDownToLine, Check, Loader2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "@multica/views/i18n";
 
 type CheckState =
   | { status: "idle" }
@@ -10,6 +11,7 @@ type CheckState =
   | { status: "error"; message: string };
 
 export function UpdatesSettingsTab() {
+  const { t } = useT("settings");
   const [state, setState] = useState<CheckState>({ status: "idle" });
   const currentVersion = window.desktopAPI.appInfo.version;
 
@@ -29,17 +31,15 @@ export function UpdatesSettingsTab() {
 
   return (
     <div>
-      <h2 className="text-lg font-semibold">Updates</h2>
+      <h2 className="text-lg font-semibold">{t(($) => $.desktop.updates.title)}</h2>
       <p className="text-sm text-muted-foreground mt-1">
-        The desktop app checks for new versions automatically once an hour and
-        shortly after launch, downloading them in the background. You&apos;ll
-        be prompted to restart once an update is ready.
+        {t(($) => $.desktop.updates.description)}
       </p>
 
       <div className="mt-6 divide-y">
         <div className="flex items-center justify-between gap-6 py-4">
           <div className="min-w-0">
-            <p className="text-sm font-medium">Current version</p>
+            <p className="text-sm font-medium">{t(($) => $.desktop.updates.current_version)}</p>
             <p className="text-sm text-muted-foreground mt-0.5 font-mono">
               v{currentVersion}
             </p>
@@ -48,23 +48,20 @@ export function UpdatesSettingsTab() {
 
         <div className="flex items-start justify-between gap-6 py-4">
           <div className="min-w-0">
-            <p className="text-sm font-medium">Check for updates</p>
+            <p className="text-sm font-medium">{t(($) => $.desktop.updates.check_section_title)}</p>
             <p className="text-sm text-muted-foreground mt-0.5">
-              Trigger a check now instead of waiting for the next automatic
-              poll. Available updates download in the background and show a
-              restart prompt when ready.
+              {t(($) => $.desktop.updates.check_section_description)}
             </p>
             {state.status === "up-to-date" && (
               <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
                 <Check className="size-3.5 text-success" />
-                You&apos;re on the latest version.
+                {t(($) => $.desktop.updates.up_to_date)}
               </p>
             )}
             {state.status === "available" && (
               <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
                 <ArrowDownToLine className="size-3.5 text-primary" />
-                v{state.latestVersion} is downloading in the background —
-                you&apos;ll be notified when it&apos;s ready to install.
+                {t(($) => $.desktop.updates.downloading, { version: state.latestVersion })}
               </p>
             )}
             {state.status === "error" && (
@@ -84,10 +81,10 @@ export function UpdatesSettingsTab() {
               {state.status === "checking" ? (
                 <>
                   <Loader2 className="size-3.5 animate-spin" />
-                  Checking…
+                  {t(($) => $.desktop.updates.checking)}
                 </>
               ) : (
-                "Check now"
+                t(($) => $.desktop.updates.check_now)
               )}
             </Button>
           </div>

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -25,11 +25,39 @@ import { AgentsPage } from "@multica/views/agents";
 import { SquadsPage, SquadDetailPage as SquadDetailPageView } from "@multica/views/squads/components";
 import { InboxPage } from "@multica/views/inbox";
 import { SettingsPage } from "@multica/views/settings";
+import { useT } from "@multica/views/i18n";
 import { ErrorBoundary } from "@multica/ui/components/common/error-boundary";
 import { Download, Server } from "lucide-react";
 import { DaemonSettingsTab } from "./components/daemon-settings-tab";
 import { UpdatesSettingsTab } from "./components/updates-settings-tab";
 import { WorkspaceRouteLayout } from "./components/workspace-route-layout";
+
+/**
+ * Wraps `SettingsPage` so the desktop-only extra tabs can pull their labels
+ * from i18n. The route element has to be a component (not a literal JSX
+ * value) for `useT` to run.
+ */
+function DesktopSettingsRoute() {
+  const { t } = useT("settings");
+  return (
+    <SettingsPage
+      extraAccountTabs={[
+        {
+          value: "daemon",
+          label: "Daemon",
+          icon: Server,
+          content: <DaemonSettingsTab />,
+        },
+        {
+          value: "updates",
+          label: t(($) => $.desktop.tabs.updates),
+          icon: Download,
+          content: <UpdatesSettingsTab />,
+        },
+      ]}
+    />
+  );
+}
 
 /**
  * Sets document.title from the deepest matched route's handle.title.
@@ -173,24 +201,7 @@ export const appRoutes: RouteObject[] = [
           },
           {
             path: "settings",
-            element: (
-              <SettingsPage
-                extraAccountTabs={[
-                  {
-                    value: "daemon",
-                    label: "Daemon",
-                    icon: Server,
-                    content: <DaemonSettingsTab />,
-                  },
-                  {
-                    value: "updates",
-                    label: "Updates",
-                    icon: Download,
-                    content: <UpdatesSettingsTab />,
-                  },
-                ]}
-              />
-            ),
+            element: <DesktopSettingsRoute />,
             handle: { title: "Settings" },
           },
         ],

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -235,6 +235,22 @@
     "toast_saved": "Repositories saved",
     "toast_save_failed": "Failed to save repositories"
   },
+  "desktop": {
+    "tabs": {
+      "updates": "Updates"
+    },
+    "updates": {
+      "title": "Updates",
+      "description": "The desktop app checks for new versions automatically once an hour and shortly after launch, downloading them in the background. You'll be prompted to restart once an update is ready.",
+      "current_version": "Current version",
+      "check_section_title": "Check for updates",
+      "check_section_description": "Trigger a check now instead of waiting for the next automatic poll. Available updates download in the background and show a restart prompt when ready.",
+      "up_to_date": "You're on the latest version.",
+      "downloading": "v{{version}} is downloading in the background — you'll be notified when it's ready to install.",
+      "check_now": "Check now",
+      "checking": "Checking…"
+    }
+  },
   "members": {
     "section_title": "Members ({{count}})",
     "invite_title": "Invite member",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -241,14 +241,14 @@
     },
     "updates": {
       "title": "更新",
-      "description": "桌面 app 每小时以及启动后不久会自动检查新版本，并在后台下载。更新就绪后会提示你重启。",
+      "description": "桌面端每小时以及启动后不久会自动检查新版本，并在后台下载。更新就绪后会提示你重启。",
       "current_version": "当前版本",
       "check_section_title": "检查更新",
       "check_section_description": "立即检查更新，而不是等待下一次自动轮询。可用的更新会在后台下载，就绪时弹出重启提示。",
       "up_to_date": "已是最新版本。",
       "downloading": "v{{version}} 正在后台下载——准备好安装时会通知你。",
       "check_now": "立即检查",
-      "checking": "检查中…"
+      "checking": "检查中..."
     }
   },
   "members": {

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -235,6 +235,22 @@
     "toast_saved": "已保存代码仓库",
     "toast_save_failed": "保存代码仓库失败"
   },
+  "desktop": {
+    "tabs": {
+      "updates": "更新"
+    },
+    "updates": {
+      "title": "更新",
+      "description": "桌面 app 每小时以及启动后不久会自动检查新版本，并在后台下载。更新就绪后会提示你重启。",
+      "current_version": "当前版本",
+      "check_section_title": "检查更新",
+      "check_section_description": "立即检查更新，而不是等待下一次自动轮询。可用的更新会在后台下载，就绪时弹出重启提示。",
+      "up_to_date": "已是最新版本。",
+      "downloading": "v{{version}} 正在后台下载——准备好安装时会通知你。",
+      "check_now": "立即检查",
+      "checking": "检查中…"
+    }
+  },
   "members": {
     "section_title": "成员（{{count}}）",
     "invite_title": "邀请成员",


### PR DESCRIPTION
## Summary

- The Updates tab in Settings was hardcoded English (label + body), so the panel stayed in English even when the rest of the app was switched to Chinese — see MUL-2515.
- Wrap the desktop `settings` route in a small `DesktopSettingsRoute` component so the tab label can be pulled from i18n (`settings.desktop.tabs.updates`).
- Move all panel copy into a new `settings.desktop.updates.*` namespace and translate it for `zh-Hans`. EN keys keep the original wording.
- The sibling `Daemon` tab is left untouched — it is out of scope for this issue and has more content to translate.

Related: [MUL-2515](mention://issue/a9283652-e580-4b27-986d-7682bbe2b7a6)

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run locales/parity.test.ts` — locale parity passes
- [x] `pnpm typecheck` — all 6 typecheck tasks pass
- [x] `pnpm test` — all 8 test suites / 748 unit tests pass
- [ ] Manual: switch language to 中文 in Preferences, open Settings → Updates, verify the tab label and panel render in Chinese