### PR TITLE
fix(ui): coalesce split task transcript messages

### DIFF
--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -24,9 +24,10 @@ import { Markdown } from "@multica/views/common/markdown";
 import { copyMarkdown } from "../../editor";
 import { AttachmentList } from "../../issues/components/comment-card";
 import type { AgentAvailability } from "@multica/core/agents";
-import type { ChatMessage, ChatPendingTask, TaskMessagePayload, TaskFailureReason } from "@multica/core/types";
+import type { ChatMessage, ChatPendingTask, TaskFailureReason } from "@multica/core/types";
 import type { ChatTimelineItem } from "@multica/core/chat";
 import { failureReasonLabel } from "../../agents/components/tabs/task-failure";
+import { buildTimeline } from "../../common/task-transcript";
 import { TaskStatusPill } from "./task-status-pill";
 import { formatElapsedMs } from "../lib/format";
 import { splitTimeline, extractCopyText } from "../lib/copy-text";
@@ -72,7 +73,7 @@ export function ChatMessageList({
     ...taskMessagesOptions(pendingTaskId ?? ""),
     enabled: canFetchLiveTimeline,
   });
-  const liveTimeline: ChatTimelineItem[] = (liveTaskMessages ?? []).map(toTimelineItem);
+  const liveTimeline: ChatTimelineItem[] = buildTimeline(liveTaskMessages ?? []);
   const hasLive = showLiveTimeline && liveTimeline.length > 0;
   const showStatusPill = !!pendingTaskId && !pendingAlreadyPersisted && !!pendingTask;
 
@@ -134,17 +135,6 @@ export function ChatMessageSkeleton() {
   );
 }
 
