### PR TITLE
Fix runtime deletion with archived squad leaders

### DIFF
--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -588,6 +588,19 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(archivedAgentIDs) > 0 {
+		activeSquads, err := h.Queries.ListActiveSquadsByLeaderIDs(r.Context(), archivedAgentIDs)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to check squad dependencies")
+			return
+		}
+		if len(activeSquads) > 0 {
+			writeJSON(w, http.StatusConflict, runtimeHasActiveSquadLeadersResponse(activeSquads))
+			return
+		}
+		if err := h.Queries.DeleteArchivedSquadsByLeaderIDs(r.Context(), archivedAgentIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to clean up archived squads")
+			return
+		}
 		if err := h.Queries.PauseAutopilotsByAgentAssignees(r.Context(), archivedAgentIDs); err != nil {
 			slog.Warn("pause autopilots for archived agents failed",
 				"runtime_id", uuidToString(rt.ID), "error", err)
@@ -636,6 +649,18 @@ func runtimeHasActiveAgentsResponse(agents []db.Agent) map[string]any {
 		"error":         "cannot delete runtime: it has active agents bound to it. Archive or reassign the agents first.",
 		"code":          "runtime_has_active_agents",
 		"active_agents": resp,
+	}
+}
+
+func runtimeHasActiveSquadLeadersResponse(squads []db.Squad) map[string]any {
+	resp := make([]SquadResponse, len(squads))
+	for i, s := range squads {
+		resp[i] = squadToResponse(s)
+	}
+	return map[string]any{
+		"error":         "cannot delete runtime: archived agents on this runtime still lead active squads. Change or archive those squads first.",
+		"code":          "runtime_has_active_squad_leaders",
+		"active_squads": resp,
 	}
 }
 
@@ -803,6 +828,19 @@ func (h *Handler) ArchiveAgentsAndDeleteRuntime(w http.ResponseWriter, r *http.R
 		return
 	}
 	if len(allArchivedIDs) > 0 {
+		activeSquads, err := qtx.ListActiveSquadsByLeaderIDs(r.Context(), allArchivedIDs)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to check squad dependencies")
+			return
+		}
+		if len(activeSquads) > 0 {
+			writeJSON(w, http.StatusConflict, runtimeHasActiveSquadLeadersResponse(activeSquads))
+			return
+		}
+		if err := qtx.DeleteArchivedSquadsByLeaderIDs(r.Context(), allArchivedIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to clean up archived squads")
+			return
+		}
 		if err := qtx.PauseAutopilotsByAgentAssignees(r.Context(), allArchivedIDs); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to pause autopilots")
 			return

--- a/server/internal/handler/runtime_cascade_test.go
+++ b/server/internal/handler/runtime_cascade_test.go
@@ -209,6 +209,95 @@ func TestArchiveAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 	}
 }
 
+// TestDeleteAgentRuntime_ArchivedSquadLeaderCleanup covers the production
+// failure mode: an already-archived agent on the runtime still leads an
+// archived squad, whose leader_id FK used to block hard-deleting the agent.
+func TestDeleteAgentRuntime_ArchivedSquadLeaderCleanup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	runtimeID := createCascadeFixtureRuntime(t, ctx, "Archived Squad Runtime")
+	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Archived Squad Leader")
+	squadID := createCascadeFixtureSquad(t, ctx, agentID, "Archived Squad", true)
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent SET archived_at = now(), archived_by = $2 WHERE id = $1
+	`, agentID, testUserID); err != nil {
+		t.Fatalf("archive fixture agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.DeleteAgentRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var rtRows, agentRows, squadRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
+		t.Fatalf("count runtime rows: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent WHERE id = $1`, agentID).Scan(&agentRows); err != nil {
+		t.Fatalf("count agent rows: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM squad WHERE id = $1`, squadID).Scan(&squadRows); err != nil {
+		t.Fatalf("count squad rows: %v", err)
+	}
+	if rtRows != 0 || agentRows != 0 || squadRows != 0 {
+		t.Fatalf("expected runtime/agent/archived squad deleted, got runtime=%d agent=%d squad=%d", rtRows, agentRows, squadRows)
+	}
+}
+
+func TestDeleteAgentRuntime_ActiveSquadLeaderBlocks(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	runtimeID := createCascadeFixtureRuntime(t, ctx, "Active Squad Runtime")
+	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Active Squad Leader")
+	squadID := createCascadeFixtureSquad(t, ctx, agentID, "Active Squad", false)
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent SET archived_at = now(), archived_by = $2 WHERE id = $1
+	`, agentID, testUserID); err != nil {
+		t.Fatalf("archive fixture agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/runtimes/"+runtimeID, nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.DeleteAgentRuntime(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Code         string          `json:"code"`
+		ActiveSquads []SquadResponse `json:"active_squads"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Code != "runtime_has_active_squad_leaders" {
+		t.Fatalf("expected code runtime_has_active_squad_leaders, got %q", body.Code)
+	}
+	if len(body.ActiveSquads) != 1 || body.ActiveSquads[0].ID != squadID {
+		t.Fatalf("expected active squad %s in response, got %+v", squadID, body.ActiveSquads)
+	}
+
+	var rtRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&rtRows); err != nil {
+		t.Fatalf("count runtime rows: %v", err)
+	}
+	if rtRows != 1 {
+		t.Fatalf("expected runtime to survive active-squad blocker, count=%d", rtRows)
+	}
+}
+
 // TestArchiveAgentsAndDeleteRuntime_PlanChanged proves the dialog-confirm
 // race guard: if the user's snapshot of active agents drifts from the live
 // set (somebody added or archived an agent while the dialog was open), the
