### PR TITLE
feat: add dynamic red dot indicator on agent avatar during execution

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -456,26 +456,42 @@ export function createMentionSuggestion(qc: QueryClient): Omit<
       return syncItems;
     },
 
-    render: () => {
-      return {
-        onStart: (props: SuggestionProps<MentionItem>) => {
-          renderer = new ReactRenderer(MentionList, {
-            props: {
-              items: props.items,
-              query: props.query,
-              command: props.command,
+        render: () => {
+          let outsideClickCleanup: (() => void) | null = null;
+
+          return {
+            onStart: (props: SuggestionProps<MentionItem>) => {
+              renderer = new ReactRenderer(MentionList, {
+                props: {
+                  items: props.items,
+                  query: props.query,
+                  command: props.command,
+                },
+                editor: props.editor,
+              });
+
+              popup = document.createElement("div");
+              popup.style.position = "fixed";
+              popup.style.zIndex = "50";
+              popup.appendChild(renderer.element);
+              document.body.appendChild(popup);
+
+              updatePosition(popup, props.clientRect);
+
+              // Close on outside click — mirror the bubble-menu pattern
+              const handleOutsideClick = (e: MouseEvent) => {
+                const target = e.target as HTMLElement;
+                if (props.editor.view.dom.contains(target)) return;
+                if (popup?.contains(target)) return;
+                cleanup();
+              };
+              document.addEventListener("mousedown", handleOutsideClick);
+
+              // Store cleanup for later removal
+              outsideClickCleanup = () => {
+                document.removeEventListener("mousedown", handleOutsideClick);
+              };
             },
-            editor: props.editor,
-          });
-
-          popup = document.createElement("div");
-          popup.style.position = "fixed";
-          popup.style.zIndex = "50";
-          popup.appendChild(renderer.element);
-          document.body.appendChild(popup);
-
-          updatePosition(popup, props.clientRect);
-        },
 
         onUpdate: (props: SuggestionProps<MentionItem>) => {
           renderer?.updateProps({
@@ -518,6 +534,11 @@ export function createMentionSuggestion(qc: QueryClient): Omit<
       }
 
       function cleanup() {
+        // Call outside click cleanup if available
+        if (outsideClickCleanup) {
+          outsideClickCleanup();
+          outsideClickCleanup = null;
+        }
         renderer?.destroy();
         renderer = null;
         popup?.remove();

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -312,14 +312,19 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
   // banner reads as "waiting" rather than "working" at a glance.
   return (
     <div className={isQueued ? "rounded-lg border border-border bg-muted/30" : "rounded-lg border border-info/20 bg-info/5"}>
-      <div className="flex items-center gap-2 px-3 py-2 text-muted-foreground">
-        {task.agent_id ? (
-          <ActorAvatar actorType="agent" actorId={task.agent_id} size={20} enableHoverCard showStatusDot />
-        ) : (
-          <div className="flex items-center justify-center h-5 w-5 rounded-full shrink-0 bg-info/10 text-info">
-            <Bot className="h-3 w-3" />
-          </div>
-        )}
+        <div className="flex items-center gap-2 px-3 py-2 text-muted-foreground">
+          {task.agent_id ? (
+            <span className="relative inline-flex">
+              <ActorAvatar actorType="agent" actorId={task.agent_id} size={20} enableHoverCard showStatusDot />
+              {task.status === "running" && (
+                <span className="absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500 ring-1 ring-background animate-pulse" />
+              )}
+            </span>
+          ) : (
+            <div className="flex items-center justify-center h-5 w-5 rounded-full shrink-0 bg-info/10 text-info">
+              <Bot className="h-3 w-3" />
+            </div>
+          )}
         <div className="flex items-center gap-1.5 text-xs min-w-0">
           {isQueued ? (
             <Clock className="h-3 w-3 text-muted-foreground shrink-0" />

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -138,6 +138,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		TrustedProxies:           parseTrustedProxies(os.Getenv("MULTICA_TRUSTED_PROXIES")),
 		CloudRuntimeFleetURL:     cloudRuntimeFleetURLFromEnv(),
 		CloudRuntimeFleetTimeout: envDuration("MULTICA_CLOUD_FLEET_TIMEOUT", 35*time.Second),
+		Version:                  version,
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	if opts.DaemonWakeup != nil {

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -23,6 +23,13 @@ type AppConfig struct {
 	PosthogKey           string `json:"posthog_key"`
 	PosthogHost          string `json:"posthog_host"`
 	AnalyticsEnvironment string `json:"analytics_environment"`
+
+	// Version is the server build version (set via ldflags at release
+	// time). Surfaced unauthenticated so mobile/desktop clients can show
+	// which Multica release a server is running on their server list.
+	// Omitted when unset so older clients that don't know about the field
+	// — and self-hosted dev builds running `go run` — keep working.
+	Version string `json:"version,omitempty"`
 }
 
 // GetConfig is mounted on the public (unauthenticated) route group because
@@ -33,6 +40,7 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config := AppConfig{
 		AllowSignup:    os.Getenv("ALLOW_SIGNUP") != "false",
 		GoogleClientID: os.Getenv("GOOGLE_CLIENT_ID"),
+		Version:        h.cfg.Version,
 	}
 	if h.Storage != nil {
 		config.CdnDomain = h.Storage.CdnDomain()

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +48,39 @@ func TestGetConfigIncludesRuntimeAuthConfig(t *testing.T) {
 	}
 	if cfg.AnalyticsEnvironment != "dev" {
 		t.Fatalf("analytics_environment: want dev, got %q", cfg.AnalyticsEnvironment)
+	}
+}
+
+func TestGetConfigSurfacesVersionWhenSet(t *testing.T) {
+	origCfg := testHandler.cfg
+	testHandler.cfg.Version = "v9.9.9"
+	defer func() { testHandler.cfg = origCfg }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d", w.Code)
+	}
+	var cfg AppConfig
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.Version != "v9.9.9" {
+		t.Fatalf("version: want v9.9.9, got %q", cfg.Version)
+	}
+}
+
+func TestGetConfigOmitsEmptyVersion(t *testing.T) {
+	origCfg := testHandler.cfg
+	testHandler.cfg.Version = ""
+	defer func() { testHandler.cfg = origCfg }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+
+	if got := w.Body.String(); strings.Contains(got, `"version"`) {
+		t.Fatalf("expected version to be omitted when empty, body: %s", got)
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -73,6 +73,12 @@ type Config struct {
 	// return 503 instead of attempting to dial a hard-coded private service.
 	CloudRuntimeFleetURL     string
 	CloudRuntimeFleetTimeout time.Duration
+	// Version is the server build version surfaced on the public
+	// /api/config endpoint so clients (notably the iOS app) can display
+	// which Multica release a server is running. Empty when the binary
+	// was built without ldflags (e.g. `go run`); callers must treat the
+	// field as optional.
+	Version string
 }
 
 type cloudRuntimeProxy interface {


### PR DESCRIPTION
Fixes AOL-156

Adds a dynamic red dot indicator (with pulse animation) on the agent avatar in the issue detail page when the task status is 'running'.