### PR TITLE
fix: randomize POSTGRES_PASSWORD in install.sh (MUL-2614)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -317,16 +317,19 @@ setup_server() {
 
   # Generate .env if needed
   if [ ! -f .env ]; then
-    info "Creating .env with random JWT_SECRET..."
+    info "Creating .env with random secrets..."
     cp .env.example .env
-    local jwt
+    local jwt pgpass
     jwt=$(openssl rand -hex 32)
+    pgpass=$(openssl rand -hex 16)
     if [ "$(uname -s)" = "Darwin" ]; then
       sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
+      sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
     else
       sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
+      sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
     fi
-    ok "Generated .env with random JWT_SECRET"
+    ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else
     ok "Using existing .env"
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -321,13 +321,15 @@ setup_server() {
     cp .env.example .env
     local jwt pgpass
     jwt=$(openssl rand -hex 32)
-    pgpass=$(openssl rand -hex 16)
+    pgpass=$(openssl rand -hex 24)
     if [ "$(uname -s)" = "Darwin" ]; then
       sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
       sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
+      sed -i '' "s|^DATABASE_URL=postgres://[^:]*:[^@]*@|DATABASE_URL=postgres://multica:${pgpass}@|" .env
     else
       sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
       sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
+      sed -i "s|^DATABASE_URL=postgres://[^:]*:[^@]*@|DATABASE_URL=postgres://multica:${pgpass}@|" .env
     fi
     ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -325,11 +325,11 @@ setup_server() {
     if [ "$(uname -s)" = "Darwin" ]; then
       sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
       sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
-      sed -i '' "s|^DATABASE_URL=postgres://[^:]*:[^@]*@|DATABASE_URL=postgres://multica:${pgpass}@|" .env
+      sed -i '' -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]+(@.*)#\1${pgpass}\2#" .env
     else
       sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
       sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pgpass/" .env
-      sed -i "s|^DATABASE_URL=postgres://[^:]*:[^@]*@|DATABASE_URL=postgres://multica:${pgpass}@|" .env
+      sed -i -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]+(@.*)#\1${pgpass}\2#" .env
     fi
     ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else


### PR DESCRIPTION
## What does this PR do?

`scripts/install.sh` randomizes `JWT_SECRET` on first install but leaves `POSTGRES_PASSWORD` as the hardcoded default `multica`. This means every fresh self-host deployment has a predictable database credential — a security risk the issue reporter identified as a potential code-execution vector via `agent_task_queue` table writes.

This PR generates a random 48-char password via `openssl rand -hex 24` and writes it to **both** `POSTGRES_PASSWORD` and the password segment inside `DATABASE_URL`, using a position-aware sed that preserves user/host/port/db values.

## Related Issue

Closes #2757

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — generate `pgpass` via `openssl rand -hex 24`
- Replace `POSTGRES_PASSWORD=` line (both macOS and Linux sed variants)
- Replace password segment inside `DATABASE_URL=postgres://...:...@` using `|` delimiter to avoid escaping issues

## How to Test

1. `git clone https://github.com/multica-ai/multica.git && cd multica`
2. `bash scripts/install.sh --with-server`
3. `grep -E '^(POSTGRES_PASSWORD|DATABASE_URL)=' .env`
4. Verify `POSTGRES_PASSWORD` is a 48-char hex string
5. Verify the same password appears in `DATABASE_URL`
6. Run `bash scripts/install.sh --with-server` again — verify existing `.env` is preserved (idempotent)

## Checklist

- [x] I have run tests locally and they pass (`installer` CI job passes for both ubuntu-latest and macos-latest)
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** OpenCode (Sisyphus agent)

**Prompt / approach:** Identified the bug from GitHub issue #2757, implemented the fix matching the issue's suggested approach (mirror JWT_SECRET pattern with DATABASE_URL rewrite), verified against competing PRs #2758 and #2879.