### PR TITLE
Require structured completion evidence before agent done

### DIFF
--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -361,6 +361,7 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const tone = STATUS_TONE[task.status];
   const label = useStatusLabel(task.status);
   const trigger = useTriggerText(task);
+  const evidence = useCompletionEvidenceText(task);
   const time = task.completed_at ? timeAgo(task.completed_at) : "—";
   const failureLabel =
     task.status === "failed" && task.failure_reason
@@ -391,7 +392,10 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
 
   return (
     <RowShell task={task}>
-      <TriggerText text={trigger} />
+      <div className="min-w-0 flex-1">
+        <TriggerText text={trigger} />
+        {evidence && <EvidenceText text={evidence} />}
+      </div>
       <span className="shrink-0 whitespace-nowrap text-xs">
         <span className={tone}>{failureLabel ?? label}</span>
         <span className="text-muted-foreground"> · {time}</span>
@@ -423,6 +427,51 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
       </RowActions>
     </RowShell>
   );
+}
+
+function useCompletionEvidenceText(task: AgentTask): string | null {
+  const { t } = useT("issues");
+  if (task.status !== "completed") return null;
+  const payload = taskResultPayload(task.result);
+  const parts: string[] = [];
+  if (payload?.pr_url) {
+    parts.push(t(($) => $.execution_log.evidence_pr, { value: compactUrl(payload.pr_url) }));
+  }
+  const outputLine = firstEvidenceLine(payload?.output);
+  if (outputLine) {
+    parts.push(t(($) => $.execution_log.evidence_output, { value: outputLine }));
+  }
+  if (task.work_dir) {
+    parts.push(t(($) => $.execution_log.evidence_workdir, { value: task.work_dir }));
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function taskResultPayload(result: unknown): { pr_url?: string; output?: string } | null {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return null;
+  const record = result as Record<string, unknown>;
+  return {
+    pr_url: typeof record.pr_url === "string" ? record.pr_url : undefined,
+    output: typeof record.output === "string" ? record.output : undefined,
+  };
+}
+
+function firstEvidenceLine(output?: string): string | null {
+  const line = output
+    ?.split(/\r?\n/)
+    .map((part) => part.trim())
+    .find(Boolean);
+  if (!line) return null;
+  return line.length > 120 ? `${line.slice(0, 117)}...` : line;
+}
+
+function compactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.hostname}${url.pathname}`;
+  } catch {
+    return value;
+  }
 }
 
 // ─── Shared row chrome ─────────────────────────────────────────────────────
@@ -460,7 +509,18 @@ function RowShell({
 function TriggerText({ text }: { text: string }) {
   return (
     <span
-      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs text-muted-foreground"
+      className="block min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs text-muted-foreground"
+      style={TRIGGER_MASK_STYLE}
+    >
+      {text}
+    </span>
+  );
+}
+
+function EvidenceText({ text }: { text: string }) {
+  return (
+    <span
+      className="mt-0.5 block min-w-0 overflow-hidden whitespace-nowrap text-[11px] leading-3 text-muted-foreground/80"
       style={TRIGGER_MASK_STYLE}
     >
       {text}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -340,7 +340,10 @@
     "status_running": "Working",
     "status_completed": "Completed",
     "status_failed": "Failed",
-    "status_cancelled": "Cancelled"
+    "status_cancelled": "Cancelled",
+    "evidence_pr": "PR {{value}}",
+    "evidence_output": "Result {{value}}",
+    "evidence_workdir": "Path {{value}}"
   },
   "terminate_dialog": {
     "title": "Stop this task?",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -333,7 +333,10 @@
     "status_running": "处理中",
     "status_completed": "已完成",
     "status_failed": "失败",
-    "status_cancelled": "已取消"
+    "status_cancelled": "已取消",
+    "evidence_pr": "PR {{value}}",
+    "evidence_output": "结果 {{value}}",
+    "evidence_workdir": "路径 {{value}}"
   },
   "terminate_dialog": {
     "title": "确定停止该 task？",

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2673,9 +2673,9 @@ func TestAgentCannotMarkDoneWithoutStructuredCompletionEvidence(t *testing.T) {
 		t.Fatalf("failed to create task: %v", err)
 	}
 	if _, err := testPool.Exec(ctx, `
-		INSERT INTO comment (issue_id, author_type, author_id, content, type, created_at)
-		VALUES ($1, 'agent', $2, 'Implemented the change.', 'comment', now())
-	`, issueID, agentID); err != nil {
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, $2, 'agent', $3, 'Implemented the change.', 'comment', now())
+	`, issueID, testWorkspaceID, agentID); err != nil {
 		t.Fatalf("failed to create generic comment: %v", err)
 	}
 
