### PR TITLE
fix(tasks): make issue task cancellation idempotent

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -21,6 +21,7 @@ import type {
   AgentEnvResponse,
   UpdateAgentEnvRequest,
   AgentTask,
+  CancelTaskResult,
   AgentActivityBucket,
   AgentRunCount,
   AgentRuntime,
@@ -1406,7 +1407,7 @@ export class ApiClient {
     return this.fetch(`/api/issues/${issueId}/usage`);
   }
 
-  async cancelTask(issueId: string, taskId: string): Promise<AgentTask> {
+  async cancelTask(issueId: string, taskId: string): Promise<CancelTaskResult> {
     return this.fetch(`/api/issues/${issueId}/tasks/${taskId}/cancel`, {
       method: "POST",
     });

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -224,6 +224,14 @@ export interface AgentTask {
   relative_work_dir?: string;
 }
 
+export type CancelTaskState = "cancelled" | "already_terminal";
+
+export interface CancelTaskResult {
+  task: AgentTask;
+  cancel_state: CancelTaskState;
+  message: string;
+}
+
 export interface Agent {
   id: string;
   workspace_id: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -5,6 +5,8 @@ export type {
   AgentRuntimeMode,
   AgentVisibility,
   AgentTask,
+  CancelTaskResult,
+  CancelTaskState,
   AgentActivityBucket,
   AgentRunCount,
   TaskFailureReason,

--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -1,12 +1,22 @@
 // @vitest-environment jsdom
 
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { issueKeys } from "@multica/core/issues/queries";
 import type { AgentTask } from "@multica/core/types";
 import { renderWithI18n } from "../../test/i18n";
 
 const mockState = vi.hoisted(() => ({
+  cancelTask: vi.fn(),
   taskMessagesOptions: vi.fn(),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    cancelTask: mockState.cancelTask,
+    rerunIssue: vi.fn(),
+  },
 }));
 
 vi.mock("@multica/core/chat/queries", () => ({
@@ -24,7 +34,18 @@ vi.mock("../../common/task-transcript", () => ({
 }));
 
 vi.mock("./terminate-task-confirm-dialog", () => ({
-  TerminateTaskConfirmDialog: () => null,
+  TerminateTaskConfirmDialog: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={onConfirm}>
+        Confirm cancel
+      </button>
+    ) : null,
 }));
 
 import { ActiveTaskRow } from "./execution-log-section";
@@ -48,6 +69,19 @@ function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
   };
 }
 
+function renderRow(task = makeTask(), issueId = "issue-1") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const result = renderWithI18n(
+    <QueryClientProvider client={queryClient}>
+      <ActiveTaskRow task={task} issueId={issueId} />
+    </QueryClientProvider>,
+  );
+  return { ...result, invalidateSpy };
+}
+
 beforeEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -61,7 +95,7 @@ afterEach(() => {
 
 describe("ActiveTaskRow", () => {
   it("renders running status as elapsed time only", () => {
-    renderWithI18n(<ActiveTaskRow task={makeTask()} issueId="issue-1" />);
+    renderRow();
 
     expect(screen.getByText("5m 04s")).toBeInTheDocument();
     expect(screen.queryByText(/events?/i)).not.toBeInTheDocument();
@@ -71,7 +105,7 @@ describe("ActiveTaskRow", () => {
   });
 
   it("does not make transcript actions depend on hover-only rendering", () => {
-    renderWithI18n(<ActiveTaskRow task={makeTask()} issueId="issue-1" />);
+    renderRow();
 
     const transcriptButton = screen.getByRole("button", { name: "View transcript" });
     const status = screen.getByText("5m 04s");
@@ -85,5 +119,26 @@ describe("ActiveTaskRow", () => {
     expect(transcriptButton.parentElement?.className).toContain(
       "[@media(hover:hover)]:group-hover/execution-log-row:flex",
     );
+  });
+
+  it("invalidates the issue task list after cancel completes", async () => {
+    mockState.cancelTask.mockResolvedValueOnce({
+      task: makeTask({ status: "completed", completed_at: "2026-06-08T08:05:00Z" }),
+      cancel_state: "already_terminal",
+      message: "Task already finished",
+    });
+    const { invalidateSpy } = renderRow();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Cancel task" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirm cancel" }));
+    });
+
+    expect(mockState.cancelTask).toHaveBeenCalledWith("issue-1", "task-1");
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: issueKeys.tasks("issue-1"),
+    });
   });
 });

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Ban, CheckCircle2, ChevronRight, Loader2, RotateCcw, Square, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
@@ -253,6 +253,7 @@ export function ActiveTaskRow({
   issueId: string;
 }) {
   const { t } = useT("issues");
+  const queryClient = useQueryClient();
   const [cancelling, setCancelling] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const tone = STATUS_TONE[task.status];
@@ -287,6 +288,8 @@ export function ActiveTaskRow({
       await api.cancelTask(issueId, task.id);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : t(($) => $.execution_log.cancel_failed));
+    } finally {
+      await queryClient.invalidateQueries({ queryKey: issueKeys.tasks(issueId) });
       setCancelling(false);
     }
   };

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -326,6 +326,12 @@ type AgentTaskResponse struct {
 	AuthToken string `json:"auth_token,omitempty"`
 }
 
+type CancelTaskResponse struct {
+	Task        AgentTaskResponse `json:"task"`
+	CancelState string            `json:"cancel_state"`
+	Message     string            `json:"message"`
+}
+
 // ChatAttachmentMeta is the structured attachment metadata embedded in
 // claim responses for chat tasks. The agent uses these to run
 // `multica attachment download <id>` rather than guessing from the

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2344,15 +2344,32 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.TaskService.CancelTask(r.Context(), existing.ID)
+	result, err := h.TaskService.CancelTaskWithResult(r.Context(), existing.ID)
 	if err != nil {
 		slog.Warn("cancel task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	slog.Info("task cancelled by user", "task_id", taskID, "issue_id", uuidToString(task.IssueID))
-	writeJSON(w, http.StatusOK, taskToResponse(*task, uuidToString(issue.WorkspaceID)))
+	slog.Info("task cancel requested by user",
+		"task_id", taskID,
+		"issue_id", uuidToString(result.Task.IssueID),
+		"cancel_state", string(result.CancelState),
+	)
+	writeJSON(w, http.StatusOK, CancelTaskResponse{
+		Task:        taskToResponse(result.Task, uuidToString(issue.WorkspaceID)),
+		CancelState: string(result.CancelState),
+		Message:     cancelTaskMessage(result.CancelState),
+	})
+}
+
+func cancelTaskMessage(state service.TaskCancelState) string {
+	switch state {
+	case service.TaskCancelStateAlreadyTerminal:
+		return "Task already finished"
+	default:
+		return "Task cancelled"
+	}
 }
 
 // ListTasksByIssue returns all tasks (any status) for an issue — used for execution history.

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1163,6 +1163,86 @@ func TestCancelTask_SameIssue_Succeeds(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("CancelTask with matching issueId/taskId: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
+
+	var resp CancelTaskResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if resp.CancelState != "cancelled" {
+		t.Fatalf("cancel_state: expected cancelled, got %q", resp.CancelState)
+	}
+	if resp.Task.ID != taskID || resp.Task.Status != "cancelled" {
+		t.Fatalf("task response mismatch: id=%q status=%q", resp.Task.ID, resp.Task.Status)
+	}
+}
+
+// TestCancelTask_SameIssueTerminal_ReturnsAlreadyTerminal verifies that a
+// cancel racing with normal completion is user-facing-idempotent: if the task
+// still belongs to this issue but is already terminal, the command succeeds
+// and tells the caller why no transition happened.
+func TestCancelTask_SameIssueTerminal_ReturnsAlreadyTerminal(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID, taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'cancel-terminal-path', 'todo', 'medium', $2, 'member', 91004, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id, completed_at)
+		VALUES ($1, $2, 'completed', $3, now())
+		RETURNING id
+	`, agentID, issueID, runtimeID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create terminal task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/tasks/"+taskID+"/cancel", nil)
+	req = withURLParams(req, "id", issueID, "taskId", taskID)
+
+	testHandler.CancelTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CancelTask with terminal same-issue task: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CancelTaskResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if resp.CancelState != "already_terminal" {
+		t.Fatalf("cancel_state: expected already_terminal, got %q", resp.CancelState)
+	}
+	if resp.Task.ID != taskID || resp.Task.Status != "completed" {
+		t.Fatalf("task response mismatch: id=%q status=%q", resp.Task.ID, resp.Task.Status)
+	}
+
+	var status string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM agent_task_queue WHERE id = $1`, taskID,
+	).Scan(&status); err != nil {
+		t.Fatalf("read task status: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("terminal task status was mutated: expected 'completed', got %q", status)
+	}
 }
 
 // TestListTasksByIssue_CrossWorkspace_Returns404 verifies that task history

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -48,6 +48,19 @@ type TaskWakeupNotifier interface {
 	NotifyTaskAvailable(runtimeID, taskID string)
 }
 
+type TaskCancelState string
+
+const (
+	TaskCancelStateCancelled       TaskCancelState = "cancelled"
+	TaskCancelStateAlreadyTerminal TaskCancelState = "already_terminal"
+)
+
+type CancelTaskResult struct {
+	Task                 db.AgentTaskQueue
+	CancelState          TaskCancelState
+	CancelledChatMessage *CancelledChatMessageResult
+}
+
 // triggerSummaryMaxLen caps the snapshot length so the row stays cheap to
 // transmit (it ends up in every task list response). 200 is enough for a
 // recognisable preview of a one-paragraph comment.
@@ -831,11 +844,6 @@ type CancelledChatMessageResult struct {
 	Attachments []db.Attachment
 }
 
-type CancelTaskResult struct {
-	Task                 db.AgentTaskQueue
-	CancelledChatMessage *CancelledChatMessageResult
-}
-
 // CancelTask cancels a single task by ID. It broadcasts a task:cancelled event
 // so frontends can update immediately.
 func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.AgentTaskQueue, error) {
@@ -846,8 +854,11 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 	return &result.Task, nil
 }
 
-// CancelTaskWithResult cancels a single task and returns any chat-specific
-// cleanup result needed by user-facing callers.
+// CancelTaskWithResult cancels a single task by ID. Active tasks transition to
+// cancelled and broadcast task:cancelled; terminal tasks are returned as an
+// idempotent success so stale clients can refresh without surfacing a false
+// error. It also returns any chat-specific cleanup result needed by
+// user-facing callers.
 func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UUID) (*CancelTaskResult, error) {
 	task, err := s.Queries.CancelAgentTask(ctx, taskID)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -855,7 +866,7 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		if err != nil {
 			return nil, fmt.Errorf("cancel task: %w", err)
 		}
-		return &CancelTaskResult{Task: existing}, nil
+		return &CancelTaskResult{Task: existing, CancelState: TaskCancelStateAlreadyTerminal}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cancel task: %w", err)
@@ -868,11 +879,12 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 
-	// Broadcast cancellation as a task:failed event so frontends clear the live card
+	// Broadcast cancellation so frontends clear the live card.
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 
 	return &CancelTaskResult{
 		Task:                 task,
+		CancelState:          TaskCancelStateCancelled,
 		CancelledChatMessage: cancelledChatMessage,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Return structured issue-task cancel responses with `cancel_state: "cancelled" | "already_terminal"`.
- Preserve the legacy `TaskService.CancelTask` shape while adding `CancelTaskWithResult` for handlers that need command outcome details.
- Refresh issue execution UI after cancel and reconcile the live banner when cancel races with terminal task completion.

## Test Plan
- [x] `go test ./internal/handler -run 'TestCancelTask'`
- [x] `go test ./internal/service`
- [x] `pnpm -C packages/views test -- issues/components/agent-live-card.test.tsx`
- [x] `pnpm -C packages/core typecheck`
- [x] `pnpm -C packages/views typecheck`
- [x] `pnpm typecheck`

## Notes
- `go test ./internal/service ./internal/handler` currently fails in this local database baseline outside this change: `contact_sales_inquiry` is missing, and child-done tests hit the existing `comment_author_type_check` fixture/schema mismatch. The targeted cancel handler suite and service package pass.

Related: #3052
