### PR TITLE
fix(storage): add S3/COS file serving via /uploads proxy v2

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -231,11 +231,16 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		realtime.HandleWebSocket(hub, mc, pr, slugResolver, w, r)
 	})
 
-	// Local file serving (when using local storage)
+	// File serving (local storage or S3/COS proxy)
 	if local, ok := store.(*storage.LocalStorage); ok {
 		r.Get("/uploads/*", func(w http.ResponseWriter, r *http.Request) {
 			file := strings.TrimPrefix(r.URL.Path, "/uploads/")
 			local.ServeFile(w, r, file)
+		})
+	} else if s3, ok := store.(*storage.S3Storage); ok {
+		r.Get("/uploads/*", func(w http.ResponseWriter, r *http.Request) {
+			file := strings.TrimPrefix(r.URL.Path, "/uploads/")
+			s3.ServeFile(w, r, file)
 		})
 	}
 

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
@@ -191,6 +192,56 @@ func (s *S3Storage) DeleteKeys(ctx context.Context, keys []string) {
 	for _, key := range keys {
 		s.Delete(ctx, key)
 	}
+}
+
+// ServeFile proxies a GET /uploads/* request to S3/COS.
+// It extracts the key from the URL path, fetches the object from storage,
+// and streams it to the client with appropriate headers.
+func (s *S3Storage) ServeFile(w http.ResponseWriter, r *http.Request, key string) {
+	if key == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Prevent path traversal - key should not contain ".."
+	if strings.Contains(key, "..") {
+		http.NotFound(w, r)
+		return
+	}
+
+	obj, err := s.client.GetObject(r.Context(), &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		slog.Error("s3 proxy GetObject failed", "key", key, "error", err)
+		http.NotFound(w, r)
+		return
+	}
+	defer obj.Body.Close()
+
+	// Set content-type if provided by S3
+	contentType := ""
+	if obj.ContentType != nil {
+		contentType = *obj.ContentType
+		w.Header().Set("Content-Type", contentType)
+	}
+
+	// Set content-length if known
+	if obj.ContentLength != nil {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", *obj.ContentLength))
+	}
+
+	// Set content-disposition if provided
+	if obj.ContentDisposition != nil {
+		w.Header().Set("Content-Disposition", *obj.ContentDisposition)
+	}
+
+	// Set cache headers - uploads are immutable
+	w.Header().Set("Cache-Control", "max-age=31536000,public")
+
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, obj.Body)
 }
 
 func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,8 +18,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
+// s3Client abstracts *s3.Client for testing.
+type s3Client interface {
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
 type S3Storage struct {
-	client      *s3.Client
+	client      s3Client
 	bucket      string
 	region      string // used to construct virtual-hosted-style public URLs when no CDN/endpoint is set
 	cdnDomain   string // if set, returned URLs use this instead of bucket name
@@ -203,28 +211,32 @@ func (s *S3Storage) ServeFile(w http.ResponseWriter, r *http.Request, key string
 		return
 	}
 
-	// Prevent path traversal - key should not contain ".."
-	if strings.Contains(key, "..") {
-		http.NotFound(w, r)
-		return
-	}
-
 	obj, err := s.client.GetObject(r.Context(), &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			http.NotFound(w, r)
+			return
+		}
 		slog.Error("s3 proxy GetObject failed", "key", key, "error", err)
-		http.NotFound(w, r)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return
 	}
 	defer obj.Body.Close()
 
+	// Handle conditional GET (If-None-Match)
+	if obj.ETag != nil && r.Header.Get("If-None-Match") == *obj.ETag {
+		w.Header().Set("ETag", *obj.ETag)
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
 	// Set content-type if provided by S3
-	contentType := ""
 	if obj.ContentType != nil {
-		contentType = *obj.ContentType
-		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Type", *obj.ContentType)
 	}
 
 	// Set content-length if known
@@ -237,11 +249,20 @@ func (s *S3Storage) ServeFile(w http.ResponseWriter, r *http.Request, key string
 		w.Header().Set("Content-Disposition", *obj.ContentDisposition)
 	}
 
-	// Set cache headers - uploads are immutable
-	w.Header().Set("Cache-Control", "max-age=31536000,public")
+	// Forward ETag for client-side caching
+	if obj.ETag != nil {
+		w.Header().Set("ETag", *obj.ETag)
+	}
+
+	// Set cache headers - uploads are immutable. Using private (not public) since
+	// /uploads/* is an unauthenticated route and uploads may contain semi-sensitive
+	// content like screenshots. Matches the upload-side max-age (5 days).
+	w.Header().Set("Cache-Control", "private, max-age=31536000")
 
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, obj.Body)
+	if _, err := io.Copy(w, obj.Body); err != nil {
+		slog.Warn("s3 proxy io.Copy failed", "key", key, "error", err)
+	}
 }
 
 func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
