### PR TITLE
feat: add modal for issues

### DIFF
--- a/packages/core/modals/store.ts
+++ b/packages/core/modals/store.ts
@@ -13,6 +13,7 @@ type ModalType =
   | "issue-add-child"
   | "issue-delete-confirm"
   | "issue-backlog-agent-hint"
+  | "issue-detail"
   | null;
 
 interface ModalStore {

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useModalStore } from "@multica/core/modals";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useTimeAgo } from "../../i18n";
@@ -345,6 +346,10 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
         <AppLink
           href={p.issueDetail(issue.id)}
           className={`group block transition-colors ${isDragging ? "pointer-events-none" : ""}`}
+          disablePush
+          onClick={() => {
+            useModalStore.getState().open("issue-detail", { issueId: issue.id });
+          }}
         >
           <BoardCardContent issue={issue} editable childProgress={childProgress} />
         </AppLink>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -14,6 +14,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleCheck,
+  Maximize2,
   MoreHorizontal,
   PanelRight,
   Pin,
@@ -649,13 +650,15 @@ interface IssueDetailProps {
   layoutId?: string;
   /** When set, the issue detail will auto-scroll to this comment and briefly highlight it. */
   highlightCommentId?: string;
+  showMaximize?: boolean;
+  onMaximize?: () => void;
 }
 
 // ---------------------------------------------------------------------------
 // IssueDetail
 // ---------------------------------------------------------------------------
 
-export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
+export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId, showMaximize, onMaximize }: IssueDetailProps) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const id = issueId;
@@ -1718,6 +1721,29 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               />
               <TooltipContent side="bottom">{t(($) => $.detail.sidebar_tooltip)}</TooltipContent>
             </Tooltip>
