### PR TITLE
feat: add issue view swimlane (MUL-2607)

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -79,15 +79,7 @@ export interface IssueViewState {
   listCollapsedStatuses: IssueStatus[];
   ganttZoom: GanttZoom;
   ganttShowCompleted: boolean;
-  // User-defined order for swimlane view parent lanes, keyed by parent
-  // issue id.  Lanes whose id is absent from this array fall back to the
-  // natural order from the data; "No parent" is always pinned at the top
-  // and is not represented here.  Persisted per-workspace.
   swimlaneOrder: string[];
-  // Collapsed swimlane keys.  Entries are parent issue ids, plus the
-  // sentinel string `"none"` for the "No parent" lane.  Membership ==
-  // collapsed; absence == expanded.  Persisted per-workspace so collapsed
-  // state survives reload — mirrors `listCollapsedStatuses`.
   collapsedSwimlanes: string[];
   setViewMode: (mode: ViewMode) => void;
   setGanttZoom: (zoom: GanttZoom) => void;

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -9,7 +9,7 @@ import { ALL_STATUSES } from "../config";
 import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
-export type ViewMode = "board" | "list" | "gantt";
+export type ViewMode = "board" | "list" | "gantt" | "swimlane";
 export type GanttZoom = "day" | "week" | "month";
 export type IssueGrouping = "status" | "assignee";
 export type SortField = "position" | "priority" | "start_date" | "due_date" | "created_at" | "title";

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -79,6 +79,16 @@ export interface IssueViewState {
   listCollapsedStatuses: IssueStatus[];
   ganttZoom: GanttZoom;
   ganttShowCompleted: boolean;
+  // User-defined order for swimlane view parent lanes, keyed by parent
+  // issue id.  Lanes whose id is absent from this array fall back to the
+  // natural order from the data; "No parent" is always pinned at the top
+  // and is not represented here.  Persisted per-workspace.
+  swimlaneOrder: string[];
+  // Collapsed swimlane keys.  Entries are parent issue ids, plus the
+  // sentinel string `"none"` for the "No parent" lane.  Membership ==
+  // collapsed; absence == expanded.  Persisted per-workspace so collapsed
+  // state survives reload — mirrors `listCollapsedStatuses`.
+  collapsedSwimlanes: string[];
   setViewMode: (mode: ViewMode) => void;
   setGanttZoom: (zoom: GanttZoom) => void;
   toggleGanttShowCompleted: () => void;
@@ -99,6 +109,8 @@ export interface IssueViewState {
   setSortDirection: (dir: SortDirection) => void;
   toggleCardProperty: (key: keyof CardProperties) => void;
   toggleListCollapsed: (status: IssueStatus) => void;
+  setSwimlaneOrder: (order: string[]) => void;
+  toggleSwimlaneCollapsed: (key: string) => void;
 }
 
 export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): IssueViewState => ({
@@ -128,6 +140,8 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   listCollapsedStatuses: [],
   ganttZoom: "week",
   ganttShowCompleted: false,
+  swimlaneOrder: [],
+  collapsedSwimlanes: [],
 
   setViewMode: (mode) => set({ viewMode: mode }),
   setGanttZoom: (zoom) => set({ ganttZoom: zoom }),
@@ -233,6 +247,13 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.listCollapsedStatuses.filter((s) => s !== status)
         : [...state.listCollapsedStatuses, status],
     })),
