### PR TITLE
fix(daemon): sync codex hook files into task homes

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -76,6 +76,20 @@ var daemonDiskUsageCmd = &cobra.Command{
 	RunE: runDaemonDiskUsage,
 }
 
+var daemonCommentCmd = &cobra.Command{
+	Use:   "comment",
+	Short: "Post daemon-authenticated system comments",
+}
+
+var daemonCommentAddCmd = &cobra.Command{
+	Use:   "add <issue-id>",
+	Short: "Post a system comment using a daemon token",
+	Long: "Post a system comment using MULTICA_DAEMON_TOKEN. Local daemon tasks receive this token in their environment; " +
+		"background scripts can keep it and call this command after the task-scoped MULTICA_TOKEN expires.",
+	Args: cobra.ExactArgs(1),
+	RunE: runDaemonCommentAdd,
+}
+
 func init() {
 	f := daemonStartCmd.Flags()
 	f.Bool("foreground", false, "Run in the foreground instead of background")
@@ -117,12 +131,20 @@ func init() {
 	df.String("workspaces-root", "", "Override the workspaces root path (default: same as the daemon)")
 	df.Bool("all-profiles", false, "Scan every workspace root (default root + all ~/.multica/profiles/* roots, incl. the Desktop app's) and report a combined total")
 
+	daemonCommentAddCmd.Flags().String("content", "", "Comment content (decodes \\n, \\r, \\t, \\\\; pipe via --content-stdin for multi-line bodies or to preserve literal backslashes)")
+	daemonCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (preserves multi-line content verbatim)")
+	daemonCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file")
+	daemonCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
+	daemonCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
+
 	daemonCmd.AddCommand(daemonStartCmd)
 	daemonCmd.AddCommand(daemonStopCmd)
 	daemonCmd.AddCommand(daemonRestartCmd)
 	daemonCmd.AddCommand(daemonStatusCmd)
 	daemonCmd.AddCommand(daemonLogsCmd)
 	daemonCmd.AddCommand(daemonDiskUsageCmd)
+	daemonCommentCmd.AddCommand(daemonCommentAddCmd)
+	daemonCmd.AddCommand(daemonCommentCmd)
 }
 
 // daemonDirForProfile returns the state directory for the given profile.
@@ -141,6 +163,54 @@ func daemonPIDPathForProfile(profile string) string {
 
 func daemonLogPathForProfile(profile string) string {
 	return filepath.Join(daemonDirForProfile(profile), "daemon.log")
+}
+
+func runDaemonCommentAdd(cmd *cobra.Command, args []string) error {
+	content, hasContent, err := resolveTextFlag(cmd, "content")
+	if err != nil {
+		return err
+	}
+	if !hasContent {
+		return fmt.Errorf("--content, --content-stdin, or --content-file is required")
+	}
+
+	token, err := resolveDaemonCommentToken()
+	if err != nil {
+		return err
+	}
+	serverURL := resolveServerURL(cmd)
+	client := cli.NewAPIClient(serverURL, "", token)
+
+	body := map[string]any{"content": content}
+	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
+		body["parent_id"] = parentID
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/daemon/issues/"+args[0]+"/comments", body, &result); err != nil {
+		return fmt.Errorf("add daemon system comment: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "System comment added to issue %s.\n", args[0])
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+func resolveDaemonCommentToken() (string, error) {
+	token := strings.TrimSpace(os.Getenv("MULTICA_DAEMON_TOKEN"))
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv("MULTICA_TOKEN"))
+	}
+	if !strings.HasPrefix(token, "mdt_") {
+		return "", fmt.Errorf("daemon comment add requires MULTICA_DAEMON_TOKEN or MULTICA_TOKEN to contain an mdt_ daemon token")
+	}
+	return token, nil
 }
 
 // healthPortForProfile returns the health check port for the given profile.

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -418,6 +418,7 @@ func init() {
 	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
+	issueCommentAddCmd.Flags().Bool("require-task-token", false, "Require a daemon-injected mat_ task token and agent/task context; prevents fallback to a user PAT")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// issue comment resolve/unresolve
@@ -1424,6 +1425,11 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	if !hasContent {
 		return fmt.Errorf("--content, --content-stdin, or --content-file is required")
 	}
+	if requireTaskToken, _ := cmd.Flags().GetBool("require-task-token"); requireTaskToken {
+		if err := requireAgentTaskTokenContext(); err != nil {
+			return err
+		}
+	}
 
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -1488,6 +1494,20 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	return cli.PrintJSON(os.Stdout, result)
+}
+
+func requireAgentTaskTokenContext() error {
+	token := strings.TrimSpace(os.Getenv("MULTICA_TOKEN"))
+	if !strings.HasPrefix(token, "mat_") {
+		return fmt.Errorf("--require-task-token requires MULTICA_TOKEN to be a daemon-injected mat_ task token")
+	}
+	if strings.TrimSpace(os.Getenv("MULTICA_AGENT_ID")) == "" {
+		return fmt.Errorf("--require-task-token requires MULTICA_AGENT_ID")
+	}
+	if strings.TrimSpace(os.Getenv("MULTICA_TASK_ID")) == "" {
+		return fmt.Errorf("--require-task-token requires MULTICA_TASK_ID")
+	}
+	return nil
 }
 
 func runIssueCommentDelete(cmd *cobra.Command, args []string) error {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -750,6 +750,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		r.Get("/tasks/{taskId}/messages", h.ListTaskMessages)
 
 		r.Get("/issues/{issueId}/gc-check", h.GetIssueGCCheck)
+		r.Post("/issues/{issueId}/comments", h.CreateDaemonSystemComment)
 		r.Get("/chat-sessions/{sessionId}/gc-check", h.GetChatSessionGCCheck)
 		r.Get("/autopilot-runs/{runId}/gc-check", h.GetAutopilotRunGCCheck)
 		r.Get("/tasks/{taskId}/gc-check", h.GetTaskGCCheck)

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -259,6 +259,14 @@ func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages
 	}, nil)
 }
 
