### PR TITLE
fix: upgrade github.com/jackc/pgx/v5 to 5.9.2 (CVE-2026-33816, GHSA-j88v-2chj-qfwx)

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lmittmann/tint v1.1.3
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/oklog/ulid/v2 v2.1.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -71,8 +71,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
## Summary

Bump `github.com/jackc/pgx/v5` from `v5.8.0` to `v5.9.2`. Single-step upgrade that closes two security advisories at once and avoids a follow-up PR when the scanner re-runs against `v5.9.0`.

- **CVE-2026-33816** (fixed in 5.9.0) — pgproto3 memory-safety DoS from malformed messages sent by a malicious PostgreSQL server. CVSS 9.8.
- **GHSA-j88v-2chj-qfwx / CVE-2026-41889** (fixed in 5.9.2) — SQL injection via placeholder confusion with dollar-quoted literals when `QueryExecModeSimpleProtocol` is in use. Not reachable in this codebase (we use the default extended protocol everywhere — `rg QueryExecModeSimpleProtocol server/` returns zero hits), but pinned now to clear future scanner runs.

Supersedes #3190.

## Impact analysis

**No source changes required.** The full diff is a single line in `server/go.mod` plus the corresponding `server/go.sum` updates.

- No breaking API changes in `pgx`, `pgxpool`, `pgtype`, or `pgconn` across 5.8.0 → 5.9.2 per upstream [CHANGELOG](https://github.com/jackc/pgx/blob/master/CHANGELOG.md).
- pgx 5.9.0 bumps minimum Go to 1.25; repo CI runs Go 1.26.1 — safe.
- 5.9.x additions (PG protocol 3.2, SCRAM-SHA-256-PLUS, OAuth, TSVector) are opt-in; we don't use any of them.
- No code in `server/` does substring-matching on pgx error messages (only matches are against project-internal error strings), so the "better error wrapping" change in 5.9.0 cannot break tests.
- 5.9.1 fixes a real batch-result-format-corruption bug for cached prepared statements — actually a positive for our `SendBatch` callers.

## Test plan

- [x] `go build ./...` clean in `server/`
- [x] `go vet ./...` clean in `server/`
- [x] `go test -count=1 -short ./internal/util/... ./internal/metrics/... ./cmd/server/...` pass (covers the packages that import `pgx`, `pgxpool`, `pgtype` directly)
- [ ] CI: backend (build + full `go test` against real Postgres service), frontend, installer

Related: MUL-2597