### PR TITLE
fix(retry): create transient failure attempts idempotently (MYW-1745)

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -38,6 +38,7 @@ export type AgentRuntime = RuntimeDevice;
 // the agent presence derivation and the UI failure-message lookup.
 export type TaskFailureReason =
   | "agent_error"
+  | "agent_transient"
   | "timeout"
   | "codex_semantic_inactivity"
   | "runtime_offline"

--- a/packages/views/agents/components/tabs/task-failure.ts
+++ b/packages/views/agents/components/tabs/task-failure.ts
@@ -9,6 +9,7 @@ import type { TaskFailureReason } from "@multica/core/types";
 // is purely a detail-page concern now.
 export const failureReasonLabel: Record<TaskFailureReason, string> = {
   agent_error: "Agent execution error",
+  agent_transient: "Transient agent error",
   timeout: "Task timed out",
   codex_semantic_inactivity: "Codex semantic inactivity timeout",
   runtime_offline: "Daemon offline",

--- a/server/cmd/server/rerun_session_test.go
+++ b/server/cmd/server/rerun_session_test.go
@@ -296,6 +296,166 @@ func TestCreateRetryTaskKeepsOrdinaryTimeoutSession(t *testing.T) {
 	}
 }
 
+func TestMaybeRetryFailedTaskTransientCreatesNextAttempt(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	issueID, agentID, runtimeID := setupRerunTestFixture(t)
+	t.Cleanup(func() { cleanupRerunFixture(t, issueID) })
+
+	ctx := context.Background()
+
+	var parentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			started_at, completed_at, failure_reason, attempt, max_attempts
+		)
+		VALUES ($1, $2, $3, 'failed', 0,
+		        now() - interval '1 minute', now(), 'agent_transient', 1, 2)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&parentID); err != nil {
+		t.Fatalf("insert transient parent task: %v", err)
+	}
+
+	queries := db.New(testPool)
+	hub := realtime.NewHub()
+	go hub.Run()
+	bus := events.New()
+	taskService := service.NewTaskService(queries, nil, hub, bus)
+
+	parent, err := queries.GetAgentTask(ctx, pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true})
+	if err != nil {
+		t.Fatalf("load parent task: %v", err)
+	}
+
+	child, err := taskService.MaybeRetryFailedTask(ctx, parent)
+	if err != nil {
+		t.Fatalf("MaybeRetryFailedTask failed: %v", err)
+	}
+	if child == nil {
+		t.Fatal("expected transient failure to create retry child, got nil")
+	}
+	if child.Attempt != 2 {
+		t.Fatalf("child attempt = %d, want 2", child.Attempt)
+	}
+	if got := util.UUIDToString(child.ParentTaskID); got != parentID {
+		t.Fatalf("child parent_task_id = %s, want %s", got, parentID)
+	}
+}
+
+func TestMaybeRetryFailedTaskDoesNotRetryPermanentOrExhaustedFailures(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	issueID, agentID, runtimeID := setupRerunTestFixture(t)
+	t.Cleanup(func() { cleanupRerunFixture(t, issueID) })
+
+	ctx := context.Background()
+	queries := db.New(testPool)
+	hub := realtime.NewHub()
+	go hub.Run()
+	bus := events.New()
+	taskService := service.NewTaskService(queries, nil, hub, bus)
+
+	cases := []struct {
+		name        string
+		reason      string
+		attempt     int
+		maxAttempts int
+	}{
+		{name: "permanent agent error", reason: "agent_error", attempt: 1, maxAttempts: 2},
+		{name: "auth failure", reason: "api_invalid_request", attempt: 1, maxAttempts: 2},
+		{name: "budget exhausted", reason: "agent_transient", attempt: 2, maxAttempts: 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var parentID string
+			if err := testPool.QueryRow(ctx, `
+				INSERT INTO agent_task_queue (
+					agent_id, runtime_id, issue_id, status, priority,
+					started_at, completed_at, failure_reason, attempt, max_attempts
+				)
+				VALUES ($1, $2, $3, 'failed', 0,
+				        now() - interval '1 minute', now(), $4, $5, $6)
+				RETURNING id
+			`, agentID, runtimeID, issueID, tc.reason, tc.attempt, tc.maxAttempts).Scan(&parentID); err != nil {
+				t.Fatalf("insert parent task: %v", err)
+			}
+
+			parent, err := queries.GetAgentTask(ctx, pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true})
+			if err != nil {
+				t.Fatalf("load parent task: %v", err)
+			}
+			child, err := taskService.MaybeRetryFailedTask(ctx, parent)
+			if err != nil {
+				t.Fatalf("MaybeRetryFailedTask failed: %v", err)
+			}
+			if child != nil {
+				t.Fatalf("expected no retry child, got %s", util.UUIDToString(child.ID))
+			}
+
+			var childCount int
+			if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_task_queue WHERE parent_task_id = $1`, parentID).Scan(&childCount); err != nil {
+				t.Fatalf("count retry children: %v", err)
+			}
+			if childCount != 0 {
+				t.Fatalf("retry children = %d, want 0", childCount)
+			}
+		})
+	}
+}
+
+func TestCreateRetryTaskIsIdempotentForDuplicateCompletions(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	issueID, agentID, runtimeID := setupRerunTestFixture(t)
+	t.Cleanup(func() { cleanupRerunFixture(t, issueID) })
+
+	ctx := context.Background()
+
+	var parentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			started_at, completed_at, failure_reason, attempt, max_attempts
+		)
+		VALUES ($1, $2, $3, 'failed', 0,
+		        now() - interval '1 minute', now(), 'agent_transient', 1, 2)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&parentID); err != nil {
+		t.Fatalf("insert transient parent task: %v", err)
+	}
+
+	queries := db.New(testPool)
+	parentUUID := pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true}
+	first, err := queries.CreateRetryTask(ctx, parentUUID)
+	if err != nil {
+		t.Fatalf("first CreateRetryTask failed: %v", err)
+	}
+	second, err := queries.CreateRetryTask(ctx, parentUUID)
+	if err != nil {
+		t.Fatalf("second CreateRetryTask failed: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("duplicate retry creation returned different tasks: first=%s second=%s",
+			util.UUIDToString(first.ID), util.UUIDToString(second.ID))
+	}
+
+	var childCount int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_task_queue WHERE parent_task_id = $1`, parentID).Scan(&childCount); err != nil {
+		t.Fatalf("count retry children: %v", err)
+	}
+	if childCount != 1 {
+		t.Fatalf("retry children = %d, want 1", childCount)
+	}
+}
+
 // TestGetLastTaskSessionExcludesLegacyAPI400 is the MUL-1921 legacy
 // regression: pre-fix rows are tagged failure_reason='agent_error' even
 // though their error text contains the canonical Anthropic 400

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2091,7 +2091,13 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		taskLog.Error("task failed", "error", err)
 		// runTask returned without a TaskResult, so we don't have a SessionID
 		// to forward — best we can do is record the failure.
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "agent_error"); failErr != nil {
+		failureReason := "agent_error"
+		if reason, ok := classifyPoisonedError(err.Error()); ok {
+			failureReason = reason
+		} else if reason, ok := classifyTransientError(err.Error()); ok {
+			failureReason = reason
+		}
+		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", failureReason); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
 		}
 		return
