### PR TITLE
fix: return 409 instead of 500 when runtime deletion blocked by archived agents

### DIFF
--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -584,14 +584,24 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Remove archived agents so the FK constraint (ON DELETE RESTRICT) won't block deletion.
+	// Best-effort: remove archived agents so the FK constraint (ON DELETE
+	// RESTRICT) on agent.runtime_id won't block runtime deletion. If this
+	// fails — e.g. an archived agent is a squad leader and
+	// squad.leader_id has ON DELETE RESTRICT — log the error but continue.
+	// The agents are already archived and inert; blocking runtime deletion
+	// on their clean-up is worse than leaving them behind.
 	if err := h.Queries.DeleteArchivedAgentsByRuntime(r.Context(), rt.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to clean up archived agents")
-		return
+		slog.Warn("failed to delete archived agents during runtime teardown",
+			"runtime_id", uuidToString(rt.ID), "error", err)
 	}
 
 	if err := h.Queries.DeleteAgentRuntime(r.Context(), rt.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete runtime")
+		// The archived-agent cleanup above is best-effort, but if the runtime
+		// row itself can't be deleted (agents still reference it via FK), that's
+		// a real failure — the runtime would reappear on next refetch.
+		slog.Warn("runtime row deletion failed after archived-agent cleanup",
+			"runtime_id", uuidToString(rt.ID), "error", err)
+		writeError(w, http.StatusConflict, "runtime has archived agents that cannot be removed (e.g. squad leaders). Remove squad references first, then retry.")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Deleting a runtime with archived agents returns 500 because `agent.runtime_id` has `ON DELETE RESTRICT`
- If an archived agent is a squad leader, `squad.leader_id` also has `ON DELETE RESTRICT`, blocking agent deletion too
- Fix: archived-agent cleanup is now best-effort (log warning, continue)
- If runtime row deletion still fails, returns **409 Conflict** with actionable message instead of 500

## Before
```
DELETE /api/runtimes/:id → 500 Internal Server Error
```

## After
```
DELETE /api/runtimes/:id → 409 Conflict
{ "error": "runtime has archived agents that cannot be removed (e.g. squad leaders). Remove squad references first, then retry." }
```

## Test plan
- [ ] Delete a runtime with no archived agents → 200 OK
- [ ] Delete a runtime with archived agents (no squad leaders) → archived agents cleaned up, 200 OK
- [ ] Delete a runtime where an archived agent is a squad leader → 409 with actionable message
- [ ] Remove squad reference, retry delete → 200 OK

Closes #2954