### PR TITLE
fix(runtimes): price claude-opus-4-7[1m] at standard Opus tier (MUL-2584)

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -166,6 +166,24 @@ describe("estimateCost", () => {
     expect(cost).toBeCloseTo(5 + 25, 5);
   });
 
+  it("prices the 1M-context Anthropic tag form (claude-opus-4-7[1m]) at the standard Opus tier", () => {
+    // Claude Code reports the 1M-context beta as `claude-opus-4-7[1m]`.
+    // Anthropic prices it at the standard Opus rate for prompts ≤200K
+    // input tokens (with a 2× surcharge above that, which we can't see
+    // from aggregated daily totals). Strip the bracketed context tag so
+    // the tokens still land in the cost total at standard pricing —
+    // mild under-estimate, but the alternative was excluding them
+    // entirely (the bug this fixes).
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "claude-opus-4-7[1m]",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(5 + 25, 5);
+    expect(isModelPriced("claude-opus-4-7[1m]")).toBe(true);
+  });
+
   it("prices each dotted Codex catalog SKU at its own tier, not gpt-5", () => {
     // Every dotted minor version is priced independently. The resolver does
     // exact-match-after-date-strip (no startsWith fallback), so each row

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -187,7 +187,7 @@ const MODEL_PRICING: Record<
   "gpt-4o":             { input: 2.50, output: 10,   cacheRead: 1.25,  cacheWrite: 2.50 },
 };
 
-// Resolve a model string to its pricing tier. Exact match, with three
+// Resolve a model string to its pricing tier. Exact match, with four
 // tolerances applied in order:
 //
 //  1. Provider-prefixed IDs (`anthropic/claude-opus-4.7` from openclaw /
@@ -201,6 +201,12 @@ const MODEL_PRICING: Record<
 //  3. Trailing dated snapshots (`claude-sonnet-4-5-20250929`,
 //     `gpt-5-2025-08-07`) — the family is what we price, the date is
 //     volatile, so we strip a trailing date / "latest" tag.
+//  4. Trailing context-window tag (`claude-opus-4-7[1m]`) — Anthropic's
+//     1M-context beta is the same SKU at standard rates for prompts
+//     ≤200K input tokens, with a 2× surcharge above that. Aggregated
+//     usage rows don't carry per-request prompt sizes, so we price the
+//     bracketed variant at the standard tier. Slight under-estimate
+//     beats the previous behaviour of dropping the row entirely.
 //
 // Anything still unmapped falls back to the user-supplied custom pricing
 // store. No startsWith fallback: variants like `gpt-5.5-mini` must have
@@ -240,17 +246,24 @@ function canonicalCandidates(model: string): string[] {
   // semantic, so we leave `gpt-5.4` etc. alone.
   const canonAnthropic = (s: string) =>
     s.startsWith("claude-") ? s.replace(/\./g, "-") : s;
+  // Trailing context-window tag (`claude-opus-4-7[1m]`). Same family,
+  // same price tier — see resolver comment above for the 1M-context
+  // pricing trade-off.
+  const stripContextTag = (s: string) => s.replace(/\[[^\]]+\]$/, "");
 
   const raw = model;
   const noProvider = stripProvider(raw);
   const dashed = canonAnthropic(noProvider);
+  const noTag = stripContextTag(dashed);
 
   push(raw);
   push(noProvider);
   push(dashed);
+  push(noTag);
   push(stripDate(raw));
   push(stripDate(noProvider));
   push(stripDate(dashed));
+  push(stripDate(noTag));
   return out;
 }
 


### PR DESCRIPTION
## Summary

- Claude Code reports the 1M-context Opus beta as `claude-opus-4-7[1m]`. The pricing resolver in `packages/views/runtimes/utils.ts` had no tolerance for the bracketed context tag, so the row missed the maintained catalog and its tokens were silently excluded from cost totals (the "1 model has no maintained price" notice).
- Added a trailing `[...]` context-tag strip alongside the existing provider / dot↔dash / date-snapshot normalizations in `canonicalCandidates`, so `claude-opus-4-7[1m]` resolves to the existing `claude-opus-4-7` row at the standard $5 / $25 Opus tier.
- 1M-context billing applies a 2× surcharge above 200K input tokens; aggregated daily totals don't carry per-request prompt sizes, so the precise surcharge can't be applied. A mild under-estimate beats the previous $0 (tokens missing from cost totals entirely).

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run runtimes/utils.test.ts` (45 passed; new case pins `claude-opus-4-7[1m]` → $30 for 1M+1M tokens)
- [x] `pnpm --filter @multica/views typecheck`
- [ ] Manual: confirm the unmapped-models notice no longer flags `claude-opus-4-7[1m]` on the runtime detail / dashboard usage views.

Resolves MUL-2584.