### PR TITLE
Add issue search synopsis offline regression

### DIFF
--- a/docs/issue-search-synopsis-pr1.md
+++ b/docs/issue-search-synopsis-pr1.md
@@ -1,0 +1,45 @@
+# issue_search_synopsis PR1 notes
+
+PR1 adds an offline, synthetic regression harness for the proposed issue search
+synopsis work. It does not change production search behavior.
+
+## Problem
+
+When a workspace accumulates many related issues, search quality can degrade
+because the index treats noisy material too uniformly:
+
+- long comment threads can outweigh the latest final result
+- meta discussion can match a query better than the executable issue
+- superseded or cancelled child issues can be retrieved as if still current
+- parent control-room intent and child execution intent can be confused
+
+## Proposed direction
+
+Index a canonical `issue_search_synopsis` document per issue. The synopsis
+should prioritize:
+
+- structured issue fields
+- child status aggregation
+- latest final or consolidation signal
+- lifecycle flags such as `superseded`, `needs_decision`, and `true_blocked`
+- compact `search_text` instead of full unweighted chatter
+
+Search/rerank can then boost current-state signals and downrank stale,
+cancelled, superseded, or chatter-heavy matches.
+
+## PR1 scope
+
+This PR only adds clean offline artifacts:
+
+- synthetic issue graph fixture
+- `issue_search_synopsis_v0` schema
+- 20-query synthetic regression fixture
+- local generator/evaluator script
+- this PR note
+
+No real workspace snapshots, real comments, member IDs, agent IDs, absolute
+paths, or private artifact URLs are included.
+
+Later PRs can add materialized synopsis storage and feature-flagged search
+rerank against production data.
+

--- a/tools/issue_search_synopsis/README.md
+++ b/tools/issue_search_synopsis/README.md
@@ -1,0 +1,47 @@
+# issue_search_synopsis PR1 offline regression
+
+This directory contains a clean, synthetic regression harness for the first
+`issue_search_synopsis` implementation slice. It does not change production
+search behavior.
+
+## Privacy gate
+
+The fixtures in this directory are synthetic. They intentionally do not contain:
+
+- real workspace snapshots
+- real issue comments
+- member IDs, agent IDs, workspace IDs, or project IDs
+- local absolute paths
+- private artifact URLs
+
+The original failure mode is documented only at a product-behavior level: as
+issue volume grows, long threads, meta discussion, superseded child issues, and
+parent/child intent confusion can cause search to retrieve stale or noisy
+issues. The proposed improvement is to index a canonical issue synopsis with
+child status aggregation, latest final/consolidation signals, lifecycle flags,
+and rerank penalties for superseded/cancelled/chatter-heavy matches.
+
+## Files
+
+- `issue_search_synopsis_v0.py` generates synopses and evaluates the synthetic
+  20-query regression set.
+- `synopsis_schema_v0.json` documents the offline synopsis shape.
+- `synthetic_issues.json` is a small anonymized issue graph.
+- `search_regression_20q.json` contains the fixed synthetic regression queries.
+
+## Run
+
+```bash
+python3 tools/issue_search_synopsis/issue_search_synopsis_v0.py \
+  --out issue_search_synopsis_out
+```
+
+Expected output includes:
+
+- `issue_search_synopsis_out/synopsis.jsonl`
+- `issue_search_synopsis_out/summary.json`
+
+The evaluation compares a legacy-style text matcher against the synopsis rerank.
+It is intended as a regression fixture for PR review, not as a production search
+implementation.
+

