### PR TITLE
fix(agent/cursor): remove obsolete 'chat' subcommand from argv (fixes #3077)

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -396,12 +396,11 @@ var cursorBlockedArgs = map[string]blockedArgMode{
 
 // buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
 //
-// Usage: cursor-agent chat -p <prompt> --output-format stream-json
+// Usage: cursor-agent -p <prompt> --output-format stream-json
 //
 //	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
 func buildCursorArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{
-		"chat",
 		"-p", prompt,
 		"--output-format", "stream-json",
 		"--yolo",

--- a/server/pkg/agent/cursor_invocation_test.go
+++ b/server/pkg/agent/cursor_invocation_test.go
@@ -18,7 +18,7 @@ func TestChooseCursorInvocation_PassthroughForNonLauncher(t *testing.T) {
 
 	execName := "cursor-agent"
 	lookedUp := filepath.Join(t.TempDir(), "cursor-agent") // no .cmd / .bat
-	args := []string{"chat", "-p", "hello\nworld", "--output-format", "stream-json", "--yolo"}
+	args := []string{"-p", "hello\nworld", "--output-format", "stream-json", "--yolo"}
 
 	gotExec, gotArgs := chooseCursorInvocation(execName, lookedUp, args, logger)
 

--- a/server/pkg/agent/cursor_invocation_windows_test.go
+++ b/server/pkg/agent/cursor_invocation_windows_test.go
@@ -45,7 +45,6 @@ func TestPlatformCursorInvocation_RewritesCmdLauncherToPowerShellFile(t *testing
 	stubPowerShell(t, fakePS, true)
 
 	args := []string{
-		"chat",
 		"-p", "line1\nline2\nline3",
 		"--output-format", "stream-json",
 		"--yolo",
@@ -84,7 +83,7 @@ func TestPlatformCursorInvocation_SkipsWhenNotCmdOrBat(t *testing.T) {
 	stubPowerShell(t, filepath.Join(dir, "powershell.exe"), true)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	if _, _, ok := platformCursorInvocation(exePath, []string{"chat"}, logger); ok {
+	if _, _, ok := platformCursorInvocation(exePath, []string{"-p", "hello"}, logger); ok {
 		t.Fatalf("expected ok=false for non-.cmd/.bat launcher")
 	}
 }
@@ -101,7 +100,7 @@ func TestPlatformCursorInvocation_SkipsWhenPS1Missing(t *testing.T) {
 	stubPowerShell(t, filepath.Join(dir, "powershell.exe"), true)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	if _, _, ok := platformCursorInvocation(cmdPath, []string{"chat"}, logger); ok {
+	if _, _, ok := platformCursorInvocation(cmdPath, []string{"-p", "hello"}, logger); ok {
 		t.Fatalf("expected ok=false when cursor-agent.ps1 is missing")
 	}
 }
@@ -119,7 +118,7 @@ func TestPlatformCursorInvocation_SkipsWhenPowerShellMissing(t *testing.T) {
 	stubPowerShell(t, "", false)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	if _, _, ok := platformCursorInvocation(cmdPath, []string{"chat"}, logger); ok {
+	if _, _, ok := platformCursorInvocation(cmdPath, []string{"-p", "hello"}, logger); ok {
 		t.Fatalf("expected ok=false when no powershell host is available")
 	}
 }

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -27,7 +27,6 @@ func TestBuildCursorArgs(t *testing.T) {
 	}, slog.Default())
 
 	expected := []string{
-		"chat",
 		"-p", "do something",
 		"--output-format", "stream-json",
 		"--yolo",
@@ -67,7 +66,7 @@ func TestBuildCursorArgsMinimal(t *testing.T) {
 	t.Parallel()
 
 	args := buildCursorArgs("hello", ExecOptions{}, slog.Default())
-	expected := []string{"chat", "-p", "hello", "--output-format", "stream-json", "--yolo"}
+	expected := []string{"-p", "hello", "--output-format", "stream-json", "--yolo"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete `"chat"` positional argument from `buildCursorArgs()`. The current `cursor-agent` CLI no longer recognizes `chat` as a subcommand — it silently treats it as prompt text, which leaks into the user message (e.g. `"chat <actual prompt>"`).

## Related Issue

Closes #3077

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/agent/cursor.go`: Remove `"chat"` from the `args` slice in `buildCursorArgs()`, update doc comment
- `server/pkg/agent/cursor_test.go`: Update 2 test cases (`TestBuildCursorArgs`, `TestBuildCursorArgsMinimal`) to remove `"chat"` from expected args
- `server/pkg/agent/cursor_invocation_test.go`: Update test args to remove `"chat"`
- `server/pkg/agent/cursor_invocation_windows_test.go`: Update 4 test references to remove `"chat"` from args

## How to Test

1. `cd server && go test ./pkg/agent/... -run Cursor -v` — all cursor tests pass
2. Verify generated argv no longer includes `chat` as first arg:
   - Before: `cursor-agent chat -p "prompt" --output-format stream-json --yolo`
   - After: `cursor-agent -p "prompt" --output-format stream-json --yolo`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude (analysis), manual edit (implementation)

**Prompt / approach:**
Read issue #3077 which documents the exact CLI behavior change. Grepped `cursor-agent --help` output in the issue to confirm `chat` is no longer a subcommand. Traced `buildCursorArgs` → test files → invocation tests. Surgical removal of the single `"chat"` string from the args slice + all test expectations. Verified with `go test`.