### PR TITLE
[codex] Add queue gap alerts for active issues

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2266,6 +2266,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// fails best-effort.
 	if statusChanged {
 		h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
+		h.notifyQueueGapAfterStatusChange(r.Context(), prevIssue, issue)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -2687,6 +2688,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		// (MUL-2538). Best-effort; failure does not abort the batch.
 		if statusChanged {
 			h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
+			h.notifyQueueGapAfterStatusChange(r.Context(), prevIssue, issue)
 		}
 
 		updated++

--- a/server/internal/handler/issue_queue_gap.go
+++ b/server/internal/handler/issue_queue_gap.go
@@ -1,0 +1,329 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/issueguard"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const queueGapInboxType = "queue_gap"
+
+func (h *Handler) notifyQueueGapAfterStatusChange(ctx context.Context, prev, issue db.Issue) {
+	h.notifyParentQueueGap(ctx, prev, issue)
+	h.notifyProjectQueueGap(ctx, prev, issue)
+}
+
+func (h *Handler) notifyParentQueueGap(ctx context.Context, prev, issue db.Issue) {
+	if !issue.ParentIssueID.Valid {
+		return
+	}
+
+	parent, err := h.Queries.GetIssue(ctx, issue.ParentIssueID)
+	if err != nil {
+		slog.Warn("queue gap: failed to load parent",
+			"error", err,
+			"child_id", uuidToString(issue.ID),
+			"parent_id", uuidToString(issue.ParentIssueID))
+		return
+	}
+
+	children, err := h.Queries.ListChildIssues(ctx, issue.ParentIssueID)
+	if err != nil {
+		slog.Warn("queue gap: failed to list child issues",
+			"error", err,
+			"parent_id", uuidToString(issue.ParentIssueID))
+		return
+	}
+	childStates := make([]issueguard.QueueGapChildState, 0, len(children))
+	for _, child := range children {
+		childStates = append(childStates, issueguard.QueueGapChildState{Status: child.Status, Metadata: child.Metadata})
+	}
+
+	if !issueguard.ShouldEmitParentQueueGap(prev.Status, issue.Status, parent.Status, parent.Metadata, childStates) {
+		return
+	}
+	if h.hasOpenQueueGapInbox(ctx, parent.ID) {
+		return
+	}
+
+	h.createQueueGapSystemComment(ctx, parent, issue)
+	h.createQueueGapInboxItems(ctx, parent, issue, "parent_issue", h.queueGapRecipientsForIssue(ctx, parent))
+}
+
+func (h *Handler) notifyProjectQueueGap(ctx context.Context, prev, issue db.Issue) {
+	if issue.ParentIssueID.Valid || !issue.ProjectID.Valid {
+		return
+	}
+	if prev.Status != "todo" && prev.Status != "in_progress" {
+		return
+	}
+	if issue.Status != "in_review" {
+		return
+	}
+
+	project, err := h.Queries.GetProject(ctx, issue.ProjectID)
+	if err != nil {
+		slog.Warn("queue gap: failed to load project",
+			"error", err,
+			"issue_id", uuidToString(issue.ID),
+			"project_id", uuidToString(issue.ProjectID))
+		return
+	}
+	if project.Status != "in_progress" {
+		return
+	}
+	if h.projectHasAssignedActiveIssue(ctx, issue.ProjectID) || h.projectHasExplicitWait(ctx, issue.ProjectID) {
+		return
+	}
+	if h.hasOpenQueueGapInbox(ctx, issue.ID) {
+		return
+	}
+
+	h.createQueueGapInboxItems(ctx, issue, issue, "project", h.queueGapRecipientsForProject(ctx, project, issue))
+}
+
+func (h *Handler) createQueueGapSystemComment(ctx context.Context, parent, trigger db.Issue) {
+	content := "Queue gap detected: this parent issue is still `in_progress`, but its sub-issues now have no `todo` or `in_progress` work. Choose one next action: create or promote the next `todo`; mark the parent `blocked` and set `waiting_on` / `blocked_reason`; or close it as `done`/`cancelled`."
+
+	comment, err := h.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     parent.ID,
+		WorkspaceID: parent.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    pgtype.UUID{Valid: false},
+	})
+	if err != nil {
+		slog.Warn("queue gap: create system comment failed",
+			"error", err,
+			"parent_id", uuidToString(parent.ID),
+			"trigger_issue_id", uuidToString(trigger.ID))
+		return
+	}
+
+	h.publish(protocol.EventCommentCreated, uuidToString(parent.WorkspaceID), "system", "", map[string]any{
+		"comment":             commentToResponse(comment, nil, nil),
+		"issue_title":         parent.Title,
+		"issue_assignee_type": textToPtr(parent.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(parent.AssigneeID),
+		"issue_status":        parent.Status,
+	})
+}
+
+func (h *Handler) createQueueGapInboxItems(ctx context.Context, target, trigger db.Issue, scope string, recipients []pgtype.UUID) {
+	if len(recipients) == 0 {
+		return
+	}
+
+	targetID := uuidToString(target.ID)
+	triggerID := uuidToString(trigger.ID)
+	body := "No runnable work remains for this active scope. Choose one: create/promote the next `todo`; mark it `blocked` with `waiting_on` / `blocked_reason`; or close it as `done`/`cancelled`."
+	details, _ := json.Marshal(map[string]any{
+		"reason":           "queue_gap",
+		"scope":            scope,
+		"target_issue_id":  targetID,
+		"trigger_issue_id": triggerID,
+		"required_actions": []string{
+			"create_or_promote_next_todo",
+			"mark_blocked_with_waiting_on_or_blocked_reason",
+			"close_as_done_or_cancelled",
+		},
+	})
+
+	title := "Queue needs a next step: " + target.Title
+	workspaceID := uuidToString(target.WorkspaceID)
+	for _, recipientID := range recipients {
+		item, err := h.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+			WorkspaceID:   target.WorkspaceID,
+			RecipientType: "member",
+			RecipientID:   recipientID,
+			Type:          queueGapInboxType,
+			Severity:      "action_required",
+			IssueID:       target.ID,
+			Title:         title,
+			Body:          strToText(body),
+			ActorType:     strToText("system"),
+			ActorID:       pgtype.UUID{},
+			Details:       details,
+		})
+		if err != nil {
+			slog.Warn("queue gap: inbox write failed",
+				"target_issue_id", targetID,
+				"recipient_id", uuidToString(recipientID),
+				"error", err)
+			continue
+		}
+
+		h.publish(protocol.EventInboxNew, workspaceID, "system", "", map[string]any{
+			"item": queueGapInboxPayload(item, target.Status),
+		})
+	}
+}
+
+func queueGapInboxPayload(item db.InboxItem, issueStatus string) map[string]any {
+	return map[string]any{
+		"id":             uuidToString(item.ID),
+		"workspace_id":   uuidToString(item.WorkspaceID),
+		"recipient_type": item.RecipientType,
+		"recipient_id":   uuidToString(item.RecipientID),
+		"type":           item.Type,
+		"severity":       item.Severity,
+		"issue_id":       uuidToPtr(item.IssueID),
+		"title":          item.Title,
+		"body":           textToPtr(item.Body),
+		"read":           item.Read,
+		"archived":       item.Archived,
+		"created_at":     timestampToString(item.CreatedAt),
+		"actor_type":     textToPtr(item.ActorType),
+		"actor_id":       uuidToPtr(item.ActorID),
+		"details":        json.RawMessage(item.Details),
+		"issue_status":   issueStatus,
+	}
+}
+
+func (h *Handler) queueGapRecipientsForIssue(ctx context.Context, issue db.Issue) []pgtype.UUID {
+	recipients := map[string]pgtype.UUID{}
+	h.addQueueGapActorRecipients(ctx, issue.WorkspaceID, issue.AssigneeType, issue.AssigneeID, recipients)
+	h.addQueueGapActorRecipients(ctx, issue.WorkspaceID, pgtype.Text{String: issue.CreatorType, Valid: true}, issue.CreatorID, recipients)
+
+	if issue.ProjectID.Valid {
+		if project, err := h.Queries.GetProject(ctx, issue.ProjectID); err == nil {
+			h.addQueueGapActorRecipients(ctx, issue.WorkspaceID, project.LeadType, project.LeadID, recipients)
+		}
+	}
+
+	subs, err := h.Queries.ListIssueSubscribers(ctx, issue.ID)
+	if err == nil {
+		for _, sub := range subs {
+			if sub.UserType == "member" {
+				recipients[uuidToString(sub.UserID)] = sub.UserID
+			}
+		}
+	}
+	return queueGapRecipientList(recipients)
+}
+
+func (h *Handler) queueGapRecipientsForProject(ctx context.Context, project db.Project, trigger db.Issue) []pgtype.UUID {
+	recipients := map[string]pgtype.UUID{}
+	h.addQueueGapActorRecipients(ctx, project.WorkspaceID, project.LeadType, project.LeadID, recipients)
+	h.addQueueGapActorRecipients(ctx, trigger.WorkspaceID, trigger.AssigneeType, trigger.AssigneeID, recipients)
+	h.addQueueGapActorRecipients(ctx, trigger.WorkspaceID, pgtype.Text{String: trigger.CreatorType, Valid: true}, trigger.CreatorID, recipients)
+	return queueGapRecipientList(recipients)
+}
+
+func queueGapRecipientList(recipients map[string]pgtype.UUID) []pgtype.UUID {
+	result := make([]pgtype.UUID, 0, len(recipients))
+	for _, id := range recipients {
+		result = append(result, id)
+	}
+	return result
+}
+
+func (h *Handler) addQueueGapActorRecipients(ctx context.Context, workspaceID pgtype.UUID, actorType pgtype.Text, actorID pgtype.UUID, recipients map[string]pgtype.UUID) {
+	if !actorType.Valid || !actorID.Valid {
+		return
+	}
+
+	switch actorType.String {
+	case "member":
+		recipients[uuidToString(actorID)] = actorID
+	case "agent":
+		h.addQueueGapAgentOwner(ctx, workspaceID, actorID, recipients)
+	case "squad":
+		squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+			ID:          actorID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			return
+		}
+		h.addQueueGapAgentOwner(ctx, workspaceID, squad.LeaderID, recipients)
+		members, err := h.Queries.ListSquadMembers(ctx, squad.ID)
+		if err != nil {
+			return
+		}
+		for _, member := range members {
+			if member.MemberType == "member" {
+				recipients[uuidToString(member.MemberID)] = member.MemberID
+			}
+			if member.MemberType == "agent" {
+				h.addQueueGapAgentOwner(ctx, workspaceID, member.MemberID, recipients)
+			}
+		}
+	}
+}
+
+func (h *Handler) addQueueGapAgentOwner(ctx context.Context, workspaceID, agentID pgtype.UUID, recipients map[string]pgtype.UUID) {
+	agent, err := h.Queries.GetAgent(ctx, agentID)
+	if err != nil || !agent.OwnerID.Valid {
+		return
+	}
+	if _, err := h.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+		UserID:      agent.OwnerID,
+		WorkspaceID: workspaceID,
+	}); err != nil {
+		return
+	}
+	recipients[uuidToString(agent.OwnerID)] = agent.OwnerID
+}
+
+func (h *Handler) hasOpenQueueGapInbox(ctx context.Context, issueID pgtype.UUID) bool {
+	var exists bool
+	if err := h.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM inbox_item
+			 WHERE issue_id = $1
+			   AND type = $2
+			   AND archived = false
+		)
+	`, issueID, queueGapInboxType).Scan(&exists); err != nil {
+		slog.Warn("queue gap: failed to check existing inbox", "issue_id", uuidToString(issueID), "error", err)
+		return false
+	}
+	return exists
+}
+
+func (h *Handler) projectHasAssignedActiveIssue(ctx context.Context, projectID pgtype.UUID) bool {
+	var exists bool
+	if err := h.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM issue
+			 WHERE project_id = $1
+			   AND status IN ('todo', 'in_progress')
+			   AND assignee_id IS NOT NULL
+		)
+	`, projectID).Scan(&exists); err != nil {
+		slog.Warn("queue gap: failed to check active project issues", "project_id", uuidToString(projectID), "error", err)
+		return true
+	}
+	return exists
+}
+
+func (h *Handler) projectHasExplicitWait(ctx context.Context, projectID pgtype.UUID) bool {
+	var exists bool
+	if err := h.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM issue
+			 WHERE project_id = $1
+			   AND status NOT IN ('done', 'cancelled')
+			   AND (
+			    status = 'blocked'
+			    OR metadata ? 'waiting_on'
+			    OR metadata ? 'blocked_reason'
+			   )
+		)
+	`, projectID).Scan(&exists); err != nil {
+		slog.Warn("queue gap: failed to check project waits", "project_id", uuidToString(projectID), "error", err)
+		return true
+	}
+	return exists
+}

--- a/server/internal/handler/issue_queue_gap.go
+++ b/server/internal/handler/issue_queue_gap.go
@@ -77,7 +77,7 @@ func (h *Handler) notifyProjectQueueGap(ctx context.Context, prev, issue db.Issu
 	if project.Status != "in_progress" {
 		return
 	}
-	if h.projectHasAssignedActiveIssue(ctx, issue.ProjectID) || h.projectHasExplicitWait(ctx, issue.ProjectID) {
+	if h.projectHasActiveIssue(ctx, issue.ProjectID) || h.projectHasExplicitWait(ctx, issue.ProjectID) {
 		return
 	}
 	if h.hasOpenQueueGapInbox(ctx, issue.ID) {
@@ -290,7 +290,7 @@ func (h *Handler) hasOpenQueueGapInbox(ctx context.Context, issueID pgtype.UUID)
 	return exists
 }
 
-func (h *Handler) projectHasAssignedActiveIssue(ctx context.Context, projectID pgtype.UUID) bool {
+func (h *Handler) projectHasActiveIssue(ctx context.Context, projectID pgtype.UUID) bool {
 	var exists bool
 	if err := h.DB.QueryRow(ctx, `
 		SELECT EXISTS (
@@ -298,7 +298,6 @@ func (h *Handler) projectHasAssignedActiveIssue(ctx context.Context, projectID p
 			  FROM issue
 			 WHERE project_id = $1
 			   AND status IN ('todo', 'in_progress')
-			   AND assignee_id IS NOT NULL
 		)
 	`, projectID).Scan(&exists); err != nil {
 		slog.Warn("queue gap: failed to check active project issues", "project_id", uuidToString(projectID), "error", err)

--- a/server/internal/handler/issue_queue_gap_test.go
+++ b/server/internal/handler/issue_queue_gap_test.go
@@ -1,0 +1,190 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type queueGapFixture struct {
+	parent IssueResponse
+	childA IssueResponse
+	childB IssueResponse
+}
+
+func newQueueGapFixture(t *testing.T, parentMetadata string) queueGapFixture {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "queue-gap parent " + time.Now().Format(time.RFC3339Nano),
+		"status":        "in_progress",
+		"assignee_type": "member",
+		"assignee_id":   testUserID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create parent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var parent IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&parent); err != nil {
+		t.Fatalf("decode parent: %v", err)
+	}
+
+	if parentMetadata != "" {
+		if _, err := testPool.Exec(context.Background(), `UPDATE issue SET metadata = $2::jsonb WHERE id = $1`, parent.ID, parentMetadata); err != nil {
+			t.Fatalf("set parent metadata: %v", err)
+		}
+	}
+
+	childA := createQueueGapChild(t, parent.ID, "in_review")
+	childB := createQueueGapChild(t, parent.ID, "in_progress")
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		testPool.Exec(ctx, `DELETE FROM inbox_item WHERE issue_id = $1`, parent.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, childA.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, childB.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, parent.ID)
+	})
+
+	return queueGapFixture{parent: parent, childA: childA, childB: childB}
+}
+
+func createQueueGapChild(t *testing.T, parentID, status string) IssueResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":           "queue-gap child " + status + " " + time.Now().Format(time.RFC3339Nano),
+		"status":          status,
+		"parent_issue_id": parentID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create child status=%q: expected 201, got %d: %s", status, w.Code, w.Body.String())
+	}
+	var child IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&child); err != nil {
+		t.Fatalf("decode child: %v", err)
+	}
+	return child
+}
+
+func queueGapInboxItemsOn(t *testing.T, issueID string) []struct {
+	Type     string
+	Severity string
+	Details  []byte
+} {
+	t.Helper()
+
+	rows, err := testPool.Query(context.Background(), `
+		SELECT type, severity, details
+		  FROM inbox_item
+		 WHERE issue_id = $1
+		   AND type = 'queue_gap'
+		 ORDER BY created_at ASC
+	`, issueID)
+	if err != nil {
+		t.Fatalf("query queue-gap inbox items: %v", err)
+	}
+	defer rows.Close()
+
+	var items []struct {
+		Type     string
+		Severity string
+		Details  []byte
+	}
+	for rows.Next() {
+		var item struct {
+			Type     string
+			Severity string
+			Details  []byte
+		}
+		if err := rows.Scan(&item.Type, &item.Severity, &item.Details); err != nil {
+			t.Fatalf("scan queue-gap inbox item: %v", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate queue-gap inbox items: %v", err)
+	}
+	return items
+}
+
+func TestQueueGapAlertWhenLastActiveChildReturnsToReview(t *testing.T) {
+	fx := newQueueGapFixture(t, "")
+
+	updateChildStatus(t, fx.childB.ID, "in_review")
+
+	items := queueGapInboxItemsOn(t, fx.parent.ID)
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 queue_gap inbox item on parent, got %d", len(items))
+	}
+	if items[0].Severity != "action_required" {
+		t.Fatalf("expected queue_gap severity action_required, got %q", items[0].Severity)
+	}
+
+	var details map[string]any
+	if err := json.Unmarshal(items[0].Details, &details); err != nil {
+		t.Fatalf("decode queue_gap details: %v", err)
+	}
+	if details["scope"] != "parent_issue" {
+		t.Fatalf("expected parent_issue scope, got %#v", details["scope"])
+	}
+	if details["trigger_issue_id"] != fx.childB.ID {
+		t.Fatalf("expected trigger_issue_id %q, got %#v", fx.childB.ID, details["trigger_issue_id"])
+	}
+
+	content, _, parentNull, typeStr := systemCommentOn(t, fx.parent.ID)
+	if !parentNull {
+		t.Errorf("queue-gap system comment must be top-level")
+	}
+	if typeStr != "system" {
+		t.Errorf("queue-gap comment type should be system, got %q", typeStr)
+	}
+	for _, want := range []string{"Queue gap detected", "`todo`", "`blocked`", "`done`/`cancelled`"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("queue-gap comment should contain %q, got: %s", want, content)
+		}
+	}
+	for _, banned := range []string{"mention://agent/", "mention://member/", "mention://squad/"} {
+		if strings.Contains(content, banned) {
+			t.Errorf("queue-gap comment must not include %q mention side effect, got: %s", banned, content)
+		}
+	}
+}
+
+func TestQueueGapAlertSkippedWhenAnotherChildStillActive(t *testing.T) {
+	fx := newQueueGapFixture(t, "")
+	childC := createQueueGapChild(t, fx.parent.ID, "todo")
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, childC.ID)
+	})
+
+	updateChildStatus(t, fx.childB.ID, "in_review")
+
+	if got := len(queueGapInboxItemsOn(t, fx.parent.ID)); got != 0 {
+		t.Fatalf("expected no queue_gap inbox while another child is todo, got %d", got)
+	}
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+		t.Fatalf("expected no queue_gap system comment while another child is todo, got %d", got)
+	}
+}
+
+func TestQueueGapAlertSkippedWhenParentHasWaitingMetadata(t *testing.T) {
+	fx := newQueueGapFixture(t, `{"waiting_on":"human publish authorization"}`)
+
+	updateChildStatus(t, fx.childB.ID, "in_review")
+
+	if got := len(queueGapInboxItemsOn(t, fx.parent.ID)); got != 0 {
+		t.Fatalf("expected no queue_gap inbox while parent is explicitly waiting, got %d", got)
+	}
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+		t.Fatalf("expected no queue_gap system comment while parent is explicitly waiting, got %d", got)
+	}
+}

--- a/server/internal/handler/issue_queue_gap_test.go
+++ b/server/internal/handler/issue_queue_gap_test.go
@@ -75,6 +75,58 @@ func createQueueGapChild(t *testing.T, parentID, status string) IssueResponse {
 	return child
 }
 
+func createQueueGapProject(t *testing.T) ProjectResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title":     "queue-gap project " + time.Now().Format(time.RFC3339Nano),
+		"status":    "in_progress",
+		"lead_type": "member",
+		"lead_id":   testUserID,
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create project: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode project: %v", err)
+	}
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		testPool.Exec(ctx, `DELETE FROM inbox_item WHERE issue_id IN (SELECT id FROM issue WHERE project_id = $1)`, project.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE project_id = $1`, project.ID)
+		testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, project.ID)
+	})
+
+	return project
+}
+
+func createQueueGapProjectIssue(t *testing.T, projectID, status string) IssueResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":      "queue-gap project issue " + status + " " + time.Now().Format(time.RFC3339Nano),
+		"status":     status,
+		"project_id": projectID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create project issue status=%q: expected 201, got %d: %s", status, w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
+		t.Fatalf("decode project issue: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `UPDATE issue SET assignee_type = NULL, assignee_id = NULL WHERE id = $1`, issue.ID); err != nil {
+		t.Fatalf("clear project issue assignee: %v", err)
+	}
+	return issue
+}
+
 func queueGapInboxItemsOn(t *testing.T, issueID string) []struct {
 	Type     string
 	Severity string
@@ -186,5 +238,47 @@ func TestQueueGapAlertSkippedWhenParentHasWaitingMetadata(t *testing.T) {
 	}
 	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
 		t.Fatalf("expected no queue_gap system comment while parent is explicitly waiting, got %d", got)
+	}
+}
+
+func TestProjectQueueGapAlertWhenLastRootIssueReturnsToReview(t *testing.T) {
+	project := createQueueGapProject(t)
+	trigger := createQueueGapProjectIssue(t, project.ID, "in_progress")
+
+	updateChildStatus(t, trigger.ID, "in_review")
+
+	items := queueGapInboxItemsOn(t, trigger.ID)
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 project queue_gap inbox item on trigger issue, got %d", len(items))
+	}
+
+	var details map[string]any
+	if err := json.Unmarshal(items[0].Details, &details); err != nil {
+		t.Fatalf("decode queue_gap details: %v", err)
+	}
+	if details["scope"] != "project" {
+		t.Fatalf("expected project scope, got %#v", details["scope"])
+	}
+	if details["target_issue_id"] != trigger.ID {
+		t.Fatalf("expected target_issue_id %q, got %#v", trigger.ID, details["target_issue_id"])
+	}
+}
+
+func TestProjectQueueGapAlertSkippedWhenUnassignedRootIssueStillActive(t *testing.T) {
+	for _, activeStatus := range []string{"todo", "in_progress"} {
+		t.Run(activeStatus, func(t *testing.T) {
+			project := createQueueGapProject(t)
+			trigger := createQueueGapProjectIssue(t, project.ID, "in_progress")
+			active := createQueueGapProjectIssue(t, project.ID, activeStatus)
+
+			updateChildStatus(t, trigger.ID, "in_review")
+
+			if got := len(queueGapInboxItemsOn(t, trigger.ID)); got != 0 {
+				t.Fatalf("expected no project queue_gap while unassigned %s issue remains active, got %d", activeStatus, got)
+			}
+			if got := len(queueGapInboxItemsOn(t, active.ID)); got != 0 {
+				t.Fatalf("expected no queue_gap inbox on the unassigned active issue, got %d", got)
+			}
+		})
 	}
 }

