### PR TITLE
fix: swimlane empty lanes in due to pagination (MUL-2724)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -557,6 +557,19 @@ export class ApiClient {
     });
   }
 
+  /** Batched variant — returns children for multiple parents in one request.
+   *  Avoids an N-request fan-out in Swimlane (one per visible parent lane).
+   *  parentIds must be non-empty; pass a sorted, deduplicated list so the
+   *  React Query cache key is stable across renders. */
+  async listChildrenByParents(parentIds: string[]): Promise<{ issues: Issue[] }> {
+    const raw = await this.fetch<unknown>(
+      `/api/issues/children?parent_ids=${parentIds.join(",")}`,
+    );
+    return parseWithFallback(raw, ChildIssuesResponseSchema, { issues: [] }, {
+      endpoint: "GET /api/issues/children",
+    });
+  }
+
   async getChildIssueProgress(): Promise<{ progress: { parent_issue_id: string; total: number; done: number }[] }> {
     return this.fetch("/api/issues/child-progress");
   }

--- a/packages/core/issues/delete-cache.ts
+++ b/packages/core/issues/delete-cache.ts
@@ -116,6 +116,7 @@ export function invalidateDeletedIssueParentCaches(
     qc.invalidateQueries({ queryKey: issueKeys.children(wsId, parentId) });
   }
   qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+  qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
 }
 
 export function invalidateDeletedIssueDependentCaches(

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -305,6 +305,9 @@ export function useUpdateIssue() {
         });
         qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
       }
+      if (ctx?.parentId || newParentId) {
+        qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
+      }
     },
   });
 }

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -305,6 +305,12 @@ export function useUpdateIssue() {
         });
         qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
       }
+      // Invalidate the batched-children cache only when the parent link
+      // actually changed. The WS path (ws-updaters.ts) invalidates
+      // unconditionally because it doesn't know what the server change
+      // touched; here onMutate already patched issueKeys.children(parent)
+      // optimistically, so we only need to flush when the parent relation
+      // itself moved.
       if (ctx?.parentId || newParentId) {
         qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
       }

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -5,8 +5,10 @@ import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import type { Issue, ListIssuesParams, ListIssuesResponse } from "../types";
 import {
+  CHILDREN_BY_PARENTS_CHUNK_SIZE,
   PROJECT_GANTT_MAX_ISSUES,
   PROJECT_GANTT_PAGE_LIMIT,
+  childrenByParentsOptions,
   issueKeys,
   projectGanttIssuesOptions,
 } from "./queries";
