### PR TITLE
fix(runtimes): guard delete for self-healing local runtimes

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -84,9 +84,8 @@
   "detail": {
     "all_runtimes": "All runtimes",
     "read_only": "Read-only",
-    "delete_aria": "Delete runtime",
-    "delete_tooltip": "Delete runtime",
     "delete_button": "Delete runtime",
+    "delete_disabled_tooltip": "This runtime is managed by a running local daemon and will re-register itself within seconds. Stop the daemon process to remove it permanently.",
     "last_seen": "last seen {{when}}",
     "fact_owner": "Owner",
     "fact_device": "Device",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -80,9 +80,8 @@
   "detail": {
     "all_runtimes": "全部运行时",
     "read_only": "只读",
-    "delete_aria": "删除运行时",
-    "delete_tooltip": "删除运行时",
     "delete_button": "删除运行时",
+    "delete_disabled_tooltip": "该运行时由正在运行的本地 daemon 托管，删除后会在数秒内自动重新注册。需停止 daemon 进程才能彻底移除。",
     "last_seen": "最后活跃 {{when}}",
     "fact_owner": "所有者",
     "fact_device": "设备",

--- a/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
@@ -94,7 +94,10 @@ vi.mock("../../agents/presence", () => ({
   workloadConfig: { idle: { icon: () => null, textClass: "" } },
 }));
 vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
-vi.mock("../../navigation", () => ({ AppLink: () => null }));
+vi.mock("../../navigation", () => ({
+  AppLink: () => null,
+  useNavigation: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
 
 import { RuntimeDetail } from "./runtime-detail";
 

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -39,7 +39,7 @@ import {
   TooltipTrigger,
 } from "@multica/ui/components/ui/tooltip";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { AppLink } from "../../navigation";
+import { AppLink, useNavigation } from "../../navigation";
 import { availabilityConfig, workloadConfig } from "../../agents/presence";
 import { formatLastSeen } from "../utils";
 import { HealthBadge } from "./shared";
@@ -100,6 +100,7 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
   const user = useAuthStore((s) => s.user);
   const wsId = useWorkspaceId();
   const paths = useWorkspacePaths();
+  const navigation = useNavigation();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { byAgent: presenceMap } = useWorkspacePresenceMap(wsId);
@@ -129,8 +130,9 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
   const handleDelete = () => {
     deleteMutation.mutate(runtime.id, {
       onSuccess: () => {
-        toast.success(t(($) => $.detail.toast_deleted));
         setDeleteOpen(false);
+        navigation.replace(paths.runtimes());
+        toast.success(t(($) => $.detail.toast_deleted));
       },
       onError: (e) => {
         toast.error(e instanceof Error ? e.message : t(($) => $.detail.toast_delete_failed));
@@ -165,24 +167,6 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
               <Lock className="h-3 w-3" />
               {t(($) => $.detail.read_only)}
             </span>
-          )}
-          {canDelete && (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => setDeleteOpen(true)}
-                    className="text-muted-foreground hover:text-destructive"
-                    aria-label={t(($) => $.detail.delete_aria)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                }
-              />
-              <TooltipContent>{t(($) => $.detail.delete_tooltip)}</TooltipContent>
-            </Tooltip>
           )}
         </div>
       </div>
@@ -500,6 +484,10 @@ function DiagnosticsCard({
 }) {
   const { t } = useT("runtimes");
   const isLocal = runtime.runtime_mode === "local";
+  // A live local daemon re-registers itself within seconds of a server-side
+  // delete (daemon self-heal, #2404), so deleting an online local runtime
+  // from the UI has no lasting effect — disable it and explain why.
+  const selfHealing = isLocal && runtime.status === "online";
   // canDelete here doubles as the "can edit runtime" predicate — it already
   // means "workspace owner/admin OR runtime owner", which is the same gate
   // the server enforces for the visibility PATCH.
@@ -534,15 +522,41 @@ function DiagnosticsCard({
         )}
         {canDelete && (
           <div className="border-t pt-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 w-full justify-start gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              onClick={onDelete}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              {t(($) => $.detail.delete_button)}
-            </Button>
+            {selfHealing ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    // Wrapping span keeps the trigger hoverable — a disabled
+                    // <button> swallows pointer events, so the tooltip would
+                    // never open if it were the trigger itself.
+                    <span className="block w-full">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled
+                        className="h-8 w-full justify-start gap-2 text-destructive"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        {t(($) => $.detail.delete_button)}
+                      </Button>
+                    </span>
+                  }
+                />
+                <TooltipContent>
+                  {t(($) => $.detail.delete_disabled_tooltip)}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-full justify-start gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={onDelete}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                {t(($) => $.detail.delete_button)}
+              </Button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## What does this PR do?

Deleting an online **local** runtime from the runtime detail page has no lasting effect — a live daemon re-registers itself within seconds (#2404). The user sees a success toast and the runtime reappears, which looks like a bug.

This PR disables the Delete button for online local runtimes and explains why in a hover tooltip. It also removes the redundant topbar delete button (the Diagnostics card already owns the delete action) and navigates back to the runtimes list after a successful delete instead of leaving a stale detail page behind.

The disabled button is wrapped in a `<span>` so the tooltip stays hoverable — a disabled `<button>` swallows pointer events, so it cannot be the trigger itself.

## Related Issue

Closes #3075

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/runtimes/components/runtime-detail.tsx` — add `selfHealing` predicate (`isLocal && status === "online"`); render a disabled Delete button + explanatory tooltip in that case; remove the redundant topbar delete button; `navigation.replace` to the runtimes list on delete success.
- `packages/views/locales/en/runtimes.json` / `zh-Hans/runtimes.json` — drop unused `detail.delete_aria` / `detail.delete_tooltip`; add `detail.delete_disabled_tooltip`.
- `packages/views/runtimes/components/runtime-detail-visibility.test.tsx` — add `useNavigation` to the `../../navigation` mock (the component now calls it).

## How to Test

1. Open the detail page of an **online local** runtime → the Delete button in the Diagnostics card is disabled; hovering it shows the explanatory tooltip.
2. Open the detail page of an **offline local** runtime or a **cloud** runtime → Delete is enabled and works as before.
3. Delete a runtime → confirm in the dialog → on success you are navigated back to the runtimes list.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (pnpm typecheck: 6/6 packages; pnpm --filter @multica/views test: 752/752)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

### Risks

The gate keys on the raw `status` field (`"online" | "offline"`). A live daemon whose status has briefly fallen to `offline` between heartbeats still allows delete — but that is the inherent boundary of the heuristic, and the tooltip text accurately describes the `online` case.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Used Claude Code to implement the change, then ran a high-effort multi-angle code review over the staged diff before committing.
