### PR TITLE
Validate self-host websocket proxy setup

### DIFF
--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -328,10 +328,9 @@ multica.example.com {
 
 ```
 app.example.com {
-    reverse_proxy localhost:3000
-}
-
-api.example.com {
+    # The pre-built web image derives WebSocket URLs from the page origin, so
+    # /ws must be available on the frontend hostname unless you rebuild the web
+    # image with NEXT_PUBLIC_WS_URL pointing somewhere else.
     @multica_ws path /ws /ws/*
     handle @multica_ws {
         reverse_proxy localhost:8080 {
@@ -339,6 +338,10 @@ api.example.com {
         }
     }
 
+    reverse_proxy localhost:3000
+}
+
+api.example.com {
     reverse_proxy localhost:8080
 }
 ```
@@ -366,6 +369,18 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # WebSocket support for the pre-built web image. The browser connects to
+    # wss://app.example.com/ws unless NEXT_PUBLIC_WS_URL was baked into a
+    # source-built image.
+    location /ws {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400;
+    }
 }
 
 # Backend API
@@ -383,16 +398,6 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
-    # WebSocket support
-    location /ws {
-        proxy_pass http://localhost:8080;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_read_timeout 86400;
-    }
 }
 ```
 
@@ -408,6 +413,8 @@ REMOTE_API_URL=https://api.example.com
 NEXT_PUBLIC_API_URL=https://api.example.com
 NEXT_PUBLIC_WS_URL=wss://api.example.com/ws
 ```
+
+For the pre-built Docker image, runtime-only changes to `NEXT_PUBLIC_WS_URL` do not change the browser bundle. Either proxy `/ws` on `app.example.com` as shown above, or rebuild the web image with `docker-compose.selfhost.build.yml` so `NEXT_PUBLIC_WS_URL=wss://api.example.com/ws` is baked in. The default `FRONTEND_ORIGIN=http://localhost:3000` is only valid for same-machine localhost access; public or LAN deployments must set it to the browser-visible frontend origin.
 
 ## LAN / Non-localhost Access
 

--- a/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
@@ -370,10 +370,9 @@ multica.example.com {
 
 ```
 app.example.com {
-    reverse_proxy localhost:3000
-}
-
-api.example.com {
+    # The pre-built web image derives WebSocket URLs from the page origin, so
+    # /ws must be available on the frontend hostname unless you rebuild the web
+    # image with NEXT_PUBLIC_WS_URL pointing somewhere else.
     @multica_ws path /ws /ws/*
     handle @multica_ws {
         reverse_proxy localhost:8080 {
@@ -381,6 +380,10 @@ api.example.com {
         }
     }
 
+    reverse_proxy localhost:3000
+}
+
+api.example.com {
     reverse_proxy localhost:8080
 }
 ```
@@ -408,6 +411,18 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # WebSocket support for the pre-built web image. The browser connects to
+    # wss://app.example.com/ws unless NEXT_PUBLIC_WS_URL was baked into a
+    # source-built image.
+    location /ws {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400;
+    }
 }
 
 # Backend API
@@ -425,16 +440,6 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
-
-    # WebSocket support
-    location /ws {
-        proxy_pass http://localhost:8080;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_read_timeout 86400;
-    }
 }
 ```
 
@@ -450,6 +455,8 @@ REMOTE_API_URL=https://api.example.com
 NEXT_PUBLIC_API_URL=https://api.example.com
 NEXT_PUBLIC_WS_URL=wss://api.example.com/ws
 ```
+
+对于预构建的 Docker 镜像，只在运行时修改 `NEXT_PUBLIC_WS_URL` 不会改变浏览器 bundle。请按上例在 `app.example.com` 上代理 `/ws`，或者使用 `docker-compose.selfhost.build.yml` 重新构建 web 镜像，把 `NEXT_PUBLIC_WS_URL=wss://api.example.com/ws` 写入构建产物。默认的 `FRONTEND_ORIGIN=http://localhost:3000` 只适合同一台机器上的 localhost 访问；公开或 LAN 部署必须把它设置为浏览器可见的前端 origin。
 
 ## Health Check
 

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -189,6 +189,9 @@ func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 			appURL = fmt.Sprintf("http://localhost:%d", frontendPort)
 		}
 	}
