### PR TITLE
fix(views): keep sort label centered during board scroll

### DIFF
--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -123,16 +123,7 @@ export const BoardColumn = memo(function BoardColumn({
           </Tooltip>
         </div>
       </div>
-      <div
-        ref={setNodeRef}
-        className={`relative min-h-[200px] flex-1 space-y-2 overflow-y-auto rounded-lg p-1 transition-colors ${
-          isOver && sortLabel
-            ? "ring-2 ring-brand/25 bg-accent/15"
-            : isOver
-              ? "bg-accent/60"
-              : ""
-        }`}
-      >
+      <div className="relative min-h-[200px] flex-1 rounded-lg">
         {isOver && sortLabel && (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/40">
             <span className="rounded-md bg-popover px-2.5 py-1 text-xs font-medium text-popover-foreground shadow-sm border border-border">
@@ -140,17 +131,28 @@ export const BoardColumn = memo(function BoardColumn({
             </span>
           </div>
         )}
-        <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
-          {resolvedIssues.map((issue) => (
-            <DraggableBoardCard key={issue.id} issue={issue} childProgress={childProgressMap?.get(issue.id)} disableSorting={!!sortLabel} />
-          ))}
-        </SortableContext>
-        {issueIds.length === 0 && (
-          <p className="py-8 text-center text-xs text-muted-foreground">
-            {t(($) => $.board.empty_column)}
-          </p>
-        )}
-        {footer}
+        <div
+          ref={setNodeRef}
+          className={`absolute inset-0 space-y-2 overflow-y-auto rounded-lg p-1 transition-colors ${
+            isOver && sortLabel
+              ? "ring-2 ring-brand/25 bg-accent/15"
+              : isOver
+                ? "bg-accent/60"
+                : ""
+          }`}
+        >
+          <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
+            {resolvedIssues.map((issue) => (
+              <DraggableBoardCard key={issue.id} issue={issue} childProgress={childProgressMap?.get(issue.id)} disableSorting={!!sortLabel} />
+            ))}
+          </SortableContext>
+          {issueIds.length === 0 && (
+            <p className="py-8 text-center text-xs text-muted-foreground">
+              {t(($) => $.board.empty_column)}
+            </p>
+          )}
+          {footer}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Fix "Board ordered by" overlay drifting with scroll content instead of staying centered in the visible viewport
- Root cause: overlay used `absolute inset-0` inside a `overflow-y-auto` container, so it covered the entire scrollable area rather than the viewport
- Fix: wrap the scrollable container in a non-scrolling `relative` wrapper and place the overlay as a sibling, so it always aligns to the visible area

Fixes MUL-2705.

## Test plan
- [ ] Open board view with non-position sort (e.g. "Created date")
- [ ] Drag an issue over a column with enough cards to require scrolling
- [ ] Verify "Board ordered by Created date" label stays centered in the column's visible area, not the scroll content
- [ ] Verify drag-and-drop still works correctly
- [ ] Verify the ring highlight on the droppable column still appears