### PR TITLE
MUL-2746 fix(avatar): normalize relative avatar urls in desktop/web

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./workspace/queries": "./workspace/queries.ts",
     "./workspace/mutations": "./workspace/mutations.ts",
     "./workspace/hooks": "./workspace/hooks.ts",
+    "./workspace/avatar-url": "./workspace/avatar-url.ts",
     "./issues": "./issues/index.ts",
     "./issues/queries": "./issues/queries.ts",
     "./issues/mutations": "./issues/mutations.ts",

--- a/packages/core/workspace/avatar-url.test.ts
+++ b/packages/core/workspace/avatar-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolvePublicFileUrl, resolvePublicFileUrlWithBase } from "./avatar-url";
+
+vi.mock("../api", () => ({
+  api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
+  },
+}));
+
+describe("resolvePublicFileUrlWithBase", () => {
+  it("resolves root-relative URLs against base URL", () => {
+    expect(resolvePublicFileUrlWithBase("/uploads/a.png", "http://127.0.0.1:8080")).toBe(
+      "http://127.0.0.1:8080/uploads/a.png",
+    );
+  });
+
+  it("trims trailing slash in base URL", () => {
+    expect(resolvePublicFileUrlWithBase("/upload/a.png", "http://127.0.0.1:8080/")).toBe(
+      "http://127.0.0.1:8080/upload/a.png",
+    );
+  });
+
+  it("keeps absolute URLs unchanged", () => {
+    expect(resolvePublicFileUrlWithBase("https://cdn.example.com/a.png", "http://127.0.0.1:8080")).toBe(
+      "https://cdn.example.com/a.png",
+    );
+  });
+
+  it("returns null for empty values", () => {
+    expect(resolvePublicFileUrlWithBase(null, "http://127.0.0.1:8080")).toBeNull();
+    expect(resolvePublicFileUrlWithBase(undefined, "http://127.0.0.1:8080")).toBeNull();
+  });
+});
+
+describe("resolvePublicFileUrl", () => {
+  it("uses API base URL implicitly", () => {
+    expect(resolvePublicFileUrl("/uploads/a.png")).toBe("http://127.0.0.1:8080/uploads/a.png");
+  });
+});

--- a/packages/core/workspace/avatar-url.ts
+++ b/packages/core/workspace/avatar-url.ts
@@ -1,0 +1,12 @@
+import { api } from "../api";
+
+export function resolvePublicFileUrlWithBase(rawUrl: string | null | undefined, baseUrl: string): string | null {
+  if (!rawUrl) return null;
+  if (!rawUrl.startsWith("/")) return rawUrl;
+  const trimmedBaseUrl = baseUrl.replace(/\/+$/, "");
+  return `${trimmedBaseUrl}${rawUrl}`;
+}
+
+export function resolvePublicFileUrl(rawUrl: string | null | undefined): string | null {
+  return resolvePublicFileUrlWithBase(rawUrl, api.getBaseUrl());
+}

--- a/packages/core/workspace/hooks.ts
+++ b/packages/core/workspace/hooks.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "../hooks";
 import { memberListOptions, agentListOptions, squadListOptions } from "./queries";
+import { resolvePublicFileUrl } from "./avatar-url";
 
 export function useActorName() {
   const wsId = useWorkspaceId();
@@ -45,9 +46,9 @@ export function useActorName() {
   }, [getActorName]);
 
   const getActorAvatarUrl = useCallback((type: string, id: string): string | null => {
-    if (type === "member") return members.find((m) => m.user_id === id)?.avatar_url ?? null;
-    if (type === "agent") return agents.find((a) => a.id === id)?.avatar_url ?? null;
-    if (type === "squad") return squads.find((s) => s.id === id)?.avatar_url ?? null;
+    if (type === "member") return resolvePublicFileUrl(members.find((m) => m.user_id === id)?.avatar_url);
+    if (type === "agent") return resolvePublicFileUrl(agents.find((a) => a.id === id)?.avatar_url);
+    if (type === "squad") return resolvePublicFileUrl(squads.find((s) => s.id === id)?.avatar_url);
     return null;
   }, [agents, members, squads]);
 

