### PR TITLE
fix(agent): surface host OAuth token via env var on macOS isolation (MUL-2603)

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -729,11 +729,16 @@ func buildClaudeEnvWith(
 	// Code itself scrubbing it from the env it passes to the
 	// model-driven Bash tool subprocess — the property is locked in by
 	// TestClaudeCLIScrubsOAuthTokenFromBashSubprocess, which boots the
-	// real CLI with a canary OAuth token + a non-secret control var and
-	// asserts that the Bash subprocess sees the canary as UNSET while
-	// the control is CONTROL-SET. That control prong is what proves the
-	// scrub is targeted, not a side-effect of "Bash gets no env". Hook
-	// subprocesses are NOT covered by this assertion: we have not
+	// real CLI with a canary OAuth token + a non-secret control var,
+	// plus two per-run random nonces passed *only* via env vars (never
+	// in the prompt text). The assertions are: the canary is absent
+	// from the transcript, the unset-nonce appears (proving a real Bash
+	// subprocess ran AND saw CLAUDE_CODE_OAUTH_TOKEN as empty), and the
+	// control-nonce appears (proving the scrub is targeted, not a
+	// side-effect of "Bash gets no env"). Using nonces — instead of
+	// hard-coded markers that could be paraphrased back from the
+	// prompt — is what makes the proof actually pin a real subprocess.
+	// Hook subprocesses are NOT covered by this assertion: we have not
 	// reproduced the env shape they receive, so the contract here
 	// intentionally narrows to Bash; if a future hook-using feature
 	// matters we must add a hook-side regression before relying on the

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -111,7 +111,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 	}()
 
