### PR TITLE
fix(comments): defer input clearing until submit succeeds

### DIFF
--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -77,10 +77,10 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
       .filter((a) => content.includes(a.url))
       .map((a) => a.id);
     setSubmitting(true);
-    editorRef.current?.clearContent();
-    setIsEmpty(true);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
+      editorRef.current?.clearContent();
+      setIsEmpty(true);
       setPendingAttachments([]);
       clearDraft(draftKey);
     } finally {

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -96,10 +96,10 @@ function ReplyInput({
       .filter((a) => content.includes(a.url))
       .map((a) => a.id);
     setSubmitting(true);
-    editorRef.current?.clearContent();
-    setIsEmpty(true);
     try {
       await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
+      editorRef.current?.clearContent();
+      setIsEmpty(true);
       setPendingAttachments([]);
       if (draftKey) clearDraft(draftKey);
     } finally {


### PR DESCRIPTION
## Summary

- `clearContent()` and `setIsEmpty(true)` were called **before** `await onSubmit()` in both `comment-input.tsx` and `reply-input.tsx` (introduced in #3331). On network failure, user content and draft were permanently lost with no recovery path.
- Moved both calls to the success path (after `await onSubmit()`), consistent with attachment and draft cleanup.

Fixes MUL-2720.

## Test plan

- [ ] Type a comment, disconnect network, click send — verify content stays in editor on failure
- [ ] Type a comment, send successfully — verify editor clears
- [ ] Type a reply, disconnect network, click send — verify content stays in editor on failure
- [ ] Type a reply, send successfully — verify editor clears
- [ ] Verify draft persistence still works (type, navigate away, come back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)