### PR TITLE
fix(markdown): disable ligatures in code rendering

### DIFF
--- a/packages/ui/markdown/CodeBlock.tsx
+++ b/packages/ui/markdown/CodeBlock.tsx
@@ -37,6 +37,9 @@ const LANGUAGE_ALIASES: Record<string, BundledLanguage> = {
 // Simple LRU cache for highlighted code
 const highlightCache = new Map<string, string>()
 const CACHE_MAX_SIZE = 200
+export const CODE_LIGATURE_CLASS = "[font-variant-ligatures:none] [font-feature-settings:'liga'_0]"
+export const CODE_LIGATURE_DESCENDANT_CLASS =
+  '[&_code]:[font-variant-ligatures:none] [&_code]:[font-feature-settings:"liga"_0]'
 
 function getCacheKey(code: string, lang: string): string {
   return `${lang}:${code}`
@@ -142,8 +145,8 @@ export function CodeBlock({
   // Terminal mode: raw monospace with minimal styling
   if (mode === 'terminal') {
     return (
-      <pre className={cn('font-mono text-sm whitespace-pre-wrap', className)}>
-        <code className="font-mono">{code}</code>
+      <pre className={cn('font-mono text-sm whitespace-pre-wrap', CODE_LIGATURE_CLASS, className)}>
+        <code className={cn('font-mono', CODE_LIGATURE_CLASS)}>{code}</code>
       </pre>
     )
   }
@@ -152,8 +155,8 @@ export function CodeBlock({
   if (mode === 'minimal') {
     if (isLoading || !highlighted) {
       return (
-        <pre className={cn('font-mono text-sm whitespace-pre-wrap', className)}>
-          <code className="font-mono">{code}</code>
+        <pre className={cn('font-mono text-sm whitespace-pre-wrap', CODE_LIGATURE_CLASS, className)}>
+          <code className={cn('font-mono', CODE_LIGATURE_CLASS)}>{code}</code>
         </pre>
       )
     }
@@ -162,6 +165,8 @@ export function CodeBlock({
       <div
         className={cn(
           'font-mono text-sm [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:whitespace-pre-wrap [&_pre]:break-all [&_code]:!bg-transparent [&_code]:font-mono [&_pre]:font-mono',
+          CODE_LIGATURE_CLASS,
+          CODE_LIGATURE_DESCENDANT_CLASS,
           className
         )}
         dangerouslySetInnerHTML={{ __html: highlighted }}
@@ -207,12 +212,16 @@ export function CodeBlock({
       {/* Code content */}
       <div className="p-3 overflow-x-auto">
         {isLoading || !highlighted ? (
-          <pre className="font-mono text-sm whitespace-pre-wrap break-all">
-            <code className="font-mono">{code}</code>
+          <pre className={cn('font-mono text-sm whitespace-pre-wrap break-all', CODE_LIGATURE_CLASS)}>
+            <code className={cn('font-mono', CODE_LIGATURE_CLASS)}>{code}</code>
           </pre>
         ) : (
           <div
-            className="font-mono text-sm [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:whitespace-pre-wrap [&_pre]:break-all [&_code]:!bg-transparent [&_code]:font-mono [&_pre]:font-mono"
+            className={cn(
+              'font-mono text-sm [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:whitespace-pre-wrap [&_pre]:break-all [&_code]:!bg-transparent [&_code]:font-mono [&_pre]:font-mono',
+              CODE_LIGATURE_CLASS,
+              CODE_LIGATURE_DESCENDANT_CLASS
+            )}
             dangerouslySetInnerHTML={{ __html: highlighted }}
           />
         )}
@@ -236,6 +245,7 @@ export function InlineCode({
     <code
       className={cn(
         'px-1.5 py-0.5 rounded bg-foreground/[0.03] border border-foreground/[0.05] font-mono text-sm text-foreground/75',
+        CODE_LIGATURE_CLASS,
         className
       )}
     >

--- a/packages/ui/markdown/Markdown.tsx
+++ b/packages/ui/markdown/Markdown.tsx
@@ -8,7 +8,7 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import { FileText, Download } from 'lucide-react'
 import { cn } from '@multica/ui/lib/utils'
-import { CodeBlock, InlineCode } from './CodeBlock'
+import { CodeBlock, CODE_LIGATURE_CLASS, InlineCode } from './CodeBlock'
 import { isAllowedFileCardHref, preprocessFileCards } from './file-cards'
 import { preprocessLinks } from './linkify'
 import { preprocessMentionShortcodes } from './mentions'
@@ -238,8 +238,12 @@ function createComponents(
     return {
       ...baseComponents,
       // No special code handling - just monospace
-      code: ({ children }) => <code className="font-mono">{children}</code>,
-      pre: ({ children }) => <pre className="font-mono whitespace-pre-wrap my-2">{children}</pre>,
+      code: ({ children }) => <code className={cn('font-mono', CODE_LIGATURE_CLASS)}>{children}</code>,
+      pre: ({ children }) => (
+        <pre className={cn('font-mono whitespace-pre-wrap my-2', CODE_LIGATURE_CLASS)}>
+          {children}
+        </pre>
+      ),
       // Minimal paragraph spacing
       p: ({ children }) => <p className="my-1">{children}</p>,
       // Simple lists

--- a/packages/views/common/markdown.test.tsx
+++ b/packages/views/common/markdown.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Markdown } from "./markdown";
+
+vi.mock("@multica/core/config", () => ({
+  useConfigStore: (selector: (state: { cdnDomain: string }) => unknown) =>
+    selector({ cdnDomain: "" }),
+}));
+
+vi.mock("../issues/components/issue-mention-card", () => ({
+  IssueMentionCard: ({ issueId }: { issueId: string }) => (
+    <span data-testid="issue-mention-card">{issueId}</span>
+  ),
+}));
+
+const ligatureClasses = [
+  "[font-variant-ligatures:none]",
+  "[font-feature-settings:'liga'_0]",
+];
+
+describe("Markdown", () => {
+  it("disables ligatures inside raw code tags", () => {
+    render(<Markdown>{"<code>uv run --extra dev pytest -q</code>"}</Markdown>);
+
+    expect(screen.getByText("uv run --extra dev pytest -q")).toHaveClass(...ligatureClasses);
+  });
+
+  it("disables ligatures inside fenced code blocks", () => {
+    render(<Markdown>{"```sh\nuv run --extra dev pytest -q\n```"}</Markdown>);
+
+    expect(screen.getByText("uv run --extra dev pytest -q")).toHaveClass(...ligatureClasses);
+  });
+
+  it("disables ligatures in terminal-mode code", () => {
+    render(<Markdown mode="terminal">{"<code>uv run --extra dev pytest -q</code>"}</Markdown>);
+
+    expect(screen.getByText("uv run --extra dev pytest -q")).toHaveClass(...ligatureClasses);
+  });
+});


### PR DESCRIPTION
## Summary

- Disable font ligatures for markdown inline code, raw `<code>` tags, and code blocks.
- Apply the same ligature-safe rendering to terminal-mode markdown code paths.
- Add regression coverage for raw code, fenced code blocks, and terminal-mode code containing `--`.

## Context

Geist Mono includes ligatures for sequences such as `--`. In code/command output this can make command flags visually collapse or appear misaligned, especially around examples like `uv run --extra ...`. Code rendering should preserve the literal character sequence instead of applying programming/font ligatures.

Problem examples before the fix:

![before example 1](https://raw.githubusercontent.com/hansnow/multica/pr-assets/3038/code-ligatures-before.png)

![before example 2](https://raw.githubusercontent.com/hansnow/multica/pr-assets/3038/code-ligatures-after.png)

## Test Plan

- [x] `pnpm --filter @multica/views exec vitest run common/markdown.test.tsx`
- [x] `pnpm --filter @multica/ui typecheck`
- [x] `pnpm --filter @multica/views typecheck` *(fails on pre-existing missing `hast-util-to-html` declaration errors in `editor/code-block-static.tsx` and `editor/readonly-content.tsx`; same baseline failure without this change)*
