### PR TITLE
feat(api): expose server version on /api/config (AOL-141)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -138,6 +138,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		TrustedProxies:           parseTrustedProxies(os.Getenv("MULTICA_TRUSTED_PROXIES")),
 		CloudRuntimeFleetURL:     cloudRuntimeFleetURLFromEnv(),
 		CloudRuntimeFleetTimeout: envDuration("MULTICA_CLOUD_FLEET_TIMEOUT", 35*time.Second),
+		Version:                  version,
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	if opts.DaemonWakeup != nil {

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -23,6 +23,13 @@ type AppConfig struct {
 	PosthogKey           string `json:"posthog_key"`
 	PosthogHost          string `json:"posthog_host"`
 	AnalyticsEnvironment string `json:"analytics_environment"`
+
+	// Version is the server build version (set via ldflags at release
+	// time). Surfaced unauthenticated so mobile/desktop clients can show
+	// which Multica release a server is running on their server list.
+	// Omitted when unset so older clients that don't know about the field
+	// — and self-hosted dev builds running `go run` — keep working.
+	Version string `json:"version,omitempty"`
 }
 
 // GetConfig is mounted on the public (unauthenticated) route group because
@@ -33,6 +40,7 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config := AppConfig{
 		AllowSignup:    os.Getenv("ALLOW_SIGNUP") != "false",
 		GoogleClientID: os.Getenv("GOOGLE_CLIENT_ID"),
+		Version:        h.cfg.Version,
 	}
 	if h.Storage != nil {
 		config.CdnDomain = h.Storage.CdnDomain()

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +48,39 @@ func TestGetConfigIncludesRuntimeAuthConfig(t *testing.T) {
 	}
 	if cfg.AnalyticsEnvironment != "dev" {
 		t.Fatalf("analytics_environment: want dev, got %q", cfg.AnalyticsEnvironment)
+	}
+}
+
+func TestGetConfigSurfacesVersionWhenSet(t *testing.T) {
+	origCfg := testHandler.cfg
+	testHandler.cfg.Version = "v9.9.9"
+	defer func() { testHandler.cfg = origCfg }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d", w.Code)
+	}
+	var cfg AppConfig
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.Version != "v9.9.9" {
+		t.Fatalf("version: want v9.9.9, got %q", cfg.Version)
+	}
+}
+
+func TestGetConfigOmitsEmptyVersion(t *testing.T) {
+	origCfg := testHandler.cfg
+	testHandler.cfg.Version = ""
+	defer func() { testHandler.cfg = origCfg }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+
+	if got := w.Body.String(); strings.Contains(got, `"version"`) {
+		t.Fatalf("expected version to be omitted when empty, body: %s", got)
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -73,6 +73,12 @@ type Config struct {
 	// return 503 instead of attempting to dial a hard-coded private service.
 	CloudRuntimeFleetURL     string
 	CloudRuntimeFleetTimeout time.Duration
+	// Version is the server build version surfaced on the public
+	// /api/config endpoint so clients (notably the iOS app) can display
+	// which Multica release a server is running. Empty when the binary
+	// was built without ldflags (e.g. `go run`); callers must treat the
+	// field as optional.
+	Version string
 }
 
 type cloudRuntimeProxy interface {


### PR DESCRIPTION
## Summary

- Surface the Multica server build version through the public `/api/config` endpoint so unauthenticated clients (iOS app, web, desktop) can show which release a server is running.
- Reuses the existing `main.version` package var that release builds already populate via `-ldflags "-X main.version=..."` — no new build wiring needed.
- Pairs with [alanhe421/multica-ios#69](https://github.com/alanhe421/multica-ios/pull/69), which already decodes `AppConfigResponse.version` and renders a `vX.Y.Z` badge next to each server in the iOS server list.

## Changes

- `server/internal/handler/handler.go` — add `Version string` to `Config`.
- `server/cmd/server/router.go` — pass `main.version` into the handler config.
- `server/internal/handler/config.go` — add `Version string \`json:"version,omitempty"\`` to `AppConfig` and populate it from `h.cfg.Version`. `omitempty` keeps responses byte-identical for dev builds and older clients that don't know the field.
- `server/internal/handler/config_test.go` — cover the new field in both the present and omitted cases.

Tracks issue [AOL-141](mention://issue/161c2358-c3d1-44c8-8377-b497b331a00f).

## Test plan

- [x] `make test` (Go) — `config_test.go` covers presence + omitempty.
- [ ] Manual: `curl http://localhost:8080/api/config` on a release build returns `"version":"vX.Y.Z"`; on `go run` it stays absent.
- [ ] iOS PR #69 picks the field up automatically once this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)