### PR TITLE
fix(server/child-done): require sibling dependency check before promoting backlog (MUL-2618)

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -84,7 +84,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	mentionPrefix := h.buildParentAssigneeMention(ctx, parent)
 
 	content := fmt.Sprintf(
-		"%sSub-issue [%s](mention://issue/%s) — \"%s\" — is done. Confirm whether to advance the next step on this parent (and promote any waiting `backlog` sub-issues).",
+		"%sSub-issue [%s](mention://issue/%s) — \"%s\" — is done. Before promoting any waiting `backlog` sub-issue, read each sibling's description and only promote items whose stated dependencies are already satisfied — do not rely on this parent's higher-level breakdown alone. If a sibling's description conflicts with that breakdown (e.g. it lists a prerequisite the parent treats as parallel), do NOT change its status — leave it `backlog` and post a comment to confirm first.",
 		mentionPrefix, identifier, childID, title,
 	)
 


### PR DESCRIPTION
## Summary

- Tighten the system comment posted on a parent when a child issue transitions to `done`. The previous wording ("promote any waiting `backlog` sub-issues") let a planner agent flip every backlog sibling to `todo` after the first child-done signal, even when a sibling's own description listed an unfinished prerequisite — see the regression on MUL-2618 where MUL-2664 (depends on MUL-2663) was promoted alongside MUL-2663 / MUL-2665.
- New wording requires the agent to read each backlog sibling's description, only promote items whose stated dependencies are already satisfied, and leave the status alone (commenting to confirm instead) when the parent's higher-level breakdown conflicts with what a sibling lists as a prerequisite.
- This is the short-term mitigation Bohan asked for in MUL-2618. A structured `blocked_by` edge is the long-term plan and is intentionally out of scope here.

No code-path, mention plumbing, or trigger semantics change — only the natural-language guidance the system comment embeds.

## Test plan

- [x] `go build ./internal/handler/`
- [x] `go vet ./internal/handler/`
- [x] `go test ./internal/handler/ -run TestChildDone -count=1` (full child-done suite passes; nothing pins the exact wording)