### PR TITLE
feat(daemon): add Grok Build CLI as a supported runtime

### DIFF
--- a/packages/views/onboarding/steps/step-welcome.tsx
+++ b/packages/views/onboarding/steps/step-welcome.tsx
@@ -281,6 +281,7 @@ type ProviderName =
   | "hermes"
   | "kimi"
   | "kiro"
+  | "grok"
   | "pi"
   | "copilot"
   | "cursor";

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -205,6 +205,8 @@ export function ProviderLogo({
       return <KimiLogo className={className} />;
     case "kiro":
       return <KiroLogo className={className} />;
+    case "grok":
+      return <Monitor className={className} />;
     case "gemini":
       return <GeminiLogo className={className} />;
     default:

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -201,8 +201,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if e, ok := probe("MULTICA_KIRO_PATH", "kiro-cli", "MULTICA_KIRO_MODEL"); ok {
 		agents["kiro"] = e
 	}
+	if e, ok := probe("MULTICA_GROK_PATH", "grok", "MULTICA_GROK_MODEL"); ok {
+		agents["grok"] = e
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, kiro-cli, or grok and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
@@ -537,7 +540,7 @@ func shellArgsFromEnv(name string) ([]string, error) {
 // invocation, instead of paying the cost-per-miss.
 var defaultAgentCommandNames = []string{
 	"claude", "codex", "opencode", "openclaw", "hermes",
-	"gemini", "pi", "cursor-agent", "copilot", "kimi", "kiro-cli",
+	"gemini", "pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "grok",
 }
 
 // loginShellResolveTimeout caps how long the daemon will wait for the user's

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -191,6 +191,7 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 		{provider: "hermes", want: false},
 		{provider: "kiro", want: true},
 		{provider: "kimi", want: true},
+		{provider: "grok", want: false},
 		{provider: "codex", want: false},
 		{provider: "claude", want: false},
 	}

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -21,6 +21,7 @@ import (
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
 // Kiro:     skills → {workDir}/.kiro/skills/{name}/SKILL.md  (native discovery)
+// Grok:     skills → {workDir}/.grok/skills/{name}/SKILL.md  (native discovery)
 // Default:  skills → {workDir}/.agent_context/skills/{name}/SKILL.md
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 	contextDir := filepath.Join(workDir, ".agent_context")
@@ -163,6 +164,10 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 		// Kiro CLI auto-discovers project-level skills from .kiro/skills/
 		// in the workdir.
 		skillsDir = filepath.Join(workDir, ".kiro", "skills")
+	case "grok":
+		// Grok Build CLI auto-discovers project-level skills from .grok/skills/
+		// in the workdir.
+		skillsDir = filepath.Join(workDir, ".grok", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		skillsDir = filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1210,7 +1210,7 @@ func TestInjectRuntimeConfigAvailableCommandsIsNeutral(t *testing.T) {
 	t.Cleanup(func() { runtimeGOOS = saved })
 
 	for _, host := range []string{"linux", "darwin", "windows"} {
-		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "grok", "cursor", "gemini"} {
 			t.Run(provider+"/"+host, func(t *testing.T) {
 				runtimeGOOS = host
 				dir := t.TempDir()

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -59,7 +59,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 	triggerID := "22222222-2222-2222-2222-222222222222"
 
 	for _, host := range []string{"linux", "darwin"} {
-		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "grok", "cursor", "gemini"} {
 			name := provider + "/" + host
 			t.Run(name, func(t *testing.T) {
 				runtimeGOOS = host
@@ -110,7 +110,7 @@ func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
 	issueID := "11111111-1111-1111-1111-111111111111"
 	triggerID := "22222222-2222-2222-2222-222222222222"
 
-	for _, provider := range []string{"codex", "claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+	for _, provider := range []string{"codex", "claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "grok", "cursor", "gemini"} {
 		t.Run(provider+"/windows", func(t *testing.T) {
 			got := BuildCommentReplyInstructions(provider, issueID, triggerID)
 			for _, want := range []string{

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -104,7 +104,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (strin
 	switch provider {
 	case "claude":
 		return content, os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "grok":
 		return content, os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return content, os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -402,8 +402,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro":
-			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, and Kiro discover skills
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro", "grok":
+			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, Kiro, and Grok discover skills
 			// natively from their respective paths. For OpenClaw, the daemon also writes a
 			// per-task openclaw-config.json (exported via OPENCLAW_CONFIG_PATH) that pins
 			// agents.defaults.workspace to the task workdir so the CLI's scanner picks up

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -78,6 +78,8 @@ func localSkillRootForProvider(provider string) (string, bool, error) {
 		return filepath.Join(home, ".cursor", "skills"), true, nil
 	case "kiro":
 		return filepath.Join(home, ".kiro", "skills"), true, nil
+	case "grok":
+		return filepath.Join(home, ".grok", "skills"), true, nil
 	default:
 		return "", false, nil
 	}

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -105,6 +105,36 @@ func TestListRuntimeLocalSkills_Kiro(t *testing.T) {
 // path filtered every symlink out via os.ModeSymlink, so users with
 // dozens of installed skills only saw the few they had cloned in place.
 // listRuntimeLocalSkills must follow those symlinks.
+func TestListRuntimeLocalSkills_Grok(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	writeTestLocalSkill(t, filepath.Join(home, ".grok", "skills"), "review-helper", map[string]string{
+		"SKILL.md": "---\nname: Grok Review\ndescription: Review code with Grok\n---\n# Grok Review\n",
+	})
+
+	skills, supported, err := listRuntimeLocalSkills("grok")
+	if err != nil {
+		t.Fatalf("listRuntimeLocalSkills: %v", err)
+	}
+	if !supported {
+		t.Fatal("grok should be supported")
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	if skills[0].Key != "review-helper" {
+		t.Fatalf("key = %q, want review-helper", skills[0].Key)
+	}
+	if skills[0].Name != "Grok Review" {
+		t.Fatalf("name = %q, want Grok Review", skills[0].Name)
+	}
+	if skills[0].SourcePath != "~/.grok/skills/review-helper" {
+		t.Fatalf("source_path = %q", skills[0].SourcePath)
+	}
+}
+
 func TestListRuntimeLocalSkills_FollowsSymlinkedSkillDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, Grok). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -101,13 +101,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
+	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli, grok)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "grok".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -136,8 +136,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "grok":
+		return &grokBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, grok)", agentType)
 	}
 }
 
@@ -164,6 +166,7 @@ var launchHeaders = map[string]string{
 	"pi":       "pi (json mode)",
 	"kimi":     "kimi acp",
 	"kiro":     "kiro-cli acp",
+	"grok":     "grok agent stdio",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -63,6 +63,17 @@ func TestDetectVersionFailsForMissingBinary(t *testing.T) {
 	}
 }
 
+func TestNewReturnsGrokBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("grok", Config{ExecutablePath: "/nonexistent/grok"})
+	if err != nil {
+		t.Fatalf("New(grok) error: %v", err)
+	}
+	if _, ok := b.(*grokBackend); !ok {
+		t.Fatalf("expected *grokBackend, got %T", b)
+	}
+}
+
 func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +83,7 @@ func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	// entry to launchHeaders in agent.go and extend this list.
 	supported := []string{
 		"claude", "codex", "copilot", "cursor", "gemini",
-		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi",
+		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi", "grok",
 	}
 	for _, t_ := range supported {
 		if header := LaunchHeader(t_); header == "" {

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -1,0 +1,359 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// grokBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. `agent stdio` is the protocol
+// subcommand that drives the ACP JSON-RPC transport for Grok Build CLI;
+// overriding it would break the daemon↔Grok communication contract.
+var grokBlockedArgs = map[string]blockedArgMode{
+	"agent": blockedStandalone,
+	"stdio": blockedStandalone,
+}
+
+// grokBackend implements Backend by spawning `grok agent stdio` and communicating
+// via the ACP (Agent Client Protocol) JSON-RPC 2.0 over stdin/stdout.
+//
+// Grok Build CLI supports ACP out of the box via the `grok agent stdio`
+// subcommand. We reuse the existing hermesClient ACP transport since both
+// runtimes speak the same protocol — only the binary, env, and tool-name
+// extraction differ.
+type grokBackend struct {
+	cfg Config
+}
+
+func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "grok"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("grok executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	// `grok agent stdio` ignores --yolo / --auto-approve (they're flags on the
+	// root `grok` command, not on the `agent stdio` subcommand). Instead, the
+	// daemon auto-approves in hermesClient.handleAgentRequest by replying
+	// "approve_for_session" to every session/request_permission request.
+	grokArgs := append([]string{"agent", "stdio"}, filterCustomArgs(opts.CustomArgs, grokBlockedArgs, b.cfg.Logger)...)
+	cmd := exec.CommandContext(runCtx, execPath, grokArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", grokArgs)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("grok stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("grok stdin pipe: %w", err)
+	}
+	// Forward stderr to the daemon log *and* sniff provider-level
+	// errors out of it so we can surface them in the task result.
+	providerErr := newACPProviderErrorSniffer("grok")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("grok stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start grok: %w", err)
+	}
+
+	stderrSink := io.MultiWriter(newLogWriter(b.cfg.Logger, "[grok:stderr] "), providerErr)
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(stderrSink, stderr)
+	}()
+
+	b.cfg.Logger.Info("grok agent stdio started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var outputMu sync.Mutex
+	var output strings.Builder
+
+	promptDone := make(chan hermesPromptResult, 1)
+
+	// Reuse the hermesClient ACP transport — Grok speaks the same protocol.
+	c := &hermesClient{
+		cfg:          b.cfg,
+		stdin:        stdin,
+		pending:      make(map[int]*pendingRPC),
+		pendingTools: make(map[string]*pendingToolCall),
+		onMessage: func(msg Message) {
+			if msg.Type == MessageToolUse {
+				msg.Tool = grokToolNameFromTitle(msg.Tool)
+			}
+			if msg.Type == MessageText {
+				outputMu.Lock()
+				output.WriteString(msg.Content)
+				outputMu.Unlock()
+			}
+			trySend(msgCh, msg)
+		},
+		onPromptDone: func(result hermesPromptResult) {
+			select {
+			case promptDone <- result:
+			default:
+			}
+		},
+	}
+
+	// Start reading stdout in background.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("grok process exited"))
+	}()
+
+	// Drive the ACP session lifecycle in a goroutine.
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+		var sessionID string
+
+		// 1. Initialize handshake.
+		_, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("grok initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// 2. Create or resume a session.
+		cwd := opts.Cwd
+		if cwd == "" {
+			cwd = "."
+		}
+
+		if opts.ResumeSessionID != "" {
+			result, err := c.request(runCtx, "session/resume", map[string]any{
+				"cwd":       cwd,
+				"sessionId": opts.ResumeSessionID,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("grok session/resume failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "grok",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
+		} else {
+			result, err := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": []any{},
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("grok session/new failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			sessionID = extractACPSessionID(result)
+			if sessionID == "" {
+				finalStatus = "failed"
+				finalError = "grok session/new returned no session ID"
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+		}
+
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("grok session created", "session_id", sessionID)
+
+		// 3. If the caller picked a model, ask grok to switch the session to it.
+		if opts.Model != "" {
+			if _, err := c.request(runCtx, "session/set_model", map[string]any{
+				"sessionId": sessionID,
+				"modelId":   opts.Model,
+			}); err != nil {
+				b.cfg.Logger.Warn("grok set_session_model failed", "error", err, "requested_model", opts.Model)
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("grok could not switch to model %q: %v", opts.Model, err)
+				resCh <- Result{
+					Status:     finalStatus,
+					Error:      finalError,
+					DurationMs: time.Since(startTime).Milliseconds(),
+					SessionID:  sessionID,
+				}
+				return
+			}
+			b.cfg.Logger.Info("grok session model set", "model", opts.Model)
+		}
+
+		// 4. Build the prompt content. If we have a system prompt, prepend it.
+		userText := prompt
+		if opts.SystemPrompt != "" {
+			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
+		}
+
+		// 5. Send the prompt and wait for PromptResponse.
+		_, err = c.request(runCtx, "session/prompt", map[string]any{
+			"sessionId": sessionID,
+			"prompt": []map[string]any{
+				{"type": "text", "text": userText},
+			},
+		})
+		if err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("grok timed out after %s", timeout)
+			} else if runCtx.Err() == context.Canceled {
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			} else {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("grok session/prompt failed: %v", err)
+			}
+		} else {
+			select {
+			case pr := <-promptDone:
+				if pr.stopReason == "cancelled" {
+					finalStatus = "aborted"
+					finalError = "grok cancelled the prompt"
+				}
+				c.usageMu.Lock()
+				c.usage.InputTokens += pr.usage.InputTokens
+				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usageMu.Unlock()
+			default:
+			}
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("grok finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		stdin.Close()
+		cancel()
+
+		<-readerDone
+		<-stderrDone
+
+		outputMu.Lock()
+		finalOutput := output.String()
+		outputMu.Unlock()
+
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		var usageMap map[string]TokenUsage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     finalOutput,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      usageMap,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// grokToolNameFromTitle normalises tool names emitted by Grok's ACP
+// server into the snake_case identifiers the Multica UI expects.
+func grokToolNameFromTitle(title string) string {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return ""
+	}
+
+	if idx := strings.Index(t, ":"); idx > 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
+
+	lower := strings.ToLower(t)
+	switch lower {
+	case "read", "read file":
+		return "read_file"
+	case "write", "write file":
+		return "write_file"
+	case "edit", "patch":
+		return "edit_file"
+	case "shell", "bash", "terminal", "run command", "run shell command":
+		return "terminal"
+	case "search", "grep", "find":
+		return "search_files"
+	case "glob":
+		return "glob"
+	case "web search":
+		return "web_search"
+	case "fetch", "web fetch":
+		return "web_fetch"
+	case "todo", "todo write":
+		return "todo_write"
+	}
+
+	return strings.ReplaceAll(lower, " ", "_")
+}

--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestGrokToolNameFromTitle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Read file: /tmp/foo.go", "read_file"},
+		{"read", "read_file"},
+		{"Write: /tmp/bar.go", "write_file"},
+		{"Edit", "edit_file"},
+		{"Patch: /tmp/x", "edit_file"},
+		{"Shell: ls -la", "terminal"},
+		{"Bash", "terminal"},
+		{"Run command: pwd", "terminal"},
+		{"Search: foo", "search_files"},
+		{"Glob: *.go", "glob"},
+		{"Web search: golang acp", "web_search"},
+		{"Fetch: https://example.com", "web_fetch"},
+		{"Todo Write", "todo_write"},
+		// Fallback: snake_case the title.
+		{"Custom Thing", "custom_thing"},
+		// Empty input returns empty — caller decides how to react.
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := grokToolNameFromTitle(tt.title)
+		if got != tt.want {
+			t.Errorf("grokToolNameFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
+		}
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -122,6 +122,10 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
+	case "grok":
+		return cachedDiscovery(providerType, func() ([]Model, error) {
+			return discoverGrokModels(ctx, executablePath)
+		})
 	case "opencode":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)
@@ -493,6 +497,16 @@ func discoverKiroModels(ctx context.Context, executablePath string) ([]Model, er
 		defaultBin:   "kiro-cli",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kiro-discovery-",
+	})
+}
+
+// discoverGrokModels spins up a throwaway `grok agent stdio` process and parses
+// the models block Grok returns from session/new.
+func discoverGrokModels(ctx context.Context, executablePath string) ([]Model, error) {
+	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
+		defaultBin:   "grok",
+		clientName:   "multica-model-discovery",
+		tmpdirPrefix: "multica-grok-discovery-",
 	})
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -233,6 +233,21 @@ func TestListModelsKiroWithoutBinary(t *testing.T) {
 	}
 }
 
+func TestListModelsGrokWithoutBinary(t *testing.T) {
+	ctx := context.Background()
+	modelCacheMu.Lock()
+	delete(modelCache, "grok")
+	modelCacheMu.Unlock()
+
+	got, err := ListModels(ctx, "grok", "/nonexistent/grok")
+	if err != nil {
+		t.Fatalf("ListModels(grok) error: %v", err)
+	}
+	if got == nil {
+		t.Error("expected non-nil slice even when binary is missing")
+	}
+}
+
 func TestListModelsUnknownProvider(t *testing.T) {
 	ctx := context.Background()
 	_, err := ListModels(ctx, "nonexistent", "")


### PR DESCRIPTION
Adds first-class support for the Grok Build CLI (`grok agent stdio`) to the Multica daemon.

Grok speaks the same ACP JSON-RPC protocol as Hermes, Kimi, and Kiro, so the implementation reuses the existing `hermesClient` transport.

### Backend (server/pkg/agent)
- **grok.go**: new backend that spawns `grok agent stdio`, drives the ACP lifecycle, and normalizes Grok tool names into snake_case.
- **agent.go**: registers `grokBackend` in the factory and adds the launch header.
- **models.go**: model discovery via `discoverACPModels` (same pattern as Kimi/Kiro).

### Daemon detection (server/internal/daemon)
- **config.go**: `MULTICA_GROK_PATH` / `MULTICA_GROK_MODEL` env probe + `defaultAgentCommandNames`.
- **execenv/context.go**: `.grok/skills/` as the project-level skills directory.
- **execenv/runtime_config.go**: AGENTS.md injection for Grok.
- **local_skills.go**: `~/.grok/skills` as the user-level skills root.

### Frontend
- **provider-logo.tsx**: Grok case (uses generic Monitor icon until a dedicated logo is added).
- **step-welcome.tsx**: adds `grok` to the `ProviderName` type.

### Tests
All new code paths are covered by tests that mirror the Kimi/Kiro patterns:
- Backend factory, launch header, tool name normalization
- Model discovery without binary
- Inline system prompt policy
- User skills discovery (Windows-compatible)
- Config injection neutrality across all platforms

Closes multica-ai/multica#2895