### PR TITLE
feat(server): auto-cancel queued tasks when linked issue is done/cancelled (MYW-2121)

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -56,6 +56,11 @@ const (
 	// ticks and 500 rows/tick we drain 60k rows/hour worst case — plenty
 	// of headroom for the documented backlog without monopolising DB CPU.
 	queuedExpireBatchSize = 500
+	// closedIssueSweepBatchSize caps how many queued tasks a single sweeper
+	// tick cancels because their linked issue is done/cancelled. Same sizing
+	// rationale as queuedExpireBatchSize — the backlog is expected to be much
+	// smaller, but the cap keeps the transaction bounded.
+	closedIssueSweepBatchSize = 500
 )
 
 // runRuntimeSweeper periodically marks runtimes as offline if their
@@ -81,6 +86,7 @@ func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handle
 			sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 			sweepStaleTasks(ctx, queries, taskSvc, bus)
 			sweepExpiredQueuedTasks(ctx, queries, taskSvc)
+			sweepQueuedTasksForClosedIssues(ctx, queries, taskSvc)
 			gcRuntimes(ctx, queries, bus)
 		}
 	}
@@ -277,6 +283,27 @@ func sweepExpiredQueuedTasks(ctx context.Context, queries *db.Queries, taskSvc *
 
 	slog.Info("task sweeper: expired stale queued tasks", "count", len(failedTasks))
 	taskSvc.HandleFailedTasks(ctx, failedTasks)
+}
+
+// sweepQueuedTasksForClosedIssues cancels queued tasks whose linked issues have
+// reached a terminal status (done or cancelled).  This is the sweeper arm of
+// MYW-2121: it catches the gap where an issue closed without cascade-cancelling
+// its active task (API path that missed the cancel, race condition, or
+// historical backlog).  Cancelled tasks are stamped with failure_reason
+// 'issue_closed' so they do not later expire as failed/queued_expired and
+// pollute run statistics.
+func sweepQueuedTasksForClosedIssues(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService) {
+	if taskSvc == nil {
+		return
+	}
+	count, err := taskSvc.CancelQueuedTasksForClosedIssues(ctx, closedIssueSweepBatchSize)
+	if err != nil {
+		slog.Warn("task sweeper: failed to cancel queued tasks for closed issues", "error", err)
+		return
+	}
+	if count > 0 {
+		slog.Info("task sweeper: cancelled queued tasks for closed issues", "count", count)
+	}
 }
 
 // broadcastFailedTasks is preserved as a thin shim for the integration tests

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -689,6 +689,133 @@ func TestExpireStaleQueuedTasksRespectsBatchLimit(t *testing.T) {
 	}
 }
 