@@ -2239,25 +2245,25 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Repos are passed as metadata only — the agent checks them out on demand
 	// via `multica repo checkout <url>`.
 	taskCtx := execenv.TaskContextForEnv{
-		IssueID:                 task.IssueID,
-		TriggerCommentID:        task.TriggerCommentID,
-		AgentID:                 agentID,
-		AgentName:               agentName,
-		AgentInstructions:       instructions,
-		AgentSkills:             convertSkillsForEnv(skills),
-		Repos:                   convertReposForEnv(task.Repos),
-		ProjectID:               task.ProjectID,
-		ProjectTitle:            task.ProjectTitle,
-		ProjectResources:        convertProjectResourcesForEnv(task.ProjectResources),
-		ChatSessionID:           task.ChatSessionID,
-		AutopilotRunID:          task.AutopilotRunID,
-		AutopilotID:             task.AutopilotID,
-		AutopilotTitle:          task.AutopilotTitle,
-		AutopilotDescription:    task.AutopilotDescription,
-		AutopilotSource:         task.AutopilotSource,
-		AutopilotTriggerPayload: strings.TrimSpace(string(task.AutopilotTriggerPayload)),
-		QuickCreatePrompt:       task.QuickCreatePrompt,
-		IsSquadLeader:           strings.Contains(instructions, "## Squad Operating Protocol"),
+		IssueID:                          task.IssueID,
+		TriggerCommentID:                 task.TriggerCommentID,
+		AgentID:                          agentID,
+		AgentName:                        agentName,
+		AgentInstructions:                instructions,
+		AgentSkills:                      convertSkillsForEnv(skills),
+		Repos:                            convertReposForEnv(task.Repos),
+		ProjectID:                        task.ProjectID,
+		ProjectTitle:                     task.ProjectTitle,
+		ProjectResources:                 convertProjectResourcesForEnv(task.ProjectResources),
+		ChatSessionID:                    task.ChatSessionID,
+		AutopilotRunID:                   task.AutopilotRunID,
+		AutopilotID:                      task.AutopilotID,
+		AutopilotTitle:                   task.AutopilotTitle,
+		AutopilotDescription:             task.AutopilotDescription,
+		AutopilotSource:                  task.AutopilotSource,
+		AutopilotTriggerPayload:          strings.TrimSpace(string(task.AutopilotTriggerPayload)),
+		QuickCreatePrompt:                task.QuickCreatePrompt,
+		IsSquadLeader:                    strings.Contains(instructions, "## Squad Operating Protocol"),
 		RequestingUserName:               task.RequestingUserName,
 		RequestingUserProfileDescription: task.RequestingUserProfileDescription,
 	}