+  setSwimlaneOrder: (order) => set({ swimlaneOrder: order }),
+  toggleSwimlaneCollapsed: (key) =>
+    set((state) => ({
+      collapsedSwimlanes: state.collapsedSwimlanes.includes(key)
+        ? state.collapsedSwimlanes.filter((k) => k !== key)
+        : [...state.collapsedSwimlanes, key],
+    })),
 });
 
 export const viewStorePersistOptions = (name: string) => ({
@@ -259,6 +280,8 @@ export const viewStorePersistOptions = (name: string) => ({
     listCollapsedStatuses: state.listCollapsedStatuses,
     ganttZoom: state.ganttZoom,
     ganttShowCompleted: state.ganttShowCompleted,
+    swimlaneOrder: state.swimlaneOrder,
+    collapsedSwimlanes: state.collapsedSwimlanes,
   }),
   // Default Zustand merge is shallow, so a persisted `cardProperties` snapshot
   // saved before a new toggle was introduced wins entirely and the new key is

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -16,9 +16,7 @@ import {
 } from "@dnd-kit/core";
 import type { QueryKey } from "@tanstack/react-query";
 import { arrayMove } from "@dnd-kit/sortable";
-import { Eye, MoreHorizontal } from "lucide-react";
 import type { Issue, IssueAssigneeGroup, IssueAssigneeType, IssueStatus, UpdateIssueRequest } from "@multica/core/types";
-import { Button } from "@multica/ui/components/ui/button";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { AssigneeGroupedIssuesFilter, MyIssuesFilter } from "@multica/core/issues/queries";
 import {
@@ -33,6 +31,7 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { StatusIcon } from "./status-icon";
 import { BoardColumn, BOARD_CARD_WIDTH, type BoardColumnGroup } from "./board-column";
 import { BoardCardContent } from "./board-card";
+import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
@@ -534,7 +533,7 @@ export function BoardView({
         )}
 
         {grouping === "status" && hiddenStatuses.length > 0 && (
-          <HiddenColumnsPanel
+          <BoardHiddenColumnsPanel
             hiddenStatuses={hiddenStatuses}
             myIssuesOpts={myIssuesOpts}
           />
@@ -637,74 +636,41 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   );
 });
 
-function HiddenColumnsPanel({
-  hiddenStatuses,
-  myIssuesOpts,
-}: {
-  hiddenStatuses: IssueStatus[];
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
-}) {
-  const { t } = useT("issues");
-  return (
-    <div className="flex w-[240px] shrink-0 flex-col">
-      <div className="mb-2 flex items-center gap-2 px-1">
-        <span className="text-sm font-medium text-muted-foreground">
-          {t(($) => $.board.hidden_columns_label)}
-        </span>
-      </div>
-      <div className="flex-1 space-y-0.5">
-        {hiddenStatuses.map((status) => (
-          <HiddenColumnRow
-            key={status}
-            status={status}
-            myIssuesOpts={myIssuesOpts}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function HiddenColumnRow({
+/**
+ * Board-view-specific row that pulls the server-aggregated total from
+ * `useLoadMoreByStatus` and hands it to the shared {@link HiddenColumnRow}.
+ * Lives here (not in `hidden-columns-panel.tsx`) so the shared panel stays
+ * free of `useLoadMoreByStatus` / `myIssuesOpts` coupling — the swimlane
+ * uses an in-memory total instead.
+ */
+function BoardHiddenColumnRow({
   status,
   myIssuesOpts,
 }: {
   status: IssueStatus;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
-  const { t } = useT("issues");
-  const viewStoreApi = useViewStoreApi();
   const { total } = useLoadMoreByStatus(status, myIssuesOpts);
+  return <HiddenColumnRow status={status} total={total} />;
+}
+
+function BoardHiddenColumnsPanel({
+  hiddenStatuses,
+  myIssuesOpts,
+}: {
+  hiddenStatuses: IssueStatus[];
+  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+}) {
   return (
-    <div className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50">
-      <div className="flex items-center gap-2">
-        <StatusIcon status={status} className="h-3.5 w-3.5" />
-        <span className="text-sm">{t(($) => $.status[status])}</span>
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs text-muted-foreground">{total}</span>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="rounded-full text-muted-foreground"
-              >
-                <MoreHorizontal className="size-3.5" />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onClick={() => viewStoreApi.getState().showStatus(status)}
-            >
-              <Eye className="size-3.5" />
-              {t(($) => $.board.show_column)}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
+    <HiddenColumnsPanel
+      hiddenStatuses={hiddenStatuses}
+      renderRow={(status) => (
+        <BoardHiddenColumnRow
+          key={status}
+          status={status}
+          myIssuesOpts={myIssuesOpts}
+        />
+      )}
+    />
   );
 }

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -19,16 +19,9 @@ import { arrayMove } from "@dnd-kit/sortable";
 import type { Issue, IssueAssigneeGroup, IssueAssigneeType, IssueStatus, UpdateIssueRequest } from "@multica/core/types";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { AssigneeGroupedIssuesFilter, MyIssuesFilter } from "@multica/core/issues/queries";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@multica/ui/components/ui/dropdown-menu";
-import { useViewStoreApi, useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { StatusIcon } from "./status-icon";
 import { BoardColumn, BOARD_CARD_WIDTH, type BoardColumnGroup } from "./board-column";
 import { BoardCardContent } from "./board-card";
 import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";

--- a/packages/views/issues/components/hidden-columns-panel.tsx
+++ b/packages/views/issues/components/hidden-columns-panel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Eye, MoreHorizontal } from "lucide-react";
+import type { IssueStatus } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@multica/ui/components/ui/dropdown-menu";
+import { useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
+import { StatusIcon } from "./status-icon";
+import { useT } from "../../i18n";
+
+/**
+ * Single source of truth for the "Hidden columns" side panel rendered by
+ * the kanban-style views (board and swimlane).
+ *
+ * Each consumer renders its own per-row count via the {@link renderRow} slot —
+ * the board uses `useLoadMoreByStatus` to fetch the workspace-wide aggregate,
+ * while the swimlane uses an in-memory total derived from already-loaded
+ * issues. Centralising the chrome here keeps a future view (calendar /
+ * timeline / etc.) from forking yet another copy.
+ */
+export function HiddenColumnsPanel({
+  hiddenStatuses,
+  renderRow,
+}: {
+  hiddenStatuses: IssueStatus[];
+  renderRow: (status: IssueStatus) => React.ReactNode;
+}) {
+  const { t } = useT("issues");
+  return (
+    <div className="flex w-[240px] shrink-0 flex-col">
+      <div className="mb-2 flex items-center gap-2 px-1">
+        <span className="text-sm font-medium text-muted-foreground">
+          {t(($) => $.board.hidden_columns_label)}
+        </span>
+      </div>
+      <div className="flex-1 space-y-0.5">
+        {hiddenStatuses.map((status) => renderRow(status))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One row inside {@link HiddenColumnsPanel}. Pure presentational — the caller
+ * computes `total` however it likes (cached query vs. in-memory aggregate).
+ */
+export function HiddenColumnRow({
+  status,
+  total,
+}: {
+  status: IssueStatus;
+  total: number;
+}) {
+  const { t } = useT("issues");
+  const viewStoreApi = useViewStoreApi();
+  return (
+    <div className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50">
+      <div className="flex items-center gap-2">
+        <StatusIcon status={status} className="h-3.5 w-3.5" />
+        <span className="text-sm">{t(($) => $.status[status])}</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">{total}</span>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t(($) => $.board.show_column)}
+                className="rounded-full text-muted-foreground"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={() => viewStoreApi.getState().showStatus(status)}
+            >
+              <Eye className="size-3.5" />
+              {t(($) => $.board.show_column)}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -19,6 +19,7 @@ import {
   User,
   UserMinus,
   UserPen,
+  Waves,
 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import {
@@ -995,6 +996,8 @@ export function IssueDisplayControls({
                           <Columns3 className="size-3.5" />
                         ) : viewMode === "gantt" && allowGantt ? (
                           <ChartGantt className="size-3.5" />
+                        ) : viewMode === "swimlane" ? (
+                          <Waves className="size-3.5" />
                         ) : (
                           <List className="size-3.5" />
                         )}
@@ -1002,6 +1005,8 @@ export function IssueDisplayControls({
                           ? t(($) => $.view.board)
                           : viewMode === "gantt" && allowGantt
                           ? t(($) => $.view.gantt)
+                          : viewMode === "swimlane"
+                          ? t(($) => $.view.swimlane)
                           : t(($) => $.view.list)}
                       </Button>
                     }
@@ -1013,6 +1018,8 @@ export function IssueDisplayControls({
                   ? t(($) => $.view.tooltip_board)
                   : viewMode === "gantt" && allowGantt
                   ? t(($) => $.view.tooltip_gantt)
+                  : viewMode === "swimlane"
+                  ? t(($) => $.view.tooltip_swimlane)
                   : t(($) => $.view.tooltip_list)}
               </TooltipContent>
             </Tooltip>
@@ -1033,6 +1040,10 @@ export function IssueDisplayControls({
                     {t(($) => $.view.gantt)}
                   </DropdownMenuItem>
                 )}
+                <DropdownMenuItem onClick={() => act.setViewMode("swimlane")}>
+                  <Waves />
+                  {t(($) => $.view.swimlane)}
+                </DropdownMenuItem>
               </DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -221,6 +221,7 @@ export function IssuesPage() {
               <SwimLaneView
                 issues={issues}
                 visibleStatuses={visibleStatuses}
+                hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
               />

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -22,6 +22,7 @@ import { PageHeader } from "../../layout/page-header";
 import { IssuesHeader } from "./issues-header";
 import { BoardView } from "./board-view";
 import { ListView } from "./list-view";
+import { SwimLaneView } from "./swimlane-view";
 import { BatchActionToolbar } from "./batch-action-toolbar";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
@@ -148,7 +149,7 @@ export function IssuesPage() {
 
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
-    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position">, onSettled?: () => void) => {
+    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position" | "parent_issue_id">, onSettled?: () => void) => {
       updateIssueMutation.mutate(
         { id: issueId, ...updates },
         {
@@ -213,6 +214,13 @@ export function IssuesPage() {
                 assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
+                onMoveIssue={handleMoveIssue}
+                childProgressMap={childProgressMap}
+              />
+            ) : viewMode === "swimlane" ? (
+              <SwimLaneView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
               />

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -133,6 +133,13 @@ export function IssuesPage() {
     [scopedIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, agentRunningFilter, runningIssueIds],
   );
 
+  // Status-unfiltered companion for Swimlane — same narrowing as `issues`
+  // minus the status filter.
+  const swimlaneIssues = useMemo(
+    () => filterIssues(scopedIssues, { statusFilters: [], priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, agentRunningFilter, runningIssueIds }),
+    [scopedIssues, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, agentRunningFilter, runningIssueIds],
+  );
+
   // Fetch sub-issue progress from the backend so counts are accurate
   // regardless of client-side pagination or filtering of done issues.
   const { data: childProgressMap = EMPTY_CHILD_PROGRESS } = useQuery(childIssueProgressOptions(wsId));
@@ -220,6 +227,7 @@ export function IssuesPage() {
             ) : viewMode === "swimlane" ? (
               <SwimLaneView
                 issues={issues}
+                unfilteredIssues={swimlaneIssues}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -269,8 +269,6 @@ function renderWithI18n(ui: React.ReactNode) {
 describe("SwimLaneView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset mutable mock state between tests so stored lane order /
-    // collapsed state from one test doesn't leak into the next.
     mockViewState.swimlaneOrder = [];
     mockViewState.collapsedSwimlanes = [];
     useLoadMoreByStatusMock.mockImplementation(() => ({
@@ -303,10 +301,7 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // No parent (orphan swimlane)
     expect(screen.getAllByText("No parent").length).toBeGreaterThanOrEqual(1);
-
-    // Parent Issue 1 swimlane
     expect(screen.getAllByText("Parent Issue 1").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("PROJ-1").length).toBeGreaterThanOrEqual(1);
   });
@@ -319,11 +314,9 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Orphan-1 is a true orphan → card in "No parent" + Backlog.
     expect(screen.getByText("Orphan Issue 1")).toBeInTheDocument();
 
-    // Parent Issue 1 is promoted to a lane header (has child-1 as a
-    // sub-issue) and must NOT also render as a card in "No parent".
+    // parent-1 is promoted to a lane header — must not also appear as a card.
     const parentTitleMatches = screen.getAllByText("Parent Issue 1");
     expect(parentTitleMatches).toHaveLength(1);
     expect(parentTitleMatches[0]!.closest("div")?.textContent).toContain("PROJ-1");
@@ -339,8 +332,6 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Find the per-cell "+" button by its aria-label (set to the
-    // `board.add_issue_tooltip` translation).
     const addButtons = screen.getAllByRole("button", { name: /add issue/i });
     expect(addButtons.length).toBeGreaterThan(0);
 
@@ -366,10 +357,7 @@ describe("SwimLaneView", () => {
     );
   });
 
-  // Child whose parent_issue_id points at an issue not in the loaded set
-  // (e.g. parent filtered out server-side by "assigned to me", or hidden
-  // by a status filter without an unfilteredIssues prop). Falls into the
-  // "Other parents" display-only lane.
+  // A child whose parent isn't in the loaded set — lands in "Other parents".
   const orphanChild: Issue = {
     id: "lonely-child",
     workspace_id: "ws-1",
@@ -446,16 +434,9 @@ describe("SwimLaneView", () => {
     expect(mockOnMoveIssue).not.toHaveBeenCalled();
   });
 
-  it("hides parent lanes whose only children are filtered out, while still rendering visible children of visible parents", () => {
-    // Round 2 review B — lane discovery walks the visible `issues` set,
-    // not the broader `unfilteredIssues`, so a status filter that hides
-    // all of a parent's children also hides that parent's lane (the
-    // parent itself can still render as a card via the unfilteredIssues
-    // path when the caller wires it through).
-    //
-    // Fixture: parent-1 + its only child (in_progress). With visibleStatuses
-    // restricted to ["todo"], child-1 isn't in `issues`, so parent-1's
-    // lane should disappear.
+  it("hides a parent lane when all its children are in hidden statuses", () => {
+    // child-1 (in_progress) is not in the visible set — parent-1's lane
+    // is dropped. parent-1 itself falls into the No-parent lane as a card.
     renderWithI18n(
       <SwimLaneView
         issues={mockIssues.filter((i) => i.status === "todo")}
@@ -466,21 +447,11 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Parent Issue 1 — its only child (child-1) is in_progress (hidden),
-    // so its lane is dropped. Only the "No parent" lane should render,
-    // and parent-1 itself shows up as a card within it (status: todo,
-    // not a lane header because no visible children reference it).
     expect(screen.queryByText("Child Issue 1")).not.toBeInTheDocument();
-    // Header still appears for "No parent"; "Parent Issue 1" is now a
-    // regular card.
-    const parentTitleMatches = screen.getAllByText("Parent Issue 1");
-    expect(parentTitleMatches).toHaveLength(1);
+    expect(screen.getAllByText("Parent Issue 1")).toHaveLength(1);
   });
 
   it("does not call onMoveIssue when a card is dragged out of 'Other parents'", () => {
-    // Same defense in the opposite direction — a card whose parent we
-    // don't know about must not be re-anchored to a different parent by
-    // accident.
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView
@@ -507,16 +478,12 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // The pencil link uses aria-label "Open parent issue" and href to /issues/<id>.
-    // Only the "Parent Issue 1" lane (parent-1) has a parent issue id; the
-    // orphan lane ("No parent") must not render this link.
     const links = screen.getAllByRole("link", { name: "Open parent issue" });
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute("href", expect.stringContaining("parent-1"));
   });
 
   it("renders HiddenColumnsPanel only when hiddenStatuses is non-empty", () => {
-    // Case 1: no hidden statuses → panel is absent.
     const { unmount } = renderWithI18n(
       <SwimLaneView
         issues={mockIssues}
@@ -526,8 +493,6 @@ describe("SwimLaneView", () => {
     expect(screen.queryByText("Hidden columns")).not.toBeInTheDocument();
     unmount();
 
-    // Case 2: hide a status → panel shows the localized status name + count.
-    // "cancelled" is excluded from BOARD_STATUSES, so we pass "blocked" as hidden.
     renderWithI18n(
       <SwimLaneView
         issues={mockIssues}
@@ -549,11 +514,6 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    expect(lastOnDragOver).toBeDefined();
-    expect(lastOnDragEnd).toBeDefined();
-
-    // Drag orphan-1 (status: backlog, parent: null, in "No parent" lane)
-    // to the "in_progress" column of the same "No parent" lane.
     const targetCellId = "swim:parent:none:in_progress";
 
     act(() => {
@@ -573,14 +533,11 @@ describe("SwimLaneView", () => {
     expect(mockOnMoveIssue).toHaveBeenCalledWith("orphan-1", {
       parent_issue_id: null,
       status: "in_progress",
-      position: 300, // maintains its position since it's the only item in target
+      position: 300,
     });
   });
 
   it("does not call onMoveIssue when drop target equals source cell (no-op)", () => {
-    // Drop "parent-1" (status: todo, parent_issue_id: null) onto its own
-    // current cell. The handler must detect the no-op and skip the mutation
-    // so the network and the optimistic cache aren't churned.
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
@@ -597,9 +554,6 @@ describe("SwimLaneView", () => {
   });
 
   it("emits parent_issue_id when dragging from orphan into a parent lane", () => {
-    // Drag "orphan-1" (parent_issue_id: null, status: backlog) into the
-    // "Parent Issue 1" lane's `todo` column. The contract: payload must
-    // carry the new parent_issue_id (parent-1) and the new status (todo).
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
@@ -629,8 +583,6 @@ describe("SwimLaneView", () => {
   });
 
   it("renders count for hidden statuses from in-memory statusTotals", () => {
-    // mockIssues: 1 backlog (orphan-1), 0 blocked. parent-1 is a lane
-    // header so it's excluded from totals.
     renderWithI18n(
       <SwimLaneView
         issues={mockIssues}
@@ -648,8 +600,6 @@ describe("SwimLaneView", () => {
   });
 
   it("hidden-column totals come from unfilteredIssues when provided", () => {
-    // Without unfilteredIssues, a status-filtered `issues` prop would
-    // make hidden statuses always read 0.
     const unfiltered: Issue[] = [
       ...mockIssues,
       {
@@ -679,13 +629,6 @@ describe("SwimLaneView", () => {
     expect(counts.filter((c) => c === "1").length).toBeGreaterThanOrEqual(2);
   });
 
-  // ------------------------------------------------------------------
-  // Lane reordering via drag-and-drop
-  //
-  // Two parent fixtures (parent-1, parent-2) so we can test cross-lane
-  // reordering.  Each needs a child issue so a swimlane is actually created
-  // (parentGroups skips parents with no children loaded).
-  // ------------------------------------------------------------------
   const multiParentIssues: Issue[] = [
     {
       id: "parent-1",
@@ -782,8 +725,6 @@ describe("SwimLaneView", () => {
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
     );
 
-    // Drag lane parent-1 onto lane parent-2 — expect order to become
-    // [parent-2, parent-1].
     act(() => {
       lastOnDragEnd({
         active: { id: "lane:parent-1" },
@@ -795,10 +736,6 @@ describe("SwimLaneView", () => {
   });
 
   it("appends newly-visible parents to the persisted order on first reorder", () => {
-    // stored=[parent-1] (parent-2 is new in this view). User drags
-    // parent-1 below parent-2, so the visible order flips. Persisted
-    // result must include both — earlier logic dropped the new entry
-    // when its slot in `stored` had been consumed.
     mockViewState.swimlaneOrder = ["parent-1"];
 
     renderWithI18n(
@@ -816,9 +753,6 @@ describe("SwimLaneView", () => {
   });
 
   it("preserves persisted entries that aren't currently visible during a reorder", () => {
-    // Persisted order contains two ids (filtered-a, filtered-b) that are
-    // not in the currently rendered set — they must keep their slots
-    // when the user reorders the visible lanes.
     mockViewState.swimlaneOrder = ["filtered-a", "parent-1", "filtered-b", "parent-2"];
 
     renderWithI18n(
@@ -856,7 +790,6 @@ describe("SwimLaneView", () => {
   });
 
   it("does not call onMoveIssue when a lane drag ends (no card mutation)", () => {
-    // Lane drags must not accidentally trigger card-position mutations.
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={mockOnMoveIssue} />,
@@ -873,7 +806,6 @@ describe("SwimLaneView", () => {
   });
 
   it("renders parent lanes in stored swimlaneOrder when set", () => {
-    // Set persisted order to put parent-2 first, then parent-1.
     mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
 
     renderWithI18n(
@@ -888,9 +820,6 @@ describe("SwimLaneView", () => {
   });
 
   it("keeps 'No parent' lane pinned at top regardless of stored order", () => {
-    // Even if the user could somehow include a synthetic "no parent" key,
-    // the No-parent lane is rendered outside the SortableContext and
-    // always appears first.
     mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
 
     renderWithI18n(
@@ -907,8 +836,6 @@ describe("SwimLaneView", () => {
   // ------------------------------------------------------------------
 
   it("collapses a parent lane when its id is in stored collapsedSwimlanes", () => {
-    // Pre-seed the store as if the lane had been collapsed in a prior
-    // session. Child cards inside that lane must not render.
     mockViewState.collapsedSwimlanes = ["parent-1"];
 
     renderWithI18n(
@@ -924,9 +851,6 @@ describe("SwimLaneView", () => {
   });
 
   it("collapses the 'No parent' lane when 'none' is in stored collapsedSwimlanes", () => {
-    // Sentinel key "none" represents the No-parent lane. mockIssues
-    // contains the orphan "Orphan Issue 1" — when collapsed, its card
-    // must be absent from the DOM.
     mockViewState.collapsedSwimlanes = ["none"];
 
     renderWithI18n(
@@ -942,7 +866,6 @@ describe("SwimLaneView", () => {
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
     );
 
-    // The Parent A lane header is the <button> containing the text "Parent A".
     const parentAHeader = screen.getByText("Parent A").closest("button");
     expect(parentAHeader).not.toBeNull();
     fireEvent.click(parentAHeader!);
@@ -955,9 +878,8 @@ describe("SwimLaneView", () => {
       <SwimLaneView issues={mockIssues} onMoveIssue={vi.fn()} />,
     );
 
-    // mockIssues' orphan card has description "No parent", so the literal
-    // appears twice in the DOM (lane title + card description). The lane
-    // title is the one inside a <button> — disambiguate by closest button.
+    // "No parent" appears twice (lane title + orphan-1's card description);
+    // find the one inside a button.
     const matches = screen.getAllByText("No parent");
     const noParentHeader = matches.map((m) => m.closest("button")).find(Boolean);
     expect(noParentHeader).toBeDefined();

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SwimLaneView } from "./swimlane-view";
+import type { Issue } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+// Mock hooks
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+// Mock paths
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useWorkspaceSlug: () => "acme",
+    useRequiredWorkspaceSlug: () => "acme",
+    useWorkspacePaths: () => actual.paths.workspace("acme"),
+  };
+});
+
+// Mock @multica/core/auth
+const mockAuthUser = { id: "user-1", email: "test@test.com", name: "Test User" };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => {
+      const state = { user: mockAuthUser, isAuthenticated: true };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ user: mockAuthUser, isAuthenticated: true }) },
+  ),
+  registerAuthStore: vi.fn(),
+  createAuthStore: vi.fn(),
+}));
+
+// Mock navigation
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigation: () => ({ push: vi.fn(), pathname: "/issues" }),
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock issue config
+vi.mock("@multica/core/issues/config", () => ({
+  ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  BOARD_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
+  STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  STATUS_CONFIG: {
+    backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+    todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+    in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10" },
+    in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10" },
+    done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10" },
+    blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10" },
+    cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
+  },
+  PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_CONFIG: {
+    urgent: { label: "Urgent", bars: 4, color: "text-destructive" },
+    high: { label: "High", bars: 3, color: "text-warning" },
+    medium: { label: "Medium", bars: 2, color: "text-warning" },
+    low: { label: "Low", bars: 1, color: "text-info" },
+    none: { label: "No priority", bars: 0, color: "text-muted-foreground" },
+  },
+}));
+
+// Mock view store
+const mockViewState = {
+  sortBy: "position" as const,
+  sortDirection: "asc" as const,
+  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
+};
+
+vi.mock("@multica/core/issues/stores/view-store-context", () => ({
+  ViewStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  useViewStore: (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
+  useViewStoreApi: () => ({ getState: () => mockViewState, setState: vi.fn(), subscribe: vi.fn() }),
+}));
+
+// Mock modal store
+const mockOpenModal = vi.fn();
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    () => ({ open: mockOpenModal }),
+    { getState: () => ({ open: mockOpenModal }) },
+  ),
+}));
+
+// Mock dnd-kit
+let lastOnDragEnd: any = null;
+let lastOnDragOver: any = null;
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children, onDragEnd, onDragOver }: any) => {
+    lastOnDragEnd = onDragEnd;
+    lastOnDragOver = onDragOver;
+    return children;
+  },
+  DragOverlay: () => null,
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  pointerWithin: vi.fn(),
+  closestCenter: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: any) => children,
+  verticalListSortingStrategy: {},
+  arrayMove: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+const mockIssues: Issue[] = [
+  {
+    id: "parent-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "PROJ-1",
+    title: "Parent Issue 1",
+    description: "Parent description",
+    status: "todo",
+    priority: "high",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 100,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "child-1",
+    workspace_id: "ws-1",
+    number: 2,
+    identifier: "PROJ-2",
+    title: "Child Issue 1",
+    description: "Child description",
+    status: "in_progress",
+    priority: "medium",
+    assignee_type: "member",
+    assignee_id: "user-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: "parent-1",
+    project_id: null,
+    position: 200,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "orphan-1",
+    workspace_id: "ws-1",
+    number: 3,
+    identifier: "PROJ-3",
+    title: "Orphan Issue 1",
+    description: "No parent",
+    status: "backlog",
+    priority: "low",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 300,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function renderWithI18n(ui: React.ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <I18nProvider resources={TEST_RESOURCES} locale="en">
+        {ui}
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SwimLaneView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders status columns as headers", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByText("Todo")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+  });
+
+  it("renders parent swimlanes and orphans section", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // No parent (orphan swimlane)
+    expect(screen.getAllByText("No parent").length).toBeGreaterThanOrEqual(1);
+
+    // Parent Issue 1 swimlane
+    expect(screen.getAllByText("Parent Issue 1").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("PROJ-1").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders cards in their corresponding cell", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Orphan Issue 1 is in "No parent" + Backlog
+    expect(screen.getByText("Orphan Issue 1")).toBeInTheDocument();
+
+    // Parent Issue 1 is in "No parent" + Todo
+    expect(screen.getAllByText("Parent Issue 1").length).toBeGreaterThanOrEqual(1);
+
+    // Child Issue 1 is in "Parent Issue 1" + In Progress
+    expect(screen.getByText("Child Issue 1")).toBeInTheDocument();
+  });
+
+  it("triggers modal open when add button is clicked", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Click the Add Issue button inside SwimLaneCell
+    const addButtons = screen.getAllByRole("button");
+    const fullWidthAddButton = addButtons.find(btn => btn.classList.contains("w-full"));
+    expect(fullWidthAddButton).toBeDefined();
+    
+    fireEvent.click(fullWidthAddButton!);
+    expect(mockOpenModal).toHaveBeenCalledWith("create-issue", expect.any(Object));
+  });
+
+  it("calls onMoveIssue on drag-and-drop end", () => {
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={mockOnMoveIssue}
+      />,
+    );
+
+    expect(lastOnDragOver).toBeDefined();
+    expect(lastOnDragEnd).toBeDefined();
+
+    // Parent Issue 1 (id: "parent-1", status: "todo")
+    // We simulate dragging "parent-1" over the "In Progress" column of the "No parent" swimlane
+    // Cell ID format: `swim:${parentKey}:${status}`
+    const targetCellId = "swim:parent:none:in_progress";
+
+    act(() => {
+      lastOnDragOver({
+        active: { id: "parent-1" },
+        over: { id: targetCellId },
+      });
+    });
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "parent-1" },
+        over: { id: targetCellId },
+      });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith("parent-1", {
+      parent_issue_id: null,
+      status: "in_progress",
+      position: 100, // maintains its position since it's the only item
+    });
+  });
+});

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -76,12 +76,32 @@ vi.mock("@multica/core/issues/config", () => ({
   },
 }));
 
-// Mock view store
-const mockViewState = {
-  sortBy: "position" as const,
-  sortDirection: "asc" as const,
+// Mock view store. `swimlaneOrder` is mutable on the captured object so
+// tests can simulate persisted lane order and assert that
+// `setSwimlaneOrder` was called by drag-end handlers.
+const mockViewState: {
+  sortBy: "position";
+  sortDirection: "asc";
+  cardProperties: Record<string, boolean>;
+  swimlaneOrder: string[];
+  collapsedSwimlanes: string[];
+  setSwimlaneOrder: (order: string[]) => void;
+  toggleSwimlaneCollapsed: (key: string) => void;
+  hideStatus: (s: string) => void;
+  showStatus: (s: string) => void;
+} = {
+  sortBy: "position",
+  sortDirection: "asc",
   cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
+  swimlaneOrder: [],
+  collapsedSwimlanes: [],
+  setSwimlaneOrder: vi.fn(),
+  toggleSwimlaneCollapsed: vi.fn(),
+  hideStatus: vi.fn(),
+  showStatus: vi.fn(),
 };
+const mockSetSwimlaneOrder = mockViewState.setSwimlaneOrder as ReturnType<typeof vi.fn>;
+const mockToggleSwimlaneCollapsed = mockViewState.toggleSwimlaneCollapsed as ReturnType<typeof vi.fn>;
 
 vi.mock("@multica/core/issues/stores/view-store-context", () => ({
   ViewStoreProvider: ({ children }: { children: React.ReactNode }) => children,
@@ -120,7 +140,15 @@ vi.mock("@dnd-kit/core", () => ({
 vi.mock("@dnd-kit/sortable", () => ({
   SortableContext: ({ children }: any) => children,
   verticalListSortingStrategy: {},
-  arrayMove: vi.fn(),
+  // Real arrayMove implementation — the production code uses this both for
+  // card reordering and lane reordering, so returning undefined would break
+  // every reorder assertion.
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const copy = arr.slice();
+    const [item] = copy.splice(from, 1);
+    copy.splice(to, 0, item!);
+    return copy;
+  },
   useSortable: () => ({
     attributes: {},
     listeners: {},
@@ -220,6 +248,10 @@ function renderWithI18n(ui: React.ReactNode) {
 describe("SwimLaneView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset mutable mock state between tests so stored lane order /
+    // collapsed state from one test doesn't leak into the next.
+    mockViewState.swimlaneOrder = [];
+    mockViewState.collapsedSwimlanes = [];
   });
 
   it("renders status columns as headers", () => {
@@ -277,12 +309,12 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Click the Add Issue button inside SwimLaneCell
-    const addButtons = screen.getAllByRole("button");
-    const fullWidthAddButton = addButtons.find(btn => btn.classList.contains("w-full"));
-    expect(fullWidthAddButton).toBeDefined();
-    
-    fireEvent.click(fullWidthAddButton!);
+    // Find the per-cell "+" button by its aria-label (set to the
+    // `board.add_issue_tooltip` translation).
+    const addButtons = screen.getAllByRole("button", { name: /add issue/i });
+    expect(addButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(addButtons[0]!);
     expect(mockOpenModal).toHaveBeenCalledWith("create-issue", expect.any(Object));
   });
 
@@ -339,29 +371,341 @@ describe("SwimLaneView", () => {
     expect(lastOnDragOver).toBeDefined();
     expect(lastOnDragEnd).toBeDefined();
 
-    // Parent Issue 1 (id: "parent-1", status: "todo")
-    // We simulate dragging "parent-1" over the "In Progress" column of the "No parent" swimlane
-    // Cell ID format: `swim:${parentKey}:${status}`
+    // Drag orphan-1 (status: backlog, parent: null, in "No parent" lane)
+    // to the "in_progress" column of the same "No parent" lane.
     const targetCellId = "swim:parent:none:in_progress";
 
     act(() => {
       lastOnDragOver({
-        active: { id: "parent-1" },
+        active: { id: "orphan-1" },
         over: { id: targetCellId },
       });
     });
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "parent-1" },
+        active: { id: "orphan-1" },
         over: { id: targetCellId },
       });
     });
 
-    expect(mockOnMoveIssue).toHaveBeenCalledWith("parent-1", {
+    expect(mockOnMoveIssue).toHaveBeenCalledWith("orphan-1", {
       parent_issue_id: null,
       status: "in_progress",
-      position: 100, // maintains its position since it's the only item
+      position: 300, // maintains its position since it's the only item in target
     });
+  });
+
+  it("does not call onMoveIssue when drop target equals source cell (no-op)", () => {
+    // Drop "parent-1" (status: todo, parent_issue_id: null) onto its own
+    // current cell. The handler must detect the no-op and skip the mutation
+    // so the network and the optimistic cache aren't churned.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "parent-1" },
+        over: { id: "swim:parent:none:todo" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
+  });
+
+  it("emits parent_issue_id when dragging from orphan into a parent lane", () => {
+    // Drag "orphan-1" (parent_issue_id: null, status: backlog) into the
+    // "Parent Issue 1" lane's `todo` column. The contract: payload must
+    // carry the new parent_issue_id (parent-1) and the new status (todo).
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    const target = "swim:parent:parent-1:todo";
+    act(() => {
+      lastOnDragOver({
+        active: { id: "orphan-1" },
+        over: { id: target },
+      });
+    });
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "orphan-1" },
+        over: { id: target },
+      });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "orphan-1",
+      expect.objectContaining({
+        parent_issue_id: "parent-1",
+        status: "todo",
+      }),
+    );
+  });
+
+  it("renders count for hidden statuses based on in-memory issues", () => {
+    // statusTotals must count every issue's status, including statuses that
+    // are not currently rendered as columns. mockIssues has 1 `backlog` and
+    // 0 `blocked`. Hide both and assert the panel shows the right counts.
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        visibleStatuses={["todo", "in_progress", "in_review", "done"]}
+        hiddenStatuses={["backlog", "blocked"]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    const panel = screen.getByText("Hidden columns").parentElement!.parentElement!;
+    // Backlog row should show "1"; Blocked row should show "0".
+    expect(panel).toHaveTextContent("Backlog");
+    expect(panel).toHaveTextContent("Blocked");
+    expect(panel).toHaveTextContent("1");
+    expect(panel).toHaveTextContent("0");
+  });
+
+  // ------------------------------------------------------------------
+  // Lane reordering via drag-and-drop
+  //
+  // Two parent fixtures (parent-1, parent-2) so we can test cross-lane
+  // reordering.  Each needs a child issue so a swimlane is actually created
+  // (parentGroups skips parents with no children loaded).
+  // ------------------------------------------------------------------
+  const multiParentIssues: Issue[] = [
+    {
+      id: "parent-1",
+      workspace_id: "ws-1",
+      number: 1,
+      identifier: "PROJ-1",
+      title: "Parent A",
+      description: null,
+      status: "todo",
+      priority: "high",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 100,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "parent-2",
+      workspace_id: "ws-1",
+      number: 2,
+      identifier: "PROJ-10",
+      title: "Parent B",
+      description: null,
+      status: "todo",
+      priority: "high",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 200,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "child-of-1",
+      workspace_id: "ws-1",
+      number: 3,
+      identifier: "PROJ-2",
+      title: "Child of A",
+      description: null,
+      status: "in_progress",
+      priority: "medium",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: "parent-1",
+      project_id: null,
+      position: 300,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "child-of-2",
+      workspace_id: "ws-1",
+      number: 4,
+      identifier: "PROJ-11",
+      title: "Child of B",
+      description: null,
+      status: "in_progress",
+      priority: "medium",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: "parent-2",
+      project_id: null,
+      position: 400,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  ];
+
+  it("persists lane order via setSwimlaneOrder when a lane is dragged onto another", () => {
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // Drag lane parent-1 onto lane parent-2 — expect order to become
+    // [parent-2, parent-1].
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lane:parent-1" },
+        over: { id: "lane:parent-2" },
+      });
+    });
+
+    expect(mockSetSwimlaneOrder).toHaveBeenCalledWith(["parent-2", "parent-1"]);
+  });
+
+  it("does not call setSwimlaneOrder when a lane is dropped onto itself", () => {
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lane:parent-1" },
+        over: { id: "lane:parent-1" },
+      });
+    });
+
+    expect(mockSetSwimlaneOrder).not.toHaveBeenCalled();
+  });
+
+  it("does not call onMoveIssue when a lane drag ends (no card mutation)", () => {
+    // Lane drags must not accidentally trigger card-position mutations.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lane:parent-1" },
+        over: { id: "lane:parent-2" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
+  });
+
+  it("renders parent lanes in stored swimlaneOrder when set", () => {
+    // Set persisted order to put parent-2 first, then parent-1.
+    mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    const parentA = screen.getByText("Parent A");
+    const parentB = screen.getByText("Parent B");
+    // DOM order: "Parent B" must precede "Parent A".
+    // compareDocumentPosition: bitmask, DOCUMENT_POSITION_FOLLOWING = 4
+    expect(parentB.compareDocumentPosition(parentA) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps 'No parent' lane pinned at top regardless of stored order", () => {
+    // Even if the user could somehow include a synthetic "no parent" key,
+    // the No-parent lane is rendered outside the SortableContext and
+    // always appears first.
+    mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    const noParent = screen.getByText("No parent");
+    const parentB = screen.getByText("Parent B");
+    expect(noParent.compareDocumentPosition(parentB) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // ------------------------------------------------------------------
+  // Persisted collapsed-lane state
+  // ------------------------------------------------------------------
+
+  it("collapses a parent lane when its id is in stored collapsedSwimlanes", () => {
+    // Pre-seed the store as if the lane had been collapsed in a prior
+    // session. Child cards inside that lane must not render.
+    mockViewState.collapsedSwimlanes = ["parent-1"];
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // The lane HEADER for Parent A is still visible…
+    expect(screen.getByText("Parent A")).toBeInTheDocument();
+    // …but its child card is not.
+    expect(screen.queryByText("Child of A")).not.toBeInTheDocument();
+    // Parent B (not collapsed) still shows its child.
+    expect(screen.getByText("Child of B")).toBeInTheDocument();
+  });
+
+  it("collapses the 'No parent' lane when 'none' is in stored collapsedSwimlanes", () => {
+    // Sentinel key "none" represents the No-parent lane. mockIssues
+    // contains the orphan "Orphan Issue 1" — when collapsed, its card
+    // must be absent from the DOM.
+    mockViewState.collapsedSwimlanes = ["none"];
+
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    expect(screen.getByText("No parent")).toBeInTheDocument();
+    expect(screen.queryByText("Orphan Issue 1")).not.toBeInTheDocument();
+  });
+
+  it("calls toggleSwimlaneCollapsed with the raw parent id when a lane header is clicked", () => {
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // The Parent A lane header is the <button> containing the text "Parent A".
+    const parentAHeader = screen.getByText("Parent A").closest("button");
+    expect(parentAHeader).not.toBeNull();
+    fireEvent.click(parentAHeader!);
+
+    expect(mockToggleSwimlaneCollapsed).toHaveBeenCalledWith("parent-1");
+  });
+
+  it("calls toggleSwimlaneCollapsed with 'none' when the No-parent lane header is clicked", () => {
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // mockIssues' orphan card has description "No parent", so the literal
+    // appears twice in the DOM (lane title + card description). The lane
+    // title is the one inside a <button> — disambiguate by closest button.
+    const matches = screen.getAllByText("No parent");
+    const noParentHeader = matches.map((m) => m.closest("button")).find(Boolean);
+    expect(noParentHeader).toBeDefined();
+    fireEvent.click(noParentHeader!);
+
+    expect(mockToggleSwimlaneCollapsed).toHaveBeenCalledWith("none");
   });
 });

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -403,11 +403,6 @@ describe("SwimLaneView", () => {
   });
 
   it("does not render the add-issue button inside 'Other parents' cells", () => {
-    // The orphan lane is display-only: clicking + would create an issue
-    // with no parent context (it doesn't belong to any known parent),
-    // so the affordance is suppressed. mockIssues contains parent-1,
-    // child-1, orphan-1 — combine with orphanChild so both a real lane
-    // and the orphan lane are rendered.
     renderWithI18n(
       <SwimLaneView
         issues={[...mockIssues, orphanChild]}
@@ -415,10 +410,9 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Real lanes still render + buttons (No parent + Parent Issue 1 lanes
-    // each have one per visible status column). The orphan lane adds
-    // zero buttons regardless of how many statuses are visible.
-    const realLaneCount = 2; // No parent + Parent Issue 1
+    // No parent + Parent Issue 1 each have one + per visible status column.
+    // The Other parents lane must add zero.
+    const realLaneCount = 2;
     const visibleStatusCount = 6; // BOARD_STATUSES default
     expect(
       screen.getAllByRole("button", { name: /add issue/i }).length,
@@ -426,12 +420,8 @@ describe("SwimLaneView", () => {
   });
 
   it("does not call onMoveIssue when a card is dropped onto the empty whitespace of an 'Other parents' cell", () => {
-    // Round 3 review — the critical failure path is a drop onto the
-    // *empty area* of an orphan cell. With the cell re-enabled in the
-    // collision graph (so it absorbs whitespace drops instead of falling
-    // through to the nearest real cell), dnd-kit emits the cell's own
-    // droppable id as `over.id`. The ORPHAN_LANE_KEY guard must fire
-    // for that id, not just for orphan cards.
+    // `over.id` is the orphan cell id — what dnd-kit emits when the
+    // pointer lands on the cell's empty area.
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView
@@ -440,18 +430,15 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Simulate drag-over first (optimistic UI must not move the card).
     act(() => {
       lastOnDragOver({
-        active: { id: "orphan-1" },
+        active: { id: "child-1" },
         over: { id: "swim:parent:__orphans__:todo" },
       });
     });
-
-    // Then drag-end onto the empty orphan cell area.
     act(() => {
       lastOnDragEnd({
-        active: { id: "orphan-1" },
+        active: { id: "child-1" },
         over: { id: "swim:parent:__orphans__:todo" },
       });
     });
@@ -488,36 +475,6 @@ describe("SwimLaneView", () => {
     // regular card.
     const parentTitleMatches = screen.getAllByText("Parent Issue 1");
     expect(parentTitleMatches).toHaveLength(1);
-  });
-
-  it("does not call onMoveIssue when a card from a real lane is dropped onto orphan cell whitespace", () => {
-    // Round 3 — the real failure path: drag a card from a real parent
-    // lane onto the empty whitespace of an orphan cell. Previously the
-    // cell was disabled, so dnd-kit fell through to the nearest real
-    // cell and silently re-parented. Now the cell is enabled and absorbs
-    // the drop; the guard rejects any move into/out of ORPHAN_LANE_KEY.
-    const mockOnMoveIssue = vi.fn();
-    renderWithI18n(
-      <SwimLaneView
-        issues={[...mockIssues, orphanChild]}
-        onMoveIssue={mockOnMoveIssue}
-      />,
-    );
-
-    act(() => {
-      lastOnDragOver({
-        active: { id: "child-1" },
-        over: { id: "swim:parent:__orphans__:todo" },
-      });
-    });
-    act(() => {
-      lastOnDragEnd({
-        active: { id: "child-1" },
-        over: { id: "swim:parent:__orphans__:todo" },
-      });
-    });
-
-    expect(mockOnMoveIssue).not.toHaveBeenCalled();
   });
 
   it("does not call onMoveIssue when a card is dragged out of 'Other parents'", () => {

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -76,6 +76,19 @@ vi.mock("@multica/core/issues/config", () => ({
   },
 }));
 
+// Mock @multica/core/issues/mutations for hidden column status counts
+vi.mock("@multica/core/issues/mutations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/issues/mutations")>();
+  return {
+    ...actual,
+    useLoadMoreByStatus: (status: string) => {
+      if (status === "backlog") return { total: 1, loaded: 1, hasMore: false, isLoading: false, loadMore: vi.fn() };
+      if (status === "blocked") return { total: 0, loaded: 0, hasMore: false, isLoading: false, loadMore: vi.fn() };
+      return { total: 0, loaded: 0, hasMore: false, isLoading: false, loadMore: vi.fn() };
+    },
+  };
+});
+
 // Mock view store. `swimlaneOrder` is mutable on the captured object so
 // tests can simulate persisted lane order and assert that
 // `setSwimlaneOrder` was called by drag-end handlers.

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -425,10 +425,13 @@ describe("SwimLaneView", () => {
     ).toBe(realLaneCount * visibleStatusCount);
   });
 
-  it("does not call onMoveIssue when a card is dropped into an 'Other parents' cell", () => {
-    // Round 2 review A1 — dropping onto the display-only lane previously
-    // committed a stealth re-position by computing position from
-    // unrelated cards.
+  it("does not call onMoveIssue when a card is dropped onto the empty whitespace of an 'Other parents' cell", () => {
+    // Round 3 review — the critical failure path is a drop onto the
+    // *empty area* of an orphan cell. With the cell re-enabled in the
+    // collision graph (so it absorbs whitespace drops instead of falling
+    // through to the nearest real cell), dnd-kit emits the cell's own
+    // droppable id as `over.id`. The ORPHAN_LANE_KEY guard must fire
+    // for that id, not just for orphan cards.
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(
       <SwimLaneView
@@ -437,6 +440,15 @@ describe("SwimLaneView", () => {
       />,
     );
 
+    // Simulate drag-over first (optimistic UI must not move the card).
+    act(() => {
+      lastOnDragOver({
+        active: { id: "orphan-1" },
+        over: { id: "swim:parent:__orphans__:todo" },
+      });
+    });
+
+    // Then drag-end onto the empty orphan cell area.
     act(() => {
       lastOnDragEnd({
         active: { id: "orphan-1" },
@@ -476,6 +488,36 @@ describe("SwimLaneView", () => {
     // regular card.
     const parentTitleMatches = screen.getAllByText("Parent Issue 1");
     expect(parentTitleMatches).toHaveLength(1);
+  });
+
+  it("does not call onMoveIssue when a card from a real lane is dropped onto orphan cell whitespace", () => {
+    // Round 3 — the real failure path: drag a card from a real parent
+    // lane onto the empty whitespace of an orphan cell. Previously the
+    // cell was disabled, so dnd-kit fell through to the nearest real
+    // cell and silently re-parented. Now the cell is enabled and absorbs
+    // the drop; the guard rejects any move into/out of ORPHAN_LANE_KEY.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, orphanChild]}
+        onMoveIssue={mockOnMoveIssue}
+      />,
+    );
+
+    act(() => {
+      lastOnDragOver({
+        active: { id: "child-1" },
+        over: { id: "swim:parent:__orphans__:todo" },
+      });
+    });
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "child-1" },
+        over: { id: "swim:parent:__orphans__:todo" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
   });
 
   it("does not call onMoveIssue when a card is dragged out of 'Other parents'", () => {

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -286,6 +286,47 @@ describe("SwimLaneView", () => {
     expect(mockOpenModal).toHaveBeenCalledWith("create-issue", expect.any(Object));
   });
 
+  it("renders an open-parent link for lanes with a real parent", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // The pencil link uses aria-label "Open parent issue" and href to /issues/<id>.
+    // Only the "Parent Issue 1" lane (parent-1) has a parent issue id; the
+    // orphan lane ("No parent") must not render this link.
+    const links = screen.getAllByRole("link", { name: "Open parent issue" });
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", expect.stringContaining("parent-1"));
+  });
+
+  it("renders HiddenColumnsPanel only when hiddenStatuses is non-empty", () => {
+    // Case 1: no hidden statuses → panel is absent.
+    const { unmount } = renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Hidden columns")).not.toBeInTheDocument();
+    unmount();
+
+    // Case 2: hide a status → panel shows the localized status name + count.
+    // "cancelled" is excluded from BOARD_STATUSES, so we pass "blocked" as hidden.
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        visibleStatuses={["backlog", "todo", "in_progress", "in_review", "done"]}
+        hiddenStatuses={["blocked"]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Hidden columns")).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+  });
+
   it("calls onMoveIssue on drag-and-drop end", () => {
     const mockOnMoveIssue = vi.fn();
     renderWithI18n(

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -366,40 +366,138 @@ describe("SwimLaneView", () => {
     );
   });
 
-  it("renders children whose parent is not in the loaded set under an 'Other parents' fallback lane", () => {
-    // Child with parent_issue_id pointing at an issue that isn't in the
-    // dataset (e.g. parent filtered out server-side by "assigned to me",
-    // or hidden by a status filter without an unfilteredIssues prop).
-    // Previously these silently disappeared from Swimlane.
-    const orphanChild: Issue = {
-      id: "lonely-child",
-      workspace_id: "ws-1",
-      number: 99,
-      identifier: "PROJ-99",
-      title: "Lonely Child",
-      description: null,
-      status: "todo",
-      priority: "medium",
-      assignee_type: "member",
-      assignee_id: "user-1",
-      creator_type: "member",
-      creator_id: "user-1",
-      parent_issue_id: "missing-parent",
-      project_id: null,
-      position: 400,
-      start_date: null,
-      due_date: null,
-      metadata: {},
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-01T00:00:00Z",
-    };
+  // Child whose parent_issue_id points at an issue not in the loaded set
+  // (e.g. parent filtered out server-side by "assigned to me", or hidden
+  // by a status filter without an unfilteredIssues prop). Falls into the
+  // "Other parents" display-only lane.
+  const orphanChild: Issue = {
+    id: "lonely-child",
+    workspace_id: "ws-1",
+    number: 99,
+    identifier: "PROJ-99",
+    title: "Lonely Child",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: "member",
+    assignee_id: "user-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: "missing-parent",
+    project_id: null,
+    position: 400,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
 
+  it("renders children whose parent is not in the loaded set under an 'Other parents' fallback lane", () => {
     renderWithI18n(
       <SwimLaneView issues={[orphanChild]} onMoveIssue={vi.fn()} />,
     );
 
     expect(screen.getByText("Other parents")).toBeInTheDocument();
     expect(screen.getByText("Lonely Child")).toBeInTheDocument();
+  });
+
+  it("does not render the add-issue button inside 'Other parents' cells", () => {
+    // The orphan lane is display-only: clicking + would create an issue
+    // with no parent context (it doesn't belong to any known parent),
+    // so the affordance is suppressed. mockIssues contains parent-1,
+    // child-1, orphan-1 — combine with orphanChild so both a real lane
+    // and the orphan lane are rendered.
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, orphanChild]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Real lanes still render + buttons (No parent + Parent Issue 1 lanes
+    // each have one per visible status column). The orphan lane adds
+    // zero buttons regardless of how many statuses are visible.
+    const realLaneCount = 2; // No parent + Parent Issue 1
+    const visibleStatusCount = 6; // BOARD_STATUSES default
+    expect(
+      screen.getAllByRole("button", { name: /add issue/i }).length,
+    ).toBe(realLaneCount * visibleStatusCount);
+  });
+
+  it("does not call onMoveIssue when a card is dropped into an 'Other parents' cell", () => {
+    // Round 2 review A1 — dropping onto the display-only lane previously
+    // committed a stealth re-position by computing position from
+    // unrelated cards.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, orphanChild]}
+        onMoveIssue={mockOnMoveIssue}
+      />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "orphan-1" },
+        over: { id: "swim:parent:__orphans__:todo" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
+  });
+
+  it("hides parent lanes whose only children are filtered out, while still rendering visible children of visible parents", () => {
+    // Round 2 review B — lane discovery walks the visible `issues` set,
+    // not the broader `unfilteredIssues`, so a status filter that hides
+    // all of a parent's children also hides that parent's lane (the
+    // parent itself can still render as a card via the unfilteredIssues
+    // path when the caller wires it through).
+    //
+    // Fixture: parent-1 + its only child (in_progress). With visibleStatuses
+    // restricted to ["todo"], child-1 isn't in `issues`, so parent-1's
+    // lane should disappear.
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues.filter((i) => i.status === "todo")}
+        unfilteredIssues={mockIssues}
+        visibleStatuses={["todo"]}
+        hiddenStatuses={["backlog", "in_progress", "in_review", "done", "blocked"]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Parent Issue 1 — its only child (child-1) is in_progress (hidden),
+    // so its lane is dropped. Only the "No parent" lane should render,
+    // and parent-1 itself shows up as a card within it (status: todo,
+    // not a lane header because no visible children reference it).
+    expect(screen.queryByText("Child Issue 1")).not.toBeInTheDocument();
+    // Header still appears for "No parent"; "Parent Issue 1" is now a
+    // regular card.
+    const parentTitleMatches = screen.getAllByText("Parent Issue 1");
+    expect(parentTitleMatches).toHaveLength(1);
+  });
+
+  it("does not call onMoveIssue when a card is dragged out of 'Other parents'", () => {
+    // Same defense in the opposite direction — a card whose parent we
+    // don't know about must not be re-anchored to a different parent by
+    // accident.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, orphanChild]}
+        onMoveIssue={mockOnMoveIssue}
+      />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lonely-child" },
+        over: { id: "swim:parent:parent-1:in_progress" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
   });
 
   it("renders an open-parent link for lanes with a real parent", () => {
@@ -687,6 +785,27 @@ describe("SwimLaneView", () => {
 
     // Drag lane parent-1 onto lane parent-2 — expect order to become
     // [parent-2, parent-1].
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lane:parent-1" },
+        over: { id: "lane:parent-2" },
+      });
+    });
+
+    expect(mockSetSwimlaneOrder).toHaveBeenCalledWith(["parent-2", "parent-1"]);
+  });
+
+  it("appends newly-visible parents to the persisted order on first reorder", () => {
+    // stored=[parent-1] (parent-2 is new in this view). User drags
+    // parent-1 below parent-2, so the visible order flips. Persisted
+    // result must include both — earlier logic dropped the new entry
+    // when its slot in `stored` had been consumed.
+    mockViewState.swimlaneOrder = ["parent-1"];
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
     act(() => {
       lastOnDragEnd({
         active: { id: "lane:parent-1" },

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -76,16 +76,24 @@ vi.mock("@multica/core/issues/config", () => ({
   },
 }));
 
-// Mock @multica/core/issues/mutations for hidden column status counts
+// Default mock returns hasMore=false so the load-more sentinels render
+// as no-op divs and don't pull IntersectionObserver into JSDOM.
+const mockLoadMore = vi.fn();
+const useLoadMoreByStatusMock = vi.fn(
+  (_status: string, _opts?: unknown) => ({
+    total: 0,
+    loaded: 0,
+    hasMore: false,
+    isLoading: false,
+    loadMore: mockLoadMore,
+  }),
+);
 vi.mock("@multica/core/issues/mutations", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@multica/core/issues/mutations")>();
   return {
     ...actual,
-    useLoadMoreByStatus: (status: string) => {
-      if (status === "backlog") return { total: 1, loaded: 1, hasMore: false, isLoading: false, loadMore: vi.fn() };
-      if (status === "blocked") return { total: 0, loaded: 0, hasMore: false, isLoading: false, loadMore: vi.fn() };
-      return { total: 0, loaded: 0, hasMore: false, isLoading: false, loadMore: vi.fn() };
-    },
+    useLoadMoreByStatus: (status: string, opts?: unknown) =>
+      useLoadMoreByStatusMock(status, opts),
   };
 });
 
@@ -265,6 +273,13 @@ describe("SwimLaneView", () => {
     // collapsed state from one test doesn't leak into the next.
     mockViewState.swimlaneOrder = [];
     mockViewState.collapsedSwimlanes = [];
+    useLoadMoreByStatusMock.mockImplementation(() => ({
+      total: 0,
+      loaded: 0,
+      hasMore: false,
+      isLoading: false,
+      loadMore: mockLoadMore,
+    }));
   });
 
   it("renders status columns as headers", () => {
@@ -304,13 +319,15 @@ describe("SwimLaneView", () => {
       />,
     );
 
-    // Orphan Issue 1 is in "No parent" + Backlog
+    // Orphan-1 is a true orphan → card in "No parent" + Backlog.
     expect(screen.getByText("Orphan Issue 1")).toBeInTheDocument();
 
-    // Parent Issue 1 is in "No parent" + Todo
-    expect(screen.getAllByText("Parent Issue 1").length).toBeGreaterThanOrEqual(1);
+    // Parent Issue 1 is promoted to a lane header (has child-1 as a
+    // sub-issue) and must NOT also render as a card in "No parent".
+    const parentTitleMatches = screen.getAllByText("Parent Issue 1");
+    expect(parentTitleMatches).toHaveLength(1);
+    expect(parentTitleMatches[0]!.closest("div")?.textContent).toContain("PROJ-1");
 
-    // Child Issue 1 is in "Parent Issue 1" + In Progress
     expect(screen.getByText("Child Issue 1")).toBeInTheDocument();
   });
 
@@ -329,6 +346,60 @@ describe("SwimLaneView", () => {
 
     fireEvent.click(addButtons[0]!);
     expect(mockOpenModal).toHaveBeenCalledWith("create-issue", expect.any(Object));
+  });
+
+  it("includes project_id in the create payload when projectId prop is set", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        onMoveIssue={vi.fn()}
+        projectId="proj-42"
+      />,
+    );
+
+    const addButtons = screen.getAllByRole("button", { name: /add issue/i });
+    fireEvent.click(addButtons[0]!);
+
+    expect(mockOpenModal).toHaveBeenCalledWith(
+      "create-issue",
+      expect.objectContaining({ project_id: "proj-42" }),
+    );
+  });
+
+  it("renders children whose parent is not in the loaded set under an 'Other parents' fallback lane", () => {
+    // Child with parent_issue_id pointing at an issue that isn't in the
+    // dataset (e.g. parent filtered out server-side by "assigned to me",
+    // or hidden by a status filter without an unfilteredIssues prop).
+    // Previously these silently disappeared from Swimlane.
+    const orphanChild: Issue = {
+      id: "lonely-child",
+      workspace_id: "ws-1",
+      number: 99,
+      identifier: "PROJ-99",
+      title: "Lonely Child",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      assignee_type: "member",
+      assignee_id: "user-1",
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: "missing-parent",
+      project_id: null,
+      position: 400,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    renderWithI18n(
+      <SwimLaneView issues={[orphanChild]} onMoveIssue={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Other parents")).toBeInTheDocument();
+    expect(screen.getByText("Lonely Child")).toBeInTheDocument();
   });
 
   it("renders an open-parent link for lanes with a real parent", () => {
@@ -460,10 +531,9 @@ describe("SwimLaneView", () => {
     );
   });
 
-  it("renders count for hidden statuses based on in-memory issues", () => {
-    // statusTotals must count every issue's status, including statuses that
-    // are not currently rendered as columns. mockIssues has 1 `backlog` and
-    // 0 `blocked`. Hide both and assert the panel shows the right counts.
+  it("renders count for hidden statuses from in-memory statusTotals", () => {
+    // mockIssues: 1 backlog (orphan-1), 0 blocked. parent-1 is a lane
+    // header so it's excluded from totals.
     renderWithI18n(
       <SwimLaneView
         issues={mockIssues}
@@ -474,11 +544,42 @@ describe("SwimLaneView", () => {
     );
 
     const panel = screen.getByText("Hidden columns").parentElement!.parentElement!;
-    // Backlog row should show "1"; Blocked row should show "0".
     expect(panel).toHaveTextContent("Backlog");
     expect(panel).toHaveTextContent("Blocked");
     expect(panel).toHaveTextContent("1");
     expect(panel).toHaveTextContent("0");
+  });
+
+  it("hidden-column totals come from unfilteredIssues when provided", () => {
+    // Without unfilteredIssues, a status-filtered `issues` prop would
+    // make hidden statuses always read 0.
+    const unfiltered: Issue[] = [
+      ...mockIssues,
+      {
+        ...mockIssues[2]!,
+        id: "blocked-1",
+        identifier: "PROJ-99",
+        title: "Blocked Issue",
+        status: "blocked",
+        position: 500,
+      },
+    ];
+
+    renderWithI18n(
+      <SwimLaneView
+        issues={mockIssues}
+        unfilteredIssues={unfiltered}
+        visibleStatuses={["todo", "in_progress", "in_review", "done"]}
+        hiddenStatuses={["backlog", "blocked"]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    const panel = screen.getByText("Hidden columns").parentElement!.parentElement!;
+    expect(panel).toHaveTextContent("Backlog");
+    expect(panel).toHaveTextContent("Blocked");
+    const counts = [...panel.querySelectorAll("span")].map((el) => el.textContent);
+    expect(counts.filter((c) => c === "1").length).toBeGreaterThanOrEqual(2);
   });
 
   // ------------------------------------------------------------------
@@ -594,6 +695,31 @@ describe("SwimLaneView", () => {
     });
 
     expect(mockSetSwimlaneOrder).toHaveBeenCalledWith(["parent-2", "parent-1"]);
+  });
+
+  it("preserves persisted entries that aren't currently visible during a reorder", () => {
+    // Persisted order contains two ids (filtered-a, filtered-b) that are
+    // not in the currently rendered set — they must keep their slots
+    // when the user reorders the visible lanes.
+    mockViewState.swimlaneOrder = ["filtered-a", "parent-1", "filtered-b", "parent-2"];
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "lane:parent-1" },
+        over: { id: "lane:parent-2" },
+      });
+    });
+
+    expect(mockSetSwimlaneOrder).toHaveBeenCalledWith([
+      "filtered-a",
+      "parent-2",
+      "filtered-b",
+      "parent-1",
+    ]);
   });
 
   it("does not call setSwimlaneOrder when a lane is dropped onto itself", () => {

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -15,8 +15,9 @@ import {
   type DragEndEvent,
   type DragOverEvent,
 } from "@dnd-kit/core";
-import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
-import { Eye, EyeOff, MoreHorizontal, Pencil, Plus } from "lucide-react";
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ChevronRight, EyeOff, GripVertical, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import type { UpdateIssueRequest } from "@multica/core/types";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
@@ -31,10 +32,11 @@ import { sortIssues } from "../utils/sort";
 import { BOARD_STATUSES, STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
 import { DraggableBoardCard, BoardCardContent } from "./board-card";
+import { StatusIcon } from "./status-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { StatusHeading } from "./status-heading";
-import { StatusIcon } from "./status-icon";
+import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
 import { AppLink } from "../../navigation";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
@@ -87,6 +89,18 @@ function cellId(parentKey: string, status: IssueStatus): string {
   return `swim:${parentKey}:${status}`;
 }
 
+const LANE_ID_PREFIX = "lane:";
+
+/** Sortable id for a draggable swimlane header (parents only). */
+function laneId(parentIssueId: string): string {
+  return `${LANE_ID_PREFIX}${parentIssueId}`;
+}
+
+function parseLaneId(id: string): string | null {
+  if (!id.startsWith(LANE_ID_PREFIX)) return null;
+  return id.slice(LANE_ID_PREFIX.length);
+}
+
 function computePosition(ids: string[], activeId: string, issueMap: Map<string, Issue>): number {
   const idx = ids.indexOf(activeId);
   if (idx === -1) return 0;
@@ -102,6 +116,8 @@ interface ParentGroup {
   parentIssueId: string | null;
   identifier: string;
   title: string;
+  /** Full Issue object for the parent — available for parent lanes, null for "No parent". */
+  issue: Issue | null;
 }
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
@@ -124,6 +140,7 @@ export function SwimLaneView({
   const viewStoreApi = useViewStoreApi();
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
+  const swimlaneOrder = useViewStore((s) => s.swimlaneOrder);
 
   const sortedStatuses = useMemo(
     () => BOARD_STATUSES.filter((s) => visibleStatuses.includes(s)),
@@ -142,11 +159,15 @@ export function SwimLaneView({
         const key = `parent:${issue.parent_issue_id}`;
         if (!seen.has(key)) {
           const parent = issueMap.get(issue.parent_issue_id);
+          // If the parent issue was deleted (not in the loaded set), skip
+          // the entire lane — its orphaned sub-issues are just noise.
+          if (!parent) continue;
           seen.set(key, {
             key,
             parentIssueId: issue.parent_issue_id,
-            identifier: parent?.identifier ?? issue.parent_issue_id.slice(0, 8),
-            title: parent?.title ?? "(deleted)",
+            identifier: parent.identifier,
+            title: parent.title,
+            issue: parent,
           });
         }
       }
@@ -157,10 +178,36 @@ export function SwimLaneView({
       parentIssueId: null,
       identifier: "",
       title: t(($) => $.swimlane.no_parent),
+      issue: null,
     };
 
-    return [noParentGroup, ...seen.values()];
-  }, [issues, t]);
+    // Apply user-defined lane order: stored entries first (in the order they
+    // were saved), then any newly-introduced parents that aren't in the
+    // stored order yet (in natural data order, so they don't randomly
+    // shuffle around). "No parent" is always pinned at the very top.
+    const orderIndex = new Map<string, number>();
+    swimlaneOrder.forEach((parentId, idx) => {
+      orderIndex.set(`parent:${parentId}`, idx);
+    });
+    const ordered = Array.from(seen.values()).sort((a, b) => {
+      const ai = orderIndex.get(a.key);
+      const bi = orderIndex.get(b.key);
+      if (ai !== undefined && bi !== undefined) return ai - bi;
+      if (ai !== undefined) return -1; // a is stored, b isn't → a first
+      if (bi !== undefined) return 1;
+      return 0; // both unstored → preserve insertion order
+    });
+
+    return [noParentGroup, ...ordered];
+  }, [issues, t, swimlaneOrder]);
+
+  // Issues that act as swimlane headers (they have children in the loaded
+  // set) should not also appear as cards in the "No parent" lane — that
+  // would be redundant noise since the lane header already represents them.
+  const parentIssueIds = useMemo(
+    () => new Set(parentGroups.map((g) => g.parentIssueId).filter(Boolean)),
+    [parentGroups],
+  );
 
   const cells = useMemo(() => {
     const result: Record<string, Record<string, string[]>> = {};
@@ -170,11 +217,14 @@ export function SwimLaneView({
         cellMap[status] = [];
       }
       const parentIssues = sortIssues(
-        issues.filter((issue) =>
-          parent.parentIssueId === null
-            ? issue.parent_issue_id === null
-            : issue.parent_issue_id === parent.parentIssueId,
-        ),
+        issues.filter((issue) => {
+          if (parent.parentIssueId === null) {
+            // "No parent" lane: include only orphans that are not themselves
+            // a parent (those already have their own swimlane).
+            return issue.parent_issue_id === null && !parentIssueIds.has(issue.id);
+          }
+          return issue.parent_issue_id === parent.parentIssueId;
+        }),
         sortBy,
         sortDirection,
       );
@@ -199,13 +249,50 @@ export function SwimLaneView({
     return ids;
   }, [parentGroups, sortedStatuses]);
 
+  // The set of parent-group keys lets us quickly test whether an issue
+  // belongs to any displayed lane (its parent exists and has a lane, OR it
+  // belongs to "No parent" and isn't itself a parent promoted to a header).
+  const parentGroupKeys = useMemo(
+    () => new Set(parentGroups.map((g) => g.key)),
+    [parentGroups],
+  );
+
+  // Count only issues that would be rendered as cards in the swimlane —
+  // across ALL statuses (visible + hidden).  This ensures hidden-column
+  // counts match the number of cards the user would see if the column were
+  // un-hidden, while still excluding parent-header issues and orphaned
+  // sub-issues of deleted parents.
   const statusTotals = useMemo(() => {
     const totals = new Map<IssueStatus, number>();
     for (const issue of issues) {
+      // Skip issues promoted to lane headers
+      if (parentIssueIds.has(issue.id)) continue;
+      // Skip issues whose parent was deleted (no lane for them)
+      if (issue.parent_issue_id && !parentGroupKeys.has(`parent:${issue.parent_issue_id}`)) continue;
       totals.set(issue.status, (totals.get(issue.status) ?? 0) + 1);
     }
     return totals;
-  }, [issues]);
+  }, [issues, parentIssueIds, parentGroupKeys]);
+
+  // Collapsed swimlanes — persisted per-workspace via the view store.
+  // The store keys are raw parent issue ids (or "none" for the "No parent"
+  // lane), but lane keys in this component are namespaced as
+  // `parent:<id>` / `parent:none`.  Convert on read/write.
+  const collapsedSwimlanes = useViewStore((s) => s.collapsedSwimlanes);
+  const collapsedLanes = useMemo(() => {
+    const set = new Set<string>();
+    for (const id of collapsedSwimlanes) {
+      set.add(id === "none" ? "parent:none" : `parent:${id}`);
+    }
+    return set;
+  }, [collapsedSwimlanes]);
+  const toggleLane = useCallback(
+    (laneKey: string) => {
+      const storeKey = laneKey === "parent:none" ? "none" : laneKey.slice("parent:".length);
+      viewStoreApi.getState().toggleSwimlaneCollapsed(storeKey);
+    },
+    [viewStoreApi],
+  );
 
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
   const isDraggingRef = useRef(false);
@@ -252,7 +339,14 @@ export function SwimLaneView({
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     isDraggingRef.current = true;
-    const issue = issueMapRef.current.get(event.active.id as string) ?? null;
+    const activeId = event.active.id as string;
+    // Lane drags don't carry an Issue payload — clear the card overlay so
+    // we don't show a stale card during a lane reorder.
+    if (parseLaneId(activeId)) {
+      setActiveIssue(null);
+      return;
+    }
+    const issue = issueMapRef.current.get(activeId) ?? null;
     setActiveIssue(issue);
   }, []);
 
@@ -339,6 +433,27 @@ export function SwimLaneView({
 
       const activeId = active.id as string;
       const overId = over.id as string;
+
+      // Lane reorder branch — runs before the card-move logic because lane
+      // ids don't resolve to any cell, so we must handle them explicitly.
+      const activeParentId = parseLaneId(activeId);
+      const overParentId = parseLaneId(overId);
+      if (activeParentId && overParentId && activeParentId !== overParentId) {
+        // Build the new order from the currently rendered parent lanes
+        // (excluding "No parent"), then arrayMove between active/over.
+        const currentOrder = parentGroups
+          .filter((g) => g.parentIssueId !== null)
+          .map((g) => g.parentIssueId!);
+        const fromIdx = currentOrder.indexOf(activeParentId);
+        const toIdx = currentOrder.indexOf(overParentId);
+        if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
+        const nextOrder = arrayMove(currentOrder, fromIdx, toIdx);
+        viewStoreApi.getState().setSwimlaneOrder(nextOrder);
+        return;
+      }
+      // Defensive: if only one side is a lane id, treat as no-op.
+      if (activeParentId || overParentId) return;
+
       const cols = localCellsRef.current;
 
       const activeCell = findCellIn(cols, cellSet, activeId);
@@ -402,7 +517,7 @@ export function SwimLaneView({
         position: newPosition,
       });
     },
-    [cells, cellSet, onMoveIssue],
+    [cells, cellSet, onMoveIssue, parentGroups, viewStoreApi],
   );
 
   // Grid template: one column per status, fixed width COLUMN_WIDTH, gap COLUMN_GAP.
@@ -440,8 +555,10 @@ export function SwimLaneView({
                     <DropdownMenuTrigger
                       render={
                         <Button
+                          type="button"
                           variant="ghost"
                           size="icon-sm"
+                          aria-label={t(($) => $.board.hide_column)}
                           className="rounded-full text-muted-foreground"
                         >
                           <MoreHorizontal className="size-3.5" />
@@ -463,57 +580,49 @@ export function SwimLaneView({
           </div>
         </div>
 
-        {/* Parent rows */}
+        {/* Parent rows. "No parent" is pinned at top and non-draggable;
+            the rest are wrapped in a SortableContext so users can reorder
+            lanes by dragging the grip handle. */}
         <div className="flex flex-col gap-4">
-          {parentGroups.map((parent) => (
-            <div key={parent.key} className="flex flex-col">
-              {/* Lane header — spans full width above the row */}
-              <div className="mb-2 flex items-center gap-2 px-1">
-                <span className="truncate text-sm font-semibold">
-                  {parent.title}
-                </span>
-                {parent.identifier && (
-                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-                    {parent.identifier}
-                  </span>
-                )}
-                {parent.parentIssueId && (
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <AppLink
-                          href={paths.issueDetail(parent.parentIssueId)}
-                          aria-label={t(($) => $.swimlane.open_parent)}
-                          className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-                        >
-                          <Pencil className="size-3" />
-                        </AppLink>
-                      }
-                    />
-                    <TooltipContent>{t(($) => $.swimlane.open_parent)}</TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
-              {/* Cells row — each cell mirrors a BoardColumn body */}
-              <div style={gridStyle}>
-                {sortedStatuses.map((status) => {
-                  const cId = cellId(parent.key, status);
-                  const issueIds = localCells[parent.key]?.[status] ?? [];
-                  return (
-                    <SwimLaneCell
-                      key={cId}
-                      cellId={cId}
-                      issueIds={issueIds}
-                      issueMap={issueMapRef.current}
-                      childProgressMap={childProgressMap}
-                      status={status}
-                      parentGroup={parent}
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+          {parentGroups
+            .filter((p) => p.parentIssueId === null)
+            .map((parent) => (
+              <DraggableSwimLane
+                key={parent.key}
+                parent={parent}
+                isCollapsed={collapsedLanes.has(parent.key)}
+                onToggleCollapse={() => toggleLane(parent.key)}
+                localCells={localCells}
+                sortedStatuses={sortedStatuses}
+                issueMap={issueMapRef.current}
+                childProgressMap={childProgressMap}
+                gridStyle={gridStyle}
+                paths={paths}
+              />
+            ))}
+          <SortableContext
+            items={parentGroups
+              .filter((p) => p.parentIssueId !== null)
+              .map((p) => laneId(p.parentIssueId!))}
+            strategy={verticalListSortingStrategy}
+          >
+            {parentGroups
+              .filter((p) => p.parentIssueId !== null)
+              .map((parent) => (
+                <DraggableSwimLane
+                  key={parent.key}
+                  parent={parent}
+                  isCollapsed={collapsedLanes.has(parent.key)}
+                  onToggleCollapse={() => toggleLane(parent.key)}
+                  localCells={localCells}
+                  sortedStatuses={sortedStatuses}
+                  issueMap={issueMapRef.current}
+                  childProgressMap={childProgressMap}
+                  gridStyle={gridStyle}
+                  paths={paths}
+                />
+              ))}
+          </SortableContext>
         </div>
         </div>
 
@@ -533,6 +642,136 @@ export function SwimLaneView({
         ) : null}
       </DragOverlay>
     </DndContext>
+  );
+}
+
+/**
+ * Renders a single swimlane (lane header + cells row).
+ *
+ * Lanes with a real parent are made draggable via `useSortable` so users can
+ * reorder them.  The "No parent" lane passes through with `disabled: true`
+ * so it stays pinned and unclickable for drag — useSortable must still be
+ * called unconditionally to satisfy the rules of hooks.
+ *
+ * Click vs drag: PointerSensor has `activationConstraint: { distance: 5 }`,
+ * so taps on the header still toggle collapse while a >=5px drag starts the
+ * sortable interaction. The "Open parent" pencil link stops pointer events
+ * so users can click it without inadvertently starting a drag.
+ */
+function DraggableSwimLane({
+  parent,
+  isCollapsed,
+  onToggleCollapse,
+  localCells,
+  sortedStatuses,
+  issueMap,
+  childProgressMap,
+  gridStyle,
+  paths,
+}: {
+  parent: ParentGroup;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  localCells: Record<string, Record<string, string[]>>;
+  sortedStatuses: IssueStatus[];
+  issueMap: Map<string, Issue>;
+  childProgressMap: Map<string, ChildProgress>;
+  gridStyle: React.CSSProperties;
+  paths: ReturnType<typeof useWorkspacePaths>;
+}) {
+  const { t } = useT("issues");
+  const isNoParent = parent.parentIssueId === null;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    // Always provide a valid id (rules of hooks) — the "No parent" lane is
+    // disabled, so its id is never used as a sortable target.
+    id: isNoParent ? "lane:__no_parent__" : laneId(parent.parentIssueId!),
+    disabled: isNoParent,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const laneTotal = sortedStatuses.reduce(
+    (sum, s) => sum + (localCells[parent.key]?.[s]?.length ?? 0),
+    0,
+  );
+
+  // Stop pointer events from bubbling into the sortable's pointer listener
+  // so clicking interactive elements (open-parent link) does not start a drag.
+  const stopPointer = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  return (
+    <div ref={setNodeRef} style={style} className={`flex flex-col ${isDragging ? "opacity-50" : ""}`}>
+      {/* Lane header — full width above the row. Spread `listeners` so the
+          header itself acts as the drag affordance; the leading GripVertical
+          icon is a visual hint, not a separate handle. */}
+      <button
+        type="button"
+        className="mb-2 flex w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-accent/70"
+        onClick={onToggleCollapse}
+        {...attributes}
+        {...listeners}
+      >
+        {!isNoParent && (
+          <GripVertical className="!size-3 shrink-0 cursor-grab text-muted-foreground/60" />
+        )}
+        <ChevronRight
+          className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+        />
+        {parent.issue && (
+          <StatusIcon status={parent.issue.status} className="size-3.5" />
+        )}
+        <span className="truncate text-sm font-semibold">{parent.title}</span>
+        {parent.identifier && (
+          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+            {parent.identifier}
+          </span>
+        )}
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          {laneTotal}
+        </span>
+        {parent.parentIssueId && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <AppLink
+                  href={paths.issueDetail(parent.parentIssueId)}
+                  aria-label={t(($) => $.swimlane.open_parent)}
+                  className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                  onClick={stopPointer}
+                  onPointerDown={stopPointer}
+                >
+                  <Pencil className="size-3" />
+                </AppLink>
+              }
+            />
+            <TooltipContent>{t(($) => $.swimlane.open_parent)}</TooltipContent>
+          </Tooltip>
+        )}
+      </button>
+      {/* Cells row — each cell mirrors a BoardColumn body */}
+      {!isCollapsed && (
+        <div style={gridStyle}>
+          {sortedStatuses.map((status) => {
+            const cId = cellId(parent.key, status);
+            const issueIds = localCells[parent.key]?.[status] ?? [];
+            return (
+              <SwimLaneCell
+                key={cId}
+                cellId={cId}
+                issueIds={issueIds}
+                issueMap={issueMap}
+                childProgressMap={childProgressMap}
+                status={status}
+                parentGroup={parent}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -599,8 +838,10 @@ function SwimLaneCell({
         <TooltipTrigger
           render={
             <Button
+              type="button"
               variant="ghost"
               size="icon-sm"
+              aria-label={t(($) => $.board.add_issue_tooltip)}
               className="mt-1 w-full rounded-md text-muted-foreground hover:text-foreground"
               onClick={handleAdd}
             >
@@ -614,6 +855,12 @@ function SwimLaneCell({
   );
 }
 
+/**
+ * Swimlane-specific wrapper around the shared {@link HiddenColumnsPanel}.
+ * Per-status total is computed from the in-memory `issues` array (already
+ * filtered/paginated upstream), so unlike the board this avoids a separate
+ * `useLoadMoreByStatus` query per hidden column.
+ */
 function SwimLaneHiddenColumnsPanel({
   hiddenStatuses,
   statusTotals,
@@ -621,54 +868,16 @@ function SwimLaneHiddenColumnsPanel({
   hiddenStatuses: IssueStatus[];
   statusTotals: Map<IssueStatus, number>;
 }) {
-  const { t } = useT("issues");
-  const viewStoreApi = useViewStoreApi();
   return (
-    <div className="flex w-[240px] shrink-0 flex-col">
-      <div className="mb-2 flex items-center gap-2 px-1">
-        <span className="text-sm font-medium text-muted-foreground">
-          {t(($) => $.board.hidden_columns_label)}
-        </span>
-      </div>
-      <div className="flex-1 space-y-0.5">
-        {hiddenStatuses.map((status) => (
-          <div
-            key={status}
-            className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50"
-          >
-            <div className="flex items-center gap-2">
-              <StatusIcon status={status} className="h-3.5 w-3.5" />
-              <span className="text-sm">{t(($) => $.status[status])}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs text-muted-foreground">
-                {statusTotals.get(status) ?? 0}
-              </span>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="rounded-full text-muted-foreground"
-                    >
-                      <MoreHorizontal className="size-3.5" />
-                    </Button>
-                  }
-                />
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={() => viewStoreApi.getState().showStatus(status)}
-                  >
-                    <Eye className="size-3.5" />
-                    {t(($) => $.board.show_column)}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <HiddenColumnsPanel
+      hiddenStatuses={hiddenStatuses}
+      renderRow={(status) => (
+        <HiddenColumnRow
+          key={status}
+          status={status}
+          total={statusTotals.get(status) ?? 0}
+        />
+      )}
+    />
   );
 }

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -16,18 +16,31 @@ import {
   type DragOverEvent,
 } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
-import { Plus } from "lucide-react";
+import { Eye, EyeOff, MoreHorizontal, Pencil, Plus } from "lucide-react";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import type { UpdateIssueRequest } from "@multica/core/types";
-import { useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
+import { useWorkspacePaths } from "@multica/core/paths";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@multica/ui/components/ui/dropdown-menu";
 import { sortIssues } from "../utils/sort";
 import { BOARD_STATUSES, STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
 import { DraggableBoardCard, BoardCardContent } from "./board-card";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
+import { StatusHeading } from "./status-heading";
+import { StatusIcon } from "./status-icon";
+import { AppLink } from "../../navigation";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
+
+const COLUMN_WIDTH = 280;
+const COLUMN_GAP = 16;
 
 type SwimLaneMoveUpdates = Pick<
   UpdateIssueRequest,
@@ -96,15 +109,19 @@ const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 export function SwimLaneView({
   issues,
   visibleStatuses = BOARD_STATUSES,
+  hiddenStatuses = [],
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
 }: {
   issues: Issue[];
   visibleStatuses?: IssueStatus[];
+  hiddenStatuses?: IssueStatus[];
   onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
   childProgressMap?: Map<string, ChildProgress>;
 }) {
   const { t } = useT("issues");
+  const paths = useWorkspacePaths();
+  const viewStoreApi = useViewStoreApi();
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
 
@@ -181,6 +198,14 @@ export function SwimLaneView({
     }
     return ids;
   }, [parentGroups, sortedStatuses]);
+
+  const statusTotals = useMemo(() => {
+    const totals = new Map<IssueStatus, number>();
+    for (const issue of issues) {
+      totals.set(issue.status, (totals.get(issue.status) ?? 0) + 1);
+    }
+    return totals;
+  }, [issues]);
 
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
   const isDraggingRef = useRef(false);
@@ -380,6 +405,15 @@ export function SwimLaneView({
     [cells, cellSet, onMoveIssue],
   );
 
+  // Grid template: one column per status, fixed width COLUMN_WIDTH, gap COLUMN_GAP.
+  const trackWidth = sortedStatuses.length * COLUMN_WIDTH + Math.max(0, sortedStatuses.length - 1) * COLUMN_GAP;
+  const gridStyle = {
+    display: "grid",
+    gridTemplateColumns: `repeat(${sortedStatuses.length}, ${COLUMN_WIDTH}px)`,
+    columnGap: `${COLUMN_GAP}px`,
+    width: `${trackWidth}px`,
+  } as const;
+
   return (
     <DndContext
       sensors={sensors}
@@ -388,59 +422,107 @@ export function SwimLaneView({
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex flex-1 min-h-0 overflow-x-auto">
-        <div className="flex flex-col min-w-0" style={{ width: sortedStatuses.length * 280 }}>
-          <div className="flex h-10 border-b border-border bg-background sticky top-0 z-10">
+      <div className="flex flex-1 min-h-0 gap-4 overflow-auto p-4">
+        <div className="flex shrink-0 flex-col" style={{ width: `${trackWidth}px` }}>
+        {/* Sticky status header row — visually matches the top of a BoardColumn */}
+        <div className="sticky top-0 z-10 mb-2 bg-background/95 pb-2 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+          <div style={gridStyle}>
             {sortedStatuses.map((status) => {
               const cfg = STATUS_CONFIG[status];
+              const total = statusTotals.get(status) ?? 0;
               return (
                 <div
                   key={status}
-                  className="flex w-[280px] shrink-0 items-center gap-2 px-3"
+                  className={`flex items-center justify-between rounded-xl ${cfg?.columnBg ?? "bg-muted/40"} px-3 py-2`}
                 >
-                  <span className={`h-2 w-2 rounded-full ${cfg?.iconColor ? cfg.iconColor.replace("text-", "bg-") : "bg-muted"}`} />
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {t(($) => $.status[status])}
-                  </span>
+                  <StatusHeading status={status} count={total} />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="rounded-full text-muted-foreground"
+                        >
+                          <MoreHorizontal className="size-3.5" />
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => viewStoreApi.getState().hideStatus(status)}
+                      >
+                        <EyeOff className="size-3.5" />
+                        {t(($) => $.board.hide_column)}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               );
             })}
           </div>
-
-          <div className="flex-1">
-            {parentGroups.map((parent) => (
-              <div key={parent.key}>
-                <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/30 bg-muted/20">
-                  <span className="text-sm font-semibold text-accent truncate">
-                    {parent.title}
-                  </span>
-                  {parent.identifier && (
-                    <span className="text-xs text-muted-foreground tabular-nums truncate">
-                      {parent.identifier}
-                    </span>
-                  )}
-                </div>
-                <div className="flex border-b border-border/50">
-                  {sortedStatuses.map((status) => {
-                    const cId = cellId(parent.key, status);
-                    const issueIds = localCells[parent.key]?.[status] ?? [];
-                    return (
-                      <SwimLaneCell
-                        key={cId}
-                        cellId={cId}
-                        issueIds={issueIds}
-                        issueMap={issueMapRef.current}
-                        childProgressMap={childProgressMap}
-                        status={status}
-                        parentGroup={parent}
-                      />
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
         </div>
+
+        {/* Parent rows */}
+        <div className="flex flex-col gap-4">
+          {parentGroups.map((parent) => (
+            <div key={parent.key} className="flex flex-col">
+              {/* Lane header — spans full width above the row */}
+              <div className="mb-2 flex items-center gap-2 px-1">
+                <span className="truncate text-sm font-semibold">
+                  {parent.title}
+                </span>
+                {parent.identifier && (
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+                    {parent.identifier}
+                  </span>
+                )}
+                {parent.parentIssueId && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <AppLink
+                          href={paths.issueDetail(parent.parentIssueId)}
+                          aria-label={t(($) => $.swimlane.open_parent)}
+                          className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                        >
+                          <Pencil className="size-3" />
+                        </AppLink>
+                      }
+                    />
+                    <TooltipContent>{t(($) => $.swimlane.open_parent)}</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+              {/* Cells row — each cell mirrors a BoardColumn body */}
+              <div style={gridStyle}>
+                {sortedStatuses.map((status) => {
+                  const cId = cellId(parent.key, status);
+                  const issueIds = localCells[parent.key]?.[status] ?? [];
+                  return (
+                    <SwimLaneCell
+                      key={cId}
+                      cellId={cId}
+                      issueIds={issueIds}
+                      issueMap={issueMapRef.current}
+                      childProgressMap={childProgressMap}
+                      status={status}
+                      parentGroup={parent}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+        </div>
+
+        {hiddenStatuses.length > 0 && (
+          <SwimLaneHiddenColumnsPanel
+            hiddenStatuses={hiddenStatuses}
+            statusTotals={statusTotals}
+          />
+        )}
       </div>
 
       <DragOverlay dropAnimation={null}>
@@ -471,6 +553,7 @@ function SwimLaneCell({
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: cId });
   const { t } = useT("issues");
+  const cfg = STATUS_CONFIG[status];
 
   const resolvedIssues = useMemo(
     () =>
@@ -490,42 +573,101 @@ function SwimLaneCell({
   }, [status, parentGroup]);
 
   return (
-    <div
-      ref={setNodeRef}
-      className={`flex w-[280px] shrink-0 flex-col rounded-lg p-1 transition-colors ${
-        isOver ? "bg-accent/60" : ""
-      }`}
-    >
-      <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
-        {resolvedIssues.map((issue) => (
-          <DraggableBoardCard
-            key={issue.id}
-            issue={issue}
-            childProgress={childProgressMap.get(issue.id)}
-          />
+    <div className={`flex min-h-[120px] flex-col rounded-xl ${cfg?.columnBg ?? "bg-muted/40"} p-2`}>
+      <div
+        ref={setNodeRef}
+        className={`flex-1 space-y-2 rounded-lg p-1 transition-colors ${
+          isOver ? "bg-accent/60" : ""
+        }`}
+      >
+        <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
+          {resolvedIssues.map((issue) => (
+            <DraggableBoardCard
+              key={issue.id}
+              issue={issue}
+              childProgress={childProgressMap.get(issue.id)}
+            />
+          ))}
+        </SortableContext>
+        {issueIds.length === 0 && (
+          <p className="py-6 text-center text-xs text-muted-foreground">
+            &mdash;
+          </p>
+        )}
+      </div>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="mt-1 w-full rounded-md text-muted-foreground hover:text-foreground"
+              onClick={handleAdd}
+            >
+              <Plus className="size-3.5" />
+            </Button>
+          }
+        />
+        <TooltipContent>{t(($) => $.board.add_issue_tooltip)}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function SwimLaneHiddenColumnsPanel({
+  hiddenStatuses,
+  statusTotals,
+}: {
+  hiddenStatuses: IssueStatus[];
+  statusTotals: Map<IssueStatus, number>;
+}) {
+  const { t } = useT("issues");
+  const viewStoreApi = useViewStoreApi();
+  return (
+    <div className="flex w-[240px] shrink-0 flex-col">
+      <div className="mb-2 flex items-center gap-2 px-1">
+        <span className="text-sm font-medium text-muted-foreground">
+          {t(($) => $.board.hidden_columns_label)}
+        </span>
+      </div>
+      <div className="flex-1 space-y-0.5">
+        {hiddenStatuses.map((status) => (
+          <div
+            key={status}
+            className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50"
+          >
+            <div className="flex items-center gap-2">
+              <StatusIcon status={status} className="h-3.5 w-3.5" />
+              <span className="text-sm">{t(($) => $.status[status])}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {statusTotals.get(status) ?? 0}
+              </span>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="rounded-full text-muted-foreground"
+                    >
+                      <MoreHorizontal className="size-3.5" />
+                    </Button>
+                  }
+                />
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={() => viewStoreApi.getState().showStatus(status)}
+                  >
+                    <Eye className="size-3.5" />
+                    {t(($) => $.board.show_column)}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
         ))}
-      </SortableContext>
-      {issueIds.length === 0 && (
-        <p className="py-8 text-center text-xs text-muted-foreground">
-          &mdash;
-        </p>
-      )}
-      <div className="mt-auto pt-1">
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="w-full rounded-md text-muted-foreground hover:text-foreground"
-                onClick={handleAdd}
-              >
-                <Plus className="size-3.5" />
-              </Button>
-            }
-          />
-          <TooltipContent>{t(($) => $.board.add_issue_tooltip)}</TooltipContent>
-        </Tooltip>
       </div>
     </div>
   );

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  pointerWithin,
+  closestCenter,
+  type CollisionDetection,
+  type DragStartEvent,
+  type DragEndEvent,
+  type DragOverEvent,
+} from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import { Plus } from "lucide-react";
+import type { Issue, IssueStatus } from "@multica/core/types";
+import type { UpdateIssueRequest } from "@multica/core/types";
+import { useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { sortIssues } from "../utils/sort";
+import { BOARD_STATUSES, STATUS_CONFIG } from "@multica/core/issues/config";
+import { useModalStore } from "@multica/core/modals";
+import { DraggableBoardCard, BoardCardContent } from "./board-card";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import { Button } from "@multica/ui/components/ui/button";
+import type { ChildProgress } from "./list-row";
+import { useT } from "../../i18n";
+
+type SwimLaneMoveUpdates = Pick<
+  UpdateIssueRequest,
+  "parent_issue_id" | "status" | "position"
+>;
+
+function makeSwimLaneCollision(cellIds: Set<string>): CollisionDetection {
+  return (args) => {
+    const pointer = pointerWithin(args);
+    if (pointer.length > 0) {
+      const cards = pointer.filter((c) => !cellIds.has(c.id as string));
+      if (cards.length > 0) return cards;
+    }
+    return closestCenter(args);
+  };
+}
+
+function parseCellId(id: string): { parentKey: string; status: string } | null {
+  if (!id.startsWith("swim:")) return null;
+  const rest = id.slice(5);
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon === -1) return null;
+  return {
+    parentKey: rest.slice(0, lastColon),
+    status: rest.slice(lastColon + 1),
+  };
+}
+
+function findCellIn(
+  data: Record<string, Record<string, string[]>>,
+  cellIds: Set<string>,
+  id: string,
+): { parentKey: string; status: string } | null {
+  if (cellIds.has(id)) return parseCellId(id);
+  for (const [pk, statusMap] of Object.entries(data)) {
+    for (const [status, ids] of Object.entries(statusMap)) {
+      if (ids.includes(id)) return { parentKey: pk, status };
+    }
+  }
+  return null;
+}
+
+function cellId(parentKey: string, status: IssueStatus): string {
+  return `swim:${parentKey}:${status}`;
+}
+
+function computePosition(ids: string[], activeId: string, issueMap: Map<string, Issue>): number {
+  const idx = ids.indexOf(activeId);
+  if (idx === -1) return 0;
+  const getPos = (id: string) => issueMap.get(id)?.position ?? 0;
+  if (ids.length === 1) return issueMap.get(activeId)?.position ?? 0;
+  if (idx === 0) return getPos(ids[1]!) - 1;
+  if (idx === ids.length - 1) return getPos(ids[idx - 1]!) + 1;
+  return (getPos(ids[idx - 1]!) + getPos(ids[idx + 1]!)) / 2;
+}
+
+interface ParentGroup {
+  key: string;
+  parentIssueId: string | null;
+  identifier: string;
+  title: string;
+}
+
+const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+
+export function SwimLaneView({
+  issues,
+  visibleStatuses = BOARD_STATUSES,
+  onMoveIssue,
+  childProgressMap = EMPTY_PROGRESS_MAP,
+}: {
+  issues: Issue[];
+  visibleStatuses?: IssueStatus[];
+  onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
+  childProgressMap?: Map<string, ChildProgress>;
+}) {
+  const { t } = useT("issues");
+  const sortBy = useViewStore((s) => s.sortBy);
+  const sortDirection = useViewStore((s) => s.sortDirection);
+
+  const sortedStatuses = useMemo(
+    () => BOARD_STATUSES.filter((s) => visibleStatuses.includes(s)),
+    [visibleStatuses],
+  );
+
+  const parentGroups = useMemo<ParentGroup[]>(() => {
+    const seen = new Map<string, ParentGroup>();
+    const issueMap = new Map<string, Issue>();
+    for (const issue of issues) {
+      issueMap.set(issue.id, issue);
+    }
+
+    for (const issue of issues) {
+      if (issue.parent_issue_id) {
+        const key = `parent:${issue.parent_issue_id}`;
+        if (!seen.has(key)) {
+          const parent = issueMap.get(issue.parent_issue_id);
+          seen.set(key, {
+            key,
+            parentIssueId: issue.parent_issue_id,
+            identifier: parent?.identifier ?? issue.parent_issue_id.slice(0, 8),
+            title: parent?.title ?? "(deleted)",
+          });
+        }
+      }
+    }
+
+    const noParentGroup: ParentGroup = {
+      key: "parent:none",
+      parentIssueId: null,
+      identifier: "",
+      title: t(($) => $.swimlane.no_parent),
+    };
+
+    return [noParentGroup, ...seen.values()];
+  }, [issues, t]);
+
+  const cells = useMemo(() => {
+    const result: Record<string, Record<string, string[]>> = {};
+    for (const parent of parentGroups) {
+      const cellMap: Record<string, string[]> = {};
+      for (const status of sortedStatuses) {
+        cellMap[status] = [];
+      }
+      const parentIssues = sortIssues(
+        issues.filter((issue) =>
+          parent.parentIssueId === null
+            ? issue.parent_issue_id === null
+            : issue.parent_issue_id === parent.parentIssueId,
+        ),
+        sortBy,
+        sortDirection,
+      );
+      for (const issue of parentIssues) {
+        const s = issue.status;
+        if (cellMap[s]) {
+          cellMap[s].push(issue.id);
+        }
+      }
+      result[parent.key] = cellMap;
+    }
+    return result;
+  }, [issues, parentGroups, sortedStatuses, sortBy, sortDirection]);
+
+  const cellSet = useMemo(() => {
+    const ids = new Set<string>();
+    for (const parent of parentGroups) {
+      for (const status of sortedStatuses) {
+        ids.add(cellId(parent.key, status));
+      }
+    }
+    return ids;
+  }, [parentGroups, sortedStatuses]);
+
+  const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
+  const isDraggingRef = useRef(false);
+
+  const issueMap = useMemo(() => {
+    const map = new Map<string, Issue>();
+    for (const issue of issues) map.set(issue.id, issue);
+    return map;
+  }, [issues]);
+
+  const issueMapRef = useRef(issueMap);
+  if (!isDraggingRef.current) {
+    issueMapRef.current = issueMap;
+  }
+
+  const [localCells, setLocalCells] = useState(cells);
+  const localCellsRef = useRef(localCells);
+  localCellsRef.current = localCells;
+
+  useEffect(() => {
+    if (!isDraggingRef.current) {
+      setLocalCells(cells);
+    }
+  }, [cells]);
+
+  const recentlyMovedRef = useRef(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      recentlyMovedRef.current = false;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [localCells]);
+
+  const collisionDetection = useMemo(
+    () => makeSwimLaneCollision(cellSet),
+    [cellSet],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    isDraggingRef.current = true;
+    const issue = issueMapRef.current.get(event.active.id as string) ?? null;
+    setActiveIssue(issue);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over || recentlyMovedRef.current) return;
+
+      const activeId = active.id as string;
+      const overId = over.id as string;
+
+      setLocalCells((prev) => {
+        const activeCell = findCellIn(prev, cellSet, activeId);
+        const overCell = findCellIn(prev, cellSet, overId);
+        if (!activeCell || !overCell) return prev;
+        if (
+          activeCell.parentKey === overCell.parentKey &&
+          activeCell.status === overCell.status
+        ) {
+          return prev;
+        }
+
+        recentlyMovedRef.current = true;
+
+        if (activeCell.parentKey === overCell.parentKey) {
+          // Same parent row, different status column
+          const row = prev[activeCell.parentKey] ?? {};
+          const sourceIds = (row[activeCell.status] ?? []).filter((id) => id !== activeId);
+          const targetIds = (row[overCell.status] ?? []).filter((id) => id !== activeId);
+
+          const overIndex = targetIds.indexOf(overId);
+          const insertIndex = overIndex >= 0 ? overIndex : targetIds.length;
+          targetIds.splice(insertIndex, 0, activeId);
+
+          return {
+            ...prev,
+            [activeCell.parentKey]: {
+              ...row,
+              [activeCell.status]: sourceIds,
+              [overCell.status]: targetIds,
+            },
+          };
+        } else {
+          // Different parent rows
+          const sourceRow = prev[activeCell.parentKey] ?? {};
+          const targetRow = prev[overCell.parentKey] ?? {};
+
+          const sourceIds = (sourceRow[activeCell.status] ?? []).filter((id) => id !== activeId);
+          const targetIds = (targetRow[overCell.status] ?? []).filter((id) => id !== activeId);
+
+          const overIndex = targetIds.indexOf(overId);
+          const insertIndex = overIndex >= 0 ? overIndex : targetIds.length;
+          targetIds.splice(insertIndex, 0, activeId);
+
+          return {
+            ...prev,
+            [activeCell.parentKey]: {
+              ...sourceRow,
+              [activeCell.status]: sourceIds,
+            },
+            [overCell.parentKey]: {
+              ...targetRow,
+              [overCell.status]: targetIds,
+            },
+          };
+        }
+      });
+    },
+    [cellSet],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      isDraggingRef.current = false;
+      setActiveIssue(null);
+
+      const reset = () => setLocalCells(cells);
+
+      if (!over) {
+        reset();
+        return;
+      }
+
+      const activeId = active.id as string;
+      const overId = over.id as string;
+      const cols = localCellsRef.current;
+
+      const activeCell = findCellIn(cols, cellSet, activeId);
+      const overCell = findCellIn(cols, cellSet, overId);
+      if (!activeCell || !overCell) {
+        reset();
+        return;
+      }
+
+      let finalCells = cols;
+      // Handle reordering within the same target cell upon drop.
+      if (
+        activeCell.parentKey === overCell.parentKey &&
+        activeCell.status === overCell.status
+      ) {
+        const ids = cols[activeCell.parentKey]?.[activeCell.status];
+        if (ids) {
+          const oldIndex = ids.indexOf(activeId);
+          const newIndex = ids.indexOf(overId);
+          if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+            const reordered = arrayMove(ids, oldIndex, newIndex);
+            finalCells = {
+              ...cols,
+              [activeCell.parentKey]: {
+                ...cols[activeCell.parentKey],
+                [activeCell.status]: reordered,
+              },
+            };
+            setLocalCells(finalCells);
+          }
+        }
+      }
+
+      const finalOverCell = findCellIn(finalCells, cellSet, activeId);
+      if (!finalOverCell) {
+        reset();
+        return;
+      }
+
+      const finalIds = finalCells[finalOverCell.parentKey]?.[finalOverCell.status] ?? [];
+      const newPosition = computePosition(finalIds, activeId, issueMapRef.current);
+      const currentIssue = issueMapRef.current.get(activeId);
+
+      const expectedParent =
+        finalOverCell.parentKey === "parent:none"
+          ? null
+          : finalOverCell.parentKey.replace("parent:", "");
+
+      if (
+        currentIssue &&
+        currentIssue.parent_issue_id === expectedParent &&
+        currentIssue.status === (finalOverCell.status as IssueStatus) &&
+        currentIssue.position === newPosition
+      ) {
+        return;
+      }
+
+      onMoveIssue(activeId, {
+        parent_issue_id: expectedParent,
+        status: finalOverCell.status as IssueStatus,
+        position: newPosition,
+      });
+    },
+    [cells, cellSet, onMoveIssue],
+  );
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={collisionDetection}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex flex-1 min-h-0 overflow-x-auto">
+        <div className="flex flex-col min-w-0" style={{ width: sortedStatuses.length * 280 }}>
+          <div className="flex h-10 border-b border-border bg-background sticky top-0 z-10">
+            {sortedStatuses.map((status) => {
+              const cfg = STATUS_CONFIG[status];
+              return (
+                <div
+                  key={status}
+                  className="flex w-[280px] shrink-0 items-center gap-2 px-3"
+                >
+                  <span className={`h-2 w-2 rounded-full ${cfg?.iconColor ? cfg.iconColor.replace("text-", "bg-") : "bg-muted"}`} />
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t(($) => $.status[status])}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex-1">
+            {parentGroups.map((parent) => (
+              <div key={parent.key}>
+                <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/30 bg-muted/20">
+                  <span className="text-sm font-semibold text-accent truncate">
+                    {parent.title}
+                  </span>
+                  {parent.identifier && (
+                    <span className="text-xs text-muted-foreground tabular-nums truncate">
+                      {parent.identifier}
+                    </span>
+                  )}
+                </div>
+                <div className="flex border-b border-border/50">
+                  {sortedStatuses.map((status) => {
+                    const cId = cellId(parent.key, status);
+                    const issueIds = localCells[parent.key]?.[status] ?? [];
+                    return (
+                      <SwimLaneCell
+                        key={cId}
+                        cellId={cId}
+                        issueIds={issueIds}
+                        issueMap={issueMapRef.current}
+                        childProgressMap={childProgressMap}
+                        status={status}
+                        parentGroup={parent}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <DragOverlay dropAnimation={null}>
+        {activeIssue ? (
+          <div className="w-[280px] rotate-2 scale-105 cursor-grabbing opacity-90 shadow-lg shadow-black/10">
+            <BoardCardContent issue={activeIssue} childProgress={childProgressMap.get(activeIssue.id)} />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+
+function SwimLaneCell({
+  cellId: cId,
+  issueIds,
+  issueMap,
+  childProgressMap,
+  status,
+  parentGroup,
+}: {
+  cellId: string;
+  issueIds: string[];
+  issueMap: Map<string, Issue>;
+  childProgressMap: Map<string, ChildProgress>;
+  status: IssueStatus;
+  parentGroup: ParentGroup;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: cId });
+  const { t } = useT("issues");
+
+  const resolvedIssues = useMemo(
+    () =>
+      issueIds.flatMap((id) => {
+        const issue = issueMap.get(id);
+        return issue ? [issue] : [];
+      }),
+    [issueIds, issueMap],
+  );
+
+  const handleAdd = useCallback(() => {
+    const data: Record<string, unknown> = { status };
+    if (parentGroup.parentIssueId) {
+      data.parent_issue_id = parentGroup.parentIssueId;
+    }
+    useModalStore.getState().open("create-issue", data);
+  }, [status, parentGroup]);
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex w-[280px] shrink-0 flex-col rounded-lg p-1 transition-colors ${
+        isOver ? "bg-accent/60" : ""
+      }`}
+    >
+      <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
+        {resolvedIssues.map((issue) => (
+          <DraggableBoardCard
+            key={issue.id}
+            issue={issue}
+            childProgress={childProgressMap.get(issue.id)}
+          />
+        ))}
+      </SortableContext>
+      {issueIds.length === 0 && (
+        <p className="py-8 text-center text-xs text-muted-foreground">
+          &mdash;
+        </p>
+      )}
+      <div className="mt-auto pt-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="w-full rounded-md text-muted-foreground hover:text-foreground"
+                onClick={handleAdd}
+              >
+                <Plus className="size-3.5" />
+              </Button>
+            }
+          />
+          <TooltipContent>{t(($) => $.board.add_issue_tooltip)}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -53,12 +53,36 @@ type SwimLaneMoveUpdates = Pick<
 
 function makeSwimLaneCollision(cellIds: Set<string>): CollisionDetection {
   return (args) => {
+    const activeId = args.active.id as string;
+    const isLaneDrag = activeId.startsWith("lane:");
+
     const pointer = pointerWithin(args);
     if (pointer.length > 0) {
-      const cards = pointer.filter((c) => !cellIds.has(c.id as string));
-      if (cards.length > 0) return cards;
+      let filtered = pointer;
+      if (isLaneDrag) {
+        // Lane dragging: only consider other lane headers
+        filtered = pointer.filter((c) => (c.id as string).startsWith("lane:"));
+      } else {
+        // Card dragging: ignore parent lane headers entirely
+        filtered = pointer.filter((c) => !(c.id as string).startsWith("lane:"));
+      }
+
+      if (filtered.length > 0) {
+        const cards = filtered.filter((c) => !cellIds.has(c.id as string));
+        if (cards.length > 0) return cards;
+        return filtered;
+      }
     }
-    return closestCenter(args);
+
+    const closest = closestCenter(args);
+    let filteredClosest = closest;
+    if (isLaneDrag) {
+      filteredClosest = closest.filter((c) => (c.id as string).startsWith("lane:"));
+    } else {
+      filteredClosest = closest.filter((c) => !(c.id as string).startsWith("lane:"));
+    }
+
+    return filteredClosest;
   };
 }
 
@@ -251,7 +275,7 @@ export function SwimLaneView({
       result[parent.key] = cellMap;
     }
     return result;
-  }, [issues, parentGroups, sortedStatuses, sortBy, sortDirection]);
+  }, [issues, parentGroups, sortedStatuses, sortBy, sortDirection, parentIssueIds]);
 
   const cellSet = useMemo(() => {
     const ids = new Set<string>();

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -165,9 +165,12 @@ export function SwimLaneView({
 }: {
   issues: Issue[];
   /**
-   * Status-unfiltered companion set used for lane discovery and status
-   * totals — without it, children whose parent sits in a hidden status
-   * would vanish and hidden-column counts would always read 0.
+   * Status-unfiltered companion set used for parent metadata lookup and
+   * status totals. Lane discovery still drives off the visible `issues`
+   * set so that parents whose children are all in hidden statuses don't
+   * produce empty rows, but header chrome (identifier, title, issue ref
+   * for the Open-parent link) and hidden-column counts read from here so
+   * a parent in a hidden status still surfaces its label correctly.
    */
   unfilteredIssues?: Issue[];
   visibleStatuses?: IssueStatus[];
@@ -334,11 +337,16 @@ export function SwimLaneView({
     return ids;
   }, [parentGroups, sortedStatuses]);
 
-  // Drives both visible status-header counts AND hidden-column panel rows,
-  // so both sides agree on a single semantic. Counts what would render as a
-  // card — every issue minus those promoted to lane headers. Children
-  // whose parent isn't loaded still count because they land in the
-  // "Other parents" fallback lane.
+  // Drives both visible status-header counts AND hidden-column panel rows.
+  // Known limitation: `parentIssueIds` is derived from lanes that exist
+  // in the current render (only parents with ≥1 visible child). A parent
+  // whose children are all hidden doesn't get a lane, so it counts as a
+  // card here. When the user un-hides that status the parent gets
+  // promoted to a lane header and the count for that status drops by 1.
+  // The visible-column total and the "would-see-if-unhidden" total are
+  // therefore subtly different aggregates — fixing this requires a
+  // second parentIssueIds set built from laneSourceIssues rather than
+  // the rendered parentGroups. Tracked as a follow-up.
   const statusTotals = useMemo(() => {
     const totals = new Map<IssueStatus, number>();
     for (const issue of laneSourceIssues) {
@@ -925,10 +933,14 @@ function SwimLaneCell({
    */
   readOnly?: boolean;
 }) {
-  // Hook is called unconditionally (rules of hooks), but readOnly cells
-  // discard the ref so dnd-kit never registers them — no `isOver`
-  // affordance, no collision detection target.
-  const { setNodeRef, isOver } = useDroppable({ id: cId, disabled: readOnly });
+  // The orphan cell stays enabled in the collision graph so that drops
+  // onto its whitespace area are absorbed here instead of falling through
+  // to the nearest real cell. The ORPHAN_LANE_KEY guards in
+  // handleDragOver / handleDragEnd reject the actual move.
+  const { setNodeRef, isOver: droppableIsOver } = useDroppable({ id: cId });
+  // Never show the hover highlight on a readOnly cell — the guards will
+  // reject the drop, so visual confirmation would be misleading.
+  const isOver = readOnly ? false : droppableIsOver;
   const { t } = useT("issues");
   const cfg = STATUS_CONFIG[status];
 

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -22,6 +22,8 @@ import type { Issue, IssueStatus } from "@multica/core/types";
 import type { UpdateIssueRequest } from "@multica/core/types";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
+import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -128,12 +130,16 @@ export function SwimLaneView({
   hiddenStatuses = [],
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  myIssuesScope,
+  myIssuesFilter,
 }: {
   issues: Issue[];
   visibleStatuses?: IssueStatus[];
   hiddenStatuses?: IssueStatus[];
   onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
   childProgressMap?: Map<string, ChildProgress>;
+  myIssuesScope?: string;
+  myIssuesFilter?: MyIssuesFilter;
 }) {
   const { t } = useT("issues");
   const paths = useWorkspacePaths();
@@ -141,6 +147,14 @@ export function SwimLaneView({
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
   const swimlaneOrder = useViewStore((s) => s.swimlaneOrder);
+
+  const myIssuesOpts = useMemo(
+    () =>
+      myIssuesScope
+        ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
+        : undefined,
+    [myIssuesScope, myIssuesFilter],
+  );
 
   const sortedStatuses = useMemo(
     () => BOARD_STATUSES.filter((s) => visibleStatuses.includes(s)),
@@ -629,7 +643,7 @@ export function SwimLaneView({
         {hiddenStatuses.length > 0 && (
           <SwimLaneHiddenColumnsPanel
             hiddenStatuses={hiddenStatuses}
-            statusTotals={statusTotals}
+            myIssuesOpts={myIssuesOpts}
           />
         )}
       </div>
@@ -855,27 +869,37 @@ function SwimLaneCell({
   );
 }
 
+function SwimLaneHiddenColumnRow({
+  status,
+  myIssuesOpts,
+}: {
+  status: IssueStatus;
+  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+}) {
+  const { total } = useLoadMoreByStatus(status, myIssuesOpts);
+  return <HiddenColumnRow status={status} total={total} />;
+}
+
 /**
  * Swimlane-specific wrapper around the shared {@link HiddenColumnsPanel}.
- * Per-status total is computed from the in-memory `issues` array (already
- * filtered/paginated upstream), so unlike the board this avoids a separate
- * `useLoadMoreByStatus` query per hidden column.
+ * Uses `useLoadMoreByStatus` to get accurate cached/live status counts from
+ * the React Query cache, mirroring the board's hidden column behavior.
  */
 function SwimLaneHiddenColumnsPanel({
   hiddenStatuses,
-  statusTotals,
+  myIssuesOpts,
 }: {
   hiddenStatuses: IssueStatus[];
-  statusTotals: Map<IssueStatus, number>;
+  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
   return (
     <HiddenColumnsPanel
       hiddenStatuses={hiddenStatuses}
       renderRow={(status) => (
-        <HiddenColumnRow
+        <SwimLaneHiddenColumnRow
           key={status}
           status={status}
-          total={statusTotals.get(status) ?? 0}
+          myIssuesOpts={myIssuesOpts}
         />
       )}
     />

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -39,6 +39,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import { Button } from "@multica/ui/components/ui/button";
 import { StatusHeading } from "./status-heading";
 import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
+import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import { AppLink } from "../../navigation";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
@@ -117,6 +118,9 @@ function cellId(parentKey: string, status: IssueStatus): string {
 
 const LANE_ID_PREFIX = "lane:";
 
+/** Sentinel key for the "Other parents" fallback lane. */
+const ORPHAN_LANE_KEY = "parent:__orphans__";
+
 /** Sortable id for a draggable swimlane header (parents only). */
 function laneId(parentIssueId: string): string {
   return `${LANE_ID_PREFIX}${parentIssueId}`;
@@ -150,20 +154,30 @@ const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 
 export function SwimLaneView({
   issues,
+  unfilteredIssues,
   visibleStatuses = BOARD_STATUSES,
   hiddenStatuses = [],
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  projectId,
 }: {
   issues: Issue[];
+  /**
+   * Status-unfiltered companion set used for lane discovery and status
+   * totals — without it, children whose parent sits in a hidden status
+   * would vanish and hidden-column counts would always read 0.
+   */
+  unfilteredIssues?: Issue[];
   visibleStatuses?: IssueStatus[];
   hiddenStatuses?: IssueStatus[];
   onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  /** Pre-fills `project_id` on the create form for the in-cell "+" button. */
+  projectId?: string;
 }) {
   const { t } = useT("issues");
   const paths = useWorkspacePaths();
@@ -171,6 +185,8 @@ export function SwimLaneView({
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
   const swimlaneOrder = useViewStore((s) => s.swimlaneOrder);
+
+  const laneSourceIssues = unfilteredIssues ?? issues;
 
   const myIssuesOpts = useMemo(
     () =>
@@ -186,38 +202,36 @@ export function SwimLaneView({
   );
 
   const parentGroups = useMemo<ParentGroup[]>(() => {
-    const seen = new Map<string, ParentGroup>();
     const issueMap = new Map<string, Issue>();
-    for (const issue of issues) {
+    for (const issue of laneSourceIssues) {
       issueMap.set(issue.id, issue);
     }
 
-    for (const issue of issues) {
-      if (issue.parent_issue_id) {
-        const key = `parent:${issue.parent_issue_id}`;
-        if (!seen.has(key)) {
-          const parent = issueMap.get(issue.parent_issue_id);
-          // If the parent issue was deleted (not in the loaded set), skip
-          // the entire lane — its orphaned sub-issues are just noise.
-          if (!parent) continue;
-          seen.set(key, {
-            key,
-            parentIssueId: issue.parent_issue_id,
-            identifier: parent.identifier,
-            title: parent.title,
-            issue: parent,
-          });
-        }
+    // A parent earns a lane whenever any child references it — even if
+    // all those children are currently in hidden statuses, the lane
+    // stays so the user keeps the grouping context they came in with.
+    // (The parent's own visibility status is irrelevant here; the lane
+    // exists to group its children, not to render the parent itself.)
+    const seen = new Map<string, ParentGroup>();
+    let hasOrphan = false;
+    for (const issue of laneSourceIssues) {
+      if (issue.parent_issue_id === null) continue;
+      const parent = issueMap.get(issue.parent_issue_id);
+      if (!parent) {
+        hasOrphan = true;
+        continue;
+      }
+      const key = `parent:${issue.parent_issue_id}`;
+      if (!seen.has(key)) {
+        seen.set(key, {
+          key,
+          parentIssueId: issue.parent_issue_id,
+          identifier: parent.identifier,
+          title: parent.title,
+          issue: parent,
+        });
       }
     }
-
-    const noParentGroup: ParentGroup = {
-      key: "parent:none",
-      parentIssueId: null,
-      identifier: "",
-      title: t(($) => $.swimlane.no_parent),
-      issue: null,
-    };
 
     // Apply user-defined lane order: stored entries first (in the order they
     // were saved), then any newly-introduced parents that aren't in the
@@ -236,8 +250,27 @@ export function SwimLaneView({
       return 0; // both unstored → preserve insertion order
     });
 
-    return [noParentGroup, ...ordered];
-  }, [issues, t, swimlaneOrder]);
+    const groups: ParentGroup[] = [
+      {
+        key: "parent:none",
+        parentIssueId: null,
+        identifier: "",
+        title: t(($) => $.swimlane.no_parent),
+        issue: null,
+      },
+    ];
+    if (hasOrphan) {
+      groups.push({
+        key: ORPHAN_LANE_KEY,
+        parentIssueId: null,
+        identifier: "",
+        title: t(($) => $.swimlane.other_parents),
+        issue: null,
+      });
+    }
+    groups.push(...ordered);
+    return groups;
+  }, [laneSourceIssues, t, swimlaneOrder]);
 
   // Issues that act as swimlane headers (they have children in the loaded
   // set) should not also appear as cards in the "No parent" lane — that
@@ -256,10 +289,22 @@ export function SwimLaneView({
       }
       const parentIssues = sortIssues(
         issues.filter((issue) => {
+          // Issues that are themselves lane headers are rendered by the
+          // header, not as a card — avoids a double render for multi-level
+          // nesting (a parent that also has a grandparent).
+          if (parentIssueIds.has(issue.id)) return false;
+          if (parent.key === ORPHAN_LANE_KEY) {
+            // Fallback bucket: children whose parent isn't in the loaded
+            // set (deleted, or filtered out by a server-side scope like
+            // "assigned to me"). Catches them so they don't silently
+            // vanish from Swimlane while still visible in Board/List.
+            return (
+              issue.parent_issue_id !== null &&
+              !parentIssueIds.has(issue.parent_issue_id)
+            );
+          }
           if (parent.parentIssueId === null) {
-            // "No parent" lane: include only orphans that are not themselves
-            // a parent (those already have their own swimlane).
-            return issue.parent_issue_id === null && !parentIssueIds.has(issue.id);
+            return issue.parent_issue_id === null;
           }
           return issue.parent_issue_id === parent.parentIssueId;
         }),
@@ -287,30 +332,19 @@ export function SwimLaneView({
     return ids;
   }, [parentGroups, sortedStatuses]);
 
-  // The set of parent-group keys lets us quickly test whether an issue
-  // belongs to any displayed lane (its parent exists and has a lane, OR it
-  // belongs to "No parent" and isn't itself a parent promoted to a header).
-  const parentGroupKeys = useMemo(
-    () => new Set(parentGroups.map((g) => g.key)),
-    [parentGroups],
-  );
-
-  // Count only issues that would be rendered as cards in the swimlane —
-  // across ALL statuses (visible + hidden).  This ensures hidden-column
-  // counts match the number of cards the user would see if the column were
-  // un-hidden, while still excluding parent-header issues and orphaned
-  // sub-issues of deleted parents.
+  // Drives both visible status-header counts AND hidden-column panel rows,
+  // so both sides agree on a single semantic. Counts what would render as a
+  // card — every issue minus those promoted to lane headers. Children
+  // whose parent isn't loaded still count because they land in the
+  // "Other parents" fallback lane.
   const statusTotals = useMemo(() => {
     const totals = new Map<IssueStatus, number>();
-    for (const issue of issues) {
-      // Skip issues promoted to lane headers
+    for (const issue of laneSourceIssues) {
       if (parentIssueIds.has(issue.id)) continue;
-      // Skip issues whose parent was deleted (no lane for them)
-      if (issue.parent_issue_id && !parentGroupKeys.has(`parent:${issue.parent_issue_id}`)) continue;
       totals.set(issue.status, (totals.get(issue.status) ?? 0) + 1);
     }
     return totals;
-  }, [issues, parentIssueIds, parentGroupKeys]);
+  }, [laneSourceIssues, parentIssueIds]);
 
   // Collapsed swimlanes — persisted per-workspace via the view store.
   // The store keys are raw parent issue ids (or "none" for the "No parent"
@@ -472,24 +506,42 @@ export function SwimLaneView({
       const activeId = active.id as string;
       const overId = over.id as string;
 
-      // Lane reorder branch — runs before the card-move logic because lane
-      // ids don't resolve to any cell, so we must handle them explicitly.
+      // Lane reorder runs before the card-move logic because lane ids
+      // don't resolve to any cell.
       const activeParentId = parseLaneId(activeId);
       const overParentId = parseLaneId(overId);
       if (activeParentId && overParentId && activeParentId !== overParentId) {
-        // Build the new order from the currently rendered parent lanes
-        // (excluding "No parent"), then arrayMove between active/over.
-        const currentOrder = parentGroups
+        const visibleOrder = parentGroups
           .filter((g) => g.parentIssueId !== null)
           .map((g) => g.parentIssueId!);
-        const fromIdx = currentOrder.indexOf(activeParentId);
-        const toIdx = currentOrder.indexOf(overParentId);
+        const fromIdx = visibleOrder.indexOf(activeParentId);
+        const toIdx = visibleOrder.indexOf(overParentId);
         if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
-        const nextOrder = arrayMove(currentOrder, fromIdx, toIdx);
-        viewStoreApi.getState().setSwimlaneOrder(nextOrder);
+        const visibleNext = arrayMove(visibleOrder, fromIdx, toIdx);
+
+        // Merge into the persisted order without clobbering entries that
+        // aren't currently visible (e.g. hidden by a status filter). Each
+        // visible slot in `stored` is overwritten with the next id from
+        // `visibleNext`; everything else stays exactly where it was.
+        const stored = viewStoreApi.getState().swimlaneOrder;
+        const visibleSet = new Set(visibleOrder);
+        const merged: string[] = [];
+        let cursor = 0;
+        for (const id of stored) {
+          if (visibleSet.has(id)) {
+            merged.push(visibleNext[cursor]!);
+            cursor++;
+          } else {
+            merged.push(id);
+          }
+        }
+        for (let i = cursor; i < visibleNext.length; i++) {
+          if (!stored.includes(visibleNext[i]!)) merged.push(visibleNext[i]!);
+        }
+
+        viewStoreApi.getState().setSwimlaneOrder(merged);
         return;
       }
-      // Defensive: if only one side is a lane id, treat as no-op.
       if (activeParentId || overParentId) return;
 
       const cols = localCellsRef.current;
@@ -535,8 +587,13 @@ export function SwimLaneView({
       const newPosition = computePosition(finalIds, activeId, issueMapRef.current);
       const currentIssue = issueMapRef.current.get(activeId);
 
-      const expectedParent =
-        finalOverCell.parentKey === "parent:none"
+      // Dropping into the "Other parents" fallback lane keeps the issue's
+      // existing parent — the lane is a display-only bucket for children
+      // whose parent isn't loaded, not a target you can re-parent into.
+      const droppedInOrphanLane = finalOverCell.parentKey === ORPHAN_LANE_KEY;
+      const expectedParent = droppedInOrphanLane
+        ? currentIssue?.parent_issue_id ?? null
+        : finalOverCell.parentKey === "parent:none"
           ? null
           : finalOverCell.parentKey.replace("parent:", "");
 
@@ -636,6 +693,7 @@ export function SwimLaneView({
                 childProgressMap={childProgressMap}
                 gridStyle={gridStyle}
                 paths={paths}
+                projectId={projectId}
               />
             ))}
           <SortableContext
@@ -658,16 +716,24 @@ export function SwimLaneView({
                   childProgressMap={childProgressMap}
                   gridStyle={gridStyle}
                   paths={paths}
+                  projectId={projectId}
                 />
               ))}
           </SortableContext>
+
+          {/* Per-status load-more sentinels — same bucketed cache as Board. */}
+          <SwimLaneLoadMoreRow
+            sortedStatuses={sortedStatuses}
+            gridStyle={gridStyle}
+            myIssuesOpts={myIssuesOpts}
+          />
         </div>
         </div>
 
         {hiddenStatuses.length > 0 && (
           <SwimLaneHiddenColumnsPanel
             hiddenStatuses={hiddenStatuses}
-            myIssuesOpts={myIssuesOpts}
+            statusTotals={statusTotals}
           />
         )}
       </div>
@@ -706,6 +772,7 @@ function DraggableSwimLane({
   childProgressMap,
   gridStyle,
   paths,
+  projectId,
 }: {
   parent: ParentGroup;
   isCollapsed: boolean;
@@ -716,6 +783,7 @@ function DraggableSwimLane({
   childProgressMap: Map<string, ChildProgress>;
   gridStyle: React.CSSProperties;
   paths: ReturnType<typeof useWorkspacePaths>;
+  projectId?: string;
 }) {
   const { t } = useT("issues");
   const isNoParent = parent.parentIssueId === null;
@@ -736,40 +804,45 @@ function DraggableSwimLane({
     0,
   );
 
-  // Stop pointer events from bubbling into the sortable's pointer listener
-  // so clicking interactive elements (open-parent link) does not start a drag.
-  const stopPointer = (e: React.SyntheticEvent) => e.stopPropagation();
-
   return (
     <div ref={setNodeRef} style={style} className={`flex flex-col ${isDragging ? "opacity-50" : ""}`}>
-      {/* Lane header — full width above the row. Spread `listeners` so the
-          header itself acts as the drag affordance; the leading GripVertical
-          icon is a visual hint, not a separate handle. */}
-      <button
-        type="button"
-        className="mb-2 flex w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-accent/70"
-        onClick={onToggleCollapse}
+      {/* Non-interactive container — the inner collapse button and the
+          open-parent link are independent controls so we don't nest an
+          <a> inside a <button>. The drag listeners attach here so the
+          whole header row is the drag surface. */}
+      <div
+        className="mb-2 flex w-full items-center gap-2 rounded-md px-1 py-1"
         {...attributes}
         {...listeners}
       >
         {!isNoParent && (
-          <GripVertical className="!size-3 shrink-0 cursor-grab text-muted-foreground/60" />
+          <GripVertical
+            className="!size-3 shrink-0 cursor-grab text-muted-foreground/60"
+            aria-hidden
+          />
         )}
-        <ChevronRight
-          className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${isCollapsed ? "" : "rotate-90"}`}
-        />
-        {parent.issue && (
-          <StatusIcon status={parent.issue.status} className="size-3.5" />
-        )}
-        <span className="truncate text-sm font-semibold">{parent.title}</span>
-        {parent.identifier && (
-          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-            {parent.identifier}
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          aria-label={t(($) => $.swimlane.toggle_collapse)}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left transition-colors hover:bg-accent/70"
+        >
+          <ChevronRight
+            className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+          />
+          {parent.issue && (
+            <StatusIcon status={parent.issue.status} className="size-3.5" />
+          )}
+          <span className="truncate text-sm font-semibold">{parent.title}</span>
+          {parent.identifier && (
+            <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+              {parent.identifier}
+            </span>
+          )}
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+            {laneTotal}
           </span>
-        )}
-        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-          {laneTotal}
-        </span>
+        </button>
         {parent.parentIssueId && (
           <Tooltip>
             <TooltipTrigger
@@ -778,8 +851,6 @@ function DraggableSwimLane({
                   href={paths.issueDetail(parent.parentIssueId)}
                   aria-label={t(($) => $.swimlane.open_parent)}
                   className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-                  onClick={stopPointer}
-                  onPointerDown={stopPointer}
                 >
                   <Pencil className="size-3" />
                 </AppLink>
@@ -788,7 +859,7 @@ function DraggableSwimLane({
             <TooltipContent>{t(($) => $.swimlane.open_parent)}</TooltipContent>
           </Tooltip>
         )}
-      </button>
+      </div>
       {/* Cells row — each cell mirrors a BoardColumn body */}
       {!isCollapsed && (
         <div style={gridStyle}>
@@ -804,6 +875,7 @@ function DraggableSwimLane({
                 childProgressMap={childProgressMap}
                 status={status}
                 parentGroup={parent}
+                projectId={projectId}
               />
             );
           })}
@@ -820,6 +892,7 @@ function SwimLaneCell({
   childProgressMap,
   status,
   parentGroup,
+  projectId,
 }: {
   cellId: string;
   issueIds: string[];
@@ -827,6 +900,7 @@ function SwimLaneCell({
   childProgressMap: Map<string, ChildProgress>;
   status: IssueStatus;
   parentGroup: ParentGroup;
+  projectId?: string;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: cId });
   const { t } = useT("issues");
@@ -843,11 +917,10 @@ function SwimLaneCell({
 
   const handleAdd = useCallback(() => {
     const data: Record<string, unknown> = { status };
-    if (parentGroup.parentIssueId) {
-      data.parent_issue_id = parentGroup.parentIssueId;
-    }
+    if (parentGroup.parentIssueId) data.parent_issue_id = parentGroup.parentIssueId;
+    if (projectId) data.project_id = projectId;
     useModalStore.getState().open("create-issue", data);
-  }, [status, parentGroup]);
+  }, [status, parentGroup, projectId]);
 
   return (
     <div className={`flex min-h-[120px] flex-col rounded-xl ${cfg?.columnBg ?? "bg-muted/40"} p-2`}>
@@ -893,39 +966,57 @@ function SwimLaneCell({
   );
 }
 
-function SwimLaneHiddenColumnRow({
+function SwimLaneHiddenColumnsPanel({
+  hiddenStatuses,
+  statusTotals,
+}: {
+  hiddenStatuses: IssueStatus[];
+  statusTotals: Map<IssueStatus, number>;
+}) {
+  return (
+    <HiddenColumnsPanel
+      hiddenStatuses={hiddenStatuses}
+      renderRow={(status) => (
+        <HiddenColumnRow
+          key={status}
+          status={status}
+          total={statusTotals.get(status) ?? 0}
+        />
+      )}
+    />
+  );
+}
+
+function SwimLaneLoadMoreRow({
+  sortedStatuses,
+  gridStyle,
+  myIssuesOpts,
+}: {
+  sortedStatuses: IssueStatus[];
+  gridStyle: React.CSSProperties;
+  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+}) {
+  return (
+    <div style={gridStyle}>
+      {sortedStatuses.map((status) => (
+        <SwimLaneLoadMoreCell
+          key={status}
+          status={status}
+          myIssuesOpts={myIssuesOpts}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SwimLaneLoadMoreCell({
   status,
   myIssuesOpts,
 }: {
   status: IssueStatus;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
-  const { total } = useLoadMoreByStatus(status, myIssuesOpts);
-  return <HiddenColumnRow status={status} total={total} />;
-}
-
-/**
- * Swimlane-specific wrapper around the shared {@link HiddenColumnsPanel}.
- * Uses `useLoadMoreByStatus` to get accurate cached/live status counts from
- * the React Query cache, mirroring the board's hidden column behavior.
- */
-function SwimLaneHiddenColumnsPanel({
-  hiddenStatuses,
-  myIssuesOpts,
-}: {
-  hiddenStatuses: IssueStatus[];
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
-}) {
-  return (
-    <HiddenColumnsPanel
-      hiddenStatuses={hiddenStatuses}
-      renderRow={(status) => (
-        <SwimLaneHiddenColumnRow
-          key={status}
-          status={status}
-          myIssuesOpts={myIssuesOpts}
-        />
-      )}
-    />
-  );
+  const { loadMore, hasMore, isLoading } = useLoadMoreByStatus(status, myIssuesOpts);
+  if (!hasMore) return <div />;
+  return <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />;
 }

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -202,21 +202,23 @@ export function SwimLaneView({
   );
 
   const parentGroups = useMemo<ParentGroup[]>(() => {
-    const issueMap = new Map<string, Issue>();
+    // Metadata lookup spans the broader unfiltered set so a parent whose
+    // status is currently hidden still surfaces its identifier / title
+    // when one of its children is visible.
+    const metadataMap = new Map<string, Issue>();
     for (const issue of laneSourceIssues) {
-      issueMap.set(issue.id, issue);
+      metadataMap.set(issue.id, issue);
     }
 
-    // A parent earns a lane whenever any child references it — even if
-    // all those children are currently in hidden statuses, the lane
-    // stays so the user keeps the grouping context they came in with.
-    // (The parent's own visibility status is irrelevant here; the lane
-    // exists to group its children, not to render the parent itself.)
+    // Lane discovery drives off the visible `issues` set — a lane is
+    // only rendered when at least one visible card belongs in it. This
+    // avoids a stack of empty rows for parents whose children all live
+    // in currently-filtered-out statuses.
     const seen = new Map<string, ParentGroup>();
     let hasOrphan = false;
-    for (const issue of laneSourceIssues) {
+    for (const issue of issues) {
       if (issue.parent_issue_id === null) continue;
-      const parent = issueMap.get(issue.parent_issue_id);
+      const parent = metadataMap.get(issue.parent_issue_id);
       if (!parent) {
         hasOrphan = true;
         continue;
@@ -270,7 +272,7 @@ export function SwimLaneView({
     }
     groups.push(...ordered);
     return groups;
-  }, [laneSourceIssues, t, swimlaneOrder]);
+  }, [issues, laneSourceIssues, t, swimlaneOrder]);
 
   // Issues that act as swimlane headers (they have children in the loaded
   // set) should not also appear as cards in the "No parent" lane — that
@@ -440,6 +442,17 @@ export function SwimLaneView({
         ) {
           return prev;
         }
+        // The "Other parents" lane is display-only: never let a card
+        // enter or leave it via drag. The lane represents children whose
+        // canonical parent isn't loaded, so any cross-lane move would
+        // either lose that parent (when leaving) or invent a new one
+        // (when entering).
+        if (
+          activeCell.parentKey === ORPHAN_LANE_KEY ||
+          overCell.parentKey === ORPHAN_LANE_KEY
+        ) {
+          return prev;
+        }
 
         recentlyMovedRef.current = true;
 
@@ -520,24 +533,18 @@ export function SwimLaneView({
         const visibleNext = arrayMove(visibleOrder, fromIdx, toIdx);
 
         // Merge into the persisted order without clobbering entries that
-        // aren't currently visible (e.g. hidden by a status filter). Each
-        // visible slot in `stored` is overwritten with the next id from
-        // `visibleNext`; everything else stays exactly where it was.
+        // aren't currently visible (e.g. hidden by a status filter).
+        // Walk stored, overwriting each visible slot with the next id
+        // from `visibleNext`; non-visible entries pass through verbatim.
+        // Any remaining `visibleNext` ids (visible parents that weren't
+        // in stored at all) get appended at the end.
         const stored = viewStoreApi.getState().swimlaneOrder;
         const visibleSet = new Set(visibleOrder);
-        const merged: string[] = [];
         let cursor = 0;
-        for (const id of stored) {
-          if (visibleSet.has(id)) {
-            merged.push(visibleNext[cursor]!);
-            cursor++;
-          } else {
-            merged.push(id);
-          }
-        }
-        for (let i = cursor; i < visibleNext.length; i++) {
-          if (!stored.includes(visibleNext[i]!)) merged.push(visibleNext[i]!);
-        }
+        const merged = stored.map((id) =>
+          visibleSet.has(id) ? visibleNext[cursor++]! : id,
+        );
+        for (const id of visibleNext.slice(cursor)) merged.push(id);
 
         viewStoreApi.getState().setSwimlaneOrder(merged);
         return;
@@ -549,6 +556,18 @@ export function SwimLaneView({
       const activeCell = findCellIn(cols, cellSet, activeId);
       const overCell = findCellIn(cols, cellSet, overId);
       if (!activeCell || !overCell) {
+        reset();
+        return;
+      }
+
+      // The "Other parents" lane is display-only. Refuse any drop where
+      // either the source or the original target cell belongs to it —
+      // no re-parenting (we don't know the canonical parent), no
+      // position write (siblings here belong to different parents).
+      if (
+        activeCell.parentKey === ORPHAN_LANE_KEY ||
+        overCell.parentKey === ORPHAN_LANE_KEY
+      ) {
         reset();
         return;
       }
@@ -587,13 +606,8 @@ export function SwimLaneView({
       const newPosition = computePosition(finalIds, activeId, issueMapRef.current);
       const currentIssue = issueMapRef.current.get(activeId);
 
-      // Dropping into the "Other parents" fallback lane keeps the issue's
-      // existing parent — the lane is a display-only bucket for children
-      // whose parent isn't loaded, not a target you can re-parent into.
-      const droppedInOrphanLane = finalOverCell.parentKey === ORPHAN_LANE_KEY;
-      const expectedParent = droppedInOrphanLane
-        ? currentIssue?.parent_issue_id ?? null
-        : finalOverCell.parentKey === "parent:none"
+      const expectedParent =
+        finalOverCell.parentKey === "parent:none"
           ? null
           : finalOverCell.parentKey.replace("parent:", "");
 
@@ -876,6 +890,7 @@ function DraggableSwimLane({
                 status={status}
                 parentGroup={parent}
                 projectId={projectId}
+                readOnly={parent.key === ORPHAN_LANE_KEY}
               />
             );
           })}
@@ -893,6 +908,7 @@ function SwimLaneCell({
   status,
   parentGroup,
   projectId,
+  readOnly = false,
 }: {
   cellId: string;
   issueIds: string[];
@@ -901,8 +917,18 @@ function SwimLaneCell({
   status: IssueStatus;
   parentGroup: ParentGroup;
   projectId?: string;
+  /**
+   * Display-only cell — the create affordance is suppressed and drag-end
+   * upstream refuses to honour drops that would re-anchor a card to this
+   * lane. Used by the "Other parents" fallback lane whose contents
+   * belong to parents we don't have loaded.
+   */
+  readOnly?: boolean;
 }) {
-  const { setNodeRef, isOver } = useDroppable({ id: cId });
+  // Hook is called unconditionally (rules of hooks), but readOnly cells
+  // discard the ref so dnd-kit never registers them — no `isOver`
+  // affordance, no collision detection target.
+  const { setNodeRef, isOver } = useDroppable({ id: cId, disabled: readOnly });
   const { t } = useT("issues");
   const cfg = STATUS_CONFIG[status];
 
@@ -945,23 +971,25 @@ function SwimLaneCell({
           </p>
         )}
       </div>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t(($) => $.board.add_issue_tooltip)}
-              className="mt-1 w-full rounded-md text-muted-foreground hover:text-foreground"
-              onClick={handleAdd}
-            >
-              <Plus className="size-3.5" />
-            </Button>
-          }
-        />
-        <TooltipContent>{t(($) => $.board.add_issue_tooltip)}</TooltipContent>
-      </Tooltip>
+      {!readOnly && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t(($) => $.board.add_issue_tooltip)}
+                className="mt-1 w-full rounded-md text-muted-foreground hover:text-foreground"
+                onClick={handleAdd}
+              >
+                <Plus className="size-3.5" />
+              </Button>
+            }
+          />
+          <TooltipContent>{t(($) => $.board.add_issue_tooltip)}</TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -80,10 +80,12 @@
     "tooltip_board": "Board view",
     "tooltip_list": "List view",
     "tooltip_gantt": "Gantt view",
+    "tooltip_swimlane": "Swimlane view",
     "section": "View",
     "board": "Board",
     "list": "List",
-    "gantt": "Gantt"
+    "gantt": "Gantt",
+    "swimlane": "Swimlane"
   },
   "gantt": {
     "header_issue": "Issue",
@@ -121,6 +123,10 @@
   "list": {
     "empty_status": "No issues",
     "add_issue_tooltip": "Add issue"
+  },
+  "swimlane": {
+    "parent_column": "Parent",
+    "no_parent": "No parent"
   },
   "board": {
     "hidden_columns_label": "Hidden columns",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -125,9 +125,10 @@
     "add_issue_tooltip": "Add issue"
   },
   "swimlane": {
-    "parent_column": "Parent",
     "no_parent": "No parent",
-    "open_parent": "Open parent issue"
+    "other_parents": "Other parents",
+    "open_parent": "Open parent issue",
+    "toggle_collapse": "Toggle lane"
   },
   "board": {
     "hidden_columns_label": "Hidden columns",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -126,7 +126,8 @@
   },
   "swimlane": {
     "parent_column": "Parent",
-    "no_parent": "No parent"
+    "no_parent": "No parent",
+    "open_parent": "Open parent issue"
   },
   "board": {
     "hidden_columns_label": "Hidden columns",

--- a/packages/views/locales/en/my-issues.json
+++ b/packages/views/locales/en/my-issues.json
@@ -32,9 +32,11 @@
     "card_properties": "Card properties",
     "view_board": "Board view",
     "view_list": "List view",
+    "view_swimlane": "Swimlane view",
     "view_label": "View",
     "view_board_short": "Board",
     "view_list_short": "List",
+    "view_swimlane_short": "Swimlane",
     "sort_manual": "Manual"
   },
   "errors": {

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -78,10 +78,12 @@
     "tooltip_board": "看板视图",
     "tooltip_list": "列表视图",
     "tooltip_gantt": "甘特图",
+    "tooltip_swimlane": "泳道视图",
     "section": "视图",
     "board": "看板",
     "list": "列表",
-    "gantt": "甘特图"
+    "gantt": "甘特图",
+    "swimlane": "泳道"
   },
   "gantt": {
     "header_issue": "Issue",
@@ -119,6 +121,10 @@
   "list": {
     "empty_status": "无 issue",
     "add_issue_tooltip": "新建 issue"
+  },
+  "swimlane": {
+    "parent_column": "父级",
+    "no_parent": "无父级"
   },
   "board": {
     "hidden_columns_label": "隐藏的列",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -123,9 +123,10 @@
     "add_issue_tooltip": "新建 issue"
   },
   "swimlane": {
-    "parent_column": "父级",
     "no_parent": "无父级",
-    "open_parent": "打开父级 issue"
+    "other_parents": "其他父级",
+    "open_parent": "打开父级 issue",
+    "toggle_collapse": "切换泳道"
   },
   "board": {
     "hidden_columns_label": "隐藏的列",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -124,7 +124,8 @@
   },
   "swimlane": {
     "parent_column": "父级",
-    "no_parent": "无父级"
+    "no_parent": "无父级",
+    "open_parent": "打开父级 issue"
   },
   "board": {
     "hidden_columns_label": "隐藏的列",

--- a/packages/views/locales/zh-Hans/my-issues.json
+++ b/packages/views/locales/zh-Hans/my-issues.json
@@ -31,9 +31,11 @@
     "card_properties": "卡片属性",
     "view_board": "看板视图",
     "view_list": "列表视图",
+    "view_swimlane": "泳道视图",
     "view_label": "视图",
     "view_board_short": "看板",
     "view_list_short": "列表",
+    "view_swimlane_short": "泳道",
     "sort_manual": "手动"
   },
   "errors": {

--- a/packages/views/my-issues/components/my-issues-header.tsx
+++ b/packages/views/my-issues/components/my-issues-header.tsx
@@ -13,6 +13,7 @@ import {
   List,
   SignalHigh,
   SlidersHorizontal,
+  Waves,
 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import {
@@ -425,6 +426,8 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
                     <Button variant="outline" size="icon-sm" className="text-muted-foreground">
                       {viewMode === "board" ? (
                         <Columns3 className="size-4" />
+                      ) : viewMode === "swimlane" ? (
+                        <Waves className="size-4" />
                       ) : (
                         <List className="size-4" />
                       )}
@@ -434,7 +437,11 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
               }
             />
             <TooltipContent side="bottom">
-              {viewMode === "board" ? t(($) => $.header.view_board) : t(($) => $.header.view_list)}
+              {viewMode === "board"
+                ? t(($) => $.header.view_board)
+                : viewMode === "swimlane"
+                ? t(($) => $.header.view_swimlane)
+                : t(($) => $.header.view_list)}
             </TooltipContent>
           </Tooltip>
           <DropdownMenuContent align="end" className="w-auto">
@@ -447,6 +454,10 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
               <DropdownMenuItem onClick={() => act.setViewMode("list")}>
                 <List />
                 {t(($) => $.header.view_list_short)}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => act.setViewMode("swimlane")}>
+                <Waves />
+                {t(($) => $.header.view_swimlane_short)}
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </DropdownMenuContent>

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -263,6 +263,8 @@ export function MyIssuesPage() {
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                myIssuesScope={scope}
+                myIssuesFilter={filter}
               />
             ) : (
               <ListView

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -260,6 +260,7 @@ export function MyIssuesPage() {
               <SwimLaneView
                 issues={issues}
                 visibleStatuses={visibleStatuses}
+                hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
               />

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -147,6 +147,24 @@ export function MyIssuesPage() {
     [myIssues, statusFilters, priorityFilters, agentRunningFilter, runningIssueIds],
   );
 
+  // Status-unfiltered companion for Swimlane.
+  const swimlaneIssues = useMemo(
+    () =>
+      filterIssues(myIssues, {
+        statusFilters: [],
+        priorityFilters,
+        assigneeFilters: [],
+        includeNoAssignee: false,
+        creatorFilters: [],
+        projectFilters: [],
+        includeNoProject: false,
+        labelFilters: [],
+        agentRunningFilter,
+        runningIssueIds,
+      }),
+    [myIssues, priorityFilters, agentRunningFilter, runningIssueIds],
+  );
+
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
 
   const visibleStatuses = useMemo(() => {
@@ -259,6 +277,7 @@ export function MyIssuesPage() {
             ) : viewMode === "swimlane" ? (
               <SwimLaneView
                 issues={issues}
+                unfilteredIssues={swimlaneIssues}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -16,6 +16,7 @@ import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-contex
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BoardView } from "../../issues/components/board-view";
 import { ListView } from "../../issues/components/list-view";
+import { SwimLaneView } from "../../issues/components/swimlane-view";
 import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar";
 import { useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -160,7 +161,7 @@ export function MyIssuesPage() {
 
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
-    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position">, onSettled?: () => void) => {
+    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position" | "parent_issue_id">, onSettled?: () => void) => {
       updateIssueMutation.mutate(
         { id: issueId, ...updates },
         {
@@ -254,6 +255,13 @@ export function MyIssuesPage() {
                 childProgressMap={childProgressMap}
                 myIssuesScope={scope}
                 myIssuesFilter={filter}
+              />
+            ) : viewMode === "swimlane" ? (
+              <SwimLaneView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                onMoveIssue={handleMoveIssue}
+                childProgressMap={childProgressMap}
               />
             ) : (
               <ListView

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -243,6 +243,8 @@ function ProjectIssuesContent({
           hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}
           childProgressMap={childProgressMap}
+          myIssuesScope={scope}
+          myIssuesFilter={filter}
         />
       )}
     </div>

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -142,6 +142,12 @@ function ProjectIssuesContent({
     [projectIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
   );
 
+  // Status-unfiltered companion for Swimlane.
+  const swimlaneIssues = useMemo(
+    () => filterIssues(projectIssues, { statusFilters: [], priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
+    [projectIssues, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
+  );
+
   // Gantt rides its own dedicated query (scheduled-only) so it doesn't have
   // to wait for every status bucket to paginate in. View-store filters still
   // apply so toggling priority / assignee / label hides the same bars.
@@ -239,12 +245,14 @@ function ProjectIssuesContent({
       {viewMode === "swimlane" && (
         <SwimLaneView
           issues={issues}
+          unfilteredIssues={swimlaneIssues}
           visibleStatuses={visibleStatuses}
           hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}
           childProgressMap={childProgressMap}
           myIssuesScope={scope}
           myIssuesFilter={filter}
+          projectId={projectId}
         />
       )}
     </div>

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -240,6 +240,7 @@ function ProjectIssuesContent({
         <SwimLaneView
           issues={issues}
           visibleStatuses={visibleStatuses}
+          hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}
           childProgressMap={childProgressMap}
         />

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -41,6 +41,7 @@ import { IssuesHeader } from "../../issues/components/issues-header";
 import { BoardView } from "../../issues/components/board-view";
 import { ListView } from "../../issues/components/list-view";
 import { GanttView } from "../../issues/components/gantt-view";
+import { SwimLaneView } from "../../issues/components/swimlane-view";
 import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
@@ -164,7 +165,7 @@ function ProjectIssuesContent({
 
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
-    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position">, onSettled?: () => void) => {
+    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position" | "parent_issue_id">, onSettled?: () => void) => {
       updateIssueMutation.mutate(
         { id: issueId, ...updates },
         {
@@ -181,12 +182,12 @@ function ProjectIssuesContent({
     [updateIssueMutation, t],
   );
 
-  // Gantt has its own data source (scheduled-only) and its own empty axis —
-  // we never short-circuit it here, otherwise an unscheduled-but-non-empty
-  // project would surface a misleading "no issues" CTA. For Board/List the
-  // bucketed cache really is the ground truth, so an empty result means an
-  // empty project.
-  if (viewMode !== "gantt" && projectIssues.length === 0) {
+  // Gantt and Swimlane have their own data sources and empty states —
+  // we never short-circuit them here, otherwise an unscheduled/unparented
+  // but non-empty project would surface a misleading "no issues" CTA.
+  // For Board/List the bucketed cache really is the ground truth,
+  // so an empty result means an empty project.
+  if (viewMode !== "gantt" && viewMode !== "swimlane" && projectIssues.length === 0) {
     return (
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-muted-foreground">
         <ListTodo className="h-10 w-10 text-muted-foreground/40" />
@@ -235,6 +236,14 @@ function ProjectIssuesContent({
         />
       )}
       {viewMode === "gantt" && <GanttView issues={filteredGanttIssues} />}
+      {viewMode === "swimlane" && (
+        <SwimLaneView
+          issues={issues}
+          visibleStatuses={visibleStatuses}
+          onMoveIssue={handleMoveIssue}
+          childProgressMap={childProgressMap}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

When you have an issue with massive amount of sub tasks, and that scale to many issues, you can't group or tell what issue is this sub task from and the board becomes messy. While it is still achievable with workaround and Projects, it is not the most ideal right now.

I'm proposing similar on what YouTrack allow you to do called [Swimlane view](https://www.jetbrains.com/help/youtrack/server/configure-agile-board.html). It allows you to still have your Kamban board status, but it will group the parent issue as a "lane", and display the sub issues as it is now.

## Related Issue

Closes #2951

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

### 1. Persistent State Management
- **`packages/core/issues/stores/view-store.ts`**:
  - Registered `"swimlane"` to `ViewMode` type.
  - Added persistent `swimlaneOrder` (string array) and `collapsedSwimlanes` (string array) to save customized lane ordering and collapsible section states per-workspace.
  - Implemented `setSwimlaneOrder` and `toggleSwimlaneCollapsed` state actions in the workspace-aware store slice.
  - 
### 2. Layout & Interactions (Swimlane View)
- **`packages/views/issues/components/swimlane-view.tsx`**:
  - Implemented `SwimLaneView` rendering a 2D grid utilizing `dnd-kit` where parent issues form horizontal collapsible lanes and columns represent statuses.
  - Built sticky status column headers and sticky row headers with grab handles for swimlane reordering.
  - Integrated localized "+" action buttons in cells to pre-fill parent issue and status fields upon creation.
  - Excluded parent duplicate cards from the "No parent" lane and filtered deleted-parent or unloaded-parent rows.
  - Connected hidden column totaling directly to the React Query cache via `useLoadMoreByStatus` to ensure dynamic, accurate counts.
  - 
### 3. Component De-duplication
- **`packages/views/issues/components/hidden-columns-panel.tsx`**:
  - Extracted shared presentational layers and dropdown menus to eliminate duplication between Board and Swimlane views.
- **`packages/views/issues/components/board-view.tsx`**:
  - Refactored to consume the newly shared `HiddenColumnsPanel` and `HiddenColumnRow`.
  - 
### 4. Integration & Localization
- **`packages/views/issues/components/issues-header.tsx` & `my-issues-header.tsx`**:
  - Added toggle controls (Waves icon) for the new `"swimlane"` view mode.
- **`packages/views/issues/components/issues-page.tsx` & `my-issues-page.tsx` & `project-detail.tsx`**:
  - Wired `SwimLaneView` on all issue containers, passing down scope/filters for query-cache totals.
- **`packages/views/locales/{en, zh-Hans}/*`**:
  - Added localized strings for English and Chinese, keeping terminology rules (mixed-rule) intact.
  - 
### 5. Test Suite
- **`packages/views/issues/components/swimlane-view.test.tsx`**:
  - Added **19 comprehensive unit tests** verifying 2D layout mapping, cell rendering, parent detail links, and lane drag/drop and collapsed state persistence.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Navigate to {{url}}/{{workspace}}/issues
2. Click over the icon to change views.
3. Select Swimlane from the dropdown

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [X] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [X] I have considered and documented any risks above
- [X] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Opencode

**Prompt / approach:**

We analyzed the `dnd-kit` sorting context constraints and modeled a robust 2D grid that maps parents to lanes and statuses to columns. We integrated collapsed states and lane ordering directly into the workspace-aware Zustand store slice. We extracted shared presentational elements into a centralized `HiddenColumnsPanel` component and wired hidden counts directly to the React Query cache via `useLoadMoreByStatus`. We followed a TDD-based approach.

## Screenshots (optional)

https://github.com/user-attachments/assets/1316cf78-83d1-4495-8d52-ef6e7fe854f0