+// TestSweepQueuedTasksForClosedIssues verifies MYW-2121: queued tasks whose
+// linked issues are done or cancelled are automatically cancelled by the
+// sweeper so they do not later expire as failed/queued_expired and pollute
+// run/task statistics.
+func TestSweepQueuedTasksForClosedIssues(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a
+		JOIN member m ON m.workspace_id = a.workspace_id
+		JOIN "user" u ON u.id = m.user_id
+		WHERE u.email = $1
+		LIMIT 1
+	`, integrationTestEmail).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	mkIssue := func(status string) string {
+		var issueID string
+		if err := testPool.QueryRow(ctx, `
+			WITH bumped AS (
+				UPDATE workspace SET issue_counter = issue_counter + 1
+				WHERE id = $1 RETURNING issue_counter
+			)
+			INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, assignee_type, assignee_id, number)
+			SELECT $1, $3, $4, 'none', 'member', m.user_id, 'agent', $2, (SELECT issue_counter FROM bumped)
+			FROM member m WHERE m.workspace_id = $1 LIMIT 1
+			RETURNING id
+		`, testWorkspaceID, agentID, "Closed issue sweep test", status).Scan(&issueID); err != nil {
+			t.Fatalf("failed to create %s issue: %v", status, err)
+		}
+		return issueID
+	}
+
+	doneIssueID := mkIssue("done")
+	cancelledIssueID := mkIssue("cancelled")
+	openIssueID := mkIssue("todo")
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2, $3)`, doneIssueID, cancelledIssueID, openIssueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id IN ($1, $2, $3)`, doneIssueID, cancelledIssueID, openIssueID)
+	})
+
+	var doneTaskID, cancelledTaskID, openTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, doneIssueID).Scan(&doneTaskID); err != nil {
+		t.Fatalf("failed to insert done-issue task: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, cancelledIssueID).Scan(&cancelledTaskID); err != nil {
+		t.Fatalf("failed to insert cancelled-issue task: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, openIssueID).Scan(&openTaskID); err != nil {
+		t.Fatalf("failed to insert open-issue task: %v", err)
+	}
+
+	queries := db.New(testPool)
+	cancelled, err := queries.CancelQueuedTasksForClosedIssues(ctx, 100)
+	if err != nil {
+		t.Fatalf("CancelQueuedTasksForClosedIssues failed: %v", err)
+	}
+	if len(cancelled) != 2 {
+		t.Fatalf("expected exactly 2 cancelled tasks, got %d", len(cancelled))
+	}
+
+	// Verify done-issue task
+	var doneStatus, doneReason, doneErr string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, COALESCE(failure_reason, ''), COALESCE(error, '')
+		FROM agent_task_queue WHERE id = $1
+	`, doneTaskID).Scan(&doneStatus, &doneReason, &doneErr); err != nil {
+		t.Fatalf("failed to read done-issue task: %v", err)
+	}
+	if doneStatus != "cancelled" {
+		t.Fatalf("done-issue task: expected status=cancelled, got %q", doneStatus)
+	}
+	if doneReason != "issue_closed" {
+		t.Fatalf("done-issue task: expected failure_reason=issue_closed, got %q", doneReason)
+	}
+	if !strings.Contains(doneErr, "done") {
+		t.Fatalf("done-issue task: expected error to mention 'done', got %q", doneErr)
+	}
+
+	// Verify cancelled-issue task
+	var cStatus, cReason, cErr string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, COALESCE(failure_reason, ''), COALESCE(error, '')
+		FROM agent_task_queue WHERE id = $1
+	`, cancelledTaskID).Scan(&cStatus, &cReason, &cErr); err != nil {
+		t.Fatalf("failed to read cancelled-issue task: %v", err)
+	}
+	if cStatus != "cancelled" {
+		t.Fatalf("cancelled-issue task: expected status=cancelled, got %q", cStatus)
+	}
+	if cReason != "issue_closed" {
+		t.Fatalf("cancelled-issue task: expected failure_reason=issue_closed, got %q", cReason)
+	}
+	if !strings.Contains(cErr, "cancelled") {
+		t.Fatalf("cancelled-issue task: expected error to mention 'cancelled', got %q", cErr)
+	}
+
+	// Verify open-issue task is untouched
+	var openStatus string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status FROM agent_task_queue WHERE id = $1
+	`, openTaskID).Scan(&openStatus); err != nil {
+		t.Fatalf("failed to read open-issue task: %v", err)
+	}
+	if openStatus != "queued" {
+		t.Fatalf("open-issue task: expected status=queued, got %q", openStatus)
+	}
+}
+
 // parseUUIDBytes converts a UUID string to the 16-byte array used by pgtype.UUID.
 func parseUUIDBytes(s string) [16]byte {
 	s = strings.ReplaceAll(s, "-", "")

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -651,6 +651,31 @@ func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UU
 	return nil
 }
 
+// CancelQueuedTasksForClosedIssues sweeps queued tasks whose linked issues have
+// reached a terminal status (done or cancelled) and cancels them.  This closes
+// the gap where an issue closes through a path that does not cascade-cancel
+// active tasks (API edge case, race, or historical backlog before the fix).
+//
+// Cancelled tasks are stamped with failure_reason='issue_closed' and an error
+// text that records the triggering issue status, preserving auditability.  Both
+// autopilot and regular agent tasks use the same cancelled semantics — the
+// autopilot event bus listener (EventTaskCancelled → syncRunFromTaskEvent)
+// already updates the run state, so no special autopilot handling is needed.
+//
+// Returns the number of tasks cancelled so callers can log/metric.
+func (s *TaskService) CancelQueuedTasksForClosedIssues(ctx context.Context, maxPerTick int32) (int, error) {
+	cancelled, err := s.Queries.CancelQueuedTasksForClosedIssues(ctx, maxPerTick)
+	if err != nil {
+		return 0, err
+	}
+	for _, t := range cancelled {
+		s.captureTaskCancelled(ctx, t)
+		s.ReconcileAgentStatus(ctx, t.AgentID)
+		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
+	}
+	return len(cancelled), nil
+}
+
 // CancelTasksForAgent cancels every active task belonging to an agent
 // (queued + dispatched + running), reconciles the agent's status, and
 // broadcasts task:cancelled events. Used by the agent-level "Cancel all

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -445,6 +445,84 @@ func (q *Queries) CancelAgentTasksByTriggerComment(ctx context.Context, triggerC
 	return items, nil
 }
 
