### PR TITLE
fix(agent): time out lingering cmd.Wait() after stdout closes (MUL-2660)

### DIFF
--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"time"
 )
 
@@ -171,4 +172,41 @@ var launchHeaders = map[string]string{
 // users understand which command their custom_args get appended to.
 func LaunchHeader(agentType string) string {
 	return launchHeaders[agentType]
+}
+
+// processExitTimeout is how long waitTimeout allows for a graceful process
+// exit after stdout has been closed. The subprocess already finished its work;
+// this window covers cleanup (session persistence, child reaping, network
+// flush). Anything longer is a genuine hang.
+const processExitTimeout = 60 * time.Second
+
+// ErrProcessKilled is returned by waitTimeout when the process did not exit
+// within the timeout and had to be killed. Callers should treat this as "the
+// agent finished its work but the subprocess hung during cleanup" — the output
+// already collected is still valid.
+var ErrProcessKilled = fmt.Errorf("process killed after %s exit timeout", processExitTimeout)
+
+// waitTimeout waits for cmd to exit within the given timeout. If the process
+// doesn't exit in time, it is killed and ErrProcessKilled is returned. The
+// caller should proceed with whatever output it has already collected. A
+// subprocess that has closed stdout (ending the scanner loop) but failed to
+// exit is a real observed failure mode: the agent completed its work, but a
+// cleanup step (child process, network flush, session persistence) keeps the
+// parent alive. Without a timeout, cmd.Wait() blocks indefinitely and the
+// idle watchdog eventually force-stops the run with a misleading "no new
+// messages" reason.
+func waitTimeout(cmd *exec.Cmd, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		_ = cmd.Process.Kill()
+		return ErrProcessKilled
+	}
 }

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"context"
+	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestNewReturnsClaudeBackend(t *testing.T) {
@@ -85,5 +87,49 @@ func TestLaunchHeaderReturnsEmptyForUnknownType(t *testing.T) {
 	t.Parallel()
 	if header := LaunchHeader("made-up-agent"); header != "" {
 		t.Errorf("expected empty header for unknown type, got %q", header)
+	}
+}
+
+func TestWaitTimeoutReturnsWhenProcessExits(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	err := waitTimeout(cmd, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error for successful exit, got %v", err)
+	}
+}
+
+func TestWaitTimeoutKillsStuckProcess(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	start := time.Now()
+	err := waitTimeout(cmd, 100*time.Millisecond)
+	elapsed := time.Since(start)
+	if err != ErrProcessKilled {
+		t.Fatalf("expected ErrProcessKilled after kill, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected fast kill, took %v", elapsed)
+	}
+}
+
+func TestWaitTimeoutPropagatesNonZeroExit(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("false")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	err := waitTimeout(cmd, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected non-nil error for non-zero exit")
+	}
+	if err == ErrProcessKilled {
+		t.Fatal("expected exit error, not ErrProcessKilled")
 	}
 }

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -189,8 +189,15 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			}
 		}
 
-		// Wait for process exit
-		exitErr := cmd.Wait()
+		// Wait for process exit. If the subprocess closed stdout (ending
+		// the scanner loop) but fails to exit, kill it — the agent
+		// already finished its work and the Result is ready.
+		exitErr := waitTimeout(cmd, processExitTimeout)
+		if exitErr == ErrProcessKilled {
+			b.cfg.Logger.Warn("subprocess did not exit after stdout close, killed",
+				"pid", cmd.Process.Pid,
+			)
+		}
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -199,7 +206,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		} else if runCtx.Err() == context.Canceled {
 			finalStatus = "aborted"
 			finalError = "execution cancelled"
-		} else if exitErr != nil && finalStatus == "completed" {
+		} else if exitErr != nil && exitErr != ErrProcessKilled && finalStatus == "completed" {
 			finalStatus = "failed"
 			finalError = fmt.Sprintf("claude exited with error: %v", exitErr)
 		}

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -276,7 +276,12 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			slog.Warn("copilot stdout scanner error", "err", err)
 		}
 