@@ -2732,9 +2732,9 @@ func TestAgentCanMarkDoneAfterStructuredCompletionEvidence(t *testing.T) {
 		t.Fatalf("failed to create task: %v", err)
 	}
 	if _, err := testPool.Exec(ctx, `
-		INSERT INTO comment (issue_id, author_type, author_id, content, type, created_at)
-		VALUES ($1, 'agent', $2, $3, 'comment', now())
-	`, issueID, agentID, strings.Join([]string{
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, $2, 'agent', $3, $4, 'comment', now())
+	`, issueID, testWorkspaceID, agentID, strings.Join([]string{
 		"Completion evidence:",
 		"Executor: Done Evidence Present Agent",
 		"Repository: https://github.com/AndyMental/multica",

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2651,13 +2651,8 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 func TestAgentCannotMarkDoneWithoutStructuredCompletionEvidence(t *testing.T) {
 	ctx := context.Background()
 
-	var agentID, runtimeID string
-	if err := testPool.QueryRow(ctx,
-		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
-		testWorkspaceID, "Handler Test Agent",
-	).Scan(&agentID, &runtimeID); err != nil {
-		t.Fatalf("failed to find test agent: %v", err)
-	}
+	agentID := createHandlerTestAgent(t, "Done Evidence Missing Agent", nil)
+	runtimeID := handlerTestRuntimeID(t)
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `
@@ -2715,13 +2710,8 @@ func TestAgentCannotMarkDoneWithoutStructuredCompletionEvidence(t *testing.T) {
 func TestAgentCanMarkDoneAfterStructuredCompletionEvidence(t *testing.T) {
 	ctx := context.Background()
 
-	var agentID, runtimeID string
-	if err := testPool.QueryRow(ctx,
-		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
-		testWorkspaceID, "Handler Test Agent",
-	).Scan(&agentID, &runtimeID); err != nil {
-		t.Fatalf("failed to find test agent: %v", err)
-	}
+	agentID := createHandlerTestAgent(t, "Done Evidence Present Agent", nil)
+	runtimeID := handlerTestRuntimeID(t)
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `
@@ -2746,7 +2736,7 @@ func TestAgentCanMarkDoneAfterStructuredCompletionEvidence(t *testing.T) {
 		VALUES ($1, 'agent', $2, $3, 'comment', now())
 	`, issueID, agentID, strings.Join([]string{
 		"Completion evidence:",
-		"Executor: Handler Test Agent",
+		"Executor: Done Evidence Present Agent",
 		"Repository: https://github.com/AndyMental/multica",
 		"Path: /workdir/multica",
 		"Branch: agent/dev/test",
@@ -2784,13 +2774,8 @@ func TestAgentCanMarkDoneAfterStructuredCompletionEvidence(t *testing.T) {
 func TestAgentBatchDoneWithoutStructuredCompletionEvidenceReturnsConflict(t *testing.T) {
 	ctx := context.Background()
 
-	var agentID, runtimeID string
-	if err := testPool.QueryRow(ctx,
-		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
-		testWorkspaceID, "Handler Test Agent",
-	).Scan(&agentID, &runtimeID); err != nil {
-		t.Fatalf("failed to find test agent: %v", err)
-	}
+	agentID := createHandlerTestAgent(t, "Batch Done Evidence Missing Agent", nil)
+	runtimeID := handlerTestRuntimeID(t)
 
 	var issueID string
 	if err := testPool.QueryRow(ctx, `

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2648,6 +2648,199 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
 }
 
+func TestAgentCannotMarkDoneWithoutStructuredCompletionEvidence(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, assignee_type, assignee_id, creator_type, creator_id, number, position)
+		VALUES ($1, 'done evidence missing test', 'in_progress', 'none', 'agent', $2, 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1), 0)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now() - interval '1 second')
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO comment (issue_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, 'agent', $2, 'Implemented the change.', 'comment', now())
+	`, issueID, agentID); err != nil {
+		t.Fatalf("failed to create generic comment: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "done"})
+	req = withURLParam(req, "id", issueID)
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("UpdateIssue without structured evidence: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "structured completion evidence") {
+		t.Fatalf("expected completion evidence error, got %s", w.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM issue WHERE id = $1`, issueID).Scan(&status); err != nil {
+		t.Fatalf("failed to read issue status: %v", err)
+	}
+	if status != "in_progress" {
+		t.Fatalf("status changed without evidence: got %q", status)
+	}
+}
+
+func TestAgentCanMarkDoneAfterStructuredCompletionEvidence(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, assignee_type, assignee_id, creator_type, creator_id, number, position)
+		VALUES ($1, 'done evidence present test', 'in_progress', 'none', 'agent', $2, 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1), 0)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now() - interval '1 second')
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO comment (issue_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, 'agent', $2, $3, 'comment', now())
+	`, issueID, agentID, strings.Join([]string{
+		"Completion evidence:",
+		"Executor: Handler Test Agent",
+		"Repository: https://github.com/AndyMental/multica",
+		"Path: /workdir/multica",
+		"Branch: agent/dev/test",
+		"Changes: server/internal/handler/issue.go and handler tests",
+		"Validation: go test ./internal/handler -run TestAgentCanMarkDoneAfterStructuredCompletionEvidence",
+	}, "\n")); err != nil {
+		t.Fatalf("failed to create evidence comment: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "done"})
+	req = withURLParam(req, "id", issueID)
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue with evidence: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if updated.Status != "done" {
+		t.Fatalf("status = %q, want done", updated.Status)
+	}
+}
+
+func TestAgentBatchDoneWithoutStructuredCompletionEvidenceReturnsConflict(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, assignee_type, assignee_id, creator_type, creator_id, number, position)
+		VALUES ($1, 'batch done evidence missing test', 'in_progress', 'none', 'agent', $2, 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1), 0)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID},
+		"updates":   map[string]any{"status": "done"},
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("BatchUpdateIssues without structured evidence: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "structured completion evidence") {
+		t.Fatalf("expected completion evidence error, got %s", w.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM issue WHERE id = $1`, issueID).Scan(&status); err != nil {
+		t.Fatalf("failed to read issue status: %v", err)
+	}
+	if status != "in_progress" {
+		t.Fatalf("status changed without evidence: got %q", status)
+	}
+}
+
 // TestBacklogToTodoByAgentTriggersDifferentAssignee verifies that the
 // documented sub-task chain works: when an agent (parent / Step 1) promotes
 // a backlog issue assigned to a different agent (child / Step 2), the

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2376,6 +2376,14 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	if req.Status != nil && prevIssue.Status != "done" && *req.Status == "done" {
+		if status, msg := h.validateAgentDoneEvidence(r, actorType, actorID, prevIssue.ID); status != 0 {
+			writeError(w, status, msg)
+			return
+		}
+	}
+
 	issue, err := h.Queries.UpdateIssue(r.Context(), params)
 	if err != nil {
 		slog.Warn("update issue failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", workspaceID)...)
@@ -2403,9 +2411,6 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	prevDueDate := timestampToPtr(prevIssue.DueDate)
 	dueDateChanged := prevDueDate != resp.DueDate && (prevDueDate == nil) != (resp.DueDate == nil) ||
 		(prevDueDate != nil && resp.DueDate != nil && *prevDueDate != *resp.DueDate)
-
-	// Determine actor identity: agent (via X-Agent-ID header) or member.
-	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 
 	h.publish(protocol.EventIssueUpdated, workspaceID, actorType, actorID, map[string]any{
 		"issue":               resp,
@@ -2550,6 +2555,100 @@ func (h *Handler) validateAssigneePair(ctx context.Context, r *http.Request, wor
 	default:
 		return http.StatusBadRequest, "assignee_type must be 'member', 'agent', or 'squad'"
 	}
+}
+
+func (h *Handler) validateAgentDoneEvidence(r *http.Request, actorType, actorID string, issueID pgtype.UUID) (int, string) {
+	if actorType != "agent" {
+		return 0, ""
+	}
+	taskIDStr := r.Header.Get("X-Task-ID")
+	if taskIDStr == "" {
+		return http.StatusConflict, "agent cannot mark issue done without task evidence"
+	}
+	taskID, err := util.ParseUUID(taskIDStr)
+	if err != nil {
+		return http.StatusConflict, "agent cannot mark issue done without task evidence"
+	}
+	task, err := h.Queries.GetAgentTask(r.Context(), taskID)
+	if err != nil || uuidToString(task.AgentID) != actorID || !task.IssueID.Valid || task.IssueID != issueID {
+		return http.StatusConflict, "agent cannot mark issue done without task evidence"
+	}
+	since := task.StartedAt
+	if !since.Valid {
+		since = task.CreatedAt
+	}
+	hasEvidence, err := h.hasStructuredCompletionEvidenceSince(r.Context(), issueID, task.AgentID, since)
+	if err != nil {
+		slog.Warn("done evidence check failed", "task_id", taskIDStr, "issue_id", uuidToString(issueID), "error", err)
+		return http.StatusInternalServerError, "failed to verify completion evidence"
+	}
+	if !hasEvidence {
+		return http.StatusConflict, "agent must post structured completion evidence before marking issue done; include Executor, Repository, Path, Branch or PR, Changes, and Validation"
+	}
+	return 0, ""
+}
+
+func (h *Handler) hasStructuredCompletionEvidenceSince(ctx context.Context, issueID, agentID pgtype.UUID, since pgtype.Timestamptz) (bool, error) {
+	if h.DB == nil {
+		return false, nil
+	}
+	rows, err := h.DB.Query(ctx, `
+		SELECT content
+		FROM comment
+		WHERE issue_id = $1
+		  AND author_type = 'agent'
+		  AND author_id = $2
+		  AND created_at >= $3
+		ORDER BY created_at DESC
+	`, issueID, agentID, since)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			return false, err
+		}
+		if isStructuredCompletionEvidence(content) {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func isStructuredCompletionEvidence(content string) bool {
+	fields := map[string]bool{}
+	for _, line := range strings.Split(content, "\n") {
+		label, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(label))
+		switch key {
+		case "executor":
+			fields["executor"] = true
+		case "repository", "repo":
+			fields["repository"] = true
+		case "path", "repo/path", "workspace path":
+			fields["path"] = true
+		case "branch":
+			fields["branch_or_pr"] = true
+		case "pr", "pr url", "pull request":
+			fields["branch_or_pr"] = true
+		case "changes", "changed files", "summary":
+			fields["changes"] = true
+		case "validation", "checks", "tests":
+			fields["validation"] = true
+		}
+	}
+	return fields["executor"] &&
+		fields["repository"] &&
+		fields["path"] &&
+		fields["branch_or_pr"] &&
+		fields["changes"] &&
+		fields["validation"]
 }
 
 // shouldEnqueueAgentTask returns true when an issue creation or assignment
@@ -2756,6 +2855,28 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	if req.Updates.Status != nil && *req.Updates.Status == "done" {
+		for _, issueID := range req.IssueIDs {
+			issueUUID, err := util.ParseUUID(issueID)
+			if err != nil {
+				continue
+			}
+			prevIssue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          issueUUID,
+				WorkspaceID: wsUUID,
+			})
+			if err != nil {
+				continue
+			}
+			if prevIssue.Status != "done" {
+				if status, msg := h.validateAgentDoneEvidence(r, actorType, actorID, prevIssue.ID); status != 0 {
+					writeError(w, status, msg)
+					return
+				}
+			}
+		}
+	}
 	updated := 0
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)
@@ -2905,7 +3026,6 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 		resp := issueToResponse(issue, prefix)
-		actorType, actorID := h.resolveActor(r, userID, workspaceID)
 
 		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&
 			(prevIssue.AssigneeType.String != issue.AssigneeType.String || uuidToString(prevIssue.AssigneeID) != uuidToString(issue.AssigneeID))

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -84,6 +84,37 @@ func addHumanMember(t *testing.T, squadID pgtype.UUID, userID, role string) {
 	}
 }
 
+func createSquadBriefingAgent(t *testing.T, name string) (agentID, runtimeID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'online', $4, '{}'::jsonb, now())
+		RETURNING id
+	`, testWorkspaceID, name+" Runtime", "squad_briefing_test", "Squad briefing test runtime").Scan(&runtimeID); err != nil {
+		t.Fatalf("create briefing runtime: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID) })
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args, mcp_config
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, name, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create briefing agent: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
+
+	return agentID, runtimeID
+}
+
 // seededLeaderAgent loads the first seeded agent in the test workspace.
 func seededLeaderAgent(t *testing.T) (id, name string) {
 	t.Helper()
@@ -226,34 +257,34 @@ func TestBuildSquadLeaderBriefing_MentionsRoundTrip(t *testing.T) {
 // claimAndDecodeAgent runs ClaimTaskByRuntime for the given runtime and
 // returns the agent block of the response. Fails the test on non-200.
 func claimAndDecodeAgent(t *testing.T, runtimeID string) *TaskAgentData {
-t.Helper()
-w := httptest.NewRecorder()
-req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-squad-briefing")
-req = withURLParam(req, "runtimeId", runtimeID)
-testHandler.ClaimTaskByRuntime(w, req)
-if w.Code != http.StatusOK {
-t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
-}
-var resp struct {
-Task *struct {
-Agent *TaskAgentData `json:"agent"`
-} `json:"task"`
-}
-if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-t.Fatalf("decode: %v", err)
-}
-if resp.Task == nil || resp.Task.Agent == nil {
-t.Fatalf("expected task.agent in response, got: %s", w.Body.String())
-}
-return resp.Task.Agent
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-squad-briefing")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Task *struct {
+			Agent *TaskAgentData `json:"agent"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task == nil || resp.Task.Agent == nil {
+		t.Fatalf("expected task.agent in response, got: %s", w.Body.String())
+	}
+	return resp.Task.Agent
 }
 
 // queueSquadIssueTaskFor creates an issue assigned to the squad and a queued
 // task for the given (agentID, runtimeID). Returns the issue + task IDs.
 func queueSquadIssueTaskFor(t *testing.T, squadID, agentID, runtimeID string, issueNumber int) (issueID, taskID string) {
-t.Helper()
-ctx := context.Background()
-if err := testPool.QueryRow(ctx, `
+	t.Helper()
+	ctx := context.Background()
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO issue (
 workspace_id, title, status, priority, creator_id, creator_type,
 assignee_type, assignee_id, number, position
@@ -261,101 +292,98 @@ assignee_type, assignee_id, number, position
 'squad', $3, $4, 0)
 RETURNING id
 `, testWorkspaceID, testUserID, squadID, issueNumber).Scan(&issueID); err != nil {
-t.Fatalf("create squad-assigned issue: %v", err)
-}
-t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+		t.Fatalf("create squad-assigned issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
 
-if err := testPool.QueryRow(ctx, `
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
 VALUES ($1, $2, $3, 'queued', 0)
 RETURNING id
 `, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-t.Fatalf("queue task: %v", err)
-}
-t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
-return
+		t.Fatalf("queue task: %v", err)
+	}
+	task, err := testHandler.Queries.GetAgentTask(ctx, util.MustParseUUID(taskID))
+	if err != nil {
+		t.Fatalf("load queued task: %v", err)
+	}
+	testHandler.TaskService.NotifyTaskEnqueued(ctx, task)
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	return
 }
 
 // TestClaimTask_LeaderGetsBriefing — when the squad leader claims a task on
 // a squad-assigned issue, the response's agent.instructions must include
 // the Operating Protocol + Roster + user instructions.
 func TestClaimTask_LeaderGetsBriefing(t *testing.T) {
-if testHandler == nil {
-t.Skip("database not available")
-}
-ctx := context.Background()
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
 
-var leaderID, runtimeID string
-if err := testPool.QueryRow(ctx,
-`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
-testWorkspaceID,
-).Scan(&leaderID, &runtimeID); err != nil {
-t.Fatalf("get leader agent: %v", err)
-}
+	leaderID, runtimeID := createSquadBriefingAgent(t, "Briefing Leader")
+	squad := seedSquadForBriefing(t, leaderID, "Briefing Claim Squad", "Be terse.")
 
-squad := seedSquadForBriefing(t, leaderID, "Briefing Claim Squad", "Be terse.")
+	helper := createHandlerTestAgent(t, "Briefing Helper", []byte("[]"))
+	addAgentMember(t, squad.ID, helper, "implementer")
 
-helper := createHandlerTestAgent(t, "Briefing Helper", []byte("[]"))
-addAgentMember(t, squad.ID, helper, "implementer")
+	queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), leaderID, runtimeID, 95001)
 
-queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), leaderID, runtimeID, 95001)
-
-agent := claimAndDecodeAgent(t, runtimeID)
-for _, want := range []string{
-"## Squad Operating Protocol",
-"## Squad Roster",
-"Leader (you):",
-"## Squad Instructions (Briefing Claim Squad)",
-"Be terse.",
-"`[@Briefing Helper](mention://agent/" + helper + ")`",
-} {
-if !strings.Contains(agent.Instructions, want) {
-t.Errorf("expected agent.instructions to contain %q\n--- instructions ---\n%s", want, agent.Instructions)
-}
-}
+	agent := claimAndDecodeAgent(t, runtimeID)
+	for _, want := range []string{
+		"## Squad Operating Protocol",
+		"## Squad Roster",
+		"Leader (you):",
+		"## Squad Instructions (Briefing Claim Squad)",
+		"Be terse.",
+		"`[@Briefing Helper](mention://agent/" + helper + ")`",
+	} {
+		if !strings.Contains(agent.Instructions, want) {
+			t.Errorf("expected agent.instructions to contain %q\n--- instructions ---\n%s", want, agent.Instructions)
+		}
+	}
 }
 
 // TestClaimTask_NonLeaderGetsNoBriefing — when a non-leader squad member
 // claims a task on a squad-assigned issue, NO briefing is injected.
 func TestClaimTask_NonLeaderGetsNoBriefing(t *testing.T) {
-if testHandler == nil {
-t.Skip("database not available")
-}
-ctx := context.Background()
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
 
-var leaderID string
-if err := testPool.QueryRow(ctx,
-`SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
-testWorkspaceID,
-).Scan(&leaderID); err != nil {
-t.Fatalf("get leader agent: %v", err)
-}
+	var leaderID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&leaderID); err != nil {
+		t.Fatalf("get leader agent: %v", err)
+	}
 
-squad := seedSquadForBriefing(t, leaderID, "Non-Leader Squad", "Squad guidance.")
+	squad := seedSquadForBriefing(t, leaderID, "Non-Leader Squad", "Squad guidance.")
 
-// Create a second agent (NOT the leader) with its own runtime so the
-// claim path picks its task without ambiguity.
-helperID := createHandlerTestAgent(t, "Non Leader Helper", []byte("[]"))
-addAgentMember(t, squad.ID, helperID, "")
-var helperRuntime string
-if err := testPool.QueryRow(ctx,
-`SELECT runtime_id FROM agent WHERE id = $1`, helperID,
-).Scan(&helperRuntime); err != nil {
-t.Fatalf("get helper runtime: %v", err)
-}
+	// Create a second agent (NOT the leader) with its own runtime so the
+	// claim path picks its task without ambiguity.
+	helperID := createHandlerTestAgent(t, "Non Leader Helper", []byte("[]"))
+	addAgentMember(t, squad.ID, helperID, "")
+	var helperRuntime string
+	if err := testPool.QueryRow(ctx,
+		`SELECT runtime_id FROM agent WHERE id = $1`, helperID,
+	).Scan(&helperRuntime); err != nil {
+		t.Fatalf("get helper runtime: %v", err)
+	}
 
-queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), helperID, helperRuntime, 95002)
+	queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), helperID, helperRuntime, 95002)
 
-agent := claimAndDecodeAgent(t, helperRuntime)
-for _, mustNot := range []string{
-"Squad Operating Protocol",
-"Squad Roster",
-"Squad Instructions (Non-Leader Squad)",
-} {
-if strings.Contains(agent.Instructions, mustNot) {
-t.Errorf("non-leader claim should NOT contain %q\n--- instructions ---\n%s", mustNot, agent.Instructions)
-}
-}
+	agent := claimAndDecodeAgent(t, helperRuntime)
+	for _, mustNot := range []string{
+		"Squad Operating Protocol",
+		"Squad Roster",
+		"Squad Instructions (Non-Leader Squad)",
+	} {
+		if strings.Contains(agent.Instructions, mustNot) {
+			t.Errorf("non-leader claim should NOT contain %q\n--- instructions ---\n%s", mustNot, agent.Instructions)
+		}
+	}
 }
 
 // Avoid "imported and not used: pgtype" if helpers above are the only users.


### PR DESCRIPTION
## What does this PR do?

Requires structured completion evidence before an agent-authored transition to `done`, and exposes compact completion evidence in the issue execution log. This addresses the auditability gap from AND-4926: issue pages need to show who completed the work, where it happened, what changed, and what validation ran or was skipped.

The follow-up commit `74409cf0` isolates the new completion-evidence handler tests so they no longer consume the shared handler test agent capacity used by `TestClaimTask_LeaderGetsBriefing`.

## Related Issue

Closes AND-4926
Follow-up CI regression: AND-5122

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/issue.go`: require a structured completion-evidence comment for agent-authored `done` transitions, and return an explicit conflict for blocked batch `done` transitions.
- `server/internal/handler/handler_test.go`: add handler coverage for missing/generic evidence rejection, structured evidence acceptance, batch conflict behavior, and isolate the new tests onto temporary agents.
- `packages/views/issues/components/execution-log-section.tsx`: show completion evidence details in the execution log.
- `packages/views/locales/en/issues.json` and `packages/views/locales/zh-Hans/issues.json`: add evidence UI strings.

## How to Test

1. As an agent with an active task, try to mark an issue `done` after only a generic comment; the API should return conflict and leave the issue status unchanged.
2. Post structured evidence containing executor, repository, path, branch or PR, changes, and validation; then mark the issue `done`; the API should allow the transition.
3. Verify the issue execution log renders the completion evidence summary.

## Verification

- `git diff --check origin/main...HEAD` passed locally on the PR branch tip (`74409cf0`).
- `make worktree-env` passed locally.
- `make test` could not run in this Multica runtime because `docker` is not installed.
- Focused backend check attempted but could not run because `go` is not installed: `cd server && go test ./internal/handler -run 'TestAgent(CannotMarkDoneWithoutStructuredCompletionEvidence|CanMarkDoneAfterStructuredCompletionEvidence|BatchDoneWithoutStructuredCompletionEvidenceReturnsConflict)|TestClaimTask_LeaderGetsBriefing'`.
- `gofmt -w server/internal/handler/handler_test.go` could not run because `gofmt` is not installed; the diff is whitespace-clean under `git diff --check`.
- `pnpm typecheck` was not run because `pnpm` is not installed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent / Codex

**Prompt / approach:** Implemented from the AND-4926 issue requirements and review feedback. The approach was to enforce a structured evidence gate at the backend status transition, expose the resulting evidence in the issue execution log, add focused handler regression coverage, then apply the AND-5122 follow-up to isolate the new tests from the existing squad leader claim-task fixture.

## Screenshots (optional)

Not captured in this runtime.
