### PR TITLE
fix(views): move member count to section label in squad popover (MUL-2586)

### DIFF
--- a/packages/views/squads/components/squad-profile-card.tsx
+++ b/packages/views/squads/components/squad-profile-card.tsx
@@ -93,11 +93,6 @@ export function SquadProfileCard({ squadId }: SquadProfileCardProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <p className="truncate text-sm font-semibold">{squad.name}</p>
-            <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-              {t(($) => $.profile_card.member_count, {
-                count: memberStatuses.length,
-              })}
-            </span>
             {isArchived && (
               <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                 {t(($) => $.profile_card.archived)}
@@ -153,8 +148,9 @@ function MembersList({
     <div className="flex flex-col gap-1.5 text-xs">
       <span className="text-muted-foreground">
         {t(($) => $.profile_card.members_section)}
+        <span className="ml-1 tabular-nums">· {members.length}</span>
       </span>
-      <div className="flex flex-col gap-0.5">
+      <div className="flex max-h-[132px] flex-col gap-0.5 overflow-y-auto">
         {visible.map((m) => {
           const isLeader =
             m.member_type === "agent" && m.member_id === leaderId;


### PR DESCRIPTION
## Summary
- Removed standalone `{memberCount} members` badge from the squad profile card header — it cluttered the name row
- Added inline count to the `Members` section label: `Members · N`
- Added `max-h-[132px] overflow-y-auto` on the member list container to prevent card overflow with many members

Existing overflow protections verified:
- Squad name: `truncate` on `<p>` (line 95)
- Member names: `min-w-0 truncate` on `<span>` (line 199)
- Description: `line-clamp-2` (line 114)
- Header container: `min-w-0 flex-1` (line 93)

Closes MUL-2586

## Test plan
- [x] `pnpm typecheck` — 6/6 pass
- [x] `pnpm --filter @multica/views exec vitest run` — 767/767 pass
- [ ] Visual check: hover a squad avatar → popover shows name without badge, "Members · N" label, scroll on 4+ members

🤖 Generated with [Claude Code](https://claude.com/claude-code)