### PR TITLE
fix(editor): code block Enter + readonly code block rendering

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -118,6 +118,17 @@ export function createEditorExtensions(
       addNodeView() {
         return ReactNodeViewRenderer(CodeBlockView);
       },
+      addKeyboardShortcuts() {
+        const parentShortcuts = this.parent?.();
+        return {
+          ...parentShortcuts,
+          Enter: ({ editor }) => {
+            if (!editor.isActive("codeBlock")) return false;
+            if (parentShortcuts?.Enter?.({ editor })) return true;
+            return editor.commands.newlineInCode();
+          },
+        };
+      },
     }).configure({ lowlight }),
     // ⚠️ Link MUST appear before markdownPaste in this array.
     // linkOnPaste relies on Link's handlePaste plugin firing first;

--- a/packages/views/editor/extensions/list-item.test.ts
+++ b/packages/views/editor/extensions/list-item.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
+import CodeBlock from "@tiptap/extension-code-block";
 import { PatchedListItem } from "./list-item";
 
 interface JsonNode {
@@ -177,5 +178,212 @@ describe("PatchedListItem Enter behaviour", () => {
     const outer = list?.content?.[0];
     const outerText = outer?.content?.[0]?.content?.[0]?.text ?? "";
     expect(outerText).toBe("outer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Code-block interaction tests
+// ---------------------------------------------------------------------------
+
+/** Return the text-offset position inside the i-th codeBlock. */
+function codeBlockTextPos(editor: Editor, index = 0): number {
+  let count = 0;
+  let pos = -1;
+  editor.state.doc.descendants((node, p) => {
+    if (node.type.name === "codeBlock") {
+      if (count === index) {
+        pos = p + 1; // step over <codeBlock> open
+        return false;
+      }
+      count += 1;
+    }
+    return true;
+  });
+  if (pos < 0) throw new Error(`no codeBlock at index ${index}`);
+  return pos;
+}
+
+/**
+ * Editor with PatchedListItem + CodeBlock extended with our explicit
+ * Enter → newlineInCode fallback (mirrors index.ts production config).
+ */
+function makeEditorWithCodeBlock(content: JsonNode) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit.configure({ listItem: false, codeBlock: false }),
+      PatchedListItem,
+      CodeBlock.extend({
+        addKeyboardShortcuts() {
+          const parentShortcuts = this.parent?.();
+          return {
+            ...parentShortcuts,
+            Enter: ({ editor }: { editor: Editor }) => {
+              if (!editor.isActive("codeBlock")) return false;
+              if (parentShortcuts?.Enter?.({ editor })) return true;
+              return editor.commands.newlineInCode();
+            },
+          };
+        },
+      }),
+    ],
+    content,
+  });
+}
+
+/** Invoke the codeBlock extension's Enter shortcut directly. */
+function pressCodeBlockEnter(editor: Editor): boolean {
+  const ext = editor.extensionManager.extensions.find(
+    (e) => e.name === "codeBlock",
+  );
+  if (!ext) throw new Error("codeBlock extension not registered");
+  const shortcuts = (
+    ext.config.addKeyboardShortcuts as
+      | (() => Record<string, (args: { editor: Editor }) => boolean>)
+      | undefined
+  )?.bind({
+    editor,
+    name: "codeBlock",
+    options: ext.options,
+    type: editor.schema.nodes.codeBlock,
+    storage: ext.storage,
+    parent: ext.parent
+      ? () =>
+          (
+            ext.parent!.config.addKeyboardShortcuts as
+              | (() => Record<string, (args: { editor: Editor }) => boolean>)
+              | undefined
+          )?.bind({
+            editor,
+            name: "codeBlock",
+            options: ext.options,
+            type: editor.schema.nodes.codeBlock,
+            storage: ext.storage,
+          } as never)()
+      : undefined,
+  } as never)();
+  const enter = shortcuts?.Enter;
+  if (!enter) throw new Error("Enter shortcut not bound on codeBlock");
+  return enter({ editor });
+}
+
+describe("PatchedListItem — codeBlock guard", () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+    document.body.innerHTML = "";
+  });
+
+  it("yields (returns false) when cursor is inside a code block in a list item", () => {
+    editor = makeEditorWithCodeBlock({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "item" }],
+                },
+                {
+                  type: "codeBlock",
+                  content: [{ type: "text", text: "code" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    editor.commands.setTextSelection(codeBlockTextPos(editor));
+    expect(pressEnter(editor)).toBe(false);
+  });
+});
+
+describe("CodeBlock Enter — newlineInCode fallback", () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+    document.body.innerHTML = "";
+  });
+
+  it("inserts a newline in a top-level code block", () => {
+    editor = makeEditorWithCodeBlock({
+      type: "doc",
+      content: [
+        { type: "codeBlock", content: [{ type: "text", text: "line1" }] },
+      ],
+    });
+
+    editor.commands.setTextSelection(codeBlockTextPos(editor) + 5);
+    pressCodeBlockEnter(editor);
+
+    const json = editor.getJSON() as JsonNode;
+    expect(json.content?.[0]?.type).toBe("codeBlock");
+    expect(json.content?.[0]?.content?.[0]?.text).toContain("\n");
+  });
+
+  it("inserts a newline in a code block inside a list item", () => {
+    editor = makeEditorWithCodeBlock({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "item" }],
+                },
+                {
+                  type: "codeBlock",
+                  content: [{ type: "text", text: "code" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    editor.commands.setTextSelection(codeBlockTextPos(editor) + 4);
+    pressCodeBlockEnter(editor);
+
+    const codeBlock = (editor.getJSON() as JsonNode).content?.[0]
+      ?.content?.[0]?.content?.[1];
+    expect(codeBlock?.type).toBe("codeBlock");
+    expect(codeBlock?.content?.[0]?.text).toContain("\n");
+  });
+
+  it("exits the code block on triple-Enter (does not regress)", () => {
+    editor = makeEditorWithCodeBlock({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          content: [{ type: "text", text: "hello\n\n" }],
+        },
+      ],
+    });
+
+    const pos = codeBlockTextPos(editor);
+    editor.commands.setTextSelection(pos + 7);
+    pressCodeBlockEnter(editor);
+
+    const json = editor.getJSON() as JsonNode;
+    const last = json.content?.[json.content.length - 1];
+    expect(last?.type).toBe("paragraph");
   });
 });

