### PR TITLE
Randomize self-host Postgres password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,8 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
-		JWT=$$(openssl rand -hex 32); \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		else \
-			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		fi; \
-		echo "==> Generated random JWT_SECRET"; \
+		bash -c 'set -euo pipefail; MULTICA_INSTALL_SH_SOURCE_ONLY=1 . scripts/install.sh; JWT=$$(random_hex 32); POSTGRES_PASSWORD=$$(random_hex 24); DATABASE_URL=$$(env_file_value .env DATABASE_URL ""); set_env_file_value .env JWT_SECRET "$$JWT"; set_env_file_value .env POSTGRES_PASSWORD "$$POSTGRES_PASSWORD"; if [ -n "$$DATABASE_URL" ]; then set_env_file_value .env DATABASE_URL "$$(postgres_url_with_password "$$DATABASE_URL" "$$POSTGRES_PASSWORD")"; fi'; \
+		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Pulling official Multica images..."
 	@if ! docker compose -f docker-compose.selfhost.yml pull; then \
@@ -107,13 +102,8 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
-		JWT=$$(openssl rand -hex 32); \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		else \
-			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		fi; \
-		echo "==> Generated random JWT_SECRET"; \
+		bash -c 'set -euo pipefail; MULTICA_INSTALL_SH_SOURCE_ONLY=1 . scripts/install.sh; JWT=$$(random_hex 32); POSTGRES_PASSWORD=$$(random_hex 24); DATABASE_URL=$$(env_file_value .env DATABASE_URL ""); set_env_file_value .env JWT_SECRET "$$JWT"; set_env_file_value .env POSTGRES_PASSWORD "$$POSTGRES_PASSWORD"; if [ -n "$$DATABASE_URL" ]; then set_env_file_value .env DATABASE_URL "$$(postgres_url_with_password "$$DATABASE_URL" "$$POSTGRES_PASSWORD")"; fi'; \
+		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Building Multica from the current checkout..."
 	docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-run selfhost-build selfhost-build-run selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -60,6 +60,9 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 		bash -c 'set -euo pipefail; MULTICA_INSTALL_SH_SOURCE_ONLY=1 . scripts/install.sh; JWT=$$(random_hex 32); POSTGRES_PASSWORD=$$(random_hex 24); DATABASE_URL=$$(env_file_value .env DATABASE_URL ""); set_env_file_value .env JWT_SECRET "$$JWT"; set_env_file_value .env POSTGRES_PASSWORD "$$POSTGRES_PASSWORD"; if [ -n "$$DATABASE_URL" ]; then set_env_file_value .env DATABASE_URL "$$(postgres_url_with_password "$$DATABASE_URL" "$$POSTGRES_PASSWORD")"; fi'; \
 		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
+	@$(MAKE) selfhost-run
+
+selfhost-run:
 	@echo "==> Pulling official Multica images..."
 	@if ! docker compose -f docker-compose.selfhost.yml pull; then \
 		echo ""; \
@@ -105,6 +108,9 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 		bash -c 'set -euo pipefail; MULTICA_INSTALL_SH_SOURCE_ONLY=1 . scripts/install.sh; JWT=$$(random_hex 32); POSTGRES_PASSWORD=$$(random_hex 24); DATABASE_URL=$$(env_file_value .env DATABASE_URL ""); set_env_file_value .env JWT_SECRET "$$JWT"; set_env_file_value .env POSTGRES_PASSWORD "$$POSTGRES_PASSWORD"; if [ -n "$$DATABASE_URL" ]; then set_env_file_value .env DATABASE_URL "$$(postgres_url_with_password "$$DATABASE_URL" "$$POSTGRES_PASSWORD")"; fi'; \
 		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
+	@$(MAKE) selfhost-build-run
+
+selfhost-build-run:
 	@echo "==> Building Multica from the current checkout..."
 	docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
 	@echo "==> Waiting for backend to be ready..."

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -417,11 +417,17 @@ cd multica
 cp .env.example .env
 ```
 
-Edit `.env` — at minimum, change `JWT_SECRET`:
+Edit `.env` — at minimum, change `JWT_SECRET`, `POSTGRES_PASSWORD`, and the password segment in `DATABASE_URL`:
 
 ```bash
 JWT_SECRET=$(openssl rand -hex 32)
