### PR TITLE
Publish Helm chart as release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ jobs:
           go-version-file: server/go.mod
           cache-dependency-path: server/go.sum
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint Helm chart
+        run: helm lint deploy/helm/multica
+
       - name: Run tests
         run: cd server && go test ./...
 
@@ -321,6 +327,67 @@ jobs:
         run: |
           docker buildx imagetools inspect \
             ghcr.io/${{ github.repository_owner }}/multica-web:${{ steps.meta.outputs.version }}
+
+  helm-chart:
+    needs: [verify, docker-backend-merge, docker-web-merge]
+    if: github.repository_owner == 'multica-ai'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-helm-chart-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Compute chart metadata
+        id: chart_meta
+        shell: bash
+        run: |
+          tag="${{ needs.verify.outputs.tag_name }}"
+          chart_version="${tag#v}"
+          echo "chart_version=$chart_version" >> "$GITHUB_OUTPUT"
+          echo "chart_ref=oci://ghcr.io/${{ github.repository_owner }}/charts/multica" >> "$GITHUB_OUTPUT"
+
+      - name: Lint Helm chart
+        run: helm lint deploy/helm/multica
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p /tmp/helm-package
+          helm package deploy/helm/multica \
+            --version "${{ steps.chart_meta.outputs.chart_version }}" \
+            --app-version "${{ needs.verify.outputs.tag_name }}" \
+            --destination /tmp/helm-package
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Push Helm chart
+        run: |
+          helm push \
+            "/tmp/helm-package/multica-${{ steps.chart_meta.outputs.chart_version }}.tgz" \
+            "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
+      - name: Verify chart can be pulled
+        env:
+          HELM_CACHE_HOME: /tmp/helm-verify/cache
+          HELM_CONFIG_HOME: /tmp/helm-verify/config
+          HELM_DATA_HOME: /tmp/helm-verify/data
+        run: |
+          mkdir -p /tmp/helm-pull "$HELM_CACHE_HOME" "$HELM_CONFIG_HOME" "$HELM_DATA_HOME"
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+          helm pull "${{ steps.chart_meta.outputs.chart_ref }}" \
+            --version "${{ steps.chart_meta.outputs.chart_version }}" \
+            --destination /tmp/helm-pull
+          helm show chart "/tmp/helm-pull/multica-${{ steps.chart_meta.outputs.chart_version }}.tgz"
 
   # Build the Desktop installers for Linux and Windows and upload them to
   # the GitHub Release that the `release` job above just published. macOS

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -139,7 +139,7 @@ multica daemon status
 
 ## Kubernetes Deployment (Alternative)
 
-If you already run a Kubernetes cluster, you can deploy Multica there instead of Docker Compose using the Helm chart at [`deploy/helm/multica/`](deploy/helm/multica/). It targets a typical k3s / k8s setup with an Ingress controller and a default `ReadWriteOnce` StorageClass — authored against k3s + Traefik + `local-path`, and should work on any cluster with minor tweaks.
+If you already run a Kubernetes cluster, you can deploy Multica there instead of Docker Compose using the published Helm chart at `oci://ghcr.io/multica-ai/charts/multica`. It targets a typical k3s / k8s setup with an Ingress controller and a default `ReadWriteOnce` StorageClass — authored against k3s + Traefik + `local-path`, and should work on any cluster with minor tweaks.
 
 The chart creates the following resources in the target namespace:
 
