### PR TITLE
Fix: Add parent_issue_id to autopilot-created issues

### DIFF
--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -170,7 +170,7 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 		// the same agent the issue listener will end up enqueueing.
 		CreatorType:   "agent",
 		CreatorID:     leader.ID,
-		ParentIssueID: pgtype.UUID{},
+		ParentIssueID: ap.ParentIssueID,
 		Position:      0,
 		StartDate:     pgtype.Timestamptz{},
 		DueDate:       pgtype.Timestamptz{},

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -130,6 +130,7 @@ type Autopilot struct {
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
 	AssigneeType       string             `json:"assignee_type"`
 	ProjectID          pgtype.UUID        `json:"project_id"`
+	ParentIssueID      pgtype.UUID        `json:"parent_issue_id"`
 }
 
 type AutopilotRun struct {


### PR DESCRIPTION
Fixes #3131

This PR addresses issue #3131 by adding a `ParentIssueID` field to the `Autopilot` struct and updating the `dispatchCreateIssue` function to use this field when creating issues. This enables autopilots to create sub-issues by correctly propagating the `parent_issue_id` to the database.