### PR TITLE
feat(views): always-visible ⌘↵ hint on send buttons (MUL-2713)

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -304,6 +304,14 @@ export function ChatInput({
               onSelect={(file) => editorRef.current?.uploadFile(file)}
             />
           )}
+          {!isRunning && (
+            <kbd
+              aria-hidden
+              className="hidden sm:inline-flex h-4 items-center gap-0.5 rounded border border-border/50 bg-background/30 px-1 font-mono text-[10px] leading-none text-muted-foreground select-none"
+            >
+              {formatShortcut(modKey, enterKey)}
+            </kbd>
+          )}
           <SubmitButton
             onClick={handleSend}
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -163,6 +163,12 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           multiple
           onSelect={(file) => editorRef.current?.uploadFile(file)}
         />
+        <kbd
+          aria-hidden
+          className="hidden sm:inline-flex h-4 items-center gap-0.5 rounded border border-border/50 bg-background/30 px-1 font-mono text-[10px] leading-none text-muted-foreground select-none"
+        >
+          {formatShortcut(modKey, enterKey)}
+        </kbd>
         <SubmitButton
           onClick={handleSubmit}
           disabled={isEmpty}


### PR DESCRIPTION
## Summary

- Render the Cmd/Ctrl+Enter shortcut as a visible `<kbd>` next to the chat input and comment composer send buttons.
- Previously the hint lived only in a hover tooltip — users pressing bare Enter saw nothing happen and had no clue Cmd+Enter was required.
- Feedback modal and quick-create agent panel already had visible inline hints; this brings the other two send surfaces in line with that pattern.

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views exec vitest run chat/components/chat-input.test.tsx`
- [x] `pnpm --filter @multica/views exec vitest run issues/components`
- [ ] Visually confirm the kbd hint renders on chat input and issue comment composer