### PR TITLE
feat(agents): sort agents by name by default (JZA-742)

### DIFF
--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -107,7 +107,7 @@ export function AgentsPage() {
   const setScope = useAgentsViewStore((s) => s.setScope);
   const [availabilityFilter, setAvailabilityFilter] =
     useState<AvailabilityFilter>("all");
-  const [sort, setSort] = useState<SortKey>("recent");
+  const [sort, setSort] = useState<SortKey>("name");
   const [search, setSearch] = useState("");
   const [showCreate, setShowCreate] = useState(false);
   // When set, the Create dialog opens pre-populated with this agent's

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1572,7 +1572,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 const listAgents = `-- name: ListAgents :many
 SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
-ORDER BY created_at ASC
+ORDER BY name ASC
 `
 
 func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Agent, error) {
@@ -1620,7 +1620,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 const listAllAgents = `-- name: ListAllAgents :many
 SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model FROM agent
 WHERE workspace_id = $1
-ORDER BY created_at ASC
+ORDER BY name ASC
 `
 
 func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Agent, error) {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1,12 +1,12 @@
 -- name: ListAgents :many
 SELECT * FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
-ORDER BY created_at ASC;
+ORDER BY name ASC;
 
 -- name: ListAllAgents :many
 SELECT * FROM agent
 WHERE workspace_id = $1
-ORDER BY created_at ASC;
+ORDER BY name ASC;
 
 -- name: GetAgent :one
 SELECT * FROM agent


### PR DESCRIPTION
## Summary

- Change `ORDER BY created_at ASC` to `ORDER BY name ASC` in `ListAgents` and `ListAllAgents` SQL queries
- Update generated Go SQL constant strings to match
- Set frontend default sort state from `"recent"` to `"name"` so the Agents page opens alphabetically sorted

## Test plan

- [ ] Open the Agents page — agents should appear sorted alphabetically by name by default
- [ ] Verify the sort dropdown still shows "Recent" as an option and switches correctly
- [ ] Verify API responses return agents in name order