### PR TITLE
[codex] Keep Multica agent runs out of Codex history

### DIFF
--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -14,7 +14,7 @@ For guidance on picking a tool when creating an agent, see [Creating and configu
 | Tool | Vendor | Session resumption | MCP | Skill injection path | Model selection |
 |---|---|---|---|---|---|
 | **Claude Code** | Anthropic | ✅ | **✅ (the only one that actually uses it)** | `.claude/skills/` | Static + flag |
-| **Codex** | OpenAI | ⚠️ Code exists but unreachable | ❌ | `$CODEX_HOME/skills/` | Static |
+| **Codex** | OpenAI | ❌ Deliberately disabled | ❌ | `$CODEX_HOME/skills/` | Static |
 | **Copilot** | GitHub | ✅ | ❌ | `.github/skills/` | Static (determined by account entitlement) |
 | **Cursor** | Anysphere | ⚠️ Code exists but unusable | ❌ | `.cursor/skills/` | Dynamic discovery |
 | **Gemini** | Google | ❌ | ❌ | `.agent_context/skills/` | Static |
@@ -33,7 +33,7 @@ From Anthropic. **First choice for new users** — the most complete feature set
 
 ### Codex
 
-From OpenAI. Uses JSON-RPC 2.0, has stronger statefulness, and a finer-grained approve mechanism (manual approval for `exec_command` and `patch_apply`). **Session resumption code exists but is currently unreachable** — if you need resume, pick Claude Code or one of the ACP family.
+From OpenAI. Uses JSON-RPC 2.0, has stronger statefulness, and a finer-grained approve mechanism (manual approval for `exec_command` and `patch_apply`). Multica starts Codex threads as **ephemeral app-server threads** so automated Multica runs do not appear in the user's Codex desktop, mobile, or CLI history. Because those threads are intentionally not materialized into Codex history, Codex session resumption is treated as unsupported — if you need provider-level resume, pick Claude Code or one of the ACP family.
 
 ### Copilot
 
@@ -78,7 +78,8 @@ The session resumption mechanism is covered in [Tasks](/tasks#can-a-task-continu
 | Status | Tools | Meaning |
 |---|---|---|
 | ✅ Really works | Claude Code, Copilot, Hermes, Kimi, Kiro CLI, OpenCode, OpenClaw, Pi | Pass the resume id and it continues from the previous context |
-| ⚠️ Code exists but unreachable | Codex, Cursor | Resume paths exist in the code but aren't actually reached (Codex silently falls back; Cursor doesn't return session id) — **treat as unsupported** |
+| ❌ Deliberately disabled | Codex | Multica uses ephemeral Codex app-server threads so automated runs do not pollute the user's Codex app history |
+| ⚠️ Code exists but unreachable | Cursor | Resume paths exist in the code but aren't actually reached because the CLI doesn't return a usable session id — **treat as unsupported** |
 | ❌ None | Gemini | The CLI has no resume mechanism |
 
 **For your decision**: if your workflow needs agents to preserve context across tasks (failure retries, manual reruns, conversational iteration), pick only from the ✅ row.

--- a/apps/docs/content/docs/providers.zh.mdx
+++ b/apps/docs/content/docs/providers.zh.mdx
@@ -14,7 +14,7 @@ Multica 内置支持 **11 款 AI 编程工具**。它们都实现了同一套接
 | 工具 | 厂商 | 会话恢复 | MCP | Skill 注入路径 | 模型选择 |
 |---|---|---|---|---|---|
 | **Claude Code** | Anthropic | ✅ | **✅（唯一真用）** | `.claude/skills/` | 静态 + flag |
-| **Codex** | OpenAI | ⚠️ 代码存在但不可达 | ❌ | `$CODEX_HOME/skills/` | 静态 |
+| **Codex** | OpenAI | ❌ 有意关闭 | ❌ | `$CODEX_HOME/skills/` | 静态 |
 | **Copilot** | GitHub | ✅ | ❌ | `.github/skills/` | 静态（账号权益决定）|
 | **Cursor** | Anysphere | ⚠️ 代码存在但不可用 | ❌ | `.cursor/skills/` | 动态发现 |
 | **Gemini** | Google | ❌ | ❌ | `.agent_context/skills/` | 静态 |
@@ -33,7 +33,7 @@ Anthropic 出品。**新用户首选**——功能最完整：会话恢复真用
 
 ### Codex
 
-OpenAI 出品。使用 JSON-RPC 2.0 协议，状态化更强，approve 机制更细（手动批准 `exec_command` 和 `patch_apply`）。**会话恢复代码存在但当前不可达**——如果你需要 resume，选 Claude Code 或 ACP 系列。
+OpenAI 出品。使用 JSON-RPC 2.0 协议，状态化更强，approve 机制更细（手动批准 `exec_command` 和 `patch_apply`）。Multica 会把 Codex 任务作为 **ephemeral app-server thread** 启动，所以自动化的 Multica 运行不会出现在用户的 Codex 桌面端、移动端或 CLI 历史里。因为这些 thread 有意不落入 Codex 历史，Codex 会话恢复视为不支持——如果你需要 provider 层 resume，选 Claude Code 或 ACP 系列。
 
 ### Copilot
 
@@ -78,7 +78,8 @@ Inflection AI 出品，极简主义。**会话恢复机制特殊**——session 
 | 状态 | 工具 | 含义 |
 |---|---|---|
 | ✅ 真用 | Claude Code、Copilot、Hermes、Kimi、Kiro CLI、OpenCode、OpenClaw、Pi | 传 resume id，会从上次上下文接着继续 |
-| ⚠️ 代码存在但不可达 | Codex、Cursor | 代码里有 resume 路径但实际走不到（Codex 静默回落、Cursor session id 不回传）—— **当作不支持** |
+| ❌ 有意关闭 | Codex | Multica 使用 ephemeral Codex app-server thread，避免自动运行污染用户的 Codex app 历史 |
+| ⚠️ 代码存在但不可达 | Cursor | 代码里有 resume 路径但实际走不到，因为 CLI 不回传可用的 session id—— **当作不支持** |
 | ❌ 无 | Gemini | CLI 无 resume 机制 |
 
 **对你的决策**：如果工作流需要智能体在多次任务之间保持上下文（失败重试、手动重跑、对话式迭代），只选 ✅ 那一行的工具。

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -376,6 +376,9 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		}
 	}
 
