### PR TITLE
fix: attribute Hermes usage to current model (MUL-2696)

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -191,6 +191,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		finalStatus := "completed"
 		var finalError string
 		var sessionID string
+		effectiveModel := strings.TrimSpace(opts.Model)
 
 		// 1. Initialize handshake.
 		_, err := c.request(runCtx, "initialize", map[string]any{
@@ -234,6 +235,9 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					"actual", sessionID,
 				)
 			}
+			if effectiveModel == "" {
+				effectiveModel = extractACPCurrentModelID(result)
+			}
 		} else {
 			result, err := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 			if err != nil {
@@ -248,6 +252,9 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				finalError = "hermes session/new returned no session ID"
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
+			}
+			if effectiveModel == "" {
+				effectiveModel = extractACPCurrentModelID(result)
 			}
 		}
 
@@ -324,6 +331,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				c.usageMu.Lock()
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
 				c.usageMu.Unlock()
 			default:
 			}
@@ -367,7 +375,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		var usageMap map[string]TokenUsage
 		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 {
-			model := opts.Model
+			model := effectiveModel
 			if model == "" {
 				model = "unknown"
 			}
@@ -1133,6 +1141,35 @@ func extractACPSessionID(result json.RawMessage) string {
 		return ""
 	}
 	return r.SessionID
+}
+
+// extractACPCurrentModelID pulls the model selected by the ACP runtime out of
+// a session/new or session/resume response. Hermes returns this when it uses
+// its own default model, so token usage can still be attributed to a real model
+// even when Multica did not pass an explicit agent.model override.
+func extractACPCurrentModelID(result json.RawMessage) string {
+	var r struct {
+		Models struct {
+			CurrentModelID      string `json:"currentModelId"`
+			CurrentModelIDSnake string `json:"current_model_id"`
+		} `json:"models"`
+		CurrentModelID      string `json:"currentModelId"`
+		CurrentModelIDSnake string `json:"current_model_id"`
+	}
+	if err := json.Unmarshal(result, &r); err != nil {
+		return ""
+	}
+	for _, candidate := range []string{
+		r.Models.CurrentModelID,
+		r.Models.CurrentModelIDSnake,
+		r.CurrentModelID,
+		r.CurrentModelIDSnake,
+	} {
+		if model := strings.TrimSpace(candidate); model != "" {
+			return model
+		}
+	}
+	return ""
 }
 
 // resolveResumedSessionID picks which session id we should treat as live

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -51,6 +51,43 @@ func TestExtractACPSessionIDInvalidJSON(t *testing.T) {
 	}
 }
 
