### PR TITLE
fix(daemon): close stdin pipe in Pi adapter to deliver EOF (#2188) (MUL-2613)

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -220,12 +220,26 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		cancel()
 		return nil, fmt.Errorf("pi stdout pipe: %w", err)
 	}
+	// Attach an explicit stdin pipe so we can close it ourselves. Pi reads
+	// its prompt from argv (positional, see buildPiArgs) and never expects
+	// interactive input, but when the parent leaves cmd.Stdin nil and the
+	// daemon is run under systemd, Pi has been observed to block in its
+	// event loop awaiting stdin events instead of progressing to "done"
+	// (#2188). Closing the pipe immediately after Start delivers an
+	// explicit EOF on a FIFO, which unblocks Pi's readable side.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("pi stdin pipe: %w", err)
+	}
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[pi:stderr] ")
 
 	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
 		cancel()
 		return nil, fmt.Errorf("start pi: %w", err)
 	}
+	_ = stdin.Close()
 
 	b.cfg.Logger.Info("pi started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -1,9 +1,13 @@
 package agent
 
 import (
+	"context"
 	"log/slog"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
@@ -51,6 +55,67 @@ func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("custom --tools should pass through via custom_args, got: %v", args)
+	}
+}
+
+// TestPiExecuteAttachesStdinPipe verifies that the Pi backend spawns the
+// child with an explicit stdin pipe (FIFO) instead of leaving cmd.Stdin
+// nil. Without an explicit pipe, Pi has been observed to block under
+// systemd waiting for stdin events (#2188); attaching and immediately
+// closing a pipe delivers a clean EOF on a FIFO and unblocks Pi.
+//
+// The probe is structural rather than behavioral: a shell script in
+// place of `pi` inspects /proc/self/fd/0 and only emits a valid event
+// stream if stdin is a FIFO. If the fix regresses (stdin nil → /dev/null
+// char device), the fake exits non-zero and the test fails.
+func TestPiExecuteAttachesStdinPipe(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "linux" {
+		// /proc/self/fd/0 is Linux-specific; skipping elsewhere keeps
+		// the assertion portable without losing CI coverage.
+		t.Skip("stdin fd inspection relies on /proc/self/fd/0")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	script := "#!/bin/sh\n" +
+		"kind=$(stat -c '%F' -L /proc/self/fd/0 2>/dev/null || echo unknown)\n" +
+		"case \"$kind\" in\n" +
+		"  fifo|*pipe*)\n" +
+		"    printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
+		"    printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":2}}}'\n" +
+		"    exit 0\n" +
+		"    ;;\n" +
+		"esac\n" +
+		"printf 'stdin was %s; expected fifo\\n' \"$kind\" >&2\n" +
+		"exit 1\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed (stdin attached as fifo), got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Pi backend now attaches an explicit `cmd.StdinPipe()` and closes it immediately after `Start`, delivering an EOF on a FIFO so Pi unblocks instead of hanging in its event loop.
- Adds a Linux-only structural test that probes `/proc/self/fd/0` from a shell-stub `pi` to assert stdin is a FIFO (regression-safe).

## Background

Closes #2188.

Pi reads its prompt from argv (`-p <prompt>`, positional in [`buildPiArgs`](https://github.com/multica-ai/multica/blob/main/server/pkg/agent/pi.go)), so the Pi adapter never had a reason to write to stdin and just left `cmd.Stdin` nil. Go's default for nil is `/dev/null`, which is a character device. Under systemd in particular, Pi has been observed to block forever in its readable-side wait against `/dev/null` — runs stay in "working" indefinitely (issue thread).

[Maintainer feedback in #2188](https://github.com/multica-ai/multica/issues/2188) explicitly endorsed a daemon-side defensive fix:

> We can definitely add the daemon-side stdin EOF as a defensive guard

Reporter also noted Pi is mid-refactor and not accepting issues upstream right now, so the daemon side is where the fix has to live.

## Change

`server/pkg/agent/pi.go`:

```go
stdin, err := cmd.StdinPipe()
if err != nil { ... }
if err := cmd.Start(); err != nil {
    _ = stdin.Close()
    ...
}
_ = stdin.Close()
```

This matches the same pattern already used by the Claude / Codex / Hermes / Kiro / Kimi adapters in the same package — Pi was the only backend not attaching an explicit stdin pipe.

## Edge cases reviewed

- **Custom args**: `piBlockedArgs` already pins `-p` / `--print` / `--mode` / `--session`, so users cannot flip Pi into a mode that consumes stdin. Closing it immediately is safe.
- **Resume sessions** (`ResumeSessionID`): `--session` is a file path on disk, not stdin. No interaction.
- **Windows**: explicit pipes pair with `hideAgentWindow` cleanly — the same combination is exercised by `claude.go` / `codex.go`.
- **`cmd.Start()` failure**: close the pipe in the error path before returning to avoid leaking the FD pair.
- **Forward compatibility**: even after Pi itself stops blocking on stdin, an immediate close of a pipe is a no-op for any process that does not read from stdin — so this guard never needs to be removed.

## Test plan

- [x] Added `TestPiExecuteAttachesStdinPipe` (Linux-only; skips on macOS/Windows where `/proc/self/fd/0` is not available). The shell-stub `pi` only emits a valid event stream when stdin is a FIFO; if `StdinPipe` is dropped in the future, the stub exits non-zero and the test fails.
- [x] Other Pi tests (`TestBuildPiArgs*`, `TestStripPiToolCallMarkup`, …) are unaffected — no arg-builder or parsing changes.
- [ ] Manual confirmation by a user running the daemon under systemd that Pi runs no longer hang would be the strongest end-to-end signal, but that environment is not reproducible in CI.

## Compatibility / breaking change

None. The Pi CLI does not read from stdin in `-p` mode, so receiving an immediate EOF on a FIFO is indistinguishable from the previous `/dev/null` behavior for any version of Pi that does read from stdin. No public API changes, no config changes.