-function toTimelineItem(m: TaskMessagePayload): ChatTimelineItem {
-  return {
-    seq: m.seq,
-    type: m.type,
-    tool: m.tool,
-    content: m.content,
-    input: m.input,
-    output: m.output,
-  };
-}
-
 // ─── Message bubbles ─────────────────────────────────────────────────────
 
 function MessageBubble({ message, isPending }: { message: ChatMessage; isPending: boolean }) {
@@ -190,7 +180,7 @@ function AssistantMessage({
     enabled: canFetchTaskMessages,
   });
 
-  const timeline: ChatTimelineItem[] = (taskMessages ?? []).map(toTimelineItem);
+  const timeline: ChatTimelineItem[] = buildTimeline(taskMessages ?? []);
 
   // Failure bubble path: when the server's FailTask wrote a failure
   // chat_message (failure_reason set), render a destructive bubble with the

--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { TaskMessagePayload } from "@multica/core/types/events";
+import { appendTimelineItem, buildTimeline, coalesceTimelineItems, type TimelineItem } from "./build-timeline";
+
+function message(seq: number, type: TaskMessagePayload["type"], content?: string): TaskMessagePayload {
+  return {
+    task_id: "task-1",
+    issue_id: "issue-1",
+    seq,
+    type,
+    content,
+  };
+}
+
+describe("task transcript timeline", () => {
+  it("merges adjacent text and thinking fragments split by streaming flushes", () => {
+    const items = buildTimeline([
+      message(2, "text", "world"),
+      message(1, "text", "hello "),
+      message(3, "thinking", "step "),
+      message(4, "thinking", "one"),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({ seq: 1, type: "text", content: "hello world" }),
+      expect.objectContaining({ seq: 3, type: "thinking", content: "step one" }),
+    ]);
+  });
+
+  it("does not merge across tool or error boundaries", () => {
+    const items = coalesceTimelineItems([
+      { seq: 1, type: "text", content: "before" },
+      { seq: 2, type: "tool_use", tool: "bash" },
+      { seq: 3, type: "text", content: "after" },
+      { seq: 4, type: "error", content: "failed" },
+      { seq: 5, type: "text", content: "done" },
+    ]);
+
+    expect(items.map((item) => item.content ?? item.tool)).toEqual([
+      "before",
+      "bash",
+      "after",
+      "failed",
+      "done",
+    ]);
+  });
+
+  it("coalesces newly appended live text with the previous text item", () => {
+    const existing: TimelineItem[] = [{ seq: 1, type: "text", content: "hello" }];
+    const items = appendTimelineItem(existing, { seq: 2, type: "text", content: " world" });
+
+    expect(items).toEqual([
+      expect.objectContaining({ seq: 1, type: "text", content: "hello world" }),
+    ]);
+  });
+
+  it("coalesces out-of-order raw text by sequence", () => {
+    const existing: TimelineItem[] = [
+      { seq: 1, type: "text", content: "A" },
+      { seq: 3, type: "text", content: "C" },
+    ];
+    const items = appendTimelineItem(existing, { seq: 2, type: "text", content: "B" });
+
+    expect(items).toEqual([
+      expect.objectContaining({ seq: 1, type: "text", content: "ABC" }),
+    ]);
+  });
+
+  it("redacts secrets after adjacent chunks are coalesced", () => {
+    const items = buildTimeline([
+      message(1, "text", "Authorization: Bearer abc123xyz."),
+      message(2, "text", "def456"),
+    ]);
+
+    expect(items[0]?.content).toBe("Authorization: Bearer [REDACTED]");
+    expect(items[0]?.content).not.toContain("abc123xyz");
+    expect(items[0]?.content).not.toContain("def456");
+  });
+});

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -11,6 +11,42 @@ export interface TimelineItem {
   output?: string;
 }
 
+function canMergeStreamingText(prev: TimelineItem, next: TimelineItem): boolean {
+  return (prev.type === "thinking" || prev.type === "text") && prev.type === next.type;
+}
+
+/** Merge adjacent text/thinking fragments that were split only by daemon flush timing. */
+export function coalesceTimelineItems(items: TimelineItem[]): TimelineItem[] {
+  const sorted = [...items].sort((a, b) => a.seq - b.seq);
+  const out: TimelineItem[] = [];
+
+  for (const item of sorted) {
+    const prev = out[out.length - 1];
+    if (prev && canMergeStreamingText(prev, item)) {
+      out[out.length - 1] = {
+        ...prev,
+        content: `${prev.content ?? ""}${item.content ?? ""}`,
+      };
+      continue;
+    }
+    out.push(item);
+  }
+
+  return out;
+}
+
+export function appendTimelineItem(items: TimelineItem[], item: TimelineItem): TimelineItem[] {
+  return coalesceTimelineItems([...items, item]);
+}
+
+function redactTimelineItems(items: TimelineItem[]): TimelineItem[] {
+  return items.map((item) => ({
+    ...item,
+    content: item.content ? redactSecrets(item.content) : item.content,
+    output: item.output ? redactSecrets(item.output) : item.output,
+  }));
+}
+
 /** Build a chronologically ordered timeline from raw task messages. */
 export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
   const items: TimelineItem[] = [];
@@ -19,10 +55,10 @@ export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
       seq: msg.seq,
       type: msg.type,
       tool: msg.tool,
-      content: msg.content ? redactSecrets(msg.content) : msg.content,
+      content: msg.content,
       input: msg.input,
-      output: msg.output ? redactSecrets(msg.output) : msg.output,
+      output: msg.output,
     });
   }
-  return items.sort((a, b) => a.seq - b.seq);
+  return redactTimelineItems(coalesceTimelineItems(items));
 }

--- a/packages/views/common/task-transcript/index.ts
+++ b/packages/views/common/task-transcript/index.ts
@@ -1,4 +1,4 @@
 export { AgentTranscriptDialog } from "./agent-transcript-dialog";
 export { TranscriptButton } from "./transcript-button";
