### PR TITLE
fix: add ping/pong heartbeat to WebSocket client

### DIFF
--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -37,6 +37,11 @@ export class WSClient {
   private onReconnectCallbacks = new Set<() => void>();
   private anyHandlers = new Set<(msg: WSMessage) => void>();
   private logger: Logger;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private pongTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private pongReceived = false;
+  private pingIntervalMs: number;
+  private pongTimeoutMs: number;
 
   constructor(
     url: string,
@@ -44,12 +49,16 @@ export class WSClient {
       logger?: Logger;
       cookieAuth?: boolean;
       identity?: WSClientIdentity;
+      pingInterval?: number;
+      pongTimeout?: number;
     },
   ) {
     this.baseUrl = url;
     this.logger = options?.logger ?? noopLogger;
     this.cookieAuth = options?.cookieAuth ?? false;
     this.identity = options?.identity;
+    this.pingIntervalMs = options?.pingInterval ?? 30_000;
+    this.pongTimeoutMs = options?.pongTimeout ?? 10_000;
   }
 
   setAuth(token: string | null, workspaceSlug: string) {
@@ -100,6 +109,15 @@ export class WSClient {
         this.onAuthenticated();
         return;
       }
+      if ((msg as any).type === "pong") {
+        this.pongReceived = true;
+        this.clearPongTimeoutTimer();
+        return;
+      }
+      if ((msg as any).type === "ping") {
+        this.send({ type: "pong" } as any);
+        return;
+      }
       this.logger.debug("received", msg.type);
       const eventHandlers = this.handlers.get(msg.type);
       if (eventHandlers) {
@@ -113,6 +131,7 @@ export class WSClient {
     };
 
     this.ws.onclose = () => {
+      this.stopPing();
       this.logger.warn("disconnected, reconnecting in 3s");
       this.reconnectTimer = setTimeout(() => this.connect(), 3000);
     };
@@ -125,6 +144,7 @@ export class WSClient {
 
   private onAuthenticated() {
     this.logger.info("connected");
+    this.startPing();
     if (this.hasConnectedBefore) {
       for (const cb of this.onReconnectCallbacks) {
         try {
@@ -137,7 +157,38 @@ export class WSClient {
     this.hasConnectedBefore = true;
   }
 
+  private startPing() {
+    this.stopPing();
+    this.pingTimer = setInterval(() => {
+      this.pongReceived = false;
+      this.send({ type: "ping" } as any);
+      this.pongTimeoutTimer = setTimeout(() => {
+        if (!this.pongReceived && this.ws) {
+          this.logger.warn("ws: pong timeout, closing connection");
+          this.stopPing();
+          this.ws.close();
+        }
+      }, this.pongTimeoutMs);
+    }, this.pingIntervalMs);
+  }
+
+  private stopPing() {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+    this.clearPongTimeoutTimer();
+  }
+
+  private clearPongTimeoutTimer() {
+    if (this.pongTimeoutTimer) {
+      clearTimeout(this.pongTimeoutTimer);
+      this.pongTimeoutTimer = null;
+    }
+  }
+
   disconnect() {
+    this.stopPing();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;


### PR DESCRIPTION
## What does this PR do?

WebSocket connections silently die without detection when the server or network drops the TCP connection. No `close`/`error` event fires, so the client never reconnects and the UI goes stale — issues disappear from the board until a full page reload.

As diagnosed by maintainer @Bohan-J in the issue comments, this is caused by the combination of:
1. **No WS ping/pong heartbeats** → connection enters half-open state after idle
2. **`staleTime: Infinity`** in React Query → cache never auto-refreshes
3. **Lost WS events** (`issue:created`, `issue:updated`) → stale/incomplete UI

This PR adds a configurable ping/pong heartbeat to the WS client. The server already handles `{"type":"ping"}` → `{"type":"pong"}` at `hub.go:818`.

## Related Issue

Closes #951

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/core/api/ws-client.ts` — add ping/pong heartbeat with configurable intervals (default: 30s ping, 10s pong timeout)
- Client sends `{"type":"ping"}` every 30s after authentication
- If no `{"type":"pong"}` response within 10s, force-closes WebSocket → triggers reconnect
- Also responds to server-initiated pings with `{"type":"pong"}`
- All timers cleaned up on disconnect/close

## How to Test

1. Open Multica UI, verify WebSocket connects normally (check browser console)
2. Kill the server process → verify client detects dead connection within ~40s and reconnects when server comes back
3. Verify no ping/pong spam in console under normal operation
4. Leave the UI idle for 5+ minutes → verify issues still appear (no stale state)
5. Optional: test custom intervals via constructor options

## Checklist

- [x] I have run tests locally and they pass (frontend CI passes — TypeScript typecheck + lint)
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** OpenCode (Sisyphus agent)

**Prompt / approach:** Analyzed the maintainer's diagnosis in issue #951 comments, confirmed server-side ping handler exists at `hub.go:818`, implemented client-side heartbeat with configurable intervals and proper cleanup.