### PR TITLE
fix(editor): render code blocks when lowlight highlightAuto returns empty

### DIFF
--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -151,6 +151,15 @@ describe("ReadonlyContent code styling", () => {
     expect(blockCode?.textContent).toBe(literalCode);
   });
 
+  it("renders code blocks without a language tag (lowlight highlightAuto fallback)", () => {
+    const token = "mul_407ec1e4464b580304362ed749f821901fd7d310";
+    const { container } = render(
+      <ReadonlyContent content={["```", token, "```"].join("\n")} />,
+    );
+    const blockCode = container.querySelector("pre code");
+    expect(blockCode?.textContent?.trim()).toBe(token);
+  });
+
   it("keeps editor code literal by disabling font ligatures", () => {
     const codeCss = readFileSync("editor/styles/code.css", "utf8");
 

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -242,20 +242,23 @@ function buildComponents(): Partial<Components> {
         const tree = lang
           ? lowlight.highlight(lang, code)
           : lowlight.highlightAuto(code);
-        return (
-          <code
-            className={cn("hljs", lang && `language-${lang}`)}
-            dangerouslySetInnerHTML={{ __html: toHtml(tree) }}
-          />
-        );
+        const html = toHtml(tree);
+        if (html) {
+          return (
+            <code
+              className={cn("hljs", lang && `language-${lang}`)}
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          );
+        }
       } catch {
-        // Fallback — render without highlighting
-        return (
-          <code className={className} {...props}>
-            {children}
-          </code>
-        );
+        // fall through to plain render
       }
+      return (
+        <code className={cn("hljs", className)} {...props}>
+          {children}
+        </code>
+      );
     },
 
     // Pre — pass through (CSS handles styling via .rich-text-editor pre).


### PR DESCRIPTION
## Summary
- `lowlight.highlightAuto()` returns a tree with zero children for content it cannot classify (e.g. `mul_407ec1e4464b580304362ed749f821901fd7d310`). `toHtml()` of that empty tree produces `""`, causing `dangerouslySetInnerHTML` to render a blank `<code>` — the `<pre>` grey background was visible but the text was gone.
- Fix: fall through to plain-text render when `toHtml()` returns empty string.
- Regression test added.

Closes MUL-2745.

## Test plan
- [x] Existing 12 `readonly-content.test.tsx` tests pass
- [x] New regression test: fenced code block without language tag renders content
- [x] Full `pnpm typecheck` and `pnpm test` (837 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)