### PR TITLE
fix: add issue detail jump button

### DIFF
--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -46,7 +46,7 @@ export function ChatFab() {
       <TooltipTrigger
         onClick={handleClick}
         className={cn(
-          "fixed bottom-2 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95",
+          "absolute bottom-2 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95",
           // Impulse the button itself while a chat task is running — no
           // outer ring to keep things calm.
           isRunning && "animate-chat-impulse",

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -46,7 +46,7 @@ export function ChatFab() {
       <TooltipTrigger
         onClick={handleClick}
         className={cn(
-          "absolute bottom-2 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95",
+          "fixed bottom-2 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95",
           // Impulse the button itself while a chat task is running — no
           // outer ring to keep things calm.
           isRunning && "animate-chat-impulse",

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -831,7 +831,7 @@ describe("IssueDetail (shared)", () => {
     renderIssueDetail();
 
     const jumpToBottom = await screen.findByRole("button", { name: "Jump to latest activity" });
-    expect(jumpToBottom).toHaveClass("fixed", "bottom-14", "right-2", "z-50", "size-10");
+    expect(jumpToBottom).toHaveClass("absolute", "bottom-14", "right-2", "z-50", "size-10");
 
     fireEvent.click(jumpToBottom);
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -29,6 +29,13 @@ vi.mock("@multica/core/hooks", () => ({
 
 // Mock @multica/core/auth
 const mockAuthUser = { id: "user-1", email: "test@test.com", name: "Test User" };
+vi.mock("@multica/core/chat", () => ({
+  useChatStore: (selector?: any) => {
+    const state = { isOpen: false };
+    return selector ? selector(state) : state;
+  },
+}));
+
 vi.mock("@multica/core/auth", () => ({
   useAuthStore: Object.assign(
     (selector?: any) => {
@@ -309,6 +316,7 @@ vi.mock("@multica/core/issues/stores", () => ({
 // it by default) so tests can assert the deep-link effect dispatched a
 // native scroll on the target node.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
+const virtuosoScrollToIndexSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("react-virtuoso", () => ({
   Virtuoso: forwardRef(function MockVirtuoso(
@@ -316,10 +324,8 @@ vi.mock("react-virtuoso", () => ({
     ref: any,
   ) {
     useImperativeHandle(ref, () => ({
-      // Real Virtuoso ref methods are not exercised by tests in this file
-      // since the cold-path uses native scrollIntoView on the DOM node.
       scrollIntoView: vi.fn(),
-      scrollToIndex: vi.fn(),
+      scrollToIndex: virtuosoScrollToIndexSpy,
     }));
     return (
       <div data-testid="virtuoso-mock">
@@ -335,6 +341,25 @@ vi.mock("react-virtuoso", () => ({
 // with a spy so the deep-link effect's call can be observed.
 beforeEach(() => {
   scrollIntoViewSpy.mockClear();
+  virtuosoScrollToIndexSpy.mockClear();
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => 0,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => 0,
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: 0,
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    writable: true,
+    value: vi.fn(),
+  });
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     writable: true,
@@ -780,6 +805,42 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
+  });
+
+  it("jumps to the latest activity using Virtuoso when the timeline overflows", async () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get: () => 1500,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get: () => 500,
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      writable: true,
+      value: scrollTo,
+    });
+
+    renderIssueDetail();
+
+    const jumpToBottom = await screen.findByRole("button", { name: "Jump to latest activity" });
+    expect(jumpToBottom).toHaveClass("fixed", "bottom-14", "right-2", "z-50", "size-10");
+
+    fireEvent.click(jumpToBottom);
+
+    expect(virtuosoScrollToIndexSpy).toHaveBeenCalledWith({
+      index: 1,
+      align: "end",
+      behavior: "smooth",
+    });
+    expect(scrollTo).not.toHaveBeenCalledWith({ top: 1000, behavior: "smooth" });
   });
 
   it("collapses non-trailing activity blocks and expands the last one by default", async () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef, Fragment } from "react";
-import { Virtuoso } from "react-virtuoso";
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, Fragment } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink } from "../../navigation";
 import { useNavigation } from "../../navigation";
@@ -54,6 +54,7 @@ import { CommentInput } from "./comment-input";
 import { ResolvedThreadBar } from "./resolved-thread-bar";
 import { collectThreadReplies } from "./thread-utils";
 import { AgentLiveCard } from "./agent-live-card";
+import { IssueJumpFab } from "./issue-jump-fab";
 import { ExecutionLogSection } from "./execution-log-section";
 import { PullRequestList } from "./pull-request-list";
 import { useGitHubSettings } from "@multica/core/github";
@@ -76,6 +77,7 @@ import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
+import { useChatStore } from "@multica/core/chat";
 import { timeAgo } from "@multica/core/utils";
 import { cn } from "@multica/ui/lib/utils";
 
@@ -678,7 +680,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso prop would never receive the element. Callback ref + state fixes
   // that: setState triggers the re-render that hands Virtuoso the element.
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const [canJumpScroll, setCanJumpScroll] = useState(false);
+  const [isNearScrollBottom, setIsNearScrollBottom] = useState(false);
+  const isChatOpen = useChatStore((s) => s.isOpen);
 
   // Per-session: which resolved threads the user has temporarily expanded.
   // Not persisted (matches Linear) — reload collapses everything back to bars.
@@ -1002,6 +1008,54 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [allChildrenSelected, childIssueIds, deselectIds, selectIds]);
 
   const loading = issueLoading;
+
+  const updateJumpScrollState = useCallback(() => {
+    if (!scrollContainerEl) return;
+
+    const maxScrollTop = scrollContainerEl.scrollHeight - scrollContainerEl.clientHeight;
+    setCanJumpScroll(maxScrollTop > 80);
+    setIsNearScrollBottom(maxScrollTop - scrollContainerEl.scrollTop <= 80);
+  }, [scrollContainerEl]);
+
+  useLayoutEffect(() => {
+    if (!scrollContainerEl) return;
+
+    updateJumpScrollState();
+    scrollContainerEl.addEventListener("scroll", updateJumpScrollState, { passive: true });
+    window.addEventListener("resize", updateJumpScrollState);
+
+    const observer = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => updateJumpScrollState())
+      : null;
+    observer?.observe(scrollContainerEl);
+
+    return () => {
+      scrollContainerEl.removeEventListener("scroll", updateJumpScrollState);
+      window.removeEventListener("resize", updateJumpScrollState);
+      observer?.disconnect();
+    };
+  }, [scrollContainerEl, updateJumpScrollState, items.length]);
+
+  const handleJumpScroll = useCallback(() => {
+    if (!scrollContainerEl) return;
+
+    if (isNearScrollBottom) {
+      scrollContainerEl.scrollTo({ top: 0, behavior: "smooth" });
+      return;
+    }
+
+    if (virtuosoRef.current && items.length > 0) {
+      virtuosoRef.current.scrollToIndex({
+        index: items.length - 1,
+        align: "end",
+        behavior: "smooth",
+      });
+      return;
+    }
+
+    const maxScrollTop = scrollContainerEl.scrollHeight - scrollContainerEl.clientHeight;
+    scrollContainerEl.scrollTo({ top: maxScrollTop, behavior: "smooth" });
+  }, [isNearScrollBottom, items.length, scrollContainerEl]);
 
   // Deep-link landing. Semantically equivalent to navigating to
   // `#comment-${id}`: find the element with that id, scrollIntoView it.
@@ -1926,6 +1980,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 ) : (
                   <div className="mt-4">
                     <Virtuoso
+                      ref={virtuosoRef}
                       key={`${wsId}:${id}`}
                       customScrollParent={scrollContainerEl}
                       data={items}
@@ -1963,6 +2018,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           </div>
         </div>
         </div>
+        {canJumpScroll && !isChatOpen && (
+          <IssueJumpFab
+            isNearBottom={isNearScrollBottom}
+            onClick={handleJumpScroll}
+            jumpToTopLabel={t(($) => $.detail.jump_to_top)}
+            jumpToBottomLabel={t(($) => $.detail.jump_to_bottom)}
+          />
+        )}
       </div>
   );
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1590,7 +1590,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   };
 
   const detailContent = (
-    <div className="flex h-full min-w-0 flex-1 flex-col">
+    <div className="relative flex h-full min-w-0 flex-1 flex-col">
         <PageHeader className="gap-2 bg-background text-sm">
           <div className="flex flex-1 items-center gap-1.5 min-w-0">
             {workspace && (

--- a/packages/views/issues/components/issue-jump-fab.tsx
+++ b/packages/views/issues/components/issue-jump-fab.tsx
@@ -30,7 +30,7 @@ export function IssueJumpFab({
             type="button"
             onClick={onClick}
             aria-label={label}
-            className="fixed bottom-14 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm ring-1 ring-foreground/10 transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
+            className="absolute bottom-14 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm ring-1 ring-foreground/10 transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
           >
             {isNearBottom ? <ArrowUp className="size-5" /> : <ArrowDown className="size-5" />}
           </button>

--- a/packages/views/issues/components/issue-jump-fab.tsx
+++ b/packages/views/issues/components/issue-jump-fab.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ArrowDown, ArrowUp } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@multica/ui/components/ui/tooltip";
+
+type IssueJumpFabProps = {
+  isNearBottom: boolean;
+  onClick: () => void;
+  jumpToTopLabel: string;
+  jumpToBottomLabel: string;
+};
+
+export function IssueJumpFab({
+  isNearBottom,
+  onClick,
+  jumpToTopLabel,
+  jumpToBottomLabel,
+}: IssueJumpFabProps) {
+  const label = isNearBottom ? jumpToTopLabel : jumpToBottomLabel;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={onClick}
+            aria-label={label}
+            className="fixed bottom-14 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm ring-1 ring-foreground/10 transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
+          >
+            {isNearBottom ? <ArrowUp className="size-5" /> : <ArrowDown className="size-5" />}
+          </button>
+        }
+      />
+      <TooltipContent side="left" sideOffset={10}>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -197,6 +197,8 @@
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
     "sidebar_tooltip": "Toggle sidebar",
+    "jump_to_bottom": "Jump to latest activity",
+    "jump_to_top": "Jump to top",
     "cmdf_toast_title": "Find on page only covers what's visible",
     "cmdf_toast_description": "The timeline is virtualized — ⌘F can't see off-screen comments. Full in-app search is coming.",
     "update_failed": "Failed to update issue",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -196,6 +196,8 @@
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
     "sidebar_tooltip": "切换侧边栏",
+    "jump_to_bottom": "跳转到最新动态",
+    "jump_to_top": "跳转到顶部",
     "cmdf_toast_title": "页面内查找仅覆盖可见区",
     "cmdf_toast_description": "评论列表已虚拟滚动,⌘F 找不到视口外的评论。完整应用内搜索即将推出。",
     "update_failed": "更新 issue 失败",


### PR DESCRIPTION
## What does this PR do?

Adds a floating jump control to the issue detail timeline so users can quickly move to the latest activity, and back to the top when already near the bottom. The issue timeline is virtualized with Virtuoso, so the bottom jump uses `scrollToIndex` instead of relying on partially measured `scrollHeight`.

## Related Issue

No GitHub issue found/linked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx`: tracks overflow/near-bottom state and renders the jump FAB when useful, scoped to the issue detail pane.
- `packages/views/issues/components/issue-jump-fab.tsx`: adds the tooltip + button component for jump-to-top/bottom.
- `packages/views/locales/*/issues.json`: adds jump labels.
- `packages/views/issues/components/issue-detail.test.tsx`: covers Virtuoso-backed jump behavior.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views lint`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: low UI-only change, but manual mobile verification is still recommended because this adds a floating issue-detail control and Virtuoso scrolling behavior.

## AI Disclosure

**AI tool used:** Hermes Agent / GPT-5.5

**Prompt / approach:**
Implemented from user feedback that issue detail lacks a quick way to jump to the latest/bottom comment. Kept issue timeline virtualization intact, scoped the FAB to the issue detail pane to avoid overlaying the sidebar, and validated with focused unit test/typecheck/lint.

## Screenshots (optional)

Not included; manual mobile visual check recommended before merge.