+const cancelQueuedTasksForClosedIssues = `-- name: CancelQueuedTasksForClosedIssues :many
+WITH victims AS (
+    SELECT atq.id, i.status AS issue_status
+    FROM agent_task_queue atq
+    JOIN issue i ON i.id = atq.issue_id
+    WHERE atq.status = 'queued'
+      AND i.status IN ('done', 'cancelled')
+    ORDER BY atq.created_at ASC
+    LIMIT $1::int
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE agent_task_queue t
+SET status = 'cancelled',
+    completed_at = now(),
+    failure_reason = 'issue_closed',
+    error = 'linked issue was ' || v.issue_status
+FROM victims v
+WHERE t.id = v.id
+  AND t.status = 'queued'
+RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task
+`
+
+// Cancels queued tasks whose linked issues are done or cancelled.
+// This is the sweeper arm of the "linked issue closed but task still queued"
+// fix (MYW-2121): it catches cases where the issue reached a terminal status
+// through a path that did not cascade-cancel the task (e.g. API gap, race,
+// historical backlog).  Tasks are marked cancelled with an audit failure_reason
+// so they do not later expire as failed/queued_expired and pollute run stats.
+//
+// Concurrency safety: FOR UPDATE SKIP LOCKED + re-check status='queued' on
+// the outer UPDATE so a daemon claim racing in between selection and update
+// is not clobbered.  Capped per tick so a large backlog cannot monopolise DB.
+func (q *Queries) CancelQueuedTasksForClosedIssues(ctx context.Context, maxPerTick int32) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, cancelQueuedTasksForClosedIssues, maxPerTick)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const claimAgentTask = `-- name: ClaimAgentTask :one
 UPDATE agent_task_queue
 SET status = 'dispatched', dispatched_at = now()

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -413,6 +413,37 @@ WHERE t.id = v.id
   AND t.created_at < now() - make_interval(secs => @ttl_secs::double precision)
 RETURNING t.*;
 
+-- name: CancelQueuedTasksForClosedIssues :many
+-- Cancels queued tasks whose linked issues are done or cancelled.
+-- This is the sweeper arm of the "linked issue closed but task still queued"
+-- fix (MYW-2121): it catches cases where the issue reached a terminal status
+-- through a path that did not cascade-cancel the task (e.g. API gap, race,
+-- historical backlog).  Tasks are marked cancelled with an audit failure_reason
+-- so they do not later expire as failed/queued_expired and pollute run stats.
+--
+-- Concurrency safety: FOR UPDATE SKIP LOCKED + re-check status='queued' on
+-- the outer UPDATE so a daemon claim racing in between selection and update
+-- is not clobbered.  Capped per tick so a large backlog cannot monopolise DB.
+WITH victims AS (
+    SELECT atq.id, i.status AS issue_status
+    FROM agent_task_queue atq
+    JOIN issue i ON i.id = atq.issue_id
+    WHERE atq.status = 'queued'
+      AND i.status IN ('done', 'cancelled')
+    ORDER BY atq.created_at ASC
+    LIMIT @max_per_tick::int
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE agent_task_queue t
+SET status = 'cancelled',
+    completed_at = now(),
+    failure_reason = 'issue_closed',
+    error = 'linked issue was ' || v.issue_status
+FROM victims v
+WHERE t.id = v.id
+  AND t.status = 'queued'
+RETURNING t.*;
+
 -- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()


### PR DESCRIPTION
## Summary

When a linked issue reaches `done` or `cancelled`, any remaining `queued` tasks are now automatically cancelled by the runtime sweeper. This prevents them from later expiring as `queued_expired` failures and polluting run/task statistics.

## Changes

- **SQL**: Add `CancelQueuedTasksForClosedIssues` query with CTE + `FOR UPDATE SKIP LOCKED` for concurrency safety
- **Service**: Add `TaskService.CancelQueuedTasksForClosedIssues` method with proper event broadcast and agent reconcile
- **Sweeper**: Integrate into `runtime_sweeper` (30s tick, 500 rows/batch cap)
- **Test**: Add `TestSweepQueuedTasksForClosedIssues` integration test

## Target Semantics

- Cancelled tasks get `status = cancelled`, `failure_reason = 'issue_closed'`
- Autopilot tasks are handled automatically via existing `task:cancelled` event listener

## Related

- Closes MYW-2121
- Parent: MYW-2114