### PR TITLE
security(db): scope DELETE/UpdateIssueStatus by workspace_id (defense-in-depth)

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -305,7 +305,7 @@ func broadcastFailedTasks(ctx context.Context, queries *db.Queries, taskSvc *ser
 				if issue.Status == "in_progress" && !processedIssues[issueKey] {
 					processedIssues[issueKey] = true
 					if hasActive, herr := queries.HasActiveTaskForIssue(ctx, t.IssueID); herr == nil && !hasActive {
-						queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{ID: t.IssueID, Status: "todo"})
+						queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{ID: t.IssueID, Status: "todo", WorkspaceID: issue.WorkspaceID})
 					}
 				}
 			}

--- a/server/cmd/server/workspace_scope_guard_test.go
+++ b/server/cmd/server/workspace_scope_guard_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestWorkspaceScopeGuard locks in the SQL-layer tenant guard added in PR #3027.
+// For each scoped query, it creates a resource in workspace A (the integration
+// fixture workspace), then invokes the query with a foreign workspace UUID and
+// asserts the row is untouched:
+//   - :exec queries return (0 rows affected, nil) — silent no-op.
+//   - :one queries return pgx.ErrNoRows.
+//
+// If a future refactor drops the workspace_id arg from any of these queries,
+// the cross-workspace call would mutate the row and this test will fail.
+func TestWorkspaceScopeGuard(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	ctx := context.Background()
+	queries := db.New(testPool)
+	wsA := parseUUID(testWorkspaceID)
+	wsB := randomUUID(t) // never-existed workspace; the guard predicate must reject it
+
+	t.Run("DeleteIssue", func(t *testing.T) {
+		id := seedIssue(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteIssue(ctx, db.DeleteIssueParams{ID: id, WorkspaceID: wsB}); err != nil {
+			t.Fatalf("cross-workspace DeleteIssue: expected nil error (no-op), got %v", err)
+		}
+		assertRowExists(t, ctx, "issue", id)
+	})
+
+	t.Run("DeleteComment", func(t *testing.T) {
+		issueID := seedIssue(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, util.UUIDToString(issueID)) })
+		id := seedComment(t, ctx, issueID)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteComment(ctx, db.DeleteCommentParams{ID: id, WorkspaceID: wsB}); err != nil {
+			t.Fatalf("cross-workspace DeleteComment: expected nil error (no-op), got %v", err)
+		}
+		assertRowExists(t, ctx, "comment", id)
+	})
+
+	t.Run("DeleteProject", func(t *testing.T) {
+		id := seedProject(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteProject(ctx, db.DeleteProjectParams{ID: id, WorkspaceID: wsB}); err != nil {
+			t.Fatalf("cross-workspace DeleteProject: expected nil error (no-op), got %v", err)
+		}
+		assertRowExists(t, ctx, "project", id)
+	})
+
+	t.Run("DeleteSkill", func(t *testing.T) {
+		id := seedSkill(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM skill WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteSkill(ctx, db.DeleteSkillParams{ID: id, WorkspaceID: wsB}); err != nil {
+			t.Fatalf("cross-workspace DeleteSkill: expected nil error (no-op), got %v", err)
+		}
+		assertRowExists(t, ctx, "skill", id)
+	})
+
+	t.Run("DeleteChatSession", func(t *testing.T) {
+		id := seedChatSession(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteChatSession(ctx, db.DeleteChatSessionParams{ID: id, WorkspaceID: wsB}); err != nil {
+			t.Fatalf("cross-workspace DeleteChatSession: expected nil error (no-op), got %v", err)
+		}
+		assertRowExists(t, ctx, "chat_session", id)
+	})
+
+	t.Run("UpdateIssueStatus", func(t *testing.T) {
+		id := seedIssue(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, util.UUIDToString(id)) })
+
+		_, err := queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+			ID:          id,
+			Status:      "in_progress",
+			WorkspaceID: wsB,
+		})
+		if !errors.Is(err, pgx.ErrNoRows) {
+			t.Fatalf("cross-workspace UpdateIssueStatus: expected pgx.ErrNoRows, got %v", err)
+		}
+
+		// Status must still be the original 'todo'.
+		var status string
+		if err := testPool.QueryRow(ctx, `SELECT status FROM issue WHERE id = $1`, util.UUIDToString(id)).Scan(&status); err != nil {
+			t.Fatalf("re-read issue: %v", err)
+		}
+		if status != "todo" {
+			t.Fatalf("issue status changed across workspace boundary: got %q, want 'todo'", status)
+		}
+	})
+
+	// Sanity check: a buggy guard that returns no-op for every call would
+	// also satisfy the cross-workspace assertions above. This sub-test
+	// proves the in-workspace path still mutates.
+	t.Run("InWorkspaceCallsStillWork", func(t *testing.T) {
+		id := seedIssue(t, ctx)
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, util.UUIDToString(id)) })
+
+		if err := queries.DeleteIssue(ctx, db.DeleteIssueParams{ID: id, WorkspaceID: wsA}); err != nil {
+			t.Fatalf("in-workspace DeleteIssue: %v", err)
+		}
+		var count int
+		if err := testPool.QueryRow(ctx, `SELECT count(*) FROM issue WHERE id = $1`, util.UUIDToString(id)).Scan(&count); err != nil {
+			t.Fatalf("count issue: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("in-workspace DeleteIssue did not remove the row")
+		}
+	})
+}
+
+// ---- seed helpers (resource lives in testWorkspaceID) ----
+
+func seedIssue(t *testing.T, ctx context.Context) pgtype.UUID {
+	t.Helper()
+	var s string
+	// number is unique per workspace; pick a high-range random value to
+	// avoid colliding with concurrent integration tests in the same DB.
+	n := 1_000_000 + rand.IntN(1_000_000)
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number)
+		VALUES ($1, 'scope-guard test issue', 'todo', 'none', 'member', $2, 0, $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, n).Scan(&s); err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	return parseUUID(s)
+}
+
+func seedComment(t *testing.T, ctx context.Context, issueID pgtype.UUID) pgtype.UUID {
+	t.Helper()
+	var s string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'scope-guard test comment', 'comment')
+		RETURNING id
+	`, util.UUIDToString(issueID), testWorkspaceID, testUserID).Scan(&s); err != nil {
+		t.Fatalf("seed comment: %v", err)
+	}
+	return parseUUID(s)
+}
+
+func seedProject(t *testing.T, ctx context.Context) pgtype.UUID {
+	t.Helper()
+	var s string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title, status, priority)
+		VALUES ($1, 'scope-guard test project', 'planned', 'none')
+		RETURNING id
+	`, testWorkspaceID).Scan(&s); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	return parseUUID(s)
+}
+
+func seedSkill(t *testing.T, ctx context.Context) pgtype.UUID {
+	t.Helper()
+	var s string
+	// skill name is UNIQUE per workspace; add a random suffix to avoid colliding
+	// with previous runs on the same DB.
+	name := uniqueName("scope-guard skill")
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
+		VALUES ($1, $2, '', '', '{}'::jsonb, $3)
+		RETURNING id
+	`, testWorkspaceID, name, testUserID).Scan(&s); err != nil {
+		t.Fatalf("seed skill: %v", err)
+	}
+	return parseUUID(s)
+}
+
+func seedChatSession(t *testing.T, ctx context.Context) pgtype.UUID {
+	t.Helper()
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("find test agent: %v", err)
+	}
+	var s string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, runtime_id)
+		VALUES ($1, $2, $3, 'scope-guard chat', (SELECT runtime_id FROM agent WHERE id = $2))
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&s); err != nil {
+		t.Fatalf("seed chat_session: %v", err)
+	}
+	return parseUUID(s)
+}
+
+func assertRowExists(t *testing.T, ctx context.Context, table string, id pgtype.UUID) {
+	t.Helper()
+	var count int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE id = $1`, util.UUIDToString(id)).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if count != 1 {
+		t.Fatalf("row in %s was removed across workspace boundary (count = %d)", table, count)
+	}
+}
+
+// randomUUID returns a never-existed workspace UUID for cross-tenant probes.
+func randomUUID(t *testing.T) pgtype.UUID {
+	t.Helper()
+	u, err := uuid.NewRandom()
+	if err != nil {
+		t.Fatalf("uuid.NewRandom: %v", err)
+	}
+	return parseUUID(u.String())
+}
+
+// uniqueName returns prefix + a short random suffix to avoid UNIQUE collisions
+// across reruns on the same database.
+func uniqueName(prefix string) string {
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return prefix
+	}
+	return prefix + "-" + u.String()[:8]
+}

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -343,7 +343,10 @@ func (h *Handler) DeleteChatSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := qtx.DeleteChatSession(r.Context(), session.ID); err != nil {
+	if err := qtx.DeleteChatSession(r.Context(), db.DeleteChatSessionParams{
+		ID:          session.ID,
+		WorkspaceID: session.WorkspaceID,
+	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete chat session")
 		return
 	}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1123,7 +1123,10 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("cancel tasks for deleted trigger comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentId)...)
 	}
 
-	if err := h.Queries.DeleteComment(r.Context(), comment.ID); err != nil {
+	if err := h.Queries.DeleteComment(r.Context(), db.DeleteCommentParams{
+		ID:          comment.ID,
+		WorkspaceID: comment.WorkspaceID,
+	}); err != nil {
 		slog.Warn("delete comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentId)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete comment")
 		return

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1044,8 +1044,9 @@ func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtyp
 
 func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, workspaceID string) {
 	updated, err := h.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-		ID:     issue.ID,
-		Status: "done",
+		ID:          issue.ID,
+		Status:      "done",
+		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil {
 		slog.Warn("github: advance issue to done failed", "err", err)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2393,7 +2393,10 @@ func (h *Handler) DeleteIssue(w http.ResponseWriter, r *http.Request) {
 	// Collect all attachment URLs (issue-level + comment-level) before CASCADE delete.
 	attachmentURLs, _ := h.Queries.ListAttachmentURLsByIssueOrComments(r.Context(), issue.ID)
 
-	err := h.Queries.DeleteIssue(r.Context(), issue.ID)
+	err := h.Queries.DeleteIssue(r.Context(), db.DeleteIssueParams{
+		ID:          issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete issue")
 		return
@@ -2724,7 +2727,10 @@ func (h *Handler) BatchDeleteIssues(w http.ResponseWriter, r *http.Request) {
 		// Collect attachment URLs before CASCADE delete to clean up S3 objects.
 		attachmentURLs, _ := h.Queries.ListAttachmentURLsByIssueOrComments(r.Context(), issue.ID)
 
-		if err := h.Queries.DeleteIssue(r.Context(), issue.ID); err != nil {
+		if err := h.Queries.DeleteIssue(r.Context(), db.DeleteIssueParams{
+			ID:          issue.ID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
 			slog.Warn("batch delete issue failed", "issue_id", issueID, "error", err)
 			continue
 		}

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -454,7 +454,10 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.Queries.DeleteProject(r.Context(), project.ID); err != nil {
+	if err := h.Queries.DeleteProject(r.Context(), db.DeleteProjectParams{
+		ID:          project.ID,
+		WorkspaceID: project.WorkspaceID,
+	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete project")
 		return
 	}

--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -752,7 +753,10 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 		// side-effects so the retry lands on a clean slate.
 		slog.Error("local skill import Complete failed — rolling back created skill",
 			"error", err, "request_id", requestID, "skill_id", resp.ID)
-		if delErr := h.Queries.DeleteSkill(r.Context(), parseUUID(resp.ID)); delErr != nil {
+		if delErr := h.Queries.DeleteSkill(r.Context(), db.DeleteSkillParams{
+			ID:          parseUUID(resp.ID),
+			WorkspaceID: rt.WorkspaceID,
+		}); delErr != nil {
 			slog.Warn("orphan skill rollback failed", "error", delErr, "skill_id", resp.ID)
 		}
 		writeError(w, http.StatusInternalServerError, "failed to persist import completion")

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -435,7 +435,10 @@ func (h *Handler) DeleteSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteSkill(r.Context(), skill.ID); err != nil {
+	if err := h.Queries.DeleteSkill(r.Context(), db.DeleteSkillParams{
+		ID:          skill.ID,
+		WorkspaceID: skill.WorkspaceID,
+	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete skill")
 		return
 	}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1517,8 +1517,9 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 						)
 					} else if !hasActive {
 						if _, updateErr := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-							ID:     t.IssueID,
-							Status: "todo",
+							ID:          t.IssueID,
+							Status:      "todo",
+							WorkspaceID: issue.WorkspaceID,
 						}); updateErr != nil {
 							slog.Warn("handle failed tasks: reset stuck issue failed",
 								"issue_id", issueKey,

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -139,8 +139,13 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 }
 
 const deleteChatSession = `-- name: DeleteChatSession :exec
-DELETE FROM chat_session WHERE id = $1
+DELETE FROM chat_session WHERE id = $1 AND workspace_id = $2
 `
+
+type DeleteChatSessionParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
 
 // Hard delete. chat_message rows cascade via FK ON DELETE CASCADE; the
 // chat_session_id on agent_task_queue is set NULL by FK so completed/failed
@@ -148,9 +153,10 @@ DELETE FROM chat_session WHERE id = $1
 // the same transaction that holds LockChatSessionForDelete and that has
 // already cancelled any in-flight tasks (see CancelAgentTasksByChatSession)
 // so the daemon does not keep running work whose result has nowhere to
-// land.
-func (q *Queries) DeleteChatSession(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteChatSession, id)
+// land. workspace_id in the WHERE clause is a SQL-layer tenant guard; see
+// DeleteIssue.
+func (q *Queries) DeleteChatSession(ctx context.Context, arg DeleteChatSessionParams) error {
+	_, err := q.db.Exec(ctx, deleteChatSession, arg.ID, arg.WorkspaceID)
 	return err
 }
 

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -74,11 +74,17 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 }
 
 const deleteComment = `-- name: DeleteComment :exec
-DELETE FROM comment WHERE id = $1
+DELETE FROM comment WHERE id = $1 AND workspace_id = $2
 `
 
-func (q *Queries) DeleteComment(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteComment, id)
+type DeleteCommentParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+func (q *Queries) DeleteComment(ctx context.Context, arg DeleteCommentParams) error {
+	_, err := q.db.Exec(ctx, deleteComment, arg.ID, arg.WorkspaceID)
 	return err
 }
 

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -329,11 +329,21 @@ func (q *Queries) CreateIssueWithOrigin(ctx context.Context, arg CreateIssueWith
 }
 
 const deleteIssue = `-- name: DeleteIssue :exec
-DELETE FROM issue WHERE id = $1
+DELETE FROM issue WHERE id = $1 AND workspace_id = $2
 `
 
-func (q *Queries) DeleteIssue(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteIssue, id)
+type DeleteIssueParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Defense-in-depth: the workspace_id predicate makes the tenant invariant a
+// SQL-layer guarantee rather than a handler-layer one. Handler loaders
+// (loadIssueForUser / GetIssueInWorkspace) already enforce membership today,
+// but a future loader bypass or a new caller skipping the loader would be
+// silently catastrophic without this guard. See incident #1661.
+func (q *Queries) DeleteIssue(ctx context.Context, arg DeleteIssueParams) error {
+	_, err := q.db.Exec(ctx, deleteIssue, arg.ID, arg.WorkspaceID)
 	return err
 }
 
@@ -1129,17 +1139,19 @@ const updateIssueStatus = `-- name: UpdateIssueStatus :one
 UPDATE issue SET
     status = $2,
     updated_at = now()
-WHERE id = $1
+WHERE id = $1 AND workspace_id = $3
 RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
 `
 
 type UpdateIssueStatusParams struct {
-	ID     pgtype.UUID `json:"id"`
-	Status string      `json:"status"`
+	ID          pgtype.UUID `json:"id"`
+	Status      string      `json:"status"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
 }
 
+// Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
 func (q *Queries) UpdateIssueStatus(ctx context.Context, arg UpdateIssueStatusParams) (Issue, error) {
-	row := q.db.QueryRow(ctx, updateIssueStatus, arg.ID, arg.Status)
+	row := q.db.QueryRow(ctx, updateIssueStatus, arg.ID, arg.Status, arg.WorkspaceID)
 	var i Issue
 	err := row.Scan(
 		&i.ID,

--- a/server/pkg/db/generated/project.sql.go
+++ b/server/pkg/db/generated/project.sql.go
@@ -72,11 +72,17 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 }
 
 const deleteProject = `-- name: DeleteProject :exec
-DELETE FROM project WHERE id = $1
+DELETE FROM project WHERE id = $1 AND workspace_id = $2
 `
 
-func (q *Queries) DeleteProject(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteProject, id)
+type DeleteProjectParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+func (q *Queries) DeleteProject(ctx context.Context, arg DeleteProjectParams) error {
+	_, err := q.db.Exec(ctx, deleteProject, arg.ID, arg.WorkspaceID)
 	return err
 }
 

--- a/server/pkg/db/generated/skill.sql.go
+++ b/server/pkg/db/generated/skill.sql.go
@@ -67,11 +67,17 @@ func (q *Queries) CreateSkill(ctx context.Context, arg CreateSkillParams) (Skill
 }
 
 const deleteSkill = `-- name: DeleteSkill :exec
-DELETE FROM skill WHERE id = $1
+DELETE FROM skill WHERE id = $1 AND workspace_id = $2
 `
 
-func (q *Queries) DeleteSkill(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteSkill, id)
+type DeleteSkillParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+func (q *Queries) DeleteSkill(ctx context.Context, arg DeleteSkillParams) error {
+	_, err := q.db.Exec(ctx, deleteSkill, arg.ID, arg.WorkspaceID)
 	return err
 }
 

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -65,8 +65,9 @@ FOR UPDATE;
 -- the same transaction that holds LockChatSessionForDelete and that has
 -- already cancelled any in-flight tasks (see CancelAgentTasksByChatSession)
 -- so the daemon does not keep running work whose result has nowhere to
--- land.
-DELETE FROM chat_session WHERE id = $1;
+-- land. workspace_id in the WHERE clause is a SQL-layer tenant guard; see
+-- DeleteIssue.
+DELETE FROM chat_session WHERE id = $1 AND workspace_id = $2;
 
 -- name: TouchChatSession :exec
 UPDATE chat_session SET updated_at = now()

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -238,7 +238,8 @@ SELECT count(*) > 0 AS has_replied FROM comment
 WHERE parent_id = @parent_id AND author_type = 'agent' AND author_id = @agent_id;
 
 -- name: DeleteComment :exec
-DELETE FROM comment WHERE id = $1;
+-- Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+DELETE FROM comment WHERE id = $1 AND workspace_id = $2;
 
 -- name: ResolveComment :one
 -- Idempotent: re-resolving keeps the original resolved_at + resolver. Always

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -100,10 +100,11 @@ WHERE id = $1
 RETURNING *;
 
 -- name: UpdateIssueStatus :one
+-- Workspace_id in the WHERE clause is a SQL-layer tenant guard; see DeleteIssue.
 UPDATE issue SET
     status = $2,
     updated_at = now()
-WHERE id = $1
+WHERE id = $1 AND workspace_id = $3
 RETURNING *;
 
 -- name: CreateIssueWithOrigin :one
@@ -131,7 +132,12 @@ ORDER BY created_at ASC
 LIMIT 1;
 
 -- name: DeleteIssue :exec
-DELETE FROM issue WHERE id = $1;
+-- Defense-in-depth: the workspace_id predicate makes the tenant invariant a
+-- SQL-layer guarantee rather than a handler-layer one. Handler loaders
+-- (loadIssueForUser / GetIssueInWorkspace) already enforce membership today,
+-- but a future loader bypass or a new caller skipping the loader would be
+-- silently catastrophic without this guard. See incident #1661.
+DELETE FROM issue WHERE id = $1 AND workspace_id = $2;
 
 -- name: ListOpenIssues :many
 -- See ListIssues for the semantics of involves_user_id (mirrors the 4-branch

--- a/server/pkg/db/queries/project.sql
+++ b/server/pkg/db/queries/project.sql
@@ -35,7 +35,8 @@ WHERE id = $1
 RETURNING *;
 
 -- name: DeleteProject :exec
-DELETE FROM project WHERE id = $1;
+-- Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+DELETE FROM project WHERE id = $1 AND workspace_id = $2;
 
 -- name: CountIssuesByProject :one
 SELECT count(*) FROM issue

--- a/server/pkg/db/queries/skill.sql
+++ b/server/pkg/db/queries/skill.sql
@@ -47,7 +47,8 @@ WHERE id = $1
 RETURNING *;
 
 -- name: DeleteSkill :exec
-DELETE FROM skill WHERE id = $1;
+-- Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.
+DELETE FROM skill WHERE id = $1 AND workspace_id = $2;
 
 -- Skill File CRUD
 


### PR DESCRIPTION
Closes #3026.

## Summary

- Add `AND workspace_id = $N` to the WHERE clause of `DeleteIssue`, `DeleteComment`, `DeleteProject`, `DeleteSkill`, `DeleteChatSession`, and `UpdateIssueStatus`.
- Thread `WorkspaceID` through every `*Params` struct and every caller (handlers + service + sweeper fallback).
- The handler-layer loaders (`loadIssueForUser`, etc.) still enforce membership today — this is **defense-in-depth**, not a fix for a known live exploit. See the linked issue for the threat model.
- Add `server/cmd/server/workspace_scope_guard_test.go` — for each of the 6 scoped queries, creates the resource in workspace A, invokes the query with workspace B's ID, and asserts the row is untouched (0 rows affected for `:exec`, `pgx.ErrNoRows` for `:one`). Locks the invariant so a future refactor that drops the `workspace_id` arg fails loudly.

## Why

The tenant invariant is currently a handler-layer property. A future loader bypass or a refactor that drops a membership check would silently allow cross-tenant writes — the SQL itself would happily delete by primary key alone. Same class of failure as **#1661** (silent zero-UUID on invalid input → 204 on a no-op DELETE), prevented one layer deeper.

What this PR *actually buys today* is narrower than "the schema is now the trust boundary": most current callers pass `entity.WorkspaceID` — i.e. the workspace_id loaded from the same row being acted on — so the SQL predicate is tautological on those paths. **The SQL layer adds an extra guard** that becomes load-bearing once callers obtain `workspace_id` from a request-scoped source (URL slug / authenticated session) rather than the entity itself; that follow-up is what makes the schema a true trust boundary. This PR is the half that has to land first.

Behavior on a forged sibling-workspace UUID:
- `:exec` queries (the 5 DELETEs) return `0 rows affected, nil` — an idempotent no-op, not an error.
- `:one` queries (`UpdateIssueStatus`) return `pgx.ErrNoRows` — the only path that surfaces the mismatch as an error.

## What's NOT in this PR

Multi-narg UPDATE queries — `UpdateIssue`, `UpdateProject`, `UpdateSkill`, `UpdateComment`, `UpdateChatSessionTitle`, `UpdateChatSessionSession` — are deferred to a follow-up. Each requires its narg pinning shifted (the new `workspace_id` arg lives in WHERE, after every SET arg), and every caller has to be audited individually. Bundling them here would make this diff much harder to review for the actual security gain.

## Notes for reviewers

- sqlc was regenerated by hand (no local sqlc toolchain on my dev machine). Every regenerated function follows the existing codegen pattern in this repo (`type FooParams struct { ID, WorkspaceID pgtype.UUID }; q.db.Exec(ctx, sql, arg.ID, arg.WorkspaceID)`). CI's `backend` job is the authoritative compile check.
- `UpdateIssueStatus` is a `:one` and was the simplest 2-narg `:one` to scope alongside the DELETEs.
- I verified every caller already has the workspace UUID in scope on the entity being acted on; the signature change is mechanical.

## Test plan

- [x] CI `backend` job compiles and passes existing tests
- [x] New `TestWorkspaceScopeGuard` covers all 6 queries with a cross-workspace UUID (see commit)
- [ ] Manual: forge a UUID from another workspace and confirm the DELETE returns no rows changed (404/204 idempotent path)
- [ ] No behavior change for correct in-tenant callers (existing handler tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