+            {showMaximize && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground"
+                      onClick={() => {
+                        if (onMaximize) {
+                          onMaximize();
+                        } else {
+                          router.push(paths.issueDetail(issue.id));
+                        }
+                      }}
+                    >
+                      <Maximize2 className="size-4" />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="bottom">{t(($) => $.detail.open_full_page_tooltip || "Open in full page")}</TooltipContent>
+              </Tooltip>
+            )}
             </>
           }
         />

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -9,6 +9,7 @@ import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { useModalStore } from "@multica/core/modals";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
@@ -98,6 +99,10 @@ function ListRowContent({
         <AppLink
           href={p.issueDetail(issue.id)}
           className={`flex flex-1 items-center gap-2 min-w-0 ${isDragging ? "pointer-events-none" : ""}`}
+          disablePush
+          onClick={() => {
+            useModalStore.getState().open("issue-detail", { issueId: issue.id });
+          }}
         >
           <span className="w-16 shrink-0 text-xs text-muted-foreground">
             {issue.identifier}

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -1294,6 +1294,10 @@ function DraggableSwimLane({
                   href={paths.issueDetail(lane.parentIssue.id)}
                   aria-label={t(($) => $.swimlane.open_parent)}
                   className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                  disablePush
+                  onClick={() => {
+                    useModalStore.getState().open("issue-detail", { issueId: lane.parentIssue!.id });
+                  }}
                 >
                   <Pencil className="size-3" />
                 </AppLink>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -212,6 +212,7 @@
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
     "sidebar_tooltip": "Toggle sidebar",
+    "open_full_page_tooltip": "Open in full page",
     "cmdf_toast_title": "Find on page only covers what's visible",
     "cmdf_toast_description": "The timeline is virtualized — ⌘F can't see off-screen comments. Full in-app search is coming.",
     "update_failed": "Failed to update issue",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -209,6 +209,7 @@
     "pin_tooltip": "サイドバーにピン留め",
     "unpin_tooltip": "サイドバーのピン留めを解除",
     "sidebar_tooltip": "サイドバーの開閉",
+    "open_full_page_tooltip": "フルページで開く",
     "cmdf_toast_title": "ページ内検索は表示中の内容のみが対象です",
     "cmdf_toast_description": "タイムラインは仮想化されているため、画面外のコメントは ⌘F で見つかりません。アプリ全体の検索は近日提供予定です。",
     "update_failed": "イシューを更新できませんでした",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -212,6 +212,7 @@
     "pin_tooltip": "사이드바에 고정",
     "unpin_tooltip": "사이드바 고정 해제",
     "sidebar_tooltip": "사이드바 열기/닫기",
+    "open_full_page_tooltip": "전체 페이지로 열기",
     "cmdf_toast_title": "페이지 내 찾기는 보이는 내용만 검색합니다",
     "cmdf_toast_description": "타임라인은 가상화되어 있어 화면 밖 댓글은 ⌘F로 찾을 수 없습니다. 앱 전체 검색은 곧 제공됩니다.",
     "update_failed": "이슈를 업데이트하지 못했습니다",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -210,6 +210,7 @@
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
     "sidebar_tooltip": "切换侧边栏",
+    "open_full_page_tooltip": "在新页面打开",
     "cmdf_toast_title": "页面内查找仅覆盖可见区",
     "cmdf_toast_description": "评论列表已虚拟滚动,⌘F 找不到视口外的评论。完整应用内搜索即将推出。",
     "update_failed": "更新 issue 失败",

--- a/packages/views/modals/issue-detail-modal.test.tsx
+++ b/packages/views/modals/issue-detail-modal.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IssueDetailModal } from "./issue-detail-modal";
+
+// Mock IssueDetail to avoid rendering its heavy children
+vi.mock("../issues/components/issue-detail", () => ({
+  IssueDetail: ({ issueId }: { issueId: string }) => (
+    <div data-testid="mock-issue-detail">Issue ID: {issueId}</div>
+  ),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: { id: "MUL-123", identifier: "MUL-123" } }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/issues/queries", () => ({
+  issueDetailOptions: vi.fn(),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    issueDetail: (id: string) => `/test-workspace/issues/${id}`,
+    issues: () => "/test-workspace/issues",
+  }),
+}));
+
+let mockPathname = "/test-workspace/issues";
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({
+    pathname: mockPathname,
+    searchParams: new URLSearchParams("?view=board"),
+    push: vi.fn(),
+  }),
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-dialog">{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-dialog-content">{children}</div>,
+}));
+
+describe("IssueDetailModal", () => {
+  const originalPushState = window.history.pushState;
+  const mockPushState = vi.fn();
+
+  beforeEach(() => {
+    mockPathname = "/test-workspace/issues";
+    window.history.pushState = mockPushState;
+  });
+
+  afterEach(() => {
+    window.history.pushState = originalPushState;
+    mockPushState.mockClear();
+  });
+
+  it("renders the dialog and passes issueId to IssueDetail", () => {
+    render(<IssueDetailModal onClose={vi.fn()} data={{ issueId: "MUL-123" }} />);
+
+    expect(screen.getByTestId("mock-dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-issue-detail")).toHaveTextContent("Issue ID: MUL-123");
+  });
+
+  it("updates URL on mount and restores it on unmount", () => {
+    const { unmount } = render(
+      <IssueDetailModal onClose={vi.fn()} data={{ issueId: "MUL-456" }} />
+    );
+
+    // Should push the issue detail URL on mount
+    expect(mockPushState).toHaveBeenCalledWith(null, "", "/test-workspace/issues/MUL-456");
+
+    unmount();
+
+    // Should push the initial URL back on unmount
+    expect(mockPushState).toHaveBeenLastCalledWith(null, "", "/test-workspace/issues?view=board");
+  });
+
+  it("closes the modal and skips restoring URL on router pathname change", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <IssueDetailModal onClose={onClose} data={{ issueId: "MUL-789" }} />
+    );
+
+    expect(mockPushState).toHaveBeenCalledWith(null, "", "/test-workspace/issues/MUL-789");
+
+    // Simulate route navigation by changing mockPathname and rerendering
+    mockPathname = "/test-workspace/settings";
+    rerender(<IssueDetailModal onClose={onClose} data={{ issueId: "MUL-789" }} />);
+
+    // onClose should have been called because navigation occurred
+    expect(onClose).toHaveBeenCalled();
+
+    // The cleanup should skip restoring the URL (mockPushState was NOT called with /test-workspace/issues?view=board)
+    const initialUrlRestorations = mockPushState.mock.calls.filter(
+      (call) => call[2] === "/test-workspace/issues?view=board"
+    );
+    expect(initialUrlRestorations).toHaveLength(0);
+  });
+});

