### PR TITLE
fix(views): widen assignee picker and add text truncation

### DIFF
--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -109,7 +109,7 @@ export function AssigneePicker({
         setOpen(v);
         if (!v) setFilter("");
       }}
-      width="w-52"
+      width="w-64"
       align={align}
       searchable
       searchPlaceholder={t(($) => $.pickers.assignee.search_placeholder)}
@@ -156,7 +156,7 @@ export function AssigneePicker({
               }}
             >
               <ActorAvatar actorType="member" actorId={m.user_id} size={18} />
-              <span>{m.name}</span>
+              <span className="truncate">{m.name}</span>
             </PickerItem>
           ))}
         </PickerSection>
@@ -192,7 +192,7 @@ export function AssigneePicker({
                 }}
               >
                 <ActorAvatar actorType="agent" actorId={a.id} size={18} showStatusDot />
-                <span className={allowed ? "" : "text-muted-foreground"}>{a.name}</span>
+                <span className={`truncate ${allowed ? "" : "text-muted-foreground"}`}>{a.name}</span>
                 {a.visibility === "private" && (
                   <Lock className="ml-auto h-3 w-3 text-muted-foreground" />
                 )}
@@ -219,7 +219,7 @@ export function AssigneePicker({
               }}
             >
               <ActorAvatar actorType="squad" actorId={s.id} size={18} />
-              <span>{s.name}</span>
+              <span className="truncate">{s.name}</span>
             </PickerItem>
           ))}
         </PickerSection>


### PR DESCRIPTION
## Summary

- Widened assignee picker popover from `w-52` (208px) to `w-64` (256px) to prevent long names from being clipped
- Added `truncate` class to member/agent/squad name spans to handle edge cases with extremely long names

Closes #2947

## Test plan

- [ ] Open issue detail → click assignee picker → verify names display fully
- [ ] Test with long names (Chinese + English combinations) → verify truncation with ellipsis instead of overflow