### PR TITLE
Fix Cursor launch args

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -385,25 +385,24 @@ func cursorErrorText(evt *cursorStreamEvent) string {
 	return ""
 }
 
-// cursorBlockedArgs are flags hardcoded by the daemon that must not be
-// overridden by user-configured custom_args. Overriding these would break
-// the daemon↔cursor-agent communication protocol.
+// cursorBlockedArgs are flags user-configured custom_args must not pass
+// through. Protocol flags are owned by the daemon; unsupported flags are
+// blocked here so custom_args cannot reintroduce known launch failures.
 var cursorBlockedArgs = map[string]blockedArgMode{
 	"-p":              blockedStandalone, // non-interactive print mode
 	"--output-format": blockedWithValue,  // stream-json protocol
-	"--yolo":          blockedStandalone, // auto-approval for autonomous operation
+	"--yolo":          blockedStandalone, // unsupported by cursor-agent versions that reject unknown flags
 }
 
 // buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
 //
 // Usage: cursor-agent -p <prompt> --output-format stream-json
 //
-//	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
+//	--workspace <cwd> [--model <m>] [--resume <id>]
 func buildCursorArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{
 		"-p", prompt,
 		"--output-format", "stream-json",
-		"--yolo",
 	}
 	if opts.Cwd != "" {
 		args = append(args, "--workspace", opts.Cwd)

--- a/server/pkg/agent/cursor_invocation_test.go
+++ b/server/pkg/agent/cursor_invocation_test.go
@@ -18,7 +18,7 @@ func TestChooseCursorInvocation_PassthroughForNonLauncher(t *testing.T) {
 
 	execName := "cursor-agent"
 	lookedUp := filepath.Join(t.TempDir(), "cursor-agent") // no .cmd / .bat
-	args := []string{"-p", "hello\nworld", "--output-format", "stream-json", "--yolo"}
+	args := []string{"-p", "hello\nworld", "--output-format", "stream-json"}
 
 	gotExec, gotArgs := chooseCursorInvocation(execName, lookedUp, args, logger)
 

--- a/server/pkg/agent/cursor_invocation_windows_test.go
+++ b/server/pkg/agent/cursor_invocation_windows_test.go
@@ -47,7 +47,6 @@ func TestPlatformCursorInvocation_RewritesCmdLauncherToPowerShellFile(t *testing
 	args := []string{
 		"-p", "line1\nline2\nline3",
 		"--output-format", "stream-json",
-		"--yolo",
 		"--workspace", `C:\some\workspace`,
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -29,7 +29,6 @@ func TestBuildCursorArgs(t *testing.T) {
 	expected := []string{
 		"-p", "do something",
 		"--output-format", "stream-json",
-		"--yolo",
 		"--workspace", "/tmp/work",
 		"--model", "composer-1.5",
 	}
@@ -66,7 +65,7 @@ func TestBuildCursorArgsMinimal(t *testing.T) {
 	t.Parallel()
 
 	args := buildCursorArgs("hello", ExecOptions{}, slog.Default())
-	expected := []string{"-p", "hello", "--output-format", "stream-json", "--yolo"}
+	expected := []string{"-p", "hello", "--output-format", "stream-json"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
@@ -100,36 +99,38 @@ func TestBuildCursorArgsCustomArgs(t *testing.T) {
 		CustomArgs: []string{"--extra", "val", "--yolo", "--output-format", "text"},
 	}, slog.Default())
 
-	// --extra val should be present; --yolo and --output-format should be filtered out
+	// --extra val should be present; --yolo and --output-format should be filtered out.
 	hasExtra := false
-	hasBlockedYolo := false
 	hasBlockedFormat := false
 	for i, a := range args {
 		if a == "--extra" && i+1 < len(args) && args[i+1] == "val" {
 			hasExtra = true
 		}
 	}
-	// Count occurrences of --yolo (should be exactly 1 — the hardcoded one)
-	yoloCount := 0
 	for _, a := range args {
 		if a == "--yolo" {
-			yoloCount++
+			t.Fatalf("--yolo should be filtered from cursor-agent args, got %v", args)
 		}
 		if a == "text" {
 			hasBlockedFormat = true
 		}
 	}
-	if yoloCount > 1 {
-		hasBlockedYolo = true
-	}
 	if !hasExtra {
 		t.Fatalf("expected --extra val in args, got %v", args)
 	}
-	if hasBlockedYolo {
-		t.Fatalf("--yolo from custom args should be filtered, got %v", args)
-	}
 	if hasBlockedFormat {
 		t.Fatalf("--output-format from custom args should be filtered, got %v", args)
+	}
+}
+
+func TestBuildCursorArgsDoesNotEmitYolo(t *testing.T) {
+	t.Parallel()
+
+	args := buildCursorArgs("task", ExecOptions{}, slog.Default())
+	for _, a := range args {
+		if a == "--yolo" {
+			t.Fatalf("cursor-agent rejects --yolo in affected versions; got %v", args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove the hardcoded Cursor Agent `--yolo` launch flag
- keep `--yolo` blocked from Cursor custom args so users cannot reintroduce the unsupported flag
- update Cursor arg and invocation tests to match the new launch shape

## Verification
- `git diff --check`
- Not run: `gofmt` / `go test ./pkg/agent -run 'TestBuildCursorArgs|TestChooseCursorInvocation|TestPlatformCursorInvocation'` (Go tooling is not installed in this sandbox)