@@ -195,16 +195,24 @@ Leave optional values empty for now — you can fill them in later (see [Step 5 
 
 ### Step 4 — Install the chart
 
+Chart versions match Multica release tags without the leading `v`: release `v0.2.4` publishes chart version `0.2.4`. Released charts set `appVersion` to the full release tag, and the backend/frontend image tags default to that value.
+
 ```bash
-helm install multica deploy/helm/multica -n multica
+helm pull oci://ghcr.io/multica-ai/charts/multica --version 0.2.4
+
+helm install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.4 \
+  -n multica
 ```
 
-To override defaults, copy `deploy/helm/multica/values.yaml`, edit it, and pass it with `-f`:
+To override defaults, create a values file and pass it with `-f`:
 
 ```bash
-cp deploy/helm/multica/values.yaml my-values.yaml
 # edit my-values.yaml — e.g. change ingress hosts, image tags, resource limits
-helm install multica deploy/helm/multica -n multica -f my-values.yaml
+helm install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.4 \
+  -n multica \
+  -f my-values.yaml
 ```
 
 Watch the pods come up:
@@ -245,7 +253,8 @@ The chart defaults to `APP_ENV=production` (set in `values.yaml` under `backend.
 - **Deterministic local/private testing:** set `backend.config.appEnv: development` in your values file and `MULTICA_DEV_VERIFICATION_CODE=888888` in the Secret, then `helm upgrade` and restart. This fixed code is ignored when `APP_ENV=production`.
 
   ```bash
-  helm upgrade multica deploy/helm/multica -n multica \
+  helm upgrade multica oci://ghcr.io/multica-ai/charts/multica -n multica \
+    --version 0.2.4 \
     -f my-values.yaml --set backend.config.appEnv=development
   kubectl -n multica patch secret multica-secrets --type=merge \
     -p '{"stringData":{"MULTICA_DEV_VERIFICATION_CODE":"888888"}}'
@@ -270,13 +279,22 @@ Make sure the machine running the daemon has the same `/etc/hosts` (or DNS) entr
 
 ### Updating
 
-To pull the latest images without changing the chart version:
+To upgrade to a newer Multica release, install the matching chart version:
+
+```bash
+helm upgrade --install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.5 \
+  -n multica \
+  -f my-values.yaml
+```
+
+To pull rebuilt images without changing the chart version:
 
 ```bash
 kubectl -n multica rollout restart deploy/multica-backend deploy/multica-frontend
 ```
 
-To pin a specific Multica release, set the image tags in your values file:
+To override images independently from the chart version, set the image tags in your values file:
 
 ```yaml
 images:
@@ -289,7 +307,10 @@ images:
 Then upgrade:
 
 ```bash
-helm upgrade multica deploy/helm/multica -n multica -f my-values.yaml
+helm upgrade multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.5 \
+  -n multica \
+  -f my-values.yaml
 ```
 
 To roll back if an upgrade goes sideways:

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -200,7 +200,7 @@ Full reference — including the Kubernetes `CronJob` template and the upgrade o
 
 ## Kubernetes deployment (alternative)
 
-If you already run a Kubernetes cluster, the repo also ships a Helm chart at `deploy/helm/multica/`. It's the equivalent of `make selfhost` for k8s — same backend image, frontend image, and `pgvector/pgvector:pg17` Postgres, packaged as Deployments / Services / Ingresses with one `ConfigMap` rendered from `values.yaml`. Authored against k3s + Traefik + `local-path` and should work on any cluster with an Ingress controller and a default `ReadWriteOnce` StorageClass.
+If you already run a Kubernetes cluster, Multica publishes a Helm chart to GHCR at `oci://ghcr.io/multica-ai/charts/multica`. It's the equivalent of `make selfhost` for k8s — same backend image, frontend image, and `pgvector/pgvector:pg17` Postgres, packaged as Deployments / Services / Ingresses with one `ConfigMap` rendered from `values.yaml`. Authored against k3s + Traefik + `local-path` and should work on any cluster with an Ingress controller and a default `ReadWriteOnce` StorageClass.
 
 The chart **does not template secret values**. It references a Secret named `multica-secrets` by name, so real JWT / DB / Resend / Google keys never need to live in git or in `values.yaml`. Create the namespace + Secret once with kubectl:
 
@@ -216,15 +216,17 @@ kubectl -n multica create secret generic multica-secrets \
   --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 ```
 
-Then install the chart:
+Then install the chart. Chart versions match Multica release tags without the leading `v`: release `v0.2.4` publishes chart version `0.2.4`, and the chart defaults its backend/frontend image tags to that release tag.
 
 ```bash
-git clone https://github.com/multica-ai/multica.git
-cd multica
-helm install multica deploy/helm/multica -n multica
+helm pull oci://ghcr.io/multica-ai/charts/multica --version 0.2.4
+
+helm install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.4 \
+  -n multica
 ```
 
-Defaults assume the hostnames `multica.dev.lan` (web) and `api.multica.dev.lan` (backend). Add them to `/etc/hosts` (or local DNS) pointing at any node IP where your Ingress is reachable. To use different hostnames, copy `deploy/helm/multica/values.yaml`, edit `ingress.frontend.host` / `ingress.backend.host` and the matching `backend.config.appUrl` / `frontendOrigin` / `localUploadBaseUrl` / `googleRedirectUri`, then install with `-f my-values.yaml`.
+Defaults assume the hostnames `multica.dev.lan` (web) and `api.multica.dev.lan` (backend). Add them to `/etc/hosts` (or local DNS) pointing at any node IP where your Ingress is reachable. To use different hostnames, create a values file that sets `ingress.frontend.host` / `ingress.backend.host` and the matching `backend.config.appUrl` / `frontendOrigin` / `localUploadBaseUrl` / `googleRedirectUri`, then install with `-f my-values.yaml`.
 
 On a cold cluster the backend can stay `Running` but not `Ready` for a few minutes while it waits on Postgres and runs migrations — a startupProbe absorbs this, so the pod should not restart. Once it's `Ready`:
 
@@ -241,7 +243,16 @@ multica setup self-host \
   --app-url http://multica.dev.lan
 ```
 
-To pull the latest images without changing the chart, `kubectl -n multica rollout restart deploy/multica-backend deploy/multica-frontend`. To pin a specific Multica release, set `images.backend.tag` / `images.frontend.tag` in your values file and `helm upgrade`. `helm -n multica uninstall multica` removes the workloads but keeps the PVCs and Secret; `kubectl delete namespace multica` wipes everything.
+To upgrade to a newer release, install the matching chart version:
+
+```bash
+helm upgrade --install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.5 \
+  -n multica \
+  -f my-values.yaml
+```
+
+To pull rebuilt images without changing the chart, `kubectl -n multica rollout restart deploy/multica-backend deploy/multica-frontend`. To override the image tag independently from the chart, set `images.backend.tag` / `images.frontend.tag` in your values file and `helm upgrade`. `helm -n multica uninstall multica` removes the workloads but keeps the PVCs and Secret; `kubectl delete namespace multica` wipes everything.
 
 The full reference — three login modes, the `backend` ExternalName workaround for the build-time-baked `REMOTE_API_URL` in the web image, resource limits, and TLS — lives in the repo's [`SELF_HOSTING.md`](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING.md#kubernetes-deployment-alternative).
 

--- a/apps/docs/content/docs/self-host-quickstart.zh.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.zh.mdx
@@ -199,7 +199,7 @@ docker compose -f docker-compose.selfhost.yml exec backend \
 
 ## Kubernetes 部署（替代方案）
 
-如果你已经在跑 Kubernetes 集群，仓库里也带了一个 Helm chart，路径 `deploy/helm/multica/`。它就是 k8s 版的 `make selfhost`——一样的 backend 镜像、frontend 镜像、`pgvector/pgvector:pg17` Postgres，封装成 Deployment / Service / Ingress，再加上一个由 `values.yaml` 渲染出来的 `ConfigMap`。这套 chart 是按照 k3s + Traefik + `local-path` 写的，集群里只要有 Ingress controller 和默认的 `ReadWriteOnce` StorageClass 就能跑，其他类型的集群稍微改一改也能用。
+如果你已经在跑 Kubernetes 集群，Multica 会把 Helm chart 发布到 GHCR：`oci://ghcr.io/multica-ai/charts/multica`。它就是 k8s 版的 `make selfhost`——一样的 backend 镜像、frontend 镜像、`pgvector/pgvector:pg17` Postgres，封装成 Deployment / Service / Ingress，再加上一个由 `values.yaml` 渲染出来的 `ConfigMap`。这套 chart 是按照 k3s + Traefik + `local-path` 写的，集群里只要有 Ingress controller 和默认的 `ReadWriteOnce` StorageClass 就能跑，其他类型的集群稍微改一改也能用。
 
 这个 chart **不会模板化任何敏感值**。它通过 name 引用一个叫 `multica-secrets` 的 Secret，所以真实的 JWT / DB / Resend / Google 密钥永远不用进 git，也不用进 `values.yaml`。先用 kubectl 一次性把命名空间和 Secret 建好：
 
@@ -215,15 +215,17 @@ kubectl -n multica create secret generic multica-secrets \
   --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 ```
 
-再装 chart：
+再装 chart。Chart version 和 Multica release tag 对齐，但不带开头的 `v`：release `v0.2.4` 会发布 chart version `0.2.4`，并默认让 backend/frontend 镜像 tag 使用这个 release tag。
 
 ```bash
-git clone https://github.com/multica-ai/multica.git
-cd multica
-helm install multica deploy/helm/multica -n multica
+helm pull oci://ghcr.io/multica-ai/charts/multica --version 0.2.4
+
+helm install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.4 \
+  -n multica
 ```
 
-默认主机名是 `multica.dev.lan`（web）和 `api.multica.dev.lan`（backend）。把它们加进 `/etc/hosts`（或者本地 DNS），指向任意一个 Ingress 可达的节点 IP 就行。要换主机名，就把 `deploy/helm/multica/values.yaml` 复制一份，改掉 `ingress.frontend.host` / `ingress.backend.host`，再把 `backend.config.appUrl` / `frontendOrigin` / `localUploadBaseUrl` / `googleRedirectUri` 改成相应的地址，然后 `helm install ... -f my-values.yaml`。
+默认主机名是 `multica.dev.lan`（web）和 `api.multica.dev.lan`（backend）。把它们加进 `/etc/hosts`（或者本地 DNS），指向任意一个 Ingress 可达的节点 IP 就行。要换主机名，就创建一个 values 文件，设置 `ingress.frontend.host` / `ingress.backend.host`，再把 `backend.config.appUrl` / `frontendOrigin` / `localUploadBaseUrl` / `googleRedirectUri` 改成相应的地址，然后 `helm install ... -f my-values.yaml`。
 
 冷集群上 backend 可能会 `Running` 但 `Not Ready` 持续几分钟，等 Postgres 起来并跑完 migration——startupProbe 会兜住这一段，pod 不会被 liveness 重启。等它 `Ready` 之后：
 
@@ -240,7 +242,16 @@ multica setup self-host \
   --app-url http://multica.dev.lan
 ```
 
-只想拉最新镜像、不动 chart：`kubectl -n multica rollout restart deploy/multica-backend deploy/multica-frontend`。要锁到某个 Multica 版本，就在 values 文件里设 `images.backend.tag` / `images.frontend.tag`，再 `helm upgrade`。`helm -n multica uninstall multica` 只删工作负载，PVC 和 Secret 都保留；`kubectl delete namespace multica` 才会全清。
+要升级到新版本，安装对应的 chart version：
+
+```bash
+helm upgrade --install multica oci://ghcr.io/multica-ai/charts/multica \
+  --version 0.2.5 \
+  -n multica \
+  -f my-values.yaml
+```
+
+只想拉重新构建过的镜像、不动 chart：`kubectl -n multica rollout restart deploy/multica-backend deploy/multica-frontend`。要让镜像 tag 独立于 chart version，就在 values 文件里设 `images.backend.tag` / `images.frontend.tag`，再 `helm upgrade`。`helm -n multica uninstall multica` 只删工作负载，PVC 和 Secret 都保留；`kubectl delete namespace multica` 才会全清。
 
 完整参考——三种登录方式、为了绕过 web 镜像 build-time 写死的 `REMOTE_API_URL` 而加的 `backend` ExternalName 别名、资源限制、TLS——都在仓库的 [`SELF_HOSTING.md`](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING.md#kubernetes-deployment-alternative)。
 

--- a/deploy/helm/multica/templates/backend.yaml
+++ b/deploy/helm/multica/templates/backend.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: backend
-          image: "{{ .Values.images.backend.repository }}:{{ .Values.images.backend.tag }}"
+          image: "{{ .Values.images.backend.repository }}:{{ default .Chart.AppVersion .Values.images.backend.tag }}"
           imagePullPolicy: {{ .Values.images.backend.pullPolicy }}
           ports:
             - containerPort: 8080

--- a/deploy/helm/multica/templates/frontend.yaml
+++ b/deploy/helm/multica/templates/frontend.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: "{{ .Values.images.frontend.repository }}:{{ .Values.images.frontend.tag }}"
+          image: "{{ .Values.images.frontend.repository }}:{{ default .Chart.AppVersion .Values.images.frontend.tag }}"
           imagePullPolicy: {{ .Values.images.frontend.pullPolicy }}
           ports:
             - containerPort: 3000

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -4,11 +4,15 @@
 images:
   backend:
     repository: ghcr.io/multica-ai/multica-backend
-    tag: latest
+    # Empty defaults to Chart.appVersion. Released chart artifacts set
+    # appVersion to the Multica tag, so installs use matching images.
+    tag: ""
     pullPolicy: IfNotPresent
   frontend:
     repository: ghcr.io/multica-ai/multica-web
-    tag: latest
+    # Empty defaults to Chart.appVersion. Released chart artifacts set
+    # appVersion to the Multica tag, so installs use matching images.
+    tag: ""
     pullPolicy: IfNotPresent
   postgres:
     repository: pgvector/pgvector


### PR DESCRIPTION
## Summary
- publish the Helm chart to GHCR as `oci://ghcr.io/<owner>/charts/multica` during tagged releases after backend/web image manifests are available
- package released charts with chart version derived from the release tag without `v`, and `appVersion` set to the full Multica tag
- default backend/frontend chart image tags to `.Chart.AppVersion`, with docs for OCI pull/install/upgrade flows

## Verification
- `helm lint deploy/helm/multica` using temporary Helm v3.15.4 binary
- `helm template multica deploy/helm/multica` renders backend/web images with `latest` for the raw local chart
- `helm package deploy/helm/multica --version 0.2.4 --app-version v0.2.4` then `helm template` renders backend/web images with `v0.2.4`
- `git diff --check`
- `npx js-yaml .github/workflows/release.yml` with npm cache under `/tmp`

Not run: `go test ./...` / pnpm checks; Go and pnpm are not installed in this container.
