### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,12 @@ CORS_ALLOWED_ORIGINS=
 # `Authorization: Bearer <token>`.
 # REALTIME_METRICS_TOKEN=
 
+# Astraflow (OpenAI-compatible, 200+ models — https://astraflow.ucloud-global.com)
+# Global endpoint — sign up at https://astraflow.ucloud-global.com
+ASTRAFLOW_API_KEY=
+# China endpoint — sign up at https://astraflow.ucloud.cn
+ASTRAFLOW_CN_API_KEY=
+
 # GitHub App integration (Settings → GitHub "Connect GitHub")
 # Both must be set for the Connect button to enable and for webhooks to be
 # accepted; leave empty to disable the integration. See docs/github-integration.

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -138,6 +138,19 @@ function GeminiLogo({ className }: { className: string }) {
   );
 }
 
+// Astraflow (UCloud) — brand mark using UCloud blue (#0052D9)
+function AstraflowLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <rect width="24" height="24" rx="5" fill="#0052D9" />
+      <path
+        d="M12 4L19 18H14.5L12 13L9.5 18H5L12 4Z"
+        fill="#FFFFFF"
+      />
+    </svg>
+  );
+}
+
 // Kiro CLI — official icon sourced from kiro.dev/icon.svg.
 function KiroLogo({ className }: { className: string }) {
   const maskId = `kiro-logo-mask-${useId().replace(/:/g, "")}`;
@@ -207,6 +220,9 @@ export function ProviderLogo({
       return <KiroLogo className={className} />;
     case "gemini":
       return <GeminiLogo className={className} />;
+    case "astraflow":
+    case "astraflow-cn":
+      return <AstraflowLogo className={className} />;
     default:
       return <Monitor className={className} />;
   }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
-	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro
+	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, astraflow, astraflow-cn
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
@@ -200,6 +200,21 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	if e, ok := probe("MULTICA_KIRO_PATH", "kiro-cli", "MULTICA_KIRO_MODEL"); ok {
 		agents["kiro"] = e
+	}
+	// Astraflow: OpenAI-compatible platform (200+ models, global endpoint).
+	// Requires opencode on PATH and ASTRAFLOW_API_KEY set.
+	// The opencode binary is reused; OPENAI_API_KEY + OPENAI_BASE_URL are
+	// injected at task-execution time by the astraflow backend in pkg/agent.
+	if _, astraflowKeySet := os.LookupEnv("ASTRAFLOW_API_KEY"); astraflowKeySet {
+		if e, ok := probe("MULTICA_ASTRAFLOW_PATH", "opencode", "MULTICA_ASTRAFLOW_MODEL"); ok {
+			agents["astraflow"] = e
+		}
+	}
+	// Astraflow CN: China endpoint variant.
+	if _, astraflowCNKeySet := os.LookupEnv("ASTRAFLOW_CN_API_KEY"); astraflowCNKeySet {
+		if e, ok := probe("MULTICA_ASTRAFLOW_CN_PATH", "opencode", "MULTICA_ASTRAFLOW_CN_MODEL"); ok {
+			agents["astraflow-cn"] = e
+		}
 	}
 	if len(agents) == 0 {
 		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, Astraflow). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -107,7 +107,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "astraflow", "astraflow-cn".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -136,8 +136,29 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "astraflow":
+		// Astraflow is OpenAI-compatible; reuse opencodeBackend with the
+		// global endpoint injected via OPENAI_BASE_URL / OPENAI_API_KEY.
+		if cfg.Env == nil {
+			cfg.Env = map[string]string{}
+		}
+		cfg.Env["OPENAI_BASE_URL"] = "https://api-us-ca.umodelverse.ai/v1"
+		if key := cfg.Env["ASTRAFLOW_API_KEY"]; key != "" {
+			cfg.Env["OPENAI_API_KEY"] = key
+		}
+		return &opencodeBackend{cfg: cfg}, nil
+	case "astraflow-cn":
+		// Astraflow CN: China endpoint variant.
+		if cfg.Env == nil {
+			cfg.Env = map[string]string{}
+		}
+		cfg.Env["OPENAI_BASE_URL"] = "https://api.modelverse.cn/v1"
+		if key := cfg.Env["ASTRAFLOW_CN_API_KEY"]; key != "" {
+			cfg.Env["OPENAI_API_KEY"] = key
+		}
+		return &opencodeBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, astraflow, astraflow-cn)", agentType)
 	}
 }
 