+	// Multica keeps task history in its own database. Codex app-server
+	// threads are therefore transient implementation details and should not
+	// be materialized into the user's Codex app history.
 	startParams := map[string]any{
 		"model":                  nilIfEmpty(opts.Model),
 		"modelProvider":          nil,
@@ -388,8 +391,9 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
 		"compactPrompt":          nil,
 		"includeApplyPatchTool":  nil,
+		"ephemeral":              true,
 		"experimentalRawEvents":  false,
-		"persistExtendedHistory": true,
+		"persistExtendedHistory": false,
 	}
 	applyCodexReasoningEffort(startParams, opts.ThinkingLevel)
 	startResult, err := c.request(ctx, "thread/start", startParams)

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -803,8 +803,11 @@ func TestCodexStartOrResumeThreadStartsFresh(t *testing.T) {
 				if params["cwd"] != "/work" {
 					t.Errorf("cwd = %v, want /work", params["cwd"])
 				}
-				if params["persistExtendedHistory"] != true {
-					t.Error("expected persistExtendedHistory=true on thread/start")
+				if params["ephemeral"] != true {
+					t.Error("expected ephemeral=true on thread/start")
+				}
+				if params["persistExtendedHistory"] != false {
+					t.Error("expected persistExtendedHistory=false on thread/start")
 				}
 			},
 		},
@@ -874,6 +877,14 @@ func TestCodexStartOrResumeThreadFallsBackOnResumeError(t *testing.T) {
 		{
 			method: "thread/start",
 			result: json.RawMessage(`{"thread":{"id":"thr_new"}}`),
+			assertFn: func(t *testing.T, params map[string]any) {
+				if params["ephemeral"] != true {
+					t.Error("expected fallback thread/start to stay ephemeral")
+				}
+				if params["persistExtendedHistory"] != false {
+					t.Error("expected fallback thread/start to skip extended history persistence")
+				}
+			},
 		},
 	})
 	defer wait()


### PR DESCRIPTION
## Summary

- Start Multica-created Codex app-server threads with `ephemeral: true`
- Stop requesting extended Codex history persistence for Multica-managed Codex runs
- Document Codex provider-level resume as unsupported while these runs are intentionally kept out of Codex app history

## Why

Addresses the user-facing problem reported in #2746: Multica-launched Codex sessions can appear as normal Codex app history entries and crowd out real user/project chats.

The issue discussion traced one root cause to Codex app-server sessions being persisted under the `vscode` source. This PR takes the Multica-side path that matches how Multica uses Codex today: Multica already stores task/run history in its own database, so the Codex app-server thread is a transient execution detail and does not need to be materialized into Codex desktop/mobile/CLI history at all.

That is also consistent with the existing provider docs treating Codex resume as unsupported for Multica workflows. New Codex runs will start fresh, stay visible in Multica's own task history, and avoid polluting the user's Codex app history.

## Validation

- `git diff --check`

`go test ./server/pkg/agent` could not be run locally because Go is not installed in this environment.
