### PR TITLE
fix(views): always show assignee meta row on board cards MUL-2658

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -98,16 +98,15 @@ export const BoardCardContent = memo(function BoardCardContent({
 
   const showPriority = storeProperties.priority;
   const showDescription = storeProperties.description && issue.description;
-  const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
+  const showAssigneeSection = storeProperties.assignee;
+  const hasAssignee = !!issue.assignee_type && !!issue.assignee_id;
   const showStartDate = storeProperties.startDate && issue.start_date;
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showLabels = storeProperties.labels && labels.length > 0;
 
-  // Dates need the horizontal space; compact child progress can share the row
-  // with assignee identity.
-  const showAssigneeName = !!showAssignee && !showStartDate && !showDueDate;
+  const showAssigneeName = showAssigneeSection && hasAssignee && !showStartDate && !showDueDate;
   const showUpdatedHint = showAssigneeName && !showChildProgress;
   const { getActorName } = useActorName();
   const assigneeName =
@@ -146,7 +145,7 @@ export const BoardCardContent = memo(function BoardCardContent({
     ? "flex min-w-0 max-w-full items-center"
     : "inline-flex items-center";
 
-  const assigneeInner = showAssignee ? (
+  const assigneeInner = hasAssignee ? (
     <span className="flex min-w-0 max-w-full items-center gap-1.5">
       <ActorAvatar
         actorType={issue.assignee_type!}
@@ -159,16 +158,18 @@ export const BoardCardContent = memo(function BoardCardContent({
         <span className="min-w-0 truncate text-xs text-foreground">{assigneeName}</span>
       )}
     </span>
-  ) : null;
+  ) : (
+    <span className="text-xs text-muted-foreground">{t(($) => $.pickers.assignee.trigger_unassigned)}</span>
+  );
 
-  const assigneeNode = showAssignee ? (
+  const assigneeNode = showAssigneeSection ? (
     editable ? (
       <PickerWrapper className={assigneeContainerClass}>
         <AssigneePicker
           assigneeType={issue.assignee_type}
           assigneeId={issue.assignee_id}
           onUpdate={handleUpdate}
-          trigger={assigneeInner!}
+          trigger={assigneeInner}
         />
       </PickerWrapper>
     ) : (
@@ -176,7 +177,7 @@ export const BoardCardContent = memo(function BoardCardContent({
     )
   ) : null;
 
-  const showMetaRow = showAssignee || showStartDate || showDueDate || showChildProgress;
+  const showMetaRow = showAssigneeSection || showStartDate || showDueDate || showChildProgress;
   const showRightMeta = !!showStartDate || !!showDueDate || !!showChildProgress || showUpdatedHint;
 
   return (
@@ -223,7 +224,7 @@ export const BoardCardContent = memo(function BoardCardContent({
       {/* Meta row: assignee (left), start date, due date, child progress (right) */}
       {showMetaRow && (
         <div className="mt-2 flex items-center justify-between gap-2">
-          {showAssignee && (
+          {showAssigneeSection && (
             <div className="min-w-0 flex-1">
               {assigneeNode}
             </div>


### PR DESCRIPTION
## Summary
- Board 卡片在没有 assignee 时 meta row（底部行）整行消失，因为 `showAssignee` 同时依赖 `storeProperties.assignee` 和 `issue.assignee_id`
- 拆分为 `showAssigneeSection`（只看用户配置）和 `hasAssignee`（看实际数据），meta row 始终显示
- 无 assignee 时显示 "Unassigned" 文字，可点击打开 AssigneePicker

## Test plan
- [ ] Board 视图下创建一个没有 assignee 的 issue，确认卡片底部行显示 "Unassigned"
- [ ] 点击 "Unassigned" 文字，确认 AssigneePicker 弹出
- [ ] 分配 assignee 后确认头像和名字正常显示
- [ ] 取消分配后确认回到 "Unassigned" 状态
- [ ] 关闭 card properties 中的 assignee 开关，确认 meta row 不再显示 assignee 区域

🤖 Generated with [Claude Code](https://claude.com/claude-code)