### PR TITLE
Show autopilot context in agent activity rows

### DIFF
--- a/packages/views/agents/components/tabs/activity-tab.test.ts
+++ b/packages/views/agents/components/tabs/activity-tab.test.ts
@@ -3,6 +3,7 @@ import type { AgentTask } from "@multica/core/types";
 import {
   deriveAvgDurationLast30d,
   formatDurationMs,
+  taskDisplayTitle,
 } from "./activity-tab";
 
 const NOW = new Date("2026-04-28T12:00:00Z").getTime();
@@ -105,5 +106,68 @@ describe("formatDurationMs", () => {
   it("handles zero / negative defensively", () => {
     expect(formatDurationMs(0)).toBe("—");
     expect(formatDurationMs(-100)).toBe("—");
+  });
+});
+
+describe("taskDisplayTitle", () => {
+  const labels = {
+    issueShortFallback: "Issue 12345678...",
+    sourceFallback: "Autopilot run",
+  };
+
+  it("prefers the loaded issue title for issue-linked tasks", () => {
+    expect(
+      taskDisplayTitle(
+        task({
+          issue_id: "issue-id",
+          trigger_summary: "Fix from webhook",
+        }),
+        { title: "Fix activity row labels" },
+        labels,
+      ),
+    ).toBe("Fix activity row labels");
+  });
+
+  it("uses the issue fallback while an issue-linked task title is loading", () => {
+    expect(
+      taskDisplayTitle(
+        task({
+          issue_id: "issue-id",
+          trigger_summary: "Fix from webhook",
+        }),
+        undefined,
+        labels,
+      ),
+    ).toBe("Issue 12345678...");
+  });
+
+  it("uses trigger_summary as the primary title for no-issue autopilot tasks", () => {
+    expect(
+      taskDisplayTitle(
+        task({
+          issue_id: "",
+          trigger_summary: "Sync failed GitHub PR checks",
+          autopilot_run_id: "run-id",
+          kind: "autopilot",
+        }),
+        undefined,
+        labels,
+      ),
+    ).toBe("Sync failed GitHub PR checks");
+  });
+
+  it("falls back to the source label when no contextual title exists", () => {
+    expect(
+      taskDisplayTitle(
+        task({
+          issue_id: "",
+          trigger_summary: "   ",
+          autopilot_run_id: "run-id",
+          kind: "autopilot",
+        }),
+        undefined,
+        labels,
+      ),
+    ).toBe("Autopilot run");
   });
 });

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -400,6 +400,14 @@ function TaskRow({
           ? t(($) => $.tab_body.activity.source_autopilot_run)
           : t(($) => $.tab_body.activity.source_untracked)
     : null;
+  const displayTitle = taskDisplayTitle(task, issue, {
+    issueShortFallback: t(($) => $.tab_body.activity.issue_short_fallback, {
+      prefix: task.issue_id.slice(0, 8),
+    }),
+    sourceFallback: sourceFallback ?? t(($) => $.tab_body.activity.source_untracked),
+  });
+  const showTriggerTooltip =
+    !!task.trigger_summary && task.trigger_summary !== displayTitle;
 
   const SourceIcon = hasIssue
     ? Hash
@@ -464,7 +472,7 @@ function TaskRow({
               {issue.identifier}
             </span>
           )}
-          {task.trigger_summary ? (
+          {showTriggerTooltip ? (
             // Hover surfaces "why this task ran" — the snapshot lets the
             // agent-side row stay anchored on issue.title (the
             // identification axis here) while still letting the user
@@ -474,10 +482,7 @@ function TaskRow({
               <TooltipTrigger
                 render={
                   <span className="truncate text-sm">
-                    {issue?.title ??
-                      (hasIssue
-                        ? t(($) => $.tab_body.activity.issue_short_fallback, { prefix: task.issue_id.slice(0, 8) })
-                        : (sourceFallback ?? t(($) => $.tab_body.activity.source_untracked)))}
+                    {displayTitle}
                   </span>
                 }
               />
@@ -492,10 +497,7 @@ function TaskRow({
             </Tooltip>
           ) : (
             <span className="truncate text-sm">
-              {issue?.title ??
-                (hasIssue
-                  ? t(($) => $.tab_body.activity.issue_short_fallback, { prefix: task.issue_id.slice(0, 8) })
-                  : (sourceFallback ?? t(($) => $.tab_body.activity.source_untracked)))}
+              {displayTitle}
             </span>
           )}
         </div>
@@ -601,6 +603,23 @@ function Sep() {
 
 type AgentsT = ReturnType<typeof useT<"agents">>["t"];
 type TimeAgoFn = (dateStr: string) => string;
+
+interface TaskDisplayLabels {
+  issueShortFallback: string;
+  sourceFallback: string;
+}
+
+export function taskDisplayTitle(
+  task: Pick<AgentTask, "issue_id" | "trigger_summary">,
+  issue: Pick<Issue, "title"> | undefined,
+  labels: TaskDisplayLabels,
+): string {
+  if (issue?.title) return issue.title;
+  if (task.issue_id !== "") return labels.issueShortFallback;
+  const summary = task.trigger_summary?.trim();
+  if (summary) return summary;
+  return labels.sourceFallback;
+}
 
 function activeTaskTimeText(task: AgentTask, t: AgentsT, timeAgo: TimeAgoFn): string {
   if (task.status === "running" && task.started_at) {


### PR DESCRIPTION
## Summary
- Use issue titles when available for Agent Activity Recent Work rows
- Fall back to issue keys while loading issue details
- Use task `trigger_summary` for no-issue autopilot runs before falling back to generic source labels
- Add focused coverage for issue title, issue fallback, trigger summary, and source fallback behavior

Fixes #3361

## Verification
- `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm corepack pnpm --filter @multica/views exec vitest run agents/components/tabs/activity-tab.test.ts`
- `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm corepack pnpm --filter @multica/views typecheck`

Note: reviewer later attempted to rerun the focused Vitest command in a fresh checkout, but dependencies were not installed there (`vitest` not found). The implementation handoff above includes successful reruns from the original prepared branch.
