### PR TITLE
fix(security): force attachment disposition for SVG uploads

### DIFF
--- a/server/internal/storage/local_test.go
+++ b/server/internal/storage/local_test.go
@@ -259,6 +259,14 @@ func TestLocalStorage_ServeFile_ContentDispositionFromSidecar(t *testing.T) {
 			filename:    "weird\";name.txt",
 			wantHeader:  `attachment; filename="weird__name.txt"`,
 		},
+		{
+			// SVG can carry <script>/onload — never serve inline.
+			name:        "attachment for svg (stored-XSS prevention)",
+			key:         "workspaces/ws-1/jkl.svg",
+			contentType: "image/svg+xml",
+			filename:    "logo.svg",
+			wantHeader:  `attachment; filename="logo.svg"`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/server/internal/storage/util.go
+++ b/server/internal/storage/util.go
@@ -22,7 +22,15 @@ func sanitizeFilename(name string) string {
 // isInlineContentType returns true for media types that browsers should
 // display inline (images, video, audio, PDF). Everything else triggers a
 // download via Content-Disposition: attachment.
+//
+// SVG is excluded even though its MIME type is image/svg+xml: SVG is XML
+// and can carry <script>, <foreignObject>, or onload= attributes that
+// execute in the document's origin when rendered inline. Forcing
+// attachment disposition prevents stored-XSS via uploaded .svg files.
 func isInlineContentType(ct string) bool {
+	if ct == "image/svg+xml" {
+		return false
+	}
 	return strings.HasPrefix(ct, "image/") ||
 		strings.HasPrefix(ct, "video/") ||
 		strings.HasPrefix(ct, "audio/") ||

--- a/server/internal/storage/util_test.go
+++ b/server/internal/storage/util_test.go
@@ -1,0 +1,31 @@
+package storage
+
+import "testing"
+
+func TestIsInlineContentType(t *testing.T) {
+	cases := []struct {
+		ct   string
+		want bool
+	}{
+		{"image/png", true},
+		{"image/jpeg", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"video/mp4", true},
+		{"audio/mpeg", true},
+		{"application/pdf", true},
+
+		// SVG must NOT render inline — it can carry executable script.
+		{"image/svg+xml", false},
+
+		{"text/html", false},
+		{"application/octet-stream", false},
+		{"text/plain", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isInlineContentType(tc.ct); got != tc.want {
+			t.Errorf("isInlineContentType(%q) = %v, want %v", tc.ct, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3022.

Uploaded SVG files were served with `Content-Disposition: inline` because `isInlineContentType` returned `true` for any `image/*` MIME type. SVG is XML — `<script>`, `<foreignObject>`, and `onload=` execute when rendered inline — so a workspace member could upload a crafted `.svg`, share its attachment URL, and any clicker would execute attacker-controlled JS in the application's first-party origin (cookie theft, authenticated API calls).

This PR excludes `image/svg+xml` from `isInlineContentType`, so the local and S3 storage backends both serve SVG with `Content-Disposition: attachment`. Browsers do not run scripts in downloaded files.

## Why this approach

- Single-file behavior change in a shared helper used by both storage backends — guaranteed coverage.
- No upload-time rejection: existing SVG attachments (logos, diagrams) keep working; they download instead of rendering inline.
- A full SVG sanitizer would be a larger, separate change. Forcing attachment is the minimal sufficient fix.

## Test plan

- [x] New `server/internal/storage/util_test.go` covers `isInlineContentType` with `image/svg+xml` → `false` and the existing inline types → `true`.
- [x] Extended `TestLocalStorage_ServeFile_ContentDispositionFromSidecar` with an SVG case asserting `Content-Disposition: attachment; filename="logo.svg"`.
- [ ] `make test` (reviewer-side; my local environment lacks Go).