### PR TITLE
fix: default to HEREDOC for agent comment templates on Linux/macOS

### DIFF
--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -161,19 +161,20 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 			issueID, triggerCommentID,
 		)
 	}
-	// Non-Codex providers on Linux/macOS: lightweight inline template, no
-	// platform branch. Pre-#1795 default, restored after we found that
-	// #1795 / #1851 had expanded a Codex-specific fix into a global mandate
-	// that broke Windows non-ASCII for every provider. The CLI decodes
-	// `\n` etc. server-side, so escaped multi-line is fine; for richer
-	// formatting the agent can still reach for `--content-stdin` (works
-	// on Linux/macOS) or `--content-file <path>` (works on every platform),
-	// both listed in Available Commands above.
+	// Non-Codex providers on Linux/macOS: default to HEREDOC via
+	// --content-stdin. Inline `--content "..."` is vulnerable to shell
+	// command substitution — backticks in agent-authored content get
+	// silently eaten by bash/zsh before the bytes reach the CLI
+	// (see ONE-102). HEREDOC sidesteps this entirely. The agent can
+	// still use `--content-file <path>` as a platform-agnostic
+	// alternative (works on Windows too).
 	return fmt.Sprintf(
 		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
 			"Use this form, preserving the same issue ID and --parent value:\n\n"+
-			"    multica issue comment add %s --parent %s --content \"...\"\n\n"+
+			"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
+			"    Your reply here. Use `backticks` freely.\n"+
+			"    COMMENT\n\n"+
 			"For multi-line bodies, code blocks, or content with quotes/backticks, prefer `--content-stdin` "+
 			"(pipe a HEREDOC) or `--content-file <path>` (read a UTF-8 file). See Available Commands above for the full menu.\n",
 		issueID, triggerCommentID,

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -43,12 +43,10 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 }
 
 // TestBuildCommentReplyInstructionsNonCodexLinux pins that every non-Codex
-// provider on Linux/macOS gets the lightweight pre-#1795 inline template.
-// The "MUST stdin" mandate was originally a Codex-specific fix that
-// #1795 / #1851 accidentally spread to every provider, breaking Windows
-// non-ASCII for all of them (#2198 / #2236 / #2376). Non-Codex providers
-// handle inline escaping correctly and the CLI server-decodes `\n` etc.,
-// so the inline template works on every non-Windows platform.
+// provider on Linux/macOS gets the HEREDOC template (via --content-stdin).
+// Inline `--content "..."` is vulnerable to shell command substitution —
+// backticks get silently eaten by bash/zsh (see ONE-102). HEREDOC
+// sidesteps this entirely.
 //
 // Not parallel: mutates the package-level runtimeGOOS.
 func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
@@ -66,7 +64,8 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 				got := BuildCommentReplyInstructions(provider, issueID, triggerID)
 
 				for _, want := range []string{
-					"multica issue comment add " + issueID + " --parent " + triggerID + " --content \"...\"",
+					"multica issue comment add " + issueID + " --parent " + triggerID + " --content-stdin",
+					"<<'COMMENT'",
 					"do NOT reuse --parent values from previous turns",
 					"If you decide to reply",
 				} {
@@ -75,13 +74,12 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					}
 				}
 
