### PR TITLE
ci: split mobile lint/typecheck out of frontend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,12 @@ jobs:
           git diff --exit-code -- packages/core/paths/reserved-slugs.ts
 
       - name: Build, type check, lint, and test
-        run: pnpm exec turbo build typecheck lint test --filter='!@multica/docs'
+        # Mobile lives in a parallel mobile-verify workflow (path-filtered
+        # to apps/mobile/** + packages/core/types/**) so it doesn't add
+        # ~50s of expo-lint + tsc to every web/desktop PR. Keep this
+        # filter in sync with the root package.json scripts, which also
+        # exclude @multica/mobile.
+        run: pnpm exec turbo build typecheck lint test --filter='!@multica/docs' --filter='!@multica/mobile'
 
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/mobile-verify.yml
+++ b/.github/workflows/mobile-verify.yml
@@ -1,8 +1,17 @@
 name: Mobile Verify
 
 # Runs lint + typecheck for apps/mobile only, parallel to the main CI
-# workflow. Path-filtered so PRs that don't touch mobile (or the type
-# surface mobile imports from @multica/core/types) pay zero cost.
+# workflow. Path-filtered so PRs that don't touch mobile (or anything
+# mobile transitively depends on) pay zero cost.
+#
+# Path scope rationale — mobile transitively depends on:
+# - apps/mobile/**                — the app itself
+# - packages/core/**              — mobile imports types AND pure functions
+#                                   (agents, markdown, permissions, api/schemas, …),
+#                                   not only @multica/core/types
+# - package.json / pnpm-lock.yaml — install graph
+# - pnpm-workspace.yaml           — catalog versions
+# - turbo.json                    — turbo task pipeline
 #
 # Mobile has no vitest suite today; if one lands, add `test` to the turbo
 # task list below.
@@ -12,13 +21,21 @@ on:
     branches: [main]
     paths:
       - "apps/mobile/**"
-      - "packages/core/types/**"
+      - "packages/core/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
       - ".github/workflows/mobile-verify.yml"
   pull_request:
     branches: [main]
     paths:
       - "apps/mobile/**"
-      - "packages/core/types/**"
+      - "packages/core/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
       - ".github/workflows/mobile-verify.yml"
 
 concurrency:

--- a/.github/workflows/mobile-verify.yml
+++ b/.github/workflows/mobile-verify.yml
@@ -1,0 +1,48 @@
+name: Mobile Verify
+
+# Runs lint + typecheck for apps/mobile only, parallel to the main CI
+# workflow. Path-filtered so PRs that don't touch mobile (or the type
+# surface mobile imports from @multica/core/types) pay zero cost.
+#
+# Mobile has no vitest suite today; if one lands, add `test` to the turbo
+# task list below.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/mobile/**"
+      - "packages/core/types/**"
+      - ".github/workflows/mobile-verify.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/mobile/**"
+      - "packages/core/types/**"
+      - ".github/workflows/mobile-verify.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mobile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Type check and lint
+        run: pnpm exec turbo typecheck lint --filter=@multica/mobile


### PR DESCRIPTION
## Summary

- Frontend CI job no longer builds/typechecks/lints `@multica/mobile`. Mobile lint (~38s) + typecheck (~13s) was running on every web/desktop PR even though mobile has no vitest suite — pure dead weight on the critical path.
- New `mobile-verify.yml` workflow runs mobile lint + typecheck in parallel, path-filtered to `apps/mobile/**` and `packages/core/types/**`. PRs that don't touch mobile pay zero CI time for it.
- Root `package.json` already excludes `@multica/mobile` from `pnpm test`/`lint`/`typecheck`/`build` — CI now matches local behavior.

This is half of the two-pronged plan from MUL-2729; the Turbo Remote Cache half is owned separately and lands in its own PR.

Refs MUL-2729.

## Test plan

- [ ] CI: `frontend` job runs on this PR (it touches `.github/workflows/ci.yml`, the changed file lives outside `apps/mobile/**`).
- [ ] CI: `mobile-verify` job does NOT run on this PR (no `apps/mobile/**` or `packages/core/types/**` changes).
- [ ] Follow-up sanity check after merge: a PR that touches `apps/mobile/**` should trigger `mobile-verify` and not block on the unrelated `frontend` job.
- [ ] `pnpm exec turbo typecheck lint --filter=@multica/mobile` resolves to only `@multica/mobile` locally (verified via `--dry=json`).
- [ ] `pnpm exec turbo build typecheck lint test --filter='!@multica/docs' --filter='!@multica/mobile'` no longer includes `@multica/mobile` (verified via `--dry=json` — only `@multica/{core,desktop,eslint-config,tsconfig,ui,views,web}` remain).