### PR TITLE
fix: strengthen issue task completion guard

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1181,6 +1181,8 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 			for _, want := range []string{
 				"Final results MUST be delivered via `multica issue comment add`",
 				"does NOT see your terminal output",
+				"Before ending any issue task, verify that you have called `multica issue comment add`",
+				"If you have not posted a Multica issue comment, the task is not complete",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s: Output warning missing %q", tc.name, want)
@@ -3522,10 +3524,10 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			want: withSection,
 		},
 		{
-			name:                "assignment_triggered",
-			ctx:                 TaskContextForEnv{IssueID: "issue-md-2"},
-			provider:            "claude",
-			filename:            "CLAUDE.md",
+			name:     "assignment_triggered",
+			ctx:      TaskContextForEnv{IssueID: "issue-md-2"},
+			provider: "claude",
+			filename: "CLAUDE.md",
 			workflowStepPresent: []string{
 				"multica issue metadata list issue-md-2 --output json",
 				"See the `## Issue Metadata` section above",

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -465,6 +465,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		} else {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output, assistant chat text, or run logs — only comments on the issue. A task that finishes without a result comment is invisible to the user, even if the work itself was correct.\n\n")
 		}
+		b.WriteString("Before ending any issue task, verify that you have called `multica issue comment add` unless this is an allowed squad-leader `no_action` exit. ")
+		b.WriteString("If you have not posted a Multica issue comment, the task is not complete; publish the comment first or report the blocker explicitly.\n\n")
 		b.WriteString("Keep comments concise and natural — state the outcome, not the process.\n")
 		b.WriteString("Good: \"Fixed the login redirect. PR: https://...\"\n")
 		b.WriteString("Bad: \"1. Read the issue 2. Found the bug in auth.go 3. Created branch 4. ...\"\n")


### PR DESCRIPTION
## Summary

- strengthen the injected runtime Output section for issue-bound tasks
- require agents to verify `multica issue comment add` before ending an issue task
- tell agents to publish the comment first or report the blocker explicitly when no comment was posted
- pin the contract in the runtime config test

Fixes #3353

## Tests

- `go test ./internal/daemon/execenv`