### PR TITLE
[codex] fix non-user issue subscriber mentions

### DIFF
--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -39,6 +39,9 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 		// Subscribe @mentioned users in description
 		if issue.Description != nil && *issue.Description != "" {
 			for _, m := range parseMentions(*issue.Description) {
+				if !isIssueSubscriberUserType(m.Type) {
+					continue
+				}
 				addSubscriber(bus, queries, e.WorkspaceID, issue.ID, m.Type, m.ID, "mentioned")
 			}
 		}
@@ -69,10 +72,16 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 				prevMentioned := map[string]bool{}
 				if prevDescription, _ := payload["prev_description"].(*string); prevDescription != nil {
 					for _, m := range parseMentions(*prevDescription) {
+						if !isIssueSubscriberUserType(m.Type) {
+							continue
+						}
 						prevMentioned[m.Type+":"+m.ID] = true
 					}
 				}
 				for _, m := range newMentions {
+					if !isIssueSubscriberUserType(m.Type) {
+						continue
+					}
 					if !prevMentioned[m.Type+":"+m.ID] {
 						addSubscriber(bus, queries, e.WorkspaceID, issue.ID, m.Type, m.ID, "mentioned")
 					}
@@ -147,6 +156,16 @@ func extractIssueFields(v any) (handler.IssueResponse, bool) {
 // addSubscriber adds a user as an issue subscriber and publishes a
 // subscriber:added event for real-time frontend sync.
 func addSubscriber(bus *events.Bus, queries *db.Queries, workspaceID, issueID, userType, userID, reason string) {
+	if !isIssueSubscriberUserType(userType) {
+		slog.Debug("skipping non-user issue subscriber",
+			"issue_id", issueID,
+			"user_type", userType,
+			"user_id", userID,
+			"reason", reason,
+		)
+		return
+	}
+
 	err := queries.AddIssueSubscriber(context.Background(), db.AddIssueSubscriberParams{
 		IssueID:  parseUUID(issueID),
 		UserType: userType,
@@ -174,4 +193,8 @@ func addSubscriber(bus *events.Bus, queries *db.Queries, workspaceID, issueID, u
 			"reason":    reason,
 		},
 	})
+}
+
+func isIssueSubscriberUserType(userType string) bool {
+	return userType == "member" || userType == "agent"
 }

--- a/server/cmd/server/subscriber_listeners_test.go
+++ b/server/cmd/server/subscriber_listeners_test.go
@@ -309,6 +309,30 @@ func TestSubscriberCommentCreated_CommenterSubscribed(t *testing.T) {
 	}
 }
 
+func TestAddSubscriberSkipsNonUserTypes(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+
+	var subscriberEvents []events.Event
+	bus.Subscribe(protocol.EventSubscriberAdded, func(e events.Event) {
+		subscriberEvents = append(subscriberEvents, e)
+	})
+
+	addSubscriber(bus, queries, testWorkspaceID, issueID, "issue", issueID, "mentioned")
+	addSubscriber(bus, queries, testWorkspaceID, issueID, "squad", issueID, "mentioned")
+	addSubscriber(bus, queries, testWorkspaceID, issueID, "all", "all", "mentioned")
+
+	if count := subscriberCount(t, queries, issueID); count != 0 {
+		t.Fatalf("expected 0 subscribers for non-user mention types, got %d", count)
+	}
+	if len(subscriberEvents) != 0 {
+		t.Fatalf("expected 0 subscriber:added events, got %d", len(subscriberEvents))
+	}
+}
+
 func TestSubscriberAddedEventPublished(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()


### PR DESCRIPTION
## Summary

Fixes a noisy PostgreSQL constraint violation in the issue subscriber listener when issue descriptions contain non-user mentions such as `mention://issue/...`.

The `issue_subscriber.user_type` check constraint only allows `member` and `agent`, but `parseMentions` can also return `issue`, `squad`, and `all`. The previous listener path passed every parsed description mention into `addSubscriber`, so an issue reference could attempt to insert `user_type = 'issue'` and log:

```text
new row for relation "issue_subscriber" violates check constraint "issue_subscriber_user_type_check"
```

## Changes

- Filter description mentions before auto-subscribing users on `issue:created` and `issue:updated`.
- Add a defensive guard in `addSubscriber` so non-user mention types never reach the database insert.
- Add coverage for `issue`, `squad`, and `all` inputs to ensure they do not create subscriber rows or publish `subscriber:added` events.

## Validation

- `go test ./cmd/server -run 'Test(AddSubscriberSkipsNonUserTypes|SubscriberIssueCreated|SubscriberIssueUpdated|SubscriberCommentCreated|SubscriberSystemCommentDoesNotSubscribe)'`
- `go test ./internal/util`
- `git diff --check`
