### PR TITLE
feat(chat): UX overhaul — bug fixes + fullscreen mode + status indicators

### DIFF
--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -14,6 +14,7 @@ export const DRAFT_NEW_SESSION = "__new__";
 const CHAT_WIDTH_KEY = "multica:chat:width";
 const CHAT_HEIGHT_KEY = "multica:chat:height";
 const CHAT_EXPANDED_KEY = "multica:chat:expanded";
+const CHAT_FULLSCREEN_KEY = "multica:chat:fullscreen";
 /** Focus mode is a personal preference — global across workspaces/sessions. */
 const FOCUS_MODE_KEY = "multica:chat:focusMode";
 /**
@@ -99,6 +100,7 @@ export interface ChatState {
   chatWidth: number;
   chatHeight: number;
   isExpanded: boolean;
+  isFullscreen: boolean;
   setOpen: (open: boolean) => void;
   toggle: () => void;
   setActiveSession: (id: string | null) => void;
@@ -110,6 +112,7 @@ export interface ChatState {
   /** Persist raw size and auto-exit expanded mode. */
   setChatSize: (width: number, height: number) => void;
   setExpanded: (expanded: boolean) => void;
+  setFullscreen: (fullscreen: boolean) => void;
 }
 
 export interface ChatStoreOptions {
@@ -139,6 +142,7 @@ export function createChatStore(options: ChatStoreOptions) {
     chatWidth: Number(storage.getItem(CHAT_WIDTH_KEY)) || CHAT_DEFAULT_W,
     chatHeight: Number(storage.getItem(CHAT_HEIGHT_KEY)) || CHAT_DEFAULT_H,
     isExpanded: storage.getItem(wsKey(CHAT_EXPANDED_KEY)) === "true",
+    isFullscreen: storage.getItem(wsKey(CHAT_FULLSCREEN_KEY)) === "true",
     setOpen: (open) => {
       logger.debug("setOpen", { from: get().isOpen, to: open });
       storage.setItem(OPEN_KEY, String(open));
@@ -206,12 +210,22 @@ export function createChatStore(options: ChatStoreOptions) {
       }
       set({ isExpanded: expanded });
     },
+    setFullscreen: (fullscreen) => {
+      logger.info("setFullscreen", { to: fullscreen });
+      if (fullscreen) {
+        storage.setItem(wsKey(CHAT_FULLSCREEN_KEY), "true");
+      } else {
+        storage.removeItem(wsKey(CHAT_FULLSCREEN_KEY));
+      }
+      set({ isFullscreen: fullscreen });
+    },
   }));
 
   registerForWorkspaceRehydration(() => {
     const nextSession = storage.getItem(wsKey(SESSION_STORAGE_KEY));
     const nextAgent = storage.getItem(wsKey(AGENT_STORAGE_KEY));
     const nextDrafts = readDrafts(storage, wsKey(DRAFTS_KEY));
+    const nextFullscreen = storage.getItem(wsKey(CHAT_FULLSCREEN_KEY)) === "true";
     logger.info("workspace rehydration", {
       prevSession: store.getState().activeSessionId,
       nextSession,
@@ -223,6 +237,7 @@ export function createChatStore(options: ChatStoreOptions) {
       activeSessionId: nextSession,
       selectedAgentId: nextAgent,
       inputDrafts: nextDrafts,
+      isFullscreen: nextFullscreen,
     });
   });
 

--- a/packages/views/chat/components/chat-fullscreen.tsx
+++ b/packages/views/chat/components/chat-fullscreen.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import type { CSSProperties } from "react";
 import { Minimize2, Plus } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
@@ -130,114 +131,124 @@ export function ChatFullscreen({
 
   return (
     <>
-      <div className="fixed inset-0 z-50 flex bg-sidebar">
-        {/* Left sidebar — session list */}
-        <div className="flex w-64 shrink-0 flex-col border-r">
-          <div className="flex items-center justify-between border-b px-3 py-2.5">
-            <span className="text-sm font-medium text-muted-foreground">
-              {t(($) => $.window.active_group)}
-            </span>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="rounded-full text-muted-foreground"
-                    onClick={onNewChat}
-                  />
-                }
-              >
-                <Plus />
-              </TooltipTrigger>
-              <TooltipContent side="right">
+      <div className="fixed inset-0 z-50 flex flex-col bg-sidebar">
+        {/* Drag region for Electron — browsers ignore WebkitAppRegion */}
+        <div
+          aria-hidden
+          className="h-12 shrink-0"
+          style={{ WebkitAppRegion: "drag" } as CSSProperties}
+        />
+
+        <div className="flex flex-1 min-h-0">
+          {/* Left sidebar — session list */}
+          <div className="flex w-64 shrink-0 flex-col">
+            <div className="flex items-center justify-between px-3 pb-2">
+              <span className="text-[13px] font-medium text-foreground">
                 {t(($) => $.window.new_chat_tooltip)}
-              </TooltipContent>
-            </Tooltip>
+              </span>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="size-7 rounded-md text-muted-foreground hover:text-foreground"
+                      onClick={onNewChat}
+                      style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
+                    />
+                  }
+                >
+                  <Plus className="size-4" />
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  {t(($) => $.window.new_chat_tooltip)}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <div className="flex-1 overflow-y-auto px-2 space-y-0.5">
+              {[...active, ...archived].map((session) => (
+                <SessionListItem
+                  key={session.id}
+                  session={session}
+                  agent={agentById.get(session.agent_id) ?? null}
+                  isCurrent={session.id === activeSessionId}
+                  isRunning={inFlightSessionIds.has(session.id)}
+                  isRenaming={renamingId === session.id}
+                  formatTimeAgo={formatTimeAgo}
+                  onSelect={() => onSelectSession(session)}
+                  onStartRename={() => setRenamingId(session.id)}
+                  onSubmitRename={(value) => handleSubmitRename(session.id, value)}
+                  onCancelRename={() => setRenamingId(null)}
+                  onDelete={() => setPendingDelete(session)}
+                />
+              ))}
+            </div>
           </div>
-          <div className="flex-1 overflow-y-auto p-1.5 space-y-0.5">
-            {[...active, ...archived].map((session) => (
-              <SessionListItem
-                key={session.id}
-                session={session}
-                agent={agentById.get(session.agent_id) ?? null}
-                isCurrent={session.id === activeSessionId}
-                isRunning={inFlightSessionIds.has(session.id)}
-                isRenaming={renamingId === session.id}
-                formatTimeAgo={formatTimeAgo}
-                onSelect={() => onSelectSession(session)}
-                onStartRename={() => setRenamingId(session.id)}
-                onSubmitRename={(value) => handleSubmitRename(session.id, value)}
-                onCancelRename={() => setRenamingId(null)}
-                onDelete={() => setPendingDelete(session)}
+
+          {/* Right content area */}
+          <div className="flex flex-1 flex-col min-w-0 bg-background rounded-tl-xl">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-2.5">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-[13px] font-medium truncate">{sessionTitle}</span>
+              </div>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground"
+                      onClick={() => setFullscreen(false)}
+                    />
+                  }
+                >
+                  <Minimize2 />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {t(($) => $.window.restore_tooltip)}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+
+            {/* Messages */}
+            {showSkeleton ? (
+              <ChatMessageSkeleton />
+            ) : hasMessages ? (
+              <ChatMessageList
+                messages={messages}
+                pendingTask={pendingTask}
+                availability={availability}
               />
-            ))}
-          </div>
-        </div>
+            ) : (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="text-sm text-muted-foreground">
+                  {t(($) => $.empty_state.returning_subtitle)}
+                </p>
+              </div>
+            )}
 
-        {/* Right content area */}
-        <div className="flex flex-1 flex-col min-w-0">
-          {/* Header */}
-          <div className="flex items-center justify-between border-b px-4 py-2.5">
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="text-sm font-medium truncate">{sessionTitle}</span>
-            </div>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="text-muted-foreground"
-                    onClick={() => setFullscreen(false)}
-                  />
-                }
-              >
-                <Minimize2 />
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {t(($) => $.window.restore_tooltip)}
-              </TooltipContent>
-            </Tooltip>
-          </div>
+            {/* Banners */}
+            {noAgent ? (
+              <NoAgentBanner />
+            ) : (
+              <OfflineBanner agentName={activeAgent?.name} availability={availability} />
+            )}
 
