### PR TITLE
feat(landing): move Contact Sales into hero as text-only link

### DIFF
--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -54,15 +54,6 @@ export function LandingHeader({
             {t.header.changelog}
           </Link>
           <Link
-            href="/contact-sales"
-            className={cn(
-              headerButtonClassName("ghost", variant),
-              "hidden md:inline-flex",
-            )}
-          >
-            {t.header.contactSales}
-          </Link>
-          <Link
             href={githubUrl}
             target="_blank"
             rel="noreferrer"

--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Download } from "lucide-react";
+import { ArrowRight, Download } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
 import { captureDownloadIntent } from "@multica/core/analytics";
 import { useLocale } from "../i18n";
@@ -50,6 +50,16 @@ export function LandingHero() {
               >
                 <Download className="size-4" aria-hidden />
                 {t.hero.downloadDesktop}
+              </Link>
+              <Link
+                href="/contact-sales"
+                className="group inline-flex items-center justify-center gap-1.5 rounded-[12px] px-3 py-3 text-[14px] font-semibold text-white/80 transition-colors hover:text-white"
+              >
+                {t.hero.talkToSales}
+                <ArrowRight
+                  className="size-4 transition-transform group-hover:translate-x-0.5"
+                  aria-hidden
+                />
               </Link>
             </div>
           </div>

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -8,7 +8,6 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     login: "Log in",
     dashboard: "Dashboard",
     changelog: "Changelog",
-    contactSales: "Contact Sales",
   },
 
   hero: {
@@ -18,6 +17,7 @@ export function createEnDict(allowSignup: boolean): LandingDict {
       "Multica is an open-source platform that turns coding agents into real teammates. Assign tasks, track progress, compound skills \u2014 manage your human + agent workforce in one place.",
     cta: "Start free trial",
     downloadDesktop: "Download Desktop",
+    talkToSales: "Talk to sales",
     worksWith: "Works with",
     imageAlt: "Multica board view \u2014 issues managed by humans and agents",
   },

--- a/apps/web/features/landing/i18n/types.ts
+++ b/apps/web/features/landing/i18n/types.ts
@@ -27,7 +27,6 @@ export type LandingDict = {
     login: string;
     dashboard: string;
     changelog: string;
-    contactSales: string;
   };
   hero: {
     headlineLine1: string;
@@ -35,6 +34,7 @@ export type LandingDict = {
     subheading: string;
     cta: string;
     downloadDesktop: string;
+    talkToSales: string;
     worksWith: string;
     imageAlt: string;
   };

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -8,7 +8,6 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     login: "\u767b\u5f55",
     dashboard: "\u8fdb\u5165\u5de5\u4f5c\u53f0",
     changelog: "\u66f4\u65b0\u65e5\u5fd7",
-    contactSales: "\u8054\u7cfb\u5546\u52a1",
   },
 
   hero: {
@@ -18,6 +17,7 @@ export function createZhDict(allowSignup: boolean): LandingDict {
       "Multica \u662f\u4e00\u4e2a\u5f00\u6e90\u5e73\u53f0\uff0c\u5c06\u7f16\u7801 智能体 \u53d8\u6210\u771f\u6b63\u7684\u961f\u53cb\u3002\u5206\u914d\u4efb\u52a1\u3001\u8ddf\u8e2a\u8fdb\u5ea6\u3001\u79ef\u7d2f\u6280\u80fd\u2014\u2014\u5728\u4e00\u4e2a\u5730\u65b9\u7ba1\u7406\u4f60\u7684\u4eba\u7c7b + 智能体 \u56e2\u961f\u3002",
     cta: "免费开始",
     downloadDesktop: "下载桌面端",
+    talkToSales: "联系商务",
     worksWith: "支持",
     imageAlt: "Multica \u770b\u677f\u89c6\u56fe\u2014\u2014\u4eba\u7c7b\u548c 智能体 \u534f\u540c\u7ba1\u7406\u4efb\u52a1",
   },


### PR DESCRIPTION
## Summary

Per design feedback in MUL-2493, move the Contact Sales entry from the landing header into the hero CTA row, styled as a text-only "Talk to sales →" link (no background, no border) alongside "Start free trial" and "Download Desktop".

- `apps/web/features/landing/components/landing-hero.tsx` — new third button: text + `ArrowRight` icon, white/80 → white on hover, arrow nudges right on hover.
- `apps/web/features/landing/components/landing-header.tsx` — drop the header's Contact Sales link (it now lives in the hero and footer).
- `apps/web/features/landing/i18n/{en,zh,types}.ts` — add `hero.talkToSales` ("Talk to sales" / "联系商务") and remove the now-unused `header.contactSales`.

Footer's "Contact Sales" entry under Company is untouched.

Refs MUL-2493.

## Test plan

- [x] `pnpm --filter @multica/web exec tsc --noEmit` (clean)
- [x] `pnpm --filter @multica/web lint` (no new warnings)
- [ ] Visual check after Vercel deploy: hero now shows 3 CTAs in EN + ZH; "Talk to sales" navigates to `/contact-sales`; header no longer shows Contact Sales.