### PR TITLE
fix(issues): move local-directory hint out of the comment composer (MUL-2752)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1951,6 +1951,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               </div>
             </div>
 
+            <LocalDirectoryHint projectId={issue?.project_id} />
+
             {/* Agent live output — sticky banner in the activity section,
                 keyed by issue id so switching issues remounts the card and
                 clears any in-flight task state from the previous issue.
@@ -2024,7 +2026,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
             {/* Bottom comment input — no avatar, full width */}
             <div className="mt-4">
-              <LocalDirectoryHint projectId={issue?.project_id} />
               {/* key={id}: web's /issues/[id] route doesn't remount on
                   issueId change, so without an explicit key the editor
                   keeps the previous issue's in-memory content and the

--- a/packages/views/projects/components/local-directory-hint.tsx
+++ b/packages/views/projects/components/local-directory-hint.tsx
@@ -9,14 +9,14 @@ import { useLocalDaemonStatus } from "../../platform";
 import { useT } from "../../i18n";
 
 /**
- * Banner shown above the chat / comment composer when the issue's project
- * is pinned to a `local_directory` resource on **this** daemon. Tells the
- * user "starting an agent here will use {label} ({path}) in-place" so they
- * notice they are not getting an isolated git worktree.
+ * Banner shown at the top of the issue's Activity section when the
+ * project is pinned to a `local_directory` resource on **this** daemon.
+ * Tells the user "starting an agent here will use {label} ({path}) in-
+ * place" so they notice they are not getting an isolated git worktree.
  *
  * Rendered only on desktop: web has no daemon to compare against, so the
  * "this machine" check would always fail. Web users will see local_directory
- * resources read-only in the sidebar but no chat-input hint.
+ * resources read-only in the sidebar but no Activity-section hint.
  *
  * SSR-safe: the underlying hook reads `window.daemonAPI` defensively, so
  * server renders return null.
@@ -48,7 +48,7 @@ export function LocalDirectoryHint({
   if (matches.length === 0) return null;
 
   return (
-    <div className="mb-2 space-y-1 rounded-md border border-dashed bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+    <div className="mt-3 space-y-1 rounded-md border border-dashed bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
       {matches.map((resource) => {
         const ref = resource.resource_ref;
         const label = (ref.label || resource.label || ref.local_path).trim() ||


### PR DESCRIPTION
## Summary

The "Agent will work in-place at …" banner used to render directly above the comment input, so it read like an input adornment rather than information about the issue / project context.

Move it to the top of the Activity section — right below the **Activity** heading and above the live agent card — so it reads as section context instead of composer chrome. The banner only renders when the project has a `local_directory` resource pinned to this daemon, so the empty case is unchanged.

- Move the `<LocalDirectoryHint />` call site in `issue-detail.tsx`.
- Update the JSDoc on `LocalDirectoryHint` to reflect the new placement.
- Swap `mb-2` → `mt-3` so the banner has breathing room from the heading instead of from the composer below it.

## Test plan

- [x] `pnpm vitest run projects/components/local-directory-hint.test.tsx` — 4/4 pass
- [x] `tsc --noEmit` clean
- [ ] Visually verify in Desktop: when the project has a local_directory resource on this daemon, the banner shows immediately under the **Activity** heading (and the comment composer no longer carries it).
- [ ] Verify the banner still does not render on web (no daemon) and on issues whose project has no matching local_directory resource.

MUL-2752