-export { buildTimeline, type TimelineItem } from "./build-timeline";
+export { appendTimelineItem, buildTimeline, coalesceTimelineItems, type TimelineItem } from "./build-timeline";
 export { redactSecrets } from "./redact";

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -57,9 +57,13 @@ vi.mock("../../common/actor-avatar", () => ({
 
 vi.mock("../../common/task-transcript", async () => {
   const buildTimeline = vi.fn().mockReturnValue([]);
+  const coalesceTimelineItems = vi.fn((items) => items);
+  const appendTimelineItem = vi.fn((items, item) => [...items, item]);
   return {
     TranscriptButton: () => <button data-testid="transcript-button">transcript</button>,
+    appendTimelineItem,
     buildTimeline,
+    coalesceTimelineItems,
   };
 });
 

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -26,7 +26,7 @@ import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
 // ExecutionLogSection — this card is just a header-style anchor that
 // answers "is anyone working on this issue right now?" at a glance.
 //
-// We still maintain per-task TimelineItem[] state here so the live
+// We still maintain per-task raw message state here so the live
 // TranscriptButton on the sticky banner can open the dialog with live
 // items already attached (the dialog stays in sync via WS as messages
 // arrive). The right-panel rows use the lazy mode of TranscriptButton
@@ -43,7 +43,7 @@ function formatElapsed(startedAt: string): string {
 
 interface TaskState {
   task: AgentTask;
-  items: TimelineItem[];
+  messages: TaskMessagePayload[];
 }
 
 interface AgentLiveCardProps {
@@ -92,8 +92,8 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
         for (const task of tasks) {
           const existing = prev.get(task.id);
           next.set(task.id, existing
-            ? { task, items: existing.items }
-            : { task, items: [] });
+            ? { task, messages: existing.messages }
+            : { task, messages: [] });
         }
         return next;
       });
@@ -116,16 +116,15 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
         hydratedTaskIds.current.add(task.id);
         api.listTaskMessages(task.id).then((msgs) => {
           if (!mountedRef.current) return;
-          const timeline = buildTimeline(msgs);
           for (const m of msgs) seenSeqs.current.add(`${m.task_id}:${m.seq}`);
           setTaskStates((prev) => {
             const next = new Map(prev);
             const existing = next.get(task.id);
             if (!existing) return prev;
-            const loadedSeqs = new Set(timeline.map((i) => i.seq));
-            const wsOnly = existing.items.filter((i) => !loadedSeqs.has(i.seq));
-            const merged = [...timeline, ...wsOnly].sort((a, b) => a.seq - b.seq);
-            next.set(task.id, { task: existing.task, items: merged });
+            const loadedSeqs = new Set(msgs.map((i) => i.seq));
+            const wsOnly = existing.messages.filter((i) => !loadedSeqs.has(i.seq));
+            const messages = [...msgs, ...wsOnly].sort((a, b) => a.seq - b.seq);
+            next.set(task.id, { task: existing.task, messages });
             return next;
           });
         }).catch((e) => {
@@ -156,21 +155,12 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
       if (seenSeqs.current.has(key)) return;
       seenSeqs.current.add(key);
 
-      const item: TimelineItem = {
-        seq: msg.seq,
-        type: msg.type,
-        tool: msg.tool,
-        content: msg.content,
-        input: msg.input,
-        output: msg.output,
-      };
-
       setTaskStates((prev) => {
         const next = new Map(prev);
         const existing = next.get(msg.task_id);
         if (existing) {
-          const items = [...existing.items, item].sort((a, b) => a.seq - b.seq);
-          next.set(msg.task_id, { ...existing, items });
+          const messages = [...existing.messages, msg].sort((a, b) => a.seq - b.seq);
+          next.set(msg.task_id, { ...existing, messages });
         }
         return next;
       });
@@ -239,7 +229,7 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
       <div className="mt-4 sticky top-4 z-10 rounded-lg bg-background/80 supports-[backdrop-filter]:bg-background/55 backdrop-blur-md">
         <SingleAgentLiveCard
           task={firstEntry.task}
-          items={firstEntry.items}
+          items={buildTimeline(firstEntry.messages)}
           issueId={issueId}
           agentName={firstEntry.task.agent_id ? getActorName("agent", firstEntry.task.agent_id) : t(($) => $.agent_live.fallback_name)}
         />
@@ -247,11 +237,11 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
       {/* Additional agents — non-sticky, scroll with the page */}
       {restEntries.length > 0 && (
         <div className="mt-1.5 space-y-1.5">
-          {restEntries.map(({ task, items }) => (
+          {restEntries.map(({ task, messages }) => (
             <SingleAgentLiveCard
               key={task.id}
               task={task}
-              items={items}
+              items={buildTimeline(messages)}
               issueId={issueId}
               agentName={task.agent_id ? getActorName("agent", task.agent_id) : t(($) => $.agent_live.fallback_name)}
             />


### PR DESCRIPTION
## Summary

Task transcript text and thinking output can be split into many adjacent UI rows when daemon flushes streaming chunks separately.

This behavior is observed on the Pi runtime. Pi emits thinking-like task message fields that can arrive as adjacent fragments.

Claude Code and Codex do not expose comparable thinking fields, so the issue is primarily visible in Pi transcript rendering.

This PR:
- merges adjacent `text` and `thinking` task transcript chunks;
- applies the shared coalescing helper to hydrated task messages, chat timelines, and live WebSocket appends;
- keeps tool calls, tool results, and errors as separate timeline boundaries;
- adds a focused regression test for transcript timeline coalescing.

## Testing

- User verified the patch locally before PR creation.

Fixes #3096
