### PR TITLE
MUL-2610 feat: include repo description in agent brief

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3088,7 +3088,7 @@ func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {
 	}
 	result := make([]execenv.RepoContextForEnv, len(repos))
 	for i, r := range repos {
-		result[i] = execenv.RepoContextForEnv{URL: r.URL}
+		result[i] = execenv.RepoContextForEnv{URL: r.URL, Description: r.Description}
 	}
 	return result
 }

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -14,7 +14,8 @@ import (
 
 // RepoContextForEnv describes a workspace repo available for checkout.
 type RepoContextForEnv struct {
-	URL string // remote URL
+	URL         string // remote URL
+	Description string // optional repo description
 }
 
 // ProjectResourceForEnv describes a single resource attached to the issue's

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -248,7 +248,11 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("The following code repositories are available in this workspace.\n")
 		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory. Add `--ref <branch-or-sha>` when you need an exact branch, tag, or commit.\n\n")
 		for _, repo := range ctx.Repos {
-			fmt.Fprintf(&b, "- %s\n", repo.URL)
+			if repo.Description != "" {
+				fmt.Fprintf(&b, "- %s — %s\n", repo.URL, repo.Description)
+			} else {
+				fmt.Fprintf(&b, "- %s\n", repo.URL)
+			}
 		}
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed, and can pass `--ref` for review/QA on a non-default branch or commit.\n\n")
 	}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -18,7 +18,8 @@ type Runtime struct {
 
 // RepoData holds repository information from the workspace.
 type RepoData struct {
-	URL string `json:"url"`
+	URL         string `json:"url"`
+	Description string `json:"description,omitempty"`
 }
 
 // ProjectResourceData mirrors handler.ProjectResourceData — a single project

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -123,7 +123,8 @@ func agentToResponse(a db.Agent) AgentResponse {
 // RepoData holds repository information included in claim responses so the
 // daemon can set up worktrees for each workspace repo.
 type RepoData struct {
-	URL string `json:"url"`
+	URL         string `json:"url"`
+	Description string `json:"description,omitempty"`
 }
 
 // ProjectResourceData is the wire shape for a project resource included in a

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -192,7 +192,7 @@ func normalizeWorkspaceRepos(repos []RepoData) []RepoData {
 			continue
 		}
 		seen[url] = struct{}{}
-		normalized = append(normalized, RepoData{URL: url})
+		normalized = append(normalized, RepoData{URL: url, Description: repo.Description})
 	}
 	return normalized
 }


### PR DESCRIPTION
## Summary

Add `Description` field to `RepoData` structs so workspace repo descriptions (set via the settings UI) flow through to the agent brief.

When a description is present, the brief renders:
```
- https://github.com/org/repo — Main backend service
```

When no description is set, the existing format is unchanged:
```
- https://github.com/org/repo
```

## Changes

- `handler/agent.go`: Added `Description` field to `RepoData`
- `daemon/types.go`: Added `Description` field to `RepoData`
- `handler/daemon.go`: `normalizeWorkspaceRepos` preserves description
- `daemon/execenv/execenv.go`: Added `Description` to `RepoContextForEnv`
- `daemon/daemon.go`: Passes description through in conversion
- `daemon/execenv/runtime_config.go`: Conditional rendering with description

## Testing

- `go build ./...` passes
- `go test ./internal/daemon/execenv/` passes (all repo-related tests green)

Closes MUL-2610