### PR TITLE
Improve landing header CTA hierarchy

### DIFF
--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -77,7 +77,10 @@ export function LandingHeader({
             aria-label={isMenuOpen ? t.header.closeMenu : t.header.openMenu}
             aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen((open) => !open)}
-            className={cn(headerButtonClassName("ghost", variant), "px-3 md:hidden")}
+            className={cn(
+              headerButtonClassName("ghost", variant),
+              "px-3 md:hidden",
+            )}
           >
             {isMenuOpen ? (
               <X className="size-4" aria-hidden />
@@ -97,18 +100,10 @@ export function LandingHeader({
             <GitHubMark className="size-3.5" />
             {t.header.github}
           </Link>
-          {!user ? (
-            <Link
-              href="/login"
-              className={cn(
-                headerButtonClassName("ghost", variant),
-                "hidden sm:inline-flex",
-              )}
-            >
-              {t.header.login}
-            </Link>
-          ) : null}
-          <Link href={ctaHref} className={headerButtonClassName("solid", variant)}>
+          <Link
+            href={ctaHref}
+            className={headerButtonClassName("solid", variant)}
+          >
             {ctaLabel}
           </Link>
         </div>
@@ -151,15 +146,6 @@ export function LandingHeader({
               <GitHubMark className="size-3.5" />
               {t.header.github}
             </Link>
-            {!user ? (
-              <Link
-                href="/login"
-                onClick={() => setIsMenuOpen(false)}
-                className={mobileNavLinkClassName(variant)}
-              >
-                {t.header.login}
-              </Link>
-            ) : null}
           </div>
         </div>
       ) : null}

--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import { Menu, X } from "lucide-react";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 import { cn } from "@multica/ui/lib/utils";
 import { useAuthStore } from "@multica/core/auth";
-import { useLocale } from "../i18n";
+import { isZhLocale, useLocale } from "../i18n";
 import { GitHubMark, githubUrl, headerButtonClassName } from "./shared";
 
 export function LandingHeader({
@@ -12,73 +14,173 @@ export function LandingHeader({
 }: {
   variant?: "dark" | "light";
 }) {
-  const { t } = useLocale();
+  const { t, locale } = useLocale();
   const user = useAuthStore((s) => s.user);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const docsHref = isZhLocale(locale) ? "/docs/zh" : "/docs";
+  const navLinks = [
+    { href: "/usecases", label: t.header.useCases },
+    { href: docsHref, label: t.header.docs },
+    { href: "/changelog", label: t.header.changelog },
+  ];
+  const ctaHref = user ? "/" : "/login";
+  const ctaLabel = user ? t.header.dashboard : t.header.cta;
 
   return (
     <header
       className={cn(
-        "inset-x-0 top-0 z-30",
+        "relative inset-x-0 top-0 z-30",
         variant === "dark"
           ? "absolute bg-transparent"
           : "border-b border-[#0a0d12]/8 bg-white",
       )}
     >
       <div className="mx-auto flex h-[76px] max-w-[1320px] items-center justify-between px-4 sm:px-6 lg:px-8">
-        <Link href="/" className="flex items-center gap-3">
-          <MulticaIcon
-            className={cn(
-              "size-5",
-              variant === "dark" ? "text-white" : "text-[#0a0d12]",
-            )}
-            noSpin
-          />
-          <span
-            className={cn(
-              "text-[18px] font-semibold tracking-[0.04em] lowercase sm:text-[20px]",
-              variant === "dark" ? "text-white/92" : "text-[#0a0d12]",
-            )}
-          >
-            multica
-          </span>
-        </Link>
+        <div className="flex min-w-0 items-center gap-6 lg:gap-8">
+          <Link href="/" className="flex shrink-0 items-center gap-3">
+            <MulticaIcon
+              className={cn(
+                "size-5",
+                variant === "dark" ? "text-white" : "text-[#0a0d12]",
+              )}
+              noSpin
+            />
+            <span
+              className={cn(
+                "text-[18px] font-semibold tracking-[0.04em] lowercase sm:text-[20px]",
+                variant === "dark" ? "text-white/92" : "text-[#0a0d12]",
+              )}
+            >
+              multica
+            </span>
+          </Link>
 
-        <div className="flex items-center gap-2.5 sm:gap-3">
-          <Link
-            href="/usecases"
-            className={cn(
-              headerButtonClassName("ghost", variant),
-              "hidden sm:inline-flex",
-            )}
+          <nav
+            aria-label={t.header.navigation}
+            className="hidden items-center gap-1 md:flex"
           >
-            {t.header.useCases}
-          </Link>
-          <Link
-            href="/changelog"
-            className={cn(
-              headerButtonClassName("ghost", variant),
-              "hidden sm:inline-flex",
-            )}
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={navLinkClassName(variant)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2 sm:gap-2.5">
+          <button
+            type="button"
+            aria-label={isMenuOpen ? t.header.closeMenu : t.header.openMenu}
+            aria-expanded={isMenuOpen}
+            onClick={() => setIsMenuOpen((open) => !open)}
+            className={cn(headerButtonClassName("ghost", variant), "px-3 md:hidden")}
           >
-            {t.header.changelog}
-          </Link>
+            {isMenuOpen ? (
+              <X className="size-4" aria-hidden />
+            ) : (
+              <Menu className="size-4" aria-hidden />
+            )}
+          </button>
           <Link
             href={githubUrl}
             target="_blank"
             rel="noreferrer"
-            className={headerButtonClassName("ghost", variant)}
+            className={cn(
+              headerButtonClassName("ghost", variant),
+              "hidden lg:inline-flex",
+            )}
           >
             <GitHubMark className="size-3.5" />
             {t.header.github}
           </Link>
-          <Link
-            href={user ? "/" : "/login"}
-            className={headerButtonClassName("solid", variant)}
-          >
-            {user ? t.header.dashboard : t.header.login}
+          {!user ? (
+            <Link
+              href="/login"
+              className={cn(
+                headerButtonClassName("ghost", variant),
+                "hidden sm:inline-flex",
+              )}
+            >
+              {t.header.login}
+            </Link>
+          ) : null}
+          <Link href={ctaHref} className={headerButtonClassName("solid", variant)}>
+            {ctaLabel}
           </Link>
         </div>
       </div>
+
+      {isMenuOpen ? (
+        <div
+          className={cn(
+            "absolute left-4 right-4 top-[calc(100%+8px)] z-50 rounded-[14px] border p-2 shadow-[0_18px_60px_rgba(0,0,0,0.18)] backdrop-blur-xl md:hidden",
+            variant === "dark"
+              ? "border-white/14 bg-[#070a10]/95 text-white"
+              : "border-[#0a0d12]/10 bg-white text-[#0a0d12]",
+          )}
+        >
+          <nav aria-label={t.header.navigation} className="flex flex-col">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setIsMenuOpen(false)}
+                className={mobileNavLinkClassName(variant)}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          <div
+            className={cn(
+              "mt-2 border-t pt-2",
+              variant === "dark" ? "border-white/10" : "border-[#0a0d12]/8",
+            )}
+          >
+            <Link
+              href={githubUrl}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => setIsMenuOpen(false)}
+              className={mobileNavLinkClassName(variant)}
+            >
+              <GitHubMark className="size-3.5" />
+              {t.header.github}
+            </Link>
+            {!user ? (
+              <Link
+                href="/login"
+                onClick={() => setIsMenuOpen(false)}
+                className={mobileNavLinkClassName(variant)}
+              >
+                {t.header.login}
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
     </header>
+  );
+}
+
+function navLinkClassName(variant: "dark" | "light") {
+  return cn(
+    "inline-flex h-9 items-center rounded-[9px] px-3 text-[13px] font-medium transition-colors",
+    variant === "dark"
+      ? "text-white/72 hover:bg-white/8 hover:text-white"
+      : "text-[#0a0d12]/62 hover:bg-[#0a0d12]/5 hover:text-[#0a0d12]",
+  );
+}
+
+function mobileNavLinkClassName(variant: "dark" | "light") {
+  return cn(
+    "flex min-h-11 items-center gap-2 rounded-[10px] px-3 text-[14px] font-medium transition-colors",
+    variant === "dark"
+      ? "text-white/76 hover:bg-white/8 hover:text-white"
+      : "text-[#0a0d12]/68 hover:bg-[#0a0d12]/5 hover:text-[#0a0d12]",
   );
 }

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -5,7 +5,6 @@ export function createEnDict(allowSignup: boolean): LandingDict {
   return {
   header: {
     github: "GitHub",
-    login: "Log in",
     cta: "Get started",
     dashboard: "Dashboard",
     docs: "Docs",

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -6,9 +6,14 @@ export function createEnDict(allowSignup: boolean): LandingDict {
   header: {
     github: "GitHub",
     login: "Log in",
+    cta: "Get started",
     dashboard: "Dashboard",
+    docs: "Docs",
     changelog: "Changelog",
     useCases: "Use cases",
+    navigation: "Primary navigation",
+    openMenu: "Open navigation menu",
+    closeMenu: "Close navigation menu",
   },
 
   hero: {

--- a/apps/web/features/landing/i18n/types.ts
+++ b/apps/web/features/landing/i18n/types.ts
@@ -37,7 +37,6 @@ export type ContactSalesOption = { value: string; label: string };
 export type LandingDict = {
   header: {
     github: string;
-    login: string;
     cta: string;
     dashboard: string;
     docs: string;

--- a/apps/web/features/landing/i18n/types.ts
+++ b/apps/web/features/landing/i18n/types.ts
@@ -38,9 +38,14 @@ export type LandingDict = {
   header: {
     github: string;
     login: string;
+    cta: string;
     dashboard: string;
+    docs: string;
     changelog: string;
     useCases: string;
+    navigation: string;
+    openMenu: string;
+    closeMenu: string;
   };
   hero: {
     headlineLine1: string;

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -5,7 +5,6 @@ export function createZhDict(allowSignup: boolean): LandingDict {
   return {
   header: {
     github: "GitHub",
-    login: "\u767b\u5f55",
     cta: "\u5f00\u59cb\u4f7f\u7528",
     dashboard: "\u8fdb\u5165\u5de5\u4f5c\u53f0",
     docs: "\u6587\u6863",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -6,9 +6,14 @@ export function createZhDict(allowSignup: boolean): LandingDict {
   header: {
     github: "GitHub",
     login: "\u767b\u5f55",
+    cta: "\u5f00\u59cb\u4f7f\u7528",
     dashboard: "\u8fdb\u5165\u5de5\u4f5c\u53f0",
+    docs: "\u6587\u6863",
     changelog: "\u66f4\u65b0\u65e5\u5fd7",
     useCases: "\u6848\u4f8b",
+    navigation: "\u4e3b\u5bfc\u822a",
+    openMenu: "\u6253\u5f00\u5bfc\u822a\u83dc\u5355",
+    closeMenu: "\u5173\u95ed\u5bfc\u822a\u83dc\u5355",
   },
 
   hero: {


### PR DESCRIPTION
## Summary
- Move Use cases, Docs, and Changelog into primary landing navigation
- Keep GitHub/Login as secondary actions and add a dedicated Get started CTA
- Add a mobile menu so docs/resource links remain reachable on small screens

## Verification
- pnpm --filter @multica/web typecheck
- pnpm --filter @multica/web lint (passes with existing login page hook dependency warning)
- git diff --check

Note: skipped browser/dev-server visual verification because the user asked not to start local services.