### PR TITLE
feat(views): swimlane supports parent / project / assignee grouping (MUL-2711)

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -12,8 +12,11 @@ import { defaultStorage } from "../../platform/storage";
 export type ViewMode = "board" | "list" | "gantt" | "swimlane";
 export type GanttZoom = "day" | "week" | "month";
 export type IssueGrouping = "status" | "assignee";
+export type SwimlaneGrouping = "parent" | "project" | "assignee";
 export type SortField = "position" | "priority" | "start_date" | "due_date" | "created_at" | "title";
 export type SortDirection = "asc" | "desc";
+
+export const SWIMLANE_GROUPINGS: SwimlaneGrouping[] = ["parent", "project", "assignee"];
 
 export interface CardProperties {
   priority: boolean;
@@ -79,8 +82,15 @@ export interface IssueViewState {
   listCollapsedStatuses: IssueStatus[];
   ganttZoom: GanttZoom;
   ganttShowCompleted: boolean;
-  swimlaneOrder: string[];
-  collapsedSwimlanes: string[];
+  /** Active swimlane grouping dimension. */
+  swimlaneGrouping: SwimlaneGrouping;
+  /** Persisted lane order, keyed by grouping. Entries are raw lane ids
+   *  (parent issue id, project id, or `<assigneeType>:<assigneeId>`). */
+  swimlaneOrders: Record<SwimlaneGrouping, string[]>;
+  /** Persisted collapsed lanes, keyed by grouping. Same id space as
+   *  `swimlaneOrders`, plus the sentinel `"none"` for the pinned
+   *  no-X lane and `"__orphans__"` for the parent-grouping fallback. */
+  collapsedSwimlanes: Record<SwimlaneGrouping, string[]>;
   setViewMode: (mode: ViewMode) => void;
   setGanttZoom: (zoom: GanttZoom) => void;
   toggleGanttShowCompleted: () => void;
@@ -101,7 +111,10 @@ export interface IssueViewState {
   setSortDirection: (dir: SortDirection) => void;
   toggleCardProperty: (key: keyof CardProperties) => void;
   toggleListCollapsed: (status: IssueStatus) => void;
+  setSwimlaneGrouping: (grouping: SwimlaneGrouping) => void;
+  /** Update the lane order for the currently active swimlane grouping. */
   setSwimlaneOrder: (order: string[]) => void;
+  /** Toggle a lane key in the currently active swimlane grouping. */
   toggleSwimlaneCollapsed: (key: string) => void;
 }
 
@@ -132,8 +145,9 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   listCollapsedStatuses: [],
   ganttZoom: "week",
   ganttShowCompleted: false,
-  swimlaneOrder: [],
-  collapsedSwimlanes: [],
+  swimlaneGrouping: "parent",
+  swimlaneOrders: { parent: [], project: [], assignee: [] },
+  collapsedSwimlanes: { parent: [], project: [], assignee: [] },
 
   setViewMode: (mode) => set({ viewMode: mode }),
   setGanttZoom: (zoom) => set({ ganttZoom: zoom }),
@@ -239,13 +253,22 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.listCollapsedStatuses.filter((s) => s !== status)
         : [...state.listCollapsedStatuses, status],
     })),
-  setSwimlaneOrder: (order) => set({ swimlaneOrder: order }),
-  toggleSwimlaneCollapsed: (key) =>
+  setSwimlaneGrouping: (grouping) => set({ swimlaneGrouping: grouping }),
+  setSwimlaneOrder: (order) =>
     set((state) => ({
-      collapsedSwimlanes: state.collapsedSwimlanes.includes(key)
-        ? state.collapsedSwimlanes.filter((k) => k !== key)
-        : [...state.collapsedSwimlanes, key],
+      swimlaneOrders: { ...state.swimlaneOrders, [state.swimlaneGrouping]: order },
     })),
