### PR TITLE
feat(issues): hide done/cancelled issues older than 14 days from board

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -448,6 +448,7 @@ export class ApiClient {
     }
     if (params?.open_only) search.set("open_only", "true");
     if (params?.scheduled) search.set("scheduled", "true");
+    if (params?.updated_after) search.set("updated_after", params.updated_after);
     const path = `/api/issues?${search}`;
     const raw = await this.fetch<unknown>(path);
     return parseWithFallback(raw, ListIssuesResponseSchema, EMPTY_LIST_ISSUES_RESPONSE, {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -30,6 +30,7 @@ import type {
   CreateIssueRequest,
   UpdateIssueRequest,
   ListIssuesCache,
+  ListIssuesParams,
 } from "../types";
 import type { TimelineEntry, IssueSubscriber, Reaction } from "../types";
 import { sortTimelineEntriesAsc } from "./timeline-sort";
@@ -55,21 +56,26 @@ export type ToggleIssueReactionVars = {
 // ---------------------------------------------------------------------------
 
 /**
- * Paginate one status column into the cache. Works for both the workspace
- * issue list and per-scope My Issues lists (pass `myIssues` to target the
- * latter).
+ * Paginate one status column into the cache. Works for the workspace
+ * issue list, the board list, and per-scope My Issues lists.
  */
 export function useLoadMoreByStatus(
   status: IssueStatus,
   myIssues?: { scope: string; filter: MyIssuesFilter },
+  opts?: {
+    queryKey?: QueryKey;
+    terminalUpdatedAfter?: string;
+  },
 ) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   const [isLoading, setIsLoading] = useState(false);
 
-  const queryKey = myIssues
-    ? issueKeys.myList(wsId, myIssues.scope, myIssues.filter)
-    : issueKeys.list(wsId);
+  const queryKey = opts?.queryKey ?? (
+    myIssues
+      ? issueKeys.myList(wsId, myIssues.scope, myIssues.filter)
+      : issueKeys.list(wsId)
+  );
   const cache = qc.getQueryData<ListIssuesCache>(queryKey);
   const bucket = cache?.byStatus[status];
   const loaded = bucket?.issues.length ?? 0;
@@ -80,12 +86,19 @@ export function useLoadMoreByStatus(
     if (isLoading || !hasMore) return;
     setIsLoading(true);
     try {
-      const res = await api.listIssues({
+      const params: ListIssuesParams = {
         status,
         limit: ISSUE_PAGE_SIZE,
         offset: loaded,
         ...myIssues?.filter,
-      });
+      };
+      if (
+        opts?.terminalUpdatedAfter &&
+        (status === "done" || status === "cancelled")
+      ) {
+        params.updated_after = opts.terminalUpdatedAfter;
+      }
+      const res = await api.listIssues(params);
       qc.setQueryData<ListIssuesCache>(queryKey, (old) => {
         if (!old) return old;
         const prev = getBucket(old, status);
@@ -99,7 +112,16 @@ export function useLoadMoreByStatus(
     } finally {
       setIsLoading(false);
     }
-  }, [qc, queryKey, status, loaded, hasMore, isLoading, myIssues?.filter]);
+  }, [
+    qc,
+    queryKey,
+    status,
+    loaded,
+    hasMore,
+    isLoading,
+    myIssues?.filter,
+    opts?.terminalUpdatedAfter,
+  ]);
 
   return { loadMore, hasMore, isLoading, total };
 }

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -13,6 +13,7 @@ import { BOARD_STATUSES } from "./config";
 export const issueKeys = {
   all: (wsId: string) => ["issues", wsId] as const,
   list: (wsId: string) => [...issueKeys.all(wsId), "list"] as const,
+  boardList: (wsId: string) => [...issueKeys.list(wsId), "board"] as const,
   assigneeGroupsAll: (wsId: string) =>
     [...issueKeys.all(wsId), "assignee-groups"] as const,
   assigneeGroups: (wsId: string, filter: AssigneeGroupedIssuesFilter) =>
@@ -91,11 +92,26 @@ export function flattenIssueBuckets(data: ListIssuesCache) {
   return out;
 }
 
-async function fetchFirstPages(filter: MyIssuesFilter = {}): Promise<ListIssuesCache> {
+async function fetchFirstPages(
+  filter: MyIssuesFilter = {},
+  terminalUpdatedAfter?: string,
+): Promise<ListIssuesCache> {
   const responses = await Promise.all(
-    PAGINATED_STATUSES.map((status) =>
-      api.listIssues({ status, limit: ISSUE_PAGE_SIZE, offset: 0, ...filter }),
-    ),
+    PAGINATED_STATUSES.map((status) => {
+      const params: ListIssuesParams = {
+        status,
+        limit: ISSUE_PAGE_SIZE,
+        offset: 0,
+        ...filter,
+      };
+      if (
+        terminalUpdatedAfter &&
+        (status === "done" || status === "cancelled")
+      ) {
+        params.updated_after = terminalUpdatedAfter;
+      }
+      return api.listIssues(params);
+    }),
   );
   const byStatus: ListIssuesCache["byStatus"] = {};
   PAGINATED_STATUSES.forEach((status, i) => {
@@ -214,6 +230,30 @@ export function issueListOptions(wsId: string) {
   return queryOptions({
     queryKey: issueKeys.list(wsId),
     queryFn: () => fetchFirstPages(),
+    select: flattenIssueBuckets,
+  });
+}
+
+/** Number of days after which done / cancelled issues are hidden from the board by default. */
+export const BOARD_OLD_DONE_CUTOFF_DAYS = 14;
+
+export function getTerminalUpdatedAfter(): string {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - BOARD_OLD_DONE_CUTOFF_DAYS);
+  cutoff.setHours(0, 0, 0, 0);
+  return cutoff.toISOString();
+}
+
+/**
+ * Board-specific issue list. When `showOldDone` is false (default), done /
+ * cancelled items older than {@link BOARD_OLD_DONE_CUTOFF_DAYS} days are
+ * excluded. Uses a separate cache key so the unfiltered workspace list
+ * (used by detail pages, etc.) is untouched.
+ */
+export function boardIssueListOptions(wsId: string, showOldDone = false) {
+  return queryOptions({
+    queryKey: [...issueKeys.boardList(wsId), showOldDone ? "all" : "filtered"],
+    queryFn: () => fetchFirstPages({}, showOldDone ? undefined : getTerminalUpdatedAfter()),
     select: flattenIssueBuckets,
   });
 }

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -79,6 +79,8 @@ export interface IssueViewState {
   listCollapsedStatuses: IssueStatus[];
   ganttZoom: GanttZoom;
   ganttShowCompleted: boolean;
+  /** When false (default), the board hides done / cancelled issues older than 14 days. */
+  boardShowOldDone: boolean;
   setViewMode: (mode: ViewMode) => void;
   setGanttZoom: (zoom: GanttZoom) => void;
   toggleGanttShowCompleted: () => void;
@@ -99,6 +101,7 @@ export interface IssueViewState {
   setSortDirection: (dir: SortDirection) => void;
   toggleCardProperty: (key: keyof CardProperties) => void;
   toggleListCollapsed: (status: IssueStatus) => void;
+  toggleBoardShowOldDone: () => void;
 }
 
 export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): IssueViewState => ({
@@ -128,6 +131,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   listCollapsedStatuses: [],
   ganttZoom: "week",
   ganttShowCompleted: false,
+  boardShowOldDone: false,
 
   setViewMode: (mode) => set({ viewMode: mode }),
   setGanttZoom: (zoom) => set({ ganttZoom: zoom }),
@@ -233,6 +237,8 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.listCollapsedStatuses.filter((s) => s !== status)
         : [...state.listCollapsedStatuses, status],
     })),
+  toggleBoardShowOldDone: () =>
+    set((state) => ({ boardShowOldDone: !state.boardShowOldDone })),
 });
 
 export const viewStorePersistOptions = (name: string) => ({

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -18,6 +18,7 @@ export function onIssueCreated(
   qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
     old ? addIssueToBuckets(old, issue) : old,
   );
+  qc.invalidateQueries({ queryKey: issueKeys.boardList(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
@@ -54,6 +55,7 @@ export function onIssueUpdated(
   qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
     old ? patchIssueInBuckets(old, issue.id, issue) : old,
   );
+  qc.invalidateQueries({ queryKey: issueKeys.boardList(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
@@ -108,6 +110,7 @@ export function onIssueLabelsChanged(
   qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
     old ? patchIssueInBuckets(old, issueId, { labels }) : old,
   );
+  qc.invalidateQueries({ queryKey: issueKeys.boardList(wsId) });
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );
@@ -151,6 +154,7 @@ export function onIssueMetadataChanged(
   qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
     old ? patchIssueInBuckets(old, issueId, { metadata }) : old,
   );
+  qc.invalidateQueries({ queryKey: issueKeys.boardList(wsId) });
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
     old ? { ...old, metadata } : old,
   );

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -64,6 +64,12 @@ export interface ListIssuesParams {
    * majority on the client.
    */
   scheduled?: boolean;
+  /**
+   * When set, done / cancelled issues whose `updated_at` is older than
+   * this RFC3339 timestamp are excluded. Non-terminal statuses are
+   * unaffected.
+   */
+  updated_after?: string;
 }
 
 export interface IssueActorRef {

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -21,6 +21,7 @@ import type { Issue, IssueAssigneeGroup, IssueAssigneeType, IssueStatus, UpdateI
 import { Button } from "@multica/ui/components/ui/button";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { AssigneeGroupedIssuesFilter, MyIssuesFilter } from "@multica/core/issues/queries";
+import { getTerminalUpdatedAfter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -223,6 +224,7 @@ export function BoardView({
   myIssuesScope,
   myIssuesFilter,
   projectId,
+  boardQueryKey,
 }: {
   issues: Issue[];
   assigneeGroups?: IssueAssigneeGroup[];
@@ -237,6 +239,8 @@ export function BoardView({
   myIssuesFilter?: MyIssuesFilter;
   /** When set, the per-column "+" pre-fills the project on the create form. */
   projectId?: string;
+  /** Query key for the board-specific issue list (hides old done / cancelled items). */
+  boardQueryKey?: QueryKey;
 }) {
   const { t } = useT("issues");
   const sortBy = useViewStore((s) => s.sortBy);
@@ -483,6 +487,7 @@ export function BoardView({
                 childProgressMap={childProgressMap}
                 myIssuesOpts={myIssuesOpts}
                 projectId={projectId}
+                boardQueryKey={boardQueryKey}
               />
             ) : (
               assigneeGroupQueryKey && assigneeGroupFilter ? (
@@ -515,6 +520,7 @@ export function BoardView({
           <HiddenColumnsPanel
             hiddenStatuses={hiddenStatuses}
             myIssuesOpts={myIssuesOpts}
+            boardQueryKey={boardQueryKey}
           />
         )}
       </div>
@@ -580,6 +586,7 @@ function PaginatedBoardColumn({
   childProgressMap,
   myIssuesOpts,
   projectId,
+  boardQueryKey,
 }: {
   group: BoardColumnGroup & { status: IssueStatus };
   issueIds: string[];
@@ -587,10 +594,18 @@ function PaginatedBoardColumn({
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
+  boardQueryKey?: QueryKey;
 }) {
+  const boardShowOldDone = useViewStore((s) => s.boardShowOldDone);
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     group.status,
     myIssuesOpts,
+    boardQueryKey
+      ? {
+          queryKey: boardQueryKey,
+          terminalUpdatedAfter: boardShowOldDone ? undefined : getTerminalUpdatedAfter(),
+        }
+      : undefined,
   );
   return (
     <BoardColumn
@@ -612,9 +627,11 @@ function PaginatedBoardColumn({
 function HiddenColumnsPanel({
   hiddenStatuses,
   myIssuesOpts,
+  boardQueryKey,
 }: {
   hiddenStatuses: IssueStatus[];
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  boardQueryKey?: QueryKey;
 }) {
   const { t } = useT("issues");
   return (
@@ -630,6 +647,7 @@ function HiddenColumnsPanel({
             key={status}
             status={status}
             myIssuesOpts={myIssuesOpts}
+            boardQueryKey={boardQueryKey}
           />
         ))}
       </div>
@@ -640,13 +658,25 @@ function HiddenColumnsPanel({
 function HiddenColumnRow({
   status,
   myIssuesOpts,
+  boardQueryKey,
 }: {
   status: IssueStatus;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  boardQueryKey?: QueryKey;
 }) {
   const { t } = useT("issues");
   const viewStoreApi = useViewStoreApi();
-  const { total } = useLoadMoreByStatus(status, myIssuesOpts);
+  const boardShowOldDone = useViewStore((s) => s.boardShowOldDone);
+  const { total } = useLoadMoreByStatus(
+    status,
+    myIssuesOpts,
+    boardQueryKey
+      ? {
+          queryKey: boardQueryKey,
+          terminalUpdatedAfter: boardShowOldDone ? undefined : getTerminalUpdatedAfter(),
+        }
+      : undefined,
+  );
   return (
     <div className="flex items-center justify-between rounded-lg px-2.5 py-2 hover:bg-muted/50">
       <div className="flex items-center gap-2">

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -599,6 +599,7 @@ export function IssueDisplayControls({
   const sortDirection = useViewStore((s) => s.sortDirection);
   const grouping = useViewStore((s) => s.grouping);
   const cardProperties = useViewStore((s) => s.cardProperties);
+  const boardShowOldDone = useViewStore((s) => s.boardShowOldDone);
   const act = useViewStoreApi().getState();
 
   const counts = useIssueCounts(scopedIssues);
@@ -881,6 +882,20 @@ export function IssueDisplayControls({
                       ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
+                </div>
+              </div>
+            )}
+
+            {viewMode === "board" && grouping === "status" && (
+              <div className="border-b px-3 py-2.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t(($) => $.display.show_old_done)}
+                  </span>
+                  <Switch
+                    checked={boardShowOldDone}
+                    onCheckedChange={() => act.toggleBoardShowOldDone()}
+                  />
                 </div>
               </div>
             )}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -14,7 +14,7 @@ import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { WorkspaceAvatar } from "../../workspace/workspace-avatar";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
+import { issueAssigneeGroupsOptions, issueListOptions, boardIssueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -42,6 +42,7 @@ export function IssuesPage() {
   const includeNoProject = useIssueViewStore((s) => s.includeNoProject);
   const labelFilters = useIssueViewStore((s) => s.labelFilters);
   const agentRunningFilter = useIssueViewStore((s) => s.agentRunningFilter);
+  const boardShowOldDone = useIssueViewStore((s) => s.boardShowOldDone);
   const usesAssigneeBoard = viewMode === "board" && grouping === "assignee";
 
   // Derive the set of issue ids that currently have at least one
@@ -80,6 +81,10 @@ export function IssuesPage() {
     ...issueListOptions(wsId),
     enabled: !usesAssigneeBoard,
   });
+  const boardIssuesQuery = useQuery({
+    ...boardIssueListOptions(wsId, boardShowOldDone),
+    enabled: !usesAssigneeBoard && viewMode === "board",
+  });
   const assigneeGroupsQuery = useQuery({
     ...assigneeGroupsOptions,
     enabled: usesAssigneeBoard,
@@ -88,13 +93,19 @@ export function IssuesPage() {
     () => statusIssuesQuery.data ?? [],
     [statusIssuesQuery.data],
   );
+  const boardIssues = useMemo(
+    () => boardIssuesQuery.data ?? [],
+    [boardIssuesQuery.data],
+  );
   const assigneeIssues = useMemo(
     () => assigneeGroupsQuery.data?.groups.flatMap((group) => group.issues) ?? [],
     [assigneeGroupsQuery.data],
   );
   const loading = usesAssigneeBoard
     ? assigneeGroupsQuery.isLoading
-    : statusIssuesQuery.isLoading;
+    : viewMode === "board"
+      ? statusIssuesQuery.isLoading || boardIssuesQuery.isLoading
+      : statusIssuesQuery.isLoading;
 
   // Clear filter state when switching between workspaces (URL-driven).
   useClearFiltersOnWorkspaceChange(useIssueViewStore, wsId);
@@ -218,7 +229,7 @@ export function IssuesPage() {
           <div className="flex flex-col flex-1 min-h-0">
             {viewMode === "board" ? (
               <BoardView
-                issues={usesAssigneeBoard ? assigneeIssues : issues}
+                issues={usesAssigneeBoard ? assigneeIssues : boardIssues}
                 assigneeGroups={usesAssigneeBoard ? assigneeGroupsQuery.data?.groups : undefined}
                 assigneeGroupQueryKey={usesAssigneeBoard ? assigneeGroupsOptions.queryKey : undefined}
                 assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
@@ -226,6 +237,7 @@ export function IssuesPage() {
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                boardQueryKey={usesAssigneeBoard ? undefined : boardIssueListOptions(wsId).queryKey}
               />
             ) : (
               <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} />

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -53,6 +53,7 @@
   "display": {
     "tooltip": "Display settings",
     "grouping_section": "Grouping",
+    "show_old_done": "Show old done items",
     "ordering_section": "Ordering",
     "card_properties_section": "Card properties",
     "ascending_title": "Ascending",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -52,6 +52,7 @@
   "display": {
     "tooltip": "显示设置",
     "grouping_section": "分组",
+    "show_old_done": "显示旧的已完成事项",
     "ordering_section": "排序",
     "card_properties_section": "卡片属性",
     "ascending_title": "升序",

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -825,6 +825,19 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		statusFilter = pgtype.Text{String: s, Valid: true}
 	}
 
+	// updated_after hides terminal-status (done / cancelled) issues whose
+	// updated_at is older than the cutoff. Non-terminal statuses are
+	// unaffected so the board’s active columns remain complete.
+	var updatedAfter pgtype.Timestamptz
+	if ua := r.URL.Query().Get("updated_after"); ua != "" {
+		t, err := time.Parse(time.RFC3339, ua)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid updated_after format; expected RFC3339")
+			return
+		}
+		updatedAfter = pgtype.Timestamptz{Time: t, Valid: true}
+	}
+
 	// scheduled=true restricts the result to issues that have at least one of
 	// start_date / due_date set. Used by the Project Gantt view, which only
 	// renders schedulable rows and shouldn't pay for the full project list.
@@ -846,6 +859,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		InvolvesUserID: involvesUserFilter,
 		Scheduled:      scheduledFilter,
 		MetadataFilter: metadataFilter,
+		UpdatedAfter:   updatedAfter,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -864,6 +878,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		InvolvesUserID: involvesUserFilter,
 		Scheduled:      scheduledFilter,
 		MetadataFilter: metadataFilter,
+		UpdatedAfter:   updatedAfter,
 	})
 	if err != nil {
 		total = int64(len(issues))

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -105,6 +105,11 @@ WHERE i.workspace_id = $1
   AND ($8::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND ($9::jsonb IS NULL OR i.metadata @> $9::jsonb)
   AND (
+    $11::timestamptz IS NULL
+    OR i.status NOT IN ('done', 'cancelled')
+    OR i.updated_at > $11::timestamptz
+  )
+  AND (
     $10::uuid IS NULL
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (
           SELECT a.id FROM agent a
@@ -139,16 +144,17 @@ WHERE i.workspace_id = $1
 `
 
 type CountIssuesParams struct {
-	WorkspaceID    pgtype.UUID   `json:"workspace_id"`
-	Status         pgtype.Text   `json:"status"`
-	Priority       pgtype.Text   `json:"priority"`
-	AssigneeID     pgtype.UUID   `json:"assignee_id"`
-	AssigneeIds    []pgtype.UUID `json:"assignee_ids"`
-	CreatorID      pgtype.UUID   `json:"creator_id"`
-	ProjectID      pgtype.UUID   `json:"project_id"`
-	Scheduled      pgtype.Bool   `json:"scheduled"`
-	MetadataFilter []byte        `json:"metadata_filter"`
-	InvolvesUserID pgtype.UUID   `json:"involves_user_id"`
+	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
+	Status         pgtype.Text        `json:"status"`
+	Priority       pgtype.Text        `json:"priority"`
+	AssigneeID     pgtype.UUID        `json:"assignee_id"`
+	AssigneeIds    []pgtype.UUID      `json:"assignee_ids"`
+	CreatorID      pgtype.UUID        `json:"creator_id"`
+	ProjectID      pgtype.UUID        `json:"project_id"`
+	Scheduled      pgtype.Bool        `json:"scheduled"`
+	MetadataFilter []byte             `json:"metadata_filter"`
+	InvolvesUserID pgtype.UUID        `json:"involves_user_id"`
+	UpdatedAfter   pgtype.Timestamptz `json:"updated_after"`
 }
 
 // See ListIssues for the semantics of involves_user_id.
@@ -164,6 +170,7 @@ func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64
 		arg.Scheduled,
 		arg.MetadataFilter,
 		arg.InvolvesUserID,
+		arg.UpdatedAfter,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -688,6 +695,11 @@ WHERE i.workspace_id = $1
   AND ($10::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND ($11::jsonb IS NULL OR i.metadata @> $11::jsonb)
   AND (
+    $13::timestamptz IS NULL
+    OR i.status NOT IN ('done', 'cancelled')
+    OR i.updated_at > $13::timestamptz
+  )
+  AND (
     $12::uuid IS NULL
     -- (1) assignee is an agent owned by the user
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (
@@ -732,18 +744,19 @@ LIMIT $2 OFFSET $3
 `
 
 type ListIssuesParams struct {
-	WorkspaceID    pgtype.UUID   `json:"workspace_id"`
-	Limit          int32         `json:"limit"`
-	Offset         int32         `json:"offset"`
-	Status         pgtype.Text   `json:"status"`
-	Priority       pgtype.Text   `json:"priority"`
-	AssigneeID     pgtype.UUID   `json:"assignee_id"`
-	AssigneeIds    []pgtype.UUID `json:"assignee_ids"`
-	CreatorID      pgtype.UUID   `json:"creator_id"`
-	ProjectID      pgtype.UUID   `json:"project_id"`
-	Scheduled      pgtype.Bool   `json:"scheduled"`
-	MetadataFilter []byte        `json:"metadata_filter"`
-	InvolvesUserID pgtype.UUID   `json:"involves_user_id"`
+	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
+	Limit          int32              `json:"limit"`
+	Offset         int32              `json:"offset"`
+	Status         pgtype.Text        `json:"status"`
+	Priority       pgtype.Text        `json:"priority"`
+	AssigneeID     pgtype.UUID        `json:"assignee_id"`
+	AssigneeIds    []pgtype.UUID      `json:"assignee_ids"`
+	CreatorID      pgtype.UUID        `json:"creator_id"`
+	ProjectID      pgtype.UUID        `json:"project_id"`
+	Scheduled      pgtype.Bool        `json:"scheduled"`
+	MetadataFilter []byte             `json:"metadata_filter"`
+	InvolvesUserID pgtype.UUID        `json:"involves_user_id"`
+	UpdatedAfter   pgtype.Timestamptz `json:"updated_after"`
 }
 
 type ListIssuesRow struct {
@@ -788,6 +801,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 		arg.Scheduled,
 		arg.MetadataFilter,
 		arg.InvolvesUserID,
+		arg.UpdatedAfter,
 	)
 	if err != nil {
 		return nil, err

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -19,6 +19,11 @@ WHERE i.workspace_id = $1
   AND (sqlc.narg('scheduled')::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR i.metadata @> sqlc.narg('metadata_filter')::jsonb)
   AND (
+    sqlc.narg('updated_after')::timestamptz IS NULL
+    OR i.status NOT IN ('done', 'cancelled')
+    OR i.updated_at > sqlc.narg('updated_after')::timestamptz
+  )
+  AND (
     sqlc.narg('involves_user_id')::uuid IS NULL
     -- (1) assignee is an agent owned by the user
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (
@@ -200,6 +205,11 @@ WHERE i.workspace_id = $1
   AND (sqlc.narg('project_id')::uuid IS NULL OR i.project_id = sqlc.narg('project_id'))
   AND (sqlc.narg('scheduled')::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (sqlc.narg('metadata_filter')::jsonb IS NULL OR i.metadata @> sqlc.narg('metadata_filter')::jsonb)
+  AND (
+    sqlc.narg('updated_after')::timestamptz IS NULL
+    OR i.status NOT IN ('done', 'cancelled')
+    OR i.updated_at > sqlc.narg('updated_after')::timestamptz
+  )
   AND (
     sqlc.narg('involves_user_id')::uuid IS NULL
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (


### PR DESCRIPTION
Adds an \`updated_after\` query parameter to the issue list API that filters out terminal-status (done, cancelled) issues whose \`updated_at\` is older than the cutoff. Non-terminal statuses are unaffected.

On the frontend, the board view now uses a separate cache key that fetches with the 14-day cutoff applied to done/cancelled columns. A toggle in the board Display settings popover lets users opt into showing all old done items (default: hidden).

This keeps the Done column manageable without introducing new data semantics or breaking existing list/search/detail views.

Closes https://github.com/multica-ai/multica/issues/3246