### PR TITLE
fix(list): improve drag-and-drop for empty status groups

### DIFF
--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -29,7 +29,7 @@ import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
-  makeKanbanCollision,
+  makeListCollision,
   statusGroupId,
   buildColumns,
   computePosition,
@@ -149,7 +149,7 @@ export function ListView({
   }
 
   const collisionDetection = useMemo(
-    () => makeKanbanCollision(groupIds),
+    () => makeListCollision(groupIds),
     [groupIds],
   );
 
@@ -406,7 +406,7 @@ function StatusAccordionItem({
     <Accordion.Item value={status} ref={dragEnabled ? setDroppableRef : undefined}>
       <Accordion.Header
         className={`group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent ${
-          isOver && !isExpanded
+          isOver && (!isExpanded || issues.length === 0 || disableSorting)
             ? "ring-2 ring-brand/25 bg-accent/15"
             : ""
         }`}
@@ -481,9 +481,13 @@ function StatusAccordionItem({
             </>
           )
         ) : (
-          <p className="py-6 text-center text-xs text-muted-foreground">
-            {t(($) => $.list.empty_status)}
-          </p>
+          <div className={`flex min-h-20 items-center justify-center rounded-lg transition-colors ${
+            isOver ? "bg-accent/30 ring-2 ring-brand/25" : ""
+          }`}>
+            <p className="text-xs text-muted-foreground">
+              {t(($) => $.list.empty_status)}
+            </p>
+          </div>
         )}
       </Accordion.Panel>
     </Accordion.Item>

--- a/packages/views/issues/utils/drag-utils.ts
+++ b/packages/views/issues/utils/drag-utils.ts
@@ -26,6 +26,24 @@ export function makeKanbanCollision(groupIds: Set<string>): CollisionDetection {
   };
 }
 
+export function makeListCollision(groupIds: Set<string>): CollisionDetection {
+  return (args) => {
+    const pointer = pointerWithin(args);
+    if (pointer.length > 0) {
+      const items = pointer.filter((c) => !groupIds.has(c.id as string));
+      if (items.length > 0) return items;
+      return pointer;
+    }
+    const groupOnly = {
+      ...args,
+      droppableContainers: args.droppableContainers.filter(
+        (c) => groupIds.has(c.id as string),
+      ),
+    };
+    return closestCenter(groupOnly);
+  };
+}
+
 export function statusGroupId(status: IssueStatus): string {
   return `status:${status}`;
 }


### PR DESCRIPTION
## Summary
- **Collision detection**: new `makeListCollision` restricts `closestCenter` fallback to group containers only — prevents pointer oscillation between adjacent vertical groups when the cursor lands in the gap
- **Header highlight**: expanded ring feedback to cover expanded empty groups and non-manual sort mode (was collapsed-only)
- **Empty drop zone**: replaced the `<p className="py-6">` (~48px) with a `min-h-20` (80px) div that shows `ring-2 ring-brand/25 bg-accent/30` on hover, matching the board view's visual language

Stacked on #3284.

## Test plan
- [ ] Drag issue to an expanded empty status group → visual ring + background appears, drop succeeds
- [ ] Drag issue to a collapsed status group → ring on header (existing behavior preserved)
- [ ] Drag between groups under non-manual sort (e.g. priority) → header ring highlights target group
- [ ] Drag within same group (manual sort) → reorder works, no header ring
- [ ] Board view drag behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)