### PR TITLE
fix(views): normalize plain comment mentions

### DIFF
--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -25,6 +25,10 @@ import {
   issueTimelineOptions,
   issueKeys,
 } from "@multica/core/issues/queries";
+import { getCurrentWsId } from "@multica/core/platform";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import { useAuthStore } from "@multica/core/auth";
+import { canAssignAgentToIssue } from "@multica/core/permissions";
 import {
   useCreateComment,
   useUpdateComment,
@@ -37,6 +41,11 @@ import { sortTimelineEntriesAsc } from "@multica/core/issues/timeline-sort";
 import { useWSEvent, useWSReconnect } from "@multica/core/realtime";
 import { toast } from "sonner";
 import { useT } from "../../i18n";
+import type { Agent, MemberWithUser } from "@multica/core/types";
+import {
+  normalizePlainMentions,
+  type PlainMentionTarget,
+} from "../utils/plain-mention-normalizer";
 
 type TLCache = TimelineEntry[];
 
@@ -62,6 +71,8 @@ function commentToTimelineEntry(c: Comment): TimelineEntry {
 export function useIssueTimeline(issueId: string, userId?: string) {
   const { t } = useT("issues");
   const qc = useQueryClient();
+  const qcRef = useRef(qc);
+  qcRef.current = qc;
 
   const query = useQuery(issueTimelineOptions(issueId));
   const { data, isLoading: loading } = query;
@@ -78,6 +89,46 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   const { mutateAsync: deleteCommentAsync } = useDeleteComment(issueId);
   const { mutateAsync: resolveCommentAsync } = useResolveComment(issueId);
   const { mutate: toggleCommentReaction } = useToggleCommentReaction(issueId);
+
+  const normalizeCommentContent = useCallback(
+    (content: string): string => {
+      const wsId = getCurrentWsId();
+      if (!wsId) return content;
+
+      const members: MemberWithUser[] =
+        qcRef.current.getQueryData(workspaceKeys.members(wsId)) ?? [];
+      const agents: Agent[] =
+        qcRef.current.getQueryData(workspaceKeys.agents(wsId)) ?? [];
+      const currentUserId = useAuthStore.getState().user?.id ?? null;
+      const role =
+        members.find((member) => member.user_id === currentUserId)?.role ?? null;
+
+      const targets: PlainMentionTarget[] = [
+        ...members.map((member) => ({
+          id: member.user_id,
+          name: member.name,
+          type: "member" as const,
+        })),
+        ...agents
+          .filter(
+            (agent) =>
+              !agent.archived_at &&
+              canAssignAgentToIssue(agent, {
+                userId: currentUserId,
+                role,
+              }).allowed,
+          )
+          .map((agent) => ({
+            id: agent.id,
+            name: agent.name,
+            type: "agent" as const,
+          })),
+      ];
+
+      return normalizePlainMentions(content, targets);
+    },
+    [],
+  );
 
   // Reconnect recovery: invalidate so the next render refetches the full
   // timeline. Cheaper than diffing across a possibly-long disconnect.
@@ -262,7 +313,10 @@ export function useIssueTimeline(issueId: string, userId?: string) {
     async (content: string, attachmentIds?: string[]) => {
       if (!content.trim() || !userId) return;
       try {
-        await createComment({ content, attachmentIds });
+        await createComment({
+          content: normalizeCommentContent(content),
+          attachmentIds,
+        });
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
@@ -271,7 +325,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
         );
       }
     },
-    [userId, createComment, t],
+    [userId, createComment, normalizeCommentContent, t],
   );
 
   const submitReply = useCallback(
@@ -279,7 +333,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
       if (!content.trim() || !userId) return;
       try {
         await createComment({
-          content,
+          content: normalizeCommentContent(content),
           type: "comment",
           parentId,
           attachmentIds,
@@ -292,13 +346,17 @@ export function useIssueTimeline(issueId: string, userId?: string) {
         );
       }
     },
-    [userId, createComment, t],
+    [userId, createComment, normalizeCommentContent, t],
   );
 
   const editComment = useCallback(
     async (commentId: string, content: string, attachmentIds: string[]) => {
       try {
-        await updateComment({ commentId, content, attachmentIds });
+        await updateComment({
+          commentId,
+          content: normalizeCommentContent(content),
+          attachmentIds,
+        });
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
@@ -307,7 +365,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
         );
       }
     },
-    [updateComment, t],
+    [updateComment, normalizeCommentContent, t],
   );
 
   const deleteComment = useCallback(

--- a/packages/views/issues/utils/plain-mention-normalizer.test.ts
+++ b/packages/views/issues/utils/plain-mention-normalizer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { normalizePlainMentions, type PlainMentionTarget } from "./plain-mention-normalizer";
+
+const targets: PlainMentionTarget[] = [
+  { id: "agent-1", name: "한소희(designer)", type: "agent" },
+  { id: "agent-2", name: "하니(fe)", type: "agent" },
+  { id: "member-1", name: "Alice", type: "member" },
+  { id: "member-2", name: "David[TF]", type: "member" },
+];
+
+describe("normalizePlainMentions", () => {
+  it("converts plain agent and member mentions to triggerable markdown", () => {
+    expect(normalizePlainMentions("@한소희(designer) 확인 부탁 @Alice", targets)).toBe(
+      "[@한소희(designer)](mention://agent/agent-1) 확인 부탁 [@Alice](mention://member/member-1)",
+    );
+  });
+
+  it("does not rewrite existing mention markdown or regular links", () => {
+    const text = "이미 [@하니(fe)](mention://agent/agent-2) 와 [@Alice](https://example.com)";
+    expect(normalizePlainMentions(text, targets)).toBe(text);
+  });
+
+  it("does not rewrite code, escaped mentions, or email-like text", () => {
+    const text = [
+      "`@Alice`",
+      "\\@Alice",
+      "ops@Alice.com",
+      "```",
+      "@한소희(designer)",
+      "```",
+    ].join("\n");
+    expect(normalizePlainMentions(text, targets)).toBe(text);
+  });
+
+  it("escapes markdown-sensitive label characters", () => {
+    expect(normalizePlainMentions("@David[TF]", targets)).toBe(
+      "[@David\\[TF\\]](mention://member/member-2)",
+    );
+  });
+
+  it("prefers the longest matching name", () => {
+    const overlapping: PlainMentionTarget[] = [
+      { id: "member-short", name: "Alice", type: "member" },
+      { id: "member-long", name: "Alice Kim", type: "member" },
+    ];
+    expect(normalizePlainMentions("@Alice Kim", overlapping)).toBe(
+      "[@Alice Kim](mention://member/member-long)",
+    );
+  });
+});

--- a/packages/views/issues/utils/plain-mention-normalizer.ts
+++ b/packages/views/issues/utils/plain-mention-normalizer.ts
@@ -1,0 +1,91 @@
+export interface PlainMentionTarget {
+  id: string;
+  name: string;
+  type: "member" | "agent";
+}
+
+interface Range {
+  start: number;
+  end: number;
+}
+
+const LINK_RE = /\[[^\]]*](?:\([^)]*\))/g;
+const FENCED_CODE_RE = /(^|\n)(```|~~~)[\s\S]*?\n\2(?=\n|$)/g;
+const INLINE_CODE_RE = /`[^`\n]*`/g;
+
+function collectProtectedRanges(text: string): Range[] {
+  const ranges: Range[] = [];
+  for (const re of [FENCED_CODE_RE, INLINE_CODE_RE, LINK_RE]) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text))) {
+      ranges.push({ start: match.index, end: match.index + match[0].length });
+    }
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+function isProtected(index: number, ranges: Range[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function isEmailLikePrefix(text: string, atIndex: number): boolean {
+  const prev = text[atIndex - 1];
+  return Boolean(prev && /[\p{L}\p{N}._%+-]/u.test(prev));
+}
+
+function hasWordSuffix(text: string, index: number): boolean {
+  const next = text[index];
+  return Boolean(next && /[\p{L}\p{N}_-]/u.test(next));
+}
+
+function escapeMentionLabel(label: string): string {
+  return label.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/]/g, "\\]");
+}
+
+export function normalizePlainMentions(
+  text: string,
+  targets: PlainMentionTarget[],
+): string {
+  if (!text || targets.length === 0 || !text.includes("@")) return text;
+
+  const ranges = collectProtectedRanges(text);
+  const sortedTargets = [...targets]
+    .filter((target) => target.id && target.name.trim())
+    .sort((a, b) => b.name.length - a.name.length);
+
+  if (sortedTargets.length === 0) return text;
+
+  let out = "";
+  let i = 0;
+  while (i < text.length) {
+    if (
+      text[i] !== "@" ||
+      isProtected(i, ranges) ||
+      text[i - 1] === "\\" ||
+      isEmailLikePrefix(text, i)
+    ) {
+      out += text[i];
+      i += 1;
+      continue;
+    }
+
+    const match = sortedTargets.find((target) => {
+      const start = i + 1;
+      const end = start + target.name.length;
+      return text.startsWith(target.name, start) && !hasWordSuffix(text, end);
+    });
+
+    if (!match) {
+      out += text[i];
+      i += 1;
+      continue;
+    }
+
+    const label = escapeMentionLabel(match.name);
+    out += `[@${label}](mention://${match.type}/${match.id})`;
+    i += match.name.length + 1;
+  }
+
+  return out;
+}


### PR DESCRIPTION
## 요약
- 이슈 댓글/답글/수정 저장 직전에 plain `@이름` 멘션을 `mention://member|agent/UUID` markdown으로 정규화합니다.
- 기존 mention markdown, 일반 markdown link, inline/fenced code, escape된 `\@`, email-like 문자열은 변환하지 않습니다.
- agent 자동 변환 대상은 archived 제외 및 현재 사용자가 assign 가능한 agent로 제한했습니다.

## 검증
- `pnpm --dir packages/views exec vitest run issues/utils/plain-mention-normalizer.test.ts issues/hooks/use-issue-timeline.test.tsx`
- `pnpm --dir packages/views exec vitest run issues/components/issue-detail.test.tsx editor/extensions/mention-suggestion.test.tsx`
- `pnpm --dir packages/views typecheck`
- `pnpm --dir packages/views lint`

## 배포/롤백
- 배포: PR merge 후 기존 웹 배포 파이프라인으로 배포
- 롤백: 본 PR revert 후 재배포
