### PR TITLE
MUL-2690 fix(deps): pin @xmldom/xmldom to ^0.8.13 via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     ],
     "overrides": {
       "@types/react": "catalog:",
-      "@types/react-dom": "catalog:"
+      "@types/react-dom": "catalog:",
+      "@xmldom/xmldom": "^0.8.13"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,7 @@ catalogs:
 overrides:
   '@types/react': ^19.2.0
   '@types/react-dom': ^19.2.0
+  '@xmldom/xmldom': ^0.8.13
 
 importers:
 
@@ -419,7 +420,7 @@ importers:
         version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+        version: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
@@ -4693,8 +4694,8 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   abbrev@3.0.1:
@@ -11828,7 +11829,7 @@ snapshots:
       ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -11904,7 +11905,7 @@ snapshots:
       ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(sz7ge56yy7giy7pypish4aerfa)
+      expo-router: 55.0.14(8e96a26c61ba5d82f3cb5fb823dc6716)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12134,7 +12135,7 @@ snapshots:
 
   '@expo/plist@0.5.3':
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -12175,7 +12176,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -12190,7 +12191,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.3(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(sz7ge56yy7giy7pypish4aerfa)
+      expo-router: 55.0.14(8e96a26c61ba5d82f3cb5fb823dc6716)
       react-dom: 19.2.3(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -15146,7 +15147,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@3.0.1: {}
 
@@ -17285,7 +17286,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.14(fb4q2ydjsib3h2ixce2lptexem):
+  expo-router@55.0.14(28857138dad78e037ca803b5df54c4f8):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -17333,7 +17334,7 @@ snapshots:
       - expo-font
       - supports-color
 
-  expo-router@55.0.14(sz7ge56yy7giy7pypish4aerfa):
+  expo-router@55.0.14(8e96a26c61ba5d82f3cb5fb823dc6716):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.3(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -20369,7 +20370,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary

Close MUL-2690. Pin `@xmldom/xmldom` to `^0.8.13` via `pnpm.overrides` so every transitive resolution under `expo` ships a patched build. All four lockfile entries move from `0.8.12` → `0.8.13`. No new direct dependencies are added — the multica codebase does not import xmldom itself.

## Why this approach (vs. PR #3191)

PR #3191 (closing it in favor of this PR) added `@xmldom/xmldom` as a root direct dependency. That:

1. Did **not** actually patch every path — `pnpm-lock.yaml` still resolved `plist@3.1.0 → @xmldom/xmldom: 0.8.12`, so `pnpm audit` continued to flag the same four advisories.
2. Misled future maintainers into thinking the repo consumes xmldom directly (it does not).

Using `pnpm.overrides` is the canonical pnpm way to enforce a transitive version across the graph. It guarantees a single resolution and leaves the root `dependencies` block clean.

## Advisories closed

All four CVE/GHSA entries against `@xmldom/xmldom <0.8.13`:

- [GHSA-2v35-w6hq-6mfw](https://github.com/advisories/GHSA-2v35-w6hq-6mfw) — uncontrolled recursion in serialization (DoS)
- [GHSA-f6ww-3ggp-fr8h](https://github.com/advisories/GHSA-f6ww-3ggp-fr8h) — XML injection via DocumentType serialization
- [GHSA-x6wf-f3px-wcqx](https://github.com/advisories/GHSA-x6wf-f3px-wcqx) — XML node injection via processing-instruction serialization
- [GHSA-j759-j44w-7fr8](https://github.com/advisories/GHSA-j759-j44w-7fr8) — XML node injection via comment serialization

## Changes

- `package.json` — add `"@xmldom/xmldom": "^0.8.13"` inside the existing `pnpm.overrides` block.
- `pnpm-lock.yaml` — regenerated via `pnpm install --lockfile-only`. All four `@xmldom/xmldom` entries (top-level resolution, snapshot block, and the two consumers `@expo/plist@0.5.3` and `plist@3.1.0`) move from `0.8.12` to `0.8.13`. The remaining churn is just expo-router peer-hash IDs, which is normal pnpm behavior when the resolved graph changes.

`^0.8.13` was chosen over `0.9.x` because both consumers (`@expo/plist@0.5.3`, `plist@3.1.0`) declare `^0.8.8` — staying inside the `0.8.x` line keeps the override compatible with their declared range.

## Verification

```
$ pnpm audit --prod --audit-level high 2>&1 | grep -i xmldom
$ # (no matches — xmldom advisories no longer reported on this branch)
```

Other unrelated advisories (`brace-expansion`, `picomatch`, `hono`, etc.) remain on `main` and are out of scope for this PR.

Closes #3191.
