### PR TITLE
MUL-2764: feat(agents): add MCP config tab to agent detail page

### DIFF
--- a/packages/core/agents/index.ts
+++ b/packages/core/agents/index.ts
@@ -7,3 +7,4 @@ export * from "./use-workspace-presence-prefetch";
 export * from "./constants";
 export * from "./visibility-label";
 export * from "./use-workspace-agent-availability";
+export * from "./mcp-support";

--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -1,0 +1,11 @@
+// The set of runtime providers whose backend reads `agent.mcp_config` and
+// forwards MCP servers to the underlying CLI. The MCP config tab is hidden
+// for every other provider so a user can't save a value the runtime will
+// silently ignore. Keep this list in sync with the backends in
+// `server/pkg/agent/` that read `ExecOptions.McpConfig`.
+const MCP_SUPPORTED_PROVIDERS = new Set(["claude", "codex"]);
+
+export function providerSupportsMcpConfig(provider: string | undefined | null): boolean {
+  if (!provider) return false;
+  return MCP_SUPPORTED_PROVIDERS.has(provider);
+}

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -153,6 +153,27 @@ export interface Agent {
    * alongside `has_custom_env`. Treat `undefined` as zero. MUL-2600.
    */
   custom_env_key_count?: number;
+  /**
+   * MCP server configuration forwarded to the runtime CLI (Claude's
+   * `--mcp-config`). The shape is opaque to the platform — whatever
+   * JSON the CLI accepts, the daemon writes to disk verbatim. `null`
+   * (or the field omitted on legacy backends) means no config; the
+   * daemon falls back to the CLI's own default. MUL-2764.
+   *
+   * When the caller can't see secrets (an agent actor, or a non-owner
+   * non-admin), the server replaces the value with `null` and sets
+   * `mcp_config_redacted` to true so the UI can render a "configured
+   * but hidden" state without exposing potentially sensitive fields.
+   */
+  mcp_config?: unknown | null;
+  /**
+   * True when the server stripped `mcp_config` from this response
+   * because the caller lacks permission to see secrets. The UI uses
+   * this to distinguish "no config" (`mcp_config === null &&
+   * !mcp_config_redacted`) from "config exists but you can't see it".
+   * Older backends omit this field; treat `undefined` as false.
+   */
+  mcp_config_redacted?: boolean;
   visibility: AgentVisibility;
   status: AgentStatus;
   max_concurrent_tasks: number;
@@ -295,6 +316,15 @@ export interface UpdateAgentRequest {
    * MUL-2600.
    */
   custom_args?: string[];
+  /**
+   * MCP server configuration. Tri-state semantics (MUL-2764):
+   *   - field omitted → no change
+   *   - `null` → clear the column; the daemon falls back to the CLI's
+   *     built-in default at launch
+   *   - object → replace the stored JSON verbatim; the platform does
+   *     not validate the shape (MCP CLI accepts whatever it accepts)
+   */
+  mcp_config?: unknown | null;
   visibility?: AgentVisibility;
   status?: AgentStatus;
   max_concurrent_tasks?: number;

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Agent, AgentRuntime } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+// AgentOverviewPane pulls in ActorIssuesPanel which in turn touches the api
+// layer. The test only cares about which top-of-pane tab buttons render,
+// not what each tab does, so we stub the heavy children.
+vi.mock("./tabs/activity-tab", () => ({
+  ActivityTab: () => <div>activity-tab</div>,
+}));
+vi.mock("./tabs/instructions-tab", () => ({
+  InstructionsTab: () => <div>instructions-tab</div>,
+}));
+vi.mock("./tabs/skills-tab", () => ({
+  SkillsTab: () => <div>skills-tab</div>,
+}));
+vi.mock("./tabs/env-tab", () => ({
+  EnvTab: () => <div>env-tab</div>,
+}));
+vi.mock("./tabs/custom-args-tab", () => ({
+  CustomArgsTab: () => <div>custom-args-tab</div>,
+}));
+vi.mock("./tabs/mcp-config-tab", () => ({
+  McpConfigTab: () => <div>mcp-config-tab</div>,
+}));
+vi.mock("../../common/actor-issues-panel", () => ({
+  ActorIssuesPanel: () => <div>actor-issues-panel</div>,
+}));
+
+import { AgentOverviewPane } from "./agent-overview-pane";
+
+const baseAgent: Agent = {
+  id: "agent-1",
+  workspace_id: "ws-1",
+  runtime_id: "runtime-1",
+  name: "Agent",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "local",
+  runtime_config: {},
+  custom_args: [],
+  visibility: "workspace",
+  status: "idle",
+  max_concurrent_tasks: 1,
+  model: "",
+  owner_id: "user-1",
+  skills: [],
+  created_at: "2026-05-28T00:00:00Z",
+  updated_at: "2026-05-28T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
+};
+
+function makeRuntime(provider: string): AgentRuntime {
+  return {
+    id: "runtime-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "Runtime",
+    runtime_mode: "local",
+    provider,
+    launch_header: "",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    visibility: "private",
+    last_seen_at: null,
+    created_at: "2026-05-28T00:00:00Z",
+    updated_at: "2026-05-28T00:00:00Z",
+  };
+}
+
+function renderPane(runtimes: AgentRuntime[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={queryClient}>
+        <AgentOverviewPane
+          agent={baseAgent}
+          runtimes={runtimes}
+          onUpdate={vi.fn().mockResolvedValue(undefined)}
+        />
+      </QueryClientProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("AgentOverviewPane MCP tab visibility", () => {
+  it("renders the MCP tab when the agent runs on the Claude runtime", () => {
+    renderPane([makeRuntime("claude")]);
+    expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
+  });
+
+  it("renders the MCP tab when the agent runs on the Codex runtime", () => {
+    // Codex now reads mcp_config too — must not be hidden from the tab strip.
+    renderPane([makeRuntime("codex")]);
+    expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
+  });
+
+  it("hides the MCP tab for providers whose backend does not read mcp_config", () => {
+    // Saving an MCP config on e.g. Gemini would be a silent no-op at run
+    // time — that's the bug this hiding logic is meant to prevent.
+    renderPane([makeRuntime("gemini")]);
+    expect(
+      screen.queryByRole("button", { name: /^MCP$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the MCP tab visible when the runtime row hasn't loaded yet", () => {
+    // Empty runtimes[] mimics the brief window between the page mounting and
+    // the runtimes query resolving. Hiding the tab would flicker it off and
+    // then back on, which reads as a bug.
+    renderPane([]);
+    expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
+  });
+});

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   KeyRound,
   ListTodo,
+  Plug,
   Terminal,
 } from "lucide-react";
 import type { Agent, AgentRuntime } from "@multica/core/types";
@@ -25,6 +26,7 @@ import { InstructionsTab } from "./tabs/instructions-tab";
 import { SkillsTab } from "./tabs/skills-tab";
 import { EnvTab } from "./tabs/env-tab";
 import { CustomArgsTab } from "./tabs/custom-args-tab";
+import { McpConfigTab } from "./tabs/mcp-config-tab";
 import { ActorIssuesPanel } from "../../common/actor-issues-panel";
 import { useT } from "../../i18n";
 
@@ -34,15 +36,17 @@ type DetailTab =
   | "instructions"
   | "skills"
   | "env"
-  | "custom_args";
+  | "custom_args"
+  | "mcp_config";
 
-const TAB_LABEL_KEY: Record<DetailTab, "activity" | "tasks" | "instructions" | "skills" | "environment" | "custom_args"> = {
+const TAB_LABEL_KEY: Record<DetailTab, "activity" | "tasks" | "instructions" | "skills" | "environment" | "custom_args" | "mcp_config"> = {
   activity: "activity",
   tasks: "tasks",
   instructions: "instructions",
   skills: "skills",
   env: "environment",
   custom_args: "custom_args",
+  mcp_config: "mcp_config",
 };
 
 const detailTabs: {
@@ -55,6 +59,7 @@ const detailTabs: {
   { id: "skills", icon: BookOpenText },
   { id: "env", icon: KeyRound },
   { id: "custom_args", icon: Terminal },
+  { id: "mcp_config", icon: Plug },
 ];
 
 interface AgentOverviewPaneProps {
@@ -180,6 +185,15 @@ export function AgentOverviewPane({
             <CustomArgsTab
               agent={agent}
               runtimeDevice={runtime ?? undefined}
+              onSave={(updates) => onUpdate(agent.id, updates)}
+              onDirtyChange={setActiveDirty}
+            />
+          </TabContent>
+        )}
+        {activeTab === "mcp_config" && (
+          <TabContent>
+            <McpConfigTab
+              agent={agent}
               onSave={(updates) => onUpdate(agent.id, updates)}
               onDirtyChange={setActiveDirty}
             />

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -194,6 +194,7 @@ export function AgentOverviewPane({
           <TabContent>
             <McpConfigTab
               agent={agent}
+              runtimeDevice={runtime ?? undefined}
               onSave={(updates) => onUpdate(agent.id, updates)}
               onDirtyChange={setActiveDirty}
             />

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Activity,
   BookOpenText,
@@ -11,6 +11,7 @@ import {
   Terminal,
 } from "lucide-react";
 import type { Agent, AgentRuntime } from "@multica/core/types";
+import { providerSupportsMcpConfig } from "@multica/core/agents";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -108,6 +109,24 @@ export function AgentOverviewPane({
     ? runtimes.find((r) => r.id === agent.runtime_id) ?? null
     : null;
 
+  // The MCP tab is only shown when the agent's runtime backend actually
+  // consumes mcp_config — see providerSupportsMcpConfig. We default to
+  // showing it when the runtime row hasn't loaded yet so a slow fetch
+  // can't transiently flicker the tab off and then on.
+  const visibleTabs = useMemo(() => {
+    const showMcp = runtime ? providerSupportsMcpConfig(runtime.provider) : true;
+    return detailTabs.filter((tab) => tab.id !== "mcp_config" || showMcp);
+  }, [runtime]);
+
+  // If the active tab disappears (e.g. user just switched the agent's
+  // runtime to one that doesn't read mcp_config), fall back to Activity
+  // for this render so the pane is never empty. The user's stored
+  // activeTab is left alone — switching back to a supporting runtime
+  // brings their selection back.
+  const effectiveTab: DetailTab = visibleTabs.some((tab) => tab.id === activeTab)
+    ? activeTab
+    : "activity";
+
   const requestTabChange = (next: DetailTab) => {
     if (next === activeTab) return;
     if (activeDirty) {
@@ -134,13 +153,13 @@ export function AgentOverviewPane({
     // the grid-driven full-height behavior on tablet and up.
     <div className="flex min-h-[60vh] flex-col overflow-hidden rounded-lg border bg-background md:h-full md:min-h-0">
       <div className="flex shrink-0 items-center gap-0 overflow-x-auto border-b px-2 md:px-4">
-        {detailTabs.map((tab) => (
+        {visibleTabs.map((tab) => (
           <button
             key={tab.id}
             type="button"
             onClick={() => requestTabChange(tab.id)}
             className={`flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2.5 text-xs font-medium transition-colors ${
-              activeTab === tab.id
+              effectiveTab === tab.id
                 ? "border-foreground text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
@@ -152,13 +171,13 @@ export function AgentOverviewPane({
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {activeTab === "activity" && <ActivityTab agent={agent} />}
-        {activeTab === "tasks" && (
+        {effectiveTab === "activity" && <ActivityTab agent={agent} />}
+        {effectiveTab === "tasks" && (
           <div className="flex h-full min-h-[520px] flex-col">
             <ActorIssuesPanel actorType="agent" actorId={agent.id} />
           </div>
         )}
-        {activeTab === "instructions" && (
+        {effectiveTab === "instructions" && (
           <TabContent>
             <InstructionsTab
               agent={agent}
@@ -167,12 +186,12 @@ export function AgentOverviewPane({
             />
           </TabContent>
         )}
-        {activeTab === "skills" && (
+        {effectiveTab === "skills" && (
           <TabContent>
             <SkillsTab agent={agent} />
           </TabContent>
         )}
-        {activeTab === "env" && (
+        {effectiveTab === "env" && (
           <TabContent>
             <EnvTab
               agent={agent}
@@ -180,7 +199,7 @@ export function AgentOverviewPane({
             />
           </TabContent>
         )}
-        {activeTab === "custom_args" && (
+        {effectiveTab === "custom_args" && (
           <TabContent>
             <CustomArgsTab
               agent={agent}
@@ -190,11 +209,10 @@ export function AgentOverviewPane({
             />
           </TabContent>
         )}
-        {activeTab === "mcp_config" && (
+        {effectiveTab === "mcp_config" && (
           <TabContent>
             <McpConfigTab
               agent={agent}
-              runtimeDevice={runtime ?? undefined}
               onSave={(updates) => onUpdate(agent.id, updates)}
               onDirtyChange={setActiveDirty}
             />

--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Agent } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../../locales/en/common.json";
+import enAgents from "../../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { McpConfigTab } from "./mcp-config-tab";
+
+const baseAgent: Agent = {
+  id: "agent-1",
+  workspace_id: "ws-1",
+  runtime_id: "runtime-1",
+  name: "Agent",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "local",
+  runtime_config: {},
+  custom_args: [],
+  visibility: "workspace",
+  status: "idle",
+  max_concurrent_tasks: 1,
+  model: "",
+  owner_id: "user-1",
+  skills: [],
+  created_at: "2026-05-28T00:00:00Z",
+  updated_at: "2026-05-28T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
+};
+
+function renderTab(overrides: Partial<Agent> = {}, onSave = vi.fn().mockResolvedValue(undefined)) {
+  const agent = { ...baseAgent, ...overrides };
+  const result = render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <McpConfigTab agent={agent} onSave={onSave} />
+    </I18nProvider>,
+  );
+  return { ...result, onSave };
+}
+
+describe("McpConfigTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a read-only redacted state when the server omitted the value", () => {
+    // mcp_config_redacted means the server knows there IS a config but
+    // hid it from this caller. The tab must NOT expose the editor or
+    // any input — even an empty textarea would let a non-privileged
+    // member silently overwrite an admin-owned config on save.
+    renderTab({ mcp_config: null, mcp_config_redacted: true });
+
+    expect(screen.getByText(/hidden from your view/i)).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the editor empty when no config is set, and Save stays disabled", () => {
+    renderTab({ mcp_config: null });
+
+    const editor = screen.getByLabelText(/MCP config JSON editor/i) as HTMLTextAreaElement;
+    expect(editor.value).toBe("");
+
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("pretty-prints the existing config and saves a parsed object", async () => {
+    const user = userEvent.setup();
+    const stored = { mcpServers: { fetch: { command: "uvx" } } };
+    const { onSave } = renderTab({ mcp_config: stored });
+
+    const editor = screen.getByLabelText(/MCP config JSON editor/i) as HTMLTextAreaElement;
+    expect(editor.value).toBe(JSON.stringify(stored, null, 2));
+
+    // userEvent.type interprets `{` / `[` as keyboard modifiers, so a
+    // raw JSON paste goes through fireEvent.change instead — the same
+    // path the browser uses when the user pastes.
+    const replacement = JSON.stringify({
+      mcpServers: { fetch: { command: "npx" } },
+    });
+    fireEvent.change(editor, { target: { value: replacement } });
+
+    const save = screen.getByRole("button", { name: /save/i });
+    expect(save).toBeEnabled();
+    await user.click(save);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    // We pass the parsed object, not the raw string, so the backend
+    // gets a real JSON shape and not an escaped string.
+    expect(onSave).toHaveBeenCalledWith({
+      mcp_config: { mcpServers: { fetch: { command: "npx" } } },
+    });
+  });
+
+  it("clearing the editor saves null to wipe the column", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderTab({ mcp_config: { mcpServers: {} } });
+
+    const editor = screen.getByLabelText(/MCP config JSON editor/i) as HTMLTextAreaElement;
+    await user.clear(editor);
+
+    const save = screen.getByRole("button", { name: /save/i });
+    await user.click(save);
+
+    // null is what the backend reads as "clear this column" — sending
+    // an empty string or {} would either fail validation or store an
+    // empty object, both of which surprise the user.
+    expect(onSave).toHaveBeenCalledWith({ mcp_config: null });
+  });
+
+  it("disables Save and surfaces an inline error on invalid JSON", () => {
+    const { onSave } = renderTab({ mcp_config: null });
+
+    const editor = screen.getByLabelText(/MCP config JSON editor/i);
+    fireEvent.change(editor, { target: { value: "{ not json" } });
+
+    expect(screen.getByText(/Invalid JSON/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("rejects top-level arrays and primitives", () => {
+    renderTab({ mcp_config: null });
+
+    const editor = screen.getByLabelText(/MCP config JSON editor/i);
+    fireEvent.change(editor, { target: { value: "[1,2,3]" } });
+
+    expect(
+      screen.getByText(/MCP config must be a JSON object/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+});

--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Agent, RuntimeDevice } from "@multica/core/types";
+import type { Agent } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
@@ -42,35 +42,14 @@ const baseAgent: Agent = {
   archived_by: null,
 };
 
-function makeRuntime(provider: string): RuntimeDevice {
-  return {
-    id: "runtime-1",
-    workspace_id: "ws-1",
-    daemon_id: null,
-    name: "Runtime",
-    runtime_mode: "local",
-    provider,
-    launch_header: "",
-    status: "online",
-    device_info: "",
-    metadata: {},
-    owner_id: null,
-    visibility: "private",
-    last_seen_at: null,
-    created_at: "2026-05-28T00:00:00Z",
-    updated_at: "2026-05-28T00:00:00Z",
-  };
-}
-
 function renderTab(
   overrides: Partial<Agent> = {},
   onSave = vi.fn().mockResolvedValue(undefined),
-  runtimeDevice?: RuntimeDevice,
 ) {
   const agent = { ...baseAgent, ...overrides };
   const result = render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <McpConfigTab agent={agent} onSave={onSave} runtimeDevice={runtimeDevice} />
+      <McpConfigTab agent={agent} onSave={onSave} />
     </I18nProvider>,
   );
   return { ...result, onSave };
@@ -240,21 +219,4 @@ describe("McpConfigTab", () => {
     expect(editor.value).toBe(draft);
   });
 
-  it("warns when the agent's runtime provider is not Claude", () => {
-    renderTab({ mcp_config: null }, undefined, makeRuntime("codex"));
-
-    expect(
-      screen.getByText(/Only the Claude runtime reads this config/i),
-    ).toBeInTheDocument();
-    // Editor is still rendered — the warning is informational, not a block.
-    expect(screen.getByLabelText(/MCP config JSON editor/i)).toBeInTheDocument();
-  });
-
-  it("does not warn for a Claude runtime", () => {
-    renderTab({ mcp_config: null }, undefined, makeRuntime("claude"));
-
-    expect(
-      screen.queryByText(/Only the Claude runtime reads this config/i),
-    ).not.toBeInTheDocument();
-  });
 });

--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Agent } from "@multica/core/types";
+import type { Agent, RuntimeDevice } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
@@ -42,11 +42,35 @@ const baseAgent: Agent = {
   archived_by: null,
 };
 
-function renderTab(overrides: Partial<Agent> = {}, onSave = vi.fn().mockResolvedValue(undefined)) {
+function makeRuntime(provider: string): RuntimeDevice {
+  return {
+    id: "runtime-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "Runtime",
+    runtime_mode: "local",
+    provider,
+    launch_header: "",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    visibility: "private",
+    last_seen_at: null,
+    created_at: "2026-05-28T00:00:00Z",
+    updated_at: "2026-05-28T00:00:00Z",
+  };
+}
+
+function renderTab(
+  overrides: Partial<Agent> = {},
+  onSave = vi.fn().mockResolvedValue(undefined),
+  runtimeDevice?: RuntimeDevice,
+) {
   const agent = { ...baseAgent, ...overrides };
   const result = render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <McpConfigTab agent={agent} onSave={onSave} />
+      <McpConfigTab agent={agent} onSave={onSave} runtimeDevice={runtimeDevice} />
     </I18nProvider>,
   );
   return { ...result, onSave };
@@ -143,5 +167,94 @@ describe("McpConfigTab", () => {
       screen.getByText(/MCP config must be a JSON object/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("syncs the editor to a refreshed agent prop when the user hasn't edited", () => {
+    // Reproduces the stale-editor bug: a background refetch / WS event swaps
+    // in a newer `agent.mcp_config`, and the editor must follow it (so the
+    // next Save writes the new value, not the old one). Comparing the draft
+    // against the *previous* original — not the new one — is what makes this
+    // work. Without the ref, the effect would self-defeat: on re-render the
+    // draft already equals the new original, the equality check is true,
+    // but the conditional only re-assigns `original` to itself, so a draft
+    // that started life equal to the OLD original is never touched.
+    const initial = { mcpServers: { fetch: { command: "uvx" } } };
+    const updated = { mcpServers: { fetch: { command: "npx" } } };
+    const agent = { ...baseAgent, mcp_config: initial };
+
+    const { rerender } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <McpConfigTab agent={agent} onSave={vi.fn()} />
+      </I18nProvider>,
+    );
+
+    const editor = screen.getByLabelText(
+      /MCP config JSON editor/i,
+    ) as HTMLTextAreaElement;
+    expect(editor.value).toBe(JSON.stringify(initial, null, 2));
+
+    rerender(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <McpConfigTab
+          agent={{ ...agent, mcp_config: updated }}
+          onSave={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    // Editor follows the new prop and the dirty hint is NOT shown — if it
+    // were, the next Save would write the *old* JSON back over the new one.
+    expect(editor.value).toBe(JSON.stringify(updated, null, 2));
+    expect(screen.queryByText(/unsaved changes/i)).not.toBeInTheDocument();
+  });
+
+  it("preserves an in-flight edit when the agent prop is refreshed underneath", () => {
+    // The mirror of the test above: if the user IS editing, a background
+    // refresh must not clobber their draft.
+    const initial = { mcpServers: { fetch: { command: "uvx" } } };
+    const updated = { mcpServers: { fetch: { command: "npx" } } };
+    const agent = { ...baseAgent, mcp_config: initial };
+
+    const { rerender } = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <McpConfigTab agent={agent} onSave={vi.fn()} />
+      </I18nProvider>,
+    );
+
+    const editor = screen.getByLabelText(
+      /MCP config JSON editor/i,
+    ) as HTMLTextAreaElement;
+    const draft = JSON.stringify({ mcpServers: { fetch: { command: "wip" } } });
+    fireEvent.change(editor, { target: { value: draft } });
+    expect(editor.value).toBe(draft);
+
+    rerender(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <McpConfigTab
+          agent={{ ...agent, mcp_config: updated }}
+          onSave={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(editor.value).toBe(draft);
+  });
+
+  it("warns when the agent's runtime provider is not Claude", () => {
+    renderTab({ mcp_config: null }, undefined, makeRuntime("codex"));
+
+    expect(
+      screen.getByText(/Only the Claude runtime reads this config/i),
+    ).toBeInTheDocument();
+    // Editor is still rendered — the warning is informational, not a block.
+    expect(screen.getByLabelText(/MCP config JSON editor/i)).toBeInTheDocument();
+  });
+
+  it("does not warn for a Claude runtime", () => {
+    renderTab({ mcp_config: null }, undefined, makeRuntime("claude"));
+
+    expect(
+      screen.queryByText(/Only the Claude runtime reads this config/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Eraser, Loader2, Lock, Save } from "lucide-react";
+import type { Agent } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import { Textarea } from "@multica/ui/components/ui/textarea";
+import { toast } from "sonner";
+import { useT } from "../../../i18n";
+
+// `null` and the empty string are the two ways the user can mean "no
+// config" — the server stores either as a NULL column and the daemon
+// falls back to the runtime CLI default at launch. We normalise to
+// the empty string in the editor so the dirty check has one canonical
+// form to compare against.
+function configToText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value, null, 2);
+}
+
+export function McpConfigTab({
+  agent,
+  onSave,
+  onDirtyChange,
+}: {
+  agent: Agent;
+  onSave: (updates: { mcp_config: unknown | null }) => Promise<void>;
+  onDirtyChange?: (dirty: boolean) => void;
+}) {
+  const { t } = useT("agents");
+
+  const redacted = agent.mcp_config_redacted === true;
+  const original = useMemo(() => configToText(agent.mcp_config), [agent.mcp_config]);
+  const [text, setText] = useState(original);
+  const [saving, setSaving] = useState(false);
+
+  // Sync local draft when the agent prop changes (e.g. after a successful
+  // save invalidates the cache and a fresh agent arrives). We only sync
+  // when the user has no in-flight edits — otherwise a background WS
+  // event would clobber whatever they typed.
+  useEffect(() => {
+    setText((current) => (current === original ? original : current));
+  }, [original]);
+
+  const trimmed = text.trim();
+  const parseResult = useMemo<
+    | { ok: true; value: unknown | null }
+    | { ok: false; error: string }
+  >(() => {
+    if (trimmed === "") return { ok: true, value: null };
+    try {
+      const value = JSON.parse(trimmed);
+      // The MCP CLI accepts an object (`{"mcpServers": …}`); a top-level
+      // array or primitive is almost certainly a user mistake, so reject
+      // here rather than surprise them with a server-side error later.
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        return {
+          ok: false,
+          error: "mcp_config_not_object",
+        };
+      }
+      return { ok: true, value };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : "invalid JSON",
+      };
+    }
+  }, [trimmed]);
+
+  const dirty = text !== original;
+
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+
+  if (redacted) {
+    return (
+      <div className="space-y-3">
+        <p className="flex items-center gap-2 text-sm font-medium">
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+          {t(($) => $.tab_body.mcp_config.redacted_title)}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t(($) => $.tab_body.mcp_config.redacted_hint)}
+        </p>
+      </div>
+    );
+  }
+
+  const handleSave = async () => {
+    if (!parseResult.ok) return;
+    setSaving(true);
+    try {
+      await onSave({ mcp_config: parseResult.value });
+      // Normalise the editor to the pretty-printed canonical form so the
+      // dirty check stops firing after a successful save (the user's
+      // raw input may differ from what configToText would emit).
+      setText(configToText(parseResult.value));
+      toast.success(t(($) => $.tab_body.mcp_config.saved_toast));
+    } catch (err) {
+      toast.error(
+        err instanceof Error && err.message
+          ? err.message
+          : t(($) => $.tab_body.mcp_config.save_failed_toast),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = () => {
+    setText("");
+  };
+
+  const showInvalid = trimmed !== "" && !parseResult.ok;
+  const invalidMessage = !parseResult.ok && parseResult.error === "mcp_config_not_object"
+    ? t(($) => $.tab_body.mcp_config.invalid_not_object)
+    : !parseResult.ok
+      ? t(($) => $.tab_body.mcp_config.invalid_json, { error: parseResult.error })
+      : "";
+
+  return (
+    <div className="flex h-full flex-col space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {t(($) => $.tab_body.mcp_config.intro)}
+        </p>
+        {trimmed !== "" && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleClear}
+            className="shrink-0"
+          >
+            <Eraser className="h-3 w-3" />
+            {t(($) => $.tab_body.mcp_config.clear_action)}
+          </Button>
+        )}
+      </div>
+
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={t(($) => $.tab_body.mcp_config.placeholder)}
+        aria-invalid={showInvalid || undefined}
+        aria-label={t(($) => $.tab_body.mcp_config.editor_aria)}
+        spellCheck={false}
+        className="min-h-[240px] flex-1 font-mono text-xs"
+      />
+
+      {showInvalid && (
+        <p className="text-xs text-destructive">{invalidMessage}</p>
+      )}
+
+      <div className="flex items-center justify-end gap-3">
+        {dirty && (
+          <span className="text-xs text-muted-foreground">
+            {t(($) => $.tab_body.common.unsaved_changes)}
+          </span>
+        )}
+        <Button
+          onClick={handleSave}
+          disabled={!dirty || !parseResult.ok || saving}
+          size="sm"
+        >
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          {t(($) => $.tab_body.common.save)}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Eraser, Loader2, Lock, Save } from "lucide-react";
-import type { Agent } from "@multica/core/types";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Eraser, Info, Loader2, Lock, Save } from "lucide-react";
+import type { Agent, RuntimeDevice } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import { Textarea } from "@multica/ui/components/ui/textarea";
 import { toast } from "sonner";
@@ -20,10 +20,12 @@ function configToText(value: unknown): string {
 
 export function McpConfigTab({
   agent,
+  runtimeDevice,
   onSave,
   onDirtyChange,
 }: {
   agent: Agent;
+  runtimeDevice?: RuntimeDevice;
   onSave: (updates: { mcp_config: unknown | null }) => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
@@ -36,11 +38,27 @@ export function McpConfigTab({
 
   // Sync local draft when the agent prop changes (e.g. after a successful
   // save invalidates the cache and a fresh agent arrives). We only sync
-  // when the user has no in-flight edits — otherwise a background WS
-  // event would clobber whatever they typed.
+  // when the user has no in-flight edits — comparing the current draft
+  // against the *previous* original (not the new one) is what tells us
+  // "they haven't touched this since the last sync". Comparing against
+  // the new original would skip the sync whenever the server-side value
+  // changes underneath an untouched draft, leaving the editor showing a
+  // stale value that a later Save would write back, clobbering another
+  // admin's edit.
+  const previousOriginalRef = useRef(original);
   useEffect(() => {
-    setText((current) => (current === original ? original : current));
+    setText((current) =>
+      current === previousOriginalRef.current ? original : current,
+    );
+    previousOriginalRef.current = original;
   }, [original]);
+
+  // Only the Claude runtime currently consumes `mcp_config` — the daemon
+  // forwards it via Claude's `--mcp-config` flag and no other provider
+  // reads it. We surface that explicitly so saving on e.g. a Codex agent
+  // doesn't quietly look like it took effect.
+  const providerSupportsMcp =
+    runtimeDevice === undefined || runtimeDevice.provider === "claude";
 
   const trimmed = text.trim();
   const parseResult = useMemo<
@@ -139,6 +157,20 @@ export function McpConfigTab({
           </Button>
         )}
       </div>
+
+      {!providerSupportsMcp && (
+        <div
+          role="note"
+          className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-2.5 text-xs text-warning-foreground"
+        >
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <p>
+            {t(($) => $.tab_body.mcp_config.provider_unsupported, {
+              provider: runtimeDevice?.provider ?? "",
+            })}
+          </p>
+        </div>
+      )}
 
       <Textarea
         value={text}

--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Eraser, Info, Loader2, Lock, Save } from "lucide-react";
-import type { Agent, RuntimeDevice } from "@multica/core/types";
+import { Eraser, Loader2, Lock, Save } from "lucide-react";
+import type { Agent } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import { Textarea } from "@multica/ui/components/ui/textarea";
 import { toast } from "sonner";
@@ -20,12 +20,10 @@ function configToText(value: unknown): string {
 
 export function McpConfigTab({
   agent,
-  runtimeDevice,
   onSave,
   onDirtyChange,
 }: {
   agent: Agent;
-  runtimeDevice?: RuntimeDevice;
   onSave: (updates: { mcp_config: unknown | null }) => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
@@ -52,13 +50,6 @@ export function McpConfigTab({
     );
     previousOriginalRef.current = original;
   }, [original]);
-
-  // Only the Claude runtime currently consumes `mcp_config` — the daemon
-  // forwards it via Claude's `--mcp-config` flag and no other provider
-  // reads it. We surface that explicitly so saving on e.g. a Codex agent
-  // doesn't quietly look like it took effect.
-  const providerSupportsMcp =
-    runtimeDevice === undefined || runtimeDevice.provider === "claude";
 
   const trimmed = text.trim();
   const parseResult = useMemo<
@@ -157,20 +148,6 @@ export function McpConfigTab({
           </Button>
         )}
       </div>
-
-      {!providerSupportsMcp && (
-        <div
-          role="note"
-          className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 p-2.5 text-xs text-warning-foreground"
-        >
-          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <p>
-            {t(($) => $.tab_body.mcp_config.provider_unsupported, {
-              provider: runtimeDevice?.provider ?? "",
-            })}
-          </p>
-        </div>
-      )}
 
       <Textarea
         value={text}

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -296,7 +296,7 @@
       "save_failed_toast": "Failed to save custom arguments"
     },
     "mcp_config": {
-      "intro": "MCP server configuration forwarded to the runtime CLI (Claude via --mcp-config, Codex via -c mcp_servers.*). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default.",
+      "intro": "MCP server configuration forwarded to the runtime CLI (Claude via --mcp-config, Codex via $CODEX_HOME/config.toml). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default.",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP config JSON editor",
       "clear_action": "Clear",

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -296,7 +296,7 @@
       "save_failed_toast": "Failed to save custom arguments"
     },
     "mcp_config": {
-      "intro": "MCP server configuration forwarded to the runtime CLI (e.g. Claude's --mcp-config). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default.",
+      "intro": "MCP server configuration forwarded to the runtime CLI (Claude via --mcp-config, Codex via -c mcp_servers.*). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default.",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP config JSON editor",
       "clear_action": "Clear",
@@ -305,8 +305,7 @@
       "saved_toast": "MCP config saved",
       "save_failed_toast": "Failed to save MCP config",
       "redacted_title": "Configured — hidden from your view",
-      "redacted_hint": "Only the agent owner or a workspace admin can read this config.",
-      "provider_unsupported": "Only the Claude runtime reads this config. This agent runs on a \"{{provider}}\" runtime, so the value will be stored but the CLI won't load it at launch."
+      "redacted_hint": "Only the agent owner or a workspace admin can read this config."
     },
     "skills": {
       "intro": "Workspace skills assigned to this agent. Local runtime skills are always available automatically.",

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -195,6 +195,7 @@
     "skills": "Skills",
     "environment": "Environment",
     "custom_args": "Custom Args",
+    "mcp_config": "MCP",
     "discard_dialog_title": "Discard unsaved changes?",
     "discard_dialog_description": "You have unsaved changes in this tab. Leaving now will discard them.",
     "discard_keep": "Keep editing",
@@ -293,6 +294,18 @@
       "remove_aria": "Remove argument",
       "saved_toast": "Custom arguments saved",
       "save_failed_toast": "Failed to save custom arguments"
+    },
+    "mcp_config": {
+      "intro": "MCP server configuration forwarded to the runtime CLI (e.g. Claude's --mcp-config). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default.",
+      "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
+      "editor_aria": "MCP config JSON editor",
+      "clear_action": "Clear",
+      "invalid_json": "Invalid JSON: {{error}}",
+      "invalid_not_object": "MCP config must be a JSON object (e.g. {\"mcpServers\": …}).",
+      "saved_toast": "MCP config saved",
+      "save_failed_toast": "Failed to save MCP config",
+      "redacted_title": "Configured — hidden from your view",
+      "redacted_hint": "Only the agent owner or a workspace admin can read this config."
     },
     "skills": {
       "intro": "Workspace skills assigned to this agent. Local runtime skills are always available automatically.",

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -305,7 +305,8 @@
       "saved_toast": "MCP config saved",
       "save_failed_toast": "Failed to save MCP config",
       "redacted_title": "Configured — hidden from your view",
-      "redacted_hint": "Only the agent owner or a workspace admin can read this config."
+      "redacted_hint": "Only the agent owner or a workspace admin can read this config.",
+      "provider_unsupported": "Only the Claude runtime reads this config. This agent runs on a \"{{provider}}\" runtime, so the value will be stored but the CLI won't load it at launch."
     },
     "skills": {
       "intro": "Workspace skills assigned to this agent. Local runtime skills are always available automatically.",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -191,6 +191,7 @@
     "skills": "Skills",
     "environment": "环境变量",
     "custom_args": "自定义参数",
+    "mcp_config": "MCP",
     "discard_dialog_title": "放弃未保存的修改？",
     "discard_dialog_description": "当前 tab 有未保存的修改，离开会丢弃这些修改。",
     "discard_keep": "继续编辑",
@@ -287,6 +288,18 @@
       "remove_aria": "移除参数",
       "saved_toast": "已保存自定义参数",
       "save_failed_toast": "保存自定义参数失败"
+    },
+    "mcp_config": {
+      "intro": "转发给运行时 CLI 的 MCP 服务器配置（例如 Claude 的 --mcp-config）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。",
+      "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
+      "editor_aria": "MCP 配置 JSON 编辑器",
+      "clear_action": "清空",
+      "invalid_json": "JSON 无效：{{error}}",
+      "invalid_not_object": "MCP 配置必须是 JSON 对象（例如 {\"mcpServers\": …}）。",
+      "saved_toast": "已保存 MCP 配置",
+      "save_failed_toast": "保存 MCP 配置失败",
+      "redacted_title": "已配置 —— 当前账号无权查看",
+      "redacted_hint": "只有智能体所有者或工作区管理员可以读取该配置。"
     },
     "skills": {
       "intro": "分配给该智能体的工作区 skill。本地运行时 skill 会自动可用。",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -290,7 +290,7 @@
       "save_failed_toast": "保存自定义参数失败"
     },
     "mcp_config": {
-      "intro": "转发给运行时 CLI 的 MCP 服务器配置（Claude 通过 --mcp-config，Codex 通过 -c mcp_servers.*）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。",
+      "intro": "转发给运行时 CLI 的 MCP 服务器配置（Claude 通过 --mcp-config，Codex 通过 $CODEX_HOME/config.toml）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP 配置 JSON 编辑器",
       "clear_action": "清空",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -290,7 +290,7 @@
       "save_failed_toast": "保存自定义参数失败"
     },
     "mcp_config": {
-      "intro": "转发给运行时 CLI 的 MCP 服务器配置（例如 Claude 的 --mcp-config）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。",
+      "intro": "转发给运行时 CLI 的 MCP 服务器配置（Claude 通过 --mcp-config，Codex 通过 -c mcp_servers.*）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP 配置 JSON 编辑器",
       "clear_action": "清空",
@@ -299,8 +299,7 @@
       "saved_toast": "已保存 MCP 配置",
       "save_failed_toast": "保存 MCP 配置失败",
       "redacted_title": "已配置 —— 当前账号无权查看",
-      "redacted_hint": "只有智能体所有者或工作区管理员可以读取该配置。",
-      "provider_unsupported": "目前只有 Claude 运行时会读取此配置。该智能体运行在「{{provider}}」运行时上，保存后 CLI 启动时不会加载该值。"
+      "redacted_hint": "只有智能体所有者或工作区管理员可以读取该配置。"
     },
     "skills": {
       "intro": "分配给该智能体的工作区 skill。本地运行时 skill 会自动可用。",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -299,7 +299,8 @@
       "saved_toast": "已保存 MCP 配置",
       "save_failed_toast": "保存 MCP 配置失败",
       "redacted_title": "已配置 —— 当前账号无权查看",
-      "redacted_hint": "只有智能体所有者或工作区管理员可以读取该配置。"
+      "redacted_hint": "只有智能体所有者或工作区管理员可以读取该配置。",
+      "provider_unsupported": "目前只有 Claude 运行时会读取此配置。该智能体运行在「{{provider}}」运行时上，保存后 CLI 启动时不会加载该值。"
     },
     "skills": {
       "intro": "分配给该智能体的工作区 skill。本地运行时 skill 会自动可用。",

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -75,15 +76,38 @@ type codexBackend struct {
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{"app-server", "--listen", "stdio://"}
-	args = append(args, filterCodexCustomConfigOverrides(
-		filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger),
-		logger,
-	)...)
-	args = append(args, filterCodexCustomConfigOverrides(
-		filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger),
-		logger,
-	)...)
+	extra := filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)
+	custom := filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)
+	// Only claim ownership of the `mcp_servers` namespace when the agent
+	// actually has a managed mcp_config in the MCP Tab. Otherwise existing
+	// users who configure MCP via `custom_args: ["-c", "mcp_servers.…"]`
+	// would silently lose those entries after this PR ships. With managed
+	// mcp_config present, daemon-written `$CODEX_HOME/config.toml` is the
+	// authoritative source and stray `-c mcp_servers.*` overrides are
+	// dropped to keep last-wins from re-shadowing it.
+	if hasManagedCodexMcpConfig(opts.McpConfig) {
+		extra = filterCodexCustomConfigOverrides(extra, logger)
+		custom = filterCodexCustomConfigOverrides(custom, logger)
+	}
+	args = append(args, extra...)
+	args = append(args, custom...)
 	return args
+}
+
+// hasManagedCodexMcpConfig reports whether the agent's mcp_config field is
+// "present" in the API three-state sense: a non-null JSON value. Both
+// `{}` and `{"mcpServers":{}}` count as present (the admin saved an empty
+// managed set — strict mode, no global fallback); only SQL NULL or the
+// literal JSON `null` count as absent (CLI default).
+func hasManagedCodexMcpConfig(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return false
+	}
+	return true
 }
 
 // codexManagedMcpConfigKeyRe matches the daemon-managed config namespace
@@ -190,31 +214,44 @@ func ensureCodexMcpConfig(configPath string, mcpConfig json.RawMessage, logger *
 	// converge on a clean state.
 	stripped := codexMcpBlockRe.ReplaceAllString(existing, "")
 
-	block, hasServers, renderErr := renderCodexMcpServersBlock(mcpConfig)
+	managed := hasManagedCodexMcpConfig(mcpConfig)
+	block, _, renderErr := renderCodexMcpServersBlock(mcpConfig)
 	if renderErr != nil {
 		return renderErr
 	}
 
 	var updated string
-	if hasServers {
-		// With an agent-managed set, strip any user-defined `[mcp_servers.*]`
-		// tables inherited from the shared `~/.codex/config.toml`. Two reasons:
-		//   1. TOML rejects redefining the same table; a user table named
-		//      `[mcp_servers.fetch]` would crash codex if the agent also
-		//      defined `fetch`.
-		//   2. The agent's mcp_config is meant to be the strict source for
-		//      this task — same as Claude's `--strict-mcp-config`. Mixing in
-		//      user-global servers would surprise the admin who edited the
-		//      MCP Tab expecting an explicit list.
+	if managed {
+		// Agent has a managed MCP set (possibly empty — `{}` /
+		// `{"mcpServers":{}}` count as "saved an empty set" in the API's
+		// three-state semantics, distinct from nil/null which means
+		// "fall back to CLI default"). Strip any user-defined
+		// `[mcp_servers.*]` tables inherited from `~/.codex/config.toml`
+		// so the managed set is strict — mirrors Claude's
+		// `--strict-mcp-config`. Two reasons we cannot mix:
+		//   1. TOML rejects redefining the same table; a user table
+		//      named `[mcp_servers.fetch]` would crash codex if the
+		//      agent also defined `fetch`.
+		//   2. An admin saving an explicit list in the MCP Tab would
+		//      otherwise see user-global servers silently joined in,
+		//      which contradicts the UI affordance.
 		stripped = stripCodexUserMcpServerTables(stripped)
 		stripped = strings.TrimRight(stripped, "\n")
+		// When the managed set is empty we still write the marker
+		// block (with no tables between). This pins "managed but
+		// empty" on disk so the next run can find and strip the
+		// markers, and so the file's intent is grep-able by ops.
+		if block == "" {
+			block = multicaCodexMcpBeginMarker + "\n" + multicaCodexMcpEndMarker + "\n"
+		}
 		if stripped == "" {
 			updated = block
 		} else {
 			updated = stripped + "\n\n" + block
 		}
 	} else {
-		// No managed servers: leave any inherited user tables alone.
+		// No managed config: just remove any prior managed block and
+		// leave inherited user tables alone (CLI default fallback).
 		updated = stripped
 	}
 
@@ -235,7 +272,7 @@ func ensureCodexMcpConfig(configPath string, mcpConfig json.RawMessage, logger *
 	}
 	if logger != nil {
 		logger.Debug("codex: wrote managed mcp_servers block to config.toml",
-			"config_path", configPath, "has_servers", hasServers)
+			"config_path", configPath, "managed", managed)
 	}
 	return nil
 }
@@ -482,13 +519,22 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	// config.toml at 0o600 keeps the secret values out of argv and logs.
 	if codexHome := strings.TrimSpace(b.cfg.Env["CODEX_HOME"]); codexHome != "" {
 		if err := ensureCodexMcpConfig(filepath.Join(codexHome, "config.toml"), opts.McpConfig, b.cfg.Logger); err != nil {
-			// A malformed mcp_config shouldn't kill the run — the agent
-			// still launches, just without the configured MCP servers.
-			// The admin sees the warning in daemon logs and can fix it.
-			b.cfg.Logger.Warn("codex: ignoring invalid mcp_config", "error", err)
+			// Fail closed when we can't materialise the managed config.
+			// Warning-and-launching would silently fall back to the
+			// user's global `~/.codex/config.toml` MCP servers and
+			// look indistinguishable from "the saved config was
+			// applied", which is exactly the surprise the MCP Tab is
+			// supposed to remove.
+			cancel()
+			return nil, fmt.Errorf("apply codex mcp_config: %w", err)
 		}
-	} else if len(opts.McpConfig) > 0 {
-		b.cfg.Logger.Warn("codex: mcp_config provided but CODEX_HOME is not set; MCP servers will not be loaded")
+	} else if hasManagedCodexMcpConfig(opts.McpConfig) {
+		// Managed mcp_config saved but no CODEX_HOME to anchor it.
+		// Same reasoning as above: silently launching would inherit
+		// whatever MCP setup the host user has, which is the wrong
+		// shape of failure.
+		cancel()
+		return nil, fmt.Errorf("codex: mcp_config is set but CODEX_HOME env var is not configured; cannot apply managed MCP")
 	}
 
 	codexArgs := buildCodexArgs(opts, b.cfg.Logger)

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -9,13 +9,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
 // codexBlockedArgs are flags hardcoded by the daemon that must not be
-// overridden by user-configured custom_args.
+// overridden by user-configured custom_args. The mcp_servers config keys
+// are injected by buildCodexMcpArgs from agent.mcp_config — a user-supplied
+// `-c mcp_servers.…` would silently override the daemon's value.
 var codexBlockedArgs = map[string]blockedArgMode{
 	"--listen": blockedWithValue, // stdio:// transport for daemon communication
 }
@@ -68,9 +72,178 @@ type codexBackend struct {
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{"app-server", "--listen", "stdio://"}
+	// MCP servers from agent.mcp_config are injected first so they sit
+	// inside Codex's config layer before any user-supplied custom_args
+	// can collide with them.
+	if mcpArgs, err := buildCodexMcpArgs(opts.McpConfig); err != nil {
+		// A malformed mcp_config shouldn't kill the run — the agent will
+		// still launch, just without the configured MCP servers. The
+		// admin sees the warning in daemon logs and can fix the JSON.
+		logger.Warn("codex: ignoring invalid mcp_config", "error", err)
+	} else {
+		args = append(args, mcpArgs...)
+	}
 	args = append(args, filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)...)
 	args = append(args, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)...)
 	return args
+}
+
+// buildCodexMcpArgs translates the agent's mcp_config JSON (Claude-style
+// `{"mcpServers": {...}}`) into Codex `-c mcp_servers.<name>=<toml>`
+// overrides. Each server is emitted as one inline TOML table so the entire
+// per-server config is replaced as a unit (a dotted-path-per-leaf approach
+// would leave stale fields from the user's global config.toml fused into
+// the daemon-managed entry, which the user would never see).
+//
+// We translate Claude-style camelCase keys (`args`, `env`, `command`,
+// `url`) to whatever Codex's config schema expects — today they happen to
+// be the same names so the JSON passes through verbatim. If Codex ever
+// diverges, do the rename here, not in the UI editor.
+func buildCodexMcpArgs(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var parsed struct {
+		McpServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("parse mcp_config json: %w", err)
+	}
+	if len(parsed.McpServers) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(parsed.McpServers))
+	for name := range parsed.McpServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	args := make([]string, 0, len(names)*2)
+	for _, name := range names {
+		if !isCodexBareTomlKey(name) {
+			return nil, fmt.Errorf("mcp server name %q must be ASCII alphanumeric / _ / - to fit Codex's bare-key requirement", name)
+		}
+		var serverVal any
+		if err := json.Unmarshal(parsed.McpServers[name], &serverVal); err != nil {
+			return nil, fmt.Errorf("mcp_servers.%s: %w", name, err)
+		}
+		if _, ok := serverVal.(map[string]any); !ok {
+			return nil, fmt.Errorf("mcp_servers.%s must be a JSON object", name)
+		}
+		tomlValue, err := jsonValueToCodexTOMLInline(serverVal)
+		if err != nil {
+			return nil, fmt.Errorf("mcp_servers.%s: %w", name, err)
+		}
+		args = append(args, "-c", fmt.Sprintf("mcp_servers.%s=%s", name, tomlValue))
+	}
+	return args, nil
+}
+
+// jsonValueToCodexTOMLInline serialises a JSON value as a TOML inline
+// value. Only the subset Codex's `-c` accepts is supported: strings,
+// numbers, booleans, arrays, and inline tables. JSON nulls are rejected
+// because TOML has no null and silently dropping them would be confusing.
+func jsonValueToCodexTOMLInline(v any) (string, error) {
+	switch x := v.(type) {
+	case nil:
+		return "", fmt.Errorf("null is not a valid TOML value")
+	case bool:
+		if x {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		if x == float64(int64(x)) {
+			return strconv.FormatInt(int64(x), 10), nil
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64), nil
+	case string:
+		return codexTOMLBasicString(x), nil
+	case []any:
+		parts := make([]string, len(x))
+		for i, e := range x {
+			p, err := jsonValueToCodexTOMLInline(e)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = p
+		}
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, len(keys))
+		for i, k := range keys {
+			p, err := jsonValueToCodexTOMLInline(x[k])
+			if err != nil {
+				return "", err
+			}
+			parts[i] = codexTOMLKey(k) + " = " + p
+		}
+		return "{ " + strings.Join(parts, ", ") + " }", nil
+	default:
+		return "", fmt.Errorf("unsupported value type %T", v)
+	}
+}
+
+func codexTOMLBasicString(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s) + 2)
+	sb.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			sb.WriteString(`\\`)
+		case '"':
+			sb.WriteString(`\"`)
+		case '\b':
+			sb.WriteString(`\b`)
+		case '\t':
+			sb.WriteString(`\t`)
+		case '\n':
+			sb.WriteString(`\n`)
+		case '\f':
+			sb.WriteString(`\f`)
+		case '\r':
+			sb.WriteString(`\r`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				sb.WriteString(fmt.Sprintf(`\u%04x`, r))
+			} else {
+				sb.WriteRune(r)
+			}
+		}
+	}
+	sb.WriteByte('"')
+	return sb.String()
+}
+
+func codexTOMLKey(s string) string {
+	if isCodexBareTomlKey(s) {
+		return s
+	}
+	return codexTOMLBasicString(s)
+}
+
+func isCodexBareTomlKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,8 +19,10 @@ import (
 
 // codexBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args. The mcp_servers config keys
-// are injected by buildCodexMcpArgs from agent.mcp_config — a user-supplied
-// `-c mcp_servers.…` would silently override the daemon's value.
+// live in the per-task `$CODEX_HOME/config.toml` (written by
+// ensureCodexMcpConfig); user-supplied `-c mcp_servers.…` overrides are
+// stripped separately by filterCodexCustomConfigOverrides because they
+// share the `-c` flag with legitimate non-MCP overrides like `-c model=…`.
 var codexBlockedArgs = map[string]blockedArgMode{
 	"--listen": blockedWithValue, // stdio:// transport for daemon communication
 }
@@ -72,45 +75,193 @@ type codexBackend struct {
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{"app-server", "--listen", "stdio://"}
-	// MCP servers from agent.mcp_config are injected first so they sit
-	// inside Codex's config layer before any user-supplied custom_args
-	// can collide with them.
-	if mcpArgs, err := buildCodexMcpArgs(opts.McpConfig); err != nil {
-		// A malformed mcp_config shouldn't kill the run — the agent will
-		// still launch, just without the configured MCP servers. The
-		// admin sees the warning in daemon logs and can fix the JSON.
-		logger.Warn("codex: ignoring invalid mcp_config", "error", err)
-	} else {
-		args = append(args, mcpArgs...)
-	}
-	args = append(args, filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)...)
-	args = append(args, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)...)
+	args = append(args, filterCodexCustomConfigOverrides(
+		filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger),
+		logger,
+	)...)
+	args = append(args, filterCodexCustomConfigOverrides(
+		filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger),
+		logger,
+	)...)
 	return args
 }
 
-// buildCodexMcpArgs translates the agent's mcp_config JSON (Claude-style
-// `{"mcpServers": {...}}`) into Codex `-c mcp_servers.<name>=<toml>`
-// overrides. Each server is emitted as one inline TOML table so the entire
-// per-server config is replaced as a unit (a dotted-path-per-leaf approach
-// would leave stale fields from the user's global config.toml fused into
-// the daemon-managed entry, which the user would never see).
+// codexManagedMcpConfigKeyRe matches the daemon-managed config namespace
+// (`mcp_servers.…`) when it appears as the value of a Codex `-c` /
+// `--config` flag. Used by filterCodexCustomConfigOverrides to drop user
+// overrides that would otherwise shadow what the MCP Tab writes into
+// `$CODEX_HOME/config.toml`.
+var codexManagedMcpConfigKeyRe = regexp.MustCompile(`^\s*mcp_servers(?:\s*\.|\s*=|\s*$)`)
+
+// filterCodexCustomConfigOverrides drops `-c mcp_servers.…=` and
+// `--config mcp_servers.…=` entries from custom args. Codex's `-c` is
+// last-wins (verified against codex-cli 0.132.0), so without this filter a
+// user-written `-c mcp_servers.fetch=…` in custom_args would silently
+// override whatever the MCP Tab saved into the per-task config.toml. We
+// own the `mcp_servers` namespace via the managed block, so user attempts
+// to write into it are dropped with a warning rather than allowed to win.
+// Other `-c`/`--config` keys (e.g. `-c model="o3"`) pass through unchanged.
+func filterCodexCustomConfigOverrides(args []string, logger *slog.Logger) []string {
+	if len(args) == 0 {
+		return args
+	}
+	filtered := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		flag := arg
+		inlineValue := ""
+		hasInlineValue := false
+		if idx := strings.Index(arg, "="); idx > 0 {
+			flag = arg[:idx]
+			inlineValue = arg[idx+1:]
+			hasInlineValue = true
+		}
+		if flag == "-c" || flag == "--config" {
+			value := inlineValue
+			if !hasInlineValue && i+1 < len(args) {
+				value = args[i+1]
+			}
+			if codexManagedMcpConfigKeyRe.MatchString(value) {
+				if logger != nil {
+					// Log the key only, never the value — mcp_servers.<name>.env
+					// is allowed to carry secrets and the whole point of moving
+					// this to config.toml is to keep raw values out of logs/argv.
+					key := value
+					if eqIdx := strings.Index(value, "="); eqIdx >= 0 {
+						key = value[:eqIdx]
+					}
+					logger.Warn("custom_args: blocked mcp_servers override; daemon manages this via CODEX_HOME/config.toml",
+						"flag", flag, "key", strings.TrimSpace(key))
+				}
+				if !hasInlineValue && i+1 < len(args) {
+					i++ // skip the value arg
+				}
+				continue
+			}
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+// Markers delimiting the daemon-managed `[mcp_servers.*]` block in
+// `$CODEX_HOME/config.toml`. Match the existing sandbox / multi-agent /
+// memory marker pattern so ops can grep all managed blocks consistently.
+const (
+	multicaCodexMcpBeginMarker = "# BEGIN multica-managed mcp_servers (do not edit; regenerated by daemon)"
+	multicaCodexMcpEndMarker   = "# END multica-managed mcp_servers"
+)
+
+var codexMcpBlockRe = regexp.MustCompile(
+	`(?ms)^` + regexp.QuoteMeta(multicaCodexMcpBeginMarker) +
+		`.*?^` + regexp.QuoteMeta(multicaCodexMcpEndMarker) + `\n*`)
+
+// userCodexMcpServersTableHeaderRe matches `[mcp_servers.<name>]` (and its
+// quoted-key form `[mcp_servers."<name>"]`) at the start of a line. Used
+// to strip user-provided mcp_servers tables from the per-task config when
+// the agent has its own mcp_config — mirrors Claude's `--strict-mcp-config`
+// model where the daemon's set is authoritative.
+var userCodexMcpServersTableHeaderRe = regexp.MustCompile(
+	`^\s*\[\s*mcp_servers\s*\.\s*(?:"[^"]*"|[^\]\s]+)\s*\]\s*(?:#.*)?$`)
+
+// ensureCodexMcpConfig writes (or clears) the daemon-managed
+// `[mcp_servers.*]` block in `$CODEX_HOME/config.toml`. The block is the
+// authoritative source of MCP servers for this run: with mcp_config set
+// in the agent UI the daemon also strips any inherited
+// `[mcp_servers.*]` tables from the per-task config so the user's global
+// `~/.codex/config.toml` doesn't shadow or collide with the managed set.
 //
-// We translate Claude-style camelCase keys (`args`, `env`, `command`,
-// `url`) to whatever Codex's config schema expects — today they happen to
-// be the same names so the JSON passes through verbatim. If Codex ever
-// diverges, do the rename here, not in the UI editor.
-func buildCodexMcpArgs(raw json.RawMessage) ([]string, error) {
+// The file mode is 0o600 because `mcp_servers.<id>.env` values may carry
+// secrets (API keys, bearer tokens); the per-task home is owned by the
+// daemon's user, so 0o600 keeps secrets out of any world-readable copy
+// while still letting the codex child read them.
+//
+// A malformed mcp_config is returned as an error and the caller decides
+// whether to surface or warn — same fail-soft contract the prior argv
+// path had.
+func ensureCodexMcpConfig(configPath string, mcpConfig json.RawMessage, logger *slog.Logger) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	existing := string(data)
+
+	// Always strip a prior managed block so reruns and clear-config flows
+	// converge on a clean state.
+	stripped := codexMcpBlockRe.ReplaceAllString(existing, "")
+
+	block, hasServers, renderErr := renderCodexMcpServersBlock(mcpConfig)
+	if renderErr != nil {
+		return renderErr
+	}
+
+	var updated string
+	if hasServers {
+		// With an agent-managed set, strip any user-defined `[mcp_servers.*]`
+		// tables inherited from the shared `~/.codex/config.toml`. Two reasons:
+		//   1. TOML rejects redefining the same table; a user table named
+		//      `[mcp_servers.fetch]` would crash codex if the agent also
+		//      defined `fetch`.
+		//   2. The agent's mcp_config is meant to be the strict source for
+		//      this task — same as Claude's `--strict-mcp-config`. Mixing in
+		//      user-global servers would surprise the admin who edited the
+		//      MCP Tab expecting an explicit list.
+		stripped = stripCodexUserMcpServerTables(stripped)
+		stripped = strings.TrimRight(stripped, "\n")
+		if stripped == "" {
+			updated = block
+		} else {
+			updated = stripped + "\n\n" + block
+		}
+	} else {
+		// No managed servers: leave any inherited user tables alone.
+		updated = stripped
+	}
+
+	if updated == existing {
+		return nil
+	}
+	if err := os.WriteFile(configPath, []byte(updated), 0o600); err != nil {
+		return fmt.Errorf("write config.toml: %w", err)
+	}
+	// os.WriteFile applies the mode only when creating a new file; if the
+	// per-task config.toml was already on disk at 0o644 (the default mode
+	// used by execenv.copyFile when seeding from ~/.codex/config.toml),
+	// the secret-bearing values we just wrote would inherit that wider
+	// mode. Chmod unconditionally to keep the secret in the daemon
+	// owner's lane regardless of the prior mode.
+	if err := os.Chmod(configPath, 0o600); err != nil {
+		return fmt.Errorf("chmod config.toml to 0600: %w", err)
+	}
+	if logger != nil {
+		logger.Debug("codex: wrote managed mcp_servers block to config.toml",
+			"config_path", configPath, "has_servers", hasServers)
+	}
+	return nil
+}
+
+// renderCodexMcpServersBlock renders the agent's mcp_config JSON
+// (Claude-style `{"mcpServers": {...}}`) as a TOML block of
+// `[mcp_servers.<name>]` tables wrapped in BEGIN/END markers. Returns
+// (block, hasServers, err); hasServers=false means the input had no
+// servers to render (empty/null mcp_config) and the caller should only
+// strip the prior managed block.
+//
+// Claude-style camelCase keys (`args`, `env`, `command`, `url`) pass
+// through verbatim — Codex's config schema happens to use the same
+// names today. If they ever diverge, rename here rather than in the UI.
+func renderCodexMcpServersBlock(raw json.RawMessage) (string, bool, error) {
 	if len(raw) == 0 {
-		return nil, nil
+		return "", false, nil
 	}
 	var parsed struct {
 		McpServers map[string]json.RawMessage `json:"mcpServers"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return nil, fmt.Errorf("parse mcp_config json: %w", err)
+		return "", false, fmt.Errorf("parse mcp_config json: %w", err)
 	}
 	if len(parsed.McpServers) == 0 {
-		return nil, nil
+		return "", false, nil
 	}
 
 	names := make([]string, 0, len(parsed.McpServers))
@@ -119,25 +270,80 @@ func buildCodexMcpArgs(raw json.RawMessage) ([]string, error) {
 	}
 	sort.Strings(names)
 
-	args := make([]string, 0, len(names)*2)
-	for _, name := range names {
+	var sb strings.Builder
+	sb.WriteString(multicaCodexMcpBeginMarker)
+	sb.WriteString("\n")
+	for i, name := range names {
 		if !isCodexBareTomlKey(name) {
-			return nil, fmt.Errorf("mcp server name %q must be ASCII alphanumeric / _ / - to fit Codex's bare-key requirement", name)
+			return "", false, fmt.Errorf("mcp server name %q must be ASCII alphanumeric / _ / - to fit Codex's bare-key requirement", name)
 		}
-		var serverVal any
+		var serverVal map[string]any
 		if err := json.Unmarshal(parsed.McpServers[name], &serverVal); err != nil {
-			return nil, fmt.Errorf("mcp_servers.%s: %w", name, err)
+			return "", false, fmt.Errorf("mcp_servers.%s: %w", name, err)
 		}
-		if _, ok := serverVal.(map[string]any); !ok {
-			return nil, fmt.Errorf("mcp_servers.%s must be a JSON object", name)
+		if serverVal == nil {
+			return "", false, fmt.Errorf("mcp_servers.%s must be a JSON object", name)
 		}
-		tomlValue, err := jsonValueToCodexTOMLInline(serverVal)
-		if err != nil {
-			return nil, fmt.Errorf("mcp_servers.%s: %w", name, err)
+		if i > 0 {
+			sb.WriteString("\n")
 		}
-		args = append(args, "-c", fmt.Sprintf("mcp_servers.%s=%s", name, tomlValue))
+		sb.WriteString("[mcp_servers.")
+		sb.WriteString(name)
+		sb.WriteString("]\n")
+		keys := make([]string, 0, len(serverVal))
+		for k := range serverVal {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			tomlValue, err := jsonValueToCodexTOMLInline(serverVal[k])
+			if err != nil {
+				return "", false, fmt.Errorf("mcp_servers.%s.%s: %w", name, k, err)
+			}
+			sb.WriteString(codexTOMLKey(k))
+			sb.WriteString(" = ")
+			sb.WriteString(tomlValue)
+			sb.WriteString("\n")
+		}
 	}
-	return args, nil
+	sb.WriteString(multicaCodexMcpEndMarker)
+	sb.WriteString("\n")
+	return sb.String(), true, nil
+}
+
+// stripCodexUserMcpServerTables removes every `[mcp_servers.*]` table
+// (header + body lines until the next top-level table header or EOF) from
+// a TOML config string. Sub-tables like `[mcp_servers.fetch.env]` count
+// as part of the parent table and are dropped along with it.
+func stripCodexUserMcpServerTables(content string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	for _, line := range lines {
+		if userCodexMcpServersTableHeaderRe.MatchString(line) {
+			skipping = true
+			continue
+		}
+		if skipping {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "[") {
+				// Next table header. If it's still an `mcp_servers.*`
+				// table (including a sub-table), keep skipping; otherwise
+				// stop and emit this line.
+				if userCodexMcpServersTableHeaderRe.MatchString(line) ||
+					strings.HasPrefix(trimmed, "[mcp_servers.") ||
+					strings.HasPrefix(trimmed, "[ mcp_servers.") {
+					continue
+				}
+				skipping = false
+				out = append(out, line)
+				continue
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
 }
 
 // jsonValueToCodexTOMLInline serialises a JSON value as a TOML inline
@@ -264,6 +470,26 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		semanticInactivityTimeout = defaultCodexSemanticInactivityTimeout
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	// Materialise the agent's MCP config into the per-task
+	// `$CODEX_HOME/config.toml`. Argv would be the simpler path, but
+	// `mcp_servers.<id>.env` is allowed to carry secrets (Codex docs:
+	// https://developers.openai.com/codex/mcp#configure-with-configtoml)
+	// and our UI already treats mcp_config as a redacted-for-non-admins
+	// field. Process argv ends up in OS-level `ps` listings and is also
+	// echoed into the daemon's `agent command` log line below, so any
+	// inline env-bearing TOML would defeat the redaction. Writing through
+	// config.toml at 0o600 keeps the secret values out of argv and logs.
+	if codexHome := strings.TrimSpace(b.cfg.Env["CODEX_HOME"]); codexHome != "" {
+		if err := ensureCodexMcpConfig(filepath.Join(codexHome, "config.toml"), opts.McpConfig, b.cfg.Logger); err != nil {
+			// A malformed mcp_config shouldn't kill the run — the agent
+			// still launches, just without the configured MCP servers.
+			// The admin sees the warning in daemon logs and can fix it.
+			b.cfg.Logger.Warn("codex: ignoring invalid mcp_config", "error", err)
+		}
+	} else if len(opts.McpConfig) > 0 {
+		b.cfg.Logger.Warn("codex: mcp_config provided but CODEX_HOME is not set; MCP servers will not be loaded")
+	}
 
 	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1440,3 +1440,200 @@ func TestBuildCodexArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
 		t.Fatalf("expected extra args before custom args, got %v", args)
 	}
 }
+
+func TestBuildCodexMcpArgsEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	args, err := buildCodexMcpArgs(nil)
+	if err != nil {
+		t.Fatalf("nil config should not error: %v", err)
+	}
+	if args != nil {
+		t.Fatalf("nil config should yield no args, got %v", args)
+	}
+
+	args, err = buildCodexMcpArgs(json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("empty object should not error: %v", err)
+	}
+	if args != nil {
+		t.Fatalf("empty object should yield no args, got %v", args)
+	}
+
+	args, err = buildCodexMcpArgs(json.RawMessage(`{"mcpServers":{}}`))
+	if err != nil {
+		t.Fatalf("empty mcpServers should not error: %v", err)
+	}
+	if args != nil {
+		t.Fatalf("empty mcpServers should yield no args, got %v", args)
+	}
+}
+
+func TestBuildCodexMcpArgsStdioServer(t *testing.T) {
+	t.Parallel()
+
+	// Plain stdio server with command + args + env should become a single
+	// `-c mcp_servers.<name>=<inline-table>` flag. The inline table must
+	// quote string values and keep the env nested inside the same table.
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch","--cache"],"env":{"FOO":"bar"}}}}`)
+	args, err := buildCodexMcpArgs(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[0] != "-c" {
+		t.Fatalf("expected one -c flag pair, got %v", args)
+	}
+	got := args[1]
+	wantPrefix := "mcp_servers.fetch="
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected prefix %q in %q", wantPrefix, got)
+	}
+	value := strings.TrimPrefix(got, wantPrefix)
+	for _, want := range []string{
+		`command = "uvx"`,
+		`args = ["mcp-server-fetch", "--cache"]`,
+		`env = { FOO = "bar" }`,
+	} {
+		if !strings.Contains(value, want) {
+			t.Fatalf("expected substring %q in inline TOML %q", want, value)
+		}
+	}
+}
+
+func TestBuildCodexMcpArgsMultipleServersAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Two servers should emit two flag pairs in a stable order so daemon
+	// logs and tests don't churn between runs.
+	raw := json.RawMessage(`{"mcpServers":{"zeta":{"command":"a"},"alpha":{"command":"b"}}}`)
+	args, err := buildCodexMcpArgs(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 4 {
+		t.Fatalf("expected 4 args (-c pair per server), got %v", args)
+	}
+	if !strings.HasPrefix(args[1], "mcp_servers.alpha=") {
+		t.Fatalf("expected alpha first (alphabetical), got %v", args)
+	}
+	if !strings.HasPrefix(args[3], "mcp_servers.zeta=") {
+		t.Fatalf("expected zeta second, got %v", args)
+	}
+}
+
+func TestBuildCodexMcpArgsURLServer(t *testing.T) {
+	t.Parallel()
+
+	// HTTP-style servers use `url` + bearer-token env var. Verify the
+	// scalar fields pass through and the URL stays quoted.
+	raw := json.RawMessage(`{"mcpServers":{"remote":{"url":"https://example.com/mcp","bearer_token_env_var":"TOKEN"}}}`)
+	args, err := buildCodexMcpArgs(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 {
+		t.Fatalf("expected one -c pair, got %v", args)
+	}
+	value := strings.TrimPrefix(args[1], "mcp_servers.remote=")
+	for _, want := range []string{
+		`url = "https://example.com/mcp"`,
+		`bearer_token_env_var = "TOKEN"`,
+	} {
+		if !strings.Contains(value, want) {
+			t.Fatalf("expected %q in %q", want, value)
+		}
+	}
+}
+
+func TestBuildCodexMcpArgsStringEscaping(t *testing.T) {
+	t.Parallel()
+
+	// Backslashes, quotes and newlines must escape into TOML basic-string
+	// form so the value round-trips through Codex's TOML parser intact.
+	raw := json.RawMessage(`{"mcpServers":{"esc":{"command":"a\"b\\c\nd"}}}`)
+	args, err := buildCodexMcpArgs(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	value := strings.TrimPrefix(args[1], "mcp_servers.esc=")
+	if !strings.Contains(value, `command = "a\"b\\c\nd"`) {
+		t.Fatalf("expected escaped string in %q", value)
+	}
+}
+
+func TestBuildCodexMcpArgsRejectsBadShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"non-json", `not json`},
+		{"top-level array", `[1,2,3]`},
+		{"server is array", `{"mcpServers":{"x":[1,2]}}`},
+		{"server is string", `{"mcpServers":{"x":"oops"}}`},
+		{"null value inside server", `{"mcpServers":{"x":{"command":null}}}`},
+		{"bad server name", `{"mcpServers":{"has space":{"command":"a"}}}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := buildCodexMcpArgs(json.RawMessage(tc.raw)); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestBuildCodexArgsInjectsMcpBeforeCustomArgs(t *testing.T) {
+	t.Parallel()
+
+	// MCP overrides need to land in Codex's arg list ahead of any -c the
+	// user wrote in custom_args, otherwise a `-c mcp_servers.foo=bar` in
+	// custom_args could silently shadow the daemon's server entry.
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`)
+	args := buildCodexArgs(ExecOptions{
+		McpConfig:  raw,
+		CustomArgs: []string{"-c", "model=\"o3\""},
+	}, slog.Default())
+
+	mcpIdx, customIdx := -1, -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.fetch=") {
+			mcpIdx = i
+		}
+		if args[i] == "-c" && args[i+1] == "model=\"o3\"" {
+			customIdx = i
+		}
+	}
+	if mcpIdx == -1 {
+		t.Fatalf("expected mcp -c flag, got %v", args)
+	}
+	if customIdx == -1 {
+		t.Fatalf("expected user custom -c flag preserved, got %v", args)
+	}
+	if mcpIdx >= customIdx {
+		t.Fatalf("expected mcp args before custom args (mcp=%d, custom=%d): %v", mcpIdx, customIdx, args)
+	}
+}
+
+func TestBuildCodexArgsTolerantOfMalformedMcp(t *testing.T) {
+	t.Parallel()
+
+	// A malformed mcp_config must NOT crash the run — buildCodexArgs logs
+	// and continues so the agent still launches without MCP servers.
+	args := buildCodexArgs(ExecOptions{
+		McpConfig: json.RawMessage(`{not json`),
+	}, slog.Default())
+
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			t.Fatalf("expected no mcp_servers args when JSON is invalid, got %v", args)
+		}
+	}
+	// The base launch flags must still be there.
+	if len(args) < 3 || args[0] != "app-server" || args[1] != "--listen" || args[2] != "stdio://" {
+		t.Fatalf("expected base app-server flags, got %v", args)
+	}
+}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1481,6 +1481,129 @@ func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
 	}
 }
 
+func TestCodexExecuteFailsClosedWhenMcpConfigInvalid(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// When the admin has a managed mcp_config but the JSON is malformed
+	// (or any other reason ensureCodexMcpConfig fails), fail closed
+	// instead of silently launching with the user's global MCP — that
+	// would look indistinguishable from "the saved config was applied"
+	// and is exactly the surprise the MCP Tab is supposed to remove.
+	fakePath := writeFakeCodexAppServer(t, "exit 0\n")
+
+	codexHome := t.TempDir()
+	backend, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"CODEX_HOME": codexHome},
+	})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:   2 * time.Second,
+		McpConfig: json.RawMessage(`not json`),
+	})
+	if err == nil {
+		t.Fatal("expected Execute to fail closed on malformed mcp_config, got nil error")
+	}
+	if !strings.Contains(err.Error(), "mcp_config") {
+		t.Fatalf("expected error to mention mcp_config, got %q", err)
+	}
+}
+
+func TestCodexExecuteFailsClosedWhenManagedMcpButNoCodexHome(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Managed mcp_config saved but no CODEX_HOME to anchor it — same
+	// fail-closed reasoning: silently launching would inherit whatever
+	// MCP setup the host user has, which is the wrong shape of failure.
+	fakePath := writeFakeCodexAppServer(t, "exit 0\n")
+
+	backend, err := New("codex", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{}, // no CODEX_HOME
+	})
+	if err != nil {
+		t.Fatalf("new codex backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:   2 * time.Second,
+		McpConfig: json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`),
+	})
+	if err == nil {
+		t.Fatal("expected Execute to fail closed when managed mcp_config but no CODEX_HOME, got nil error")
+	}
+	if !strings.Contains(err.Error(), "CODEX_HOME") {
+		t.Fatalf("expected error to mention CODEX_HOME, got %q", err)
+	}
+}
+
+func TestBuildCodexArgsPreservesCustomMcpOverridesWhenUnmanaged(t *testing.T) {
+	t.Parallel()
+
+	// Existing Codex agents may rely on `custom_args: ["-c", "mcp_servers.…"]`
+	// because before MUL-2764 there was no MCP Tab. When the agent has
+	// no managed mcp_config saved, the daemon must leave those entries
+	// alone — silently dropping them would break the only way those
+	// users had to configure MCP. We only claim the `mcp_servers`
+	// namespace once an admin opts in via the MCP Tab.
+	args := buildCodexArgs(ExecOptions{
+		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "uvx" }`, "-c", `model="o3"`},
+	}, slog.Default())
+	foundMcp := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			foundMcp = true
+		}
+	}
+	if !foundMcp {
+		t.Fatalf("custom_args mcp_servers entry must survive when agent has no managed mcp_config, got %v", args)
+	}
+}
+
+func TestBuildCodexArgsDropsCustomMcpOverridesWhenManaged(t *testing.T) {
+	t.Parallel()
+
+	// Once an admin saves a managed mcp_config, the daemon owns
+	// the `mcp_servers` namespace via $CODEX_HOME/config.toml. Codex's
+	// `-c` is last-wins, so any `-c mcp_servers.…` left in custom_args
+	// would silently shadow the saved managed entries.
+	raw := json.RawMessage(`{"mcpServers":{"managed":{"command":"managed-cmd"}}}`)
+	args := buildCodexArgs(ExecOptions{
+		McpConfig:  raw,
+		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "evil" }`, "-c", `model="o3"`},
+	}, slog.Default())
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			t.Fatalf("custom_args mcp_servers must be filtered when managed mcp_config is present, got %v", args)
+		}
+	}
+	// Unrelated -c key still passes through.
+	foundModel := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == `model="o3"` {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Fatalf("unrelated -c override must still survive, got %v", args)
+	}
+}
+
 func TestFilterCodexCustomConfigOverridesDropsMcpServers(t *testing.T) {
 	t.Parallel()
 
@@ -1734,19 +1857,17 @@ func TestEnsureCodexMcpConfigRejectsBadShapes(t *testing.T) {
 	}
 }
 
-func TestEnsureCodexMcpConfigEmptyInputsAreNoop(t *testing.T) {
+func TestEnsureCodexMcpConfigAbsentLeavesUserTablesAlone(t *testing.T) {
 	t.Parallel()
 
-	// nil / empty object / empty mcpServers must all clear any prior
-	// managed block but produce no error and leave non-managed content
-	// alone.
-	for _, raw := range []json.RawMessage{
-		nil,
-		json.RawMessage(`{}`),
-		json.RawMessage(`{"mcpServers":{}}`),
-	} {
+	// nil / `null` map to the API's "absent" state: the agent has no
+	// managed mcp_config, so the daemon must not touch the user's
+	// inherited `[mcp_servers.*]` tables — the run falls back to the
+	// user's global CLI config.
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
 		tmp := filepath.Join(t.TempDir(), "config.toml")
-		initial := "sandbox_mode = \"workspace-write\"\n"
+		initial := "sandbox_mode = \"workspace-write\"\n\n" +
+			"[mcp_servers.user_global]\ncommand = \"keep\"\n"
 		if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
@@ -1754,8 +1875,100 @@ func TestEnsureCodexMcpConfigEmptyInputsAreNoop(t *testing.T) {
 			t.Fatalf("ensure (%q): %v", string(raw), err)
 		}
 		data, _ := os.ReadFile(tmp)
-		if string(data) != initial {
-			t.Fatalf("file mutated for empty input %q: %q", string(raw), data)
+		got := string(data)
+		if !strings.Contains(got, "[mcp_servers.user_global]") {
+			t.Fatalf("absent mcp_config (%q) must leave user MCP tables alone, got:\n%s", string(raw), got)
 		}
+		if strings.Contains(got, multicaCodexMcpBeginMarker) {
+			t.Fatalf("absent mcp_config (%q) must not write managed markers, got:\n%s", string(raw), got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigEmptyManagedSetStripsUserMcp(t *testing.T) {
+	t.Parallel()
+
+	// `{}` / `{"mcpServers":{}}` map to the API's "present, empty" state.
+	// The admin saved an explicit (empty) MCP list, so the daemon must
+	// strip inherited user `[mcp_servers.*]` tables and pin the managed
+	// markers — equivalent to Claude's --strict-mcp-config with an empty
+	// servers map. Falling back to the user's global MCP would defeat
+	// the affordance.
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"mcpServers":{}}`),
+	} {
+		tmp := filepath.Join(t.TempDir(), "config.toml")
+		initial := "sandbox_mode = \"workspace-write\"\n\n" +
+			"[mcp_servers.user_global]\ncommand = \"keep\"\n"
+		if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+			t.Fatalf("ensure (%q): %v", string(raw), err)
+		}
+		data, _ := os.ReadFile(tmp)
+		got := string(data)
+		if strings.Contains(got, "user_global") {
+			t.Fatalf("managed empty set (%q) must strip user MCP tables, got:\n%s", string(raw), got)
+		}
+		if !strings.Contains(got, multicaCodexMcpBeginMarker) || !strings.Contains(got, multicaCodexMcpEndMarker) {
+			t.Fatalf("managed empty set (%q) must still write markers so future runs find them, got:\n%s", string(raw), got)
+		}
+		if !strings.Contains(got, `sandbox_mode = "workspace-write"`) {
+			t.Fatalf("unrelated content must survive (%q), got:\n%s", string(raw), got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigEmptyManagedSetIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Running ensure twice with the same `{}` input must produce
+	// byte-identical output — guards against the empty-marker block
+	// accreting blank lines or duplicate markers across reruns.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	raw := json.RawMessage(`{}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	first, _ := os.ReadFile(tmp)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	second, _ := os.ReadFile(tmp)
+	if string(first) != string(second) {
+		t.Fatalf("non-idempotent write:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestHasManagedCodexMcpConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty bytes", json.RawMessage(""), false},
+		{"whitespace only", json.RawMessage("   \n\t"), false},
+		{"json null", json.RawMessage(`null`), false},
+		{"json null with whitespace", json.RawMessage(" null \n"), false},
+		{"empty object", json.RawMessage(`{}`), true},
+		{"empty mcp servers map", json.RawMessage(`{"mcpServers":{}}`), true},
+		{"populated", json.RawMessage(`{"mcpServers":{"x":{"command":"a"}}}`), true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasManagedCodexMcpConfig(tc.raw); got != tc.want {
+				t.Fatalf("hasManagedCodexMcpConfig(%q) = %v, want %v", string(tc.raw), got, tc.want)
+			}
+		})
 	}
 }

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -1441,127 +1443,273 @@ func TestBuildCodexArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
 	}
 }
 
-func TestBuildCodexMcpArgsEmptyConfig(t *testing.T) {
+func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
 	t.Parallel()
 
-	args, err := buildCodexMcpArgs(nil)
-	if err != nil {
-		t.Fatalf("nil config should not error: %v", err)
-	}
-	if args != nil {
-		t.Fatalf("nil config should yield no args, got %v", args)
-	}
+	// MCP config is materialised into $CODEX_HOME/config.toml, never into
+	// argv — otherwise `mcp_servers.<id>.env` secrets would land in
+	// `ps aux` output and in the daemon's `agent command` log line. This
+	// test pins the contract: even with a non-empty mcp_config, no -c /
+	// --config / mcp_servers.* entry shows up in buildCodexArgs output.
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","env":{"SECRET":"hunter2"}}}}`)
+	args := buildCodexArgs(ExecOptions{
+		McpConfig:  raw,
+		CustomArgs: []string{"-c", `model="o3"`},
+	}, slog.Default())
 
-	args, err = buildCodexMcpArgs(json.RawMessage(`{}`))
-	if err != nil {
-		t.Fatalf("empty object should not error: %v", err)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "mcp_servers") {
+		t.Fatalf("argv must not mention mcp_servers (now lives in config.toml), got %v", args)
 	}
-	if args != nil {
-		t.Fatalf("empty object should yield no args, got %v", args)
+	if strings.Contains(joined, "hunter2") {
+		t.Fatalf("argv must not leak secret env values, got %v", args)
 	}
-
-	args, err = buildCodexMcpArgs(json.RawMessage(`{"mcpServers":{}}`))
-	if err != nil {
-		t.Fatalf("empty mcpServers should not error: %v", err)
-	}
-	if args != nil {
-		t.Fatalf("empty mcpServers should yield no args, got %v", args)
-	}
-}
-
-func TestBuildCodexMcpArgsStdioServer(t *testing.T) {
-	t.Parallel()
-
-	// Plain stdio server with command + args + env should become a single
-	// `-c mcp_servers.<name>=<inline-table>` flag. The inline table must
-	// quote string values and keep the env nested inside the same table.
-	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch","--cache"],"env":{"FOO":"bar"}}}}`)
-	args, err := buildCodexMcpArgs(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(args) != 2 || args[0] != "-c" {
-		t.Fatalf("expected one -c flag pair, got %v", args)
-	}
-	got := args[1]
-	wantPrefix := "mcp_servers.fetch="
-	if !strings.HasPrefix(got, wantPrefix) {
-		t.Fatalf("expected prefix %q in %q", wantPrefix, got)
-	}
-	value := strings.TrimPrefix(got, wantPrefix)
-	for _, want := range []string{
-		`command = "uvx"`,
-		`args = ["mcp-server-fetch", "--cache"]`,
-		`env = { FOO = "bar" }`,
-	} {
-		if !strings.Contains(value, want) {
-			t.Fatalf("expected substring %q in inline TOML %q", want, value)
+	for i := 0; i+1 < len(args); i++ {
+		if (args[i] == "-c" || args[i] == "--config") && strings.HasPrefix(args[i+1], "mcp_servers.") {
+			t.Fatalf("expected no -c mcp_servers.* in argv, got %v", args)
 		}
 	}
-}
-
-func TestBuildCodexMcpArgsMultipleServersAreDeterministic(t *testing.T) {
-	t.Parallel()
-
-	// Two servers should emit two flag pairs in a stable order so daemon
-	// logs and tests don't churn between runs.
-	raw := json.RawMessage(`{"mcpServers":{"zeta":{"command":"a"},"alpha":{"command":"b"}}}`)
-	args, err := buildCodexMcpArgs(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(args) != 4 {
-		t.Fatalf("expected 4 args (-c pair per server), got %v", args)
-	}
-	if !strings.HasPrefix(args[1], "mcp_servers.alpha=") {
-		t.Fatalf("expected alpha first (alphabetical), got %v", args)
-	}
-	if !strings.HasPrefix(args[3], "mcp_servers.zeta=") {
-		t.Fatalf("expected zeta second, got %v", args)
-	}
-}
-
-func TestBuildCodexMcpArgsURLServer(t *testing.T) {
-	t.Parallel()
-
-	// HTTP-style servers use `url` + bearer-token env var. Verify the
-	// scalar fields pass through and the URL stays quoted.
-	raw := json.RawMessage(`{"mcpServers":{"remote":{"url":"https://example.com/mcp","bearer_token_env_var":"TOKEN"}}}`)
-	args, err := buildCodexMcpArgs(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(args) != 2 {
-		t.Fatalf("expected one -c pair, got %v", args)
-	}
-	value := strings.TrimPrefix(args[1], "mcp_servers.remote=")
-	for _, want := range []string{
-		`url = "https://example.com/mcp"`,
-		`bearer_token_env_var = "TOKEN"`,
-	} {
-		if !strings.Contains(value, want) {
-			t.Fatalf("expected %q in %q", want, value)
+	// Legitimate non-mcp `-c model=…` from custom_args must still survive.
+	foundModel := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == `model="o3"` {
+			foundModel = true
 		}
 	}
+	if !foundModel {
+		t.Fatalf("expected non-mcp -c override to be preserved, got %v", args)
+	}
 }
 
-func TestBuildCodexMcpArgsStringEscaping(t *testing.T) {
+func TestFilterCodexCustomConfigOverridesDropsMcpServers(t *testing.T) {
 	t.Parallel()
 
-	// Backslashes, quotes and newlines must escape into TOML basic-string
-	// form so the value round-trips through Codex's TOML parser intact.
-	raw := json.RawMessage(`{"mcpServers":{"esc":{"command":"a\"b\\c\nd"}}}`)
-	args, err := buildCodexMcpArgs(raw)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Codex `-c` is last-wins, so a user-supplied `-c mcp_servers.…` in
+	// custom_args would silently shadow whatever the MCP Tab wrote into
+	// CODEX_HOME/config.toml. Verify that all spellings of the override
+	// get dropped, while unrelated `-c` keys pass through.
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "separated -c mcp_servers.fetch=…",
+			in:   []string{"-c", `mcp_servers.fetch={ command = "evil" }`, "-c", `model="o3"`},
+			want: []string{"-c", `model="o3"`},
+		},
+		{
+			name: "inline -c=mcp_servers.fetch=…",
+			in:   []string{`-c=mcp_servers.fetch={ command = "evil" }`, "--listen=keep"},
+			want: []string{"--listen=keep"},
+		},
+		{
+			name: "long form --config mcp_servers.x.env.KEY=val",
+			in:   []string{"--config", `mcp_servers.x.env.KEY="leak"`, "--config", `sandbox="workspace-write"`},
+			want: []string{"--config", `sandbox="workspace-write"`},
+		},
+		{
+			name: "passes through unrelated -c overrides",
+			in:   []string{"-c", `model="o3"`, "-c", `sandbox.network_access=true`},
+			want: []string{"-c", `model="o3"`, "-c", `sandbox.network_access=true`},
+		},
+		{
+			name: "matches mcp_servers root assignment",
+			in:   []string{"-c", `mcp_servers={fetch={command="evil"}}`, "-c", `model="o3"`},
+			want: []string{"-c", `model="o3"`},
+		},
 	}
-	value := strings.TrimPrefix(args[1], "mcp_servers.esc=")
-	if !strings.Contains(value, `command = "a\"b\\c\nd"`) {
-		t.Fatalf("expected escaped string in %q", value)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterCodexCustomConfigOverrides(tc.in, slog.Default())
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("filterCodexCustomConfigOverrides(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
-func TestBuildCodexMcpArgsRejectsBadShapes(t *testing.T) {
+func TestEnsureCodexMcpConfigEmptyClearsBlock(t *testing.T) {
+	t.Parallel()
+
+	// When agent.mcp_config is null/empty the managed block is removed
+	// from config.toml, but unrelated content (sandbox block, user-level
+	// `[mcp_servers.user]`) is left untouched.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	initial := "sandbox_mode = \"workspace-write\"\n\n" +
+		multicaCodexMcpBeginMarker + "\n" +
+		"[mcp_servers.fetch]\ncommand = \"uvx\"\n" +
+		multicaCodexMcpEndMarker + "\n\n" +
+		"[mcp_servers.user_global]\ncommand = \"keep\"\n"
+	if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := ensureCodexMcpConfig(tmp, nil, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, multicaCodexMcpBeginMarker) {
+		t.Fatalf("managed block should be cleared, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.user_global]") {
+		t.Fatalf("user-defined mcp_servers should be left alone when agent has no mcp_config, got:\n%s", got)
+	}
+	if !strings.Contains(got, `sandbox_mode = "workspace-write"`) {
+		t.Fatalf("unrelated config preserved, got:\n%s", got)
+	}
+}
+
+func TestEnsureCodexMcpConfigWritesManagedBlock(t *testing.T) {
+	t.Parallel()
+
+	// A non-empty mcp_config writes one `[mcp_servers.<name>]` table per
+	// server, in stable alphabetical order, into the managed block. The
+	// file mode is 0o600 because env values may carry secrets.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"zeta":{"command":"b"},"alpha":{"command":"a","env":{"K":"v"}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, multicaCodexMcpBeginMarker) || !strings.Contains(got, multicaCodexMcpEndMarker) {
+		t.Fatalf("expected managed block markers, got:\n%s", got)
+	}
+	alphaIdx := strings.Index(got, "[mcp_servers.alpha]")
+	zetaIdx := strings.Index(got, "[mcp_servers.zeta]")
+	if alphaIdx == -1 || zetaIdx == -1 {
+		t.Fatalf("expected both server tables, got:\n%s", got)
+	}
+	if alphaIdx > zetaIdx {
+		t.Fatalf("expected alpha before zeta (alphabetical), got:\n%s", got)
+	}
+	for _, want := range []string{
+		`command = "a"`,
+		`env = { K = "v" }`,
+		`command = "b"`,
+		`sandbox_mode = "workspace-write"`, // unrelated user content preserved
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+
+	fi, err := os.Stat(tmp)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := fi.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("expected mode 0o600 for secret-bearing config, got %o", mode)
+	}
+}
+
+func TestEnsureCodexMcpConfigForces0600OnPreexistingFile(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permissions only")
+	}
+
+	// `execenv.copyFile` seeds the per-task config.toml at 0o644. Once we
+	// add secret-bearing mcp_servers tables to it, the mode must drop to
+	// 0o600 — `os.WriteFile` alone keeps the existing mode, so the chmod
+	// is the part we need to pin.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","env":{"API_KEY":"secret"}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	fi, err := os.Stat(tmp)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := fi.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("expected 0o600 after overwrite of pre-existing 0o644 file, got %o", mode)
+	}
+}
+
+func TestEnsureCodexMcpConfigStripsUserMcpServersWhenManaged(t *testing.T) {
+	t.Parallel()
+
+	// When agent.mcp_config is non-empty, ALL user-defined `[mcp_servers.*]`
+	// tables (inherited from ~/.codex/config.toml) are stripped to avoid
+	// (a) TOML "table already exists" errors when names collide and (b) the
+	// user's global servers silently being mixed in with the strict
+	// agent-managed list. Sub-tables like `[mcp_servers.x.env]` are also
+	// dropped as part of their parent.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	initial := "sandbox_mode = \"workspace-write\"\n\n" +
+		"[mcp_servers.global_fetch]\ncommand = \"uvx-old\"\n\n" +
+		"[mcp_servers.global_fetch.env]\nOLD_KEY = \"old\"\n\n" +
+		"[other_section]\nkeep_me = true\n"
+	if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"new_server":{"command":"new"}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, _ := os.ReadFile(tmp)
+	got := string(data)
+
+	if strings.Contains(got, "global_fetch") {
+		t.Fatalf("user mcp_servers tables must be stripped when agent has its own mcp_config, got:\n%s", got)
+	}
+	if strings.Contains(got, "OLD_KEY") {
+		t.Fatalf("user mcp_servers sub-tables must be stripped too, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[other_section]") || !strings.Contains(got, "keep_me = true") {
+		t.Fatalf("unrelated tables must survive, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.new_server]") {
+		t.Fatalf("managed server should be written, got:\n%s", got)
+	}
+}
+
+func TestEnsureCodexMcpConfigIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Running ensure twice with the same input must produce byte-identical
+	// output — needed because Prepare and Reuse may both call into this on
+	// the same per-task config.toml across a task's lifetime.
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["a","b"]}}}`)
+
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	first, _ := os.ReadFile(tmp)
+
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	second, _ := os.ReadFile(tmp)
+
+	if string(first) != string(second) {
+		t.Fatalf("non-idempotent write:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestEnsureCodexMcpConfigRejectsBadShapes(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -1569,7 +1717,6 @@ func TestBuildCodexMcpArgsRejectsBadShapes(t *testing.T) {
 		raw  string
 	}{
 		{"non-json", `not json`},
-		{"top-level array", `[1,2,3]`},
 		{"server is array", `{"mcpServers":{"x":[1,2]}}`},
 		{"server is string", `{"mcpServers":{"x":"oops"}}`},
 		{"null value inside server", `{"mcpServers":{"x":{"command":null}}}`},
@@ -1579,61 +1726,36 @@ func TestBuildCodexMcpArgsRejectsBadShapes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := buildCodexMcpArgs(json.RawMessage(tc.raw)); err == nil {
+			tmp := filepath.Join(t.TempDir(), "config.toml")
+			if err := ensureCodexMcpConfig(tmp, json.RawMessage(tc.raw), slog.Default()); err == nil {
 				t.Fatalf("expected error for %s, got nil", tc.name)
 			}
 		})
 	}
 }
 
-func TestBuildCodexArgsInjectsMcpBeforeCustomArgs(t *testing.T) {
+func TestEnsureCodexMcpConfigEmptyInputsAreNoop(t *testing.T) {
 	t.Parallel()
 
-	// MCP overrides need to land in Codex's arg list ahead of any -c the
-	// user wrote in custom_args, otherwise a `-c mcp_servers.foo=bar` in
-	// custom_args could silently shadow the daemon's server entry.
-	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx"}}}`)
-	args := buildCodexArgs(ExecOptions{
-		McpConfig:  raw,
-		CustomArgs: []string{"-c", "model=\"o3\""},
-	}, slog.Default())
-
-	mcpIdx, customIdx := -1, -1
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.fetch=") {
-			mcpIdx = i
+	// nil / empty object / empty mcpServers must all clear any prior
+	// managed block but produce no error and leave non-managed content
+	// alone.
+	for _, raw := range []json.RawMessage{
+		nil,
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"mcpServers":{}}`),
+	} {
+		tmp := filepath.Join(t.TempDir(), "config.toml")
+		initial := "sandbox_mode = \"workspace-write\"\n"
+		if err := os.WriteFile(tmp, []byte(initial), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
 		}
-		if args[i] == "-c" && args[i+1] == "model=\"o3\"" {
-			customIdx = i
+		if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+			t.Fatalf("ensure (%q): %v", string(raw), err)
 		}
-	}
-	if mcpIdx == -1 {
-		t.Fatalf("expected mcp -c flag, got %v", args)
-	}
-	if customIdx == -1 {
-		t.Fatalf("expected user custom -c flag preserved, got %v", args)
-	}
-	if mcpIdx >= customIdx {
-		t.Fatalf("expected mcp args before custom args (mcp=%d, custom=%d): %v", mcpIdx, customIdx, args)
-	}
-}
-
-func TestBuildCodexArgsTolerantOfMalformedMcp(t *testing.T) {
-	t.Parallel()
-
-	// A malformed mcp_config must NOT crash the run — buildCodexArgs logs
-	// and continues so the agent still launches without MCP servers.
-	args := buildCodexArgs(ExecOptions{
-		McpConfig: json.RawMessage(`{not json`),
-	}, slog.Default())
-
-	for i := 0; i+1 < len(args); i++ {
-		if args[i] == "-c" && strings.HasPrefix(args[i+1], "mcp_servers.") {
-			t.Fatalf("expected no mcp_servers args when JSON is invalid, got %v", args)
+		data, _ := os.ReadFile(tmp)
+		if string(data) != initial {
+			t.Fatalf("file mutated for empty input %q: %q", string(raw), data)
 		}
-	}
-	// The base launch flags must still be there.
-	if len(args) < 3 || args[0] != "app-server" || args[1] != "--listen" || args[2] != "stdio://" {
-		t.Fatalf("expected base app-server flags, got %v", args)
 	}
 }


### PR DESCRIPTION
## Summary

- Add an **MCP** tab on the agent detail page with a JSON editor that pretty-prints, validates, and saves the agent's `mcp_config`.
- Wire `mcp_config` / `mcp_config_redacted` into `packages/core/types/agent.ts` (`Agent` + `UpdateAgentRequest`).
- Save goes through the existing `PUT /api/agents/{id}` path; clearing the editor sends `mcp_config: null` so the handler wipes the column and the daemon falls back to the CLI default.
- When the caller lacks permission to see secrets the server already returns `mcp_config: null` with `mcp_config_redacted: true`; the tab renders a read-only "configured but hidden" state so a non-privileged member can't silently overwrite an admin-owned config.

Closes MUL-2764. Implementation is independent of community PR #2894 (used for context only).

## Files

- `packages/core/types/agent.ts` — new `mcp_config?: unknown | null` and `mcp_config_redacted?: boolean` on `Agent`; tri-state `mcp_config` on `UpdateAgentRequest`.
- `packages/views/agents/components/tabs/mcp-config-tab.tsx` — new tab. Top-level non-object JSON (arrays, primitives) is rejected client-side so the user sees the mistake before a server round-trip.
- `packages/views/agents/components/agent-overview-pane.tsx` — register the tab with the existing dirty-guard plumbing.
- `packages/views/locales/{en,zh-Hans}/agents.json` — labels for the tab + body strings.
- `packages/views/agents/components/tabs/mcp-config-tab.test.tsx` — component tests covering the redacted read-only state, pretty-print on mount, save with parsed object, clear-to-null, and validation errors.

## Test plan

- [x] `pnpm --filter @multica/views test` — 96 files / 872 tests pass (including 6 new `McpConfigTab` tests and the locale parity test).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings in unrelated files only).
- [ ] Manual: open an agent detail page, pick **MCP**, paste a config, save, reload, confirm it round-trips; clear the editor and save, confirm the column goes back to `NULL`; sign in as a non-owner member to confirm the redacted read-only state renders.