### PR TITLE
React Doctor cleanup: button types, useContext→use(), toSorted, error fixes

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -34,6 +34,7 @@ function SidebarTopBar() {
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       >
         <button
+          type="button"
           onClick={goBack}
           disabled={!canGoBack}
           aria-label="Go back"
@@ -42,6 +43,7 @@ function SidebarTopBar() {
           <ChevronLeft className="size-4" />
         </button>
         <button
+          type="button"
           onClick={goForward}
           disabled={!canGoForward}
           aria-label="Go forward"

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -124,6 +124,7 @@ function SortableTabItem({
 
   const tabButton = (
     <button
+      type="button"
       ref={setNodeRef}
       style={style}
       {...attributes}
@@ -221,6 +222,7 @@ function NewTabButton() {
 
   return (
     <button
+      type="button"
       onClick={handleClick}
       style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted/50 hover:text-muted-foreground"

--- a/apps/desktop/src/renderer/src/components/update-notification.tsx
+++ b/apps/desktop/src/renderer/src/components/update-notification.tsx
@@ -26,6 +26,7 @@ export function UpdateNotification() {
   return (
     <div className="fixed bottom-4 right-4 z-50 w-80 rounded-lg border border-border bg-background p-4 shadow-lg animate-in slide-in-from-bottom-2 fade-in duration-300">
       <button
+        type="button"
         onClick={() => setDismissed(true)}
         className="absolute top-2 right-2 rounded-md p-1 text-muted-foreground hover:text-foreground transition-colors"
       >
@@ -43,12 +44,14 @@ export function UpdateNotification() {
           </p>
           <div className="mt-2 flex items-center gap-1.5">
             <button
+              type="button"
               onClick={() => setDismissed(true)}
               className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent transition-colors"
             >
               Later
             </button>
             <button
+              type="button"
               onClick={() => window.updater.installUpdate()}
               className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
             >

--- a/apps/docs/components/locale-link.tsx
+++ b/apps/docs/components/locale-link.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import {
   createContext,
-  useContext,
+  use,
   type AnchorHTMLAttributes,
   type ReactNode,
 } from "react";
@@ -30,7 +30,7 @@ export function DocsLocaleProvider({
 }
 
 export function useDocsLocale(): Lang {
-  return useContext(DocsLocaleContext);
+  return use(DocsLocaleContext);
 }
 
 // Drop-in replacement for the MDX-rendered `<a>` element. Keeps the same

--- a/apps/mobile/app/(app)/[workspace]/new-issue.tsx
+++ b/apps/mobile/app/(app)/[workspace]/new-issue.tsx
@@ -14,7 +14,7 @@
  * — both surfaces produce canonical `[@name](mention://type/id)` markdown
  * recognised by util.ParseMentions on the server.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
@@ -93,18 +93,16 @@ export default function NewIssueModal() {
     createIssue,
   ]);
 
-  const headerRight = useMemo(() => {
-    function HeaderRight() {
-      return (
-        <SubmitIssueButton
-          disabled={!canSubmit}
-          loading={isSubmitting}
-          onPress={onSubmit}
-        />
-      );
-    }
-    return HeaderRight;
-  }, [canSubmit, isSubmitting, onSubmit]);
+  const headerRight = useCallback(
+    () => (
+      <SubmitIssueButton
+        disabled={!canSubmit}
+        loading={isSubmitting}
+        onPress={onSubmit}
+      />
+    ),
+    [canSubmit, isSubmitting, onSubmit],
+  );
 
   return (
     <>

--- a/apps/mobile/components/ui/text.tsx
+++ b/apps/mobile/components/ui/text.tsx
@@ -74,7 +74,7 @@ function Text({
   TextVariantProps & {
     asChild?: boolean;
   }) {
-  const textClass = React.useContext(TextClassContext);
+  const textClass = React.use(TextClassContext);
   const Component = asChild ? Slot : RNText;
   return (
     <Component

--- a/apps/mobile/data/realtime/realtime-provider.tsx
+++ b/apps/mobile/data/realtime/realtime-provider.tsx
@@ -29,7 +29,7 @@
  */
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useRef,
   useState,
@@ -58,7 +58,7 @@ const RealtimeContext = createContext<WSClient | null>(null);
  *  (cold start, between workspace switches, signed out). Consumers must
  *  guard with `if (!ws) return` in their effect. */
 export function useWSClient(): WSClient | null {
-  return useContext(RealtimeContext);
+  return use(RealtimeContext);
 }
 
 export function RealtimeProvider({ children }: { children: React.ReactNode }) {

--- a/apps/mobile/lib/markdown/lightbox-provider.tsx
+++ b/apps/mobile/lib/markdown/lightbox-provider.tsx
@@ -9,7 +9,7 @@
  * `![]()` URL while rendering a comment and pass the array through so
  * a left/right swipe walks the gallery.
  */
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { createContext, use, useState, type ReactNode } from "react";
 import ImageView from "react-native-image-viewing";
 
 interface LightboxApi {
@@ -24,7 +24,7 @@ const LightboxContext = createContext<LightboxApi>({
 });
 
 export function useLightbox(): LightboxApi {
-  return useContext(LightboxContext);
+  return use(LightboxContext);
 }
 
 export function LightboxProvider({ children }: { children: ReactNode }) {

--- a/apps/web/features/landing/components/faq-section.tsx
+++ b/apps/web/features/landing/components/faq-section.tsx
@@ -24,6 +24,7 @@ export function FAQSection() {
           {t.faq.items.map((faq, i) => (
             <div key={i}>
               <button
+                type="button"
                 onClick={() => setOpenIndex(openIndex === i ? null : i)}
                 className="flex w-full items-start justify-between gap-4 py-6 text-left"
               >

--- a/apps/web/features/landing/components/features-section.tsx
+++ b/apps/web/features/landing/components/features-section.tsx
@@ -238,6 +238,7 @@ function TeammatesVisual() {
                 <div className="relative">
                   <PropRow label="Status">
                     <button
+                      type="button"
                       className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors"
                       onClick={() => { setStatusOpen(!statusOpen); setPriorityOpen(false); }}
                     >
@@ -249,6 +250,7 @@ function TeammatesVisual() {
                     <div className="absolute left-0 top-full z-10 mt-1 w-44 overflow-hidden rounded-md border bg-popover shadow-md">
                       {statusCycle.map((s) => (
                         <button
+                          type="button"
                           key={s}
                           className={cn(
                             "flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-accent transition-colors",
@@ -269,6 +271,7 @@ function TeammatesVisual() {
                 <div className="relative">
                   <PropRow label="Priority">
                     <button
+                      type="button"
                       className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors"
                       onClick={() => { setPriorityOpen(!priorityOpen); setStatusOpen(false); }}
                     >
@@ -280,6 +283,7 @@ function TeammatesVisual() {
                     <div className="absolute left-0 top-full z-10 mt-1 w-44 overflow-hidden rounded-md border bg-popover shadow-md">
                       {priorityCycle.map((p) => (
                         <button
+                          type="button"
                           key={p}
                           className={cn(
                             "flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-accent transition-colors",
@@ -299,6 +303,7 @@ function TeammatesVisual() {
                 {/* Assignee — clickable to toggle picker */}
                 <PropRow label="Assignee">
                   <button
+                    type="button"
                     className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors"
                     onClick={() => { setPickerOpen(!pickerOpen); setStatusOpen(false); setPriorityOpen(false); }}
                   >
@@ -323,6 +328,7 @@ function TeammatesVisual() {
                 </div>
                 <div className="p-1">
                   <button
+                    type="button"
                     className={cn(
                       "flex w-full items-center gap-2 rounded-sm px-2 py-1 text-xs text-muted-foreground hover:bg-accent transition-colors",
                       !assignee.type && "bg-accent",
@@ -340,6 +346,7 @@ function TeammatesVisual() {
                 <div className="p-1 pt-0">
                   {allAssignees.filter((a) => a.type === "member").map((m) => (
                     <button
+                      type="button"
                       key={m.id}
                       className={cn(
                         "flex w-full items-center gap-2 rounded-sm px-2 py-1 text-xs hover:bg-accent transition-colors",
@@ -359,6 +366,7 @@ function TeammatesVisual() {
                 <div className="p-1 pt-0">
                   {allAssignees.filter((a) => a.type === "agent").map((a) => (
                     <button
+                      type="button"
                       key={a.id}
                       className={cn(
                         "flex w-full items-center gap-2 rounded-sm px-2 py-1 text-xs hover:bg-accent transition-colors",
@@ -446,6 +454,7 @@ function AutonomousVisual() {
               if (item.type === "thinking") {
                 return (
                   <button
+                    type="button"
                     key={i}
                     className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-info/5 transition-colors"
                     onClick={() => setExpanded(isExpanded ? null : i)}
@@ -460,6 +469,7 @@ function AutonomousVisual() {
               if (item.type === "tool_use") {
                 return (
                   <button
+                    type="button"
                     key={i}
                     className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-info/5 transition-colors"
                     onClick={() => setExpanded(isExpanded ? null : i)}
@@ -474,6 +484,7 @@ function AutonomousVisual() {
               /* tool_result */
               return (
                 <button
+                  type="button"
                   key={i}
                   className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-accent/50 transition-colors"
                   onClick={() => setExpanded(isExpanded ? null : i)}
@@ -540,13 +551,14 @@ function SkillsVisual() {
         <div className="w-[200px] shrink-0 border-r flex flex-col">
           <div className="flex items-center justify-between border-b px-3 py-2">
             <span className="text-xs font-semibold">Skills</span>
-            <button className="rounded p-0.5 text-muted-foreground hover:bg-accent transition-colors">
+            <button type="button" className="rounded p-0.5 text-muted-foreground hover:bg-accent transition-colors">
               <Sparkles className="h-3.5 w-3.5" />
             </button>
           </div>
           <div className="flex-1 overflow-hidden divide-y">
             {mockSkills.map((skill, i) => (
               <button
+                type="button"
                 key={skill.name}
                 className={cn(
                   "flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors",
@@ -585,6 +597,7 @@ function SkillsVisual() {
               <div className="py-1">
                 {mockFileTree.map((f) => (
                   <button
+                    type="button"
                     key={f.name}
                     className={cn(
                       "flex w-full items-center gap-1.5 py-1 text-xs transition-colors",
@@ -806,6 +819,7 @@ function RuntimesVisual() {
           <div className="flex-1 overflow-hidden">
             {mockRuntimeList.map((rt, i) => (
               <button
+                type="button"
                 key={rt.name}
                 className={cn(
                   "flex w-full items-center gap-2.5 px-3 py-2.5 transition-colors",
@@ -860,6 +874,7 @@ function RuntimesVisual() {
               <div className="flex items-center gap-1">
                 {(["7d", "30d", "90d"] as const).map((range) => (
                   <button
+                    type="button"
                     key={range}
                     onClick={() => setTimeRange(range)}
                     className={cn(
@@ -996,6 +1011,7 @@ export function FeaturesSection() {
             <div className="sticky top-28 flex flex-col gap-0 py-28">
               {features.map((f, i) => (
                 <button
+                  type="button"
                   key={f.label}
                   onClick={() => scrollToPanel(i)}
                   className={cn(

--- a/apps/web/features/landing/components/landing-footer.tsx
+++ b/apps/web/features/landing/components/landing-footer.tsx
@@ -100,6 +100,7 @@ export function LandingFooter() {
           <div className="flex items-center">
             {locales.map((l, i) => (
               <button
+                type="button"
                 key={l}
                 onClick={() => setLocale(l)}
                 className={cn(

--- a/apps/web/features/landing/i18n/context.tsx
+++ b/apps/web/features/landing/i18n/context.tsx
@@ -2,8 +2,8 @@
 
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useMemo,
   useState,
   useTransition,
@@ -73,7 +73,7 @@ export function LocaleProvider({
 }
 
 export function useLocale() {
-  const ctx = useContext(LocaleContext);
+  const ctx = use(LocaleContext);
   if (!ctx) throw new Error("useLocale must be used within LocaleProvider");
   return ctx;
 }

--- a/packages/core/i18n/adapter-context.tsx
+++ b/packages/core/i18n/adapter-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, use, type ReactNode } from "react";
 import type { LocaleAdapter } from "./types";
 
 const LocaleAdapterContext = createContext<LocaleAdapter | null>(null);
@@ -20,7 +20,7 @@ export function LocaleAdapterProvider({
 }
 
 export function useLocaleAdapter(): LocaleAdapter {
-  const ctx = useContext(LocaleAdapterContext);
+  const ctx = use(LocaleAdapterContext);
   if (!ctx) {
     throw new Error(
       "useLocaleAdapter must be used within <LocaleAdapterProvider>",

--- a/packages/core/issues/stores/view-store-context.tsx
+++ b/packages/core/issues/stores/view-store-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 import { useStore, type StoreApi } from "zustand";
 import type { IssueViewState } from "./view-store";
 
@@ -21,14 +21,14 @@ export function ViewStoreProvider({
 }
 
 export function useViewStore<T>(selector: (state: IssueViewState) => T): T {
-  const store = useContext(ViewStoreContext);
+  const store = use(ViewStoreContext);
   if (!store)
     throw new Error("useViewStore must be used within ViewStoreProvider");
   return useStore(store, selector);
 }
 
 export function useViewStoreApi(): StoreApi<IssueViewState> {
-  const store = useContext(ViewStoreContext);
+  const store = use(ViewStoreContext);
   if (!store)
     throw new Error("useViewStoreApi must be used within ViewStoreProvider");
   return store;

--- a/packages/core/paths/hooks.tsx
+++ b/packages/core/paths/hooks.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, use, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Workspace } from "../types";
 import { workspaceListOptions } from "../workspace/queries";
@@ -35,7 +35,7 @@ export function WorkspaceSlugProvider({
 
 /** Current workspace slug from URL, or null outside workspace-scoped routes. */
 export function useWorkspaceSlug(): string | null {
-  return useContext(WorkspaceSlugContext);
+  return use(WorkspaceSlugContext);
 }
 
 /** Same as useWorkspaceSlug, but throws if called outside a workspace route. */

--- a/packages/core/realtime/provider.tsx
+++ b/packages/core/realtime/provider.tsx
@@ -2,7 +2,7 @@
 
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useState,
   useCallback,
@@ -144,7 +144,7 @@ export function WSProvider({
 }
 
 export function useWS() {
-  const ctx = useContext(WSContext);
+  const ctx = use(WSContext);
   if (!ctx) throw new Error("useWS must be used within WSProvider");
   return ctx;
 }

--- a/packages/ui/components/ui/carousel.tsx
+++ b/packages/ui/components/ui/carousel.tsx
@@ -33,7 +33,7 @@ type CarouselContextProps = {
 const CarouselContext = React.createContext<CarouselContextProps | null>(null)
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.use(CarouselContext)
 
   if (!context) {
     throw new Error("useCarousel must be used within a <Carousel />")

--- a/packages/ui/components/ui/chart.tsx
+++ b/packages/ui/components/ui/chart.tsx
@@ -30,7 +30,7 @@ type ChartContextProps = {
 const ChartContext = React.createContext<ChartContextProps | null>(null)
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.use(ChartContext)
 
   if (!context) {
     throw new Error("useChart must be used within a <ChartContainer />")

--- a/packages/ui/components/ui/input-otp.tsx
+++ b/packages/ui/components/ui/input-otp.tsx
@@ -47,7 +47,7 @@ function InputOTPSlot({
 }: React.ComponentProps<"div"> & {
   index: number
 }) {
-  const inputOTPContext = React.useContext(OTPInputContext)
+  const inputOTPContext = React.use(OTPInputContext)
   const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
 
   return (

--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -52,12 +52,16 @@ type SidebarContextProps = {
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
 function useSidebar() {
-  const context = React.useContext(SidebarContext)
+  const context = React.use(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")
   }
 
   return context
+}
+
+function useSidebarSafe() {
+  return React.use(SidebarContext)
 }
 
 function SidebarProvider({
@@ -332,6 +336,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
 
   return (
     <button
+      type="button"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label={toggleLabel}
@@ -770,4 +775,5 @@ export {
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
+  useSidebarSafe,
 }

--- a/packages/ui/components/ui/toggle-group.tsx
+++ b/packages/ui/components/ui/toggle-group.tsx
@@ -63,7 +63,7 @@ function ToggleGroupItem({
   size = "default",
   ...props
 }: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext)
+  const context = React.use(ToggleGroupContext)
 
   return (
     <TogglePrimitive

--- a/packages/views/agents/components/inspector/runtime-picker.tsx
+++ b/packages/views/agents/components/inspector/runtime-picker.tsx
@@ -55,7 +55,7 @@ export function RuntimePicker({
       filter === "mine" && currentUserId
         ? runtimes.filter((r) => r.owner_id === currentUserId)
         : runtimes;
-    return [...list].sort((a, b) => {
+    return list.toSorted((a, b) => {
       const aMine = a.owner_id === currentUserId;
       const bMine = b.owner_id === currentUserId;
       if (aMine && !bMine) return -1;

--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -176,6 +176,7 @@ export function ModelDropdown({
                   )}
                   {list.map((m) => (
                     <button
+                      type="button"
                       key={m.id}
                       onClick={() => select(m.id)}
                       className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors ${
@@ -208,6 +209,7 @@ export function ModelDropdown({
 
             {canCreate && (
               <button
+                type="button"
                 onClick={() => select(trimmedSearch)}
                 className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-primary transition-colors hover:bg-accent/50"
               >
@@ -220,6 +222,7 @@ export function ModelDropdown({
 
             {value && (
               <button
+                type="button"
                 onClick={() => select("")}
                 className="mt-1 flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/50"
               >

--- a/packages/views/agents/components/runtime-picker.tsx
+++ b/packages/views/agents/components/runtime-picker.tsx
@@ -249,7 +249,7 @@ function computeFilteredRuntimes(
     filter === "mine" && currentUserId
       ? runtimes.filter((r) => r.owner_id === currentUserId)
       : runtimes;
-  return [...filtered].sort((a, b) => {
+  return filtered.toSorted((a, b) => {
     const aMine = a.owner_id === currentUserId;
     const bMine = b.owner_id === currentUserId;
     if (aMine && !bMine) return -1;

--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -499,6 +499,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
               <TooltipTrigger
                 render={
                   <button
+                    type="button"
                     onClick={() => setIsExpanded((v) => !v)}
                     className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                   >
@@ -514,6 +515,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
               <TooltipTrigger
                 render={
                   <button
+                    type="button"
                     onClick={() => onOpenChange(false)}
                     className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                   >

--- a/packages/views/autopilots/components/trigger-config.tsx
+++ b/packages/views/autopilots/components/trigger-config.tsx
@@ -110,7 +110,7 @@ export function getDefaultTriggerConfig(): TriggerConfig {
 }
 
 function sortedDays(days: number[]): number[] {
-  return [...new Set(days)].sort((a, b) => a - b);
+  return Array.from(new Set(days)).toSorted((a, b) => a - b);
 }
 
 export function toCronExpression(cfg: TriggerConfig): string {

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -413,6 +413,7 @@ export function AgentTranscriptDialog({
                 </DropdownMenu>
               )}
               <button
+                type="button"
                 onClick={handleCopyAll}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
               >
@@ -420,6 +421,7 @@ export function AgentTranscriptDialog({
                 {copied ? t(($) => $.transcript.copied) : selectedTools.size > 0 ? t(($) => $.transcript.copy_filtered) : t(($) => $.transcript.copy_all)}
               </button>
               <button
+                type="button"
                 onClick={() => onOpenChange(false)}
                 className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
               >
@@ -649,6 +651,7 @@ function TimelineBar({
 
         return (
           <button
+            type="button"
             key={seg.startIdx}
             className={cn(
               "h-full transition-all duration-150 hover:opacity-80 relative group",

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -646,7 +646,7 @@ function Leaderboard({
   // applies inside an equal-bucket.
   const sortedRows = useMemo(() => {
     const metric = SORT_METRIC[sortBy];
-    return [...rows].sort((a, b) => metric(b) - metric(a));
+    return rows.toSorted((a, b) => metric(b) - metric(a));
   }, [rows, sortBy]);
 
   const maxValue = useMemo(() => {

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -64,8 +64,8 @@ export function aggregateDailyCost(usage: DashboardUsageDaily[]): DailyCostStack
     map.set(u.date, entry);
   }
   const round = (n: number) => Math.round(n * 100) / 100;
-  return [...map.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+  return Array.from(map.entries())
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([date, s]) => {
       const input = round(s.input);
       const output = round(s.output);
@@ -105,8 +105,8 @@ export function aggregateDailyTokens(usage: DashboardUsageDaily[]): DailyTokenDa
     entry.cacheWrite += u.cache_write_tokens;
     map.set(u.date, entry);
   }
-  return [...map.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+  return Array.from(map.entries())
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([date, t]) => ({
       date,
       label: formatDateLabel(date),
@@ -170,7 +170,7 @@ export function aggregateAgentTokens(rows: DashboardUsageByAgent[]): AgentCostRo
     entry.taskCount += r.task_count;
     map.set(r.agent_id, entry);
   }
-  return [...map.values()].sort((a, b) => b.cost - a.cost);
+  return Array.from(map.values()).toSorted((a, b) => b.cost - a.cost);
 }
 
 export interface AgentDashboardRow {
@@ -221,7 +221,7 @@ export function mergeAgentDashboardRows(
       taskCount: r.task_count,
     });
   }
-  return [...merged.values()].sort((a, b) => {
+  return Array.from(merged.values()).toSorted((a, b) => {
     if (b.cost !== a.cost) return b.cost - a.cost;
     return b.seconds - a.seconds;
   });
@@ -328,8 +328,7 @@ export function aggregateWeeklyTasks(
 // DailyTimeChart. Sorted ascending so the x-axis reads oldest-to-newest,
 // matching the cost / tokens aggregators.
 export function aggregateDailyTime(rows: DashboardRunTimeDaily[]): DailyTimeData[] {
-  return [...rows]
-    .sort((a, b) => a.date.localeCompare(b.date))
+  return rows.toSorted((a, b) => a.date.localeCompare(b.date))
     .map((r) => ({
       date: r.date,
       label: formatDateLabel(r.date),
@@ -341,8 +340,7 @@ export function aggregateDailyTime(rows: DashboardRunTimeDaily[]): DailyTimeData
 // counts for the DailyTasksChart's stacked bar (failed_count is a subset
 // of task_count, so completed = task_count - failed_count).
 export function aggregateDailyTasks(rows: DashboardRunTimeDaily[]): DailyTasksData[] {
-  return [...rows]
-    .sort((a, b) => a.date.localeCompare(b.date))
+  return rows.toSorted((a, b) => a.date.localeCompare(b.date))
     .map((r) => {
       const failed = r.failed_count;
       const completed = Math.max(0, r.task_count - failed);

--- a/packages/views/editor/attachment-download-context.tsx
+++ b/packages/views/editor/attachment-download-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { createContext, use, useMemo, type ReactNode } from "react";
 import type { Attachment } from "@multica/core/types";
 import { openExternal } from "../platform";
 import { useDownloadAttachment } from "./use-download-attachment";
@@ -71,7 +71,7 @@ export function AttachmentDownloadProvider({ attachments, children }: ProviderPr
  * usable in editor surfaces that haven't been wired up yet.
  */
 export function useAttachmentDownloadResolver(): ResolvedDownload {
-  const ctx = useContext(AttachmentDownloadContext);
+  const ctx = use(AttachmentDownloadContext);
   // Hooks-must-be-unconditional: always create the fallback object, but
   // memoization is unnecessary here because each NodeView render also
   // re-runs the click handler closure.

--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -272,6 +272,7 @@ function HeadingDropdown({ editor, onOpenChange, activeLevel }: { editor: Editor
       >
         {items.map((item) => (
           <button
+            type="button"
             key={item.label}
             className="flex w-full cursor-default items-center gap-2 rounded-md px-1.5 py-1 text-xs outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
             onMouseDown={(e) => {
@@ -323,6 +324,7 @@ function ListDropdown({ editor, onOpenChange, isBullet, isOrdered }: { editor: E
         finalFocus={false}
       >
         <button
+          type="button"
           className="flex w-full cursor-default items-center gap-2 rounded-md px-1.5 py-1 text-xs outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
           onMouseDown={(e) => {
             e.preventDefault();
@@ -334,6 +336,7 @@ function ListDropdown({ editor, onOpenChange, isBullet, isOrdered }: { editor: E
           {isBullet && <Check className="ml-auto size-3.5" />}
         </button>
         <button
+          type="button"
           className="flex w-full cursor-default items-center gap-2 rounded-md px-1.5 py-1 text-xs outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
           onMouseDown={(e) => {
             e.preventDefault();

--- a/packages/views/editor/extensions/mention-recency.ts
+++ b/packages/views/editor/extensions/mention-recency.ts
@@ -91,7 +91,7 @@ export function sortUserItemsByRecency(
   items: MentionItem[],
   recency: RecencyMap,
 ): MentionItem[] {
-  return [...items].sort((a, b) => {
+  return items.toSorted((a, b) => {
     const ra = recency[recencyKey(a)] ?? 0;
     const rb = recency[recencyKey(b)] ?? 0;
     if (ra !== rb) return rb - ra;

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -303,6 +303,7 @@ function MentionRow({
     const isClosed = item.status === "done" || item.status === "cancelled";
     return (
       <button
+        type="button"
         ref={buttonRef}
         className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
           selected ? "bg-accent" : "hover:bg-accent/50"
@@ -326,6 +327,7 @@ function MentionRow({
 
   return (
     <button
+      type="button"
       ref={buttonRef}
       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
         selected ? "bg-accent" : "hover:bg-accent/50"

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -42,6 +42,7 @@ export function InboxListItem({
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
         isSelected ? "bg-accent" : "hover:bg-accent/50"

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -351,6 +351,7 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
             />
           )}
           <button
+            type="button"
             onClick={requestCancel}
             disabled={cancelling}
             className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -97,7 +97,7 @@ function buildGroups(
     none: 3,
   };
 
-  return [...groups.values()].sort((a, b) => {
+  return Array.from(groups.values()).toSorted((a, b) => {
     const aOrder = order[a.assigneeType ?? "none"] ?? 99;
     const bOrder = order[b.assigneeType ?? "none"] ?? 99;
     if (aOrder !== bOrder) return aOrder - bOrder;

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -104,7 +104,7 @@ export function ExecutionLogSection({ issueId }: ExecutionLogSectionProps) {
     // Stable sort: failed first, cancelled second, completed last.
     // Within group: newest completed_at first (fall back to created_at
     // for malformed rows missing completed_at).
-    return [...past].sort((a, b) => {
+    return past.toSorted((a, b) => {
       const rankDiff =
         (PAST_STATUS_RANK[a.status] ?? 99) -
         (PAST_STATUS_RANK[b.status] ?? 99);
@@ -120,6 +120,7 @@ export function ExecutionLogSection({ issueId }: ExecutionLogSectionProps) {
   return (
     <div>
       <button
+        type="button"
         className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${
           open ? "" : "text-muted-foreground hover:text-foreground"
         }`}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1288,6 +1288,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       {/* Properties */}
       <div>
         <button
+          type="button"
           className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${propertiesOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
           onClick={() => setPropertiesOpen(!propertiesOpen)}
         >
@@ -1409,6 +1410,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       {parentIssue && (
         <div>
           <button
+            type="button"
             className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${parentIssueOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
             onClick={() => setParentIssueOpen(!parentIssueOpen)}
           >
@@ -1434,6 +1436,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       {githubSettings.prSidebar && (
         <div>
           <button
+            type="button"
             className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${pullRequestsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
             onClick={() => setPullRequestsOpen(!pullRequestsOpen)}
           >
@@ -1447,6 +1450,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       {/* Details */}
       <div>
         <button
+          type="button"
           className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${detailsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
           onClick={() => setDetailsOpen(!detailsOpen)}
         >
@@ -1476,6 +1480,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       {usage && usage.task_count > 0 && (
         <div>
           <button
+            type="button"
             className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${tokenUsageOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
             onClick={() => setTokenUsageOpen(!tokenUsageOpen)}
           >
@@ -1905,6 +1910,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               </div>
               <div className="flex items-center gap-2">
                 <button
+                  type="button"
                   onClick={handleToggleSubscribe}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >

--- a/packages/views/issues/utils/sort.ts
+++ b/packages/views/issues/utils/sort.ts
@@ -11,7 +11,7 @@ export function sortIssues(
   field: SortField,
   direction: SortDirection
 ): Issue[] {
-  const sorted = [...issues].sort((a, b) => {
+  const sorted = issues.toSorted((a, b) => {
     switch (field) {
       case "priority":
         return (

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { cn } from "@multica/ui/lib/utils";
-import { SidebarTrigger, useSidebar } from "@multica/ui/components/ui/sidebar";
+import { SidebarTrigger, useSidebarSafe } from "@multica/ui/components/ui/sidebar";
 
 function MobileSidebarTrigger() {
-  try {
-    useSidebar();
-  } catch {
-    return null;
-  }
+  const sidebar = useSidebarSafe();
+  if (!sidebar) return null;
   return <SidebarTrigger className="mr-2 md:hidden" />;
 }
 

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -415,6 +415,7 @@ export function ManualCreatePanel({
                   <TooltipTrigger
                     render={
                       <button
+                        type="button"
                         onClick={() => setIsExpanded(!isExpanded)}
                         className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                       >
@@ -432,6 +433,7 @@ export function ManualCreatePanel({
                   <TooltipTrigger
                     render={
                       <button
+                        type="button"
                         onClick={onClose}
                         className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                       >

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -243,6 +243,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
               <TooltipTrigger
                 render={
                   <button
+                    type="button"
                     onClick={() => setIsExpanded(!isExpanded)}
                     className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                   >
@@ -260,6 +261,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
               <TooltipTrigger
                 render={
                   <button
+                    type="button"
                     onClick={onClose}
                     className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                   >

--- a/packages/views/modals/create-squad.tsx
+++ b/packages/views/modals/create-squad.tsx
@@ -475,6 +475,8 @@ function AdditionalMembersPicker({
             <div
               role="combobox"
               aria-haspopup="listbox"
+              aria-expanded={open}
+              aria-controls="squad-member-listbox"
               tabIndex={0}
               className="flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             >
@@ -522,7 +524,7 @@ function AdditionalMembersPicker({
               className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
             />
           </div>
-          <div className="max-h-72 overflow-y-auto p-1">
+          <div id="squad-member-listbox" role="listbox" className="max-h-72 overflow-y-auto p-1">
             {filteredMine.length > 0 && (
               <PickerSection label={t(($) => $.create_squad.group_my_agents)}>
                 {filteredMine.map((a) => (

--- a/packages/views/navigation/context.tsx
+++ b/packages/views/navigation/context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useMemo, useTransition } from "react";
+import { createContext, use, useMemo, useTransition } from "react";
 import type { NavigationAdapter } from "./types";
 
 const NavigationContext = createContext<NavigationAdapter | null>(null);
@@ -37,7 +37,7 @@ export function NavigationProvider({
 }
 
 export function useNavigation(): NavigationAdapter {
-  const ctx = useContext(NavigationContext);
+  const ctx = use(NavigationContext);
   if (!ctx)
     throw new Error("useNavigation must be used within NavigationProvider");
   return ctx;
@@ -45,5 +45,5 @@ export function useNavigation(): NavigationAdapter {
 
 /** True while a transition-wrapped push/replace is committing. */
 export function useIsNavigating(): boolean {
-  return useContext(NavigationPendingContext);
+  return use(NavigationPendingContext);
 }

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -508,6 +508,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       {/* Properties */}
       <div>
         <button
+          type="button"
           className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${propertiesOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
           onClick={() => setPropertiesOpen(!propertiesOpen)}
         >
@@ -640,6 +641,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
         return (
           <div>
             <button
+              type="button"
               className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${progressOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => setProgressOpen(!progressOpen)}
             >
@@ -664,6 +666,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       {/* Description */}
       <div>
         <button
+          type="button"
           className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${descriptionOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
           onClick={() => setDescriptionOpen(!descriptionOpen)}
         >

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -86,6 +86,7 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
   return (
     <div>
       <button
+        type="button"
         className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${open ? "" : "text-muted-foreground hover:text-foreground"}`}
         onClick={() => setOpen(!open)}
       >

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -56,7 +56,7 @@ export function CloudRuntimeDialog({ onClose }: { onClose: () => void }) {
 
   const sortedNodes = useMemo(
     () =>
-      [...(nodesQuery.data ?? [])].sort(
+      (nodesQuery.data ?? []).toSorted(
         (a, b) =>
           new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
       ),

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -168,7 +168,7 @@ function finalizeRuntimeMachine(
   draft: RuntimeMachineDraft,
   options: RuntimeMachineOptions,
 ): RuntimeMachine {
-  const runtimes = [...draft.runtimes].sort((a, b) =>
+  const runtimes = draft.runtimes.toSorted((a, b) =>
     a.provider.localeCompare(b.provider),
   );
   const first = runtimes[0];

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -322,7 +322,7 @@ export function collectUnmappedModels(rows: readonly Priceable[]): string[] {
   for (const r of rows) {
     if (r.model && !isModelPriced(r.model)) set.add(r.model);
   }
-  return [...set].sort();
+  return Array.from(set).toSorted();
 }
 
 // Anything carrying per-model token totals can be priced — RuntimeUsage,
@@ -500,20 +500,20 @@ export function aggregateByDate(usage: RuntimeUsage[]): {
     return `${date.getMonth() + 1}/${date.getDate()}`;
   };
 
-  const dailyTokens = [...dateMap.values()]
-    .sort((a, b) => a.date.localeCompare(b.date))
+  const dailyTokens = Array.from(dateMap.values())
+    .toSorted((a, b) => a.date.localeCompare(b.date))
     .map((d) => ({ ...d, label: formatLabel(d.date) }));
 
-  const dailyCost = [...costMap.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+  const dailyCost = Array.from(costMap.entries())
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([date, cost]) => ({
       date,
       label: formatLabel(date),
       cost: Math.round(cost * 100) / 100,
     }));
 
-  const dailyCostStack = [...stackMap.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+  const dailyCostStack = Array.from(stackMap.entries())
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([date, s]) => {
       const round = (n: number) => Math.round(n * 100) / 100;
       const input = round(s.input);
@@ -635,12 +635,12 @@ export function aggregateByWeek(
     };
   };
 
-  const weeklyTokens: WeeklyTokenData[] = [...tokenMap.values()]
-    .sort((a, b) => a.weekStart.localeCompare(b.weekStart))
+  const weeklyTokens: WeeklyTokenData[] = Array.from(tokenMap.values())
+    .toSorted((a, b) => a.weekStart.localeCompare(b.weekStart))
     .map((t) => ({ ...t, ...decorate(t.weekStart) }));
 
-  const weeklyCostStack: WeeklyCostStackData[] = [...stackMap.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+  const weeklyCostStack: WeeklyCostStackData[] = Array.from(stackMap.entries())
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([weekStart, s]) => {
       const round = (n: number) => Math.round(n * 100) / 100;
       const input = round(s.input);
@@ -774,7 +774,7 @@ export function aggregateCostByAgent(rows: RuntimeUsageByAgent[]): CostByKey[] {
     entry.taskCount += r.task_count;
     map.set(r.agent_id, entry);
   }
-  return [...map.values()].sort((a, b) => b.cost - a.cost);
+  return Array.from(map.values()).toSorted((a, b) => b.cost - a.cost);
 }
 
 // Per-(date, model) rows → per-model totals (the "By model" tab reuses the
@@ -789,7 +789,7 @@ export function aggregateCostByModel(rows: RuntimeUsage[]): CostByKey[] {
     entry.cost += estimateCost(r);
     map.set(key, entry);
   }
-  return [...map.values()].sort((a, b) => b.cost - a.cost);
+  return Array.from(map.values()).toSorted((a, b) => b.cost - a.cost);
 }
 
 // Sum of estimated cost over the trailing window

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -165,6 +165,7 @@ export function PreferencesTab() {
             const active = theme === opt.value;
             return (
               <button
+                type="button"
                 key={opt.value}
                 role="radio"
                 aria-checked={active}
@@ -219,6 +220,7 @@ export function PreferencesTab() {
             const active = currentLocale === opt.value;
             return (
               <button
+                type="button"
                 key={opt.value}
                 role="radio"
                 aria-checked={active}

--- a/packages/views/skills/components/file-tree.tsx
+++ b/packages/views/skills/components/file-tree.tsx
@@ -99,6 +99,7 @@ function TreeNodeItem({
     return (
       <div>
         <button
+          type="button"
           onClick={() => setExpanded(!expanded)}
           className="flex w-full items-center gap-1.5 py-1 text-left text-xs hover:bg-accent/50 rounded-sm"
           style={{ paddingLeft: `${depth * 12 + 8}px` }}
@@ -128,6 +129,7 @@ function TreeNodeItem({
 
   return (
     <button
+      type="button"
       onClick={() => onSelect(node.path)}
       className={cn(
         "flex w-full items-center gap-1.5 py-1 text-left text-xs rounded-sm",


### PR DESCRIPTION
## Summary

- Add explicit `type="button"` to 61 `<button>` elements — prevents accidental form submission
- Replace `useContext()` with React 19 `use()` across 16 context consumers — API modernization
- Replace `[...arr].sort()` with `arr.toSorted()` in 12 web/desktop files — ES2023 immutable sort (mobile excluded, Hermes doesn't support it)
- Fix `rules-of-hooks` violation in page-header.tsx — `useSidebar` try/catch → `useSidebarSafe` null check
- Fix nested component definition in new-issue.tsx — `useMemo` wrapping component → `useCallback`
- Fix missing ARIA in create-squad.tsx — add `aria-expanded` + `aria-controls` to combobox

React Doctor score: 23 → 30/100. 51 files, +142 −82. No behavioral changes.

## Test plan

- [x] `pnpm typecheck` passes (all failures pre-existing)
- [x] Manual test: web app starts and runs normally
- [x] Verified mobile `toSorted()` rolled back (Hermes incompatible)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)