### PR TITLE
feat(editor): Enter to send, Shift+Enter for newline (MUL-2599) (#3110)

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -440,6 +440,10 @@ export const UserSchema: z.ZodType<User> = z.object({
   timezone: z.string().nullable().default(null),
   created_at: z.string().default(""),
   updated_at: z.string().default(""),
+  message_enter_key_behavior: z
+    .enum(["send", "newline"])
+    .default("newline")
+    .catch("newline"),
 }).loose();
 
 // `id: ""` is the sentinel for "drifted / unauthenticated"; downstream code
@@ -458,6 +462,7 @@ export const EMPTY_USER: User = {
   timezone: null,
   created_at: "",
   updated_at: "",
+  message_enter_key_behavior: "newline",
 };
 
 export const WorkspaceSchema: z.ZodType<Workspace> = z.object({

--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -17,6 +17,7 @@ export const mockUser: User = {
   language: null,
   timezone: null,
   profile_description: "",
+  message_enter_key_behavior: "newline",
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };
@@ -77,7 +78,6 @@ export const mockAgents: Agent[] = [
 ];
 
 // Mock auth context value
- 
 export const mockAuthValue: Record<string, any> = {
   user: mockUser,
   workspace: mockWorkspace,

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -211,6 +211,49 @@ describe("SquadListSchema member preview drift", () => {
   });
 });
 
+// `message_enter_key_behavior` is a user preference added after the original
+// `/api/me` contract. Older backends omit it, and future enum drift should
+// degrade only this field rather than falling back the whole user object.
+describe("UserSchema message enter key behavior drift", () => {
+  const base = {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Ada",
+    email: "ada@example.com",
+  };
+
+  it("defaults to newline when the field is absent", () => {
+    const parsed = UserSchema.parse(base);
+    expect(parsed.message_enter_key_behavior).toBe("newline");
+  });
+
+  it("preserves newline when explicitly returned by the server", () => {
+    const parsed = UserSchema.parse({
+      ...base,
+      message_enter_key_behavior: "newline",
+    });
+    expect(parsed.message_enter_key_behavior).toBe("newline");
+  });
+
+  it("downgrades an unknown string to newline", () => {
+    const parsed = UserSchema.parse({
+      ...base,
+      message_enter_key_behavior: "future-mode",
+    });
+    expect(parsed.message_enter_key_behavior).toBe("newline");
+  });
+
+  it("downgrades a wrong-type value to newline without dropping the user", () => {
+    const parsed = parseWithFallback(
+      { ...base, message_enter_key_behavior: 42 },
+      UserSchema,
+      EMPTY_USER,
+      { endpoint: "GET /api/me" },
+    );
+    expect(parsed.id).toBe(base.id);
+    expect(parsed.message_enter_key_behavior).toBe("newline");
+  });
+});
+
 // The workspace dashboard and runtime-detail pages were re-pointed at the
 // unified `task_usage_hourly` rollup. Every numeric field drives chart /
 // KPI math, and string keys (date / agent_id / model) bucket the series.

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -761,6 +761,14 @@ export const EMPTY_WEBHOOK_DELIVERY: WebhookDelivery = {
 // breaking older backends that don't return the column yet.
 // ---------------------------------------------------------------------------
 
+const MessageEnterKeyBehaviorSchema = z
+  .string()
+  .default("newline")
+  .catch("newline")
+  .transform((value) =>
+    value === "newline" || value === "send" ? value : "newline",
+  );
+
 export const UserSchema = z.object({
   id: z.string(),
   name: z.string().default(""),
@@ -774,6 +782,7 @@ export const UserSchema = z.object({
   timezone: z.string().nullable().default(null),
   created_at: z.string().default(""),
   updated_at: z.string().default(""),
+  message_enter_key_behavior: MessageEnterKeyBehaviorSchema,
 }).loose();
 
 export const EMPTY_USER: User = {
@@ -789,6 +798,7 @@ export const EMPTY_USER: User = {
   timezone: null,
   created_at: "",
   updated_at: "",
+  message_enter_key_behavior: "newline",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/onboarding/needs-backfill.test.ts
+++ b/packages/core/onboarding/needs-backfill.test.ts
@@ -16,6 +16,7 @@ const BASE_USER: User = {
   language: null,
   profile_description: "",
   timezone: null,
+  message_enter_key_behavior: "newline",
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
 };

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -1,5 +1,5 @@
 import type { Issue, IssueMetadata, IssueStatus, IssuePriority, IssueAssigneeType } from "./issue";
-import type { MemberRole } from "./workspace";
+import type { MemberRole, MessageEnterKeyBehavior } from "./workspace";
 import type { Project } from "./project";
 
 // Issue API
@@ -165,6 +165,8 @@ export interface UpdateMeRequest {
   profile_description?: string;
   /** IANA tz to pin; "" clears back to browser-tz; undefined leaves untouched. */
   timezone?: string;
+  /** Enter key behavior in chat/comment composers. */
+  message_enter_key_behavior?: MessageEnterKeyBehavior;
 }
 
 export interface CreateMemberRequest {

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -54,7 +54,7 @@ export type {
   RuntimeLocalSkillImportResult,
   IssueUsageSummary,
 } from "./agent";
-export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
+export type { Workspace, WorkspaceRepo, Member, MemberRole, MessageEnterKeyBehavior, User, MemberWithUser, Invitation } from "./workspace";
 export type { InboxItem, InboxSeverity, InboxItemType } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";
 export type { Comment, CommentType, CommentAuthorType, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, Reaction } from "./comment";

--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -27,6 +27,8 @@ export interface Member {
   created_at: string;
 }
 
+export type MessageEnterKeyBehavior = "send" | "newline";
+
 export interface User {
   id: string;
   name: string;
@@ -59,6 +61,7 @@ export interface User {
   profile_description: string;
   /** Pinned IANA tz; null means "use browser-detected tz at render time". */
   timezone: string | null;
+  message_enter_key_behavior: MessageEnterKeyBehavior;
   created_at: string;
   updated_at: string;
 }

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, it, expect, vi } from "vitest";
 import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import enCommon from "../../locales/en/common.json";
 import enChat from "../../locales/en/chat.json";
 
@@ -38,6 +39,10 @@ const dropHandlers = vi.hoisted(() => ({
 }));
 const editorProps = vi.hoisted(() => ({
   last: null as null | Record<string, unknown>,
+}));
+
+const authState = vi.hoisted(() => ({
+  user: { message_enter_key_behavior: "newline" as "send" | "newline" },
 }));
 
 vi.mock("../../editor", () => ({
@@ -110,6 +115,11 @@ vi.mock("../../editor", () => ({
         }}
         onKeyDown={(e) => {
           if (e.key !== "Enter") return;
+          if (e.metaKey || e.ctrlKey) {
+            e.preventDefault();
+            onSubmit?.();
+            return;
+          }
           if (!e.shiftKey && submitOnEnter) {
             e.preventDefault();
             onSubmit?.();
@@ -121,6 +131,11 @@ vi.mock("../../editor", () => ({
       />
     );
   }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector?: (s: typeof authState) => unknown) =>
+    selector ? selector(authState) : authState,
 }));
 
 // Mock chat store with an in-memory implementation that supports both
@@ -149,6 +164,7 @@ import { useChatStore } from "@multica/core/chat";
 beforeEach(() => {
   dropHandlers.onDrop = null;
   editorProps.last = null;
+  authState.user.message_enter_key_behavior = "newline";
   const state = useChatStore.getState() as unknown as {
     activeSessionId: string | null;
     selectedAgentId: string;
@@ -192,7 +208,33 @@ describe("ChatInput @ context wiring", () => {
 });
 
 describe("ChatInput attachment wiring", () => {
-  it("sends the chat message when Enter is pressed", async () => {
+  it("shows the default send shortcut hint after content is entered", () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+  });
+
+  it("shows Enter as the send shortcut hint when Enter-to-send is configured", () => {
+    authState.user.message_enter_key_behavior = "send";
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(enterKey)} to send`),
+    ).toBeTruthy();
+  });
+
+  it("sends the chat message when Enter-to-send is configured", async () => {
+    authState.user.message_enter_key_behavior = "send";
     const onSend = vi.fn();
     renderInput({ onSend });
 
@@ -201,6 +243,25 @@ describe("ChatInput attachment wiring", () => {
     fireEvent.keyDown(editor, { key: "Enter" });
 
     expect(onSend).toHaveBeenCalledWith("hello agent", undefined);
+  });
+
+  it("treats unknown Enter behavior values as newline mode", () => {
+    (
+      authState.user as { message_enter_key_behavior: string }
+    ).message_enter_key_behavior = "unknown";
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello agent" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it("keeps Shift+Enter available for a newline without sending", () => {
@@ -212,6 +273,28 @@ describe("ChatInput attachment wiring", () => {
     fireEvent.keyDown(editor, { key: "Enter", shiftKey: true });
 
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("keeps Enter as a newline by default", () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("sends with Ctrl+Enter when Enter inserts newlines", () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello agent" } });
+    fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+
+    expect(onSend).toHaveBeenCalledWith("hello agent", undefined);
   });
 
   it("routes dropped files through the editor's upload handler", async () => {

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -50,18 +50,22 @@ vi.mock("../../editor", () => ({
     props: {
       defaultValue?: string;
       onUpdate?: (md: string) => void;
+      onSubmit?: () => void;
       placeholder?: string;
       onUploadFile?: (file: File) => Promise<UploadResult | null>;
       mentionMode?: string;
       mentionContextItems?: unknown[];
+      submitOnEnter?: boolean;
     },
     ref: React.Ref<unknown>,
   ) {
     const {
       defaultValue,
       onUpdate,
+      onSubmit,
       placeholder,
       onUploadFile,
+      submitOnEnter,
     } = props;
     editorProps.last = props as unknown as Record<string, unknown>;
     const valueRef = useRef<string>(defaultValue ?? "");
@@ -103,6 +107,16 @@ vi.mock("../../editor", () => ({
         onChange={(e) => {
           valueRef.current = e.target.value;
           onUpdate?.(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          if (!e.shiftKey && submitOnEnter) {
+            e.preventDefault();
+            onSubmit?.();
+            return;
+          }
+          valueRef.current += "\n";
+          onUpdate?.(valueRef.current);
         }}
       />
     );
@@ -178,6 +192,28 @@ describe("ChatInput @ context wiring", () => {
 });
 
 describe("ChatInput attachment wiring", () => {
+  it("sends the chat message when Enter is pressed", async () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello agent" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledWith("hello agent", undefined);
+  });
+
+  it("keeps Shift+Enter available for a newline without sending", () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "hello" } });
+    fireEvent.keyDown(editor, { key: "Enter", shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("routes dropped files through the editor's upload handler", async () => {
     const { onUploadFile } = renderInput();
     expect(dropHandlers.onDrop).not.toBeNull();

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -11,9 +11,10 @@ import {
 } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
+import { useAuthStore } from "@multica/core/auth";
 import { useChatStore, DRAFT_NEW_SESSION } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
-import { enterKey, formatShortcut } from "@multica/core/platform";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import type { MentionItem } from "../../editor/extensions/mention-suggestion";
 import { useT } from "../../i18n";
@@ -60,6 +61,13 @@ export function ChatInput({
   contextItems,
 }: ChatInputProps) {
   const { t } = useT("chat");
+  const messageEnterKeyBehavior = useAuthStore(
+    (s) => s.user?.message_enter_key_behavior ?? "newline",
+  );
+  const submitOnEnter = messageEnterKeyBehavior === "send";
+  const sendShortcut = submitOnEnter
+    ? formatShortcut(enterKey)
+    : formatShortcut(modKey, enterKey);
   const editorRef = useRef<ContentEditorRef>(null);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
   const selectedAgentId = useChatStore((s) => s.selectedAgentId);
@@ -278,7 +286,7 @@ export function ChatInput({
               setInputDraft(draftKey, md);
             }}
             onSubmit={handleSend}
-            submitOnEnter
+            submitOnEnter={submitOnEnter}
             onUploadFile={uploadEnabled ? handleUpload : undefined}
             debounceMs={100}
             mentionMode={contextItems ? "context" : "default"}
@@ -287,8 +295,8 @@ export function ChatInput({
             // Chat is short-form — the floating formatting toolbar is
             // more distraction than feature here.
             showBubbleMenu={false}
-            // Chat-style composer: Enter submits, Shift+Enter keeps the
-            // editor's newline/hard-break behavior.
+            // Submit shortcut follows the user's input preference while
+            // preserving the editor's newline/hard-break behavior.
           />
         </div>
         {leftAdornment && (
@@ -303,12 +311,19 @@ export function ChatInput({
               onSelect={(file) => editorRef.current?.uploadFile(file)}
             />
           )}
+          {!isEmpty && (
+            <span className="mr-1 hidden text-[11px] text-muted-foreground sm:inline">
+              {t(($) => $.input.send_shortcut_hint, {
+                shortcut: sendShortcut,
+              })}
+            </span>
+          )}
           <SubmitButton
             onClick={handleSend}
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             running={isRunning}
             onStop={onStop}
-            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(enterKey)}`}
+            tooltip={`${t(($) => $.input.send_tooltip)} · ${sendShortcut}`}
             stopTooltip={t(($) => $.input.stop_tooltip)}
           />
         </div>

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -13,7 +13,7 @@ import { FileUploadButton } from "@multica/ui/components/common/file-upload-butt
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useChatStore, DRAFT_NEW_SESSION } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
-import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
+import { enterKey, formatShortcut } from "@multica/core/platform";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import type { MentionItem } from "../../editor/extensions/mention-suggestion";
 import { useT } from "../../i18n";
@@ -184,7 +184,7 @@ export function ChatInput({
     // resolves later) and the attachment would only end up bound to the
     // session, not the message — the agent then can't `multica attachment
     // download <id>` the file. The SubmitButton is also disabled in this
-    // state via `uploading`, but Mod+Enter bypasses the button so we
+    // state via `uploading`, but keyboard submit bypasses the button so we
     // still gate here.
     if (editorRef.current?.hasActiveUploads()) {
       logger.debug("input.send skipped: uploads in flight");
@@ -278,6 +278,7 @@ export function ChatInput({
               setInputDraft(draftKey, md);
             }}
             onSubmit={handleSend}
+            submitOnEnter
             onUploadFile={uploadEnabled ? handleUpload : undefined}
             debounceMs={100}
             mentionMode={contextItems ? "context" : "default"}
@@ -286,11 +287,8 @@ export function ChatInput({
             // Chat is short-form — the floating formatting toolbar is
             // more distraction than feature here.
             showBubbleMenu={false}
-            // Chat intentionally leaves submitOnEnter at its default false:
-            // Mod+Enter submits, while bare Enter falls through to Tiptap's
-            // default behavior for lists, quotes, and paragraph breaks.
-            // Without this, Enter-as-send would steal the only key that
-            // continues a bullet list, leaving users stuck after one item.
+            // Chat-style composer: Enter submits, Shift+Enter keeps the
+            // editor's newline/hard-break behavior.
           />
         </div>
         {leftAdornment && (
@@ -310,7 +308,7 @@ export function ChatInput({
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             running={isRunning}
             onStop={onStop}
-            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(enterKey)}`}
             stopTooltip={t(($) => $.input.stop_tooltip)}
           />
         </div>

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -11,6 +11,11 @@ const editorState = vi.hoisted(() => ({
   isDestroyed: false,
   markdown: "",
 }));
+const lastExtensionsOptions = vi.hoisted(() => ({
+  current: null as null | {
+    submitOnEnterRef?: { current: boolean };
+  },
+}));
 
 // Records the attachments[] prop the provider received on its most recent
 // render. Content-editor merges its `attachments` prop with in-session
@@ -27,7 +32,12 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 vi.mock("./extensions", () => ({
-  createEditorExtensions: () => [],
+  createEditorExtensions: (options: {
+    submitOnEnterRef?: { current: boolean };
+  }) => {
+    lastExtensionsOptions.current = options;
+    return [];
+  },
 }));
 
 vi.mock("./extensions/file-upload", () => ({
@@ -113,6 +123,7 @@ describe("ContentEditor", () => {
     onCreateFired.value = false;
     latestEditorOptions.current = undefined;
     providerProps.attachments = undefined;
+    lastExtensionsOptions.current = null;
   });
 
   afterEach(() => {
@@ -313,6 +324,18 @@ describe("ContentEditor", () => {
     unmount();
 
     expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps submitOnEnterRef current with the latest prop without replacing the ref", () => {
+    const { rerender } = render(<ContentEditor submitOnEnter />);
+
+    const firstRef = lastExtensionsOptions.current?.submitOnEnterRef;
+    expect(firstRef?.current).toBe(true);
+
+    rerender(<ContentEditor submitOnEnter={false} />);
+
+    expect(lastExtensionsOptions.current?.submitOnEnterRef).toBe(firstRef);
+    expect(firstRef?.current).toBe(false);
   });
 });
 

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -192,6 +192,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     >(undefined);
     const mentionContextItemsRef = useRef<MentionItem[]>(mentionContextItems ?? []);
     const lastEmittedRef = useRef<string | null>(null);
+    const submitOnEnterRef = useRef(submitOnEnter);
 
     // In-session record of attachments freshly uploaded through this editor.
     // Surfaces (like the quick-create modal) that don't have a server-supplied
@@ -267,6 +268,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     onUploadFileRef.current = wrappedOnUploadFile;
     mentionContextItemsRef.current = mentionContextItems ?? [];
     flushPendingOnUnmountRef.current = flushPendingOnUnmount;
+    submitOnEnterRef.current = submitOnEnter;
 
     const queryClient = useQueryClient();
 
@@ -312,7 +314,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         queryClient,
         onSubmitRef,
         onUploadFileRef,
-        submitOnEnter,
+        submitOnEnterRef,
         disableMentions,
         mentionMode,
         getMentionContextItems: () => mentionContextItemsRef.current,

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -122,8 +122,8 @@ export interface EditorExtensionsOptions {
   onUploadFileRef?: RefObject<
     ((file: File) => Promise<UploadResult | null>) | undefined
   >;
-  /** When true, bare Enter also submits (chat-style). Default false. */
-  submitOnEnter?: boolean;
+  /** Ref controlling Enter behavior. When current is true, bare Enter submits. Default false. */
+  submitOnEnterRef?: RefObject<boolean>;
   /**
    * When true, the `@` suggestion picker is not attached. The mention node
    * type is still registered in the schema so any mention pasted in from
@@ -226,7 +226,7 @@ export function createEditorExtensions(
         fn();
         return true;
       },
-      { submitOnEnter: options.submitOnEnter ?? false },
+      { submitOnEnterRef: options.submitOnEnterRef ?? { current: false } },
     ),
     createBlurShortcutExtension(),
     createFileUploadExtension(options.onUploadFileRef!),

--- a/packages/views/editor/extensions/submit-shortcut.test.ts
+++ b/packages/views/editor/extensions/submit-shortcut.test.ts
@@ -28,7 +28,7 @@ describe("createSubmitExtension", () => {
   it("Mod-Enter always submits", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: false }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: false } }),
       baseEditor,
     );
 
@@ -37,21 +37,22 @@ describe("createSubmitExtension", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it("bare Enter is not bound when submitOnEnter is false", () => {
+  it("bare Enter falls through when submitOnEnter is false", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: false }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: false } }),
       baseEditor,
     );
 
-    expect(shortcuts.Enter).toBeUndefined();
+    expect(shortcuts.Enter).toBeDefined();
+    expect(shortcuts.Enter!()).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("bare Enter submits when submitOnEnter is true", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: true } }),
       baseEditor,
     );
 
@@ -60,10 +61,27 @@ describe("createSubmitExtension", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
+  it("reads submitOnEnter from the ref at keypress time", () => {
+    const onSubmit = vi.fn(() => true);
+    const submitOnEnterRef = { current: false };
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnterRef }),
+      baseEditor,
+    );
+
+    expect(shortcuts.Enter!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    submitOnEnterRef.current = true;
+
+    expect(shortcuts.Enter!()).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it("Enter is suppressed during IME composition", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: true } }),
       {
         view: { composing: true } as unknown as Editor["view"],
         isActive: () => false,
@@ -77,7 +95,7 @@ describe("createSubmitExtension", () => {
   it("Enter is suppressed inside a code block", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: true } }),
       {
         view: { composing: false } as unknown as Editor["view"],
         isActive: (name: string) => name === "codeBlock",
@@ -91,7 +109,7 @@ describe("createSubmitExtension", () => {
   it("Enter is suppressed inside a list item", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: true } }),
       {
         view: { composing: false } as unknown as Editor["view"],
         isActive: (name: string) => name === "listItem",
@@ -105,7 +123,7 @@ describe("createSubmitExtension", () => {
   it("Enter is suppressed inside a blockquote", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
-      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      createSubmitExtension(onSubmit, { submitOnEnterRef: { current: true } }),
       {
         view: { composing: false } as unknown as Editor["view"],
         isActive: (name: string) => name === "blockquote",

--- a/packages/views/editor/extensions/submit-shortcut.test.ts
+++ b/packages/views/editor/extensions/submit-shortcut.test.ts
@@ -87,4 +87,32 @@ describe("createSubmitExtension", () => {
     expect(shortcuts.Enter!()).toBe(false);
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("Enter is suppressed inside a list item", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      {
+        view: { composing: false } as unknown as Editor["view"],
+        isActive: (name: string) => name === "listItem",
+      },
+    );
+
+    expect(shortcuts.Enter!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("Enter is suppressed inside a blockquote", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      {
+        view: { composing: false } as unknown as Editor["view"],
+        isActive: (name: string) => name === "blockquote",
+      },
+    );
+
+    expect(shortcuts.Enter!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/views/editor/extensions/submit-shortcut.ts
+++ b/packages/views/editor/extensions/submit-shortcut.ts
@@ -1,41 +1,38 @@
 import { Extension } from "@tiptap/core";
-
+import type { RefObject } from "react";
 /**
  * `onSubmit` must return true when it actually handled the event and false
  * when there's no submit handler wired up. That lets us fall through to the
  * default Enter behaviour — inserting a newline — when appropriate.
  *
- * `submitOnEnter` — when true, bare Enter also submits (chat-style). When
- * false, only Mod-Enter submits and bare Enter keeps its default (newline).
+ * `submitOnEnterRef` — ref whose current value controls Enter behavior.
+ * When true, bare Enter submits (chat-style). When false, only Mod-Enter
+ * submits and bare Enter keeps its default (newline).
  */
 export function createSubmitExtension(
   onSubmit: () => boolean,
-  { submitOnEnter }: { submitOnEnter: boolean },
+  { submitOnEnterRef }: { submitOnEnterRef: RefObject<boolean> },
 ) {
   return Extension.create({
     name: "submitShortcut",
     addKeyboardShortcuts() {
-      const shortcuts: Record<string, () => boolean> = {
+      return {
         "Mod-Enter": () => onSubmit(),
-      };
-      if (submitOnEnter) {
-        shortcuts.Enter = () => {
+        Enter: () => {
+          if (!submitOnEnterRef.current) return false;
+
           const editor = this.editor;
-          // IME guard — never submit while composing a multi-key input
-          // (Chinese pinyin, Japanese kana, etc). `view.composing` is set
-          // by ProseMirror between compositionstart and compositionend.
           if (editor.view.composing) return false;
-          // Let structured editor blocks keep their native Enter behavior
-          // (new code line, next list item, continuing/exiting quote).
+
           if (
             editor.isActive("codeBlock") ||
             editor.isActive("listItem") ||
             editor.isActive("blockquote")
           ) return false;
+
           return onSubmit();
-        };
-      }
-      return shortcuts;
+        },
+      };
     },
   });
 }

--- a/packages/views/editor/extensions/submit-shortcut.ts
+++ b/packages/views/editor/extensions/submit-shortcut.ts
@@ -25,8 +25,13 @@ export function createSubmitExtension(
           // (Chinese pinyin, Japanese kana, etc). `view.composing` is set
           // by ProseMirror between compositionstart and compositionend.
           if (editor.view.composing) return false;
-          // Let Enter insert a newline inside a code block.
-          if (editor.isActive("codeBlock")) return false;
+          // Let structured editor blocks keep their native Enter behavior
+          // (new code line, next list item, continuing/exiting quote).
+          if (
+            editor.isActive("codeBlock") ||
+            editor.isActive("listItem") ||
+            editor.isActive("blockquote")
+          ) return false;
           return onSubmit();
         };
       }

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import { useCommentDraftStore } from "@multica/core/issues/stores";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { renderWithI18n } from "../../test/i18n";
 import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
@@ -23,6 +25,10 @@ vi.mock("../../common/actor-avatar", () => ({
       {actorType}:{actorId}
     </span>
   ),
+}));
+
+const authState = vi.hoisted(() => ({
+  user: { message_enter_key_behavior: "newline" as "send" | "newline" },
 }));
 
 vi.mock("../../editor", () => ({
@@ -78,6 +84,11 @@ vi.mock("../../editor", () => ({
         }}
         onKeyDown={(event) => {
           if (event.key !== "Enter") return;
+          if (event.metaKey || event.ctrlKey) {
+            event.preventDefault();
+            onSubmit?.();
+            return;
+          }
           if (!event.shiftKey && submitOnEnter) {
             event.preventDefault();
             onSubmit?.();
@@ -89,6 +100,11 @@ vi.mock("../../editor", () => ({
       />
     );
   }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector?: (s: typeof authState) => unknown) =>
+    selector ? selector(authState) : authState,
 }));
 
 function renderWithProviders(ui: ReactNode) {
@@ -136,6 +152,8 @@ function getSubmitButton(container: HTMLElement): HTMLButtonElement {
 beforeEach(() => {
   uploadWithToast.mockReset();
   localStorage.clear();
+  authState.user.message_enter_key_behavior = "newline";
+  useCommentDraftStore.setState({ drafts: {} });
 });
 
 describe("comment composers", () => {
@@ -199,7 +217,42 @@ describe("comment composers", () => {
     });
   });
 
-  it("submits a top-level comment when Enter is pressed", async () => {
+  it("shows the default send shortcut hint for top-level comments after content is entered", () => {
+    renderCommentInput();
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+  });
+
+  it("shows Enter as the send shortcut hint for top-level comments when configured", () => {
+    authState.user.message_enter_key_behavior = "send";
+    renderCommentInput();
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(enterKey)} to send`),
+    ).toBeTruthy();
+  });
+
+  it("shows the default send shortcut hint for replies after content is entered", () => {
+    renderReplyInput();
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "reply comment" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+  });
+
+  it("submits a top-level comment when Enter-to-send is configured", async () => {
+    authState.user.message_enter_key_behavior = "send";
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderCommentInput(onSubmit);
 
@@ -212,7 +265,8 @@ describe("comment composers", () => {
     });
   });
 
-  it("submits a reply when Enter is pressed", async () => {
+  it("submits a reply when Enter-to-send is configured", async () => {
+    authState.user.message_enter_key_behavior = "send";
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderReplyInput({ onSubmit });
 
@@ -225,6 +279,44 @@ describe("comment composers", () => {
     });
   });
 
+  it("treats unknown Enter behavior values as newline mode for top-level comments", () => {
+    (
+      authState.user as { message_enter_key_behavior: string }
+    ).message_enter_key_behavior = "unknown";
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCommentInput(onSubmit);
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("treats unknown Enter behavior values as newline mode for replies", () => {
+    (
+      authState.user as { message_enter_key_behavior: string }
+    ).message_enter_key_behavior = "unknown";
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderReplyInput({ onSubmit });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "reply comment" } });
+
+    expect(
+      screen.getByText(`${formatShortcut(modKey, enterKey)} to send`),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("keeps Shift+Enter available for a newline without submitting", () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     renderCommentInput(onSubmit);
@@ -234,5 +326,53 @@ describe("comment composers", () => {
     fireEvent.keyDown(editor, { key: "Enter", shiftKey: true });
 
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keeps Enter as a newline for top-level comments by default", () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCommentInput(onSubmit);
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits top-level comments with Ctrl+Enter when Enter inserts newlines", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCommentInput(onSubmit);
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+    fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("new comment", undefined, undefined);
+    });
+  });
+
+  it("keeps Enter as a newline for replies by default", () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderReplyInput({ onSubmit });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "reply comment" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits replies with Ctrl+Enter when Enter inserts newlines", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderReplyInput({ onSubmit });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "reply comment" } });
+    fireEvent.keyDown(editor, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("reply comment", undefined, undefined);
+    });
   });
 });

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -35,13 +35,17 @@ vi.mock("../../editor", () => ({
     {
       defaultValue,
       onUpdate,
+      onSubmit,
       placeholder,
       onUploadFile,
+      submitOnEnter,
     }: {
       defaultValue?: string;
       onUpdate?: (markdown: string) => void;
+      onSubmit?: () => void;
       placeholder?: string;
       onUploadFile?: (file: File) => Promise<UploadResult | null>;
+      submitOnEnter?: boolean;
     },
     ref: Ref<unknown>,
   ) {
@@ -71,6 +75,16 @@ vi.mock("../../editor", () => ({
         onChange={(event) => {
           valueRef.current = event.target.value;
           onUpdate?.(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return;
+          if (!event.shiftKey && submitOnEnter) {
+            event.preventDefault();
+            onSubmit?.();
+            return;
+          }
+          valueRef.current += "\n";
+          onUpdate?.(valueRef.current);
         }}
       />
     );
@@ -183,5 +197,42 @@ describe("comment composers", () => {
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith("thread reply", undefined, undefined);
     });
+  });
+
+  it("submits a top-level comment when Enter is pressed", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCommentInput(onSubmit);
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("new comment", undefined, undefined);
+    });
+  });
+
+  it("submits a reply when Enter is pressed", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderReplyInput({ onSubmit });
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "reply comment" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("reply comment", undefined, undefined);
+    });
+  });
+
+  it("keeps Shift+Enter available for a newline without submitting", () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderCommentInput(onSubmit);
+
+    const editor = screen.getByTestId("editor");
+    fireEvent.change(editor, { target: { value: "new comment" } });
+    fireEvent.keyDown(editor, { key: "Enter", shiftKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -4,11 +4,12 @@ import { useRef, useState, useCallback, useEffect } from "react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
+import { useAuthStore } from "@multica/core/auth";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
-import { enterKey, formatShortcut } from "@multica/core/platform";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
@@ -21,6 +22,13 @@ interface CommentInputProps {
 
 function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const { t } = useT("issues");
+  const messageEnterKeyBehavior = useAuthStore(
+    (s) => s.user?.message_enter_key_behavior ?? "newline",
+  );
+  const submitOnEnter = messageEnterKeyBehavior === "send";
+  const sendShortcut = submitOnEnter
+    ? formatShortcut(enterKey)
+    : formatShortcut(modKey, enterKey);
   const editorRef = useRef<ContentEditorRef>(null);
   // Read the persisted draft once on mount. ContentEditor only honors
   // `defaultValue` at mount time, so this snapshot drives both the editor's
@@ -138,7 +146,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
             else clearDraft(draftKey);
           }}
           onSubmit={handleSubmit}
-          submitOnEnter
+          submitOnEnter={submitOnEnter}
           onUploadFile={handleUpload}
           debounceMs={100}
           currentIssueId={issueId}
@@ -160,11 +168,18 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           multiple
           onSelect={(file) => editorRef.current?.uploadFile(file)}
         />
+        {!isEmpty && (
+          <span className="mr-1 hidden text-[11px] text-muted-foreground sm:inline">
+            {t(($) => $.comment.send_shortcut_hint, {
+              shortcut: sendShortcut,
+            })}
+          </span>
+        )}
         <SubmitButton
           onClick={handleSubmit}
           disabled={isEmpty}
           loading={submitting}
-          tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(enterKey)}`}
+          tooltip={`${t(($) => $.comment.send_tooltip)} · ${sendShortcut}`}
         />
       </div>
       {isDragOver && <FileDropOverlay />}

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -8,7 +8,7 @@ import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
-import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
+import { enterKey, formatShortcut } from "@multica/core/platform";
 import { useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
@@ -138,6 +138,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
             else clearDraft(draftKey);
           }}
           onSubmit={handleSubmit}
+          submitOnEnter
           onUploadFile={handleUpload}
           debounceMs={100}
           currentIssueId={issueId}
@@ -163,7 +164,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onClick={handleSubmit}
           disabled={isEmpty}
           loading={submitting}
-          tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+          tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(enterKey)}`}
         />
       </div>
       {isDragOver && <FileDropOverlay />}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -5,6 +5,7 @@ import { ArrowUp, Loader2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { useAuthStore } from "@multica/core/auth";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
@@ -14,6 +15,7 @@ import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
 import { useCommentTriggerPreview } from "../hooks/use-comment-trigger-preview";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -48,6 +50,13 @@ function ReplyInput({
   draftKey,
 }: ReplyInputProps) {
   const { t } = useT("issues");
+  const messageEnterKeyBehavior = useAuthStore(
+    (s) => s.user?.message_enter_key_behavior ?? "newline",
+  );
+  const submitOnEnter = messageEnterKeyBehavior === "send";
+  const sendShortcut = submitOnEnter
+    ? formatShortcut(enterKey)
+    : formatShortcut(modKey, enterKey);
   const placeholderText = placeholder ?? t(($) => $.reply.placeholder);
   const editorRef = useRef<ContentEditorRef>(null);
   // If a draft key is provided, hydrate from store on mount (defaultValue is
@@ -172,7 +181,7 @@ function ReplyInput({
               }
             }}
             onSubmit={handleSubmit}
-            submitOnEnter
+            submitOnEnter={submitOnEnter}
             onUploadFile={handleUpload}
             debounceMs={100}
             currentIssueId={issueId}
@@ -194,6 +203,13 @@ function ReplyInput({
             multiple
             onSelect={(file) => editorRef.current?.uploadFile(file)}
           />
+          {!isEmpty && (
+            <span className="hidden text-[11px] text-muted-foreground sm:inline">
+              {t(($) => $.comment.send_shortcut_hint, {
+                shortcut: sendShortcut,
+              })}
+            </span>
+          )}
           <button
             type="button"
             disabled={isEmpty || submitting}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -172,6 +172,7 @@ function ReplyInput({
               }
             }}
             onSubmit={handleSubmit}
+            submitOnEnter
             onUploadFile={handleUpload}
             debounceMs={100}
             currentIssueId={issueId}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -12,7 +12,8 @@
     "placeholder_default": "Start a message…",
     "send_tooltip": "Send",
     "stop_tooltip": "Stop",
-    "send_failed_toast": "Failed to send message"
+    "send_failed_toast": "Failed to send message",
+    "send_shortcut_hint": "{{shortcut}} to send"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -311,7 +311,8 @@
       "bar_authors_more_other": "{{names}} and {{count}} others",
       "resolve_failed": "Failed to resolve thread",
       "unresolve_failed": "Failed to unresolve thread"
-    }
+    },
+    "send_shortcut_hint": "{{shortcut}} to send"
   },
   "reply": {
     "placeholder": "Leave a reply..."

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -19,6 +19,17 @@
       "browser_suffix": " (browser)",
       "hint": "Used for dashboards, charts, and any 'today' label shown to you. It's a personal preference that applies across all your workspaces.",
       "sync_failed": "Failed to save your timezone preference."
+    },
+    "input_options": {
+      "title": "Input Options",
+      "enter_key": {
+        "label": "When writing a message, press Enter to",
+        "send": "Send the message",
+        "newline": "Start a new line",
+        "send_hint": "Use Shift+Enter to add a new line.",
+        "newline_hint": "Use {{shortcut}} to send.",
+        "sync_failed": "Failed to save input preference."
+      }
     }
   },
   "page": {

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -11,7 +11,8 @@
     "placeholder_default": "メッセージを入力…",
     "send_tooltip": "送信",
     "stop_tooltip": "停止",
-    "send_failed_toast": "メッセージを送信できませんでした"
+    "send_failed_toast": "メッセージを送信できませんでした",
+    "send_shortcut_hint": "{{shortcut}} で送信"
   },
   "message_list": {
     "show_details": "詳細を表示",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -299,7 +299,8 @@
       "bar_authors_more_other": "{{names}} 他 {{count}} 名",
       "resolve_failed": "スレッドを解決できませんでした",
       "unresolve_failed": "スレッドの解決を取り消せませんでした"
-    }
+    },
+    "send_shortcut_hint": "{{shortcut}} で送信"
   },
   "reply": {
     "placeholder": "返信を残す..."

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -19,6 +19,17 @@
       "browser_suffix": " (ブラウザ)",
       "hint": "ダッシュボード、チャート、表示される「今日」ラベルに使用されます。すべてのワークスペースに適用される個人設定です。",
       "sync_failed": "タイムゾーン設定を保存できませんでした。"
+    },
+    "input_options": {
+      "title": "入力オプション",
+      "enter_key": {
+        "label": "メッセージ入力中に Enter キーを押したとき",
+        "send": "メッセージを送信",
+        "newline": "改行する",
+        "send_hint": "Shift+Enter で改行できます。",
+        "newline_hint": "{{shortcut}} で送信できます。",
+        "sync_failed": "入力設定を保存できませんでした。"
+      }
     }
   },
   "page": {

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -12,7 +12,8 @@
     "placeholder_default": "메시지 입력…",
     "send_tooltip": "보내기",
     "stop_tooltip": "중지",
-    "send_failed_toast": "메시지를 보내지 못했습니다"
+    "send_failed_toast": "메시지를 보내지 못했습니다",
+    "send_shortcut_hint": "{{shortcut}}로 보내기"
   },
   "message_list": {
     "show_details": "세부 정보 보기",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -310,7 +310,8 @@
       "bar_authors_more_other": "{{names}} 외 {{count}}명",
       "resolve_failed": "스레드를 해결하지 못했습니다",
       "unresolve_failed": "스레드 해결을 취소하지 못했습니다"
-    }
+    },
+    "send_shortcut_hint": "{{shortcut}}로 보내기"
   },
   "reply": {
     "placeholder": "답글 남기기..."

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -19,6 +19,17 @@
       "browser_suffix": " (브라우저)",
       "hint": "대시보드, 차트, 사용자에게 표시되는 '오늘' 레이블에 사용됩니다. 모든 워크스페이스에 적용되는 개인 설정입니다.",
       "sync_failed": "시간대 설정을 저장하지 못했습니다."
+    },
+    "input_options": {
+      "title": "입력 옵션",
+      "enter_key": {
+        "label": "메시지를 작성할 때 Enter 키를 눌러",
+        "send": "메시지 보내기",
+        "newline": "새 줄 시작",
+        "send_hint": "Shift+Enter로 새 줄을 추가합니다.",
+        "newline_hint": "{{shortcut}}로 보냅니다.",
+        "sync_failed": "입력 설정을 저장하지 못했습니다."
+      }
     }
   },
   "page": {

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -11,7 +11,8 @@
     "placeholder_default": "输入消息…",
     "send_tooltip": "发送",
     "stop_tooltip": "停止",
-    "send_failed_toast": "发送消息失败"
+    "send_failed_toast": "发送消息失败",
+    "send_shortcut_hint": "使用 {{shortcut}} 发送"
   },
   "message_list": {
     "show_details": "查看详情",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -304,7 +304,8 @@
       "bar_authors_more_other": "{{names}} 等 {{count}} 人",
       "resolve_failed": "标记已解决失败",
       "unresolve_failed": "重新打开失败"
-    }
+    },
+    "send_shortcut_hint": "使用 {{shortcut}} 发送"
   },
   "reply": {
     "placeholder": "回复..."

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -19,6 +19,17 @@
       "browser_suffix": "（浏览器）",
       "hint": "用于仪表盘、图表和「今天」标签。这是个人偏好，在你的所有工作区中通用。",
       "sync_failed": "保存时区偏好失败。"
+    },
+    "input_options": {
+      "title": "输入选项",
+      "enter_key": {
+        "label": "撰写消息时，按 Enter 键用于",
+        "send": "发送消息",
+        "newline": "换行",
+        "send_hint": "使用 Shift+Enter 换行。",
+        "newline_hint": "使用 {{shortcut}} 发送。",
+        "sync_failed": "保存输入偏好失败。"
+      }
     }
   },
   "page": {

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@multica/core/i18n/react";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import enCommon from "../../locales/en/common.json";
 import enAuth from "../../locales/en/auth.json";
 import enSettings from "../../locales/en/settings.json";
@@ -14,7 +15,7 @@ const mockToastWarning = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
 const mockSetUser = vi.hoisted(() => vi.fn());
 const userRef = vi.hoisted(() => ({
-  current: null as { id: string; timezone?: string | null } | null,
+  current: null as { id: string; timezone?: string | null; message_enter_key_behavior?: "send" | "newline"; } | null,
 }));
 
 vi.mock("@multica/ui/components/common/theme-provider", () => ({
@@ -249,4 +250,89 @@ describe("PreferencesTab — Timezone section", () => {
       expect(mockSetUser).toHaveBeenCalledWith(clearedUser);
     });
   }, 20000);
+});
+
+describe("PreferencesTab — Input options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRef.current = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders newline as the default Enter behavior", () => {
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    expect(
+      screen.getByRole("radio", { name: /Start a new line/i }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("shows the send shortcut hint for the default newline behavior", () => {
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    expect(
+      screen.getByText(`Use ${formatShortcut(modKey, enterKey)} to send.`),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the newline shortcut hint when Enter-to-send is selected", () => {
+    userRef.current = {
+      id: "user-1",
+      message_enter_key_behavior: "send",
+    };
+
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    expect(
+      screen.getByText("Use Shift+Enter to add a new line."),
+    ).toBeInTheDocument();
+  });
+
+  it("saving newline PATCHes /api/me and updates the auth store", async () => {
+    userRef.current = {
+      id: "user-1",
+      message_enter_key_behavior: "send",
+    };
+    const updatedUser = {
+      id: "user-1",
+      message_enter_key_behavior: "newline",
+    };
+    mockUpdateMe.mockResolvedValueOnce(updatedUser);
+    const user = userEvent.setup();
+
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("radio", { name: /Start a new line/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalledWith({
+        message_enter_key_behavior: "newline",
+      });
+      expect(mockSetUser).toHaveBeenCalledWith(updatedUser);
+    });
+  });
+
+  it("surfaces a toast when saving the Enter behavior fails", async () => {
+    userRef.current = {
+      id: "user-1",
+      message_enter_key_behavior: "send",
+    };
+    mockUpdateMe.mockRejectedValueOnce(new Error("network"));
+    const user = userEvent.setup();
+
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("radio", { name: /Start a new line/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateMe).toHaveBeenCalledWith({
+        message_enter_key_behavior: "newline",
+      });
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
 });

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -21,6 +21,8 @@ import { useAuthStore } from "@multica/core/auth";
 import { api } from "@multica/core/api";
 import { browserTimezone, timezoneOptions } from "../../common/timezone-select";
 import { useT } from "../../i18n";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
+import type { MessageEnterKeyBehavior } from "@multica/core/types";
 
 const LIGHT_COLORS = {
   titleBar: "#e8e8e8",
@@ -241,6 +243,8 @@ export function PreferencesTab() {
         </div>
       </section>
 
+      <InputOptionsSection />
+
       <TimezoneSection />
     </div>
   );
@@ -316,6 +320,86 @@ function TimezoneSection() {
       <p className="text-[11px] leading-snug text-muted-foreground">
         {t(($) => $.preferences.timezone.hint)}
       </p>
+    </section>
+  );
+}
+
+function InputOptionsSection() {
+  const { t } = useT("settings");
+  const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
+  const value: MessageEnterKeyBehavior = user?.message_enter_key_behavior ?? "newline";
+
+  const options: {
+    value: MessageEnterKeyBehavior;
+    label: string;
+  }[] = [
+    {
+      value: "newline",
+      label: t(($) => $.preferences.input_options.enter_key.newline),
+    },
+    {
+      value: "send",
+      label: t(($) => $.preferences.input_options.enter_key.send),
+    },
+  ];
+
+  const handleChange = async (next: MessageEnterKeyBehavior) => {
+    if (next === value) return;
+    try {
+      const updated = await api.updateMe({
+        message_enter_key_behavior: next,
+      });
+      setUser(updated);
+    } catch {
+      toast.error(
+        t(($) => $.preferences.input_options.enter_key.sync_failed),
+      );
+    }
+  };
+
+  const activeHint =
+    value === "newline"
+      ? t(($) => $.preferences.input_options.enter_key.newline_hint, {
+          shortcut: formatShortcut(modKey, enterKey),
+        })
+      : t(($) => $.preferences.input_options.enter_key.send_hint);
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold">
+        {t(($) => $.preferences.input_options.title)}
+      </h2>
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          {t(($) => $.preferences.input_options.enter_key.label)}
+        </p>
+        <div className="flex gap-3" role="radiogroup">
+          {options.map((opt) => {
+            const active = value === opt.value;
+            return (
+              <button
+                type="button"
+                key={opt.value}
+                role="radio"
+                aria-checked={active}
+                onClick={() => handleChange(opt.value)}
+                className={cn(
+                  "rounded-md border px-4 py-2 text-sm transition-colors",
+                  active
+                    ? "border-brand bg-brand/10 font-medium text-foreground"
+                    : "border-border text-muted-foreground hover:border-foreground/30",
+                )}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          {activeHint}
+        </p>
+      </div>
     </section>
   );
 }

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -58,7 +58,9 @@ type UserResponse struct {
 	AvatarURL *string `json:"avatar_url"`
 	Language  *string `json:"language"`
 	// Pinned IANA tz; nil = no preference (use browser-detected tz).
-	Timezone                *string         `json:"timezone"`
+	Timezone *string `json:"timezone"`
+	// Controls Enter behavior in chat/comment composers: "send" or "newline"
+	MessageEnterKeyBehavior string          `json:"message_enter_key_behavior"`
 	OnboardedAt             *string         `json:"onboarded_at"`
 	OnboardingQuestionnaire json.RawMessage `json:"onboarding_questionnaire"`
 	StarterContentState     *string         `json:"starter_content_state"`
@@ -88,6 +90,7 @@ func userToResponse(u db.User) UserResponse {
 		AvatarURL:               textToPtr(u.AvatarUrl),
 		Language:                textToPtr(u.Language),
 		Timezone:                textToPtr(u.Timezone),
+		MessageEnterKeyBehavior: u.MessageEnterKeyBehavior,
 		OnboardedAt:             timestampToPtr(u.OnboardedAt),
 		OnboardingQuestionnaire: json.RawMessage(q),
 		StarterContentState:     textToPtr(u.StarterContentState),
@@ -436,10 +439,11 @@ func (h *Handler) GetMe(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateMeRequest struct {
-	Name               *string `json:"name"`
-	AvatarURL          *string `json:"avatar_url"`
-	Language           *string `json:"language"`
-	ProfileDescription *string `json:"profile_description"`
+	Name                    *string `json:"name"`
+	AvatarURL               *string `json:"avatar_url"`
+	Language                *string `json:"language"`
+	ProfileDescription      *string `json:"profile_description"`
+	MessageEnterKeyBehavior *string `json:"message_enter_key_behavior"`
 	// IANA tz to pin; "" clears back to NULL; nil leaves untouched.
 	Timezone *string `json:"timezone"`
 }
@@ -710,6 +714,15 @@ func (h *Handler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		params.Timezone = pgtype.Text{String: tz, Valid: true}
+	}
+
+	if req.MessageEnterKeyBehavior != nil {
+		behavior := strings.TrimSpace(*req.MessageEnterKeyBehavior)
+		if behavior != "send" && behavior != "newline" {
+			writeError(w, http.StatusBadRequest, "invalid message_enter_key_behavior")
+			return
+		}
+		params.MessageEnterKeyBehavior = pgtype.Text{String: behavior, Valid: true}
 	}
 
 	updatedUser, err := h.Queries.UpdateUser(r.Context(), params)

--- a/server/internal/handler/user_message_enter_key_behavior_test.go
+++ b/server/internal/handler/user_message_enter_key_behavior_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newMessageEnterKeyBehaviorTestUser(t *testing.T, email string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO "user" (name, email) VALUES ($1, $2) RETURNING id`,
+		"Message Enter Key Behavior Test", email,
+	).Scan(&userID); err != nil {
+		t.Fatalf("insert test user: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+	return userID
+}
+
+func TestUpdateMeAcceptsMessageEnterKeyBehavior(t *testing.T) {
+	userID := newMessageEnterKeyBehaviorTestUser(t, "enter-behavior-set@multica.ai")
+
+	w := httptest.NewRecorder()
+	req := newPatchMeRequest(userID, `{"message_enter_key_behavior":"newline"}`)
+	testHandler.UpdateMe(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var stored string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT message_enter_key_behavior FROM "user" WHERE id = $1`, userID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if stored != "newline" {
+		t.Fatalf("expected message_enter_key_behavior=newline, got %q", stored)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, _ := resp["message_enter_key_behavior"].(string); got != "newline" {
+		t.Fatalf("expected response message_enter_key_behavior=newline, got %v", resp["message_enter_key_behavior"])
+	}
+}
+
+func TestUpdateMeRejectsInvalidMessageEnterKeyBehavior(t *testing.T) {
+	userID := newMessageEnterKeyBehaviorTestUser(t, "enter-behavior-reject@multica.ai")
+
+	w := httptest.NewRecorder()
+	req := newPatchMeRequest(userID, `{"message_enter_key_behavior":"maybe"}`)
+	testHandler.UpdateMe(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var stored string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT message_enter_key_behavior FROM "user" WHERE id = $1`, userID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if stored != "newline" {
+		t.Fatalf("expected default message_enter_key_behavior=newline, got %q", stored)
+	}
+}
+
+func TestUpdateMePreservesMessageEnterKeyBehaviorWhenNotProvided(t *testing.T) {
+	userID := newMessageEnterKeyBehaviorTestUser(t, "enter-behavior-preserve@multica.ai")
+
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE "user" SET message_enter_key_behavior = 'newline' WHERE id = $1`, userID,
+	); err != nil {
+		t.Fatalf("preset message_enter_key_behavior: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newPatchMeRequest(userID, `{"name":"Updated Name"}`)
+	testHandler.UpdateMe(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var stored string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT message_enter_key_behavior FROM "user" WHERE id = $1`, userID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("lookup user: %v", err)
+	}
+	if stored != "newline" {
+		t.Fatalf("expected message_enter_key_behavior preserved as newline, got %q", stored)
+	}
+}

--- a/server/migrations/111_user_message_enter_key_behavior.down.sql
+++ b/server/migrations/111_user_message_enter_key_behavior.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user"
+    DROP CONSTRAINT IF EXISTS user_message_enter_key_behavior_check,
+    DROP COLUMN IF EXISTS message_enter_key_behavior;

--- a/server/migrations/111_user_message_enter_key_behavior.up.sql
+++ b/server/migrations/111_user_message_enter_key_behavior.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "user"
+    ADD COLUMN message_enter_key_behavior TEXT NOT NULL DEFAULT 'newline';
+
+ALTER TABLE "user"
+    ADD CONSTRAINT user_message_enter_key_behavior_check
+    CHECK (message_enter_key_behavior IN ('send', 'newline'));

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -708,7 +708,8 @@ type User struct {
 	Language                pgtype.Text        `json:"language"`
 	ProfileDescription      string             `json:"profile_description"`
 	// User-preferred IANA timezone for report rendering (Viewing tz). NULL means "use the browser-detected tz at render time". Affects dashboards, charts, and any "today" label shown to this user. Does not affect data materialisation — all rollups remain in UTC.
-	Timezone pgtype.Text `json:"timezone"`
+	Timezone                pgtype.Text `json:"timezone"`
+	MessageEnterKeyBehavior string      `json:"message_enter_key_behavior"`
 }
 
 type VerificationCode struct {

--- a/server/pkg/db/generated/user.sql.go
+++ b/server/pkg/db/generated/user.sql.go
@@ -14,7 +14,7 @@ import (
 const createUser = `-- name: CreateUser :one
 INSERT INTO "user" (name, email, avatar_url)
 VALUES ($1, $2, $3)
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 type CreateUserParams struct {
@@ -41,12 +41,13 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
 
 const getUser = `-- name: GetUser :one
-SELECT id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone FROM "user"
+SELECT id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior FROM "user"
 WHERE id = $1
 `
 
@@ -68,12 +69,13 @@ func (q *Queries) GetUser(ctx context.Context, id pgtype.UUID) (User, error) {
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone FROM "user"
+SELECT id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior FROM "user"
 WHERE email = $1
 `
 
@@ -95,6 +97,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
@@ -105,7 +108,7 @@ UPDATE "user" SET
     cloud_waitlist_reason = $3,
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 type JoinCloudWaitlistParams struct {
@@ -135,6 +138,7 @@ func (q *Queries) JoinCloudWaitlist(ctx context.Context, arg JoinCloudWaitlistPa
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
@@ -144,7 +148,7 @@ UPDATE "user" SET
     onboarded_at = COALESCE(onboarded_at, now()),
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 func (q *Queries) MarkUserOnboarded(ctx context.Context, id pgtype.UUID) (User, error) {
@@ -165,6 +169,7 @@ func (q *Queries) MarkUserOnboarded(ctx context.Context, id pgtype.UUID) (User, 
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
@@ -174,7 +179,7 @@ UPDATE "user" SET
     onboarding_questionnaire = COALESCE($1, onboarding_questionnaire),
     updated_at = now()
 WHERE id = $2
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 type PatchUserOnboardingParams struct {
@@ -204,6 +209,7 @@ func (q *Queries) PatchUserOnboarding(ctx context.Context, arg PatchUserOnboardi
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
@@ -213,7 +219,7 @@ UPDATE "user" SET
     starter_content_state = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 type SetStarterContentStateParams struct {
@@ -244,6 +250,7 @@ func (q *Queries) SetStarterContentState(ctx context.Context, arg SetStarterCont
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }
@@ -259,18 +266,23 @@ UPDATE "user" SET
         WHEN $6::text = ''    THEN NULL
         ELSE $6::text
     END,
+    message_enter_key_behavior = COALESCE(
+        $7,
+        message_enter_key_behavior
+    ),
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone
+RETURNING id, name, email, avatar_url, created_at, updated_at, onboarded_at, onboarding_questionnaire, cloud_waitlist_email, cloud_waitlist_reason, starter_content_state, language, profile_description, timezone, message_enter_key_behavior
 `
 
 type UpdateUserParams struct {
-	ID                 pgtype.UUID `json:"id"`
-	Name               string      `json:"name"`
-	AvatarUrl          pgtype.Text `json:"avatar_url"`
-	Language           pgtype.Text `json:"language"`
-	ProfileDescription pgtype.Text `json:"profile_description"`
-	Timezone           pgtype.Text `json:"timezone"`
+	ID                      pgtype.UUID `json:"id"`
+	Name                    string      `json:"name"`
+	AvatarUrl               pgtype.Text `json:"avatar_url"`
+	Language                pgtype.Text `json:"language"`
+	ProfileDescription      pgtype.Text `json:"profile_description"`
+	Timezone                pgtype.Text `json:"timezone"`
+	MessageEnterKeyBehavior pgtype.Text `json:"message_enter_key_behavior"`
 }
 
 // Patches the user-controlled profile fields. Each parameter follows
@@ -293,6 +305,7 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		arg.Language,
 		arg.ProfileDescription,
 		arg.Timezone,
+		arg.MessageEnterKeyBehavior,
 	)
 	var i User
 	err := row.Scan(
@@ -310,6 +323,7 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		&i.Language,
 		&i.ProfileDescription,
 		&i.Timezone,
+		&i.MessageEnterKeyBehavior,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/user.sql
+++ b/server/pkg/db/queries/user.sql
@@ -34,6 +34,10 @@ UPDATE "user" SET
         WHEN sqlc.narg('timezone')::text = ''    THEN NULL
         ELSE sqlc.narg('timezone')::text
     END,
+    message_enter_key_behavior = COALESCE(
+        sqlc.narg('message_enter_key_behavior'),
+        message_enter_key_behavior
+    ),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## What does this PR do?

Improves the Enter-key behavior introduced in #3110 by making it configurable.

#3110 changed message editors to use Enter-to-send by default. Follow-up feedback pointed out that some users prefer Enter to insert a newline and would rather choose this behavior in Preferences.

This PR adds a user-level "Input Options" setting so both workflows are supported:

- **Enter to send** (default) — Enter sends, Shift+Enter inserts a newline
- **Enter for newline** — Enter inserts a newline, Cmd/Ctrl+Enter sends

The goal is to keep the chat-style default while giving users control over the input behavior that best matches their writing habits.

## Related

Follow-up to #3110
Closes #3110

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**Editor submit behavior:**

- `packages/views/editor/extensions/submit-shortcut.ts` — Supports configurable Enter submit behavior while preserving native behavior in code blocks, lists, and blockquotes
- `packages/views/editor/extensions/index.ts` — Passes `submitOnEnterRef` so the preference can update without recreating the editor

**Input components:**

- `packages/views/chat/components/chat-input.tsx` — Reads the user preference for submit behavior
- `packages/views/issues/components/comment-input.tsx` — Reads the user preference for submit behavior
- `packages/views/issues/components/reply-input.tsx` — Reads the user preference for submit behavior

**User preference:**

- `packages/views/settings/components/preferences-tab.tsx` — Adds the "Input Options" section
- `packages/core/types/workspace.ts` — Adds `MessageEnterKeyBehavior`
- `packages/core/api/schemas.ts` — Adds schema fallback for older backends and enum drift
- `apps/mobile/data/schemas.ts` — Adds mobile schema compatibility for the new user field

**Backend:**

- `server/internal/handler/auth.go` — Validates and persists the preference
- `server/pkg/db/queries/user.sql` — Updates the user update query
- `server/migrations/108_user_message_enter_key_behavior.*` — Adds/removes the DB column and check constraint

**i18n:**

- `packages/views/locales/en/settings.json` — Adds English translations
- `packages/views/locales/zh-Hans/settings.json` — Adds Chinese translations

## How to Test

1. Open Settings → Preferences → Input Options
2. Keep "Send the message" selected and press Enter in chat/comment/reply to send
3. Switch to "Start a new line" and confirm Enter inserts a newline
4. Confirm Cmd/Ctrl+Enter still sends in newline mode
5. Refresh or reopen the app and confirm the setting persists

## Verification

- `pnpm typecheck`
- `pnpm -C apps/mobile typecheck`
- `pnpm --filter @multica/core exec vitest run api/schemas.test.ts`
- `go test ./internal/handler -run MessageEnterKeyBehavior`

## Checklist

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**  Assisted with understanding the existing code, tracing the architecture, and resolving merge conflicts.