### PR TITLE
Fix Pi runtime message delivery

### DIFF
--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -232,7 +232,8 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		cancel()
 		return nil, fmt.Errorf("pi stdin pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[pi:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[pi:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		_ = stdin.Close()
@@ -370,7 +371,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			finalError = "execution cancelled"
 		} else if waitErr != nil && finalStatus == "completed" {
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("pi exited with error: %v", waitErr)
+			finalError = withAgentStderr(fmt.Sprintf("pi exited with error: %v", waitErr), "pi", stderrBuf.Tail())
 		}
 
 		b.cfg.Logger.Info("pi finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -41,6 +41,29 @@ func TestBuildPiArgsBasicFlags(t *testing.T) {
 	}
 }
 
+func TestBuildPiArgsPreservesPromptAsFinalArg(t *testing.T) {
+	prompts := []string{
+		"plain task",
+		"spaces and \"quotes\" and 'apostrophes'",
+		"line one\nline two",
+		`literal \n text`,
+	}
+
+	for _, prompt := range prompts {
+		t.Run(prompt, func(t *testing.T) {
+			args := buildPiArgs(prompt, "/tmp/s.jsonl", ExecOptions{
+				Model:        "anthropic/claude-sonnet-4-20250514",
+				SystemPrompt: "be helpful",
+				CustomArgs:   []string{"--some-pi-flag", "value"},
+			}, slog.Default())
+
+			if got := args[len(args)-1]; got != prompt {
+				t.Fatalf("prompt should be exact final arg, got %q, want %q", got, prompt)
+			}
+		})
+	}
+}
+
 func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	// Users can still restrict tools via custom_args if desired.
 	args := buildPiArgs("prompt", "/tmp/s.jsonl", ExecOptions{
@@ -55,6 +78,62 @@ func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("custom --tools should pass through via custom_args, got: %v", args)
+	}
+}
+
+func TestPiExecutePassesPromptAsFinalArg(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	wantPrompt := "deploy task with spaces, \"quotes\", and newline\nsecond line with literal \\n"
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	script := "#!/bin/sh\n" +
+		"last=\n" +
+		"for arg do last=$arg; done\n" +
+		"if [ \"$last\" != \"$EXPECTED_PROMPT\" ]; then\n" +
+		"  printf 'last arg mismatch\\nwant: %s\\ngot: %s\\n' \"$EXPECTED_PROMPT\" \"$last\" >&2\n" +
+		"  exit 3\n" +
+		"fi\n" +
+		"printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"delta\":\"received exact prompt\"}}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":2}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("pi", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"EXPECTED_PROMPT": wantPrompt},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, wantPrompt, ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "received exact prompt" {
+			t.Fatalf("unexpected output: %q", result.Output)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 
@@ -113,6 +192,53 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 		}
 		if result.Status != "completed" {
 			t.Fatalf("expected status=completed (stdin attached as fifo), got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestPiExecuteSurfacesStderrOnNonZeroResult(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	script := "#!/bin/sh\n" +
+		"echo \"provider rejected prompt payload\" >&2\n" +
+		"exit 2\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "provider rejected prompt payload") {
+			t.Fatalf("expected error to include stderr hint, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "pi stderr:") {
+			t.Fatalf("expected stderr label in error, got %q", result.Error)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")


### PR DESCRIPTION
## Summary
- capture Pi stderr tails and include them in failed runtime results
- add regression coverage that the user prompt remains the exact final Pi argv entry
- add fake-Pi execute coverage for exact prompt delivery and stderr surfacing

## Provider path
The daemon runs `pi -p --mode json --session <session-file> [--provider <provider>] [--model <model>] [--append-system-prompt <text>] ... <user prompt>`. The user prompt is sent as the final positional argv value; stdout is parsed as newline-delimited Pi JSON events.

## Verification
- `git diff --check`
- Not run locally: `gofmt` and `go test ./pkg/agent -run 'Test(BuildPiArgs|PiExecute|StripPi|DrainPi|FlushPi)'` because this sandbox has no `go` or `gofmt` on PATH. CI should run with the repo's Go toolchain.

Refs AND-4881.
