### PR TITLE
Fix local runtime grouping fallback

### DIFF
--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -157,6 +157,110 @@ describe("runtime machine grouping", () => {
     });
   });
 
+  it("keeps exact daemon id matching as the current machine signal", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          daemon_id: "daemon-1",
+          name: "Claude (different-host.local)",
+          device_info: "different-host.local",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "daemon-1",
+        localMachineName: "dev-machine.local",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      id: "local:daemon-1",
+      title: "dev-machine.local",
+      section: "local",
+      isCurrent: true,
+    });
+  });
+
+  it("falls back to the local hostname when the daemon id has drifted", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-claude",
+          daemon_id: "stale-daemon-1",
+          provider: "claude",
+          name: "Claude (dev-machine.local)",
+          device_info: "dev-machine.local · claude 1.0.0",
+        }),
+        makeRuntime({
+          id: "rt-codex",
+          daemon_id: "stale-daemon-2",
+          provider: "codex",
+          name: "Codex (dev-machine.local)",
+          device_info: "dev-machine.local · codex-cli 0.118.0",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "current-daemon",
+        localMachineName: "dev-machine",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      id: "local:current-daemon",
+      title: "dev-machine",
+      section: "local",
+      isCurrent: true,
+      onlineCount: 2,
+      providerNames: ["claude", "codex"],
+    });
+  });
+
+  it("does not group unrelated remote local runtimes into the local fallback", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-local",
+          daemon_id: "stale-daemon-1",
+          name: "Claude (dev-machine.local)",
+          device_info: "dev-machine.local",
+        }),
+        makeRuntime({
+          id: "rt-remote",
+          daemon_id: "remote-daemon",
+          name: "Claude (remote-machine.local)",
+          device_info: "remote-machine.local",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "current-daemon",
+        localMachineName: "dev-machine.local",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(2);
+    expect(machines.find((machine) => machine.isCurrent)).toMatchObject({
+      id: "local:current-daemon",
+      runtimes: expect.arrayContaining([
+        expect.objectContaining({ id: "rt-local" }),
+      ]),
+    });
+    expect(machines.find((machine) => machine.daemonId === "remote-daemon"))
+      .toMatchObject({
+        section: "remote",
+        isCurrent: false,
+        runtimes: expect.arrayContaining([
+          expect.objectContaining({ id: "rt-remote" }),
+        ]),
+      });
+  });
+
   it("keeps cloud runtimes as cloud workers when they have no daemon", () => {
     const machines = buildRuntimeMachines(
       [

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -76,7 +76,7 @@ export function buildRuntimeMachines(
   const drafts = new Map<string, RuntimeMachineDraft>();
 
   for (const runtime of runtimes) {
-    const id = runtimeMachineId(runtime);
+    const id = runtimeMachineId(runtime, options);
     const draft =
       drafts.get(id) ??
       ({
@@ -98,6 +98,10 @@ export function buildRuntimeMachines(
   }
 
   return machines.sort(compareRuntimeMachines);
+}
+
+function localMachineKey(options: RuntimeMachineOptions): string | null {
+  return normalizeMachineName(options.localMachineName);
 }
 
 function placeholderLocalMachine(
@@ -173,8 +177,7 @@ function finalizeRuntimeMachine(
   );
   const first = runtimes[0];
   const providerNames = Array.from(new Set(runtimes.map((r) => r.provider))).sort();
-  const isCurrent =
-    !!options.localDaemonId && draft.daemonId === options.localDaemonId;
+  const isCurrent = runtimes.some((runtime) => isCurrentRuntime(runtime, options));
   const title = machineTitle(runtimes, {
     isCurrent,
     localMachineName: options.localMachineName,
@@ -231,20 +234,62 @@ function finalizeRuntimeMachine(
   };
 }
 
-function runtimeMachineId(runtime: AgentRuntime): string {
+function runtimeMachineId(
+  runtime: AgentRuntime,
+  options: RuntimeMachineOptions,
+): string {
+  if (isCurrentRuntime(runtime, options)) {
+    return options.localDaemonId
+      ? `local:${options.localDaemonId}`
+      : `local:device:${localMachineKey(options)}`;
+  }
   if (runtime.daemon_id) return `${runtime.runtime_mode}:${runtime.daemon_id}`;
   const deviceName = runtimeDeviceName(runtime);
   if (deviceName) return `${runtime.runtime_mode}:device:${deviceName}`;
   return `${runtime.runtime_mode}:runtime:${runtime.id}`;
 }
 
+function isCurrentRuntime(
+  runtime: AgentRuntime,
+  options: RuntimeMachineOptions,
+): boolean {
+  if (options.localDaemonId && runtime.daemon_id === options.localDaemonId) {
+    return true;
+  }
+
+  const localKey = localMachineKey(options);
+  if (!localKey || runtime.runtime_mode !== "local") return false;
+  return runtimeMachineNameKeys(runtime).includes(localKey);
+}
+
 function runtimeDeviceName(runtime: AgentRuntime): string | null {
+  return runtimeMachineNames(runtime)[0] ?? null;
+}
+
+function runtimeMachineNameKeys(runtime: AgentRuntime): string[] {
+  return runtimeMachineNames(runtime)
+    .map((name) => normalizeMachineName(name))
+    .filter((name): name is string => Boolean(name));
+}
+
+function runtimeMachineNames(runtime: AgentRuntime): string[] {
+  const names: string[] = [];
   const host = splitRuntimeName(runtime.name).hostname;
-  if (host) return host;
+  if (host) names.push(host);
 
   const raw = runtime.device_info?.trim();
-  if (!raw) return null;
-  return raw.split(" · ")[0]?.trim() || null;
+  const deviceName = raw?.split(" · ")[0]?.trim();
+  if (deviceName && deviceName !== host) names.push(deviceName);
+  return names;
+}
+
+function normalizeMachineName(name: string | null | undefined): string | null {
+  const normalized = name
+    ?.trim()
+    .toLowerCase()
+    .replace(/\.local$/, "")
+    .replace(/\s+/g, " ");
+  return normalized || null;
 }
 
 function machineTitle(


### PR DESCRIPTION
## Summary
- keep exact local daemon UUID matching as the primary current-machine signal
- fall back to normalized hostname/device-name matching when local daemon IDs drift
- avoid grouping unrelated remote/local runtimes into the current local machine

## Verification
- `pnpm --filter @multica/views exec vitest run runtimes/components/runtime-machines.test.ts` (11 passed)
- `pnpm --filter @multica/views exec eslint runtimes/components/runtime-machines.ts runtimes/components/runtime-machines.test.ts`
- `pnpm --filter @multica/views typecheck`
- `git diff --check`
