### PR TITLE
fix(landing): call API origin directly from Contact Sales form

### DIFF
--- a/apps/web/features/landing/components/contact-sales-page-client.tsx
+++ b/apps/web/features/landing/components/contact-sales-page-client.tsx
@@ -89,7 +89,13 @@ export function ContactSalesPageClient() {
     setState({ status: "submitting" });
 
     try {
-      const res = await fetch("/api/contact-sales", {
+      // Call the API origin directly (same as the rest of the web app via
+      // `apiBaseUrl={process.env.NEXT_PUBLIC_API_URL}`). The `/api/*` Vercel
+      // rewrite uses server-only `REMOTE_API_URL`, which on Vercel may not
+      // be publicly resolvable — relying on it makes this endpoint 404 even
+      // when every other API works.
+      const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+      const res = await fetch(`${apiBase}/api/contact-sales`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
## Why

After #2988, `/contact-sales` was loading fine on `multica-app.copilothub.ai` but the form submit was 404'ing with `x-vercel-error: DNS_HOSTNAME_RESOLVED_PRIVATE`, while every other API call from the same web app worked.

Root cause: the form did `fetch("/api/contact-sales", …)` — a relative URL — which on Vercel hits the `/api/*` rewrite in `apps/web/next.config.ts` and proxies through `REMOTE_API_URL`. On the Vercel project for `multica-app.copilothub.ai`, `REMOTE_API_URL` points at a private hostname that Vercel's edge can't resolve, so the rewrite returns 404.

Everything else in the web app calls the API via the `@multica/core` client, which is initialized with `apiBaseUrl={process.env.NEXT_PUBLIC_API_URL}` (publicly resolvable, e.g. `https://multica-api.copilothub.ai`) — so those requests work.

## What

Make the Contact Sales form follow the same convention: prefix the request with `process.env.NEXT_PUBLIC_API_URL`. If the env var isn't set (local dev, self-hosted same-origin), it falls back to a relative URL and the existing Next.js rewrite still works.

CORS preflight from `https://multica-app.copilothub.ai` to the API origin is already allowed (verified with `curl -X OPTIONS` against the live dev API).

## Test plan

- [x] `pnpm --filter @multica/web exec tsc --noEmit`
- [x] `pnpm --filter @multica/web lint`
- [x] `curl -X OPTIONS` preflight from `multica-app.copilothub.ai` origin returns 200 with `Access-Control-Allow-Origin`
- [x] `curl -X POST` returns the expected 400 (`first_name is required`) over the API origin
- [ ] After deploy: load `multica-app.copilothub.ai/contact-sales`, submit a valid form, expect success state instead of 404

MUL-2493