### PR TITLE
feat(ui): add repository search to resource pickers

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -105,6 +105,8 @@
     "repos_pill_count_other": "{{count}} repos",
     "repos_heading": "Attach GitHub repos to this project",
     "repos_empty": "No workspace-level repos yet. Paste a URL below to attach one ad-hoc.",
+    "repos_search_placeholder": "Search repositories...",
+    "repos_search_empty": "No repositories match your search.",
     "repos_url_placeholder": "https://github.com/owner/repo or git@github.com:owner/repo.git",
     "repos_add": "Add",
     "repos_selected": "Selected"

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -71,6 +71,8 @@
     "empty": "No resources attached.",
     "add_button": "Add resource",
     "popover_title": "Attach a GitHub repo",
+    "repos_search_placeholder": "Search repositories...",
+    "repos_search_empty": "No repositories match your search.",
     "attached_badge": "attached",
     "remove_tooltip": "Remove",
     "url_placeholder": "https://github.com/owner/repo or git@github.com:owner/repo.git",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -105,6 +105,8 @@
     "repos_pill_count_other": "{{count}} 个仓库",
     "repos_heading": "为此项目关联 GitHub 仓库",
     "repos_empty": "还没有工作区级别的仓库。可以在下方粘贴 URL 临时关联一个。",
+    "repos_search_placeholder": "搜索仓库...",
+    "repos_search_empty": "没有匹配的仓库。",
     "repos_url_placeholder": "https://github.com/owner/repo 或 git@github.com:owner/repo.git",
     "repos_add": "添加",
     "repos_selected": "已选"

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -71,6 +71,8 @@
     "empty": "还没有关联资源。",
     "add_button": "添加资源",
     "popover_title": "关联 GitHub 仓库",
+    "repos_search_placeholder": "搜索仓库...",
+    "repos_search_empty": "没有匹配的仓库。",
     "attached_badge": "已关联",
     "remove_tooltip": "移除",
     "url_placeholder": "https://github.com/owner/repo 或 git@github.com:owner/repo.git",

--- a/packages/views/modals/create-project.test.tsx
+++ b/packages/views/modals/create-project.test.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithI18n } from "../test/i18n";
 
 const longRepoUrl =
   "https://github.com/multica-ai/a-very-long-repository-name-that-needs-a-tooltip";
