### PR TITLE
feat(cli): support agent MCP config flags

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -164,6 +164,9 @@ func init() {
 	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to set an empty map.")
 	agentCreateCmd.Flags().Bool("custom-env-stdin", false, "Read the --custom-env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
 	agentCreateCmd.Flags().String("custom-env-file", "", "Read the --custom-env JSON object from a file path (suggested mode: 0600). Mutually exclusive with --custom-env and --custom-env-stdin.")
+	agentCreateCmd.Flags().String("mcp-config", "", "MCP server config as JSON. Treated as secret material — prefer --mcp-config-stdin or --mcp-config-file for real secrets.")
+	agentCreateCmd.Flags().Bool("mcp-config-stdin", false, "Read MCP server config JSON from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --mcp-config and --mcp-config-file.")
+	agentCreateCmd.Flags().String("mcp-config-file", "", "Read MCP server config JSON from a file path (suggested mode: 0600). Mutually exclusive with --mcp-config and --mcp-config-stdin.")
 	agentCreateCmd.Flags().String("visibility", "private", "Visibility: private or workspace")
 	agentCreateCmd.Flags().Int32("max-concurrent-tasks", 6, "Maximum concurrent tasks")
 	agentCreateCmd.Flags().String("output", "json", "Output format: table or json")
@@ -176,6 +179,9 @@ func init() {
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
 	agentUpdateCmd.Flags().String("custom-args", "", "New custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
+	agentUpdateCmd.Flags().String("mcp-config", "", "New MCP server config as JSON. Pass null to clear. Treated as secret material — prefer --mcp-config-stdin or --mcp-config-file for real secrets.")
+	agentUpdateCmd.Flags().Bool("mcp-config-stdin", false, "Read the new MCP server config JSON from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --mcp-config and --mcp-config-file.")
+	agentUpdateCmd.Flags().String("mcp-config-file", "", "Read the new MCP server config JSON from a file path (suggested mode: 0600). Mutually exclusive with --mcp-config and --mcp-config-stdin.")
 	// custom_env is intentionally NOT part of `agent update`. Use
 	// `multica agent env set <id>` — that path is owner/admin-only,
 	// denies agent actors, and writes a persisted audit trail.
@@ -448,6 +454,11 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 	} else if ok {
 		body["custom_env"] = ce
 	}
+	if mc, ok, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if ok {
+		body["mcp_config"] = mc
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -500,6 +511,11 @@ func runAgentCreateFromTemplate(cmd *cobra.Command, client *cli.APIClient, name,
 	if cmd.Flags().Changed("max-concurrent-tasks") {
 		v, _ := cmd.Flags().GetInt32("max-concurrent-tasks")
 		body["max_concurrent_tasks"] = v
+	}
+	if mc, ok, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if ok {
+		body["mcp_config"] = mc
 	}
 
 	// 60s ceiling: templates fan out N HTTP fetches to GitHub, each ~200-500ms.
@@ -566,6 +582,11 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		}
 		body["custom_args"] = ca
 	}
+	if mc, ok, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if ok {
+		body["mcp_config"] = mc
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -584,7 +605,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --mcp-config, --mcp-config-stdin, --mcp-config-file, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -960,6 +981,21 @@ func parseCustomArgs(raw string) ([]string, error) {
 	return ca, nil
 }
 
+// parseMcpConfig validates an MCP config JSON payload and returns it as raw
+// JSON so the CLI can forward exact object shape to the API. Error messages
+// are intentionally content-free because MCP configs often embed tokens.
+func parseMcpConfig(raw string) (json.RawMessage, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("--mcp-config: empty input; pass null to clear")
+	}
+	var v any
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return nil, fmt.Errorf("--mcp-config must be valid JSON")
+	}
+	return json.RawMessage(trimmed), nil
+}
+
 // resolveCustomEnv collects the --custom-env, --custom-env-stdin, and
 // --custom-env-file flags and returns the parsed map, a bool indicating
 // whether the caller supplied any of them, and any error. The three input
@@ -1026,6 +1062,67 @@ func resolveCustomEnv(cmd *cobra.Command) (map[string]string, bool, error) {
 		return nil, false, err
 	}
 	return ce, true, nil
+}
+
+// resolveMcpConfig collects the --mcp-config, --mcp-config-stdin, and
+// --mcp-config-file flags. The same secret-safe input rules as custom_env
+// apply: at most one source, no empty stdin/file bodies, and no payload echo
+// on JSON parse failures.
+func resolveMcpConfig(cmd *cobra.Command) (json.RawMessage, bool, error) {
+	inline := cmd.Flags().Changed("mcp-config")
+	fromStdin, _ := cmd.Flags().GetBool("mcp-config-stdin")
+	filePath, _ := cmd.Flags().GetString("mcp-config-file")
+	fromFile := cmd.Flags().Changed("mcp-config-file")
+
+	count := 0
+	if inline {
+		count++
+	}
+	if fromStdin {
+		count++
+	}
+	if fromFile {
+		count++
+	}
+	switch {
+	case count == 0:
+		return nil, false, nil
+	case count > 1:
+		return nil, false, fmt.Errorf("--mcp-config, --mcp-config-stdin, and --mcp-config-file are mutually exclusive; pick one")
+	}
+
+	var raw string
+	switch {
+	case inline:
+		raw, _ = cmd.Flags().GetString("mcp-config")
+	case fromStdin:
+		buf, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, false, fmt.Errorf("read --mcp-config-stdin: %w", err)
+		}
+		raw = string(buf)
+		if strings.TrimSpace(raw) == "" {
+			return nil, false, fmt.Errorf("--mcp-config-stdin: empty input; pass null to clear")
+		}
+	case fromFile:
+		if filePath == "" {
+			return nil, false, fmt.Errorf("--mcp-config-file: path must not be empty")
+		}
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, false, fmt.Errorf("read --mcp-config-file: %w", err)
+		}
+		raw = string(buf)
+		if strings.TrimSpace(raw) == "" {
+			return nil, false, fmt.Errorf("--mcp-config-file %q: empty contents; pass null to clear", filePath)
+		}
+	}
+
+	mc, err := parseMcpConfig(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return mc, true, nil
 }
 
 func strVal(m map[string]any, key string) string {

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -32,6 +32,57 @@ func freshAgentEnvSetCmd() *cobra.Command {
 	return c
 }
 
+func freshAgentMcpConfigCmd() *cobra.Command {
+	c := &cobra.Command{Use: "mcp"}
+	c.Flags().String("mcp-config", "", "")
+	c.Flags().Bool("mcp-config-stdin", false, "")
+	c.Flags().String("mcp-config-file", "", "")
+	return c
+}
+
+func freshAgentCreateCmdForTest() *cobra.Command {
+	c := &cobra.Command{Use: "create"}
+	c.Flags().String("name", "", "")
+	c.Flags().String("description", "", "")
+	c.Flags().String("instructions", "", "")
+	c.Flags().String("runtime-id", "", "")
+	c.Flags().String("from-template", "", "")
+	c.Flags().String("runtime-config", "", "")
+	c.Flags().String("model", "", "")
+	c.Flags().String("custom-args", "", "")
+	c.Flags().String("custom-env", "", "")
+	c.Flags().Bool("custom-env-stdin", false, "")
+	c.Flags().String("custom-env-file", "", "")
+	c.Flags().String("mcp-config", "", "")
+	c.Flags().Bool("mcp-config-stdin", false, "")
+	c.Flags().String("mcp-config-file", "", "")
+	c.Flags().String("visibility", "private", "")
+	c.Flags().Int32("max-concurrent-tasks", 6, "")
+	c.Flags().String("output", "json", "")
+	c.Flags().String("profile", "", "")
+	return c
+}
+
+func freshAgentUpdateCmdForTest() *cobra.Command {
+	c := &cobra.Command{Use: "update"}
+	c.Flags().String("name", "", "")
+	c.Flags().String("description", "", "")
+	c.Flags().String("instructions", "", "")
+	c.Flags().String("runtime-id", "", "")
+	c.Flags().String("runtime-config", "", "")
+	c.Flags().String("model", "", "")
+	c.Flags().String("custom-args", "", "")
+	c.Flags().String("mcp-config", "", "")
+	c.Flags().Bool("mcp-config-stdin", false, "")
+	c.Flags().String("mcp-config-file", "", "")
+	c.Flags().String("visibility", "", "")
+	c.Flags().String("status", "", "")
+	c.Flags().Int32("max-concurrent-tasks", 0, "")
+	c.Flags().String("output", "json", "")
+	c.Flags().String("profile", "", "")
+	return c
+}
+
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
 // the cross-workspace contamination bug (#1235). Inside a daemon-spawned
 // agent task (MULTICA_AGENT_ID / MULTICA_TASK_ID set), the CLI must NOT
@@ -278,6 +329,20 @@ func TestParseCustomArgsErrorSanitization(t *testing.T) {
 	}
 }
 
