### PR TITLE
MUL-2706 fix(cli): show real MEMBERS count in `multica squad list`

### DIFF
--- a/server/cmd/multica/cmd_squad.go
+++ b/server/cmd/multica/cmd_squad.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 	"time"
 
@@ -52,10 +53,23 @@ func runSquadList(cmd *cobra.Command, _ []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tNAME\tLEADER ID\tMEMBERS")
 	for _, s := range squads {
-		fmt.Fprintf(w, "%s\t%s\t%s\t-\n",
-			strVal(s, "id"), strVal(s, "name"), strVal(s, "leader_id"))
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			strVal(s, "id"), strVal(s, "name"), strVal(s, "leader_id"),
+			memberCountDisplay(s))
 	}
 	return w.Flush()
+}
+
+func memberCountDisplay(m map[string]any) string {
+	v, ok := m["member_count"]
+	if !ok || v == nil {
+		return "-"
+	}
+	n, ok := v.(float64)
+	if !ok || n <= 0 {
+		return "-"
+	}
+	return strconv.Itoa(int(n))
 }
 
 // ── Get ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`multica squad list` rendered the MEMBERS column as `-` for every squad, even when the backend already returned a non-zero `member_count`. The bug was purely in the CLI's table formatter — `runSquadList` ignored the response field and hardcoded `-`. JSON output and `squad get` were never affected, which is why this looked cosmetic but still made every squad appear empty.

This change:

- Reads `member_count` from each squad row in the table branch of `runSquadList`.
- Adds a small `memberCountDisplay` helper that returns the count as a string, or `-` when the field is missing/zero, so empty squads stay visually distinct from squads with members.
- Leaves JSON output and the `squad get` human view untouched (scope kept tight to the reported bug).

Closes multica-ai/multica#3304 (MUL-2706).

## Test plan

- [x] `go build ./cmd/multica/...` from `server/` — compiles cleanly.
- [ ] Manual: `multica squad list` against a workspace with at least one squad that has members — MEMBERS column shows the count instead of `-`. Empty squads still show `-`.
- [ ] `multica squad list --output json` — unchanged.