### PR TITLE
docs: clarify Chinese README license label

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -176,4 +176,4 @@ iOS 移动端代码位于 [`apps/mobile/`](apps/mobile/)，自己编译装到手
 
 ## 开源协议
 
-[Apache 2.0](LICENSE)
+[Modified Apache 2.0 (with commercial restrictions)](LICENSE)


### PR DESCRIPTION
## Summary

Closes #3144.

The repo's `LICENSE` is Apache 2.0 with additional commercial-use restrictions, but `README.zh-CN.md` advertised the project as plain `Apache 2.0`, which is inaccurate. Update the label to `Modified Apache 2.0 (with commercial restrictions)` so it matches the real terms.

GitHub's auto-detected license metadata is already `NOASSERTION` / `Other` (licensee can't fingerprint the modified file), so no settings change is required there — only the README copy was out of date.

The English `README.md` has no license section, so nothing to change on that side.

Related: MUL-2594

## Test plan

- [x] `git diff` — single-line label change in `README.zh-CN.md`