### PR TITLE
feat(views): sticky group headers in list view

### DIFF
--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -171,7 +171,7 @@ export function IssuesPage() {
           </div>
         </div>
         {viewMode === "list" ? (
-          <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-1">
+          <div className="flex-1 min-h-0 overflow-y-auto p-2 pt-0 space-y-1">
             {Array.from({ length: 4 }).map((_, i) => (
               <Skeleton key={i} className="h-10 w-full rounded-lg" />
             ))}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -171,7 +171,7 @@ export function IssuesPage() {
           </div>
         </div>
         {viewMode === "list" ? (
-          <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
+          <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-1">
             {Array.from({ length: 4 }).map((_, i) => (
               <Skeleton key={i} className="h-10 w-full rounded-lg" />
             ))}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -126,7 +126,7 @@ function StatusAccordionItem({
 
   return (
     <Accordion.Item value={status}>
-      <Accordion.Header className="group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent/50">
+      <Accordion.Header className="group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent">
         <div className="pl-3 flex items-center">
           <input
             type="checkbox"
@@ -144,7 +144,7 @@ function StatusAccordionItem({
             className="cursor-pointer accent-primary"
           />
         </div>
-        <Accordion.Trigger className="group/trigger flex flex-1 items-center gap-2 px-2 h-full text-left outline-none">
+        <Accordion.Trigger className="group/trigger flex flex-1 items-center gap-2 px-2 h-full text-left outline-none cursor-pointer">
           <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-aria-expanded/trigger:rotate-90" />
           <StatusHeading status={status} count={total} />
         </Accordion.Trigger>

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -67,7 +67,7 @@ export function ListView({
     : undefined;
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+    <div className="flex-1 min-h-0 overflow-y-auto p-2 pt-0">
       <Accordion.Root
         multiple
         className="space-y-1"

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -126,7 +126,7 @@ function StatusAccordionItem({
 
   return (
     <Accordion.Item value={status}>
-      <Accordion.Header className="group/header flex h-10 items-center rounded-lg bg-muted/40 transition-colors hover:bg-accent/30">
+      <Accordion.Header className="group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent/50">
         <div className="pl-3 flex items-center">
           <input
             type="checkbox"

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -67,7 +67,7 @@ export function ListView({
     : undefined;
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-2">
+    <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
       <Accordion.Root
         multiple
         className="space-y-1"

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -185,7 +185,7 @@ export function MyIssuesPage() {
           </div>
         </div>
         {viewMode === "list" ? (
-          <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-1">
+          <div className="flex-1 min-h-0 overflow-y-auto p-2 pt-0 space-y-1">
             {Array.from({ length: 4 }).map((_, i) => (
               <Skeleton key={i} className="h-10 w-full rounded-lg" />
             ))}

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -185,7 +185,7 @@ export function MyIssuesPage() {
           </div>
         </div>
         {viewMode === "list" ? (
-          <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
+          <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-1">
             {Array.from({ length: 4 }).map((_, i) => (
               <Skeleton key={i} className="h-10 w-full rounded-lg" />
             ))}


### PR DESCRIPTION
## Summary
- Add `sticky top-0 z-10` to `Accordion.Header` in `list-view.tsx:129` so group headers stay pinned while scrolling
- Change background from `bg-muted/40` → `bg-muted` (opaque) to prevent content bleeding through
- Adjust hover from `hover:bg-accent/30` → `hover:bg-accent/50` for better contrast on the deeper base

Closes MUL-2640

## Test plan
- [ ] Open issues page in list view with multiple status groups expanded
- [ ] Scroll — each group header should stick at top until that group scrolls out
- [ ] Verify the next group's header pushes the previous one away naturally
- [ ] Check with few issues (no scroll needed) — no visual regression
- [ ] Verify in all 4 consumers: issues-page, project-detail, my-issues-page, actor-issues-panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)