### PR TITLE
fix(security): normalize MIME type in isInlineContentType

### DIFF
--- a/server/internal/storage/util.go
+++ b/server/internal/storage/util.go
@@ -27,12 +27,22 @@ func sanitizeFilename(name string) string {
 // and can carry <script>, <foreignObject>, or onload= attributes that
 // execute in the document's origin when rendered inline. Forcing
 // attachment disposition prevents stored-XSS via uploaded .svg files.
+//
+// Input is normalized (trim, lowercase, strip parameters) before matching
+// so that values like "image/svg+xml; charset=utf-8" or "IMAGE/SVG+XML"
+// can't slip past the SVG carve-out. RFC 2045 §5.1 defines MIME type
+// matching as case-insensitive with optional parameters; this is the
+// security boundary, so normalize here instead of trusting callers.
 func isInlineContentType(ct string) bool {
-	if ct == "image/svg+xml" {
+	mediaType := strings.ToLower(strings.TrimSpace(ct))
+	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
+		mediaType = strings.TrimSpace(mediaType[:i])
+	}
+	if mediaType == "image/svg+xml" {
 		return false
 	}
-	return strings.HasPrefix(ct, "image/") ||
-		strings.HasPrefix(ct, "video/") ||
-		strings.HasPrefix(ct, "audio/") ||
-		ct == "application/pdf"
+	return strings.HasPrefix(mediaType, "image/") ||
+		strings.HasPrefix(mediaType, "video/") ||
+		strings.HasPrefix(mediaType, "audio/") ||
+		mediaType == "application/pdf"
 }

--- a/server/internal/storage/util_test.go
+++ b/server/internal/storage/util_test.go
@@ -17,6 +17,18 @@ func TestIsInlineContentType(t *testing.T) {
 
 		// SVG must NOT render inline — it can carry executable script.
 		{"image/svg+xml", false},
+		// MIME types are case-insensitive (RFC 2045 §5.1) and may carry
+		// parameters. The SVG carve-out is a security boundary, so any
+		// variant that resolves to image/svg+xml must also be blocked.
+		{"IMAGE/SVG+XML", false},
+		{"Image/Svg+Xml", false},
+		{"image/svg+xml; charset=utf-8", false},
+		{"image/svg+xml;charset=utf-8", false},
+		{"  image/svg+xml  ", false},
+		// Normalization must not break the positive cases either.
+		{"IMAGE/PNG", true},
+		{"image/png; foo=bar", true},
+		{"  application/pdf", true},
 
 		{"text/html", false},
 		{"application/octet-stream", false},


### PR DESCRIPTION
## Summary

Follow-up to #3023 (MUL-2535). `isInlineContentType` is the helper that decides whether an uploaded file is served with `Content-Disposition: inline` (rendered in the document origin) or `attachment`. The SVG carve-out added in #3023 only matched the exact literal `image/svg+xml`, so callers that supply `IMAGE/SVG+XML`, `image/svg+xml; charset=utf-8`, or whitespace-padded variants would still see `inline`.

MIME type matching is case-insensitive per RFC 2045 §5.1 and may carry parameters, so the safe move is to normalize at the boundary instead of trusting every caller.

## What this does

Inside `isInlineContentType` (`server/internal/storage/util.go`):

- Trim whitespace, lowercase, and strip parameters (`; charset=...`) before matching.
- Apply the SVG carve-out and the `image/`, `video/`, `audio/`, `application/pdf` checks against the normalized value.

`server/internal/storage/util_test.go` gets a handful of new cases covering uppercase, mixed case, `; charset=utf-8`, no-space `;charset=utf-8`, leading/trailing whitespace, plus equivalent positive cases for `IMAGE/PNG`, `image/png; foo=bar`, and `  application/pdf` so the normalization can't regress the inline-allowed types.

## Is this a live regression?

No — defense-in-depth only. Today both call sites (`S3.Upload`, `LocalStorage.Serve`) feed in the exact literal `image/svg+xml` because `server/internal/handler/file.go` overrides `.svg` to that canonical string before storage sees it. This change hardens the helper so any future caller (including one that ever trusts a client-supplied Content-Type) stays behind the same guard.

## Test plan

- [x] `go test ./internal/storage/... -run TestIsInlineContentType -v` — passes, all new cases green.
- [x] `go test ./internal/storage/...` — passes.
- [x] `go vet ./internal/storage/...` — clean.

MUL-2535