### PR TITLE
fix(editor): cap rendered prose at 70ch for readability

### DIFF
--- a/packages/views/editor/styles/shell.css
+++ b/packages/views/editor/styles/shell.css
@@ -8,6 +8,10 @@
 .rich-text-editor.ProseMirror {
   color: var(--foreground);
   caret-color: var(--foreground);
+  /* Cap measure at ~70ch (Bringhurst / Nielsen Norman readability range);
+     wide elements (tables, code blocks, images) still overflow horizontally
+     via their own rules. */
+  max-width: min(100%, 70ch);
 }
 
 .rich-text-editor.ProseMirror:focus {


### PR DESCRIPTION
## Summary

Cap `.rich-text-editor.ProseMirror` at `min(100%, 70ch)` so long comments and issue descriptions stop running the full panel width (~130+ chars per line on a wide editor).

70ch sits in the classic 50–75ch readability sweet spot (Bringhurst, Nielsen Norman). Wide elements (tables, code blocks, images) still overflow horizontally via the rules already in `code.css` / `media.css` / `attachment.css` — only the prose measure is capped.

## Context

We've been running this in our deployment for a couple of weeks. Long-form issue descriptions and comment threads went from "I lose the line every wrap" to comfortably readable, with no regressions for short content.

## What this changes

- `packages/views/editor/styles/shell.css`: 4 added lines on `.rich-text-editor.ProseMirror`.

## What this does NOT change

- Editor toolbar / floating chrome
- Code blocks, tables, media — those have their own width rules and still overflow horizontally
- Mobile behavior (the cap is a `min(100%, …)` so narrow viewports use 100%)

## Test plan

- [ ] Open an issue with a long-paragraph description on a wide screen and confirm prose wraps at ~70ch
- [ ] Confirm a wide table or code block still overflows horizontally inside its own container
- [ ] Confirm narrow viewport (mobile) still uses full width