### PR TITLE
feat: add description field to workspace repository settings (MUL-2604)

### DIFF
--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -2,6 +2,7 @@ export type MemberRole = "owner" | "admin" | "member";
 
 export interface WorkspaceRepo {
   url: string;
+  description?: string;
 }
 
 export interface Workspace {

--- a/packages/views/settings/components/repositories-tab.test.tsx
+++ b/packages/views/settings/components/repositories-tab.test.tsx
@@ -12,7 +12,7 @@ const workspaceRef = vi.hoisted(() => ({
     id: "workspace-1",
     name: "Test Workspace",
     slug: "test-workspace",
-    repos: [{ url: "https://github.com/multica-ai/multica" }] as { url: string }[],
+    repos: [{ url: "https://github.com/multica-ai/multica" }] as { url: string; description?: string }[],
   },
 }));
 const membersRef = vi.hoisted(() => ({
@@ -97,13 +97,13 @@ describe("RepositoriesTab — view/edit toggle", () => {
 
     await user.click(screen.getByRole("button", { name: "Edit repository" }));
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
-    expect(input.value).toBe("https://github.com/multica-ai/multica");
+    const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    expect(inputs[0]!.value).toBe("https://github.com/multica-ai/multica");
   });
 
   it("Save re-enables after editing, then returns to display mode + disabled on success", async () => {
     const user = userEvent.setup();
-    mockUpdateWorkspace.mockImplementation(async (_id: string, payload: { repos: { url: string }[] }) => ({
+    mockUpdateWorkspace.mockImplementation(async (_id: string, payload: { repos: { url: string; description?: string }[] }) => ({
       ...workspaceRef.current,
       repos: payload.repos,
     }));
@@ -111,7 +111,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     render(<RepositoriesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("button", { name: "Edit repository" }));
-    const input = screen.getByRole("textbox");
+    const input = screen.getAllByRole("textbox")[0]!;
     await user.clear(input);
     await user.type(input, "https://github.com/multica-ai/edited");
 
@@ -121,7 +121,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     // Simulate the workspace cache resync that the parent provider does
     // after a successful save — `setQueryData` updates the cache and the
     // useCurrentWorkspace hook would yield the new value on the next render.
-    mockUpdateWorkspace.mockImplementationOnce(async (_id: string, payload: { repos: { url: string }[] }) => {
+    mockUpdateWorkspace.mockImplementationOnce(async (_id: string, payload: { repos: { url: string; description?: string }[] }) => {
       workspaceRef.current = { ...workspaceRef.current, repos: payload.repos };
       return workspaceRef.current;
     });
@@ -146,7 +146,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     expect(screen.queryByRole("textbox")).toBeNull();
     await user.click(screen.getByRole("button", { name: /Add repository/ }));
 
-    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.getAllByRole("textbox").length).toBe(2); // url + description
     expect(screen.getByRole("button", { name: /^Save$/ })).not.toBeDisabled();
   });
 
@@ -155,7 +155,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     render(<RepositoriesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("button", { name: "Edit repository" }));
-    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.getAllByRole("textbox").length).toBe(2);
 
     await user.click(screen.getByRole("button", { name: "Cancel edit" }));
 
@@ -170,7 +170,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     render(<RepositoriesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("button", { name: "Edit repository" }));
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getAllByRole("textbox")[0] as HTMLInputElement;
     await user.clear(input);
     await user.type(input, "https://github.com/multica-ai/changed");
     expect(screen.getByRole("button", { name: /^Save$/ })).not.toBeDisabled();
@@ -187,7 +187,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     render(<RepositoriesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("button", { name: /Add repository/ }));
-    expect(screen.getByRole("textbox")).toBeTruthy();
+    expect(screen.getAllByRole("textbox").length).toBe(2);
 
     await user.click(screen.getByRole("button", { name: "Cancel edit" }));
 
@@ -200,7 +200,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
   it("accepts scp-like shorthand without browser URL validation blocking submit", async () => {
     const user = userEvent.setup();
     mockUpdateWorkspace.mockImplementation(
-      async (_id: string, payload: { repos: { url: string }[] }) => {
+      async (_id: string, payload: { repos: { url: string; description?: string }[] }) => {
         workspaceRef.current = { ...workspaceRef.current, repos: payload.repos };
         return workspaceRef.current;
       },
@@ -209,7 +209,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     render(<RepositoriesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("button", { name: "Edit repository" }));
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getAllByRole("textbox")[0] as HTMLInputElement;
     await user.clear(input);
     await user.type(input, "git@github.com:multica-ai/multica.git");
 
@@ -238,7 +238,7 @@ describe("RepositoriesTab — view/edit toggle", () => {
     // Edit the second row.
     const editButtons = screen.getAllByRole("button", { name: "Edit repository" });
     await user.click(editButtons[1]!);
-    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(
+    expect((screen.getAllByRole("textbox")[0] as HTMLInputElement).value).toBe(
       "https://b.example/repo.git",
     );
 
@@ -247,7 +247,41 @@ describe("RepositoriesTab — view/edit toggle", () => {
     const deleteButtons = screen.getAllByRole("button", { name: "Delete repository" });
     await user.click(deleteButtons[0]!);
 
-    const input = screen.getByRole("textbox") as HTMLInputElement;
+    const input = screen.getAllByRole("textbox")[0] as HTMLInputElement;
     expect(input.value).toBe("https://b.example/repo.git");
+  });
+
+  it("description field is editable and included in save payload", async () => {
+    workspaceRef.current = {
+      ...workspaceRef.current,
+      repos: [{ url: "https://github.com/multica-ai/multica", description: "Main app" }],
+    };
+    const user = userEvent.setup();
+    mockUpdateWorkspace.mockImplementation(
+      async (_id: string, payload: { repos: { url: string; description?: string }[] }) => {
+        workspaceRef.current = { ...workspaceRef.current, repos: payload.repos };
+        return workspaceRef.current;
+      },
+    );
+
+    render(<RepositoriesTab />, { wrapper: I18nWrapper });
+
+    // Description is shown in display mode.
+    expect(screen.getByText("Main app")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Edit repository" }));
+    const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    expect(inputs[1]!.value).toBe("Main app");
+
+    await user.clear(inputs[1]!);
+    await user.type(inputs[1]!, "Updated description");
+
+    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith("workspace-1", {
+        repos: [{ url: "https://github.com/multica-ai/multica", description: "Updated description" }],
+      });
+    });
   });
 });

--- a/packages/views/settings/components/repositories-tab.tsx
+++ b/packages/views/settings/components/repositories-tab.tsx
@@ -26,7 +26,7 @@ function dropAndShiftIndex(set: Set<number>, removed: number): Set<number> {
 
 function isDirty(local: WorkspaceRepo[], saved: WorkspaceRepo[]): boolean {
   if (local.length !== saved.length) return true;
-  return local.some((r, i) => r.url !== saved[i]?.url);
+  return local.some((r, i) => r.url !== saved[i]?.url || (r.description ?? "") !== (saved[i]?.description ?? ""));
 }
 
 export function RepositoriesTab() {
@@ -79,8 +79,8 @@ export function RepositoriesTab() {
     setEditingIndices(dropAndShiftIndex(editingIndices, index));
   };
 
-  const handleRepoChange = (index: number, value: string) => {
-    setRepos(repos.map((r, i) => (i === index ? { ...r, url: value } : r)));
+  const handleRepoChange = (index: number, field: keyof WorkspaceRepo, value: string) => {
+    setRepos(repos.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
   };
 
   const handleEditRepo = (index: number) => {
@@ -88,13 +88,13 @@ export function RepositoriesTab() {
   };
 
   const handleCancelEdit = (index: number) => {
-    const savedUrl = savedRepos[index]?.url;
-    if (savedUrl === undefined) {
+    const saved = savedRepos[index];
+    if (saved === undefined) {
       // Newly added row that was never persisted — drop it entirely.
       handleRemoveRepo(index);
       return;
     }
-    setRepos(repos.map((r, i) => (i === index ? { ...r, url: savedUrl } : r)));
+    setRepos(repos.map((r, i) => (i === index ? { ...r, url: saved.url, description: saved.description } : r)));
     const next = new Set(editingIndices);
     next.delete(index);
     setEditingIndices(next);
@@ -124,31 +124,48 @@ export function RepositoriesTab() {
               return (
                 <div
                   key={index}
-                  className="group flex items-center gap-2"
+                  className="group flex items-start gap-2"
                 >
                   {isEditing ? (
-                    <Input
-                      type="text"
-                      value={repo.url}
-                      onChange={(e) => handleRepoChange(index, e.target.value)}
-                      disabled={!canManageWorkspace}
-                      placeholder={t(($) => $.repositories.url_placeholder)}
-                      className="flex-1 min-w-0 text-sm"
-                    />
+                    <div className="flex-1 min-w-0 space-y-1.5">
+                      <Input
+                        type="text"
+                        value={repo.url}
+                        onChange={(e) => handleRepoChange(index, "url", e.target.value)}
+                        disabled={!canManageWorkspace}
+                        placeholder={t(($) => $.repositories.url_placeholder)}
+                        className="text-sm"
+                      />
+                      <Input
+                        type="text"
+                        value={repo.description ?? ""}
+                        onChange={(e) => handleRepoChange(index, "description", e.target.value)}
+                        disabled={!canManageWorkspace}
+                        placeholder={t(($) => $.repositories.description_placeholder)}
+                        className="text-sm"
+                      />
+                    </div>
                   ) : (
-                    <div
-                      className="flex-1 min-w-0 truncate rounded-md border bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground"
-                      title={repo.url}
-                    >
-                      {repo.url || t(($) => $.repositories.url_empty)}
+                    <div className="flex-1 min-w-0 rounded-md border bg-muted/50 px-3 py-2">
+                      <div
+                        className="truncate font-mono text-xs text-muted-foreground"
+                        title={repo.url}
+                      >
+                        {repo.url || t(($) => $.repositories.url_empty)}
+                      </div>
+                      {repo.description && (
+                        <div className="mt-0.5 truncate text-xs text-muted-foreground/70" title={repo.description}>
+                          {repo.description}
+                        </div>
+                      )}
                     </div>
                   )}
                   {canManageWorkspace && (
                     <div
                       className={
                         isEditing
-                          ? "flex shrink-0 items-center gap-0.5"
-                          : "flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100"
+                          ? "flex shrink-0 items-center gap-0.5 pt-1.5"
+                          : "flex shrink-0 items-center gap-0.5 pt-1.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100"
                       }
                     >
                       {!isEditing && (


### PR DESCRIPTION
Adds an optional `description` field to each workspace repository entry in Settings → Repositories.

**Changes:**
- `WorkspaceRepo` type now includes `description?: string`
- Edit mode shows a description input below the URL input
- View mode displays the description text below the URL
- `isDirty` compares descriptions for save-button state
- Tests updated for the new field

Closes MUL-2604