### PR TITLE
fix(settings): remove orphan repo count from GitHub tab shortcut card

### DIFF
--- a/packages/views/settings/components/github-tab.tsx
+++ b/packages/views/settings/components/github-tab.tsx
@@ -70,9 +70,6 @@ export function GitHubTab() {
   const [disconnectTarget, setDisconnectTarget] = useState<string | null>(null);
   const [disconnecting, setDisconnecting] = useState(false);
 
-  const githubRepoCount =
-    workspace?.repos?.filter((r) => /github\.com/i.test(r.url ?? "")).length ?? 0;
-
   async function persistSetting(key: SettingsKey, next: boolean) {
     if (!workspace || savingKey) return;
     setSavingKey(key);
@@ -314,14 +311,9 @@ export function GitHubTab() {
         <Card>
           <CardContent>
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">
-                  {t(($) => $.github.repositories_shortcut_label)}
-                </p>
-                <p className="text-xs text-muted-foreground tabular-nums">
-                  {githubRepoCount}
-                </p>
-              </div>
+              <p className="text-sm font-medium">
+                {t(($) => $.github.repositories_shortcut_label)}
+              </p>
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Summary

The Repositories shortcut card in **Settings → GitHub** shows an unlabeled number (e.g. `2`) under the line *"Repository URLs live in the Repositories tab"*. The number is the GitHub repo count, but with no label and no semantic link to the surrounding sentence, users read it as a typo / leftover (MUL-2725).

This card is a **navigation shortcut**, not a status panel — the canonical count is one click away on the Repositories tab. Removing the bare number.

### Before / After

| Before | After |
| --- | --- |
| `Repository URLs live in the Repositories tab`<br/>`2`<br/>`[Manage repositories →]` | `Repository URLs live in the Repositories tab`<br/>`[Manage repositories →]` |

## Changes

- Drop `githubRepoCount` derivation and its `<p>` render in `packages/views/settings/components/github-tab.tsx`.
- Collapse the now single-child wrapper `<div className="space-y-1">` — the label `<p>` becomes a flex child directly.

No i18n strings, no API, no behavior change otherwise.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` passes
- [x] `eslint` clean on the changed file
- [ ] Visual check on Settings → GitHub: the "Repositories" card now shows only the label + "Manage repositories →" button.

MUL-2725