### PR TITLE
Fix issue detail scroll restoration after mention navigation

### DIFF
--- a/e2e/issues.spec.ts
+++ b/e2e/issues.spec.ts
@@ -82,6 +82,32 @@ test.describe("Issues", () => {
     ).toBeVisible();
   });
 
+  test("restores issue detail scroll after opening an issue mention and going back", async ({ page }) => {
+    const mentioned = await api.createIssue("E2E Mention Target " + Date.now());
+    const filler = Array.from({ length: 70 }, (_, i) => `Filler line ${i + 1}`).join("\n\n");
+    const original = await api.createIssue("E2E Long Mention Source " + Date.now(), {
+      description: `${filler}\n\nOpen [${mentioned.identifier}](mention://issue/${mentioned.id}) from here.\n\n${filler}`,
+    });
+
+    await page.goto(`/e2e-workspace/issues/${original.id}`);
+    const scrollRoot = page.getByTestId("issue-detail-scroll-root");
+    await expect(scrollRoot).toBeVisible();
+
+    const mention = page.locator(`a.issue-mention[href$="/issues/${mentioned.id}"]`).first();
+    await mention.scrollIntoViewIfNeeded();
+    const before = await scrollRoot.evaluate((el) => el.scrollTop);
+    expect(before).toBeGreaterThan(200);
+
+    await mention.click();
+    await page.waitForURL(new RegExp(`/issues/${mentioned.id}$`));
+    await page.goBack();
+    await page.waitForURL(new RegExp(`/issues/${original.id}$`));
+
+    await expect
+      .poll(() => scrollRoot.evaluate((el) => el.scrollTop))
+      .toBeGreaterThan(before - 80);
+  });
+
   test("can dismiss issue creation", async ({ page }) => {
     await page.getByRole("button", { name: "New Issue" }).click();
 

--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -19,6 +19,7 @@ import type { NodeViewProps } from "@tiptap/react";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useNavigation } from "../../navigation";
 import { IssueChip } from "../../issues/components/issue-chip";
+import { saveIssueDetailScrollPositionFromTarget } from "../../issues/utils/issue-detail-scroll-state";
 
 export function MentionView({ node }: NodeViewProps) {
   const { type, id, label } = node.attrs;
@@ -52,6 +53,7 @@ function IssueMention({
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    saveIssueDetailScrollPositionFromTarget(e.currentTarget);
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
       if (openInNewTab) openInNewTab(issuePath, fallbackLabel);
       return;

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -34,6 +34,7 @@ import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
 import type { Attachment } from "@multica/core/types";
 import { useNavigation } from "../navigation";
 import { IssueMentionCard } from "../issues/components/issue-mention-card";
+import { saveIssueDetailScrollPositionFromTarget } from "../issues/utils/issue-detail-scroll-state";
 import { useLinkHover, LinkHoverCard } from "./link-hover-card";
 import { openLink, isMentionHref } from "./utils/link-handler";
 import { isAllowedFileCardHref } from "@multica/ui/markdown";
@@ -112,6 +113,7 @@ function IssueMentionLink({ issueId, label }: { issueId: string; label?: string 
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
+        saveIssueDetailScrollPositionFromTarget(e.currentTarget);
         if (e.metaKey || e.ctrlKey || e.shiftKey) {
           if (openInNewTab) {
             openInNewTab(path, label);

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -335,6 +335,7 @@ vi.mock("react-virtuoso", () => ({
 // with a spy so the deep-link effect's call can be observed.
 beforeEach(() => {
   scrollIntoViewSpy.mockClear();
+  resetIssueDetailScrollPositionsForTest();
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     writable: true,
@@ -435,6 +436,10 @@ const mockTimeline: TimelineEntry[] = [
 // ---------------------------------------------------------------------------
 
 import { IssueDetail } from "./issue-detail";
+import {
+  resetIssueDetailScrollPositionsForTest,
+  saveIssueDetailScrollPosition,
+} from "../utils/issue-detail-scroll-state";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1108,6 +1113,16 @@ describe("IssueDetail (shared)", () => {
         "issue-1",
         expect.objectContaining({ description: "" }),
       );
+    });
+  });
+
+  it("restores the saved issue-detail scroll position on remount", async () => {
+    saveIssueDetailScrollPosition("ws-1", "issue-1", 640);
+    renderIssueDetail();
+
+    const scrollRoot = await screen.findByTestId("issue-detail-scroll-root");
+    await waitFor(() => {
+      expect(scrollRoot.scrollTop).toBe(640);
     });
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -83,6 +83,10 @@ import { cn } from "@multica/ui/lib/utils";
 import { ProgressRing } from "./progress-ring";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useT } from "../../i18n";
+import {
+  getIssueDetailScrollPosition,
+  saveIssueDetailScrollPosition,
+} from "../utils/issue-detail-scroll-state";
 
 function SubscriberPopoverContent({
   members,
@@ -724,6 +728,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!scrollContainerEl) return;
+    const save = () => saveIssueDetailScrollPosition(wsId, id, scrollContainerEl.scrollTop);
+    scrollContainerEl.addEventListener("scroll", save, { passive: true });
+    return () => {
+      scrollContainerEl.removeEventListener("scroll", save);
+      save();
+    };
+  }, [id, scrollContainerEl, wsId]);
+
   // Per-session: which resolved threads the user has temporarily expanded.
   // Not persisted (matches Linear) — reload collapses everything back to bars.
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(() => new Set());
@@ -1060,6 +1074,25 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [allChildrenSelected, childIssueIds, deselectIds, selectIds]);
 
   const loading = issueLoading;
+
+  useEffect(() => {
+    if (!scrollContainerEl || highlightCommentId || loading) return;
+    const savedScrollTop = getIssueDetailScrollPosition(wsId, id);
+    if (savedScrollTop === undefined) return;
+
+    let frame = 0;
+    let cancelled = false;
+    const restore = (remainingFrames: number) => {
+      scrollContainerEl.scrollTop = savedScrollTop;
+      if (cancelled || remainingFrames <= 0) return;
+      frame = window.requestAnimationFrame(() => restore(remainingFrames - 1));
+    };
+    restore(8);
+    return () => {
+      cancelled = true;
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, [highlightCommentId, id, loading, scrollContainerEl, wsId]);
 
   // Deep-link landing. Semantically equivalent to navigating to
   // `#comment-${id}`: find the element with that id, scrollIntoView it.
@@ -1740,6 +1773,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         <div
           ref={setScrollContainerEl}
           data-tab-scroll-root
+          data-issue-detail-scroll-root
+          data-workspace-id={wsId}
+          data-issue-id={id}
+          data-testid="issue-detail-scroll-root"
           className="relative flex-1 overflow-y-auto"
         >
         <div className="mx-auto w-full max-w-4xl px-8 py-8">

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -3,6 +3,7 @@
 import { AppLink } from "../../navigation";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { IssueChip } from "./issue-chip";
+import { saveIssueDetailScrollPositionFromTarget } from "../utils/issue-detail-scroll-state";
 
 interface IssueMentionCardProps {
   issueId: string;
@@ -18,7 +19,11 @@ interface IssueMentionCardProps {
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
   return (
-    <AppLink href={p.issueDetail(issueId)} className="issue-mention not-prose inline-flex">
+    <AppLink
+      href={p.issueDetail(issueId)}
+      className="issue-mention not-prose inline-flex"
+      onClick={(e) => saveIssueDetailScrollPositionFromTarget(e.currentTarget)}
+    >
       <IssueChip
         issueId={issueId}
         fallbackLabel={fallbackLabel}

--- a/packages/views/issues/utils/issue-detail-scroll-state.ts
+++ b/packages/views/issues/utils/issue-detail-scroll-state.ts
@@ -1,0 +1,36 @@
+"use client";
+
+const SCROLL_ROOT_SELECTOR = "[data-issue-detail-scroll-root]";
+const positions = new Map<string, number>();
+
+function keyFor(workspaceId: string, issueId: string) {
+  return `${workspaceId}:${issueId}`;
+}
+
+export function saveIssueDetailScrollPosition(
+  workspaceId: string,
+  issueId: string,
+  scrollTop: number,
+) {
+  positions.set(keyFor(workspaceId, issueId), scrollTop);
+}
+
+export function getIssueDetailScrollPosition(
+  workspaceId: string,
+  issueId: string,
+) {
+  return positions.get(keyFor(workspaceId, issueId));
+}
+
+export function saveIssueDetailScrollPositionFromTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) return;
+  const root = target.closest<HTMLElement>(SCROLL_ROOT_SELECTOR);
+  const workspaceId = root?.dataset.workspaceId;
+  const issueId = root?.dataset.issueId;
+  if (!root || !workspaceId || !issueId) return;
+  saveIssueDetailScrollPosition(workspaceId, issueId, root.scrollTop);
+}
+
+export function resetIssueDetailScrollPositionsForTest() {
+  positions.clear();
+}


### PR DESCRIPTION
## Summary
- save issue-detail scroll position per workspace/issue and restore it on remount/back navigation
- capture current scroll before internal issue mention navigation from markdown chips, readonly editor links, and Tiptap mention views
- add Vitest and Playwright regression coverage for opening an issue mention from a long issue and going back

## Verification
- `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx` (26 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (passed with existing warnings)
- `pnpm exec playwright test e2e/issues.spec.ts --list`
- `git diff --check`

Full Playwright browser execution was not run; it requires the full app/backend e2e environment.