@@ -302,4 +391,27 @@ func createCascadeFixtureAgent(t *testing.T, ctx context.Context, runtimeID, nam
 		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
 	})
 	return agentID
+}
+
+func createCascadeFixtureSquad(t *testing.T, ctx context.Context, leaderID, name string, archived bool) string {
+	t.Helper()
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, name, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("insert cascade fixture squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+	if archived {
+		if _, err := testPool.Exec(ctx, `
+			UPDATE squad SET archived_at = now(), archived_by = $2 WHERE id = $1
+		`, squadID, testUserID); err != nil {
+			t.Fatalf("archive fixture squad: %v", err)
+		}
+	}
+	return squadID
 }

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -114,6 +114,19 @@ func (q *Queries) DeleteArchivedAgentsByRuntime(ctx context.Context, runtimeID p
 	return err
 }
 
+const deleteArchivedSquadsByLeaderIDs = `-- name: DeleteArchivedSquadsByLeaderIDs :exec
+DELETE FROM squad
+WHERE archived_at IS NOT NULL AND leader_id = ANY($1::uuid[])
+`
+
+// Archived squads are hidden and have no restore path. Remove them before
+// deleting archived leader agents so squad.leader_id's ON DELETE RESTRICT FK
+// does not block runtime teardown.
+func (q *Queries) DeleteArchivedSquadsByLeaderIDs(ctx context.Context, leaderIds []pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteArchivedSquadsByLeaderIDs, leaderIds)
+	return err
+}
+
 const deleteStaleOfflineRuntimes = `-- name: DeleteStaleOfflineRuntimes :many
 DELETE FROM agent_runtime
 WHERE status = 'offline'
@@ -493,6 +506,47 @@ func (q *Queries) ListArchivedAgentIDsByRuntime(ctx context.Context, runtimeID p
 			return nil, err
 		}
 		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActiveSquadsByLeaderIDs = `-- name: ListActiveSquadsByLeaderIDs :many
+SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad
+WHERE archived_at IS NULL AND leader_id = ANY($1::uuid[])
+ORDER BY name ASC
+`
+
+// Active squads still depend on their leader agent. Runtime deletion must not
+// hard-delete those leaders; surface these as explicit blockers instead.
+func (q *Queries) ListActiveSquadsByLeaderIDs(ctx context.Context, leaderIds []pgtype.UUID) ([]Squad, error) {
+	rows, err := q.db.Query(ctx, listActiveSquadsByLeaderIDs, leaderIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Squad{}
+	for rows.Next() {
+		var i Squad
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Name,
+			&i.Description,
+			&i.LeaderID,
+			&i.CreatorID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ArchivedAt,
+			&i.ArchivedBy,
+			&i.AvatarUrl,
+			&i.Instructions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -202,6 +202,20 @@ SELECT count(*) FROM agent WHERE runtime_id = $1 AND archived_at IS NULL;
 -- name: DeleteArchivedAgentsByRuntime :exec
 DELETE FROM agent WHERE runtime_id = $1 AND archived_at IS NOT NULL;
 
+-- name: ListActiveSquadsByLeaderIDs :many
+-- Active squads still depend on their leader agent. Runtime deletion must not
+-- hard-delete those leaders; surface these as explicit blockers instead.
+SELECT * FROM squad
+WHERE archived_at IS NULL AND leader_id = ANY(@leader_ids::uuid[])
+ORDER BY name ASC;
+
+-- name: DeleteArchivedSquadsByLeaderIDs :exec
+-- Archived squads are hidden and have no restore path. Remove them before
+-- deleting archived leader agents so squad.leader_id's ON DELETE RESTRICT FK
+-- does not block runtime teardown.
+DELETE FROM squad
+WHERE archived_at IS NOT NULL AND leader_id = ANY(@leader_ids::uuid[]);
+
 -- name: PauseAutopilotsByAgentAssignees :exec
 -- Pauses every active autopilot whose agent assignee is in the supplied list.
 -- Called before hard-deleting archived agents on runtime teardown so the rows


### PR DESCRIPTION
## Summary
- clean up archived squads led by archived agents before deleting archived runtime agents
- block runtime deletion with a structured 409 when archived runtime agents still lead active squads
- add regression coverage for archived squad cleanup and active squad blocker behavior

## Verification
- `git diff --check`
- `make sqlc` attempted, blocked: `sqlc: not found`
- `make test` attempted after `make worktree-env`, blocked: `docker: command not found`
- `go`/`gofmt` are unavailable in this container, so Go formatting/tests could not be run locally

Closes multica-ai/multica#2954