-          {/* Messages */}
-          {showSkeleton ? (
-            <ChatMessageSkeleton />
-          ) : hasMessages ? (
-            <ChatMessageList
-              messages={messages}
-              pendingTask={pendingTask}
-              availability={availability}
+            {/* Input */}
+            <ChatInput
+              onSend={onSend}
+              onUploadFile={onUploadFile}
+              onStop={onStop}
+              isRunning={!!pendingTaskId}
+              disabled={isSessionArchived}
+              noAgent={noAgent}
+              agentName={activeAgent?.name}
+              topSlot={<ContextAnchorCard />}
+              leftAdornment={agentDropdown}
+              rightAdornment={contextAnchorButton}
             />
-          ) : (
-            <div className="flex flex-1 items-center justify-center">
-              <p className="text-sm text-muted-foreground">
-                {t(($) => $.empty_state.returning_subtitle)}
-              </p>
-            </div>
-          )}
-
-          {/* Banners */}
-          {noAgent ? (
-            <NoAgentBanner />
-          ) : (
-            <OfflineBanner agentName={activeAgent?.name} availability={availability} />
-          )}
-
-          {/* Input */}
-          <ChatInput
-            onSend={onSend}
-            onUploadFile={onUploadFile}
-            onStop={onStop}
-            isRunning={!!pendingTaskId}
-            disabled={isSessionArchived}
-            noAgent={noAgent}
-            agentName={activeAgent?.name}
-            topSlot={<ContextAnchorCard />}
-            leftAdornment={agentDropdown}
-            rightAdornment={contextAnchorButton}
-          />
+          </div>
         </div>
       </div>
 

