### PR TITLE
fix(daemon): harden agent comment posting (MUL-2567)

### DIFF
--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -20,15 +20,9 @@ import "fmt"
 //     non-ASCII as `?`; cmd.exe is at the mercy of `chcp`). The original
 //     reports — #2198 (Chinese), #2236 (Chinese), #2376 (Cyrillic, observed
 //     on a non-Codex agent) — all match this signature.
-//   - Linux/macOS + Codex → stdin/HEREDOC. Codex tends to emit literal `\n`
-//     escapes inside `--content "..."` and produce broken multi-line stored
-//     comments (MUL-1467); stdin sidesteps that.
-//   - Linux/macOS + non-Codex → lightweight inline `--content "..."`.
-//     The CLI's `util.UnescapeBackslashEscapes` decodes `\n` server-side,
-//     so escaped multi-line works correctly. This is the pre-#1795 default,
-//     restored after we found #1795 / #1851 had expanded a Codex-specific
-//     fix into a global mandate that broke Windows non-ASCII for every
-//     provider.
+//   - Linux/macOS + any provider → stdin/single-quoted HEREDOC. Inline
+//     `--content "..."` lets the agent shell expand `$()`, variables, and
+//     quote-sensitive text before multica receives the body.
 func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) string {
 	if triggerCommentID == "" {
 		return ""
@@ -48,37 +42,18 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 			issueID, triggerCommentID,
 		)
 	}
-	if provider == "codex" {
-		return fmt.Sprintf(
-			"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
-				"do NOT reuse --parent values from previous turns in this session.\n\n"+
-				"Always use `--content-stdin` with a HEREDOC for agent-authored issue comments, even when the reply is a single line. "+
-				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
-				"Use this form, preserving the same issue ID and --parent value:\n\n"+
-				"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
-				"    First paragraph.\n"+
-				"\n"+
-				"    Second paragraph.\n"+
-				"    COMMENT\n\n"+
-				"Do NOT write literal `\\n` escapes to simulate line breaks; the HEREDOC preserves real newlines.\n",
-			issueID, triggerCommentID,
-		)
-	}
-	// Non-Codex providers on Linux/macOS: lightweight inline template, no
-	// platform branch. Pre-#1795 default, restored after we found that
-	// #1795 / #1851 had expanded a Codex-specific fix into a global mandate
-	// that broke Windows non-ASCII for every provider. The CLI decodes
-	// `\n` etc. server-side, so escaped multi-line is fine; for richer
-	// formatting the agent can still reach for `--content-stdin` (works
-	// on Linux/macOS) or `--content-file <path>` (works on every platform),
-	// both listed in Available Commands above.
 	return fmt.Sprintf(
 		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
+			"Always use `--content-stdin` with a single-quoted HEREDOC (`<<'COMMENT'`) for agent-authored issue comments, even when the reply is a single line. "+
+			"Do NOT use inline `--content`; shell expansion can corrupt text containing `$()`, variables, quotes, or code snippets.\n\n"+
 			"Use this form, preserving the same issue ID and --parent value:\n\n"+
-			"    multica issue comment add %s --parent %s --content \"...\"\n\n"+
-			"For multi-line bodies, code blocks, or content with quotes/backticks, prefer `--content-stdin` "+
-			"(pipe a HEREDOC) or `--content-file <path>` (read a UTF-8 file). See Available Commands above for the full menu.\n",
+			"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
+			"    First paragraph.\n"+
+			"\n"+
+			"    Second paragraph.\n"+
+			"    COMMENT\n\n"+
+			"Do NOT write literal `\\n` escapes to simulate line breaks; the HEREDOC preserves real newlines.\n",
 		issueID, triggerCommentID,
 	)
 }

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -43,12 +43,9 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 }
 
 // TestBuildCommentReplyInstructionsNonCodexLinux pins that every non-Codex
-// provider on Linux/macOS gets the lightweight pre-#1795 inline template.
-// The "MUST stdin" mandate was originally a Codex-specific fix that
-// #1795 / #1851 accidentally spread to every provider, breaking Windows
-// non-ASCII for all of them (#2198 / #2236 / #2376). Non-Codex providers
-// handle inline escaping correctly and the CLI server-decodes `\n` etc.,
-// so the inline template works on every non-Windows platform.
+// provider on Linux/macOS gets the same single-quoted HEREDOC template as
+// Codex. Inline `--content "..."` lets the agent shell expand `$()`,
+// variables, quotes, and code snippets before multica receives the body.
 //
 // Not parallel: mutates the package-level runtimeGOOS.
 func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