+// ── extractACPCurrentModelID ──
+
+func TestExtractACPCurrentModelID(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{
+		"sessionId": "ses_123",
+		"models": {
+			"currentModelId": "nous:moonshotai/kimi-k2.6"
+		}
+	}`)
+	got := extractACPCurrentModelID(raw)
+	if got != "nous:moonshotai/kimi-k2.6" {
+		t.Errorf("got %q, want current model", got)
+	}
+}
+
+func TestExtractACPCurrentModelIDSnakeCase(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{
+		"session_id": "ses_123",
+		"models": {
+			"current_model_id": "openrouter:anthropic/claude-sonnet-4.6"
+		}
+	}`)
+	got := extractACPCurrentModelID(raw)
+	if got != "openrouter:anthropic/claude-sonnet-4.6" {
+		t.Errorf("got %q, want current model", got)
+	}
+}
+
+func TestExtractACPCurrentModelIDMissing(t *testing.T) {
+	t.Parallel()
+	if got := extractACPCurrentModelID(json.RawMessage(`{"sessionId":"ses_123"}`)); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
 // ── resolveResumedSessionID ──
 
 func TestResolveResumedSessionIDMatching(t *testing.T) {
@@ -1036,6 +1073,74 @@ func TestHermesProviderErrorSnifferBoundedBuffer(t *testing.T) {
 	}
 	if len(s.lines) > acpMaxErrorLines {
 		t.Errorf("sniffer kept %d lines, limit is %d", len(s.lines), acpMaxErrorLines)
+	}
+}
+
+func fakeHermesACPUsageWithDefaultModelScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_model","models":{"currentModelId":"nous:moonshotai/kimi-k2.6","availableModels":[{"modelId":"nous:moonshotai/kimi-k2.6","name":"moonshotai/kimi-k2.6"}]}}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":17,"outputTokens":5,"cachedReadTokens":3}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestHermesBackendAttributesUsageToACPDefaultModel(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPUsageWithDefaultModelScript()))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected completed result, got %q: %s", result.Status, result.Error)
+		}
+		if _, ok := result.Usage["unknown"]; ok {
+			t.Fatalf("usage should not be attributed to unknown: %+v", result.Usage)
+		}
+		usage, ok := result.Usage["nous:moonshotai/kimi-k2.6"]
+		if !ok {
+			t.Fatalf("expected usage under Hermes current model, got %+v", result.Usage)
+		}
+		if usage.InputTokens != 17 || usage.OutputTokens != 5 || usage.CacheReadTokens != 3 {
+			t.Fatalf("usage = %+v, want input=17 output=5 cache_read=3", usage)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -697,42 +697,63 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 // the caller can distinguish "parsed with no models" (valid but
 // empty catalog) from "couldn't find the structure at all".
 func parseACPSessionNewModels(raw json.RawMessage) []Model {
+	type acpModelInfo struct {
+		ModelID      string `json:"modelId"`
+		ModelIDSnake string `json:"model_id"`
+		Name         string `json:"name"`
+		Description  string `json:"description"`
+	}
 	var resp struct {
 		Models struct {
-			AvailableModels []struct {
-				ModelID     string `json:"modelId"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-			} `json:"availableModels"`
-			CurrentModelID string `json:"currentModelId"`
+			AvailableModels      []acpModelInfo `json:"availableModels"`
+			AvailableModelsSnake []acpModelInfo `json:"available_models"`
+			CurrentModelID       string         `json:"currentModelId"`
+			CurrentModelIDSnake  string         `json:"current_model_id"`
 		} `json:"models"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil
 	}
-	models := make([]Model, 0, len(resp.Models.AvailableModels))
+	availableModels := resp.Models.AvailableModels
+	if len(availableModels) == 0 && resp.Models.AvailableModelsSnake != nil {
+		availableModels = resp.Models.AvailableModelsSnake
+	}
+	currentModelID := strings.TrimSpace(resp.Models.CurrentModelID)
+	if currentModelID == "" {
+		currentModelID = strings.TrimSpace(resp.Models.CurrentModelIDSnake)
+	}
+	models := make([]Model, 0, len(availableModels))
 	seen := map[string]bool{}
-	for _, m := range resp.Models.AvailableModels {
-		if m.ModelID == "" || seen[m.ModelID] {
+	for _, m := range availableModels {
+		modelID := strings.TrimSpace(m.ModelID)
+		if modelID == "" {
+			modelID = strings.TrimSpace(m.ModelIDSnake)
+		}
+		if modelID == "" || seen[modelID] {
 			continue
 		}
-		seen[m.ModelID] = true
-		label := m.Name
-		if label == "" {
-			label = m.ModelID
-		}
+		seen[modelID] = true
+		label := acpModelLabel(m.Name, modelID)
 		provider := ""
-		if idx := strings.Index(m.ModelID, ":"); idx > 0 {
-			provider = m.ModelID[:idx]
+		if idx := strings.Index(modelID, ":"); idx > 0 {
+			provider = modelID[:idx]
 		}
 		models = append(models, Model{
-			ID:       m.ModelID,
+			ID:       modelID,
 			Label:    label,
 			Provider: provider,
-			Default:  m.ModelID == resp.Models.CurrentModelID,
+			Default:  modelID == currentModelID,
 		})
 	}
 	return models
+}
+
+func acpModelLabel(name, modelID string) string {
+	label := strings.TrimSpace(name)
+	if label == "" || strings.EqualFold(label, "unknown") {
+		return modelID
+	}
+	return label
 }
 
 // discoverCursorModels runs `cursor-agent --list-models` and parses

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -144,9 +144,9 @@ func TestInferCopilotProvider(t *testing.T) {
 		"raptor-mini":       "",
 		// negative cases: must not be misidentified as OpenAI
 		// reasoning series even though they start with `o`.
-		"opus-fake":         "",
-		"omni":              "",
-		"o":                 "",
+		"opus-fake": "",
+		"omni":      "",
+		"o":         "",
 	}
 	for id, want := range cases {
 		if got := inferCopilotProvider(id); got != want {
@@ -508,6 +508,32 @@ func TestParseHermesSessionNewModels(t *testing.T) {
 	}
 	if models[1].ID != "nous:anthropic/claude-opus-4.7" {
 		t.Errorf("expected current model second: %+v", models[1])
+	}
+}
+
+func TestParseHermesSessionNewModelsSnakeCaseAndUnknownNames(t *testing.T) {
+	raw := []byte(`{
+      "session_id": "ses_123",
+      "models": {
+        "available_models": [
+          {"model_id": "nous:moonshotai/kimi-k2.6", "name": "Unknown", "description": "Provider: Nous"},
+          {"model_id": "nous:anthropic/claude-sonnet-4.6", "name": "unknown", "description": "Provider: Nous"}
+        ],
+        "current_model_id": "nous:moonshotai/kimi-k2.6"
+      }
+    }`)
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d: %+v", len(models), models)
+	}
+	if models[0].Label != "nous:moonshotai/kimi-k2.6" {
+		t.Errorf("Unknown label should fall back to model id, got %+v", models[0])
+	}
+	if !models[0].Default {
+		t.Errorf("snake_case current_model_id should mark default: %+v", models[0])
+	}
+	if models[1].Label != "nous:anthropic/claude-sonnet-4.6" {
+		t.Errorf("lowercase unknown label should fall back to model id, got %+v", models[1])
 	}
 }
 


### PR DESCRIPTION
Summary:
- Attribute Hermes token usage to ACP currentModelId when no explicit agent model is configured, avoiding unknown usage buckets.
- Preserve cache-read tokens from Hermes prompt responses.
- Harden ACP model-list parsing for snake_case payloads and upstream Unknown display names.

Tested:
- cd server && go test ./pkg/agent

Multica issue: MUL-2696