### PR TITLE
MUL-2771: feat(transcript): server-derived relative work_dir chip

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -120,9 +120,21 @@ export interface AgentTask {
   kind?: "comment" | "autopilot" | "chat" | "quick_create" | "direct";
   /**
    * Local working directory pinned for this task by the daemon. Empty until
-   * the daemon reports a work_dir (typically once execution starts).
+   * the daemon reports a work_dir (typically once execution starts). This is
+   * the canonical absolute path the agent runs in; UI surfaces should prefer
+   * `relative_work_dir` to avoid leaking the user's home directory.
    */
   work_dir?: string;
+  /**
+   * Privacy-safe display form of `work_dir`, derived on the server. For
+   * standard tasks the daemon's workspaces root has been stripped off
+   * (`<wsUUID>/<taskShort>/workdir`); for local_directory tasks where the
+   * path lives outside that layout, only the trailing two path segments
+   * are returned so neither the home directory nor the username leak into
+   * the UI. Older backends omit the field — render it conditionally and
+   * fall back to hiding the chip rather than rendering `work_dir` raw.
+   */
+  relative_work_dir?: string;
 }
 
 export interface Agent {

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -129,10 +129,13 @@ export interface AgentTask {
    * Privacy-safe display form of `work_dir`, derived on the server. For
    * standard tasks the daemon's workspaces root has been stripped off
    * (`<wsUUID>/<taskShort>/workdir`); for local_directory tasks where the
-   * path lives outside that layout, only the trailing two path segments
-   * are returned so neither the home directory nor the username leak into
-   * the UI. Older backends omit the field — render it conditionally and
-   * fall back to hiding the chip rather than rendering `work_dir` raw.
+   * path lives outside that layout, the server strips recognised home
+   * prefixes (`/Users/<name>/`, `/home/<name>/`, `<drive>:/Users/<name>/`)
+   * and otherwise falls back to the basename so neither the home directory
+   * nor the username leak into the UI. Older backends omit the field —
+   * render it conditionally and never render `work_dir` raw (not even in
+   * a tooltip / `title` / `aria-label`, since the goal is that screen
+   * shares and screenshots also stay safe).
    */
   relative_work_dir?: string;
 }

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -17,6 +17,7 @@ import {
   Cloud,
   Cpu,
   Filter,
+  FolderTree,
   ArrowDownNarrowWide,
   ArrowUpNarrowWide,
 } from "lucide-react";
@@ -472,6 +473,17 @@ export function AgentTranscriptDialog({
                 ? t(($) => $.transcript.events_filtered, { shown: filteredItems.length, total: items.length })
                 : t(($) => $.transcript.events, { count: items.length })}
             </MetadataChip>
+
+            {/* Working directory — server-derived display path. Falls back to
+                nothing when older backends omit the field rather than rendering
+                `work_dir` raw and leaking the user's home directory. */}
+            {task.relative_work_dir && (
+              <MetadataChip icon={<FolderTree className="h-3 w-3" />}>
+                <span className="font-mono" title={task.work_dir || task.relative_work_dir}>
+                  {task.relative_work_dir}
+                </span>
+              </MetadataChip>
+            )}
 
             {/* Created time */}
             {task.created_at && (

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -476,12 +476,14 @@ export function AgentTranscriptDialog({
 
             {/* Working directory — server-derived display path. Falls back to
                 nothing when older backends omit the field rather than rendering
-                `work_dir` raw and leaking the user's home directory. */}
+                `work_dir` raw and leaking the user's home directory. The
+                absolute `task.work_dir` deliberately never reaches the DOM
+                (no title/aria/data attribute), since the goal of this chip is
+                that recordings, screen shares, and screenshots never expose
+                $HOME or the username. */}
             {task.relative_work_dir && (
               <MetadataChip icon={<FolderTree className="h-3 w-3" />}>
-                <span className="font-mono" title={task.work_dir || task.relative_work_dir}>
-                  {task.relative_work_dir}
-                </span>
+                <span className="font-mono">{task.relative_work_dir}</span>
               </MetadataChip>
             )}
 

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
@@ -184,6 +185,15 @@ type AgentTaskResponse struct {
 	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
 	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
 	WorkDir                 string                `json:"work_dir,omitempty"`                  // local working directory pinned for this task; populated once the daemon reports it
+	// RelativeWorkDir is a privacy-safe display form of WorkDir intended for
+	// the UI. For standard tasks it strips the daemon's workspaces root so
+	// the user sees `<wsUUID>/<taskShort>/workdir`; for local_directory
+	// tasks the absolute path lives outside the envRoot layout, so we fall
+	// back to the last two path segments to avoid leaking the home dir or
+	// username. Empty when WorkDir is empty or workspace can't be resolved.
+	// See relativeWorkDir() for the full rules. Older clients can still
+	// read WorkDir directly; newer UIs should prefer RelativeWorkDir.
+	RelativeWorkDir         string                `json:"relative_work_dir,omitempty"`
 	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
 	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
 	TriggerSummary          *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
@@ -249,7 +259,13 @@ type TaskAgentData struct {
 	ThinkingLevel string                   `json:"thinking_level,omitempty"`
 }
 
-func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
+// taskToResponse maps a queue row to its wire shape. workspaceID is threaded
+// in because the row itself doesn't carry one (workspace lives on the agent
+// / issue / chat session) — we ask the caller to resolve it once and pass it
+// down. It populates WorkspaceID and powers the privacy-safe RelativeWorkDir
+// derivation; pass "" only on daemon-facing paths that genuinely don't have
+// it, in which case RelativeWorkDir falls back to the existing WorkDir.
+func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 	var result any
 	if t.Result != nil {
 		json.Unmarshal(t.Result, &result)
@@ -267,6 +283,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		AgentID:          uuidToString(t.AgentID),
 		RuntimeID:        uuidToString(t.RuntimeID),
 		IssueID:          uuidToString(t.IssueID),
+		WorkspaceID:      workspaceID,
 		Status:           t.Status,
 		Priority:         t.Priority,
 		DispatchedAt:     timestampToPtr(t.DispatchedAt),
@@ -282,6 +299,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
 		TriggerSummary:   textToPtr(t.TriggerSummary),
 		WorkDir:          workDir,
+		RelativeWorkDir:  relativeWorkDir(workDir, workspaceID, uuidToString(t.ID)),
 		// Surface task source so the UI can distinguish issue-linked tasks
 		// from chat-spawned or autopilot-spawned ones; all three may arrive
 		// with issue_id = "" once a task has no linked issue.
@@ -289,6 +307,71 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		AutopilotRunID: uuidToString(t.AutopilotRunID),
 		Kind:           computeTaskKind(t),
 	}
+}
+
+// relativeWorkDir produces a privacy-safe display form of the daemon-reported
+// absolute work_dir.
+//
+//   - For standard tasks (work_dir laid out as `<workspacesRoot>/<wsUUID>/
+//     <taskShort>/workdir` by execenv.Prepare), it strips everything up to and
+//     including the workspaces root, returning `<wsUUID>/<taskShort>/workdir`.
+//   - For local_directory tasks where work_dir is the user's own absolute
+//     path, the envRoot substring is absent. We fall back to the last two
+//     path segments — enough context ("repos/foo") for the user to
+//     recognise the directory without leaking the home dir or username.
+//
+// Returns empty when work_dir is empty or workspace_id / task_id are
+// missing. shortTaskID() must stay in lock-step with
+// server/internal/daemon/execenv/git.go:shortID — both consume the same
+// task UUID; if that helper changes, this one must too or the envRoot
+// match silently degrades to the local_directory fallback.
+func relativeWorkDir(workDir, workspaceID, taskID string) string {
+	if workDir == "" {
+		return ""
+	}
+	// Normalize Windows separators so the rest of the function only
+	// reasons about forward slashes.
+	normalized := strings.ReplaceAll(workDir, "\\", "/")
+
+	if workspaceID != "" && taskID != "" {
+		envRootSuffix := workspaceID + "/" + shortTaskID(taskID)
+		if idx := strings.Index(normalized, envRootSuffix); idx >= 0 {
+			return normalized[idx:]
+		}
+	}
+
+	return tailPathSegments(normalized, 2)
+}
+
+// shortTaskID mirrors execenv.shortID — first 8 hex chars of the UUID
+// with dashes stripped. Kept inline here so the agent handler has zero
+// imports from the daemon package (which would create an unwanted cycle
+// between handler and daemon).
+func shortTaskID(uuid string) string {
+	s := strings.ReplaceAll(uuid, "-", "")
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
+}
+
+// tailPathSegments returns the trailing n non-empty segments of a forward-
+// slash path, joined with "/". Used as the privacy-safe fallback for
+// local_directory work_dirs — n=2 keeps "<parent>/<basename>" which is
+// usually enough context without leaking $HOME or the username.
+func tailPathSegments(p string, n int) string {
+	if n <= 0 || p == "" {
+		return ""
+	}
+	parts := strings.Split(p, "/")
+	out := make([]string, 0, n)
+	for i := len(parts) - 1; i >= 0 && len(out) < n; i-- {
+		if parts[i] == "" {
+			continue
+		}
+		out = append([]string{parts[i]}, out...)
+	}
+	return strings.Join(out, "/")
 }
 
 // computeTaskKind picks the source-discriminator string the activity UI uses
@@ -1120,7 +1203,7 @@ func (h *Handler) ListAgentTasks(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]AgentTaskResponse, len(tasks))
 	for i, t := range tasks {
-		resp[i] = taskToResponse(t)
+		resp[i] = taskToResponse(t, workspaceID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -1257,7 +1340,7 @@ func (h *Handler) ListWorkspaceAgentTaskSnapshot(w http.ResponseWriter, r *http.
 		if _, ok := allowed[uuidToString(t.AgentID)]; !ok {
 			continue
 		}
-		resp = append(resp, taskToResponse(t))
+		resp = append(resp, taskToResponse(t, workspaceID))
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -188,11 +189,13 @@ type AgentTaskResponse struct {
 	// RelativeWorkDir is a privacy-safe display form of WorkDir intended for
 	// the UI. For standard tasks it strips the daemon's workspaces root so
 	// the user sees `<wsUUID>/<taskShort>/workdir`; for local_directory
-	// tasks the absolute path lives outside the envRoot layout, so we fall
-	// back to the last two path segments to avoid leaking the home dir or
-	// username. Empty when WorkDir is empty or workspace can't be resolved.
-	// See relativeWorkDir() for the full rules. Older clients can still
-	// read WorkDir directly; newer UIs should prefer RelativeWorkDir.
+	// tasks the absolute path lives outside the envRoot layout, so we strip
+	// recognised home-directory prefixes (`/Users/<name>/`, `/home/<name>/`,
+	// `<drive>:/Users/<name>/`) and otherwise fall back to the basename so
+	// the field never carries the user's home dir or account name. Empty
+	// when WorkDir is empty, or when stripping leaves nothing. See
+	// relativeWorkDir() for the full rules. Older clients can still read
+	// WorkDir directly; newer UIs should prefer RelativeWorkDir.
 	RelativeWorkDir         string                `json:"relative_work_dir,omitempty"`
 	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
 	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
@@ -310,21 +313,28 @@ func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 }
 
 // relativeWorkDir produces a privacy-safe display form of the daemon-reported
-// absolute work_dir.
+// absolute work_dir. The contract: the returned string must never contain
+// the user's home directory prefix or their account name. The chip is
+// rendered in transcripts that frequently end up in screen shares,
+// screenshots, and recordings, so this function is the only guard.
 //
 //   - For standard tasks (work_dir laid out as `<workspacesRoot>/<wsUUID>/
 //     <taskShort>/workdir` by execenv.Prepare), it strips everything up to and
 //     including the workspaces root, returning `<wsUUID>/<taskShort>/workdir`.
-//   - For local_directory tasks where work_dir is the user's own absolute
-//     path, the envRoot substring is absent. We fall back to the last two
-//     path segments — enough context ("repos/foo") for the user to
-//     recognise the directory without leaking the home dir or username.
+//   - For local_directory tasks the absolute path lives outside the envRoot
+//     layout. We try to recognise common home-directory prefixes
+//     (`/Users/<name>/`, `/home/<name>/`, `<drive>:/Users/<name>/`) and strip
+//     them, returning the remainder (e.g. `repos/foo`). When the prefix
+//     can't be recognised — unusual home layouts, network mounts, paths
+//     under `/opt`, `/srv`, etc. — we fall back to the basename so we never
+//     accidentally render a path component that happens to be a username.
 //
-// Returns empty when work_dir is empty or workspace_id / task_id are
-// missing. shortTaskID() must stay in lock-step with
-// server/internal/daemon/execenv/git.go:shortID — both consume the same
-// task UUID; if that helper changes, this one must too or the envRoot
-// match silently degrades to the local_directory fallback.
+// Returns empty when work_dir is empty, or when stripping leaves nothing
+// (i.e. work_dir was exactly the user's home — rendering nothing is
+// preferable to a chip that says `<name>`). shortTaskID() must stay in
+// lock-step with server/internal/daemon/execenv/git.go:shortID — both
+// consume the same task UUID; if that helper changes, this one must too
+// or the envRoot match silently degrades to the local_directory fallback.
 func relativeWorkDir(workDir, workspaceID, taskID string) string {
 	if workDir == "" {
 		return ""
@@ -340,7 +350,11 @@ func relativeWorkDir(workDir, workspaceID, taskID string) string {
 		}
 	}
 
-	return tailPathSegments(normalized, 2)
+	if stripped, ok := stripHomePrefix(normalized); ok {
+		return stripped
+	}
+
+	return basename(normalized)
 }
 
 // shortTaskID mirrors execenv.shortID — first 8 hex chars of the UUID
@@ -355,23 +369,46 @@ func shortTaskID(uuid string) string {
 	return s
 }
 
-// tailPathSegments returns the trailing n non-empty segments of a forward-
-// slash path, joined with "/". Used as the privacy-safe fallback for
-// local_directory work_dirs — n=2 keeps "<parent>/<basename>" which is
-// usually enough context without leaking $HOME or the username.
-func tailPathSegments(p string, n int) string {
-	if n <= 0 || p == "" {
+// homeDirPattern matches the well-known per-user home layouts on macOS,
+// Linux, and Windows after backslash normalization:
+//
+//	/Users/<name>[/<rest>]
+//	/home/<name>[/<rest>]
+//	<drive>:/Users/<name>[/<rest>]
+//
+// Case-insensitive because macOS and Windows are case-insensitive at the
+// filesystem layer; matching `/users/...` the same as `/Users/...` keeps
+// the strip robust against unusual casings seen on shared drives.
+// Capture group 1 is the optional remainder after the username segment.
+var homeDirPattern = regexp.MustCompile(`(?i)^(?:[A-Za-z]:)?/(?:Users|home)/[^/]+(?:/(.*))?$`)
+
+// stripHomePrefix recognises common home-directory layouts and returns
+// the path remainder after the username segment. Returns (remainder, true)
+// when a known home prefix matched. The remainder may be the empty string
+// (work_dir was exactly the home directory) — the caller treats that as
+// "nothing safe to display".
+func stripHomePrefix(p string) (string, bool) {
+	m := homeDirPattern.FindStringSubmatch(p)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// basename returns the last non-empty segment of a forward-slash path.
+// Used as the ultimate privacy-safe fallback when we can't otherwise
+// recognise the path: a single segment can never expose the home prefix,
+// and the leaf is almost always the most useful piece of context anyway
+// (typically the repo directory name for local_directory tasks).
+func basename(p string) string {
+	p = strings.TrimRight(p, "/")
+	if p == "" {
 		return ""
 	}
-	parts := strings.Split(p, "/")
-	out := make([]string, 0, n)
-	for i := len(parts) - 1; i >= 0 && len(out) < n; i-- {
-		if parts[i] == "" {
-			continue
-		}
-		out = append([]string{parts[i]}, out...)
+	if idx := strings.LastIndex(p, "/"); idx >= 0 {
+		return p[idx+1:]
 	}
-	return strings.Join(out, "/")
+	return p
 }
 
 // computeTaskKind picks the source-discriminator string the activity UI uses

--- a/server/internal/handler/agent_work_dir_test.go
+++ b/server/internal/handler/agent_work_dir_test.go
@@ -1,0 +1,154 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// TestRelativeWorkDir covers the privacy-safe display derivation that
+// agent-transcript dialogs render in the work_dir chip. Two regression
+// concerns drive the table:
+//
+//  1. Standard tasks must strip the daemon's workspaces root so the chip
+//     doesn't expose the user's home directory or username (the bug in
+//     PR #3379 that this fix replaces).
+//  2. local_directory tasks have a work_dir outside the envRoot layout —
+//     we must NOT leak `/Users/<name>/...`, so the fallback returns only
+//     the trailing two path segments.
+func TestRelativeWorkDir(t *testing.T) {
+	const (
+		wsID   = "a05b0e10-ee7a-4603-a72d-a548b2390cb2"
+		taskID = "5c57b65b-ee7a-4603-a72d-a548b2390cb2"
+	)
+
+	tests := []struct {
+		name     string
+		workDir  string
+		wsID     string
+		taskID   string
+		expected string
+	}{
+		{
+			name:     "empty work_dir returns empty",
+			workDir:  "",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "",
+		},
+		{
+			name:     "standard envRoot path strips workspaces root",
+			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: wsID + "/5c57b65b/workdir",
+		},
+		{
+			name:     "standard envRoot path without trailing workdir",
+			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: wsID + "/5c57b65b",
+		},
+		{
+			name:     "local_directory path keeps last two segments (no home leak)",
+			workDir:  "/Users/df007df/repos/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "repos/foo",
+		},
+		{
+			name:     "local_directory deep path still trims to two segments",
+			workDir:  "/Users/df007df/code/work/projects/multica/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "multica/foo",
+		},
+		{
+			name:     "short local path returns what's available",
+			workDir:  "/opt/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "opt/foo",
+		},
+		{
+			name:     "single-segment local path returns the segment",
+			workDir:  "/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "foo",
+		},
+		{
+			name:     "Windows backslash separators are normalized",
+			workDir:  `C:\Users\alice\multica_workspaces\` + wsID + `\5c57b65b\workdir`,
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: wsID + "/5c57b65b/workdir",
+		},
+		{
+			name:     "Windows local_directory path falls back to tail segments",
+			workDir:  `C:\Users\alice\repos\foo`,
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "repos/foo",
+		},
+		{
+			name:     "missing workspace_id falls back to tail segments even for envRoot path",
+			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir",
+			wsID:     "",
+			taskID:   taskID,
+			expected: "5c57b65b/workdir",
+		},
+		{
+			name:     "missing task_id falls back to tail segments even for envRoot path",
+			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir",
+			wsID:     wsID,
+			taskID:   "",
+			expected: "5c57b65b/workdir",
+		},
+		{
+			name:     "trailing slash on envRoot path is preserved in returned suffix",
+			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir/",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: wsID + "/5c57b65b/workdir/",
+		},
+		{
+			name:     "wsID prefix appearing elsewhere only matches when followed by shortID",
+			workDir:  "/var/" + wsID + "/something/else",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "something/else",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := relativeWorkDir(tc.workDir, tc.wsID, tc.taskID)
+			if got != tc.expected {
+				t.Fatalf("relativeWorkDir(%q, %q, %q) = %q, want %q",
+					tc.workDir, tc.wsID, tc.taskID, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestShortTaskIDMatchesDaemon pins shortTaskID() to execenv.PredictRootDir's
+// path layout. Both helpers consume the same task UUID; if the daemon's
+// shortID logic drifts, this test trips loudly instead of letting the UI
+// silently fall back to the "tail two segments" branch. Without this guard,
+// a daemon-side change to, say, a 12-char prefix would not break a build —
+// it would just quietly degrade every standard-task work_dir chip into the
+// local_directory fallback.
+func TestShortTaskIDMatchesDaemon(t *testing.T) {
+	const (
+		workspacesRoot = "/tmp/workspaces"
+		workspaceID    = "a05b0e10-ee7a-4603-a72d-a548b2390cb2"
+		taskID         = "5c57b65b-ee7a-4603-a72d-a548b2390cb2"
+	)
+	daemonRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+	expected := workspacesRoot + "/" + workspaceID + "/" + shortTaskID(taskID)
+	if daemonRoot != expected {
+		t.Fatalf("daemon PredictRootDir = %q, handler-side reconstruction = %q — shortTaskID is out of sync with execenv.shortID", daemonRoot, expected)
+	}
+}

--- a/server/internal/handler/agent_work_dir_test.go
+++ b/server/internal/handler/agent_work_dir_test.go
@@ -14,8 +14,11 @@ import (
 //     doesn't expose the user's home directory or username (the bug in
 //     PR #3379 that this fix replaces).
 //  2. local_directory tasks have a work_dir outside the envRoot layout —
-//     we must NOT leak `/Users/<name>/...`, so the fallback returns only
-//     the trailing two path segments.
+//     we must NOT leak `/Users/<name>/...`, `/home/<name>/...`, or
+//     `<drive>:/Users/<name>/...` even on shallow paths like
+//     `/Users/alice/foo`. The function strips recognised home prefixes
+//     and otherwise falls back to the basename, which can never carry a
+//     username segment.
 func TestRelativeWorkDir(t *testing.T) {
 	const (
 		wsID   = "a05b0e10-ee7a-4603-a72d-a548b2390cb2"
@@ -51,25 +54,74 @@ func TestRelativeWorkDir(t *testing.T) {
 			expected: wsID + "/5c57b65b",
 		},
 		{
-			name:     "local_directory path keeps last two segments (no home leak)",
+			name:     "local_directory path under /Users home is stripped",
 			workDir:  "/Users/df007df/repos/foo",
 			wsID:     wsID,
 			taskID:   taskID,
 			expected: "repos/foo",
 		},
 		{
-			name:     "local_directory deep path still trims to two segments",
+			name:     "local_directory deep path under home keeps full remainder",
 			workDir:  "/Users/df007df/code/work/projects/multica/foo",
 			wsID:     wsID,
 			taskID:   taskID,
-			expected: "multica/foo",
+			expected: "code/work/projects/multica/foo",
 		},
 		{
-			name:     "short local path returns what's available",
+			name:     "shallow /Users home path strips username segment",
+			workDir:  "/Users/alice/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "foo",
+		},
+		{
+			name:     "shallow Linux /home path strips username segment",
+			workDir:  "/home/alice/project",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "project",
+		},
+		{
+			name:     "shallow Windows /Users path strips username segment",
+			workDir:  `C:\Users\alice\foo`,
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "foo",
+		},
+		{
+			name:     "exact home directory returns empty (would only render username)",
+			workDir:  "/Users/alice",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "",
+		},
+		{
+			name:     "exact home directory with trailing slash returns empty",
+			workDir:  "/Users/alice/",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "",
+		},
+		{
+			name:     "Windows local_directory path under home strips username",
+			workDir:  `C:\Users\alice\repos\foo`,
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "repos/foo",
+		},
+		{
+			name:     "non-home local path falls back to basename only",
 			workDir:  "/opt/foo",
 			wsID:     wsID,
 			taskID:   taskID,
-			expected: "opt/foo",
+			expected: "foo",
+		},
+		{
+			name:     "non-home deep local path falls back to basename only",
+			workDir:  "/srv/git/repo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "repo",
 		},
 		{
 			name:     "single-segment local path returns the segment",
@@ -86,25 +138,18 @@ func TestRelativeWorkDir(t *testing.T) {
 			expected: wsID + "/5c57b65b/workdir",
 		},
 		{
-			name:     "Windows local_directory path falls back to tail segments",
-			workDir:  `C:\Users\alice\repos\foo`,
-			wsID:     wsID,
-			taskID:   taskID,
-			expected: "repos/foo",
-		},
-		{
-			name:     "missing workspace_id falls back to tail segments even for envRoot path",
+			name:     "missing workspace_id under home strips home prefix instead of envRoot",
 			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir",
 			wsID:     "",
 			taskID:   taskID,
-			expected: "5c57b65b/workdir",
+			expected: "multica_workspaces/" + wsID + "/5c57b65b/workdir",
 		},
 		{
-			name:     "missing task_id falls back to tail segments even for envRoot path",
+			name:     "missing task_id under home strips home prefix instead of envRoot",
 			workDir:  "/Users/alice/multica_workspaces/" + wsID + "/5c57b65b/workdir",
 			wsID:     wsID,
 			taskID:   "",
-			expected: "5c57b65b/workdir",
+			expected: "multica_workspaces/" + wsID + "/5c57b65b/workdir",
 		},
 		{
 			name:     "trailing slash on envRoot path is preserved in returned suffix",
@@ -114,11 +159,18 @@ func TestRelativeWorkDir(t *testing.T) {
 			expected: wsID + "/5c57b65b/workdir/",
 		},
 		{
-			name:     "wsID prefix appearing elsewhere only matches when followed by shortID",
+			name:     "wsID prefix appearing elsewhere falls back to basename when not under home",
 			workDir:  "/var/" + wsID + "/something/else",
 			wsID:     wsID,
 			taskID:   taskID,
-			expected: "something/else",
+			expected: "else",
+		},
+		{
+			name:     "case-insensitive /users matches the same as /Users",
+			workDir:  "/users/alice/repos/foo",
+			wsID:     wsID,
+			taskID:   taskID,
+			expected: "repos/foo",
 		},
 	}
 

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -736,7 +736,7 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, taskToResponse(*cancelled))
+	writeJSON(w, http.StatusOK, taskToResponse(*cancelled, workspaceID))
 }
 
 // ---------------------------------------------------------------------------

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -93,9 +93,21 @@ func (h *Handler) requireDaemonRuntimeAccess(w http.ResponseWriter, r *http.Requ
 
 // requireDaemonTaskAccess looks up a task and verifies the caller owns its workspace.
 func (h *Handler) requireDaemonTaskAccess(w http.ResponseWriter, r *http.Request, taskID string) (db.AgentTaskQueue, bool) {
+	task, _, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
+	return task, ok
+}
+
+// requireDaemonTaskAccessWithWorkspace is the workspace-aware variant of
+// requireDaemonTaskAccess. It returns the resolved workspace ID alongside
+// the task row so callers that need to forward workspace_id into
+// taskToResponse (powering RelativeWorkDir) don't have to repeat the
+// ResolveTaskWorkspaceID lookup. The two helpers share their entire
+// implementation; the simpler one is preserved for ergonomic call sites
+// that genuinely don't need workspace_id.
+func (h *Handler) requireDaemonTaskAccessWithWorkspace(w http.ResponseWriter, r *http.Request, taskID string) (db.AgentTaskQueue, string, bool) {
 	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "task_id")
 	if !ok {
-		return db.AgentTaskQueue{}, false
+		return db.AgentTaskQueue{}, "", false
 	}
 	task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil {
@@ -104,23 +116,23 @@ func (h *Handler) requireDaemonTaskAccess(w http.ResponseWriter, r *http.Request
 		// error must not be reported as a deletion.
 		if isNotFound(err) {
 			writeError(w, http.StatusNotFound, "task not found")
-			return db.AgentTaskQueue{}, false
+			return db.AgentTaskQueue{}, "", false
 		}
 		slog.Warn("get agent task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to load task")
-		return db.AgentTaskQueue{}, false
+		return db.AgentTaskQueue{}, "", false
 	}
 
 	wsID := h.TaskService.ResolveTaskWorkspaceID(r.Context(), task)
 	if wsID == "" {
 		writeError(w, http.StatusNotFound, "task not found")
-		return db.AgentTaskQueue{}, false
+		return db.AgentTaskQueue{}, "", false
 	}
 
 	if !h.requireDaemonWorkspaceAccess(w, r, wsID) {
-		return db.AgentTaskQueue{}, false
+		return db.AgentTaskQueue{}, "", false
 	}
-	return task, true
+	return task, wsID, true
 }
 
 // verifyDaemonWorkspaceAccess checks workspace access without writing an HTTP error.
@@ -1095,7 +1107,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	buildStart = time.Now()
 
 	// Build response with fresh agent data (name + skills + custom_env + custom_args).
-	resp := taskToResponse(*task)
+	resp := taskToResponse(*task, runtimeWorkspaceID)
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
 		var customEnv map[string]string
@@ -1601,9 +1613,11 @@ func (h *Handler) ListPendingTasksByRuntime(w http.ResponseWriter, r *http.Reque
 	runtimeID := chi.URLParam(r, "runtimeId")
 
 	// Verify the caller owns this runtime's workspace.
-	if _, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID); !ok {
+	runtime, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID)
+	if !ok {
 		return
 	}
+	workspaceID := uuidToString(runtime.WorkspaceID)
 
 	tasks, err := h.Queries.ListPendingTasksByRuntime(r.Context(), parseUUID(runtimeID))
 	if err != nil {
@@ -1613,7 +1627,7 @@ func (h *Handler) ListPendingTasksByRuntime(w http.ResponseWriter, r *http.Reque
 
 	resp := make([]AgentTaskResponse, len(tasks))
 	for i, t := range tasks {
-		resp[i] = taskToResponse(t)
+		resp[i] = taskToResponse(t, workspaceID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -1628,7 +1642,8 @@ func (h *Handler) StartTask(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
 
 	// Verify the caller owns this task's workspace.
-	if _, ok := h.requireDaemonTaskAccess(w, r, taskID); !ok {
+	_, workspaceID, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
+	if !ok {
 		return
 	}
 
@@ -1640,7 +1655,7 @@ func (h *Handler) StartTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("task started", "task_id", taskID, "agent_id", uuidToString(task.AgentID))
-	writeJSON(w, http.StatusOK, taskToResponse(*task))
+	writeJSON(w, http.StatusOK, taskToResponse(*task, workspaceID))
 }
 
 // TaskWaitLocalDirectoryRequest is the body the daemon POSTs when it parks
@@ -1660,7 +1675,8 @@ type TaskWaitLocalDirectoryRequest struct {
 func (h *Handler) MarkTaskWaitingLocalDirectory(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
 
-	if _, ok := h.requireDaemonTaskAccess(w, r, taskID); !ok {
+	_, workspaceID, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
+	if !ok {
 		return
 	}
 
@@ -1679,7 +1695,7 @@ func (h *Handler) MarkTaskWaitingLocalDirectory(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	writeJSON(w, http.StatusOK, taskToResponse(*task))
+	writeJSON(w, http.StatusOK, taskToResponse(*task, workspaceID))
 }
 
 // ReportTaskProgress broadcasts a progress update.
@@ -1727,7 +1743,8 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
 
 	// Verify the caller owns this task's workspace.
-	if _, ok := h.requireDaemonTaskAccess(w, r, taskID); !ok {
+	_, workspaceID, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
+	if !ok {
 		return
 	}
 
@@ -1758,7 +1775,7 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("task completed", "task_id", taskID, "agent_id", uuidToString(task.AgentID))
-	writeJSON(w, http.StatusOK, taskToResponse(*task))
+	writeJSON(w, http.StatusOK, taskToResponse(*task, workspaceID))
 }
 
 // emitIssueExecutedOnFirstCompletion atomically flips issue.first_executed_at
@@ -1873,7 +1890,8 @@ func (h *Handler) FailTask(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
 
 	// Verify the caller owns this task's workspace.
-	if _, ok := h.requireDaemonTaskAccess(w, r, taskID); !ok {
+	_, workspaceID, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
+	if !ok {
 		return
 	}
 
@@ -1898,7 +1916,7 @@ func (h *Handler) FailTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("task failed", "task_id", taskID, "agent_id", uuidToString(task.AgentID), "task_error", req.Error, "failure_reason", req.FailureReason)
-	writeJSON(w, http.StatusOK, taskToResponse(*task))
+	writeJSON(w, http.StatusOK, taskToResponse(*task, workspaceID))
 }
 
 // ---------------------------------------------------------------------------
@@ -2056,9 +2074,10 @@ func (h *Handler) GetActiveTaskForIssue(w http.ResponseWriter, r *http.Request) 
 		tasks = nil
 	}
 
+	workspaceID := uuidToString(issue.WorkspaceID)
 	resp := make([]AgentTaskResponse, len(tasks))
 	for i, t := range tasks {
-		resp[i] = taskToResponse(t)
+		resp[i] = taskToResponse(t, workspaceID)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"tasks": resp})
@@ -2090,7 +2109,7 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("task cancelled by user", "task_id", taskID, "issue_id", uuidToString(task.IssueID))
-	writeJSON(w, http.StatusOK, taskToResponse(*task))
+	writeJSON(w, http.StatusOK, taskToResponse(*task, uuidToString(issue.WorkspaceID)))
 }
 
 // ListTasksByIssue returns all tasks (any status) for an issue — used for execution history.
@@ -2107,9 +2126,10 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	workspaceID := uuidToString(issue.WorkspaceID)
 	resp := make([]AgentTaskResponse, len(tasks))
 	for i, t := range tasks {
-		resp[i] = taskToResponse(t)
+		resp[i] = taskToResponse(t, workspaceID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/server/internal/handler/task_lifecycle.go
+++ b/server/internal/handler/task_lifecycle.go
@@ -149,5 +149,5 @@ func (h *Handler) RerunIssue(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusAccepted, taskToResponse(*task))
+	writeJSON(w, http.StatusAccepted, taskToResponse(*task, uuidToString(issue.WorkspaceID)))
 }


### PR DESCRIPTION
## Summary

- Adds a privacy-safe `relative_work_dir` field to the agent task wire shape, derived in `taskToResponse` so every endpoint that serves a task (list / snapshot / claim / rerun / cancel / complete / fail) populates it consistently.
- Renders the new field as a `FolderTree`-iconed chip in the transcript dialog header, alongside the existing runtime / duration / event chips.
- Replaces the front-end stripping attempt in #3379, which passed `issue_id` where `workspace_id` was required and therefore rendered the full absolute home-directory path on every standard task.

## Why a new PR

[MUL-2771](https://multica-app.copilothub.ai/issue/MUL-2771) reviewed #3379 and surfaced six issues:

1. 🔴 The chip leaked the user's home directory because the strip helper received `issue_id` instead of `workspace_id`.
2. 🟡 The front-end's `shortID` had to stay in lock-step with the daemon's `execenv.shortID` — a cross-process coupling with no test guard.
3. 🟡 The `local_directory` task flow has work_dirs outside `envRoot` (e.g. `/Users/<name>/repos/foo`) that the helper had no story for.
4. 🟡 Indentation regression on line 488.
5. 🟡 Icon collided with the Runtime-provider `Cpu` chip on the same row.
6. 🟡 The `stripBeforeWorkspaces` helper had five branches and zero tests.

The product call ("我们来支持吧") confirmed the feature is wanted, so this PR re-implements it correctly rather than patching the buggy version.

## Implementation

**Backend** (`server/internal/handler/agent.go`)
- New `relativeWorkDir(workDir, workspaceID, taskID)` helper:
  - Standard tasks: matches `<wsUUID>/<shortTaskID>` against the absolute path and returns the suffix (`<wsUUID>/<taskShort>/workdir`).
  - `local_directory` tasks: falls back to the trailing two path segments (`repos/foo`) — never exposes `$HOME` or the username.
  - Normalises Windows backslashes so the same logic works for daemons running on Windows.
- `shortTaskID` mirrors `execenv.shortID`. A colocated test (`TestShortTaskIDMatchesDaemon`) pins the two helpers together so a daemon-side layout change cannot silently degrade every standard-task chip into the `local_directory` fallback.
- `taskToResponse` now accepts `workspaceID` and also populates the previously-declared-but-empty `WorkspaceID` field.
- New `requireDaemonTaskAccessWithWorkspace` returns the workspace ID alongside the task row so daemon-facing endpoints can forward it into `taskToResponse` without a second `ResolveTaskWorkspaceID` lookup.
- 12 caller updates across `agent.go`, `daemon.go`, `chat.go`, `task_lifecycle.go`.

**Frontend**
- `packages/core/types/agent.ts`: adds `relative_work_dir?: string` and a docstring pointing future readers at the right field. Older backends omit it; the UI hides the chip rather than rendering `work_dir` raw.
- `packages/views/common/task-transcript/agent-transcript-dialog.tsx`: adds a `FolderTree`-iconed chip rendering `task.relative_work_dir`, with the absolute path on hover via `title` for users who want to `cd` into it.

**Tests** — `server/internal/handler/agent_work_dir_test.go` (12 cases)
- Empty input, standard envRoot match, envRoot path without trailing `workdir`, deep `local_directory` path, short `/opt/foo` path, single-segment path, Windows backslashes for both branches, missing workspace_id / task_id fallback, trailing-slash preservation, and a substring-collision case (`/var/<wsID>/something/else`) to verify the match requires `<wsID>/<shortTaskID>` as a unit, not just the workspace prefix.

## Test plan
- [x] `pnpm typecheck` (all 6 packages)
- [x] `pnpm --filter @multica/views test --run` (866 passed)
- [x] `pnpm --filter @multica/core test --run` (412 passed)
- [x] `go build ./...` and `go vet ./...` clean
- [x] New `agent_work_dir_test.go` compiles cleanly; runs in CI where Postgres is up (skipped locally — no DB)
- [ ] Manual: open a transcript dialog for a standard task → chip shows `<wsUUID>/<taskShort>/workdir`; hover → absolute path
- [ ] Manual: open a transcript dialog for a `local_directory`-bound task → chip shows `<parent>/<basename>` only, no `/Users/...`

[MUL-2771](https://multica-app.copilothub.ai/issue/MUL-2771)