### PR TITLE
feat(agents): hide skills_local toggle for runtimes that don't honour it (MUL-2603)

### DIFF
--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -32,7 +32,7 @@ Workspace skills under `{workDir}/.claude/skills/` (and the equivalent workdir-s
 - **Claude Code** — when set to **Off**, `CLAUDE_CONFIG_DIR` points at a per-task scratch dir that mirrors the host's effective Claude config dir *except* for `skills/` (see above).
 - **Codex** — Codex always runs inside a per-task `CODEX_HOME`. When set to **On (default)** the daemon seeds that `CODEX_HOME` with user-installed skills from the shared `~/.codex/skills/`; when set to **Off** the seed step is skipped, so the Codex CLI sees only workspace skills.
 
-For every other runtime (Hermes / Kimi / Kiro / Copilot / Cursor / Gemini / Pi / OpenCode / OpenClaw) the daemon leaves the user's `$HOME` untouched and does not actively manage user-level skill discovery — whether that runtime reads any user-level skill directory is entirely up to its own CLI. **The toggle is a no-op for these runtimes today**, regardless of where it is set; a future change can extend per-runtime isolation as upstream CLIs ship the necessary knobs.
+For every other runtime (Hermes / Kimi / Kiro / Copilot / Cursor / Gemini / Pi / OpenCode / OpenClaw) the daemon leaves the user's `$HOME` untouched and does not actively manage user-level skill discovery — whether that runtime reads any user-level skill directory is entirely up to its own CLI. **The toggle is hidden in the Create Agent dialog and the Skills tab for these runtimes** to avoid implying behavior the daemon won't deliver today; a future change can extend per-runtime isolation as upstream CLIs ship the necessary knobs.
 
 ## Importing a skill
 

--- a/apps/docs/content/docs/skills.zh.mdx
+++ b/apps/docs/content/docs/skills.zh.mdx
@@ -32,7 +32,7 @@ Multica 支持两种 Skill 来源：
 - **Claude Code** —— 关闭时把 `CLAUDE_CONFIG_DIR` 指向按任务隔离的目录，里面镜像了主机有效的 Claude 配置目录中除 `skills/` 之外的内容（见上）。
 - **Codex** —— Codex 一向运行在按任务隔离的 `CODEX_HOME` 下。开启（默认）时守护进程会把共享的 `~/.codex/skills/` seed 到该目录；关闭时跳过这一步，Codex CLI 只能看到工作区 skill。
 
-对其它运行时（Hermes / Kimi / Kiro / Copilot / Cursor / Gemini / Pi / OpenCode / OpenClaw），守护进程既不改写用户的 `$HOME`，也不主动管理用户级 skill 发现——这些运行时是否读取任何用户级 skill 目录，完全由各自的 CLI 决定。**无论该开关如何设置，对这些运行时都是 no-op**；待上游 CLI 提供必要的隔离开关后，可以再补齐。
+对其它运行时（Hermes / Kimi / Kiro / Copilot / Cursor / Gemini / Pi / OpenCode / OpenClaw），守护进程既不改写用户的 `$HOME`，也不主动管理用户级 skill 发现——这些运行时是否读取任何用户级 skill 目录，完全由各自的 CLI 决定。**在创建 Agent 弹窗和 Skills 标签页里，这些运行时下不会展示该开关**，避免让用户误以为守护进程会替它们做隔离；待上游 CLI 提供必要的隔离开关后，可以再补齐。
 
 ## 导入 Skill
 

--- a/packages/core/agents/index.ts
+++ b/packages/core/agents/index.ts
@@ -7,3 +7,4 @@ export * from "./use-workspace-presence-prefetch";
 export * from "./constants";
 export * from "./visibility-label";
 export * from "./use-workspace-agent-availability";
+export * from "./skills-local-support";

--- a/packages/core/agents/skills-local-support.test.ts
+++ b/packages/core/agents/skills-local-support.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isSkillsLocalSupportedProvider } from "./skills-local-support";
+
+describe("isSkillsLocalSupportedProvider", () => {
+  it("returns true for the providers whose runtime honours skills_local", () => {
+    expect(isSkillsLocalSupportedProvider("claude")).toBe(true);
+    expect(isSkillsLocalSupportedProvider("codex")).toBe(true);
+  });
+
+  it("returns false for every other provider in the daemon catalog", () => {
+    // Snapshot of the providers daemon recognises today (MUL-2603 thread).
+    // None of them currently enforce skills_local at exec time, so the UI
+    // hides the toggle for all of them.
+    for (const p of [
+      "copilot",
+      "opencode",
+      "openclaw",
+      "pi",
+      "cursor",
+      "kimi",
+      "kiro",
+      "gemini",
+      "hermes",
+    ]) {
+      expect(isSkillsLocalSupportedProvider(p)).toBe(false);
+    }
+  });
+
+  it("returns false for missing / unknown provider values", () => {
+    expect(isSkillsLocalSupportedProvider(null)).toBe(false);
+    expect(isSkillsLocalSupportedProvider(undefined)).toBe(false);
+    expect(isSkillsLocalSupportedProvider("")).toBe(false);
+    expect(isSkillsLocalSupportedProvider("not-a-real-provider")).toBe(false);
+  });
+});

