### PR TITLE
fix(editor): sync TitleEditor when defaultValue changes externally (MUL-2565)

### DIFF
--- a/packages/views/editor/title-editor.test.tsx
+++ b/packages/views/editor/title-editor.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+const mockFocus = vi.hoisted(() => vi.fn());
+const mockSetContent = vi.hoisted(() => vi.fn());
+const mockBlur = vi.hoisted(() => vi.fn());
+const editorState = vi.hoisted(() => ({
+  isFocused: false,
+  isDestroyed: false,
+  text: "",
+}));
+
+vi.mock("../i18n", () => ({
+  useT: () => ({ t: (fn: unknown) => (typeof fn === "function" ? "" : "") }),
+}));
+
+const editorRef = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
+
+vi.mock("@tiptap/react", () => ({
+  useEditor: () => {
+    if (!editorRef.current) {
+      editorRef.current = {
+        get isFocused() {
+          return editorState.isFocused;
+        },
+        get isDestroyed() {
+          return editorState.isDestroyed;
+        },
+        commands: {
+          focus: mockFocus,
+          blur: mockBlur,
+          setContent: mockSetContent,
+        },
+        getText: () => editorState.text,
+      };
+    }
+    return editorRef.current;
+  },
+  EditorContent: () => <div data-testid="editor-content" />,
+}));
+
+import { TitleEditor } from "./title-editor";
+
+describe("TitleEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    editorState.isFocused = false;
+    editorState.isDestroyed = false;
+    editorState.text = "";
+    editorRef.current = null;
+  });
+
+  it("syncs editor content when defaultValue changes externally and editor is unfocused", () => {
+    editorState.text = "old title";
+    const { rerender } = render(<TitleEditor defaultValue="old title" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+
+    rerender(<TitleEditor defaultValue="new title from server" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "new title from server" }],
+          },
+        ],
+      },
+      { emitUpdate: false },
+    );
+  });
+
+  it("does not overwrite the user's in-flight edits when the editor is focused", () => {
+    editorState.text = "old title";
+    const { rerender } = render(<TitleEditor defaultValue="old title" />);
+
+    editorState.isFocused = true;
+    editorState.text = "user typed but not yet blurred";
+
+    rerender(<TitleEditor defaultValue="external update" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits when editor text already equals incoming defaultValue", () => {
+    editorState.text = "same title";
+    const { rerender } = render(<TitleEditor defaultValue="same title" />);
+
+    // Force the effect to re-run by rendering with a different prop, then
+    // back to the same value. Even an identity-equal prop should be skipped.
+    rerender(<TitleEditor defaultValue="same title" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("clears the editor when defaultValue transitions to empty", () => {
+    editorState.text = "old title";
+    const { rerender } = render(<TitleEditor defaultValue="old title" />);
+
+    rerender(<TitleEditor defaultValue="" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith("", { emitUpdate: false });
+  });
+});

--- a/packages/views/editor/title-editor.test.tsx
+++ b/packages/views/editor/title-editor.test.tsx
@@ -73,7 +73,7 @@ describe("TitleEditor", () => {
     );
   });
 
-  it("does not overwrite the user's in-flight edits when the editor is focused", () => {
+  it("does not overwrite the user's in-flight edits when the editor is focused and dirty", () => {
     editorState.text = "old title";
     const { rerender } = render(<TitleEditor defaultValue="old title" />);
 
@@ -83,6 +83,36 @@ describe("TitleEditor", () => {
     rerender(<TitleEditor defaultValue="external update" />);
 
     expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  // Regression: a focused but clean editor (user clicked in but never typed)
+  // must still accept external updates, otherwise the subsequent blur would
+  // compare stale editor text to the new server value and silently roll the
+  // external update back.
+  it("syncs to new defaultValue when editor is focused but clean", () => {
+    editorState.text = "old title";
+    const { rerender } = render(<TitleEditor defaultValue="old title" />);
+
+    // User clicked into the title field but has not typed anything yet:
+    // editor text still equals the previous defaultValue.
+    editorState.isFocused = true;
+    editorState.text = "old title";
+
+    rerender(<TitleEditor defaultValue="new title from server" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "new title from server" }],
+          },
+        ],
+      },
+      { emitUpdate: false },
+    );
   });
 
   it("short-circuits when editor text already equals incoming defaultValue", () => {

--- a/packages/views/editor/title-editor.tsx
+++ b/packages/views/editor/title-editor.tsx
@@ -132,6 +132,29 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
       return undefined;
     }, [autoFocus, editor]);
 
+    // Sync external `defaultValue` changes into the editor.
+    // Tiptap `useEditor` consumes `content` only at mount, so a WS-driven
+    // title update would otherwise leave the editor showing stale text — and
+    // the next blur would silently roll the external change back via onBlur's
+    // value-vs-issue.title compare.
+    useEffect(() => {
+      if (!editor || editor.isDestroyed) return;
+      // User is typing — preserve in-flight edits.
+      if (editor.isFocused) return;
+      if (editor.getText() === defaultValue) return;
+      editor.commands.setContent(
+        defaultValue
+          ? {
+              type: "doc",
+              content: [
+                { type: "paragraph", content: [{ type: "text", text: defaultValue }] },
+              ],
+            }
+          : "",
+        { emitUpdate: false },
+      );
+    }, [defaultValue, editor]);
+
     useImperativeHandle(ref, () => ({
       getText: () => editor?.getText() ?? "",
       focus: () => {

--- a/packages/views/editor/title-editor.tsx
+++ b/packages/views/editor/title-editor.tsx
@@ -132,6 +132,11 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
       return undefined;
     }, [autoFocus, editor]);
 
+    // Track the last `defaultValue` we've reconciled against, so we can tell
+    // "focused + dirty" (user typed something that diverges from external)
+    // apart from "focused + clean" (user just clicked in without typing).
+    const lastDefaultValueRef = useRef(defaultValue);
+
     // Sync external `defaultValue` changes into the editor.
     // Tiptap `useEditor` consumes `content` only at mount, so a WS-driven
     // title update would otherwise leave the editor showing stale text — and
@@ -139,9 +144,19 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
     // value-vs-issue.title compare.
     useEffect(() => {
       if (!editor || editor.isDestroyed) return;
-      // User is typing — preserve in-flight edits.
-      if (editor.isFocused) return;
+      const prevDefaultValue = lastDefaultValueRef.current;
+      lastDefaultValueRef.current = defaultValue;
+
+      // Already in sync — nothing to do.
       if (editor.getText() === defaultValue) return;
+
+      // Focused + dirty: editor text diverges from the previous external
+      // value, meaning the user has typed in this session. Preserve input.
+      // Focused + clean (text still equals prev defaultValue) falls through
+      // so we accept the new external value instead of letting the next blur
+      // roll it back.
+      if (editor.isFocused && editor.getText() !== prevDefaultValue) return;
+
       editor.commands.setContent(
         defaultValue
           ? {


### PR DESCRIPTION
## Summary

Fixes [MUL-2565](https://multica.ai) — TitleEditor not refreshing after external title updates + silent rollback on blur.

**Root cause** (single root, two symptoms): Tiptap's `useEditor` consumes `content` only at mount ([ueberdosis/tiptap#5831](https://github.com/ueberdosis/tiptap/issues/5831)). The `TitleEditor` callsite in `issue-detail.tsx` keys on `title-${id}`, so the editor only remounts when switching issues — same-issue title changes (e.g. WS `issue:updated`) never reach the doc.

1. **Stale display:** WS pushes `title="B"` → React Query cache updated → component re-renders with new `defaultValue` → Tiptap doc still shows `"A"`.
2. **Silent rollback on blur:** Editor doc still `"A"`. User clicks elsewhere → `onBlur(value="A")` → `"A" !== issue.title("B")` → `handleUpdateField({ title: "A" })` mutates the external change away.

## Fix

`packages/views/editor/title-editor.tsx` — add a `useEffect` that calls `editor.commands.setContent(...)` when `defaultValue` diverges and the editor is unfocused. Guards:

- `editor.isFocused` → skip (preserve user's in-flight typing)
- `editor.getText() === defaultValue` → skip (already in sync; avoids no-op transactions)
- `emitUpdate: false` → don't echo through `onUpdate` and create a self-write loop

Same shape as the existing `content-editor.tsx` sync (lines 232–279), simplified for the single-paragraph case (no debounce, no markdown preprocess, no caret clamp).

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run editor/title-editor.test.tsx` — 4 new tests pass:
  - syncs when unfocused
  - preserves user typing when focused
  - short-circuits when already equal
  - clears when transitioning to empty
- [x] `pnpm --filter @multica/views exec tsc -p tsconfig.json --noEmit` — clean
- [x] `pnpm --filter @multica/views lint` — no new errors/warnings in touched files

## Out of scope (per assignment)

- Backend `multica issue update` contract / handler — untouched
- No rewrite of `TitleEditor`; change is ~25 lines in one effect
- 5 callsites (`issue-detail`, `project-detail`, `autopilot-dialog`, `create-issue`, `create-project`) get the fix automatically without code changes
- No feature flag, dialog, or i18n added