-				// Non-Codex / non-Windows providers must NOT receive the
-				// Codex-specific "MUST stdin" mandate or its HEREDOC
-				// template — that was the over-spread of #1795 / #1851.
+				// The primary template must NOT show inline --content
+				// as the example command — that's the vulnerable form.
+				// It may still appear in supplementary notes about
+				// alternatives, which is fine.
 				for _, banned := range []string{
 					"Always use `--content-stdin`",
-					"<<'COMMENT'",
-					"--parent " + triggerID + " --content-stdin",
 					"--parent " + triggerID + " --content-file",
 				} {
 					if strings.Contains(got, banned) {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -604,9 +604,17 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "4. Run `multica issue status %s in_progress`\n", ctx.IssueID)
 		b.WriteString("5. Follow your Skills and Agent Identity to complete the task (write code, investigate, etc.)\n")
 		if ctx.IsSquadLeader {
-			fmt.Fprintf(&b, "6. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity %s no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently): `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID, ctx.IssueID)
+			fmt.Fprintf(&b, "6. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity %s no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently). Use `--content-stdin` with a HEREDOC to avoid shell backtick issues:\n\n"+
+			"       cat <<'COMMENT' | multica issue comment add %s --content-stdin\n"+
+			"       Your results here.\n"+
+			"       COMMENT\n\n"+
+			"    Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID, ctx.IssueID)
 		} else {
-			fmt.Fprintf(&b, "6. **Post your final results as a comment — this step is mandatory**: `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
+			fmt.Fprintf(&b, "6. **Post your final results as a comment — this step is mandatory**. Use `--content-stdin` with a HEREDOC to avoid shell backtick issues:\n\n"+
+			"       cat <<'COMMENT' | multica issue comment add %s --content-stdin\n"+
+			"       Your results here.\n"+
+			"       COMMENT\n\n"+
+			"    Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
 		}
 		b.WriteString("7. Before exiting: only if this run produced a fact that clears the high bar (important AND likely to be re-read by future runs on this same issue, e.g. a new PR URL or deploy URL), or you noticed a metadata key from entry that is now stale, pin or clear it via `multica issue metadata set`/`delete`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write. See the `## Issue Metadata` section above for the full bar.\n")
 		fmt.Fprintf(&b, "8. When done, run `multica issue status %s in_review`\n", ctx.IssueID)


### PR DESCRIPTION
## Problem

Inline `--content "..."` is vulnerable to shell command substitution. Backticks in agent-authored content (config keys, model names, file paths, markdown inline code) get **silently eaten** by bash/zsh before the bytes reach the CLI. This causes silent data corruption — no error, no warning, just missing text.

Example: agent sends `--content "1. \`config.key\` → \`axon\`"` → stored as `1.  → `

## Root Cause

Bash/zsh interpret backticks as command substitution. When the agent passes `--content "..."` through shell, any backtick-wrapped text is executed as a command (usually not found → empty string).

## Related Issue

Relates to #3047 (daemon context reduction and Pi markup cleanup)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

1. **`server/internal/daemon/execenv/reply_instructions.go`** — Non-Codex Linux/macOS reply template now uses `cat <<'COMMENT' | ... --content-stdin` instead of `--content "..."`. Updated comment explaining the rationale.
2. **`server/internal/daemon/execenv/runtime_config.go`** — Assignment workflow step 6 (both squad-leader and non-squad-leader paths) now uses HEREDOC template via `--content-stdin`.
3. **`server/internal/daemon/execenv/reply_instructions_test.go`** — Updated assertions to match new HEREDOC default. Primary template now asserts `--content-stdin` and `<<'COMMENT'` are present; banned list updated to no longer block HEREDOC forms.

## What's NOT changed

- **Windows** — already uses `--content-file` (unchanged)
- **Codex** — already uses HEREDOC (unchanged)
- **Available Commands** — already shows all three options neutrally (unchanged)

## How to Test

1. `cd server && go test ./internal/daemon/execenv/ -run TestBuildCommentReplyInstructionsNonCodexLinux -v` — verifies non-Codex Linux/macOS template now uses HEREDOC
2. `go test ./internal/daemon/execenv/ -run TestBuildCommentReplyInstructionsCodexLinux -v` — verifies Codex template unchanged
3. `go test ./internal/daemon/execenv/ -run TestBuildCommentReplyInstructionsWindowsUsesContentFile -v` — verifies Windows template unchanged
4. `go test ./internal/daemon/execenv/ -v` — full test suite passes

## Checklist

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Hermes)

**Prompt / approach:** Agent diagnosed the backtick-silent-data-loss bug through testing in [ONE-101], then performed root cause analysis against the daemon source code. Implementation was guided by the existing Codex template pattern in `reply_instructions.go` — the fix simply extends the same HEREDOC approach to non-Codex providers.