+func TestParseMcpConfigErrorSanitization(t *testing.T) {
+	secretish := `{"mcpServers":{"drive":{"env":{"TOKEN":verySensitiveValue}}}}`
+	_, err := parseMcpConfig(secretish)
+	if err == nil {
+		t.Fatal("expected parse error for invalid JSON")
+	}
+	msg := err.Error()
+	for _, leak := range []string{"TOKEN", "verySensitiveValue", "drive"} {
+		if strings.Contains(msg, leak) {
+			t.Fatalf("parseMcpConfig error leaked input fragment %q: %q", leak, msg)
+		}
+	}
+}
+
 // TestAgentCreateAndEnvSetExposeSecretSafeFlags guarantees the
 // --custom-env-stdin and --custom-env-file alternatives stay wired
 // up on both commands that accept env input (`agent create` and the
@@ -305,6 +370,16 @@ func TestAgentCreateAndEnvSetExposeSecretSafeFlags(t *testing.T) {
 		low := strings.ToLower(c.usage)
 		if !strings.Contains(low, "shell history") || !strings.Contains(low, "'ps'") {
 			t.Fatalf("%s --custom-env usage must warn about shell history and 'ps' exposure; got: %q", c.name, c.usage)
+		}
+	}
+}
+
+func TestAgentCreateAndUpdateExposeMcpConfigFlags(t *testing.T) {
+	for _, cmd := range []*cobra.Command{agentCreateCmd, agentUpdateCmd} {
+		for _, flag := range []string{"mcp-config", "mcp-config-stdin", "mcp-config-file"} {
+			if cmd.Flag(flag) == nil {
+				t.Fatalf("%s must expose --%s", cmd.CommandPath(), flag)
+			}
 		}
 	}
 }
