### PR TITLE
feat(cli): add roots-only issue comment listing (MUL-2805)

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -313,6 +313,7 @@ func init() {
 	issueCommentListCmd.Flags().String("thread", "", "Comment UUID — return the thread containing this comment (root + every descendant). May be a root or a reply id.")
 	issueCommentListCmd.Flags().Int("tail", 0, "Only valid with --thread. Cap reply count to the N most recent replies; the thread root is always included (even with --tail 0). Use --before/--before-id to scroll to older replies.")
 	issueCommentListCmd.Flags().Int("recent", 0, "Return the N most recently active threads (root + descendants per thread). Use --before/--before-id from the previous response to scroll to older threads.")
+	issueCommentListCmd.Flags().Bool("roots-only", false, "Only return top-level comments (parent_id is null)")
 	issueCommentListCmd.Flags().String("before", "", "Cursor (RFC3339Nano timestamp). With --recent: thread cursor (last_activity_at). With --thread + --tail: reply cursor (reply created_at). Read from the X-Multica-Next-Before response header; must be paired with --before-id.")
 	issueCommentListCmd.Flags().String("before-id", "", "Cursor UUID. With --recent: thread root UUID. With --thread + --tail: oldest reply UUID. Read from the X-Multica-Next-Before-Id response header; must be paired with --before.")
 
@@ -938,6 +939,7 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 	thread, _ := cmd.Flags().GetString("thread")
 	recent, _ := cmd.Flags().GetInt("recent")
 	tail, _ := cmd.Flags().GetInt("tail")
+	rootsOnly, _ := cmd.Flags().GetBool("roots-only")
 	// Flags().Changed distinguishes "user did not pass --recent" from
 	// "user explicitly passed --recent 0" (or a negative value). The
 	// GetInt zero-value collapses both cases, which would otherwise
@@ -962,6 +964,18 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 	if thread != "" && recentSet {
 		return fmt.Errorf("--thread and --recent are mutually exclusive")
 	}
+	if rootsOnly && thread != "" {
+		return fmt.Errorf("--roots-only and --thread are mutually exclusive")
+	}
+	if rootsOnly && recentSet {
+		return fmt.Errorf("--roots-only and --recent are mutually exclusive")
+	}
+	if rootsOnly && tailSet {
+		return fmt.Errorf("--roots-only and --tail are mutually exclusive")
+	}
+	if rootsOnly && before != "" {
+		return fmt.Errorf("--roots-only does not support --before / --before-id")
+	}
 	if tailSet && thread == "" {
 		return fmt.Errorf("--tail requires --thread (it is a thread-scoped limit)")
 	}
@@ -975,6 +989,9 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 	params := url.Values{}
 	if since != "" {
 		params.Set("since", since)
+	}
+	if rootsOnly {
+		params.Set("roots_only", "true")
 	}
 	if thread != "" {
 		params.Set("thread", thread)

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -1552,6 +1552,7 @@ func newIssueCommentListTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "list"}
 	cmd.Flags().String("output", "json", "")
 	cmd.Flags().String("since", "", "")
+	cmd.Flags().Bool("roots-only", false, "")
 	cmd.Flags().String("thread", "", "")
 	cmd.Flags().Int("recent", 0, "")
 	cmd.Flags().Int("tail", 0, "")
@@ -1561,7 +1562,7 @@ func newIssueCommentListTestCmd() *cobra.Command {
 }
 
 // TestRunIssueCommentListFlagGuards locks the CLI-side flag combination
-// matrix. Two behaviours matter here:
+// matrix. Three behaviours matter here:
 //
 //   - --recent 0 / --recent -3 must error rather than silently fall back to
 //     the default list path. Previously `recent > 0` collapsed "not passed"
@@ -1571,8 +1572,10 @@ func newIssueCommentListTestCmd() *cobra.Command {
 //   - --before / --before-id without --recent must error. Before this fix
 //     the cursor would be sent to the server but ignored because RecentN=0,
 //     so callers asking for "comments before X" got the full timeline.
+//   - --roots-only is mutually exclusive with the thread/recent/pagination
+//     modes; it may only combine with --since.
 //
-// All four cases must fail before any HTTP round-trip — verified by an
+// These cases must fail before any HTTP round-trip — verified by an
 // httptest server that fatals if /api/issues/<key>/comments is hit.
 func TestRunIssueCommentListFlagGuards(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1662,6 +1665,39 @@ func TestRunIssueCommentListFlagGuards(t *testing.T) {
 			},
 			wantMsg: "require --recent",
 		},
+		{
+			name: "roots-only + thread rejected",
+			setup: func(c *cobra.Command) {
+				_ = c.Flags().Set("roots-only", "true")
+				_ = c.Flags().Set("thread", "00000000-0000-0000-0000-000000000001")
+			},
+			wantMsg: "--roots-only and --thread are mutually exclusive",
+		},
+		{
+			name: "roots-only + recent rejected",
+			setup: func(c *cobra.Command) {
+				_ = c.Flags().Set("roots-only", "true")
+				_ = c.Flags().Set("recent", "3")
+			},
+			wantMsg: "--roots-only and --recent are mutually exclusive",
+		},
+		{
+			name: "roots-only + tail rejected",
+			setup: func(c *cobra.Command) {
+				_ = c.Flags().Set("roots-only", "true")
+				_ = c.Flags().Set("tail", "3")
+			},
+			wantMsg: "--roots-only and --tail are mutually exclusive",
+		},
+		{
+			name: "roots-only + before rejected",
+			setup: func(c *cobra.Command) {
+				_ = c.Flags().Set("roots-only", "true")
+				_ = c.Flags().Set("before", "2026-01-01T00:00:00Z")
+				_ = c.Flags().Set("before-id", "00000000-0000-0000-0000-000000000001")
+			},
+			wantMsg: "--roots-only does not support --before / --before-id",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1675,6 +1711,52 @@ func TestRunIssueCommentListFlagGuards(t *testing.T) {
 				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantMsg)
 			}
 		})
