### PR TITLE
feat(blueprints): add workspace blueprint export

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -563,6 +563,11 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				})
 			})
 
+			// Workspace blueprints
+			r.Route("/api/blueprints", func(r chi.Router) {
+				r.Post("/export", h.ExportBlueprint)
+			})
+
 			// Dashboard — workspace-wide token + run-time rollups for the
 			// "/{slug}/dashboard" page. Optional ?project_id filter scopes
 			// the rollup to a single project.

--- a/server/internal/blueprint/manifest.go
+++ b/server/internal/blueprint/manifest.go
@@ -1,0 +1,394 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const SchemaVersion = "multica.workspace_blueprint/v1"
+
+type Manifest struct {
+	Schema     string    `json:"schema"`
+	Name       string    `json:"name"`
+	ExportedAt string    `json:"exported_at"`
+	Squads     []Squad   `json:"squads"`
+	Agents     []Agent   `json:"agents"`
+	Skills     []Skill   `json:"skills"`
+	Warnings   []Warning `json:"warnings,omitempty"`
+}
+
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type Squad struct {
+	Ref          string        `json:"ref"`
+	Name         string        `json:"name"`
+	Description  string        `json:"description,omitempty"`
+	Instructions string        `json:"instructions,omitempty"`
+	AvatarURL    *string       `json:"avatar_url,omitempty"`
+	LeaderRef    string        `json:"leader_ref"`
+	Members      []SquadMember `json:"members"`
+}
+
+type SquadMember struct {
+	Ref  string `json:"ref"`
+	Role string `json:"role,omitempty"`
+}
+
+type Agent struct {
+	Ref                string   `json:"ref"`
+	Name               string   `json:"name"`
+	Description        string   `json:"description,omitempty"`
+	Instructions       string   `json:"instructions,omitempty"`
+	AvatarURL          *string  `json:"avatar_url,omitempty"`
+	Runtime            Runtime  `json:"runtime"`
+	Visibility         string   `json:"visibility"`
+	MaxConcurrentTasks int32    `json:"max_concurrent_tasks"`
+	CustomEnvSchema    []EnvVar `json:"custom_env_schema,omitempty"`
+	CustomArgs         []string `json:"custom_args,omitempty"`
+	MCPConfigRedacted  bool     `json:"mcp_config_redacted,omitempty"`
+	SkillRefs          []string `json:"skill_refs,omitempty"`
+}
+
+type Runtime struct {
+	Mode          string `json:"mode"`
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinking_level,omitempty"`
+}
+
+type EnvVar struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+	Secret   bool   `json:"secret"`
+}
+
+type Skill struct {
+	Ref         string          `json:"ref"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Content     string          `json:"content,omitempty"`
+	Config      json.RawMessage `json:"config"`
+	Files       []SkillFile     `json:"files,omitempty"`
+}
+
+type SkillFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type Source struct {
+	Name          string
+	ExportedAt    time.Time
+	Squads        []SourceSquad
+	SquadMembers  map[string][]SourceSquadMember
+	Agents        []SourceAgent
+	AgentSkillIDs map[string][]string
+	Skills        []SourceSkill
+	SkillFiles    map[string][]SourceSkillFile
+}
+
+type SourceSquad struct {
+	ID           string
+	Name         string
+	Description  string
+	Instructions string
+	AvatarURL    *string
+	LeaderID     string
+}
+
+type SourceSquadMember struct {
+	MemberType string
+	MemberID   string
+	Role       string
+}
+
+type SourceAgent struct {
+	ID                 string
+	Name               string
+	Description        string
+	Instructions       string
+	AvatarURL          *string
+	RuntimeID          string
+	RuntimeMode        string
+	RuntimeProvider    string
+	RuntimeConfig      json.RawMessage
+	Visibility         string
+	MaxConcurrentTasks int32
+	Model              string
+	ThinkingLevel      string
+	CustomEnv          map[string]string
+	CustomArgs         []string
+	MCPConfig          json.RawMessage
+}
+
+type SourceSkill struct {
+	ID          string
+	Name        string
+	Description string
+	Content     string
+	Config      json.RawMessage
+}
+
+type SourceSkillFile struct {
+	Path    string
+	Content string
+}
+
+func BuildManifest(src Source) (Manifest, error) {
+	exportedAt := src.ExportedAt
+	if exportedAt.IsZero() {
+		exportedAt = time.Now().UTC()
+	}
+
+	name := strings.TrimSpace(src.Name)
+	if name == "" {
+		name = "Workspace Blueprint"
+	}
+
+	squadRefs := refsFor(src.Squads, "squad", func(s SourceSquad) string { return s.ID }, func(s SourceSquad) string { return s.Name })
+	agentRefs := refsFor(src.Agents, "agent", func(a SourceAgent) string { return a.ID }, func(a SourceAgent) string { return a.Name })
+	skillRefs := refsFor(src.Skills, "skill", func(s SourceSkill) string { return s.ID }, func(s SourceSkill) string { return s.Name })
+
+	manifest := Manifest{
+		Schema:     SchemaVersion,
+		Name:       name,
+		ExportedAt: exportedAt.UTC().Format(time.RFC3339),
+		Squads:     make([]Squad, 0, len(src.Squads)),
+		Agents:     make([]Agent, 0, len(src.Agents)),
+		Skills:     make([]Skill, 0, len(src.Skills)),
+	}
+
+	for _, squad := range src.Squads {
+		leaderRef := agentRefs[squad.LeaderID]
+		members := make([]SquadMember, 0, len(src.SquadMembers[squad.ID]))
+		for _, member := range src.SquadMembers[squad.ID] {
+			if member.MemberType != "agent" {
+				continue
+			}
+			ref := agentRefs[member.MemberID]
+			if ref == "" {
+				continue
+			}
+			members = append(members, SquadMember{
+				Ref:  ref,
+				Role: member.Role,
+			})
+		}
+		manifest.Squads = append(manifest.Squads, Squad{
+			Ref:          squadRefs[squad.ID],
+			Name:         squad.Name,
+			Description:  squad.Description,
+			Instructions: squad.Instructions,
+			AvatarURL:    squad.AvatarURL,
+			LeaderRef:    leaderRef,
+			Members:      members,
+		})
+	}
+
+	for _, agent := range src.Agents {
+		skillRefsForAgent := make([]string, 0, len(src.AgentSkillIDs[agent.ID]))
+		for _, skillID := range src.AgentSkillIDs[agent.ID] {
+			if ref := skillRefs[skillID]; ref != "" {
+				skillRefsForAgent = append(skillRefsForAgent, ref)
+			}
+		}
+		sort.Strings(skillRefsForAgent)
+
+		manifest.Agents = append(manifest.Agents, Agent{
+			Ref:          agentRefs[agent.ID],
+			Name:         agent.Name,
+			Description:  agent.Description,
+			Instructions: agent.Instructions,
+			AvatarURL:    agent.AvatarURL,
+			Runtime: Runtime{
+				Mode:          agent.RuntimeMode,
+				Provider:      agent.RuntimeProvider,
+				Model:         agent.Model,
+				ThinkingLevel: agent.ThinkingLevel,
+			},
+			Visibility:         agent.Visibility,
+			MaxConcurrentTasks: agent.MaxConcurrentTasks,
+			CustomEnvSchema:    envSchema(agent.CustomEnv),
+			CustomArgs:         append([]string(nil), agent.CustomArgs...),
+			MCPConfigRedacted:  hasJSONObject(agent.MCPConfig),
+			SkillRefs:          skillRefsForAgent,
+		})
+	}
+
+	for _, skill := range src.Skills {
+		files := make([]SkillFile, 0, len(src.SkillFiles[skill.ID]))
+		for _, file := range src.SkillFiles[skill.ID] {
+			files = append(files, SkillFile{Path: file.Path, Content: file.Content})
+		}
+		config := json.RawMessage(`{}`)
+		if len(strings.TrimSpace(string(skill.Config))) > 0 {
+			config = append(json.RawMessage(nil), skill.Config...)
+		}
+		manifest.Skills = append(manifest.Skills, Skill{
+			Ref:         skillRefs[skill.ID],
+			Name:        skill.Name,
+			Description: skill.Description,
+			Content:     skill.Content,
+			Config:      config,
+			Files:       files,
+		})
+	}
+
+	if err := ValidateManifest(manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func ValidateManifest(manifest Manifest) error {
+	var errs []error
+	if manifest.Schema != SchemaVersion {
+		errs = append(errs, fmt.Errorf("schema must be %q", SchemaVersion))
+	}
+
+	seenRefs := map[string]struct{}{}
+	skillRefs := map[string]struct{}{}
+	agentRefs := map[string]struct{}{}
+
+	checkRef := func(ref, kind string) {
+		if strings.TrimSpace(ref) == "" {
+			errs = append(errs, fmt.Errorf("%s ref is required", kind))
+			return
+		}
+		if _, ok := seenRefs[ref]; ok {
+			errs = append(errs, fmt.Errorf("duplicate ref %q", ref))
+			return
+		}
+		seenRefs[ref] = struct{}{}
+	}
+
+	for _, skill := range manifest.Skills {
+		checkRef(skill.Ref, "skill")
+		skillRefs[skill.Ref] = struct{}{}
+		if strings.TrimSpace(skill.Name) == "" {
+			errs = append(errs, fmt.Errorf("skill %q name is required", skill.Ref))
+		}
+		if len(skill.Config) > 0 && !json.Valid(skill.Config) {
+			errs = append(errs, fmt.Errorf("skill %q config must be valid JSON", skill.Ref))
+		}
+		for _, file := range skill.Files {
+			if !safeSkillFilePath(file.Path) {
+				errs = append(errs, fmt.Errorf("unsafe skill file path %q in %s", file.Path, skill.Ref))
+			}
+		}
+	}
+
+	for _, agent := range manifest.Agents {
+		checkRef(agent.Ref, "agent")
+		agentRefs[agent.Ref] = struct{}{}
+		if strings.TrimSpace(agent.Name) == "" {
+			errs = append(errs, fmt.Errorf("agent %q name is required", agent.Ref))
+		}
+		if agent.Runtime.Mode != "local" && agent.Runtime.Mode != "cloud" {
+			errs = append(errs, fmt.Errorf("agent %q runtime mode must be local or cloud", agent.Ref))
+		}
+		for _, skillRef := range agent.SkillRefs {
+			if _, ok := skillRefs[skillRef]; !ok {
+				errs = append(errs, fmt.Errorf("agent %q references missing skill %q", agent.Ref, skillRef))
+			}
+		}
+	}
+
+	for _, squad := range manifest.Squads {
+		checkRef(squad.Ref, "squad")
+		if strings.TrimSpace(squad.Name) == "" {
+			errs = append(errs, fmt.Errorf("squad %q name is required", squad.Ref))
+		}
+		if squad.LeaderRef == "" {
+			errs = append(errs, fmt.Errorf("squad %q leader_ref is required", squad.Ref))
+		} else if _, ok := agentRefs[squad.LeaderRef]; !ok {
+			errs = append(errs, fmt.Errorf("squad %q references missing leader %q", squad.Ref, squad.LeaderRef))
+		}
+		for _, member := range squad.Members {
+			if _, ok := agentRefs[member.Ref]; !ok {
+				errs = append(errs, fmt.Errorf("squad %q references missing member %q", squad.Ref, member.Ref))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func refsFor[T any](items []T, kind string, idFn func(T) string, nameFn func(T) string) map[string]string {
+	refs := make(map[string]string, len(items))
+	used := map[string]int{}
+	for _, item := range items {
+		id := idFn(item)
+		if id == "" {
+			continue
+		}
+		base := slugify(nameFn(item))
+		if base == "" {
+			base = kind
+		}
+		count := used[base]
+		used[base] = count + 1
+		if count > 0 {
+			base = fmt.Sprintf("%s-%d", base, count+1)
+		}
+		refs[id] = kind + "." + base
+	}
+	return refs
+}
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = slugRe.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+func envSchema(env map[string]string) []EnvVar {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	schema := make([]EnvVar, 0, len(keys))
+	for _, key := range keys {
+		schema = append(schema, EnvVar{Name: key, Required: false, Secret: true})
+	}
+	return schema
+}
+
+func hasJSONObject(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	return trimmed != "" && trimmed != "null" && trimmed != "{}"
+}
+
+func safeSkillFilePath(p string) bool {
+	if strings.TrimSpace(p) == "" {
+		return false
+	}
+	if strings.HasPrefix(p, "/") || strings.Contains(p, "\\") {
+		return false
+	}
+	clean := path.Clean(p)
+	if clean == "." || clean != p {
+		return false
+	}
+	for _, part := range strings.Split(clean, "/") {
+		if part == ".." || part == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/blueprint/manifest_test.go
+++ b/server/internal/blueprint/manifest_test.go
@@ -1,0 +1,206 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildManifestExportsPortableRefsAndRelationships(t *testing.T) {
+	exportedAt := time.Date(2026, 5, 24, 10, 30, 0, 0, time.UTC)
+	manifest, err := BuildManifest(Source{
+		Name:       "Release Squad",
+		ExportedAt: exportedAt,
+		Squads: []SourceSquad{{
+			ID:           "squad-db-id",
+			Name:         "Release Squad",
+			Description:  "Ships weekly releases",
+			Instructions: "Coordinate release tasks.",
+			LeaderID:     "agent-lead-id",
+		}},
+		SquadMembers: map[string][]SourceSquadMember{
+			"squad-db-id": {
+				{MemberType: "agent", MemberID: "agent-lead-id", Role: "lead"},
+				{MemberType: "agent", MemberID: "agent-reviewer-id", Role: "review"},
+				{MemberType: "member", MemberID: "human-member-id", Role: "stakeholder"},
+			},
+		},
+		Agents: []SourceAgent{
+			{
+				ID:                 "agent-lead-id",
+				Name:               "Release Lead",
+				Description:        "Plans release work",
+				Instructions:       "Own the release checklist.",
+				RuntimeMode:        "local",
+				RuntimeProvider:    "codex",
+				Visibility:         "workspace",
+				MaxConcurrentTasks: 2,
+				Model:              "gpt-5.4",
+				ThinkingLevel:      "medium",
+			},
+			{
+				ID:                 "agent-reviewer-id",
+				Name:               "Release Reviewer",
+				Description:        "Reviews release notes",
+				Instructions:       "Review release notes.",
+				RuntimeMode:        "cloud",
+				RuntimeProvider:    "multica_agent",
+				Visibility:         "private",
+				MaxConcurrentTasks: 1,
+			},
+		},
+		AgentSkillIDs: map[string][]string{
+			"agent-lead-id": {"skill-runbook-id"},
+		},
+		Skills: []SourceSkill{{
+			ID:          "skill-runbook-id",
+			Name:        "Release Runbook",
+			Description: "Release process",
+			Content:     "# Release",
+			Config:      json.RawMessage(`{"scope":"release"}`),
+		}},
+		SkillFiles: map[string][]SourceSkillFile{
+			"skill-runbook-id": {
+				{Path: "steps/checklist.md", Content: "- Verify changelog"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest returned error: %v", err)
+	}
+
+	if manifest.Schema != SchemaVersion {
+		t.Fatalf("schema = %q, want %q", manifest.Schema, SchemaVersion)
+	}
+	if manifest.ExportedAt != exportedAt.Format(time.RFC3339) {
+		t.Fatalf("exported_at = %q, want %q", manifest.ExportedAt, exportedAt.Format(time.RFC3339))
+	}
+	if len(manifest.Squads) != 1 {
+		t.Fatalf("squads len = %d, want 1", len(manifest.Squads))
+	}
+	squad := manifest.Squads[0]
+	if squad.Ref != "squad.release-squad" {
+		t.Fatalf("squad ref = %q, want portable slug ref", squad.Ref)
+	}
+	if squad.LeaderRef != "agent.release-lead" {
+		t.Fatalf("leader_ref = %q, want agent.release-lead", squad.LeaderRef)
+	}
+	if len(squad.Members) != 2 {
+		t.Fatalf("agent squad members len = %d, want 2", len(squad.Members))
+	}
+	if squad.Members[1].Ref != "agent.release-reviewer" {
+		t.Fatalf("second member ref = %q, want agent.release-reviewer", squad.Members[1].Ref)
+	}
+
+	if len(manifest.Agents) != 2 {
+		t.Fatalf("agents len = %d, want 2", len(manifest.Agents))
+	}
+	lead := manifest.Agents[0]
+	if lead.Ref != "agent.release-lead" {
+		t.Fatalf("agent ref = %q, want agent.release-lead", lead.Ref)
+	}
+	if len(lead.SkillRefs) != 1 || lead.SkillRefs[0] != "skill.release-runbook" {
+		t.Fatalf("agent skill_refs = %#v, want [skill.release-runbook]", lead.SkillRefs)
+	}
+	if lead.Runtime.Provider != "codex" {
+		t.Fatalf("runtime provider = %q, want codex", lead.Runtime.Provider)
+	}
+
+	if len(manifest.Skills) != 1 {
+		t.Fatalf("skills len = %d, want 1", len(manifest.Skills))
+	}
+	skill := manifest.Skills[0]
+	if skill.Ref != "skill.release-runbook" {
+		t.Fatalf("skill ref = %q, want skill.release-runbook", skill.Ref)
+	}
+	if len(skill.Files) != 1 || skill.Files[0].Path != "steps/checklist.md" {
+		t.Fatalf("skill files = %#v, want steps/checklist.md", skill.Files)
+	}
+}
+
+func TestBuildManifestRedactsSensitiveAgentFields(t *testing.T) {
+	manifest, err := BuildManifest(Source{
+		Name: "Secret Squad",
+		Agents: []SourceAgent{{
+			ID:                 "agent-secret-id",
+			Name:               "Secret Agent",
+			RuntimeID:          "runtime-db-id",
+			RuntimeMode:        "local",
+			RuntimeProvider:    "codex",
+			RuntimeConfig:      json.RawMessage(`{"workdir":"/private/tmp/project","provider":"codex"}`),
+			Visibility:         "private",
+			MaxConcurrentTasks: 1,
+			CustomEnv: map[string]string{
+				"GITHUB_TOKEN": "ghp_secret",
+				"OPENAI_KEY":   "sk-secret",
+			},
+			CustomArgs: []string{"--safe-mode"},
+			MCPConfig:  json.RawMessage(`{"servers":{"github":{"env":{"GITHUB_TOKEN":"ghp_secret"}}}}`),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest returned error: %v", err)
+	}
+	if len(manifest.Agents) != 1 {
+		t.Fatalf("agents len = %d, want 1", len(manifest.Agents))
+	}
+	agent := manifest.Agents[0]
+
+	encoded, err := json.Marshal(agent)
+	if err != nil {
+		t.Fatalf("marshal agent: %v", err)
+	}
+	for _, forbidden := range []string{"ghp_secret", "sk-secret", "runtime-db-id", "/private/tmp/project"} {
+		if containsJSON(encoded, forbidden) {
+			t.Fatalf("agent manifest leaked %q: %s", forbidden, encoded)
+		}
+	}
+	if len(agent.CustomEnvSchema) != 2 {
+		t.Fatalf("custom_env_schema len = %d, want 2", len(agent.CustomEnvSchema))
+	}
+	if agent.CustomEnvSchema[0].Name != "GITHUB_TOKEN" || !agent.CustomEnvSchema[0].Secret {
+		t.Fatalf("first env schema = %#v, want secret GITHUB_TOKEN", agent.CustomEnvSchema[0])
+	}
+	if !agent.MCPConfigRedacted {
+		t.Fatalf("mcp_config_redacted = false, want true")
+	}
+	if len(agent.CustomArgs) != 1 || agent.CustomArgs[0] != "--safe-mode" {
+		t.Fatalf("custom_args = %#v, want preserved non-secret args", agent.CustomArgs)
+	}
+}
+
+func TestValidateManifestRejectsDuplicateRefsAndUnsafeSkillFiles(t *testing.T) {
+	manifest := Manifest{
+		Schema: SchemaVersion,
+		Name:   "Invalid",
+		Agents: []Agent{
+			{Ref: "agent.same", Name: "A", Runtime: Runtime{Mode: "local"}},
+			{Ref: "agent.same", Name: "B", Runtime: Runtime{Mode: "cloud"}},
+		},
+		Skills: []Skill{{
+			Ref:   "skill.bad",
+			Name:  "Bad Skill",
+			Files: []SkillFile{{Path: "../secret.txt", Content: "nope"}},
+		}},
+	}
+
+	err := ValidateManifest(manifest)
+	if err == nil {
+		t.Fatal("ValidateManifest returned nil, want duplicate ref/path error")
+	}
+	if !containsError(err, "duplicate ref") {
+		t.Fatalf("ValidateManifest error = %v, want duplicate ref", err)
+	}
+	if !containsError(err, "unsafe skill file path") {
+		t.Fatalf("ValidateManifest error = %v, want unsafe skill file path", err)
+	}
+}
+
+func containsJSON(raw []byte, needle string) bool {
+	return json.Valid(raw) && strings.Contains(string(raw), needle)
+}
+
+func containsError(err error, needle string) bool {
+	return err != nil && strings.Contains(err.Error(), needle)
+}

--- a/server/internal/handler/blueprint.go
+++ b/server/internal/handler/blueprint.go
@@ -1,0 +1,283 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/multica-ai/multica/server/internal/blueprint"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type ExportBlueprintRequest struct {
+	Name     string   `json:"name"`
+	SquadIDs []string `json:"squad_ids"`
+	AgentIDs []string `json:"agent_ids"`
+	SkillIDs []string `json:"skill_ids"`
+}
+
+func (h *Handler) ExportBlueprint(w http.ResponseWriter, r *http.Request) {
+	workspaceID := h.resolveWorkspaceID(r)
+	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
+		return
+	}
+
+	var req ExportBlueprintRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(req.SquadIDs) == 0 && len(req.AgentIDs) == 0 && len(req.SkillIDs) == 0 {
+		writeError(w, http.StatusBadRequest, "at least one squad_id, agent_id, or skill_id is required")
+		return
+	}
+
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	squadIDs, ok := parseBlueprintExportIDs(w, req.SquadIDs, "squad_ids")
+	if !ok {
+		return
+	}
+	explicitAgentIDs, ok := parseBlueprintExportIDs(w, req.AgentIDs, "agent_ids")
+	if !ok {
+		return
+	}
+	explicitSkillIDs, ok := parseBlueprintExportIDs(w, req.SkillIDs, "skill_ids")
+	if !ok {
+		return
+	}
+
+	source := blueprint.Source{
+		Name:          req.Name,
+		SquadMembers:  map[string][]blueprint.SourceSquadMember{},
+		AgentSkillIDs: map[string][]string{},
+		SkillFiles:    map[string][]blueprint.SourceSkillFile{},
+	}
+
+	agentIDs := orderedIDSet{}
+	skillIDs := orderedIDSet{}
+
+	for _, squadID := range squadIDs {
+		squad, err := h.Queries.GetSquadInWorkspace(r.Context(), db.GetSquadInWorkspaceParams{
+			ID:          parseUUID(squadID),
+			WorkspaceID: wsUUID,
+		})
+		if err != nil {
+			if isNotFound(err) {
+				writeError(w, http.StatusNotFound, "squad not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "failed to load squad")
+			return
+		}
+		source.Squads = append(source.Squads, sourceSquadFromDB(squad))
+		agentIDs.add(uuidToString(squad.LeaderID))
+
+		members, err := h.Queries.ListSquadMembers(r.Context(), squad.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load squad members")
+			return
+		}
+		memberSources := make([]blueprint.SourceSquadMember, 0, len(members))
+		for _, member := range members {
+			memberID := uuidToString(member.MemberID)
+			memberSources = append(memberSources, blueprint.SourceSquadMember{
+				MemberType: member.MemberType,
+				MemberID:   memberID,
+				Role:       member.Role,
+			})
+			if member.MemberType == "agent" {
+				agentIDs.add(memberID)
+			}
+		}
+		source.SquadMembers[uuidToString(squad.ID)] = memberSources
+	}
+
+	for _, agentID := range explicitAgentIDs {
+		agentIDs.add(agentID)
+	}
+	for _, skillID := range explicitSkillIDs {
+		skillIDs.add(skillID)
+	}
+
+	userID := requestUserID(r)
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	for _, agentID := range agentIDs.ids {
+		agent, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
+			ID:          parseUUID(agentID),
+			WorkspaceID: wsUUID,
+		})
+		if err != nil {
+			if isNotFound(err) {
+				writeError(w, http.StatusNotFound, "agent not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "failed to load agent")
+			return
+		}
+		if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
+			writeError(w, http.StatusForbidden, "you do not have access to this agent")
+			return
+		}
+
+		runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{
+			ID:          agent.RuntimeID,
+			WorkspaceID: wsUUID,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load agent runtime")
+			return
+		}
+		source.Agents = append(source.Agents, sourceAgentFromDB(agent, runtime.Provider))
+
+		agentSkills, err := h.Queries.ListAgentSkills(r.Context(), agent.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+			return
+		}
+		for _, skill := range agentSkills {
+			skillID := uuidToString(skill.ID)
+			source.AgentSkillIDs[agentID] = append(source.AgentSkillIDs[agentID], skillID)
+			skillIDs.add(skillID)
+		}
+	}
+
+	for _, skillID := range skillIDs.ids {
+		skill, err := h.Queries.GetSkillInWorkspace(r.Context(), db.GetSkillInWorkspaceParams{
+			ID:          parseUUID(skillID),
+			WorkspaceID: wsUUID,
+		})
+		if err != nil {
+			if isNotFound(err) {
+				writeError(w, http.StatusNotFound, "skill not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "failed to load skill")
+			return
+		}
+		source.Skills = append(source.Skills, sourceSkillFromDB(skill))
+
+		files, err := h.Queries.ListSkillFiles(r.Context(), skill.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load skill files")
+			return
+		}
+		fileSources := make([]blueprint.SourceSkillFile, 0, len(files))
+		for _, file := range files {
+			fileSources = append(fileSources, blueprint.SourceSkillFile{
+				Path:    file.Path,
+				Content: file.Content,
+			})
+		}
+		source.SkillFiles[skillID] = fileSources
+	}
+
+	manifest, err := blueprint.BuildManifest(source)
+	if err != nil {
+		slog.Warn("blueprint export failed", "workspace_id", workspaceID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to build blueprint")
+		return
+	}
+	writeJSON(w, http.StatusOK, manifest)
+}
+
+func parseBlueprintExportIDs(w http.ResponseWriter, ids []string, fieldName string) ([]string, bool) {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		u, ok := parseUUIDOrBadRequest(w, id, fieldName)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, uuidToString(u))
+	}
+	return out, true
+}
+
+type orderedIDSet struct {
+	ids  []string
+	seen map[string]struct{}
+}
+
+func (s *orderedIDSet) add(id string) {
+	if id == "" {
+		return
+	}
+	if s.seen == nil {
+		s.seen = map[string]struct{}{}
+	}
+	if _, ok := s.seen[id]; ok {
+		return
+	}
+	s.seen[id] = struct{}{}
+	s.ids = append(s.ids, id)
+}
+
+func sourceSquadFromDB(s db.Squad) blueprint.SourceSquad {
+	return blueprint.SourceSquad{
+		ID:           uuidToString(s.ID),
+		Name:         s.Name,
+		Description:  s.Description,
+		Instructions: s.Instructions,
+		AvatarURL:    textToPtr(s.AvatarUrl),
+		LeaderID:     uuidToString(s.LeaderID),
+	}
+}
+
+func sourceAgentFromDB(a db.Agent, runtimeProvider string) blueprint.SourceAgent {
+	customEnv := map[string]string{}
+	if len(a.CustomEnv) > 0 {
+		if err := json.Unmarshal(a.CustomEnv, &customEnv); err != nil {
+			slog.Warn("failed to unmarshal agent custom_env for blueprint export", "agent_id", uuidToString(a.ID), "error", err)
+			customEnv = map[string]string{}
+		}
+	}
+
+	customArgs := []string{}
+	if len(a.CustomArgs) > 0 {
+		if err := json.Unmarshal(a.CustomArgs, &customArgs); err != nil {
+			slog.Warn("failed to unmarshal agent custom_args for blueprint export", "agent_id", uuidToString(a.ID), "error", err)
+			customArgs = []string{}
+		}
+	}
+
+	var mcpConfig json.RawMessage
+	if len(a.McpConfig) > 0 {
+		mcpConfig = append(json.RawMessage(nil), a.McpConfig...)
+	}
+
+	return blueprint.SourceAgent{
+		ID:                 uuidToString(a.ID),
+		Name:               a.Name,
+		Description:        a.Description,
+		Instructions:       a.Instructions,
+		AvatarURL:          textToPtr(a.AvatarUrl),
+		RuntimeID:          uuidToString(a.RuntimeID),
+		RuntimeMode:        a.RuntimeMode,
+		RuntimeProvider:    runtimeProvider,
+		RuntimeConfig:      append(json.RawMessage(nil), a.RuntimeConfig...),
+		Visibility:         a.Visibility,
+		MaxConcurrentTasks: a.MaxConcurrentTasks,
+		Model:              a.Model.String,
+		ThinkingLevel:      a.ThinkingLevel.String,
+		CustomEnv:          customEnv,
+		CustomArgs:         customArgs,
+		MCPConfig:          mcpConfig,
+	}
+}
+
+func sourceSkillFromDB(s db.Skill) blueprint.SourceSkill {
+	config := json.RawMessage(`{}`)
+	if len(s.Config) > 0 {
+		config = append(json.RawMessage(nil), s.Config...)
+	}
+	return blueprint.SourceSkill{
+		ID:          uuidToString(s.ID),
+		Name:        s.Name,
+		Description: s.Description,
+		Content:     s.Content,
+		Config:      config,
+	}
+}

--- a/server/internal/handler/blueprint_export_test.go
+++ b/server/internal/handler/blueprint_export_test.go
@@ -1,0 +1,187 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/blueprint"
+)
+
+func TestExportBlueprint_ExportsSelectedSquadGraphAndRedactsSecrets(t *testing.T) {
+	ctx := context.Background()
+	leaderID := insertBlueprintExportAgent(t, "Blueprint Release Lead", map[string]string{
+		"GITHUB_TOKEN": "ghp_secret",
+	}, []byte(`{"servers":{"github":{"env":{"GITHUB_TOKEN":"ghp_secret"}}}}`))
+	skillID := insertBlueprintExportSkill(t, "Blueprint Release Runbook", "# Release")
+	insertBlueprintExportSkillFile(t, skillID, "steps/checklist.md", "- Verify changelog")
+	linkBlueprintExportAgentSkill(t, leaderID, skillID)
+	squadID := insertBlueprintExportSquad(t, "Blueprint Release Squad", leaderID)
+	addBlueprintExportSquadMember(t, squadID, "agent", leaderID, "lead")
+	addBlueprintExportSquadMember(t, squadID, "member", testUserID, "stakeholder")
+
+	req := newRequest("POST", "/api/blueprints/export?workspace_id="+testWorkspaceID, map[string]any{
+		"name":      "Release Package",
+		"squad_ids": []string{squadID},
+	})
+	w := httptest.NewRecorder()
+
+	testHandler.ExportBlueprint(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ExportBlueprint: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+
+	var manifest blueprint.Manifest
+	if err := json.Unmarshal([]byte(body), &manifest); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if manifest.Schema != blueprint.SchemaVersion {
+		t.Fatalf("schema = %q, want %q", manifest.Schema, blueprint.SchemaVersion)
+	}
+	if len(manifest.Squads) != 1 || manifest.Squads[0].LeaderRef == "" {
+		t.Fatalf("squads = %#v, want selected squad with leader_ref", manifest.Squads)
+	}
+	if len(manifest.Squads[0].Members) != 1 {
+		t.Fatalf("agent members len = %d, want 1 human members excluded", len(manifest.Squads[0].Members))
+	}
+	if len(manifest.Agents) != 1 {
+		t.Fatalf("agents len = %d, want 1", len(manifest.Agents))
+	}
+	if len(manifest.Agents[0].SkillRefs) != 1 {
+		t.Fatalf("agent skill_refs = %#v, want one runbook skill", manifest.Agents[0].SkillRefs)
+	}
+	if manifest.Agents[0].Runtime.Provider != "handler_test_runtime" {
+		t.Fatalf("runtime provider = %q, want handler_test_runtime", manifest.Agents[0].Runtime.Provider)
+	}
+	if len(manifest.Agents[0].CustomEnvSchema) != 1 || manifest.Agents[0].CustomEnvSchema[0].Name != "GITHUB_TOKEN" {
+		t.Fatalf("custom_env_schema = %#v, want redacted GITHUB_TOKEN schema", manifest.Agents[0].CustomEnvSchema)
+	}
+	if !manifest.Agents[0].MCPConfigRedacted {
+		t.Fatalf("mcp_config_redacted = false, want true")
+	}
+	if len(manifest.Skills) != 1 || len(manifest.Skills[0].Files) != 1 {
+		t.Fatalf("skills = %#v, want runbook with one file", manifest.Skills)
+	}
+
+	for _, forbidden := range []string{leaderID, skillID, squadID, testWorkspaceID, testRuntimeID, "ghp_secret"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("manifest leaked local id or secret %q: %s", forbidden, body)
+		}
+	}
+
+	var exists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM squad WHERE id = $1)`, squadID).Scan(&exists); err != nil {
+		t.Fatalf("verify squad still exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("export should not mutate source squad")
+	}
+}
+
+func insertBlueprintExportAgent(t *testing.T, name string, customEnv map[string]string, mcpConfig []byte) string {
+	t.Helper()
+	envRaw, err := json.Marshal(customEnv)
+	if err != nil {
+		t.Fatalf("marshal custom env: %v", err)
+	}
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args, mcp_config, model, thinking_level
+		)
+		VALUES ($1, $2, 'Blueprint export fixture', 'cloud', '{"workdir":"/private/tmp/should-not-export"}'::jsonb,
+			$3, 'private', 2, $4, 'Run the release process.', $5::jsonb, '["--safe-mode"]'::jsonb, $6, 'gpt-5.4', 'medium')
+		RETURNING id
+	`, testWorkspaceID, name, testRuntimeID, testUserID, envRaw, mcpConfig).Scan(&agentID); err != nil {
+		t.Fatalf("insert blueprint export agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+	return agentID
+}
+
+func insertBlueprintExportSkill(t *testing.T, name, content string) string {
+	t.Helper()
+	name = name + "-" + t.Name()
+	var skillID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
+		VALUES ($1, $2, 'Blueprint export fixture', $3, '{"scope":"release"}'::jsonb, $4)
+		RETURNING id
+	`, testWorkspaceID, name, content, testUserID).Scan(&skillID); err != nil {
+		t.Fatalf("insert blueprint export skill: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, skillID)
+	})
+	return skillID
+}
+
+func insertBlueprintExportSkillFile(t *testing.T, skillID, filePath, content string) {
+	t.Helper()
+	var fileID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO skill_file (skill_id, path, content)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, skillID, filePath, content).Scan(&fileID); err != nil {
+		t.Fatalf("insert blueprint export skill file: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM skill_file WHERE id = $1`, fileID)
+	})
+}
+
+func linkBlueprintExportAgentSkill(t *testing.T, agentID, skillID string) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO agent_skill (agent_id, skill_id)
+		VALUES ($1, $2)
+	`, agentID, skillID); err != nil {
+		t.Fatalf("link blueprint export agent skill: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_skill WHERE agent_id = $1 AND skill_id = $2`, agentID, skillID)
+	})
+}
+
+func insertBlueprintExportSquad(t *testing.T, name, leaderID string) string {
+	t.Helper()
+	name = name + "-" + t.Name()
+	var squadID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id, instructions)
+		VALUES ($1, $2, 'Blueprint export fixture', $3, $4, 'Coordinate the release squad.')
+		RETURNING id
+	`, testWorkspaceID, name, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("insert blueprint export squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+	return squadID
+}
+
+func addBlueprintExportSquadMember(t *testing.T, squadID, memberType, memberID, role string) {
+	t.Helper()
+	var rowID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO squad_member (squad_id, member_type, member_id, role)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, squadID, memberType, memberID, role).Scan(&rowID); err != nil {
+		t.Fatalf("insert blueprint export squad member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad_member WHERE id = $1`, rowID)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Adds the first backend slice for workspace blueprints: a workspace-member API endpoint that exports selected squads, agents, and skills into a portable JSON manifest.