+func (c *Client) CreateSystemComment(ctx context.Context, issueID, content, parentID string) error {
+	body := map[string]any{"content": content}
+	if parentID != "" {
+		body["parent_id"] = parentID
+	}
+	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/issues/%s/comments", issueID), body, nil)
+}
+
 func (c *Client) CompleteTask(ctx context.Context, taskID, output, branchName, sessionID, workDir string) error {
 	body := map[string]any{"output": output}
 	if branchName != "" {
@@ -491,6 +499,7 @@ type RegisterResponse struct {
 	Repos        []RepoData      `json:"repos"`
 	ReposVersion string          `json:"repos_version"`
 	Settings     json.RawMessage `json:"settings,omitempty"`
+	DaemonToken  string          `json:"daemon_token,omitempty"`
 }
 
 func (c *Client) Register(ctx context.Context, req map[string]any) (*RegisterResponse, error) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -125,6 +125,7 @@ var (
 type workspaceState struct {
 	workspaceID     string
 	runtimeIDs      []string
+	daemonToken     string
 	reposVersion    string // stored for future use: skip refresh when version unchanged
 	allowedRepoURLs map[string]struct{}
 	taskRepoURLs    map[string]struct{}
@@ -594,6 +595,9 @@ func (d *Daemon) applyRegisterResponseInPlace(workspaceID string, resp *Register
 	// for a surviving provider (e.g. schema change); the daemon converges on
 	// what the server says without leaving stale heartbeat goroutines.
 	ws.runtimeIDs = newIDs
+	if resp.DaemonToken != "" {
+		ws.daemonToken = strings.TrimSpace(resp.DaemonToken)
+	}
 	if resp.ReposVersion != "" {
 		ws.reposVersion = resp.ReposVersion
 		ws.allowedRepoURLs = repoAllowlist(resp.Repos)
@@ -1169,12 +1173,33 @@ func profileSetSignature(profiles []RuntimeProfile) string {
 }
 
 func newWorkspaceState(workspaceID string, runtimeIDs []string, reposVersion string, repos []RepoData, settings json.RawMessage) *workspaceState {
+	return newWorkspaceStateWithDaemonToken(workspaceID, runtimeIDs, "", reposVersion, repos, settings)
+}
+
+func newWorkspaceStateWithDaemonToken(workspaceID string, runtimeIDs []string, daemonToken string, reposVersion string, repos []RepoData, settings json.RawMessage) *workspaceState {
 	return &workspaceState{
 		workspaceID:     workspaceID,
 		runtimeIDs:      runtimeIDs,
+		daemonToken:     strings.TrimSpace(daemonToken),
 		reposVersion:    reposVersion,
 		allowedRepoURLs: repoAllowlist(repos),
 		settings:        settings,
+	}
+}
+
+func (d *Daemon) workspaceDaemonToken(workspaceID string) string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	ws, ok := d.workspaces[workspaceID]
+	if !ok {
+		return ""
+	}
+	return ws.daemonToken
+}
+
+func (d *Daemon) injectDaemonTokenEnv(agentEnv map[string]string, workspaceID string) {
+	if token := d.workspaceDaemonToken(workspaceID); token != "" {
+		agentEnv["MULTICA_DAEMON_TOKEN"] = token
 	}
 }
 
@@ -3923,6 +3948,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"MULTICA_TASK_ID":      task.ID,
 		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
 	}
+	d.injectDaemonTokenEnv(agentEnv, task.WorkspaceID)
 	if task.AutopilotRunID != "" {
 		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID
 	}

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -143,13 +143,21 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	// Codex keys hook trust by the hooks.json source path. The per-task home
 	// loads codex-home/hooks.json, so trust accepted for the shared
 	// ~/.codex/hooks.json must be mirrored to that per-task source ID.
-	if err := syncCodexHookTrustState(
+	hookTrustResult, err := syncCodexHookTrustStateWithResult(
 		filepath.Join(sharedHome, "config.toml"),
 		filepath.Join(codexHome, "config.toml"),
 		filepath.Join(sharedHome, "hooks.json"),
 		filepath.Join(codexHome, "hooks.json"),
-	); err != nil {
+	)
+	if err != nil {
 		logger.Warn("execenv: codex-home hook trust sync failed", "error", err)
+	} else {
+		logger.Info("execenv: codex-home hook trust sync",
+			"codex_home", codexHome,
+			"shared_hooks", hookTrustResult.SharedHooksCount,
+			"mapped_hooks", hookTrustResult.MappedHooksCount,
+			"stale_hooks", hookTrustResult.StaleHooksCount,
+			"changed", hookTrustResult.Changed)
 	}
 
 	if err := syncCodexModelCatalog(codexHome, sharedHome); err != nil {

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -18,9 +18,11 @@ var codexSymlinkedDirs = []string{
 	"sessions",
 }
 
-// Optional directories to symlink from the shared ~/.codex/ into the per-task
+// Optional directories to expose from the shared ~/.codex/ into the per-task
 // CODEX_HOME. Missing sources are skipped so environments without Codex hooks
-// do not get empty hook directories.
+// do not get empty hook directories. Codex does not discover this directory
+// by itself, but hooks.json commonly references helper scripts stored there
+// (for example via $CODEX_HOME/hooks/...).
 var codexOptionalSymlinkedDirs = []string{
 	"hooks",
 }
@@ -31,9 +33,10 @@ var codexSymlinkedFiles = []string{
 	"auth.json",
 }
 
-// Optional files to symlink from the shared ~/.codex/ into the per-task
+// Optional files to expose from the shared ~/.codex/ into the per-task
 // CODEX_HOME. Missing or invalid sources clear any stale per-task copy/link
-// so removed hook configuration does not survive workspace reuse.
+// so removed hook configuration does not survive workspace reuse. Codex
+// discovers hooks.json next to the active CODEX_HOME config layer.
 var codexOptionalSymlinkedFiles = []string{
 	"hooks.json",
 }
@@ -88,7 +91,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
-	// Symlink optional shared directories only when they already exist.
+	// Expose optional shared directories only when they already exist.
 	for _, name := range codexOptionalSymlinkedDirs {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
@@ -106,7 +109,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
-	// Symlink optional hook config only when the shared source is valid.
+	// Expose optional hook config only when the shared source is valid.
 	for _, name := range codexOptionalSymlinkedFiles {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -18,10 +18,24 @@ var codexSymlinkedDirs = []string{
 	"sessions",
 }
 
+// Optional directories to symlink from the shared ~/.codex/ into the per-task
+// CODEX_HOME. Missing sources are skipped so environments without Codex hooks
+// do not get empty hook directories.
+var codexOptionalSymlinkedDirs = []string{
+	"hooks",
+}
+
 // Files to symlink from the shared ~/.codex/ into the per-task CODEX_HOME.
 // Symlinks share state (e.g. auth tokens) so changes propagate automatically.
 var codexSymlinkedFiles = []string{
 	"auth.json",
+}
+
+// Optional files to symlink from the shared ~/.codex/ into the per-task
+// CODEX_HOME. Missing or invalid sources clear any stale per-task copy/link
+// so removed hook configuration does not survive workspace reuse.
+var codexOptionalSymlinkedFiles = []string{
+	"hooks.json",
 }
 
 // Files to copy from the shared ~/.codex/ into the per-task CODEX_HOME.
@@ -65,7 +79,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		return fmt.Errorf("create codex-home dir: %w", err)
 	}
 
-	// Symlink shared directories (sessions) so logs stay in the global home.
+	// Symlink shared directories so session logs stay in the global home.
 	for _, name := range codexSymlinkedDirs {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
@@ -74,12 +88,30 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
-	// Symlink shared files (auth).
+	// Symlink optional shared directories only when they already exist.
+	for _, name := range codexOptionalSymlinkedDirs {
+		src := filepath.Join(sharedHome, name)
+		dst := filepath.Join(codexHome, name)
+		if err := ensureExistingDirSymlink(src, dst); err != nil {
+			logger.Warn("execenv: codex-home optional dir symlink failed", "dir", name, "error", err)
+		}
+	}
+
+	// Symlink shared files so auth changes propagate automatically.
 	for _, name := range codexSymlinkedFiles {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
 		if err := ensureSymlink(src, dst); err != nil {
 			logger.Warn("execenv: codex-home symlink failed", "file", name, "error", err)
+		}
+	}
+
+	// Symlink optional hook config only when the shared source is valid.
+	for _, name := range codexOptionalSymlinkedFiles {
+		src := filepath.Join(sharedHome, name)
+		dst := filepath.Join(codexHome, name)
+		if err := ensureOptionalFileSymlink(src, dst); err != nil {
+			logger.Warn("execenv: codex-home optional file symlink failed", "file", name, "error", err)
 		}
 	}
 
@@ -284,6 +316,96 @@ func ensureDirSymlink(src, dst string) error {
 	}
 
 	return createDirLink(src, dst)
+}
+
+// ensureExistingDirSymlink creates a symlink dst -> src only when src already
+// exists as a directory. Missing or non-directory sources clear stale dst
+// residue left by earlier prepares or Windows junction/copy fallbacks.
+func ensureExistingDirSymlink(src, dst string) error {
+	fi, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		return removeOptionalPath(dst)
+	}
+	if err != nil {
+		return fmt.Errorf("stat shared dir %s: %w", src, err)
+	}
+	if !fi.IsDir() {
+		return removeOptionalPath(dst)
+	}
+
+	if fi, err := os.Lstat(dst); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(dst)
+			if err == nil && target == src {
+				return nil
+			}
+			if err := os.Remove(dst); err != nil {
+				return fmt.Errorf("remove stale dir link %s: %w", dst, err)
+			}
+		} else {
+			if err := os.RemoveAll(dst); err != nil {
+				return fmt.Errorf("remove stale dir path %s: %w", dst, err)
+			}
+		}
+	}
+
+	return createDirLink(src, dst)
+}
+
+// ensureOptionalFileSymlink creates a symlink/copy dst -> src only when src
+// exists as a regular file. Missing or invalid hook config removes any stale
+// per-task copy/link so workspace reuse reflects the shared home lifecycle.
+func ensureOptionalFileSymlink(src, dst string) error {
+	fi, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		return removeOptionalPath(dst)
+	}
+	if err != nil {
+		return fmt.Errorf("stat shared file %s: %w", src, err)
+	}
+	if !fi.Mode().IsRegular() {
+		return removeOptionalPath(dst)
+	}
+
+	if fi, err := os.Lstat(dst); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(dst)
+			if err == nil && target == src {
+				return nil
+			}
+			if err := os.Remove(dst); err != nil {
+				return fmt.Errorf("remove stale optional file link %s: %w", dst, err)
+			}
+		} else {
+			if err := os.RemoveAll(dst); err != nil {
+				return fmt.Errorf("remove stale optional file path %s: %w", dst, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat optional file dst %s: %w", dst, err)
+	}
+
+	return createFileLink(src, dst)
+}
+
+func removeOptionalPath(path string) error {
+	fi, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat optional dst %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove optional dst link %s: %w", path, err)
+		}
+		return nil
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("remove optional dst path %s: %w", path, err)
+	}
+	return nil
 }
 
 // ensureSymlink ensures dst tracks src. If src doesn't exist, it's a no-op.

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -140,6 +140,18 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		logger.Warn("execenv: codex-home sanitize config failed", "error", err)
 	}
 
+	// Codex keys hook trust by the hooks.json source path. The per-task home
+	// loads codex-home/hooks.json, so trust accepted for the shared
+	// ~/.codex/hooks.json must be mirrored to that per-task source ID.
+	if err := syncCodexHookTrustState(
+		filepath.Join(sharedHome, "config.toml"),
+		filepath.Join(codexHome, "config.toml"),
+		filepath.Join(sharedHome, "hooks.json"),
+		filepath.Join(codexHome, "hooks.json"),
+	); err != nil {
+		logger.Warn("execenv: codex-home hook trust sync failed", "error", err)
+	}
+
 	if err := syncCodexModelCatalog(codexHome, sharedHome); err != nil {
 		return fmt.Errorf("sync codex model_catalog_json: %w", err)
 	}

--- a/server/internal/daemon/execenv/codex_hook_trust.go
+++ b/server/internal/daemon/execenv/codex_hook_trust.go
@@ -1,0 +1,149 @@
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type codexHookTrustBlock struct {
+	suffix string
+	body   []string
+}
+
+var hooksStateTableHeaderRe = regexp.MustCompile(`^\s*\[\s*hooks\s*\.\s*state\s*\.\s*"((?:\\.|[^"\\])*)"\s*\]\s*(?:#.*)?$`)
+
+// syncCodexHookTrustState maps trusted shared ~/.codex/hooks.json handlers
+// into the per-task CODEX_HOME/hooks.json source IDs that Codex actually
+// evaluates at startup.
+func syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath string) error {
+	taskData, err := os.ReadFile(taskConfigPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read per-task config.toml: %w", err)
+	}
+	originalTaskContent := string(taskData)
+	taskContent := removeHooksStateBlocks(originalTaskContent, taskHooksPath)
+
+	if regularFileExists(sharedHooksPath) && regularFileExists(taskHooksPath) {
+		sharedData, err := os.ReadFile(sharedConfigPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("read shared config.toml: %w", err)
+		}
+		blocks := extractHooksStateBlocks(string(sharedData), sharedHooksPath)
+		taskContent = appendMappedHooksStateBlocks(taskContent, taskHooksPath, blocks)
+	}
+
+	if taskContent == originalTaskContent {
+		return nil
+	}
+	if err := os.WriteFile(taskConfigPath, []byte(taskContent), 0o644); err != nil {
+		return fmt.Errorf("write per-task config.toml: %w", err)
+	}
+	return nil
+}
+
+func regularFileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
+}
+
+func extractHooksStateBlocks(content, sourcePath string) []codexHookTrustBlock {
+	prefix := sourcePath + ":"
+	lines := splitLinesKeepingEndings(content)
+	blocks := make([]codexHookTrustBlock, 0)
+	for i := 0; i < len(lines); {
+		key, ok := hooksStateKey(lines[i])
+		if !ok || !strings.HasPrefix(key, prefix) {
+			i++
+			continue
+		}
+
+		start := i + 1
+		i = start
+		for i < len(lines) && !isTOMLTableHeader(lines[i]) {
+			i++
+		}
+		body := append([]string(nil), lines[start:i]...)
+		blocks = append(blocks, codexHookTrustBlock{
+			suffix: strings.TrimPrefix(key, sourcePath),
+			body:   body,
+		})
+	}
+	return blocks
+}
+
+func removeHooksStateBlocks(content, sourcePath string) string {
+	prefix := sourcePath + ":"
+	lines := splitLinesKeepingEndings(content)
+	out := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); {
+		key, ok := hooksStateKey(lines[i])
+		if !ok || !strings.HasPrefix(key, prefix) {
+			out = append(out, lines[i])
+			i++
+			continue
+		}
+
+		i++
+		for i < len(lines) && !isTOMLTableHeader(lines[i]) {
+			i++
+		}
+	}
+	return strings.Join(out, "")
+}
+
+func appendMappedHooksStateBlocks(content, taskHooksPath string, blocks []codexHookTrustBlock) string {
+	if len(blocks) == 0 {
+		return content
+	}
+
+	var b strings.Builder
+	trimmed := strings.TrimRight(content, "\n")
+	if trimmed != "" {
+		b.WriteString(trimmed)
+		b.WriteString("\n\n")
+	}
+
+	for _, block := range blocks {
+		b.WriteString("[hooks.state.")
+		b.WriteString(quoteTOMLBasicString(taskHooksPath + block.suffix))
+		b.WriteString("]\n")
+		body := strings.Trim(strings.Join(block.body, ""), "\n")
+		if body != "" {
+			b.WriteString(body)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+func hooksStateKey(line string) (string, bool) {
+	matches := hooksStateTableHeaderRe.FindStringSubmatch(line)
+	if matches == nil {
+		return "", false
+	}
+	key, err := strconv.Unquote(`"` + matches[1] + `"`)
+	if err != nil {
+		return "", false
+	}
+	return key, true
+}
+
+func quoteTOMLBasicString(value string) string {
+	return strconv.Quote(value)
+}
+
+func isTOMLTableHeader(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "[")
+}
+
+func splitLinesKeepingEndings(content string) []string {
+	if content == "" {
+		return nil
+	}
+	return strings.SplitAfter(content, "\n")
+}

--- a/server/internal/daemon/execenv/codex_hook_trust.go
+++ b/server/internal/daemon/execenv/codex_hook_trust.go
@@ -13,35 +13,53 @@ type codexHookTrustBlock struct {
 	body   []string
 }
 
+type codexHookTrustSyncResult struct {
+	SharedHooksCount int
+	MappedHooksCount int
+	StaleHooksCount  int
+	Changed          bool
+}
+
 var hooksStateTableHeaderRe = regexp.MustCompile(`^\s*\[\s*hooks\s*\.\s*state\s*\.\s*"((?:\\.|[^"\\])*)"\s*\]\s*(?:#.*)?$`)
 
 // syncCodexHookTrustState maps trusted shared ~/.codex/hooks.json handlers
 // into the per-task CODEX_HOME/hooks.json source IDs that Codex actually
 // evaluates at startup.
 func syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath string) error {
+	_, err := syncCodexHookTrustStateWithResult(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath)
+	return err
+}
+
+func syncCodexHookTrustStateWithResult(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath string) (codexHookTrustSyncResult, error) {
+	var result codexHookTrustSyncResult
+
 	taskData, err := os.ReadFile(taskConfigPath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read per-task config.toml: %w", err)
+		return result, fmt.Errorf("read per-task config.toml: %w", err)
 	}
 	originalTaskContent := string(taskData)
-	taskContent := removeHooksStateBlocks(originalTaskContent, taskHooksPath)
+	taskContent, staleCount := removeHooksStateBlocksWithCount(originalTaskContent, taskHooksPath)
+	result.StaleHooksCount = staleCount
 
 	if regularFileExists(sharedHooksPath) && regularFileExists(taskHooksPath) {
 		sharedData, err := os.ReadFile(sharedConfigPath)
 		if err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("read shared config.toml: %w", err)
+			return result, fmt.Errorf("read shared config.toml: %w", err)
 		}
 		blocks := extractHooksStateBlocks(string(sharedData), sharedHooksPath)
+		result.SharedHooksCount = len(blocks)
+		result.MappedHooksCount = len(blocks)
 		taskContent = appendMappedHooksStateBlocks(taskContent, taskHooksPath, blocks)
 	}
 
 	if taskContent == originalTaskContent {
-		return nil
+		return result, nil
 	}
 	if err := os.WriteFile(taskConfigPath, []byte(taskContent), 0o644); err != nil {
-		return fmt.Errorf("write per-task config.toml: %w", err)
+		return result, fmt.Errorf("write per-task config.toml: %w", err)
 	}
-	return nil
+	result.Changed = true
+	return result, nil
 }
 
 func regularFileExists(path string) bool {
@@ -75,9 +93,15 @@ func extractHooksStateBlocks(content, sourcePath string) []codexHookTrustBlock {
 }
 
 func removeHooksStateBlocks(content, sourcePath string) string {
+	updated, _ := removeHooksStateBlocksWithCount(content, sourcePath)
+	return updated
+}
+
+func removeHooksStateBlocksWithCount(content, sourcePath string) (string, int) {
 	prefix := sourcePath + ":"
 	lines := splitLinesKeepingEndings(content)
 	out := make([]string, 0, len(lines))
+	removed := 0
 	for i := 0; i < len(lines); {
 		key, ok := hooksStateKey(lines[i])
 		if !ok || !strings.HasPrefix(key, prefix) {
@@ -86,12 +110,13 @@ func removeHooksStateBlocks(content, sourcePath string) string {
 			continue
 		}
 
+		removed++
 		i++
 		for i < len(lines) && !isTOMLTableHeader(lines[i]) {
 			i++
 		}
 	}
-	return strings.Join(out, "")
+	return strings.Join(out, ""), removed
 }
 
 func appendMappedHooksStateBlocks(content, taskHooksPath string, blocks []codexHookTrustBlock) string {

--- a/server/internal/daemon/execenv/codex_hook_trust_test.go
+++ b/server/internal/daemon/execenv/codex_hook_trust_test.go
@@ -1,0 +1,256 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func hookStateHeader(path, suffix string) string {
+	return "[hooks.state." + quoteTOMLBasicString(path+suffix) + "]"
+}
+
+func assertConfigContains(t *testing.T, content, want string) {
+	t.Helper()
+	if !strings.Contains(content, want) {
+		t.Fatalf("config missing %q:\n%s", want, content)
+	}
+}
+
+func TestSyncCodexHookTrustStateMapsSharedHooksJSONSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sharedHome := filepath.Join(dir, "shared")
+	codexHome := filepath.Join(dir, "task", "codex-home")
+	if err := os.MkdirAll(sharedHome, 0o755); err != nil {
+		t.Fatalf("create shared home: %v", err)
+	}
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	taskHooksPath := filepath.Join(codexHome, "hooks.json")
+	sharedConfigPath := filepath.Join(sharedHome, "config.toml")
+	taskConfigPath := filepath.Join(codexHome, "config.toml")
+	if err := os.WriteFile(sharedHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	if err := os.WriteFile(taskHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write task hooks.json: %v", err)
+	}
+
+	sharedConfig := `[hooks.state]
+
+` + hookStateHeader(sharedHooksPath, ":pre_tool_use:0:0") + `
+trusted_hash = "sha256:aaa"
+
+` + hookStateHeader(sharedHooksPath, ":pre_tool_use:0:1") + `
+trusted_hash = "sha256:bbb"
+
+[hooks.state."plugin@local:hooks/codex-hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:plugin"
+`
+	if err := os.WriteFile(sharedConfigPath, []byte(sharedConfig), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(taskConfigPath, []byte(`model = "o3"`+"\n"), 0o644); err != nil {
+		t.Fatalf("write task config.toml: %v", err)
+	}
+
+	if err := syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath); err != nil {
+		t.Fatalf("syncCodexHookTrustState: %v", err)
+	}
+	data, err := os.ReadFile(taskConfigPath)
+	if err != nil {
+		t.Fatalf("read task config.toml: %v", err)
+	}
+	content := string(data)
+	assertConfigContains(t, content, hookStateHeader(taskHooksPath, ":pre_tool_use:0:0"))
+	assertConfigContains(t, content, `trusted_hash = "sha256:aaa"`)
+	assertConfigContains(t, content, hookStateHeader(taskHooksPath, ":pre_tool_use:0:1"))
+	assertConfigContains(t, content, `trusted_hash = "sha256:bbb"`)
+	if strings.Contains(content, "plugin@local") {
+		t.Fatalf("plugin hook trust state should not be remapped into task hooks.json:\n%s", content)
+	}
+
+	if err := syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath); err != nil {
+		t.Fatalf("syncCodexHookTrustState second run: %v", err)
+	}
+	data, err = os.ReadFile(taskConfigPath)
+	if err != nil {
+		t.Fatalf("read task config.toml after second run: %v", err)
+	}
+	content = string(data)
+	if count := strings.Count(content, taskHooksPath+":pre_tool_use:0:0"); count != 1 {
+		t.Fatalf("mapped hook state should be idempotent, count=%d:\n%s", count, content)
+	}
+}
+
+func TestSyncCodexHookTrustStateRefreshesMappedBlocksFromSharedConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sharedHome := filepath.Join(dir, "shared")
+	codexHome := filepath.Join(dir, "task", "codex-home")
+	if err := os.MkdirAll(sharedHome, 0o755); err != nil {
+		t.Fatalf("create shared home: %v", err)
+	}
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	taskHooksPath := filepath.Join(codexHome, "hooks.json")
+	sharedConfigPath := filepath.Join(sharedHome, "config.toml")
+	taskConfigPath := filepath.Join(codexHome, "config.toml")
+	if err := os.WriteFile(sharedHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	if err := os.WriteFile(taskHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write task hooks.json: %v", err)
+	}
+	if err := os.WriteFile(sharedConfigPath, []byte(hookStateHeader(sharedHooksPath, ":pre_tool_use:0:0")+"\ntrusted_hash = \"sha256:new\"\n"), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	staleTaskConfig := hookStateHeader(taskHooksPath, ":pre_tool_use:0:0") + "\ntrusted_hash = \"sha256:old\"\n"
+	if err := os.WriteFile(taskConfigPath, []byte(staleTaskConfig), 0o644); err != nil {
+		t.Fatalf("write stale task config.toml: %v", err)
+	}
+
+	if err := syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath); err != nil {
+		t.Fatalf("syncCodexHookTrustState: %v", err)
+	}
+	data, err := os.ReadFile(taskConfigPath)
+	if err != nil {
+		t.Fatalf("read task config.toml: %v", err)
+	}
+	content := string(data)
+	assertConfigContains(t, content, `trusted_hash = "sha256:new"`)
+	if strings.Contains(content, "sha256:old") {
+		t.Fatalf("stale mapped trust state was not removed:\n%s", content)
+	}
+}
+
+func TestSyncCodexHookTrustStateClearsMappedBlocksWhenHooksMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sharedHome := filepath.Join(dir, "shared")
+	codexHome := filepath.Join(dir, "task", "codex-home")
+	if err := os.MkdirAll(sharedHome, 0o755); err != nil {
+		t.Fatalf("create shared home: %v", err)
+	}
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	taskHooksPath := filepath.Join(codexHome, "hooks.json")
+	sharedConfigPath := filepath.Join(sharedHome, "config.toml")
+	taskConfigPath := filepath.Join(codexHome, "config.toml")
+	taskConfig := `model = "o3"
+
+` + hookStateHeader(taskHooksPath, ":pre_tool_use:0:0") + `
+trusted_hash = "sha256:stale"
+
+[hooks.state."plugin@local:hooks/codex-hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:plugin"
+`
+	if err := os.WriteFile(taskConfigPath, []byte(taskConfig), 0o644); err != nil {
+		t.Fatalf("write task config.toml: %v", err)
+	}
+
+	if err := syncCodexHookTrustState(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath); err != nil {
+		t.Fatalf("syncCodexHookTrustState: %v", err)
+	}
+	data, err := os.ReadFile(taskConfigPath)
+	if err != nil {
+		t.Fatalf("read task config.toml: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, taskHooksPath) || strings.Contains(content, "sha256:stale") {
+		t.Fatalf("stale task hooks.json trust state should be cleared:\n%s", content)
+	}
+	assertConfigContains(t, content, "plugin@local")
+}
+
+func TestPrepareCodexHomeMapsCodexHookTrustStateFromSharedConfig(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	if err := os.WriteFile(sharedHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	sharedConfig := hookStateHeader(sharedHooksPath, ":session_start:0:0") + "\ntrusted_hash = \"sha256:session\"\n"
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(sharedConfig), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, discardLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read per-task config.toml: %v", err)
+	}
+	taskHooksPath := filepath.Join(codexHome, "hooks.json")
+	content := string(data)
+	assertConfigContains(t, content, hookStateHeader(taskHooksPath, ":session_start:0:0"))
+	assertConfigContains(t, content, `trusted_hash = "sha256:session"`)
+}
+
+func TestReuseRefreshesCodexHookTrustStateFromSharedConfig(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	if err := os.WriteFile(sharedHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sharedHome, "hooks"), 0o755); err != nil {
+		t.Fatalf("create shared hooks dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(hookStateHeader(sharedHooksPath, ":pre_tool_use:0:0")+"\ntrusted_hash = \"sha256:v1\"\n"), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-codex-hook-trust-reuse",
+		TaskID:         "a6f7a8b9-c0d1-2345-fabc-678901234567",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-hook-trust-test"},
+	}, discardLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(hookStateHeader(sharedHooksPath, ":pre_tool_use:0:0")+"\ntrusted_hash = \"sha256:v2\"\n"), 0o644); err != nil {
+		t.Fatalf("update shared config.toml: %v", err)
+	}
+
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-hook-trust-test"}}, discardLogger())
+	if reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	data, err := os.ReadFile(filepath.Join(reused.CodexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read reused config.toml: %v", err)
+	}
+	content := string(data)
+	assertConfigContains(t, content, `trusted_hash = "sha256:v2"`)
+	staleMappedBlock := hookStateHeader(filepath.Join(reused.CodexHome, "hooks.json"), ":pre_tool_use:0:0") + "\ntrusted_hash = \"sha256:v1\""
+	if strings.Contains(content, staleMappedBlock) {
+		t.Fatalf("reuse should refresh mapped hook trust state from shared config:\n%s", content)
+	}
+}

--- a/server/internal/daemon/execenv/codex_hook_trust_test.go
+++ b/server/internal/daemon/execenv/codex_hook_trust_test.go
@@ -134,6 +134,48 @@ func TestSyncCodexHookTrustStateRefreshesMappedBlocksFromSharedConfig(t *testing
 	}
 }
 
