### PR TITLE
fix(daemon): expand tilde in custom env values

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2395,7 +2395,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 				d.logger.Warn("custom_env: blocked key skipped", "key", k)
 				continue
 			}
-			agentEnv[k] = v
+			agentEnv[k] = expandCustomEnvValue(v)
 		}
 	}
 	backend, err := agent.New(provider, agent.Config{

--- a/server/internal/daemon/helpers.go
+++ b/server/internal/daemon/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +17,25 @@ func envOrDefault(key, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func expandCustomEnvValue(value string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return value
+	}
+	return expandCustomEnvValueWithHome(value, home)
+}
+
+func expandCustomEnvValueWithHome(value, home string) string {
+	switch {
+	case value == "~":
+		return home
+	case strings.HasPrefix(value, "~/"):
+		return filepath.Join(home, strings.TrimPrefix(value, "~/"))
+	default:
+		return value
+	}
 }
 
 func durationFromEnv(key string, fallback time.Duration) (time.Duration, error) {

--- a/server/internal/daemon/helpers_test.go
+++ b/server/internal/daemon/helpers_test.go
@@ -1,9 +1,63 @@
 package daemon
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestExpandCustomEnvValueWithHome(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator), "home", "alice")
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "tilde slash path",
+			value: "~/.claude-personal",
+			want:  filepath.Join(home, ".claude-personal"),
+		},
+		{
+			name:  "bare tilde",
+			value: "~",
+			want:  home,
+		},
+		{
+			name:  "tilde slash root",
+			value: "~/",
+			want:  home,
+		},
+		{
+			name:  "non-leading tilde",
+			value: "/tmp/~/.claude-personal",
+			want:  "/tmp/~/.claude-personal",
+		},
+		{
+			name:  "shell variable",
+			value: "$HOME/.claude-personal",
+			want:  "$HOME/.claude-personal",
+		},
+		{
+			name:  "named user tilde",
+			value: "~alice/.claude-personal",
+			want:  "~alice/.claude-personal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := expandCustomEnvValueWithHome(tc.value, home)
+			if got != tc.want {
+				t.Errorf("expandCustomEnvValueWithHome(%q, %q) = %q, want %q", tc.value, home, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestParseFlexDuration(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What does this PR do?

Expands custom agent Environment values that use the home-directory shorthand before the daemon starts the agent process.

This fixes the case from #3020 where `CLAUDE_CONFIG_DIR=~/.claude-personal` is passed through literally, causing Claude to look for a directory named `~` and ask the user to login again. The change intentionally keeps the behavior narrow: it expands only `~` and `~/...`, while leaving `$HOME`, `~user/...`, and non-leading `~` values unchanged.

## Related Issue

Closes #3020

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/helpers.go`: added custom env value expansion for `~` and `~/...`.
- `server/internal/daemon/daemon.go`: applies the expansion after blocked-key filtering and before passing env values to the agent process.
- `server/internal/daemon/helpers_test.go`: covers the fixed Claude config path shape plus boundary cases that should remain unchanged.

## How to Test

1. `go test ./internal/daemon -run TestExpandCustomEnvValueWithHome -count=1`
2. `go test ./internal/daemon -count=1`
3. `go test ./... -count=1 -p 1`
4. `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A)
- [x] I have updated relevant documentation to reflect my changes (N/A)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** AI coding assistant

**Prompt / approach:**
Used an assistant to inspect the issue, find the daemon custom env injection path, keep the behavior narrower than shell expansion, and draft the focused patch and tests. I reviewed the diff and ran the validation commands listed above.

## Screenshots (optional)

N/A
