### PR TITLE
test(cli): cover autopilot JSON escaping

### DIFF
--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -65,19 +65,32 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+		_ = w.Close()
+		_ = r.Close()
+	}()
+
+	type readResult struct {
+		out []byte
+		err error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		out, err := io.ReadAll(r)
+		readCh <- readResult{out: out, err: err}
+	}()
 
 	runErr := fn()
 	closeErr := w.Close()
-	os.Stdout = old
-	out, readErr := io.ReadAll(r)
-	_ = r.Close()
+	result := <-readCh
 	if closeErr != nil {
 		t.Fatalf("close stdout pipe: %v", closeErr)
 	}
-	if readErr != nil {
-		t.Fatalf("read stdout pipe: %v", readErr)
+	if result.err != nil {
+		t.Fatalf("read stdout pipe: %v", result.err)
 	}
-	return string(out), runErr
+	return string(result.out), runErr
 }
 
 func TestResolveAgent(t *testing.T) {

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,6 +40,44 @@ func newAutopilotUpdateTestCmd() *cobra.Command {
 	cmd.Flags().String("issue-title-template", "", "")
 	cmd.Flags().String("output", "json", "")
 	return cmd
+}
+
+func newAutopilotListTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().Bool("full-id", false, "")
+	return cmd
+}
+
+func newAutopilotGetTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := fn()
+	closeErr := w.Close()
+	os.Stdout = old
+	out, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if closeErr != nil {
+		t.Fatalf("close stdout pipe: %v", closeErr)
+	}
+	if readErr != nil {
+		t.Fatalf("read stdout pipe: %v", readErr)
+	}
+	return string(out), runErr
 }
 
 func TestResolveAgent(t *testing.T) {
@@ -126,6 +166,106 @@ func TestResolveAgent(t *testing.T) {
 			t.Errorf("got %q, want %q", got, id)
 		}
 	})
+}
+
+func TestRunAutopilotListJSONEscapesDescriptionBackslashes(t *testing.T) {
+	const autopilotID = "11111111-1111-1111-1111-111111111111"
+	description := "Regex ITT-\\d+ and Windows path C:\\Temp\\new plus invalid JSON escape candidate \\q"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"autopilots": []map[string]any{{
+				"id":             autopilotID,
+				"title":          "Escaping fixture",
+				"description":    description,
+				"execution_mode": "run_only",
+				"status":         "active",
+			}},
+			"total": 1,
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	out, err := captureStdout(t, func() error {
+		return runAutopilotList(newAutopilotListTestCmd(), nil)
+	})
+	if err != nil {
+		t.Fatalf("runAutopilotList: %v", err)
+	}
+
+	var got struct {
+		Autopilots []map[string]any `json:"autopilots"`
+		Total      int              `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("list output is not valid JSON: %v\n%s", err, out)
+	}
+	if got.Total != 1 || len(got.Autopilots) != 1 {
+		t.Fatalf("unexpected list response: %#v", got)
+	}
+	if got.Autopilots[0]["description"] != description {
+		t.Fatalf("description = %#v, want %q", got.Autopilots[0]["description"], description)
+	}
+}
+
+func TestRunAutopilotGetJSONEscapesDescriptionBackslashes(t *testing.T) {
+	const autopilotID = "22222222-2222-2222-2222-222222222222"
+	description := "Prompt includes markdown <id>, regex ITT-\\d+, and a literal bad escape candidate \\q"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"autopilot": map[string]any{
+				"id":             autopilotID,
+				"title":          "Escaping fixture",
+				"description":    description,
+				"execution_mode": "run_only",
+				"status":         "active",
+			},
+			"triggers": []map[string]any{{
+				"id":    "trigger-1",
+				"kind":  "schedule",
+				"label": "contains backslash \\q",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	out, err := captureStdout(t, func() error {
+		return runAutopilotGet(newAutopilotGetTestCmd(), []string{autopilotID})
+	})
+	if err != nil {
+		t.Fatalf("runAutopilotGet: %v", err)
+	}
+
+	var got struct {
+		Autopilot map[string]any   `json:"autopilot"`
+		Triggers  []map[string]any `json:"triggers"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("get output is not valid JSON: %v\n%s", err, out)
+	}
+	if got.Autopilot["description"] != description {
+		t.Fatalf("description = %#v, want %q", got.Autopilot["description"], description)
+	}
+	if len(got.Triggers) != 1 || got.Triggers[0]["label"] != "contains backslash \\q" {
+		t.Fatalf("unexpected triggers: %#v", got.Triggers)
+	}
 }
 
 func TestRunAutopilotCreateSendsProjectID(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for `multica autopilot list --output json` and `multica autopilot get --output json` so autopilot descriptions containing backslashes and escape-like sequences remain valid JSON.

The CLI path already uses the shared `encoding/json`-based `cli.PrintJSON` output helper. This PR locks that behavior down with fixtures that would fail if the output path regressed to manual JSON string construction.

Risk: low. This is test-only coverage and does not change runtime CLI behavior.

## Related Issue

Multica: ITT-255

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `autopilot list --output json` regression coverage for descriptions containing fragile escape sequences.
- Added `autopilot get --output json` regression coverage for the same JSON escaping behavior.
- Included fixture values such as `ITT-\d+`, `C:\Temp\new`, `\q`, and `<id>` to guard against invalid escape output.
- Verified that the CLI output remains parseable through the standard JSON encoder path.

## How to Test

1. Run `go test ./cmd/multica -run 'TestRunAutopilot(List|Get)JSONEscapesDescriptionBackslashes|TestResolveAgent'`.
2. Run `go test ./cmd/multica`.
3. Run `go run ./cmd/multica autopilot list --output json | python3 -m json.tool >/tmp/itt255-pr-source-list.json`.
4. Run `go run ./cmd/multica autopilot get 1ae43c30-8e75-4657-a143-8939183723df --output json | python3 -m json.tool >/tmp/itt255-pr-source-get.json`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Notes on unchecked items: this PR is test-only and does not affect UI, documentation, runtime/coding tools, landing copy, docs content, or Chinese product copy.

## AI Disclosure

**AI tool used:** Codex via Multica Agent

**Prompt / approach:**
Codex reproduced the JSON escaping concern through targeted CLI test fixtures, confirmed the CLI JSON output path uses the shared `encoding/json`-based helper, added regression tests around both list and get output, and ran the focused and full `cmd/multica` test suites plus JSON parse checks.

## Screenshots (optional)

Not applicable. This is a CLI test coverage change with no UI impact.
