### PR TITLE
feat(server): drive hourly usage rollup with in-process ticker

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -318,6 +318,7 @@ func main() {
 	go runAutopilotScheduler(autopilotCtx, queries, autopilotSvc)
 	go runAutopilotFailureMonitor(autopilotCtx, queries, bus, envFailureMonitorConfig())
 	go runDBStatsLogger(sweepCtx, pool)
+	go runTaskUsageRollup(sweepCtx, pool)
 
 	if metricsServer != nil {
 		go func() {

--- a/server/cmd/server/task_usage_rollup.go
+++ b/server/cmd/server/task_usage_rollup.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// taskUsageRollupInterval matches the cadence documented for the pg_cron entry
+// in migration 102 (`*/5 * * * *`). In steady state each tick rolls a tiny
+// `now()-5min` window; the function caps catch-up at one day per tick.
+const taskUsageRollupInterval = 5 * time.Minute
+
+// runTaskUsageRollup periodically drives rollup_task_usage_hourly(), which
+// aggregates raw task_usage rows into task_usage_hourly (the table the
+// dashboard and runtime-trend reads consume).
+//
+// On cloud this is scheduled via pg_cron per the operator playbook, but the
+// default self-host Postgres image (pgvector/pgvector:pg17) ships without
+// pg_cron, so nothing ever ran the rollup and task_usage_hourly stayed empty.
+// This in-process ticker removes that dependency: it works on any Postgres and
+// the function's own advisory lock 4246 makes a tick a no-op while a backfill
+// or another instance holds it, so concurrent runs are safe.
+func runTaskUsageRollup(ctx context.Context, pool *pgxpool.Pool) {
+	// Run once at startup so a freshly-started self-host instance populates
+	// task_usage_hourly without waiting a full interval.
+	tickTaskUsageRollup(ctx, pool)
+
+	ticker := time.NewTicker(taskUsageRollupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickTaskUsageRollup(ctx, pool)
+		}
+	}
+}
+
+// tickTaskUsageRollup runs a single rollup pass and logs the outcome.
+func tickTaskUsageRollup(ctx context.Context, pool *pgxpool.Pool) {
+	var rows int64
+	if err := pool.QueryRow(ctx, `SELECT rollup_task_usage_hourly()`).Scan(&rows); err != nil {
+		slog.Warn("task usage rollup: tick failed", "error", err)
+		return
+	}
+	if rows > 0 {
+		slog.Info("task usage rollup: rolled up hourly buckets", "rows_touched", rows)
+	}
+}

--- a/server/cmd/server/task_usage_rollup_test.go
+++ b/server/cmd/server/task_usage_rollup_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestTickTaskUsageRollup_Callable guards against drift between this caller and
+// migration 102's rollup_task_usage_hourly() definition: a renamed function or
+// changed return type would surface here rather than as a silent no-op in prod.
+func TestTickTaskUsageRollup_Callable(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	var rows int64
+	if err := testPool.QueryRow(context.Background(), `SELECT rollup_task_usage_hourly()`).Scan(&rows); err != nil {
+		t.Fatalf("rollup_task_usage_hourly() not callable: %v", err)
+	}
+	if rows < 0 {
+		t.Fatalf("expected non-negative rows_touched, got %d", rows)
+	}
+
+	// The ticker's tick wrapper must also run cleanly against the real schema.
+	tickTaskUsageRollup(context.Background(), testPool)
+}
+
+// TestRunTaskUsageRollup_StopsOnCancel verifies the loop returns when its
+// context is cancelled, so server shutdown doesn't leak the goroutine.
+func TestRunTaskUsageRollup_StopsOnCancel(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runTaskUsageRollup(ctx, testPool)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runTaskUsageRollup did not return after context cancel")
+	}
+}


### PR DESCRIPTION
task_usage_hourly was only populated by a pg_cron job that no migration schedules; the default self-host Postgres image ships without pg_cron, so the rollup never ran and dashboard/runtime usage views read an empty table.

Add a Go background ticker (cmd/server) that drives rollup_task_usage_hourly() every 5 minutes, mirroring runtime_sweeper/autopilot_scheduler. Advisory lock 4246 inside the function keeps ticks idempotent and safe alongside pg_cron or a backfill, so cloud is unaffected.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
