### PR TITLE
fix(autopilots): normalize webhook event filters at write time

### DIFF
--- a/server/internal/handler/autopilot_webhook.go
+++ b/server/internal/handler/autopilot_webhook.go
@@ -634,6 +634,29 @@ func validateWebhookEventFilters(filters []WebhookEventFilter) error {
 	return nil
 }
 
+// normalizeWebhookEventFilters trims surrounding whitespace from every event
+// and action and drops actions that are empty after trimming. The matcher
+// compares exact strings, so a stored `" workflow_run "` would pass write
+// validation (which only trims for the emptiness check) yet never match a
+// real envelope. Normalizing at marshal time means whatever lands in the
+// column is exactly what the matcher can compare against.
+func normalizeWebhookEventFilters(filters []WebhookEventFilter) []WebhookEventFilter {
+	if filters == nil {
+		return nil
+	}
+	normalized := make([]WebhookEventFilter, 0, len(filters))
+	for _, f := range filters {
+		nf := WebhookEventFilter{Event: strings.TrimSpace(f.Event)}
+		for _, a := range f.Actions {
+			if trimmed := strings.TrimSpace(a); trimmed != "" {
+				nf.Actions = append(nf.Actions, trimmed)
+			}
+		}
+		normalized = append(normalized, nf)
+	}
+	return normalized
+}
+
 // encodeWebhookEventFilters returns the JSONB bytes to persist for a CREATE.
 // nil/empty input maps to nil bytes (column stays NULL → matcher allows
 // every event), so we never write an explicit `[]` on create.
@@ -641,7 +664,7 @@ func encodeWebhookEventFilters(filters []WebhookEventFilter) ([]byte, error) {
 	if len(filters) == 0 {
 		return nil, nil
 	}
-	return json.Marshal(filters)
+	return json.Marshal(normalizeWebhookEventFilters(filters))
 }
 
 // encodeWebhookEventFiltersAlways always returns non-nil bytes, even for an
@@ -653,7 +676,7 @@ func encodeWebhookEventFiltersAlways(filters []WebhookEventFilter) ([]byte, erro
 	if filters == nil {
 		filters = []WebhookEventFilter{}
 	}
-	return json.Marshal(filters)
+	return json.Marshal(normalizeWebhookEventFilters(filters))
 }
 
 // webhookEventAllowedByTriggerScope returns true when the trigger has no

--- a/server/internal/handler/autopilot_webhook_test.go
+++ b/server/internal/handler/autopilot_webhook_test.go
@@ -353,3 +353,64 @@ func TestSplitWebhookEvent(t *testing.T) {
 		}
 	}
 }
+
+// TestEncodeWebhookEventFilters_TrimsWhitespace is follow-up 2 from the PR
+// #3231 review: validation only trims for the emptiness check but used to
+// persist the raw string, so a `" workflow_run "` entry passed validation
+// and then never matched at read time (the matcher compares exact strings).
+// Normalizing at marshal time fixes this end to end — the stored bytes match
+// a real envelope.
+func TestEncodeWebhookEventFilters_TrimsWhitespace(t *testing.T) {
+	filters := []WebhookEventFilter{
+		{Event: "  workflow_run  ", Actions: []string{" completed ", "requested"}},
+	}
+	encoded, err := encodeWebhookEventFilters(filters)
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+
+	var got []WebhookEventFilter
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(got) != 1 || got[0].Event != "workflow_run" {
+		t.Fatalf("event not trimmed: %+v", got)
+	}
+	if len(got[0].Actions) != 2 || got[0].Actions[0] != "completed" || got[0].Actions[1] != "requested" {
+		t.Fatalf("actions not trimmed: %+v", got[0].Actions)
+	}
+
+	// The normalized bytes must actually match a real envelope at read time.
+	env := WebhookEnvelope{
+		Event:        "github.workflow_run.completed",
+		EventPayload: json.RawMessage(`{"action":"completed"}`),
+	}
+	if !webhookEventAllowedByTriggerScope(encoded, env) {
+		t.Fatal("normalized filter should match workflow_run.completed; raw-stored whitespace would have dropped it")
+	}
+}
+
+// TestNormalizeWebhookEventFilters_DropsEmptyActions guards the action list:
+// blank-after-trim actions are dropped so a stray comma in the UI input
+// (e.g. "completed,,failed") can't persist an unmatchable empty entry.
+func TestNormalizeWebhookEventFilters_DropsEmptyActions(t *testing.T) {
+	out := normalizeWebhookEventFilters([]WebhookEventFilter{
+		{Event: "push", Actions: []string{"completed", "   ", ""}},
+	})
+	if len(out) != 1 || len(out[0].Actions) != 1 || out[0].Actions[0] != "completed" {
+		t.Fatalf("blank actions not dropped: %+v", out)
+	}
+}
+
+// TestEncodeWebhookEventFiltersAlways_EmptyStaysExplicitArray pins the
+// tri-state contract: an explicit empty slice must still marshal to `[]`
+// (the UPDATE path relies on this to clear filters), not `null`.
+func TestEncodeWebhookEventFiltersAlways_EmptyStaysExplicitArray(t *testing.T) {
+	encoded, err := encodeWebhookEventFiltersAlways([]WebhookEventFilter{})
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("empty filters should encode to [], got %q", string(encoded))
+	}
+}


### PR DESCRIPTION
Follow-up 2 from PR #3231 review.

`validateWebhookEventFilters` trims only for its emptiness check but the encoders persisted the raw string, so an entry like `" workflow_run "` passed validation yet never matched at read time (the matcher compares exact strings).

- New `normalizeWebhookEventFilters` (trims each event/action, drops blank-after-trim actions), applied inside both `encodeWebhookEventFilters` and `encodeWebhookEventFiltersAlways` — so create and update normalize at marshal time.
- Tests: trim round-trip (stored bytes match a real envelope), blank-action dropping, and explicit empty slice still encodes to `[]` for the tri-state clear.

Verified: `go test ./internal/handler/ -run 'WebhookEventFilter|NormalizeWebhookEventFilters'` passes.