### PR TITLE
fix(issues): surface AskUserQuestion fallback

### DIFF
--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/packages/views/issues/components/agent-live-card.test.tsx
+++ b/packages/views/issues/components/agent-live-card.test.tsx
@@ -251,6 +251,32 @@ describe("AgentLiveCard queued rendering", () => {
     expect(screen.getByText("Stop")).toBeTruthy();
   });
 
+  it("surfaces AskUserQuestion tool events as unsupported input requests", async () => {
+    const runningTask = makeTask("task-r", { status: "running" });
+    mockApi.getActiveTasksForIssue.mockResolvedValueOnce({ tasks: [runningTask] });
+
+    renderCard();
+
+    await waitFor(() => {
+      expect(screen.getByText(/is working/)).toBeTruthy();
+    });
+
+    act(() => {
+      fireEvent("task:message", {
+        task_id: "task-r",
+        issue_id: "issue-1",
+        seq: 1,
+        type: "tool_use",
+        tool: "AskUserQuestion",
+        input: { question: "Which branch should I update?" },
+      });
+    });
+
+    expect(screen.getByText(/asked for input, but this runtime cannot receive answers here/)).toBeTruthy();
+    expect(screen.getByText("Which branch should I update?")).toBeTruthy();
+    expect(screen.getByTestId("transcript-button")).toBeTruthy();
+  });
+
   it("Stop button opens a confirm dialog and only calls cancelTask after the user confirms", async () => {
     const runningTask = makeTask("task-r", { status: "running" });
     mockApi.getActiveTasksForIssue.mockResolvedValueOnce({ tasks: [runningTask] });

--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Bot, Clock, Loader2, Square } from "lucide-react";
+import { AlertCircle, Bot, Clock, Loader2, Square } from "lucide-react";
 import { api } from "@multica/core/api";
 import { useWSEvent, useWSReconnect } from "@multica/core/realtime";
 import type { TaskMessagePayload } from "@multica/core/types/events";
@@ -48,6 +48,22 @@ interface TaskState {
 
 interface AgentLiveCardProps {
   issueId: string;
+}
+
+function isUserQuestionTool(item: TimelineItem): boolean {
+  if (item.type !== "tool_use") return false;
+  const tool = item.tool?.toLowerCase().replace(/[^a-z]/g, "");
+  return tool === "askuserquestion" || tool === "question";
+}
+
+function getUserQuestionPrompt(item: TimelineItem | undefined): string {
+  if (!item?.input) return "";
+  const question =
+    item.input.question ??
+    item.input.prompt ??
+    item.input.message ??
+    item.input.text;
+  return typeof question === "string" ? question.trim() : "";
 }
 
 export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
@@ -287,6 +303,9 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const isQueued = task.status === "queued";
+  const userQuestionItem = [...items].reverse().find(isUserQuestionTool);
+  const userQuestionPrompt = getUserQuestionPrompt(userQuestionItem);
+  const isUnsupportedUserQuestion = Boolean(userQuestionItem);
   // `waiting_local_directory` is the daemon-parked stage of an otherwise-
   // active task: it's been dispatched (no longer pure-queued) but hasn't
   // entered the running phase yet because another task on this daemon
@@ -294,7 +313,7 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
   const isWaitingLocalDirectory = task.status === "waiting_local_directory";
   // Treat parked + queued the same visually (non-shimmering, muted accent),
   // but the label below is distinct so the user sees the specific reason.
-  const isParked = isQueued || isWaitingLocalDirectory;
+  const isParked = isQueued || isWaitingLocalDirectory || isUnsupportedUserQuestion;
 
   // Elapsed time — ticks every second so users see the agent is alive.
   // For queued tasks neither started_at nor dispatched_at is set yet, so
@@ -339,20 +358,24 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
           </div>
         )}
         <div className="flex items-center gap-1.5 text-xs min-w-0">
-          {isParked ? (
+          {isUnsupportedUserQuestion ? (
+            <AlertCircle className="h-3 w-3 text-warning shrink-0" />
+          ) : isParked ? (
             <Clock className="h-3 w-3 text-muted-foreground shrink-0" />
           ) : (
             <Loader2 className="h-3 w-3 animate-spin text-info shrink-0" />
           )}
           <span className="font-medium text-foreground truncate">
-            {isWaitingLocalDirectory
+            {isUnsupportedUserQuestion
+              ? t(($) => $.agent_live.unsupported_user_question, { name: agentName })
+              : isWaitingLocalDirectory
               ? t(($) => $.agent_live.is_waiting_local_directory, { name: agentName })
               : isQueued
                 ? t(($) => $.agent_live.is_queued, { name: agentName })
                 : t(($) => $.agent_live.is_working, { name: agentName })}
           </span>
           <span className="text-muted-foreground tabular-nums shrink-0">
-            {isParked
+            {isParked && !isUnsupportedUserQuestion
               ? t(($) => $.agent_live.queued_elapsed_prefix, { elapsed })
               : elapsed}
           </span>
@@ -360,8 +383,13 @@ function SingleAgentLiveCard({ task, items, issueId, agentName }: SingleAgentLiv
             <span className="text-muted-foreground shrink-0">{t(($) => $.agent_live.tool_count, { count: toolCount })}</span>
           )}
         </div>
+        {isUnsupportedUserQuestion && userQuestionPrompt && (
+          <div className="min-w-0 flex-1 text-xs text-muted-foreground truncate">
+            {userQuestionPrompt}
+          </div>
+        )}
         <div className="ml-auto flex items-center gap-1 shrink-0">
-          {!isParked && (
+          {(!isParked || isUnsupportedUserQuestion) && (
             <TranscriptButton
               task={task}
               agentName={agentName}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -307,6 +307,7 @@
     "is_working": "{{name}} is working",
     "is_queued": "{{name}} is queued",
     "is_waiting_local_directory": "{{name}} is waiting for the local directory",
+    "unsupported_user_question": "{{name}} asked for input, but this runtime cannot receive answers here",
     "queued_elapsed_prefix": "queued for {{elapsed}}",
     "fallback_name": "Agent",
     "tool_count_one": "{{count}} tool",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -301,6 +301,7 @@
     "is_working": "{{name}} 正在处理",
     "is_queued": "{{name}} 排队中",
     "is_waiting_local_directory": "{{name}} 正在等待本地目录",
+    "unsupported_user_question": "{{name}} 请求输入，但此运行时无法在这里接收回答",
     "queued_elapsed_prefix": "已排队 {{elapsed}}",
     "fallback_name": "智能体",
     "tool_count_other": "{{count}} 次工具调用",


### PR DESCRIPTION
## Summary
- surface AskUserQuestion-style tool events in the issue live card instead of hiding them as ordinary tool traffic
- clarify that the runtime cannot receive answers in this unsupported path
- add regression coverage for the visible prompt, unsupported-runtime copy, and transcript affordance

## Verification
- `HOME=/tmp/home COREPACK_HOME=/tmp/corepack-home XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache PNPM_HOME=/tmp/pnpm-home ELECTRON_CACHE=/tmp/electron-cache corepack pnpm --filter @multica/views exec vitest run issues/components/agent-live-card.test.tsx`
- `HOME=/tmp/home COREPACK_HOME=/tmp/corepack-home XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache PNPM_HOME=/tmp/pnpm-home ELECTRON_CACHE=/tmp/electron-cache corepack pnpm --filter @multica/views typecheck`
- `git diff --check`

Closes AND-4904.