+func TestSyncCodexHookTrustStateReportsCounts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sharedHome := filepath.Join(dir, "shared")
+	codexHome := filepath.Join(dir, "task", "codex-home")
+	if err := os.MkdirAll(sharedHome, 0o755); err != nil {
+		t.Fatalf("create shared home: %v", err)
+	}
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+
+	sharedHooksPath := filepath.Join(sharedHome, "hooks.json")
+	taskHooksPath := filepath.Join(codexHome, "hooks.json")
+	sharedConfigPath := filepath.Join(sharedHome, "config.toml")
+	taskConfigPath := filepath.Join(codexHome, "config.toml")
+	if err := os.WriteFile(sharedHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	if err := os.WriteFile(taskHooksPath, []byte(`{"hooks":true}`), 0o644); err != nil {
+		t.Fatalf("write task hooks.json: %v", err)
+	}
+	sharedConfig := hookStateHeader(sharedHooksPath, ":pre_tool_use:0:0") + "\ntrusted_hash = \"sha256:a\"\n\n" +
+		hookStateHeader(sharedHooksPath, ":post_tool_use:0:0") + "\ntrusted_hash = \"sha256:b\"\n"
+	if err := os.WriteFile(sharedConfigPath, []byte(sharedConfig), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	taskConfig := hookStateHeader(taskHooksPath, ":pre_tool_use:0:0") + "\ntrusted_hash = \"sha256:stale\"\n"
+	if err := os.WriteFile(taskConfigPath, []byte(taskConfig), 0o644); err != nil {
+		t.Fatalf("write task config.toml: %v", err)
+	}
+
+	result, err := syncCodexHookTrustStateWithResult(sharedConfigPath, taskConfigPath, sharedHooksPath, taskHooksPath)
+	if err != nil {
+		t.Fatalf("syncCodexHookTrustStateWithResult: %v", err)
+	}
+	if result.SharedHooksCount != 2 || result.MappedHooksCount != 2 || result.StaleHooksCount != 1 || !result.Changed {
+		t.Fatalf("unexpected sync result: %+v", result)
+	}
+}
+
 func TestSyncCodexHookTrustStateClearsMappedBlocksWhenHooksMissing(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/cursor_mcp.go
+++ b/server/internal/daemon/execenv/cursor_mcp.go
@@ -165,9 +165,24 @@ func cursorProjectRoot(workDir string) string {
 		dir = workDir
 	}
 	fallback := dir
+	tmpRoot := os.TempDir()
+	if resolvedTmp, err := filepath.EvalSymlinks(tmpRoot); err == nil {
+		tmpRoot = resolvedTmp
+	}
+	if absTmp, err := filepath.Abs(tmpRoot); err == nil {
+		tmpRoot = absTmp
+	}
 	for {
-		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-			return dir
+		// Test and scratch workdirs often live under os.TempDir. A stray
+		// /tmp/.git must not turn every temp workdir into one shared Cursor
+		// project and make managed .cursor/mcp.json collide globally.
+		if dir != tmpRoot {
+			if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+				return dir
+			}
+		}
+		if dir == tmpRoot {
+			return fallback
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/server/internal/daemon/execenv/cursor_mcp_test.go
+++ b/server/internal/daemon/execenv/cursor_mcp_test.go
@@ -119,6 +119,18 @@ func TestPrepareCursorMcpConfigManagedEmptySet(t *testing.T) {
 	}
 }
 
+func TestCursorProjectRootStopsAtTempRootGit(t *testing.T) {
+	t.Parallel()
+
+	workDir := filepath.Join(t.TempDir(), "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workDir: %v", err)
+	}
+	if got := cursorProjectRoot(workDir); got != workDir {
+		t.Fatalf("cursorProjectRoot(%q) = %q, want workDir when only os.TempDir has .git", workDir, got)
+	}
+}
+
 func TestPrepareCursorMcpConfigNilDoesNotTakeOwnership(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2061,6 +2061,45 @@ func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexHomeExposesSharedHooks(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	sharedHooksJSON := `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"python3 ~/.codex/hooks/session_start.py"}]}]}}`
+	if err := os.WriteFile(filepath.Join(sharedHome, "hooks.json"), []byte(sharedHooksJSON), 0o644); err != nil {
+		t.Fatalf("write shared hooks.json: %v", err)
+	}
+	sharedHooksDir := filepath.Join(sharedHome, "hooks")
+	if err := os.MkdirAll(sharedHooksDir, 0o755); err != nil {
+		t.Fatalf("create shared hooks dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHooksDir, "session_start.py"), []byte("print('session')"), 0o755); err != nil {
+		t.Fatalf("write shared hook script: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "hooks.json"))
+	if err != nil {
+		t.Fatalf("read per-task hooks.json: %v", err)
+	}
+	if string(data) != sharedHooksJSON {
+		t.Fatalf("per-task hooks.json content = %q, want shared content", data)
+	}
+
+	data, err = os.ReadFile(filepath.Join(codexHome, "hooks", "session_start.py"))
+	if err != nil {
+		t.Fatalf("read per-task hook script: %v", err)
+	}
+	if string(data) != "print('session')" {
+		t.Fatalf("per-task hook script content = %q, want shared content", data)
+	}
+}
+
 // Regression test for #1753 — Codex Desktop writes plugin-backed
 // `[[skills.config]]` entries without a `path` field, and the CLI's TOML
 // parser rejects them with `missing field path`. prepareCodexHome must drop
@@ -2396,6 +2435,48 @@ env_key = "OLD_API_KEY"
 	} {
 		if !strings.Contains(s, marker) {
 			t.Errorf("daemon-managed marker %q missing after shared source removed, got:\n%s", marker, s)
+		}
+	}
+}
+
+func TestPrepareCodexHome_DropsSharedHooksWhenSourceRemoved(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "hooks.json"), []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"true"}]}]}}`), 0o644); err != nil {
+		t.Fatalf("seed shared hooks.json: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sharedHome, "hooks"), 0o755); err != nil {
+		t.Fatalf("seed shared hooks dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "hooks", "stop.sh"), []byte("#!/bin/sh\ntrue\n"), 0o755); err != nil {
+		t.Fatalf("seed shared hook script: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("first prepareCodexHome: %v", err)
+	}
+	for _, name := range []string{"hooks.json", "hooks"} {
+		if _, err := os.Stat(filepath.Join(codexHome, name)); err != nil {
+			t.Fatalf("first prepare did not expose per-task %s: %v", name, err)
+		}
+	}
+
+	if err := os.Remove(filepath.Join(sharedHome, "hooks.json")); err != nil {
+		t.Fatalf("remove shared hooks.json: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(sharedHome, "hooks")); err != nil {
+		t.Fatalf("remove shared hooks dir: %v", err)
+	}
+
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("second prepareCodexHome: %v", err)
+	}
+	for _, name := range []string{"hooks.json", "hooks"} {
+		if _, err := os.Lstat(filepath.Join(codexHome, name)); !os.IsNotExist(err) {
+			t.Fatalf("per-task %s still exists after shared source removed (lstat err = %v)", name, err)
 		}
 	}
 }

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -171,7 +171,7 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 				"Use this form, preserving the same issue ID and --parent value:\n\n"+
 				"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
 				"    # 2. Post the comment:\n"+
-				"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
+				"    multica issue comment add %s --parent %s --content-file ./reply.md --require-task-token\n"+
 				"    # 3. Remove the temp file so a later run does not pick up stale content:\n"+
 				"    Remove-Item ./reply.md\n\n"+
 				"Do NOT write literal `\\n` escapes to simulate line breaks; the file preserves real newlines.\n",
@@ -197,7 +197,7 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 			"Use this form, preserving the same issue ID and --parent value:\n\n"+
 			"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
 			"    # 2. Post the comment:\n"+
-			"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
+			"    multica issue comment add %s --parent %s --content-file ./reply.md --require-task-token\n"+
 			"    # 3. Remove the temp file so a later run does not pick up stale content:\n"+
 			"    rm ./reply.md\n\n"+
 			"Do NOT write literal `\\n` escapes to simulate line breaks; the file preserves real newlines.\n",

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -36,6 +36,7 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 		"rm ./reply.md",
 		"Do NOT write literal `\\n` escapes to simulate line breaks",
 		"do NOT reuse --parent values from previous turns",
+		"--require-task-token",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("codex/linux reply instructions missing %q\n---\n%s", want, got)
@@ -92,6 +93,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					"rm ./reply.md",
 					"do NOT reuse --parent values from previous turns",
 					"If you decide to reply",
+					"--require-task-token",
 				} {
 					if !strings.Contains(got, want) {
 						t.Errorf("%s reply instructions missing %q\n---\n%s", name, want, got)
@@ -142,6 +144,7 @@ func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
 				"Do NOT pipe via `--content-stdin`",
 				"silently drops non-ASCII",
 				"$OutputEncoding",
+				"--require-task-token",
 			} {
 				if !strings.Contains(got, want) {
 					t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, got)
@@ -201,6 +204,7 @@ func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
 		triggerID,
 		"multica issue comment add " + issueID + " --parent " + triggerID,
 		"do NOT reuse --parent values from previous turns",
+		"--require-task-token",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("CLAUDE.md missing %q", want)

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1192,81 +1192,12 @@ func (h *Handler) CreateDaemonSystemComment(w http.ResponseWriter, r *http.Reque
 		parentComment = &parent
 	}
 
-	content := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
 	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
 		IssueID:     issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 		AuthorType:  "system",
 		AuthorID:    pgtype.UUID{Valid: true},
-		Content:     content,
-		Type:        "system",
-		ParentID:    parentID,
-	})
-	if err != nil {
-		slog.Warn("create daemon system comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
-		writeError(w, http.StatusInternalServerError, "failed to create comment: "+err.Error())
-		return
-	}
-
-	resp := commentToResponse(comment, nil, nil)
-	slog.Info("daemon system comment created", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
-	h.publish(protocol.EventCommentCreated, uuidToString(issue.WorkspaceID), "system", "", map[string]any{
-		"comment":             resp,
-		"issue_title":         issue.Title,
-		"issue_assignee_type": textToPtr(issue.AssigneeType),
-		"issue_assignee_id":   uuidToPtr(issue.AssigneeID),
-		"issue_status":        issue.Status,
-	})
-	h.TaskService.AutoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), "system", "")
-
-	writeJSON(w, http.StatusCreated, resp)
-}
-
-func (h *Handler) CreateDaemonSystemComment(w http.ResponseWriter, r *http.Request) {
-	if !requireDaemonTokenAuth(w, r) {
-		return
-	}
-
-	issueID := chi.URLParam(r, "issueId")
-	issue, ok := h.loadIssueForDaemon(w, r, issueID)
-	if !ok {
-		return
-	}
-
-	var req CreateCommentRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
-		return
-	}
-	if req.Content == "" {
-		writeError(w, http.StatusBadRequest, "content is required")
-		return
-	}
-
-	var parentID pgtype.UUID
-	var parentComment *db.Comment
-	if req.ParentID != nil {
-		var parsed pgtype.UUID
-		parsed, ok = parseUUIDOrBadRequest(w, *req.ParentID, "parent_id")
-		if !ok {
-			return
-		}
-		parentID = parsed
-		parent, err := h.Queries.GetComment(r.Context(), parentID)
-		if err != nil || uuidToString(parent.IssueID) != uuidToString(issue.ID) {
-			writeError(w, http.StatusBadRequest, "invalid parent comment")
-			return
-		}
-		parentComment = &parent
-	}
-
-	content := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
-	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
-		IssueID:     issue.ID,
-		WorkspaceID: issue.WorkspaceID,
-		AuthorType:  "system",
-		AuthorID:    pgtype.UUID{Valid: true},
-		Content:     content,
+		Content:     req.Content,
 		Type:        "system",
 		ParentID:    parentID,
 	})

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1154,6 +1154,74 @@ func (h *Handler) PreviewCommentTriggers(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (h *Handler) CreateDaemonSystemComment(w http.ResponseWriter, r *http.Request) {
+	if !requireDaemonTokenAuth(w, r) {
+		return
+	}
+
+	issueID := chi.URLParam(r, "issueId")
+	issue, ok := h.loadIssueForDaemon(w, r, issueID)
+	if !ok {
+		return
+	}
+
+	var req CreateCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Content == "" {
+		writeError(w, http.StatusBadRequest, "content is required")
+		return
+	}
+
+	var parentID pgtype.UUID
+	var parentComment *db.Comment
+	if req.ParentID != nil {
+		var parsed pgtype.UUID
+		parsed, ok = parseUUIDOrBadRequest(w, *req.ParentID, "parent_id")
+		if !ok {
+			return
+		}
+		parentID = parsed
+		parent, err := h.Queries.GetComment(r.Context(), parentID)
+		if err != nil || uuidToString(parent.IssueID) != uuidToString(issue.ID) {
+			writeError(w, http.StatusBadRequest, "invalid parent comment")
+			return
+		}
+		parentComment = &parent
+	}
+
+	content := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
+	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    parentID,
+	})
+	if err != nil {
+		slog.Warn("create daemon system comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
+		writeError(w, http.StatusInternalServerError, "failed to create comment: "+err.Error())
+		return
+	}
+
+	resp := commentToResponse(comment, nil, nil)
+	slog.Info("daemon system comment created", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
+	h.publish(protocol.EventCommentCreated, uuidToString(issue.WorkspaceID), "system", "", map[string]any{
+		"comment":             resp,
+		"issue_title":         issue.Title,
+		"issue_assignee_type": textToPtr(issue.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(issue.AssigneeID),
+		"issue_status":        issue.Status,
+	})
+	h.TaskService.AutoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), "system", "")
+
+	writeJSON(w, http.StatusCreated, resp)
+}
+
 func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
 	issue, ok := h.loadIssueForUser(w, r, issueID)

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1222,6 +1222,74 @@ func (h *Handler) CreateDaemonSystemComment(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusCreated, resp)
 }
 
+func (h *Handler) CreateDaemonSystemComment(w http.ResponseWriter, r *http.Request) {
+	if !requireDaemonTokenAuth(w, r) {
+		return
+	}
+
+	issueID := chi.URLParam(r, "issueId")
+	issue, ok := h.loadIssueForDaemon(w, r, issueID)
+	if !ok {
+		return
+	}
+
+	var req CreateCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Content == "" {
+		writeError(w, http.StatusBadRequest, "content is required")
+		return
+	}
+
+	var parentID pgtype.UUID
+	var parentComment *db.Comment
+	if req.ParentID != nil {
+		var parsed pgtype.UUID
+		parsed, ok = parseUUIDOrBadRequest(w, *req.ParentID, "parent_id")
+		if !ok {
+			return
+		}
+		parentID = parsed
+		parent, err := h.Queries.GetComment(r.Context(), parentID)
+		if err != nil || uuidToString(parent.IssueID) != uuidToString(issue.ID) {
+			writeError(w, http.StatusBadRequest, "invalid parent comment")
+			return
+		}
+		parentComment = &parent
+	}
+
+	content := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
+	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    parentID,
+	})
+	if err != nil {
+		slog.Warn("create daemon system comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
+		writeError(w, http.StatusInternalServerError, "failed to create comment: "+err.Error())
+		return
+	}
+
+	resp := commentToResponse(comment, nil, nil)
+	slog.Info("daemon system comment created", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
+	h.publish(protocol.EventCommentCreated, uuidToString(issue.WorkspaceID), "system", "", map[string]any{
+		"comment":             resp,
+		"issue_title":         issue.Title,
+		"issue_assignee_type": textToPtr(issue.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(issue.AssigneeID),
+		"issue_status":        issue.Status,
+	})
+	h.TaskService.AutoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), "system", "")
+
+	writeJSON(w, http.StatusCreated, resp)
+}
+
 func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
 	issue, ok := h.loadIssueForUser(w, r, issueID)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -68,6 +68,48 @@ func (h *Handler) requireDaemonWorkspaceAccess(w http.ResponseWriter, r *http.Re
 	return ok
 }
 
+// requireDaemonTokenAuth rejects the PAT/JWT fallback accepted by the broader
+// daemon API. System-authored daemon comments are a privileged platform action;
+// allowing user-token fallback would recreate the "background script posted as
+// a member" failure mode this path is meant to avoid.
+func requireDaemonTokenAuth(w http.ResponseWriter, r *http.Request) bool {
+	if middleware.DaemonAuthPathFromContext(r.Context()) != middleware.DaemonAuthPathDaemonToken {
+		writeError(w, http.StatusForbidden, "daemon token required")
+		return false
+	}
+	return true
+}
+
+func (h *Handler) loadIssueForDaemon(w http.ResponseWriter, r *http.Request, issueID string) (db.Issue, bool) {
+	workspaceID := middleware.DaemonWorkspaceIDFromContext(r.Context())
+	if workspaceID == "" {
+		writeError(w, http.StatusForbidden, "daemon token required")
+		return db.Issue{}, false
+	}
+
+	if issue, ok := h.resolveIssueByIdentifier(r.Context(), issueID, workspaceID); ok {
+		return issue, true
+	}
+
+	issueUUID, ok := parseUUIDOrBadRequest(w, issueID, "issue_id")
+	if !ok {
+		return db.Issue{}, false
+	}
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return db.Issue{}, false
+	}
+	issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+		ID:          issueUUID,
+		WorkspaceID: workspaceUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "issue not found")
+		return db.Issue{}, false
+	}
+	return issue, true
+}
+
 // requireDaemonRuntimeAccess looks up a runtime and verifies the caller owns its workspace.
 //
 // Only pgx.ErrNoRows is treated as a real "runtime gone" 404 — the daemon uses
@@ -202,6 +244,8 @@ type daemonWorkspaceReposResponse struct {
 	ReposVersion string          `json:"repos_version"`
 	Settings     json.RawMessage `json:"settings,omitempty"`
 }
+
+const daemonTokenTTL = 30 * 24 * time.Hour
 
 func normalizeWorkspaceRepos(repos []RepoData) []RepoData {
 	if len(repos) == 0 {
@@ -571,13 +615,53 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	})
 
 	repoResp := workspaceReposResponse(req.WorkspaceID, ws.Repos, ws.Settings)
+	daemonToken, ok := h.issueDaemonToken(w, r, wsUUID, req.DaemonID)
+	if !ok {
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"runtimes":      resp,
 		"repos":         repoResp.Repos,
 		"repos_version": repoResp.ReposVersion,
 		"settings":      repoResp.Settings,
+		"daemon_token":  daemonToken,
 	})
+}
+
+func (h *Handler) issueDaemonToken(w http.ResponseWriter, r *http.Request, workspaceID pgtype.UUID, daemonID string) (string, bool) {
+	if err := h.Queries.DeleteExpiredDaemonTokens(r.Context()); err != nil {
+		slog.Warn("daemon token cleanup failed", "daemon_id", daemonID, "error", err)
+	}
+	if hashes, err := h.Queries.DeleteDaemonTokensByWorkspaceAndDaemons(r.Context(), db.DeleteDaemonTokensByWorkspaceAndDaemonsParams{
+		WorkspaceID: workspaceID,
+		DaemonIds:   []string{daemonID},
+	}); err != nil {
+		slog.Warn("daemon token rotation cleanup failed", "daemon_id", daemonID, "error", err)
+	} else {
+		for _, hash := range hashes {
+			h.DaemonTokenCache.Invalidate(r.Context(), hash)
+		}
+	}
+
+	rawToken, err := auth.GenerateDaemonToken()
+	if err != nil {
+		slog.Warn("generate daemon token failed", "daemon_id", daemonID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to generate daemon token")
+		return "", false
+	}
+	expiresAt := time.Now().Add(daemonTokenTTL)
+	if _, err := h.Queries.CreateDaemonToken(r.Context(), db.CreateDaemonTokenParams{
+		TokenHash:   auth.HashToken(rawToken),
+		WorkspaceID: workspaceID,
+		DaemonID:    daemonID,
+		ExpiresAt:   pgtype.Timestamptz{Time: expiresAt, Valid: true},
+	}); err != nil {
+		slog.Warn("create daemon token failed", "daemon_id", daemonID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create daemon token")
+		return "", false
+	}
+	return rawToken, true
 }
 
 // mergeLegacyRuntimes folds every runtime row keyed on a prior hostname-derived


### PR DESCRIPTION
## What does this PR do?

This PR makes Multica propagate Codex hook configuration from the shared Codex home into each per-task `CODEX_HOME`.

Before this change, task-level Codex homes did not expose shared `~/.codex/hooks` or `~/.codex/hooks.json`, so Codex hooks configured on the host could not reliably work inside Multica-managed task environments. This change treats those hook assets as optional shared Codex home entries: when they exist and have the expected type, they are symlinked into the task home; when they are missing or invalid, stale per-task hook files/directories are removed during prepare and reuse.

The approach keeps `auth.json` behavior unchanged, avoids creating empty hook paths for environments without hooks, and makes reused task homes reflect the current shared Codex home state.

## Related Issue

Related: QIA-112

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/execenv/codex_home.go`
  - Added optional Codex home symlink support for shared `hooks` and `hooks.json`.
  - Added cleanup behavior for missing or invalid optional hook sources so reused task homes do not retain stale hook configuration.
  - Kept existing required symlink behavior for `auth.json` unchanged.