@@ -158,12 +179,14 @@ var launchHeaders = map[string]string{
 	"copilot":  "copilot (json)",
 	"cursor":   "cursor-agent (stream-json)",
 	"gemini":   "gemini (stream-json)",
-	"hermes":   "hermes acp",
-	"openclaw": "openclaw agent (json)",
-	"opencode": "opencode run (json)",
-	"pi":       "pi (json mode)",
-	"kimi":     "kimi acp",
-	"kiro":     "kiro-cli acp",
+	"hermes":        "hermes acp",
+	"openclaw":      "openclaw agent (json)",
+	"opencode":      "opencode run (json)",
+	"pi":            "pi (json mode)",
+	"kimi":          "kimi acp",
+	"kiro":          "kiro-cli acp",
+	"astraflow":     "opencode run (json) [Astraflow global]",
+	"astraflow-cn":  "opencode run (json) [Astraflow CN]",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -122,6 +122,13 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
+	case "astraflow", "astraflow-cn":
+		// Astraflow is OpenAI-compatible; delegate to the opencode model
+		// discovery path which enumerates whatever the configured endpoint
+		// supports via `opencode models`.
+		return cachedDiscovery(providerType, func() ([]Model, error) {
+			return discoverOpenCodeModels(ctx, executablePath)
+		})
 	case "opencode":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)


### PR DESCRIPTION
## What does this PR do?

Adds **Astraflow** (by UCloud / 优刻得) as a new agent provider — an OpenAI-compatible AI model aggregation platform supporting 200+ models.

Since Astraflow exposes an OpenAI-compatible API, this integration reuses the existing `opencode` CLI backend and injects the appropriate `OPENAI_BASE_URL` + `OPENAI_API_KEY` env vars at task-execution time. No new SDK or subprocess is required.

Two variants are supported:

| Provider key   | Endpoint                              | Env var                |
|----------------|---------------------------------------|------------------------|
| `astraflow`    | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY`    |
| `astraflow-cn` | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |

- **Global**: sign up at https://astraflow.ucloud-global.com
- **China**: sign up at https://astraflow.ucloud.cn

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `.env.example` — Documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`
- `server/internal/daemon/config.go` — Probes `opencode` binary when an Astraflow API key env var is set; registers `astraflow` / `astraflow-cn` agent entries
- `server/pkg/agent/agent.go` — Adds `astraflow` and `astraflow-cn` cases to the `New()` factory; each injects `OPENAI_BASE_URL` + `OPENAI_API_KEY` into the `opencodeBackend` config; updates `launchHeaders`
- `server/pkg/agent/models.go` — Adds `astraflow` / `astraflow-cn` cases to `ListModels()`, delegating to `discoverOpenCodeModels`
- `packages/views/runtimes/components/provider-logo.tsx` — Adds `AstraflowLogo` SVG (UCloud blue `#0052D9`) and the `astraflow` / `astraflow-cn` switch cases

## How to Test

1. Set the API key env var:
   ```bash
   # Global endpoint
   export ASTRAFLOW_API_KEY=your-key-here

   # China endpoint (optional)
   export ASTRAFLOW_CN_API_KEY=your-cn-key-here
   ```
2. Start the daemon as usual.
3. Verify that `astraflow` (and/or `astraflow-cn`) appears as an auto-detected runtime alongside other configured providers, and that model listing and task execution work correctly against the Astraflow endpoint.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->

## Screenshots (optional)

N/A