@@ -66,7 +63,9 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 				got := BuildCommentReplyInstructions(provider, issueID, triggerID)
 
 				for _, want := range []string{
-					"multica issue comment add " + issueID + " --parent " + triggerID + " --content \"...\"",
+					"multica issue comment add " + issueID + " --parent " + triggerID + " --content-stdin",
+					"Always use `--content-stdin` with a single-quoted HEREDOC",
+					"<<'COMMENT'",
 					"do NOT reuse --parent values from previous turns",
 					"If you decide to reply",
 				} {
@@ -75,17 +74,12 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					}
 				}
 
-				// Non-Codex / non-Windows providers must NOT receive the
-				// Codex-specific "MUST stdin" mandate or its HEREDOC
-				// template — that was the over-spread of #1795 / #1851.
 				for _, banned := range []string{
-					"Always use `--content-stdin`",
-					"<<'COMMENT'",
-					"--parent " + triggerID + " --content-stdin",
 					"--parent " + triggerID + " --content-file",
+					"--content \"...\"",
 				} {
 					if strings.Contains(got, banned) {
-						t.Errorf("%s reply instructions still steers at codex template: %q\n---\n%s", name, banned, got)
+						t.Errorf("%s reply instructions should not contain %q\n---\n%s", name, banned, got)
 					}
 				}
 			})

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -23,7 +23,7 @@ var runtimeGOOS = runtime.GOOS
 //
 // CR/LF and other whitespace control bytes collapse to a single space; other
 // C0 controls and DEL are dropped; markdown structural characters that have
-// meaning in inline context (`*`, `_`, `` ` ``, `\`, `[`, `]`, `<`) are
+// meaning in inline context (`*`, `_`, “ ` “, `\`, `[`, `]`, `<`) are
 // backslash-escaped. Trailing whitespace is trimmed.
 func sanitizeNameForBriefMarkdown(name string) string {
 	var b strings.Builder
@@ -357,9 +357,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "4. Run `multica issue status %s in_progress`\n", ctx.IssueID)
 		b.WriteString("5. Follow your Skills and Agent Identity to complete the task (write code, investigate, etc.)\n")
 		if ctx.IsSquadLeader {
-			fmt.Fprintf(&b, "6. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity %s no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently): `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID, ctx.IssueID)
+			fmt.Fprintf(&b, "6. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity %s no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently). Use `multica issue comment add %s --content-file ./reply.md` or `--content-stdin` with `<<'EOF'`; never use inline `--content` for agent-authored comments. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID, ctx.IssueID)
 		} else {
-			fmt.Fprintf(&b, "6. **Post your final results as a comment — this step is mandatory**: `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
+			fmt.Fprintf(&b, "6. **Post your final results as a comment — this step is mandatory**. Use `multica issue comment add %s --content-file ./reply.md` or `--content-stdin` with `<<'EOF'`; never use inline `--content` for agent-authored comments. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
 		}
 		b.WriteString("7. Before exiting: only if this run produced a fact that clears the high bar (important AND likely to be re-read by future runs on this same issue, e.g. a new PR URL or deploy URL), or you noticed a metadata key from entry that is now stale, pin or clear it via `multica issue metadata set`/`delete`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write. See the `## Issue Metadata` section above for the full bar.\n")
 		fmt.Fprintf(&b, "8. When done, run `multica issue status %s in_review`\n", ctx.IssueID)


### PR DESCRIPTION
Refs #3047

## Summary
- Remove inline `--content "..."` examples from daemon agent-authored comment instructions.
- Use `--content-file` on Windows to avoid PowerShell/cmd pipe encoding loss.
- Use `--content-stdin` with a single-quoted HEREDOC on Linux/macOS so shells do not expand `$()`, variables, quotes, or code snippets before `multica` receives the body.
- Update assignment-triggered final-result guidance to point at `--content-file` / HEREDOC instead of inline content.

## Problem solved
Agent-authored comments can contain shell-sensitive text. Inline `--content "..."` lets the shell interpret parts of the comment body before the CLI receives it, which can corrupt comments or execute unintended substitutions.

## Validation
- `go test ./internal/daemon/execenv -run 'TestBuildCommentReplyInstructions|TestInjectRuntimeConfigCommentTriggerUsesHelper|TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin|TestInjectRuntimeConfigRequiresExplicitCommentPost|TestInjectRuntimeConfigAvailableCommandsIsNeutral|TestInjectRuntimeConfigCodexLinuxEmphasizesStdin|TestInjectRuntimeConfigCodexWindowsUsesContentFile'`