--- a/packages/views/chat/components/chat-fullscreen.tsx
+++ b/packages/views/chat/components/chat-fullscreen.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Minimize2, Plus } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@multica/ui/components/ui/alert-dialog";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useChatStore } from "@multica/core/chat";
+import { pendingChatTasksOptions } from "@multica/core/chat/queries";
+import {
+  useDeleteChatSession,
+  useUpdateChatSession,
+} from "@multica/core/chat/mutations";
+import { SessionListItem } from "./session-list-item";
+import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
+import { ChatInput } from "./chat-input";
+import { ContextAnchorCard } from "./context-anchor";
+import { OfflineBanner } from "./offline-banner";
+import { NoAgentBanner } from "./no-agent-banner";
+import { useT } from "../../i18n";
+import type { Agent, ChatMessage, ChatPendingTask, ChatSession } from "@multica/core/types";
+import type { AgentAvailability } from "@multica/core/agents";
+import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+
+interface ChatFullscreenProps {
+  sessions: ChatSession[];
+  agents: Agent[];
+  activeSessionId: string | null;
+  activeAgent: Agent | null;
+  messages: ChatMessage[];
+  messagesLoading: boolean;
+  pendingTask: ChatPendingTask | null | undefined;
+  pendingTaskId: string | null;
+  availability: AgentAvailability | undefined;
+  noAgent: boolean;
+  isSessionArchived: boolean;
+  onSend: (content: string, attachmentIds?: string[]) => void;
+  onUploadFile: (file: File) => Promise<UploadResult | null>;
+  onStop: () => void;
+  onSelectSession: (session: ChatSession) => void;
+  onNewChat: () => void;
+  agentDropdown: ReactNode;
+  contextAnchorButton: ReactNode;
+}
+
+export function ChatFullscreen({
+  sessions,
+  agents,
+  activeSessionId,
+  activeAgent,
+  messages,
+  messagesLoading,
+  pendingTask,
+  pendingTaskId,
+  availability,
+  noAgent,
+  isSessionArchived,
+  onSend,
+  onUploadFile,
+  onStop,
+  onSelectSession,
+  onNewChat,
+  agentDropdown,
+  contextAnchorButton,
+}: ChatFullscreenProps) {
+  const { t } = useT("chat");
+  const wsId = useWorkspaceId();
+  const setFullscreen = useChatStore((s) => s.setFullscreen);
+
+  const agentById = useMemo(() => new Map(agents.map((a) => [a.id, a])), [agents]);
+  const { data: pending } = useQuery(pendingChatTasksOptions(wsId));
+  const inFlightSessionIds = useMemo(
+    () => new Set((pending?.tasks ?? []).map((t) => t.chat_session_id)),
+    [pending],
+  );
+
+  const deleteSession = useDeleteChatSession();
+  const updateSession = useUpdateChatSession();
+  const setActiveSession = useChatStore((s) => s.setActiveSession);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<ChatSession | null>(null);
+  const formatTimeAgo = useFormatTimeAgo();
+
+  const { active, archived } = useMemo(() => {
+    const active: ChatSession[] = [];
+    const archived: ChatSession[] = [];
+    for (const s of sessions) {
+      if (s.status === "archived") archived.push(s);
+      else active.push(s);
+    }
+    return { active, archived };
+  }, [sessions]);
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete) return;
+    const sessionId = pendingDelete.id;
+    if (activeSessionId === sessionId) setActiveSession(null);
+    deleteSession.mutate(sessionId, {
+      onSettled: () => setPendingDelete(null),
+    });
+  };
+
+  const handleSubmitRename = (sessionId: string, raw: string) => {
+    const trimmed = raw.trim();
+    const current = sessions.find((s) => s.id === sessionId);
+    setRenamingId(null);
+    if (!trimmed || trimmed === current?.title) return;
+    updateSession.mutate({ sessionId, title: trimmed });
+  };
+
+  const showSkeleton = !!activeSessionId && messagesLoading;
+  const hasMessages = messages.length > 0 || !!pendingTaskId;
+
+  const currentSession = activeSessionId
+    ? sessions.find((s) => s.id === activeSessionId)
+    : null;
+  const sessionTitle = currentSession?.title?.trim() || t(($) => $.window.untitled);
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 flex bg-sidebar">
+        {/* Left sidebar — session list */}
+        <div className="flex w-64 shrink-0 flex-col border-r">
+          <div className="flex items-center justify-between border-b px-3 py-2.5">
+            <span className="text-sm font-medium text-muted-foreground">
+              {t(($) => $.window.active_group)}
+            </span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="rounded-full text-muted-foreground"
+                    onClick={onNewChat}
+                  />
+                }
+              >
+                <Plus />
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                {t(($) => $.window.new_chat_tooltip)}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <div className="flex-1 overflow-y-auto p-1.5 space-y-0.5">
+            {[...active, ...archived].map((session) => (
+              <SessionListItem
+                key={session.id}
+                session={session}
+                agent={agentById.get(session.agent_id) ?? null}
+                isCurrent={session.id === activeSessionId}
+                isRunning={inFlightSessionIds.has(session.id)}
+                isRenaming={renamingId === session.id}
+                formatTimeAgo={formatTimeAgo}
+                onSelect={() => onSelectSession(session)}
+                onStartRename={() => setRenamingId(session.id)}
+                onSubmitRename={(value) => handleSubmitRename(session.id, value)}
+                onCancelRename={() => setRenamingId(null)}
+                onDelete={() => setPendingDelete(session)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Right content area */}
+        <div className="flex flex-1 flex-col min-w-0">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b px-4 py-2.5">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-sm font-medium truncate">{sessionTitle}</span>
+            </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={() => setFullscreen(false)}
+                  />
+                }
+              >
+                <Minimize2 />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {t(($) => $.window.restore_tooltip)}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          {/* Messages */}
+          {showSkeleton ? (
+            <ChatMessageSkeleton />
+          ) : hasMessages ? (
+            <ChatMessageList
+              messages={messages}
+              pendingTask={pendingTask}
+              availability={availability}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center">
+              <p className="text-sm text-muted-foreground">
+                {t(($) => $.empty_state.returning_subtitle)}
+              </p>
+            </div>
+          )}
+
+          {/* Banners */}
+          {noAgent ? (
+            <NoAgentBanner />
+          ) : (
+            <OfflineBanner agentName={activeAgent?.name} availability={availability} />
+          )}
+
+          {/* Input */}
+          <ChatInput
+            onSend={onSend}
+            onUploadFile={onUploadFile}
+            onStop={onStop}
+            isRunning={!!pendingTaskId}
+            disabled={isSessionArchived}
+            noAgent={noAgent}
+            agentName={activeAgent?.name}
+            topSlot={<ContextAnchorCard />}
+            leftAdornment={agentDropdown}
+            rightAdornment={contextAnchorButton}
+          />
+        </div>
+      </div>
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={!!pendingDelete}
+        onOpenChange={(open) => {
+          if (!open && !deleteSession.isPending) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t(($) => $.session_history.delete_dialog.title)}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete?.title
+                ? t(($) => $.session_history.delete_dialog.description_with_title, {
+                    title: pendingDelete.title,
+                  })
+                : t(($) => $.session_history.delete_dialog.description_default)}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteSession.isPending}>
+              {t(($) => $.session_history.delete_dialog.cancel)}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleteSession.isPending}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              {deleteSession.isPending
+                ? t(($) => $.session_history.delete_dialog.confirming)
+                : t(($) => $.session_history.delete_dialog.confirm)}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function useFormatTimeAgo(): (dateStr: string) => string {
+  const { t } = useT("chat");
+  return (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return t(($) => $.session_history.time.just_now);
+    if (diffMins < 60) return t(($) => $.session_history.time.minutes, { count: diffMins });
+    if (diffHours < 24) return t(($) => $.session_history.time.hours, { count: diffHours });
+    if (diffDays < 7) return t(($) => $.session_history.time.days, { count: diffDays });
+    return date.toLocaleDateString();
+  };
+}

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -83,30 +83,28 @@ export function ChatMessageList({
       style={fadeStyle}
       className="flex-1 overflow-y-auto"
     >
-      {/* Inner container matches issue / project detail width convention
-       *  (max-w-4xl + mx-auto) so switching between chat and content
-       *  views doesn't jolt the reading width. px-5 is a touch tighter
-       *  than issue-detail's px-8 because the chat window can be narrow. */}
-      <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-4">
-        {messages.map((msg) => (
-          <MessageBubble
-            key={msg.id}
-            message={msg}
-            isPending={!!pendingTaskId && msg.task_id === pendingTaskId}
-          />
-        ))}
-        {hasLive && (
-          <div className="w-full space-y-1.5">
-            <TimelineView items={liveTimeline} isStreaming />
-          </div>
-        )}
-        {showStatusPill && pendingTask && (
-          <TaskStatusPill
-            pendingTask={pendingTask}
-            taskMessages={liveTaskMessages ?? []}
-            availability={availability}
-          />
-        )}
+      <div className="flex min-h-full flex-col justify-end">
+        <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-4">
+          {messages.map((msg) => (
+            <MessageBubble
+              key={msg.id}
+              message={msg}
+              isPending={!!pendingTaskId && msg.task_id === pendingTaskId}
+            />
+          ))}
+          {hasLive && (
+            <div className="w-full space-y-1.5">
+              <TimelineView items={liveTimeline} isStreaming />
+            </div>
+          )}
+          {showStatusPill && pendingTask && (
+            <TaskStatusPill
+              pendingTask={pendingTask}
+              taskMessages={liveTaskMessages ?? []}
+              availability={availability}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { motion } from "motion/react";
-import { Minus, Maximize2, Minimize2, ChevronDown, ChevronRight, Plus, Check, Trash2, Pencil } from "lucide-react";
+import { Minus, Maximize2, ChevronDown, ChevronRight, Plus, Check, Trash2, Pencil } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import {
@@ -50,6 +50,7 @@ import {
   useUpdateChatSession,
 } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
+import { ChatFullscreen } from "./chat-fullscreen";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import {
@@ -76,6 +77,8 @@ export function ChatWindow() {
   const setOpen = useChatStore((s) => s.setOpen);
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const setSelectedAgentId = useChatStore((s) => s.setSelectedAgentId);
+  const isFullscreen = useChatStore((s) => s.isFullscreen);
+  const setFullscreen = useChatStore((s) => s.setFullscreen);
   const user = useAuthStore((s) => s.user);
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: members = [] } = useQuery(memberListOptions(wsId));
@@ -435,13 +438,45 @@ export function ChatWindow() {
   const isExpanded = useChatStore((s) => s.isExpanded);
 
   const windowRef = useRef<HTMLDivElement>(null);
-  const { renderWidth, renderHeight, isAtMax, boundsReady, isDragging, toggleExpand, startDrag } = useChatResize(windowRef);
+  const { renderWidth, renderHeight, boundsReady, isDragging, startDrag } = useChatResize(windowRef);
 
   // Show the list (vs empty state) as soon as there's anything to display —
   // a real message, or a pending task whose timeline will stream in.
   const hasMessages = messages.length > 0 || !!pendingTaskId;
 
   const isVisible = isOpen && (isExpanded || boundsReady);
+
+  if (isOpen && isFullscreen) {
+    return (
+      <ChatFullscreen
+        sessions={sessions}
+        agents={agents}
+        activeSessionId={activeSessionId}
+        activeAgent={activeAgent}
+        messages={messages}
+        messagesLoading={messagesLoading}
+        pendingTask={pendingTask}
+        pendingTaskId={pendingTaskId}
+        availability={availability}
+        noAgent={noAgent}
+        isSessionArchived={isSessionArchived}
+        onSend={handleSend}
+        onUploadFile={handleUploadFile}
+        onStop={handleStop}
+        onSelectSession={handleSelectSession}
+        onNewChat={handleNewChat}
+        agentDropdown={
+          <AgentDropdown
+            agents={availableAgents}
+            activeAgent={activeAgent}
+            userId={user?.id}
+            onSelect={handleSelectAgent}
+          />
+        }
+        contextAnchorButton={<ContextAnchorButton />}
+      />
+    );
+  }
 
   const containerClass = "absolute bottom-2 right-2 z-50 flex flex-col rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
   const containerStyle: React.CSSProperties = {
@@ -504,14 +539,14 @@ export function ChatWindow() {
                   variant="ghost"
                   size="icon-sm"
                   className="text-muted-foreground"
-                  onClick={toggleExpand}
+                  onClick={() => setFullscreen(true)}
                 />
               }
             >
-              {isExpanded || isAtMax ? <Minimize2 /> : <Maximize2 />}
+              <Maximize2 />
             </TooltipTrigger>
             <TooltipContent side="top">
-              {isExpanded || isAtMax ? t(($) => $.window.restore_tooltip) : t(($) => $.window.expand_tooltip)}
+              {t(($) => $.window.expand_tooltip)}
             </TooltipContent>
           </Tooltip>
           <Tooltip>

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -32,6 +32,7 @@ import { canAssignAgent } from "@multica/views/issues/components";
 import { api } from "@multica/core/api";
 import { useAgentPresenceDetail, useWorkspaceAgentAvailability } from "@multica/core/agents";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
+import { UnicodeSpinner } from "@multica/ui/components/common/unicode-spinner";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { OfflineBanner } from "./offline-banner";
 import { NoAgentBanner } from "./no-agent-banner";
@@ -850,14 +851,18 @@ function SessionDropdown({
           <span
             aria-label={t(($) => $.window.running)}
             title={t(($) => $.window.running)}
-            className="size-1.5 shrink-0 rounded-full bg-amber-500 animate-pulse"
-          />
+            className="shrink-0"
+          >
+            <UnicodeSpinner name="breathe" className="text-muted-foreground text-sm" />
+          </span>
         ) : !isRenaming && session.has_unread ? (
           <span
             aria-label={t(($) => $.window.unread)}
             title={t(($) => $.window.unread)}
-            className="size-1.5 shrink-0 rounded-full bg-brand"
-          />
+            className="shrink-0"
+          >
+            <Check className="size-3.5 text-brand" />
+          </span>
         ) : null}
         {!isRenaming && isCurrent && (
           <Check className="size-3.5 text-muted-foreground shrink-0" />
@@ -885,6 +890,7 @@ function SessionDropdown({
             </button>
             <button
               type="button"
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();
@@ -919,14 +925,18 @@ function SessionDropdown({
             <span
               aria-label={t(($) => $.window.another_running)}
               title={t(($) => $.window.another_running)}
-              className="size-1.5 shrink-0 rounded-full bg-amber-500 animate-pulse"
-            />
+              className="shrink-0"
+            >
+              <UnicodeSpinner name="breathe" className="text-muted-foreground text-sm" />
+            </span>
           ) : otherSessionUnread ? (
             <span
               aria-label={t(($) => $.window.another_unread)}
               title={t(($) => $.window.another_unread)}
-              className="size-1.5 shrink-0 rounded-full bg-brand"
-            />
+              className="shrink-0"
+            >
+              <Check className="size-3.5 text-brand" />
+            </span>
           ) : null}
           <ChevronDown className="size-3 text-muted-foreground shrink-0" />
         </DropdownMenuTrigger>

--- a/packages/views/chat/components/session-list-item.tsx
+++ b/packages/views/chat/components/session-list-item.tsx
@@ -51,7 +51,7 @@ export function SessionListItem({
         if (e.key === "Enter" && !isRenaming) onSelect();
       }}
       className={cn(
-        "group flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm cursor-default transition-colors",
+        "group flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 cursor-default transition-colors",
         isCurrent ? "bg-accent" : "hover:bg-accent/50",
         className,
       )}
@@ -76,10 +76,10 @@ export function SessionListItem({
           />
         ) : (
           <>
-            <div className="truncate text-sm">
+            <div className="truncate text-[13px]">
               {session.title?.trim() || t(($) => $.window.untitled)}
             </div>
-            <div className="truncate text-xs text-muted-foreground/70">
+            <div className="truncate text-xs text-muted-foreground/60">
               {formatTimeAgo(session.updated_at)}
             </div>
           </>
@@ -171,7 +171,7 @@ function SessionRenameInlineInput({
         }
       }}
       onBlur={() => onSubmit(value)}
-      className="w-full rounded-sm bg-background px-1 py-0.5 text-sm outline-none ring-1 ring-border focus-visible:ring-brand"
+      className="w-full rounded-md bg-background px-1.5 py-0.5 text-[13px] outline-none ring-1 ring-border/50 focus-visible:ring-brand"
     />
   );
 }

--- a/packages/views/chat/components/session-list-item.tsx
+++ b/packages/views/chat/components/session-list-item.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Pencil, Trash2 } from "lucide-react";
+import { cn } from "@multica/ui/lib/utils";
+import { UnicodeSpinner } from "@multica/ui/components/common/unicode-spinner";
+import { ActorAvatar } from "../../common/actor-avatar";
+import { useT } from "../../i18n";
+import type { Agent, ChatSession } from "@multica/core/types";
+
+interface SessionListItemProps {
+  session: ChatSession;
+  agent: Agent | null;
+  isCurrent: boolean;
+  isRunning: boolean;
+  isRenaming: boolean;
+  formatTimeAgo: (dateStr: string) => string;
+  onSelect: () => void;
+  onStartRename: () => void;
+  onSubmitRename: (value: string) => void;
+  onCancelRename: () => void;
+  onDelete: () => void;
+  className?: string;
+}
+
+export function SessionListItem({
+  session,
+  agent,
+  isCurrent,
+  isRunning,
+  isRenaming,
+  formatTimeAgo,
+  onSelect,
+  onStartRename,
+  onSubmitRename,
+  onCancelRename,
+  onDelete,
+  className,
+}: SessionListItemProps) {
+  const { t } = useT("chat");
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        if (isRenaming) return;
+        onSelect();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && !isRenaming) onSelect();
+      }}
+      className={cn(
+        "group flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm cursor-default transition-colors",
+        isCurrent ? "bg-accent" : "hover:bg-accent/50",
+        className,
+      )}
+    >
+      {agent ? (
+        <ActorAvatar
+          actorType="agent"
+          actorId={agent.id}
+          size={24}
+          enableHoverCard
+          showStatusDot
+        />
+      ) : (
+        <span className="size-6 shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        {isRenaming ? (
+          <SessionRenameInlineInput
+            initialValue={session.title ?? ""}
+            onSubmit={onSubmitRename}
+            onCancel={onCancelRename}
+          />
+        ) : (
+          <>
+            <div className="truncate text-sm">
+              {session.title?.trim() || t(($) => $.window.untitled)}
+            </div>
+            <div className="truncate text-xs text-muted-foreground/70">
+              {formatTimeAgo(session.updated_at)}
+            </div>
+          </>
+        )}
+      </div>
+      {!isRenaming && isRunning ? (
+        <span
+          aria-label={t(($) => $.window.running)}
+          title={t(($) => $.window.running)}
+          className="shrink-0"
+        >
+          <UnicodeSpinner name="breathe" className="text-muted-foreground text-sm" />
+        </span>
+      ) : !isRenaming && session.has_unread ? (
+        <span
+          aria-label={t(($) => $.window.unread)}
+          title={t(($) => $.window.unread)}
+          className="shrink-0"
+        >
+          <Check className="size-3.5 text-brand" />
+        </span>
+      ) : null}
+      {!isRenaming && isCurrent && !session.has_unread && !isRunning && (
+        <Check className="size-3.5 text-muted-foreground shrink-0" />
+      )}
+      {!isRenaming && (
+        <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onStartRename();
+            }}
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label={t(($) => $.session_history.row_rename_aria)}
+            title={t(($) => $.session_history.row_rename_aria)}
+          >
+            <Pencil className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            aria-label={t(($) => $.session_history.row_delete_aria)}
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionRenameInlineInput({
+  initialValue,
+  onSubmit,
+  onCancel,
+}: {
+  initialValue: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useT("chat");
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <input
+      ref={(el) => {
+        el?.focus();
+        el?.select();
+      }}
+      type="text"
+      value={value}
+      maxLength={200}
+      aria-label={t(($) => $.session_history.row_rename_aria)}
+      onChange={(e) => setValue(e.target.value)}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onSubmit(value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={() => onSubmit(value)}
+      className="w-full rounded-sm bg-background px-1 py-0.5 text-sm outline-none ring-1 ring-border focus-visible:ring-brand"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **Fix delete button closing dropdown** — add `onPointerDown` stopPropagation to the delete button, matching the rename button pattern (Base UI closes on pointerdown, not click)
- **Upgrade session status indicators** — replace 6px colored dots with `UnicodeSpinner` (breathe) for running sessions and brand-colored `Check` icon for unread/done
- **Add `isFullscreen` state to chat store** — workspace-scoped, persisted to storage, separate from `isExpanded`
- **Extract `SessionListItem` component** — standalone session row for reuse in dropdown and fullscreen sidebar
- **Build fullscreen layout** — fixed overlay with left sidebar (session list) and right content area (messages + input); expand button now enters fullscreen
- **Vertically align messages near input** — wrap message container in `flex justify-end` so messages stay near input when list is short

## Test plan

- [ ] Open chat → click delete button on a session row → dropdown should stay open, delete dialog appears
- [ ] Running session shows braille spinner instead of amber dot in both row and dropdown trigger
- [ ] Unread session shows brand check icon instead of brand dot
- [ ] Click expand (Maximize2) button → enters fullscreen with sidebar + content layout
- [ ] Click Minimize2 in fullscreen header → exits back to floating window
- [ ] Fullscreen sidebar shows all sessions, clicking switches session
- [ ] Inline rename works in fullscreen sidebar (blur commits)
- [ ] Delete session from fullscreen sidebar works
- [ ] New chat (⊕) in fullscreen sidebar works
- [ ] Few messages in chat → content sits near input, not at top
- [ ] Many messages → normal scroll, no layout breakage
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (825/825)

🤖 Generated with [Claude Code](https://claude.com/claude-code)