@@ -2696,9 +2702,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		// classifier a corrupt image or oversized payload baked into the
 		// conversation permanently blocks the issue: every follow-up
 		// task resumes the same poisoned session and hits the same 400.
-		failureReason, _ := classifyPoisonedError(errMsg)
-		if failureReason != "" {
+		failureReason, poisoned := classifyPoisonedError(errMsg)
+		if poisoned {
 			taskLog.Warn("agent failed with poisoned API error, classifying as blocked",
+				"failure_reason", failureReason,
+			)
+		} else if reason, ok := classifyTransientError(errMsg); ok {
+			failureReason = reason
+			taskLog.Warn("agent failed with transient infrastructure error, classifying as retryable",
 				"failure_reason", failureReason,
 			)
 		}

--- a/server/internal/daemon/poisoned.go
+++ b/server/internal/daemon/poisoned.go
@@ -29,6 +29,7 @@ const (
 	FailureReasonAgentFallbackMsg        = "agent_fallback_message"
 	FailureReasonAPIInvalidRequest       = "api_invalid_request"
 	FailureReasonCodexSemanticInactivity = "codex_semantic_inactivity"
+	FailureReasonAgentTransient          = "agent_transient"
 )
 
 // poisonedOutputMaxLen caps how long an output can be and still be
@@ -104,6 +105,104 @@ func classifyPoisonedError(errMsg string) (string, bool) {
 	// the request body — i.e. the conversation history — is the problem.
 	if strings.Contains(lowered, "invalid_request_error") && strings.Contains(lowered, "400") {
 		return FailureReasonAPIInvalidRequest, true
+	}
+	return "", false
+}
+
+// permanentErrorPatterns are terminal failure shapes that must not become
+// retryable even when the message also contains a generic transient-looking
+// word. Keep this list conservative: false negatives surface to users, while
+// false positives can create noisy retry loops.
+var permanentErrorPatterns = []string{
+	"authentication_error",
+	"invalid api key",
+	"unauthorized",
+	"forbidden",
+	"permission denied",
+	"not permitted",
+	"configuration error",
+	"not configured",
+	"missing api key",
+	"content policy",
+	"content_policy",
+	"content blocked",
+	"invalid_request_error",
+	"invalid request",
+	"bad request",
+}
+
+// transientErrorPatterns are infrastructure/provider interruption markers.
+// Some strings come from external CLI stdout/stderr rather than Go literals
+// in this repository, so absence from ripgrep is not enough to delete them.
+var transientErrorPatterns = []string{
+	"database is locked",
+	"database locked",
+	"sqlite busy",
+	"sqlite_busy",
+	"context deadline exceeded",
+	"i/o timeout",
+	"timed out",
+	"timeout exceeded",
+	"deadline exceeded",
+	"returned empty output",
+	"empty output",
+	"empty response",
+	"no output from",
+	"produced no output",
+	"no parseable output",
+	"stream interrupted",
+	"stream closed",
+	"connection reset",
+	"connection refused",
+	"connection aborted",
+	"broken pipe",
+	"unexpected eof",
+	"temporary failure",
+	"temporarily unavailable",
+	"try again",
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+	"api error: 429",
+	"status 429",
+	" 429 ",
+	"api error: 502",
+	"status 502",
+	" 502 ",
+	"api error: 503",
+	"status 503",
+	" 503 ",
+	"api error: 504",
+	"status 504",
+	" 504 ",
+	"overloaded_error",
+	"overloaded",
+	"service unavailable",
+	"bad gateway",
+	"gateway timeout",
+}
+
+// classifyTransientError reports whether an agent error is retryable
+// infrastructure/provider flakiness. It intentionally excludes auth,
+// permission, configuration, content-policy, and invalid-request failures.
+func classifyTransientError(errMsg string) (string, bool) {
+	trimmed := strings.TrimSpace(errMsg)
+	if trimmed == "" {
+		return "", false
+	}
+	if _, ok := classifyPoisonedError(trimmed); ok {
+		return "", false
+	}
+	lowered := strings.ToLower(trimmed)
+	for _, marker := range permanentErrorPatterns {
+		if strings.Contains(lowered, marker) {
+			return "", false
+		}
+	}
+	for _, marker := range transientErrorPatterns {
+		if strings.Contains(lowered, marker) {
+			return FailureReasonAgentTransient, true
+		}
 	}
 	return "", false
 }

--- a/server/internal/daemon/poisoned_test.go
+++ b/server/internal/daemon/poisoned_test.go
@@ -172,6 +172,88 @@ func TestClassifyPoisonedError(t *testing.T) {
 	}
 }
 