+	}
+}
+
+// TestRunIssueCommentList_RootsOnlyPassesThroughWithSince pins the CLI side
+// of #3164: the flag must be forwarded as the server's roots_only query param,
+// and it must still allow the existing --since incremental polling filter.
+func TestRunIssueCommentList_RootsOnlyPassesThroughWithSince(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/issues/") && !strings.Contains(r.URL.Path, "/comments") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         "issue-1",
+				"identifier": "MUL-1",
+			})
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments") {
+			gotQuery = r.URL.Query()
+			w.Write([]byte("[]"))
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueCommentListTestCmd()
+	if err := cmd.Flags().Set("roots-only", "true"); err != nil {
+		t.Fatalf("set roots-only: %v", err)
+	}
+	if err := cmd.Flags().Set("since", "2026-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("set since: %v", err)
+	}
+	if err := runIssueCommentList(cmd, []string{"MUL-1"}); err != nil {
+		t.Fatalf("runIssueCommentList: %v", err)
+	}
+
+	if got := gotQuery.Get("roots_only"); got != "true" {
+		t.Errorf("roots_only query = %q, want true", got)
+	}
+	if got := gotQuery.Get("since"); got != "2026-01-01T00:00:00Z" {
+		t.Errorf("since query = %q, want timestamp", got)
 	}
 }
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -69,30 +69,39 @@ const commentHardCap = 2000
 
 // ListComments returns comments for an issue. The default behaviour is
 // unchanged — full chronological dump capped at commentHardCap — so existing
-// callers and the desktop UI keep working as-is. Four optional query params
-// give agent-style readers a thread-aware view that scales to long issues
-// without dragging every prior comment into context:
+// callers and the desktop UI keep working as-is. Optional query params give
+// agent-style readers bounded views that scale to long issues without dragging
+// every prior reply into context:
+//
+//   - roots_only=true — return only top-level comments (parent_id IS NULL).
+//     May combine with since for incremental polling of newly created roots,
+//     but is exclusive with thread/recent/tail/cursor modes because those
+//     have their own grouping or pagination semantics.
 //
 //   - thread=<comment-uuid> — return the root of the thread containing this
 //     comment plus every descendant. The anchor may be a root or any reply;
 //     the server walks up to the root via a recursive CTE, so callers do not
 //     need to know whether the id they have is a root.
+//
 //   - tail=<N> — only valid with thread. Cap the reply count at the N most
 //     recent replies (per (created_at, id)). The thread root is always
 //     returned, even when N=0, so the reader keeps the "what is this thread
 //     about" context. Without tail, thread returns the entire thread (the
 //     pre-MUL-2421 behavior).
+//
 //   - recent=<N> — return the N most recently active threads (root + every
 //     descendant per thread). A thread's recency is MAX(created_at) across
 //     the whole subtree, so a stale-but-recently-replied thread ranks ahead
 //     of an active-but-quiet one. Row-based "newest N comments" is
 //     deliberately NOT exposed — it surfaces unrelated thread tails and
 //     hides relevant history (#2340).
