### PR TITLE
feat(issues): redesign board card layout + extract useTimeAgo i18n hook

### DIFF
--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -1,14 +1,3 @@
-export function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
 export function generateUUID(): string {
   const cryptoObj = globalThis.crypto;
 

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -19,7 +19,8 @@ import {
 } from "@multica/core/agents";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
-import { isImeComposing, timeAgo } from "@multica/core/utils";
+import { isImeComposing } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { Button } from "@multica/ui/components/ui/button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Input } from "@multica/ui/components/ui/input";
@@ -92,6 +93,7 @@ export function AgentDetailInspector({
   onUpdate,
 }: InspectorProps) {
   const { t } = useT("agents");
+  const timeAgo = useTimeAgo();
   const update = (data: Record<string, unknown>) => onUpdate(agent.id, data);
   const isOnline = runtime?.status === "online";
 

--- a/packages/views/agents/components/agent-live-peek-card.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.tsx
@@ -11,11 +11,10 @@ import {
   useAgentPresenceDetail,
 } from "@multica/core/agents";
 import { issueDetailOptions } from "@multica/core/issues";
-import { timeAgo } from "@multica/core/utils";
 import type { AgentTask } from "@multica/core/types";
 import { AlertTriangle } from "lucide-react";
 import { AppLink } from "../../navigation";
-import { useT } from "../../i18n";
+import { useT, useTimeAgo } from "../../i18n";
 import { workloadConfig } from "../presence";
 
 interface AgentLivePeekCardProps {
@@ -200,6 +199,7 @@ function LastActivityRow({
   emptyLabel: string;
   failedLabel: string;
 }) {
+  const timeAgo = useTimeAgo();
   return (
     <div className="flex items-center gap-1.5">
       <span className="w-16 shrink-0 text-muted-foreground">{label}</span>

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -34,13 +34,12 @@ import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { issueDetailOptions } from "@multica/core/issues/queries";
-import { timeAgo } from "@multica/core/utils";
 import { AppLink } from "../../../navigation";
 import { TranscriptButton } from "../../../common/task-transcript";
 import { taskStatusConfig } from "../../config";
 import { failureReasonLabel } from "./task-failure";
 import { Sparkline } from "../sparkline";
-import { useT } from "../../../i18n";
+import { useT, useTimeAgo } from "../../../i18n";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 // Recent work pagination: small initial cohort to keep the section
@@ -353,6 +352,7 @@ function TaskRow({
   agent: Agent;
 }) {
   const { t } = useT("agents");
+  const timeAgo = useTimeAgo();
   const paths = useWorkspacePaths();
   const [cancelling, setCancelling] = useState(false);
   const cfg = taskStatusConfig[task.status] ?? taskStatusConfig.queued!;
@@ -418,7 +418,7 @@ function TaskRow({
 
   const timeText =
     timeMode === "active"
-      ? activeTaskTimeText(task, t)
+      ? activeTaskTimeText(task, t, timeAgo)
       : task.completed_at
         ? timeAgo(task.completed_at)
         : "—";
@@ -600,8 +600,9 @@ function Sep() {
 }
 
 type AgentsT = ReturnType<typeof useT<"agents">>["t"];
+type TimeAgoFn = (dateStr: string) => string;
 
-function activeTaskTimeText(task: AgentTask, t: AgentsT): string {
+function activeTaskTimeText(task: AgentTask, t: AgentsT, timeAgo: TimeAgoFn): string {
   if (task.status === "running" && task.started_at) {
     return t(($) => $.tab_body.activity.started_prefix, { when: timeAgo(task.started_at) });
   }

--- a/packages/views/i18n/index.ts
+++ b/packages/views/i18n/index.ts
@@ -1,1 +1,2 @@
 export { useT } from "./use-t";
+export { useTimeAgo } from "./use-time-ago";

--- a/packages/views/i18n/use-time-ago.ts
+++ b/packages/views/i18n/use-time-ago.ts
@@ -1,0 +1,17 @@
+import { useT } from "./use-t";
+
+// Localized relative-time formatter. Returns a function so call-site usage
+// stays terse: `const timeAgo = useTimeAgo(); ...timeAgo(dateStr)`.
+export function useTimeAgo() {
+  const { t } = useT("common");
+  return (dateStr: string): string => {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return t(($) => $.time.just_now);
+    if (minutes < 60) return t(($) => $.time.minutes_ago, { count: minutes });
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return t(($) => $.time.hours_ago, { count: hours });
+    const days = Math.floor(hours / 24);
+    return t(($) => $.time.days_ago, { count: days });
+  };
+}

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -13,11 +13,12 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { useTimeAgo } from "../../i18n";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { PriorityIcon } from "./priority-icon";
 import { PriorityPicker, AssigneePicker, StartDatePicker, DueDatePicker } from "./pickers";
-import { PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { ProgressRing } from "./progress-ring";
 import type { ChildProgress } from "./list-row";
@@ -45,13 +46,13 @@ function descriptionPreview(markdown: string): string {
 }
 
 /** Stops event from bubbling to Link/drag handlers */
-function PickerWrapper({ children }: { children: React.ReactNode }) {
+function PickerWrapper({ children, className }: { children: React.ReactNode; className?: string }) {
   const stop = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     e.preventDefault();
   };
   return (
-    <div onClick={stop} onMouseDown={stop} onPointerDown={stop}>
+    <div onClick={stop} onMouseDown={stop} onPointerDown={stop} className={className}>
       {children}
     </div>
   );
@@ -67,8 +68,8 @@ export const BoardCardContent = memo(function BoardCardContent({
   childProgress?: ChildProgress;
 }) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const storeProperties = useViewStore((s) => s.cardProperties);
-  const priorityCfg = PRIORITY_CONFIG[issue.priority];
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery({
     ...projectListOptions(wsId),
@@ -104,11 +105,87 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showLabels = storeProperties.labels && labels.length > 0;
 
+  // When assignee is the only meta-row property, expand it with name on the left
+  // and a relative "updated" hint on the right — fills the otherwise empty row.
+  const metaIsAssigneeOnly =
+    !!showAssignee && !showStartDate && !showDueDate && !showChildProgress;
+  const { getActorName } = useActorName();
+  const assigneeName =
+    metaIsAssigneeOnly && issue.assignee_type && issue.assignee_id
+      ? getActorName(issue.assignee_type, issue.assignee_id)
+      : null;
+
+  const priorityLabel = t(($) => $.priority[issue.priority]);
+  const priorityIconNode = showPriority ? (
+    editable ? (
+      <PickerWrapper>
+        <PriorityPicker
+          priority={issue.priority}
+          onUpdate={handleUpdate}
+          triggerRender={
+            <button
+              type="button"
+              aria-label={priorityLabel}
+              className="inline-flex items-center justify-center rounded hover:bg-muted/60"
+            >
+              <PriorityIcon priority={issue.priority} />
+            </button>
+          }
+        />
+      </PickerWrapper>
+    ) : (
+      <span aria-label={priorityLabel} className="inline-flex items-center justify-center">
+        <PriorityIcon priority={issue.priority} />
+      </span>
+    )
+  ) : null;
+
+  // When showing only an avatar (no name), keep natural width; when showing
+  // avatar + name, allow the container to shrink (min-w-0) and cap with a
+  // sensible max so a 30-char agent name can't push the rest of the row off.
+  const assigneeContainerClass = assigneeName
+    ? "inline-flex items-center gap-1.5 min-w-0 max-w-[160px]"
+    : "inline-flex items-center";
+
+  const assigneeInner = showAssignee ? (
+    <span className="inline-flex items-center gap-1.5 min-w-0">
+      <ActorAvatar
+        actorType={issue.assignee_type!}
+        actorId={issue.assignee_id!}
+        size={20}
+        enableHoverCard
+      />
+      {assigneeName && (
+        <span className="text-xs text-foreground truncate">{assigneeName}</span>
+      )}
+    </span>
+  ) : null;
+
+  const assigneeNode = showAssignee ? (
+    editable ? (
+      <PickerWrapper className={assigneeContainerClass}>
+        <AssigneePicker
+          assigneeType={issue.assignee_type}
+          assigneeId={issue.assignee_id}
+          onUpdate={handleUpdate}
+          trigger={assigneeInner!}
+        />
+      </PickerWrapper>
+    ) : (
+      <span className={assigneeContainerClass}>{assigneeInner}</span>
+    )
+  ) : null;
+
+  const showMetaRow = showAssignee || showStartDate || showDueDate || showChildProgress;
+
   return (
     <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
-      {/* Row 1: Identifier + agent activity indicator (top-right) */}
+      {/* Row 1: priority + identifier (left), agent activity + assignee (right) */}
       <div className="flex items-center justify-between gap-2">
-        <p className="text-xs text-muted-foreground">{issue.identifier}</p>
+        <div className="flex items-center gap-1.5 min-w-0">
+          {priorityIconNode}
+          <p className="text-xs text-muted-foreground truncate">{issue.identifier}</p>
+        </div>
         <IssueAgentActivityIndicator issueId={issue.id} />
       </div>
 
@@ -117,17 +194,19 @@ export const BoardCardContent = memo(function BoardCardContent({
         {issue.title}
       </p>
 
-      {/* Sub-issue progress + project + labels */}
-      {(showChildProgress || showProject || showLabels) && (
+      {showDescription && (() => {
+        const preview = descriptionPreview(issue.description!);
+        if (!preview) return null;
+        return (
+          <p className="mt-1 text-xs text-muted-foreground line-clamp-1">
+            {preview}
+          </p>
+        );
+      })()}
+
+      {/* Chip row: project + labels */}
+      {(showProject || showLabels) && (
         <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
-          {showChildProgress && (
-            <div className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
-              <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
-              <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
-                {childProgress!.done}/{childProgress!.total}
-              </span>
-            </div>
-          )}
           {showProject && (
             <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground max-w-[160px]">
               <ProjectIcon project={project} size="sm" />
@@ -140,121 +219,76 @@ export const BoardCardContent = memo(function BoardCardContent({
         </div>
       )}
 
-      {showDescription && (() => {
-        const preview = descriptionPreview(issue.description!);
-        if (!preview) return null;
-        return (
-          <p className="mt-1 text-xs text-muted-foreground line-clamp-1">
-            {preview}
-          </p>
-        );
-      })()}
-
-      {/* Row 3: Assignee, priority badge, start date, due date */}
-      {(showAssignee || showPriority || showStartDate || showDueDate) && (
-        <div className="mt-3 flex items-center gap-2">
-          {showAssignee &&
-            (editable ? (
-              <PickerWrapper>
-                <AssigneePicker
-                  assigneeType={issue.assignee_type}
-                  assigneeId={issue.assignee_id}
+      {/* Meta row: assignee (left), start date, due date, child progress (right) */}
+      {showMetaRow && (
+        <div className="mt-2 flex items-center gap-2">
+          {assigneeNode}
+          {showStartDate && (
+            editable ? (
+              <PickerWrapper className="shrink-0">
+                <StartDatePicker
+                  startDate={issue.start_date}
                   onUpdate={handleUpdate}
                   trigger={
-                    <ActorAvatar
-                      actorType={issue.assignee_type!}
-                      actorId={issue.assignee_id!}
-                      size={22}
-                      enableHoverCard
-                    />
-                  }
-                />
-              </PickerWrapper>
-            ) : (
-              <ActorAvatar
-                actorType={issue.assignee_type!}
-                actorId={issue.assignee_id!}
-                size={22}
-                enableHoverCard
-              />
-            ))}
-          {showPriority &&
-            (editable ? (
-              <PickerWrapper>
-                <PriorityPicker
-                  priority={issue.priority}
-                  onUpdate={handleUpdate}
-                  trigger={
-                    <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${priorityCfg.badgeBg} ${priorityCfg.badgeText}`}>
-                      <PriorityIcon priority={issue.priority} className="h-3 w-3" inheritColor />
-                      {t(($) => $.priority[issue.priority])}
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <CalendarClock className="size-3" />
+                      {formatDate(issue.start_date!)}
                     </span>
                   }
                 />
               </PickerWrapper>
             ) : (
-              <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${priorityCfg.badgeBg} ${priorityCfg.badgeText}`}>
-                <PriorityIcon priority={issue.priority} className="h-3 w-3" inheritColor />
-                {priorityCfg.label}
+              <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                <CalendarClock className="size-3" />
+                {formatDate(issue.start_date!)}
               </span>
-            ))}
-          {showStartDate && (
-            <div className={showDueDate ? undefined : "ml-auto"}>
-              {editable ? (
-                <PickerWrapper>
-                  <StartDatePicker
-                    startDate={issue.start_date}
-                    onUpdate={handleUpdate}
-                    trigger={
-                      <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                        <CalendarClock className="size-3" />
-                        {formatDate(issue.start_date!)}
-                      </span>
-                    }
-                  />
-                </PickerWrapper>
-              ) : (
-                <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <CalendarClock className="size-3" />
-                  {formatDate(issue.start_date!)}
-                </span>
-              )}
-            </div>
+            )
           )}
           {showDueDate && (
-            <div className="ml-auto">
-              {editable ? (
-                <PickerWrapper>
-                  <DueDatePicker
-                    dueDate={issue.due_date}
-                    onUpdate={handleUpdate}
-                    trigger={
-                      <span
-                        className={`flex items-center gap-1 text-xs ${
-                          new Date(issue.due_date!) < new Date()
-                            ? "text-destructive"
-                            : "text-muted-foreground"
-                        }`}
-                      >
-                        <CalendarDays className="size-3" />
-                        {formatDate(issue.due_date!)}
-                      </span>
-                    }
-                  />
-                </PickerWrapper>
-              ) : (
-                <span
-                  className={`flex items-center gap-1 text-xs ${
-                    new Date(issue.due_date!) < new Date()
-                      ? "text-destructive"
-                      : "text-muted-foreground"
-                  }`}
-                >
-                  <CalendarDays className="size-3" />
-                  {formatDate(issue.due_date!)}
-                </span>
-              )}
+            editable ? (
+              <PickerWrapper className="shrink-0">
+                <DueDatePicker
+                  dueDate={issue.due_date}
+                  onUpdate={handleUpdate}
+                  trigger={
+                    <span
+                      className={`flex items-center gap-1 text-xs ${
+                        new Date(issue.due_date!) < new Date()
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      <CalendarDays className="size-3" />
+                      {formatDate(issue.due_date!)}
+                    </span>
+                  }
+                />
+              </PickerWrapper>
+            ) : (
+              <span
+                className={`flex shrink-0 items-center gap-1 text-xs ${
+                  new Date(issue.due_date!) < new Date()
+                    ? "text-destructive"
+                    : "text-muted-foreground"
+                }`}
+              >
+                <CalendarDays className="size-3" />
+                {formatDate(issue.due_date!)}
+              </span>
+            )
+          )}
+          {showChildProgress && (
+            <div className="ml-auto inline-flex shrink-0 items-center gap-1">
+              <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
+              <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
+                {childProgress!.done}/{childProgress!.total}
+              </span>
             </div>
+          )}
+          {metaIsAssigneeOnly && (
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              {t(($) => $.card.updated_ago, { time: timeAgo(issue.updated_at) })}
+            </span>
           )}
         </div>
       )}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -29,7 +29,7 @@ import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { QuickEmojiPicker } from "@multica/ui/components/common/quick-emoji-picker";
 import { cn } from "@multica/ui/lib/utils";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { timeAgo } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { ContentEditor, type ContentEditorRef, copyMarkdown, ReadonlyContent, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -180,6 +180,7 @@ function CommentRow({
   onToggleReaction: (commentId: string, emoji: string) => void;
 }) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
   const [editing, setEditing] = useState(false);
   const editEditorRef = useRef<ContentEditorRef>(null);
@@ -417,6 +418,7 @@ function CommentCardImpl({
   highlightedCommentId,
 }: CommentCardProps) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
   const { uploadWithToast } = useFileUpload(api);
   const isCollapsed = useCommentCollapseStore((s) => s.isCollapsed(issueId, entry.id));

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { issueKeys } from "@multica/core/issues/queries";
 import type { AgentTask, TaskFailureReason } from "@multica/core/types";
-import { timeAgo } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import {
   Tooltip,
   TooltipContent,
@@ -209,7 +209,7 @@ const STATUS_TONE: Record<AgentTask["status"], string> = {
 // Time anchor depends on status. Active rows want "Started 2m ago" /
 // "Queued 30s ago" — what's happening now. Past rows want "5m ago" — when
 // the verdict landed.
-function activeTimeText(task: AgentTask): string {
+function activeTimeText(task: AgentTask, timeAgo: (dateStr: string) => string): string {
   if (task.status === "running" && task.started_at) {
     return timeAgo(task.started_at);
   }
@@ -257,12 +257,13 @@ function useStatusLabel(status: AgentTask["status"]): string {
 
 function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const [cancelling, setCancelling] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const tone = STATUS_TONE[task.status];
   const label = useStatusLabel(task.status);
   const trigger = useTriggerText(task);
-  const time = activeTimeText(task);
+  const time = activeTimeText(task, timeAgo);
 
   // Transcript only meaningful once messages exist — pure-queued tasks
   // have nothing to show yet.
@@ -337,6 +338,7 @@ function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
 
 function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const [retrying, setRetrying] = useState(false);
   const tone = STATUS_TONE[task.status];
   const label = useStatusLabel(task.status);

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -350,11 +350,6 @@ vi.mock("@multica/core/modals", () => ({
   ),
 }));
 
-// Mock core/utils
-vi.mock("@multica/core/utils", () => ({
-  timeAgo: () => "1d ago",
-}));
-
 // Mock core/hooks/use-file-upload
 vi.mock("@multica/core/hooks/use-file-upload", () => ({
   useFileUpload: () => ({ uploadWithToast: vi.fn().mockResolvedValue("https://example.com/file.png") }),

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -76,7 +76,7 @@ import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
-import { timeAgo } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { cn } from "@multica/ui/lib/utils";
 
 import { ProgressRing } from "./progress-ring";
@@ -397,12 +397,14 @@ function ActivityBlock({
   onToggle,
   getActorName,
   t,
+  timeAgo,
 }: {
   entries: TimelineEntry[];
   expanded: boolean;
   onToggle: () => void;
   getActorName: (type: string, id: string) => string;
   t: ActivityT;
+  timeAgo: (dateStr: string) => string;
 }) {
   if (!expanded) {
     const count = entries.length;
@@ -614,6 +616,7 @@ interface IssueDetailProps {
 
 export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const { t } = useT("issues");
+  const timeAgo = useTimeAgo();
   const id = issueId;
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
@@ -1531,6 +1534,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         onToggle={() => toggleActivityBlock(item.id, expanded)}
         getActorName={getActorName}
         t={t}
+        timeAgo={timeAgo}
       />
     );
   };

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -532,8 +532,8 @@ describe("IssuesPage (shared)", () => {
     renderWithQuery(<IssuesPage />);
 
     await screen.findByText("Test User");
-    expect(screen.getByText("Agent One")).toBeInTheDocument();
-    expect(screen.getByText("Squad One")).toBeInTheDocument();
+    expect(screen.getAllByText("Agent One").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Squad One").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("No assignee")).toBeInTheDocument();
   });
 

--- a/packages/views/locales/en/common.json
+++ b/packages/views/locales/en/common.json
@@ -3,5 +3,11 @@
   "cancel": "Cancel",
   "delete": "Delete",
   "confirm": "Confirm",
-  "loading": "Loading..."
+  "loading": "Loading...",
+  "time": {
+    "just_now": "just now",
+    "minutes_ago": "{{count}}m ago",
+    "hours_ago": "{{count}}h ago",
+    "days_ago": "{{count}}d ago"
+  }
 }

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -350,7 +350,8 @@
     "cancel": "Cancel"
   },
   "card": {
-    "update_failed": "Failed to update issue"
+    "update_failed": "Failed to update issue",
+    "updated_ago": "Updated {{time}}"
   },
   "actions": {
     "status": "Status",

--- a/packages/views/locales/zh-Hans/common.json
+++ b/packages/views/locales/zh-Hans/common.json
@@ -3,5 +3,11 @@
   "cancel": "取消",
   "delete": "删除",
   "confirm": "确认",
-  "loading": "加载中..."
+  "loading": "加载中...",
+  "time": {
+    "just_now": "刚刚",
+    "minutes_ago": "{{count}} 分钟前",
+    "hours_ago": "{{count}} 小时前",
+    "days_ago": "{{count}} 天前"
+  }
 }

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -340,7 +340,8 @@
     "cancel": "取消"
   },
   "card": {
-    "update_failed": "更新 issue 失败"
+    "update_failed": "更新 issue 失败",
+    "updated_ago": "更新于 {{time}}"
   },
   "actions": {
     "status": "状态",

--- a/packages/views/skills/components/skill-columns.tsx
+++ b/packages/views/skills/components/skill-columns.tsx
@@ -15,7 +15,7 @@ import type {
   MemberWithUser,
   SkillSummary,
 } from "@multica/core/types";
-import { timeAgo } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import {
   Tooltip,
@@ -52,6 +52,7 @@ const COL_WIDTHS = {
 // price for header strings — same pattern used by inbox `useTypeLabels`.
 export function useSkillColumns(): ColumnDef<SkillRow>[] {
   const { t } = useT("skills");
+  const timeAgo = useTimeAgo();
   return [
     {
       id: "name",

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -26,7 +26,7 @@ import type {
 import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
-import { timeAgo } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import {
@@ -243,6 +243,7 @@ function OriginSidebarCard({
 
 export function SkillDetailPage({ skillId }: { skillId: string }) {
   const { t } = useT("skills");
+  const timeAgo = useTimeAgo();
   const wsId = useWorkspaceId();
   const qc = useQueryClient();
   const paths = useWorkspacePaths();

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -7,7 +7,8 @@ import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
-import { isImeComposing, timeAgo } from "@multica/core/utils";
+import { isImeComposing } from "@multica/core/utils";
+import { useTimeAgo } from "../../i18n";
 import { agentListOptions, memberListOptions, squadMemberStatusOptions, workspaceKeys } from "@multica/core/workspace/queries";
 import { runtimeListOptions } from "@multica/core/runtimes";
 import { CreateAgentDialog } from "../../agents/components/create-agent-dialog";
@@ -809,6 +810,7 @@ function SquadDetailInspector({
   onUpdateDescription: (next: string) => Promise<void>;
 }) {
   const { t } = useT("squads");
+  const timeAgo = useTimeAgo();
   const initials = squad.name
     .split(" ")
     .map((w) => w[0])
@@ -1148,6 +1150,7 @@ function SquadMembersTab({
   setLeaderPending: boolean;
 }) {
   const { t } = useT("squads");
+  const timeAgo = useTimeAgo();
   const p = useWorkspacePaths();
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- Board cards were getting messy with every new property (priority badge + start date + due date all crammed into the bottom row). Restructured into four semantic rows so each row carries one signal type.
- Priority moves to the top-left as an icon-only indicator (color already conveys urgency, the text label was redundant). Assignee stays on the meta row's left and expands to avatar + name when no other meta property is present, with a relative "Updated 2d ago" filling the right side.
- Long agent/team names truncate cleanly: assignee container is `min-w-0 max-w-[160px]`, dates/progress are `shrink-0` so they never get squished.
- Replaced the static `timeAgo` in `packages/core/utils.ts` with a localized `useTimeAgo` hook in `packages/views/i18n` (backed by new `common.time.*` translation keys). Static timeAgo was hardcoded English, producing "更新于 2d ago" mixed-language strings in zh locale. Migrated all 10 view-side call sites.

## Test plan
- [ ] Open a workspace with diverse issues (some with priority/assignee/dates/labels, some with only assignee)
- [ ] Switch to board view — verify card layout looks clean with various property combinations
- [ ] Toggle each property in the view properties menu — verify rows show/hide cleanly
- [ ] Find an agent with a long name (>20 chars) — verify the name truncates and doesn't push dates off
- [ ] Switch language to 简体中文 — verify timestamps show "5 分钟前" / "2 天前" (not "5m ago")
- [ ] Hover/click priority icon → verify picker opens (no nested-button warning in console)
- [ ] Group board by assignee → verify cards still readable (assignee name shown in both column header and card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)