### PR TITLE
fix(issues): hide activity-block header while only recent entries are shown

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -865,10 +865,13 @@ describe("IssueDetail (shared)", () => {
 
     renderIssueDetail();
 
-    // The block header reports the full count.
+    // In the truncated default state the "N activities" collapse header
+    // stays hidden — the "Show N more" link is the only control we want
+    // to expose for a glance at recent activity.
     await waitFor(() => {
-      expect(screen.getByText("10 activities")).toBeInTheDocument();
+      expect(screen.getByText("Show 2 more activities")).toBeInTheDocument();
     });
+    expect(screen.queryByText("10 activities")).not.toBeInTheDocument();
 
     // Only the 8 most recent entries (act-3..act-10) are rendered by default.
     // act-1 and act-2 are folded behind the show-more line.
@@ -877,18 +880,15 @@ describe("IssueDetail (shared)", () => {
     expect(screen.queryByText(/from Todo to In Progress/i)).not.toBeInTheDocument(); // act-1
     expect(screen.queryByText(/from Low to Medium/i)).not.toBeInTheDocument(); // act-2
 
-    // The show-more toggle reports the count of hidden older entries (2).
-    const showMore = screen.getByText("Show 2 more activities");
-    expect(showMore).toBeInTheDocument();
-
-    // Clicking the toggle reveals the older entries in place; the rest of the
-    // block stays visible.
-    fireEvent.click(showMore);
+    // Clicking the toggle reveals the older entries in place and brings the
+    // full "N activities" header back (so the user can fold the block).
+    fireEvent.click(screen.getByText("Show 2 more activities"));
     await waitFor(() => {
       expect(screen.getByText(/from Todo to In Progress/i)).toBeInTheDocument();
     });
     expect(screen.getByText(/from Low to Medium/i)).toBeInTheDocument();
     expect(screen.getByText(/set due date to/i)).toBeInTheDocument();
+    expect(screen.getByText("10 activities")).toBeInTheDocument();
     expect(screen.queryByText(/Show \d+ more activit/i)).not.toBeInTheDocument();
   });
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -442,16 +442,25 @@ function ActivityBlock({
       : 0;
   const visibleEntries =
     hiddenOlderCount > 0 ? entries.slice(-LAST_ACTIVITY_BLOCK_VISIBLE_LIMIT) : entries;
+  // Hide the "v N activities" collapse header while we're in the truncated
+  // default state. The "Show N more" link is the only control users need
+  // when they're glancing at recent activity — stacking two chevron rows
+  // looked like nested folds and added visual noise without value. Once the
+  // user explicitly reveals older entries, the header reappears so they can
+  // fold the whole block back to a single count line.
+  const showHeader = hiddenOlderCount === 0;
   return (
     <div className="pb-3 px-4 flex flex-col gap-3">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ChevronDown className="h-3 w-3 shrink-0" />
-        <span>{t(($) => $.activity.activity_count, { count: entries.length })}</span>
-      </button>
+      {showHeader && (
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronDown className="h-3 w-3 shrink-0" />
+          <span>{t(($) => $.activity.activity_count, { count: entries.length })}</span>
+        </button>
+      )}
       {hiddenOlderCount > 0 && (
         <button
           type="button"


### PR DESCRIPTION
Follow-up polish on the recent activity-truncation work. The trailing block was rendering two stacked chevron rows in its default state:

\`\`\`
v 40 activities
> Show 32 more activities
[entry 1..8]
\`\`\`

That looked like nested folds, but the two controls are parallel — the top one collapses the whole block to a count, the bottom one reveals older entries within the block. When you're glancing at recent activity you don't need either of those affordances stacked on top.

## Change
Hide the \`v N activities\` header while the block is in the truncated default state. The \"Show N more\" link is the only control we want in that state. Once the user clicks \"Show N more\" and sees the full block, the header reappears so they can fold the block back to a single count line if they want.

Blocks that fit within the 8-entry limit (and non-trailing blocks, which never truncate) keep their header — the rule only changes for the truncated case.

## Test plan
- [x] \`pnpm --filter @multica/views test\` — 786 / 786 pass (updated the trailing-block truncation test to assert header hidden in default, visible after expanding)
- [x] \`pnpm --filter @multica/views typecheck\`
- [x] Manual: scroll a long issue's timeline, confirm the trailing block now shows just \"Show N more activities\" plus the latest 8 entries; clicking \"Show N more\" brings the \"v N activities\" header back at the top