-		exitErr := cmd.Wait()
+		exitErr := waitTimeout(cmd, processExitTimeout)
+		if exitErr == ErrProcessKilled {
+			b.cfg.Logger.Warn("subprocess did not exit after stdout close, killed",
+				"pid", cmd.Process.Pid,
+			)
+		}
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -285,7 +290,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 		} else if runCtx.Err() == context.Canceled {
 			st.finalStatus = "aborted"
 			st.finalError = "execution cancelled"
-		} else if exitErr != nil && st.finalStatus == "completed" {
+		} else if exitErr != nil && exitErr != ErrProcessKilled && st.finalStatus == "completed" {
 			st.finalStatus = "failed"
 			st.finalError = fmt.Sprintf("copilot exited with error: %v", exitErr)
 		}

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -139,7 +139,12 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			}
 		}
 
-		waitErr := cmd.Wait()
+		waitErr := waitTimeout(cmd, processExitTimeout)
+		if waitErr == ErrProcessKilled {
+			b.cfg.Logger.Warn("subprocess did not exit after stdout close, killed",
+				"pid", cmd.Process.Pid,
+			)
+		}
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -148,7 +153,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		} else if runCtx.Err() == context.Canceled {
 			finalStatus = "aborted"
 			finalError = "execution cancelled"
-		} else if waitErr != nil && finalStatus == "completed" {
+		} else if waitErr != nil && waitErr != ErrProcessKilled && finalStatus == "completed" {
 			finalStatus = "failed"
 			finalError = fmt.Sprintf("gemini exited with error: %v", waitErr)
 		}
