### PR TITLE
feat(daemon): add MULTICA_POST_CHECKOUT_HOOK for repo checkout extensibility

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -3,6 +3,7 @@
 package repocache
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
 )
 
 // gitEnv returns an environment for git subprocesses that contact remotes.
@@ -465,6 +465,8 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			}
 		}
 
+		runPostCheckoutHook(worktreePath, params.RepoURL, actualBranch, c.logger)
+
 		c.logger.Info("repo checkout: existing worktree updated",
 			"url", params.RepoURL,
 			"path", worktreePath,
@@ -502,6 +504,8 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			c.logger.Warn("repo checkout: remove co-authored-by hook failed (non-fatal)", "error", err)
 		}
 	}
+
+	runPostCheckoutHook(worktreePath, params.RepoURL, actualBranch, c.logger)
 
 	c.logger.Info("repo checkout: worktree created",
 		"url", params.RepoURL,
@@ -809,6 +813,70 @@ fi
 # Use git interpret-trailers for proper formatting.
 git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
 `
+
+// postCheckoutHookTimeout caps how long a user-supplied hook may run before
+// the daemon kills it. 30s is generous enough for a hook to fetch secrets or
+// install a small set of files, while short enough that a hung hook cannot
+// stall task spawning for the agent.
+const postCheckoutHookTimeout = 30 * time.Second
+
+// runPostCheckoutHook executes a user-provided script after a worktree is
+// created or updated. The hook path comes from the MULTICA_POST_CHECKOUT_HOOK
+// environment variable; if unset or empty, this is a no-op.
+//
+// The hook is invoked with the worktree as CWD and the following env vars set
+// so it can act on the worktree without re-deriving them from CWD or git state:
+//
+//   - MULTICA_WORKTREE_PATH: absolute path to the worktree directory
+//   - MULTICA_REPO_URL:      the URL passed to `multica repo checkout`
+//   - MULTICA_REPO_NAME:     basename of the worktree path (the repo dir name)
+//   - MULTICA_BRANCH:        the actual branch name the worktree is on
+//
+// Failures are logged at WARN and never abort the checkout — the agent
+// receives a working worktree regardless. A 30s timeout caps the hook's
+// runtime so a hung hook can't stall task spawning indefinitely.
+//
+// This hook is intentionally fire-and-log: the daemon does not propagate
+// hook stdout/stderr back to the agent. Operators who need richer signaling
+// should have the hook write a file inside MULTICA_WORKTREE_PATH that the
+// agent can read after checkout.
+func runPostCheckoutHook(worktreePath, repoURL, branchName string, logger *slog.Logger) {
+	hookPath := strings.TrimSpace(os.Getenv("MULTICA_POST_CHECKOUT_HOOK"))
+	if hookPath == "" {
+		return
+	}
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		logger.Warn("repo checkout: post-checkout hook stat failed (non-fatal)",
+			"path", hookPath, "error", err)
+		return
+	}
+	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		logger.Warn("repo checkout: post-checkout hook is not an executable file (non-fatal)",
+			"path", hookPath, "mode", info.Mode().String())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), postCheckoutHookTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, hookPath)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(),
+		"MULTICA_WORKTREE_PATH="+worktreePath,
+		"MULTICA_REPO_URL="+repoURL,
+		"MULTICA_REPO_NAME="+filepath.Base(worktreePath),
+		"MULTICA_BRANCH="+branchName,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Warn("repo checkout: post-checkout hook failed (non-fatal)",
+			"path", hookPath, "worktree", worktreePath,
+			"error", err, "output", strings.TrimSpace(string(out)))
+		return
+	}
+	logger.Info("repo checkout: post-checkout hook ran",
+		"path", hookPath, "worktree", worktreePath, "branch", branchName)
+}
 
 // installCoAuthoredByHook installs a prepare-commit-msg git hook that appends
 // a Co-authored-by trailer for the Multica Agent. The hook is installed in the

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -1455,3 +1455,99 @@ func TestGetRemoteDefaultBranchAmbiguousOriginReturnsEmpty(t *testing.T) {
 		t.Fatalf("getRemoteDefaultBranch = %q, want \"\" (ambiguous origin/* must not guess)", got)
 	}
 }
+
+// TestRunPostCheckoutHookNoop verifies that an unset MULTICA_POST_CHECKOUT_HOOK
+// is a no-op — no errors, no logs that imply the hook ran.
+func TestRunPostCheckoutHookNoop(t *testing.T) {
+	t.Setenv("MULTICA_POST_CHECKOUT_HOOK", "")
+	worktree := t.TempDir()
+	runPostCheckoutHook(worktree, "https://example.com/foo.git", "main", testLogger())
+	// If we got here without panicking, no-op is honored.
+}
+
+// TestRunPostCheckoutHookRuns verifies a real hook is invoked with the
+// documented env vars and worktree CWD.
+func TestRunPostCheckoutHookRuns(t *testing.T) {
+	worktree := t.TempDir()
+	marker := filepath.Join(worktree, "hook-ran.txt")
+
+	hookDir := t.TempDir()
+	hookPath := filepath.Join(hookDir, "hook.sh")
+	// The hook writes a record of the env vars it received so the test can
+	// assert that the daemon-set variables reached the process.
+	script := `#!/bin/sh
+{
+  echo "PWD=$PWD"
+  echo "WORKTREE=$MULTICA_WORKTREE_PATH"
+  echo "REPO_URL=$MULTICA_REPO_URL"
+  echo "REPO_NAME=$MULTICA_REPO_NAME"
+  echo "BRANCH=$MULTICA_BRANCH"
+} > "` + marker + `"
+`
+	if err := os.WriteFile(hookPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	t.Setenv("MULTICA_POST_CHECKOUT_HOOK", hookPath)
+	runPostCheckoutHook(worktree, "https://example.com/my-repo.git", "agent/test/abc", testLogger())
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("hook did not produce marker file: %v", err)
+	}
+	contents := string(got)
+	// macOS symlinks /tmp → /private/tmp, so the shell's PWD resolves to the
+	// canonical path even though Go saw the unresolved one. Compare against
+	// the resolved form so the assertion passes on both Linux and macOS.
+	resolvedWorktree, err := filepath.EvalSymlinks(worktree)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", worktree, err)
+	}
+	wantSubstrings := []string{
+		"PWD=" + resolvedWorktree,
+		"WORKTREE=" + worktree,
+		"REPO_URL=https://example.com/my-repo.git",
+		"REPO_NAME=" + filepath.Base(worktree),
+		"BRANCH=agent/test/abc",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(contents, want) {
+			t.Errorf("hook output missing %q.\nfull output:\n%s", want, contents)
+		}
+	}
+}
+
+// TestRunPostCheckoutHookNonExecutableIgnored verifies a non-executable file
+// at the hook path is logged-and-skipped rather than executed.
+func TestRunPostCheckoutHookNonExecutableIgnored(t *testing.T) {
+	hookDir := t.TempDir()
+	hookPath := filepath.Join(hookDir, "hook.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+	t.Setenv("MULTICA_POST_CHECKOUT_HOOK", hookPath)
+	// Should not panic and should not attempt execution. We can't directly
+	// observe the skip without a captured logger, but the absence of a crash
+	// or test-runtime side effect is the contract: non-fatal, ignored.
+	runPostCheckoutHook(t.TempDir(), "url", "main", testLogger())
+}
+
+// TestRunPostCheckoutHookMissingPathIgnored verifies a non-existent hook
+// path is logged-and-skipped (matches the contract that this never aborts
+// the checkout).
+func TestRunPostCheckoutHookMissingPathIgnored(t *testing.T) {
+	t.Setenv("MULTICA_POST_CHECKOUT_HOOK", filepath.Join(t.TempDir(), "does-not-exist.sh"))
+	runPostCheckoutHook(t.TempDir(), "url", "main", testLogger())
+}
+
+// TestRunPostCheckoutHookFailureNonFatal verifies a hook that exits non-zero
+// is logged but does not panic the caller.
+func TestRunPostCheckoutHookFailureNonFatal(t *testing.T) {
+	hookDir := t.TempDir()
+	hookPath := filepath.Join(hookDir, "hook.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 42\n"), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+	t.Setenv("MULTICA_POST_CHECKOUT_HOOK", hookPath)
+	runPostCheckoutHook(t.TempDir(), "url", "main", testLogger())
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `MULTICA_POST_CHECKOUT_HOOK` environment variable. When set to an executable path, the daemon runs that script after every successful worktree create or update in `repocache.CreateWorktree`. The hook receives the worktree as CWD and the following env vars: `MULTICA_WORKTREE_PATH`, `MULTICA_REPO_URL`, `MULTICA_REPO_NAME`, `MULTICA_BRANCH`.

### Why

Self-hosted deployments often need to materialize per-repo state into the worktree immediately after checkout — typical examples:

- **Per-repo secret injection** — write `.env` from an external secret store (Infisical, Vault, Doppler) so dotenv-based tooling (`pnpm dev`, `pytest`, `python-dotenv`) just works once the agent `cd`s in.
- **Per-repo bootstrap** — `pnpm install`, `python -m venv .venv`, `poetry install`, etc.
- **Per-repo skill files** — drop project-specific skill markdown into the worktree.

Today, agents must remember to run such steps manually after `multica repo checkout`. A daemon-level hook makes the bootstrap step transparent and reliable.

### Design

- **Fire-and-log:** failures are warnings, not errors. Checkout always succeeds for the agent regardless of hook outcome.
- **30s timeout** via `context.WithTimeout` so a hung hook cannot stall task spawning.
- **Defensive validation:** missing path / directory / non-executable file are skipped with a warning rather than executed or panicked.
- **No new dependency on Config.** Read directly via `os.Getenv`, matching the `gitEnv` pattern already used in this file.
- **Idempotent at the daemon level:** the hook runs after both fresh worktree creation AND worktree update — so on a reused environment, the hook gets a chance to refresh whatever it manages.

### Behavior matrix

| MULTICA_POST_CHECKOUT_HOOK | Result |
|---|---|
| Unset / empty | No-op (default behavior unchanged) |
| Path to executable file | Hook runs; output logged at INFO if exit 0, WARN with stderr if non-zero |
| Path to missing file | WARN + skip |
| Path to directory | WARN + skip |
| Path to non-executable file | WARN + skip |
| Hook exits non-zero | WARN + checkout still succeeds |
| Hook exceeds 30s | Killed via context cancellation + WARN |

## Test plan

- [x] Unit tests cover: no-op (unset), happy path (env vars + CWD reach the hook), missing path, non-executable file, non-zero exit. All in `cache_test.go`.
- [x] `go test ./internal/daemon/repocache/` — passes
- [x] `go test ./internal/daemon/...` — passes (no regression in sibling packages)
- [ ] Manual e2e on a self-hosted instance with a real hook that writes a `.env` file — pending (will report in a comment).

## Compatibility

Fully backwards compatible. The env var defaults to unset, in which case behavior is identical to today's.