### PR TITLE
fix(daemon): allow Codex checkout Git metadata writes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2442,11 +2442,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Prepare against a stable user path is cheap (no clone, no copy).
 	if task.PriorWorkDir != "" && localAssignment == nil {
 		env = execenv.Reuse(execenv.ReuseParams{
-			WorkDir:      task.PriorWorkDir,
-			Provider:     provider,
-			CodexVersion: codexVersion,
-			OpenclawBin:  openclawBin,
-			Task:         taskCtx,
+			WorkDir:        task.PriorWorkDir,
+			WorkspacesRoot: d.cfg.WorkspacesRoot,
+			WorkspaceID:    task.WorkspaceID,
+			Provider:       provider,
+			CodexVersion:   codexVersion,
+			OpenclawBin:    openclawBin,
+			Task:           taskCtx,
 		}, d.logger)
 	}
 	if env == nil {

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -41,6 +41,10 @@ type CodexHomeOptions struct {
 	// Empty means use runtime.GOOS. Primarily exists so tests can exercise
 	// both macOS and Linux paths deterministically.
 	GOOS string
+	// WritableRoots are extra absolute paths Codex may write under
+	// workspace-write. The daemon uses this for git metadata that belongs to
+	// checked-out worktrees but lives outside the task workdir.
+	WritableRoots []string
 }
 
 // prepareCodexHome is a thin wrapper around prepareCodexHomeWithOpts kept for
@@ -113,6 +117,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	// need to fall back to danger-full-access because of openai/codex#10390;
 	// see codex_sandbox.go for the full rationale.
 	policy := codexSandboxPolicyFor(opts.GOOS, opts.CodexVersion)
+	policy.WritableRoots = opts.WritableRoots
 	if err := ensureCodexSandboxConfig(filepath.Join(codexHome, "config.toml"), policy, opts.CodexVersion, logger); err != nil {
 		logger.Warn("execenv: codex-home ensure sandbox config failed", "error", err)
 	}

--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -40,6 +41,10 @@ type codexSandboxPolicy struct {
 	NetworkAccess bool
 	// Reason is a short human-readable label used in warn-level logs.
 	Reason string
+	// WritableRoots are additional absolute paths Codex may write when Mode is
+	// workspace-write. The task cwd is already writable; this is for support
+	// paths such as git worktree metadata that intentionally live outside cwd.
+	WritableRoots []string
 }
 
 // codexSandboxPolicyFor picks the right policy for the given platform and
@@ -134,10 +139,38 @@ func renderMulticaManagedBlock(policy codexSandboxPolicy) string {
 	b.WriteString(fmt.Sprintf("sandbox_mode = %q\n", policy.Mode))
 	if policy.Mode == "workspace-write" {
 		b.WriteString(fmt.Sprintf("sandbox_workspace_write.network_access = %t\n", policy.NetworkAccess))
+		if roots := cleanCodexWritableRoots(policy.WritableRoots); len(roots) > 0 {
+			b.WriteString("sandbox_workspace_write.writable_roots = [")
+			for i, root := range roots {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				b.WriteString(strconv.Quote(root))
+			}
+			b.WriteString("]\n")
+		}
 	}
 	b.WriteString(multicaManagedEndMarker)
 	b.WriteString("\n")
 	return b.String()
+}
+
+func cleanCodexWritableRoots(roots []string) []string {
+	cleaned := make([]string, 0, len(roots))
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" || !filepath.IsAbs(root) {
+			continue
+		}
+		root = filepath.Clean(root)
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		cleaned = append(cleaned, root)
+	}
+	return cleaned
 }
 
 // managedBlockRe captures the daemon-owned block (including the surrounding

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -197,7 +197,10 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, "codex-home")
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{
+			CodexVersion:  params.CodexVersion,
+			WritableRoots: codexRepoCacheWritableRoots(params.WorkspacesRoot, params.WorkspaceID),
+		}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, logger); err != nil {
@@ -229,10 +232,12 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 // the per-provider knobs (CodexVersion, OpenclawBin) so callers can pass
 // the same resolved binary path on both first-run and reuse paths.
 type ReuseParams struct {
-	WorkDir      string
-	Provider     string
-	CodexVersion string // only used when Provider == "codex"
-	OpenclawBin  string // only used when Provider == "openclaw"; empty = PATH lookup
+	WorkDir        string
+	WorkspacesRoot string
+	WorkspaceID    string
+	Provider       string
+	CodexVersion   string // only used when Provider == "codex"
+	OpenclawBin    string // only used when Provider == "openclaw"; empty = PATH lookup
 	// LocalDirectory is true when the reused WorkDir is a user-supplied
 	// directory (the local_directory flow). The flag is propagated into
 	// the returned Environment so downstream callers (notably the GC
@@ -279,7 +284,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{
+			CodexVersion:  params.CodexVersion,
+			WritableRoots: codexRepoCacheWritableRoots(params.WorkspacesRoot, params.WorkspaceID),
+		}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome
@@ -307,6 +315,13 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 
 	logger.Info("execenv: reusing env", "workdir", params.WorkDir)
 	return env
+}
+
+func codexRepoCacheWritableRoots(workspacesRoot, workspaceID string) []string {
+	if workspacesRoot == "" || workspaceID == "" {
+		return nil
+	}
+	return []string{filepath.Join(workspacesRoot, ".repos", workspaceID)}
 }
 
 // hydrateCodexSkills populates the per-task CODEX_HOME/skills directory with

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -1978,6 +1979,52 @@ func TestEnsureCodexSandboxConfigCreatesDefaultLinux(t *testing.T) {
 	}
 }
 