+  toggleSwimlaneCollapsed: (key) =>
+    set((state) => {
+      const grouping = state.swimlaneGrouping;
+      const current = state.collapsedSwimlanes[grouping];
+      const next = current.includes(key)
+        ? current.filter((k) => k !== key)
+        : [...current, key];
+      return {
+        collapsedSwimlanes: { ...state.collapsedSwimlanes, [grouping]: next },
+      };
+    }),
 });
 
 export const viewStorePersistOptions = (name: string) => ({
@@ -272,7 +295,8 @@ export const viewStorePersistOptions = (name: string) => ({
     listCollapsedStatuses: state.listCollapsedStatuses,
     ganttZoom: state.ganttZoom,
     ganttShowCompleted: state.ganttShowCompleted,
-    swimlaneOrder: state.swimlaneOrder,
+    swimlaneGrouping: state.swimlaneGrouping,
+    swimlaneOrders: state.swimlaneOrders,
     collapsedSwimlanes: state.collapsedSwimlanes,
   }),
   // Default Zustand merge is shallow, so a persisted `cardProperties` snapshot
@@ -293,6 +317,13 @@ export function mergeViewStatePersisted<T extends IssueViewState>(
   current: T,
 ): T {
   const p = (persisted ?? {}) as Partial<T>;
+  // `collapsedSwimlanes` changed shape from `string[]` to
+  // `Record<SwimlaneGrouping, string[]>`. A snapshot saved in the old
+  // shape would otherwise overwrite the default record with an array
+  // and crash on first read — fall back to the default when the
+  // persisted value isn't a plain object.
+  const isRecord = (v: unknown): v is Record<string, unknown> =>
+    v !== null && typeof v === "object" && !Array.isArray(v);
   return {
     ...current,
     ...p,
@@ -300,6 +331,12 @@ export function mergeViewStatePersisted<T extends IssueViewState>(
       ...current.cardProperties,
       ...(p.cardProperties ?? {}),
     },
+    swimlaneOrders: isRecord(p.swimlaneOrders)
+      ? { ...current.swimlaneOrders, ...p.swimlaneOrders }
+      : current.swimlaneOrders,
+    collapsedSwimlanes: isRecord(p.collapsedSwimlanes)
+      ? { ...current.collapsedSwimlanes, ...p.collapsedSwimlanes }
+      : current.collapsedSwimlanes,
   };
 }
 

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -145,7 +145,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   listCollapsedStatuses: [],
   ganttZoom: "week",
   ganttShowCompleted: false,
-  swimlaneGrouping: "parent",
+  swimlaneGrouping: "assignee",
   swimlaneOrders: { parent: [], project: [], assignee: [] },
   collapsedSwimlanes: { parent: [], project: [], assignee: [] },
 

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -59,11 +59,12 @@ import { LabelChip } from "../../labels/label-chip";
 import {
   SORT_OPTIONS,
   GROUPING_OPTIONS,
+  SWIMLANE_GROUPINGS,
   CARD_PROPERTY_OPTIONS,
   type ActorFilterValue,
 } from "@multica/core/issues/stores/view-store";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
-import type { SortField, IssueGrouping, ViewMode } from "@multica/core/issues/stores/view-store";
+import type { SortField, IssueGrouping, SwimlaneGrouping, ViewMode } from "@multica/core/issues/stores/view-store";
 import {
   useIssuesScopeStore,
   type IssuesScope,
@@ -602,6 +603,7 @@ export function IssueDisplayControls({
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
   const grouping = useViewStore((s) => s.grouping);
+  const swimlaneGrouping = useViewStore((s) => s.swimlaneGrouping);
   const cardProperties = useViewStore((s) => s.cardProperties);
   const act = useViewStoreApi().getState();
 
@@ -631,6 +633,11 @@ export function IssueDisplayControls({
     status: "group_status",
     assignee: "group_assignee",
   };
+  const SWIMLANE_GROUPING_LABEL_KEY: Record<SwimlaneGrouping, "group_parent" | "group_project" | "group_assignee"> = {
+    parent: "group_parent",
+    project: "group_project",
+    assignee: "group_assignee",
+  };
   const CARD_PROPERTY_LABEL_KEY: Record<typeof CARD_PROPERTY_OPTIONS[number]["key"], "card_priority" | "card_description" | "card_assignee" | "card_start_date" | "card_due_date" | "card_project" | "card_labels" | "card_child_progress"> = {
     priority: "card_priority",
     description: "card_description",
@@ -643,6 +650,7 @@ export function IssueDisplayControls({
   };
   const sortLabel = t(($) => $.display[SORT_LABEL_KEY[sortBy]]);
   const groupingLabel = t(($) => $.display[GROUPING_LABEL_KEY[grouping]]);
+  const swimlaneGroupingLabel = t(($) => $.display[SWIMLANE_GROUPING_LABEL_KEY[swimlaneGrouping]]);
 
   return (
     <div className="flex items-center gap-1">
@@ -903,6 +911,41 @@ export function IssueDisplayControls({
                         {GROUPING_OPTIONS.map((opt) => (
                           <DropdownMenuRadioItem key={opt.value} value={opt.value}>
                             {t(($) => $.display[GROUPING_LABEL_KEY[opt.value]])}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </div>
+            )}
+            {viewMode === "swimlane" && (
+              <div className="border-b px-3 py-2.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {t(($) => $.display.grouping_section)}
+                </span>
+                <div className="mt-2">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full justify-between text-xs"
+                        >
+                          {swimlaneGroupingLabel}
+                          <ChevronDown className="size-3 text-muted-foreground" />
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent align="start" className="w-auto">
+                      <DropdownMenuRadioGroup
+                        value={swimlaneGrouping}
+                        onValueChange={(v) => act.setSwimlaneGrouping(v as SwimlaneGrouping)}
+                      >
+                        {SWIMLANE_GROUPINGS.map((value) => (
+                          <DropdownMenuRadioItem key={value} value={value}>
+                            {t(($) => $.display[SWIMLANE_GROUPING_LABEL_KEY[value]])}
                           </DropdownMenuRadioItem>
                         ))}
                       </DropdownMenuRadioGroup>

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -27,6 +27,32 @@ vi.mock("@multica/core/paths", async () => {
   };
 });
 
+// Stub backend-bound queries that the swimlane invokes for project /
+// assignee groupings. The hook MUST return a stable reference each call
+// — production `useActorName` wraps its returns in `useMemo`, and the
+// swimlane feeds the result into a `useMemo(..., [getActorName, ...])`
+// that then drives a `useEffect(setLocalCells, [cells])` chain. A fresh
+// object per render therefore loops the effect indefinitely.
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: (_wsId: string) => ({
+    queryKey: ["projects", _wsId, "list"],
+    queryFn: () => Promise.resolve([]),
+  }),
+}));
+const { mockActorNameResult } = vi.hoisted(() => ({
+  mockActorNameResult: {
+    getActorName: (_type: string, _id: string) => "Mock Actor",
+    getActorInitials: () => "MA",
+    getActorAvatarUrl: () => null,
+    getMemberName: () => "Mock Member",
+    getAgentName: () => "Mock Agent",
+    getSquadName: () => "Mock Squad",
+  },
+}));
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => mockActorNameResult,
+}));
+
 // Mock @multica/core/auth
 const mockAuthUser = { id: "user-1", email: "test@test.com", name: "Test User" };
 vi.mock("@multica/core/auth", () => ({
@@ -97,15 +123,22 @@ vi.mock("@multica/core/issues/mutations", async (importOriginal) => {
   };
 });
 
-// Mock view store. `swimlaneOrder` is mutable on the captured object so
-// tests can simulate persisted lane order and assert that
-// `setSwimlaneOrder` was called by drag-end handlers.
+type SwimlaneGroupingMock = "parent" | "project" | "assignee";
+
+// Mock view store. The lane order and collapsed-lane fields are mutable
+// records on the captured object so tests can simulate persisted state
+// (per grouping) and assert that `setSwimlaneOrder` was called by drag-end
+// handlers. The store actions operate on `swimlaneGrouping` — tests that
+// flip grouping must set both `swimlaneGrouping` and the matching slice
+// in `swimlaneOrders` / `collapsedSwimlanes`.
 const mockViewState: {
   sortBy: "position";
   sortDirection: "asc";
   cardProperties: Record<string, boolean>;
-  swimlaneOrder: string[];
-  collapsedSwimlanes: string[];
+  swimlaneGrouping: SwimlaneGroupingMock;
+  swimlaneOrders: Record<SwimlaneGroupingMock, string[]>;
+  collapsedSwimlanes: Record<SwimlaneGroupingMock, string[]>;
+  setSwimlaneGrouping: (g: SwimlaneGroupingMock) => void;
   setSwimlaneOrder: (order: string[]) => void;
   toggleSwimlaneCollapsed: (key: string) => void;
   hideStatus: (s: string) => void;
@@ -114,8 +147,10 @@ const mockViewState: {
   sortBy: "position",
   sortDirection: "asc",
   cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
-  swimlaneOrder: [],
-  collapsedSwimlanes: [],
+  swimlaneGrouping: "parent",
+  swimlaneOrders: { parent: [], project: [], assignee: [] },
+  collapsedSwimlanes: { parent: [], project: [], assignee: [] },
+  setSwimlaneGrouping: vi.fn(),
   setSwimlaneOrder: vi.fn(),
   toggleSwimlaneCollapsed: vi.fn(),
   hideStatus: vi.fn(),
@@ -269,8 +304,9 @@ function renderWithI18n(ui: React.ReactNode) {
 describe("SwimLaneView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockViewState.swimlaneOrder = [];
-    mockViewState.collapsedSwimlanes = [];
+    mockViewState.swimlaneGrouping = "parent";
+    mockViewState.swimlaneOrders = { parent: [], project: [], assignee: [] };
+    mockViewState.collapsedSwimlanes = { parent: [], project: [], assignee: [] };
     useLoadMoreByStatusMock.mockImplementation(() => ({
       total: 0,
       loaded: 0,
@@ -727,8 +763,8 @@ describe("SwimLaneView", () => {
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "lane:parent-1" },
-        over: { id: "lane:parent-2" },
+        active: { id: "lane:parent:parent-1" },
+        over: { id: "lane:parent:parent-2" },
       });
     });
 
@@ -736,7 +772,10 @@ describe("SwimLaneView", () => {
   });
 
   it("appends newly-visible parents to the persisted order on first reorder", () => {
-    mockViewState.swimlaneOrder = ["parent-1"];
+    mockViewState.swimlaneOrders = {
+      ...mockViewState.swimlaneOrders,
+      parent: ["parent-1"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
@@ -744,8 +783,8 @@ describe("SwimLaneView", () => {
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "lane:parent-1" },
-        over: { id: "lane:parent-2" },
+        active: { id: "lane:parent:parent-1" },
+        over: { id: "lane:parent:parent-2" },
       });
     });
 
@@ -753,7 +792,10 @@ describe("SwimLaneView", () => {
   });
 
   it("preserves persisted entries that aren't currently visible during a reorder", () => {
-    mockViewState.swimlaneOrder = ["filtered-a", "parent-1", "filtered-b", "parent-2"];
+    mockViewState.swimlaneOrders = {
+      ...mockViewState.swimlaneOrders,
+      parent: ["filtered-a", "parent-1", "filtered-b", "parent-2"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
@@ -761,8 +803,8 @@ describe("SwimLaneView", () => {
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "lane:parent-1" },
-        over: { id: "lane:parent-2" },
+        active: { id: "lane:parent:parent-1" },
+        over: { id: "lane:parent:parent-2" },
       });
     });
 
@@ -781,8 +823,8 @@ describe("SwimLaneView", () => {
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "lane:parent-1" },
-        over: { id: "lane:parent-1" },
+        active: { id: "lane:parent:parent-1" },
+        over: { id: "lane:parent:parent-1" },
       });
     });
 
@@ -797,8 +839,8 @@ describe("SwimLaneView", () => {
 
     act(() => {
       lastOnDragEnd({
-        active: { id: "lane:parent-1" },
-        over: { id: "lane:parent-2" },
+        active: { id: "lane:parent:parent-1" },
+        over: { id: "lane:parent:parent-2" },
       });
     });
 
@@ -806,7 +848,10 @@ describe("SwimLaneView", () => {
   });
 
   it("renders parent lanes in stored swimlaneOrder when set", () => {
-    mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
+    mockViewState.swimlaneOrders = {
+      ...mockViewState.swimlaneOrders,
+      parent: ["parent-2", "parent-1"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
@@ -820,7 +865,10 @@ describe("SwimLaneView", () => {
   });
 
   it("keeps 'No parent' lane pinned at top regardless of stored order", () => {
-    mockViewState.swimlaneOrder = ["parent-2", "parent-1"];
+    mockViewState.swimlaneOrders = {
+      ...mockViewState.swimlaneOrders,
+      parent: ["parent-2", "parent-1"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
@@ -836,7 +884,10 @@ describe("SwimLaneView", () => {
   // ------------------------------------------------------------------
 
   it("collapses a parent lane when its id is in stored collapsedSwimlanes", () => {
-    mockViewState.collapsedSwimlanes = ["parent-1"];
+    mockViewState.collapsedSwimlanes = {
+      ...mockViewState.collapsedSwimlanes,
+      parent: ["parent-1"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
@@ -851,7 +902,10 @@ describe("SwimLaneView", () => {
   });
 
   it("collapses the 'No parent' lane when 'none' is in stored collapsedSwimlanes", () => {
-    mockViewState.collapsedSwimlanes = ["none"];
+    mockViewState.collapsedSwimlanes = {
+      ...mockViewState.collapsedSwimlanes,
+      parent: ["none"],
+    };
 
     renderWithI18n(
       <SwimLaneView issues={mockIssues} onMoveIssue={vi.fn()} />,
@@ -886,5 +940,210 @@ describe("SwimLaneView", () => {
     fireEvent.click(noParentHeader!);
 
     expect(mockToggleSwimlaneCollapsed).toHaveBeenCalledWith("none");
+  });
+
+  // ------------------------------------------------------------------
+  // Project grouping
+  // ------------------------------------------------------------------
+
+  const projectIssues: Issue[] = [
+    {
+      ...mockIssues[0]!,
+      id: "issue-a",
+      identifier: "PROJ-100",
+      title: "Issue A",
+      project_id: "proj-1",
+      parent_issue_id: null,
+      status: "todo",
+    },
+    {
+      ...mockIssues[0]!,
+      id: "issue-b",
+      identifier: "PROJ-101",
+      title: "Issue B",
+      project_id: "proj-2",
+      parent_issue_id: null,
+      status: "in_progress",
+    },
+    {
+      ...mockIssues[0]!,
+      id: "issue-c",
+      identifier: "PROJ-102",
+      title: "Issue C",
+      project_id: null,
+      parent_issue_id: null,
+      status: "todo",
+    },
+  ];
+
+  it("groups by project when swimlaneGrouping is 'project'", () => {
+    mockViewState.swimlaneGrouping = "project";
+
+    renderWithI18n(
+      <SwimLaneView issues={projectIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // No-project pinned lane is always present.
+    expect(screen.getAllByText("No project").length).toBeGreaterThanOrEqual(1);
+    // Both issue cards from real projects render — production fetches
+    // project titles from the API; in tests the mocked listProjects
+    // returns [] so the lane headers fall back to an empty title and
+    // we assert on card visibility, not lane title text.
+    expect(screen.getByText("Issue A")).toBeInTheDocument();
+    expect(screen.getByText("Issue B")).toBeInTheDocument();
+    expect(screen.getByText("Issue C")).toBeInTheDocument();
+  });
+
+  it("emits project_id when a card is dropped into a project lane", () => {
+    mockViewState.swimlaneGrouping = "project";
+    const mockOnMoveIssue = vi.fn();
+
+    renderWithI18n(
+      <SwimLaneView issues={projectIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    // Drop "issue-c" (no project) into proj-1's todo cell.
+    const target = "swim:project:proj-1:todo";
+    act(() => {
+      lastOnDragOver({ active: { id: "issue-c" }, over: { id: target } });
+    });
+    act(() => {
+      lastOnDragEnd({ active: { id: "issue-c" }, over: { id: target } });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "issue-c",
+      expect.objectContaining({ project_id: "proj-1", status: "todo" }),
+    );
+  });
+
+  it("emits null project_id when a card is dropped into the 'No project' lane", () => {
+    mockViewState.swimlaneGrouping = "project";
+    const mockOnMoveIssue = vi.fn();
+
+    renderWithI18n(
+      <SwimLaneView issues={projectIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    const target = "swim:project:none:in_review";
+    act(() => {
+      lastOnDragOver({ active: { id: "issue-a" }, over: { id: target } });
+    });
+    act(() => {
+      lastOnDragEnd({ active: { id: "issue-a" }, over: { id: target } });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "issue-a",
+      expect.objectContaining({ project_id: null, status: "in_review" }),
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // Assignee grouping
+  // ------------------------------------------------------------------
+
+  const assigneeIssues: Issue[] = [
+    {
+      ...mockIssues[0]!,
+      id: "issue-x",
+      identifier: "PROJ-200",
+      title: "Issue X",
+      assignee_type: "member",
+      assignee_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      status: "todo",
+    },
+    {
+      ...mockIssues[0]!,
+      id: "issue-y",
+      identifier: "PROJ-201",
+      title: "Issue Y",
+      assignee_type: "agent",
+      assignee_id: "agent-1",
+      parent_issue_id: null,
+      project_id: null,
+      status: "in_progress",
+    },
+    {
+      ...mockIssues[0]!,
+      id: "issue-z",
+      identifier: "PROJ-202",
+      title: "Issue Z",
+      assignee_type: null,
+      assignee_id: null,
+      parent_issue_id: null,
+      project_id: null,
+      status: "todo",
+    },
+  ];
+
+  it("groups by assignee when swimlaneGrouping is 'assignee'", () => {
+    mockViewState.swimlaneGrouping = "assignee";
+
+    renderWithI18n(
+      <SwimLaneView issues={assigneeIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    // Unassigned pinned lane is always rendered.
+    expect(screen.getAllByText("Unassigned").length).toBeGreaterThanOrEqual(1);
+    // Mock actor name fallback for both member and agent.
+    expect(screen.getAllByText("Mock Actor").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Issue X")).toBeInTheDocument();
+    expect(screen.getByText("Issue Y")).toBeInTheDocument();
+    expect(screen.getByText("Issue Z")).toBeInTheDocument();
+  });
+
+  it("emits assignee_type + assignee_id when a card is dropped into an actor lane", () => {
+    mockViewState.swimlaneGrouping = "assignee";
+    const mockOnMoveIssue = vi.fn();
+
+    renderWithI18n(
+      <SwimLaneView issues={assigneeIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    const target = "swim:assignee:member:user-1:in_review";
+    act(() => {
+      lastOnDragOver({ active: { id: "issue-z" }, over: { id: target } });
+    });
+    act(() => {
+      lastOnDragEnd({ active: { id: "issue-z" }, over: { id: target } });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "issue-z",
+      expect.objectContaining({
+        assignee_type: "member",
+        assignee_id: "user-1",
+        status: "in_review",
+      }),
+    );
+  });
+
+  it("emits null assignee when a card is dropped into the 'Unassigned' lane", () => {
+    mockViewState.swimlaneGrouping = "assignee";
+    const mockOnMoveIssue = vi.fn();
+
+    renderWithI18n(
+      <SwimLaneView issues={assigneeIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    const target = "swim:assignee:none:done";
+    act(() => {
+      lastOnDragOver({ active: { id: "issue-x" }, over: { id: target } });
+    });
+    act(() => {
+      lastOnDragEnd({ active: { id: "issue-x" }, over: { id: target } });
+    });
+
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "issue-x",
+      expect.objectContaining({
+        assignee_type: null,
+        assignee_id: null,
+        status: "done",
+      }),
+    );
   });
 });

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -18,10 +18,20 @@ import {
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { ChevronRight, EyeOff, GripVertical, MoreHorizontal, Pencil, Plus } from "lucide-react";
-import type { Issue, IssueStatus } from "@multica/core/types";
-import type { UpdateIssueRequest } from "@multica/core/types";
+import { useQuery } from "@tanstack/react-query";
+import type {
+  Issue,
+  IssueAssigneeType,
+  IssueStatus,
+  Project,
+  UpdateIssueRequest,
+} from "@multica/core/types";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
+import type { SwimlaneGrouping } from "@multica/core/issues/stores/view-store";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { projectListOptions } from "@multica/core/projects/queries";
+import { useActorName } from "@multica/core/workspace/hooks";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
 import {
@@ -41,6 +51,8 @@ import { StatusHeading } from "./status-heading";
 import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import { AppLink } from "../../navigation";
+import { ProjectIcon } from "../../projects/components/project-icon";
+import { ActorAvatar } from "../../common/actor-avatar";
 import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
 
@@ -49,7 +61,12 @@ const COLUMN_GAP = 16;
 
 type SwimLaneMoveUpdates = Pick<
   UpdateIssueRequest,
-  "parent_issue_id" | "status" | "position"
+  | "parent_issue_id"
+  | "project_id"
+  | "assignee_type"
+  | "assignee_id"
+  | "status"
+  | "position"
 >;
 
 function makeSwimLaneCollision(cellIds: Set<string>): CollisionDetection {
@@ -87,13 +104,13 @@ function makeSwimLaneCollision(cellIds: Set<string>): CollisionDetection {
   };
 }
 
-function parseCellId(id: string): { parentKey: string; status: string } | null {
+function parseCellId(id: string): { laneKey: string; status: string } | null {
   if (!id.startsWith("swim:")) return null;
   const rest = id.slice(5);
   const lastColon = rest.lastIndexOf(":");
   if (lastColon === -1) return null;
   return {
-    parentKey: rest.slice(0, lastColon),
+    laneKey: rest.slice(0, lastColon),
     status: rest.slice(lastColon + 1),
   };
 }
@@ -102,33 +119,46 @@ function findCellIn(
   data: Record<string, Record<string, string[]>>,
   cellIds: Set<string>,
   id: string,
-): { parentKey: string; status: string } | null {
+): { laneKey: string; status: string } | null {
   if (cellIds.has(id)) return parseCellId(id);
   for (const [pk, statusMap] of Object.entries(data)) {
     for (const [status, ids] of Object.entries(statusMap)) {
-      if (ids.includes(id)) return { parentKey: pk, status };
+      if (ids.includes(id)) return { laneKey: pk, status };
     }
   }
   return null;
 }
 
-function cellId(parentKey: string, status: IssueStatus): string {
-  return `swim:${parentKey}:${status}`;
+function cellId(laneKey: string, status: IssueStatus): string {
+  return `swim:${laneKey}:${status}`;
 }
 
 const LANE_ID_PREFIX = "lane:";
 
-/** Sentinel key for the "Other parents" fallback lane. */
-const ORPHAN_LANE_KEY = "parent:__orphans__";
+/** Sentinel id slice (after the grouping prefix) for the pinned no-X lane. */
+const NONE_LANE_ID = "none";
 
-/** Sortable id for a draggable swimlane header (parents only). */
-function laneId(parentIssueId: string): string {
-  return `${LANE_ID_PREFIX}${parentIssueId}`;
+/** Sentinel id slice for the parent-grouping orphan fallback lane. */
+const ORPHAN_LANE_ID = "__orphans__";
+
+/**
+ * Sortable id for a draggable swimlane header. Pinned lanes (no-X) and the
+ * orphan fallback get a stable but unique-per-grouping id so dnd-kit doesn't
+ * silently collapse them onto a real lane id when both happen to be empty.
+ */
+function laneIdFor(grouping: SwimlaneGrouping, rawId: string): string {
+  return `${LANE_ID_PREFIX}${grouping}:${rawId}`;
 }
 
-function parseLaneId(id: string): string | null {
+function parseLaneId(id: string): { grouping: string; rawId: string } | null {
   if (!id.startsWith(LANE_ID_PREFIX)) return null;
-  return id.slice(LANE_ID_PREFIX.length);
+  const rest = id.slice(LANE_ID_PREFIX.length);
+  const firstColon = rest.indexOf(":");
+  if (firstColon === -1) return null;
+  return {
+    grouping: rest.slice(0, firstColon),
+    rawId: rest.slice(firstColon + 1),
+  };
 }
 
 function computePosition(ids: string[], activeId: string, issueMap: Map<string, Issue>): number {
@@ -141,16 +171,261 @@ function computePosition(ids: string[], activeId: string, issueMap: Map<string, 
   return (getPos(ids[idx - 1]!) + getPos(ids[idx + 1]!)) / 2;
 }
 
-interface ParentGroup {
+/**
+ * One swimlane row. Lanes are produced by a per-grouping builder
+ * (`buildParentLanes` / `buildProjectLanes` / `buildAssigneeLanes`) and then
+ * consumed uniformly by the renderer. The matcher/move-updates closures hide
+ * the grouping-specific details behind a single interface so the drag-end
+ * handler doesn't need to branch on grouping.
+ */
+interface LaneGroup {
+  /** Full lane key — `<grouping>:<rawId>`. Used in cell ids and as the dictionary key. */
   key: string;
-  parentIssueId: string | null;
-  identifier: string;
+  /** Unique-within-grouping id slice (after the grouping prefix). */
+  rawId: string;
+  /** Pinned lane (no-X). Always rendered at the top, never draggable. */
+  isPinned: boolean;
+  /**
+   * Display-only fallback bucket for the parent grouping — children whose
+   * canonical parent isn't in the loaded set. Drops in/out are rejected
+   * because we can't synthesize the missing parent id.
+   */
+  isOrphan: boolean;
   title: string;
-  /** Full Issue object for the parent — available for parent lanes, null for "No parent". */
-  issue: Issue | null;
+  identifier: string;
+  /** Parent issue (parent grouping only) — drives the open-parent link + status icon in the header. */
+  parentIssue: Issue | null;
+  /** Project metadata (project grouping only) — drives the icon in the header. */
+  project: Project | null;
+  /** Actor (assignee grouping only) — drives the avatar in the header. */
+  actor: { type: IssueAssigneeType; id: string } | null;
+  /** Whether this lane owns `issue`. */
+  matches: (issue: Issue) => boolean;
+  /**
+   * Payload fragment emitted to `onMoveIssue` when an issue is dropped into
+   * this lane. Status + position are filled in by the drag-end handler.
+   */
+  moveUpdates: SwimLaneMoveUpdates;
 }
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+const EMPTY_PROJECTS: Project[] = [];
+
+/**
+ * Build parent-grouping lanes. The "No parent" lane is always pinned at the
+ * top; the "Other parents" fallback (children whose parent isn't loaded) is
+ * appended after it when present.
+ */
+function buildParentLanes(
+  visibleIssues: Issue[],
+  metadataIssues: Issue[],
+  storedOrder: string[],
+  labels: { noParent: string; otherParents: string },
+): LaneGroup[] {
+  const metadataMap = new Map<string, Issue>();
+  for (const issue of metadataIssues) metadataMap.set(issue.id, issue);
+
+  const seen = new Map<string, LaneGroup>();
+  let hasOrphan = false;
+  for (const issue of visibleIssues) {
+    if (issue.parent_issue_id === null) continue;
+    const parent = metadataMap.get(issue.parent_issue_id);
+    if (!parent) {
+      hasOrphan = true;
+      continue;
+    }
+    const key = `parent:${issue.parent_issue_id}`;
+    if (!seen.has(key)) {
+      const parentId = issue.parent_issue_id;
+      seen.set(key, {
+        key,
+        rawId: parentId,
+        isPinned: false,
+        isOrphan: false,
+        title: parent.title,
+        identifier: parent.identifier,
+        parentIssue: parent,
+        project: null,
+        actor: null,
+        matches: (i) => i.parent_issue_id === parentId,
+        moveUpdates: { parent_issue_id: parentId },
+      });
+    }
+  }
+
+  const orderIndex = new Map<string, number>();
+  storedOrder.forEach((parentId, idx) => orderIndex.set(`parent:${parentId}`, idx));
+  const ordered = Array.from(seen.values()).sort((a, b) => {
+    const ai = orderIndex.get(a.key);
+    const bi = orderIndex.get(b.key);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    return 0;
+  });
+
+  const lanes: LaneGroup[] = [
+    {
+      key: `parent:${NONE_LANE_ID}`,
+      rawId: NONE_LANE_ID,
+      isPinned: true,
+      isOrphan: false,
+      title: labels.noParent,
+      identifier: "",
+      parentIssue: null,
+      project: null,
+      actor: null,
+      matches: (i) => i.parent_issue_id === null,
+      moveUpdates: { parent_issue_id: null },
+    },
+  ];
+  if (hasOrphan) {
+    lanes.push({
+      key: `parent:${ORPHAN_LANE_ID}`,
+      rawId: ORPHAN_LANE_ID,
+      isPinned: true,
+      isOrphan: true,
+      title: labels.otherParents,
+      identifier: "",
+      parentIssue: null,
+      project: null,
+      actor: null,
+      // Match the canonical filter logic: a child whose parent isn't a
+      // header lane in the current render.
+      matches: () => false,
+      moveUpdates: {},
+    });
+  }
+  lanes.push(...ordered);
+  return lanes;
+}
+
+function buildProjectLanes(
+  visibleIssues: Issue[],
+  projects: Project[],
+  storedOrder: string[],
+  labels: { noProject: string },
+): LaneGroup[] {
+  const projectMap = new Map<string, Project>();
+  for (const p of projects) projectMap.set(p.id, p);
+
+  const seen = new Map<string, LaneGroup>();
+  for (const issue of visibleIssues) {
+    if (issue.project_id === null) continue;
+    const key = `project:${issue.project_id}`;
+    if (seen.has(key)) continue;
+    const project = projectMap.get(issue.project_id) ?? null;
+    const projectId = issue.project_id;
+    seen.set(key, {
+      key,
+      rawId: projectId,
+      isPinned: false,
+      isOrphan: false,
+      title: project?.title ?? "",
+      identifier: "",
+      parentIssue: null,
+      project,
+      actor: null,
+      matches: (i) => i.project_id === projectId,
+      moveUpdates: { project_id: projectId },
+    });
+  }
+
+  const orderIndex = new Map<string, number>();
+  storedOrder.forEach((id, idx) => orderIndex.set(`project:${id}`, idx));
+  const ordered = Array.from(seen.values()).sort((a, b) => {
+    const ai = orderIndex.get(a.key);
+    const bi = orderIndex.get(b.key);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  return [
+    {
+      key: `project:${NONE_LANE_ID}`,
+      rawId: NONE_LANE_ID,
+      isPinned: true,
+      isOrphan: false,
+      title: labels.noProject,
+      identifier: "",
+      parentIssue: null,
+      project: null,
+      actor: null,
+      matches: (i) => i.project_id === null,
+      moveUpdates: { project_id: null },
+    },
+    ...ordered,
+  ];
+}
+
+function buildAssigneeLanes(
+  visibleIssues: Issue[],
+  getActorName: (type: string, id: string) => string,
+  storedOrder: string[],
+  labels: { noAssignee: string },
+): LaneGroup[] {
+  const seen = new Map<string, LaneGroup>();
+  for (const issue of visibleIssues) {
+    if (issue.assignee_type === null || issue.assignee_id === null) continue;
+    const assigneeType: IssueAssigneeType = issue.assignee_type;
+    const assigneeId = issue.assignee_id;
+    const rawId = `${assigneeType}:${assigneeId}`;
+    const key = `assignee:${rawId}`;
+    if (seen.has(key)) continue;
+    seen.set(key, {
+      key,
+      rawId,
+      isPinned: false,
+      isOrphan: false,
+      title: getActorName(assigneeType, assigneeId),
+      identifier: "",
+      parentIssue: null,
+      project: null,
+      actor: { type: assigneeType, id: assigneeId },
+      matches: (i) =>
+        i.assignee_type === assigneeType && i.assignee_id === assigneeId,
+      moveUpdates: {
+        assignee_type: assigneeType,
+        assignee_id: assigneeId,
+      },
+    });
+  }
+
+  // Sort by actor type (members before agents before squads) then by name.
+  const typeOrder: Record<string, number> = { member: 0, agent: 1, squad: 2 };
+  const orderIndex = new Map<string, number>();
+  storedOrder.forEach((id, idx) => orderIndex.set(`assignee:${id}`, idx));
+  const ordered = Array.from(seen.values()).sort((a, b) => {
+    const ai = orderIndex.get(a.key);
+    const bi = orderIndex.get(b.key);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    const at = typeOrder[a.actor?.type ?? ""] ?? 99;
+    const bt = typeOrder[b.actor?.type ?? ""] ?? 99;
+    if (at !== bt) return at - bt;
+    return a.title.localeCompare(b.title);
+  });
+
+  return [
+    {
+      key: `assignee:${NONE_LANE_ID}`,
+      rawId: NONE_LANE_ID,
+      isPinned: true,
+      isOrphan: false,
+      title: labels.noAssignee,
+      identifier: "",
+      parentIssue: null,
+      project: null,
+      actor: null,
+      matches: (i) => i.assignee_id === null,
+      moveUpdates: { assignee_type: null, assignee_id: null },
+    },
+    ...ordered,
+  ];
+}
 
 export function SwimLaneView({
   issues,
@@ -190,7 +465,16 @@ export function SwimLaneView({
   const viewStoreApi = useViewStoreApi();
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
-  const swimlaneOrder = useViewStore((s) => s.swimlaneOrder);
+  const swimlaneGrouping = useViewStore((s) => s.swimlaneGrouping);
+  const swimlaneOrders = useViewStore((s) => s.swimlaneOrders);
+  const swimlaneOrder = swimlaneOrders[swimlaneGrouping];
+
+  const wsId = useWorkspaceId();
+  const { data: projects = EMPTY_PROJECTS } = useQuery({
+    ...projectListOptions(wsId),
+    enabled: swimlaneGrouping === "project",
+  });
+  const { getActorName } = useActorName();
 
   const laneSourceIssues = unfilteredIssues ?? issues;
 
@@ -207,176 +491,142 @@ export function SwimLaneView({
     [visibleStatuses],
   );
 
-  const parentGroups = useMemo<ParentGroup[]>(() => {
-    // Metadata lookup spans the broader unfiltered set so a parent whose
-    // status is currently hidden still surfaces its identifier / title
-    // when one of its children is visible.
-    const metadataMap = new Map<string, Issue>();
-    for (const issue of laneSourceIssues) {
-      metadataMap.set(issue.id, issue);
-    }
-
-    // Lane discovery drives off the visible `issues` set — a lane is
-    // only rendered when at least one visible card belongs in it. This
-    // avoids a stack of empty rows for parents whose children all live
-    // in currently-filtered-out statuses.
-    const seen = new Map<string, ParentGroup>();
-    let hasOrphan = false;
-    for (const issue of issues) {
-      if (issue.parent_issue_id === null) continue;
-      const parent = metadataMap.get(issue.parent_issue_id);
-      if (!parent) {
-        hasOrphan = true;
-        continue;
-      }
-      const key = `parent:${issue.parent_issue_id}`;
-      if (!seen.has(key)) {
-        seen.set(key, {
-          key,
-          parentIssueId: issue.parent_issue_id,
-          identifier: parent.identifier,
-          title: parent.title,
-          issue: parent,
-        });
-      }
-    }
-
-    // Apply user-defined lane order: stored entries first (in the order they
-    // were saved), then any newly-introduced parents that aren't in the
-    // stored order yet (in natural data order, so they don't randomly
-    // shuffle around). "No parent" is always pinned at the very top.
-    const orderIndex = new Map<string, number>();
-    swimlaneOrder.forEach((parentId, idx) => {
-      orderIndex.set(`parent:${parentId}`, idx);
-    });
-    const ordered = Array.from(seen.values()).sort((a, b) => {
-      const ai = orderIndex.get(a.key);
-      const bi = orderIndex.get(b.key);
-      if (ai !== undefined && bi !== undefined) return ai - bi;
-      if (ai !== undefined) return -1; // a is stored, b isn't → a first
-      if (bi !== undefined) return 1;
-      return 0; // both unstored → preserve insertion order
-    });
-
-    const groups: ParentGroup[] = [
-      {
-        key: "parent:none",
-        parentIssueId: null,
-        identifier: "",
-        title: t(($) => $.swimlane.no_parent),
-        issue: null,
-      },
-    ];
-    if (hasOrphan) {
-      groups.push({
-        key: ORPHAN_LANE_KEY,
-        parentIssueId: null,
-        identifier: "",
-        title: t(($) => $.swimlane.other_parents),
-        issue: null,
-      });
-    }
-    groups.push(...ordered);
-    return groups;
-  }, [issues, laneSourceIssues, t, swimlaneOrder]);
-
-  // Issues that act as swimlane headers (they have children in the loaded
-  // set) should not also appear as cards in the "No parent" lane — that
-  // would be redundant noise since the lane header already represents them.
-  const parentIssueIds = useMemo(
-    () => new Set(parentGroups.map((g) => g.parentIssueId).filter(Boolean)),
-    [parentGroups],
+  const laneLabels = useMemo(
+    () => ({
+      noParent: t(($) => $.swimlane.no_parent),
+      otherParents: t(($) => $.swimlane.other_parents),
+      noProject: t(($) => $.swimlane.no_project),
+      noAssignee: t(($) => $.swimlane.no_assignee),
+    }),
+    [t],
   );
 
+  const laneGroups = useMemo<LaneGroup[]>(() => {
+    if (swimlaneGrouping === "project") {
+      return buildProjectLanes(issues, projects, swimlaneOrder, laneLabels);
+    }
+    if (swimlaneGrouping === "assignee") {
+      return buildAssigneeLanes(issues, getActorName, swimlaneOrder, laneLabels);
+    }
+    return buildParentLanes(issues, laneSourceIssues, swimlaneOrder, laneLabels);
+  }, [
+    swimlaneGrouping,
+    issues,
+    laneSourceIssues,
+    projects,
+    getActorName,
+    swimlaneOrder,
+    laneLabels,
+  ]);
+
+  // For parent grouping: issues that are themselves lane headers should not
+  // also appear as cards (that would be a double-render). Other groupings
+  // never collide this way (lanes are projects/actors, not issues), so the
+  // set is empty there.
+  const headerIssueIds = useMemo(() => {
+    if (swimlaneGrouping !== "parent") return new Set<string>();
+    return new Set(
+      laneGroups
+        .filter((g) => g.parentIssue !== null)
+        .map((g) => g.parentIssue!.id),
+    );
+  }, [laneGroups, swimlaneGrouping]);
+
+  // Map of issue id → owning lane key. Used by orphan detection for parent
+  // grouping (a child whose canonical parent isn't a lane header here lands
+  // in the fallback) and as the matcher hot-path for project/assignee.
   const cells = useMemo(() => {
     const result: Record<string, Record<string, string[]>> = {};
-    for (const parent of parentGroups) {
+    for (const lane of laneGroups) {
       const cellMap: Record<string, string[]> = {};
-      for (const status of sortedStatuses) {
-        cellMap[status] = [];
-      }
-      const parentIssues = sortIssues(
-        issues.filter((issue) => {
-          // Issues that are themselves lane headers are rendered by the
-          // header, not as a card — avoids a double render for multi-level
-          // nesting (a parent that also has a grandparent).
-          if (parentIssueIds.has(issue.id)) return false;
-          if (parent.key === ORPHAN_LANE_KEY) {
-            // Fallback bucket: children whose parent isn't in the loaded
-            // set (deleted, or filtered out by a server-side scope like
-            // "assigned to me"). Catches them so they don't silently
-            // vanish from Swimlane while still visible in Board/List.
-            return (
-              issue.parent_issue_id !== null &&
-              !parentIssueIds.has(issue.parent_issue_id)
-            );
+      for (const status of sortedStatuses) cellMap[status] = [];
+      result[lane.key] = cellMap;
+    }
+
+    const orphanLane =
+      swimlaneGrouping === "parent"
+        ? laneGroups.find((g) => g.isOrphan) ?? null
+        : null;
+
+    const filtered = issues.filter((i) => !headerIssueIds.has(i.id));
+    const sorted = sortIssues(filtered, sortBy, sortDirection);
+    for (const issue of sorted) {
+      let placed = false;
+      for (const lane of laneGroups) {
+        if (lane.isOrphan) continue;
+        if (lane.matches(issue)) {
+          const status = issue.status;
+          if (result[lane.key]?.[status]) {
+            result[lane.key]![status]!.push(issue.id);
+            placed = true;
+            break;
           }
-          if (parent.parentIssueId === null) {
-            return issue.parent_issue_id === null;
-          }
-          return issue.parent_issue_id === parent.parentIssueId;
-        }),
-        sortBy,
-        sortDirection,
-      );
-      for (const issue of parentIssues) {
-        const s = issue.status;
-        if (cellMap[s]) {
-          cellMap[s].push(issue.id);
         }
       }
-      result[parent.key] = cellMap;
+      // Parent grouping: a child whose parent isn't a header here falls
+      // into the orphan fallback so it doesn't silently disappear.
+      if (!placed && orphanLane && issue.parent_issue_id !== null) {
+        const status = issue.status;
+        if (result[orphanLane.key]?.[status]) {
+          result[orphanLane.key]![status]!.push(issue.id);
+        }
+      }
     }
     return result;
-  }, [issues, parentGroups, sortedStatuses, sortBy, sortDirection, parentIssueIds]);
+  }, [issues, laneGroups, sortedStatuses, sortBy, sortDirection, headerIssueIds, swimlaneGrouping]);
+
+  const laneByKey = useMemo(() => {
+    const map = new Map<string, LaneGroup>();
+    for (const lane of laneGroups) map.set(lane.key, lane);
+    return map;
+  }, [laneGroups]);
 
   const cellSet = useMemo(() => {
     const ids = new Set<string>();
-    for (const parent of parentGroups) {
+    for (const lane of laneGroups) {
       for (const status of sortedStatuses) {
-        ids.add(cellId(parent.key, status));
+        ids.add(cellId(lane.key, status));
       }
     }
     return ids;
-  }, [parentGroups, sortedStatuses]);
+  }, [laneGroups, sortedStatuses]);
 
   // Drives both visible status-header counts AND hidden-column panel rows.
-  // Known limitation: `parentIssueIds` is derived from lanes that exist
-  // in the current render (only parents with ≥1 visible child). A parent
-  // whose children are all hidden doesn't get a lane, so it counts as a
-  // card here. When the user un-hides that status the parent gets
-  // promoted to a lane header and the count for that status drops by 1.
-  // The visible-column total and the "would-see-if-unhidden" total are
-  // therefore subtly different aggregates — fixing this requires a
-  // second parentIssueIds set built from laneSourceIssues rather than
-  // the rendered parentGroups. Tracked as a follow-up.
+  // Known limitation (parent grouping): `headerIssueIds` is derived from
+  // lanes that exist in the current render (only parents with ≥1 visible
+  // child). A parent whose children are all hidden doesn't get a lane, so
+  // it counts as a card here. When the user un-hides that status the
+  // parent gets promoted to a lane header and the count for that status
+  // drops by 1. Tracked as a follow-up.
   const statusTotals = useMemo(() => {
     const totals = new Map<IssueStatus, number>();
     for (const issue of laneSourceIssues) {
-      if (parentIssueIds.has(issue.id)) continue;
+      if (headerIssueIds.has(issue.id)) continue;
       totals.set(issue.status, (totals.get(issue.status) ?? 0) + 1);
     }
     return totals;
-  }, [laneSourceIssues, parentIssueIds]);
+  }, [laneSourceIssues, headerIssueIds]);
 
-  // Collapsed swimlanes — persisted per-workspace via the view store.
-  // The store keys are raw parent issue ids (or "none" for the "No parent"
-  // lane), but lane keys in this component are namespaced as
-  // `parent:<id>` / `parent:none`.  Convert on read/write.
-  const collapsedSwimlanes = useViewStore((s) => s.collapsedSwimlanes);
+  // Collapsed swimlanes — persisted per-grouping via the view store. The
+  // store keys are raw lane ids (or sentinel `NONE_LANE_ID` / `ORPHAN_LANE_ID`
+  // for the pinned lanes), namespaced here as `<grouping>:<rawId>`. Convert
+  // on read/write so the store can stay grouping-agnostic.
+  const collapsedSwimlanesMap = useViewStore((s) => s.collapsedSwimlanes);
   const collapsedLanes = useMemo(() => {
+    const stored = collapsedSwimlanesMap[swimlaneGrouping] ?? [];
     const set = new Set<string>();
-    for (const id of collapsedSwimlanes) {
-      set.add(id === "none" ? "parent:none" : `parent:${id}`);
-    }
+    for (const id of stored) set.add(`${swimlaneGrouping}:${id}`);
     return set;
-  }, [collapsedSwimlanes]);
+  }, [collapsedSwimlanesMap, swimlaneGrouping]);
   const toggleLane = useCallback(
     (laneKey: string) => {
-      const storeKey = laneKey === "parent:none" ? "none" : laneKey.slice("parent:".length);
+      const prefix = `${swimlaneGrouping}:`;
+      const storeKey = laneKey.startsWith(prefix)
+        ? laneKey.slice(prefix.length)
+        : laneKey;
       viewStoreApi.getState().toggleSwimlaneCollapsed(storeKey);
     },
-    [viewStoreApi],
+    [viewStoreApi, swimlaneGrouping],
   );
 
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
@@ -427,7 +677,7 @@ export function SwimLaneView({
     const activeId = event.active.id as string;
     // Lane drags don't carry an Issue payload — clear the card overlay so
     // we don't show a stale card during a lane reorder.
-    if (parseLaneId(activeId)) {
+    if (parseLaneId(activeId) !== null) {
       setActiveIssue(null);
       return;
     }
@@ -448,7 +698,7 @@ export function SwimLaneView({
         const overCell = findCellIn(prev, cellSet, overId);
         if (!activeCell || !overCell) return prev;
         if (
-          activeCell.parentKey === overCell.parentKey &&
+          activeCell.laneKey === overCell.laneKey &&
           activeCell.status === overCell.status
         ) {
           return prev;
@@ -459,17 +709,17 @@ export function SwimLaneView({
         // either lose that parent (when leaving) or invent a new one
         // (when entering).
         if (
-          activeCell.parentKey === ORPHAN_LANE_KEY ||
-          overCell.parentKey === ORPHAN_LANE_KEY
+          laneByKey.get(activeCell.laneKey)?.isOrphan ||
+          laneByKey.get(overCell.laneKey)?.isOrphan
         ) {
           return prev;
         }
 
         recentlyMovedRef.current = true;
 
-        if (activeCell.parentKey === overCell.parentKey) {
-          // Same parent row, different status column
-          const row = prev[activeCell.parentKey] ?? {};
+        if (activeCell.laneKey === overCell.laneKey) {
+          // Same lane row, different status column
+          const row = prev[activeCell.laneKey] ?? {};
           const sourceIds = (row[activeCell.status] ?? []).filter((id) => id !== activeId);
           const targetIds = (row[overCell.status] ?? []).filter((id) => id !== activeId);
 
@@ -479,16 +729,16 @@ export function SwimLaneView({
 
           return {
             ...prev,
-            [activeCell.parentKey]: {
+            [activeCell.laneKey]: {
               ...row,
               [activeCell.status]: sourceIds,
               [overCell.status]: targetIds,
             },
           };
         } else {
-          // Different parent rows
-          const sourceRow = prev[activeCell.parentKey] ?? {};
-          const targetRow = prev[overCell.parentKey] ?? {};
+          // Different lane rows
+          const sourceRow = prev[activeCell.laneKey] ?? {};
+          const targetRow = prev[overCell.laneKey] ?? {};
 
           const sourceIds = (sourceRow[activeCell.status] ?? []).filter((id) => id !== activeId);
           const targetIds = (targetRow[overCell.status] ?? []).filter((id) => id !== activeId);
@@ -499,11 +749,11 @@ export function SwimLaneView({
 
           return {
             ...prev,
-            [activeCell.parentKey]: {
+            [activeCell.laneKey]: {
               ...sourceRow,
               [activeCell.status]: sourceIds,
             },
-            [overCell.parentKey]: {
+            [overCell.laneKey]: {
               ...targetRow,
               [overCell.status]: targetIds,
             },
@@ -511,7 +761,7 @@ export function SwimLaneView({
         }
       });
     },
-    [cellSet],
+    [cellSet, laneByKey],
   );
 
   const handleDragEnd = useCallback(
@@ -532,14 +782,19 @@ export function SwimLaneView({
 
       // Lane reorder runs before the card-move logic because lane ids
       // don't resolve to any cell.
-      const activeParentId = parseLaneId(activeId);
-      const overParentId = parseLaneId(overId);
-      if (activeParentId && overParentId && activeParentId !== overParentId) {
-        const visibleOrder = parentGroups
-          .filter((g) => g.parentIssueId !== null)
-          .map((g) => g.parentIssueId!);
-        const fromIdx = visibleOrder.indexOf(activeParentId);
-        const toIdx = visibleOrder.indexOf(overParentId);
+      const activeLaneRef = parseLaneId(activeId);
+      const overLaneRef = parseLaneId(overId);
+      if (
+        activeLaneRef &&
+        overLaneRef &&
+        activeLaneRef.rawId !== overLaneRef.rawId
+      ) {
+        // Visible non-pinned lanes, in current render order.
+        const visibleOrder = laneGroups
+          .filter((g) => !g.isPinned && !g.isOrphan)
+          .map((g) => g.rawId);
+        const fromIdx = visibleOrder.indexOf(activeLaneRef.rawId);
+        const toIdx = visibleOrder.indexOf(overLaneRef.rawId);
         if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
         const visibleNext = arrayMove(visibleOrder, fromIdx, toIdx);
 
@@ -547,9 +802,10 @@ export function SwimLaneView({
         // aren't currently visible (e.g. hidden by a status filter).
         // Walk stored, overwriting each visible slot with the next id
         // from `visibleNext`; non-visible entries pass through verbatim.
-        // Any remaining `visibleNext` ids (visible parents that weren't
+        // Any remaining `visibleNext` ids (visible lanes that weren't
         // in stored at all) get appended at the end.
-        const stored = viewStoreApi.getState().swimlaneOrder;
+        const stored =
+          viewStoreApi.getState().swimlaneOrders[swimlaneGrouping] ?? [];
         const visibleSet = new Set(visibleOrder);
         let cursor = 0;
         const merged = stored.map((id) =>
@@ -560,7 +816,7 @@ export function SwimLaneView({
         viewStoreApi.getState().setSwimlaneOrder(merged);
         return;
       }
-      if (activeParentId || overParentId) return;
+      if (activeLaneRef || overLaneRef) return;
 
       const cols = localCellsRef.current;
 
@@ -576,8 +832,8 @@ export function SwimLaneView({
       // no re-parenting (we don't know the canonical parent), no
       // position write (siblings here belong to different parents).
       if (
-        activeCell.parentKey === ORPHAN_LANE_KEY ||
-        overCell.parentKey === ORPHAN_LANE_KEY
+        laneByKey.get(activeCell.laneKey)?.isOrphan ||
+        laneByKey.get(overCell.laneKey)?.isOrphan
       ) {
         reset();
         return;
@@ -586,10 +842,10 @@ export function SwimLaneView({
       let finalCells = cols;
       // Handle reordering within the same target cell upon drop.
       if (
-        activeCell.parentKey === overCell.parentKey &&
+        activeCell.laneKey === overCell.laneKey &&
         activeCell.status === overCell.status
       ) {
-        const ids = cols[activeCell.parentKey]?.[activeCell.status];
+        const ids = cols[activeCell.laneKey]?.[activeCell.status];
         if (ids) {
           const oldIndex = ids.indexOf(activeId);
           const newIndex = ids.indexOf(overId);
@@ -597,8 +853,8 @@ export function SwimLaneView({
             const reordered = arrayMove(ids, oldIndex, newIndex);
             finalCells = {
               ...cols,
-              [activeCell.parentKey]: {
-                ...cols[activeCell.parentKey],
+              [activeCell.laneKey]: {
+                ...cols[activeCell.laneKey],
                 [activeCell.status]: reordered,
               },
             };
@@ -613,18 +869,18 @@ export function SwimLaneView({
         return;
       }
 
-      const finalIds = finalCells[finalOverCell.parentKey]?.[finalOverCell.status] ?? [];
+      const finalIds = finalCells[finalOverCell.laneKey]?.[finalOverCell.status] ?? [];
       const newPosition = computePosition(finalIds, activeId, issueMapRef.current);
       const currentIssue = issueMapRef.current.get(activeId);
-
-      const expectedParent =
-        finalOverCell.parentKey === "parent:none"
-          ? null
-          : finalOverCell.parentKey.replace("parent:", "");
+      const targetLane = laneByKey.get(finalOverCell.laneKey);
+      if (!targetLane) {
+        reset();
+        return;
+      }
 
       if (
         currentIssue &&
-        currentIssue.parent_issue_id === expectedParent &&
+        targetLane.matches(currentIssue) &&
         currentIssue.status === (finalOverCell.status as IssueStatus) &&
         currentIssue.position === newPosition
       ) {
@@ -632,12 +888,12 @@ export function SwimLaneView({
       }
 
       onMoveIssue(activeId, {
-        parent_issue_id: expectedParent,
+        ...targetLane.moveUpdates,
         status: finalOverCell.status as IssueStatus,
         position: newPosition,
       });
     },
-    [cells, cellSet, onMoveIssue, parentGroups, viewStoreApi],
+    [cells, cellSet, laneByKey, laneGroups, onMoveIssue, swimlaneGrouping, viewStoreApi],
   );
 
   // Grid template: one column per status, fixed width COLUMN_WIDTH, gap COLUMN_GAP.
@@ -700,18 +956,20 @@ export function SwimLaneView({
           </div>
         </div>
 
-        {/* Parent rows. "No parent" is pinned at top and non-draggable;
-            the rest are wrapped in a SortableContext so users can reorder
-            lanes by dragging the grip handle. */}
+        {/* Lane rows. Pinned lanes (the no-X bucket, and parent-grouping's
+            orphan fallback) sit at the top and are non-draggable; the rest
+            are wrapped in a SortableContext so users can reorder lanes by
+            dragging the grip handle. */}
         <div className="flex flex-col gap-4">
-          {parentGroups
-            .filter((p) => p.parentIssueId === null)
-            .map((parent) => (
+          {laneGroups
+            .filter((g) => g.isPinned)
+            .map((lane) => (
               <DraggableSwimLane
-                key={parent.key}
-                parent={parent}
-                isCollapsed={collapsedLanes.has(parent.key)}
-                onToggleCollapse={() => toggleLane(parent.key)}
+                key={lane.key}
+                lane={lane}
+                grouping={swimlaneGrouping}
+                isCollapsed={collapsedLanes.has(lane.key)}
+                onToggleCollapse={() => toggleLane(lane.key)}
                 localCells={localCells}
                 sortedStatuses={sortedStatuses}
                 issueMap={issueMapRef.current}
@@ -722,19 +980,20 @@ export function SwimLaneView({
               />
             ))}
           <SortableContext
-            items={parentGroups
-              .filter((p) => p.parentIssueId !== null)
-              .map((p) => laneId(p.parentIssueId!))}
+            items={laneGroups
+              .filter((g) => !g.isPinned)
+              .map((g) => laneIdFor(swimlaneGrouping, g.rawId))}
             strategy={verticalListSortingStrategy}
           >
-            {parentGroups
-              .filter((p) => p.parentIssueId !== null)
-              .map((parent) => (
+            {laneGroups
+              .filter((g) => !g.isPinned)
+              .map((lane) => (
                 <DraggableSwimLane
-                  key={parent.key}
-                  parent={parent}
-                  isCollapsed={collapsedLanes.has(parent.key)}
-                  onToggleCollapse={() => toggleLane(parent.key)}
+                  key={lane.key}
+                  lane={lane}
+                  grouping={swimlaneGrouping}
+                  isCollapsed={collapsedLanes.has(lane.key)}
+                  onToggleCollapse={() => toggleLane(lane.key)}
                   localCells={localCells}
                   sortedStatuses={sortedStatuses}
                   issueMap={issueMapRef.current}
@@ -778,18 +1037,20 @@ export function SwimLaneView({
 /**
  * Renders a single swimlane (lane header + cells row).
  *
- * Lanes with a real parent are made draggable via `useSortable` so users can
- * reorder them.  The "No parent" lane passes through with `disabled: true`
- * so it stays pinned and unclickable for drag — useSortable must still be
- * called unconditionally to satisfy the rules of hooks.
+ * Non-pinned lanes are made draggable via `useSortable` so users can reorder
+ * them. Pinned lanes (the no-X bucket, and parent-grouping's orphan
+ * fallback) pass through with `disabled: true` so they stay pinned and
+ * unclickable for drag — `useSortable` must still be called unconditionally
+ * to satisfy the rules of hooks.
  *
- * Click vs drag: PointerSensor has `activationConstraint: { distance: 5 }`,
- * so taps on the header still toggle collapse while a >=5px drag starts the
+ * Click vs drag: `PointerSensor` has `activationConstraint: { distance: 5 }`,
+ * so taps on the header still toggle collapse while a ≥5px drag starts the
  * sortable interaction. The "Open parent" pencil link stops pointer events
  * so users can click it without inadvertently starting a drag.
  */
 function DraggableSwimLane({
-  parent,
+  lane,
+  grouping,
   isCollapsed,
   onToggleCollapse,
   localCells,
@@ -800,7 +1061,8 @@ function DraggableSwimLane({
   paths,
   projectId,
 }: {
-  parent: ParentGroup;
+  lane: LaneGroup;
+  grouping: SwimlaneGrouping;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
   localCells: Record<string, Record<string, string[]>>;
@@ -812,12 +1074,9 @@ function DraggableSwimLane({
   projectId?: string;
 }) {
   const { t } = useT("issues");
-  const isNoParent = parent.parentIssueId === null;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    // Always provide a valid id (rules of hooks) — the "No parent" lane is
-    // disabled, so its id is never used as a sortable target.
-    id: isNoParent ? "lane:__no_parent__" : laneId(parent.parentIssueId!),
-    disabled: isNoParent,
+    id: laneIdFor(grouping, lane.rawId),
+    disabled: lane.isPinned,
   });
 
   const style = {
@@ -826,22 +1085,22 @@ function DraggableSwimLane({
   };
 
   const laneTotal = sortedStatuses.reduce(
-    (sum, s) => sum + (localCells[parent.key]?.[s]?.length ?? 0),
+    (sum, s) => sum + (localCells[lane.key]?.[s]?.length ?? 0),
     0,
   );
 
   return (
     <div ref={setNodeRef} style={style} className={`flex flex-col ${isDragging ? "opacity-50" : ""}`}>
-      {/* Non-interactive container — the inner collapse button and the
-          open-parent link are independent controls so we don't nest an
-          <a> inside a <button>. The drag listeners attach here so the
-          whole header row is the drag surface. */}
+      {/* Non-interactive container — the inner collapse button and any
+          ancillary links (e.g. open-parent) are independent controls so we
+          don't nest an <a> inside a <button>. The drag listeners attach
+          here so the whole header row is the drag surface. */}
       <div
         className="mb-2 flex w-full items-center gap-2 rounded-md px-1 py-1"
         {...attributes}
         {...listeners}
       >
-        {!isNoParent && (
+        {!lane.isPinned && (
           <GripVertical
             className="!size-3 shrink-0 cursor-grab text-muted-foreground/60"
             aria-hidden
@@ -856,25 +1115,33 @@ function DraggableSwimLane({
           <ChevronRight
             className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${isCollapsed ? "" : "rotate-90"}`}
           />
-          {parent.issue && (
-            <StatusIcon status={parent.issue.status} className="size-3.5" />
+          {lane.parentIssue && (
+            <StatusIcon status={lane.parentIssue.status} className="size-3.5" />
           )}
-          <span className="truncate text-sm font-semibold">{parent.title}</span>
-          {parent.identifier && (
+          {lane.project && <ProjectIcon project={lane.project} size="sm" />}
+          {lane.actor && (
+            <ActorAvatar
+              actorType={lane.actor.type}
+              actorId={lane.actor.id}
+              size={18}
+            />
+          )}
+          <span className="truncate text-sm font-semibold">{lane.title}</span>
+          {lane.identifier && (
             <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-              {parent.identifier}
+              {lane.identifier}
             </span>
           )}
           <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
             {laneTotal}
           </span>
         </button>
-        {parent.parentIssueId && (
+        {lane.parentIssue && (
           <Tooltip>
             <TooltipTrigger
               render={
                 <AppLink
-                  href={paths.issueDetail(parent.parentIssueId)}
+                  href={paths.issueDetail(lane.parentIssue.id)}
                   aria-label={t(($) => $.swimlane.open_parent)}
                   className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
@@ -890,8 +1157,8 @@ function DraggableSwimLane({
       {!isCollapsed && (
         <div style={gridStyle}>
           {sortedStatuses.map((status) => {
-            const cId = cellId(parent.key, status);
-            const issueIds = localCells[parent.key]?.[status] ?? [];
+            const cId = cellId(lane.key, status);
+            const issueIds = localCells[lane.key]?.[status] ?? [];
             return (
               <SwimLaneCell
                 key={cId}
@@ -900,9 +1167,9 @@ function DraggableSwimLane({
                 issueMap={issueMap}
                 childProgressMap={childProgressMap}
                 status={status}
-                parentGroup={parent}
+                lane={lane}
                 projectId={projectId}
-                readOnly={parent.key === ORPHAN_LANE_KEY}
+                readOnly={lane.isOrphan}
               />
             );
           })}
@@ -918,7 +1185,7 @@ function SwimLaneCell({
   issueMap,
   childProgressMap,
   status,
-  parentGroup,
+  lane,
   projectId,
   readOnly = false,
 }: {
@@ -927,20 +1194,20 @@ function SwimLaneCell({
   issueMap: Map<string, Issue>;
   childProgressMap: Map<string, ChildProgress>;
   status: IssueStatus;
-  parentGroup: ParentGroup;
+  lane: LaneGroup;
   projectId?: string;
   /**
    * Display-only cell — the create affordance is suppressed and drag-end
    * upstream refuses to honour drops that would re-anchor a card to this
-   * lane. Used by the "Other parents" fallback lane whose contents
+   * lane. Used by the parent-grouping orphan fallback whose contents
    * belong to parents we don't have loaded.
    */
   readOnly?: boolean;
 }) {
   // The orphan cell stays enabled in the collision graph so that drops
   // onto its whitespace area are absorbed here instead of falling through
-  // to the nearest real cell. The ORPHAN_LANE_KEY guards in
-  // handleDragOver / handleDragEnd reject the actual move.
+  // to the nearest real cell. The `isOrphan` guards in handleDragOver /
+  // handleDragEnd reject the actual move.
   const { setNodeRef, isOver: droppableIsOver } = useDroppable({ id: cId });
   // Never show the hover highlight on a readOnly cell — the guards will
   // reject the drop, so visual confirmation would be misleading.
@@ -958,11 +1225,12 @@ function SwimLaneCell({
   );
 
   const handleAdd = useCallback(() => {
-    const data: Record<string, unknown> = { status };
-    if (parentGroup.parentIssueId) data.parent_issue_id = parentGroup.parentIssueId;
+    const data: Record<string, unknown> = { status, ...lane.moveUpdates };
+    // Per-page project override takes precedence (e.g. Project Detail
+    // pre-fills its own project id regardless of grouping).
     if (projectId) data.project_id = projectId;
     useModalStore.getState().open("create-issue", data);
-  }, [status, parentGroup, projectId]);
+  }, [status, lane, projectId]);
 
   return (
     <div className={`flex min-h-[120px] flex-col rounded-xl ${cfg?.columnBg ?? "bg-muted/40"} p-2`}>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -61,6 +61,8 @@
     "descending_title": "Descending",
     "group_status": "Status",
     "group_assignee": "Assignee",
+    "group_parent": "Parent issue",
+    "group_project": "Project",
     "sort_manual": "Manual",
     "sort_priority": "Priority",
     "sort_start_date": "Start date",
@@ -127,6 +129,8 @@
   "swimlane": {
     "no_parent": "No parent",
     "other_parents": "Other parents",
+    "no_project": "No project",
+    "no_assignee": "Unassigned",
     "open_parent": "Open parent issue",
     "toggle_collapse": "Toggle lane"
   },

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -59,6 +59,8 @@
     "descending_title": "降序",
     "group_status": "状态",
     "group_assignee": "负责人",
+    "group_parent": "父级 issue",
+    "group_project": "项目",
     "sort_manual": "手动",
     "sort_priority": "优先级",
     "sort_start_date": "开始日期",
@@ -125,6 +127,8 @@
   "swimlane": {
     "no_parent": "无父级",
     "other_parents": "其他父级",
+    "no_project": "无项目",
+    "no_assignee": "未指派",
     "open_parent": "打开父级 issue",
     "toggle_collapse": "切换泳道"
   },


### PR DESCRIPTION
## Summary

Closes MUL-2711. The swimlane view was hard-coded to group by parent issue; this adds a display dropdown so users can pick **parent (default), project, or assignee** — analogous to how the board view exposes its grouping option.

- Generalise the lane builder in `swimlane-view.tsx` behind a `LaneGroup` abstraction (matcher + per-grouping `moveUpdates` payload) so the drag-end handler no longer branches on grouping. Cell ids gain a `<grouping>:<rawId>` prefix and lane sortable ids include the grouping so dnd-kit cannot collide entries from different groupings.
- Extend the view store with `swimlaneGrouping`, `swimlaneOrders` (one saved order per grouping), and a grouping-keyed `collapsedSwimlanes`. The persist `merge` defends against the old `string[]` shape so a pre-upgrade snapshot doesn't crash on first read.
- Wire `setSwimlaneGrouping` into the issues display popover next to the existing board grouping control. Add en / zh-Hans copy for the three swimlane buckets (Parent issue / Project / Assignee) and the two new pinned lanes (No project / Unassigned).
- Expand swimlane tests with parent / project / assignee smoke cases and update existing mocks to the new lane-id format.

## Test plan

- [x] `pnpm --filter @multica/core typecheck` — green
- [x] `pnpm --filter @multica/views typecheck` — green
- [x] `pnpm --filter @multica/web typecheck` — green
- [x] `pnpm --filter @multica/desktop typecheck` — green
- [x] `pnpm --filter @multica/views exec vitest run` — 824 tests pass (including 6 new swimlane-grouping cases)
- [x] `pnpm --filter @multica/core exec vitest run` — 395 tests pass
- [x] `pnpm --filter @multica/web exec vitest run` — 31 tests pass
- [ ] Manual: switch grouping to Project on a workspace with multi-project issues, drag a card across project lanes, confirm `project_id` updates server-side and the optimistic lane move sticks.
- [ ] Manual: same drill for Assignee grouping — drop a card into a member / agent lane and onto the "Unassigned" lane.
- [ ] Manual: verify lane reorder + collapse state persists per-grouping (collapsing in Parent shouldn't affect Project view).