### PR TITLE
fix: refresh project progress counters on issue status / membership changes (MUL-2549)

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -8,6 +8,7 @@ import {
   type IssueSortParam,
   type MyIssuesFilter,
 } from "./queries";
+import { projectKeys } from "../projects/queries";
 import {
   addIssueToBuckets,
   findIssueLocation,
@@ -201,6 +202,7 @@ export function useCreateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
+      qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
     },
   });
 }
@@ -283,6 +285,12 @@ export function useUpdateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
+      if (
+        vars.status !== undefined ||
+        Object.prototype.hasOwnProperty.call(vars, "project_id")
+      ) {
+        qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+      }
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
       // to resolve text-preview Eye gates, and unlike other mutations this
@@ -380,6 +388,7 @@ export function useDeleteIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
+      qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
       if (ctx?.metadata) invalidateDeletedIssueParentCaches(qc, wsId, ctx.metadata);
     },
   });
@@ -444,6 +453,12 @@ export function useBatchUpdateIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
+      if (
+        _vars.updates.status !== undefined ||
+        Object.prototype.hasOwnProperty.call(_vars.updates, "project_id")
+      ) {
+        qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+      }
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {
           qc.invalidateQueries({
@@ -555,6 +570,7 @@ export function useBatchDeleteIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
+      qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
       if (ctx?.parentIssueIds && ctx.parentIssueIds.size > 0) {
         invalidateDeletedIssueParentCaches(qc, wsId, {
           parentIssueIds: Array.from(ctx.parentIssueIds),

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./ws-updaters";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
+import { projectKeys } from "../projects/queries";
 import type {
   AgentActivityBucket,
   AgentRunCount,
@@ -35,6 +36,7 @@ const ISSUE_ID = "issue-1";
 const OTHER_ISSUE_ID = "issue-2";
 const PARENT_ISSUE_ID = "parent-1";
 const AGENT_ID = "agent-1";
+const PROJECT_ID = "project-1";
 
 const labelA: Label = {
   id: "label-a",
@@ -213,6 +215,50 @@ describe("onIssueMetadataChanged", () => {
 
     expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toBeUndefined();
     expect(qc.getQueryData(issueKeys.list(WS_ID))).toBeUndefined();
+  });
+});
+
+describe("project progress invalidation", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+    qc.setQueryData(projectKeys.list(WS_ID), [
+      {
+        id: PROJECT_ID,
+        workspace_id: WS_ID,
+        title: "Project",
+        description: null,
+        icon: null,
+        status: "in_progress",
+        priority: "none",
+        lead_type: null,
+        lead_id: null,
+        issue_count: 1,
+        done_count: 0,
+        resource_count: 0,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+      },
+    ]);
+  });
+
+  it("invalidates project queries when an issue status changes", () => {
+    onIssueUpdated(qc, WS_ID, {
+      id: ISSUE_ID,
+      status: "done",
+    });
+
+    expectInvalidated(qc, projectKeys.list(WS_ID));
+  });
+
+  it("invalidates project queries when a project issue is created", () => {
+    onIssueCreated(qc, WS_ID, {
+      ...baseIssue,
+      project_id: PROJECT_ID,
+    });
+
+    expectInvalidated(qc, projectKeys.list(WS_ID));
   });
 });
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
+import { projectKeys } from "../projects/queries";
 import {
   addIssueToBuckets,
   findIssueLocation,
@@ -21,6 +22,9 @@ export function onIssueCreated(
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+  if (issue.project_id) {
+    qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+  }
   // Refresh every Project Gantt cache that might be observing this issue.
   // We invalidate the whole prefix rather than the issue's own project
   // because a fresh issue isn't necessarily scheduled yet; the active Gantt
@@ -61,6 +65,9 @@ export function onIssueUpdated(
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+  if (issue.status !== undefined || issue.project_id !== undefined) {
+    qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+  }
   // Any field change can shift Gantt membership — start_date / due_date may
   // have moved in or out of the `scheduled` set, project_id may have
   // changed, or the row that is in the cache may need to mirror updated
@@ -170,4 +177,5 @@ export function onIssueDeleted(
   cleanupDeletedIssueCaches(qc, wsId, issueId);
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+  qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
 }

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -446,6 +446,7 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := projectToResponse(project)
+	resp.IssueCount, resp.DoneCount = h.loadProjectIssueStats(r.Context(), project.ID)
 	resp.ResourceCount = h.loadProjectResourceCount(r.Context(), project.ID)
 	h.publish(protocol.EventProjectUpdated, workspaceID, "member", userID, map[string]any{"project": resp})
 	writeJSON(w, http.StatusOK, resp)

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -566,8 +567,31 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 		t.Fatalf("project %s not found in ListProjects response", project.ID)
 	}
 
+	var number int
+	if err := testPool.QueryRow(context.Background(), `
+		UPDATE workspace
+		SET issue_counter = GREATEST(issue_counter, (SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)) + 1
+		WHERE id = $1 RETURNING issue_counter
+	`, testWorkspaceID).Scan(&number); err != nil {
+		t.Fatalf("next issue number: %v", err)
+	}
+	var issueID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (
+			workspace_id, creator_type, creator_id, title, status, priority,
+			project_id, number, position
+		)
+		VALUES ($1, 'member', $2, 'Project update stats breadcrumb', 'done', 'none', $3, $4, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID, project.ID, number).Scan(&issueID); err != nil {
+		t.Fatalf("create project issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
 	// UpdateProject must preserve the breadcrumb. A title-only PUT used to
-	// reset resource_count to 0 because UpdateProject didn't reload the count.
+	// reset derived counts to 0 because UpdateProject didn't reload them.
 	w = httptest.NewRecorder()
 	req = newRequest("PUT", "/api/projects/"+project.ID, map[string]any{
 		"title": "Resource count breadcrumb (updated)",
@@ -583,6 +607,9 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	}
 	if updated.ResourceCount != 1 {
 		t.Errorf("UpdateProject ResourceCount = %d, want 1", updated.ResourceCount)
+	}
+	if updated.IssueCount != 1 || updated.DoneCount != 1 {
+		t.Errorf("UpdateProject issue stats = %d/%d, want 1/1", updated.DoneCount, updated.IssueCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Invalidate project queries when issue membership or status changes so project progress counters refresh after manual status changes.
- Preserve derived issue/resource counters on project update responses.
- Advance assigned-agent and assigned-squad comment-triggered issues to `in_progress` after a task is successfully queued.

## Root Cause
- Project progress was cached separately from issue status mutations and WebSocket issue updates, so a project could keep showing stale `done_count` / `issue_count` after an issue moved to `done`.
- Comment-triggered agent work queued a task but did not update the issue status from `in_review` to `in_progress`, leaving active AI work visually stuck in review.

## Validation
- `go test ./internal/handler -run 'TestCreateComment_AssignedAgentReopensReviewToInProgress|TestCreateComment_AssignedSquadReopensReviewToInProgress|TestCreateComment_MentionedAgentDoesNotChangeIssueStatus|TestProjectResourceCountBreadcrumb'`
- `go test ./internal/handler`
- `corepack pnpm --filter @multica/core exec vitest run issues/ws-updaters.test.ts`
- `corepack pnpm --filter @multica/core test`