--- a/packages/views/agents/components/agent-live-peek-card.test.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.test.tsx
@@ -22,6 +22,12 @@ vi.mock("@multica/core/paths", () => ({
   }),
 }));
 
+vi.mock("@multica/core/api", () => ({
+  api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
+  },
+}));
+
 // AppLink is just a plain anchor here — wiring the navigation adapter would
 // add nothing to these assertions.
 vi.mock("../../navigation", () => ({

--- a/packages/views/agents/components/agent-live-peek-card.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { agentListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import {
   agentTaskSnapshotOptions,
   useAgentPresenceDetail,
@@ -82,7 +83,7 @@ export function AgentLivePeekCard({ agentId }: AgentLivePeekCardProps) {
         <ActorAvatarBase
           name={agent.name}
           initials={initials}
-          avatarUrl={agent.avatar_url}
+          avatarUrl={resolvePublicFileUrl(agent.avatar_url)}
           isAgent
           size={40}
           className="rounded-md"

--- a/packages/views/agents/components/agent-profile-card.tsx
+++ b/packages/views/agents/components/agent-profile-card.tsx
@@ -9,6 +9,7 @@ import {
   type RuntimeHealth,
 } from "@multica/core/runtimes";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { runtimeListOptions } from "@multica/core/runtimes/queries";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
@@ -76,7 +77,7 @@ export function AgentProfileCard({ agentId }: AgentProfileCardProps) {
         <ActorAvatarBase
           name={agent.name}
           initials={initials}
-          avatarUrl={agent.avatar_url}
+          avatarUrl={resolvePublicFileUrl(agent.avatar_url)}
           isAgent
           size={40}
           className="rounded-md"

--- a/packages/views/agents/components/avatar-picker.tsx
+++ b/packages/views/agents/components/avatar-picker.tsx
@@ -5,6 +5,7 @@ import { Camera, ImagePlus, Loader2, X } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 
@@ -85,7 +86,7 @@ export function AvatarPicker({ value, onChange, size = 56 }: AvatarPickerProps) 
       >
         {hasValue ? (
           <img
-            src={value ?? undefined}
+            src={resolvePublicFileUrl(value) ?? undefined}
             alt=""
             className="h-full w-full object-cover"
             onError={() => setPreviewError(true)}

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -115,6 +115,7 @@ const mockListSquads = vi.hoisted(() =>
 );
 vi.mock("@multica/core/api", () => ({
   api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
     listIssues: (...args: any[]) => mockListIssues(...args),
     listGroupedIssues: (...args: any[]) => mockListGroupedIssues(...args),
     updateIssue: vi.fn(),

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -99,7 +99,16 @@ vi.mock("@multica/core/paths", () => ({
     projectDetail: (id: string) => `/acme/projects/${id}`,
   }),
 }));
-vi.mock("@multica/core/api", async (importOriginal) => ({ ...(await importOriginal<typeof import("@multica/core/api")>()), api: {} }));
+vi.mock("@multica/core/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getBaseUrl: () => "http://127.0.0.1:8080",
+    },
+  };
+});
 vi.mock("@multica/core/inbox/queries", () => ({ deduplicateInboxItems: (items: unknown[]) => items, inboxKeys: { list: () => ["inbox"] } }));
 vi.mock("@multica/core/issues/queries", () => ({ issueDetailOptions: () => ({ queryKey: ["issue"] }) }));
 vi.mock("@multica/core/issues/stores/create-mode-store", () => ({

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -67,6 +67,7 @@ import {
 import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths, paths } from "@multica/core/paths";
 import { workspaceListOptions, myInvitationListOptions, workspaceKeys } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
 import { api, ApiError } from "@multica/core/api";
@@ -493,7 +494,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <ActorAvatar
                       name={user?.name ?? ""}
                       initials={(user?.name ?? "U").charAt(0).toUpperCase()}
-                      avatarUrl={user?.avatar_url}
+                      avatarUrl={resolvePublicFileUrl(user?.avatar_url)}
                       size={32}
                     />
                     <div className="min-w-0 flex-1">

--- a/packages/views/members/member-detail-page.tsx
+++ b/packages/views/members/member-detail-page.tsx
@@ -6,6 +6,7 @@ import type { MemberRole } from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { memberListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { PageHeader } from "../layout/page-header";
@@ -56,7 +57,7 @@ export function MemberDetailPage({ userId }: { userId: string }) {
         <ActorAvatarBase
           name={member.name}
           initials={initials}
-          avatarUrl={member.avatar_url}
+          avatarUrl={resolvePublicFileUrl(member.avatar_url)}
           size={44}
           className="rounded-full"
         />

--- a/packages/views/members/member-profile-card.tsx
+++ b/packages/views/members/member-profile-card.tsx
@@ -5,6 +5,7 @@ import type { Agent, MemberRole } from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core";
 import { agentRunCounts30dOptions } from "@multica/core/agents";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
@@ -80,7 +81,7 @@ export function MemberProfileCard({ userId }: MemberProfileCardProps) {
         <ActorAvatarBase
           name={member.name}
           initials={initials}
-          avatarUrl={member.avatar_url}
+          avatarUrl={resolvePublicFileUrl(member.avatar_url)}
           size={40}
           className="rounded-full"
         />

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -67,6 +67,7 @@ const {
 
 vi.mock("@multica/core/api", () => ({
   api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
     searchIssues: mockSearchIssues,
     searchProjects: mockSearchProjects,
   },

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -43,6 +43,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import type { WorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { memberListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { StatusIcon } from "../issues/components";
 import { ProjectIcon } from "../projects/components/project-icon";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
@@ -571,7 +572,7 @@ export function SearchCommand() {
                     <ActorAvatarBase
                       name={member.name}
                       initials={memberInitials(member.name)}
-                      avatarUrl={member.avatar_url}
+                      avatarUrl={resolvePublicFileUrl(member.avatar_url)}
                       size={22}
                     />
                     <div className="min-w-0 flex-1">

--- a/packages/views/settings/components/account-tab.tsx
+++ b/packages/views/settings/components/account-tab.tsx
@@ -10,6 +10,7 @@ import { Textarea } from "@multica/ui/components/ui/textarea";
 import { toast } from "sonner";
 import { useAuthStore } from "@multica/core/auth";
 import { api } from "@multica/core/api";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { useT } from "../../i18n";
 
@@ -96,7 +97,7 @@ export function AccountTab() {
               >
                 {user?.avatar_url ? (
                   <img
-                    src={user.avatar_url}
+                    src={resolvePublicFileUrl(user.avatar_url) ?? undefined}
                     alt={user.name}
                     className="h-full w-full object-cover"
                   />

--- a/packages/views/skills/components/skill-columns.tsx
+++ b/packages/views/skills/components/skill-columns.tsx
@@ -23,6 +23,7 @@ import {
   TooltipTrigger,
 } from "@multica/ui/components/ui/tooltip";
 import { readOrigin, totalFileCount } from "../lib/origin";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useT } from "../../i18n";
 
 // Per-row data assembled at the page level. The columns reach into
@@ -160,7 +161,7 @@ function AgentAssignees({ agents }: { agents: Agent[] }) {
                 <ActorAvatar
                   name={a.name}
                   initials={a.name.slice(0, 2).toUpperCase()}
-                  avatarUrl={a.avatar_url}
+                  avatarUrl={resolvePublicFileUrl(a.avatar_url)}
                   isAgent
                   size={22}
                 />
@@ -222,7 +223,7 @@ function SourceCell({
           <ActorAvatar
             name={creator.name}
             initials={creator.name.slice(0, 2).toUpperCase()}
-            avatarUrl={creator.avatar_url}
+            avatarUrl={resolvePublicFileUrl(creator.avatar_url)}
             size={14}
           />
           <span className="truncate">{t(($) => $.table.by_creator, { name: creator.name })}</span>

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -36,6 +36,7 @@ import {
   skillDetailOptions,
   workspaceKeys,
 } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { runtimeListOptions } from "@multica/core/runtimes";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { Button, buttonVariants } from "@multica/ui/components/ui/button";
@@ -165,7 +166,7 @@ function UsedBySection({ agents }: { agents: Agent[] }) {
           <ActorAvatar
             name={a.name}
             initials={a.name.slice(0, 2).toUpperCase()}
-            avatarUrl={a.avatar_url}
+            avatarUrl={resolvePublicFileUrl(a.avatar_url)}
             isAgent
             size={22}
           />
@@ -730,7 +731,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
                     <ActorAvatar
                       name={creator.name}
                       initials={creator.name.slice(0, 2).toUpperCase()}
-                      avatarUrl={creator.avatar_url}
+                      avatarUrl={resolvePublicFileUrl(creator.avatar_url)}
                       size={14}
                     />
                     {t(($) => $.detail.subline.by_creator, { name: creator.name })}

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -6,6 +6,7 @@ import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { isImeComposing } from "@multica/core/utils";
 import { useTimeAgo } from "../../i18n";
@@ -370,7 +371,7 @@ function SquadHeaderAvatar({ squad, initials }: { squad: Squad; initials: string
     <ActorAvatarBase
       name={squad.name}
       initials={initials}
-      avatarUrl={squad.avatar_url}
+      avatarUrl={resolvePublicFileUrl(squad.avatar_url)}
       size={16}
       className="rounded"
     />
@@ -422,7 +423,7 @@ function SquadAvatarEditor({
           <ActorAvatarBase
             name={squad.name}
             initials={initials}
-            avatarUrl={squad.avatar_url}
+            avatarUrl={resolvePublicFileUrl(squad.avatar_url)}
             size={64}
             className="rounded-none"
           />

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { agentListOptions, memberListOptions, squadListOptions } from "@multica/core/workspace/queries";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useAuthStore } from "@multica/core/auth";
 import { useSquadsViewStore } from "@multica/core/squads/stores";
 import { AppLink } from "../../navigation";
@@ -221,7 +222,7 @@ function SquadAvatar({ squad }: { squad: Squad }) {
       <ActorAvatarBase
         name={squad.name}
         initials={initials}
-        avatarUrl={squad.avatar_url}
+        avatarUrl={resolvePublicFileUrl(squad.avatar_url)}
         size={36}
         className="rounded-md"
       />

--- a/packages/views/workspace/welcome-after-onboarding.test.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.test.tsx
@@ -67,6 +67,7 @@ vi.mock("@multica/core/paths", async () => {
 
 vi.mock("@multica/core/api", () => ({
   api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
     listAgents: (...args: unknown[]) => mockListAgents(...args),
     createAgent: (...args: unknown[]) => mockCreateAgent(...args),
     createIssue: (...args: unknown[]) => mockCreateIssue(...args),

--- a/packages/views/workspace/welcome-after-onboarding.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.tsx
@@ -7,6 +7,7 @@ import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import { useWelcomeStore } from "@multica/core/onboarding";
 import { paths, useCurrentWorkspace } from "@multica/core/paths";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { issueKeys } from "@multica/core/issues/queries";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, CreateIssueRequest, Issue } from "@multica/core/types";
@@ -560,7 +561,7 @@ function RuntimeWelcome({
       >
         <div className="flex flex-col items-center gap-3 pt-4 animate-onboarding-enter">
           <img
-            src={agent.avatar_url || HELPER_AVATAR_URL}
+            src={resolvePublicFileUrl(agent.avatar_url) ?? HELPER_AVATAR_URL}
             alt=""
             aria-hidden
             className="h-14 w-14 rounded-xl ring-1 ring-foreground/10"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This PR fixes avatar rendering issues caused by relative file paths (for example /uploads/...) when running in Desktop (file://) and keeps behavior consistent on Web.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #3099 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added a shared resolver in `@multica/core/workspace/avatar-url`:
   - `resolvePublicFileUrl(rawUrl)`
   - `resolvePublicFileUrlWithBase(rawUrl, baseUrl)`
- Exported `./workspace/avatar-url` from packages/core/package.json
- Updated avatar consumers to use the shared resolver across members/agents/squads/sidebar/search/skills/settings/welcome screens
- Updated `useActorName().getActorAvatarUrl` to always return normalized URLs

Why:

- Backend may return relative avatar URLs.
- In Desktop (file://), relative paths do not resolve to the API host, so avatars break.
- Centralizing URL normalization removes repeated per-call base-url handling and reduces regression risk.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `pnpm dev:desktop`
2. see the avatars of agents/humans renders correctly 

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** Codex <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:** Just use multica.
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->