--- a/packages/core/agents/skills-local-support.ts
+++ b/packages/core/agents/skills-local-support.ts
@@ -1,0 +1,16 @@
+// Providers whose runtime actually honours the per-agent `skills_local`
+// toggle today. Claude isolates `~/.claude/skills` via `CLAUDE_CONFIG_DIR`;
+// Codex isolates `~/.codex/skills` via per-task `CODEX_HOME`. Every other
+// provider currently stores the field but treats it as a no-op at exec
+// time, so surfacing the toggle in their agent pages would mislead users
+// into thinking it gates host-skill access for them. See MUL-2603 discussion.
+export const SKILLS_LOCAL_SUPPORTED_PROVIDERS = ["claude", "codex"] as const;
+
+export function isSkillsLocalSupportedProvider(
+  provider: string | null | undefined,
+): boolean {
+  if (!provider) return false;
+  return (SKILLS_LOCAL_SUPPORTED_PROVIDERS as readonly string[]).includes(
+    provider,
+  );
+}

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -9,10 +9,11 @@ export type AgentVisibility = "workspace" | "private";
  * user-global skill directory into the agent. "merge" (default) preserves the
  * inherit-from-machine behavior; "ignore" isolates the runtime so a broken
  * local skill on one operator's machine cannot crash a shared agent (#3052).
