### PR TITLE
Fix self-host web image startup contract (MUL-2789)

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -58,6 +58,14 @@ By default it pulls the latest stable release images from GHCR. To build the bac
 If the selected GHCR tag has not been published yet, `make selfhost` now tells you to fall back to `make selfhost-build`.
 `make selfhost-build` uses local `multica-backend:dev` / `multica-web:dev` tags, so it does not overwrite the pulled `:latest` images.
 
+The prebuilt `multica-web` image is intended for the documented Compose topology:
+
+- the backend service is named `backend` on the Docker network
+- browser traffic reaches the web app on one origin, and `/api`, `/auth`, `/uploads`, and `/ws` are proxied by the web server to the backend
+- the browser WebSocket URL is derived from the page origin unless `NEXT_PUBLIC_WS_URL` was baked into a locally built image
+
+For most custom-domain installs, put a reverse proxy in front of the frontend and preserve those same paths on the same origin. If you need the browser bundle to call a separate public API or WebSocket origin, build the web image locally with `make selfhost-build` and set the relevant build-time values before building; setting `NEXT_PUBLIC_*` only in the `environment:` block of a prebuilt image does not rewrite an already-built Next.js bundle.
+
 Once ready:
 
 - **Frontend:** http://localhost:3000
@@ -428,6 +436,15 @@ Then start everything:
 ```bash
 docker compose -f docker-compose.selfhost.yml pull
 docker compose -f docker-compose.selfhost.yml up -d
+```
+
+For the official prebuilt images, keep `docker-compose.selfhost.yml` as the base file. The frontend service explicitly starts the Next.js standalone server with `node apps/web/server.js`; database migrations run in the backend container. A healthy startup should show `postgres`, `backend`, and `frontend` running, with the frontend healthcheck passing after Next.js is ready.
+
+If your deployment requires build-time frontend values such as `NEXT_PUBLIC_WS_URL`, use the local-build override instead:
+
+```bash
+NEXT_PUBLIC_WS_URL=wss://api.example.com/ws \
+docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
 ```
 
 ## Manual CLI Configuration

--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -93,10 +93,22 @@ services:
     image: ${MULTICA_WEB_IMAGE:-ghcr.io/multica-ai/multica-web}:${MULTICA_IMAGE_TAG:-latest}
     depends_on:
       - backend
+    entrypoint: ["node"]
+    command: ["apps/web/server.js"]
     ports:
       - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
     environment:
       HOSTNAME: "0.0.0.0"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:3000').then((r) => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
     restart: unless-stopped
 
 volumes:

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -8,7 +8,7 @@ require_config() {
   local config=$1
   local expected=$2
 
-  if ! grep -Fq "$expected" <<<"$config"; then
+  if ! grep -Fq -- "$expected" <<<"$config"; then
     echo "Missing expected docker compose config value:"
     echo "  $expected"
     exit 1
@@ -19,7 +19,7 @@ require_env() {
   local output=$1
   local expected=$2
 
-  if ! grep -Fxq "$expected" <<<"$output"; then
+  if ! grep -Fxq -- "$expected" <<<"$output"; then
     echo "Missing expected derived env value:"
     echo "  $expected"
     echo "Observed:"
@@ -27,6 +27,16 @@ require_env() {
     exit 1
   fi
 }
+
+if grep -Eq '(^|[[:space:]])(ENTRYPOINT|CMD).*(migrate|/app/server)' Dockerfile.web; then
+  echo "Dockerfile.web must start only the Next.js standalone server, not backend migrations or binaries."
+  exit 1
+fi
+
+if ! grep -Fq 'CMD ["node", "apps/web/server.js"]' Dockerfile.web; then
+  echo 'Dockerfile.web must keep the web runtime command as: CMD ["node", "apps/web/server.js"]'
+  exit 1
+fi
 
 config="$(
   FRONTEND_PORT=3100 BACKEND_PORT=9100 docker compose \
@@ -40,6 +50,13 @@ require_config "$config" 'published: "9100"'
 require_config "$config" 'FRONTEND_ORIGIN: http://localhost:3100'
 require_config "$config" 'GOOGLE_REDIRECT_URI: http://localhost:3100/auth/callback'
 require_config "$config" 'MULTICA_APP_URL: http://localhost:3100'
+require_config "$config" 'entrypoint:'
+require_config "$config" '- node'
+require_config "$config" 'command:'
+require_config "$config" '- apps/web/server.js'
+require_config "$config" 'image: ghcr.io/multica-ai/multica-web:latest'
+require_config "$config" 'HOSTNAME: 0.0.0.0'
+require_config "$config" "fetch('http://127.0.0.1:3000')"
 
 for script in scripts/dev.sh scripts/check.sh; do
   if ! grep -Fq '. scripts/local-env.sh' "$script"; then


### PR DESCRIPTION
## What does this PR do?

Fixes the documented self-host prebuilt web image path so the frontend container starts the Next.js server directly instead of inheriting a backend-style migration entrypoint. It also adds a compose healthcheck and a focused shell guard for the self-host web image startup contract, plus docs for when operators need a local web image build for baked `NEXT_PUBLIC_*` values.

## Related Issue

Closes #1948

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `docker-compose.selfhost.yml`: explicitly starts the frontend with `node apps/web/server.js` and adds a frontend healthcheck.
- `scripts/selfhost-config.test.sh`: validates the web image, frontend command/entrypoint contract, host config, and healthcheck output.
- `SELF_HOSTING.md`: documents prebuilt-image versus local-build behavior and the build-time `NEXT_PUBLIC_*` caveat.

## How to Test

1. `bash -n scripts/selfhost-config.test.sh`
2. `git diff --check origin/main...HEAD`
3. In a Docker-equipped environment, run `bash scripts/selfhost-config.test.sh`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented from the workspace issue brief and prior review feedback. The fix was scoped to the self-host compose/docs/test surfaces around the prebuilt web image startup contract.

## Screenshots (optional)

N/A

## Verification Notes

Workspace verification reported:
- `bash -n scripts/selfhost-config.test.sh` passed.
- `git diff --check` passed.
- `git diff --check origin/main...HEAD` passed after pushing.

Not run in the implementation runtime:
- Full `bash scripts/selfhost-config.test.sh`, because Docker was unavailable.
- Focused web Vitest, because pnpm was unavailable in that runtime.
