### PR TITLE
feat: add Railway deployment configuration

### DIFF
--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -1,0 +1,166 @@
+# Deploying Multica on Railway
+
+This guide walks you through deploying the full Multica stack (PostgreSQL, backend API, frontend) on [Railway](https://railway.app).
+
+## Architecture on Railway
+
+| Service | Dockerfile | Internal URL |
+|---------|-----------|--------------|
+| `postgres` | Railway PostgreSQL plugin | `${{Postgres.DATABASE_URL}}` |
+| `backend` | `Dockerfile` | `http://backend.railway.internal:8080` |
+| `frontend` | `Dockerfile.web` | Public Railway domain / custom domain |
+
+The frontend proxies all API, WebSocket, auth, and upload requests to the backend through Next.js rewrites — the browser never talks to the backend directly.
+
+## Prerequisites
+
+- [Railway account](https://railway.app)
+- Your fork of this repository pushed to GitHub
+- Railway CLI (optional): `npm i -g @railway/cli`
+
+---
+
+## Step 1 — Create a Railway Project
+
+1. Go to [railway.app/new](https://railway.app/new) and click **Start a New Project**.
+2. Choose **Empty Project** and give it a name (e.g. `multica`).
+
+---
+
+## Step 2 — Add PostgreSQL
+
+1. In your project dashboard, click **+ New** → **Database** → **Add PostgreSQL**.
+2. Railway automatically provisions a `pgvector`-compatible PostgreSQL instance and exposes `DATABASE_URL`.
+
+> **Note:** Multica requires the `pgvector` extension. Railway's PostgreSQL plugin includes it. If you use an external database, ensure `pgvector` is installed on PostgreSQL 17+.
+
+---
+
+## Step 3 — Deploy the Backend
+
+1. Click **+ New** → **GitHub Repo** → select your fork.
+2. Railway auto-detects `railway.toml` at the repository root and will use `Dockerfile` as the builder.
+3. **Before the first deploy**, set the following environment variables in **Service → Variables**:
+
+### Required backend variables
+
+| Variable | Value / Notes |
+|----------|---------------|
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` (Railway reference — copy as-is) |
+| `JWT_SECRET` | Generate: `openssl rand -hex 32` |
+| `APP_ENV` | `production` |
+| `PORT` | `8080` (keep fixed so the frontend can reach it internally) |
+| `FRONTEND_ORIGIN` | Frontend public URL, e.g. `https://multica-web.up.railway.app` (set after Step 4) |
+| `MULTICA_APP_URL` | Same as `FRONTEND_ORIGIN` |
+| `MULTICA_PUBLIC_URL` | Backend public URL, e.g. `https://multica-backend.up.railway.app` |
+
+### Optional backend variables
+
+| Variable | Notes |
+|----------|-------|
+| `RESEND_API_KEY` | Email delivery (recommended for production) |
+| `RESEND_FROM_EMAIL` | Sender address, default `noreply@multica.ai` |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` | Alternative to Resend |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth login |
+| `GOOGLE_REDIRECT_URI` | e.g. `https://multica-web.up.railway.app/auth/callback` |
+| `S3_BUCKET` / `S3_REGION` | File uploads via S3 (leave unset to use local disk storage) |
+| `CLOUDFRONT_DOMAIN` / `CLOUDFRONT_KEY_PAIR_ID` / `CLOUDFRONT_PRIVATE_KEY` | CloudFront CDN for uploads |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allowed origins if needed |
+| `ALLOW_SIGNUP` | `true` (default) — set `false` to lock registration |
+| `ALLOWED_EMAIL_DOMAINS` | Restrict signups to specific domains |
+| `MULTICA_DEV_VERIFICATION_CODE` | **Never set in production** — development bypass only |
+| `REDIS_URL` | Redis for rate limiting (optional) |
+| `GITHUB_APP_SLUG` / `GITHUB_WEBHOOK_SECRET` | GitHub App integration |
+
+4. Click **Deploy**. The entrypoint automatically runs database migrations before starting the server.
+5. Health check: Railway polls `GET /live` and waits up to 300 s for a `200 OK`.
+
+---
+
+## Step 4 — Deploy the Frontend
+
+Because `Dockerfile.web` requires the full monorepo as its Docker build context, the frontend service must also use `/` (repository root) as its root directory, with the Dockerfile path overridden in Railway settings.
+
+1. Click **+ New** → **GitHub Repo** → select the **same fork**.
+2. Railway will again detect `railway.toml` (backend config). Override it:
+   - Go to **Service → Settings → Build**
+   - Set **Dockerfile Path** → `Dockerfile.web`
+   - Set **Build Context** → `/` (repository root — ensures pnpm workspaces are available)
+3. Set the following environment variables in **Service → Variables**:
+
+### Required frontend variables
+
+| Variable | Value / Notes |
+|----------|---------------|
+| `REMOTE_API_URL` | `http://backend.railway.internal:8080` (Railway private network — replace `backend` with your backend service name if different) |
+| `NEXT_PUBLIC_WS_URL` | Backend **public** WebSocket URL, e.g. `wss://multica-backend.up.railway.app` |
+
+### Optional frontend variables
+
+| Variable | Notes |
+|----------|-------|
+| `NEXT_PUBLIC_APP_VERSION` | App version string shown in UI, defaults to `dev` |
+| `POSTHOG_API_KEY` / `POSTHOG_HOST` | Product analytics |
+
+4. Click **Deploy**. The Next.js standalone server starts on `$PORT` (Railway-injected).
+
+---
+
+## Step 5 — Wire Up Cross-Service URLs
+
+After both services are deployed and have public URLs:
+
+1. **Backend** → Variables → set `FRONTEND_ORIGIN` and `MULTICA_APP_URL` to the frontend's Railway domain.
+2. **Frontend** → Variables → confirm `REMOTE_API_URL` matches the backend's private URL and `NEXT_PUBLIC_WS_URL` matches the backend's public domain.
+3. Redeploy both services for the new variables to take effect.
+
+---
+
+## Internal Networking
+
+Railway services in the same project communicate over a private network using the pattern:
+
+```
+http://<service-name>.railway.internal:<PORT>
+```
+
+The backend service is named `backend` by default and listens on port `8080` (set `PORT=8080` explicitly to keep it stable). The frontend reaches it at:
+
+```
+http://backend.railway.internal:8080
+```
+
+If you rename the backend service in Railway, update `REMOTE_API_URL` in the frontend accordingly.
+
+---
+
+## Custom Domains
+
+1. In **Service → Settings → Networking**, click **Generate Domain** to get a Railway subdomain, or **Add Custom Domain** to use your own.
+2. Update `FRONTEND_ORIGIN`, `MULTICA_APP_URL`, and `MULTICA_PUBLIC_URL` in the backend to match the production URLs.
+3. Update `NEXT_PUBLIC_WS_URL` in the frontend to the backend's final domain.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Backend exits immediately | Check `DATABASE_URL` is set and the PostgreSQL plugin is running |
+| `migrate: connection refused` | Railway deploys services in parallel — the PostgreSQL healthcheck must pass before the backend starts; Railway retries automatically |
+| Frontend shows blank page / API errors | Verify `REMOTE_API_URL` points to the correct backend private URL |
+| WebSocket disconnects | Ensure `NEXT_PUBLIC_WS_URL` uses `wss://` (not `ws://`) for production |
+| Email verification not arriving | Set `RESEND_API_KEY` or SMTP variables; in dev set `MULTICA_DEV_VERIFICATION_CODE=888888` (never in production) |
+| Build fails: `pnpm install --frozen-lockfile` | The lockfile is checked in — ensure no local changes to `pnpm-lock.yaml` were accidentally committed |
+
+---
+
+## One-Click Deploy (optional)
+
+Add this button to your README after forking:
+
+```markdown
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/new?template=https://github.com/<your-org>/multica)
+```
+
+Replace `<your-org>` with your GitHub username or organization.

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,18 @@
+# Railway configuration — Backend (API + WebSocket) service.
+#
+# This file is picked up automatically by the Backend service in Railway when
+# the service root directory is set to "/" (repository root).
+#
+# Frontend service: create a second Railway service from this same repo, then
+# in Service → Settings → Build set "Dockerfile Path" to "Dockerfile.web" and
+# "Build Context" to "/". See RAILWAY.md for the full step-by-step guide.
+
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/live"
+healthcheckTimeout = 300
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
Adds railway.toml (backend service config) and RAILWAY.md (step-by-step deployment guide) to make the project deployable on Railway.

- railway.toml: configures the backend service to build from Dockerfile, sets /live healthcheck, and on_failure restart policy
- RAILWAY.md: documents how to deploy all three services (PostgreSQL plugin, backend, frontend), required/optional environment variables, internal networking via railway.internal, custom domains, and troubleshooting

No code changes were needed: the Go server already reads PORT from env, Dockerfile.web already accepts REMOTE_API_URL as a build arg, and both health endpoints (/live, /ready) already exist.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