+func TestEnsureCodexSandboxConfigWritesWritableRoots(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	repoCacheRoot := filepath.Join(dir, "workspaces", ".repos", "ws-1")
+
+	policy := codexSandboxPolicyFor("linux", "0.121.0")
+	policy.WritableRoots = []string{repoCacheRoot, repoCacheRoot + string(os.PathSeparator), "relative/path", repoCacheRoot}
+	if err := ensureCodexSandboxConfig(configPath, policy, "0.121.0", testLogger()); err != nil {
+		t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config.toml: %v", err)
+	}
+	s := string(data)
+	want := "sandbox_workspace_write.writable_roots = [" + strconv.Quote(filepath.Clean(repoCacheRoot)) + "]"
+	if !strings.Contains(s, want) {
+		t.Errorf("missing writable_roots entry %q, got:\n%s", want, s)
+	}
+	if strings.Contains(s, "relative/path") {
+		t.Errorf("relative writable root should be ignored, got:\n%s", s)
+	}
+}
+
+func TestEnsureCodexSandboxConfigOmitsWritableRootsOutsideWorkspaceWrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	policy := codexSandboxPolicyFor("darwin", "0.121.0")
+	policy.WritableRoots = []string{filepath.Join(dir, "workspaces", ".repos", "ws-1")}
+	if err := ensureCodexSandboxConfig(configPath, policy, "0.121.0", testLogger()); err != nil {
+		t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config.toml: %v", err)
+	}
+	if strings.Contains(string(data), "writable_roots") {
+		t.Errorf("danger-full-access policy should not emit writable_roots, got:\n%s", data)
+	}
+}
+
 func TestEnsureCodexSandboxConfigDarwinFallsBack(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -2240,6 +2287,38 @@ func TestPrepareCodexHomeEnsuresNetworkAccess(t *testing.T) {
 	}
 	if !strings.Contains(s, `sandbox_mode = "workspace-write"`) {
 		t.Error("config.toml missing sandbox_mode")
+	}
+}
+
+func TestPrepareCodexHomeAllowsWorkspaceRepoCacheRoot(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	workspacesRoot := t.TempDir()
+	workspaceID := "ws-codex-repo-cache"
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    workspaceID,
+		TaskID:         "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "issue-1",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(env.CodexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	repoCacheRoot := filepath.Join(workspacesRoot, ".repos", workspaceID)
+	want := "sandbox_workspace_write.writable_roots = [" + strconv.Quote(repoCacheRoot) + "]"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("codex config missing repo-cache writable root %q, got:\n%s", want, data)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add the current workspace repo cache under Codex `workspace-write` writable roots
- pass the repo-cache root through both initial Codex environment setup and reused task environments
- add regression coverage for writable root rendering, danger-full-access omission, and Prepare wiring

## Verification
- `git diff --check` passed
- `gofmt -w server/internal/daemon/daemon.go server/internal/daemon/execenv/codex_home.go server/internal/daemon/execenv/codex_sandbox.go server/internal/daemon/execenv/execenv.go server/internal/daemon/execenv/execenv_test.go` could not run: `gofmt` is not installed on PATH in this runtime
- `go test ./server/internal/daemon/execenv` could not run: `go` is not installed on PATH in this runtime

## Notes
The original Multica checkout in this task still reproduces the blocker when committing: Git tries to write `/home/andy/multica_workspaces/.repos/b5c65be2-ea3a-4cb9-89ca-416e839264c9/github.com+AndyMental+multica.git/worktrees/multica272/index.lock` and fails with `Read-only file system`. I used a standalone `/tmp` clone to preserve and push this branch because `/tmp` keeps Git metadata inside a writable root.