@@ -256,7 +277,7 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		Body:               bytes.NewReader(data),
 		ContentType:        aws.String(contentType),
 		ContentDisposition: aws.String(fmt.Sprintf(`%s; filename="%s"`, disposition, safe)),
-		CacheControl:       aws.String("max-age=432000,public"),
+		CacheControl:       aws.String("private, max-age=31536000"),
 		StorageClass:       s.storageClass(),
 	})
 	if err != nil {
@@ -266,26 +287,14 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 }
 
 // uploadedURL returns the URL stored for client consumption after an upload.
-// Priority: CDN domain > custom endpoint > AWS S3 region-qualified host. The CDN
-// domain wins even when a custom endpoint is set so S3-compatible backends
-// (MinIO, R2, B2, Wasabi, etc.) can be paired with a separate public-read
-// domain — writes still go through the SDK with the custom endpoint; only the
-// reader-facing URL changes.
-//
-// For the default AWS S3 case, virtual-hosted-style is preferred:
-// https://<bucket>.s3.<region>.amazonaws.com/<key>. When the bucket name
-// contains dots, the AWS-issued wildcard TLS certificate (`*.s3.amazonaws.com`)
-// fails to validate the host, so we fall back to path-style:
-// https://s3.<region>.amazonaws.com/<bucket>/<key>.
+// Priority: CDN domain > relative proxy path. When cdnDomain is set, the full
+// absolute URL is returned so the CDN handles serving. When cdnDomain is empty,
+// a relative /uploads/<key> path is returned so the browser routes through the
+// app's proxy endpoint — this is the same semantics as LocalStorage and is
+// required for the /uploads/* proxy route to be hit.
 func (s *S3Storage) uploadedURL(key string) string {
 	if s.cdnDomain != "" {
 		return fmt.Sprintf("https://%s/%s", s.cdnDomain, key)
 	}
-	if s.endpointURL != "" {
-		return fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
-	}
-	if strings.Contains(s.bucket, ".") {
-		return fmt.Sprintf("https://s3.%s.amazonaws.com/%s/%s", s.region, s.bucket, key)
-	}
-	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", s.bucket, s.region, key)
+	return fmt.Sprintf("/uploads/%s", key)
 }

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -1,6 +1,47 @@
 package storage
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// mockS3Client implements s3Client for testing.
+type mockS3Client struct {
+	getObjectFn   func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	deleteObjectFn func(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	putObjectFn    func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+func (m *mockS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.getObjectFn != nil {
+		return m.getObjectFn(ctx, params, optFns...)
+	}
+	return nil, errors.New("mockS3Client.GetObject not implemented")
+}
+
+func (m *mockS3Client) DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if m.deleteObjectFn != nil {
+		return m.deleteObjectFn(ctx, params, optFns...)
+	}
+	return nil, errors.New("mockS3Client.DeleteObject not implemented")
+}
+
+func (m *mockS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.putObjectFn != nil {
+		return m.putObjectFn(ctx, params, optFns...)
+	}
+	return nil, errors.New("mockS3Client.PutObject not implemented")
+}
 
 func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {
 	s := &S3Storage{
@@ -92,70 +133,229 @@ func TestLooksLikeS3Hostname(t *testing.T) {
 }
 
 func TestS3StorageUploadedURL(t *testing.T) {
-	const key = "uploads/abc/file.png"
+	const key = "abc/file.png"
 
 	cases := []struct {
-		name        string
-		bucket      string
-		region      string
-		cdnDomain   string
-		endpointURL string
-		want        string
+		name      string
+		bucket    string
+		region    string
+		cdnDomain string
+		want      string
 	}{
 		{
-			name:   "default aws virtual hosted style",
+			name:   "no cdn returns relative path",
 			bucket: "test-bucket",
 			region: "us-east-1",
-			want:   "https://test-bucket.s3.us-east-1.amazonaws.com/uploads/abc/file.png",
+			want:   "/uploads/abc/file.png",
 		},
 		{
-			name:   "default aws path style when bucket contains dots",
-			bucket: "bucket.with.dots",
-			region: "us-east-1",
-			want:   "https://s3.us-east-1.amazonaws.com/bucket.with.dots/uploads/abc/file.png",
-		},
-		{
-			name:      "cdn only",
+			name:      "cdn returns absolute url",
 			bucket:    "test-bucket",
 			region:    "us-east-1",
 			cdnDomain: "cdn.example.com",
-			want:      "https://cdn.example.com/uploads/abc/file.png",
-		},
-		{
-			name:        "endpoint only",
-			bucket:      "test-bucket",
-			region:      "us-east-1",
-			endpointURL: "http://localhost:9000",
-			want:        "http://localhost:9000/test-bucket/uploads/abc/file.png",
-		},
-		{
-			name:        "endpoint with trailing slash",
-			bucket:      "test-bucket",
-			region:      "us-east-1",
-			endpointURL: "http://localhost:9000/",
-			want:        "http://localhost:9000/test-bucket/uploads/abc/file.png",
-		},
-		{
-			name:        "endpoint and cdn both set prefers cdn",
-			bucket:      "test-bucket",
-			region:      "us-east-1",
-			cdnDomain:   "cdn.example.com",
-			endpointURL: "http://localhost:9000",
-			want:        "https://cdn.example.com/uploads/abc/file.png",
+			want:      "https://cdn.example.com/abc/file.png",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &S3Storage{
-				bucket:      tc.bucket,
-				region:      tc.region,
-				cdnDomain:   tc.cdnDomain,
-				endpointURL: tc.endpointURL,
+				bucket:    tc.bucket,
+				region:    tc.region,
+				cdnDomain: tc.cdnDomain,
 			}
 			if got := s.uploadedURL(key); got != tc.want {
 				t.Fatalf("uploadedURL() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// mockGetObjectOutput helper to build GetObjectOutput for tests.
+func mockGetObjectOutput(body []byte, opts ...func(*s3.GetObjectOutput)) *s3.GetObjectOutput {
+	out := &s3.GetObjectOutput{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: aws.Int64(int64(len(body))),
+	}
+	for _, opt := range opts {
+		opt(out)
+	}
+	return out
+}
+
+func withContentType(t string) func(*s3.GetObjectOutput) { return func(o *s3.GetObjectOutput) { o.ContentType = aws.String(t) } }
+func withContentDisposition(d string) func(*s3.GetObjectOutput) {
+	return func(o *s3.GetObjectOutput) { o.ContentDisposition = aws.String(d) }
+}
+func withETag(e string) func(*s3.GetObjectOutput)          { return func(o *s3.GetObjectOutput) { o.ETag = aws.String(e) } }
+func withLastModified(l string) func(*s3.GetObjectOutput) {
+	return func(o *s3.GetObjectOutput) {
+		t, _ := time.Parse(time.RFC1123, l)
+		o.LastModified = aws.Time(t)
+	}
+}
+
+func TestS3Storage_ServeFile_EmptyKey(t *testing.T) {
+	s := &S3Storage{bucket: "test-bucket", client: &mockS3Client{}}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestS3Storage_ServeFile_KeyWithDotDot(t *testing.T) {
+	// S3 keys are flat strings; ".." is a legitimate filename component, not a
+	// traversal mechanism. S3 will return NoSuchKey for a key literally named
+	// "../etc/passwd", which should surface as 404.
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return nil, &types.NoSuchKey{}
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/../etc/passwd", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "../etc/passwd")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestS3Storage_ServeFile_HappyPath(t *testing.T) {
+	body := []byte("hello world")
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return mockGetObjectOutput(body,
+					withContentType("text/plain"),
+					withContentDisposition(`attachment; filename="test.txt"`),
+				), nil
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/test.txt", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "test.txt")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/plain" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/plain")
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != "11" {
+		t.Errorf("Content-Length = %q, want %q", cl, "11")
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd != `attachment; filename="test.txt"` {
+		t.Errorf("Content-Disposition = %q, want %q", cd, `attachment; filename="test.txt"`)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "private, max-age=31536000" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "private, max-age=31536000")
+	}
+	if got := rec.Body.Bytes(); !bytes.Equal(got, body) {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+}
+
+func TestS3Storage_ServeFile_GetObjectError(t *testing.T) {
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return nil, errors.New("s3 error")
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/test.txt", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "test.txt")
+	// Non-NoSuchKey errors return 502
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", rec.Code)
+	}
+}
+
+func TestS3Storage_ServeFile_NoSuchKey(t *testing.T) {
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return nil, &types.NoSuchKey{}
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/nonexistent.txt", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "nonexistent.txt")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestS3Storage_ServeFile_NilHeaderFields(t *testing.T) {
+	body := []byte("test")
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return &s3.GetObjectOutput{
+					Body: io.NopCloser(bytes.NewReader(body)),
+					// Content-Type, Content-Length, Content-Disposition all nil
+				}, nil
+			},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/uploads/test.txt", nil)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "test.txt")
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	// Nil header fields should not write empty strings
+	if ct := rec.Header().Get("Content-Type"); ct != "" {
+		t.Errorf("Content-Type = %q, want empty", ct)
+	}
+}
+
+func TestS3Storage_ServeFile_ConditionalGET(t *testing.T) {
+	body := []byte("hello")
+	s := &S3Storage{
+		bucket: "test-bucket",
+		client: &mockS3Client{
+			getObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				return mockGetObjectOutput(body,
+					withETag(`"abc123"`),
+					withLastModified("Wed, 21 Oct 2025 07:28:00 GMT"),
+				), nil
+			},
+		},
+	}
+
+	// Request with If-None-Match matching ETag → 304
+	req := httptest.NewRequest(http.MethodGet, "/uploads/test.txt", nil)
+	req.Header.Set("If-None-Match", `"abc123"`)
+	rec := httptest.NewRecorder()
+	s.ServeFile(rec, req, "test.txt")
+
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want 304", rec.Code)
+	}
+	if etag := rec.Header().Get("ETag"); etag != `"abc123"` {
+		t.Errorf("ETag = %q, want %q", etag, `"abc123"`)
+	}
+
+	// Request without If-None-Match → 200
+	req2 := httptest.NewRequest(http.MethodGet, "/uploads/test.txt", nil)
+	rec2 := httptest.NewRecorder()
+	s.ServeFile(rec2, req2, "test.txt")
+
+	if rec2.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec2.Code)
 	}
 }


### PR DESCRIPTION
fix: https://github.com/multica-ai/multica/pull/2740
 
What does this PR do?
  
  This PR adds S3/COS file serving via the /uploads/* proxy route and fixes critical issues that made the proxy route non-functional.

  Problem solved: When using S3/COS storage without a CDN domain, uploadedURL() previously returned absolute S3 URLs (e.g.,
  https://bucket.s3.region.amazonaws.com/key), but the browser never actually reached those URLs because the app's file serving was configured
  to proxy /uploads/* requests. This made all uploaded files (profile pictures, screenshots, etc.) unreachable.

  The fix:
  1. uploadedURL() now returns a relative /uploads/<key> path when no CDN domain is configured, matching the LocalStorage semantics and
  ensuring the browser hits the proxy route.
  2. ServeFile method was added to S3Storage to handle GET requests by streaming files from S3/COS with appropriate headers.
  3. Router was updated to mount the S3 ServeFile handler alongside the existing local storage handler.

  Additional improvements:
  - Unified cache-control strategy (private,max-age=31536000) for both upload and serve paths
  - Proper error differentiation: NoSuchKey → 404, other errors → 502 Bad Gateway (helps self-hosted operators debug IAM/network issues)
  - ETag forwarding and 304 Not Modified conditional GET support to save origin fetches on cache hits
  - io.Copy error logging for mid-stream S3 disconnects
  - Removed meaningless path traversal check (strings.Contains(key, "..")) since S3 keys are flat strings

  ---
  Related Issue

  Closes #1004

  ---
  Type of Change

  - Bug fix (non-breaking change that fixes an issue)
  - New feature (non-breaking change that adds functionality)
  - Refactor / code improvement (no behavior change)
  - Documentation update
  - Tests (adding or improving test coverage)
  - CI / infrastructure

  ---
  Changes Made

  - server/cmd/server/router.go — Added S3 storage branch to /uploads/* route alongside existing local storage handler
  - server/internal/storage/s3.go — Added ServeFile method; refactored uploadedURL to return relative path when no CDN; updated error handling,
   cache headers, ETag support; added s3Client interface for testability
  - server/internal/storage/s3_test.go — Added mockS3Client, comprehensive ServeFile tests (empty key, NoSuchKey, non-NoSuchKey errors, happy
  path headers, nil field handling, conditional GET 304)

  ---
  How to Test

  1. Local storage proxy (existing behavior):
    - Deploy with S3_BUCKET / CLOUDFRONT_DOMAIN unset
    - Upload a workspace profile picture
    - Verify the image loads correctly (no 404)
  2. S3 storage proxy (new behavior):
    - Configure S3_BUCKET, S3_REGION, and optionally S3_ENDPOINT (for COS/MinIO)
    - Upload a file
    - Verify uploadedURL() returns /uploads/<key> when no CDN is set
    - Navigate to the URL directly — should return 200 with correct Content-Type/Length/Disposition/Cache-Control headers
  3. CDN mode:
    - Set CLOUDFRONT_DOMAIN (or equivalent CDN domain env var)
    - Verify uploadedURL() returns the absolute CDN URL instead
  4. Error handling:
    - Upload a file to S3, then delete it externally
    - Request the URL → should return 404 (NoSuchKey)
    - Temporarily misconfigure IAM permissions
    - Request the URL → should return 502 Bad Gateway (not silent 404)
  5. Conditional GET:
    - Upload a file and note the ETag response header
    - Re-request with If-None-Match: <ETag> header
    - Should receive 304 Not Modified

  ---
  Checklist

  - I have included a thinking path that traces from project context to this change
  - I have run tests locally and they pass
  - I have added or updated tests where applicable
  - If this change affects the UI, I have included before/after screenshots
  - I have updated relevant documentation to reflect my changes
  - If I added a new runtime / coding tool / UI tab, I synced the change to landing copy (apps/web/features/landing/i18n/) and relevant docs
  (apps/docs/content/docs/)
  - If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (terminology, mixed-rule
   for task / issue / skill)
  - I have considered and documented any risks above
  - I will address all reviewer comments before requesting merge

  ---
  AI Disclosure

  AI tool used: Claude Code

  Prompt / approach:
  Reviewed git commits 60b07025 (feat) and 016a74e1 (fix) to understand the S3 proxy implementation. Analyzed the full diffs including code
  changes, test additions, and error handling improvements. Traced the root cause from issue #1004 through the solution.

  ---
  Screenshots (optional)

  N/A — backend-only storage layer changes.

  ---这个 PR 做了什么？

  本 PR 添加了通过 /uploads/* 代理路由对 S3/COS 文件的服务功能，并修复了导致代理路由无法工作的关键问题。

  解决的问题： 当使用 S3/COS 存储且未配置 CDN 域名时，uploadedURL() 之前返回的是绝对 S3 URL（例如
  https://bucket.s3.region.amazonaws.com/key），但浏览器实际上从未访问到这些 URL，因为应用的文件服务配置是代理 /uploads/*
  请求的。这导致所有上传的文件（头像、截图等）都无法访问。

  修复方案：
  1. uploadedURL() 现在在未配置 CDN 域名时返回相对路径 /uploads/<key>，与 LocalStorage 的语义保持一致，确保浏览器能够命中代理路由。
  2. 为 S3Storage 添加了 ServeFile 方法，通过流式传输从 S3/COS 获取文件并设置适当的响应头。
  3. 路由已更新为同时挂载 S3 ServeFile 处理器和现有的本地存储处理器。

  其他改进：
  - 统一的缓存控制策略（private,max-age=31536000）用于上传和服务路径
  - 正确的错误区分：NoSuchKey → 404，其他错误 → 502 Bad Gateway（帮助自托管运营商调试 IAM/网络问题）
  - ETag 转发和 304 Not Modified 条件 GET 支持，在缓存命中时节省源站请求
  - io.Copy 错误日志记录，用于捕获传输过程中的 S3 断开连接
  - 移除了无意义的路径遍历检查（strings.Contains(key, "..")），因为 S3 key 是扁平字符串

  ---
  相关 Issue
  
  Closes #1004

  ---
  变更类型

  - Bug 修复（修复问题的非破坏性变更）
  - 新功能（添加功能的非破坏性变更）
  - 重构/代码改进（无行为变更）
  - 文档更新
  - 测试（添加或改进测试覆盖）
  - CI/基础设施

  ---
  变更内容

  - server/cmd/server/router.go — 在现有的本地存储处理器旁边，为 /uploads/* 路由添加了 S3 存储分支
  - server/internal/storage/s3.go — 添加了 ServeFile 方法；重构 uploadedURL 在未设置 CDN 时返回相对路径；更新了错误处理、缓存头、ETag
  支持；添加了 s3Client 接口以支持测试
  - server/internal/storage/s3_test.go — 添加了 mockS3Client 和全面的 ServeFile 测试（空 key、NoSuchKey、非 NoSuchKey 错误、正常路径响应头、nil
   字段处理、条件 GET 304）

  ---
  测试方法

  1. 本地存储代理（现有行为）：
    - 在未设置 S3_BUCKET / CLOUDFRONT_DOMAIN 的情况下部署
    - 上传工作区头像
    - 验证图片正常加载（无 404）
  2. S3 存储代理（新行为）：
    - 配置 S3_BUCKET、S3_REGION，以及可选的 S3_ENDPOINT（用于 COS/MinIO）
    - 上传文件
    - 验证在未设置 CDN 时 uploadedURL() 返回 /uploads/<key>
    - 直接访问该 URL — 应返回 200 以及正确的 Content-Type/Length/Disposition/Cache-Control 响应头
  3. CDN 模式：
    - 设置 CLOUDFRONT_DOMAIN（或等效的 CDN 域名环境变量）
    - 验证 uploadedURL() 返回绝对 CDN URL
  4. 错误处理：
    - 上传文件到 S3，然后外部删除
    - 请求该 URL → 应返回 404（NoSuchKey）
    - 临时错误配置 IAM 权限
    - 请求该 URL → 应返回 502 Bad Gateway（非静默的 404）
  5. 条件 GET：
    - 上传文件并记下 ETag 响应头
    - 使用 If-None-Match: <ETag> 头重新请求
    - 应收到 304 Not Modified

  ---
  检查清单

  - 我包含了从项目上下文到此变更的完整思考路径
  - 我已在本地运行测试并通过
  - 我已添加或更新了相关测试
  - 如果此变更影响 UI，我包含了前/后截图
  - 我已更新相关文档以反映我的变更
  - 如果我添加了新的运行时/编码工具/UI 标签，我已将变更同步到 landing 
  copy（apps/web/features/landing/i18n/）和相关文档（apps/docs/content/docs/）
  - 如果此 PR 涉及中文产品文案，我已检查是否符合 apps/docs/content/docs/developers/conventions.zh.mdx（术语、task/issue/skill 的混合规则）
  - 我已考虑并记录了上述风险
  - 我将在请求合并前解决所有审阅者的评论

  ---
  AI 披露

  使用的 AI 工具： Claude Code

  提示/方法：
  审查了提交 60b07025（feat）和 016a74e1（fix）以了解 S3 代理实现。分析了包括代码变更、测试添加和错误处理改进的完整 diff。从 issue #1004
  追溯到解决方案。