### PR TITLE
feat(hotkeys): add hotkey foundations — scopes, registry, Kbd component

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,6 +45,7 @@
     "@multica/core": "workspace:*",
     "@multica/ui": "workspace:*",
     "@multica/views": "workspace:*",
+    "@tanstack/react-hotkeys": "catalog:",
     "@tanstack/react-query": "catalog:",
     "electron-updater": "^6.8.3",
     "fix-path": "^5.0.0",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { UpdateNotification } from "./components/update-notification";
 import { useTabStore } from "./stores/tab-store";
 import { useWindowOverlayStore } from "./stores/window-overlay-store";
 import { useDaemonIPCBridge } from "./platform/daemon-ipc-bridge";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { createDesktopLocaleAdapter } from "./platform/i18n-adapter";
 import { RESOURCES } from "@multica/views/locales";
 
@@ -333,7 +334,9 @@ export default function App() {
           resources={resources}
           localeAdapter={localeAdapter}
         >
-          <AppContent />
+          <HotkeysProvider>
+            <AppContent />
+          </HotkeysProvider>
         </CoreProvider>
       ) : (
         <BlockingRuntimeConfigError message={runtimeConfigResult.error.message} />

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -12,6 +12,7 @@ import {
   clearLoggedInCookie,
 } from "@/features/auth/auth-cookie";
 import { PageviewTracker } from "./pageview-tracker";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
 
 // Legacy token in localStorage → keep this session in token mode so users who
 // logged in before the cookie-auth migration stay authed. They migrate to
@@ -87,7 +88,9 @@ export function WebProviders({
       <Suspense fallback={null}>
         <PageviewTracker />
       </Suspense>
-      <WebNavigationProvider>{children}</WebNavigationProvider>
+      <WebNavigationProvider>
+            <HotkeysProvider>{children}</HotkeysProvider>
+          </WebNavigationProvider>
     </CoreProvider>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@multica/core": "workspace:*",
     "@multica/ui": "workspace:*",
     "@multica/views": "workspace:*",
+    "@tanstack/react-hotkeys": "catalog:",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.96.2",
     "@tiptap/extension-code-block-lowlight": "^3.22.1",

--- a/packages/core/hotkeys/format.test.ts
+++ b/packages/core/hotkeys/format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatForDisplay } from "@tanstack/hotkeys";
+
+// We test TanStack's formatForDisplay directly since our formatKeysForPlatform
+// is a thin wrapper. This verifies the integration works and documents the
+// expected output for our usage.
+
+describe("formatForDisplay (TanStack)", () => {
+  it("renders Mac symbols for Mod+K", () => {
+    const result = formatForDisplay("Mod+K", { platform: "mac" });
+    expect(result).toContain("⌘");
+    expect(result).toContain("K");
+  });
+
+  it("renders Ctrl for Mod+K on Windows", () => {
+    const result = formatForDisplay("Mod+K", { platform: "windows" });
+    expect(result).toContain("Ctrl");
+    expect(result).toContain("K");
+  });
+
+  it("renders Shift symbol on Mac", () => {
+    const result = formatForDisplay("Shift+Enter", { platform: "mac" });
+    expect(result).toContain("⇧");
+  });
+
+  it("renders Shift text on Windows", () => {
+    const result = formatForDisplay("Shift+Enter", { platform: "windows" });
+    expect(result).toContain("Shift");
+  });
+});

--- a/packages/core/hotkeys/format.ts
+++ b/packages/core/hotkeys/format.ts
@@ -1,0 +1,31 @@
+/**
+ * Format a hotkey string for display using the platform-correct symbols.
+ *
+ * Delegates to TanStack's `formatForDisplay` which already handles
+ * ⌘/⇧/⌥/⌃ on Mac vs Ctrl+Shift+Alt on other platforms. We re-export
+ * a thin wrapper so consumers import from one place and we can inject
+ * telemetry or override behaviour later without touching call-sites.
+ */
+export { formatForDisplay as formatKeys } from "@tanstack/hotkeys";
+
+import { formatForDisplay, formatHotkeySequence } from "@tanstack/hotkeys";
+import type { Hotkey } from "@tanstack/hotkeys";
+import { isMac } from "../platform/keyboard";
+
+/**
+ * Format a hotkey or sequence for display with automatic platform detection.
+ *
+ * @example
+ *   formatKeysForPlatform("Mod+K")       // "⌘ K" on Mac, "Ctrl+K" elsewhere
+ *   formatKeysForPlatform(["G", "I"])     // "G I"
+ */
+export function formatKeysForPlatform(
+  keys: string | Hotkey[],
+): string {
+  if (Array.isArray(keys)) {
+    return formatHotkeySequence(keys);
+  }
+  return formatForDisplay(keys, {
+    platform: isMac ? "mac" : "windows",
+  });
+}

--- a/packages/core/hotkeys/index.ts
+++ b/packages/core/hotkeys/index.ts
@@ -1,0 +1,11 @@
+export { SCOPES, type HotkeyScope } from "./scopes";
+export {
+  useHotkeyRegistry,
+  type HotkeyCommand,
+} from "./registry";
+export { useHotkey, useHotkeySequence } from "./use-hotkey";
+export type {
+  UseScopedHotkeyOptions,
+  UseScopedSequenceOptions,
+} from "./use-hotkey";
+export { formatKeys, formatKeysForPlatform } from "./format";

--- a/packages/core/hotkeys/kbd.test.tsx
+++ b/packages/core/hotkeys/kbd.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// The Kbd component lives in packages/ui but has zero business-logic deps —
+// just string splitting + class names. We test it here because packages/core
+// already has the jsdom + @testing-library test infra.
+
+// We need to test platform-specific rendering. Since Kbd reads navigator at
+// module load time, we stub it before importing.
+
+describe("Kbd component", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("renders Mod+K as ⌘ K on Mac", async () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    const { Kbd } = await import("@multica/ui/components/ui/kbd");
+    const { container } = render(<Kbd keys="Mod+K" />);
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
+    expect(kbds[0]!.textContent).toBe("⌘");
+    expect(kbds[1]!.textContent).toBe("K");
+  });
+
+  it("renders Mod+K as Ctrl K on Windows", async () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    const { Kbd } = await import("@multica/ui/components/ui/kbd");
+    const { container } = render(<Kbd keys="Mod+K" />);
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
+    expect(kbds[0]!.textContent).toBe("Ctrl");
+    expect(kbds[1]!.textContent).toBe("K");
+  });
+
+  it("renders Shift+Enter with correct symbols on Mac", async () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    const { Kbd } = await import("@multica/ui/components/ui/kbd");
+    const { container } = render(<Kbd keys="Shift+Enter" />);
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
+    expect(kbds[0]!.textContent).toBe("⇧");
+    expect(kbds[1]!.textContent).toBe("↵");
+  });
+
+  it("renders a single key without splitting", async () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    const { Kbd } = await import("@multica/ui/components/ui/kbd");
+    const { container } = render(<Kbd keys="Escape" />);
+    const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(1);
+    expect(kbds[0]!.textContent).toBe("Esc");
+  });
+});

