### PR TITLE
fix: link sub-issues to parent when using Create With Agent

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -515,6 +515,7 @@ export class ApiClient {
     squad_id?: string;
     prompt: string;
     project_id?: string | null;
+    parent_issue_id?: string;
   }): Promise<{ task_id: string }> {
     return this.fetch("/api/issues/quick-create", {
       method: "POST",

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -369,6 +369,7 @@ export function ManualCreatePanel({
           ? { squad_id: assigneeId }
           : {}),
       ...(projectId ? { project_id: projectId } : {}),
+      ...(parentIssueId ? { parent_issue_id: parentIssueId } : {}),
     });
   };
 

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -280,6 +280,7 @@ export function AgentCreatePanel({
           : { squad_id: actor.id }),
         prompt: md,
         project_id: projectId ?? undefined,
+        parent_issue_id: (data?.parent_issue_id as string) || undefined,
       });
       setLastActor(actor.type, actor.id);
       setLastProjectId(projectId);
@@ -358,11 +359,14 @@ export function AgentCreatePanel({
         : {}),
     });
     setLastMode("manual");
-    // Hand the picked project to the manual panel through the same `data`
-    // channel that already carries agent_id / parent_issue_id. The manual
-    // panel reads `data.project_id` on mount; this preserves the user's
-    // selection across the mode flip without piping a third store through.
-    onSwitchMode?.(projectId ? { project_id: projectId } : null);
+    // Hand the picked project and parent_issue_id to the manual panel through
+    // the same `data` channel. The manual panel reads `data.project_id` and
+    // `data.parent_issue_id` on mount; this preserves the user's selection
+    // across the mode flip without piping additional stores through.
+    const carry: Record<string, unknown> = {};
+    if (projectId) carry.project_id = projectId;
+    if (data?.parent_issue_id) carry.parent_issue_id = data.parent_issue_id;
+    onSwitchMode?.(Object.keys(carry).length > 0 ? carry : null);
   };
 
   return (

--- a/server/cmd/server/quick_create_subscriber_test.go
+++ b/server/cmd/server/quick_create_subscriber_test.go
@@ -37,6 +37,7 @@ func TestQuickCreateCompletion_SubscribesRequester(t *testing.T) {
 		pgtype.UUID{},
 		"please file a bug",
 		pgtype.UUID{},
+		pgtype.UUID{},
 	)
 	if err != nil {
 		t.Fatalf("EnqueueQuickCreateTask: %v", err)
@@ -109,6 +110,7 @@ func TestQuickCreateFailure_DoesNotSubscribeRequester(t *testing.T) {
 		parseUUID(agentID),
 		pgtype.UUID{},
 		"another bug",
+		pgtype.UUID{},
 		pgtype.UUID{},
 	)
 	if err != nil {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -105,6 +105,11 @@ func buildQuickCreatePrompt(task Task) string {
 	} else {
 		b.WriteString("- **project**: omit. The platform will route the issue to the workspace default.\n")
 	}
+
+	if task.ParentIssueID != "" {
+		fmt.Fprintf(&b, "- **parent**: required for this run. Pass `--parent %q` so the new issue is created as a sub-issue of the specified parent. The user chose to create this issue under that parent — always pass the flag.\n", task.ParentIssueID)
+	}
+
 	b.WriteString("- **status**: omit (defaults to `todo`).\n")
 	b.WriteString("- **attachments**: do NOT pass `--attachment`. The flag only accepts LOCAL file paths. Any image URL in the user input is already markdown — keep it inline in `--description` instead.\n\n")
 

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -66,6 +66,7 @@ type Task struct {
 	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
 	SquadID                 string                `json:"squad_id,omitempty"`                  // when the picker was a squad, the squad's UUID; Agent is still the resolved leader
 	SquadName               string                `json:"squad_name,omitempty"`                // display name for the picker squad, used in prompt text
+	ParentIssueID           string                `json:"parent_issue_id,omitempty"`           // when set, agent must pass --parent to CLI
 	// RequestingUserName + RequestingUserProfileDescription describe the human
 	// the agent is working on behalf of. v1 sources them from the runtime
 	// owner (the user who registered the daemon). Empty when the runtime has

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -189,6 +189,7 @@ type AgentTaskResponse struct {
 	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
 	SquadID                 string                `json:"squad_id,omitempty"`                  // for quick-create tasks where the picker was a squad; Agent is still the resolved leader
 	SquadName               string                `json:"squad_name,omitempty"`                // display name for the picker squad
+	ParentIssueID           string                `json:"parent_issue_id,omitempty"`           // for quick-create tasks: pre-set parent so the agent passes --parent to CLI
 	// RequestingUserName + RequestingUserProfileDescription mirror the user
 	// the agent is acting on behalf of (see daemon/types.go). v1 sources them
 	// from the runtime owner so they're populated for daemon runtimes and

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1392,6 +1392,10 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			resp.QuickCreatePrompt = qc.Prompt
 			resp.WorkspaceID = qc.WorkspaceID
 
+			if qc.ParentIssueID != "" {
+				resp.ParentIssueID = qc.ParentIssueID
+			}
+
 			// When the user picked a project in the modal, surface its title
 			// and resources to the daemon so the agent has the same context
 			// it would for an issue-bound task: the prompt template can name

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1417,10 +1417,11 @@ func (h *Handler) ChildIssueProgress(w http.ResponseWriter, r *http.Request) {
 // instead of letting it default. The frontend remembers the user's last
 // pick per workspace, so frequent users skip retyping "in project X".
 type QuickCreateIssueRequest struct {
-	AgentID   string `json:"agent_id,omitempty"`
-	SquadID   string `json:"squad_id,omitempty"`
-	Prompt    string `json:"prompt"`
-	ProjectID string `json:"project_id,omitempty"`
+	AgentID      string `json:"agent_id,omitempty"`
+	SquadID      string `json:"squad_id,omitempty"`
+	Prompt       string `json:"prompt"`
+	ProjectID    string `json:"project_id,omitempty"`
+	ParentIssueID string `json:"parent_issue_id,omitempty"`
 }
 
 // QuickCreateIssueResponse echoes the queued task id so the frontend can
@@ -1567,7 +1568,23 @@ func (h *Handler) QuickCreateIssue(w http.ResponseWriter, r *http.Request) {
 		projectUUID = pid
 	}
 
-	task, err := h.TaskService.EnqueueQuickCreateTask(r.Context(), wsUUID, requesterUUID, agentUUID, squadUUID, prompt, projectUUID)
+	var parentIssueUUID pgtype.UUID
+	if strings.TrimSpace(req.ParentIssueID) != "" {
+		pid, ok := parseUUIDOrBadRequest(w, req.ParentIssueID, "parent_issue_id")
+		if !ok {
+			return
+		}
+		if _, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+			ID:          pid,
+			WorkspaceID: wsUUID,
+		}); err != nil {
+			writeError(w, http.StatusBadRequest, "parent issue not found")
+			return
+		}
+		parentIssueUUID = pid
+	}
+
+	task, err := h.TaskService.EnqueueQuickCreateTask(r.Context(), wsUUID, requesterUUID, agentUUID, squadUUID, prompt, projectUUID, parentIssueUUID)
 	if err != nil {
 		slog.Warn("quick-create enqueue failed", append(logger.RequestAttrs(r), "error", err)...)
 		writeError(w, http.StatusInternalServerError, "failed to enqueue quick-create task")

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -514,12 +514,13 @@ func (s *TaskService) enqueueMentionTask(ctx context.Context, issue db.Issue, ag
 // onto the agent's Instructions, matching the behavior of issue-bound
 // tasks assigned to the squad.
 type QuickCreateContext struct {
-	Type        string `json:"type"`
-	Prompt      string `json:"prompt"`
-	RequesterID string `json:"requester_id"`
-	WorkspaceID string `json:"workspace_id"`
-	ProjectID   string `json:"project_id,omitempty"`
-	SquadID     string `json:"squad_id,omitempty"`
+	Type          string `json:"type"`
+	Prompt        string `json:"prompt"`
+	RequesterID   string `json:"requester_id"`
+	WorkspaceID   string `json:"workspace_id"`
+	ProjectID     string `json:"project_id,omitempty"`
+	SquadID       string `json:"squad_id,omitempty"`
+	ParentIssueID string `json:"parent_issue_id,omitempty"`
 }
 
 // QuickCreateContextType marks a task as a quick-create job.
@@ -540,7 +541,7 @@ const QuickCreateContextType = "quick_create"
 // The handler has already resolved it to the squad's leader agent for
 // agentID; the squadID hint is stamped into the task context so the daemon
 // claim handler can inject the squad-leader briefing on dispatch.
-func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID, squadID pgtype.UUID, prompt string, projectID pgtype.UUID) (db.AgentTaskQueue, error) {
+func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID, squadID pgtype.UUID, prompt string, projectID pgtype.UUID, parentIssueID pgtype.UUID) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("load agent: %w", err)
@@ -563,6 +564,9 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 	}
 	if squadID.Valid {
 		payload.SquadID = util.UUIDToString(squadID)
+	}
+	if parentIssueID.Valid {
+		payload.ParentIssueID = util.UUIDToString(parentIssueID)
 	}
 	contextJSON, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Creating a sub-issue via "Create With Agent" (quick-create) never passed `parent_issue_id` from the modal to the server
- The daemon received a task with no issue linkage, creating an orphaned issue instead of a proper sub-issue
- Threads `parent_issue_id` through the full stack: modal → API client → server handler → daemon types → prompt template

## Changes (8 files)

| File | Change |
|---|---|
| `packages/views/modals/quick-create-issue.tsx` | Pass `parent_issue_id` to API call |
| `packages/views/modals/create-issue.tsx` | Forward `parent_issue_id` to `quickCreateIssue` |
| `packages/core/api/client.ts` | Accept `parent_issue_id` in `quickCreateIssue()` |
| `server/internal/handler/agent.go` | Propagate to daemon task creation |
| `server/internal/handler/daemon.go` | Include `parent_issue_id` in quick-create context |
| `server/internal/service/task.go` | Pass through task creation pipeline |
| `server/internal/daemon/types.go` | Add `ParentIssueID` to `QuickCreateContext` |
| `server/internal/daemon/prompt.go` | Include `--parent` flag in agent command |

## Test plan
- [ ] Open an issue → click "Create sub-issue" → "Create With Agent" → verify sub-issue is linked to parent
- [ ] Verify parent issue shows sub-issue in its children list
- [ ] Verify agent command includes `--parent <uuid>` flag
- [ ] Create a regular (non-agent) sub-issue → verify still works (no regression)

Closes #3029