### PR TITLE
Fix Claude image attachment vision payloads

### DIFF
--- a/server/internal/daemon/attachments.go
+++ b/server/internal/daemon/attachments.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"mime"
+	"strings"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+const maxClaudeImageAttachmentBytes = 5 << 20
+
+func (d *Daemon) loadClaudeImageAttachments(ctx context.Context, task Task, taskLog *slog.Logger) []agent.ImageAttachment {
+	if len(task.ChatMessageAttachments) == 0 {
+		return nil
+	}
+	images := make([]agent.ImageAttachment, 0, len(task.ChatMessageAttachments))
+	for _, att := range task.ChatMessageAttachments {
+		contentType := normalizeImageContentType(att.ContentType)
+		if !isClaudeVisionContentType(contentType) {
+			continue
+		}
+		if att.SizeBytes > maxClaudeImageAttachmentBytes {
+			taskLog.Warn("skipping oversized image attachment for claude vision",
+				"attachment_id", att.ID,
+				"filename", att.Filename,
+				"content_type", att.ContentType,
+				"size_bytes", att.SizeBytes,
+			)
+			continue
+		}
+		info, err := d.client.GetAttachment(ctx, att.ID)
+		if err != nil {
+			taskLog.Warn("failed to fetch image attachment metadata for claude vision",
+				"attachment_id", att.ID,
+				"error", err,
+			)
+			continue
+		}
+		downloadURL := info.DownloadURL
+		if downloadURL == "" {
+			downloadURL = info.URL
+		}
+		data, err := d.client.DownloadFile(ctx, downloadURL)
+		if err != nil {
+			taskLog.Warn("failed to download image attachment for claude vision",
+				"attachment_id", att.ID,
+				"error", err,
+			)
+			continue
+		}
+		if len(data) > maxClaudeImageAttachmentBytes {
+			taskLog.Warn("skipping downloaded oversized image attachment for claude vision",
+				"attachment_id", att.ID,
+				"filename", att.Filename,
+				"content_type", att.ContentType,
+				"size_bytes", len(data),
+			)
+			continue
+		}
+		images = append(images, agent.ImageAttachment{
+			ID:          att.ID,
+			Filename:    att.Filename,
+			ContentType: contentType,
+			Data:        data,
+		})
+	}
+	return images
+}
+
+func normalizeImageContentType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+	return strings.ToLower(strings.TrimSpace(mediaType))
+}
+
+func isClaudeVisionContentType(contentType string) bool {
+	switch normalizeImageContentType(contentType) {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
+}

--- a/server/internal/daemon/attachments_test.go
+++ b/server/internal/daemon/attachments_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoadClaudeImageAttachmentsDownloadsOnlyImages(t *testing.T) {
+	t.Parallel()
+
+	var sawAttachmentAuth bool
+	var sawDownloadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/attachments/img-1":
+			sawAttachmentAuth = r.Header.Get("Authorization") == "Bearer task-token"
+			_ = json.NewEncoder(w).Encode(AttachmentInfo{
+				ID:          "img-1",
+				Filename:    "screen.png",
+				DownloadURL: "/files/screen.png",
+				ContentType: "image/png",
+				SizeBytes:   4,
+			})
+		case "/files/screen.png":
+			sawDownloadAuth = r.Header.Get("Authorization") == "Bearer task-token"
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47})
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	client.SetToken("task-token")
+	d := &Daemon{client: client}
+
+	images := d.loadClaudeImageAttachments(context.Background(), Task{
+		ChatMessageAttachments: []ChatAttachmentMeta{
+			{ID: "img-1", Filename: "screen.png", ContentType: "image/png; charset=binary", SizeBytes: 4},
+			{ID: "doc-1", Filename: "notes.txt", ContentType: "text/plain", SizeBytes: 12},
+		},
+	}, slog.Default())
+
+	if len(images) != 1 {
+		t.Fatalf("expected one image attachment, got %d", len(images))
+	}
+	if images[0].ID != "img-1" || images[0].Filename != "screen.png" {
+		t.Fatalf("unexpected image metadata: %+v", images[0])
+	}
+	if images[0].ContentType != "image/png" {
+		t.Fatalf("expected normalized image/png content type, got %q", images[0].ContentType)
+	}
+	if string(images[0].Data) != string([]byte{0x89, 0x50, 0x4e, 0x47}) {
+		t.Fatalf("unexpected image bytes: %v", images[0].Data)
+	}
+	if !sawAttachmentAuth || !sawDownloadAuth {
+		t.Fatalf("expected auth on metadata and relative download requests, metadata=%v download=%v", sawAttachmentAuth, sawDownloadAuth)
+	}
+}
+
+func TestLoadClaudeImageAttachmentsSkipsOversizedBeforeDownload(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		t.Fatalf("oversized attachment should not be requested")
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	d := &Daemon{client: client}
+
+	images := d.loadClaudeImageAttachments(context.Background(), Task{
+		ChatMessageAttachments: []ChatAttachmentMeta{
+			{ID: "large", Filename: "large.jpg", ContentType: "image/jpeg", SizeBytes: maxClaudeImageAttachmentBytes + 1},
+		},
+	}, slog.Default())
+
+	if len(images) != 0 {
+		t.Fatalf("expected no images, got %d", len(images))
+	}
+	if requests != 0 {
+		t.Fatalf("expected no HTTP requests, got %d", requests)
+	}
+}

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -97,6 +98,15 @@ type Client struct {
 	platform string
 	version  string
 	os       string
+}
+
+type AttachmentInfo struct {
+	ID          string `json:"id"`
+	Filename    string `json:"filename"`
+	URL         string `json:"url"`
+	DownloadURL string `json:"download_url"`
+	ContentType string `json:"content_type"`
+	SizeBytes   int64  `json:"size_bytes"`
 }
 
 // NewClient creates a new daemon API client.
