### PR TITLE
fix(docker): copy source.config.ts into web deps stage (MUL-2649)

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -8,6 +8,8 @@ WORKDIR /app
 # Copy workspace config and all package.json files for dependency resolution
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json .npmrc ./
 COPY apps/web/package.json apps/web/
+# postinstall runs fumadocs-mdx which reads apps/web/source.config.ts
+COPY apps/web/source.config.ts apps/web/source.config.ts
 COPY packages/core/package.json packages/core/
 COPY packages/ui/package.json packages/ui/
 COPY packages/views/package.json packages/views/


### PR DESCRIPTION
## Summary

The 2026-05-25 release of `ghcr.io/multica-ai/multica-web` failed in CI because `Dockerfile.web`'s `deps` stage was missing `apps/web/source.config.ts`. The web `postinstall` script runs `fumadocs-mdx`, which requires that file, so `pnpm install --frozen-lockfile` aborted with:

```
Could not resolve "/app/apps/web/source.config.ts"
```

`source.config.ts` was introduced with the use-cases content pipeline in #2795 but the matching `Dockerfile.web` update was missed.

This PR copies `apps/web/source.config.ts` in the `deps` stage so postinstall can run. The `builder` stage already had the file via the wholesale `COPY apps/web/ apps/web/` overlay, so no change is needed there.

Refs: MUL-2649

## Test plan

- [ ] Re-run the failed `docker-web-build (linux/amd64)` and `docker-web-build (linux/arm64)` jobs from the v0.3.7 Release workflow once this lands, and confirm both go green.
- [ ] (Optional, locally) `docker buildx build -f Dockerfile.web .` completes through `deps` and `builder` without the `fumadocs-mdx` error.