@@ -182,10 +187,10 @@ func (b *geminiBackend) accumulateUsage(usage map[string]TokenUsage, stats *gemi
 // ── Gemini stream-json event types ──
 
 type geminiStreamEvent struct {
-	Type      string          `json:"type"`
-	Timestamp string          `json:"timestamp,omitempty"`
-	SessionID string          `json:"session_id,omitempty"`
-	Model     string          `json:"model,omitempty"`
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Model     string `json:"model,omitempty"`
 
 	// message fields
 	Role    string `json:"role,omitempty"`
@@ -216,12 +221,12 @@ type geminiStreamError struct {
 }
 
 type geminiStreamStats struct {
-	TotalTokens  int                          `json:"total_tokens"`
-	InputTokens  int                          `json:"input_tokens"`
-	OutputTokens int                          `json:"output_tokens"`
-	DurationMs   int                          `json:"duration_ms"`
-	ToolCalls    int                          `json:"tool_calls"`
-	Models       map[string]geminiModelStats  `json:"models,omitempty"`
+	TotalTokens  int                         `json:"total_tokens"`
+	InputTokens  int                         `json:"input_tokens"`
+	OutputTokens int                         `json:"output_tokens"`
+	DurationMs   int                         `json:"duration_ms"`
+	ToolCalls    int                         `json:"tool_calls"`
+	Models       map[string]geminiModelStats `json:"models,omitempty"`
 }
 
 type geminiModelStats struct {
@@ -242,6 +247,7 @@ type geminiModelStats struct {
 //	-o stream-json        streaming NDJSON output for live events
 //	-m <model>            optional model override
 //	-r <session>          resume a previous session (if provided)
+//
 // geminiBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args.
 var geminiBlockedArgs = map[string]blockedArgMode{

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -121,8 +121,15 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		startTime := time.Now()
 		scanResult := b.processOutput(stdout, msgCh)
 
-		// Wait for process exit.
-		exitErr := cmd.Wait()
+		// Wait for process exit. If the subprocess closed stdout but
+		// fails to exit, kill it and proceed with the output already
+		// collected.
+		exitErr := waitTimeout(cmd, processExitTimeout)
+		if exitErr == ErrProcessKilled {
+			b.cfg.Logger.Warn("subprocess did not exit after stdout close, killed",
+				"pid", cmd.Process.Pid,
+			)
+		}
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -131,7 +138,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
-		} else if exitErr != nil && scanResult.status == "completed" {
+		} else if exitErr != nil && exitErr != ErrProcessKilled && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("openclaw exited with error: %v", exitErr)
 		}

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -136,8 +136,15 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		startTime := time.Now()
 		scanResult := b.processEvents(stdout, msgCh)
 
-		// Wait for process exit.
-		exitErr := cmd.Wait()
+		// Wait for process exit. If the subprocess closed stdout but
+		// fails to exit, kill it and proceed with the output already
+		// collected.
+		exitErr := waitTimeout(cmd, processExitTimeout)
+		if exitErr == ErrProcessKilled {
+			b.cfg.Logger.Warn("subprocess did not exit after stdout close, killed",
+				"pid", cmd.Process.Pid,
+			)
+		}
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -146,7 +153,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
-		} else if exitErr != nil && scanResult.status == "completed" {
+		} else if exitErr != nil && exitErr != ErrProcessKilled && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes a backend cleanup hang where the agent has already finished producing output, the stdout scanner has ended, but the parent CLI never exits cleanly.

This PR comes from a real failure I hit locally: the agent had already finished its task, but the run never transitioned to a terminal state. It then sat idle until the daemon's watchdog observed about 30 minutes of silence and force-killed the process.

In that state the backend blocks forever on `cmd.Wait()`, never writes `Session.Result`, and the daemon later surfaces the run as an idle-watchdog failure even though the task had effectively already completed.

This PR adds a shared `waitTimeout()` helper and applies it to the stdout-scanned backends on current `main` that still call bare `cmd.Wait()` after their scanner loop: `claude`, `openclaw`, `gemini`, `copilot`, and `opencode`.

The behavioral contract is intentionally narrow:

- normal exits are unchanged
- non-zero exits still propagate as failures
- only the specific `stdout finished but process cleanup is stuck` path is softened
- in that path, Multica waits 60s for process exit, then kills the lingering process and returns the already-collected output instead of hanging the task indefinitely

This fixes the hang at the backend boundary where it actually occurs, without widening daemon watchdog logic for a provider-side cleanup problem.

## Related Issue

Closes #3251

Related context:

- #2188 — Pi agents could remain stuck in `working` after final output
- #2691 — daemon idle watchdog currently catches the symptom, not the root cause
- #3118 — Pi-specific stdin EOF guard, already present on `main`
- #3165 — active Cursor-specific PR, so Cursor is intentionally left out of this patch to avoid overlapping review scope

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/agent.go`
  - add `processExitTimeout`
  - add `ErrProcessKilled`
  - add shared `waitTimeout(cmd, timeout)` helper
- `server/pkg/agent/{claude,openclaw,gemini,copilot,opencode}.go`
  - replace bare `cmd.Wait()` with `waitTimeout(cmd, processExitTimeout)`
  - log a warning when a lingering process has to be killed after stdout has already closed
  - preserve completed output on `ErrProcessKilled`
  - continue treating ordinary non-zero exits as failures
- `server/pkg/agent/agent_test.go`
  - add helper coverage for normal successful exit, timeout + forced kill, and non-zero exit propagation

## How to Test

1. `cd server && go test ./pkg/agent -count=1`
2. Confirm the helper tests pass:
   - `TestWaitTimeoutReturnsWhenProcessExits`
   - `TestWaitTimeoutKillsStuckProcess`
   - `TestWaitTimeoutPropagatesNonZeroExit`
3. Optional manual smoke:
   - reproduce a backend subprocess that closes stdout but keeps the parent alive
   - verify the task completes with the collected output instead of later surfacing as idle-watchdog

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A — backend-only)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A — no user-facing docs surface changed)*
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) *(N/A)*
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) *(N/A)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**

Used Codex to inspect the original fork-only wait-timeout fix, compare it against current upstream Multica issues and pull requests, identify which parts were already upstreamed or overlapped with active provider-specific work, and shrink the contribution to the smallest backend-only patch that still addresses the root cause. Codex also validated the agent package tests with `go test ./pkg/agent -count=1`.

## Screenshots (optional)

N/A.
