### PR TITLE
fix(agents): tighten skills-tab intro and drop redundant import hint

### DIFF
--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { FileText, Info, Plus, Trash2 } from "lucide-react";
+import { FileText, Plus, Trash2 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { Agent, AgentSkillsLocal } from "@multica/core/types";
@@ -76,7 +76,7 @@ export function SkillsTab({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex items-center justify-between gap-3">
         <p className="text-xs text-muted-foreground">
           {t(($) => $.tab_body.skills.intro)}
         </p>
@@ -90,13 +90,6 @@ export function SkillsTab({
           <Plus className="h-3 w-3" />
           {t(($) => $.tab_body.skills.add_action)}
         </Button>
-      </div>
-
-      <div className="flex items-start gap-2 rounded-md border border-info/20 bg-info/5 px-3 py-2.5">
-        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-info" />
-        <p className="text-xs text-muted-foreground">
-          {t(($) => $.tab_body.skills.import_hint)}
-        </p>
       </div>
 
       <SkillsLocalToggle

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -298,9 +298,8 @@
       "save_failed_toast": "Failed to save custom arguments"
     },
     "skills": {
-      "intro": "Workspace skills assigned to this agent. For Claude Code and Codex, the host machine's user-global skill directory is merged by default — switch the toggle below off to isolate this agent from those host-machine skills. Other runtimes ignore this setting.",
+      "intro": "Workspace skills assigned to this agent. Every runtime loads them.",
       "add_action": "Add skill",
-      "import_hint": "Importing creates a workspace copy that your team can edit and reuse.",
       "local_label": "Allow locally installed skills",
       "local_hint_off": "Off — for Claude Code and Codex, the agent ignores the host machine's user-global skill directory (~/.claude/skills/, ~/.codex/skills/). Recommended for shared agents — a broken local skill on one operator's machine cannot crash this agent. Other runtimes ignore this setting.",
       "local_hint_on": "On (default) — for Claude Code and Codex, the host machine's user-global skill directory is merged alongside workspace skills. Other runtimes ignore this setting.",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -292,9 +292,8 @@
       "save_failed_toast": "保存自定义参数失败"
     },
     "skills": {
-      "intro": "分配给该智能体的工作区 skill。对 Claude Code 与 Codex，默认会同时合并本机用户级 skill 目录 —— 把下方开关关闭可以让该智能体与本机用户级 skill 隔离。其它运行时会忽略此设置。",
+      "intro": "分配给该智能体的工作区 skill。所有运行时都会加载。",
       "add_action": "添加 skill",
-      "import_hint": "导入会在工作区创建一份副本，团队可以编辑和复用。",
       "local_label": "允许使用本机已安装的 Skill",
       "local_hint_off": "关闭 —— 对 Claude Code 与 Codex，智能体会忽略本机用户级 skill 目录（~/.claude/skills/、~/.codex/skills/）。推荐用于共享智能体 —— 团队成员机器上有问题的本机 skill 不会拖崩这个智能体。其它运行时会忽略此设置。",
       "local_hint_on": "开启（默认）—— 对 Claude Code 与 Codex，运行时会同时合并本机用户级 skill 目录。其它运行时会忽略此设置。",


### PR DESCRIPTION
Three small UI cleanups on the agent Skills tab.

## Changes

- **Drop the blue \"Importing creates a workspace copy that your team can edit and reuse\" callout.** Visual clutter, doesn't earn its row. Removed the unused \`Info\` icon import alongside.
- **Rewrite the intro paragraph.** The old copy conflated two separate things — the workspace-skills concept (applies to every runtime) and the \`Allow locally installed skills\` toggle (only honoured by Claude Code and Codex). Reading it suggested workspace skills themselves were Claude/Codex-only, which is wrong. Verified that none of \`copilot/cursor/gemini/opencode/openclaw/hermes/pi/kimi/kiro\` read \`agent.SkillsLocal\`. The intro now only describes the main concept; the toggle's own \`local_hint_on\` / \`local_hint_off\` strings still carry the Claude/Codex caveat where it belongs.
- **Fix vertical alignment.** Trimmed intro now fits one line, so flip the header row from \`items-start\` to \`items-center\` so it sits on the same baseline as the \"Add skill\" button.

## Follow-up worth considering (not in this PR)

The \`SkillsLocalToggle\` is still rendered for every agent regardless of runtime — even for Gemini / Pi / Hermes agents where flipping it does literally nothing. \"Other runtimes ignore this setting\" in the hint is technically honest, but the cleaner move is to hide the toggle entirely when the agent's runtime isn't Claude or Codex. Left out here to keep this PR purely text-cleanup.

## Test plan
- [x] \`pnpm --filter @multica/views typecheck\`
- [x] \`pnpm --filter @multica/views exec vitest run agents\` — 32 / 32 pass
- [x] Manual: Skills tab on a Claude-backed agent shows the slimmed intro + toggle, no blue callout, intro baseline-aligned with the button