+	if err := validateSelfHostURLs(serverURL, appURL); err != nil {
+		return err
+	}
 
 	cfg := cli.CLIConfig{
 		ServerURL: serverURL,
@@ -233,6 +236,49 @@ func serverHostIsLocal(serverURL string) bool {
 	if err != nil {
 		return false
 	}
+	h := parsed.Hostname()
+	if h == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+func validateSelfHostURLs(serverURL, appURL string) error {
+	server, err := parseHTTPURL(serverURL, "--server-url")
+	if err != nil {
+		return err
+	}
+	app, err := parseHTTPURL(appURL, "--app-url")
+	if err != nil {
+		return err
+	}
+
+	serverLocal := parsedURLHostIsLocal(server)
+	appLocal := parsedURLHostIsLocal(app)
+	if !serverLocal && appLocal {
+		return fmt.Errorf("--app-url %s points at localhost, but --server-url %s is remote; use the browser-visible frontend URL and set FRONTEND_ORIGIN to the same origin on the server", appURL, serverURL)
+	}
+	if !serverLocal && app.Scheme == "https" && server.Scheme == "http" {
+		return fmt.Errorf("--app-url uses https but --server-url uses http for a remote host; browsers will block mixed-content API/WebSocket requests, so put TLS in front of the backend or use matching http URLs")
+	}
+	return nil
+}
+
+func parseHTTPURL(raw, flagName string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("%s must be an absolute URL like https://app.example.com", flagName)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("%s must use http or https", flagName)
+	}
+	return parsed, nil
+}
+
+func parsedURLHostIsLocal(parsed *url.URL) bool {
 	h := parsed.Hostname()
 	if h == "localhost" {
 		return true

--- a/server/cmd/multica/cmd_setup_test.go
+++ b/server/cmd/multica/cmd_setup_test.go
@@ -25,3 +25,61 @@ func TestServerHostIsLocal(t *testing.T) {
 	}
 }
 
+func TestValidateSelfHostURLs(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverURL string
+		appURL    string
+		wantErr   bool
+	}{
+		{
+			name:      "localhost defaults are valid",
+			serverURL: "http://localhost:8080",
+			appURL:    "http://localhost:3000",
+		},
+		{
+			name:      "remote split https hosts are valid",
+			serverURL: "https://api.example.com",
+			appURL:    "https://app.example.com",
+		},
+		{
+			name:      "lan http hosts are valid",
+			serverURL: "http://192.168.0.28:8080",
+			appURL:    "http://192.168.0.28:3000",
+		},
+		{
+			name:      "remote server with localhost app is rejected",
+			serverURL: "https://api.example.com",
+			appURL:    "http://localhost:3000",
+			wantErr:   true,
+		},
+		{
+			name:      "https app with remote http server is rejected",
+			serverURL: "http://api.example.com",
+			appURL:    "https://app.example.com",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid server URL is rejected",
+			serverURL: "api.example.com",
+			appURL:    "https://app.example.com",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid app URL is rejected",
+			serverURL: "https://api.example.com",
+			appURL:    "ftp://app.example.com",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSelfHostURLs(tc.serverURL, tc.appURL)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateSelfHostURLs(%q, %q) error = %v, wantErr %v", tc.serverURL, tc.appURL, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -688,7 +688,16 @@ func HandleWebSocket(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		slog.Error("websocket upgrade failed", "error", err)
+		slog.Error(
+			"websocket upgrade failed",
+			"error", err,
+			"host", r.Host,
+			"origin", r.Header.Get("Origin"),
+			"upgrade", r.Header.Get("Upgrade"),
+			"connection", r.Header.Get("Connection"),
+			"x_forwarded_host", r.Header.Get("X-Forwarded-Host"),
+			"x_forwarded_proto", r.Header.Get("X-Forwarded-Proto"),
+		)
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes the self-host WebSocket reverse-proxy failure mode for split frontend/backend deployments. The CLI now rejects common broken setup combinations before writing a profile, backend WebSocket upgrade logs include non-secret proxy context, and self-host docs explain where `/ws` must be proxied for prebuilt web images versus when to rebuild with `NEXT_PUBLIC_WS_URL`.

## Related Issue

Closes #2500

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_setup.go`: validates invalid self-host URLs, remote backend with localhost frontend, and HTTPS frontend with HTTP remote backend before writing a broken profile.
- `server/cmd/multica/cmd_setup_test.go`: adds focused setup validation coverage for localhost defaults, split HTTPS domains, LAN HTTP, invalid URLs, remote+localhost mismatch, and HTTPS/HTTP mismatch.
- `server/internal/realtime/hub.go`: adds non-secret request/proxy context to WebSocket upgrade failure logs.
- `SELF_HOSTING_ADVANCED.md` and `apps/docs/content/docs/getting-started/self-hosting.zh.mdx`: document frontend-host `/ws` proxying for prebuilt split-domain deployments, the `NEXT_PUBLIC_WS_URL` local-build path, and the localhost-only scope of the default `FRONTEND_ORIGIN`.

## How to Test

1. `cd server && GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /tmp/go-toolchain/go/bin/go test ./cmd/multica ./internal/realtime`
2. `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm XDG_CACHE_HOME=/tmp/.cache TMPDIR=/tmp corepack pnpm --filter @multica/docs typecheck`
3. `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented from the workspace issue brief, reviewer feedback, and the accepted verified patch artifact. The final release branch was created by applying that patch to current upstream `main`, rerunning focused verification, and preserving the existing docs and backend conventions.

## Screenshots (optional)

N/A

## Verification Notes

Passed on the release handoff branch:
- `git diff --check`
- `/tmp/go-toolchain/go/bin/gofmt -l server/cmd/multica/cmd_setup.go server/cmd/multica/cmd_setup_test.go server/internal/realtime/hub.go` returned no files
- `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /tmp/go-toolchain/go/bin/go test ./cmd/multica ./internal/realtime`
- `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm XDG_CACHE_HOME=/tmp/.cache TMPDIR=/tmp corepack pnpm install --frozen-lockfile`
- `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm XDG_CACHE_HOME=/tmp/.cache TMPDIR=/tmp corepack pnpm --filter @multica/docs typecheck`
