### PR TITLE
feat(comments): allow selecting multiple attachments

### DIFF
--- a/packages/ui/components/common/file-upload-button.tsx
+++ b/packages/ui/components/common/file-upload-button.tsx
@@ -11,6 +11,7 @@ interface FileUploadButtonProps {
   disabled?: boolean;
   className?: string;
   size?: "sm" | "default";
+  multiple?: boolean;
 }
 
 function FileUploadButton({
@@ -18,16 +19,17 @@ function FileUploadButton({
   disabled,
   className,
   size = "default",
+  multiple = false,
 }: FileUploadButtonProps) {
   const { t } = useTranslation("ui");
   const inputRef = useRef<HTMLInputElement>(null);
   const attachLabel = t(($) => $.attach_file);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
     e.target.value = "";
-    onSelect(file);
+    for (const file of files) onSelect(file);
   };
 
   const iconSize = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
@@ -52,6 +54,7 @@ function FileUploadButton({
       <input
         ref={inputRef}
         type="file"
+        multiple={multiple}
         className="hidden"
         onChange={handleChange}
       />

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -368,6 +368,7 @@ function CommentRow({
           <div className="flex items-center justify-between mt-2">
             <FileUploadButton
               size="sm"
+              multiple
               onSelect={(file) => editEditorRef.current?.uploadFile(file)}
             />
             <div className="flex items-center gap-2">
@@ -667,6 +668,7 @@ function CommentCardImpl({
                 <div className="flex items-center justify-between mt-2">
                   <FileUploadButton
                     size="sm"
+                    multiple
                     onSelect={(file) => editEditorRef.current?.uploadFile(file)}
                   />
                   <div className="flex items-center gap-2">

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -135,6 +135,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
         </Tooltip>
         <FileUploadButton
           size="sm"
+          multiple
           onSelect={(file) => editorRef.current?.uploadFile(file)}
         />
         <SubmitButton

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -166,6 +166,7 @@ function ReplyInput({
           </Tooltip>
           <FileUploadButton
             size="sm"
+            multiple
             onSelect={(file) => editorRef.current?.uploadFile(file)}
           />
           <button


### PR DESCRIPTION
## Summary

Split out from #2965. This PR only enables selecting multiple files from the attachment picker in comment surfaces.

## Scope

- Adds a `multiple` prop to the shared `FileUploadButton`.
- Iterates over every selected file and calls the existing `onSelect` upload path for each one.
- Enables multi-select on root comments, replies, and edit-mode comment upload buttons.

## Validation

- `git diff --check`

Frontend typecheck was not runnable in the isolated worktree because `node_modules` is not installed there (`tsc: command not found`); GitHub CI should cover it.