+//
 //   - before=<RFC3339> + before-id=<uuid> — cursor. The pair's meaning is
 //     context-dependent so the flag surface stays small:
 //
 //   - with recent: a *thread* cursor — (last_activity_at, root_id) — and
 //     the next page returns threads strictly less recent.
+//
 //   - with thread + tail: a *reply* cursor — (created_at, id) — and the
 //     next page returns replies in the same thread strictly older than
 //     that reply.
@@ -104,6 +113,9 @@ const commentHardCap = 2000
 //
 // Combination rules (kept narrow on purpose — Elon flagged the matrix risk):
 //
+//   - roots_only is exclusive with thread, recent, tail, and before/before-id.
+//     It may combine with since. This keeps "list issue roots" separate from
+//     "read a specific thread" and "read recently active threads".
 //   - thread is exclusive with recent. Asking for "the most recent N within
 //     thread X" mixes two different navigation models and is rejected.
 //   - thread + before/before-id requires tail. Without tail, thread returns
@@ -153,7 +165,41 @@ func (h *Handler) ListComments(w http.ResponseWriter, r *http.Request) {
 		beforeIDStr = q.Get("before-id")
 	}
 
+	rootsOnlyStr := q.Get("roots_only")
+	if rootsOnlyStr == "" {
+		// Accept hyphenated alias to match CLI flag convention.
+		rootsOnlyStr = q.Get("roots-only")
+	}
+
+	rootsOnly := false
+	if rootsOnlyStr != "" {
+		switch rootsOnlyStr {
+		case "true":
+			rootsOnly = true
+		case "false":
+		default:
+			writeError(w, http.StatusBadRequest, "invalid roots_only parameter; expected boolean")
+			return
+		}
+	}
+
 	// --- combination validation ----------------------------------------
+	if rootsOnly && threadStr != "" {
+		writeError(w, http.StatusBadRequest, "roots_only and thread are mutually exclusive")
+		return
+	}
+	if rootsOnly && recentStr != "" {
+		writeError(w, http.StatusBadRequest, "roots_only and recent are mutually exclusive")
+		return
+	}
+	if rootsOnly && tailStr != "" {
+		writeError(w, http.StatusBadRequest, "roots_only and tail are mutually exclusive")
+		return
+	}
+	if rootsOnly && (beforeTimeStr != "" || beforeIDStr != "") {
+		writeError(w, http.StatusBadRequest, "roots_only does not support before / before_id")
+		return
+	}
 	if threadStr != "" && recentStr != "" {
 		writeError(w, http.StatusBadRequest, "thread and recent are mutually exclusive")
 		return
@@ -241,6 +287,7 @@ func (h *Handler) ListComments(w http.ResponseWriter, r *http.Request) {
 		HasCursor:     hasCursor,
 		BeforeAt:      beforeCursor,
 		BeforeID:      beforeUUID,
+		RootsOnly:     rootsOnly,
 	})
 	if err != nil {
 		switch err {
@@ -295,6 +342,7 @@ func (h *Handler) ListComments(w http.ResponseWriter, r *http.Request) {
 type fetchCommentsArgs struct {
 	Issue         db.Issue
 	Since         pgtype.Timestamptz
+	RootsOnly     bool
 	ThreadAnchor  string
 	ThreadTail    int
 	ThreadTailSet bool
@@ -560,6 +608,29 @@ func (h *Handler) fetchCommentsForList(ctx context.Context, args fetchCommentsAr
 			out.NextBeforeID = uuidToString(headRoot)
 		}
 		return out, nil
+	}
+
+	if args.RootsOnly {
+		// Root-only read for issue-level orientation. This intentionally
+		// stays separate from thread/recent modes: callers get the global
+		// top-level discussion first, then fetch a specific thread only when
+		// they need reply context.
+		if args.Since.Valid {
+			comments, err := h.Queries.ListRootCommentsSinceForIssue(ctx, db.ListRootCommentsSinceForIssueParams{
+				IssueID:     issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+				CreatedAt:   args.Since,
+				Limit:       commentHardCap,
+			})
+			return fetchCommentsResult{Comments: comments}, err
+		}
+
+		comments, err := h.Queries.ListRootCommentsForIssue(ctx, db.ListRootCommentsForIssueParams{
+			IssueID:     issue.ID,
+			WorkspaceID: issue.WorkspaceID,
+			Limit:       commentHardCap,
+		})
+		return fetchCommentsResult{Comments: comments}, err
 	}
 
 	// Default + since paths preserved verbatim (no behavioural change for

--- a/server/internal/handler/comment_list_test.go
+++ b/server/internal/handler/comment_list_test.go
@@ -172,6 +172,59 @@ func TestListComments_DefaultPreservesChronologicalOrder(t *testing.T) {
 	eqIDs(t, ids(rows), want, "default order")
 }
 
+// TestListComments_RootsOnlyReturnsTopLevelComments pins the #3164 contract:
+// issue-level orientation should fetch only root comments, leaving replies for
+// a later thread-scoped read if the caller needs detail.
+func TestListComments_RootsOnlyReturnsTopLevelComments(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	fx := newCommentListFixture(t)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "underscore query", query: "roots_only=true"},
+		{name: "hyphenated alias", query: "roots-only=true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w, rows := listComments(t, fx.IssueID, tc.query)
+			eqIDs(t, ids(rows), []string{fx.Root1, fx.Root2}, tc.name)
+			for _, row := range rows {
+				if row.ParentID != nil {
+					t.Fatalf("%s: expected root comment %s to have nil parent_id, got %q", tc.name, row.ID, *row.ParentID)
+				}
+			}
+			nb, nbid := nextThreadCursor(w)
+			if nb != "" || nbid != "" {
+				t.Fatalf("%s: roots-only list should not emit cursor headers, got before=%q before_id=%q", tc.name, nb, nbid)
+			}
+		})
+	}
+}
+
+// TestListComments_RootsOnlyWithSinceReturnsNewTopLevelComments proves the
+// one allowed roots-only combination: `since` narrows the root list without
+// pulling newer replies into the response.
+func TestListComments_RootsOnlyWithSinceReturnsNewTopLevelComments(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	fx := newCommentListFixture(t)
+
+	v := url.Values{}
+	v.Set("roots_only", "true")
+	v.Set("since", fx.Base.Add(5*time.Minute).UTC().Format(time.RFC3339Nano))
+	_, rows := listComments(t, fx.IssueID, v.Encode())
+	eqIDs(t, ids(rows), []string{fx.Root2}, "roots_only + since")
+	for _, row := range rows {
+		if row.ParentID != nil {
+			t.Fatalf("roots_only + since: expected root comment %s to have nil parent_id, got %q", row.ID, *row.ParentID)
+		}
+	}
+}
+
 // TestListComments_ThreadResolvesFromAnyAnchor proves Elon's point 2:
 // regardless of whether the anchor is a root, a direct reply, or a nested
 // reply (parent_id points at another reply), the server walks up to the