@@ -276,6 +286,45 @@ func (c *Client) GetTaskStatus(ctx context.Context, taskID string) (string, erro
 		return "", err
 	}
 	return resp.Status, nil
+}
+
+func (c *Client) GetAttachment(ctx context.Context, attachmentID string) (*AttachmentInfo, error) {
+	var resp AttachmentInfo
+	if err := c.getJSON(ctx, fmt.Sprintf("/api/attachments/%s", attachmentID), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) DownloadFile(ctx context.Context, rawURL string) ([]byte, error) {
+	if rawURL == "" {
+		return nil, fmt.Errorf("missing attachment url")
+	}
+	downloadURL := rawURL
+	if u, err := url.Parse(rawURL); err == nil && !u.IsAbs() {
+		downloadURL = c.baseURL + rawURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(downloadURL, c.baseURL) && c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	c.setIdentityHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, &requestError{Method: http.MethodGet, Path: rawURL, StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(data))}
+	}
+	const maxDownloadSize = 100 << 20
+	return io.ReadAll(io.LimitReader(resp.Body, maxDownloadSize))
 }
 
 // HeartbeatResponse, PendingUpdate, etc. alias the wire types so HTTP and WS

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2743,6 +2743,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		McpConfig:                 mcpConfig,
 		ThinkingLevel:             thinkingLevel,
 	}