- * Today only the Claude runtime honours the switch — others either already
- * isolate (Codex via CODEX_HOME) or treat it as a no-op. Older backends omit
- * the field; clients MUST treat undefined as "merge" so the documented
- * default wins on drift.
+ * Only the Claude and Codex runtimes honour the switch (Claude via
+ * CLAUDE_CONFIG_DIR, Codex via CODEX_HOME); the UI hides the toggle for
+ * other runtimes so users don't get a false sense of isolation. Older
+ * backends omit the field; clients MUST treat undefined as "merge" so the
+ * documented default wins on drift.
  */
 export type AgentSkillsLocal = "ignore" | "merge";
 

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -164,7 +164,7 @@ export function AgentOverviewPane({
         )}
         {activeTab === "skills" && (
           <TabContent>
-            <SkillsTab agent={agent} />
+            <SkillsTab agent={agent} runtime={runtime} />
           </TabContent>
         )}
         {activeTab === "env" && (

--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -261,6 +261,49 @@ describe("CreateAgentDialog runtime visibility gate", () => {
     expect(onCreate.mock.calls[0]?.[0].runtime_id).toBe("rt-mine");
   });
 
+  it("renders the skills_local toggle when the selected runtime is claude", () => {
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      provider: "claude",
+    });
+    renderDialog([mine]);
+
+    expect(
+      screen.getByRole("switch", { name: /Allow locally installed skills/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the skills_local toggle for runtimes that don't honour it", async () => {
+    // Other providers either already isolate (no need for the toggle) or
+    // currently ignore the field at exec time. Showing the toggle there
+    // would mislead users into thinking it gates host-skill access for
+    // their runtime. MUL-2603 follow-up.
+    const copilot = makeRuntime({
+      id: "rt-copilot",
+      name: "Copilot Runtime",
+      owner_id: ME,
+      provider: "copilot",
+    });
+    const { onCreate } = renderDialog([copilot]);
+
+    expect(
+      screen.queryByRole("switch", {
+        name: /Allow locally installed skills/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // The payload must never carry skills_local for unsupported runtimes.
+    fireEvent.change(screen.getByPlaceholderText(/Deep Research Agent/i), {
+      target: { value: "Test" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate.mock.calls[0]?.[0].skills_local).toBeUndefined();
+  });
+
   it("disables Create when the selected runtime is locked (template + no usable fallback)", () => {
     // Edge case: template points at a locked runtime AND the workspace
     // has no usable alternatives in scope. The defense-in-depth gate on

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -36,6 +36,7 @@ import {
   AGENT_DESCRIPTION_MAX_LENGTH,
   VISIBILITY_DESCRIPTION,
   VISIBILITY_LABEL,
+  isSkillsLocalSupportedProvider,
 } from "@multica/core/agents";
 import { CharCounter } from "./char-counter";
 import { useT } from "../../i18n";
@@ -126,6 +127,13 @@ export function CreateAgentDialog({
   const selectedRuntimeLocked =
     selectedRuntime != null &&
     !isRuntimeUsableForUser(selectedRuntime, currentUserId);
+  // The skills_local switch only has runtime support on claude / codex
+  // today — everywhere else the field would be stored but ignored at
+  // exec time, so the toggle is hidden to avoid implying behavior the
+  // backend won't deliver. See MUL-2603.
+  const skillsLocalApplies = isSkillsLocalSupportedProvider(
+    selectedRuntime?.provider,
+  );
 
   // Shared squad-join follow-up. Returns nothing — the caller has
   // already shown its create-success toast; we only need to surface a
@@ -171,11 +179,15 @@ export function CreateAgentDialog({
         model: model.trim() || undefined,
         instructions: trimmedInstructions || undefined,
         avatar_url: avatarUrl ?? undefined,
-        // Only send the toggle when the user opted into isolation.
+        // Only send the toggle when the user opted into isolation AND the
+        // selected runtime actually honours it (claude / codex today).
         // "merge" is the server-side default; omitting the field keeps the
         // request body small and prevents older backends without the
-        // column from rejecting the request.
-        skills_local: skillsLocal === "ignore" ? "ignore" : undefined,
+        // column from rejecting the request. Provider gating mirrors the
+        // toggle visibility — we never persist a value the runtime would
+        // ignore at exec time.
+        skills_local:
+          skillsLocalApplies && skillsLocal === "ignore" ? "ignore" : undefined,
       };
       if (template) {
         // Duplicate path: forward the hidden config fields the source
@@ -374,11 +386,13 @@ export function CreateAgentDialog({
               onChange={setSelectedSkillIds}
             />
 
-            <SkillsLocalToggle
-              value={skillsLocal}
-              onChange={setSkillsLocal}
-              hintScope="create"
-            />
+            {skillsLocalApplies && (
+              <SkillsLocalToggle
+                value={skillsLocal}
+                onChange={setSkillsLocal}
+                hintScope="create"
+              />
+            )}
           </div>
         </div>
 

--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import type { Agent } from "@multica/core/types";
+import type { Agent, AgentRuntime } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
@@ -57,7 +57,31 @@ const agent: Agent = {
   archived_by: null,
 };
 
-function renderSkillsTab(overrides: Partial<Agent> = {}) {
+function makeRuntime(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
+  return {
+    id: "runtime-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "Runtime",
+    runtime_mode: "local",
+    provider: "claude",
+    launch_header: "",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    visibility: "public",
+    last_seen_at: null,
+    created_at: "2026-04-16T00:00:00Z",
+    updated_at: "2026-04-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderSkillsTab(
+  overrides: Partial<Agent> = {},
+  runtime: AgentRuntime | null = makeRuntime(),
+) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -69,7 +93,7 @@ function renderSkillsTab(overrides: Partial<Agent> = {}) {
   return render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <QueryClientProvider client={queryClient}>
-        <SkillsTab agent={{ ...agent, ...overrides }} />
+        <SkillsTab agent={{ ...agent, ...overrides }} runtime={runtime} />
       </QueryClientProvider>
     </I18nProvider>,
   );
@@ -129,5 +153,46 @@ describe("SkillsTab", () => {
       name: /Allow locally installed skills/i,
     });
     expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("renders the toggle for Codex runtimes too", async () => {
+    renderSkillsTab({}, makeRuntime({ provider: "codex" }));
+
+    expect(
+      await screen.findByRole("switch", {
+        name: /Allow locally installed skills/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the toggle for runtimes that don't honour skills_local", async () => {
+    // Only Claude and Codex runtimes actually enforce skills_local at exec
+    // time today (MUL-2603); on every other provider the field would be
+    // stored but ignored, so the toggle is suppressed to avoid implying
+    // behaviour the runtime won't deliver.
+    renderSkillsTab({}, makeRuntime({ provider: "copilot" }));
+
+    // The rest of the tab still renders.
+    expect(
+      await screen.findByText(/Workspace skills assigned to this agent/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", {
+        name: /Allow locally installed skills/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the toggle when the runtime cannot be resolved", async () => {
+    renderSkillsTab({}, null);
+
+    expect(
+      await screen.findByText(/Workspace skills assigned to this agent/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", {
+        name: /Allow locally installed skills/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -4,8 +4,13 @@ import { useState } from "react";
 import { FileText, Plus, Trash2 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { Agent, AgentSkillsLocal } from "@multica/core/types";
+import type {
+  Agent,
+  AgentRuntime,
+  AgentSkillsLocal,
+} from "@multica/core/types";
 import { api } from "@multica/core/api";
+import { isSkillsLocalSupportedProvider } from "@multica/core/agents";
 import { useWorkspaceId } from "@multica/core/hooks";
 import {
   skillListOptions,
@@ -18,8 +23,17 @@ import { useT } from "../../../i18n";
 
 export function SkillsTab({
   agent,
+  runtime,
 }: {
   agent: Agent;
+  /**
+   * The runtime this agent is bound to, if known. Used to decide whether
+   * the host-skill merge toggle is meaningful for this agent — only Claude
+   * and Codex runtimes honour `skills_local` today (MUL-2603). When the
+   * runtime is missing (parent couldn't resolve it, e.g. it was deleted)
+   * the toggle is hidden — there is no usable provider context to gate on.
+   */
+  runtime?: AgentRuntime | null;
 }) {
   const { t } = useT("agents");
   const qc = useQueryClient();
@@ -30,6 +44,7 @@ export function SkillsTab({
   const currentSkillsLocal: AgentSkillsLocal =
     agent.skills_local === "ignore" ? "ignore" : "merge";
   const [skillsLocalSaving, setSkillsLocalSaving] = useState(false);
+  const skillsLocalApplies = isSkillsLocalSupportedProvider(runtime?.provider);
   // Same query the SkillAddDialog uses (TanStack Query dedupes by key, so
   // this isn't an extra request) — used here only to grey out the "Add
   // skill" button when the workspace has zero skills total. When skills
@@ -92,12 +107,14 @@ export function SkillsTab({
         </Button>
       </div>
 
-      <SkillsLocalToggle
-        value={currentSkillsLocal}
-        onChange={handleSkillsLocalChange}
-        disabled={skillsLocalSaving}
-        hintScope="tab"
-      />
+      {skillsLocalApplies && (
+        <SkillsLocalToggle
+          value={currentSkillsLocal}
+          onChange={handleSkillsLocalChange}
+          disabled={skillsLocalSaving}
+          hintScope="tab"
+        />
+      )}
 
 
       {agent.skills.length === 0 ? (

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -244,8 +244,8 @@
       "list_no_match": "No skills match.",
       "search_placeholder": "Search skills…",
       "local_label": "Allow locally installed skills",
-      "local_hint_off": "Off — for Claude Code and Codex, the agent ignores the host machine's user-global skill directory (~/.claude/skills/, ~/.codex/skills/). Recommended for shared agents — a broken local skill on one operator's machine cannot crash this agent. Other runtimes ignore this setting.",
-      "local_hint_on": "On (default) — for Claude Code and Codex, the host machine's user-global skill directory is merged alongside workspace skills. Other runtimes ignore this setting."
+      "local_hint_off": "Off — the agent ignores the host machine's user-global skill directory (~/.claude/skills/, ~/.codex/skills/). Recommended for shared agents — a broken local skill on one operator's machine cannot crash this agent. This control is shown only for Claude Code and Codex.",
+      "local_hint_on": "On (default) — the host machine's user-global skill directory is merged alongside workspace skills. This control is shown only for Claude Code and Codex."
     },
     "avatar": {
       "change_aria": "Change avatar",
@@ -301,8 +301,8 @@
       "intro": "Workspace skills assigned to this agent. Every runtime loads them.",
       "add_action": "Add skill",
       "local_label": "Allow locally installed skills",
-      "local_hint_off": "Off — for Claude Code and Codex, the agent ignores the host machine's user-global skill directory (~/.claude/skills/, ~/.codex/skills/). Recommended for shared agents — a broken local skill on one operator's machine cannot crash this agent. Other runtimes ignore this setting.",
-      "local_hint_on": "On (default) — for Claude Code and Codex, the host machine's user-global skill directory is merged alongside workspace skills. Other runtimes ignore this setting.",
+      "local_hint_off": "Off — the agent ignores the host machine's user-global skill directory (~/.claude/skills/, ~/.codex/skills/). Recommended for shared agents — a broken local skill on one operator's machine cannot crash this agent. This control is shown only for Claude Code and Codex.",
+      "local_hint_on": "On (default) — the host machine's user-global skill directory is merged alongside workspace skills. This control is shown only for Claude Code and Codex.",
       "local_saved_toast": "Skill merge setting saved",
       "local_save_failed_toast": "Failed to save skill merge setting",
       "empty_title": "No skills assigned",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -239,8 +239,8 @@
       "list_no_match": "没有匹配的 skill。",
       "search_placeholder": "搜索 skill…",
       "local_label": "允许使用本机已安装的 Skill",
-      "local_hint_off": "关闭 —— 对 Claude Code 与 Codex，智能体会忽略本机用户级 skill 目录（~/.claude/skills/、~/.codex/skills/）。推荐用于共享智能体 —— 团队成员机器上有问题的本机 skill 不会拖崩这个智能体。其它运行时会忽略此设置。",
-      "local_hint_on": "开启（默认）—— 对 Claude Code 与 Codex，运行时会同时合并本机用户级 skill 目录。其它运行时会忽略此设置。"
+      "local_hint_off": "关闭 —— 智能体会忽略本机用户级 skill 目录（~/.claude/skills/、~/.codex/skills/）。推荐用于共享智能体 —— 团队成员机器上有问题的本机 skill 不会拖崩这个智能体。该开关仅对 Claude Code 与 Codex 显示。",
+      "local_hint_on": "开启（默认）—— 运行时会同时合并本机用户级 skill 目录。该开关仅对 Claude Code 与 Codex 显示。"
     },
     "avatar": {
       "change_aria": "更换头像",
@@ -295,8 +295,8 @@
       "intro": "分配给该智能体的工作区 skill。所有运行时都会加载。",
       "add_action": "添加 skill",
       "local_label": "允许使用本机已安装的 Skill",
-      "local_hint_off": "关闭 —— 对 Claude Code 与 Codex，智能体会忽略本机用户级 skill 目录（~/.claude/skills/、~/.codex/skills/）。推荐用于共享智能体 —— 团队成员机器上有问题的本机 skill 不会拖崩这个智能体。其它运行时会忽略此设置。",
-      "local_hint_on": "开启（默认）—— 对 Claude Code 与 Codex，运行时会同时合并本机用户级 skill 目录。其它运行时会忽略此设置。",
+      "local_hint_off": "关闭 —— 智能体会忽略本机用户级 skill 目录（~/.claude/skills/、~/.codex/skills/）。推荐用于共享智能体 —— 团队成员机器上有问题的本机 skill 不会拖崩这个智能体。该开关仅对 Claude Code 与 Codex 显示。",
+      "local_hint_on": "开启（默认）—— 运行时会同时合并本机用户级 skill 目录。该开关仅对 Claude Code 与 Codex 显示。",
       "local_saved_toast": "已保存 Skill 合并设置",
       "local_save_failed_toast": "保存 Skill 合并设置失败",
       "empty_title": "尚未分配 skill",


### PR DESCRIPTION
## Summary

Follow-up to MUL-2603: only Claude Code and Codex runtimes actually enforce `skills_local` at exec time (Claude via `CLAUDE_CONFIG_DIR` isolation, Codex via per-task `CODEX_HOME`). Every other runtime stores the field but ignores it, which made the toggle in the Create Agent dialog and the Skills tab misleading on those agents.

This PR hides the toggle anywhere the selected runtime is not in the supported set.

## Changes

- **New helper** `isSkillsLocalSupportedProvider()` in `packages/core/agents/` — single source of truth for the supported provider list (`claude`, `codex`). Unit-tested against the daemon's known provider catalogue.
- **`CreateAgentDialog`** — gates `<SkillsLocalToggle>` on the currently selected runtime's provider. Also drops `skills_local` from the create payload when the selected runtime is unsupported, so a runtime swap can't pin a stale `ignore` that the runtime would never honour.
- **`SkillsTab`** — accepts the resolved `runtime` as a prop and hides the toggle when the provider is unsupported (or the runtime can't be resolved). `agent-overview-pane` already had the resolved runtime; it now passes it through.
- **Docs (EN + ZH)** — updated to say the toggle is hidden for unsupported runtimes instead of "a no-op".

## Test plan
- [x] `pnpm --filter @multica/core exec vitest run agents/skills-local-support.test.ts` — unit tests for the helper (claude/codex pass, other providers fail, null/undefined fail).
- [x] `pnpm --filter @multica/views exec vitest run agents/components/tabs/skills-tab.test.tsx` — covers: toggle visible for claude, visible for codex, hidden for copilot, hidden when runtime missing.
- [x] `pnpm --filter @multica/views exec vitest run agents/components/create-agent-dialog.test.tsx` — covers: toggle visible for claude runtime, hidden for copilot runtime, and `skills_local` is omitted from the create payload when unsupported.
- [x] `pnpm --filter @multica/core exec tsc --noEmit` and `pnpm --filter @multica/views exec tsc --noEmit` — clean.
- [x] `eslint` on every touched file — clean.

MUL-2603