@@ -43,6 +45,12 @@ function makeIssue(idx: number): Issue {
 // Type-only shim — only the methods the queries.ts code path under test calls.
 function installFakeApi(listIssues: (params?: ListIssuesParams) => Promise<ListIssuesResponse>) {
   setApiInstance({ listIssues } as unknown as ApiClient);
+}
+
+function installFakeChildrenApi(
+  listChildrenByParents: (parentIds: string[]) => Promise<{ issues: Issue[] }>,
+) {
+  setApiInstance({ listChildrenByParents } as unknown as ApiClient);
 }
 
 describe("projectGanttIssuesOptions", () => {
@@ -128,5 +136,80 @@ describe("projectGanttIssuesOptions", () => {
   it("uses the project-scoped Gantt cache key", () => {
     const options = projectGanttIssuesOptions(WS_ID, PROJECT_ID);
     expect(options.queryKey).toEqual(issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+});
+
+describe("childrenByParentsOptions chunking", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("issues a single request when parentIds fit under the chunk size", async () => {
+    const parentIds = Array.from({ length: 50 }, (_, i) => `p-${i}`);
+    const listChildrenByParents = vi
+      .fn<(ids: string[]) => Promise<{ issues: Issue[] }>>()
+      .mockResolvedValue({ issues: [] });
+    installFakeChildrenApi(listChildrenByParents);
+
+    await qc.fetchQuery(childrenByParentsOptions(WS_ID, parentIds, qc));
+
+    expect(listChildrenByParents).toHaveBeenCalledTimes(1);
+    expect(listChildrenByParents).toHaveBeenCalledWith(parentIds);
+  });
+
+  it("chunks parentIds into multiple requests when over the server cap", async () => {
+    // 2.5 chunks worth of parents → 3 parallel requests.
+    const count = CHILDREN_BY_PARENTS_CHUNK_SIZE * 2 + 17;
+    const parentIds = Array.from({ length: count }, (_, i) => `p-${i}`);
+    const calls: string[][] = [];
+    const listChildrenByParents = vi
+      .fn<(ids: string[]) => Promise<{ issues: Issue[] }>>()
+      .mockImplementation(async (ids) => {
+        calls.push(ids);
+        return { issues: [] };
+      });
+    installFakeChildrenApi(listChildrenByParents);
+
+    await qc.fetchQuery(childrenByParentsOptions(WS_ID, parentIds, qc));
+
+    expect(listChildrenByParents).toHaveBeenCalledTimes(3);
+    expect(calls[0]).toHaveLength(CHILDREN_BY_PARENTS_CHUNK_SIZE);
+    expect(calls[1]).toHaveLength(CHILDREN_BY_PARENTS_CHUNK_SIZE);
+    expect(calls[2]).toHaveLength(17);
+    // Together the chunks must cover every input parent id.
+    expect(calls.flat().sort()).toEqual(parentIds.slice().sort());
+  });
+
+  it("merges children from all chunks into one grouped map", async () => {
+    const parentIds = Array.from(
+      { length: CHILDREN_BY_PARENTS_CHUNK_SIZE + 1 },
+      (_, i) => `p-${i}`,
+    );
+    // First chunk returns a child of p-0, second chunk returns a child of
+    // the last parent id (which lives alone in chunk 2).
+    const lastId = parentIds[parentIds.length - 1]!;
+    const listChildrenByParents = vi
+      .fn<(ids: string[]) => Promise<{ issues: Issue[] }>>()
+      .mockImplementation(async (ids) => {
+        if (ids.includes(lastId)) {
+          return { issues: [{ ...makeIssue(99), parent_issue_id: lastId }] };
+        }
+        return { issues: [{ ...makeIssue(1), parent_issue_id: "p-0" }] };
+      });
+    installFakeChildrenApi(listChildrenByParents);
+
+    const grouped = await qc.fetchQuery(
+      childrenByParentsOptions(WS_ID, parentIds, qc),
+    );
+
+    expect(grouped.get("p-0")).toHaveLength(1);
+    expect(grouped.get(lastId)).toHaveLength(1);
   });
 });

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -56,9 +56,12 @@ export const issueKeys = {
     [...issueKeys.all(wsId), "detail", id] as const,
   children: (wsId: string, id: string) =>
     [...issueKeys.all(wsId), "children", id] as const,
-  /** Batched children — key includes sorted parent ids for cache stability. */
+  /** Prefix for invalidating all batched-children queries in a workspace. */
+  childrenByParentsAll: (wsId: string) =>
+    [...issueKeys.all(wsId), "children-by-parents"] as const,
+  /** Full key — includes sorted parent ids for cache stability. */
   childrenByParents: (wsId: string, parentIds: readonly string[]) =>
-    [...issueKeys.all(wsId), "children-by-parents", parentIds] as const,
+    [...issueKeys.childrenByParentsAll(wsId), parentIds] as const,
   childProgress: (wsId: string) =>
     [...issueKeys.all(wsId), "child-progress"] as const,
   /** Full-issue timeline (single TanStack Query, no cursor). */
@@ -444,11 +447,6 @@ export function childrenByParentsOptions(
     queryKey: issueKeys.childrenByParents(wsId, parentIds),
     queryFn: () => fetchAndHydrateChildrenByParents(qc, wsId, parentIds),
     enabled: parentIds.length > 0,
-    // Never auto-refetch: the canonical per-parent data lives in
-    // issueKeys.children entries, kept fresh by mutations + WS events.
-    // The batch key changes whenever new un-cached parents appear, so
-    // there's no stale batch result to worry about.
-    staleTime: Infinity,
   });
 }
 

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -391,11 +391,19 @@ export function childIssuesOptions(wsId: string, id: string) {
 }
 
 /**
+ * Server cap on parent_ids per `GET /api/issues/children` request — must
+ * match `listChildrenByParentsLimit` in server/internal/handler/issue.go.
+ * Exceeding it returns 400, so the client chunks larger requests.
+ */
+export const CHILDREN_BY_PARENTS_CHUNK_SIZE = 200;
+
+/**
  * Batched variant of {@link childIssuesOptions}: fetches children for all
- * given parents in a single `GET /api/issues/children?parent_ids=…` request.
- * The queryFn also hydrates each parent's per-parent issueKeys.children cache
- * so other surfaces (issue-detail sub-issues panel, set-parent modal) hit the
- * primed cache instead of re-fetching. Hydration happens in queryFn (not a
+ * given parents in `GET /api/issues/children?parent_ids=…` requests, chunked
+ * to {@link CHILDREN_BY_PARENTS_CHUNK_SIZE} parents each. The queryFn also
+ * hydrates each parent's per-parent issueKeys.children cache so other
+ * surfaces (issue-detail sub-issues panel, set-parent modal) hit the primed
+ * cache instead of re-fetching. Hydration happens in queryFn (not a
  * useEffect) to avoid the setQueryData → re-render → effect loop.
  *
  * Used by SwimLaneView to resolve parent lanes without an N-request fan-out.
@@ -406,21 +414,30 @@ async function fetchAndHydrateChildrenByParents(
   wsId: string,
   parentIds: readonly string[],
 ) {
-  const response = await api.listChildrenByParents([...parentIds]);
-  // Group by parent and populate per-parent caches.
+  // Chunk to respect the server cap (parallel, since chunks are independent).
+  const chunks: string[][] = [];
+  for (let i = 0; i < parentIds.length; i += CHILDREN_BY_PARENTS_CHUNK_SIZE) {
+    chunks.push([...parentIds.slice(i, i + CHILDREN_BY_PARENTS_CHUNK_SIZE)]);
+  }
+  const responses = await Promise.all(chunks.map((c) => api.listChildrenByParents(c)));
   const grouped = new Map<string, Issue[]>();
-  for (const issue of response.issues) {
-    if (!issue.parent_issue_id) continue;
-    const bucket = grouped.get(issue.parent_issue_id);
-    if (bucket) {
-      bucket.push(issue);
-    } else {
-      grouped.set(issue.parent_issue_id, [issue]);
+  for (const response of responses) {
+    for (const issue of response.issues) {
+      if (!issue.parent_issue_id) continue;
+      const bucket = grouped.get(issue.parent_issue_id);
+      if (bucket) {
+        bucket.push(issue);
+      } else {
+        grouped.set(issue.parent_issue_id, [issue]);
+      }
     }
   }
   for (const [parentId, children] of grouped) {
     // Only hydrate if the per-parent cache is empty — don't overwrite a
     // fresher result that another query (e.g. issue-detail) may have written.
+    // This relies on useUpdateIssue.onMutate writing into the per-parent
+    // cache (not creating an empty one) — if that contract changes, batch
+    // hydration here would silently stop seeding new lanes.
     const existing = qc.getQueryData<Issue[]>(issueKeys.children(wsId, parentId));
     if (!existing || existing.length === 0) {
       qc.setQueryData(issueKeys.children(wsId, parentId), children);

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -56,6 +56,9 @@ export const issueKeys = {
     [...issueKeys.all(wsId), "detail", id] as const,
   children: (wsId: string, id: string) =>
     [...issueKeys.all(wsId), "children", id] as const,
+  /** Batched children — key includes sorted parent ids for cache stability. */
+  childrenByParents: (wsId: string, parentIds: readonly string[]) =>
+    [...issueKeys.all(wsId), "children-by-parents", parentIds] as const,
   childProgress: (wsId: string) =>
     [...issueKeys.all(wsId), "child-progress"] as const,
   /** Full-issue timeline (single TanStack Query, no cursor). */
@@ -381,6 +384,71 @@ export function childIssuesOptions(wsId: string, id: string) {
   return queryOptions({
     queryKey: issueKeys.children(wsId, id),
     queryFn: () => api.listChildIssues(id).then((r) => r.issues),
+  });
+}
+
+/**
+ * Batched variant of {@link childIssuesOptions}: fetches children for all
+ * given parents in a single `GET /api/issues/children?parent_ids=…` request.
+ *
+ * Used by SwimLaneView to resolve parent lanes without an N-request fan-out.
+ * Returns a Map<parentId, Issue[]> so callers can look up children by lane
+ * in O(1). parentIds must be sorted + deduplicated by the caller so the
+ * React Query cache key is stable across renders.
+ *
+ * Enabled only when parentIds is non-empty — callers should skip this
+ * query (via `enabled: false`) when there are no parent lanes to resolve.
+ */
+/**
+ * queryFn that fetches children for all given parents, then immediately
+ * writes each parent's slice into the per-parent issueKeys.children cache.
+ * Other surfaces (issue-detail sub-issues panel, set-parent modal) that
+ * call childIssuesOptions will hit the primed cache instead of re-fetching.
+ * Hydration happens in queryFn (not a useEffect) to avoid infinite render
+ * loops that would occur if setQueryData triggered a re-render cycle.
+ */
+async function fetchAndHydrateChildrenByParents(
+  qc: import("@tanstack/react-query").QueryClient,
+  wsId: string,
+  parentIds: readonly string[],
+) {
+  const response = await api.listChildrenByParents([...parentIds]);
+  // Group by parent and populate per-parent caches.
+  const grouped = new Map<string, Issue[]>();
+  for (const issue of response.issues) {
+    if (!issue.parent_issue_id) continue;
+    const bucket = grouped.get(issue.parent_issue_id);
+    if (bucket) {
+      bucket.push(issue);
+    } else {
+      grouped.set(issue.parent_issue_id, [issue]);
+    }
+  }
+  for (const [parentId, children] of grouped) {
+    // Only hydrate if the per-parent cache is empty — don't overwrite a
+    // fresher result that another query (e.g. issue-detail) may have written.
+    const existing = qc.getQueryData<Issue[]>(issueKeys.children(wsId, parentId));
+    if (!existing || existing.length === 0) {
+      qc.setQueryData(issueKeys.children(wsId, parentId), children);
+    }
+  }
+  return grouped;
+}
+
+export function childrenByParentsOptions(
+  wsId: string,
+  parentIds: readonly string[],
+  qc: import("@tanstack/react-query").QueryClient,
+) {
+  return queryOptions({
+    queryKey: issueKeys.childrenByParents(wsId, parentIds),
+    queryFn: () => fetchAndHydrateChildrenByParents(qc, wsId, parentIds),
+    enabled: parentIds.length > 0,
+    // Never auto-refetch: the canonical per-parent data lives in
+    // issueKeys.children entries, kept fresh by mutations + WS events.
+    // The batch key changes whenever new un-cached parents appear, so
+    // there's no stale batch result to worry about.
+    staleTime: Infinity,
   });
 }
 

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, queryOptions } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions, type QueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import type {
   GroupedIssuesResponse,
@@ -393,25 +393,16 @@ export function childIssuesOptions(wsId: string, id: string) {
 /**
  * Batched variant of {@link childIssuesOptions}: fetches children for all
  * given parents in a single `GET /api/issues/children?parent_ids=…` request.
+ * The queryFn also hydrates each parent's per-parent issueKeys.children cache
+ * so other surfaces (issue-detail sub-issues panel, set-parent modal) hit the
+ * primed cache instead of re-fetching. Hydration happens in queryFn (not a
+ * useEffect) to avoid the setQueryData → re-render → effect loop.
  *
  * Used by SwimLaneView to resolve parent lanes without an N-request fan-out.
- * Returns a Map<parentId, Issue[]> so callers can look up children by lane
- * in O(1). parentIds must be sorted + deduplicated by the caller so the
- * React Query cache key is stable across renders.
- *
- * Enabled only when parentIds is non-empty — callers should skip this
- * query (via `enabled: false`) when there are no parent lanes to resolve.
- */
-/**
- * queryFn that fetches children for all given parents, then immediately
- * writes each parent's slice into the per-parent issueKeys.children cache.
- * Other surfaces (issue-detail sub-issues panel, set-parent modal) that
- * call childIssuesOptions will hit the primed cache instead of re-fetching.
- * Hydration happens in queryFn (not a useEffect) to avoid infinite render
- * loops that would occur if setQueryData triggered a re-render cycle.
+ * parentIds must be sorted + deduplicated by the caller for a stable cache key.
  */
 async function fetchAndHydrateChildrenByParents(
-  qc: import("@tanstack/react-query").QueryClient,
+  qc: QueryClient,
   wsId: string,
   parentIds: readonly string[],
 ) {
@@ -441,7 +432,7 @@ async function fetchAndHydrateChildrenByParents(
 export function childrenByParentsOptions(
   wsId: string,
   parentIds: readonly string[],
-  qc: import("@tanstack/react-query").QueryClient,
+  qc: QueryClient,
 ) {
   return queryOptions({
     queryKey: issueKeys.childrenByParents(wsId, parentIds),

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -89,6 +89,7 @@ export function onIssueUpdated(
     if (issue.status !== undefined || issue.parent_issue_id !== undefined) {
       qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
     }
+    qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
   }
 }
 

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -1192,6 +1192,10 @@ describe("SwimLaneView", () => {
     // Scenario: grandparent G → parent P (loaded, becomes a lane header) →
     // grandchild GC (NOT in the initial `issues` set, returned only by the
     // batch fetch). P's lane should show GC after the batch resolves.
+    //
+    // For the batch to include P.id, the caller must pass childProgressMap
+    // signaling that P has children — without it, batchParentIds only sees
+    // GP.id (from parent.parent_issue_id) and GC is never fetched.
     const grandparent: Issue = {
       id: "gp-1",
       workspace_id: "ws-1",
@@ -1235,17 +1239,75 @@ describe("SwimLaneView", () => {
     };
 
     mockListChildrenByParents.mockResolvedValueOnce({ issues: [grandchild] });
+    const childProgressMap = new Map<string, { done: number; total: number }>([
+      ["p-1", { done: 0, total: 1 }],
+    ]);
 
     renderWithI18n(
       <SwimLaneView
         issues={[grandparent, parent]}
+        childProgressMap={childProgressMap}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Assert the batch request actually included p-1 — without this the
+    // mock would happily return GC for any request and the merge would
+    // appear to work without exercising the real path.
+    await waitFor(() => {
+      expect(mockListChildrenByParents).toHaveBeenCalled();
+    });
+    const [calledIds] = mockListChildrenByParents.mock.calls[0] as [string[]];
+    expect(calledIds).toEqual(expect.arrayContaining(["p-1"]));
+
+    await waitFor(() => {
+      expect(screen.getByText("Grandchild (batch only)")).toBeInTheDocument();
+    });
+  });
+
+  it("includes visible parents with children (via childProgressMap) in the batch request", async () => {
+    // Even without any loaded child pointing at a parent, if childProgressMap
+    // says the parent has children we should query it so deep-nested
+    // grandchildren are discoverable.
+    const parentWithUnloadedChildren: Issue = {
+      id: "p-only",
+      workspace_id: "ws-1",
+      number: 50,
+      identifier: "PROJ-50",
+      title: "Standalone parent",
+      description: null,
+      status: "todo",
+      priority: "none",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 50,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const childProgressMap = new Map<string, { done: number; total: number }>([
+      ["p-only", { done: 0, total: 3 }],
+    ]);
+
+    renderWithI18n(
+      <SwimLaneView
+        issues={[parentWithUnloadedChildren]}
+        childProgressMap={childProgressMap}
         onMoveIssue={vi.fn()}
       />,
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Grandchild (batch only)")).toBeInTheDocument();
+      expect(mockListChildrenByParents).toHaveBeenCalled();
     });
+    const [calledIds] = mockListChildrenByParents.mock.calls[0] as [string[]];
+    expect(calledIds).toEqual(expect.arrayContaining(["p-only"]));
   });
 
   it("does not fire listChildrenByParents when swimlaneGrouping is not parent", async () => {
@@ -1257,5 +1319,30 @@ describe("SwimLaneView", () => {
 
     await act(async () => {});
     expect(mockListChildrenByParents).not.toHaveBeenCalled();
+  });
+
+  it("does not call onMoveIssue when dropping a card into a lane whose header is that card", () => {
+    // parent-1 (a lane-header card in the No-parent lane) dropped onto a
+    // cell inside its own lane (`swim:parent:parent-1:in_progress`) would
+    // be a self-cycle. The client guard refuses before reaching the API.
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    act(() => {
+      lastOnDragOver({
+        active: { id: "parent-1" },
+        over: { id: "swim:parent:parent-1:in_progress" },
+      });
+    });
+    act(() => {
+      lastOnDragEnd({
+        active: { id: "parent-1" },
+        over: { id: "swim:parent:parent-1:in_progress" },
+      });
+    });
+
+    expect(mockOnMoveIssue).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SwimLaneView } from "./swimlane-view";
 import type { Issue } from "@multica/core/types";
@@ -12,6 +12,17 @@ const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
 // Mock hooks
 vi.mock("@multica/core/hooks", () => ({
   useWorkspaceId: () => "ws-1",
+}));
+
+// Mock the API so childrenByParentsOptions doesn't fire real HTTP.
+// Individual tests can override listChildrenByParents via mockResolvedValueOnce.
+const mockListChildrenByParents = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ issues: [] }),
+);
+vi.mock("@multica/core/api", () => ({
+  api: { listChildrenByParents: mockListChildrenByParents },
+  getApi: () => ({ listChildrenByParents: mockListChildrenByParents }),
+  setApiInstance: vi.fn(),
 }));
 
 // Mock paths
@@ -307,6 +318,7 @@ describe("SwimLaneView", () => {
     mockViewState.swimlaneGrouping = "parent";
     mockViewState.swimlaneOrders = { parent: [], project: [], assignee: [] };
     mockViewState.collapsedSwimlanes = { parent: [], project: [], assignee: [] };
+    mockListChildrenByParents.mockResolvedValue({ issues: [] });
     useLoadMoreByStatusMock.mockImplementation(() => ({
       total: 0,
       loaded: 0,
@@ -1145,5 +1157,105 @@ describe("SwimLaneView", () => {
         status: "done",
       }),
     );
+  });
+
+  // ------------------------------------------------------------------
+  // Batched children fetch (childrenByParentsOptions)
+  // ------------------------------------------------------------------
+
+  it("fires listChildrenByParents once with all visible parent ids on mount", async () => {
+    // multiParentIssues has parent-1 (Child of A) and parent-2 (Child of B) as
+    // visible parent lanes. Both ids should appear in one batched call.
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(mockListChildrenByParents).toHaveBeenCalledTimes(1);
+    });
+    const [calledIds] = mockListChildrenByParents.mock.calls[0] as [string[]];
+    expect(calledIds.sort()).toEqual(["parent-1", "parent-2"].sort());
+  });
+
+  it("does not fire listChildrenByParents when there are no parent lanes", async () => {
+    // All issues are top-level — no parent lanes, no batch request.
+    const flatIssues = mockIssues.filter((i) => i.parent_issue_id === null);
+    renderWithI18n(
+      <SwimLaneView issues={flatIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    await act(async () => {});
+    expect(mockListChildrenByParents).not.toHaveBeenCalled();
+  });
+
+  it("merges batch-fetched children into parent lanes so previously-empty cells populate", async () => {
+    // Scenario: grandparent G → parent P (loaded, becomes a lane header) →
+    // grandchild GC (NOT in the initial `issues` set, returned only by the
+    // batch fetch). P's lane should show GC after the batch resolves.
+    const grandparent: Issue = {
+      id: "gp-1",
+      workspace_id: "ws-1",
+      number: 10,
+      identifier: "PROJ-10",
+      title: "Grandparent",
+      description: null,
+      status: "todo",
+      priority: "none",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 10,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const parent: Issue = {
+      ...grandparent,
+      id: "p-1",
+      number: 11,
+      identifier: "PROJ-11",
+      title: "Parent",
+      parent_issue_id: "gp-1",
+      position: 11,
+    };
+    const grandchild: Issue = {
+      ...grandparent,
+      id: "gc-1",
+      number: 12,
+      identifier: "PROJ-12",
+      title: "Grandchild (batch only)",
+      status: "in_progress",
+      parent_issue_id: "p-1",
+      position: 12,
+    };
+
+    mockListChildrenByParents.mockResolvedValueOnce({ issues: [grandchild] });
+
+    renderWithI18n(
+      <SwimLaneView
+        issues={[grandparent, parent]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Grandchild (batch only)")).toBeInTheDocument();
+    });
+  });
+
+  it("does not fire listChildrenByParents when swimlaneGrouping is not parent", async () => {
+    mockViewState.swimlaneGrouping = "project";
+
+    renderWithI18n(
+      <SwimLaneView issues={multiParentIssues} onMoveIssue={vi.fn()} />,
+    );
+
+    await act(async () => {});
+    expect(mockListChildrenByParents).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -18,7 +18,7 @@ import {
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { ChevronRight, EyeOff, GripVertical, MoreHorizontal, Pencil, Plus } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueries, useQueryClient } from "@tanstack/react-query";
 import type {
   Issue,
   IssueAssigneeType,
@@ -33,7 +33,7 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
-import type { IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
+import { childrenByParentsOptions, issueKeys, type IssueSortParam, type MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -58,6 +58,15 @@ import { useT } from "../../i18n";
 
 const COLUMN_WIDTH = 280;
 const COLUMN_GAP = 16;
+
+// Hoisted out of SwimLaneView so its reference is stable across renders —
+// useQueries' combine option uses it through replaceEqualDeep, but keeping
+// the function stable saves the per-render reference check.
+function combineChildrenLists(
+  results: { data: Issue[] | undefined }[],
+): (Issue[] | undefined)[] {
+  return results.map((r) => r.data);
+}
 
 type SwimLaneMoveUpdates = Pick<
   UpdateIssueRequest,
@@ -501,6 +510,88 @@ export function SwimLaneView({
     [t],
   );
 
+  // Batched children fetch — parent grouping only. Fetches all children for
+  // visible parent lanes in a single request so grandparent lanes are never
+  // empty due to pagination. Only runs when grouping === "parent".
+  const qc = useQueryClient();
+  const batchParentIds = useMemo(() => {
+    if (swimlaneGrouping !== "parent") return [];
+    const ids = new Set<string>();
+    for (const issue of issues) {
+      if (!issue.parent_issue_id) continue;
+      if (qc.getQueryData(issueKeys.children(wsId, issue.parent_issue_id)) === undefined) {
+        ids.add(issue.parent_issue_id);
+      }
+    }
+    return Array.from(ids).sort();
+  }, [swimlaneGrouping, issues]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { data: batchChildrenMap } = useQuery(
+    childrenByParentsOptions(wsId, batchParentIds, qc),
+  );
+
+  // Grows monotonically so lanes don't lose children when the batch key
+  // changes — once a parent's cache is hydrated it stays observed.
+  const subscribedRef = useRef<Set<string>>(new Set());
+  const sortedSubscribedRef = useRef<string[]>([]);
+  const subscribedParentIds = useMemo(() => {
+    if (swimlaneGrouping !== "parent") return [];
+    let changed = false;
+    const add = (id: string | null | undefined) => {
+      if (!id || subscribedRef.current.has(id)) return;
+      subscribedRef.current.add(id);
+      changed = true;
+    };
+    for (const issue of issues) add(issue.parent_issue_id);
+    if (batchChildrenMap) for (const id of batchChildrenMap.keys()) add(id);
+    if (changed) sortedSubscribedRef.current = Array.from(subscribedRef.current).sort();
+    return sortedSubscribedRef.current;
+  }, [swimlaneGrouping, issues, batchChildrenMap]);
+
+  // Pure cache observers — enabled:false so no fetch fires, just re-renders
+  // when setQueryData writes to these keys (from batch hydration, optimistic
+  // mutations, or WS events).
+  const perParentChildrenLists = useQueries({
+    queries: subscribedParentIds.map((parentId) => ({
+      queryKey: issueKeys.children(wsId, parentId),
+      queryFn: async (): Promise<Issue[]> => [],
+      enabled: false,
+    })),
+    combine: combineChildrenLists,
+  });
+
+  // Merge paginated issues with batch-fetched children so parent lanes are
+  // populated even when children are beyond the first page.
+  const mergedIssues = useMemo(() => {
+    if (swimlaneGrouping !== "parent") return issues;
+    const existingIds = new Set(issues.map((i) => i.id));
+    const extra: Issue[] = [];
+    const covered = new Set<string>();
+    for (let i = 0; i < subscribedParentIds.length; i++) {
+      const data = perParentChildrenLists[i];
+      if (!data) continue;
+      covered.add(subscribedParentIds[i]!);
+      for (const child of data) {
+        if (!existingIds.has(child.id)) {
+          existingIds.add(child.id);
+          extra.push(child);
+        }
+      }
+    }
+    if (batchChildrenMap) {
+      for (const [parentId, children] of batchChildrenMap) {
+        if (covered.has(parentId)) continue;
+        for (const child of children) {
+          if (!existingIds.has(child.id)) {
+            existingIds.add(child.id);
+            extra.push(child);
+          }
+        }
+      }
+    }
+    return extra.length === 0 ? issues : [...issues, ...extra];
+  }, [swimlaneGrouping, issues, perParentChildrenLists, subscribedParentIds, batchChildrenMap]);
+
   const laneGroups = useMemo<LaneGroup[]>(() => {
     if (swimlaneGrouping === "project") {
       return buildProjectLanes(issues, projects, swimlaneOrder, laneLabels);
@@ -508,10 +599,11 @@ export function SwimLaneView({
     if (swimlaneGrouping === "assignee") {
       return buildAssigneeLanes(issues, getActorName, swimlaneOrder, laneLabels);
     }
-    return buildParentLanes(issues, laneSourceIssues, swimlaneOrder, laneLabels);
+    return buildParentLanes(mergedIssues, laneSourceIssues, swimlaneOrder, laneLabels);
   }, [
     swimlaneGrouping,
     issues,
+    mergedIssues,
     laneSourceIssues,
     projects,
     getActorName,
@@ -548,7 +640,10 @@ export function SwimLaneView({
         ? laneGroups.find((g) => g.isOrphan) ?? null
         : null;
 
-    const filtered = issues.filter((i) => !headerIssueIds.has(i.id));
+    // For parent grouping use mergedIssues so batch-fetched children
+    // (beyond the first page) are included in lane cells.
+    const issueSource = swimlaneGrouping === "parent" ? mergedIssues : issues;
+    const filtered = issueSource.filter((i) => !headerIssueIds.has(i.id));
     const sorted = sortIssues(filtered, sortBy, sortDirection);
     for (const issue of sorted) {
       let placed = false;
@@ -573,7 +668,7 @@ export function SwimLaneView({
       }
     }
     return result;
-  }, [issues, laneGroups, sortedStatuses, sortBy, sortDirection, headerIssueIds, swimlaneGrouping]);
+  }, [issues, mergedIssues, laneGroups, sortedStatuses, sortBy, sortDirection, headerIssueIds, swimlaneGrouping]);
 
   const laneByKey = useMemo(() => {
     const map = new Map<string, LaneGroup>();
@@ -634,9 +729,9 @@ export function SwimLaneView({
 
   const issueMap = useMemo(() => {
     const map = new Map<string, Issue>();
-    for (const issue of issues) map.set(issue.id, issue);
+    for (const issue of mergedIssues) map.set(issue.id, issue);
     return map;
-  }, [issues]);
+  }, [mergedIssues]);
 
   const issueMapRef = useRef(issueMap);
   if (!isDraggingRef.current) {
@@ -735,30 +830,30 @@ export function SwimLaneView({
               [overCell.status]: targetIds,
             },
           };
-        } else {
-          // Different lane rows
-          const sourceRow = prev[activeCell.laneKey] ?? {};
-          const targetRow = prev[overCell.laneKey] ?? {};
-
-          const sourceIds = (sourceRow[activeCell.status] ?? []).filter((id) => id !== activeId);
-          const targetIds = (targetRow[overCell.status] ?? []).filter((id) => id !== activeId);
-
-          const overIndex = targetIds.indexOf(overId);
-          const insertIndex = overIndex >= 0 ? overIndex : targetIds.length;
-          targetIds.splice(insertIndex, 0, activeId);
-
-          return {
-            ...prev,
-            [activeCell.laneKey]: {
-              ...sourceRow,
-              [activeCell.status]: sourceIds,
-            },
-            [overCell.laneKey]: {
-              ...targetRow,
-              [overCell.status]: targetIds,
-            },
-          };
         }
+
+        // Different lane rows
+        const sourceRow = prev[activeCell.laneKey] ?? {};
+        const targetRow = prev[overCell.laneKey] ?? {};
+
+        const sourceIds = (sourceRow[activeCell.status] ?? []).filter((id) => id !== activeId);
+        const targetIds = (targetRow[overCell.status] ?? []).filter((id) => id !== activeId);
+
+        const overIndex = targetIds.indexOf(overId);
+        const insertIndex = overIndex >= 0 ? overIndex : targetIds.length;
+        targetIds.splice(insertIndex, 0, activeId);
+
+        return {
+          ...prev,
+          [activeCell.laneKey]: {
+            ...sourceRow,
+            [activeCell.status]: sourceIds,
+          },
+          [overCell.laneKey]: {
+            ...targetRow,
+            [overCell.status]: targetIds,
+          },
+        };
       });
     },
     [cellSet, laneByKey],

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -648,13 +648,26 @@ export function SwimLaneView({
     // For parent grouping use mergedIssues so batch-fetched children
     // (beyond the first page) are included in lane cells.
     const issueSource = swimlaneGrouping === "parent" ? mergedIssues : issues;
-    const filtered = issueSource.filter((i) => !headerIssueIds.has(i.id));
-    const sorted = sortIssues(filtered, sortBy, sortDirection);
+    const sorted = sortIssues(issueSource, sortBy, sortDirection);
     for (const issue of sorted) {
       let placed = false;
       for (const lane of laneGroups) {
         if (lane.isOrphan) continue;
         if (lane.matches(issue)) {
+          // Parent grouping, "No parent" lane: exclude issues that are
+          // themselves lane headers. They already render as their own lane
+          // header below — showing the duplicate card in "No parent" would
+          // be redundant noise. Real-parent lanes still render their
+          // header-child as a card so grandparent lanes are never empty
+          // (dual-render is intentional for multi-level nesting).
+          if (
+            swimlaneGrouping === "parent" &&
+            lane.rawId === NONE_LANE_ID &&
+            headerIssueIds.has(issue.id)
+          ) {
+            placed = true;
+            break;
+          }
           const status = issue.status;
           if (result[lane.key]?.[status]) {
             result[lane.key]![status]!.push(issue.id);

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -219,6 +219,9 @@ interface LaneGroup {
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 const EMPTY_PROJECTS: Project[] = [];
+// Stable reference for non-parent groupings — keeps the `statusTotals` /
+// `cells` memos from busting on every render when there are no headers.
+const EMPTY_HEADER_IDS = new Set<string>();
 
 /**
  * Build parent-grouping lanes. The "No parent" lane is always pinned at the
@@ -510,32 +513,46 @@ export function SwimLaneView({
     [t],
   );
 
-  // Batched children fetch — parent grouping only. Fetches all children for
-  // visible parent lanes in a single request so grandparent lanes are never
-  // empty due to pagination. Only runs when grouping === "parent".
+  // Candidate parents for the batch fetch (parent grouping only). Union of:
+  //   - parent_issue_id of visible issues (child loaded, parent past page)
+  //   - id of visible issues with children per childProgressMap (parent
+  //     loaded, grandchild past page — the bug this PR fixes)
   const qc = useQueryClient();
   const batchParentIds = useMemo(() => {
     if (swimlaneGrouping !== "parent") return [];
     const ids = new Set<string>();
-    for (const issue of issues) {
-      if (!issue.parent_issue_id) continue;
-      if (qc.getQueryData(issueKeys.children(wsId, issue.parent_issue_id)) === undefined) {
-        ids.add(issue.parent_issue_id);
+    const consider = (id: string | null | undefined) => {
+      if (!id) return;
+      if (qc.getQueryData(issueKeys.children(wsId, id)) === undefined) {
+        ids.add(id);
       }
+    };
+    for (const issue of issues) {
+      consider(issue.parent_issue_id);
+      const progress = childProgressMap.get(issue.id);
+      if (progress && progress.total > 0) consider(issue.id);
     }
     return Array.from(ids).sort();
-  }, [swimlaneGrouping, issues]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [swimlaneGrouping, issues, childProgressMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data: batchChildrenMap } = useQuery(
     childrenByParentsOptions(wsId, batchParentIds, qc),
   );
 
   // Grows monotonically so lanes don't lose children when the batch key
-  // changes — once a parent's cache is hydrated it stays observed.
+  // changes — once a parent's cache is hydrated it stays observed. Reset
+  // when grouping leaves "parent" so a long session that toggles groupings
+  // doesn't accumulate dead subscriptions.
   const subscribedRef = useRef<Set<string>>(new Set());
   const sortedSubscribedRef = useRef<string[]>([]);
   const subscribedParentIds = useMemo(() => {
-    if (swimlaneGrouping !== "parent") return [];
+    if (swimlaneGrouping !== "parent") {
+      if (subscribedRef.current.size > 0) {
+        subscribedRef.current = new Set();
+        sortedSubscribedRef.current = [];
+      }
+      return sortedSubscribedRef.current;
+    }
     let changed = false;
     const add = (id: string | null | undefined) => {
       if (!id || subscribedRef.current.has(id)) return;
@@ -599,11 +616,9 @@ export function SwimLaneView({
     if (swimlaneGrouping === "assignee") {
       return buildAssigneeLanes(issues, getActorName, swimlaneOrder, laneLabels);
     }
-    // Lane discovery uses `mergedIssues` so batch-fetched children (beyond
-    // the first page) can promote their parents to lane headers. Metadata
-    // lookup uses `laneSourceIssues` so headers resolve even for parents in
-    // hidden statuses. buildParentLanes only creates a lane when it can
-    // resolve the parent in the metadata map, so phantom lanes can't appear.
+    // Discovery uses `mergedIssues` so batch-fetched grandchildren can
+    // promote their parents to lane headers. Metadata uses `laneSourceIssues`
+    // so headers resolve for parents in hidden statuses.
     return buildParentLanes(mergedIssues, laneSourceIssues, swimlaneOrder, laneLabels);
   }, [
     swimlaneGrouping,
@@ -621,7 +636,7 @@ export function SwimLaneView({
   // never collide this way (lanes are projects/actors, not issues), so the
   // set is empty there.
   const headerIssueIds = useMemo(() => {
-    if (swimlaneGrouping !== "parent") return new Set<string>();
+    if (swimlaneGrouping !== "parent") return EMPTY_HEADER_IDS;
     return new Set(
       laneGroups
         .filter((g) => g.parentIssue !== null)
@@ -645,8 +660,6 @@ export function SwimLaneView({
         ? laneGroups.find((g) => g.isOrphan) ?? null
         : null;
 
-    // For parent grouping use mergedIssues so batch-fetched children
-    // (beyond the first page) are included in lane cells.
     const issueSource = swimlaneGrouping === "parent" ? mergedIssues : issues;
     const sorted = sortIssues(issueSource, sortBy, sortDirection);
     for (const issue of sorted) {
@@ -654,12 +667,9 @@ export function SwimLaneView({
       for (const lane of laneGroups) {
         if (lane.isOrphan) continue;
         if (lane.matches(issue)) {
-          // Parent grouping, "No parent" lane: exclude issues that are
-          // themselves lane headers. They already render as their own lane
-          // header below — showing the duplicate card in "No parent" would
-          // be redundant noise. Real-parent lanes still render their
-          // header-child as a card so grandparent lanes are never empty
-          // (dual-render is intentional for multi-level nesting).
+          // "No parent" lane only: skip issues that are themselves lane
+          // headers (avoid duplicate card + header). Real-parent lanes keep
+          // the dual render so grandparent lanes are never empty.
           if (
             swimlaneGrouping === "parent" &&
             lane.rawId === NONE_LANE_ID &&
@@ -828,6 +838,16 @@ export function SwimLaneView({
           return prev;
         }
 
+        // Self-parent guard — see handleDragEnd for rationale.
+        const overLane = laneByKey.get(overCell.laneKey);
+        if (
+          overLane &&
+          overLane.parentIssue !== null &&
+          overLane.parentIssue.id === activeId
+        ) {
+          return prev;
+        }
+
         recentlyMovedRef.current = true;
 
         if (activeCell.laneKey === overCell.laneKey) {
@@ -947,6 +967,20 @@ export function SwimLaneView({
       if (
         laneByKey.get(activeCell.laneKey)?.isOrphan ||
         laneByKey.get(overCell.laneKey)?.isOrphan
+      ) {
+        reset();
+        return;
+      }
+
+      // Self-parent guard (parent grouping only): refuse drops where the
+      // dragged card is the same issue as the target lane's parent. The
+      // backend rejects this as a self-cycle; intercepting client-side
+      // avoids the optimistic-move → rollback flicker.
+      const targetLaneForGuard = laneByKey.get(overCell.laneKey);
+      if (
+        targetLaneForGuard &&
+        targetLaneForGuard.parentIssue !== null &&
+        targetLaneForGuard.parentIssue.id === activeId
       ) {
         reset();
         return;

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -599,6 +599,11 @@ export function SwimLaneView({
     if (swimlaneGrouping === "assignee") {
       return buildAssigneeLanes(issues, getActorName, swimlaneOrder, laneLabels);
     }
+    // Lane discovery uses `mergedIssues` so batch-fetched children (beyond
+    // the first page) can promote their parents to lane headers. Metadata
+    // lookup uses `laneSourceIssues` so headers resolve even for parents in
+    // hidden statuses. buildParentLanes only creates a lane when it can
+    // resolve the parent in the metadata map, so phantom lanes can't appear.
     return buildParentLanes(mergedIssues, laneSourceIssues, swimlaneOrder, laneLabels);
   }, [
     swimlaneGrouping,
@@ -993,12 +998,15 @@ export function SwimLaneView({
 
   // Grid template: one column per status, fixed width COLUMN_WIDTH, gap COLUMN_GAP.
   const trackWidth = sortedStatuses.length * COLUMN_WIDTH + Math.max(0, sortedStatuses.length - 1) * COLUMN_GAP;
-  const gridStyle = {
-    display: "grid",
-    gridTemplateColumns: `repeat(${sortedStatuses.length}, ${COLUMN_WIDTH}px)`,
-    columnGap: `${COLUMN_GAP}px`,
-    width: `${trackWidth}px`,
-  } as const;
+  const gridStyle = useMemo(
+    () => ({
+      display: "grid",
+      gridTemplateColumns: `repeat(${sortedStatuses.length}, ${COLUMN_WIDTH}px)`,
+      columnGap: `${COLUMN_GAP}px`,
+      width: `${trackWidth}px`,
+    }) as const,
+    [sortedStatuses.length, trackWidth],
+  );
 
   return (
     <DndContext

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -389,6 +389,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			r.Route("/api/issues", func(r chi.Router) {
 				r.Get("/search", h.SearchIssues)
 				r.Get("/child-progress", h.ChildIssueProgress)
+				r.Get("/children", h.ListChildrenByParents)
 				r.Get("/grouped", h.ListGroupedIssues)
 				r.Get("/", h.ListIssues)
 				r.Post("/", h.CreateIssue)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1544,6 +1544,75 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Cap on the number of parents we'll fan-out children for in one request.
+// Swimlane's visible-lane count is naturally bounded by what fits on screen
+// (typically <= 50), but cap explicitly so a malicious caller can't ANY()
+// across the whole workspace's issue set in a single round trip.
+const listChildrenByParentsLimit = 200
+
+// ListChildrenByParents returns the union of children for the
+// provided parent ids. Replaces the N-call fan-out Swimlane would otherwise
+// have to make on mount (one /issues/:id/children per visible parent lane).
+//
+// Workspace scope is enforced at the query level — any parent_id that doesn't
+// belong to the caller's workspace simply yields zero children, so callers
+// can't probe parents across workspace boundaries.
+func (h *Handler) ListChildrenByParents(w http.ResponseWriter, r *http.Request) {
+	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+
+	raw := r.URL.Query().Get("parent_ids")
+	if raw == "" {
+		// Empty input is a no-op response (not an error) — simplifies the
+		// client which calls this unconditionally on Swimlane mount even
+		// when there are zero visible parent lanes.
+		writeJSON(w, http.StatusOK, map[string]any{"issues": []IssueResponse{}})
+		return
+	}
+
+	parts := strings.Split(raw, ",")
+	if len(parts) > listChildrenByParentsLimit {
+		writeError(w, http.StatusBadRequest, "too many parent_ids")
+		return
+	}
+	parentIDs := make([]pgtype.UUID, 0, len(parts))
+	for _, s := range parts {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		id, ok := parseUUIDOrBadRequest(w, s, "parent_ids")
+		if !ok {
+			return
+		}
+		parentIDs = append(parentIDs, id)
+	}
+	if len(parentIDs) == 0 {
+		writeJSON(w, http.StatusOK, map[string]any{"issues": []IssueResponse{}})
+		return
+	}
+
+	children, err := h.Queries.ListChildrenByParents(r.Context(), db.ListChildrenByParentsParams{
+		WorkspaceID: wsUUID,
+		ParentIds:   parentIDs,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list child issues")
+		return
+	}
+	prefix := h.getIssuePrefix(r.Context(), wsUUID)
+	resp := make([]IssueResponse, len(children))
+	for i, child := range children {
+		resp[i] = issueToResponse(child, prefix)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issues": resp,
+	})
+}
+
 func (h *Handler) ChildIssueProgress(w http.ResponseWriter, r *http.Request) {
 	wsID := h.resolveWorkspaceID(r)
 	wsUUID, ok := parseUUIDOrBadRequest(w, wsID, "workspace_id")

--- a/server/internal/handler/issue_children_for_parents_test.go
+++ b/server/internal/handler/issue_children_for_parents_test.go
@@ -1,0 +1,163 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// childrenBatchFixture creates two parents with a couple of children each,
+// returning their ids so tests can assert the batched endpoint groups them
+// correctly. Cleanup is registered so rows are removed on test failure.
+type childrenBatchFixture struct {
+	parentA   IssueResponse
+	parentB   IssueResponse
+	childrenA []IssueResponse
+	childrenB []IssueResponse
+}
+
+func newChildrenBatchFixture(t *testing.T) childrenBatchFixture {
+	t.Helper()
+
+	mkIssue := func(title, status, parentID string) IssueResponse {
+		w := httptest.NewRecorder()
+		body := map[string]any{
+			"title":  title + " " + time.Now().Format(time.RFC3339Nano),
+			"status": status,
+		}
+		if parentID != "" {
+			body["parent_issue_id"] = parentID
+		}
+		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
+		testHandler.CreateIssue(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
+		}
+		var out IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+			t.Fatalf("decode %q: %v", title, err)
+		}
+		return out
+	}
+
+	parentA := mkIssue("children-batch parent A", "in_progress", "")
+	parentB := mkIssue("children-batch parent B", "in_progress", "")
+	a1 := mkIssue("children-batch a1", "todo", parentA.ID)
+	a2 := mkIssue("children-batch a2", "done", parentA.ID)
+	b1 := mkIssue("children-batch b1", "todo", parentB.ID)
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		for _, id := range []string{a1.ID, a2.ID, b1.ID, parentA.ID, parentB.ID} {
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, id)
+		}
+	})
+
+	return childrenBatchFixture{
+		parentA:   parentA,
+		parentB:   parentB,
+		childrenA: []IssueResponse{a1, a2},
+		childrenB: []IssueResponse{b1},
+	}
+}
+
+func decodeIssueBatch(t *testing.T, w *httptest.ResponseRecorder) []IssueResponse {
+	t.Helper()
+	var body struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return body.Issues
+}
+
+func TestListChildrenByParents_ReturnsChildrenForBothParentsInOneCall(t *testing.T) {
+	fx := newChildrenBatchFixture(t)
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids="+fx.parentA.ID+","+fx.parentB.ID, nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	got := decodeIssueBatch(t, w)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(got))
+	}
+
+	wantParents := map[string]int{fx.parentA.ID: 2, fx.parentB.ID: 1}
+	have := map[string]int{}
+	for _, issue := range got {
+		if issue.ParentIssueID == nil {
+			t.Fatalf("child %q is missing parent_issue_id", issue.ID)
+		}
+		have[*issue.ParentIssueID]++
+	}
+	for parent, want := range wantParents {
+		if have[parent] != want {
+			t.Fatalf("parent %s: want %d children, got %d", parent, want, have[parent])
+		}
+	}
+}
+
+func TestListChildrenByParents_EmptyParentIdsReturnsEmptyList(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID, nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := decodeIssueBatch(t, w); len(got) != 0 {
+		t.Fatalf("expected 0 children, got %d", len(got))
+	}
+}
+
+func TestListChildrenByParents_UnknownParentYieldsNoChildren(t *testing.T) {
+	// A well-formed UUID that doesn't exist in the workspace must produce
+	// an empty response, not an error — the client uses this endpoint
+	// optimistically and tolerates stale parent ids.
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids=00000000-0000-0000-0000-000000000000", nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := decodeIssueBatch(t, w); len(got) != 0 {
+		t.Fatalf("expected 0 children, got %d", len(got))
+	}
+}
+
+func TestListChildrenByParents_RejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids=not-a-uuid", nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListChildrenByParents_RejectsTooManyParents(t *testing.T) {
+	// A caller passing more than the documented cap is rejected; the cap
+	// prevents a single request from materializing the workspace's entire
+	// issue tree.
+	ids := make([]string, listChildrenByParentsLimit+1)
+	for i := range ids {
+		ids[i] = "00000000-0000-0000-0000-000000000000"
+	}
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids="+strings.Join(ids, ","), nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/server/internal/handler/issue_children_for_parents_test.go
+++ b/server/internal/handler/issue_children_for_parents_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // childrenBatchFixture creates two parents with a couple of children each,
@@ -159,5 +161,59 @@ func TestListChildrenByParents_RejectsTooManyParents(t *testing.T) {
 	testHandler.ListChildrenByParents(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// TestListChildrenByParents_IgnoresForeignWorkspaceParents pins the
+// workspace_id filter in the SQL query: a parent that exists but lives in a
+// different workspace must yield zero children from the caller's workspace,
+// not the foreign workspace's tree. If a future refactor drops the
+// workspace_id predicate from the query, this test fails.
+func TestListChildrenByParents_IgnoresForeignWorkspaceParents(t *testing.T) {
+	ctx := context.Background()
+
+	var foreignWorkspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, "Foreign Children Workspace", "foreign-children-"+uuid.New().String()[:8],
+		"Cross-tenant test workspace", "FCW").Scan(&foreignWorkspaceID); err != nil {
+		t.Fatalf("setup: create foreign workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM issue WHERE workspace_id = $1`, foreignWorkspaceID)
+		testPool.Exec(context.Background(),
+			`DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
+	})
+
+	var foreignParentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, number, title, status, position, creator_type, creator_id)
+		VALUES ($1, 1, 'foreign parent', 'todo', 1, 'member', $2)
+		RETURNING id
+	`, foreignWorkspaceID, testUserID).Scan(&foreignParentID); err != nil {
+		t.Fatalf("setup: insert foreign parent: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO issue (workspace_id, number, title, status, position, parent_issue_id, creator_type, creator_id)
+		VALUES ($1, 2, 'foreign child', 'todo', 2, $2, 'member', $3)
+	`, foreignWorkspaceID, foreignParentID, testUserID); err != nil {
+		t.Fatalf("setup: insert foreign child: %v", err)
+	}
+
+	// Call the endpoint from testWorkspaceID with the foreign parent's id.
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids="+foreignParentID, nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	got := decodeIssueBatch(t, w)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 children (foreign workspace isolation), got %d (first child id=%s)",
+			len(got), got[0].ID)
 	}
 }

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -673,6 +673,68 @@ func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID
 	return items, nil
 }
 
+const listChildrenByParents = `-- name: ListChildrenByParents :many
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+WHERE workspace_id = $1
+  AND parent_issue_id = ANY($2::uuid[])
+ORDER BY parent_issue_id, position ASC, created_at DESC
+`
+
+type ListChildrenByParentsParams struct {
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	ParentIds   []pgtype.UUID `json:"parent_ids"`
+}
+
+// Batched variant of ListChildIssues: returns all children for the given
+// parent set in one round trip. Used by Swimlane to avoid an N+1 fan-out
+// (one request per visible parent lane). Result is grouped client-side by
+// parent_issue_id; the workspace filter is also enforced so callers can't
+// enumerate children of parents in workspaces they don't belong to.
+func (q *Queries) ListChildrenByParents(ctx context.Context, arg ListChildrenByParentsParams) ([]Issue, error) {
+	rows, err := q.db.Query(ctx, listChildrenByParents, arg.WorkspaceID, arg.ParentIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Issue{}
+	for rows.Next() {
+		var i Issue
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Title,
+			&i.Description,
+			&i.Status,
+			&i.Priority,
+			&i.AssigneeType,
+			&i.AssigneeID,
+			&i.CreatorType,
+			&i.CreatorID,
+			&i.ParentIssueID,
+			&i.AcceptanceCriteria,
+			&i.ContextRefs,
+			&i.Position,
+			&i.DueDate,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Number,
+			&i.ProjectID,
+			&i.OriginType,
+			&i.OriginID,
+			&i.FirstExecutedAt,
+			&i.StartDate,
+			&i.Metadata,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listIssues = `-- name: ListIssues :many
 SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -238,6 +238,17 @@ SELECT * FROM issue
 WHERE parent_issue_id = $1
 ORDER BY position ASC, created_at DESC;
 
+-- name: ListChildrenByParents :many
+-- Batched variant of ListChildIssues: returns all children for the given
+-- parent set in one round trip. Used by Swimlane to avoid an N+1 fan-out
+-- (one request per visible parent lane). Result is grouped client-side by
+-- parent_issue_id; the workspace filter is also enforced so callers can't
+-- enumerate children of parents in workspaces they don't belong to.
+SELECT * FROM issue
+WHERE workspace_id = sqlc.arg('workspace_id')
+  AND parent_issue_id = ANY(sqlc.arg('parent_ids')::uuid[])
+ORDER BY parent_issue_id, position ASC, created_at DESC;
+
 -- name: GetIssueByOrigin :one
 -- Finds the issue stamped with a specific (origin_type, origin_id) pair.
 -- Used by quick-create completion to deterministically locate the issue


### PR DESCRIPTION
## What does this PR do?

Ppagination + multi-level nesting causing parent lanes to appear empty on swimlane view.

Add a backend query to batch,  to prevent n+1 queries.

## Related Issue

Follow up from #3149

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

### Server
- server/pkg/db/queries/issue.sql — ListChildrenByParents query (workspace-scoped, parent_issue_id = ANY(...))
- server/pkg/db/generated/issue.sql.go — regenerated by sqlc
- server/internal/handler/issue.go — ListChildrenByParents handler, 200-parent cap
- server/internal/handler/issue_children_for_parents_test.go — 5 handler tests
- server/cmd/server/router.go — route GET /api/issues/children

### Client — core
- packages/core/api/client.ts — listChildrenByParents method
- packages/core/issues/queries.ts — childrenByParentsOptions, issueKeys.childrenByParents / childrenByParentsAll
- packages/core/issues/mutations.ts — invalidation in useUpdateIssue.onSettled
- packages/core/issues/ws-updaters.ts — invalidation in onIssueUpdated
- packages/core/issues/delete-cache.ts — invalidation in invalidateDeletedIssueParentCaches

### Client — views
- packages/views/issues/components/swimlane-view.tsx — batched fetch wiring, monotonic subscribedParentIds, mergedIssues fallback, dual-render fix, drag guards, memo + custom comparators, refactor cleanup
- packages/views/issues/components/swimlane-view.test.tsx

## How to Test

1. Open a workspace with issues that have grandparent → parent → child nesting beyond the first page (offset > 50). Confirm grandparent lanes are no longer empty after the batch fetch resolves.
2. In Swimlane view, try dragging a lane-header card (one that has its own sub-lane) into one of its own sub-lane cells. Confirm it is refused and the card snaps back.

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [X] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [X] I have considered and documented any risks above
- [X] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Opencode

**Prompt / approach:**

Used OpenCode as a pair programmer across a multi-session workflow:

1. Bug reproduction first — seeded a local sandbox with ~2200 issues including a grandparent → parent → grandchild chain to reproduce the empty-lane bug before writing any code.
2. TDD — wrote failing tests first for each behaviour (batched fetch, dual-render, drag guards), then implemented to make them pass. All 823 tests green throughout.
3. Perf measurement — instrumented with React <Profiler> and collected real render timings before optimising. Confirmed mount 560ms → batch-update 67ms after memo + stable references. Profiler stripped after measurements.
4. Iterative review loop — each round of Bohan's review feedback was fed directly into the session. The agent read the review comments, cross-referenced the code, and proposed targeted fixes which were verified with tests before moving on.
5. Refactor phase — separate session focused only on readability: import deduplication, type/comparator declaration order, removing unnecessary else-after-return, comparator functions rewritten as single return expressions.