### PR TITLE
Fix OpenCode background process cleanup

### DIFF
--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -111,16 +111,26 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		cancel()
 		return nil, fmt.Errorf("opencode stdout pipe: %w", err)
 	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		cancel()
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+		return nil, fmt.Errorf("opencode stderr pipe: %w", err)
+	}
 	cmd.Stdout = stdoutWriter
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
+	cmd.Stderr = stderrWriter
 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		_ = stdoutReader.Close()
 		_ = stdoutWriter.Close()
+		_ = stderrReader.Close()
+		_ = stderrWriter.Close()
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
 	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
 
 	b.cfg.Logger.Info("opencode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
@@ -131,15 +141,20 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	go func() {
 		waitCh <- cmd.Wait()
 	}()
+	go func() {
+		defer stderrReader.Close()
+		_, _ = io.Copy(newLogWriter(b.cfg.Logger, "[opencode:stderr] "), stderrReader)
+	}()
 
 	stopCancelCleanup := make(chan struct{})
 	// Terminate the whole OpenCode process group when the context is cancelled,
-	// and close stdout so any inherited writer cannot keep the scanner blocked.
+	// and close pipes so inherited writers cannot keep readers blocked.
 	go func() {
 		select {
 		case <-runCtx.Done():
 			terminateOpenCodeProcessGroup(cmd)
 			_ = stdoutReader.Close()
+			_ = stderrReader.Close()
 		case <-stopCancelCleanup:
 		}
 	}()

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -153,6 +153,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		startTime := time.Now()
 		scanCh := make(chan eventResult, 1)
 		go func() {
+			defer stdoutReader.Close()
 			scanCh <- b.processEvents(stdoutReader, msgCh)
 		}()
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -81,6 +81,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	hideAgentWindow(cmd)
+	prepareOpenCodeCommand(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
@@ -105,39 +106,64 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	cmd.Env = env
 
-	stdout, err := cmd.StdoutPipe()
+	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("opencode stdout pipe: %w", err)
 	}
+	cmd.Stdout = stdoutWriter
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
 
 	if err := cmd.Start(); err != nil {
 		cancel()
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
+	_ = stdoutWriter.Close()
 
 	b.cfg.Logger.Info("opencode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	// Close stdout when the context is cancelled so the scanner unblocks.
+	waitCh := make(chan error, 1)
 	go func() {
-		<-runCtx.Done()
-		_ = stdout.Close()
+		waitCh <- cmd.Wait()
+	}()
+
+	stopCancelCleanup := make(chan struct{})
+	// Terminate the whole OpenCode process group when the context is cancelled,
+	// and close stdout so any inherited writer cannot keep the scanner blocked.
+	go func() {
+		select {
+		case <-runCtx.Done():
+			terminateOpenCodeProcessGroup(cmd)
+			_ = stdoutReader.Close()
+		case <-stopCancelCleanup:
+		}
 	}()
 
 	go func() {
 		defer cancel()
+		defer close(stopCancelCleanup)
 		defer close(msgCh)
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processEvents(stdout, msgCh)
+		scanCh := make(chan eventResult, 1)
+		go func() {
+			scanCh <- b.processEvents(stdoutReader, msgCh)
+		}()
 
 		// Wait for process exit.
-		exitErr := cmd.Wait()
+		exitErr := <-waitCh
+		backgroundAlive := openCodeProcessGroupAlive(cmd)
+		if backgroundAlive {
+			_ = stdoutReader.Close()
+		}
+
+		scanResult := <-scanCh
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -146,9 +172,15 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
+		} else if exitErr == nil && backgroundAlive {
+			scanResult.status = "failed"
+			scanResult.errMsg = "opencode exited before background processes completed"
 		} else if exitErr != nil && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
+		}
+		if backgroundAlive {
+			terminateOpenCodeProcessGroup(cmd)
 		}
 
 		b.cfg.Logger.Info("opencode finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())

--- a/server/pkg/agent/opencode_proc_other.go
+++ b/server/pkg/agent/opencode_proc_other.go
@@ -1,0 +1,17 @@
+//go:build !unix
+
+package agent
+
+import "os/exec"
+
+func prepareOpenCodeCommand(cmd *exec.Cmd) {}
+
+func openCodeProcessGroupAlive(cmd *exec.Cmd) bool {
+	return false
+}
+
+func terminateOpenCodeProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/server/pkg/agent/opencode_proc_unix.go
+++ b/server/pkg/agent/opencode_proc_unix.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package agent
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func prepareOpenCodeCommand(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+func openCodeProcessGroupAlive(cmd *exec.Cmd) bool {
+	if cmd.Process == nil {
+		return false
+	}
+	err := syscall.Kill(-cmd.Process.Pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func terminateOpenCodeProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/server/pkg/agent/opencode_process_unix_test.go
+++ b/server/pkg/agent/opencode_process_unix_test.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestOpencodeBackendFailsWhenBackgroundProcessSurvivesParentExit(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	childPIDFile := filepath.Join(tempDir, "child.pid")
+	fakePath := filepath.Join(tempDir, "opencode")
+	writeTestExecutable(t, fakePath, []byte(`#!/bin/sh
+(
+  sleep 60
+) &
+printf '%s\n' "$!" > "$OPENCODE_CHILD_PID_FILE"
+printf '{"type":"step_start","timestamp":1,"sessionID":"ses_fake","part":{"type":"step-start"}}\n'
+printf '{"type":"text","timestamp":2,"sessionID":"ses_fake","part":{"type":"text","text":"done"}}\n'
+printf '{"type":"step_finish","timestamp":3,"sessionID":"ses_fake","part":{"type":"step-finish"}}\n'
+exit 0
+`))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"OPENCODE_CHILD_PID_FILE": childPIDFile,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	if result.Status != "failed" {
+		t.Fatalf("result status = %q, error = %q; want failed", result.Status, result.Error)
+	}
+	if result.Error != "opencode exited before background processes completed" {
+		t.Fatalf("result error = %q", result.Error)
+	}
+
+	rawPID, err := os.ReadFile(childPIDFile)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(rawPID)))
+	if err != nil {
+		t.Fatalf("parse child pid: %v", err)
+	}
+	assertProcessExits(t, childPID)
+}
+
+func assertProcessExits(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("process %d is still alive", pid)
+}


### PR DESCRIPTION
## Summary
- run OpenCode sessions in their own process group
- detect surviving background processes after parent OpenCode exits and fail the run instead of leaving them orphaned
- close the manual stdout pipe reader after normal scanning completes to avoid fd accumulation
- add Unix regression coverage for background child cleanup

## Verification
- git diff --check
- go version (blocked: go is not installed on PATH in this runner)
- make test (blocked: missing .env / .env.worktree in this runner)