### PR TITLE
fix(daemon): ignore gc meta with empty parent ids (MUL-2761)

### DIFF
--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -253,6 +253,10 @@ func isAccessNotFound(err error) bool {
 }
 
 func (d *Daemon) gcDecisionIssue(ctx context.Context, taskDir string, meta *execenv.GCMeta) gcAction {
+	if strings.TrimSpace(meta.IssueID) == "" {
+		return d.orphanByMTime(taskDir, "empty issue id")
+	}
+
 	status, err := d.client.GetIssueGCCheck(ctx, meta.IssueID)
 	if err != nil {
 		if isAccessNotFound(err) {
@@ -293,6 +297,10 @@ func (d *Daemon) gcDecisionIssue(ctx context.Context, taskDir string, meta *exec
 }
 
 func (d *Daemon) gcDecisionChat(ctx context.Context, taskDir string, meta *execenv.GCMeta) gcAction {
+	if strings.TrimSpace(meta.ChatSessionID) == "" {
+		return d.orphanByMTime(taskDir, "empty chat session id")
+	}
+
 	status, err := d.client.GetChatSessionGCCheck(ctx, meta.ChatSessionID)
 	if err != nil {
 		if isAccessNotFound(err) {
@@ -339,6 +347,10 @@ func (d *Daemon) gcDecisionChat(ctx context.Context, taskDir string, meta *exece
 }
 
 func (d *Daemon) gcDecisionAutopilotRun(ctx context.Context, taskDir string, meta *execenv.GCMeta) gcAction {
+	if strings.TrimSpace(meta.AutopilotRunID) == "" {
+		return d.orphanByMTime(taskDir, "empty autopilot run id")
+	}
+
 	status, err := d.client.GetAutopilotRunGCCheck(ctx, meta.AutopilotRunID)
 	if err != nil {
 		if isAccessNotFound(err) {
@@ -390,6 +402,10 @@ func isAutopilotRunTerminal(status string) bool {
 }
 
 func (d *Daemon) gcDecisionQuickCreate(ctx context.Context, taskDir string, meta *execenv.GCMeta) gcAction {
+	if strings.TrimSpace(meta.TaskID) == "" {
+		return d.orphanByMTime(taskDir, "empty task id")
+	}
+
 	status, err := d.client.GetTaskGCCheck(ctx, meta.TaskID)
 	if err != nil {
 		if isAccessNotFound(err) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -832,6 +832,74 @@ func TestShouldCleanTaskDir_KindDispatch(t *testing.T) {
 	}
 }
 
+func TestShouldCleanTaskDir_EmptyParentIDFallsBackToOrphanMTime(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		meta *execenv.GCMeta
+	}{
+		{
+			name: "legacy issue meta",
+			meta: &execenv.GCMeta{WorkspaceID: "ws"},
+		},
+		{
+			name: "issue meta",
+			meta: &execenv.GCMeta{Kind: execenv.GCKindIssue, WorkspaceID: "ws"},
+		},
+		{
+			name: "chat meta",
+			meta: &execenv.GCMeta{Kind: execenv.GCKindChat, WorkspaceID: "ws"},
+		},
+		{
+			name: "autopilot run meta",
+			meta: &execenv.GCMeta{Kind: execenv.GCKindAutopilotRun, WorkspaceID: "ws"},
+		},
+		{
+			name: "quick create meta",
+			meta: &execenv.GCMeta{Kind: execenv.GCKindQuickCreate, WorkspaceID: "ws"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			requests := 0
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				http.Error(w, "unexpected request", http.StatusBadRequest)
+			})
+
+			d := newGCTestDaemon(t, mux)
+			d.cfg.GCOrphanTTL = 365 * 24 * time.Hour
+			taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws", tc.name, tc.meta)
+
+			got := d.shouldCleanTaskDir(context.Background(), taskDir)
+			if got != gcActionSkip {
+				t.Fatalf("empty parent id should skip while under orphan TTL, got %d", got)
+			}
+			if requests != 0 {
+				t.Fatalf("empty parent id should not call gc-check endpoint, got %d requests", requests)
+			}
+
+			old := time.Now().Add(-400 * 24 * time.Hour)
+			if err := os.Chtimes(taskDir, old, old); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+			got = d.shouldCleanTaskDir(context.Background(), taskDir)
+			if got != gcActionOrphan {
+				t.Fatalf("empty parent id over orphan TTL should orphan, got %d", got)
+			}
+			if requests != 0 {
+				t.Fatalf("empty parent id should not call gc-check endpoint after mtime fallback, got %d requests", requests)
+			}
+		})
+	}
+}
+
 // TestShouldCleanTaskDir_ChatHardDeletedFreshMtime locks acceptance #3:
 // when a user hard-deletes a chat session, the workdir must be reclaimed
 // on the next GC cycle (≤ GCInterval), not deferred to GCOrphanTTL. A


### PR DESCRIPTION
## Summary
- skip gc-check HTTP calls when GC metadata has an empty parent id
- fall back to the existing orphan-by-mtime path for malformed issue/chat/autopilot/quick-create metadata
- cover legacy empty issue metadata and all current GC metadata kinds

## Verification
- cd server && go test ./internal/daemon ./internal/daemon/execenv -count=1
- git diff --check