### PR TITLE
fix(desktop): dim navigation buttons when unfocused

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import { useTabHistory } from "@/hooks/use-tab-history";
 import { useActiveTitleSync } from "@/hooks/use-tab-sync";
+import { useWindowFocus } from "@/hooks/use-window-focus";
 import { useTabStore, resolveRouteIcon } from "@/stores/tab-store";
 import {
   SidebarProvider,
@@ -23,6 +24,9 @@ import { WindowOverlay } from "./window-overlay";
 
 function SidebarTopBar() {
   const { canGoBack, canGoForward, goBack, goForward } = useTabHistory();
+  const isWindowFocused = useWindowFocus();
+  const canTriggerBack = canGoBack && isWindowFocused;
+  const canTriggerForward = canGoForward && isWindowFocused;
 
   return (
     <div
@@ -35,17 +39,27 @@ function SidebarTopBar() {
       >
         <button
           onClick={goBack}
-          disabled={!canGoBack}
+          disabled={!canTriggerBack}
           aria-label="Go back"
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md transition-colors disabled:pointer-events-none",
+            canTriggerBack
+              ? "text-foreground hover:bg-accent"
+              : "text-muted-foreground/40",
+          )}
         >
           <ChevronLeft className="size-4" />
         </button>
         <button
           onClick={goForward}
-          disabled={!canGoForward}
+          disabled={!canTriggerForward}
           aria-label="Go forward"
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md transition-colors disabled:pointer-events-none",
+            canTriggerForward
+              ? "text-foreground hover:bg-accent"
+              : "text-muted-foreground/40",
+          )}
         >
           <ChevronRight className="size-4" />
         </button>

--- a/apps/desktop/src/renderer/src/hooks/use-window-focus.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/use-window-focus.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { readWindowFocus, useWindowFocus } from "./use-window-focus";
+
+function FocusProbe() {
+  const isFocused = useWindowFocus();
+  return <div data-testid="focus-state">{String(isFocused)}</div>;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("readWindowFocus", () => {
+  it("reads document focus state", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    expect(readWindowFocus()).toBe(false);
+
+    vi.mocked(document.hasFocus).mockReturnValue(true);
+    expect(readWindowFocus()).toBe(true);
+  });
+});
+
+describe("useWindowFocus", () => {
+  it("updates when the window gains and loses focus", () => {
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    render(<FocusProbe />);
+
+    expect(screen.getByTestId("focus-state")).toHaveTextContent("true");
+
+    hasFocus.mockReturnValue(false);
+    fireEvent.blur(window);
+    expect(screen.getByTestId("focus-state")).toHaveTextContent("false");
+
+    hasFocus.mockReturnValue(true);
+    fireEvent.focus(window);
+    expect(screen.getByTestId("focus-state")).toHaveTextContent("true");
+  });
+
+  it("syncs focus on visibility changes", () => {
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    render(<FocusProbe />);
+
+    hasFocus.mockReturnValue(false);
+    fireEvent(document, new Event("visibilitychange"));
+
+    expect(screen.getByTestId("focus-state")).toHaveTextContent("false");
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/use-window-focus.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-window-focus.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export function readWindowFocus(): boolean {
+  if (typeof document.hasFocus !== "function") return true;
+  return document.hasFocus();
+}
+
+export function useWindowFocus(): boolean {
+  const [isFocused, setIsFocused] = useState(readWindowFocus);
+
+  useEffect(() => {
+    const syncFocus = () => {
+      setIsFocused(readWindowFocus());
+    };
+
+    window.addEventListener("focus", syncFocus);
+    window.addEventListener("blur", syncFocus);
+    document.addEventListener("visibilitychange", syncFocus);
+    syncFocus();
+
+    return () => {
+      window.removeEventListener("focus", syncFocus);
+      window.removeEventListener("blur", syncFocus);
+      document.removeEventListener("visibilitychange", syncFocus);
+    };
+  }, []);
+
+  return isFocused;
+}


### PR DESCRIPTION
## Summary
- Track renderer window focus state in a small desktop hook.
- Require both tab history and window focus before the sidebar back/forward buttons render as active/clickable.
- Keep inactive or unavailable navigation arrows visually muted so the feedback matches whether page-level navigation can actually fire.

## Verification
- corepack pnpm --filter @multica/desktop exec vitest run src/renderer/src/hooks/use-window-focus.test.tsx
- corepack pnpm --filter @multica/desktop exec vitest run
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.node.json --composite false
- corepack pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.web.json --composite false
- corepack pnpm --filter @multica/desktop exec eslint src/renderer/src/hooks/use-window-focus.ts src/renderer/src/hooks/use-window-focus.test.tsx src/renderer/src/components/desktop-layout.tsx