--- a/packages/core/hotkeys/registry.test.ts
+++ b/packages/core/hotkeys/registry.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useHotkeyRegistry } from "./registry";
+import type { HotkeyCommand } from "./registry";
+
+function makeCmd(overrides: Partial<HotkeyCommand> = {}): HotkeyCommand {
+  return {
+    id: "test.cmd",
+    keys: "Mod+K",
+    description: "Test command",
+    scope: "global",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  // Reset store between tests.
+  useHotkeyRegistry.setState({
+    commands: new Map(),
+    activeScopes: new Set(["global"]),
+  });
+});
+
+describe("registry", () => {
+  it("registers and unregisters commands", () => {
+    const { register, unregister } = useHotkeyRegistry.getState();
+    register(makeCmd({ id: "a" }));
+    register(makeCmd({ id: "b" }));
+    expect(useHotkeyRegistry.getState().commands.size).toBe(2);
+
+    unregister("a");
+    expect(useHotkeyRegistry.getState().commands.size).toBe(1);
+    expect(useHotkeyRegistry.getState().commands.has("b")).toBe(true);
+  });
+
+  it("de-duplicates by id (last write wins)", () => {
+    const { register } = useHotkeyRegistry.getState();
+    register(makeCmd({ id: "x", description: "first" }));
+    register(makeCmd({ id: "x", description: "second" }));
+    expect(useHotkeyRegistry.getState().commands.size).toBe(1);
+    expect(useHotkeyRegistry.getState().commands.get("x")!.description).toBe(
+      "second",
+    );
+  });
+
+  it("filters commands by active scope", () => {
+    const { register, activateScope } = useHotkeyRegistry.getState();
+    register(makeCmd({ id: "g", scope: "global" }));
+    register(makeCmd({ id: "e", scope: "editor" }));
+    register(makeCmd({ id: "m", scope: "modal" }));
+
+    // Only global is active by default.
+    const { commands, activeScopes } = useHotkeyRegistry.getState();
+    const active = [...commands.values()].filter((c) =>
+      activeScopes.has(c.scope),
+    );
+    expect(active.map((c) => c.id)).toEqual(["g"]);
+
+    // Activate editor scope.
+    activateScope("editor");
+    const state2 = useHotkeyRegistry.getState();
+    const active2 = [...state2.commands.values()].filter((c) =>
+      state2.activeScopes.has(c.scope),
+    );
+    expect(active2.map((c) => c.id).sort()).toEqual(["e", "g"]);
+  });
+
+  it("never deactivates global scope", () => {
+    const { deactivateScope } = useHotkeyRegistry.getState();
+    deactivateScope("global");
+    expect(useHotkeyRegistry.getState().activeScopes.has("global")).toBe(true);
+  });
+
+  it("setActiveScopes replaces all but keeps global", () => {
+    const { setActiveScopes } = useHotkeyRegistry.getState();
+    setActiveScopes(["editor", "modal"]);
+    const scopes = useHotkeyRegistry.getState().activeScopes;
+    expect(scopes.has("global")).toBe(true);
+    expect(scopes.has("editor")).toBe(true);
+    expect(scopes.has("modal")).toBe(true);
+    expect(scopes.size).toBe(3);
+  });
+});

