### PR TITLE
fix(desktop): hold loading until pre-workspace overlay opens

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -25,6 +25,7 @@ import { RESOURCES } from "@multica/views/locales";
 function AppContent() {
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
+  const overlay = useWindowOverlayStore((s) => s.overlay);
   const qc = useQueryClient();
   // Deep-link login runs loginWithToken → syncToken → listWorkspaces →
   // setQueryData sequentially. loginWithToken sets user+isLoading=false
@@ -223,7 +224,18 @@ function AppContent() {
     }
   }, [user, workspaceListFetched, wsCount]);
 
-  if (isLoading || bootstrapping) {
+  // Pre-workspace flows (onboarding, invitations, create workspace) open a
+  // window-level overlay from useEffect. Until that overlay mounts,
+  // DesktopShell would render with activeWorkspaceSlug=null (TabContent →
+  // null, no sidebar) and WindowOverlay → null — a blank white window,
+  // especially visible while listMyInvitations() is in flight.
+  const needsPreWorkspaceFlow =
+    !!user &&
+    workspaceListFetched &&
+    !(hasOnboarded && wsCount > 0);
+  const awaitingPreWorkspaceOverlay = needsPreWorkspaceFlow && !overlay;
+
+  if (isLoading || bootstrapping || awaitingPreWorkspaceOverlay) {
     return (
       <div className="flex h-screen items-center justify-center">
         <MulticaIcon className="size-6 animate-pulse" />


### PR DESCRIPTION
## Summary

- Fixes a startup white screen for authenticated users who still need a pre-workspace flow (onboarding, pending invitations, or create workspace).
- Root cause: `DesktopShell` rendered before the window overlay `useEffect` ran (and before `listMyInvitations()` resolved), leaving `TabContent` and `WindowOverlay` both `null`.
- Keeps the existing MulticaIcon loading screen up until the overlay is mounted.

## Test plan

- [ ] Fresh account / `onboarded_at` null: app shows loading briefly, then onboarding or invitations overlay (no blank window).
- [ ] Onboarded user with zero workspaces: loading → create-workspace overlay.
- [ ] Onboarded user with workspace(s): normal dashboard, no extra loading delay.
- [ ] Logged-out cold start: login page unchanged.


Made with [Cursor](https://cursor.com)