--- a/packages/views/modals/issue-detail-modal.tsx
+++ b/packages/views/modals/issue-detail-modal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useMemo } from "react";
+import { useModalStore } from "@multica/core/modals";
+import { Dialog, DialogContent } from "@multica/ui/components/ui/dialog";
+import { IssueDetail } from "../issues/components/issue-detail";
+import { useNavigation, NavigationProvider } from "../navigation";
+import { useWorkspacePaths } from "@multica/core/paths";
+
+function getIssueIdFromPath(path: string): string | null {
+  const parts = path.split("/").filter(Boolean);
+  const issuesIndex = parts.indexOf("issues");
+  if (issuesIndex !== -1) {
+    return parts[issuesIndex + 1] ?? null;
+  }
+  return null;
+}
+
+export function IssueDetailModal({
+  onClose,
+  data,
+}: {
+  onClose: () => void;
+  data: Record<string, unknown> | null;
+}) {
+  const issueId = (data?.issueId as string) || "";
+  const navigation = useNavigation();
+  const paths = useWorkspacePaths();
+
+  // Keep track of initial path before opening the modal so we can restore it on close.
+  const initialPathname = useRef(
+    navigation.pathname + (navigation.searchParams.toString() ? `?${navigation.searchParams.toString()}` : "")
+  );
+
+  const initialRouterPathname = useRef(navigation.pathname);
+
+  const shouldRestoreUrl = useRef(true);
+
+  const issueUrl = paths.issueDetail(issueId);
+
+  useEffect(() => {
+    if (issueId) {
+      window.history.pushState(null, "", issueUrl);
+    }
+
+    return () => {
+      if (shouldRestoreUrl.current) {
+        window.history.pushState(null, "", initialPathname.current);
+      }
+    };
+  }, [issueId, issueUrl]);
+
+  useEffect(() => {
+    // If a real navigation occurred and changed the router's active pathname to any other page
+    // (outside of the /slug/issues/ subpath), we must close the modal and skip restoring the old URL.
+    if (
+      navigation.pathname !== initialRouterPathname.current &&
+      !navigation.pathname.startsWith(paths.issues() + "/")
+    ) {
+      shouldRestoreUrl.current = false;
+      onClose();
+    }
+  }, [navigation.pathname, paths, onClose]);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      shouldRestoreUrl.current = false;
+      onClose();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [onClose]);
+
+  const customNavigation = useMemo(() => {
+    return {
+      ...navigation,
+      push: (path: string) => {
+        const nextId = getIssueIdFromPath(path);
+        if (nextId) {
+          useModalStore.getState().open("issue-detail", { issueId: nextId });
+        } else {
+          navigation.push(path);
+        }
+      },
+      replace: (path: string) => {
+        const nextId = getIssueIdFromPath(path);
+        if (nextId) {
+          useModalStore.getState().open("issue-detail", { issueId: nextId });
+        } else {
+          navigation.replace(path);
+        }
+      },
+    };
+  }, [navigation]);
+
+  if (!issueId) return null;
+
+  return (
+    <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent
+        finalFocus={false}
+        showCloseButton={false}
+        className="p-0 gap-0 flex flex-col overflow-hidden !max-w-6xl !w-full !h-[85vh] !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !transition-all !duration-300 !ease-out"
+      >
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <NavigationProvider value={customNavigation}>
+            <IssueDetail
+              issueId={issueId}
+              onDelete={onClose}
+              onDone={onClose}
+              defaultSidebarOpen={true}
+              showMaximize={true}
+              onMaximize={() => {
+                shouldRestoreUrl.current = false;
+                onClose();
+                navigation.push(paths.issueDetail(issueId));
+              }}
+            />
+          </NavigationProvider>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/views/modals/registry.tsx
+++ b/packages/views/modals/registry.tsx
@@ -10,6 +10,7 @@ import { SetParentIssueModal } from "./set-parent-issue";
 import { AddChildIssueModal } from "./add-child-issue";
 import { DeleteIssueConfirmModal } from "./delete-issue-confirm";
 import { BacklogAgentHintModal } from "./backlog-agent-hint";
+import { IssueDetailModal } from "./issue-detail-modal";
 
 export function ModalRegistry() {
   const modal = useModalStore((s) => s.modal);
@@ -17,6 +18,8 @@ export function ModalRegistry() {
   const close = useModalStore((s) => s.close);
 
   switch (modal) {
+    case "issue-detail":
+      return <IssueDetailModal onClose={close} data={data} />;
     case "create-workspace":
       return <CreateWorkspaceModal onClose={close} />;
     // Both modal types open the same shell so the in-modal mode switch is

--- a/packages/views/navigation/app-link.tsx
+++ b/packages/views/navigation/app-link.tsx
@@ -5,11 +5,12 @@ import { useNavigation } from "./context";
 
 interface AppLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
+  disablePush?: boolean;
 }
 
 export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
   function AppLink(
-    { href, children, onClick, onMouseEnter, onFocus, ...props },
+    { href, children, onClick, onMouseEnter, onFocus, disablePush, ...props },
     ref,
   ) {
     const { push, openInNewTab, prefetch } = useNavigation();
@@ -27,7 +28,9 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
       // (close popover, clear selection, blur the trigger) lands in the
       // same tick rather than getting deferred behind the transition.
       onClick?.(e);
-      push(href);
+      if (!disablePush) {
+        push(href);
+      }
     };
 
     const handleMouseEnter = (e: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
## What does this PR do?

When you are working on many tasks, re-prompting and interacting with all your agents, navigating back and forthy is exhaustive, and a modal allows you to quick switch between tasks. While keeping the full page functionality.

## Related Issue

Closes #2993

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [X] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- **Core Modal State Extension:** Added `"issue-detail"` to the core `ModalType` in `packages/core/modals/store.ts`.
- **Created Issue Detail Modal:** Built the new `IssueDetailModal` component in `packages/views/modals/issue-detail-modal.tsx` which wraps the existing `<IssueDetail>` view inside a centered, spacious dialog (`!max-w-6xl !h-[85vh] !overflow-hidden`).
- **Deep-linking / Shallow Routing:** Implemented `window.history.pushState` on modal mount to update the browser URL to the issue's deep-link, and restore the initial list page path cleanly on unmount (dismissal).
- **Navigation Interceptor for Nested Cards:** Implemented a custom nested `NavigationProvider` wrapping the detail page within the modal. This intercepts clicks on parent issues, sub-issues, and comment mentions and replaces the active modal card natively instead of routing the outer page away.
- **Title Breadcrumb Restoration:** Restored parent issue breadcrumbs in the header as clickable `<AppLink>` components which now seamlessly swap modal cards.
- **"Open Full Page" Maximize Button:** Integrated a maximize button (`Maximize2` icon) into the header of the `<IssueDetail>` component when rendered inside a modal. This dismisses the modal and navigates statefully to the full-page route using the parent router.
- **Interceptive Path checks:** Crafted path-pattern checks to ensure that intermediate shallow router re-renders (Web) do not prematurely close the modal, while external sidebar or global navigations close the modal instantly.
- **Modal Registry Integration:** Registered the new modal under the `"issue-detail"` case inside `packages/views/modals/registry.tsx`.
- **Click Interception in Lists and Boards:** Upgraded `DraggableBoardCard` (`packages/views/issues/components/board-card.tsx`) and `ListRowContent` (`packages/views/issues/components/list-row.tsx`) to open the modal on click using a new `disablePush` prop on `AppLink` (`packages/views/navigation/app-link.tsx`), keeping middle-click and right-click navigation perfectly functional.
- **Localization support:** Added tooltip copy for "Open in full page" to English and Simplified Chinese locale bundles (`packages/views/locales/{en,zh-Hans}/issues.json`).
- **Unit Tests:** Created dedicated tests for URL routing, nested closing, and state rendering inside `packages/views/modals/issue-detail-modal.test.tsx`.

## How to Test

1. Go to the Issues list or Board view or Swimlane view
2. Click on any issue card or list row.
  - Expected: The issue details open instantly in a centered modal, and the browser's address bar updates to the issue detail URL (e.g. /slug/issues/MUL-123).
3. Click outside the modal or press Escape.
- Expected: The modal dismisses, and the URL is restored back to the original list view /slug/issues without losing list scroll positions.
4. Click the same issue card to open the modal again. Click on a sub-issue, a parent issue link in the breadcrumb, or an issue mention in the description.
- Expected: The modal content is seamlessly replaced by the target issue card, updating the address bar URL to match, without unmounting/re-rendering the outer modal frame or closing it.
5. Click the "Open in full page" maximize icon in the top right toolbar.
- Expected: The modal closes and navigates statefully to the dedicated full-page issue detail view.

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [X] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [X] I have considered and documented any risks above
- [X] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Opencode

**Prompt / approach:**

I asked the Opencode agent to learn about GitHub issue #2993 and implement the complete feature. The agent followed a systematic, test-driven approach:

1. Explore: Scanned the codebase for views, routes, AppLinks, and modal registries.
2. Design: Proposed extending the core modal store and registering an IssueDetailModal. Leveraged the existing <IssueDetail> component inside a centered, scroll-contained dialog.
3. Iterative Refinement:
  - AppLink Override: Added a disablePush prop to AppLink to safely intercept left-clicks without breaking right-click/middle-click navigation.
  - Infinite Loop Fix: Identified and fixed a route unmount loop caused by the unstable paths object in the shallow routing useEffect.
  - Nested Navigation: Built a custom nested NavigationProvider to intercept push transitions inside the modal, making sub-issues replace the modal card rather than routing the whole page.
  - External Navigation Detection: Added pattern checks to detect actual router pathname changes (such as clicking on the sidebar) and cleanly dismissed the modal.
4. Verification: Added Vitest unit tests, integrated translation strings, and ran typechecks to guarantee pristine code quality.

## Screenshots (optional)

https://github.com/user-attachments/assets/9f4d4bd9-e7e9-434a-90f5-3405a8b93e6e