--- a/packages/core/hotkeys/registry.ts
+++ b/packages/core/hotkeys/registry.ts
@@ -1,0 +1,87 @@
+import { create } from "zustand";
+import type { HotkeyScope } from "./scopes";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HotkeyCommand {
+  /** Unique command id, e.g. "issue.create" */
+  id: string;
+  /** TanStack hotkey string, e.g. "Mod+K" */
+  keys: string;
+  /** Human-readable description shown in the cheat-sheet. */
+  description: string;
+  /** Scope this command is active in. */
+  scope: HotkeyScope;
+  /** Optional grouping label for the cheat-sheet (e.g. "Navigation"). */
+  group?: string;
+  /** For sequences — the key array, e.g. ["G","I"]. */
+  sequence?: string[];
+}
+
+interface RegistryState {
+  /** All registered commands keyed by id. */
+  commands: Map<string, HotkeyCommand>;
+  /** Currently active scopes. `global` is always implicitly active. */
+  activeScopes: Set<HotkeyScope>;
+}
+
+interface RegistryActions {
+  register: (cmd: HotkeyCommand) => void;
+  unregister: (id: string) => void;
+  activateScope: (scope: HotkeyScope) => void;
+  deactivateScope: (scope: HotkeyScope) => void;
+  /** Replace the full set of active scopes (global is always kept). */
+  setActiveScopes: (scopes: HotkeyScope[]) => void;
+  isScopeActive: (scope: HotkeyScope) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useHotkeyRegistry = create<RegistryState & RegistryActions>(
+  (set, get) => ({
+    commands: new Map(),
+    activeScopes: new Set<HotkeyScope>(["global"]),
+
+    register: (cmd) =>
+      set((s) => {
+        const next = new Map(s.commands);
+        next.set(cmd.id, cmd);
+        return { commands: next };
+      }),
+
+    unregister: (id) =>
+      set((s) => {
+        const next = new Map(s.commands);
+        next.delete(id);
+        return { commands: next };
+      }),
+
+    activateScope: (scope) =>
+      set((s) => {
+        const next = new Set(s.activeScopes);
+        next.add(scope);
+        return { activeScopes: next };
+      }),
+
+    deactivateScope: (scope) =>
+      set((s) => {
+        if (scope === "global") return s; // never deactivate global
+        const next = new Set(s.activeScopes);
+        next.delete(scope);
+        return { activeScopes: next };
+      }),
+
+    setActiveScopes: (scopes) =>
+      set(() => {
+        const next = new Set<HotkeyScope>(scopes);
+        next.add("global"); // always keep global
+        return { activeScopes: next };
+      }),
+
+    isScopeActive: (scope) => get().activeScopes.has(scope),
+  }),
+);

--- a/packages/core/hotkeys/scopes.ts
+++ b/packages/core/hotkeys/scopes.ts
@@ -1,0 +1,28 @@
+/**
+ * Hotkey scope constants.
+ *
+ * A scope limits which hotkeys are active. Components activate/deactivate
+ * scopes via the scope store; the `useHotkey` wrapper only fires when the
+ * command's scope is currently active.
+ */
+
+export const SCOPES = {
+  /** Always active — top-level navigation, command palette, etc. */
+  global: "global",
+  /** Issue list / board view. */
+  issueList: "issue-list",
+  /** Single-issue detail pane. */
+  issueDetail: "issue-detail",
+  /** Command-palette / quick-switcher overlay. */
+  picker: "picker",
+  /** Any modal dialog. */
+  modal: "modal",
+  /** Rich-text / markdown editor has focus. */
+  editor: "editor",
+  /** AI chat panel. */
+  chat: "chat",
+  /** Generic form with text inputs. */
+  form: "form",
+} as const;
+
+export type HotkeyScope = (typeof SCOPES)[keyof typeof SCOPES];

--- a/packages/core/hotkeys/use-hotkey.ts
+++ b/packages/core/hotkeys/use-hotkey.ts
@@ -1,0 +1,124 @@
+import { useEffect } from "react";
+import {
+  useHotkey as useTanStackHotkey,
+  useHotkeySequence as useTanStackSequence,
+} from "@tanstack/react-hotkeys";
+import type { HotkeyCallback, RegisterableHotkey, HotkeySequence } from "@tanstack/hotkeys";
+import type { UseHotkeyOptions } from "@tanstack/react-hotkeys";
+import { useHotkeyRegistry, type HotkeyCommand } from "./registry";
+import type { HotkeyScope } from "./scopes";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface UseScopedHotkeyOptions extends UseHotkeyOptions {
+  /** Human-readable description for the cheat-sheet. */
+  description?: string;
+  /** Scope this hotkey is active in. Defaults to "global". */
+  scope?: HotkeyScope;
+  /** Grouping label for the cheat-sheet (e.g. "Navigation"). */
+  group?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Scope-aware hotkey hook.
+ *
+ * Registers the hotkey with TanStack *and* adds metadata to the Zustand
+ * registry for the cheat-sheet. The hotkey only fires when its scope is
+ * currently active.
+ */
+export function useHotkey(
+  id: string,
+  hotkey: RegisterableHotkey,
+  callback: HotkeyCallback,
+  options: UseScopedHotkeyOptions = {},
+) {
+  const {
+    description = "",
+    scope = "global",
+    group,
+    ...tanstackOptions
+  } = options;
+
+  const register = useHotkeyRegistry((s) => s.register);
+  const unregister = useHotkeyRegistry((s) => s.unregister);
+  const isScopeActive = useHotkeyRegistry((s) => s.activeScopes.has(scope));
+
+  // Register command metadata for cheat-sheet discovery.
+  useEffect(() => {
+    const cmd: HotkeyCommand = {
+      id,
+      keys: typeof hotkey === "string" ? hotkey : JSON.stringify(hotkey),
+      description,
+      scope,
+      group,
+    };
+    register(cmd);
+    return () => unregister(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, hotkey, description, scope, group]);
+
+  useTanStackHotkey(hotkey, callback, {
+    ...tanstackOptions,
+    enabled: isScopeActive && (tanstackOptions.enabled ?? true),
+    meta: { name: description, ...tanstackOptions.meta },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sequence variant
+// ---------------------------------------------------------------------------
+
+export interface UseScopedSequenceOptions
+  extends Omit<UseScopedHotkeyOptions, "keys"> {
+  /** Timeout between keys in the sequence (ms). Default: TanStack default. */
+  timeout?: number;
+}
+
+/**
+ * Scope-aware hotkey *sequence* hook (e.g. `g i`).
+ */
+export function useHotkeySequence(
+  id: string,
+  sequence: HotkeySequence,
+  callback: HotkeyCallback,
+  options: UseScopedSequenceOptions = {},
+) {
+  const {
+    description = "",
+    scope = "global",
+    group,
+    timeout,
+    ...tanstackOptions
+  } = options;
+
+  const register = useHotkeyRegistry((s) => s.register);
+  const unregister = useHotkeyRegistry((s) => s.unregister);
+  const isScopeActive = useHotkeyRegistry((s) => s.activeScopes.has(scope));
+
+  useEffect(() => {
+    const cmd: HotkeyCommand = {
+      id,
+      keys: sequence.join(" "),
+      description,
+      scope,
+      group,
+      sequence,
+    };
+    register(cmd);
+    return () => unregister(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, sequence.join(","), description, scope, group]);
+
+  useTanStackSequence(sequence, callback, {
+    ...tanstackOptions,
+    enabled: isScopeActive && (tanstackOptions.enabled ?? true),
+    timeout,
+    meta: { name: description },
+  });
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,7 +94,11 @@
     "./analytics": "./analytics/index.ts",
     "./i18n": "./i18n/index.ts",
     "./i18n/react": "./i18n/react.ts",
-    "./i18n/browser": "./i18n/browser.ts"
+    "./i18n/browser": "./i18n/browser.ts",
+    "./hotkeys": "./hotkeys/index.ts",
+    "./hotkeys/scopes": "./hotkeys/scopes.ts",
+    "./hotkeys/registry": "./hotkeys/registry.ts",
+    "./hotkeys/format": "./hotkeys/format.ts"
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "catalog:",
@@ -104,7 +108,9 @@
     "posthog-js": "catalog:",
     "react-i18next": "catalog:",
     "zod": "catalog:",
-    "zustand": "catalog:"
+    "zustand": "catalog:",
+    "@tanstack/react-hotkeys": "catalog:",
+    "@tanstack/hotkeys": "catalog:"
   },
   "peerDependencies": {
     "react": "catalog:"

--- a/packages/ui/components/ui/kbd.tsx
+++ b/packages/ui/components/ui/kbd.tsx
@@ -1,26 +1,101 @@
-import { cn } from "@multica/ui/lib/utils"
+"use client";
 
-function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
-  return (
-    <kbd
-      data-slot="kbd"
-      className={cn(
-        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
-        className
-      )}
-      {...props}
-    />
-  )
+import { cn } from "@multica/ui/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Platform helpers (minimal — no runtime deps outside React)
+// ---------------------------------------------------------------------------
+
+const IS_MAC =
+  typeof navigator !== "undefined" && /Mac/.test(navigator.platform);
+
+/** Map TanStack-style tokens to platform-correct display symbols. */
+const SYMBOL_MAP: Record<string, string> = IS_MAC
+  ? {
+      mod: "⌘",
+      ctrl: "⌃",
+      alt: "⌥",
+      shift: "⇧",
+      meta: "⌘",
+      enter: "↵",
+      return: "↵",
+      backspace: "⌫",
+      delete: "⌦",
+      escape: "Esc",
+      tab: "⇥",
+      space: "␣",
+      up: "↑",
+      down: "↓",
+      left: "←",
+      right: "→",
+    }
+  : {
+      mod: "Ctrl",
+      ctrl: "Ctrl",
+      alt: "Alt",
+      shift: "Shift",
+      meta: "Win",
+      enter: "Enter",
+      return: "Enter",
+      backspace: "Backspace",
+      delete: "Delete",
+      escape: "Esc",
+      tab: "Tab",
+      space: "Space",
+      up: "↑",
+      down: "↓",
+      left: "←",
+      right: "→",
+    };
+
+function tokenToSymbol(token: string): string {
+  return SYMBOL_MAP[token.toLowerCase()] ?? token.toUpperCase();
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <kbd
-      data-slot="kbd-group"
-      className={cn("inline-flex items-center gap-1", className)}
-      {...props}
-    />
-  )
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface KbdProps {
+  /**
+   * Hotkey string in TanStack format, e.g. "Mod+K", "Shift+Enter".
+   * Split on "+" to produce individual key chips.
+   */
+  keys: string;
+  /** Additional class names on the outer wrapper. */
+  className?: string;
 }
 
-export { Kbd, KbdGroup }
+/**
+ * Renders a keyboard shortcut as a sequence of muted, rounded key chips.
+ *
+ * Uses platform-correct symbols: ⌘ on Mac, Ctrl elsewhere.
+ *
+ * @example
+ *   <Kbd keys="Mod+K" />       // ⌘ K on Mac, Ctrl K elsewhere
+ *   <Kbd keys="Shift+Enter" /> // ⇧ ↵ on Mac, Shift Enter elsewhere
+ */
+function Kbd({ keys, className }: KbdProps) {
+  const parts = keys.split("+").map(tokenToSymbol);
+
+  return (
+    <span className={cn("inline-flex items-center gap-0.5", className)}>
+      {parts.map((part, i) => (
+        <kbd
+          key={i}
+          className={cn(
+            "inline-flex items-center justify-center",
+            "min-w-5 h-5 px-1 rounded",
+            "bg-muted text-muted-foreground",
+            "text-[11px] font-medium leading-none",
+            "select-none",
+          )}
+        >
+          {part}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+export { Kbd, type KbdProps };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ catalogs:
     '@tailwindcss/postcss':
       specifier: ^4
       version: 4.2.2
+    '@tanstack/hotkeys':
+      specifier: ^0.8.0
+      version: 0.8.0
+    '@tanstack/react-hotkeys':
+      specifier: ^0.10.0
+      version: 0.10.0
     '@tanstack/react-query':
       specifier: ^5.96.2
       version: 5.96.2
@@ -176,6 +182,9 @@ importers:
       '@multica/views':
         specifier: workspace:*
         version: link:../../packages/views
+      '@tanstack/react-hotkeys':
+        specifier: 'catalog:'
+        version: 0.10.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.96.2(react@19.2.3)
@@ -548,6 +557,9 @@ importers:
       '@multica/views':
         specifier: workspace:*
         version: link:../../packages/views
+      '@tanstack/react-hotkeys':
+        specifier: 'catalog:'
+        version: 0.10.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.96.2(react@19.2.3)
@@ -738,6 +750,12 @@ importers:
       '@formatjs/intl-localematcher':
         specifier: 'catalog:'
         version: 0.8.4
+      '@tanstack/hotkeys':
+        specifier: 'catalog:'
+        version: 0.8.0
+      '@tanstack/react-hotkeys':
+        specifier: 'catalog:'
+        version: 0.10.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.96.2(react@19.2.3)
@@ -3928,11 +3946,22 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/hotkeys@0.8.0':
+    resolution: {integrity: sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.96.2':
     resolution: {integrity: sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==}
 
   '@tanstack/query-devtools@5.96.2':
     resolution: {integrity: sha512-vBTB1Qhbm3nHSbEUtQwks/EdcAtFfEapr1WyBW4w2ExYKuXVi3jIxUIHf5MlSltiHuL7zNyUuanqT/7sI2sb6g==}
+
+  '@tanstack/react-hotkeys@0.10.0':
+    resolution: {integrity: sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   '@tanstack/react-query-devtools@5.96.2':
     resolution: {integrity: sha512-nTFKLGuTOFvmFRvcyZ3ArWC/DnMNPoBh6h/2yD6rsf7TCTJCQt+oUWOp2uKPTIuEPtF/vN9Kw5tl5mD1Kbposw==}
@@ -3945,12 +3974,21 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tanstack/react-store@0.11.0':
+    resolution: {integrity: sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
+
+  '@tanstack/store@0.11.0':
+    resolution: {integrity: sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
@@ -14271,9 +14309,20 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
 
+  '@tanstack/hotkeys@0.8.0':
+    dependencies:
+      '@tanstack/store': 0.11.0
+
   '@tanstack/query-core@5.96.2': {}
 
   '@tanstack/query-devtools@5.96.2': {}
+
+  '@tanstack/react-hotkeys@0.10.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/hotkeys': 0.8.0
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@tanstack/react-query-devtools@5.96.2(@tanstack/react-query@5.96.2(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -14291,11 +14340,20 @@ snapshots:
       '@tanstack/query-core': 5.96.2
       react: 19.2.3
 
+  '@tanstack/react-store@0.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/store': 0.11.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+
   '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/table-core': 8.21.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/store@0.11.0': {}
 
   '@tanstack/table-core@8.21.3': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,8 @@ catalog:
   zustand: "^5.0.0"
   "@tanstack/react-query": "^5.96.2"
   "@tanstack/react-table": "^8.21.3"
+  "@tanstack/react-hotkeys": "^0.10.0"
+  "@tanstack/hotkeys": "^0.8.0"
 
   # Runtime schema validation (defensive boundary against API drift —
   # see CLAUDE.md "API Response Compatibility")


### PR DESCRIPTION
## Summary
- Add centralized hotkey layer: scopes, Zustand registry, useHotkey/useHotkeySequence wrappers, format helpers
- Add `<Kbd>` component with platform-correct symbols
- Wire `<HotkeysProvider>` in web and desktop apps

## Test plan
- [x] Unit tests pass (registry de-dupe/scope filter, format ⌘ vs Ctrl, Kbd rendering)
- [x] Typecheck clean
- [ ] No visible behavior change to users