### PR TITLE
Keep Multica Codex sessions out of chat history

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -30,6 +30,9 @@ const (
 	defaultCodexSemanticInactivityTimeout  = 10 * time.Minute
 	defaultCodexFirstTurnNoProgressTimeout = 30 * time.Second
 	codexVersionDiagnosticTimeout          = 2 * time.Second
+	codexClientName                        = "multica-agent-sdk"
+	codexClientTitle                       = "Multica Agent SDK"
+	codexClientVersion                     = "0.2.0"
 )
 
 // CodexSemanticInactivityMarker prefixes timeout errors emitted when Codex
@@ -41,6 +44,8 @@ const CodexSemanticInactivityMarker = "codex semantic inactivity timeout"
 const CodexFirstTurnNoProgressMarker = "codex app-server no progress timeout"
 
 const codexModelCatalogRefreshTimeoutSignal = "failed to refresh available models: timeout waiting for child process to exit"
+
+const codexSessionServiceName = "multica-agent-sdk"
 
 type codexTimeoutKind int
 
@@ -206,16 +211,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		var finalError string
 
 		// 1. Initialize handshake
-		_, err := c.request(runCtx, "initialize", map[string]any{
-			"clientInfo": map[string]any{
-				"name":    "multica-agent-sdk",
-				"title":   "Multica Agent SDK",
-				"version": "0.2.0",
-			},
-			"capabilities": map[string]any{
-				"experimentalApi": true,
-			},
-		})
+		_, err := c.request(runCtx, "initialize", buildCodexInitializeParams())
 		if err != nil {
 			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
@@ -470,6 +466,7 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		"includeApplyPatchTool":  nil,
 		"experimentalRawEvents":  false,
 		"persistExtendedHistory": true,
+		"serviceName":            codexSessionServiceName,
 	}
 	applyCodexReasoningEffort(startParams, opts.ThinkingLevel)
 	startResult, err := c.request(ctx, "thread/start", startParams)
@@ -481,6 +478,19 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		return "", false, fmt.Errorf("codex thread/start returned no thread ID")
 	}
 	return threadID, false, nil
+}
+
+func buildCodexInitializeParams() map[string]any {
+	return map[string]any{
+		"clientInfo": map[string]any{
+			"name":    codexClientName,
+			"title":   codexClientTitle,
+			"version": codexClientVersion,
+		},
+		"capabilities": map[string]any{
+			"experimentalApi": true,
+		},
+	}
 }
 
 // applyCodexReasoningEffort writes the per-agent thinking_level into a

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -862,6 +862,9 @@ func TestCodexStartOrResumeThreadStartsFresh(t *testing.T) {
 				if params["persistExtendedHistory"] != true {
 					t.Error("expected persistExtendedHistory=true on thread/start")
 				}
+				if params["serviceName"] != codexSessionServiceName {
+					t.Errorf("serviceName = %v, want %q", params["serviceName"], codexSessionServiceName)
+				}
 			},
 		},
 	})
@@ -876,6 +879,33 @@ func TestCodexStartOrResumeThreadStartsFresh(t *testing.T) {
 	}
 	if resumed {
 		t.Error("resumed should be false when no prior session is provided")
+	}
+}
+
+func TestCodexInitializeParamsIdentifyMulticaClient(t *testing.T) {
+	t.Parallel()
+
+	params := buildCodexInitializeParams()
+	clientInfo, ok := params["clientInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("clientInfo has wrong type %T", params["clientInfo"])
+	}
+	if clientInfo["name"] != codexClientName {
+		t.Errorf("clientInfo.name = %v, want %q", clientInfo["name"], codexClientName)
+	}
+	if clientInfo["title"] != codexClientTitle {
+		t.Errorf("clientInfo.title = %v, want %q", clientInfo["title"], codexClientTitle)
+	}
+	if clientInfo["version"] != codexClientVersion {
+		t.Errorf("clientInfo.version = %v, want %q", clientInfo["version"], codexClientVersion)
+	}
+
+	capabilities, ok := params["capabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("capabilities has wrong type %T", params["capabilities"])
+	}
+	if capabilities["experimentalApi"] != true {
+		t.Errorf("experimentalApi = %v, want true", capabilities["experimentalApi"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a stable `serviceName: "multica-agent-sdk"` marker to fresh Codex `thread/start` requests
- centralize Codex initialize client metadata behind constants
- add regression coverage for the initialize metadata and emitted thread service marker

Historical session cleanup/migration is deferred; this affects newly created Codex agent sessions.

## Verification
- `PATH=/tmp/multica-go-toolchain/go/bin:$PATH HOME=/tmp/multica-test-home go test ./pkg/agent -run 'TestCodex(StartOrResumeThreadStartsFresh|InitializeParamsIdentifyMulticaClient)'`
- `PATH=/tmp/multica-go-toolchain/go/bin:$PATH HOME=/tmp/multica-test-home go test ./pkg/agent`
- `git diff --check`
