### PR TITLE
[codex] Honor duplicate title preference

### DIFF
--- a/packages/core/issues/mutations.test.ts
+++ b/packages/core/issues/mutations.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { applyIssueCreatePreferences } from "./mutations";
+import { useIssueCreatePreferencesStore } from "./stores/create-preferences-store";
+
+describe("applyIssueCreatePreferences", () => {
+  beforeEach(() => {
+    useIssueCreatePreferencesStore.setState({ duplicatePolicy: "confirm" });
+  });
+
+  it("leaves create requests unchanged when duplicate confirmation is enabled", () => {
+    const request = { title: "Ship the fix" };
+
+    expect(applyIssueCreatePreferences(request)).toBe(request);
+  });
+
+  it("adds allow_duplicate when the local preference allows duplicate titles", () => {
+    useIssueCreatePreferencesStore.setState({ duplicatePolicy: "allow" });
+
+    expect(applyIssueCreatePreferences({ title: "Ship the fix" })).toEqual({
+      title: "Ship the fix",
+      allow_duplicate: true,
+    });
+  });
+
+  it("does not override an explicit allow_duplicate value", () => {
+    useIssueCreatePreferencesStore.setState({ duplicatePolicy: "allow" });
+    const request = { title: "Ship the fix", allow_duplicate: false };
+
+    expect(applyIssueCreatePreferences(request)).toBe(request);
+  });
+});

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -25,6 +25,7 @@ import {
 } from "./delete-cache";
 import { useWorkspaceId } from "../hooks";
 import { useRecentIssuesStore } from "./stores";