+	if provider == "claude" {
+		execOpts.ImageAttachments = d.loadClaudeImageAttachments(ctx, task, taskLog)
+	}
 	// Some providers do not reliably load the per-task runtime config files we
 	// write into the task workdir:
 	//   - openclaw is pinned to the task workdir via the per-task config we

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -16,7 +16,7 @@ import (
 // Windows).
 func BuildPrompt(task Task, provider string) string {
 	if task.ChatSessionID != "" {
-		return buildChatPrompt(task)
+		return buildChatPrompt(task, provider)
 	}
 	if task.TriggerCommentID != "" {
 		return buildCommentPrompt(task, provider)
@@ -165,7 +165,7 @@ func buildCommentPrompt(task Task, provider string) string {
 }
 
 // buildChatPrompt constructs a prompt for interactive chat tasks.
-func buildChatPrompt(task Task) string {
+func buildChatPrompt(task Task, provider string) string {
 	var b strings.Builder
 	b.WriteString("You are running as a chat assistant for a Multica workspace.\n")
 	b.WriteString("A user is chatting with you directly. Respond to their message.\n\n")
@@ -174,8 +174,9 @@ func buildChatPrompt(task Task) string {
 	// the CLI. We deliberately do NOT inline the URL: chat attachments
 	// live behind a signed CDN with a short TTL, so by the time the agent
 	// has finished thinking the URL embedded in the markdown body may
-	// have expired. `multica attachment download <id>` re-signs at click
-	// time and is the only reliable path.
+	// have expired. Claude gets supported image attachments as native
+	// image blocks; other providers use `multica attachment download <id>`
+	// to re-sign at read time.
 	if len(task.ChatMessageAttachments) > 0 {
 		b.WriteString("\nAttachments on this message:\n")
 		for _, a := range task.ChatMessageAttachments {
@@ -185,9 +186,22 @@ func buildChatPrompt(task Task) string {
 				fmt.Fprintf(&b, "- id=%s filename=%q\n", a.ID, a.Filename)
 			}
 		}
-		b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it.\n")
+		if provider == "claude" && hasClaudeVisionAttachment(task.ChatMessageAttachments) {
+			b.WriteString("Supported image attachments are also sent to Claude as native image inputs. Use `multica attachment download <id>` only if you need local file bytes or need to inspect non-image files.\n")
+		} else {
+			b.WriteString("Use `multica attachment download <id>` to fetch each file locally before referring to it.\n")
+		}
 	}
 	return b.String()
+}
+
+func hasClaudeVisionAttachment(attachments []ChatAttachmentMeta) bool {
+	for _, a := range attachments {
+		if isClaudeVisionContentType(a.ContentType) {
+			return true
+		}
+	}
+	return false
 }
 
 // buildAutopilotPrompt constructs a prompt for run_only autopilot tasks.

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -341,6 +341,43 @@ func TestBuildPromptDefaultMentionsRecent(t *testing.T) {
 	}
 }
 
+func TestBuildChatPromptMentionsClaudeNativeImages(t *testing.T) {
+	out := BuildPrompt(Task{
+		ChatSessionID: "chat-1",
+		ChatMessage:   "what is in this screenshot?",
+		ChatMessageAttachments: []ChatAttachmentMeta{
+			{ID: "att-1", Filename: "screen.png", ContentType: "image/png"},
+		},
+	}, "claude")
+
+	for _, s := range []string{
+		"content_type=image/png",
+		"native image inputs",
+		"Use `multica attachment download <id>` only if",
+	} {
+		if !strings.Contains(out, s) {
+			t.Errorf("buildChatPrompt missing Claude image guidance %q\n--- output ---\n%s", s, out)
+		}
+	}
+}
+
+func TestBuildChatPromptKeepsDownloadInstructionForNonClaude(t *testing.T) {
+	out := BuildPrompt(Task{
+		ChatSessionID: "chat-1",
+		ChatMessage:   "what is in this screenshot?",
+		ChatMessageAttachments: []ChatAttachmentMeta{
+			{ID: "att-1", Filename: "screen.png", ContentType: "image/png"},
+		},
+	}, "codex")
+
+	if !strings.Contains(out, "Use `multica attachment download <id>` to fetch each file locally before referring to it.") {
+		t.Errorf("buildChatPrompt must keep manual download guidance for non-Claude providers\n--- output ---\n%s", out)
+	}
+	if strings.Contains(out, "native image inputs") {
+		t.Errorf("buildChatPrompt must not claim native image input delivery for non-Claude providers\n--- output ---\n%s", out)
+	}
+}
+
 // TestBuildPromptNonSquadLeaderNoRule verifies that non-squad-leader agents
 // do NOT get the squad leader no_action rule injected.
 func TestBuildPromptNonSquadLeaderNoRule(t *testing.T) {

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -94,6 +94,7 @@ type ChatAttachmentMeta struct {
 	ID          string `json:"id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type,omitempty"`
+	SizeBytes   int64  `json:"size_bytes,omitempty"`
 }
 
 // AgentData holds agent details returned by the claim endpoint.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -233,6 +233,7 @@ type ChatAttachmentMeta struct {
 	ID          string `json:"id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type,omitempty"`
+	SizeBytes   int64  `json:"size_bytes,omitempty"`
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1342,6 +1342,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 									ID:          uuidToString(a.ID),
 									Filename:    a.Filename,
 									ContentType: a.ContentType,
+									SizeBytes:   a.SizeBytes,
 								}
 							}
 						}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -35,6 +35,7 @@ type ExecOptions struct {
 	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs; currently read by claude and codex backends only
 	CustomArgs                []string        // per-agent CLI arguments appended after ExtraArgs
 	McpConfig                 json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
+	ImageAttachments          []ImageAttachment
 	// ThinkingLevel is the runtime-native reasoning/effort value (e.g.
 	// Claude's "low|medium|high|xhigh|max", Codex's "none|minimal|low|
 	// medium|high|xhigh"). Empty means "use the runtime/model default" —
@@ -44,6 +45,15 @@ type ExecOptions struct {
 	// field rather than fail (so MUL-2339 can grow runtime support
 	// incrementally without breaking unrelated agents).
 	ThinkingLevel string
+}
+
+// ImageAttachment is an image payload that should be sent to providers with
+// native vision support instead of being described as an opaque file.
+type ImageAttachment struct {
+	ID          string
+	Filename    string
+	ContentType string
+	Data        []byte
 }
 
 // Session represents a running agent execution.

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -3,11 +3,13 @@ package agent
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"os"
 	"os/exec"
 	"strings"
@@ -97,7 +99,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
-	if err := writeClaudeInput(stdin, prompt); err != nil {
+	if err := writeClaudeInput(stdin, prompt, opts.ImageAttachments); err != nil {
 		// claude almost certainly died during startup (broken pipe). The
 		// real reason is sitting in stderrBuf — surface it the same way the
 		// post-handshake error path does, otherwise the daemon log is the
@@ -518,8 +520,8 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	return args
 }
 
-func writeClaudeInput(w io.Writer, prompt string) error {
-	data, err := buildClaudeInput(prompt)
+func writeClaudeInput(w io.Writer, prompt string, images []ImageAttachment) error {
+	data, err := buildClaudeInput(prompt, images)
 	if err != nil {
 		return err
 	}
@@ -529,17 +531,30 @@ func writeClaudeInput(w io.Writer, prompt string) error {
 	return nil
 }
 
-func buildClaudeInput(prompt string) ([]byte, error) {
+func buildClaudeInput(prompt string, images []ImageAttachment) ([]byte, error) {
+	content := make([]map[string]any, 0, 1+len(images))
+	content = append(content, map[string]any{
+		"type": "text",
+		"text": prompt,
+	})
+	for _, img := range images {
+		if !isSupportedClaudeImageContentType(img.ContentType) || len(img.Data) == 0 {
+			continue
+		}
+		content = append(content, map[string]any{
+			"type": "image",
+			"source": map[string]string{
+				"type":       "base64",
+				"media_type": img.ContentType,
+				"data":       base64.StdEncoding.EncodeToString(img.Data),
+			},
+		})
+	}
 	payload := map[string]any{
 		"type": "user",
 		"message": map[string]any{
-			"role": "user",
-			"content": []map[string]string{
-				{
-					"type": "text",
-					"text": prompt,
-				},
-			},
+			"role":    "user",
+			"content": content,
 		},
 	}
 	data, err := json.Marshal(payload)
@@ -547,6 +562,19 @@ func buildClaudeInput(prompt string) ([]byte, error) {
 		return nil, fmt.Errorf("marshal claude input: %w", err)
 	}
 	return append(data, '\n'), nil
+}
+
+func isSupportedClaudeImageContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = contentType
+	}
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
 }
 
 // resolveSessionID decides which session id to report on the Result. When the

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -322,7 +322,7 @@ func TestBuildClaudeArgsFiltersBlockedCustomArgs(t *testing.T) {
 func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
 	t.Parallel()
 
-	data, err := buildClaudeInput("say pong")
+	data, err := buildClaudeInput("say pong", nil)
 	if err != nil {
 		t.Fatalf("buildClaudeInput: %v", err)
 	}
@@ -356,6 +356,53 @@ func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
 	}
 	if block["type"] != "text" || block["text"] != "say pong" {
 		t.Fatalf("unexpected content block: %v", block)
+	}
+}
+
+func TestBuildClaudeInputIncludesImageAttachments(t *testing.T) {
+	t.Parallel()
+
+	data, err := buildClaudeInput("describe this", []ImageAttachment{
+		{
+			ID:          "att-1",
+			Filename:    "screen.png",
+			ContentType: "image/png",
+			Data:        []byte{0x89, 0x50, 0x4e, 0x47},
+		},
+		{
+			ID:          "att-2",
+			Filename:    "notes.txt",
+			ContentType: "text/plain",
+			Data:        []byte("not an image"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildClaudeInput: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	message := payload["message"].(map[string]any)
+	content := message["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("expected text plus one image block, got %v", content)
+	}
+
+	imageBlock := content[1].(map[string]any)
+	if imageBlock["type"] != "image" {
+		t.Fatalf("expected image block, got %v", imageBlock)
+	}
+	source := imageBlock["source"].(map[string]any)
+	if source["type"] != "base64" {
+		t.Fatalf("expected base64 image source, got %v", source)
+	}
+	if source["media_type"] != "image/png" {
+		t.Fatalf("expected image/png media_type, got %v", source["media_type"])
+	}
+	if source["data"] != "iVBORw==" {
+		t.Fatalf("expected base64 image data, got %v", source["data"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve chat attachment MIME type and size metadata for daemon claims
- fetch supported Claude image attachments through the authenticated attachment API
- pass images to Claude Code as native `image` content blocks with base64 data and media type while keeping non-image/manual download guidance intact

## Verification
- `git apply --check /tmp/and-4793-claude-image-attachments.patch` passed before applying the reviewed patch
- `git diff --check` passed
- `cd server && go test ./pkg/agent ./internal/daemon` not run: `go` is not installed in this environment
- `gofmt` not run: `gofmt` is not installed in this environment
- `make test` not run: missing `.env` / `.env.worktree` in this checkout

Issue: AND-4793