+const apiRepoUrl = "https://github.com/multica-ai/api";
+const webRepoUrl = "https://github.com/multica-ai/web";
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({ data: [] }),
@@ -39,7 +43,7 @@ vi.mock("@multica/core/paths", () => ({
     id: "workspace-1",
     name: "Test Workspace",
     slug: "test-workspace",
-    repos: [{ url: longRepoUrl }],
+    repos: [{ url: longRepoUrl }, { url: apiRepoUrl }, { url: webRepoUrl }],
   }),
   useWorkspacePaths: () => ({
     projectDetail: (id: string) => `/test-workspace/projects/${id}`,
@@ -164,5 +168,30 @@ describe("CreateProjectModal", () => {
 
     expect(screen.getByTitle(longRepoUrl)).toHaveTextContent(longRepoUrl);
     expect(screen.getByRole("tooltip", { name: longRepoUrl })).toBeInTheDocument();
+  });
+
+  it("filters workspace repositories by search text", async () => {
+    const user = userEvent.setup();
+
+    renderWithI18n(<CreateProjectModal onClose={vi.fn()} />);
+
+    const repoSearchInput = screen.getByRole("textbox", { name: "Search repositories..." });
+
+    await user.type(repoSearchInput, "api");
+
+    expect(
+      screen.getByRole("button", { name: (name) => name.includes(apiRepoUrl) }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: (name) => name.includes(webRepoUrl) }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: (name) => name.includes(longRepoUrl) }),
+    ).not.toBeInTheDocument();
+
+    await user.clear(repoSearchInput);
+    await user.type(repoSearchInput, "no-match");
+
+    expect(screen.getByText("No repositories match your search.")).toBeInTheDocument();
   });
 });

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { ChevronRight, Maximize2, Minimize2, X as XIcon, UserMinus } from "lucide-react";
+import { ChevronRight, Maximize2, Minimize2, Search, X as XIcon, UserMinus } from "lucide-react";
 
 /**
  * GitHub mark — lucide-react v1 dropped brand icons, so we inline the
@@ -136,8 +136,13 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
   // persisted until handleSubmit fires the createProjectResource calls.
   const [selectedRepos, setSelectedRepos] = useState<string[]>([]);
   const [repoPopoverOpen, setRepoPopoverOpen] = useState(false);
+  const [repoSearch, setRepoSearch] = useState("");
   const [customRepoUrl, setCustomRepoUrl] = useState("");
   const workspaceRepos = workspace?.repos ?? [];
+  const repoQuery = repoSearch.trim().toLowerCase();
+  const filteredWorkspaceRepos = workspaceRepos.filter((repo) =>
+    repo.url.toLowerCase().includes(repoQuery),
+  );
 
   // Sync field changes to draft store
   const updateTitle = (v: string) => { setTitle(v); setDraft({ title: v }); };
@@ -451,7 +456,13 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
             </PopoverContent>
           </Popover>
 
-          <Popover open={repoPopoverOpen} onOpenChange={setRepoPopoverOpen}>
+          <Popover
+            open={repoPopoverOpen}
+            onOpenChange={(v) => {
+              setRepoPopoverOpen(v);
+              if (!v) setRepoSearch("");
+            }}
+          >
             <PopoverTrigger
               render={
                 <PillButton>
@@ -469,31 +480,49 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                 {t(($) => $.create_project.repos_heading)}
               </div>
               {workspaceRepos.length > 0 ? (
-                <div className="space-y-1 max-h-48 overflow-y-auto">
-                  {workspaceRepos.map((repo) => {
-                    const checked = selectedRepos.includes(repo.url);
-                    return (
-                      <button
-                        type="button"
-                        key={repo.url}
-                        onClick={() => toggleRepo(repo.url)}
-                        className={cn(
-                          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent transition-colors",
-                          checked && "bg-accent",
-                        )}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          readOnly
-                          className="size-3.5"
-                        />
-                        <GithubIcon className="size-3.5" />
-                        <RepoUrlText url={repo.url} />
-                      </button>
-                    );
-                  })}
-                </div>
+                <>
+                  <div className="relative">
+                    <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={repoSearch}
+                      onChange={(e) => setRepoSearch(e.target.value)}
+                      aria-label={t(($) => $.create_project.repos_search_placeholder)}
+                      placeholder={t(($) => $.create_project.repos_search_placeholder)}
+                      className="h-8 w-full rounded-md border bg-transparent pl-7 pr-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring"
+                    />
+                  </div>
+                  <div className="max-h-48 space-y-1 overflow-y-auto">
+                    {filteredWorkspaceRepos.length === 0 && repoQuery && (
+                      <p className="py-2 text-center text-xs text-muted-foreground">
+                        {t(($) => $.create_project.repos_search_empty)}
+                      </p>
+                    )}
+                    {filteredWorkspaceRepos.map((repo) => {
+                      const checked = selectedRepos.includes(repo.url);
+                      return (
+                        <button
+                          type="button"
+                          key={repo.url}
+                          onClick={() => toggleRepo(repo.url)}
+                          className={cn(
+                            "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent transition-colors",
+                            checked && "bg-accent",
+                          )}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            readOnly
+                            className="size-3.5"
+                          />
+                          <GithubIcon className="size-3.5" />
+                          <RepoUrlText url={repo.url} />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
               ) : (
                 <p className="text-xs text-muted-foreground">
                   {t(($) => $.create_project.repos_empty)}

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, FolderGit, Plus, Trash2 } from "lucide-react";
+import { ChevronRight, FolderGit, Plus, Search, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import {
   projectResourcesOptions,
@@ -39,6 +39,7 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
   const workspace = useCurrentWorkspace();
   const [open, setOpen] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
+  const [repoSearch, setRepoSearch] = useState("");
 
   const { data: resources = [] } = useQuery(
     projectResourcesOptions(wsId, projectId),
@@ -51,6 +52,10 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
       .filter((r) => r.resource_type === "github_repo")
       .map((r) => (r.resource_ref as GithubRepoResourceRef).url),
   );
+
+  const repoQuery = repoSearch.trim().toLowerCase();
+  const filteredRepos =
+    workspace?.repos?.filter((repo) => repo.url.toLowerCase().includes(repoQuery)) ?? [];
 
   const handleAttach = async (url: string) => {
     try {
@@ -107,7 +112,13 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
               ))}
             </div>
           )}
-          <Popover open={addOpen} onOpenChange={setAddOpen}>
+          <Popover
+            open={addOpen}
+            onOpenChange={(v) => {
+              setAddOpen(v);
+              if (!v) setRepoSearch("");
+            }}
+          >
             <PopoverTrigger
               render={
                 <Button
@@ -125,43 +136,61 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                 {t(($) => $.resources.popover_title)}
               </div>
               {workspace?.repos && workspace.repos.length > 0 && (
-                <div className="space-y-1 max-h-48 overflow-y-auto">
-                  {workspace.repos.map((repo) => {
-                    const isAttached = attachedUrls.has(repo.url);
-                    const isDisabled = isAttached || createResource.isPending;
-                    return (
-                      // Use aria-disabled instead of the native `disabled` attribute so
-                      // hover events still reach the tooltip trigger on attached rows
-                      // (browsers suppress pointer events on disabled form controls).
-                      <button
-                        key={repo.url}
-                        type="button"
-                        aria-disabled={isDisabled}
-                        onClick={async () => {
-                          if (isDisabled) return;
-                          await handleAttach(repo.url);
-                          setAddOpen(false);
-                        }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent"
-                      >
-                        <FolderGit className="size-3.5" />
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <span className="truncate flex-1">{repo.url}</span>
-                            }
-                          />
-                          <TooltipContent side="top">{repo.url}</TooltipContent>
-                        </Tooltip>
-                        {isAttached && (
-                          <span className="text-[10px] text-muted-foreground">
-                            {t(($) => $.resources.attached_badge)}
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
+                <>
+                  <div className="relative">
+                    <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={repoSearch}
+                      onChange={(e) => setRepoSearch(e.target.value)}
+                      aria-label={t(($) => $.resources.repos_search_placeholder)}
+                      placeholder={t(($) => $.resources.repos_search_placeholder)}
+                      className="h-8 w-full rounded-md border bg-transparent pl-7 pr-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring"
+                    />
+                  </div>
+                  <div className="max-h-48 space-y-1 overflow-y-auto">
+                    {filteredRepos.length === 0 && repoQuery && (
+                      <p className="py-2 text-center text-xs text-muted-foreground">
+                        {t(($) => $.resources.repos_search_empty)}
+                      </p>
+                    )}
+                    {filteredRepos.map((repo) => {
+                      const isAttached = attachedUrls.has(repo.url);
+                      const isDisabled = isAttached || createResource.isPending;
+                      return (
+                        // Use aria-disabled instead of the native `disabled` attribute so
+                        // hover events still reach the tooltip trigger on attached rows
+                        // (browsers suppress pointer events on disabled form controls).
+                        <button
+                          key={repo.url}
+                          type="button"
+                          aria-disabled={isDisabled}
+                          onClick={async () => {
+                            if (isDisabled) return;
+                            await handleAttach(repo.url);
+                            setAddOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent"
+                        >
+                          <FolderGit className="size-3.5" />
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <span className="truncate flex-1">{repo.url}</span>
+                              }
+                            />
+                            <TooltipContent side="top">{repo.url}</TooltipContent>
+                          </Tooltip>
+                          {isAttached && (
+                            <span className="text-[10px] text-muted-foreground">
+                              {t(($) => $.resources.attached_badge)}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
               )}
               <CustomRepoForm
                 onSubmit={async (url) => {

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -96,13 +96,17 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
               {t(($) => $.resources.empty)}
             </p>
           )}
-          {resources.map((resource) => (
-            <ResourceRow
-              key={resource.id}
-              resource={resource}
-              onRemove={() => handleRemove(resource)}
-            />
-          ))}
+          {resources.length > 0 && (
+            <div className="max-h-64 space-y-1.5 overflow-y-auto pr-1">
+              {resources.map((resource) => (
+                <ResourceRow
+                  key={resource.id}
+                  resource={resource}
+                  onRemove={() => handleRemove(resource)}
+                />
+              ))}
+            </div>
+          )}
           <Popover open={addOpen} onOpenChange={setAddOpen}>
             <PopoverTrigger
               render={


### PR DESCRIPTION
## What does this PR do?

Adds client-side repository search to project resource pickers so users can quickly find repositories in workspaces with many repos.

Also makes long project resource lists scroll locally to keep the project sidebar usable.

## Related Issue

Closes #3125

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added client-side repository URL search to the create-project repository picker.
- Added client-side repository URL search to the project detail add-resource picker.
- Added empty-state copy when a repository search has no matches.
- Made long project resource lists scroll locally so the project sidebar stays usable.
- Added test coverage for repository filtering in the create-project picker.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run modals/create-project.test.tsx`.
2. Run `pnpm --filter @multica/views typecheck`.
3. Open a project in a workspace with many repositories, click Add resource, and verify typing a query filters repository URLs and preserves attached-state labels.
4. Verify a project with many attached resources scrolls the resource list locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex(GPT5.5)

**Prompt / approach:**
Used Codex to inspect the project resource picker flow, implement client-side repository URL filtering in the project detail and create-project repository pickers, add localized UI copy, keep long project resource lists scrollable, and run focused validation.

## Screenshots (optional)
**Before:**
<img width="466" height="748" alt="image" src="https://github.com/user-attachments/assets/212a027a-3e4b-4915-8ab6-8762aedee2b7" />
<img width="662" height="382" alt="image" src="https://github.com/user-attachments/assets/b7d4cfc4-789f-42e3-8275-fed50bee5a78" />
**After:**
<img width="882" height="872" alt="image" src="https://github.com/user-attachments/assets/0123c380-b6f9-46c7-8006-55670841ac30" />
<img width="1436" height="970" alt="image" src="https://github.com/user-attachments/assets/d5ce4aaa-dfe5-4934-8e48-e78fb55c5a34" />