-	cmd.Env = buildClaudeEnv(b.cfg.Env, claudeConfigDir)
+	cmd.Env = buildClaudeEnv(b.cfg.Env, claudeConfigDir, b.cfg.Logger)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -626,22 +626,78 @@ func buildEnv(extra map[string]string) []string {
 // CLAUDE_CONFIG_DIR so a daemon-host env var cannot accidentally win
 // the override race. Callers in "merge" mode pass "" and behaviour
 // matches the pre-MUL-2603 buildEnv path.
-func buildClaudeEnv(extra map[string]string, claudeConfigDir string) []string {
+//
+// On macOS isolation also surfaces the host's Claude Code OAuth token
+// through CLAUDE_CODE_OAUTH_TOKEN — see buildClaudeEnvWith for why this
+// is necessary on Darwin even when .claude.json is already mirrored.
+func buildClaudeEnv(extra map[string]string, claudeConfigDir string, logger *slog.Logger) []string {
+	return buildClaudeEnvWith(extra, claudeConfigDir, logger, readHostClaudeOAuthToken)
+}
+
+// buildClaudeEnvWith is the testable seam behind buildClaudeEnv. Tests
+// inject a readOAuthToken closure so they can exercise the auth
+// passthrough without touching the real macOS keychain.
+func buildClaudeEnvWith(
+	extra map[string]string,
+	claudeConfigDir string,
+	logger *slog.Logger,
+	readOAuthToken func() (string, error),
+) []string {
 	env := mergeEnv(os.Environ(), extra)
 	if claudeConfigDir == "" {
 		return env
 	}
 	// Drop any CLAUDE_CONFIG_DIR already in the slice (from os.Environ or
 	// from custom_env) before appending the isolated override so the last
-	// entry wins deterministically.
+	// entry wins deterministically. Track whether the operator already
+	// pinned OAuth / API-key auth via env so we know whether to add a
+	// keychain-sourced token below.
 	filtered := env[:0]
+	hasOAuthToken := false
+	hasAnthropicKey := false
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "CLAUDE_CONFIG_DIR=") {
 			continue
 		}
+		if strings.HasPrefix(entry, "CLAUDE_CODE_OAUTH_TOKEN=") {
+			hasOAuthToken = true
+		}
+		if strings.HasPrefix(entry, "ANTHROPIC_API_KEY=") {
+			hasAnthropicKey = true
+		}
 		filtered = append(filtered, entry)
 	}
-	return append(filtered, "CLAUDE_CONFIG_DIR="+claudeConfigDir)
+	filtered = append(filtered, "CLAUDE_CONFIG_DIR="+claudeConfigDir)
+
+	// Auth passthrough — only meaningful in isolation mode, and only on
+	// platforms where the child CLI cannot follow the host's auth on its
+	// own. On Linux/Windows the OAuth token lives in
+	// `$CLAUDE_CONFIG_DIR/.credentials.json` and is already symlinked via
+	// mirrorHostClaudeExceptSkills, so readHostClaudeOAuthToken is a
+	// no-op there. On macOS Claude Code 2.x scopes the keychain entry by
+	// SHA-256(CLAUDE_CONFIG_DIR)[:8]; isolating the config dir changes
+	// that suffix, so the child cannot find the host token even though it
+	// is sitting in the default `Claude Code-credentials` entry. Surface
+	// the access token via CLAUDE_CODE_OAUTH_TOKEN so the child skips
+	// keychain lookup entirely (MUL-2603 follow-up regression).
+	//
+	// Precedence (highest wins): operator-pinned CLAUDE_CODE_OAUTH_TOKEN
+	// in custom_env, then ANTHROPIC_API_KEY (the user explicitly chose
+	// API-key auth — do not silently override with OAuth), then the
+	// keychain token. The first two leave the keychain alone, which keeps
+	// non-OAuth installs free of macOS prompts on every isolated run.
+	if !hasOAuthToken && !hasAnthropicKey && readOAuthToken != nil {
+		token, err := readOAuthToken()
+		if err != nil && logger != nil {
+			logger.Warn("claude: read host oauth token failed",
+				"error", err,
+			)
+		}
+		if token != "" {
+			filtered = append(filtered, "CLAUDE_CODE_OAUTH_TOKEN="+token)
+		}
+	}
+	return filtered
 }
 
 func mergeEnv(base []string, extra map[string]string) []string {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -651,7 +651,11 @@ func buildClaudeEnvWith(
 	// from custom_env) before appending the isolated override so the last
 	// entry wins deterministically. Track whether the operator already
 	// pinned OAuth / API-key auth via env so we know whether to add a
-	// keychain-sourced token below.
+	// keychain-sourced token below. "Pinned" means the value is non-empty:
+	// an empty `ANTHROPIC_API_KEY=` / `CLAUDE_CODE_OAUTH_TOKEN=` leaks in
+	// from `os.Environ()` on hosts whose login shell unsets it that way,
+	// and treating that as an explicit auth choice would silently strand
+	// the isolated child at "Not logged in" (MUL-2603 review follow-up).
 	filtered := env[:0]
 	hasOAuthToken := false
 	hasAnthropicKey := false
@@ -659,10 +663,23 @@ func buildClaudeEnvWith(
 		if strings.HasPrefix(entry, "CLAUDE_CONFIG_DIR=") {
 			continue
 		}
-		if strings.HasPrefix(entry, "CLAUDE_CODE_OAUTH_TOKEN=") {
+		if v, ok := strings.CutPrefix(entry, "CLAUDE_CODE_OAUTH_TOKEN="); ok {
+			if v == "" {
+				// Empty `CLAUDE_CODE_OAUTH_TOKEN=` is noise (login-shell
+				// quirk, stale custom_env entry) — drop so it cannot shadow
+				// a keychain-injected token later in the slice on platforms
+				// where the libc env lookup picks the first match.
+				continue
+			}
 			hasOAuthToken = true
 		}
-		if strings.HasPrefix(entry, "ANTHROPIC_API_KEY=") {
+		if v, ok := strings.CutPrefix(entry, "ANTHROPIC_API_KEY="); ok {
+			if v == "" {
+				// Same treatment as the OAuth token: empty `ANTHROPIC_API_KEY=`
+				// must not pose as a pinned API-key auth choice. Drop so the
+				// child does not see a confusing empty value either.
+				continue
+			}
 			hasAnthropicKey = true
 		}
 		filtered = append(filtered, entry)
@@ -681,11 +698,21 @@ func buildClaudeEnvWith(
 	// the access token via CLAUDE_CODE_OAUTH_TOKEN so the child skips
 	// keychain lookup entirely (MUL-2603 follow-up regression).
 	//
+	// Security boundary: CLAUDE_CODE_OAUTH_TOKEN is the host's claude.ai
+	// OAuth access token. We rely on Claude Code itself scrubbing it from
+	// the env it passes to Bash / hook subprocesses — a property we lock
+	// in with TestClaudeCLIScrubsOAuthTokenFromBashSubprocess, which boots
+	// the real CLI with a canary token and asserts `printenv` inside the
+	// model-driven Bash tool returns empty. If that test ever flips
+	// (upstream CLI change), this passthrough must move off env vars
+	// before merging.
+	//
 	// Precedence (highest wins): operator-pinned CLAUDE_CODE_OAUTH_TOKEN
 	// in custom_env, then ANTHROPIC_API_KEY (the user explicitly chose
 	// API-key auth — do not silently override with OAuth), then the
-	// keychain token. The first two leave the keychain alone, which keeps
-	// non-OAuth installs free of macOS prompts on every isolated run.
+	// keychain token. "Pinned" is gated on a non-empty value above so an
+	// empty `KEY=` inherited from os.Environ does not pose as an explicit
+	// choice and disable the keychain reader.
 	if !hasOAuthToken && !hasAnthropicKey && readOAuthToken != nil {
 		token, err := readOAuthToken()
 		if err != nil && logger != nil {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -87,6 +87,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	// from cwd regardless and are not affected by either mode.
 	isolateClaudeConfig := opts.SkillsLocal == "ignore"
 	var claudeConfigDir string
+	var hostConfigDir string
 	var claudeConfigCleanup func()
 	if isolateClaudeConfig {
 		// Resolve the *effective* Claude config source before we strip
@@ -95,8 +96,13 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// Mirroring `~/.claude` blindly when the operator has explicitly
 		// pointed Claude at a different config dir (e.g. a managed install)
 		// would copy the wrong credentials into the scratch dir and break
-		// auth — see the second Must Fix in MUL-2603 review.
-		hostConfigDir := resolveHostClaudeConfigDir(b.cfg.Env)
+		// auth — see the second Must Fix in MUL-2603 review. The same
+		// value is threaded through to buildClaudeEnv so the macOS keychain
+		// passthrough can refuse to inject the default OAuth token into a
+		// custom-dir isolated child (the unsuffixed keychain entry does not
+		// match the suffixed entry a custom CLAUDE_CONFIG_DIR would resolve
+		// to, so reading it would inject a different account's token).
+		hostConfigDir = resolveHostClaudeConfigDir(b.cfg.Env)
 		dir, cleanup, err := newIsolatedClaudeConfigDir(opts.Cwd, hostConfigDir, b.cfg.Logger)
 		if err != nil {
 			cancel()
@@ -111,7 +117,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 	}()
 
-	cmd.Env = buildClaudeEnv(b.cfg.Env, claudeConfigDir, b.cfg.Logger)
+	cmd.Env = buildClaudeEnv(b.cfg.Env, claudeConfigDir, hostConfigDir, b.cfg.Logger)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -627,20 +633,27 @@ func buildEnv(extra map[string]string) []string {
 // the override race. Callers in "merge" mode pass "" and behaviour
 // matches the pre-MUL-2603 buildEnv path.
 //
-// On macOS isolation also surfaces the host's Claude Code OAuth token
-// through CLAUDE_CODE_OAUTH_TOKEN — see buildClaudeEnvWith for why this
-// is necessary on Darwin even when .claude.json is already mirrored.
-func buildClaudeEnv(extra map[string]string, claudeConfigDir string, logger *slog.Logger) []string {
-	return buildClaudeEnvWith(extra, claudeConfigDir, logger, readHostClaudeOAuthToken)
+// hostConfigDir is the *effective* host Claude config source the scratch
+// dir was mirrored from (see resolveHostClaudeConfigDir). It is used as
+// the gate for the macOS keychain OAuth passthrough: only the default
+// `$HOME/.claude` host source matches the unsuffixed
+// `Claude Code-credentials` keychain entry, so for custom dirs we
+// deliberately skip the passthrough rather than inject the daemon
+// user's default account into a managed/custom-dir agent.
+func buildClaudeEnv(extra map[string]string, claudeConfigDir, hostConfigDir string, logger *slog.Logger) []string {
+	return buildClaudeEnvWith(extra, claudeConfigDir, hostConfigDir, logger, os.UserHomeDir, readHostClaudeOAuthToken)
 }
 
 // buildClaudeEnvWith is the testable seam behind buildClaudeEnv. Tests
-// inject a readOAuthToken closure so they can exercise the auth
-// passthrough without touching the real macOS keychain.
+// inject a homeDir resolver and readOAuthToken closure so they can
+// exercise the auth passthrough — including the default-vs-custom
+// hostConfigDir gate — without touching the real macOS keychain or
+// mutating $HOME.
 func buildClaudeEnvWith(
 	extra map[string]string,
-	claudeConfigDir string,
+	claudeConfigDir, hostConfigDir string,
 	logger *slog.Logger,
+	homeDir func() (string, error),
 	readOAuthToken func() (string, error),
 ) []string {
 	env := mergeEnv(os.Environ(), extra)
@@ -698,14 +711,35 @@ func buildClaudeEnvWith(
 	// the access token via CLAUDE_CODE_OAUTH_TOKEN so the child skips
 	// keychain lookup entirely (MUL-2603 follow-up regression).
 	//
-	// Security boundary: CLAUDE_CODE_OAUTH_TOKEN is the host's claude.ai
-	// OAuth access token. We rely on Claude Code itself scrubbing it from
-	// the env it passes to Bash / hook subprocesses — a property we lock
-	// in with TestClaudeCLIScrubsOAuthTokenFromBashSubprocess, which boots
-	// the real CLI with a canary token and asserts `printenv` inside the
-	// model-driven Bash tool returns empty. If that test ever flips
-	// (upstream CLI change), this passthrough must move off env vars
-	// before merging.
+	// Host-dir gate: the reader returns the *unsuffixed*
+	// `Claude Code-credentials` entry, which is only correct when the
+	// host config source is the default `$HOME/.claude`. A custom
+	// CLAUDE_CONFIG_DIR (set via agent custom_env or daemon-host env)
+	// maps to `Claude Code-credentials-<hash>` for a *different* account.
+	// Injecting the unsuffixed entry there would cross-pollute the
+	// managed/custom agent with the daemon user's default OAuth account
+	// — the same "do not cross accounts" boundary mirrorHostClaudeJSONIfMissing
+	// already enforces for `.claude.json`. So for custom/parent dirs we
+	// deliberately skip the passthrough and let the child rely on
+	// whatever auth lives inside the custom dir (`.credentials.json`,
+	// `apiKeyHelper`, etc.) or fall through to ANTHROPIC_API_KEY.
+	//
+	// Security boundary (Bash subprocess only): CLAUDE_CODE_OAUTH_TOKEN
+	// is the host's claude.ai OAuth access token. We rely on Claude
+	// Code itself scrubbing it from the env it passes to the
+	// model-driven Bash tool subprocess — the property is locked in by
+	// TestClaudeCLIScrubsOAuthTokenFromBashSubprocess, which boots the
+	// real CLI with a canary OAuth token + a non-secret control var and
+	// asserts that the Bash subprocess sees the canary as UNSET while
+	// the control is CONTROL-SET. That control prong is what proves the
+	// scrub is targeted, not a side-effect of "Bash gets no env". Hook
+	// subprocesses are NOT covered by this assertion: we have not
+	// reproduced the env shape they receive, so the contract here
+	// intentionally narrows to Bash; if a future hook-using feature
+	// matters we must add a hook-side regression before relying on the
+	// same env-scrub there. If the existing test ever flips (upstream
+	// CLI change), this passthrough must move off env vars (e.g. a
+	// short-lived `apiKeyHelper` script) before merging.
 	//
 	// Precedence (highest wins): operator-pinned CLAUDE_CODE_OAUTH_TOKEN
 	// in custom_env, then ANTHROPIC_API_KEY (the user explicitly chose
@@ -713,7 +747,8 @@ func buildClaudeEnvWith(
 	// keychain token. "Pinned" is gated on a non-empty value above so an
 	// empty `KEY=` inherited from os.Environ does not pose as an explicit
 	// choice and disable the keychain reader.
-	if !hasOAuthToken && !hasAnthropicKey && readOAuthToken != nil {
+	if !hasOAuthToken && !hasAnthropicKey && readOAuthToken != nil &&
+		isDefaultHostClaudeConfigDir(hostConfigDir, homeDir) {
 		token, err := readOAuthToken()
 		if err != nil && logger != nil {
 			logger.Warn("claude: read host oauth token failed",
@@ -725,6 +760,28 @@ func buildClaudeEnvWith(
 		}
 	}
 	return filtered
+}
+
+// isDefaultHostClaudeConfigDir reports whether hostConfigDir refers to the
+// default per-user Claude config path `$HOME/.claude`. The macOS keychain
+// passthrough relies on this gate because the unsuffixed
+// `Claude Code-credentials` entry only matches that default; custom
+// CLAUDE_CONFIG_DIR values map to suffixed entries for different accounts,
+// so reading the unsuffixed entry into a custom-dir isolated child would
+// cross-pollute accounts (see buildClaudeEnvWith for the full reasoning).
+//
+// Returns false when hostConfigDir is empty (merge mode) or when the home
+// directory cannot be resolved — both translate to "do not pull the
+// default keychain token", which is the safe default.
+func isDefaultHostClaudeConfigDir(hostConfigDir string, homeDir func() (string, error)) bool {
+	if hostConfigDir == "" || homeDir == nil {
+		return false
+	}
+	home, err := homeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return hostConfigDir == filepath.Join(home, ".claude")
 }
 
 func mergeEnv(base []string, extra map[string]string) []string {

--- a/server/pkg/agent/claude_keychain_darwin.go
+++ b/server/pkg/agent/claude_keychain_darwin.go
@@ -1,0 +1,87 @@
+//go:build darwin
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// claudeKeychainServiceName is the macOS keychain service name that
+// `claude /login` writes to when the user authenticates against
+// claude.ai. The payload is a JSON blob whose `claudeAiOauth.accessToken`
+// field is what we surface to the isolated child.
+const claudeKeychainServiceName = "Claude Code-credentials"
+
+// claudeKeychainReadTimeout caps how long we wait on `/usr/bin/security`.
+// Reads are normally instantaneous when the ACL already trusts the caller;
+// when macOS surfaces a "allow access" prompt this gives a present user
+// enough time to click through. We do NOT want to wait forever: a headless
+// run with no one at the console would otherwise stall the agent task
+// indefinitely on the very first run.
+const claudeKeychainReadTimeout = 10 * time.Second
+
+// readHostClaudeOAuthToken reads the host machine's Claude Code OAuth
+// access token from the macOS login keychain (entry
+// `Claude Code-credentials`). Returns ("", nil) when the token is not
+// available — entry missing, user denied / ignored the keychain prompt,
+// payload missing `claudeAiOauth.accessToken`, etc. — so callers in the
+// isolation path can fall back to whatever auth the child CLI can find on
+// its own (typically ANTHROPIC_API_KEY for headless / API-key-only hosts).
+//
+// Why this exists: Claude Code 2.x derives the keychain-lookup suffix from
+// SHA-256(CLAUDE_CONFIG_DIR)[:8], so the unsuffixed `Claude Code-credentials`
+// entry is read only when CLAUDE_CONFIG_DIR is unset or equals the install
+// default. The moment MUL-2603 isolation points the child at a scratch dir,
+// the CLI starts asking for `Claude Code-credentials-<other-hash>`, finds
+// nothing, and exits "Not logged in · Please run /login" even though the
+// host's OAuth token is sitting in the default entry. Surfacing the token
+// through CLAUDE_CODE_OAUTH_TOKEN sidesteps the suffix scheme entirely.
+//
+// Returns a non-nil error only for unexpected system failures (e.g.
+// `/usr/bin/security` not found) — the caller logs those at warn level so
+// operators can diagnose. The common "no token available" case stays
+// silent because we cannot tell "user is API-key-only" apart from "user
+// denied access" by exit code, and we do not want to spam the daemon log
+// on every isolated run for the former.
+func readHostClaudeOAuthToken() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), claudeKeychainReadTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password", "-s", claudeKeychainServiceName, "-w")
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// Non-zero exit from `security` covers entry-missing, denied,
+			// and timeout — all soft failures from our perspective.
+			return "", nil
+		}
+		// `/usr/bin/security` itself is missing or unexecutable — this is
+		// unexpected on macOS and worth surfacing so the caller can log it.
+		return "", fmt.Errorf("invoke security CLI: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return "", nil
+	}
+	var payload struct {
+		ClaudeAiOauth struct {
+			AccessToken string `json:"accessToken"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		// A malformed payload is almost certainly a Claude Code upstream
+		// change to the keychain schema; downgrade to soft failure so
+		// the child can still attempt API-key auth, but do not pretend
+		// the schema is fine — surface so we update the parser.
+		return "", fmt.Errorf("parse claude keychain payload: %w", err)
+	}
+	return payload.ClaudeAiOauth.AccessToken, nil
+}

--- a/server/pkg/agent/claude_keychain_other.go
+++ b/server/pkg/agent/claude_keychain_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package agent
+
+// readHostClaudeOAuthToken is a no-op on non-Darwin platforms. Linux and
+// Windows Claude Code persists the OAuth token to
+// `$CLAUDE_CONFIG_DIR/.credentials.json` — a file that lives inside the
+// config dir, so mirrorHostClaudeExceptSkills already symlinks it into the
+// per-run scratch dir alongside everything else. The isolated child finds
+// it via the normal config-dir path; we do not need to surface anything
+// through CLAUDE_CODE_OAUTH_TOKEN here.
+//
+// The macOS keychain workaround exists specifically because that platform
+// derives the keychain-lookup suffix from the config-dir path — see
+// claude_keychain_darwin.go for the full story.
+func readHostClaudeOAuthToken() (string, error) {
+	return "", nil
+}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -1249,23 +1251,29 @@ func TestIsDefaultHostClaudeConfigDir(t *testing.T) {
 // safe because Claude Code itself strips that variable from the env it
 // hands to the model-driven **Bash tool subprocess**, so a `printenv`
 // inside the model's bash invocation cannot echo the secret into the
-// agent transcript. The MUL-2603 review (Elon, round 2) flagged that a
-// bare "canary absent" assertion was insufficient — it false-passes any
-// time the model refuses, paraphrases, or never reaches Bash — so this
-// version adds a non-secret CONTROL variable. The three conjoined
-// assertions are:
+// agent transcript. The MUL-2603 review (Elon, round 3) flagged that
+// hard-coded proof markers like "UNSET" / "CONTROL-SET" still
+// false-passed any time the model only paraphrased the prompt without
+// invoking Bash — `strings.Contains` would match the literal that was
+// already in the prompt. This version replaces them with per-run
+// random nonces that are passed *only* via env vars (never written into
+// the prompt text); the prompt references the env var names, so the
+// nonce values can land in the transcript only if a real Bash
+// subprocess inherits those env vars and echoes them. The three
+// conjoined assertions are:
 //
 //  1. the canary CLAUDE_CODE_OAUTH_TOKEN value is NOT in the transcript
 //     (the primary safety claim);
-//  2. "UNSET" IS in the transcript (the Bash tool actually ran AND saw
-//     CLAUDE_CODE_OAUTH_TOKEN as unset, ruling out the "model refused" /
-//     "model paraphrased" false pass);
-//  3. "CONTROL-SET" IS in the transcript (ordinary env propagation works
-//     for the non-sensitive MUL2603_CONTROL variable — proves the scrub
-//     is a targeted strip of CLAUDE_CODE_OAUTH_TOKEN, not a side-effect
-//     of "the CLI sandboxes Bash with no env at all", which would not
-//     be a security property we could rely on for arbitrary future
-//     env-exposed secrets).
+//  2. the unsetNonce IS in the transcript — the Bash tool actually ran
+//     AND saw CLAUDE_CODE_OAUTH_TOKEN as unset (the model cannot
+//     paraphrase a fresh random value it never saw, so this rules out
+//     the "model refused" / "model paraphrased the prompt" false pass);
+//  3. the controlNonce IS in the transcript — ordinary env propagation
+//     works for the non-sensitive MUL2603_CONTROL variable, proving the
+//     scrub is a targeted strip of CLAUDE_CODE_OAUTH_TOKEN, not a
+//     side-effect of "the CLI sandboxes Bash with no env at all",
+//     which would not be a security property we could rely on for
+//     arbitrary future env-exposed secrets.
 //
 // The boundary intentionally narrows to the **Bash tool subprocess**.
 // We have not reproduced the env shape the CLI hands to hook
@@ -1316,20 +1324,33 @@ func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
 	const (
 		canary       = "sk-ant-oat-leak-canary-CLAUDE_CODE_OAUTH_TOKEN-MUL2603-PROBE"
 		controlValue = "mul2603-control-value-non-secret"
-		// The Bash tool emits these literal tokens; we assert on them as
-		// proof-of-execution rather than parsing the model's prose.
-		secretUnsetMarker = "UNSET"
-		secretSetMarker   = "SET"
-		controlSetMarker  = "CONTROL-SET"
 	)
 
-	// Use the *user's* shell-resolved env plus the canary + control vars.
-	// We do not use t.Setenv because the CLI is spawned via exec.Command,
-	// not as a child of the test goroutine; an explicit env list keeps
-	// the boundary obvious.
+	// Per-run random nonces. These are the proof-of-execution markers,
+	// and they are passed to Bash *only* via env vars — never written
+	// into the prompt text — so the model has no way to reproduce them
+	// by paraphrasing the prompt. If a nonce appears in the transcript,
+	// a real Bash subprocess inherited the env var and echoed it.
+	nonceBytes := func(t *testing.T, label string) string {
+		t.Helper()
+		b := make([]byte, 16)
+		if _, err := rand.Read(b); err != nil {
+			t.Fatalf("rand.Read(%s): %v", label, err)
+		}
+		return hex.EncodeToString(b)
+	}
+	unsetNonce := nonceBytes(t, "unset")
+	controlNonce := nonceBytes(t, "control")
+
+	// Use the *user's* shell-resolved env plus the canary + control vars
+	// and the two nonce vars. We do not use t.Setenv because the CLI is
+	// spawned via exec.Command, not as a child of the test goroutine;
+	// an explicit env list keeps the boundary obvious.
 	env := append(os.Environ(),
 		"CLAUDE_CODE_OAUTH_TOKEN="+canary,
 		"MUL2603_CONTROL="+controlValue,
+		"MUL2603_UNSET_NONCE="+unsetNonce,
+		"MUL2603_CONTROL_NONCE="+controlNonce,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
@@ -1341,16 +1362,21 @@ func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
 		"--allowedTools", "Bash",
 	)
 	cmd.Env = env
-	// The prompt asks the model to run two `test -n` probes back-to-back
-	// and report both raw outputs. Using `test -n` instead of `printenv`
-	// makes the assertion deterministic: an empty value and an unset key
-	// both render as "UNSET", so the test doesn't have to special-case
-	// `printenv`'s exit-status behaviour across shells.
+	// The prompt asks Bash to run two `test -n` probes and emit a nonce
+	// in each branch we care about:
+	//   - if CLAUDE_CODE_OAUTH_TOKEN is empty/unset (the safety case),
+	//     echo $MUL2603_UNSET_NONCE
+	//   - if MUL2603_CONTROL is non-empty (the env-still-flows control),
+	//     echo $MUL2603_CONTROL_NONCE
+	// The prompt never contains the nonce *values* — only the variable
+	// names. So a paraphrasing model that never spawns Bash cannot
+	// produce either nonce in its prose; only a real Bash subprocess
+	// with these env vars present will echo them.
 	cmd.Stdin = strings.NewReader(
 		"Please run this exact bash command and paste the raw output verbatim. " +
 			"Do not paraphrase, do not redact, do not summarize:\n" +
-			"`test -n \"$CLAUDE_CODE_OAUTH_TOKEN\" && echo " + secretSetMarker + " || echo " + secretUnsetMarker +
-			"; test -n \"$MUL2603_CONTROL\" && echo " + controlSetMarker + " || echo CONTROL-UNSET`",
+			"`test -n \"$CLAUDE_CODE_OAUTH_TOKEN\" || echo \"$MUL2603_UNSET_NONCE\"; " +
+			"test -n \"$MUL2603_CONTROL\" && echo \"$MUL2603_CONTROL_NONCE\"`",
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1367,17 +1393,17 @@ func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
 	// Control-prong proves the scrub is *targeted*, not "Bash has no env".
 	// Without this, a Claude Code change that walled Bash off entirely
 	// would pass the canary check but break the security model we documented.
-	if !strings.Contains(body, controlSetMarker) {
-		t.Fatalf("Bash tool did not propagate the non-secret control var %s — the scrub may have widened to all env vars, which changes the security model we documented.\nTranscript:\n%s",
-			controlSetMarker, body)
+	// The nonce can only appear if Bash ran AND inherited MUL2603_CONTROL.
+	if !strings.Contains(body, controlNonce) {
+		t.Fatalf("Bash tool did not echo the control nonce — either Bash never ran or MUL2603_CONTROL did not propagate, which would mean the scrub has widened to all env vars and changes the security model we documented.\nTranscript:\n%s",
+			body)
 	}
-	// Proof-of-execution: the Bash subprocess actually ran the probe AND
-	// saw CLAUDE_CODE_OAUTH_TOKEN as unset (the marker is what the probe
-	// emits in the false branch of `test -n`). Without this assertion a
-	// transcript where the model declined to call Bash would pass the
-	// canary check trivially and silently disarm the regression.
-	if !strings.Contains(body, secretUnsetMarker) {
-		t.Fatalf("Bash tool either did not run or saw CLAUDE_CODE_OAUTH_TOKEN as SET — both invalidate the scrub assertion.\nTranscript:\n%s",
+	// Proof-of-execution: a real Bash subprocess ran the probe AND saw
+	// CLAUDE_CODE_OAUTH_TOKEN as empty/unset (the false branch of
+	// `test -n` echoed $MUL2603_UNSET_NONCE). The nonce value is not in
+	// the prompt, so a paraphrasing/refusing model cannot fake it.
+	if !strings.Contains(body, unsetNonce) {
+		t.Fatalf("Bash tool either did not run or saw CLAUDE_CODE_OAUTH_TOKEN as SET — both invalidate the scrub assertion. The expected unset nonce never appeared in the transcript.\nTranscript:\n%s",
 			body)
 	}
 }

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -824,7 +824,7 @@ func TestClaudeExecuteMergeModeKeepsHostConfigDir(t *testing.T) {
 func TestBuildClaudeEnvAppendsIsolatedConfigDir(t *testing.T) {
 	t.Parallel()
 
-	env := buildClaudeEnv(nil, "/tmp/isolated-claude-config")
+	env := buildClaudeEnvWith(nil, "/tmp/isolated-claude-config", slog.Default(), noopOAuthTokenReader)
 
 	var last string
 	hits := 0
@@ -847,7 +847,7 @@ func TestBuildClaudeEnvSkipsOverrideWhenEmpty(t *testing.T) {
 
 	// Asking for "merge" mode passes "" through. We should not add a
 	// CLAUDE_CONFIG_DIR=… entry; the parent's value (if any) wins.
-	env := buildClaudeEnv(map[string]string{"FOO": "bar"}, "")
+	env := buildClaudeEnvWith(map[string]string{"FOO": "bar"}, "", slog.Default(), noopOAuthTokenReader)
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "CLAUDE_CONFIG_DIR=") {
 			// The parent env may legitimately have one set on a developer
@@ -864,7 +864,12 @@ func TestBuildClaudeEnvOverridesPreviousValue(t *testing.T) {
 	// Even if custom_env supplies a CLAUDE_CONFIG_DIR, the isolated dir
 	// must take precedence: a stale custom_env entry must never be able
 	// to point the child back at `~/.claude/`.
-	env := buildClaudeEnv(map[string]string{"CLAUDE_CONFIG_DIR": "/etc/hostile"}, "/tmp/safe")
+	env := buildClaudeEnvWith(
+		map[string]string{"CLAUDE_CONFIG_DIR": "/etc/hostile"},
+		"/tmp/safe",
+		slog.Default(),
+		noopOAuthTokenReader,
+	)
 
 	hits := 0
 	for _, entry := range env {
@@ -877,6 +882,177 @@ func TestBuildClaudeEnvOverridesPreviousValue(t *testing.T) {
 	}
 	if hits != 1 {
 		t.Fatalf("expected isolated dir to be present exactly once, got %d (%v)", hits, env)
+	}
+}
+
+// noopOAuthTokenReader stands in for the production keychain reader in
+// tests that do not care about the auth-passthrough branch. Returning
+// ("", nil) takes the "no token available" path: buildClaudeEnvWith
+// neither appends CLAUDE_CODE_OAUTH_TOKEN nor logs a warning.
+func noopOAuthTokenReader() (string, error) { return "", nil }
+
+// countEnvEntries returns the number of `key=…` entries in env. Used by
+// the auth-passthrough tests below to assert "exactly one" instead of
+// "at least one" — a duplicate CLAUDE_CODE_OAUTH_TOKEN entry would let
+// later behaviour depend on which one the kernel hands to the child.
+func countEnvEntries(env []string, key string) int {
+	prefix := key + "="
+	n := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// envValue returns the first value bound to key in env, or "" if absent.
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+// TestBuildClaudeEnvIsolatedInjectsKeychainOAuthToken locks in the
+// MUL-2603 follow-up: when isolation strips CLAUDE_CONFIG_DIR, the host
+// OAuth token must reach the child through CLAUDE_CODE_OAUTH_TOKEN.
+// Without this passthrough Claude Code's per-config-dir keychain suffix
+// scheme strands the isolated child at "Not logged in · Please run
+// /login" even though the host's OAuth credential is sitting in the
+// default keychain entry.
+func TestBuildClaudeEnvIsolatedInjectsKeychainOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) { return "sk-ant-oat-test", nil }
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 1 {
+		t.Fatalf("expected exactly one CLAUDE_CODE_OAUTH_TOKEN entry, got %d (%v)", got, env)
+	}
+	if got := envValue(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != "sk-ant-oat-test" {
+		t.Fatalf("expected keychain token to be surfaced verbatim, got %q", got)
+	}
+}
+
+// TestBuildClaudeEnvMergeModeDoesNotInjectOAuthToken guards the
+// merge-mode side: CLAUDE_CODE_OAUTH_TOKEN must never appear when the
+// caller opted out of isolation, because in that path the child reads
+// the host keychain itself and a stale env-var would shadow a freshly
+// refreshed token.
+func TestBuildClaudeEnvMergeModeDoesNotInjectOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) {
+		t.Fatal("readOAuthToken must not be invoked in merge mode")
+		return "", nil
+	}
+	env := buildClaudeEnvWith(nil, "", slog.Default(), reader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN in merge mode, got %d (%v)", got, env)
+	}
+}
+
+// TestBuildClaudeEnvIsolatedRespectsCustomOAuthToken documents that a
+// CLAUDE_CODE_OAUTH_TOKEN pinned via agent custom_env wins over the
+// keychain reader. Operators sometimes pin a long-lived setup-token
+// (`claude setup-token`) for shared agents that must run after the
+// interactive user logs out; calling the keychain in that case would
+// either prompt or silently replace the intended token.
+func TestBuildClaudeEnvIsolatedRespectsCustomOAuthToken(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) {
+		t.Fatal("readOAuthToken must not be invoked when custom_env pinned a token")
+		return "", nil
+	}
+	env := buildClaudeEnvWith(
+		map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-pinned"},
+		"/tmp/isolated",
+		slog.Default(),
+		reader,
+	)
+
+	if got := envValue(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != "sk-ant-oat-pinned" {
+		t.Fatalf("expected pinned custom_env token, got %q", got)
+	}
+}
+
+// TestBuildClaudeEnvIsolatedSkipsKeychainWhenAnthropicKeyPresent
+// documents that a user who explicitly chose API-key auth via
+// ANTHROPIC_API_KEY does NOT get an OAuth token shoved on top — the two
+// auth modes are mutually exclusive on the CLI side, and silently
+// adding the keychain token would surface a confusing
+// "ambiguous auth" path on every isolated run.
+func TestBuildClaudeEnvIsolatedSkipsKeychainWhenAnthropicKeyPresent(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) {
+		t.Fatal("readOAuthToken must not be invoked when ANTHROPIC_API_KEY is set")
+		return "", nil
+	}
+	env := buildClaudeEnvWith(
+		map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-test"},
+		"/tmp/isolated",
+		slog.Default(),
+		reader,
+	)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN alongside ANTHROPIC_API_KEY, got %d (%v)", got, env)
+	}
+}
+
+// TestBuildClaudeEnvIsolatedReaderErrorIsSoftFailure documents that a
+// keychain read error (e.g. /usr/bin/security missing) does NOT abort
+// the build — the child still gets a coherent env minus the OAuth
+// token, and the warning is surfaced through the injected logger so
+// operators can correlate "Not logged in" with the underlying cause.
+func TestBuildClaudeEnvIsolatedReaderErrorIsSoftFailure(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) {
+		return "", errors.New("security CLI unavailable")
+	}
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", logger, reader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN when reader errors, got %d (%v)", got, env)
+	}
+	if got := countEnvEntries(env, "CLAUDE_CONFIG_DIR"); got != 1 {
+		t.Fatalf("expected isolation env to still be intact, got %d CLAUDE_CONFIG_DIR entries", got)
+	}
+	if !strings.Contains(logBuf.String(), "read host oauth token failed") {
+		t.Fatalf("expected reader error to be logged, got %q", logBuf.String())
+	}
+}
+
+// TestBuildClaudeEnvIsolatedReaderNilTokenStaysQuiet documents the
+// common "host is not logged in" path: the reader returns ("", nil) —
+// no token, no error — and the env builder must neither append a
+// CLAUDE_CODE_OAUTH_TOKEN nor log a warning. We assert the silence
+// explicitly because a noisy warning every isolated run on every
+// API-key-only / unauthenticated host would drown out the real ones.
+func TestBuildClaudeEnvIsolatedReaderNilTokenStaysQuiet(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", logger, noopOAuthTokenReader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN when reader returns empty, got %d (%v)", got, env)
+	}
+	if logBuf.Len() != 0 {
+		t.Fatalf("expected silence on (\"\", nil) reader return, got log output %q", logBuf.String())
 	}
 }
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -1053,6 +1054,156 @@ func TestBuildClaudeEnvIsolatedReaderNilTokenStaysQuiet(t *testing.T) {
 	}
 	if logBuf.Len() != 0 {
 		t.Fatalf("expected silence on (\"\", nil) reader return, got log output %q", logBuf.String())
+	}
+}
+
+// TestBuildClaudeEnvIsolatedTreatsEmptyAnthropicAPIKeyAsUnpinned guards the
+// MUL-2603 review fix: a parent-inherited `ANTHROPIC_API_KEY=` (set but
+// empty — common on login-shell setups that conditionally export auth)
+// must not pose as an "operator pinned API key" and disable the keychain
+// reader. Without this gate the isolated child gets neither a usable env
+// var nor a keychain token, and strands at "Not logged in" while
+// pretending the user opted into API-key auth.
+//
+// CLAUDE_CODE_OAUTH_TOKEN does not need the same os.Environ test: mergeEnv
+// strips every `CLAUDE_CODE_*` key from the parent before assembling the
+// child env (isFilteredChildEnvKey), so a parent-set value cannot reach
+// the gate at all. The empty-value gate still applies on the custom_env
+// path — see TestBuildClaudeEnvIsolatedEmptyOAuthTokenInCustomEnvAsUnpinned
+// below.
+func TestBuildClaudeEnvIsolatedTreatsEmptyAnthropicAPIKeyAsUnpinned(t *testing.T) {
+	// NOT parallel — t.Setenv mutates global env.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	reader := func() (string, error) { return "sk-ant-oat-keychain", nil }
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+
+	if got := envValue(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != "sk-ant-oat-keychain" {
+		t.Fatalf("expected keychain token to be injected when ANTHROPIC_API_KEY is empty, got %q", got)
+	}
+}
+
+// TestBuildClaudeEnvIsolatedHonorsNonEmptyAnthropicAPIKey is the positive
+// counterpart: a non-empty ANTHROPIC_API_KEY in the parent env is a real
+// auth pin and must keep the keychain reader off, otherwise an isolated
+// run on a hostile/API-key host would silently shove an OAuth token in
+// on top.
+func TestBuildClaudeEnvIsolatedHonorsNonEmptyAnthropicAPIKey(t *testing.T) {
+	// NOT parallel — t.Setenv mutates global env.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-real")
+
+	reader := func() (string, error) {
+		t.Fatal("readOAuthToken must not be invoked when non-empty ANTHROPIC_API_KEY is set")
+		return "", nil
+	}
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN with non-empty ANTHROPIC_API_KEY, got %d (%v)", got, env)
+	}
+}
+
+// TestBuildClaudeEnvIsolatedEmptyOAuthTokenInCustomEnvAsUnpinned is the
+// custom_env-side mirror of the empty-value gate: an explicit
+// CLAUDE_CODE_OAUTH_TOKEN="" passed through custom_env (e.g. an agent
+// config field that the operator forgot to remove) must not block the
+// keychain reader. Same justification as the ANTHROPIC_API_KEY case —
+// silent strand at "Not logged in" while disguised as a pinned token.
+func TestBuildClaudeEnvIsolatedEmptyOAuthTokenInCustomEnvAsUnpinned(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) { return "sk-ant-oat-keychain", nil }
+	env := buildClaudeEnvWith(
+		map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": ""},
+		"/tmp/isolated",
+		slog.Default(),
+		reader,
+	)
+
+	// The keychain token must reach the child even though custom_env had
+	// the key present with an empty value.
+	if got := envValue(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != "sk-ant-oat-keychain" {
+		t.Fatalf("expected keychain token when custom_env CLAUDE_CODE_OAUTH_TOKEN is empty, got %q", got)
+	}
+}
+
+// TestClaudeCLIScrubsOAuthTokenFromBashSubprocess is the safety-boundary
+// regression test backing the security comment in buildClaudeEnvWith:
+// surfacing the host OAuth token through CLAUDE_CODE_OAUTH_TOKEN is only
+// safe because Claude Code itself strips that variable from the env it
+// hands to Bash / hook subprocesses, so a model-driven `printenv` cannot
+// echo the secret into the agent transcript. The MUL-2603 review (Elon)
+// flagged this as the blocking question for #3267, and the empirical
+// reproduction below is what the team accepted as proof.
+//
+// Skipped by default because it requires:
+//   - macOS (the keychain-suffix path the passthrough exists for)
+//   - the real `claude` CLI in PATH
+//   - a working ANTHROPIC_API_KEY (the subprocess auth that lets the model
+//     actually invoke the Bash tool — we cannot exercise the scrub
+//     boundary without the model running)
+//   - MULTICA_E2E_CLAUDE_OAUTH_SCRUB=1 (opt-in so CI never gets billed
+//     for the model call)
+//
+// Run it locally on a macOS box where you are logged into both
+// `claude /login` and have an API key handy:
+//
+//	MULTICA_E2E_CLAUDE_OAUTH_SCRUB=1 go test ./pkg/agent/ \
+//	    -run TestClaudeCLIScrubsOAuthTokenFromBashSubprocess -v
+//
+// A failure here means upstream Claude Code stopped scrubbing
+// CLAUDE_CODE_OAUTH_TOKEN before spawning Bash. In that case the
+// passthrough in buildClaudeEnvWith must move off env vars (e.g. write a
+// short-lived `apiKeyHelper` script that the CLI invokes synchronously)
+// before MUL-2603 can ship.
+func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
+	if os.Getenv("MULTICA_E2E_CLAUDE_OAUTH_SCRUB") != "1" {
+		t.Skip("set MULTICA_E2E_CLAUDE_OAUTH_SCRUB=1 to run the live claude CLI env-scrub check")
+	}
+	if runtime.GOOS != "darwin" {
+		t.Skip("env scrub test is only meaningful for the macOS keychain-suffix path")
+	}
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("set ANTHROPIC_API_KEY so the model can be invoked to drive the Bash tool")
+	}
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skipf("claude CLI not in PATH: %v", err)
+	}
+
+	// Distinctive canary the model has no reason to produce on its own.
+	// Long + structured so a substring match cannot false-positive on
+	// "sk-ant-…" prefixes that legitimately appear in CLI help text.
+	const canary = "sk-ant-oat-leak-canary-CLAUDE_CODE_OAUTH_TOKEN-MUL2603-PROBE"
+
+	// Use the *user's* shell-resolved env minus what we explicitly set so
+	// the CLI sees the canary token and the real API key. We do not use
+	// t.Setenv because Execute spawns a child of the test binary, not of
+	// the test goroutine; explicit env list keeps the boundary obvious.
+	env := append(os.Environ(), "CLAUDE_CODE_OAUTH_TOKEN="+canary)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, claudePath,
+		"--print",
+		"--output-format", "text",
+		"--allow-dangerously-skip-permissions",
+		"--allowedTools", "Bash",
+	)
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(
+		"Please run this exact bash command and paste the raw output verbatim: " +
+			"`printenv CLAUDE_CODE_OAUTH_TOKEN || echo SCRUB-OK`. " +
+			"Do not paraphrase the output, do not redact it.",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("claude --print failed: %v\noutput:\n%s", err, out)
+	}
+	body := string(out)
+	if strings.Contains(body, canary) {
+		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN leaked to Bash tool subprocess — Claude Code stopped scrubbing it.\nProof: canary %q present in transcript:\n%s",
+			canary, body)
 	}
 }
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -825,7 +825,8 @@ func TestClaudeExecuteMergeModeKeepsHostConfigDir(t *testing.T) {
 func TestBuildClaudeEnvAppendsIsolatedConfigDir(t *testing.T) {
 	t.Parallel()
 
-	env := buildClaudeEnvWith(nil, "/tmp/isolated-claude-config", slog.Default(), noopOAuthTokenReader)
+	hostDir, homeDir := noopHostGate()
+	env := buildClaudeEnvWith(nil, "/tmp/isolated-claude-config", hostDir, slog.Default(), homeDir, noopOAuthTokenReader)
 
 	var last string
 	hits := 0
@@ -848,7 +849,8 @@ func TestBuildClaudeEnvSkipsOverrideWhenEmpty(t *testing.T) {
 
 	// Asking for "merge" mode passes "" through. We should not add a
 	// CLAUDE_CONFIG_DIR=… entry; the parent's value (if any) wins.
-	env := buildClaudeEnvWith(map[string]string{"FOO": "bar"}, "", slog.Default(), noopOAuthTokenReader)
+	hostDir, homeDir := noopHostGate()
+	env := buildClaudeEnvWith(map[string]string{"FOO": "bar"}, "", hostDir, slog.Default(), homeDir, noopOAuthTokenReader)
 	for _, entry := range env {
 		if strings.HasPrefix(entry, "CLAUDE_CONFIG_DIR=") {
 			// The parent env may legitimately have one set on a developer
@@ -865,10 +867,13 @@ func TestBuildClaudeEnvOverridesPreviousValue(t *testing.T) {
 	// Even if custom_env supplies a CLAUDE_CONFIG_DIR, the isolated dir
 	// must take precedence: a stale custom_env entry must never be able
 	// to point the child back at `~/.claude/`.
+	hostDir, homeDir := noopHostGate()
 	env := buildClaudeEnvWith(
 		map[string]string{"CLAUDE_CONFIG_DIR": "/etc/hostile"},
 		"/tmp/safe",
+		hostDir,
 		slog.Default(),
+		homeDir,
 		noopOAuthTokenReader,
 	)
 
@@ -891,6 +896,27 @@ func TestBuildClaudeEnvOverridesPreviousValue(t *testing.T) {
 // ("", nil) takes the "no token available" path: buildClaudeEnvWith
 // neither appends CLAUDE_CODE_OAUTH_TOKEN nor logs a warning.
 func noopOAuthTokenReader() (string, error) { return "", nil }
+
+// defaultHostGate returns (hostConfigDir, homeDir) inputs that satisfy
+// isDefaultHostClaudeConfigDir, so buildClaudeEnvWith treats the host
+// source as the default `$HOME/.claude` and runs the keychain
+// passthrough. Tests that exercise the passthrough branch use this; the
+// chosen home lives under t.TempDir so each subtest is hermetic and the
+// real machine's $HOME never matters.
+func defaultHostGate(t *testing.T) (string, func() (string, error)) {
+	t.Helper()
+	home := t.TempDir()
+	return filepath.Join(home, ".claude"), func() (string, error) { return home, nil }
+}
+
+// noopHostGate returns (hostConfigDir, homeDir) inputs that always fail
+// the gate. Used by tests that don't care about the gate because the
+// passthrough is short-circuited earlier (merge mode, hasOAuthToken,
+// hasAnthropicKey). Returning an empty hostConfigDir is the explicit
+// "this test does not exercise the keychain branch" signal.
+func noopHostGate() (string, func() (string, error)) {
+	return "", func() (string, error) { return "", nil }
+}
 
 // countEnvEntries returns the number of `key=…` entries in env. Used by
 // the auth-passthrough tests below to assert "exactly one" instead of
@@ -929,7 +955,8 @@ func TestBuildClaudeEnvIsolatedInjectsKeychainOAuthToken(t *testing.T) {
 	t.Parallel()
 
 	reader := func() (string, error) { return "sk-ant-oat-test", nil }
-	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+	hostDir, homeDir := defaultHostGate(t)
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", hostDir, slog.Default(), homeDir, reader)
 
 	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 1 {
 		t.Fatalf("expected exactly one CLAUDE_CODE_OAUTH_TOKEN entry, got %d (%v)", got, env)
@@ -951,7 +978,8 @@ func TestBuildClaudeEnvMergeModeDoesNotInjectOAuthToken(t *testing.T) {
 		t.Fatal("readOAuthToken must not be invoked in merge mode")
 		return "", nil
 	}
-	env := buildClaudeEnvWith(nil, "", slog.Default(), reader)
+	hostDir, homeDir := noopHostGate()
+	env := buildClaudeEnvWith(nil, "", hostDir, slog.Default(), homeDir, reader)
 
 	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
 		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN in merge mode, got %d (%v)", got, env)
@@ -971,10 +999,13 @@ func TestBuildClaudeEnvIsolatedRespectsCustomOAuthToken(t *testing.T) {
 		t.Fatal("readOAuthToken must not be invoked when custom_env pinned a token")
 		return "", nil
 	}
+	hostDir, homeDir := defaultHostGate(t)
 	env := buildClaudeEnvWith(
 		map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-pinned"},
 		"/tmp/isolated",
+		hostDir,
 		slog.Default(),
+		homeDir,
 		reader,
 	)
 
@@ -996,10 +1027,13 @@ func TestBuildClaudeEnvIsolatedSkipsKeychainWhenAnthropicKeyPresent(t *testing.T
 		t.Fatal("readOAuthToken must not be invoked when ANTHROPIC_API_KEY is set")
 		return "", nil
 	}
+	hostDir, homeDir := defaultHostGate(t)
 	env := buildClaudeEnvWith(
 		map[string]string{"ANTHROPIC_API_KEY": "sk-ant-api-test"},
 		"/tmp/isolated",
+		hostDir,
 		slog.Default(),
+		homeDir,
 		reader,
 	)
 
@@ -1022,7 +1056,8 @@ func TestBuildClaudeEnvIsolatedReaderErrorIsSoftFailure(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	env := buildClaudeEnvWith(nil, "/tmp/isolated", logger, reader)
+	hostDir, homeDir := defaultHostGate(t)
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", hostDir, logger, homeDir, reader)
 
 	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
 		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN when reader errors, got %d (%v)", got, env)
@@ -1047,7 +1082,8 @@ func TestBuildClaudeEnvIsolatedReaderNilTokenStaysQuiet(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	env := buildClaudeEnvWith(nil, "/tmp/isolated", logger, noopOAuthTokenReader)
+	hostDir, homeDir := defaultHostGate(t)
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", hostDir, logger, homeDir, noopOAuthTokenReader)
 
 	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
 		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN when reader returns empty, got %d (%v)", got, env)
@@ -1076,7 +1112,8 @@ func TestBuildClaudeEnvIsolatedTreatsEmptyAnthropicAPIKeyAsUnpinned(t *testing.T
 	t.Setenv("ANTHROPIC_API_KEY", "")
 
 	reader := func() (string, error) { return "sk-ant-oat-keychain", nil }
-	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+	hostDir, homeDir := defaultHostGate(t)
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", hostDir, slog.Default(), homeDir, reader)
 
 	if got := envValue(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != "sk-ant-oat-keychain" {
 		t.Fatalf("expected keychain token to be injected when ANTHROPIC_API_KEY is empty, got %q", got)
@@ -1096,7 +1133,8 @@ func TestBuildClaudeEnvIsolatedHonorsNonEmptyAnthropicAPIKey(t *testing.T) {
 		t.Fatal("readOAuthToken must not be invoked when non-empty ANTHROPIC_API_KEY is set")
 		return "", nil
 	}
-	env := buildClaudeEnvWith(nil, "/tmp/isolated", slog.Default(), reader)
+	hostDir, homeDir := defaultHostGate(t)
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", hostDir, slog.Default(), homeDir, reader)
 
 	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
 		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN with non-empty ANTHROPIC_API_KEY, got %d (%v)", got, env)
@@ -1113,10 +1151,13 @@ func TestBuildClaudeEnvIsolatedEmptyOAuthTokenInCustomEnvAsUnpinned(t *testing.T
 	t.Parallel()
 
 	reader := func() (string, error) { return "sk-ant-oat-keychain", nil }
+	hostDir, homeDir := defaultHostGate(t)
 	env := buildClaudeEnvWith(
 		map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": ""},
 		"/tmp/isolated",
+		hostDir,
 		slog.Default(),
+		homeDir,
 		reader,
 	)
 
@@ -1127,14 +1168,112 @@ func TestBuildClaudeEnvIsolatedEmptyOAuthTokenInCustomEnvAsUnpinned(t *testing.T
 	}
 }
 
+// TestBuildClaudeEnvIsolatedSkipsKeychainForCustomHostConfigDir pins the
+// "do not cross accounts" boundary the round-2 MUL-2603 review flagged
+// as Must-fix 1: when the host config source is a custom CLAUDE_CONFIG_DIR
+// (set via agent custom_env or daemon-host env), the isolated child must
+// NOT receive the daemon user's default `Claude Code-credentials` keychain
+// token. Claude Code 2.x maps custom dirs to suffixed keychain entries
+// (`Claude Code-credentials-<sha256(dir)[:8]>`) belonging to whatever
+// account `claude /login` was last run against under that dir, so
+// injecting the unsuffixed default entry would mix accounts — the same
+// boundary mirrorHostClaudeJSONIfMissing already enforces for
+// `.claude.json` (see TestMirrorHostClaudeJSONIfMissing_CustomHostDirSkipped).
+//
+// The reader closure uses t.Fatal so a regression that re-enables the
+// keychain read for custom dirs fails loud and obvious — silent
+// re-introduction is exactly how cross-account leaks slip past review.
+func TestBuildClaudeEnvIsolatedSkipsKeychainForCustomHostConfigDir(t *testing.T) {
+	t.Parallel()
+
+	reader := func() (string, error) {
+		t.Fatal("readOAuthToken must NOT be invoked when host config dir is a custom CLAUDE_CONFIG_DIR — would inject the daemon user's default account into a managed/custom-dir agent")
+		return "", nil
+	}
+	// Home points somewhere; hostConfigDir intentionally is NOT
+	// $HOME/.claude — it's a managed/custom location an operator pinned.
+	home := t.TempDir()
+	customHost := filepath.Join(t.TempDir(), "managed-claude")
+	homeDir := func() (string, error) { return home, nil }
+
+	env := buildClaudeEnvWith(nil, "/tmp/isolated", customHost, slog.Default(), homeDir, reader)
+
+	if got := countEnvEntries(env, "CLAUDE_CODE_OAUTH_TOKEN"); got != 0 {
+		t.Fatalf("expected no CLAUDE_CODE_OAUTH_TOKEN to be injected for custom hostConfigDir, got %d (%v)", got, env)
+	}
+	// Isolation env itself must still be intact — the gate only suppresses
+	// the keychain passthrough, it does not change CLAUDE_CONFIG_DIR.
+	if got := countEnvEntries(env, "CLAUDE_CONFIG_DIR"); got != 1 {
+		t.Fatalf("expected isolated CLAUDE_CONFIG_DIR to still be set, got %d entries", got)
+	}
+}
+
+// TestIsDefaultHostClaudeConfigDir documents the gate's truth table at
+// the unit level so the keychain passthrough's host-dir boundary is
+// regression-tested even when buildClaudeEnvWith short-circuits earlier
+// (operator pinned auth, merge mode, etc.).
+func TestIsDefaultHostClaudeConfigDir(t *testing.T) {
+	t.Parallel()
+	const fakeHome = "/fake-home"
+	okHome := func() (string, error) { return fakeHome, nil }
+	emptyHome := func() (string, error) { return "", nil }
+	errHome := func() (string, error) { return "", errors.New("no home for you") }
+
+	cases := []struct {
+		name          string
+		hostConfigDir string
+		homeDir       func() (string, error)
+		want          bool
+	}{
+		{"matches default", filepath.Join(fakeHome, ".claude"), okHome, true},
+		{"custom dir under home", filepath.Join(fakeHome, "managed-claude"), okHome, false},
+		{"completely unrelated dir", "/etc/claude-managed", okHome, false},
+		{"empty hostConfigDir (merge mode)", "", okHome, false},
+		{"empty home resolves to false", filepath.Join(fakeHome, ".claude"), emptyHome, false},
+		{"home resolver error", filepath.Join(fakeHome, ".claude"), errHome, false},
+		{"nil home resolver", filepath.Join(fakeHome, ".claude"), nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDefaultHostClaudeConfigDir(tc.hostConfigDir, tc.homeDir); got != tc.want {
+				t.Fatalf("isDefaultHostClaudeConfigDir(%q, ...) = %v, want %v",
+					tc.hostConfigDir, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestClaudeCLIScrubsOAuthTokenFromBashSubprocess is the safety-boundary
 // regression test backing the security comment in buildClaudeEnvWith:
 // surfacing the host OAuth token through CLAUDE_CODE_OAUTH_TOKEN is only
 // safe because Claude Code itself strips that variable from the env it
-// hands to Bash / hook subprocesses, so a model-driven `printenv` cannot
-// echo the secret into the agent transcript. The MUL-2603 review (Elon)
-// flagged this as the blocking question for #3267, and the empirical
-// reproduction below is what the team accepted as proof.
+// hands to the model-driven **Bash tool subprocess**, so a `printenv`
+// inside the model's bash invocation cannot echo the secret into the
+// agent transcript. The MUL-2603 review (Elon, round 2) flagged that a
+// bare "canary absent" assertion was insufficient — it false-passes any
+// time the model refuses, paraphrases, or never reaches Bash — so this
+// version adds a non-secret CONTROL variable. The three conjoined
+// assertions are:
+//
+//  1. the canary CLAUDE_CODE_OAUTH_TOKEN value is NOT in the transcript
+//     (the primary safety claim);
+//  2. "UNSET" IS in the transcript (the Bash tool actually ran AND saw
+//     CLAUDE_CODE_OAUTH_TOKEN as unset, ruling out the "model refused" /
+//     "model paraphrased" false pass);
+//  3. "CONTROL-SET" IS in the transcript (ordinary env propagation works
+//     for the non-sensitive MUL2603_CONTROL variable — proves the scrub
+//     is a targeted strip of CLAUDE_CODE_OAUTH_TOKEN, not a side-effect
+//     of "the CLI sandboxes Bash with no env at all", which would not
+//     be a security property we could rely on for arbitrary future
+//     env-exposed secrets).
+//
+// The boundary intentionally narrows to the **Bash tool subprocess**.
+// We have not reproduced the env shape the CLI hands to hook
+// subprocesses (e.g. PreToolUse / PostToolUse hooks), so this test does
+// not assert anything about them — and neither do the code comment in
+// buildClaudeEnvWith nor the PR description. If a future feature
+// requires the same env-scrub property for hooks, a parallel hook
+// regression has to be added before relying on it.
 //
 // Skipped by default because it requires:
 //   - macOS (the keychain-suffix path the passthrough exists for)
@@ -1174,15 +1313,26 @@ func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
 	// Distinctive canary the model has no reason to produce on its own.
 	// Long + structured so a substring match cannot false-positive on
 	// "sk-ant-…" prefixes that legitimately appear in CLI help text.
-	const canary = "sk-ant-oat-leak-canary-CLAUDE_CODE_OAUTH_TOKEN-MUL2603-PROBE"
+	const (
+		canary       = "sk-ant-oat-leak-canary-CLAUDE_CODE_OAUTH_TOKEN-MUL2603-PROBE"
+		controlValue = "mul2603-control-value-non-secret"
+		// The Bash tool emits these literal tokens; we assert on them as
+		// proof-of-execution rather than parsing the model's prose.
+		secretUnsetMarker = "UNSET"
+		secretSetMarker   = "SET"
+		controlSetMarker  = "CONTROL-SET"
+	)
 
-	// Use the *user's* shell-resolved env minus what we explicitly set so
-	// the CLI sees the canary token and the real API key. We do not use
-	// t.Setenv because Execute spawns a child of the test binary, not of
-	// the test goroutine; explicit env list keeps the boundary obvious.
-	env := append(os.Environ(), "CLAUDE_CODE_OAUTH_TOKEN="+canary)
+	// Use the *user's* shell-resolved env plus the canary + control vars.
+	// We do not use t.Setenv because the CLI is spawned via exec.Command,
+	// not as a child of the test goroutine; an explicit env list keeps
+	// the boundary obvious.
+	env := append(os.Environ(),
+		"CLAUDE_CODE_OAUTH_TOKEN="+canary,
+		"MUL2603_CONTROL="+controlValue,
+	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, claudePath,
 		"--print",
@@ -1191,19 +1341,44 @@ func TestClaudeCLIScrubsOAuthTokenFromBashSubprocess(t *testing.T) {
 		"--allowedTools", "Bash",
 	)
 	cmd.Env = env
+	// The prompt asks the model to run two `test -n` probes back-to-back
+	// and report both raw outputs. Using `test -n` instead of `printenv`
+	// makes the assertion deterministic: an empty value and an unset key
+	// both render as "UNSET", so the test doesn't have to special-case
+	// `printenv`'s exit-status behaviour across shells.
 	cmd.Stdin = strings.NewReader(
-		"Please run this exact bash command and paste the raw output verbatim: " +
-			"`printenv CLAUDE_CODE_OAUTH_TOKEN || echo SCRUB-OK`. " +
-			"Do not paraphrase the output, do not redact it.",
+		"Please run this exact bash command and paste the raw output verbatim. " +
+			"Do not paraphrase, do not redact, do not summarize:\n" +
+			"`test -n \"$CLAUDE_CODE_OAUTH_TOKEN\" && echo " + secretSetMarker + " || echo " + secretUnsetMarker +
+			"; test -n \"$MUL2603_CONTROL\" && echo " + controlSetMarker + " || echo CONTROL-UNSET`",
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("claude --print failed: %v\noutput:\n%s", err, out)
 	}
 	body := string(out)
+
+	// Primary safety assertion: the canary OAuth value never lands in the
+	// transcript verbatim.
 	if strings.Contains(body, canary) {
 		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN leaked to Bash tool subprocess — Claude Code stopped scrubbing it.\nProof: canary %q present in transcript:\n%s",
 			canary, body)
+	}
+	// Control-prong proves the scrub is *targeted*, not "Bash has no env".
+	// Without this, a Claude Code change that walled Bash off entirely
+	// would pass the canary check but break the security model we documented.
+	if !strings.Contains(body, controlSetMarker) {
+		t.Fatalf("Bash tool did not propagate the non-secret control var %s — the scrub may have widened to all env vars, which changes the security model we documented.\nTranscript:\n%s",
+			controlSetMarker, body)
+	}
+	// Proof-of-execution: the Bash subprocess actually ran the probe AND
+	// saw CLAUDE_CODE_OAUTH_TOKEN as unset (the marker is what the probe
+	// emits in the false branch of `test -n`). Without this assertion a
+	// transcript where the model declined to call Bash would pass the
+	// canary check trivially and silently disarm the regression.
+	if !strings.Contains(body, secretUnsetMarker) {
+		t.Fatalf("Bash tool either did not run or saw CLAUDE_CODE_OAUTH_TOKEN as SET — both invalidate the scrub assertion.\nTranscript:\n%s",
+			body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Surface the host's Claude Code OAuth access token (read from the macOS login keychain via `/usr/bin/security`) as `CLAUDE_CODE_OAUTH_TOKEN` for the isolated child claude process.
- Linux/Windows are no-ops — their `.credentials.json` is already mirrored by `mirrorHostClaudeExceptSkills`.
- Operator-pinned `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` both win over the keychain reader (gated on non-empty values — see review follow-up below).
- **The keychain passthrough only fires when the resolved host config dir is the default `$HOME/.claude`.** Custom `CLAUDE_CONFIG_DIR` (via `custom_env` or daemon-host env) deliberately skips the read so the daemon user's default OAuth account does not get cross-pollinated into a managed/custom-dir agent.

## Root cause

Claude Code 2.x derives the macOS keychain credentials-entry suffix from `sha256(CLAUDE_CONFIG_DIR)[:8]`. The unsuffixed `Claude Code-credentials` entry (where `claude /login` writes the OAuth token) is only read when `CLAUDE_CONFIG_DIR` is unset or equal to the install default. The MUL-2603 isolation path points the child at a per-task scratch dir, so the CLI starts looking up `Claude Code-credentials-<scratch-hash>`, finds nothing, and exits `Not logged in · Please run /login`.

Reproduced on Bohan's host:
- `CLAUDE_CONFIG_DIR=/tmp/claude-iso-test claude auth status --json` → `{"loggedIn": false}`
- `echo -n /tmp/claude-iso-test | shasum -a 256 | cut -c1-8` → `5039e169`, which matches the empty `Claude Code-credentials-5039e169` keychain entry the CLI auto-created on first use.

`CLAUDE_CODE_OAUTH_TOKEN` bypasses keychain lookup entirely, so surfacing the host token through the child env sidesteps the suffix scheme without depending on its internal hashing.

## Security boundary — Bash tool subprocess only

**`CLAUDE_CODE_OAUTH_TOKEN` does NOT leak to the Bash tool subprocess in Claude Code 2.1.121.** The CLI explicitly strips it from the env it hands to the model-driven Bash tool, so a `printenv` invoked through the tool cannot echo the secret into the agent transcript.

Direct empirical proof (manual repro on Bohan's host):

```bash
printf 'Run this and report verbatim: test -n "$CLAUDE_CODE_OAUTH_TOKEN" && echo SET || echo UNSET; test -n "$MUL2603_CONTROL" && echo CONTROL-SET || echo CONTROL-UNSET\n' \
  | CLAUDE_CODE_OAUTH_TOKEN=sk-canary-XYZ \
    MUL2603_CONTROL=control-value \
    claude --print --output-format text \
           --allow-dangerously-skip-permissions --allowedTools Bash
```

Output:
```
UNSET
CONTROL-SET
```

`MUL2603_CONTROL` is a non-sensitive control variable that demonstrates ordinary env propagation works (the Bash subprocess inherits it). `CLAUDE_CODE_OAUTH_TOKEN` is explicitly stripped — proving the scrub is targeted, not a side-effect of "Bash gets no env".

The contract is pinned in code by `TestClaudeCLIScrubsOAuthTokenFromBashSubprocess`. After Elon's round-3 review, the proof markers are **per-run random hex nonces** generated inside the test and passed only via env vars (`MUL2603_UNSET_NONCE`, `MUL2603_CONTROL_NONCE`). The prompt references the variable *names*, never the *values*, so a paraphrasing or refusing model cannot fake nonces it never saw — only a real Bash subprocess inheriting the env vars and echoing them can land them in the transcript. The three assertions are:

1. the canary `CLAUDE_CODE_OAUTH_TOKEN` value is NOT in the transcript (primary safety claim);
2. the unset-nonce IS in the transcript (Bash actually ran AND saw `CLAUDE_CODE_OAUTH_TOKEN` as empty);
3. the control-nonce IS in the transcript (ordinary env propagation works for the non-secret `MUL2603_CONTROL` — proves the scrub is targeted, not "Bash gets no env").

The test is opt-in (`MULTICA_E2E_CLAUDE_OAUTH_SCRUB=1`, requires `ANTHROPIC_API_KEY` + `claude` in PATH + macOS) so CI is never billed for the model call, but the assertion exists in the tree as the explicit upstream contract: if Anthropic ever stops scrubbing, this test flips red and the passthrough has to move off env vars (e.g. `apiKeyHelper` script) before MUL-2603 can ship.

**Scope of the assertion (Elon round-2 review):** the scrub is verified only for the **Bash tool subprocess**. We have not reproduced the env shape Claude Code hands to hook subprocesses (PreToolUse / PostToolUse / etc.), so the security contract — both the code comment in `buildClaudeEnvWith` and this PR description — intentionally narrows to Bash. If a future feature requires the same env-scrub property for hooks, a parallel hook regression has to be added before relying on it.

## Cross-account boundary — custom CLAUDE_CONFIG_DIR (round-2 follow-up)

The keychain reader returns the *unsuffixed* `Claude Code-credentials` entry, which is the right answer only when the host config source is the default `$HOME/.claude`. A custom `CLAUDE_CONFIG_DIR` (e.g. a managed shared profile or a daemon-host override) maps to `Claude Code-credentials-<hash>` belonging to whatever account was last logged in under that dir. Injecting the unsuffixed default entry into a custom-dir isolated child would silently cross-pollinate the daemon user's default OAuth account into a managed agent — the same boundary `mirrorHostClaudeJSONIfMissing` already enforces for `.claude.json`.

Fix: `buildClaudeEnvWith` takes the resolved `hostConfigDir` and gates the passthrough on `isDefaultHostClaudeConfigDir(hostConfigDir, homeDir)`. Only the default `$HOME/.claude` source triggers the keychain read; any other value short-circuits to the standard auth flow (rely on whatever `.credentials.json` / `apiKeyHelper` lives inside the custom dir, or fall through to `ANTHROPIC_API_KEY`).

Regression coverage:
- `TestIsDefaultHostClaudeConfigDir` — unit truth table over default / custom / empty / home-error inputs.
- `TestBuildClaudeEnvIsolatedSkipsKeychainForCustomHostConfigDir` — wires a `t.Fatal`-armed reader so silently re-enabling the default-token read for custom dirs flips the build red.

## Review follow-ups

Both raised by Elon round 1 (`5de57607`):

- **Empty-value gate.** Previously a parent-inherited `ANTHROPIC_API_KEY=` (login shell quirk) or a stale custom_env `CLAUDE_CODE_OAUTH_TOKEN=""` would pose as a pinned auth choice and disable the keychain reader, silently stranding the isolated child at "Not logged in". Now both are recognised as noise, dropped from the child env (so they can't shadow the keychain-injected token in libc env lookups that pick the first match), and the keychain reader runs unchanged. Three unit tests cover the `os.Environ` and `custom_env` paths.
- **`CLAUDE_CODE_OAUTH_TOKEN` env-scrub assumption documented in code** (`buildClaudeEnvWith` security-boundary block) and pinned by `TestClaudeCLIScrubsOAuthTokenFromBashSubprocess`.

Round 2 (`c89331f9`):

- **Custom `CLAUDE_CONFIG_DIR` cross-account fix** (see *Cross-account boundary* section above).
- **Scrub test gained a control prong + proof-of-execution marker** so it cannot false-pass on a model refusal, paraphrase, or upstream "Bash gets no env" change.
- **Code comment + this PR description narrowed to "Bash tool subprocess only".** Hook subprocess env-scrub was an unverified claim before and has been removed from both.

Round 3 (`7bcd6093`):

- **Scrub test moved to per-run nonces.** The previous round still used hard-coded marker strings (`UNSET` / `CONTROL-SET`) that were literal substrings of the prompt — a paraphrasing model could land them in the transcript without ever spawning Bash, leaving the assertion false-passable. The markers are now random hex nonces generated inside the test and passed only via env vars; the prompt only references the variable names. A nonce in the transcript is necessarily proof of a real Bash subprocess execution.

## What this does NOT change

- Merge mode (`SkillsLocal != "ignore"`) is untouched — no keychain read, no env-var injection. The child reads the host keychain directly as before.
- The previous fix (#3261) still applies: `.claude.json` is mirrored from `$HOME/.claude.json` so non-auth state (project history, settings cache) keeps working. The OAuth env var alone is enough for auth, but `.claude.json` is still needed for the rest.
- Codex / Copilot / other runtimes are untouched — only Claude Code has the keychain-suffix scheme.

## Test plan
- [x] `go test ./pkg/agent/...` — full suite passes
- [x] `GOOS=windows GOARCH=amd64 go vet ./pkg/agent/...` — clean
- [x] `GOOS=linux GOARCH=amd64 go vet ./pkg/agent/...` — clean
- [x] Unit coverage on `buildClaudeEnvWith` covers: keychain reader returns token (injected), merge mode (no reader call), operator-pinned token wins, `ANTHROPIC_API_KEY` suppresses reader, reader error → soft failure with logged warning, reader `("", nil)` → silent, empty `ANTHROPIC_API_KEY=` from `os.Environ` does NOT suppress reader, non-empty `ANTHROPIC_API_KEY` still does, empty `CLAUDE_CODE_OAUTH_TOKEN=""` in `custom_env` does NOT suppress reader, **custom `hostConfigDir` skips the keychain read (cross-account boundary)**, **`isDefaultHostClaudeConfigDir` truth table over default / custom / empty / home-error**.
- [x] `TestClaudeCLIScrubsOAuthTokenFromBashSubprocess` — skip-gated live-CLI regression test asserts canary absent, unset-nonce present, control-nonce present (per-run random hex, never written into the prompt).
- [x] Regression verified by temporarily removing the gate in `buildClaudeEnvWith` — `TestBuildClaudeEnvIsolatedSkipsKeychainForCustomHostConfigDir` flips red as expected.
- [x] End-to-end verified manually: with the env shape `buildClaudeEnv` now produces (`CLAUDE_CONFIG_DIR=<scratch>`, `CLAUDE_CODE_OAUTH_TOKEN=<keychain>`), `claude --print "..."` returns successfully where it previously printed `Not logged in · Please run /login`.

MUL-2603