- `server/internal/daemon/execenv/execenv_test.go`
  - Added assertions for Codex hook symlink presence and absence.
  - Covered shared hooks being present, missing, removed, invalid, and restored.
  - Covered reuse behavior so stale per-task `hooks` / `hooks.json` are restored or cleaned according to the shared home state.

## How to Test

1. Run the targeted execenv tests:
   ```bash
   GOCACHE=/tmp/multica-go-cache GOTMPDIR=/tmp go test -count=1 -run 'TestPrepareCodexHome.*Hooks|TestReuse.*Hooks|TestCodexHome.*Hooks' ./internal/daemon/execenv

2. Run the full execenv package tests:

   ```bash
   GOCACHE=/tmp/multica-go-cache GOTMPDIR=/tmp go test -count=1 ./internal/daemon/execenv
   ```

3. Build the CLI and check formatting-sensitive diff issues:

   ```bash
   GOCACHE=/tmp/multica-go-cache GOTMPDIR=/tmp go build -o /tmp/multica-codex-hooks ./cmd/multica
   git diff --check -- server/internal/daemon/execenv/codex_home.go server/internal/daemon/execenv/execenv_test.go
   ```

## Checklist

- [x] I have included a thinking path that traces from project context to this change

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent / Codex

**Prompt / approach:**
Used Multica agents to investigate how Codex hooks should be exposed inside Multica task environments, implement the daemon-side Codex home propagation logic, review the behavior, and validate it with focused Go tests plus local build checks.

## Screenshots (optional)

<img width="733" height="142" alt="image" src="https://github.com/user-attachments/assets/2cc588b7-cb86-47df-ad83-8d392ae3e40c" />
