### PR TITLE
fix(cli): drop "Showing N comments." stderr preamble on issue comment list

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -1002,7 +1002,6 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("list comments: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Showing %d comments.\n", len(comments))
 	// The server emits the next-page cursor in headers when there is likely
 	// an older page. Surface it on stderr so an operator (and the agent
 	// prompt update that follows this PR) can scroll deeper without having

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -1780,6 +1780,44 @@ func TestRunIssueCommentList_RecentStillLabelsCursorAsThread(t *testing.T) {
 	}
 }
 
+// TestRunIssueCommentList_DoesNotPrintShowingPreamble locks in the removal of
+// the "Showing N comments." stderr preamble. The line was the only
+// `list --output json` subcommand that emitted a human-readable count, which
+// polluted stdout/stderr-merged consumers (agent harnesses, CI `2>&1`).
+// Tracks GitHub issue #3303.
+func TestRunIssueCommentList_DoesNotPrintShowingPreamble(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/issues/") && !strings.Contains(r.URL.Path, "/comments") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         "issue-1",
+				"identifier": "MUL-1",
+			})
+			return
+		}
+		w.Write([]byte(`[{"id":"c1"},{"id":"c2"}]`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	stderr := captureStderr(t)
+	defer stderr.restore()
+
+	cmd := newIssueCommentListTestCmd()
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("set output: %v", err)
+	}
+	if err := runIssueCommentList(cmd, []string{"MUL-1"}); err != nil {
+		t.Fatalf("runIssueCommentList: %v", err)
+	}
+
+	if got := stderr.read(); strings.Contains(got, "Showing") {
+		t.Errorf("stderr must not contain a 'Showing ...' preamble, got: %q", got)
+	}
+}
+
 func TestValidIssueStatuses(t *testing.T) {
 	expected := map[string]bool{
 		"backlog":     true,


### PR DESCRIPTION
## Summary

- `multica issue comment list` was the only `list` subcommand that printed a human-readable count (`Showing N comments.`) to stderr. It is the only stderr noise unique to this command — every other `list --output json` is clean.
- For stdout-only consumers (`| jq`) the line was harmless because it lives on stderr. But agent harnesses and CI logs that merge `stdout`/`stderr` (`2>&1`) saw it interleaved with the JSON array, forcing every consumer to strip a preamble that carried no information.
- In table mode the table itself shows the count one row below, so removing the line costs nothing for human readers either.
- The `Next thread cursor` / `Next reply cursor` lines are deliberately kept — those are real paging signals the agent runtime reads from stderr (see `server/internal/daemon/execenv/runtime_config.go`).

Closes #3303
MUL-2709

## Test plan

- [x] `go test ./server/cmd/multica/ -run TestRunIssueCommentList` — passes, including new `TestRunIssueCommentList_DoesNotPrintShowingPreamble` regression test that asserts stderr no longer contains a `Showing ...` preamble under `--output json`.
- [x] Existing `Next reply cursor` / `Next thread cursor` tests still pass — paging signals untouched.
- [x] `go vet ./server/cmd/multica/` and `go build ./server/cmd/multica/` clean.