--- a/packages/views/editor/extensions/list-item.ts
+++ b/packages/views/editor/extensions/list-item.ts
@@ -21,11 +21,13 @@ import { ListItem } from "@tiptap/extension-list";
 export const PatchedListItem = ListItem.extend({
   addKeyboardShortcuts() {
     return {
-      Enter: () =>
-        this.editor.commands.first(({ commands }) => [
+      Enter: () => {
+        if (this.editor.isActive("codeBlock")) return false;
+        return this.editor.commands.first(({ commands }) => [
           () => commands.splitListItem(this.name),
           () => commands.liftListItem(this.name),
-        ]),
+        ]);
+      },
       Tab: () => this.editor.commands.sinkListItem(this.name),
       "Shift-Tab": () => this.editor.commands.liftListItem(this.name),
     };

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -266,6 +266,40 @@ describe("ReadonlyContent HTML block rendering", () => {
   });
 });
 
+describe("ReadonlyContent fenced code block rendering", () => {
+  it("renders no-language fenced code block with visible text", () => {
+    const { container } = render(
+      <ReadonlyContent content={["```", "ok", "```"].join("\n")} />,
+    );
+
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe("ok");
+  });
+
+  it("renders short single-word content in a no-language fenced code block", () => {
+    const { container } = render(
+      <ReadonlyContent content={["```", "x", "```"].join("\n")} />,
+    );
+
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe("x");
+  });
+
+  it("does not regress language-tagged fenced code blocks", () => {
+    const { container } = render(
+      <ReadonlyContent
+        content={["```js", 'console.log("hi")', "```"].join("\n")}
+      />,
+    );
+
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toContain("console");
+  });
+});
+
 describe("ReadonlyContent file-card → AttachmentBlock HTML routing", () => {
   // Regression pin for readonly-content.tsx:279. The `div data-type=fileCard`
   // branch must render through <AttachmentBlock>, not the older

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -217,8 +217,10 @@ function buildComponents(): Partial<Components> {
     code: ({ className, children, node, ...props }) => {
       const lang = /language-(\w+)/.exec(className || "")?.[1];
       const isBlock =
-        node?.position &&
-        node.position.start.line !== node.position.end.line;
+        Boolean(lang) ||
+        (node?.position != null &&
+          node.position.start.line !== node.position.end.line) ||
+        String(children).endsWith("\n");
 
       if (isBlock && lang === "mermaid") {
         return <MermaidDiagram chart={String(children).replace(/\n$/, "")} />;
@@ -242,20 +244,23 @@ function buildComponents(): Partial<Components> {
         const tree = lang
           ? lowlight.highlight(lang, code)
           : lowlight.highlightAuto(code);
-        return (
-          <code
-            className={cn("hljs", lang && `language-${lang}`)}
-            dangerouslySetInnerHTML={{ __html: toHtml(tree) }}
-          />
-        );
+        const html = toHtml(tree);
+        if (html) {
+          return (
+            <code
+              className={cn("hljs", lang && `language-${lang}`)}
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          );
+        }
       } catch {
-        // Fallback — render without highlighting
-        return (
-          <code className={className} {...props}>
-            {children}
-          </code>
-        );
+        // lowlight threw — fall through to plain-text render below
       }
+      return (
+        <code className={cn("hljs", lang && `language-${lang}`)} {...props}>
+          {code}
+        </code>
+      );
     },
 
     // Pre — pass through (CSS handles styling via .rich-text-editor pre).


### PR DESCRIPTION
## Summary

Fixes two editor bugs reported in MUL-2611:

- **Bug 1 — Code block Enter**: Pressing Enter inside a code block did not insert a newline. Root cause: ProseMirror's base keymap `newlineInCode` was preempted by higher-priority extension keymaps. Fix adds an explicit Enter → `newlineInCode()` fallback in `CodeBlockLowlight` (`packages/views/editor/extensions/index.ts:118-128`) and a `codeBlock` guard in `PatchedListItem` (`packages/views/editor/extensions/list-item.ts:24`) so it yields when cursor is inside a code block.

- **Bug 2 — Readonly code block content disappears**: No-language fenced code blocks (`` ``` \nok\n``` ``) rendered empty in `ReadonlyContent`. Two causes: (a) `isBlock` detection relied solely on `node.position` which `rehype-raw` can strip (`readonly-content.tsx:219-224`), (b) `lowlight.highlightAuto` returns empty children for very short unrecognized text (`readonly-content.tsx:244-258`). Fix uses a `lang`/`position`/trailing-newline triple-fallback for `isBlock` and falls back to plain-text rendering when `highlightAuto` produces empty HTML.

## Test plan

- [x] Bug 1: Top-level code block Enter inserts newline (`list-item.test.ts`)
- [x] Bug 1: Code block inside list item Enter inserts newline (`list-item.test.ts`)
- [x] Bug 1: Triple-Enter exit from code block does not regress (`list-item.test.ts`)
- [x] Bug 1: PatchedListItem yields when cursor is in code block (`list-item.test.ts`)
- [x] Bug 2: No-language fenced code block "ok" renders visible text (`readonly-content.test.tsx`)
- [x] Bug 2: Short single-word content in no-language block renders visible (`readonly-content.test.tsx`)
- [x] Bug 2: Language-tagged fenced code blocks do not regress (`readonly-content.test.tsx`)
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 786/786 pass

Closes MUL-2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)