### PR TITLE
fix(squads): warn leader against double-triggering an agent

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -79,7 +79,14 @@ Hard rules:
   explaining the gap (and @mention the issue's reporter if possible)
   rather than silently doing the work.
 - ALWAYS call ` + "`" + `multica squad activity` + "`" + ` before ending your turn —
-  even when the outcome is no_action.`
+  even when the outcome is no_action.
+- A child issue you create with ` + "`" + `--status todo` + "`" + ` and an agent assignee
+  already fires that agent automatically — the assignment IS the trigger.
+  If you also @mention the same agent on this parent issue for the same
+  work, the agent runs twice in parallel (once from the mention, once
+  from the assignment). Pick exactly one path: either delegate by
+  @mention on this issue, or create a ` + "`" + `todo` + "`" + ` child issue assigned to
+  them. Never both for the same work.`
 
 // buildSquadLeaderBriefing composes the full system briefing appended to a
 // squad leader's Instructions when it claims a task on a squad-assigned

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -13,6 +13,24 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+// TestSquadOperatingProtocolWarnsAgainstDualTrigger locks in the rule
+// added for #3033: the protocol must tell the squad leader that a `todo`
+// child issue with an agent assignee already fires that agent, so they
+// must not also @mention the same agent on the parent issue for the
+// same work. Asserts behavior, not exact wording — keep the substrings
+// narrow so harmless rewording doesn't break the test.
+func TestSquadOperatingProtocolWarnsAgainstDualTrigger(t *testing.T) {
+	compact := strings.Join(strings.Fields(squadOperatingProtocol), " ")
+	for _, want := range []string{
+		"--status todo` and an agent assignee already fires that agent automatically",
+		"Never both for the same work.",
+	} {
+		if !strings.Contains(compact, want) {
+			t.Errorf("expected squad operating protocol to contain %q\n--- protocol ---\n%s", want, squadOperatingProtocol)
+		}
+	}
+}
+
 // seedSquadForBriefing creates a squad with the seeded test agent as
 // leader. Returns the loaded db.Squad and a cleanup-registered ID.
 func seedSquadForBriefing(t *testing.T, leaderID string, name, instructions string) db.Squad {


### PR DESCRIPTION
## Summary
- Add one hard rule to the Squad Operating Protocol: a `todo` child issue with an agent assignee already fires that agent, so don't also `@mention` the same agent on the parent issue for the same work.
- Pick one path — comment `@mention` OR `todo` child-issue assignment — never both for the same piece of work.

Alternative to #3051 — same root fix, but minimal: keeps the existing "Delegate by @mention" responsibility heading and the existing "EVERY delegation MUST use mention" hard rule untouched, and only adds the missing piece of information about the dual-trigger pitfall. The Parent/Sub-issue Protocol already explains `todo` vs `backlog` semantics; we don't need to restate that here.

Fixes #3033. Related: MUL-2541.

## Tests
- `go test ./internal/handler -run TestSquadOperatingProtocolWarnsAgainstDualTrigger`

The new test uses narrow substring matches (two strings) so harmless rewording of the rule won't break it. Other existing squad briefing tests are unchanged.