### PR TITLE
fix(agent): honor Cursor MCP config

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2448,6 +2448,15 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 	}
 }
 
+func providerSupportsMcpConfig(provider string) bool {
+	switch provider {
+	case "claude", "codex", "cursor", "hermes", "kimi", "kiro":
+		return true
+	default:
+		return false
+	}
+}
+
 func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot int, taskLog *slog.Logger) (TaskResult, error) {
 	// Refuse to spawn an agent without a workspace. An empty workspace_id
 	// here would make MULTICA_WORKSPACE_ID empty in the agent env, and the
@@ -2729,6 +2738,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.Agent != nil {
 		customArgs = task.Agent.CustomArgs
 		mcpConfig = task.Agent.McpConfig
+	}
+	if len(mcpConfig) > 0 && !providerSupportsMcpConfig(provider) {
+		return TaskResult{}, fmt.Errorf("per-agent mcp_config is not supported by %s provider; supported providers: claude, codex, cursor, hermes, kimi, kiro", provider)
 	}
 	// Two-tier model resolution: an explicit agent.model wins,
 	// then the daemon-wide MULTICA_<PROVIDER>_MODEL env var. If

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -205,6 +205,36 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestProviderSupportsMcpConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider string
+		want     bool
+	}{
+		{provider: "claude", want: true},
+		{provider: "codex", want: true},
+		{provider: "cursor", want: true},
+		{provider: "hermes", want: true},
+		{provider: "kimi", want: true},
+		{provider: "kiro", want: true},
+		{provider: "copilot", want: false},
+		{provider: "gemini", want: false},
+		{provider: "opencode", want: false},
+		{provider: "openclaw", want: false},
+		{provider: "pi", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			if got := providerSupportsMcpConfig(tc.provider); got != tc.want {
+				t.Fatalf("providerSupportsMcpConfig(%q) = %v, want %v", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestComposeOpenclawIncludeRoots — the Elon must-fix regression: the
 // daemon must grant OpenClaw permission to follow the wrapper's $include
 // link from envRoot into the user's active config dir, while preserving

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -39,6 +41,17 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
 	argv0, cmdArgs := chooseCursorInvocation(execName, lookedUp, args, b.cfg.Logger)
 
+	cleanupMcpConfig, err := prepareCursorMcpConfig(opts.Cwd, opts.McpConfig)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	defer func() {
+		if cleanupMcpConfig != nil {
+			cleanupMcpConfig()
+		}
+	}()
+
 	cmd := exec.CommandContext(runCtx, argv0, cmdArgs...)
 	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", argv0, "args", cmdArgs)
@@ -62,6 +75,11 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	b.cfg.Logger.Info("cursor-agent started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
+	// The child process has started and Cursor reads project MCP config from
+	// the workspace during execution, so the cleanup moves to the goroutine.
+	runCleanupMcpConfig := cleanupMcpConfig
+	cleanupMcpConfig = nil
+
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
@@ -69,6 +87,9 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
+		if runCleanupMcpConfig != nil {
+			defer runCleanupMcpConfig()
+		}
 
 		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
 		go func() {
@@ -418,4 +439,46 @@ func buildCursorArgs(prompt string, opts ExecOptions, logger *slog.Logger) []str
 	}
 	args = append(args, filterCustomArgs(opts.CustomArgs, cursorBlockedArgs, logger)...)
 	return args
+}
+
+// prepareCursorMcpConfig materializes the per-agent MCP config at Cursor's
+// project discovery path for the lifetime of one run.
+func prepareCursorMcpConfig(cwd string, raw json.RawMessage) (func(), error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if cwd == "" {
+		return nil, fmt.Errorf("cursor mcp_config requires a workspace cwd")
+	}
+
+	cursorDir := filepath.Join(cwd, ".cursor")
+	mcpPath := filepath.Join(cursorDir, "mcp.json")
+
+	var previous []byte
+	existed := false
+	previousMode := os.FileMode(0o600)
+	if data, err := os.ReadFile(mcpPath); err == nil {
+		previous = data
+		existed = true
+		if info, statErr := os.Stat(mcpPath); statErr == nil {
+			previousMode = info.Mode().Perm()
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read cursor mcp config: %w", err)
+	}
+
+	if err := os.MkdirAll(cursorDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create cursor config dir: %w", err)
+	}
+	if err := os.WriteFile(mcpPath, raw, 0o600); err != nil {
+		return nil, fmt.Errorf("write cursor mcp config: %w", err)
+	}
+
+	return func() {
+		if existed {
+			_ = os.WriteFile(mcpPath, previous, previousMode)
+			return
+		}
+		_ = os.Remove(mcpPath)
+	}, nil
 }

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -70,6 +72,88 @@ func TestBuildCursorArgsMinimal(t *testing.T) {
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+}
+
+func TestPrepareCursorMcpConfigNoConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cleanup, err := prepareCursorMcpConfig(dir, nil)
+	if err != nil {
+		t.Fatalf("prepareCursorMcpConfig: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatalf("expected nil cleanup for empty mcp_config")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".cursor", "mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no cursor mcp config file, stat err=%v", err)
+	}
+}
+
+func TestPrepareCursorMcpConfigWritesPerRunFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	raw := json.RawMessage(`{"mcpServers":{"demo":{"command":"echo","args":["ok"]}}}`)
+
+	cleanup, err := prepareCursorMcpConfig(dir, raw)
+	if err != nil {
+		t.Fatalf("prepareCursorMcpConfig: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatalf("expected cleanup function")
+	}
+
+	path := filepath.Join(dir, ".cursor", "mcp.json")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cursor mcp config: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("cursor mcp config = %s, want %s", string(got), string(raw))
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup to remove generated mcp config, stat err=%v", err)
+	}
+}
+
+func TestPrepareCursorMcpConfigRestoresExistingFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o700); err != nil {
+		t.Fatalf("mkdir cursor dir: %v", err)
+	}
+	path := filepath.Join(cursorDir, "mcp.json")
+	previous := []byte(`{"mcpServers":{"existing":{"command":"old"}}}`)
+	if err := os.WriteFile(path, previous, 0o600); err != nil {
+		t.Fatalf("write existing cursor mcp config: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"new":{"command":"new"}}}`)
+	cleanup, err := prepareCursorMcpConfig(dir, raw)
+	if err != nil {
+		t.Fatalf("prepareCursorMcpConfig: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written cursor mcp config: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("cursor mcp config = %s, want %s", string(got), string(raw))
+	}
+
+	cleanup()
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored cursor mcp config: %v", err)
+	}
+	if string(restored) != string(previous) {
+		t.Fatalf("restored cursor mcp config = %s, want %s", string(restored), string(previous))
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Honors per-agent `mcp_config` for Cursor runtime launches by materializing the configured MCP server set at Cursor's project discovery path for the lifetime of a single agent run.

The daemon already carries `agent.mcp_config` through task claim and `agent.ExecOptions`; Claude, Codex, and ACP runtimes now consume it upstream. Cursor still ignored the value, so Cursor agents could only use unmanaged host-global MCP config. This PR adds Cursor-specific materialization plus cleanup/restore behavior, and keeps unsupported providers from silently accepting no-op MCP config.

## Related Issue

Closes #1601

Multica workspace issue: AND-4871

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/cursor.go`: writes per-agent MCP config to `.cursor/mcp.json` before launching `cursor-agent`, then removes the generated file or restores a pre-existing file after the process exits.
- `server/pkg/agent/cursor_test.go`: covers no-config default, per-run MCP file creation, and restoring an existing Cursor MCP config.
- `server/internal/daemon/daemon.go`: fails clearly when `mcp_config` is configured for a provider that still has no runtime MCP support.
- `server/internal/daemon/daemon_test.go`: pins the provider support gate, including currently supported Claude/Codex/Cursor/ACP providers and unsupported providers.

## How to Test

1. Configure a Cursor agent with `mcp_config` containing one or more `mcpServers`.
2. Assign it a task in a workdir that has no global/unmanaged Cursor MCP config.
3. Confirm Cursor sees the configured MCP servers during the run and `.cursor/mcp.json` is removed or restored afterward.

Local verification in this environment:
- `git diff --check` passed.
- `cd server && go test ./pkg/agent ./internal/daemon` could not run because this environment does not have a Go toolchain (`go: command not found`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent / Codex

**Prompt / approach:**
Started from the Multica issue context and prior repo survey. Traced `mcp_config` from persisted agent data through daemon task execution into provider `ExecOptions`, compared Claude/Codex/ACP consumers with Cursor, then implemented the narrow Cursor runtime materialization path and focused tests. A previous PR accidentally included unrelated desktop attachment-download changes; this branch was rebuilt from current `multica-ai/main` and contains only the runtime MCP files listed above.

## Screenshots (optional)

N/A; backend/runtime behavior only.