--- a/server/internal/issueguard/queue_gap.go
+++ b/server/internal/issueguard/queue_gap.go
@@ -1,0 +1,54 @@
+package issueguard
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type QueueGapChildState struct {
+	Status   string
+	Metadata []byte
+}
+
+func ShouldEmitParentQueueGap(prevStatus, nextStatus, parentStatus string, parentMetadata []byte, children []QueueGapChildState) bool {
+	if prevStatus != "todo" && prevStatus != "in_progress" {
+		return false
+	}
+	if nextStatus != "in_review" {
+		return false
+	}
+	if parentStatus != "in_progress" || len(children) == 0 {
+		return false
+	}
+	if HasExplicitWait(parentMetadata) {
+		return false
+	}
+	for _, child := range children {
+		switch child.Status {
+		case "todo", "in_progress":
+			return false
+		case "blocked":
+			return false
+		}
+		if HasExplicitWait(child.Metadata) {
+			return false
+		}
+	}
+	return true
+}
+
+func HasExplicitWait(metadata []byte) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	var values map[string]any
+	if err := json.Unmarshal(metadata, &values); err != nil {
+		return false
+	}
+	for _, key := range []string{"waiting_on", "blocked_reason"} {
+		if v, ok := values[key]; ok && fmt.Sprint(v) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/issueguard/queue_gap_test.go
+++ b/server/internal/issueguard/queue_gap_test.go
@@ -1,0 +1,46 @@
+package issueguard
+
+import "testing"
+
+func TestShouldEmitParentQueueGapForAI44Shape(t *testing.T) {
+	children := []QueueGapChildState{
+		{Status: "in_review"},
+		{Status: "in_review"},
+		{Status: "done"},
+	}
+
+	if !ShouldEmitParentQueueGap("in_progress", "in_review", "in_progress", []byte(`{}`), children) {
+		t.Fatal("expected queue gap when active parent has no todo/in_progress children after child returns to review")
+	}
+}
+
+func TestShouldEmitParentQueueGapRequiresLastActiveChild(t *testing.T) {
+	children := []QueueGapChildState{
+		{Status: "in_review"},
+		{Status: "todo"},
+	}
+
+	if ShouldEmitParentQueueGap("in_progress", "in_review", "in_progress", []byte(`{}`), children) {
+		t.Fatal("expected no queue gap while another child remains todo")
+	}
+}
+
+func TestShouldEmitParentQueueGapTreatsWaitingMetadataAsExplicitWait(t *testing.T) {
+	children := []QueueGapChildState{
+		{Status: "in_review"},
+	}
+
+	if ShouldEmitParentQueueGap("in_progress", "in_review", "in_progress", []byte(`{"waiting_on":"owner approval"}`), children) {
+		t.Fatal("expected no queue gap when parent metadata already explains what it is waiting on")
+	}
+}
+
+func TestShouldEmitParentQueueGapDoesNotFireForBlockedTransition(t *testing.T) {
+	children := []QueueGapChildState{
+		{Status: "blocked"},
+	}
+
+	if ShouldEmitParentQueueGap("in_progress", "blocked", "in_progress", []byte(`{}`), children) {
+		t.Fatal("expected no queue gap when the child explicitly moved to blocked")
+	}
+}


### PR DESCRIPTION
## Reproduction

- Live AI-44/AI-45 signal: AI-44 is already manually/unblocker-filled again with AI-56 in progress, but its prior shape was the gap this fixes: the parent/project stayed `in_progress` while the executable sub-issue queue had fallen to no `todo` / `in_progress` work after AI-55/54/53 moved to `in_review`.
- Regression fixture: an `in_progress` parent has one child already `in_review` and the last active child transitions from `in_progress` to `in_review`. That leaves no runnable child and should produce an action-required queue-gap signal.
- Red signal: before the implementation, the pure queue-gap regression had no predicate/handler to call and failed at compile time with undefined queue-gap symbols. The final pure regression now captures the AI-44-shaped gap without requiring local Postgres.
- Handler integration fixtures in `server/internal/handler/issue_queue_gap_test.go` exercise the actual `UpdateIssue` status-change path; they compile but require the repo's local Postgres test DB to execute.

## Root Cause

Status-change handling only covered the existing child-done parent notification path. There was no aggregate guard after a handoff to `in_review` to detect that an active parent/project still said `in_progress` while no `todo` / `in_progress` executable work remained. That let agents finish review handoffs without creating/promoting the next `todo`, marking the parent blocked/waiting, or closing the parent/project.

## Changes

- Added `issueguard.ShouldEmitParentQueueGap` plus unit coverage for the AI-44 shape, active sibling suppression, explicit waiting metadata, and blocked-transition boundaries.
- Added status-change queue-gap handling after issue updates and batch updates.
- Parent gaps now emit a top-level system comment on the parent plus action-required `queue_gap` inbox items for responsible human recipients.
- Top-level project gaps now emit action-required `queue_gap` inbox items when an `in_progress` project has no assigned active issue left.
- Recipient resolution covers member assignees/creators, agent owners, squad leaders/members, project lead, and parent member subscribers.

## Fix Boundary

- Triggered only by `todo` / `in_progress` -> `in_review`; `done` keeps using the existing child-done parent notification path.
- Suppressed when any sibling/project issue is still `todo` / `in_progress`, any sibling/project issue is `blocked`, or `waiting_on` / `blocked_reason` metadata is already present.
- Does not auto-create issues, change statuses, or add mention links that could retrigger agents or notify humans through comments.
- No schema migration and no CLI surface change; this uses existing comments and inbox items.

## Verification

- PASS: `go test ./internal/issueguard -count=1`
- PASS: `go test ./cmd/multica -run '^$' -count=1`
- COMPILES/SKIPS LOCALLY: `go test ./internal/handler -run 'TestQueueGapAlert' -count=1 -v` skipped because local Postgres on `localhost:5432` was unavailable.
- COMPILES/SKIPS LOCALLY: `go test ./internal/handler -run 'TestChildDoneNotifiesParent|TestChildDoneNotificationIsIdempotent|TestChildReopenAndDoneFiresAgain' -count=1 -v` skipped for the same unavailable Postgres test DB.
- DB bootstrap attempt: `make db-up` failed because the local Docker/OrbStack daemon socket was unavailable.
- FULL SUITE NOT GREEN IN THIS WORKSPACE: `go test ./... -count=1` failed in pre-existing/environment-sensitive areas unrelated to this diff: `server/internal/daemon/repocache` co-author hook expectation, and `server/pkg/agent` initialization timeout tests.
