### PR TITLE
fix(comments): clear editor immediately on submit to eliminate WS race glitch

### DIFF
--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -265,7 +265,6 @@ function CommentRow({
   const isOwn = entry.actor_type === "member" && entry.actor_id === currentUserId;
   const canEditEntry = isOwn || (canModerate && entry.actor_type === "member");
   const canDeleteEntry = isOwn || canModerate;
-  const isTemp = entry.id.startsWith("temp-");
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const startEdit = () => {
@@ -325,7 +324,7 @@ function CommentRow({
   );
 
   return (
-    <div className={`py-3${isTemp ? " opacity-60" : ""}`}>
+    <div className="py-3">
       <div className="flex items-center gap-2.5">
         <ActorAvatar actorType={entry.actor_type} actorId={entry.actor_id} size={24} enableHoverCard showStatusDot />
         <span className="cursor-pointer text-sm font-medium">
@@ -344,8 +343,7 @@ function CommentRow({
           </TooltipContent>
         </Tooltip>
 
-        {!isTemp && (
-          <div className="ml-auto flex items-center gap-0.5">
+        <div className="ml-auto flex items-center gap-0.5">
             <QuickEmojiPicker
               onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
               align="end"
@@ -392,7 +390,6 @@ function CommentRow({
             onConfirm={() => onDelete(entry.id)}
           />
           </div>
-        )}
       </div>
 
       {editing ? (
@@ -450,16 +447,14 @@ function CommentRow({
             <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
           </div>
           <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-8" />
-          {!isTemp && (
-            <ReactionBar
-              reactions={reactions}
-              currentUserId={currentUserId}
-              onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
-              getActorName={getActorName}
-              hideAddButton={!isLongContent}
-              className="mt-1.5 pl-8"
-            />
-          )}
+          <ReactionBar
+            reactions={reactions}
+            currentUserId={currentUserId}
+            onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
+            getActorName={getActorName}
+            hideAddButton={!isLongContent}
+            className="mt-1.5 pl-8"
+          />
         </>
       )}
     </div>
@@ -527,7 +522,6 @@ function CommentCardImpl({
   // own their own outputs.
   const canEditEntry = isOwn || (canModerate && entry.actor_type === "member");
   const canDeleteEntry = isOwn || canModerate;
-  const isTemp = entry.id.startsWith("temp-");
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const startEdit = () => {
@@ -596,7 +590,7 @@ function CommentCardImpl({
   const isHighlighted = highlightedCommentId === entry.id;
 
   return (
-    <Card className={cn("!py-0 !gap-0 overflow-hidden transition-colors duration-700", isTemp && "opacity-60", isHighlighted && "ring-2 ring-brand/50 bg-brand/5")}>
+    <Card className={cn("!py-0 !gap-0 overflow-hidden transition-colors duration-700", isHighlighted && "ring-2 ring-brand/50 bg-brand/5")}>
       {onCollapseResolved && (
         <button
           type="button"
@@ -646,7 +640,7 @@ function CommentCardImpl({
               </span>
             )}
 
-            {open && !isTemp && (
+            {open && (
               <div className="ml-auto flex items-center gap-0.5">
                 <QuickEmojiPicker
                   onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
@@ -776,16 +770,14 @@ function CommentCardImpl({
                   <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
                 </div>
                 <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10" />
-                {!isTemp && (
-                  <ReactionBar
-                    reactions={reactions}
-                    currentUserId={currentUserId}
-                    onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
-                    getActorName={getActorName}
-                    hideAddButton={!isLongContent}
-                    className="mt-1.5 pl-10"
-                  />
-                )}
+                <ReactionBar
+                  reactions={reactions}
+                  currentUserId={currentUserId}
+                  onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
+                  getActorName={getActorName}
+                  hideAddButton={!isLongContent}
+                  className="mt-1.5 pl-10"
+                />
               </>
             )}
           </div>

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -344,10 +344,10 @@ function CommentRow({
         </Tooltip>
 
         <div className="ml-auto flex items-center gap-0.5">
-            <QuickEmojiPicker
-              onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
-              align="end"
-            />
+          <QuickEmojiPicker
+            onSelect={(emoji) => onToggleReaction(entry.id, emoji)}
+            align="end"
+          />
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -389,7 +389,7 @@ function CommentRow({
             onOpenChange={setConfirmDelete}
             onConfirm={() => onDelete(entry.id)}
           />
-          </div>
+        </div>
       </div>
 
       {editing ? (

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -77,11 +77,11 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
       .filter((a) => content.includes(a.url))
       .map((a) => a.id);
     setSubmitting(true);
+    editorRef.current?.clearContent();
+    setIsEmpty(true);
+    setPendingAttachments([]);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
-      editorRef.current?.clearContent();
-      setIsEmpty(true);
-      setPendingAttachments([]);
       clearDraft(draftKey);
     } finally {
       setSubmitting(false);

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -79,9 +79,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
     setSubmitting(true);
     editorRef.current?.clearContent();
     setIsEmpty(true);
-    setPendingAttachments([]);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
+      setPendingAttachments([]);
       clearDraft(draftKey);
     } finally {
       setSubmitting(false);

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -96,11 +96,11 @@ function ReplyInput({
       .filter((a) => content.includes(a.url))
       .map((a) => a.id);
     setSubmitting(true);
+    editorRef.current?.clearContent();
+    setIsEmpty(true);
+    setPendingAttachments([]);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
-      editorRef.current?.clearContent();
-      setIsEmpty(true);
-      setPendingAttachments([]);
       if (draftKey) clearDraft(draftKey);
     } finally {
       setSubmitting(false);

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -98,9 +98,9 @@ function ReplyInput({
     setSubmitting(true);
     editorRef.current?.clearContent();
     setIsEmpty(true);
-    setPendingAttachments([]);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
+      setPendingAttachments([]);
       if (draftKey) clearDraft(draftKey);
     } finally {
       setSubmitting(false);

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { useEffect, useRef, useCallback, useMemo } from "react";
 import {
   useQuery,
   useQueryClient,
@@ -67,8 +67,6 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   const { data, isLoading: loading } = query;
 
   const timeline = useMemo<TimelineEntry[]>(() => data ?? [], [data]);
-
-  const [submitting, setSubmitting] = useState(false);
 
   // Stable mutation handles. TanStack v5 returns a fresh result wrapper from
   // useMutation per render, but the inner mutateAsync / mutate functions are
@@ -262,8 +260,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
 
   const submitComment = useCallback(
     async (content: string, attachmentIds?: string[]) => {
-      if (!content.trim() || submitting || !userId) return;
-      setSubmitting(true);
+      if (!content.trim() || !userId) return;
       try {
         await createComment({ content, attachmentIds });
       } catch (err) {
@@ -272,11 +269,9 @@ export function useIssueTimeline(issueId: string, userId?: string) {
             ? err.message
             : t(($) => $.comment.send_failed),
         );
-      } finally {
-        setSubmitting(false);
       }
     },
-    [userId, submitting, createComment, t],
+    [userId, createComment, t],
   );
 
   const submitReply = useCallback(
@@ -427,7 +422,6 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   return {
     timeline: optimisticTimeline,
     loading,
-    submitting,
     submitComment,
     submitReply,
     editComment,


### PR DESCRIPTION
## Summary

- **Root cause fix**: Move `clearContent()` / `setIsEmpty(true)` / `setPendingAttachments([])` before `await onSubmit()` in both `comment-input.tsx` and `reply-input.tsx`. The editor now clears at click time, eliminating the ~60-200ms window where WS delivers the new comment while the editor still shows the same text (the "duplicate comment" flash).
- **Dead code removal**: Delete unused `submitting` state from `useIssueTimeline` — the input components already have their own `submitting` guard, making the hook-level one redundant.
- **Dead code removal**: Delete `isTemp` (`entry.id.startsWith("temp-")`) logic from `comment-card.tsx` — no code path ever creates temp-prefixed timeline entries, so this was unreachable.

Closes MUL-2720

## Test plan

- [x] `pnpm typecheck` — all 6 tasks pass
- [x] `use-issue-timeline.test.tsx` — 9/9 tests pass
- [ ] Manual: post a comment on an issue, verify editor clears immediately on click and no "duplicate" flash appears
- [ ] Manual: post a reply, same verification
- [ ] Manual: simulate HTTP failure (e.g. network offline), verify draft is preserved in store for recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)