### PR TITLE
fix(autopilot): render trigger output in trigger timezone (MUL-2742)

### DIFF
--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -31,6 +31,8 @@ type AutopilotService struct {
 	TaskSvc   *TaskService
 }
 
+const defaultAutopilotTriggerTimezone = "UTC"
+
 func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *TaskService) *AutopilotService {
 	return &AutopilotService{Queries: q, TxStarter: tx, Bus: bus, TaskSvc: taskSvc}
 }
@@ -80,7 +82,8 @@ func (s *AutopilotService) DispatchAutopilot(
 
 	switch autopilot.ExecutionMode {
 	case "create_issue":
-		if err := s.dispatchCreateIssue(ctx, autopilot, &run); err != nil {
+		triggerTimezone := s.resolveAutopilotTriggerTimezone(ctx, triggerID)
+		if err := s.dispatchCreateIssue(ctx, autopilot, &run, triggerTimezone); err != nil {
 			if skipped := s.handleDispatchSkip(ctx, autopilot, &run, err); skipped != nil {
 				return skipped, nil
 			}
@@ -133,7 +136,7 @@ func (s *AutopilotService) DispatchAutopilot(
 // Creator on the issue is always the agent that will actually do the work
 // (the resolved leader for a squad autopilot, otherwise the assignee agent
 // itself), so activity / mentions render with the right author identity.
-func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopilot, run *db.AutopilotRun) error {
+func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopilot, run *db.AutopilotRun, triggerTimezone string) error {
 	leader, _, err := s.resolveAutopilotLeader(ctx, ap)
 	if err != nil {
 		return fmt.Errorf("resolve leader: %w", err)
@@ -147,8 +150,8 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 
 	qtx := s.Queries.WithTx(tx)
 
-	title := s.interpolateTemplate(ap)
-	description := s.buildIssueDescription(ap, *run)
+	title := s.interpolateTemplate(ap, *run, triggerTimezone)
+	description := s.buildIssueDescription(ap, *run, triggerTimezone)
 
 	issueNumber, err := qtx.IncrementIssueCounter(ctx, ap.WorkspaceID)
 	if err != nil {
@@ -838,17 +841,80 @@ func autopilotRunDurationMS(run db.AutopilotRun) int64 {
 	return ms
 }
 
+func (s *AutopilotService) resolveAutopilotTriggerTimezone(ctx context.Context, triggerID pgtype.UUID) string {
+	if !triggerID.Valid || s == nil || s.Queries == nil {
+		return defaultAutopilotTriggerTimezone
+	}
+
+	trigger, err := s.Queries.GetAutopilotTrigger(ctx, triggerID)
+	if err != nil {
+		slog.Warn("failed to load autopilot trigger timezone; falling back to UTC",
+			"trigger_id", util.UUIDToString(triggerID),
+			"error", err,
+		)
+		return defaultAutopilotTriggerTimezone
+	}
+
+	timezone := strings.TrimSpace(trigger.Timezone.String)
+	if !trigger.Timezone.Valid || timezone == "" {
+		return defaultAutopilotTriggerTimezone
+	}
+	if _, err := time.LoadLocation(timezone); err != nil {
+		slog.Warn("invalid autopilot trigger timezone; falling back to UTC",
+			"trigger_id", util.UUIDToString(triggerID),
+			"timezone", timezone,
+			"error", err,
+		)
+		return defaultAutopilotTriggerTimezone
+	}
+	return timezone
+}
+
+func formatAutopilotRunTimestamp(run db.AutopilotRun, timezone string) string {
+	triggeredAt := autopilotRunTriggeredAt(run)
+	loc, label := autopilotTriggerLocation(timezone)
+	return triggeredAt.In(loc).Format("2006-01-02 15:04") + " " + label
+}
+
+func formatAutopilotRunDate(run db.AutopilotRun, timezone string) string {
+	triggeredAt := autopilotRunTriggeredAt(run)
+	loc, _ := autopilotTriggerLocation(timezone)
+	return triggeredAt.In(loc).Format("2006-01-02")
+}
+
+func autopilotRunTriggeredAt(run db.AutopilotRun) time.Time {
+	if run.TriggeredAt.Valid {
+		return run.TriggeredAt.Time
+	}
+	if run.CreatedAt.Valid {
+		return run.CreatedAt.Time
+	}
+	return time.Now().UTC()
+}
+
+func autopilotTriggerLocation(timezone string) (*time.Location, string) {
+	label := strings.TrimSpace(timezone)
+	if label == "" {
+		label = defaultAutopilotTriggerTimezone
+	}
+	loc, err := time.LoadLocation(label)
+	if err != nil {
+		return time.UTC, defaultAutopilotTriggerTimezone
+	}
+	return loc, label
+}
+
 // buildIssueDescription appends an autopilot system instruction to the
 // user-provided description, asking the agent to rename the issue after
 // it understands the actual work. For webhook-sourced runs, also appends
 // a payload section so the agent has the event context inline (otherwise
 // the agent only sees the issue body, never the run's trigger_payload).
-func (s *AutopilotService) buildIssueDescription(ap db.Autopilot, run db.AutopilotRun) pgtype.Text {
-	now := time.Now().UTC().Format("2006-01-02 15:04 UTC")
+func (s *AutopilotService) buildIssueDescription(ap db.Autopilot, run db.AutopilotRun, triggerTimezone string) pgtype.Text {
+	triggeredAt := formatAutopilotRunTimestamp(run, triggerTimezone)
 	var b strings.Builder
 	b.WriteString(ap.Description.String)
 	b.WriteString("\n\n---\n*Autopilot run triggered at ")
-	b.WriteString(now)
+	b.WriteString(triggeredAt)
 	b.WriteString(". After starting work, rename this issue to accurately reflect what you are doing.*")
 
 	if run.Source == "webhook" && len(run.TriggerPayload) > 0 {
@@ -904,17 +970,17 @@ var issueTitleTemplateTokenRE = regexp.MustCompile(`\{\{\s*([^{}]*?)\s*\}\}`)
 // tolerated so the render layer accepts every form that
 // ValidateIssueTitleTemplate accepts — otherwise users would save templates
 // that pass validation but still emit a literal token at trigger time.
-func (s *AutopilotService) interpolateTemplate(ap db.Autopilot) string {
+func (s *AutopilotService) interpolateTemplate(ap db.Autopilot, run db.AutopilotRun, triggerTimezone string) string {
 	tmpl := ap.Title
 	if ap.IssueTitleTemplate.Valid && ap.IssueTitleTemplate.String != "" {
 		tmpl = ap.IssueTitleTemplate.String
 	}
-	now := time.Now().UTC().Format("2006-01-02")
+	triggerDate := formatAutopilotRunDate(run, triggerTimezone)
 	return issueTitleTemplateTokenRE.ReplaceAllStringFunc(tmpl, func(match string) string {
 		name := strings.TrimSpace(match[2 : len(match)-2])
 		switch name {
 		case "date":
-			return now
+			return triggerDate
 		default:
 			return match
 		}

--- a/server/internal/service/autopilot_test.go
+++ b/server/internal/service/autopilot_test.go
@@ -29,9 +29,9 @@ func TestAutopilotErrorType(t *testing.T) {
 func TestBuildIssueDescription_NoTriggerPayload(t *testing.T) {
 	s := &AutopilotService{}
 	ap := db.Autopilot{Description: pgtype.Text{String: "do the thing", Valid: true}}
-	run := db.AutopilotRun{Source: "schedule"}
+	run := db.AutopilotRun{Source: "schedule", TriggeredAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
 
-	got := s.buildIssueDescription(ap, run)
+	got := s.buildIssueDescription(ap, run, "UTC")
 	if !strings.HasPrefix(got.String, "do the thing") {
 		t.Fatalf("description should preserve user description: %q", got.String)
 	}
@@ -43,13 +43,30 @@ func TestBuildIssueDescription_NoTriggerPayload(t *testing.T) {
 	}
 }
 
+func TestBuildIssueDescription_UsesTriggerTimezone(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{Description: pgtype.Text{String: "daily sync", Valid: true}}
+	run := db.AutopilotRun{
+		Source:      "schedule",
+		TriggeredAt: pgtype.Timestamptz{Time: time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC), Valid: true},
+	}
+
+	got := s.buildIssueDescription(ap, run, "Asia/Tokyo")
+	if !strings.Contains(got.String, "Autopilot run triggered at 2026-05-26 09:00 Asia/Tokyo") {
+		t.Fatalf("description should use trigger timezone: %q", got.String)
+	}
+	if strings.Contains(got.String, "2026-05-26 00:00 UTC") {
+		t.Fatalf("description must not render the trigger time in UTC when trigger timezone is known: %q", got.String)
+	}
+}
+
 func TestBuildIssueDescription_WithWebhookPayload(t *testing.T) {
 	s := &AutopilotService{}
 	ap := db.Autopilot{Description: pgtype.Text{String: "watch PRs", Valid: true}}
 	payload := []byte(`{"event":"github.pull_request.opened","eventPayload":{"number":7},"request":{"receivedAt":"2026-05-09T00:00:00Z","contentType":"application/json"}}`)
-	run := db.AutopilotRun{Source: "webhook", TriggerPayload: payload}
+	run := db.AutopilotRun{Source: "webhook", TriggerPayload: payload, TriggeredAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
 
-	got := s.buildIssueDescription(ap, run)
+	got := s.buildIssueDescription(ap, run, "UTC")
 	if !strings.HasPrefix(got.String, "watch PRs") {
 		t.Fatalf("user description not preserved: %q", got.String)
 	}
@@ -74,9 +91,9 @@ func TestBuildIssueDescription_WebhookSourceMissingEnvelope(t *testing.T) {
 	s := &AutopilotService{}
 	ap := db.Autopilot{Description: pgtype.Text{String: "thing", Valid: true}}
 	payload := []byte(`{"raw":"missing envelope"}`)
-	run := db.AutopilotRun{Source: "webhook", TriggerPayload: payload}
+	run := db.AutopilotRun{Source: "webhook", TriggerPayload: payload, TriggeredAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
 
-	got := s.buildIssueDescription(ap, run)
+	got := s.buildIssueDescription(ap, run, "UTC")
 	if !strings.Contains(got.String, "Webhook event:") {
 		t.Fatalf("should still emit webhook block: %q", got.String)
 	}
@@ -86,9 +103,9 @@ func TestBuildIssueDescription_NonWebhookSourceWithPayloadIgnored(t *testing.T) 
 	// Manual / schedule with a payload should not get a webhook block.
 	s := &AutopilotService{}
 	ap := db.Autopilot{Description: pgtype.Text{String: "thing", Valid: true}}
-	run := db.AutopilotRun{Source: "manual", TriggerPayload: []byte(`{"event":"x.y"}`)}
+	run := db.AutopilotRun{Source: "manual", TriggerPayload: []byte(`{"event":"x.y"}`), TriggeredAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
 
-	got := s.buildIssueDescription(ap, run)
+	got := s.buildIssueDescription(ap, run, "UTC")
 	if strings.Contains(got.String, "Webhook event") {
 		t.Fatalf("non-webhook source should not include webhook block: %q", got.String)
 	}
@@ -101,7 +118,8 @@ func TestBuildIssueDescription_NonWebhookSourceWithPayloadIgnored(t *testing.T) 
 // the first place — service-layer interpolation stays substitute-or-leave).
 func TestInterpolateTemplate(t *testing.T) {
 	s := &AutopilotService{}
-	today := time.Now().UTC().Format("2006-01-02")
+	run := db.AutopilotRun{TriggeredAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
+	today := run.TriggeredAt.Time.UTC().Format("2006-01-02")
 
 	cases := []struct {
 		name   string
@@ -131,10 +149,26 @@ func TestInterpolateTemplate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := s.interpolateTemplate(tc.ap); got != tc.expect {
+			if got := s.interpolateTemplate(tc.ap, run, "UTC"); got != tc.expect {
 				t.Fatalf("interpolateTemplate = %q, want %q", got, tc.expect)
 			}
 		})
+	}
+}
+
+func TestInterpolateTemplate_UsesTriggerTimezoneForDate(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{
+		Title:              "fallback",
+		IssueTitleTemplate: pgtype.Text{String: "Tokyo report {{date}}", Valid: true},
+	}
+	run := db.AutopilotRun{
+		TriggeredAt: pgtype.Timestamptz{Time: time.Date(2026, 5, 26, 23, 30, 0, 0, time.UTC), Valid: true},
+	}
+
+	got := s.interpolateTemplate(ap, run, "Asia/Tokyo")
+	if want := "Tokyo report 2026-05-27"; got != want {
+		t.Fatalf("interpolateTemplate = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- render scheduled Autopilot issue descriptions from the run trigger timestamp in the trigger timezone
- render the `{{date}}` issue title placeholder from the same timezone-aware trigger timestamp
- fall back to UTC when a run has no trigger timezone or the stored timezone cannot be loaded

Fixes #3312.

## Testing
- `go test ./internal/service -run 'Test(BuildIssueDescription|InterpolateTemplate)' -count=1`\n- `go test ./internal/service -count=1`\n- `git diff --check`\n- Attempted `go test ./...`; local run did not complete cleanly because unrelated packages timed out after 11m (`internal/daemon/execenv`, `internal/events`, `internal/handler`, `internal/mention`, `internal/metrics`, `internal/middleware`) and an unrelated `pkg/agent` Codex inactivity test failed (`TestCodexExecuteSemanticInactivityAllowsContinuousMessages`).