### PR TITLE
feat(onboarding): welcome_page → slides + Helper Stay-current rule

### DIFF
--- a/packages/views/locales/en/onboarding.json
+++ b/packages/views/locales/en/onboarding.json
@@ -205,7 +205,7 @@
           "subtitle": "I'll walk you through how issue, agent, squad, autopilot fit together."
         },
         "welcome_page": {
-          "subtitle": "I'll write you a small HTML welcome page to celebrate the kickoff."
+          "subtitle": "I'll build you a single-file HTML slide deck — tailored to your role, ready to copy and open in a browser."
         }
       },
       "success": {

--- a/packages/views/locales/zh-Hans/onboarding.json
+++ b/packages/views/locales/zh-Hans/onboarding.json
@@ -205,7 +205,7 @@
           "subtitle": "陪你走一遍 issue、agent、squad、autopilot 怎么配合。"
         },
         "welcome_page": {
-          "subtitle": "给你写一个小 HTML 页面，庆祝上手 Multica。"
+          "subtitle": "我用单文件 HTML 演示稿介绍 Multica 能为你做什么，按你的角色定制，复制下来双击就能在浏览器里打开。"
         }
       },
       "success": {

--- a/packages/views/onboarding/templates/helper-instructions.ts
+++ b/packages/views/onboarding/templates/helper-instructions.ts
@@ -51,7 +51,11 @@ A few things you can actually do (non-exhaustive — \`--help\` is the source of
 
 ## Tone
 
-Be concise and direct, like a colleague. Respond in the user's language (Chinese in, Chinese out). When pointing at a UI location, name the exact path ("Settings → Agents → New"); when pointing at a doc, link to the specific page, not the homepage. Never fabricate URLs, flags, or file paths.`;
+Be concise and direct, like a colleague. Respond in the user's language (Chinese in, Chinese out). When pointing at a UI location, name the exact path ("Settings → Agents → New"); when pointing at a doc, link to the specific page, not the homepage. Never fabricate URLs, flags, or file paths.
+
+## Stay current
+
+If you notice \`multica --help\`, the docs, or the GitHub repo contradict or meaningfully extend this instruction — renamed commands, new core concepts, removed flags — surface it to the user and propose an updated version of your own instruction before continuing. Do not silently update your instructions; wait for the user's confirmation, then apply the change via the CLI.`;
 
 const zh = `你是 Multica Helper,这个 Multica workspace 内置的 AI 助手。你的角色是帮助任何成员更好地使用 Multica —— 回答问题、给出建议、代为执行 workspace 操作。
 
@@ -76,7 +80,11 @@ Multica 是一个开源、AI 原生的团队工作区(源码:https://github.com/
 
 ## 语气
 
-像同事一样,简洁、直接。用用户的语言回复(中文进,中文出)。指向 UI 位置时给出精确路径(如 "Settings → Agents → New");指向文档时链接到具体页面,而不是首页。绝不编造 URL、参数或文件路径。`;
+像同事一样,简洁、直接。用用户的语言回复(中文进,中文出)。指向 UI 位置时给出精确路径(如 "Settings → Agents → New");指向文档时链接到具体页面,而不是首页。绝不编造 URL、参数或文件路径。
+
+## 保持同步
+
+如果你发现 \`multica --help\`、官方文档或 GitHub 仓库出现与本 instruction 相冲突或重要补充的变化(命令改名、新增核心概念、删除参数),先告诉用户、提议一份更新后的 instruction,然后再继续。不要静默地改自己的 instruction;等用户确认,再通过 CLI 应用变更。`;
 
 export const HELPER_INSTRUCTIONS = { en, zh } as const;
 export type HelperInstructionsLang = keyof typeof HELPER_INSTRUCTIONS;

--- a/packages/views/onboarding/templates/helper-starter-prompts.ts
+++ b/packages/views/onboarding/templates/helper-starter-prompts.ts
@@ -44,12 +44,62 @@ export const HELPER_STARTER_PROMPTS: Record<StarterCardId, StarterPrompt> = {
   },
   welcome_page: {
     title: {
-      en: "Make me a welcome page",
-      zh: "帮我做一个欢迎页",
+      en: "Show me what Multica can do for me — as slides",
+      zh: "用 slides 介绍 Multica 能为我做什么",
     },
     prompt: {
-      en: "Make a small HTML page (with some CSS, maybe a touch of animation) that welcomes me to Multica. Paste the full HTML in a comment on this issue so I can copy it straight from there.",
-      zh: "用 HTML + 简单 CSS 给我做一个欢迎页,庆祝我刚加入 Multica。可以加点小动效。做完后把完整 HTML 贴到这个 issue 的评论里,我直接复制就能用。",
+      en: `Build me a single-file HTML slide deck that shows what Multica can do for me. Tailor it to my role and use case (see "About me" below). Paste the FULL HTML in a fenced \`\`\`html block in a comment on this issue so I can copy it straight out, save as \`multica-intro.html\`, and double-click to open it in a browser.
+
+**Format**
+- One self-contained .html, all CSS / JS inline. Zero dependencies, no build tools, no external images (use CSS-generated visuals — gradients, geometric shapes, SVG inline).
+- 5–8 slides total:
+  1. Title — "What Multica can do for [my role]"
+  2. Four core concepts — workspace / issue / agent / runtime, one slide
+  3–6. 3–4 concrete scenarios tailored to my use case, each in the form "When you want X → here's how Multica handles it"
+  7. Closing — one specific next-step action
+
+**Viewport rules (non-negotiable)**
+- Every \`.slide\`: \`height: 100vh; height: 100dvh; overflow: hidden;\`
+- All font-size and spacing values use \`clamp(min, preferred, max)\` — never fixed px / rem.
+- Density per slide: 1 heading + ≤ 4 bullets, OR 1 heading + 2 short paragraphs. Overflow → split into another slide.
+- Respect \`prefers-reduced-motion: reduce\` (disable animations).
+
+**Aesthetic (avoid the AI-slop look)**
+- Pick a distinctive typeface from Fontshare or Google Fonts. Do NOT use Inter, Roboto, Arial, or system fonts.
+- Commit to a cohesive palette via CSS variables: one dominant color + one sharp accent. Avoid the cliché "purple gradient on white".
+- Backgrounds: layered gradients or geometric patterns for atmosphere — never flat white.
+- Animation: ONE well-orchestrated load-in per slide using staggered \`animation-delay\`. CSS-only. No scattered micro-interactions.
+
+**Navigation**
+- ArrowLeft / ArrowRight and Space to advance. Small page indicator in a corner.
+
+When done, also reply with a one-sentence summary of which scenarios you picked for me and why.`,
+      zh: `给我做一份单文件 HTML 演示稿,介绍 Multica 能为我做什么。根据我的角色和使用场景定制(见下面"关于我")。把完整 HTML 贴到这条 issue 的评论里的 \`\`\`html 代码块中,我直接复制下来存成 \`multica-intro.html\` 双击就能在浏览器里打开。
+
+**产出格式**
+- 一个自包含 .html,CSS / JS 全部 inline。零依赖、不用打包、不引外部图片(视觉用纯 CSS 生成 —— 渐变、几何形状、内联 SVG)。
+- 5-8 张 slide:
+  1. 标题页 —— "Multica 能为 [我的角色] 做什么"
+  2. 四个核心概念 —— workspace / issue / agent / runtime,一张
+  3-6. 3-4 个针对我使用场景的具体例子,形如"当你想做 X → Multica 是这样处理的"
+  7. 收尾页 —— 一个具体的下一步动作
+
+**视口约束(必须遵守)**
+- 每个 \`.slide\`:\`height: 100vh; height: 100dvh; overflow: hidden;\`
+- 所有 font-size 和 spacing 用 \`clamp(min, preferred, max)\`,不要写死 px / rem。
+- 每张密度:1 个标题 + ≤ 4 个 bullet,或 1 个标题 + 2 段短段。超出就拆下一张。
+- 兼容 \`prefers-reduced-motion: reduce\`(关动画)。
+
+**审美(避免 AI 套路感)**
+- 字体从 Fontshare 或 Google Fonts 选一个有辨识度的,不要用 Inter / Roboto / Arial / 系统字体。
+- 用 CSS 变量统一调色板:一个主色 + 一个锐利的强调色。避免烂大街的"紫色渐变 + 白底"。
+- 背景用层叠渐变或几何图案带氛围,不要纯白。
+- 每张 slide 一次性的有节奏入场动画(用 \`animation-delay\` 错峰),CSS 实现。不要散落的微动效。
+
+**导航**
+- 左右方向键和空格切换,角落放一个小的页码指示。
+
+做完后再用一句话告诉我你为我挑了哪几个场景以及为什么。`,
     },
   },
 };

--- a/packages/views/workspace/welcome-after-onboarding.test.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.test.tsx
@@ -178,7 +178,9 @@ describe("WelcomeAfterOnboarding", () => {
       expect(
         screen.getByText("Walk me through the core features"),
       ).toBeInTheDocument();
-      expect(screen.getByText("Make me a welcome page")).toBeInTheDocument();
+      expect(
+        screen.getByText("Show me what Multica can do for me — as slides"),
+      ).toBeInTheDocument();
     });
 
     it("reuses an existing Multica Helper agent instead of creating duplicates", async () => {
@@ -246,7 +248,9 @@ describe("WelcomeAfterOnboarding", () => {
 
       // Toggle two cards.
       fireEvent.click(screen.getByText("Introduce Multica to me"));
-      fireEvent.click(screen.getByText("Make me a welcome page"));
+      fireEvent.click(
+        screen.getByText("Show me what Multica can do for me — as slides"),
+      );
 
       // CTA enables and reflects the count.
       const cta = await screen.findByRole("button", { name: /assign 2/i });
@@ -257,7 +261,7 @@ describe("WelcomeAfterOnboarding", () => {
       const titles = mockCreateIssue.mock.calls.map(([args]) => args.title);
       expect(titles).toEqual([
         "Introduce Multica to me",
-        "Make me a welcome page",
+        "Show me what Multica can do for me — as slides",
       ]);
       // Both assigned to the same Helper agent.
       mockCreateIssue.mock.calls.forEach(([args]) => {


### PR DESCRIPTION
## Summary

- **Card 3 (welcome_page) prompt rewrite** — from "make me an HTML welcome page" to "build a single-file HTML slide deck introducing what Multica can do for me". Prompt inlines the frontend-slides skill's constraints (viewport 100vh, clamp typography, content-density caps, anti–AI-slop aesthetic, CSS-only staggered load-in). Cards 1 (intro) and 2 (tour) unchanged. Card IDs unchanged.
- **Helper instruction `Stay current` rule** — new short section telling Helper that when `multica --help` / docs / GitHub repo contradict or meaningfully extend its instruction, it must report to the user and propose an updated instruction. It must NOT silently self-update; the user confirms, then Helper applies via CLI.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` — clean
- [x] `pnpm --filter @multica/views exec vitest run workspace/welcome-after-onboarding.test.tsx locales/parity.test.ts` — 58 passed
- [ ] Manual: complete onboarding with a runtime → verify all 3 starter cards still render with the new card-3 title; pick card 3 → confirm Helper produces an inline HTML slide deck in the issue comment that fits the viewport rules.
- [ ] Manual: ask Helper "is there a `multica xyz` command?" with a real recent CLI change in mind — verify the Stay-current behavior (reports + proposes, does not silently update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)