### PR TITLE
feat(issues): orthogonal filter contract shared by /issues + /grouped (MUL-2782)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -28,25 +28,25 @@ import (
 
 // IssueResponse is the JSON response for an issue.
 type IssueResponse struct {
-	ID            string                  `json:"id"`
-	WorkspaceID   string                  `json:"workspace_id"`
-	Number        int32                   `json:"number"`
-	Identifier    string                  `json:"identifier"`
-	Title         string                  `json:"title"`
-	Description   *string                 `json:"description"`
-	Status        string                  `json:"status"`
-	Priority      string                  `json:"priority"`
-	AssigneeType  *string                 `json:"assignee_type"`
-	AssigneeID    *string                 `json:"assignee_id"`
-	CreatorType   string                  `json:"creator_type"`
-	CreatorID     string                  `json:"creator_id"`
-	ParentIssueID *string                 `json:"parent_issue_id"`
-	ProjectID     *string                 `json:"project_id"`
-	Position      float64                 `json:"position"`
-	StartDate     *string                 `json:"start_date"`
-	DueDate       *string                 `json:"due_date"`
-	CreatedAt     string                  `json:"created_at"`
-	UpdatedAt     string                  `json:"updated_at"`
+	ID            string  `json:"id"`
+	WorkspaceID   string  `json:"workspace_id"`
+	Number        int32   `json:"number"`
+	Identifier    string  `json:"identifier"`
+	Title         string  `json:"title"`
+	Description   *string `json:"description"`
+	Status        string  `json:"status"`
+	Priority      string  `json:"priority"`
+	AssigneeType  *string `json:"assignee_type"`
+	AssigneeID    *string `json:"assignee_id"`
+	CreatorType   string  `json:"creator_type"`
+	CreatorID     string  `json:"creator_id"`
+	ParentIssueID *string `json:"parent_issue_id"`
+	ProjectID     *string `json:"project_id"`
+	Position      float64 `json:"position"`
+	StartDate     *string `json:"start_date"`
+	DueDate       *string `json:"due_date"`
+	CreatedAt     string  `json:"created_at"`
+	UpdatedAt     string  `json:"updated_at"`
 	// Metadata is the per-issue KV map (see issue_metadata.go). Always emitted
 	// (empty object when unset) so frontend code can `issue.metadata[key]`
 	// without nil-guarding the parent field.
@@ -199,10 +199,10 @@ func assigneeGroupID(assigneeType pgtype.Text, assigneeID pgtype.UUID) string {
 // SearchIssueResponse extends IssueResponse with search metadata.
 type SearchIssueResponse struct {
 	IssueResponse
-	MatchSource                string  `json:"match_source"`
-	MatchedSnippet             *string `json:"matched_snippet,omitempty"`
-	MatchedDescriptionSnippet  *string `json:"matched_description_snippet,omitempty"`
-	MatchedCommentSnippet      *string `json:"matched_comment_snippet,omitempty"`
+	MatchSource               string  `json:"match_source"`
+	MatchedSnippet            *string `json:"matched_snippet,omitempty"`
+	MatchedDescriptionSnippet *string `json:"matched_description_snippet,omitempty"`
+	MatchedCommentSnippet     *string `json:"matched_comment_snippet,omitempty"`
 }
 
 // extractSnippet extracts a snippet of text around the first occurrence of query.
@@ -706,70 +706,64 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse optional filter params. Malformed UUIDs in filters return 400 —
-	// silently coercing them to a zero UUID would mask a client bug and let
-	// the query return an empty result set (or worse, match a NULL row).
-	var priorityFilter pgtype.Text
-	if p := r.URL.Query().Get("priority"); p != "" {
-		priorityFilter = pgtype.Text{String: p, Valid: true}
-	}
-	var assigneeFilter pgtype.UUID
-	if a := r.URL.Query().Get("assignee_id"); a != "" {
-		id, ok := parseUUIDOrBadRequest(w, a, "assignee_id")
-		if !ok {
-			return
+	// open_only=true returns all non-done/cancelled issues (no limit). This is a
+	// legacy programmatic path with no UI caller; it still uses the single-value
+	// sqlc filters rather than the orthogonal filter set the main path builds.
+	if r.URL.Query().Get("open_only") == "true" {
+		// Malformed UUIDs return 400 — silently coercing them to a zero UUID
+		// would mask a client bug and match a NULL row.
+		var priorityFilter pgtype.Text
+		if p := r.URL.Query().Get("priority"); p != "" {
+			priorityFilter = pgtype.Text{String: p, Valid: true}
 		}
-		assigneeFilter = id
-	}
-	var assigneeIdsFilter []pgtype.UUID
-	if ids := r.URL.Query().Get("assignee_ids"); ids != "" {
-		for _, raw := range strings.Split(ids, ",") {
-			if s := strings.TrimSpace(raw); s != "" {
-				id, ok := parseUUIDOrBadRequest(w, s, "assignee_ids")
-				if !ok {
-					return
+		var assigneeFilter pgtype.UUID
+		if a := r.URL.Query().Get("assignee_id"); a != "" {
+			id, ok := parseUUIDOrBadRequest(w, a, "assignee_id")
+			if !ok {
+				return
+			}
+			assigneeFilter = id
+		}
+		var assigneeIdsFilter []pgtype.UUID
+		if ids := r.URL.Query().Get("assignee_ids"); ids != "" {
+			for _, raw := range strings.Split(ids, ",") {
+				if s := strings.TrimSpace(raw); s != "" {
+					id, ok := parseUUIDOrBadRequest(w, s, "assignee_ids")
+					if !ok {
+						return
+					}
+					assigneeIdsFilter = append(assigneeIdsFilter, id)
 				}
-				assigneeIdsFilter = append(assigneeIdsFilter, id)
 			}
 		}
-	}
-	var creatorFilter pgtype.UUID
-	if c := r.URL.Query().Get("creator_id"); c != "" {
-		id, ok := parseUUIDOrBadRequest(w, c, "creator_id")
+		var creatorFilter pgtype.UUID
+		if c := r.URL.Query().Get("creator_id"); c != "" {
+			id, ok := parseUUIDOrBadRequest(w, c, "creator_id")
+			if !ok {
+				return
+			}
+			creatorFilter = id
+		}
+		var projectFilter pgtype.UUID
+		if p := r.URL.Query().Get("project_id"); p != "" {
+			id, ok := parseUUIDOrBadRequest(w, p, "project_id")
+			if !ok {
+				return
+			}
+			projectFilter = id
+		}
+		var involvesUserFilter pgtype.UUID
+		if u := r.URL.Query().Get("involves_user_id"); u != "" {
+			id, ok := parseUUIDOrBadRequest(w, u, "involves_user_id")
+			if !ok {
+				return
+			}
+			involvesUserFilter = id
+		}
+		metadataFilter, ok := parseMetadataFilterParam(w, r.URL.Query().Get("metadata"))
 		if !ok {
 			return
 		}
-		creatorFilter = id
-	}
-	var projectFilter pgtype.UUID
-	if p := r.URL.Query().Get("project_id"); p != "" {
-		id, ok := parseUUIDOrBadRequest(w, p, "project_id")
-		if !ok {
-			return
-		}
-		projectFilter = id
-	}
-	// involves_user_id widens the assignee filter to surface issues where the
-	// user is the indirect assignee (their owned agent, or a squad they belong
-	// to / lead / have an agent inside). Direct member-assignment is excluded
-	// by design — that is the meaning of `assignee_id` (tab 1), and tab 3 must
-	// be disjoint from tab 1.
-	var involvesUserFilter pgtype.UUID
-	if u := r.URL.Query().Get("involves_user_id"); u != "" {
-		id, ok := parseUUIDOrBadRequest(w, u, "involves_user_id")
-		if !ok {
-			return
-		}
-		involvesUserFilter = id
-	}
-
-	metadataFilter, ok := parseMetadataFilterParam(w, r.URL.Query().Get("metadata"))
-	if !ok {
-		return
-	}
-
-	// open_only=true returns all non-done/cancelled issues (no limit).
-	if r.URL.Query().Get("open_only") == "true" {
 		issues, err := h.Queries.ListOpenIssues(ctx, db.ListOpenIssuesParams{
 			WorkspaceID:    wsUUID,
 			Priority:       priorityFilter,
@@ -821,19 +815,6 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var statusFilter pgtype.Text
-	if s := r.URL.Query().Get("status"); s != "" {
-		statusFilter = pgtype.Text{String: s, Valid: true}
-	}
-
-	// scheduled=true restricts the result to issues that have at least one of
-	// start_date / due_date set. Used by the Project Gantt view, which only
-	// renders schedulable rows and shouldn't pay for the full project list.
-	var scheduledFilter pgtype.Bool
-	if r.URL.Query().Get("scheduled") == "true" {
-		scheduledFilter = pgtype.Bool{Bool: true, Valid: true}
-	}
-
 	// Parse sort and direction params for dynamic ORDER BY.
 	// Manual sort (position) is always ASC — direction is ignored because
 	// the user defines order through drag-and-drop, reversing it has no
@@ -865,7 +846,9 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Build dynamic SQL — same approach as ListGroupedIssues.
+	// Build dynamic SQL — shares the orthogonal filter parser with
+	// ListGroupedIssues so the two endpoints return the same set for the same
+	// filters (the contract a saved view relies on to drive either render mode).
 	where := []string{"i.workspace_id = $1"}
 	args := []any{wsUUID}
 	addArg := func(v any) string {
@@ -873,63 +856,17 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		return "$" + strconv.Itoa(len(args))
 	}
 
-	if statusFilter.Valid {
-		where = append(where, fmt.Sprintf("i.status = %s", addArg(statusFilter.String)))
+	if !h.appendIssueFilters(w, r, &where, addArg) {
+		return
 	}
-	if priorityFilter.Valid {
-		where = append(where, fmt.Sprintf("i.priority = %s", addArg(priorityFilter.String)))
-	}
-	if assigneeFilter.Valid {
-		where = append(where, fmt.Sprintf("i.assignee_id = %s::uuid", addArg(assigneeFilter)))
-	}
-	if len(assigneeIdsFilter) > 0 {
-		where = append(where, fmt.Sprintf("i.assignee_id = ANY(%s::uuid[])", addArg(assigneeIdsFilter)))
-	}
-	if creatorFilter.Valid {
-		where = append(where, fmt.Sprintf("i.creator_id = %s::uuid", addArg(creatorFilter)))
-	}
-	if projectFilter.Valid {
-		where = append(where, fmt.Sprintf("i.project_id = %s::uuid", addArg(projectFilter)))
-	}
-	if scheduledFilter.Valid {
+
+	// scheduled=true restricts the result to issues that have at least one of
+	// start_date / due_date set. Used by the Project Gantt view, which only
+	// renders schedulable rows and shouldn't pay for the full project list. It
+	// is not a filter-bar dimension, so it lives here rather than in the shared
+	// filter parser.
+	if r.URL.Query().Get("scheduled") == "true" {
 		where = append(where, "(i.start_date IS NOT NULL OR i.due_date IS NOT NULL)")
-	}
-	if metadataFilter != nil {
-		where = append(where, fmt.Sprintf("i.metadata @> %s::jsonb", addArg(string(metadataFilter))))
-	}
-	if involvesUserFilter.Valid {
-		ref := addArg(involvesUserFilter)
-		where = append(where, fmt.Sprintf(`(
-    (i.assignee_type = 'agent' AND i.assignee_id IN (
-       SELECT a.id FROM agent a
-        WHERE a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-    ))
-    OR (i.assignee_type = 'squad' AND i.assignee_id IN (
-       SELECT sm.squad_id
-         FROM squad_member sm
-         JOIN squad s ON s.id = sm.squad_id
-        WHERE s.workspace_id = $1
-          AND sm.member_type = 'member'
-          AND sm.member_id   = %[1]s::uuid
-       UNION
-       SELECT s.id
-         FROM squad s
-         JOIN agent a ON a.id = s.leader_id
-        WHERE s.workspace_id = $1
-          AND a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-       UNION
-       SELECT sm.squad_id
-         FROM squad_member sm
-         JOIN squad s ON s.id = sm.squad_id
-         JOIN agent a ON a.id = sm.member_id
-        WHERE s.workspace_id = $1
-          AND sm.member_type = 'agent'
-          AND a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-    ))
-)`, ref))
 	}
 
 	whereSql := strings.Join(where, " AND ")
@@ -1070,7 +1007,13 @@ func parseUUIDParamList(w http.ResponseWriter, raw, fieldName string) ([]pgtype.
 	return ids, true
 }
 
-func parseActorFilterList(w http.ResponseWriter, raw, fieldName string) ([]issueActorFilter, bool) {
+// meToken is the placeholder a saved view stores instead of a hardcoded user
+// UUID so the same view resolves to whoever is viewing it. The server expands
+// it to the requesting user; it only makes sense for a member actor (the
+// viewer is a person, never an agent or squad).
+const meToken = "{me}"
+
+func parseActorFilterList(w http.ResponseWriter, raw, fieldName, currentUserID string) ([]issueActorFilter, bool) {
 	parts := splitCommaParam(raw)
 	if len(parts) == 0 {
 		return nil, true
@@ -1082,16 +1025,223 @@ func parseActorFilterList(w http.ResponseWriter, raw, fieldName string) ([]issue
 			writeError(w, http.StatusBadRequest, "invalid "+fieldName)
 			return nil, false
 		}
-		id, ok := parseUUIDOrBadRequest(w, strings.TrimSpace(pieces[1]), fieldName)
+		actorType := pieces[0]
+		idRaw := strings.TrimSpace(pieces[1])
+		if idRaw == meToken {
+			if actorType != "member" {
+				writeError(w, http.StatusBadRequest, meToken+" is only valid for a member in "+fieldName)
+				return nil, false
+			}
+			if currentUserID == "" {
+				writeError(w, http.StatusBadRequest, meToken+" requires an authenticated user in "+fieldName)
+				return nil, false
+			}
+			idRaw = currentUserID
+		}
+		id, ok := parseUUIDOrBadRequest(w, idRaw, fieldName)
 		if !ok {
 			return nil, false
 		}
 		filters = append(filters, issueActorFilter{
-			actorType: pieces[0],
+			actorType: actorType,
 			actorID:   id,
 		})
 	}
 	return filters, true
+}
+
+// issueInvolvesUserFragment is the WHERE predicate that widens an assignee
+// filter to issues where the user is the indirect assignee: an agent they own,
+// or a squad they belong to / lead / have an owned agent inside. %[1]s is the
+// bind ref for the user UUID; $1 is the workspace UUID (both ListIssues and
+// ListGroupedIssues reserve $1 = workspace_id). Member-direct assignment is
+// excluded by design — that is the meaning of assignee_filters=member:<id>,
+// and the "my agents" scope must stay disjoint from it.
+const issueInvolvesUserFragment = `(
+    (i.assignee_type = 'agent' AND i.assignee_id IN (
+       SELECT a.id FROM agent a
+        WHERE a.workspace_id = $1
+          AND a.owner_id     = %[1]s::uuid
+    ))
+    OR (i.assignee_type = 'squad' AND i.assignee_id IN (
+       SELECT sm.squad_id
+         FROM squad_member sm
+         JOIN squad s ON s.id = sm.squad_id
+        WHERE s.workspace_id = $1
+          AND sm.member_type = 'member'
+          AND sm.member_id   = %[1]s::uuid
+       UNION
+       SELECT s.id
+         FROM squad s
+         JOIN agent a ON a.id = s.leader_id
+        WHERE s.workspace_id = $1
+          AND a.workspace_id = $1
+          AND a.owner_id     = %[1]s::uuid
+       UNION
+       SELECT sm.squad_id
+         FROM squad_member sm
+         JOIN squad s ON s.id = sm.squad_id
+         JOIN agent a ON a.id = sm.member_id
+        WHERE s.workspace_id = $1
+          AND sm.member_type = 'agent'
+          AND a.workspace_id = $1
+          AND a.owner_id     = %[1]s::uuid
+    ))
+)`
+
+// appendIssueFilters parses the orthogonal issue-filter query params shared by
+// ListIssues and ListGroupedIssues, appending SQL predicates to *where and
+// registering bind args through addArg. Callers must already have reserved
+// $1 = workspace_id (so the involves fragment can reference it). Returns false
+// after writing a 400 for any malformed input.
+func (h *Handler) appendIssueFilters(w http.ResponseWriter, r *http.Request, where *[]string, addArg func(any) string) bool {
+	q := r.URL.Query()
+
+	statuses := splitCommaParam(q.Get("statuses"))
+	if len(statuses) == 0 {
+		statuses = splitCommaParam(q.Get("status"))
+	}
+	if len(statuses) > 0 {
+		*where = append(*where, fmt.Sprintf("i.status = ANY(%s::text[])", addArg(statuses)))
+	}
+
+	priorities := splitCommaParam(q.Get("priorities"))
+	if len(priorities) == 0 {
+		priorities = splitCommaParam(q.Get("priority"))
+	}
+	if len(priorities) > 0 {
+		*where = append(*where, fmt.Sprintf("i.priority = ANY(%s::text[])", addArg(priorities)))
+	}
+
+	assigneeTypes := splitCommaParam(q.Get("assignee_types"))
+	assigneeFiltersRaw := q.Get("assignee_filters")
+	// assignee_types (class-level: "all members") and assignee_filters
+	// (entity-level: "these specific actors") are mutually exclusive — combining
+	// them is either redundant or contradictory, and a saved view only ever
+	// carries one. Reject up front to keep the contract sharp.
+	if len(assigneeTypes) > 0 && assigneeFiltersRaw != "" {
+		writeError(w, http.StatusBadRequest, "assignee_types and assignee_filters are mutually exclusive")
+		return false
+	}
+	if len(assigneeTypes) > 0 {
+		for _, assigneeType := range assigneeTypes {
+			if !isIssueActorType(assigneeType) {
+				writeError(w, http.StatusBadRequest, "invalid assignee_types")
+				return false
+			}
+		}
+		*where = append(*where, fmt.Sprintf("i.assignee_type = ANY(%s::text[])", addArg(assigneeTypes)))
+	}
+
+	if raw := q.Get("assignee_id"); raw != "" {
+		id, ok := parseUUIDOrBadRequest(w, raw, "assignee_id")
+		if !ok {
+			return false
+		}
+		*where = append(*where, fmt.Sprintf("i.assignee_id = %s::uuid", addArg(id)))
+	}
+	if raw := q.Get("assignee_ids"); raw != "" {
+		ids, ok := parseUUIDParamList(w, raw, "assignee_ids")
+		if !ok {
+			return false
+		}
+		if len(ids) > 0 {
+			*where = append(*where, fmt.Sprintf("i.assignee_id = ANY(%s::uuid[])", addArg(ids)))
+		}
+	}
+	if raw := q.Get("creator_id"); raw != "" {
+		id, ok := parseUUIDOrBadRequest(w, raw, "creator_id")
+		if !ok {
+			return false
+		}
+		*where = append(*where, fmt.Sprintf("i.creator_id = %s::uuid", addArg(id)))
+	}
+	if raw := q.Get("project_id"); raw != "" {
+		id, ok := parseUUIDOrBadRequest(w, raw, "project_id")
+		if !ok {
+			return false
+		}
+		*where = append(*where, fmt.Sprintf("i.project_id = %s::uuid", addArg(id)))
+	}
+	if filter, ok := parseMetadataFilterParam(w, q.Get("metadata")); !ok {
+		return false
+	} else if filter != nil {
+		*where = append(*where, fmt.Sprintf("i.metadata @> %s::jsonb", addArg(string(filter))))
+	}
+	if raw := q.Get("involves_user_id"); raw != "" {
+		id, ok := parseUUIDOrBadRequest(w, raw, "involves_user_id")
+		if !ok {
+			return false
+		}
+		*where = append(*where, fmt.Sprintf(issueInvolvesUserFragment, addArg(id)))
+	}
+
+	currentUserID := requestUserID(r)
+
+	assigneeFilters, ok := parseActorFilterList(w, assigneeFiltersRaw, "assignee_filters", currentUserID)
+	if !ok {
+		return false
+	}
+	includeNoAssignee := q.Get("include_no_assignee") == "true"
+	if len(assigneeFilters) > 0 || includeNoAssignee {
+		ors := make([]string, 0, len(assigneeFilters)+1)
+		for _, filter := range assigneeFilters {
+			ors = append(ors, fmt.Sprintf(
+				"(i.assignee_type = %s::text AND i.assignee_id = %s::uuid)",
+				addArg(filter.actorType),
+				addArg(filter.actorID),
+			))
+		}
+		if includeNoAssignee {
+			ors = append(ors, "(i.assignee_type IS NULL AND i.assignee_id IS NULL)")
+		}
+		*where = append(*where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	creatorFilters, ok := parseActorFilterList(w, q.Get("creator_filters"), "creator_filters", currentUserID)
+	if !ok {
+		return false
+	}
+	if len(creatorFilters) > 0 {
+		ors := make([]string, 0, len(creatorFilters))
+		for _, filter := range creatorFilters {
+			ors = append(ors, fmt.Sprintf(
+				"(i.creator_type = %s::text AND i.creator_id = %s::uuid)",
+				addArg(filter.actorType),
+				addArg(filter.actorID),
+			))
+		}
+		*where = append(*where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	projectIDs, ok := parseUUIDParamList(w, q.Get("project_ids"), "project_ids")
+	if !ok {
+		return false
+	}
+	includeNoProject := q.Get("include_no_project") == "true"
+	if len(projectIDs) > 0 || includeNoProject {
+		ors := make([]string, 0, 2)
+		if len(projectIDs) > 0 {
+			ors = append(ors, fmt.Sprintf("i.project_id = ANY(%s::uuid[])", addArg(projectIDs)))
+		}
+		if includeNoProject {
+			ors = append(ors, "i.project_id IS NULL")
+		}
+		*where = append(*where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	labelIDs, ok := parseUUIDParamList(w, q.Get("label_ids"), "label_ids")
+	if !ok {
+		return false
+	}
+	if len(labelIDs) > 0 {
+		*where = append(*where, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM issue_to_label itl WHERE itl.issue_id = i.id AND itl.label_id = ANY(%s::uuid[]))",
+			addArg(labelIDs),
+		))
+	}
+
+	return true
 }
 
 func (h *Handler) ListGroupedIssues(w http.ResponseWriter, r *http.Request) {
@@ -1139,174 +1289,8 @@ func (h *Handler) ListGroupedIssues(w http.ResponseWriter, r *http.Request) {
 		return "$" + strconv.Itoa(len(args))
 	}
 
-	statuses := splitCommaParam(r.URL.Query().Get("statuses"))
-	if len(statuses) == 0 {
-		statuses = splitCommaParam(r.URL.Query().Get("status"))
-	}
-	if len(statuses) > 0 {
-		where = append(where, fmt.Sprintf("i.status = ANY(%s::text[])", addArg(statuses)))
-	}
-
-	priorities := splitCommaParam(r.URL.Query().Get("priorities"))
-	if len(priorities) == 0 {
-		priorities = splitCommaParam(r.URL.Query().Get("priority"))
-	}
-	if len(priorities) > 0 {
-		where = append(where, fmt.Sprintf("i.priority = ANY(%s::text[])", addArg(priorities)))
-	}
-
-	assigneeTypes := splitCommaParam(r.URL.Query().Get("assignee_types"))
-	if len(assigneeTypes) > 0 {
-		for _, assigneeType := range assigneeTypes {
-			if !isIssueActorType(assigneeType) {
-				writeError(w, http.StatusBadRequest, "invalid assignee_types")
-				return
-			}
-		}
-		where = append(where, fmt.Sprintf("i.assignee_type = ANY(%s::text[])", addArg(assigneeTypes)))
-	}
-
-	if raw := r.URL.Query().Get("assignee_id"); raw != "" {
-		id, ok := parseUUIDOrBadRequest(w, raw, "assignee_id")
-		if !ok {
-			return
-		}
-		where = append(where, fmt.Sprintf("i.assignee_id = %s::uuid", addArg(id)))
-	}
-	if raw := r.URL.Query().Get("assignee_ids"); raw != "" {
-		ids, ok := parseUUIDParamList(w, raw, "assignee_ids")
-		if !ok {
-			return
-		}
-		if len(ids) > 0 {
-			where = append(where, fmt.Sprintf("i.assignee_id = ANY(%s::uuid[])", addArg(ids)))
-		}
-	}
-	if raw := r.URL.Query().Get("creator_id"); raw != "" {
-		id, ok := parseUUIDOrBadRequest(w, raw, "creator_id")
-		if !ok {
-			return
-		}
-		where = append(where, fmt.Sprintf("i.creator_id = %s::uuid", addArg(id)))
-	}
-	if raw := r.URL.Query().Get("project_id"); raw != "" {
-		id, ok := parseUUIDOrBadRequest(w, raw, "project_id")
-		if !ok {
-			return
-		}
-		where = append(where, fmt.Sprintf("i.project_id = %s::uuid", addArg(id)))
-	}
-	if filter, ok := parseMetadataFilterParam(w, r.URL.Query().Get("metadata")); !ok {
+	if !h.appendIssueFilters(w, r, &where, addArg) {
 		return
-	} else if filter != nil {
-		where = append(where, fmt.Sprintf("i.metadata @> %s::jsonb", addArg(string(filter))))
-	}
-	// Mirror the involves_user_id 4-branch UNION from sqlc's ListIssues /
-	// ListOpenIssues / CountIssues. ListGroupedIssues is a hand-written dynamic
-	// SQL builder that does not share parameters with sqlc, so the fragment is
-	// re-implemented here in lock-step. Member-direct assignment is excluded by
-	// design: that semantics belongs to tab 1 (`assignee_id`), and tab 3 must
-	// stay disjoint from tab 1.
-	if raw := r.URL.Query().Get("involves_user_id"); raw != "" {
-		id, ok := parseUUIDOrBadRequest(w, raw, "involves_user_id")
-		if !ok {
-			return
-		}
-		ref := addArg(id)
-		where = append(where, fmt.Sprintf(`(
-    (i.assignee_type = 'agent' AND i.assignee_id IN (
-       SELECT a.id FROM agent a
-        WHERE a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-    ))
-    OR (i.assignee_type = 'squad' AND i.assignee_id IN (
-       SELECT sm.squad_id
-         FROM squad_member sm
-         JOIN squad s ON s.id = sm.squad_id
-        WHERE s.workspace_id = $1
-          AND sm.member_type = 'member'
-          AND sm.member_id   = %[1]s::uuid
-       UNION
-       SELECT s.id
-         FROM squad s
-         JOIN agent a ON a.id = s.leader_id
-        WHERE s.workspace_id = $1
-          AND a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-       UNION
-       SELECT sm.squad_id
-         FROM squad_member sm
-         JOIN squad s ON s.id = sm.squad_id
-         JOIN agent a ON a.id = sm.member_id
-        WHERE s.workspace_id = $1
-          AND sm.member_type = 'agent'
-          AND a.workspace_id = $1
-          AND a.owner_id     = %[1]s::uuid
-    ))
-)`, ref))
-	}
-
-	assigneeFilters, ok := parseActorFilterList(w, r.URL.Query().Get("assignee_filters"), "assignee_filters")
-	if !ok {
-		return
-	}
-	includeNoAssignee := r.URL.Query().Get("include_no_assignee") == "true"
-	if len(assigneeFilters) > 0 || includeNoAssignee {
-		ors := make([]string, 0, len(assigneeFilters)+1)
-		for _, filter := range assigneeFilters {
-			ors = append(ors, fmt.Sprintf(
-				"(i.assignee_type = %s::text AND i.assignee_id = %s::uuid)",
-				addArg(filter.actorType),
-				addArg(filter.actorID),
-			))
-		}
-		if includeNoAssignee {
-			ors = append(ors, "(i.assignee_type IS NULL AND i.assignee_id IS NULL)")
-		}
-		where = append(where, "("+strings.Join(ors, " OR ")+")")
-	}
-
-	creatorFilters, ok := parseActorFilterList(w, r.URL.Query().Get("creator_filters"), "creator_filters")
-	if !ok {
-		return
-	}
-	if len(creatorFilters) > 0 {
-		ors := make([]string, 0, len(creatorFilters))
-		for _, filter := range creatorFilters {
-			ors = append(ors, fmt.Sprintf(
-				"(i.creator_type = %s::text AND i.creator_id = %s::uuid)",
-				addArg(filter.actorType),
-				addArg(filter.actorID),
-			))
-		}
-		where = append(where, "("+strings.Join(ors, " OR ")+")")
-	}
-
-	projectIDs, ok := parseUUIDParamList(w, r.URL.Query().Get("project_ids"), "project_ids")
-	if !ok {
-		return
-	}
-	includeNoProject := r.URL.Query().Get("include_no_project") == "true"
-	if len(projectIDs) > 0 || includeNoProject {
-		ors := make([]string, 0, 2)
-		if len(projectIDs) > 0 {
-			ors = append(ors, fmt.Sprintf("i.project_id = ANY(%s::uuid[])", addArg(projectIDs)))
-		}
-		if includeNoProject {
-			ors = append(ors, "i.project_id IS NULL")
-		}
-		where = append(where, "("+strings.Join(ors, " OR ")+")")
-	}
-
-	labelIDs, ok := parseUUIDParamList(w, r.URL.Query().Get("label_ids"), "label_ids")
-	if !ok {
-		return
-	}
-	if len(labelIDs) > 0 {
-		where = append(where, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM issue_to_label itl WHERE itl.issue_id = i.id AND itl.label_id = ANY(%s::uuid[]))",
-			addArg(labelIDs),
-		))
 	}
 
 	if groupAssigneeType := r.URL.Query().Get("group_assignee_type"); groupAssigneeType != "" {

--- a/server/internal/handler/issue_list_filters_test.go
+++ b/server/internal/handler/issue_list_filters_test.go
@@ -1,0 +1,299 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+)
+
+// issueFilterFixture seeds a small, self-contained issue set used by the
+// filter-contract tests: it returns the second member, the agent owned by the
+// test user, and the ids of the four issues created.
+type issueFilterFixture struct {
+	otherUserID string
+	agentID     string
+	mineTodo    string // assignee member testUserID, creator testUserID, todo
+	otherTodo   string // assignee member otherUser,  creator testUserID, todo
+	agentProg   string // assignee agent (owned by me), creator otherUser, in_progress
+	noAssignee  string // no assignee,                 creator testUserID, todo
+}
+
+func seedIssueFilterFixture(t *testing.T) issueFilterFixture {
+	t.Helper()
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	var otherUserID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email) VALUES ($1, $2) RETURNING id
+	`, "Filter Other User", fmt.Sprintf("filter-other-%d@multica.ai", suffix)).Scan(&otherUserID); err != nil {
+		t.Fatalf("create other user: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, otherUserID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')
+	`, testWorkspaceID, otherUserID); err != nil {
+		t.Fatalf("create other member: %v", err)
+	}
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Filter Agent %d", suffix), testRuntimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID) })
+
+	create := func(title, status, assigneeType, assigneeID, creatorID string) string {
+		t.Helper()
+		var number int32
+		if err := testPool.QueryRow(ctx, `
+			UPDATE workspace
+			SET issue_counter = GREATEST(
+				issue_counter,
+				(SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)
+			) + 1
+			WHERE id = $1
+			RETURNING issue_counter
+		`, testWorkspaceID).Scan(&number); err != nil {
+			t.Fatalf("next issue number: %v", err)
+		}
+		var atype, aid any
+		if assigneeType != "" {
+			atype, aid = assigneeType, assigneeID
+		}
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (
+				workspace_id, title, description, status, priority,
+				assignee_type, assignee_id, creator_type, creator_id, position, number
+			)
+			VALUES ($1, $2, NULL, $3, 'none', $4, $5, 'member', $6, 0, $7)
+			RETURNING id
+		`, testWorkspaceID, title, status, atype, aid, creatorID, number).Scan(&id); err != nil {
+			t.Fatalf("create issue %q: %v", title, err)
+		}
+		t.Cleanup(func() { _, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, id) })
+		return id
+	}
+
+	return issueFilterFixture{
+		otherUserID: otherUserID,
+		agentID:     agentID,
+		mineTodo:    create(fmt.Sprintf("mine todo %d", suffix), "todo", "member", testUserID, testUserID),
+		otherTodo:   create(fmt.Sprintf("other todo %d", suffix), "todo", "member", otherUserID, testUserID),
+		agentProg:   create(fmt.Sprintf("agent prog %d", suffix), "in_progress", "agent", agentID, otherUserID),
+		noAssignee:  create(fmt.Sprintf("no assignee %d", suffix), "todo", "", "", testUserID),
+	}
+}
+
+func listIssueIDs(t *testing.T, query string) []string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	testHandler.ListIssues(w, newRequest("GET", "/api/issues?"+query, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssues(%s): expected 200, got %d: %s", query, w.Code, w.Body.String())
+	}
+	var resp struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	ids := make([]string, 0, len(resp.Issues))
+	for _, i := range resp.Issues {
+		ids = append(ids, i.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func groupedIssueIDs(t *testing.T, query string) []string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	testHandler.ListGroupedIssues(w, newRequest("GET", "/api/issues/grouped?group_by=assignee&"+query, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListGroupedIssues(%s): expected 200, got %d: %s", query, w.Code, w.Body.String())
+	}
+	var resp GroupedIssuesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode grouped response: %v", err)
+	}
+	ids := []string{}
+	for _, g := range resp.Groups {
+		for _, i := range g.Issues {
+			ids = append(ids, i.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func expectStatus(t *testing.T, query string, want int) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	testHandler.ListIssues(w, newRequest("GET", "/api/issues?"+query, nil))
+	if w.Code != want {
+		t.Fatalf("ListIssues(%s): expected %d, got %d: %s", query, want, w.Code, w.Body.String())
+	}
+}
+
+// assertIDSet requires an exact match. Use only for entity-scoped queries
+// whose result is bounded to freshly-created fixture ids — the shared test
+// workspace accumulates issues from other tests, so class-level queries
+// (assignee_types, creator=me) must use assertContains / assertExcludes.
+func assertIDSet(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("id set mismatch: got %v want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("id set mismatch: got %v want %v", got, want)
+		}
+	}
+}
+
+func containsID(set []string, id string) bool {
+	for _, s := range set {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+func assertContains(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	for _, id := range want {
+		if !containsID(got, id) {
+			t.Fatalf("expected id %s present in %v", id, got)
+		}
+	}
+}
+
+func assertExcludes(t *testing.T, got []string, notWant ...string) {
+	t.Helper()
+	for _, id := range notWant {
+		if containsID(got, id) {
+			t.Fatalf("expected id %s absent from %v", id, got)
+		}
+	}
+}
+
+// TestListIssuesAssigneeTypeFilter verifies the new orthogonal assignee_types
+// param filters by assignee class on GET /api/issues.
+func TestListIssuesAssigneeTypeFilter(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	f := seedIssueFilterFixture(t)
+	ws := "workspace_id=" + testWorkspaceID
+
+	// The shared test workspace holds issues from other tests, so assert on the
+	// presence/absence of our own fixtures rather than the full set.
+	got := listIssueIDs(t, ws+"&statuses=todo,in_progress&assignee_types=member")
+	assertContains(t, got, f.mineTodo, f.otherTodo)
+	assertExcludes(t, got, f.agentProg, f.noAssignee)
+
+	got = listIssueIDs(t, ws+"&statuses=todo,in_progress&assignee_types=agent")
+	assertContains(t, got, f.agentProg)
+	assertExcludes(t, got, f.mineTodo, f.otherTodo, f.noAssignee)
+}
+
+// TestListIssuesMeToken verifies {me} expands to the requesting user inside
+// assignee_filters / creator_filters, and is rejected for non-member actors.
+func TestListIssuesMeToken(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	f := seedIssueFilterFixture(t)
+	ws := "workspace_id=" + testWorkspaceID
+
+	// assignee is me → our issue assigned to testUserID, never the others.
+	got := listIssueIDs(t, ws+"&assignee_filters=member:{me}")
+	assertContains(t, got, f.mineTodo)
+	assertExcludes(t, got, f.otherTodo, f.agentProg, f.noAssignee)
+
+	// creator is me → the three fixtures created by testUserID, never agentProg.
+	got = listIssueIDs(t, ws+"&creator_filters=member:{me}")
+	assertContains(t, got, f.mineTodo, f.otherTodo, f.noAssignee)
+	assertExcludes(t, got, f.agentProg)
+
+	// {me} is only meaningful for members.
+	expectStatus(t, ws+"&assignee_filters=agent:{me}", http.StatusBadRequest)
+}
+
+// TestListIssuesIncludeNoAssignee verifies include_no_assignee unions the
+// unassigned bucket with the specific assignee filters.
+func TestListIssuesIncludeNoAssignee(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	f := seedIssueFilterFixture(t)
+	ws := "workspace_id=" + testWorkspaceID
+
+	got := listIssueIDs(t, ws+"&statuses=todo&assignee_filters=member:"+testUserID+"&include_no_assignee=true")
+	assertContains(t, got, f.mineTodo, f.noAssignee)
+	assertExcludes(t, got, f.otherTodo, f.agentProg)
+}
+
+// TestListIssuesFilterValidation pins the 400 contract for malformed filters.
+func TestListIssuesFilterValidation(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	_ = seedIssueFilterFixture(t)
+	ws := "workspace_id=" + testWorkspaceID
+
+	expectStatus(t, ws+"&assignee_types=bogus", http.StatusBadRequest)
+	expectStatus(t, ws+"&assignee_filters=member:not-a-uuid", http.StatusBadRequest)
+	// assignee_types (class-level) and assignee_filters (entity-level) are
+	// mutually exclusive.
+	expectStatus(t, ws+"&assignee_types=member&assignee_filters=member:"+testUserID, http.StatusBadRequest)
+}
+
+// TestListGroupedFilterParity verifies GET /api/issues and GET
+// /api/issues/grouped return the same issue id set for identical filters —
+// the contract that lets a saved view drive either rendering mode.
+func TestListGroupedFilterParity(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	f := seedIssueFilterFixture(t)
+	ws := "workspace_id=" + testWorkspaceID
+
+	// Scope to freshly-created entity ids (otherUser / agent) so the result is
+	// bounded to our fixtures: list applies the page limit flat while grouped
+	// applies it per group, so an unbounded class-level query could legitimately
+	// diverge on a large shared workspace. Each case asserts (a) list == grouped
+	// and (b) the known fixture is present, so an empty==empty pass can't hide a
+	// broken filter.
+	cases := []struct {
+		query string
+		want  string
+	}{
+		{ws + "&assignee_filters=member:" + f.otherUserID, f.otherTodo},
+		{ws + "&assignee_filters=agent:" + f.agentID, f.agentProg},
+		{ws + "&creator_filters=member:" + f.otherUserID, f.agentProg},
+		{ws + "&statuses=in_progress&assignee_filters=agent:" + f.agentID, f.agentProg},
+	}
+	for _, c := range cases {
+		list := listIssueIDs(t, c.query+"&limit=100")
+		grouped := groupedIssueIDs(t, c.query+"&limit=100")
+		assertIDSet(t, grouped, list...)
+		assertContains(t, list, c.want)
+	}
+}

--- a/server/migrations/111_issue_creator_index.down.sql
+++ b/server/migrations/111_issue_creator_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_creator;

--- a/server/migrations/111_issue_creator_index.up.sql
+++ b/server/migrations/111_issue_creator_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_creator ON issue(creator_type, creator_id);

--- a/server/migrations/112_issue_to_label_label_index.down.sql
+++ b/server/migrations/112_issue_to_label_label_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_to_label_label;

--- a/server/migrations/112_issue_to_label_label_index.up.sql
+++ b/server/migrations/112_issue_to_label_label_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_to_label_label ON issue_to_label(label_id, issue_id);


### PR DESCRIPTION
## Summary

Phase 1 (API contract) of the Views plan in MUL-2782. Establishes the orthogonal `GET /api/issues` filter set and the `/issues`↔`/grouped` parity contract that a saved view relies on, **without adding any new `scope_key` field** (per the discussion consensus on the issue).

- **Shared filter builder** — extracted the orthogonal parser/WHERE builder out of `ListGroupedIssues` into `appendIssueFilters` (`server/internal/handler/issue.go`) and wired both `ListIssues` and `ListGroupedIssues` through it. The two endpoints now return the same set for the same filters. Net **−16 lines** in `issue.go` despite `/issues` gaining the full param set, because the copy-pasted `involves_user_id` UNION fragment is now a single-sourced const.
- **`GET /api/issues` full filter set** — `statuses`, `priorities`, `assignee_types`, `assignee_filters`, `include_no_assignee`, `creator_filters`, `project_ids`, `include_no_project`, `label_ids` (previously only legacy single-value params; `/issues` did client-side filtering). Legacy single-value params kept for desktop compatibility.
- **`{me}` token** — member-only, valid in `assignee_filters` / `creator_filters`, expands server-side to the requesting user so a saved view resolves to whoever views it. `agent:{me}` / `squad:{me}` → 400.
- **Contract hardening** — `assignee_types` and `assignee_filters` are mutually exclusive (400); malformed enum / UUID → 400.
- **Indexes** (migrations 111/112) — `idx_issue_creator(creator_type, creator_id)` and `idx_issue_to_label_label(label_id, issue_id)` back the new creator / label filters (production has 581k issues; both indexes were missing). `CONCURRENTLY` so deploy doesn't lock the table.

Out of scope for this PR (later phases): `{my_agents}`/`{my_squads}` tokens + `any_of` fan-out (Phase 2), Views CRUD (Phase 3), frontend call-site migration + ViewTabs (Phase 4). `/grouped` is intentionally retained.

Related: MUL-2782, parent MUL-2704 (Views).

## Test plan

New contract tests in `server/internal/handler/issue_list_filters_test.go`:

- [x] `assignee_types` filters by assignee class on `/issues`
- [x] `{me}` expands in `assignee_filters` (assignee) and `creator_filters` (creator); `agent:{me}` → 400
- [x] `include_no_assignee` unions the unassigned bucket
- [x] 400 contract: bad `assignee_types` enum, bad `assignee_filters` UUID, `assignee_types`+`assignee_filters` together
- [x] `/issues` and `/grouped` return the same id set for identical filters
- [x] Full `go test ./internal/handler/` green — no regression in existing grouped / involves / scheduled tests
- [x] `go vet` clean, gofmt clean

## Breaking changes

None for existing clients — new params are additive and legacy params are preserved. `/grouped` behavior change: `assignee_types`+`assignee_filters` together now returns 400 (previously ANDed); no current caller sends both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)