### PR TITLE
test(agent): use ForkLock helper to fix ETXTBSY flake in thinking tests

### DIFF
--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -127,9 +127,11 @@ func TestRunCodexDebugModels_ArgvSeenByBinary(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$@\" > '" + argvFile + "'\n" +
 		"echo '{\"models\":[]}'\n"
-	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	// Use the ForkLock-protected helper instead of os.WriteFile: under
+	// t.Parallel() with the rest of this package, a sibling test's
+	// concurrent fork can inherit our still-open write fd, causing
+	// Linux ETXTBSY when we exec the file (Go #22315).
+	writeTestExecutable(t, fake, []byte(script))
 
 	raw, err := runCodexDebugModels(context.Background(), fake)
 	if err != nil {
@@ -384,9 +386,10 @@ func writeFakeClaudeHelpBinary(t *testing.T) string {
 		"  --model <model>     Model to use\n" +
 		"  --effort <level>    Effort level for the current session (low, medium, high, xhigh, max)\n" +
 		"EOF\n"
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake claude: %v", err)
-	}
+	// Same ForkLock rationale as TestRunCodexDebugModels_ArgvSeenByBinary —
+	// the parser tests that consume this helper exec the script in parallel,
+	// so a sibling fork can otherwise inherit our write fd and trip ETXTBSY.
+	writeTestExecutable(t, path, []byte(script))
 	return path
 }
 


### PR DESCRIPTION
## Summary
Backend CI failed on main with:
\`\`\`
--- FAIL: TestRunCodexDebugModels_ArgvSeenByBinary (0.00s)
    thinking_test.go:136: runCodexDebugModels: fork/exec /tmp/.../codex: text file busy (output="")
\`\`\`

Classic Linux ETXTBSY race (Go #22315): the test wrote a fake \`codex\` shell script via \`os.WriteFile\` and immediately execed it. Under \`t.Parallel()\` with the rest of \`pkg/agent\`, a sibling test's \`fork()\` between our \`OpenFile\` and \`Close\` can inherit our write fd into its child; the kernel then refuses our \`exec\` of the same file with ETXTBSY.

The package already has \`writeTestExecutable\` in \`exec_fixture_unix_test.go\` that holds \`syscall.ForkLock\` across the write — every other fake-binary test (\`kimi\`, \`kiro\`, \`codex\`, \`claude\`, etc.) uses it. The two thinking-test helpers were the only stragglers still on raw \`os.WriteFile\`. Swapped both.

Repros: doesn't reproduce on macOS dev (Linux-only kernel behavior), but the helper is build-tagged \`unix\` so it's exercised locally too and full \`pkg/agent\` suite stays green.

## Test plan
- [x] \`go test ./pkg/agent/\` — 1 package, all tests pass
- [ ] CI on Linux runner — backend job green