+func TestClassifyTransientError(t *testing.T) {
+	cases := []struct {
+		name       string
+		errMsg     string
+		wantOK     bool
+		wantReason string
+	}{
+		{
+			name:       "sqlite database locked",
+			errMsg:     "agent failed: database is locked",
+			wantOK:     true,
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "provider empty output",
+			errMsg:     "kimi returned empty output",
+			wantOK:     true,
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "openclaw no parseable output",
+			errMsg:     "openclaw returned no parseable output",
+			wantOK:     true,
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "temporary provider interruption",
+			errMsg:     "stream interrupted: connection reset by peer",
+			wantOK:     true,
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "provider overload",
+			errMsg:     `API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantOK:     true,
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:   "auth failure is permanent",
+			errMsg: `API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"invalid api key"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "permission failure is permanent",
+			errMsg: "permission denied while opening repository",
+			wantOK: false,
+		},
+		{
+			name:   "configuration failure is permanent",
+			errMsg: "configuration error: model is not configured",
+			wantOK: false,
+		},
+		{
+			name:   "content policy failure is permanent",
+			errMsg: "content policy blocked this request",
+			wantOK: false,
+		},
+		{
+			name:   "invalid request remains poisoned permanent",
+			errMsg: `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "ordinary agent error is permanent",
+			errMsg: "tests failed in auth_test.go",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, ok := classifyTransientError(tc.errMsg)
+			if ok != tc.wantOK {
+				t.Fatalf("classifyTransientError(%q) ok=%v, want %v", tc.errMsg, ok, tc.wantOK)
+			}
+			if ok && reason != tc.wantReason {
+				t.Fatalf("classifyTransientError(%q) reason=%q, want %q", tc.errMsg, reason, tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestClassifyResumeUnsafeTimeout(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -349,7 +349,7 @@ func taskFailureReason(task db.AgentTaskQueue) string {
 
 func taskErrorType(reason string) string {
 	switch reason {
-	case "runtime_offline", "runtime_recovery":
+	case "runtime_offline", "runtime_recovery", "agent_transient":
 		return "runtime"
 	case "timeout", "codex_semantic_inactivity":
 		return "timeout"
@@ -1268,14 +1268,15 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 }
 
 // retryableReasons enumerates failure reasons that the auto-retry path is
-// allowed to act on. Agent-side errors (compile failures, model rejections,
-// etc.) are intentionally excluded — those are real problems that the user
-// should see, not infrastructure flakiness.
+// allowed to act on. Permanent agent-side errors (compile failures, model
+// rejections, etc.) are intentionally excluded — those are real problems that
+// the user should see, not infrastructure flakiness.
 var retryableReasons = map[string]bool{
 	"runtime_offline":           true,
 	"runtime_recovery":          true,
 	"timeout":                   true,
 	"codex_semantic_inactivity": true,
+	"agent_transient":           true,
 }
 
 func resumeUnsafeFailureReason(reason string) bool {

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -177,6 +177,7 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		{reason: "timeout", wantType: "timeout", wantResumeOK: true, wantRetry: true},
 		{reason: "codex_semantic_inactivity", wantType: "timeout", wantResumeOK: false, wantRetry: true},
 		{reason: "runtime_recovery", wantType: "runtime", wantResumeOK: true, wantRetry: true},
+		{reason: "agent_transient", wantType: "runtime", wantResumeOK: true, wantRetry: true},
 		{reason: "iteration_limit", wantType: "agent_output", wantResumeOK: false, wantRetry: false},
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
 		{reason: "agent_error", wantType: "agent_error", wantResumeOK: true, wantRetry: false},

--- a/server/migrations/108_retry_task_parent_idempotency.down.sql
+++ b/server/migrations/108_retry_task_parent_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_agent_task_queue_retry_parent_unique;

--- a/server/migrations/108_retry_task_parent_idempotency.up.sql
+++ b/server/migrations/108_retry_task_parent_idempotency.up.sql
@@ -1,0 +1,26 @@
+-- Ensure retry creation is idempotent at the database boundary: each failed
+-- parent task can have only one direct retry child. If historical duplicate
+-- children exist, keep the oldest back-pointer and detach the later duplicates
+-- rather than deleting task history.
+
+WITH ranked_retry_children AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY parent_task_id
+      ORDER BY created_at ASC, id ASC
+    ) AS retry_rank
+  FROM agent_task_queue
+  WHERE parent_task_id IS NOT NULL
+)
+UPDATE agent_task_queue
+SET parent_task_id = NULL
+WHERE id IN (
+  SELECT id
+  FROM ranked_retry_children
+  WHERE retry_rank > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_task_queue_retry_parent_unique
+  ON agent_task_queue(parent_task_id)
+  WHERE parent_task_id IS NOT NULL;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -869,6 +869,8 @@ SELECT
     p.is_leader_task
 FROM agent_task_queue p
 WHERE p.id = $1
+ON CONFLICT (parent_task_id) WHERE parent_task_id IS NOT NULL DO UPDATE
+SET parent_task_id = EXCLUDED.parent_task_id
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task
 `
 

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -141,6 +141,8 @@ SELECT
     p.is_leader_task
 FROM agent_task_queue p
 WHERE p.id = $1
+ON CONFLICT (parent_task_id) WHERE parent_task_id IS NOT NULL DO UPDATE
+SET parent_task_id = EXCLUDED.parent_task_id
 RETURNING *;
 
 -- name: CancelAgentTasksByIssue :many


### PR DESCRIPTION
## Summary

- Classify retryable transient daemon/provider failures as agent_transient, including timeout-shaped errors, empty output/no parseable output, database locked, stream/network interruptions, rate-limit/overload/server unavailable.
- Keep auth/permission/configuration/content-policy/invalid-request failures non-retryable.
- Add DB-level idempotency for CreateRetryTask with a unique parent_task_id index and ON CONFLICT return of the existing retry child.
- Sync agent_transient into backend analytics bucketing and frontend failure reason labeling.

## Verification

- go test ./internal/daemon -run TestClassifyTransientError (red before implementation, pass after)
- go test ./internal/service -run TestTaskFailureClassifiers (red before implementation, pass after)
- go test ./internal/daemon ./internal/service
- go test ./internal/service -count=1
- go test ./pkg/db/generated
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- git diff --check

DB-backed cmd/server retry integration tests were added but could not execute locally because Docker/Postgres is unavailable: docker API missing at /Users/liuzifan/.docker/run/docker.sock. The package still compiles; TestMain skips when DB is unreachable.

## Linked Issues

- MYW-1744
- MYW-1745

## Required Reviewer

- 程远
