### PR TITLE
docs(cli): cross-reference issue assign and issue rerun in --help

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -117,8 +117,11 @@ var issueUpdateCmd = &cobra.Command{
 var issueAssignCmd = &cobra.Command{
 	Use:   "assign <id>",
 	Short: "Assign an issue to a member, agent, or squad",
-	Args:  exactArgs(1),
-	RunE:  runIssueAssign,
+	Long: "Update an issue's assignee. NOTE: this only changes the assignee field — " +
+		"it does not queue a fresh task for the assigned agent to wake on. " +
+		"To re-enqueue a task (e.g., after a failed agent run), use `multica issue rerun <id>`.",
+	Args: exactArgs(1),
+	RunE: runIssueAssign,
 }
 
 var issueStatusCmd = &cobra.Command{
@@ -203,8 +206,12 @@ var issueRunMessagesCmd = &cobra.Command{
 var issueRerunCmd = &cobra.Command{
 	Use:   "rerun <id>",
 	Short: "Re-enqueue an issue's current agent assignment as a fresh task",
-	Args:  exactArgs(1),
-	RunE:  runIssueRerun,
+	Long: "Queue a fresh task for the issue's current assignee. Use this when an agent " +
+		"run failed (e.g., empty output, timeout) and the daemon is no longer polling " +
+		"for work. To change WHICH agent is assigned, use `multica issue assign <id> --to <name>` " +
+		"first, then rerun.",
+	Args: exactArgs(1),
+	RunE: runIssueRerun,
 }
 
 var issueCancelTaskCmd = &cobra.Command{


### PR DESCRIPTION
## Problem

`multica issue assign --help` doesn't mention that it only updates the assignee field; it does not queue a fresh task for the daemon to pick up. A user hitting a failed agent run has no way to discover from the CLI alone that `multica issue rerun` is the recovery command.

I hit this exact gap during a fresh self-host bring-up. An Orchestrator wake failed with `claude returned empty output`. I tried `multica issue assign DSF-2 --to orchestrator`, expecting the daemon to pick up a new task. It didn't — `daemon.log` kept printing `poll: no tasks`. The recovery command was `multica issue rerun DSF-2`, but I had to discover that by reading source.

## Change

Add `Long:` descriptions to both commands that cross-reference each other:

- **assign**: notes that it only changes the assignee field; points to `rerun` for queueing a fresh task.
- **rerun**: notes that it's for queueing a task on the current assignee; points to `assign --to` when you need to change WHICH agent.

Pure docs change. No behavior changes. \`go build ./cmd/multica\` clean.

## Before/after

\`\`\`
$ multica issue assign --help
Assign an issue to a member, agent, or squad

USAGE
  multica issue assign <id> [flags]
\`\`\`

(after)

\`\`\`
$ multica issue assign --help
Update an issue's assignee. NOTE: this only changes the assignee field —
it does not queue a fresh task for the assigned agent to wake on. To
re-enqueue a task (e.g., after a failed agent run), use \`multica issue rerun <id>\`.

USAGE
  multica issue assign <id> [flags]
\`\`\`

Same shape on the rerun side.