### PR TITLE
Fix Pi runtime message delivery

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -234,7 +234,8 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		cancel()
 		return nil, fmt.Errorf("pi stdin pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[pi:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[pi:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		_ = stdin.Close()
@@ -372,7 +373,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			finalError = "execution cancelled"
 		} else if waitErr != nil && finalStatus == "completed" {
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("pi exited with error: %v", waitErr)
+			finalError = withAgentStderr(fmt.Sprintf("pi exited with error: %v", waitErr), "pi", stderrBuf.Tail())
 		}
 
 		b.cfg.Logger.Info("pi finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -41,6 +41,29 @@ func TestBuildPiArgsBasicFlags(t *testing.T) {
 	}
 }
 
+func TestBuildPiArgsPreservesPromptAsFinalArg(t *testing.T) {
+	prompts := []string{
+		"plain task",
+		"spaces and \"quotes\" and 'apostrophes'",
+		"line one\nline two",
+		`literal \n text`,
+	}
+
+	for _, prompt := range prompts {
+		t.Run(prompt, func(t *testing.T) {
+			args := buildPiArgs(prompt, "/tmp/s.jsonl", ExecOptions{
+				Model:        "anthropic/claude-sonnet-4-20250514",
+				SystemPrompt: "be helpful",
+				CustomArgs:   []string{"--some-pi-flag", "value"},
+			}, slog.Default())
+
+			if got := args[len(args)-1]; got != prompt {
+				t.Fatalf("prompt should be exact final arg, got %q, want %q", got, prompt)
+			}
+		})
+	}
+}
+
 func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	// Users can still restrict tools via custom_args if desired.
 	args := buildPiArgs("prompt", "/tmp/s.jsonl", ExecOptions{
@@ -55,6 +78,62 @@ func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("custom --tools should pass through via custom_args, got: %v", args)
+	}
+}
+
+func TestPiExecutePassesPromptAsFinalArg(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	wantPrompt := "deploy task with spaces, \"quotes\", and newline\nsecond line with literal \\n"
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	script := "#!/bin/sh\n" +
+		"last=\n" +
+		"for arg do last=$arg; done\n" +
+		"if [ \"$last\" != \"$EXPECTED_PROMPT\" ]; then\n" +
+		"  printf 'last arg mismatch\\nwant: %s\\ngot: %s\\n' \"$EXPECTED_PROMPT\" \"$last\" >&2\n" +
+		"  exit 3\n" +
+		"fi\n" +
+		"printf '%s\\n' '{\"type\":\"agent_start\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"delta\":\"received exact prompt\"}}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn_end\",\"message\":{\"role\":\"assistant\",\"model\":\"test\",\"usage\":{\"input\":1,\"output\":1,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":2}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("pi", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"EXPECTED_PROMPT": wantPrompt},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, wantPrompt, ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "received exact prompt" {
+			t.Fatalf("unexpected output: %q", result.Output)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 
@@ -113,6 +192,53 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 		}
 		if result.Status != "completed" {
 			t.Fatalf("expected status=completed (stdin attached as fifo), got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestPiExecuteSurfacesStderrOnNonZeroResult(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	script := "#!/bin/sh\n" +
+		"echo \"provider rejected prompt payload\" >&2\n" +
+		"exit 2\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "provider rejected prompt payload") {
+			t.Fatalf("expected error to include stderr hint, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "pi stderr:") {
+			t.Fatalf("expected stderr label in error, got %q", result.Error)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")


### PR DESCRIPTION
Summary\n- keep Pi prompt delivery as the final positional argv value\n- capture bounded Pi stderr on non-zero exits for clearer provider failures\n- add focused Pi argv, fake execution, and failure coverage\n\nIssue: AND-4881\n\nNotes\n- Replacement for closed PR #3402 after removing unrelated desktop attachment-download changes.\n- Local Go toolchain is unavailable in this sandbox, so Go verification is expected from CI.