This is intentionally export-only. Import preview/apply, archive packaging, and UI entry points should land in follow-up PRs so the review surface stays small.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `server/internal/blueprint` manifest types, portable ref generation, validation, and secret redaction rules.
- Added `POST /api/blueprints/export` under the existing workspace-member route group.
- Export graph expands selected squads to leader/member agents, and selected/exported agents to their attached skills and skill files.
- Manifest excludes DB IDs, workspace IDs, runtime IDs, `runtime_config`, `custom_env` values, and raw `mcp_config`; env names are preserved as `custom_env_schema`.
- Added unit coverage for manifest relationships, redaction, duplicate ref validation, and unsafe skill file paths.
- Added handler coverage for squad graph export, skill file inclusion, no mutation, and no local ID/secret leakage.

## How to Test

1. `cd server && go test -count=1 ./internal/blueprint ./internal/handler -run 'TestBuildManifest|TestValidateManifest|TestExportBlueprint_ExportsSelectedSquadGraphAndRedactsSecrets'`
2. `cd server && go test -count=1 ./cmd/server -run '^$'`

I also tried `go test ./internal/blueprint ./internal/handler ./cmd/server`; the new blueprint tests passed, but the broader local run hit existing environment/fixture failures: `contact_sales_inquiry` missing in the local DB for contact sales tests, and readiness integration tests returning 503 in the current local dependency state.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Planned the workspace blueprint feature as split PRs, then implemented the first backend export slice with test-first coverage for manifest portability, secret redaction, and handler graph export.

## Screenshots (optional)

N/A — backend API only.
