### PR TITLE
fix(runtimes): consolidate local machine by device name

### DIFF
--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -157,6 +157,67 @@ describe("runtime machine grouping", () => {
     });
   });
 
+  it("treats a runtime with the local device name as the current machine", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          daemon_id: "legacy-hostname",
+          name: "Claude (My Laptop)",
+          device_info: "My Laptop · claude 1.0.0",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "daemon-uuid",
+        localMachineName: "my laptop",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      title: "my laptop",
+      section: "local",
+      isCurrent: true,
+      daemonId: "legacy-hostname",
+    });
+  });
+
+  it("does not treat a cloud runtime with the local device name as current", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "cloud-1",
+          daemon_id: null,
+          runtime_mode: "cloud",
+          provider: "codex",
+          name: "Codex (My Laptop)",
+          device_info: "My Laptop · codex 1.0.0",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "daemon-uuid",
+        localMachineName: "my laptop",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(2);
+    const cloud = machines.find((m) => m.id === "cloud:device:My Laptop");
+    expect(cloud).toMatchObject({
+      title: "My Laptop",
+      section: "cloud",
+      isCurrent: false,
+    });
+    const local = machines.find((m) => m.isCurrent);
+    expect(local).toMatchObject({
+      title: "my laptop",
+      section: "local",
+      runtimes: [],
+    });
+  });
+
   it("keeps cloud runtimes as cloud workers when they have no daemon", () => {
     const machines = buildRuntimeMachines(
       [

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -174,7 +174,15 @@ function finalizeRuntimeMachine(
   const first = runtimes[0];
   const providerNames = Array.from(new Set(runtimes.map((r) => r.provider))).sort();
   const isCurrent =
-    !!options.localDaemonId && draft.daemonId === options.localDaemonId;
+    (!!options.localDaemonId && draft.daemonId === options.localDaemonId) ||
+    (draft.mode === "local" &&
+      !!options.localMachineName &&
+      (draft.daemonId?.toLowerCase() === options.localMachineName.toLowerCase() ||
+        runtimes.some(
+          (r) =>
+            runtimeDeviceName(r)?.toLowerCase() ===
+            options.localMachineName?.toLowerCase(),
+        )));
   const title = machineTitle(runtimes, {
     isCurrent,
     localMachineName: options.localMachineName,


### PR DESCRIPTION
## Summary
- treat runtime groups as the current local machine when their daemon id or runtime device name matches the desktop local machine name
- prevent the empty `This machine` placeholder from being synthesized when active local runtimes were registered under a legacy hostname-style id
- add regression coverage for the hostname/device-name fallback

Fixes #3333

## Screenshot
![Runtimes page showing duplicate local and remote machine rows](https://raw.githubusercontent.com/XinhhD/multica/issue-assets/runtime-consolidation-screenshot/issue-assets/3333/runtime-local-remote-duplicate.png)

## Test
- `npm exec --yes pnpm@10.28.2 -- --filter @multica/views exec vitest run runtimes/components/runtime-machines.test.ts`
- `npm exec --yes pnpm@10.28.2 -- --filter @multica/views test`
- `git diff --check`
