### PR TITLE
fix(agent): recover stale Hermes ACP sessions

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -25,6 +25,8 @@ var hermesBlockedArgs = map[string]blockedArgMode{
 	"acp": blockedStandalone,
 }
 
+var acpMissingSessionErrorRe = regexp.MustCompile(`(?i)\b(no session found|session\s+not\s+found|unknown session|no such session|session[^:;,.]{0,120}\b(not found|does not exist))\b`)
+
 // hermesBackend implements Backend by spawning `hermes acp` and communicating
 // via the ACP (Agent Communication Protocol) JSON-RPC 2.0 over stdin/stdout.
 // This is the same pattern as Codex but with the ACP protocol instead of
@@ -213,13 +215,48 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		if cwd == "" {
 			cwd = "."
 		}
+		resumedSession := opts.ResumeSessionID != ""
+		recoveredStaleResume := false
 
-		if opts.ResumeSessionID != "" {
+		recoverStaleResume := func(phase string, cause error, setModel bool) error {
+			if recoveredStaleResume {
+				return cause
+			}
+			b.cfg.Logger.Warn("hermes resumed session is no longer available; retrying current prompt in a fresh session",
+				"phase", phase,
+				"requested_session_id", opts.ResumeSessionID,
+				"session_id", sessionID,
+				"error", cause,
+			)
+			streamingCurrentTurn.Store(false)
+			freshSessionID, err := createHermesSession(runCtx, c, cwd, opts.Model)
+			if err != nil {
+				return err
+			}
+			sessionID = freshSessionID
+			c.sessionID = sessionID
+			recoveredStaleResume = true
+			if setModel && opts.Model != "" {
+				if err := setHermesSessionModel(runCtx, c, sessionID, opts.Model); err != nil {
+					return fmt.Errorf("hermes could not switch fresh session to model %q: %w", opts.Model, err)
+				}
+			}
+			return nil
+		}
+
+		if resumedSession {
 			result, err := c.request(runCtx, "session/resume", map[string]any{
 				"cwd":       cwd,
 				"sessionId": opts.ResumeSessionID,
 			})
 			if err != nil {
+				if isACPMissingSessionError(err) {
+					if retryErr := recoverStaleResume("session/resume", err, false); retryErr == nil {
+						goto sessionReady
+					} else {
+						err = retryErr
+					}
+				}
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes session/resume failed: %v", err)
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
@@ -235,22 +272,16 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				)
 			}
 		} else {
-			result, err := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
+			sessionID, err = createHermesSession(runCtx, c, cwd, opts.Model)
 			if err != nil {
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/new failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
-				return
-			}
-			sessionID = extractACPSessionID(result)
-			if sessionID == "" {
-				finalStatus = "failed"
-				finalError = "hermes session/new returned no session ID"
+				finalError = err.Error()
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
 		}
 
+	sessionReady:
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("hermes session created", "session_id", sessionID)
 
@@ -263,22 +294,33 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// user would think their pick was honoured while the
 		// task actually ran on something else.
 		if opts.Model != "" {
-			if _, err := c.request(runCtx, "session/set_model", map[string]any{
-				"sessionId": sessionID,
-				"modelId":   opts.Model,
-			}); err != nil {
-				b.cfg.Logger.Warn("hermes set_session_model failed", "error", err, "requested_model", opts.Model)
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
-				resCh <- Result{
-					Status:     finalStatus,
-					Error:      finalError,
-					DurationMs: time.Since(startTime).Milliseconds(),
-					SessionID:  sessionID,
+			modelSet := false
+			if err := setHermesSessionModel(runCtx, c, sessionID, opts.Model); err != nil {
+				if resumedSession && isACPMissingSessionError(err) {
+					if retryErr := recoverStaleResume("session/set_model", err, true); retryErr == nil {
+						modelSet = true
+					} else {
+						err = retryErr
+					}
 				}
-				return
+				if !modelSet {
+					b.cfg.Logger.Warn("hermes set_session_model failed", "error", err, "requested_model", opts.Model)
+					finalStatus = "failed"
+					finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
+					resCh <- Result{
+						Status:     finalStatus,
+						Error:      finalError,
+						DurationMs: time.Since(startTime).Milliseconds(),
+						SessionID:  sessionID,
+					}
+					return
+				}
+			} else {
+				modelSet = true
 			}
-			b.cfg.Logger.Info("hermes session model set", "model", opts.Model)
+			if modelSet {
+				b.cfg.Logger.Info("hermes session model set", "model", opts.Model)
+			}
 		}
 
 		// 4. Send the prompt and wait for PromptResponse.
@@ -292,12 +334,14 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// initialize / session setup stays dropped, but every notification
 		// belonging to this turn is processed.
 		streamingCurrentTurn.Store(true)
-		_, err = c.request(runCtx, "session/prompt", map[string]any{
-			"sessionId": sessionID,
-			"prompt": []map[string]any{
-				{"type": "text", "text": prompt},
-			},
-		})
+		err = promptHermesSession(runCtx, c, sessionID, prompt)
+		if err != nil && resumedSession && isACPMissingSessionError(err) {
+			err = recoverStaleResume("session/prompt", err, true)
+			if err == nil {
+				streamingCurrentTurn.Store(true)
+				err = promptHermesSession(runCtx, c, sessionID, prompt)
+			}
+		}
 		if err != nil {
 			// If the request itself failed (not just context cancelled),
 			// check if the context was cancelled/timed out.
@@ -385,6 +429,36 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func createHermesSession(ctx context.Context, c *hermesClient, cwd, model string) (string, error) {
+	result, err := c.request(ctx, "session/new", buildHermesSessionParams(cwd, model))
+	if err != nil {
+		return "", fmt.Errorf("hermes session/new failed: %w", err)
+	}
+	sessionID := extractACPSessionID(result)
+	if sessionID == "" {
+		return "", fmt.Errorf("hermes session/new returned no session ID")
+	}
+	return sessionID, nil
+}
+
+func setHermesSessionModel(ctx context.Context, c *hermesClient, sessionID, model string) error {
+	_, err := c.request(ctx, "session/set_model", map[string]any{
+		"sessionId": sessionID,
+		"modelId":   model,
+	})
+	return err
+}
+
+func promptHermesSession(ctx context.Context, c *hermesClient, sessionID, prompt string) error {
+	_, err := c.request(ctx, "session/prompt", map[string]any{
+		"sessionId": sessionID,
+		"prompt": []map[string]any{
+			{"type": "text", "text": prompt},
+		},
+	})
+	return err
 }
 
 // ── hermesClient: ACP JSON-RPC 2.0 transport ──
@@ -1151,6 +1225,13 @@ func resolveResumedSessionID(requested string, response json.RawMessage) (string
 		return requested, false
 	}
 	return got, got != requested
+}
+
+func isACPMissingSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return acpMissingSessionErrorRe.MatchString(err.Error())
 }
 
 // buildHermesSessionParams constructs the params map for the ACP `session/new`

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -104,6 +106,58 @@ func TestResolveResumedSessionIDEmptyResponse(t *testing.T) {
 		}
 		if changed {
 			t.Errorf("body=%q: changed: got true, want false", body)
+		}
+	}
+}
+
+func TestIsACPMissingSessionError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "string data from hermes",
+			err:  errors.New("session/prompt: Internal error (code=-32603, data=No session found with id)"),
+			want: true,
+		},
+		{
+			name: "not found wording",
+			err:  errors.New("session/prompt: session not found (code=-32603)"),
+			want: true,
+		},
+		{
+			name: "session id does not exist",
+			err:  errors.New("session/set_model: Internal error (code=-32603, data=session ses_stale does not exist)"),
+			want: true,
+		},
+		{
+			name: "provider error",
+			err:  errors.New("session/prompt: No LLM provider configured (code=-32603)"),
+			want: false,
+		},
+		{
+			name: "workspace not found",
+			err:  errors.New("session/prompt: workspace not found (code=-32603)"),
+			want: false,
+		},
+		{
+			name: "model not found",
+			err:  errors.New("session/prompt: model not found (code=-32603)"),
+			want: false,
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := isACPMissingSessionError(tt.err); got != tt.want {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }
@@ -1256,4 +1310,258 @@ func TestHermesBackendDoesNotPromoteOnTransientRetry(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
 	}
+}
+
+func fakeHermesACPStaleResumeScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$MULTICA_HERMES_REQ_LOG"
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+	    *'"method":"session/resume"'*)
+	      if [ "$MULTICA_HERMES_FAIL_RESUME" = "1" ]; then
+	        printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"No session found with id"}}\n' "$id"
+	        continue
+	      fi
+	      # Some ACP servers create a replacement session internally but cannot
+	      # return its id in session/resume. The client will discover the stale id
+	      # only when session/prompt fails below.
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"models":[],"modes":[]}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_fresh"}}\n' "$id"
+      ;;
+    *'"method":"session/set_model"'*)
+      case "$line" in
+        *'"sessionId":"ses_stale"'*)
+          if [ "$MULTICA_HERMES_FAIL_STALE_SET_MODEL" = "1" ]; then
+            printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"No session found with id"}}\n' "$id"
+          else
+            printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+          fi
+          ;;
+        *)
+          printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+          ;;
+      esac
+      ;;
+    *'"method":"session/prompt"'*)
+      case "$line" in
+        *'"sessionId":"ses_stale"'*)
+          printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"No session found with id"}}\n' "$id"
+          ;;
+        *'"sessionId":"ses_fresh"'*)
+          printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_fresh","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Recovered in a fresh session."}}}}\n'
+          printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+          exit 0
+          ;;
+      esac
+      ;;
+  esac
+done
+`
+}
+
+func TestHermesBackendRetriesDirectStaleResumeFailureInFreshSession(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	fakePath := filepath.Join(tmp, "hermes")
+	reqLog := filepath.Join(tmp, "requests.jsonl")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPStaleResumeScript()))
+
+	backend, err := New("hermes", Config{
+		ExecutablePath: fakePath,
+		Env: map[string]string{
+			"MULTICA_HERMES_REQ_LOG":     reqLog,
+			"MULTICA_HERMES_FAIL_RESUME": "1",
+		},
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "please continue", ExecOptions{
+		Model:           "team-model",
+		ResumeSessionID: "ses_stale",
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected direct stale resume fallback to complete, got status=%q error=%q", result.Status, result.Error)
+		}
+		if result.SessionID != "ses_fresh" {
+			t.Fatalf("expected fresh session id, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	requests := readFileString(t, reqLog)
+	if got := strings.Count(requests, `"method":"session/resume"`); got != 1 {
+		t.Fatalf("expected exactly one failed resume, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/new"`); got != 1 {
+		t.Fatalf("expected exactly one fallback session/new, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/set_model"`); got != 1 {
+		t.Fatalf("expected model set only on fresh session, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/prompt"`); got != 1 {
+		t.Fatalf("expected prompt only on fresh session, got %d requests:\n%s", got, requests)
+	}
+}
+
+func TestHermesBackendRetriesStaleResumePromptInFreshSession(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	fakePath := filepath.Join(tmp, "hermes")
+	reqLog := filepath.Join(tmp, "requests.jsonl")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPStaleResumeScript()))
+
+	backend, err := New("hermes", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"MULTICA_HERMES_REQ_LOG": reqLog},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "please continue", ExecOptions{
+		Model:           "team-model",
+		ResumeSessionID: "ses_stale",
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected stale resume fallback to complete, got status=%q error=%q", result.Status, result.Error)
+		}
+		if result.SessionID != "ses_fresh" {
+			t.Fatalf("expected fresh session id, got %q", result.SessionID)
+		}
+		if !strings.Contains(result.Output, "Recovered in a fresh session.") {
+			t.Fatalf("expected fresh-session output, got %q", result.Output)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	requests := readFileString(t, reqLog)
+	if got := strings.Count(requests, `"method":"session/prompt"`); got != 2 {
+		t.Fatalf("expected one stale prompt and one fresh retry, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/new"`); got != 1 {
+		t.Fatalf("expected exactly one fallback session/new, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/set_model"`); got != 2 {
+		t.Fatalf("expected model set on resumed and fresh sessions, got %d requests:\n%s", got, requests)
+	}
+}
+
+func TestHermesBackendRetriesStaleResumeSetModelInFreshSession(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	fakePath := filepath.Join(tmp, "hermes")
+	reqLog := filepath.Join(tmp, "requests.jsonl")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPStaleResumeScript()))
+
+	backend, err := New("hermes", Config{
+		ExecutablePath: fakePath,
+		Env: map[string]string{
+			"MULTICA_HERMES_REQ_LOG":              reqLog,
+			"MULTICA_HERMES_FAIL_STALE_SET_MODEL": "1",
+		},
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "please continue", ExecOptions{
+		Model:           "team-model",
+		ResumeSessionID: "ses_stale",
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected stale set_model fallback to complete, got status=%q error=%q", result.Status, result.Error)
+		}
+		if result.SessionID != "ses_fresh" {
+			t.Fatalf("expected fresh session id, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	requests := readFileString(t, reqLog)
+	if got := strings.Count(requests, `"method":"session/prompt"`); got != 1 {
+		t.Fatalf("expected only the fresh prompt after set_model recovery, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/new"`); got != 1 {
+		t.Fatalf("expected exactly one fallback session/new, got %d requests:\n%s", got, requests)
+	}
+	if got := strings.Count(requests, `"method":"session/set_model"`); got != 2 {
+		t.Fatalf("expected model set on stale and fresh sessions, got %d requests:\n%s", got, requests)
+	}
+}
+
+func readFileString(tb testing.TB, path string) string {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
## Summary

- Recover Hermes ACP runs when a stored resume session id is stale by creating a fresh ACP session and retrying the current prompt once.
- Apply the same recovery when the stale id is detected during `session/resume`, `session/set_model`, or `session/prompt`.
- Keep retry detection scoped to missing-session ACP errors so unrelated provider, workspace, or model failures still fail normally.

## Problem

The second Hermes chat turn can try to resume an ACP session id that Hermes no longer has after its local state changes. The user-facing symptom is shown here:

![Hermes custom provider resume failure](https://static.multica.ai/workspaces/5200cb06-a965-4a2d-a4d7-2bb6cdd89e9b/019e4d54-6ffc-7470-97d7-df6330e0980a.png)

## Companion

- Hermes agent fix: https://github.com/NousResearch/hermes-agent/pull/30182

## Validation

- `cd server && go test ./pkg/agent`
- `git diff --check origin/main..HEAD`
- `codex review --base origin/main` (no findings)