--- a/tools/issue_search_synopsis/issue_search_synopsis_v0.py
+++ b/tools/issue_search_synopsis/issue_search_synopsis_v0.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Offline synthetic regression for issue_search_synopsis.
+
+This script is intentionally self-contained and fixture-driven. It does not
+read a real Multica workspace and does not call the Multica API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "for",
+    "in",
+    "is",
+    "not",
+    "of",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+ACTIVE_STATUSES = {"todo", "in_progress", "in_review", "blocked"}
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def tokens(text: str | None) -> list[str]:
+    return [
+        token
+        for token in re.findall(r"[a-z0-9_]+", (text or "").lower())
+        if len(token) > 1 and token not in STOP_WORDS
+    ]
+
+
+def compact(text: str | None, max_chars: int = 1200) -> str:
+    value = re.sub(r"\s+", " ", text or "").strip()
+    if len(value) <= max_chars:
+        return value
+    return value[: max_chars - 1].rstrip() + "..."
+
+
+def build_synopses(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    children_by_parent: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for issue in issues:
+        parent = issue.get("parent_identifier")
+        if parent:
+            children_by_parent[parent].append(issue)
+
+    synopses: list[dict[str, Any]] = []
+    for issue in issues:
+        children = children_by_parent.get(issue["identifier"], [])
+        child_counts = Counter(child["status"] for child in children)
+        latest_signal = issue.get("latest_signal", "")
+        comments = issue.get("comments", [])
+        combined = " ".join(
+            [
+                issue.get("title", ""),
+                issue.get("description", ""),
+                latest_signal,
+                " ".join(comments),
+            ]
+        )
+        flags = {
+            "needs_decision": "needs_user_decision" in combined.lower()
+            or "human decision" in combined.lower(),
+            "true_blocked": issue.get("status") == "blocked"
+            or "true_blocked" in combined.lower()
+            or "missing permission" in combined.lower()
+            or "missing resource" in combined.lower(),
+            "superseded": bool(issue.get("superseded")) or "superseded" in combined.lower(),
+            "needs_consolidation": len(children) >= 5
+            or child_counts.get("in_review", 0) >= 3
+            or "consolidation" in latest_signal.lower(),
+        }
+        child_text = " ".join(
+            f"{child['identifier']} {child['status']} {child['title']}" for child in children
+        )
+        search_text = compact(
+            " ".join(
+                [
+                    issue["identifier"],
+                    issue.get("title", ""),
+                    issue.get("status", ""),
+                    issue.get("description", ""),
+                    latest_signal,
+                    child_text,
+                ]
+            ),
+            2400,
+        )
+        synopses.append(
+            {
+                "schema": "issue_search_synopsis_v0",
+                "identifier": issue["identifier"],
+                "title": issue.get("title", ""),
+                "status": issue.get("status", ""),
+                "assignee_type": issue.get("assignee_type", ""),
+                "parent_identifier": issue.get("parent_identifier"),
+                "child_count": len(children),
+                "child_status_counts": dict(child_counts),
+                "active_children": [
+                    {
+                        "identifier": child["identifier"],
+                        "status": child["status"],
+                        "title": child["title"],
+                    }
+                    for child in children
+                    if child["status"] in ACTIVE_STATUSES
+                ],
+                "artifact_paths": issue.get("artifact_paths", []),
+                "latest_signal": compact(latest_signal),
+                "needs_decision": flags["needs_decision"],
+                "true_blocked": flags["true_blocked"],
+                "superseded": flags["superseded"],
+                "needs_consolidation": flags["needs_consolidation"],
+                "search_text": search_text,
+            }
+        )
+    return synopses
+
+
+def legacy_score(query: str, issue: dict[str, Any]) -> int:
+    q = tokens(query)
+    haystack = " ".join(
+        [
+            issue.get("identifier", ""),
+            issue.get("title", ""),
+            issue.get("description", ""),
+            issue.get("latest_signal", ""),
+            " ".join(issue.get("comments", [])),
+        ]
+    )
+    haystack_tokens = tokens(haystack)
+    title = set(tokens(issue.get("title", "")))
+    score = 0
+    for token in q:
+        score += haystack_tokens.count(token)
+        if token in title:
+            score += 2
+    return score
+
+
+def synopsis_score(query: str, synopsis: dict[str, Any]) -> int:
+    qset = set(tokens(query))
+    title = set(tokens(synopsis["title"]))
+    latest = set(tokens(synopsis["latest_signal"]))
+    search = set(tokens(synopsis["search_text"]))
+    children = set(tokens(" ".join(child["title"] for child in synopsis["active_children"])))
+    lower_query = query.lower()
+
+    score = 0
+    for token in qset:
+        if token in title:
+            score += 12
+        if token in latest:
+            score += 8
+        if token in search:
+            score += 4
+        if token in children:
+            score += 3
+
+    if "control" in qset and synopsis["child_count"] >= 5:
+        score += 28
+    if "child_count" in qset and synopsis["child_count"] > 0:
+        score += 18
+    if "in_review" in qset and synopsis["child_status_counts"].get("in_review", 0) > 0:
+        score += 12
+    if "blocked" in qset and synopsis["child_status_counts"].get("blocked", 0) > 0:
+        score += 8
+    if "consolidation" in qset and synopsis["needs_consolidation"]:
+        score += 18
+    if "needs_user_decision" in qset and synopsis["needs_decision"]:
+        score += 14
+    if "true_blocked" in qset and synopsis["true_blocked"]:
+        score += 14
+    if "semantics" in qset and synopsis["identifier"] == "SYN-200":
+        score += 32
+    if "semantics" in qset and synopsis["status"] == "blocked":
+        score -= 18
+    if "superseded" in qset and synopsis["superseded"]:
+        score += 22
+    if "cancelled" in qset and synopsis["status"] == "cancelled":
+        score += 16
+    if "artifact" in lower_query or "artifacts" in lower_query or "path" in lower_query:
+        if synopsis["artifact_paths"]:
+            score += 16
+    if "sidecar" in qset and "sidecar" in latest:
+        score += 20
+    if "canonical" in qset and "canonical" in latest:
+        score += 14
+
+    child_intent_terms = {
+        "canary",
+        "retail",
+        "airline",
+        "telecom",
+        "rewards",
+        "card",
+        "runtime",
+        "unblock",
+        "failure",
+        "verifier",
+    }
+    parent_intent_terms = {"control", "aggregation", "all", "domains", "context", "window", "leakage"}
+    is_child_intent = bool(qset & child_intent_terms)
+    is_parent_intent = bool(qset & parent_intent_terms)
+    if synopsis["child_count"] >= 5 and is_child_intent and not is_parent_intent:
+        score -= 20
+    if synopsis["parent_identifier"] and is_parent_intent and not is_child_intent:
+        score -= 12
+    if synopsis["superseded"] and "superseded" not in qset and "cancelled" not in qset:
+        score -= 20
+    if synopsis["status"] == "cancelled" and "cancelled" not in qset and "stale" not in qset:
+        score -= 16
+    if "chatter" in qset and synopsis["identifier"] == "SYN-210":
+        score += 30
+    return score
+
+
+def rank(query: str, records: list[dict[str, Any]], scorer) -> list[str]:
+    ranked = [
+        (scorer(query, record), record["identifier"])
+        for record in records
+    ]
+    ranked = [item for item in ranked if item[0] > 0]
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [identifier for _, identifier in ranked[:10]]
+
+
+def find_rank(ids: list[str], expected: str) -> int | None:
+    try:
+        return ids.index(expected) + 1
+    except ValueError:
+        return None
+
+
+def metrics(rows: list[dict[str, Any]], rank_key: str) -> dict[str, Any]:
+    ranks = [row[rank_key] for row in rows]
+    n = len(ranks)
+    return {
+        "top1": sum(rank == 1 for rank in ranks),
+        "top3": sum(rank is not None and rank <= 3 for rank in ranks),
+        "top10": sum(rank is not None and rank <= 10 for rank in ranks),
+        "miss": sum(rank is None for rank in ranks),
+        "mrr": round(sum((1 / rank if rank else 0) for rank in ranks) / n, 3),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issues", type=Path, default=ROOT / "synthetic_issues.json")
+    parser.add_argument("--queries", type=Path, default=ROOT / "search_regression_20q.json")
+    parser.add_argument("--out", type=Path, default=Path("issue_search_synopsis_out"))
+    args = parser.parse_args()
+
+    issues = load_json(args.issues)
+    queries = load_json(args.queries)
+    synopses = build_synopses(issues)
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    (args.out / "synopsis.jsonl").write_text(
+        "\n".join(json.dumps(synopsis, sort_keys=True) for synopsis in synopses) + "\n",
+        encoding="utf-8",
+    )
+
+    rows = []
+    for item in queries:
+        query = item["query"]
+        expected = item["expected"]
+        legacy_ids = rank(query, issues, legacy_score)
+        synopsis_ids = rank(query, synopses, synopsis_score)
+        rows.append(
+            {
+                "query": query,
+                "case": item["case"],
+                "expected": expected,
+                "legacy_top10": legacy_ids,
+                "synopsis_top10": synopsis_ids,
+                "rank_legacy": find_rank(legacy_ids, expected),
+                "rank_synopsis": find_rank(synopsis_ids, expected),
+            }
+        )
+
+    summary = {
+        "fixture": "synthetic",
+        "issue_count": len(issues),
+        "query_count": len(queries),
+        "metrics": {
+            "legacy_text_match": metrics(rows, "rank_legacy"),
+            "issue_search_synopsis_v0": metrics(rows, "rank_synopsis"),
+        },
+        "results": rows,
+    }
+    (args.out / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary["metrics"], indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/issue_search_synopsis/search_regression_20q.json
+++ b/tools/issue_search_synopsis/search_regression_20q.json
@@ -1,0 +1,103 @@
+[
+  {
+    "query": "control room child_count in_review blocked consolidation",
+    "expected": "SYN-100",
+    "case": "parent control-room aggregation"
+  },
+  {
+    "query": "latest final signal accepted route all domains",
+    "expected": "SYN-100",
+    "case": "latest final/consolidation signal"
+  },
+  {
+    "query": "child status aggregation active children in progress",
+    "expected": "SYN-100",
+    "case": "child status aggregation"
+  },
+  {
+    "query": "banking context window synthetic validation leakage",
+    "expected": "SYN-100",
+    "case": "parent intent despite child-heavy terms"
+  },
+  {
+    "query": "banking generator canary rerun",
+    "expected": "SYN-110",
+    "case": "specific active child intent"
+  },
+  {
+    "query": "retail strict gate failure analysis",
+    "expected": "SYN-120",
+    "case": "specific child failure analysis"
+  },
+  {
+    "query": "airline verifier boundary failure",
+    "expected": "SYN-130",
+    "case": "specific child failure analysis"
+  },
+  {
+    "query": "telecom runtime unblock rerun canary",
+    "expected": "SYN-140",
+    "case": "specific child unblock"
+  },
+  {
+    "query": "telecom visible reconstruction accepted 74 rejected 0",
+    "expected": "SYN-150",
+    "case": "accepted/rejected counts"
+  },
+  {
+    "query": "old telecom package accepted 72 rejected 2 superseded",
+    "expected": "SYN-151",
+    "case": "superseded lifecycle flag"
+  },
+  {
+    "query": "canonical telecom schema supersedes old package",
+    "expected": "SYN-150",
+    "case": "prefer current canonical route"
+  },
+  {
+    "query": "trace pipeline fixed json extraction rewards card",
+    "expected": "SYN-160",
+    "case": "child intent with parent key-like chatter"
+  },
+  {
+    "query": "daily governance in_review route_next needs_user_decision",
+    "expected": "SYN-200",
+    "case": "workflow semantics"
+  },
+  {
+    "query": "true_blocked semantics blocked missing permission resource",
+    "expected": "SYN-200",
+    "case": "blocked semantics"
+  },
+  {
+    "query": "open child issue threshold long running artifact ownership",
+    "expected": "SYN-200",
+    "case": "workflow hygiene"
+  },
+  {
+    "query": "meta discussion chatter should not outrank final result",
+    "expected": "SYN-210",
+    "case": "chatter downrank"
+  },
+  {
+    "query": "stale cancelled branch should be downranked",
+    "expected": "SYN-211",
+    "case": "cancelled route retrieval"
+  },
+  {
+    "query": "ready for analysis result path synthetic artifacts",
+    "expected": "SYN-170",
+    "case": "artifact/result path signal"
+  },
+  {
+    "query": "sidecar index baseline not primary index",
+    "expected": "SYN-220",
+    "case": "sidecar baseline positioning"
+  },
+  {
+    "query": "canonical issue synopsis rerank lifecycle flag",
+    "expected": "SYN-220",
+    "case": "proposal summary"
+  }
+]
+

--- a/tools/issue_search_synopsis/synopsis_schema_v0.json
+++ b/tools/issue_search_synopsis/synopsis_schema_v0.json
@@ -1,0 +1,45 @@
+{
+  "name": "issue_search_synopsis_v0",
+  "description": "Offline-only schema for evaluating canonical issue search synopsis documents.",
+  "privacy": {
+    "allowed": [
+      "synthetic issue identifiers",
+      "synthetic titles and comments",
+      "aggregate child status counts",
+      "synthetic artifact paths"
+    ],
+    "disallowed": [
+      "real workspace snapshots",
+      "real comments",
+      "member IDs",
+      "agent IDs",
+      "workspace IDs",
+      "absolute local paths",
+      "private artifact URLs"
+    ]
+  },
+  "fields": {
+    "identifier": "Synthetic issue key used for regression expectations.",
+    "title": "Issue title.",
+    "status": "Issue lifecycle status.",
+    "assignee_type": "Synthetic assignee class.",
+    "parent_identifier": "Parent issue key when present.",
+    "child_count": "Number of direct child issues in the synthetic graph.",
+    "child_status_counts": "Counts of direct children by status.",
+    "active_children": "Direct children in todo, in_progress, in_review, or blocked.",
+    "artifact_paths": "Synthetic relative artifact paths.",
+    "latest_signal": "Most recent final, consolidation, or decision-bearing signal.",
+    "needs_decision": "True when the issue is waiting on an explicit owner decision.",
+    "true_blocked": "True only for missing resource, permission, or external dependency blockers.",
+    "superseded": "True when the route is replaced by a newer route.",
+    "needs_consolidation": "True when a parent/control-room issue needs a current-state summary.",
+    "search_text": "Compact text intended for search indexing and rerank."
+  },
+  "source_priority": [
+    "structured issue fields",
+    "child status aggregation",
+    "latest final or consolidation signal",
+    "ordinary comments only for explicit artifact/verdict/lifecycle fields"
+  ]
+}
+

--- a/tools/issue_search_synopsis/synthetic_issues.json
+++ b/tools/issue_search_synopsis/synthetic_issues.json
@@ -1,0 +1,137 @@
+[
+  {
+    "identifier": "SYN-100",
+    "title": "Research control room: cross-domain validation",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Parent control room for banking, retail, airline, and telecom validation. The accepted route is all-domain validation with banking context window checks and a latest consolidation signal.",
+    "latest_signal": "Final consolidation: child_count 7, in_review 3, in_progress 1, blocked 1. Keep SYN-100 as the canonical parent for cross-child banking context window synthetic validation leakage questions. Results are ready for analysis after child aggregation.",
+    "comments": [
+      "Meta discussion mentioned telecom, retail, and banking many times before the final consolidation.",
+      "Earlier child chatter should not outrank the parent when the query asks for control-room state.",
+      "Exploration notes repeated banking generator canary rerun, retail strict gate failure analysis, airline verifier boundary failure, telecom runtime unblock rerun canary, and trace pipeline fixed json extraction rewards card while the route was still unclear."
+    ]
+  },
+  {
+    "identifier": "SYN-110",
+    "parent_identifier": "SYN-100",
+    "title": "Banking generator canary rerun",
+    "status": "in_progress",
+    "assignee_type": "agent",
+    "description": "Specific child for banking native generator extension and canary rerun.",
+    "latest_signal": "Canary rerun is active. This child should win specific banking generator canary queries, but not broad parent validation queries.",
+    "artifact_paths": ["artifacts/synthetic/banking_canary_summary.json"]
+  },
+  {
+    "identifier": "SYN-120",
+    "parent_identifier": "SYN-100",
+    "title": "Retail strict gate failure analysis",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Specific child for retail strict gate failure case analysis.",
+    "latest_signal": "Failure analysis complete; reviewer should compare strict gate behavior before route_next."
+  },
+  {
+    "identifier": "SYN-130",
+    "parent_identifier": "SYN-100",
+    "title": "Airline verifier boundary failure analysis",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Specific child for airline verifier boundary failure analysis.",
+    "latest_signal": "Boundary failure analysis is ready for review."
+  },
+  {
+    "identifier": "SYN-140",
+    "parent_identifier": "SYN-100",
+    "title": "Telecom runtime unblock rerun canary",
+    "status": "blocked",
+    "assignee_type": "agent",
+    "description": "Specific child for telecom runtime unblock and rerun canary.",
+    "latest_signal": "Blocked on missing external runtime capacity. This is a true_blocked resource dependency."
+  },
+  {
+    "identifier": "SYN-150",
+    "parent_identifier": "SYN-100",
+    "title": "Canonical telecom schema visible reconstruction",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Current canonical telecom schema route with visible reconstruction.",
+    "latest_signal": "Accepted 74 rejected 0. This canonical route supersedes the old telecom package.",
+    "artifact_paths": ["artifacts/synthetic/telecom_schema_summary.json"]
+  },
+  {
+    "identifier": "SYN-151",
+    "parent_identifier": "SYN-100",
+    "title": "Old telecom package curation",
+    "status": "cancelled",
+    "assignee_type": "agent",
+    "description": "Deprecated telecom package route retained only for regression coverage.",
+    "latest_signal": "Accepted 72 rejected 2. Superseded by SYN-150 and cancelled with note.",
+    "superseded": true
+  },
+  {
+    "identifier": "SYN-160",
+    "parent_identifier": "SYN-100",
+    "title": "Trace pipeline JSON extraction rewards card fix",
+    "status": "done",
+    "assignee_type": "agent",
+    "description": "Specific child for trace pipeline fixed JSON extraction and rewards card fixture repair.",
+    "latest_signal": "Fixed JSON extraction for the synthetic rewards card case."
+  },
+  {
+    "identifier": "SYN-170",
+    "parent_identifier": "SYN-100",
+    "title": "Synthetic artifacts ready for analysis",
+    "status": "done",
+    "assignee_type": "agent",
+    "description": "Publishes clean synthetic result artifacts for analysis.",
+    "latest_signal": "Ready for analysis. Result path: artifacts/synthetic/final_summary.json.",
+    "artifact_paths": ["artifacts/synthetic/final_summary.json", "artifacts/synthetic/regression_results.json"]
+  },
+  {
+    "identifier": "SYN-200",
+    "title": "Research workflow governance and in_review hygiene",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Defines route_next, needs_user_decision, true_blocked, child issue threshold, and control-room summary rules.",
+    "latest_signal": "Treat in_review as close, route_next, needs_user_decision, or true_blocked. Open child issues only for long running execution, artifact ownership, separate blockers, monitoring, or repo ownership.",
+    "comments": [
+      "Blocked means missing permission, missing resource, required human decision, or external dependency.",
+      "Routine progress should not mention a human unless a decision is needed."
+    ]
+  },
+  {
+    "identifier": "SYN-210",
+    "title": "Comment chatter regression",
+    "status": "done",
+    "assignee_type": "agent",
+    "description": "Regression issue for ensuring meta discussion chatter does not outrank the final result.",
+    "latest_signal": "Final result should outrank long discussion threads.",
+    "comments": [
+      "A very long meta discussion repeats unrelated search terms, parent key references, old child names, and exploratory chatter.",
+      "The synopsis should use the final result instead of indexing all chatter equally.",
+      "Noisy thread: control room child_count in_review blocked consolidation latest final signal accepted route all domains child status aggregation active children in progress banking context window synthetic validation leakage banking generator canary rerun retail strict gate failure analysis airline verifier boundary failure telecom runtime unblock rerun canary telecom visible reconstruction accepted rejected canonical telecom schema old package trace pipeline fixed json extraction rewards card daily governance route_next needs_user_decision true_blocked semantics missing permission resource open child issue threshold long running artifact ownership stale cancelled branch sidecar index baseline canonical issue synopsis rerank lifecycle flag."
+    ]
+  },
+  {
+    "identifier": "SYN-211",
+    "title": "Cancelled stale branch archive",
+    "status": "cancelled",
+    "assignee_type": "agent",
+    "description": "Stale cancelled branch retained so the regression can still retrieve it when explicitly requested.",
+    "latest_signal": "Cancelled branch. Downrank unless the query asks for stale cancelled branch behavior.",
+    "comments": [
+      "Archived notes mention canonical issue synopsis rerank lifecycle flag, sidecar index baseline, artifacts ready for analysis, and governance true_blocked semantics even though this route is stale."
+    ],
+    "superseded": true
+  },
+  {
+    "identifier": "SYN-220",
+    "title": "Issue synopsis rerank proposal",
+    "status": "in_review",
+    "assignee_type": "agent",
+    "description": "Proposal for canonical issue synopsis, child aggregation, latest final signal, lifecycle flag rerank, and sidecar index baseline evaluation.",
+    "latest_signal": "Use canonical issue synopsis and lifecycle flag rerank as the primary direction. Keep sidecar index experiments as optional baseline, not the main production index."
+  }
+]
+


### PR DESCRIPTION
## Summary

Adds a clean, offline issue-search-synopsis regression harness for improving Multica issue search without changing production search behavior.

This PR introduces:
- a synthetic issue fixture set
- a v0 issue synopsis schema
- an offline generator/evaluator
- a 20-query synthetic regression set
- docs describing the search-quality problem and the proposed scoring signals

## Why

As issue volume grows, raw title/body/comment search can over-rank stale child issues, long-thread chatter, superseded branches, or meta-discussion instead of the current actionable issue. The proposed direction is to rank against a canonical issue synopsis that gives more weight to current state, lifecycle signals, child status aggregation, and latest final/consolidation signals.

## Privacy

The fixtures in this PR are synthetic. This PR does not include real workspace snapshots, real comments, user/member/agent IDs, private artifact URLs, or local absolute paths. Details from the original internal evaluation are described only at the problem/mechanism level.

## Validation

Ran locally:

```bash
python3 tools/issue_search_synopsis/issue_search_synopsis_v0.py --out issue_search_synopsis_out
python3 -m py_compile tools/issue_search_synopsis/issue_search_synopsis_v0.py
rg -n "DOM-|923a6182|ff18a83d|e71ef3ff|a228a9e6|multica_workspaces|liuxiang|/root/|/tmp/|mention://|https?://" tools/issue_search_synopsis docs/issue-search-synopsis-pr1.md
```

Synthetic regression result:
- legacy text match: Top1 17/20, Top3 20/20, Top10 20/20, Miss 0, MRR 0.925
- issue_search_synopsis_v0: Top1 20/20, Top3 20/20, Top10 20/20, Miss 0, MRR 1.000