@@ -498,6 +573,186 @@ func TestResolveCustomEnv(t *testing.T) {
 			t.Fatalf("file {}: got %v, want empty map", got)
 		}
 	})
+}
+
+func TestResolveMcpConfig(t *testing.T) {
+	t.Run("not supplied", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || ok || got != nil {
+			t.Fatalf("unset flags: got=%s ok=%v err=%v", string(got), ok, err)
+		}
+	})
+
+	t.Run("inline flag", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config", `{"mcpServers":{"drive":{"command":"drive-mcp"}}}`)
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("inline: ok=%v err=%v", ok, err)
+		}
+		if string(got) != `{"mcpServers":{"drive":{"command":"drive-mcp"}}}` {
+			t.Fatalf("inline: got %s", string(got))
+		}
+	})
+
+	t.Run("stdin", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		cmd.SetIn(bytes.NewBufferString(`{"mcpServers":{"gmail":{"command":"gmail-mcp"}}}`))
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("stdin: ok=%v err=%v", ok, err)
+		}
+		if !strings.Contains(string(got), "gmail") {
+			t.Fatalf("stdin: got %s", string(got))
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(`{"mcpServers":{"notion":{"command":"notion-mcp"}}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("file: ok=%v err=%v", ok, err)
+		}
+		if !strings.Contains(string(got), "notion") {
+			t.Fatalf("file: got %s", string(got))
+		}
+	})
+
+	t.Run("null is accepted for clear", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config", `null`)
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("null: ok=%v err=%v", ok, err)
+		}
+		if string(got) != "null" {
+			t.Fatalf("null: got %s", string(got))
+		}
+	})
+
+	t.Run("mutually exclusive", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config", `{}`)
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+
+	t.Run("empty stdin errors", func(t *testing.T) {
+		cmd := freshAgentMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		cmd.SetIn(bytes.NewBufferString(" "))
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-stdin") {
+			t.Fatalf("expected --mcp-config-stdin empty-input error, got %v", err)
+		}
+	})
+}
+
+func TestAgentCreateSendsMcpConfig(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": got["name"]})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := freshAgentCreateCmdForTest()
+	_ = cmd.Flags().Set("name", "MCP Agent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+	_ = cmd.Flags().Set("mcp-config", `{"mcpServers":{"drive":{"command":"drive-mcp"}}}`)
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	mcp, _ := got["mcp_config"].(map[string]any)
+	servers, _ := mcp["mcpServers"].(map[string]any)
+	if _, ok := servers["drive"]; !ok {
+		t.Fatalf("mcp_config not forwarded: %#v", got["mcp_config"])
+	}
+}
+
+func TestAgentCreateFromTemplateSendsMcpConfig(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents/from-template" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"agent": map[string]any{"id": "agent-123", "name": got["name"]}})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := freshAgentCreateCmdForTest()
+	_ = cmd.Flags().Set("name", "Template MCP Agent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+	_ = cmd.Flags().Set("from-template", "code-reviewer")
+	_ = cmd.Flags().Set("mcp-config", `{"mcpServers":{"notion":{"command":"notion-mcp"}}}`)
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate from template: %v", err)
+	}
+	mcp, _ := got["mcp_config"].(map[string]any)
+	servers, _ := mcp["mcpServers"].(map[string]any)
+	if _, ok := servers["notion"]; !ok {
+		t.Fatalf("mcp_config not forwarded: %#v", got["mcp_config"])
+	}
+}
+
+func TestAgentUpdateSendsMcpConfigNull(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents/agent-123" || r.Method != http.MethodPut {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "Agent"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := freshAgentUpdateCmdForTest()
+	_ = cmd.Flags().Set("mcp-config", `null`)
+
+	if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+		t.Fatalf("runAgentUpdate: %v", err)
+	}
+	if _, ok := got["mcp_config"]; !ok {
+		t.Fatalf("expected mcp_config key in request: %#v", got)
+	}
+	if got["mcp_config"] != nil {
+		t.Fatalf("expected null mcp_config clear payload, got %#v", got["mcp_config"])
+	}
 }
 
 // TestAgentAvatarHappyPath verifies the full flow: agent pre-check, file upload,

--- a/server/internal/handler/agent_template.go
+++ b/server/internal/handler/agent_template.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -121,6 +122,7 @@ type CreateAgentFromTemplateRequest struct {
 	Name               string `json:"name"`
 	RuntimeID          string `json:"runtime_id"`
 	Model              string `json:"model,omitempty"`
+	McpConfig          json.RawMessage `json:"mcp_config,omitempty"`
 	Visibility         string `json:"visibility,omitempty"`
 	MaxConcurrentTasks int32  `json:"max_concurrent_tasks,omitempty"`
 	// Optional overrides — let the picker UI customise the template before
@@ -155,7 +157,8 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 	}
 
 	var req CreateAgentFromTemplateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	rawFields, err := decodeJSONBodyWithRawFields(r.Body, &req)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -429,6 +432,10 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 	if req.AvatarURL != nil && *req.AvatarURL != "" {
 		avatarURL = pgtype.Text{String: *req.AvatarURL, Valid: true}
 	}
+	var mc []byte
+	if rawMcpConfig, ok := rawFields["mcp_config"]; ok && !bytes.Equal(bytes.TrimSpace(rawMcpConfig), []byte("null")) {
+		mc = append([]byte(nil), rawMcpConfig...)
+	}
 
 	agent, err := qtx.CreateAgent(r.Context(), db.CreateAgentParams{
 		WorkspaceID:        wsUUID,
@@ -444,7 +451,7 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 		OwnerID:            creatorUUID,
 		CustomEnv:          ce,
 		CustomArgs:         ca,
-		McpConfig:          nil,
+		McpConfig:          mc,
 		Model:              pgtype.Text{String: req.Model, Valid: req.Model != ""},
 	})
 	if err != nil {
@@ -541,7 +548,7 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 
 	resp := agentToResponse(agent)
 	actorType, actorID := h.resolveActor(r, ownerID, workspaceID)
-	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
+	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})
 
 	h.Analytics.Capture(analytics.AgentCreated(
 		ownerID,
@@ -561,6 +568,7 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 			"reused_skill_count", len(reusedIDs),
 		)...)
 
+	redactAgentResponseForActor(&resp, actorType)
 	writeJSON(w, http.StatusCreated, CreateAgentFromTemplateResponse{
 		Agent:            resp,
 		ImportedSkillIDs: importedIDs,
@@ -650,4 +658,3 @@ func fetchSkillFromURL(client *http.Client, rawURL string) (*importedSkill, erro
 	}
 	return nil, fmt.Errorf("unknown import source for %s", rawURL)
 }
-


### PR DESCRIPTION
## Summary
- add `--mcp-config`, `--mcp-config-stdin`, and `--mcp-config-file` to `multica agent create` and `multica agent update`
- validate MCP config JSON client-side without echoing secret-bearing payloads in parse errors
- forward MCP config through `agent create --from-template` and persist it on the server
- keep `--mcp-config null` as the explicit clear path for update

Inheriting or syncing MCP servers from `~/.claude.json` is explicitly deferred; this PR adds explicit CLI input paths only.

## Verification
- `git diff --check` passed
- `make test` could not run in the Multica worktree: missing `.env` / `.env.worktree`
- targeted `go test ./server/cmd/multica ...` could not run in this sandbox because `go` is not installed
