### PR TITLE
Clarify OpenClaw missing gateway scope

### DIFF
--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -135,7 +135,7 @@ Open-source CLI agent orchestrator. **Model is bound at the agent layer** (`open
 |---|---|
 | Daemon looks for | `openclaw` |
 | Install | See the project at [github.com/openclaw-org/openclaw](https://github.com/openclaw-org/openclaw) (community-maintained). |
-| Authentication | Configure the underlying model provider per OpenClaw's docs. |
+| Authentication | Configure the underlying model provider per OpenClaw's docs. Gateway tokens must include the `operator.read` scope so Multica can probe registered agents. |
 
 ### Pi (Inflection AI)
 

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -870,7 +870,13 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 	} {
 		cmd := exec.CommandContext(runCtx, executablePath, jsonArgs...)
 		hideAgentWindow(cmd)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
 		out, err := cmd.Output()
+		combined := string(out) + "\n" + stderr.String()
+		if errMsg, ok := openclawMissingGatewayScopeError(combined); ok {
+			return nil, fmt.Errorf("openclaw gateway probe: %s", errMsg)
+		}
 		if err != nil {
 			continue
 		}
@@ -884,7 +890,13 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 	// the wrong tokens produces nonsense entries like "Identity:".
 	cmd := exec.CommandContext(runCtx, executablePath, "agents", "list")
 	hideAgentWindow(cmd)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
+	combined := string(out) + "\n" + stderr.String()
+	if errMsg, ok := openclawMissingGatewayScopeError(combined); ok {
+		return nil, fmt.Errorf("openclaw gateway probe: %s", errMsg)
+	}
 	if err != nil {
 		return []Model{}, nil
 	}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -430,6 +432,27 @@ func TestOpenclawEntriesToModelsUsesIDOverName(t *testing.T) {
 func TestParseOpenclawAgentsJSONRejectsGarbage(t *testing.T) {
 	if _, ok := parseOpenclawAgentsJSON([]byte("not json")); ok {
 		t.Error("expected ok=false for non-JSON")
+	}
+}
+
+func TestDiscoverOpenclawAgentsReportsMissingGatewayScope(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"echo 'gateway probe failed: missing scope: operator.read' >&2\n" +
+		"exit 1\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	_, err := discoverOpenclawAgents(context.Background(), fakePath)
+	if err == nil {
+		t.Fatal("expected missing operator.read scope error, got nil")
+	}
+	if !strings.Contains(err.Error(), "operator.read") {
+		t.Errorf("error missing operator.read: %v", err)
 	}
 }
 

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -21,6 +21,8 @@ import (
 // change it without also updating those consumers.
 const openclawNoParseableOutput = "openclaw returned no parseable output"
 
+const openclawGatewayOperatorReadScope = "operator.read"
+
 // minOpenclawVersion is the lowest openclaw version that emits its
 // --json result on stdout. PR #2101 swapped the adapter from reading
 // stderr to stdout; older builds wrote JSON to stderr and now appear
@@ -88,14 +90,15 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 	// openclaw writes its --json output to stdout. Stderr carries log
 	// overflow (security warnings, tool errors, etc.) — capture it via a
-	// log writer so it surfaces in daemon logs without being fed into the
-	// JSON parser.
+	// bounded log writer so actionable auth failures can also be surfaced
+	// in Result.Error without feeding stderr into the JSON parser.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("openclaw stdout pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[openclaw:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[openclaw:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -131,6 +134,9 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
+		} else if errMsg, ok := openclawMissingGatewayScopeError(stderrBuf.Tail()); ok {
+			scanResult.status = "failed"
+			scanResult.errMsg = errMsg
 		} else if exitErr != nil && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("openclaw exited with error: %v", exitErr)
@@ -267,6 +273,13 @@ func compareOpenclawVersion(a, b string) int {
 		}
 	}
 	return 0
+}
+
+func openclawMissingGatewayScopeError(raw string) (string, bool) {
+	if !strings.Contains(strings.ToLower(raw), "missing scope: "+openclawGatewayOperatorReadScope) {
+		return "", false
+	}
+	return "OpenClaw gateway token is missing required scope operator.read. Grant operator.read to the OpenClaw gateway token, then reconnect the runtime.", true
 }
 
 // ── Event handlers ──

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -1510,3 +1510,68 @@ func TestOpenclawExecuteAllowsCurrentVersion(t *testing.T) {
 		t.Fatal("timeout waiting for result")
 	}
 }
+
+func TestOpenclawMissingGatewayScopeError(t *testing.T) {
+	t.Parallel()
+
+	msg, ok := openclawMissingGatewayScopeError("gateway probe failed: missing scope: operator.read")
+	if !ok {
+		t.Fatal("expected missing operator.read scope to be detected")
+	}
+	for _, want := range []string{"operator.read", "Grant", "reconnect"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+
+	if _, ok := openclawMissingGatewayScopeError("missing scope: workspace.read"); ok {
+		t.Fatal("unexpected detection for unrelated scope")
+	}
+}
+
+func TestOpenclawExecuteReportsMissingGatewayScopeFromStderr(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo 'openclaw 2026.5.5 c37871e'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo 'gateway probe failed: missing scope: operator.read' >&2\n" +
+		"exit 1\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute returned synchronous error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if result.Status != "failed" {
+			t.Errorf("status = %q, want failed", result.Status)
+		}
+		if !strings.Contains(result.Error, "operator.read") {
+			t.Errorf("error missing operator.read: %q", result.Error)
+		}
+		if strings.Contains(result.Error, openclawNoParseableOutput) {
+			t.Errorf("missing-scope failure collapsed to generic parse error: %q", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}


### PR DESCRIPTION
## Summary
- detect OpenClaw gateway `missing scope: operator.read` output during execution and surface an actionable runtime error
- return the same missing-scope error from OpenClaw agent discovery/model probing
- document the required `operator.read` gateway token scope and add regression coverage

## Verification
- `git diff --check`
- Not run: `gofmt` / targeted Go tests (`go` and `gofmt` are not installed in this sandbox)