### PR TITLE
chore(billing): silence i18next/no-literal-string in dev-only test page

### DIFF
--- a/packages/views/billing/billing-test-page.tsx
+++ b/packages/views/billing/billing-test-page.tsx
@@ -15,7 +15,12 @@
 //
 // Anything past "make the API talk to Stripe and surface results" is
 // out of scope here on purpose — when the real billing UI ships it
-// will live elsewhere and this whole page can be deleted.
+// will live elsewhere and this whole page can be deleted. Until then,
+// the page intentionally hard-codes English labels rather than going
+// through useT(): it is dev-only, not localized, and slated for
+// deletion — so it is exempt from the package-wide i18next/no-literal-string
+// rule.
+/* eslint-disable i18next/no-literal-string */
 
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";


### PR DESCRIPTION
## Summary

`packages/views/billing/billing-test-page.tsx` (added in #3442) is failing
the `i18next/no-literal-string` rule with 40+ JSX literals, which is
blocking the frontend CI check on every unrelated PR that touches
`packages/views`.

The file is intentionally a dev-only test page — its own header comment
says it's "Not a finished UI — just every endpoint stuffed onto one
page so we can verify the proxy + Stripe flow" and explicitly notes it
"can be deleted" when the real billing UI ships. Routing every label
through `useT()` and inventing throwaway translation keys for a soon-to-be-deleted
page would just be churn.

Adding a file-level `eslint-disable i18next/no-literal-string` documents
the carve-out next to the existing "not a finished UI" comment, with a
sentence explaining why this file is exempt.

## Test plan

- [x] `pnpm --filter @multica/views lint` — 0 errors (matches CI rule
      set).