### PR TITLE
fix(agents): drop the import-hint callout on agent Skills tab (again)

### DIFF
--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { FileText, Info, Plus, Trash2 } from "lucide-react";
+import { FileText, Plus, Trash2 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { Agent } from "@multica/core/types";
@@ -51,7 +51,7 @@ export function SkillsTab({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex items-center justify-between gap-3">
         <p className="text-xs text-muted-foreground">
           {t(($) => $.tab_body.skills.intro)}
         </p>
@@ -65,13 +65,6 @@ export function SkillsTab({
           <Plus className="h-3 w-3" />
           {t(($) => $.tab_body.skills.add_action)}
         </Button>
-      </div>
-
-      <div className="flex items-start gap-2 rounded-md border border-info/20 bg-info/5 px-3 py-2.5">
-        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-info" />
-        <p className="text-xs text-muted-foreground">
-          {t(($) => $.tab_body.skills.import_hint)}
-        </p>
       </div>
 
       {agent.skills.length === 0 ? (

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -297,7 +297,6 @@
     "skills": {
       "intro": "Workspace skills assigned to this agent. Local runtime skills are always available automatically.",
       "add_action": "Add skill",
-      "import_hint": "Importing creates a workspace copy that your team can edit and reuse.",
       "empty_title": "No skills assigned",
       "empty_hint": "Add workspace skills to share team knowledge with this agent.",
       "remove_failed_toast": "Failed to remove skill",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -291,7 +291,6 @@
     "skills": {
       "intro": "分配给该智能体的工作区 skill。本地运行时 skill 会自动可用。",
       "add_action": "添加 skill",
-      "import_hint": "导入会在工作区创建一份副本，团队可以编辑和复用。",
       "empty_title": "尚未分配 skill",
       "empty_hint": "添加工作区 skill，把团队知识共享给这个智能体。",
       "remove_failed_toast": "移除 skill 失败",


### PR DESCRIPTION
#3265 already removed this blue "Importing creates a workspace copy that your team can edit and reuse" callout. #3286 (the \`skills_local\` toggle revert) accidentally brought it back along with the larger rollback. Re-removing.

The callout doesn't belong on this tab — skill imports happen on the Skills page (Add Skill → From Runtime), not in the per-agent Skills tab. Showing the hint here implies the "+ Add skill" button next to it is an import action, which it isn't.

Also flip the header row back to \`items-center\` so the now-single-line intro is baseline-aligned with the "Add skill" button.

## Test plan
- [x] \`pnpm --filter @multica/views typecheck\`
- [x] \`pnpm --filter @multica/views exec vitest run skills-tab\` — 1 / 1 pass (the existing assertion is on the intro text, which is unchanged)
- [x] Manual: agent → Skills tab, no blue callout