### PR TITLE
feat(desktop): add horizontal wheel navigation

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { useHorizontalWheelNavigation } from "@/hooks/use-horizontal-wheel-navigation";
 import { useTabHistory } from "@/hooks/use-tab-history";
 import { useActiveTitleSync } from "@/hooks/use-tab-sync";
 import { useTabStore, resolveRouteIcon } from "@/stores/tab-store";
@@ -147,6 +148,7 @@ export function DesktopShell() {
   useInternalLinkHandler();
   useActiveTitleSync();
   useNativeNavigationGestures();
+  useHorizontalWheelNavigation();
 
   // Reactive read of current workspace slug from the platform singleton.
   // On first mount, slug is null until WorkspaceRouteLayout (inside the tab
@@ -173,7 +175,10 @@ export function DesktopShell() {
             <div className="flex flex-1 min-w-0 flex-col">
               <MainTopBar />
               {/* Content area with inset styling — relative so ChatWindow/ChatFab are constrained here */}
-              <div className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl shadow-sm bg-background">
+              <div
+                data-page-navigation-surface
+                className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl shadow-sm bg-background"
+              >
                 <TabContent />
                 {slug && <ChatWindow />}
                 {slug && <ChatFab />}

--- a/apps/desktop/src/renderer/src/hooks/use-horizontal-wheel-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-horizontal-wheel-navigation.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createHorizontalWheelNavigationTracker,
+  isPageNavigationWheelCandidate,
+  wheelGestureFromDeltaX,
+} from "./use-horizontal-wheel-navigation";
+
+function makeSurface() {
+  const surface = document.createElement("div");
+  surface.setAttribute("data-page-navigation-surface", "");
+  document.body.append(surface);
+  return surface;
+}
+
+function dispatchWheel(
+  target: Element,
+  init: WheelEventInit,
+  tracker = createHorizontalWheelNavigationTracker({
+    triggerThreshold: 90,
+    debounceMs: 0,
+  }),
+) {
+  let gesture: "back" | "forward" | null = null;
+  target.addEventListener(
+    "wheel",
+    (event) => {
+      gesture = tracker.handleWheel(event as WheelEvent);
+    },
+    { once: true },
+  );
+  target.dispatchEvent(
+    new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    }),
+  );
+  return gesture;
+}
+
+function setHorizontalScrollMetrics(
+  element: HTMLElement,
+  metrics: { clientWidth: number; scrollWidth: number; scrollLeft: number },
+) {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: metrics.clientWidth },
+    scrollWidth: { configurable: true, value: metrics.scrollWidth },
+    scrollLeft: {
+      configurable: true,
+      value: metrics.scrollLeft,
+      writable: true,
+    },
+  });
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("wheelGestureFromDeltaX", () => {
+  it("maps browser-style horizontal wheel deltas to history direction", () => {
+    expect(wheelGestureFromDeltaX(-1)).toBe("back");
+    expect(wheelGestureFromDeltaX(1)).toBe("forward");
+    expect(wheelGestureFromDeltaX(0)).toBeNull();
+  });
+});
+
+describe("isPageNavigationWheelCandidate", () => {
+  it("requires a dominant horizontal wheel gesture inside the page surface", () => {
+    const surface = makeSurface();
+
+    let seen: boolean | null = null;
+    surface.addEventListener(
+      "wheel",
+      (event) => {
+        seen = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+
+    surface.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        deltaX: -20,
+        deltaY: -4,
+      }),
+    );
+
+    expect(seen).toBe(true);
+  });
+
+  it("ignores vertical wheels, modifier wheels, and events outside the page surface", () => {
+    const surface = makeSurface();
+    const outside = document.createElement("div");
+    document.body.append(outside);
+
+    let vertical: boolean | null = null;
+    surface.addEventListener(
+      "wheel",
+      (event) => {
+        vertical = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    surface.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, deltaX: -8, deltaY: -30 }),
+    );
+
+    let modified: boolean | null = null;
+    surface.addEventListener(
+      "wheel",
+      (event) => {
+        modified = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    surface.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        deltaX: -30,
+        deltaY: 0,
+        shiftKey: true,
+      }),
+    );
+
+    let outOfSurface: boolean | null = null;
+    outside.addEventListener(
+      "wheel",
+      (event) => {
+        outOfSurface = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    outside.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, deltaX: -30, deltaY: 0 }),
+    );
+
+    expect(vertical).toBe(false);
+    expect(modified).toBe(false);
+    expect(outOfSurface).toBe(false);
+  });
+
+  it("lets local horizontal scrollers consume wheels before page navigation", () => {
+    const surface = makeSurface();
+    const scroller = document.createElement("div");
+    const child = document.createElement("div");
+    scroller.append(child);
+    surface.append(scroller);
+
+    setHorizontalScrollMetrics(scroller, {
+      clientWidth: 100,
+      scrollWidth: 300,
+      scrollLeft: 50,
+    });
+
+    let candidate: boolean | null = null;
+    child.addEventListener(
+      "wheel",
+      (event) => {
+        candidate = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    child.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, deltaX: -30, deltaY: 0 }),
+    );
+
+    expect(candidate).toBe(false);
+  });
+
+  it("allows page navigation once a local horizontal scroller is at the edge", () => {
+    const surface = makeSurface();
+    const scroller = document.createElement("div");
+    const child = document.createElement("div");
+    scroller.append(child);
+    surface.append(scroller);
+
+    setHorizontalScrollMetrics(scroller, {
+      clientWidth: 100,
+      scrollWidth: 300,
+      scrollLeft: 0,
+    });
+
+    let candidate: boolean | null = null;
+    child.addEventListener(
+      "wheel",
+      (event) => {
+        candidate = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    child.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, deltaX: -30, deltaY: 0 }),
+    );
+
+    expect(candidate).toBe(true);
+  });
+
+  it("ignores editable targets", () => {
+    const surface = makeSurface();
+    const input = document.createElement("input");
+    surface.append(input);
+
+    let candidate: boolean | null = null;
+    input.addEventListener(
+      "wheel",
+      (event) => {
+        candidate = isPageNavigationWheelCandidate(event);
+      },
+      { once: true },
+    );
+    input.dispatchEvent(
+      new WheelEvent("wheel", { bubbles: true, deltaX: -30, deltaY: 0 }),
+    );
+
+    expect(candidate).toBe(false);
+  });
+});
+
+describe("createHorizontalWheelNavigationTracker", () => {
+  it("accumulates horizontal wheel movement before triggering", () => {
+    const surface = makeSurface();
+    const tracker = createHorizontalWheelNavigationTracker({
+      triggerThreshold: 90,
+      debounceMs: 0,
+    });
+
+    expect(dispatchWheel(surface, { deltaX: -45, deltaY: 0 }, tracker)).toBeNull();
+    expect(dispatchWheel(surface, { deltaX: -50, deltaY: 0 }, tracker)).toBe("back");
+  });
+
+  it("resets accumulation when the horizontal direction changes", () => {
+    const surface = makeSurface();
+    const tracker = createHorizontalWheelNavigationTracker({
+      triggerThreshold: 90,
+      debounceMs: 0,
+    });
+
+    expect(dispatchWheel(surface, { deltaX: -60, deltaY: 0 }, tracker)).toBeNull();
+    expect(dispatchWheel(surface, { deltaX: 60, deltaY: 0 }, tracker)).toBeNull();
+    expect(dispatchWheel(surface, { deltaX: 35, deltaY: 0 }, tracker)).toBe("forward");
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/use-horizontal-wheel-navigation.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-horizontal-wheel-navigation.ts
@@ -1,0 +1,186 @@
+import { useEffect, useRef } from "react";
+import { useTabHistory } from "./use-tab-history";
+
+export const PAGE_NAVIGATION_SURFACE_SELECTOR = "[data-page-navigation-surface]";
+
+type WheelNavigationGesture = "back" | "forward";
+
+interface WheelNavigationOptions {
+  minDeltaX: number;
+  axisDominanceRatio: number;
+  triggerThreshold: number;
+  gestureTimeoutMs: number;
+  debounceMs: number;
+}
+
+const DEFAULT_OPTIONS: WheelNavigationOptions = {
+  minDeltaX: 6,
+  axisDominanceRatio: 1.35,
+  triggerThreshold: 90,
+  gestureTimeoutMs: 220,
+  debounceMs: 750,
+};
+
+const SCROLL_EDGE_EPSILON = 1;
+
+export function wheelGestureFromDeltaX(
+  deltaX: number,
+): WheelNavigationGesture | null {
+  if (deltaX < 0) return "back";
+  if (deltaX > 0) return "forward";
+  return null;
+}
+
+function eventTargetElement(target: EventTarget | null): Element | null {
+  if (target instanceof Element) return target;
+  if (target instanceof Node) return target.parentElement;
+  return null;
+}
+
+function isEditableElement(element: Element): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  if (element.isContentEditable) return true;
+  const tag = element.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select";
+}
+
+function isInsideEditableTarget(target: Element, stopAt: Element): boolean {
+  for (let current: Element | null = target; current; current = current.parentElement) {
+    if (isEditableElement(current)) return true;
+    if (current === stopAt) break;
+  }
+  return false;
+}
+
+function canScrollHorizontally(element: Element, deltaX: number): boolean {
+  const { clientWidth, scrollLeft, scrollWidth } = element;
+  if (scrollWidth <= clientWidth + SCROLL_EDGE_EPSILON) return false;
+  if (deltaX < 0) return scrollLeft > SCROLL_EDGE_EPSILON;
+  if (deltaX > 0) {
+    return scrollLeft + clientWidth < scrollWidth - SCROLL_EDGE_EPSILON;
+  }
+  return false;
+}
+
+function hasScrollableAncestorInDirection(
+  target: Element,
+  stopAt: Element,
+  deltaX: number,
+): boolean {
+  for (let current: Element | null = target; current; current = current.parentElement) {
+    if (canScrollHorizontally(current, deltaX)) return true;
+    if (current === stopAt) break;
+  }
+  return false;
+}
+
+export function isPageNavigationWheelCandidate(
+  event: WheelEvent,
+  options: Pick<WheelNavigationOptions, "minDeltaX" | "axisDominanceRatio"> = DEFAULT_OPTIONS,
+): boolean {
+  if (event.defaultPrevented) return false;
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return false;
+
+  const absX = Math.abs(event.deltaX);
+  const absY = Math.abs(event.deltaY);
+  if (absX < options.minDeltaX) return false;
+  if (absX < absY * options.axisDominanceRatio) return false;
+
+  const target = eventTargetElement(event.target);
+  if (!target) return false;
+
+  const surface = target.closest(PAGE_NAVIGATION_SURFACE_SELECTOR);
+  if (!surface) return false;
+
+  if (isInsideEditableTarget(target, surface)) return false;
+  return !hasScrollableAncestorInDirection(target, surface, event.deltaX);
+}
+
+export function createHorizontalWheelNavigationTracker(
+  options: Partial<WheelNavigationOptions> = {},
+) {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  let accumulatedX = 0;
+  let lastWheelAt = Number.NEGATIVE_INFINITY;
+  let lastTriggerAt = Number.NEGATIVE_INFINITY;
+
+  return {
+    reset() {
+      accumulatedX = 0;
+      lastWheelAt = Number.NEGATIVE_INFINITY;
+    },
+    handleWheel(event: WheelEvent): WheelNavigationGesture | null {
+      if (!isPageNavigationWheelCandidate(event, resolved)) {
+        this.reset();
+        return null;
+      }
+
+      const now = event.timeStamp;
+      if (now - lastTriggerAt < resolved.debounceMs) {
+        this.reset();
+        lastWheelAt = now;
+        return null;
+      }
+
+      const shouldStartNewGesture =
+        !Number.isFinite(lastWheelAt) ||
+        now - lastWheelAt > resolved.gestureTimeoutMs ||
+        Math.sign(accumulatedX) !== Math.sign(event.deltaX);
+
+      if (shouldStartNewGesture) {
+        accumulatedX = 0;
+      }
+
+      accumulatedX += event.deltaX;
+      lastWheelAt = now;
+
+      if (Math.abs(accumulatedX) < resolved.triggerThreshold) return null;
+
+      const gesture = wheelGestureFromDeltaX(accumulatedX);
+      accumulatedX = 0;
+      lastTriggerAt = now;
+      return gesture;
+    },
+  };
+}
+
+export function useHorizontalWheelNavigation() {
+  const { canGoBack, canGoForward, goBack, goForward } = useTabHistory();
+  const navigationRef = useRef({
+    canGoBack,
+    canGoForward,
+    goBack,
+    goForward,
+  });
+
+  navigationRef.current = { canGoBack, canGoForward, goBack, goForward };
+
+  useEffect(() => {
+    if (window.desktopAPI.appInfo.os !== "macos") return;
+
+    const tracker = createHorizontalWheelNavigationTracker();
+    const handleWheel = (event: WheelEvent) => {
+      if (!document.hasFocus()) {
+        tracker.reset();
+        return;
+      }
+
+      const gesture = tracker.handleWheel(event);
+      if (!gesture) return;
+
+      const navigation = navigationRef.current;
+      if (gesture === "back" && navigation.canGoBack) {
+        event.preventDefault();
+        navigation.goBack();
+      } else if (gesture === "forward" && navigation.canGoForward) {
+        event.preventDefault();
+        navigation.goForward();
+      }
+    };
+
+    window.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      window.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Add a renderer-side macOS horizontal wheel gesture bridge for browser-style two-finger back/forward.
- Gate page-level navigation to focused windows and the main content surface.
- Let local horizontal scrollers consume the gesture first, with thresholding and debounce to avoid accidental navigation.

## Verification
- corepack pnpm --filter @multica/desktop exec vitest run src/renderer/src/hooks/use-horizontal-wheel-navigation.test.ts
- corepack pnpm --filter @multica/desktop exec vitest run
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.web.json --composite false
- corepack pnpm --filter @multica/desktop exec eslint src/renderer/src/hooks/use-horizontal-wheel-navigation.ts src/renderer/src/hooks/use-horizontal-wheel-navigation.test.ts src/renderer/src/components/desktop-layout.tsx

Note: corepack pnpm --filter @multica/desktop run typecheck could not run in this shell because the package script invokes a bare pnpm shim that is not on PATH, so I ran the equivalent node and web tsc commands directly.