@@ -546,6 +599,37 @@ func TestListComments_FlagCombinationRules(t *testing.T) {
 		{
 			name:   "non-numeric recent rejected",
 			query:  "recent=lots",
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "non-boolean roots_only rejected",
+			query:  "roots_only=yes",
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "roots_only + thread rejected",
+			query:  "roots_only=true&thread=" + fx.Root1,
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "roots_only + recent rejected",
+			query:  "roots_only=true&recent=1",
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "roots_only + tail rejected",
+			query:  "roots_only=true&tail=1",
+			status: http.StatusBadRequest,
+		},
+		{
+			name: "roots_only + cursor rejected",
+			query: (func() string {
+				v := url.Values{}
+				v.Set("roots_only", "true")
+				v.Set("before", time.Now().UTC().Format(time.RFC3339))
+				v.Set("before_id", uuid.NewString())
+				return v.Encode()
+			})(),
 			status: http.StatusBadRequest,
 		},
 	}

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -433,6 +433,111 @@ func (q *Queries) ListRecentThreadCommentsForIssue(ctx context.Context, arg List
 	return items, nil
 }
 
+const listRootCommentsForIssue = `-- name: ListRootCommentsForIssue :many
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
+WHERE issue_id = $1 AND workspace_id = $2 AND parent_id IS NULL
+ORDER BY created_at ASC, id ASC
+LIMIT $3
+`
+
+type ListRootCommentsForIssueParams struct {
+	IssueID     pgtype.UUID `json:"issue_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Limit       int32       `json:"limit"`
+}
+
+// Top-level comments only, in issue chronological order. This powers
+// `comment list --roots-only` so agents can orient around the global issue
+// discussion before fetching any specific reply thread.
+func (q *Queries) ListRootCommentsForIssue(ctx context.Context, arg ListRootCommentsForIssueParams) ([]Comment, error) {
+	rows, err := q.db.Query(ctx, listRootCommentsForIssue, arg.IssueID, arg.WorkspaceID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Comment{}
+	for rows.Next() {
+		var i Comment
+		if err := rows.Scan(
+			&i.ID,
+			&i.IssueID,
+			&i.AuthorType,
+			&i.AuthorID,
+			&i.Content,
+			&i.Type,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ParentID,
+			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRootCommentsSinceForIssue = `-- name: ListRootCommentsSinceForIssue :many
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
+WHERE issue_id = $1 AND workspace_id = $2 AND parent_id IS NULL AND created_at > $3
+ORDER BY created_at ASC, id ASC
+LIMIT $4
+`
+
+type ListRootCommentsSinceForIssueParams struct {
+	IssueID     pgtype.UUID        `json:"issue_id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	Limit       int32              `json:"limit"`
+}
+
+// Top-level comments created strictly after $3. Same semantics as
+// ListCommentsSinceForIssue, narrowed to thread roots.
+func (q *Queries) ListRootCommentsSinceForIssue(ctx context.Context, arg ListRootCommentsSinceForIssueParams) ([]Comment, error) {
+	rows, err := q.db.Query(ctx, listRootCommentsSinceForIssue,
+		arg.IssueID,
+		arg.WorkspaceID,
+		arg.CreatedAt,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Comment{}
+	for rows.Next() {
+		var i Comment
+		if err := rows.Scan(
+			&i.ID,
+			&i.IssueID,
+			&i.AuthorType,
+			&i.AuthorID,
+			&i.Content,
+			&i.Type,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ParentID,
+			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listThreadCommentsForIssue = `-- name: ListThreadCommentsForIssue :many
 WITH RECURSIVE root_of AS (
     -- Walk up from the anchor until parent_id IS NULL.

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -15,6 +15,23 @@ WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC, id ASC
 LIMIT $4;
 
+-- name: ListRootCommentsForIssue :many
+-- Top-level comments only, in issue chronological order. This powers
+-- `comment list --roots-only` so agents can orient around the global issue
+-- discussion before fetching any specific reply thread.
+SELECT * FROM comment
+WHERE issue_id = $1 AND workspace_id = $2 AND parent_id IS NULL
+ORDER BY created_at ASC, id ASC
+LIMIT $3;
+
+-- name: ListRootCommentsSinceForIssue :many
+-- Top-level comments created strictly after $3. Same semantics as
+-- ListCommentsSinceForIssue, narrowed to thread roots.
+SELECT * FROM comment
+WHERE issue_id = $1 AND workspace_id = $2 AND parent_id IS NULL AND created_at > $3
+ORDER BY created_at ASC, id ASC
+LIMIT $4;
+
 -- name: ListThreadCommentsForIssue :many
 -- Returns the root of the thread containing @anchor_id plus every descendant
 -- (recursive — defends against any future deeper nesting; today's data is two


### PR DESCRIPTION
## What does this PR do?

Adds a `--roots-only` flag to `multica issue comment list` so agents can quickly scan top-level discussion threads without fetching every reply.

Currently, `comment list` returns all comments, including roots and replies. On long-running issues, this wastes context on nested conversation details before the agent understands the overall discussion structure. `--roots-only` filters to comments where `parent_id IS NULL`, so agents can orient around an issue's discussion first, then drill into specific threads with `--thread` as needed.

## Related

Closes #3164

## Type of Change

- New feature, non-breaking

## Changes Made

### SQL

- `server/pkg/db/queries/comment.sql` adds `ListRootCommentsForIssue` and `ListRootCommentsSinceForIssue`
- `server/pkg/db/generated/comment.sql.go` regenerated with sqlc

### Handler

- `server/internal/handler/comment.go` parses the `roots_only` query param
- Accepts both `roots_only` and `roots-only`
- Allows `roots_only` with `since`
- Rejects `roots_only` with `thread`, `recent`, `tail`, and cursor params
- Routes root-only reads to the new SQL queries

### CLI

- `server/cmd/multica/cmd_issue.go` adds `--roots-only`
- Adds client-side mutual exclusion guards
- Forwards `roots_only=true` to the server

### Tests

- `server/internal/handler/comment_list_test.go` covers root-only behavior, `roots_only + since`, and invalid flag combinations
- `server/cmd/multica/cmd_issue_test.go` covers CLI guards and query forwarding

## How to Test

```bash
multica issue comment list MUL-123 --roots-only
multica issue comment list MUL-123 --roots-only --since 2026-01-01T00:00:00Z
multica issue comment list MUL-123 --roots-only --thread <uuid>
The last command should return a mutual exclusion error.
```

### Verification
go test ./internal/handler -run 'TestListComments'
go test ./cmd/multica -run 'TestRunIssueCommentList'
go test ./pkg/db/generated

### Checklist
I have run tests locally and they pass
I have added or updated tests where applicable

### AI Disclosure
AI tool used: Codex
Prompt / approach: Assisted with tracing the SQL, handler, and CLI flow, then adding focused tests for the new root-only comment listing behavior.