### PR TITLE
docs(cli): list valid statuses in issue status --help

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -124,8 +124,10 @@ var issueAssignCmd = &cobra.Command{
 var issueStatusCmd = &cobra.Command{
 	Use:   "status <id> <status>",
 	Short: "Change issue status",
-	Args:  exactArgs(2),
-	RunE:  runIssueStatus,
+	Long: "Change an issue's status. Valid statuses: " +
+		"backlog, todo, in_progress, in_review, done, blocked, cancelled.",
+	Args: exactArgs(2),
+	RunE: runIssueStatus,
 }
 
 // Comment subcommands.


### PR DESCRIPTION
## Problem

`multica issue status --help` only documents `<status>` as a required positional argument; it doesn't list the valid values. Users have to discover the valid set by trial-and-error:

```
$ multica issue status DSF-1 closed
Error: invalid status "closed"; valid values: backlog, todo, in_progress, in_review, done, blocked, cancelled
```

I hit this exact friction during a real-machine first-run.

## Change

Add a `Long:` description that lists the 7 valid statuses inline. No behavior changes. `go build ./cmd/multica` clean.

## Before/after

```
$ multica issue status --help
Change issue status

USAGE
  multica issue status <id> <status> [flags]
```

(after)

```
$ multica issue status --help
Change an issue's status. Valid statuses: backlog, todo, in_progress,
in_review, done, blocked, cancelled.

USAGE
  multica issue status <id> <status> [flags]
```