+POSTGRES_PASSWORD=$(openssl rand -hex 24)
+DATABASE_URL=postgres://multica:${POSTGRES_PASSWORD}@localhost:5432/multica?sslmode=disable
 ```
+
+If you already have a self-hosted install with `POSTGRES_PASSWORD=multica`,
+do not only edit `.env`: rotate the matching password inside Postgres during
+planned downtime, then restart the stack with the updated `.env`.
 
 Then start everything:
 

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -30,7 +30,7 @@ make selfhost
 
 `make selfhost` will:
 
-1. Generate a `.env` from `.env.example` if missing, with a **random JWT_SECRET**
+1. Generate a `.env` from `.env.example` if missing, with a **random JWT_SECRET** and **random Postgres password**
 2. Pull the official Docker images (PostgreSQL, Multica backend, Multica frontend)
 3. Bring up every service using `docker-compose.selfhost.yml`
 4. Wait until the backend's `/health` endpoint is ready
@@ -51,6 +51,10 @@ Once it's up:
 
 <Callout type="info">
 **Ports listen on `127.0.0.1` only.** `docker-compose.selfhost.yml` binds every published port to loopback — `ss -tlnp` will not show `0.0.0.0:8080`, and the services are unreachable from other machines by design. The default `JWT_SECRET` and Postgres credentials must never sit on the open internet. For cross-machine access, front the stack with a reverse proxy that terminates TLS — see [Step 5b — Cross-machine: front with a reverse proxy](#5b-cross-machine-front-with-a-reverse-proxy).
+</Callout>
+
+<Callout type="warning">
+**Existing installs are not rotated automatically.** If your `.env` still has `POSTGRES_PASSWORD=multica`, schedule downtime, update both `POSTGRES_PASSWORD` and the password segment in `DATABASE_URL`, then rotate the matching password inside Postgres before restarting the stack.
 </Callout>
 
 ## 2. Important: keep production safety on

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -56,6 +56,55 @@ function Get-EnvFileValue {
     return $value
 }
 
+function Set-EnvFileValue {
+    param(
+        [string]$Path,
+        [string]$Name,
+        [string]$Value
+    )
+
+    $lines = if (Test-Path $Path) { @(Get-Content $Path) } else { @() }
+    $prefix = "$Name="
+    $replaced = $false
+    $updated = foreach ($line in $lines) {
+        if ($line.StartsWith($prefix)) {
+            $replaced = $true
+            "$Name=$Value"
+        } else {
+            $line
+        }
+    }
+    if (-not $replaced) {
+        $updated += "$Name=$Value"
+    }
+    $updated | Set-Content $Path
+}
+
+function New-RandomHex {
+    param([int]$Bytes)
+
+    $bytes = [byte[]]::new($Bytes)
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $rng.GetBytes($bytes)
+    } finally {
+        $rng.Dispose()
+    }
+    return -join ($bytes | ForEach-Object { "{0:x2}" -f $_ })
+}
+
+function Update-PostgresUrlPassword {
+    param(
+        [string]$Url,
+        [string]$Password
+    )
+
+    if ($Url -match '^(postgres(?:ql)?://)([^:@/]+):([^@]*)@(.+)$') {
+        return "$($Matches[1])$($Matches[2]):$Password@$($Matches[4])"
+    }
+    return $Url
+}
+
 function Get-SelfHostBackendPort {
     foreach ($name in @("BACKEND_PORT", "API_PORT", "SERVER_PORT", "PORT")) {
         $value = Get-EnvFileValue -Path (Join-Path $InstallDir ".env") -Name $name -Default ""
@@ -411,11 +460,17 @@ function Install-Server {
     Write-Ok "Repository ready at $InstallDir ($serverRef)"
 
     if (-not (Test-Path ".env")) {
-        Write-Info "Creating .env with random JWT_SECRET..."
+        Write-Info "Creating .env with random secrets..."
         Copy-Item ".env.example" ".env"
-        $jwt = -join ((1..32) | ForEach-Object { "{0:x2}" -f (Get-Random -Maximum 256) })
-        (Get-Content ".env") -replace '^JWT_SECRET=.*', "JWT_SECRET=$jwt" | Set-Content ".env"
-        Write-Ok "Generated .env with random JWT_SECRET"
+        $jwt = New-RandomHex 32
+        $postgresPassword = New-RandomHex 24
+        $databaseUrl = Get-EnvFileValue -Path ".env" -Name "DATABASE_URL" -Default ""
+        Set-EnvFileValue -Path ".env" -Name "JWT_SECRET" -Value $jwt
+        Set-EnvFileValue -Path ".env" -Name "POSTGRES_PASSWORD" -Value $postgresPassword
+        if (-not [string]::IsNullOrWhiteSpace($databaseUrl)) {
+            Set-EnvFileValue -Path ".env" -Name "DATABASE_URL" -Value (Update-PostgresUrlPassword -Url $databaseUrl -Password $postgresPassword)
+        }
+        Write-Ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
     } else {
         Write-Ok "Using existing .env"
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,53 @@ env_file_value() {
   fi
 }
 
+set_env_file_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v key="$key" -v value="$value" '
+    BEGIN { replaced = 0 }
+    $0 ~ "^" key "=" {
+      print key "=" value
+      replaced = 1
+      next
+    }
+    { print }
+    END {
+      if (!replaced) {
+        print key "=" value
+      }
+    }
+  ' "$file" >"$tmp"
+  mv "$tmp" "$file"
+}
+
+postgres_url_with_password() {
+  local url="$1"
+  local password="$2"
+  local scheme rest userinfo host_and_path username
+
+  case "$url" in
+    postgres://*:*@*|postgresql://*:*@*) ;;
+    *) printf "%s" "$url"; return ;;
+  esac
+
+  scheme="${url%%://*}"
+  rest="${url#*://}"
+  userinfo="${rest%%@*}"
+  host_and_path="${rest#*@}"
+  username="${userinfo%%:*}"
+
+  printf "%s://%s:%s@%s" "$scheme" "$username" "$password" "$host_and_path"
+}
+
+random_hex() {
+  local bytes="$1"
+  openssl rand -hex "$bytes"
+}
+
 selfhost_backend_port() {
   local file="${1:-.env}"
   local value
@@ -357,16 +404,18 @@ setup_server() {
 
   # Generate .env if needed
   if [ ! -f .env ]; then
-    info "Creating .env with random JWT_SECRET..."
+    info "Creating .env with random secrets..."
     cp .env.example .env
-    local jwt
-    jwt=$(openssl rand -hex 32)
-    if [ "$(uname -s)" = "Darwin" ]; then
-      sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
-    else
-      sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
+    local jwt postgres_password database_url
+    jwt=$(random_hex 32)
+    postgres_password=$(random_hex 24)
+    database_url="$(env_file_value .env DATABASE_URL "")"
+    set_env_file_value .env JWT_SECRET "$jwt"
+    set_env_file_value .env POSTGRES_PASSWORD "$postgres_password"
+    if [ -n "$database_url" ]; then
+      set_env_file_value .env DATABASE_URL "$(postgres_url_with_password "$database_url" "$postgres_password")"
     fi
-    ok "Generated .env with random JWT_SECRET"
+    ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else
     ok "Using existing .env"
   fi
@@ -532,4 +581,6 @@ main() {
   esac
 }
 
-main "$@"
+if [ "${MULTICA_INSTALL_SH_SOURCE_ONLY:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -130,6 +130,68 @@ STUB
   _run_installer "$tmp"
 }
 
+test_generated_selfhost_env_randomizes_postgres_password() {
+  local tmp
+  MULTICA_INSTALL_SH_SOURCE_ONLY=1 source "$ROOT_DIR/scripts/install.sh"
+  trap - RETURN
+
+  tmp="$(mktemp -d)"
+
+  cp "$ROOT_DIR/.env.example" "$tmp/.env"
+
+  local jwt postgres_password database_url
+  jwt="$(random_hex 32)"
+  postgres_password="$(random_hex 24)"
+  database_url="$(env_file_value "$tmp/.env" DATABASE_URL "")"
+  set_env_file_value "$tmp/.env" JWT_SECRET "$jwt"
+  set_env_file_value "$tmp/.env" POSTGRES_PASSWORD "$postgres_password"
+  set_env_file_value "$tmp/.env" DATABASE_URL "$(postgres_url_with_password "$database_url" "$postgres_password")"
+
+  if grep -Fxq "POSTGRES_PASSWORD=multica" "$tmp/.env"; then
+    echo "expected generated .env to replace default POSTGRES_PASSWORD" >&2
+    cat "$tmp/.env" >&2
+    return 1
+  fi
+
+  if ! grep -Eq '^POSTGRES_PASSWORD=[0-9a-f]{48}$' "$tmp/.env"; then
+    echo "expected generated .env to contain a 48-character hex POSTGRES_PASSWORD" >&2
+    cat "$tmp/.env" >&2
+    return 1
+  fi
+
+  if ! grep -Fxq "DATABASE_URL=postgres://multica:${postgres_password}@localhost:5432/multica?sslmode=disable" "$tmp/.env"; then
+    echo "expected DATABASE_URL to use the generated Postgres password" >&2
+    cat "$tmp/.env" >&2
+    return 1
+  fi
+
+  if ! grep -Fxq "JWT_SECRET=$jwt" "$tmp/.env"; then
+    echo "expected generated .env to contain random JWT_SECRET" >&2
+    cat "$tmp/.env" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}
+
+test_postgres_url_password_replacement_preserves_connection_parts() {
+  MULTICA_INSTALL_SH_SOURCE_ONLY=1 source "$ROOT_DIR/scripts/install.sh"
+  trap - RETURN
+
+  local url updated
+  url='postgres://db_user:old-password@db.internal.example:6543/custom_db?sslmode=require&pool_max_conns=10'
+  updated="$(postgres_url_with_password "$url" "newpass123")"
+
+  if [[ "$updated" != 'postgres://db_user:newpass123@db.internal.example:6543/custom_db?sslmode=require&pool_max_conns=10' ]]; then
+    echo "expected DATABASE_URL password replacement to preserve user, host, port, db, and query string" >&2
+    echo "Observed: $updated" >&2
+    return 1
+  fi
+}
+
 test_brew_install_failure_falls_back_to_release_binary
 test_brew_tap_failure_falls_back_to_release_binary
+test_generated_selfhost_env_randomizes_postgres_password
+test_postgres_url_password_replacement_preserves_connection_parts
 echo "install.sh tests passed"

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -190,8 +190,64 @@ test_postgres_url_password_replacement_preserves_connection_parts() {
   fi
 }
 
+test_make_selfhost_uses_generated_postgres_password() {
+  local tmp repo log generated_password
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  repo="$tmp/repo"
+  log="$tmp/docker-env.log"
+  mkdir -p "$repo/scripts" "$tmp/stub-bin"
+  cp "$ROOT_DIR/Makefile" "$repo/Makefile"
+  cp "$ROOT_DIR/.env.example" "$repo/.env.example"
+  cp "$ROOT_DIR/scripts/install.sh" "$repo/scripts/install.sh"
+
+  cat >"$tmp/stub-bin/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s POSTGRES_PASSWORD=%s DATABASE_URL=%s\n' "$*" "$POSTGRES_PASSWORD" "$DATABASE_URL" >>"$MULTICA_TEST_DOCKER_ENV_LOG"
+exit 0
+STUB
+  chmod +x "$tmp/stub-bin/docker"
+
+  cat >"$tmp/stub-bin/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$tmp/stub-bin/curl"
+
+  PATH="$tmp/stub-bin:/usr/bin:/bin" \
+    MULTICA_TEST_DOCKER_ENV_LOG="$log" \
+    make -C "$repo" selfhost >/dev/null
+
+  generated_password="$(grep '^POSTGRES_PASSWORD=' "$repo/.env" | cut -d= -f2-)"
+  if [[ -z "$generated_password" || "$generated_password" == "multica" ]]; then
+    echo "expected make selfhost to generate a non-default POSTGRES_PASSWORD" >&2
+    cat "$repo/.env" >&2
+    return 1
+  fi
+
+  if grep -q 'POSTGRES_PASSWORD=multica' "$log"; then
+    echo "expected docker compose commands to receive the generated POSTGRES_PASSWORD, not the Makefile default" >&2
+    cat "$log" >&2
+    return 1
+  fi
+
+  if ! grep -q "POSTGRES_PASSWORD=$generated_password" "$log"; then
+    echo "expected docker compose commands to receive the generated POSTGRES_PASSWORD" >&2
+    cat "$log" >&2
+    return 1
+  fi
+
+  if ! grep -q "DATABASE_URL=postgres://multica:$generated_password@localhost:5432/multica?sslmode=disable" "$log"; then
+    echo "expected docker compose commands to receive DATABASE_URL with the generated POSTGRES_PASSWORD" >&2
+    cat "$log" >&2
+    return 1
+  fi
+}
+
 test_brew_install_failure_falls_back_to_release_binary
 test_brew_tap_failure_falls_back_to_release_binary
 test_generated_selfhost_env_randomizes_postgres_password
 test_postgres_url_password_replacement_preserves_connection_parts
+test_make_selfhost_uses_generated_postgres_password
 echo "install.sh tests passed"


### PR DESCRIPTION
Implements AND-4898 from the reviewed patch attachment.\n\nVerification run locally in a writable clone:\n- git diff --check\n- bash scripts/install.test.sh\n- make -n selfhost\n- make -n selfhost-build\n\nDocker-backed scripts/selfhost-config.test.sh remains environment-blocked where Docker is unavailable.