### PR TITLE
fix(desktop): retry tab scroll restore until virtualized content rehydrates (MUL-2602)

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-scroll-restore.ts
@@ -20,6 +20,14 @@ import { useEffect, useLayoutEffect, useRef } from "react";
  * are dropped — the new route's container shares the same marker key but
  * is a different page, and restoring the old offset would land the user
  * somewhere arbitrary on the new page.
+ *
+ * For virtualized children (Virtuoso, react-virtual, etc.) the single
+ * synchronous `scrollTop = saved` inside useLayoutEffect isn't enough:
+ * the child registers its observers in a passive useEffect that fires
+ * later, so at restore time the container's scrollHeight has collapsed
+ * to clientHeight and the browser clamps our assignment to 0. The
+ * restore loops across rAF frames until the assignment sticks, which
+ * lets virtualization rehydrate before we give up.
  */
 export function useTabScrollRestore(tabPath: string) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -33,19 +41,47 @@ export function useTabScrollRestore(tabPath: string) {
 
   // <Activity> cleans up effects on hidden and re-mounts them on visible,
   // so an empty-deps useLayoutEffect runs exactly on every hidden → visible
-  // transition. Restoring here (before the browser paints) avoids any
-  // flash at scrollTop=0.
+  // transition. Restoring here (before the browser paints) handles the
+  // common case without a flash.
+  //
+  // The synchronous set isn't enough for virtualized lists though
+  // (issue-detail uses Virtuoso with customScrollParent). Virtuoso wires
+  // its scroll/resize observers in a passive useEffect, which fires AFTER
+  // useLayoutEffect — so at the moment we try to restore, the spacer that
+  // gives the container its tall scrollHeight hasn't been re-established
+  // yet. The browser silently clamps `scrollTop = saved` down to 0 because
+  // `scrollHeight === clientHeight` in that window. Retry across rAF
+  // frames until the set sticks (or we time out around the time any sane
+  // child should have laid out, ~500ms).
   useLayoutEffect(() => {
     const root = containerRef.current;
     if (!root) return;
     const els = root.querySelectorAll<HTMLElement>("[data-tab-scroll-root]");
+    const cancellers: Array<() => void> = [];
     els.forEach((el) => {
       const key = scrollKey(el);
       const saved = savedRef.current.get(key);
-      if (saved !== undefined && el.scrollTop !== saved) {
+      if (saved === undefined) return;
+      el.scrollTop = saved;
+      if (el.scrollTop === saved) return;
+
+      let cancelled = false;
+      let attempts = 0;
+      const maxAttempts = 30; // ~500ms at 60fps
+      const tick = () => {
+        if (cancelled) return;
         el.scrollTop = saved;
-      }
+        attempts++;
+        if (el.scrollTop === saved) return;
+        if (attempts >= maxAttempts) return;
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+      cancellers.push(() => {
+        cancelled = true;
+      });
     });
+    return () => cancellers.forEach((c) => c());
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Follow-up to #3196 (MUL-2602). Switching tabs and back on a long issue still landed at `scrollTop=0` even after that PR shipped.

## Root cause

`issue-detail` uses Virtuoso with `customScrollParent`. Virtuoso wires its scroll/resize observers in a **passive `useEffect`**, which fires *after* `useLayoutEffect`. So at the moment the restore hook ran, the spacer that gives the scroll container its tall `scrollHeight` hadn't been re-established yet (`scrollHeight === clientHeight`), and the browser silently clamped `scrollTop = saved` down to `0`.

Confirmed with diagnostic logging in the user's actual repro:

\`\`\`
marker key=true saved=10356.5 currentScrollTop=0 scrollHeight=750 clientHeight=750
→ set scrollTop to 10356.5 actually now 0
\`\`\`

`rAF` and `+100ms` checks also showed `0` — nobody was overriding us after the fact, the assignment just never took because the container had no overflow at that instant.

## Fix

Keep the synchronous set as the fast path, then if the assignment was clamped, retry across `requestAnimationFrame` frames for up to ~500ms (30 frames). That gives Virtuoso's passive effect time to re-establish the spacer, after which the next tick succeeds. Cancel any in-flight retry when the effect tears down (Activity hidden again or unmount).

## Test plan
- [x] `pnpm --filter @multica/desktop test` — 157 / 157 pass (existing 4 scroll-restore tests still green, synchronous fast path covers them)
- [x] `pnpm --filter @multica/desktop typecheck`
- [x] Manual: open issue-detail with long comment thread, scroll deep, switch tabs, switch back — scroll position holds (user verified locally)

A jsdom regression test for the Virtuoso scenario didn't repro reliably (the clamp + rAF interplay needs a real browser), so coverage here is manual + the existing tests for the common case.