### PR TITLE
Fix stale sidebar working status reconciliation

### DIFF
--- a/packages/core/agents/use-workspace-presence-prefetch.test.ts
+++ b/packages/core/agents/use-workspace-presence-prefetch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTask } from "../types";
+import { hasActiveAgentTasks } from "./use-workspace-presence-prefetch";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "rt-1",
+    issue_id: "issue-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-05-27T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("hasActiveAgentTasks", () => {
+  it("returns false for an empty or missing snapshot", () => {
+    expect(hasActiveAgentTasks(undefined)).toBe(false);
+    expect(hasActiveAgentTasks([])).toBe(false);
+  });
+
+  it("returns true while a snapshot contains queued, dispatched, running, or waiting tasks", () => {
+    expect(hasActiveAgentTasks([makeTask({ status: "queued" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "dispatched" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "running" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "waiting_local_directory" })])).toBe(true);
+  });
+
+  it("returns false once the authoritative snapshot only contains terminal tasks", () => {
+    expect(
+      hasActiveAgentTasks([
+        makeTask({ id: "completed", status: "completed" }),
+        makeTask({ id: "failed", status: "failed" }),
+        makeTask({ id: "cancelled", status: "cancelled" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("keeps polling when active tasks coexist with the latest terminal rows", () => {
+    expect(
+      hasActiveAgentTasks([
+        makeTask({ id: "completed", status: "completed" }),
+        makeTask({ id: "running", status: "running" }),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/core/agents/use-workspace-presence-prefetch.ts
+++ b/packages/core/agents/use-workspace-presence-prefetch.ts
@@ -4,6 +4,22 @@ import { useQuery } from "@tanstack/react-query";
 import { agentListOptions, squadListOptions } from "../workspace/queries";
 import { runtimeListOptions } from "../runtimes/queries";
 import { agentTaskSnapshotOptions } from "./queries";
+import type { AgentTask } from "../types";
+
+const ACTIVE_AGENT_TASK_STATUSES = new Set<AgentTask["status"]>([
+  "queued",
+  "dispatched",
+  "running",
+  "waiting_local_directory",
+]);
+
+const ACTIVE_TASK_REFETCH_INTERVAL_MS = 15_000;
+
+export function hasActiveAgentTasks(
+  snapshot: readonly AgentTask[] | undefined,
+): boolean {
+  return snapshot?.some((task) => ACTIVE_AGENT_TASK_STATUSES.has(task.status)) ?? false;
+}
 
 // Subscribe to the queries that power agent presence and the @mention
 // suggestion list so they're warm by the time any hover card / inline
@@ -24,6 +40,13 @@ import { agentTaskSnapshotOptions } from "./queries";
 export function useWorkspacePresencePrefetch(wsId: string | undefined): void {
   useQuery({ ...agentListOptions(wsId ?? ""), enabled: !!wsId });
   useQuery({ ...runtimeListOptions(wsId ?? ""), enabled: !!wsId });
-  useQuery({ ...agentTaskSnapshotOptions(wsId ?? ""), enabled: !!wsId });
+  useQuery({
+    ...agentTaskSnapshotOptions(wsId ?? ""),
+    enabled: !!wsId,
+    refetchInterval: (query) =>
+      hasActiveAgentTasks(query.state.data)
+        ? ACTIVE_TASK_REFETCH_INTERVAL_MS
+        : false,
+  });
   useQuery({ ...squadListOptions(wsId ?? ""), enabled: !!wsId });
 }


### PR DESCRIPTION
## Summary
- Refetch the workspace agent task snapshot every 15s while cached presence still contains active agent tasks.
- Stop the defensive polling once the authoritative snapshot contains only terminal/no tasks.
- Add regression coverage for active-vs-terminal task snapshot detection.

## Verification
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core exec vitest run agents/use-workspace-presence-prefetch.test.ts`
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core typecheck`
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core lint` passed with one pre-existing warning in `packages/core/platform/auth-initializer.tsx`.

Fixes multica-ai/multica#1463.