+import { useIssueCreatePreferencesStore } from "./stores/create-preferences-store";
 import type { GroupedIssuesResponse, Issue, IssueAssigneeGroup, IssueReaction, IssueStatus } from "../types";
 import type {
   CreateIssueRequest,
@@ -48,6 +49,13 @@ export type ToggleIssueReactionVars = {
   emoji: string;
   existing: IssueReaction | undefined;
 };
+
+export function applyIssueCreatePreferences(data: CreateIssueRequest): CreateIssueRequest {
+  if (data.allow_duplicate !== undefined) return data;
+  return useIssueCreatePreferencesStore.getState().duplicatePolicy === "allow"
+    ? { ...data, allow_duplicate: true }
+    : data;
+}
 
 // ---------------------------------------------------------------------------
 // Per-status pagination
@@ -163,7 +171,7 @@ export function useCreateIssue() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   return useMutation({
-    mutationFn: (data: CreateIssueRequest) => api.createIssue(data),
+    mutationFn: (data: CreateIssueRequest) => api.createIssue(applyIssueCreatePreferences(data)),
     onSuccess: (newIssue) => {
       qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
         old ? addIssueToBuckets(old, newIssue) : old,

--- a/packages/core/issues/stores/create-preferences-store.ts
+++ b/packages/core/issues/stores/create-preferences-store.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { defaultStorage } from "../../platform/storage";
+
+export type IssueDuplicatePolicy = "confirm" | "allow";
+
+interface IssueCreatePreferencesState {
+  duplicatePolicy: IssueDuplicatePolicy;
+  setDuplicatePolicy: (policy: IssueDuplicatePolicy) => void;
+}
+
+export const useIssueCreatePreferencesStore = create<IssueCreatePreferencesState>()(
+  persist(
+    (set) => ({
+      duplicatePolicy: "confirm",
+      setDuplicatePolicy: (policy) => set({ duplicatePolicy: policy }),
+    }),
+    {
+      name: "multica_issue_create_preferences",
+      storage: createJSONStorage(() => defaultStorage),
+    },
+  ),
+);

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -4,6 +4,10 @@ export {
   openCreateIssueWithPreference,
   type CreateMode,
 } from "./create-mode-store";
+export {
+  useIssueCreatePreferencesStore,
+  type IssueDuplicatePolicy,
+} from "./create-preferences-store";
 export { useIssueDraftStore } from "./draft-store";
 export {
   useRecentIssuesStore,

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -15,6 +15,7 @@ export interface CreateIssueRequest {
   start_date?: string;
   due_date?: string;
   attachment_ids?: string[];
+  allow_duplicate?: boolean;
 }
 
 export interface UpdateIssueRequest {

--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -125,6 +125,8 @@
     "toast_failed": "Failed to create issue",
     "toast_duplicate_title": "Duplicate issue",
     "toast_duplicate_view": "View existing issue",
+    "toast_duplicate_create_anyway": "Create anyway",
+    "toast_duplicate_always_allow": "Always create duplicate titles",
     "toast_link_subissues_all_failed": "Failed to link sub-issues",
     "toast_link_subissues_partial": "Failed to link {{failed}} of {{total}} sub-issues",
     "switch_to_agent": "Switch to Agent",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -17,6 +17,12 @@
       "browser_suffix": " (browser)",
       "hint": "Used for dashboards, charts, and any 'today' label shown to you. It's a personal preference that applies across all your workspaces.",
       "sync_failed": "Failed to save your timezone preference."
+    },
+    "issue_create": {
+      "title": "Issue Creation",
+      "description": "Personal defaults used when you create issues in this browser.",
+      "allow_duplicate_label": "Allow duplicate issue titles",
+      "allow_duplicate_hint": "Skip the duplicate-title confirmation and create the issue directly."
     }
   },
   "page": {

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -125,6 +125,8 @@
     "toast_failed": "创建 issue 失败",
     "toast_duplicate_title": "已存在同名 issue",
     "toast_duplicate_view": "查看已有 issue",
+    "toast_duplicate_create_anyway": "仍然创建",
+    "toast_duplicate_always_allow": "以后总是创建同名 issue",
     "toast_link_subissues_all_failed": "关联子 issue 失败",
     "toast_link_subissues_partial": "{{total}} 个子 issue 中有 {{failed}} 个关联失败",
     "switch_to_agent": "切换到智能体",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -17,6 +17,12 @@
       "browser_suffix": "（浏览器）",
       "hint": "用于仪表盘、图表和「今天」标签。这是个人偏好，在你的所有工作区中通用。",
       "sync_failed": "保存时区偏好失败。"
+    },
+    "issue_create": {
+      "title": "Issue 创建",
+      "description": "你在当前浏览器中创建 issue 时使用的个人默认设置。",
+      "allow_duplicate_label": "允许创建同名 issue",
+      "allow_duplicate_hint": "跳过同名确认，直接创建 issue。"
     }
   },
   "page": {

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -25,6 +25,7 @@ const mockSetDraft = vi.hoisted(() => vi.fn());
 const mockClearDraft = vi.hoisted(() => vi.fn());
 const mockSetLastAssignee = vi.hoisted(() => vi.fn());
 const mockSetKeepOpen = vi.hoisted(() => vi.fn());
+const mockSetDuplicatePolicy = vi.hoisted(() => vi.fn());
 const mockToastCustom = vi.hoisted(() => vi.fn());
 const mockToastDismiss = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
@@ -51,6 +52,11 @@ const mockQuickCreateStore = {
   keepOpen: false,
   setKeepOpen: mockSetKeepOpen,
 };
+
+const mockIssueCreatePreferencesStore = vi.hoisted(() => ({
+  duplicatePolicy: "confirm" as "confirm" | "allow",
+  setDuplicatePolicy: mockSetDuplicatePolicy,
+}));
 
 vi.mock("../navigation", () => ({
   useNavigation: () => ({ push: mockPush }),
@@ -85,6 +91,12 @@ vi.mock("@multica/core/issues/stores/draft-store", () => ({
 vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
   useQuickCreateStore: (selector?: (state: typeof mockQuickCreateStore) => unknown) =>
     (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
+}));
+
+vi.mock("@multica/core/issues/stores/create-preferences-store", () => ({
+  useIssueCreatePreferencesStore: (
+    selector?: (state: typeof mockIssueCreatePreferencesStore) => unknown,
+  ) => (selector ? selector(mockIssueCreatePreferencesStore) : mockIssueCreatePreferencesStore),
 }));
 
 vi.mock("@multica/core/issues/mutations", () => ({
@@ -312,6 +324,10 @@ describe("CreateIssueModal", () => {
     mockSetKeepOpen.mockImplementation((v: boolean) => {
       mockQuickCreateStore.keepOpen = v;
     });
+    mockIssueCreatePreferencesStore.duplicatePolicy = "confirm";
+    mockSetDuplicatePolicy.mockImplementation((policy: "confirm" | "allow") => {
+      mockIssueCreatePreferencesStore.duplicatePolicy = policy;
+    });
     // Reset the shared draft mock so per-test assignee seeding (squad / agent)
     // doesn't leak into the next test in the suite.
     mockDraftStore.draft.assigneeType = undefined;
@@ -484,6 +500,113 @@ describe("CreateIssueModal", () => {
     await user.click(screen.getByRole("button", { name: "View existing issue" }));
     expect(mockPush).toHaveBeenCalledWith("/ws-test/issues/issue-dup");
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-dup");
+  });
+
+  it("can retry a duplicate issue create with allow_duplicate", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockCreateIssue
+      .mockRejectedValueOnce(
+        new ApiError("An active issue with this title already exists: MUL-7 – Login bug", 409, "Conflict", {
+          code: "active_duplicate_issue",
+          error: "An active issue with this title already exists: MUL-7 – Login bug",
+          issue: {
+            id: "issue-dup",
+            identifier: "MUL-7",
+            title: "Login bug",
+          },
+        }),
+      )
+      .mockResolvedValueOnce({
+        id: "issue-new",
+        identifier: "MUL-8",
+        title: "Login bug",
+        status: "todo",
+      });
+
+    renderModal(<CreateIssueModal onClose={onClose} />);
+    await user.type(screen.getByPlaceholderText("Issue title"), "Login bug");
+    await user.click(screen.getByRole("button", { name: "Create Issue" }));
+
+    await waitFor(() => expect(mockToastCustom).toHaveBeenCalledTimes(1));
+    const renderToast = mockToastCustom.mock.calls[0]?.[0];
+    render(renderToast("toast-dup"));
+
+    await user.click(screen.getByRole("button", { name: "Create anyway" }));
+
+    await waitFor(() => expect(mockCreateIssue).toHaveBeenCalledTimes(2));
+    expect(mockCreateIssue).toHaveBeenNthCalledWith(2, {
+      title: "Login bug",
+      description: undefined,
+      status: "todo",
+      priority: "none",
+      assignee_type: undefined,
+      assignee_id: undefined,
+      start_date: undefined,
+      due_date: undefined,
+      attachment_ids: undefined,
+      parent_issue_id: undefined,
+      project_id: undefined,
+      allow_duplicate: true,
+    });
+    expect(mockSetDuplicatePolicy).not.toHaveBeenCalled();
+    expect(mockToastDismiss).toHaveBeenCalledWith("toast-dup");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("persists the duplicate allow preference from the duplicate toast", async () => {
+    const user = userEvent.setup();
+    mockCreateIssue
+      .mockRejectedValueOnce(
+        new ApiError("An active issue with this title already exists: MUL-7 – Login bug", 409, "Conflict", {
+          code: "active_duplicate_issue",
+          error: "An active issue with this title already exists: MUL-7 – Login bug",
+          issue: {
+            id: "issue-dup",
+            identifier: "MUL-7",
+            title: "Login bug",
+          },
+        }),
+      )
+      .mockResolvedValueOnce({
+        id: "issue-new",
+        identifier: "MUL-8",
+        title: "Login bug",
+        status: "todo",
+      });
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+    await user.type(screen.getByPlaceholderText("Issue title"), "Login bug");
+    await user.click(screen.getByRole("button", { name: "Create Issue" }));
+
+    await waitFor(() => expect(mockToastCustom).toHaveBeenCalledTimes(1));
+    const renderToast = mockToastCustom.mock.calls[0]?.[0];
+    render(renderToast("toast-dup"));
+
+    await user.click(screen.getByLabelText("Always create duplicate titles"));
+    await user.click(screen.getByRole("button", { name: "Create anyway" }));
+
+    await waitFor(() => expect(mockCreateIssue).toHaveBeenCalledTimes(2));
+    expect(mockSetDuplicatePolicy).toHaveBeenCalledWith("allow");
+    expect(mockCreateIssue).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ allow_duplicate: true }),
+    );
+  });
+
+  it("sends allow_duplicate by default when the local preference allows duplicates", async () => {
+    const user = userEvent.setup();
+    mockIssueCreatePreferencesStore.duplicatePolicy = "allow";
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+    await user.type(screen.getByPlaceholderText("Issue title"), "Login bug");
+    await user.click(screen.getByRole("button", { name: "Create Issue" }));
+
+    await waitFor(() => {
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ allow_duplicate: true }),
+      );
+    });
   });
 
   // Schema drift safety: server returns a 409 with a body that doesn't match

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -41,6 +41,7 @@ import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
+import { useIssueCreatePreferencesStore } from "@multica/core/issues/stores/create-preferences-store";
 import { useQuickCreateStore } from "@multica/core/issues/stores/quick-create-store";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
@@ -98,6 +99,8 @@ export function ManualCreatePanel({
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
+  const duplicatePolicy = useIssueCreatePreferencesStore((s) => s.duplicatePolicy);
+  const setDuplicatePolicy = useIssueCreatePreferencesStore((s) => s.setDuplicatePolicy);
 
   const [title, setTitle] = useState(draft.title);
   const [formResetKey, setFormResetKey] = useState(0);
@@ -194,10 +197,11 @@ export function ManualCreatePanel({
     setFormResetKey((key) => key + 1);
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (forceAllowDuplicate = false) => {
     if (!title.trim() || submitting) return;
     setSubmitting(true);
     try {
+      const allowDuplicate = forceAllowDuplicate || duplicatePolicy === "allow";
       const issue = await createIssueMutation.mutateAsync({
         title: title.trim(),
         description: descEditorRef.current?.getMarkdown()?.trim() || undefined,
@@ -210,6 +214,7 @@ export function ManualCreatePanel({
         attachment_ids: attachmentIds.length > 0 ? attachmentIds : undefined,
         parent_issue_id: parentIssueId,
         project_id: projectId,
+        ...(allowDuplicate ? { allow_duplicate: true } : {}),
       });
 
       // Link queued children to the new parent. Deferred to after create
@@ -302,31 +307,20 @@ export function ManualCreatePanel({
         if (dup) {
           toast.custom(
             (toastId) => (
-              <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-[360px]">
-                <div className="flex items-center gap-2 mb-2">
-                  <div className="flex items-center justify-center size-5 rounded-full bg-amber-500/15 text-amber-500">
-                    <AlertTriangle className="size-3" />
-                  </div>
-                  <span className="text-sm font-medium">
-                    {t(($) => $.create_issue.toast_duplicate_title)}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2 text-sm text-muted-foreground ml-7">
-                  <span className="truncate">{dup.issue.identifier} – {dup.issue.title}</span>
-                </div>
-                <button
-                  type="button"
-                  className="ml-7 mt-2 text-sm text-primary hover:underline cursor-pointer"
-                  onClick={() => {
-                    router.push(p.issueDetail(dup.issue.id));
-                    toast.dismiss(toastId);
-                  }}
-                >
-                  {t(($) => $.create_issue.toast_duplicate_view)}
-                </button>
-              </div>
+              <DuplicateIssueToast
+                issue={dup.issue}
+                onViewExisting={() => {
+                  router.push(p.issueDetail(dup.issue.id));
+                  toast.dismiss(toastId);
+                }}
+                onCreateAnyway={(alwaysAllow) => {
+                  if (alwaysAllow) setDuplicatePolicy("allow");
+                  toast.dismiss(toastId);
+                  void handleSubmit(true);
+                }}
+              />
             ),
-            { duration: 5000 },
+            { duration: 10000 },
           );
           return;
         }
@@ -453,7 +447,7 @@ export function ManualCreatePanel({
                 placeholder={t(($) => $.create_issue.title_placeholder)}
                 className="text-lg font-semibold"
                 onChange={(v) => updateTitle(v)}
-                onSubmit={handleSubmit}
+                onSubmit={() => void handleSubmit()}
               />
             </div>
 
@@ -689,12 +683,12 @@ export function ManualCreatePanel({
                 {!title.trim() ? (
                   <TooltipProvider delay={200}>
                     <Tooltip>
-                      <TooltipTrigger render={<span><Button size="sm" onClick={handleSubmit} disabled>{t(($) => $.create_issue.submit)}</Button></span>} />
+                      <TooltipTrigger render={<span><Button size="sm" onClick={() => void handleSubmit()} disabled>{t(($) => $.create_issue.submit)}</Button></span>} />
                       <TooltipContent side="top">{t(($) => $.create_issue.title_required)}</TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
                 ) : (
-                  <Button size="sm" onClick={handleSubmit} disabled={submitting}>
+                  <Button size="sm" onClick={() => void handleSubmit()} disabled={submitting}>
                     {submitting ? t(($) => $.create_issue.submitting) : t(($) => $.create_issue.submit)}
                   </Button>
                 )}
@@ -703,6 +697,60 @@ export function ManualCreatePanel({
           </>
         )}
     </>
+  );
+}
+
+function DuplicateIssueToast({
+  issue,
+  onViewExisting,
+  onCreateAnyway,
+}: {
+  issue: DuplicateIssueErrorBody["issue"];
+  onViewExisting: () => void;
+  onCreateAnyway: (alwaysAllow: boolean) => void;
+}) {
+  const { t } = useT("modals");
+  const [alwaysAllow, setAlwaysAllow] = useState(false);
+
+  return (
+    <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-[380px]">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="flex items-center justify-center size-5 rounded-full bg-amber-500/15 text-amber-500">
+          <AlertTriangle className="size-3" />
+        </div>
+        <span className="text-sm font-medium">
+          {t(($) => $.create_issue.toast_duplicate_title)}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground ml-7">
+        <span className="truncate">{issue.identifier} – {issue.title}</span>
+      </div>
+      <label className="ml-7 mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={alwaysAllow}
+          onChange={(e) => setAlwaysAllow(e.target.checked)}
+          className="size-3"
+        />
+        <span>{t(($) => $.create_issue.toast_duplicate_always_allow)}</span>
+      </label>
+      <div className="ml-7 mt-3 flex items-center gap-3">
+        <button
+          type="button"
+          className="text-sm text-primary hover:underline cursor-pointer"
+          onClick={onViewExisting}
+        >
+          {t(($) => $.create_issue.toast_duplicate_view)}
+        </button>
+        <button
+          type="button"
+          className="text-sm text-primary hover:underline cursor-pointer"
+          onClick={() => onCreateAnyway(alwaysAllow)}
+        >
+          {t(($) => $.create_issue.toast_duplicate_create_anyway)}
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -13,8 +13,15 @@ const mockReload = vi.hoisted(() => vi.fn());
 const mockToastWarning = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
 const mockSetUser = vi.hoisted(() => vi.fn());
+const mockSetDuplicatePolicy = vi.hoisted(() => vi.fn());
 const userRef = vi.hoisted(() => ({
   current: null as { id: string; timezone?: string | null } | null,
+}));
+const issueCreatePreferencesRef = vi.hoisted(() => ({
+  current: {
+    duplicatePolicy: "confirm" as "confirm" | "allow",
+    setDuplicatePolicy: mockSetDuplicatePolicy,
+  },
 }));
 
 vi.mock("@multica/ui/components/common/theme-provider", () => ({
@@ -65,6 +72,15 @@ vi.mock("@multica/core/auth", async () => {
   return { ...actual, useAuthStore };
 });
 
+vi.mock("@multica/core/issues/stores/create-preferences-store", () => ({
+  useIssueCreatePreferencesStore: (
+    selector?: (s: typeof issueCreatePreferencesRef.current) => unknown,
+  ) => {
+    const state = issueCreatePreferencesRef.current;
+    return selector ? selector(state) : state;
+  },
+}));
+
 import { PreferencesTab } from "./preferences-tab";
 
 const TEST_RESOURCES = {
@@ -83,6 +99,10 @@ describe("PreferencesTab — Language switcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     userRef.current = null;
+    issueCreatePreferencesRef.current.duplicatePolicy = "confirm";
+    mockSetDuplicatePolicy.mockImplementation((policy: "confirm" | "allow") => {
+      issueCreatePreferencesRef.current.duplicatePolicy = policy;
+    });
     vi.useFakeTimers({ shouldAdvanceTime: true });
     Object.defineProperty(window, "location", {
       writable: true,
@@ -159,6 +179,10 @@ describe("PreferencesTab — Timezone section", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     userRef.current = null;
+    issueCreatePreferencesRef.current.duplicatePolicy = "confirm";
+    mockSetDuplicatePolicy.mockImplementation((policy: "confirm" | "allow") => {
+      issueCreatePreferencesRef.current.duplicatePolicy = policy;
+    });
   });
 
   // Base UI Select portals its popup onto document.body; unmount each
@@ -237,4 +261,34 @@ describe("PreferencesTab — Timezone section", () => {
       expect(mockSetUser).toHaveBeenCalledWith(clearedUser);
     });
   }, 20000);
+});
+
+describe("PreferencesTab — Issue creation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRef.current = null;
+    issueCreatePreferencesRef.current.duplicatePolicy = "confirm";
+    mockSetDuplicatePolicy.mockImplementation((policy: "confirm" | "allow") => {
+      issueCreatePreferencesRef.current.duplicatePolicy = policy;
+    });
+  });
+
+  it("toggles the local duplicate-title preference", async () => {
+    const user = userEvent.setup();
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("switch", { name: "Allow duplicate issue titles" }));
+
+    expect(mockSetDuplicatePolicy).toHaveBeenCalledWith("allow");
+  });
+
+  it("can turn the duplicate-title preference back to confirmation", async () => {
+    issueCreatePreferencesRef.current.duplicatePolicy = "allow";
+    const user = userEvent.setup();
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("switch", { name: "Allow duplicate issue titles" }));
+
+    expect(mockSetDuplicatePolicy).toHaveBeenCalledWith("confirm");
+  });
 });

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -9,6 +9,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@multica/ui/components/ui/select";
+import { Card, CardContent } from "@multica/ui/components/ui/card";
+import { Switch } from "@multica/ui/components/ui/switch";
 import { useTheme } from "@multica/ui/components/common/theme-provider";
 import { cn } from "@multica/ui/lib/utils";
 import {
@@ -19,6 +21,7 @@ import {
 import { useLocaleAdapter } from "@multica/core/i18n/react";
 import { useAuthStore } from "@multica/core/auth";
 import { api } from "@multica/core/api";
+import { useIssueCreatePreferencesStore } from "@multica/core/issues/stores/create-preferences-store";
 import { browserTimezone, timezoneOptions } from "../../common/timezone-select";
 import { useT } from "../../i18n";
 
@@ -102,6 +105,8 @@ export function PreferencesTab() {
   const { t, i18n } = useT("settings");
   const localeAdapter = useLocaleAdapter();
   const user = useAuthStore((s) => s.user);
+  const duplicatePolicy = useIssueCreatePreferencesStore((s) => s.duplicatePolicy);
+  const setDuplicatePolicy = useIssueCreatePreferencesStore((s) => s.setDuplicatePolicy);
 
   // i18next.language can be a region-tagged BCP-47 string (e.g. "en-US",
   // "zh-Hans-CN") returned by intl-localematcher. Normalize to a supported
@@ -235,6 +240,39 @@ export function PreferencesTab() {
             );
           })}
         </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold">
+            {t(($) => $.preferences.issue_create.title)}
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t(($) => $.preferences.issue_create.description)}
+          </p>
+        </div>
+
+        <Card>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5 pr-4">
+                <p className="text-sm font-medium">
+                  {t(($) => $.preferences.issue_create.allow_duplicate_label)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t(($) => $.preferences.issue_create.allow_duplicate_hint)}
+                </p>
+              </div>
+              <Switch
+                aria-label={t(($) => $.preferences.issue_create.allow_duplicate_label)}
+                checked={duplicatePolicy === "allow"}
+                onCheckedChange={(checked) =>
+                  setDuplicatePolicy(checked ? "allow" : "confirm")
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
       </section>
 
       <TimezoneSection />


### PR DESCRIPTION
## Summary

- Add a local persisted issue creation preference for duplicate-title handling.
- Surface the preference in Settings > Preferences and in the duplicate-title toast.
- Apply the preference inside `useCreateIssue()` so all frontend issue creation entry points honor it, including editor sub-issue creation.

## Why

The CLI already supports `allow_duplicate`. This follow-up completes the frontend support without adding a self-host/env setting or storing the preference in the database.

Root cause: duplicate-title override existed at the API/CLI layer, but the frontend had no local opt-in path. Keeping the behavior only in the create modal would also miss other `useCreateIssue()` callers.

## Validation

- `pnpm --filter @multica/core exec vitest run issues/mutations.test.ts issues/stores/quick-create-store.test.ts`
- `pnpm --filter @multica/views exec vitest run modals/create-issue.test.tsx settings/components/preferences-tab.test.tsx`
- `pnpm --filter @multica/core exec tsc --noEmit --pretty false`
- `git diff --check`
- `make check-worktree` fails in `@multica/views` typecheck on the existing missing declaration for `hast-util-to-html` in `packages/views/editor/code-block-static.tsx` and `packages/views/editor/readonly-content.tsx`.
