### PR TITLE
feat(issues): export issue conversation as Markdown

### DIFF
--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -14,6 +14,8 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleCheck,
+  Copy,
+  Download,
   MoreHorizontal,
   PanelRight,
   Pin,
@@ -72,6 +74,7 @@ import { useRecentIssuesStore } from "@multica/core/issues/stores";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BatchActionToolbar } from "./batch-action-toolbar";
 import { useIssueTimeline } from "../hooks/use-issue-timeline";
+import { buildIssueMarkdown, downloadMarkdown } from "../utils/build-issue-markdown";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
 import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
@@ -1154,6 +1157,36 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { data: attachedLabels = [] } = useQuery(issueLabelsOptions(wsId, id));
   const attachedLabelsCount = attachedLabels.length;
 
+  // Markdown export of the currently-fetched conversation (issue metadata +
+  // description + comments). Reuses the already-loaded React Query caches —
+  // no extra API call. Activity entries are intentionally excluded; the
+  // export is the human conversation, not the audit log.
+  const buildExportMarkdown = useCallback(() => {
+    if (!issue) return "";
+    return buildIssueMarkdown({
+      issue,
+      timeline,
+      labels: attachedLabels,
+      projectName: breadcrumbProject?.title ?? null,
+      getActorName,
+    });
+  }, [issue, timeline, attachedLabels, breadcrumbProject?.title, getActorName]);
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!issue) return;
+    try {
+      await navigator.clipboard.writeText(buildExportMarkdown());
+      toast.success(t(($) => $.detail.export_copy_success));
+    } catch {
+      toast.error(t(($) => $.detail.export_copy_failed));
+    }
+  }, [issue, buildExportMarkdown, t]);
+
+  const handleDownloadMarkdown = useCallback(() => {
+    if (!issue) return;
+    downloadMarkdown(`${issue.identifier}.md`, buildExportMarkdown());
+  }, [issue, buildExportMarkdown]);
+
   // Seed the visible-optional-props set:
   //   - on issue switch, reset to whichever fields are currently set
   //   - on the SAME issue, additively pick up fields the user just set
@@ -1910,6 +1943,36 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 <h2 className="text-base font-semibold">{t(($) => $.detail.activity_section)}</h2>
               </div>
               <div className="flex items-center gap-2">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={handleCopyMarkdown}
+                        aria-label={t(($) => $.detail.export_copy_markdown)}
+                        className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                      >
+                        <Copy className="h-4 w-4" />
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="bottom">{t(($) => $.detail.export_copy_markdown)}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={handleDownloadMarkdown}
+                        aria-label={t(($) => $.detail.export_download_markdown)}
+                        className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                      >
+                        <Download className="h-4 w-4" />
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="bottom">{t(($) => $.detail.export_download_markdown)}</TooltipContent>
+                </Tooltip>
                 <button
                   type="button"
                   onClick={handleToggleSubscribe}

--- a/packages/views/issues/utils/build-issue-markdown.test.ts
+++ b/packages/views/issues/utils/build-issue-markdown.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { buildIssueMarkdown } from "./build-issue-markdown";
+import type { Issue, TimelineEntry, Label } from "@multica/core/types";
+
+const baseIssue: Issue = {
+  id: "issue-1",
+  workspace_id: "ws-1",
+  number: 5157,
+  identifier: "AND-5157",
+  title: "Reimplement export",
+  description: "Body text",
+  status: "todo",
+  priority: "high",
+  assignee_type: "agent",
+  assignee_id: "agent-1",
+  creator_type: "member",
+  creator_id: "member-1",
+  parent_issue_id: null,
+  project_id: "proj-1",
+  position: 0,
+  start_date: null,
+  due_date: null,
+  metadata: {},
+  created_at: "2026-05-28T09:34:03Z",
+  updated_at: "2026-05-28T09:35:00Z",
+};
+
+const getActorName = (type: string, id: string) => {
+  if (type === "agent" && id === "agent-1") return "frontend";
+  if (type === "member" && id === "member-1") return "Alice";
+  if (type === "member" && id === "member-2") return "Bob";
+  return "Unknown";
+};
+
+describe("buildIssueMarkdown", () => {
+  it("renders header, metadata, description and no-comments state", () => {
+    const md = buildIssueMarkdown({
+      issue: baseIssue,
+      timeline: [],
+      projectName: "Multica Contributions",
+      getActorName,
+    });
+    expect(md).toContain("# AND-5157: Reimplement export");
+    expect(md).toContain("- **Status:** todo");
+    expect(md).toContain("- **Priority:** high");
+    expect(md).toContain("- **Assignee:** frontend (agent)");
+    expect(md).toContain("- **Creator:** Alice (member)");
+    expect(md).toContain("- **Project:** Multica Contributions");
+    expect(md).toContain("- **Created:** 2026-05-28T09:34:03Z");
+    expect(md).toContain("## Description");
+    expect(md).toContain("Body text");
+    expect(md).toContain("## Comments");
+    expect(md).toContain("_(no comments)_");
+  });
+
+  it("renders comments in chronological order with author + attachments", () => {
+    const timeline: TimelineEntry[] = [
+      {
+        type: "comment",
+        id: "c2",
+        actor_type: "member",
+        actor_id: "member-2",
+        created_at: "2026-05-28T10:00:00Z",
+        content: "second",
+        attachments: [
+          {
+            id: "att-1",
+            workspace_id: "ws-1",
+            issue_id: null,
+            comment_id: "c2",
+            chat_session_id: null,
+            chat_message_id: null,
+            uploader_type: "member",
+            uploader_id: "member-2",
+            filename: "log.txt",
+            url: "u",
+            download_url: "d",
+            content_type: "text/plain",
+            size_bytes: 1,
+            created_at: "2026-05-28T10:00:00Z",
+          },
+        ],
+      },
+      {
+        type: "activity",
+        id: "a1",
+        actor_type: "agent",
+        actor_id: "agent-1",
+        created_at: "2026-05-28T09:50:00Z",
+        action: "status_changed",
+      },
+      {
+        type: "comment",
+        id: "c1",
+        actor_type: "agent",
+        actor_id: "agent-1",
+        created_at: "2026-05-28T09:45:00Z",
+        content: "first",
+      },
+    ];
+
+    const md = buildIssueMarkdown({
+      issue: baseIssue,
+      timeline,
+      getActorName,
+    });
+
+    const firstIdx = md.indexOf("first");
+    const secondIdx = md.indexOf("second");
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+
+    expect(md).toContain("### frontend (agent) — 2026-05-28T09:45:00Z");
+    expect(md).toContain("### Bob (member) — 2026-05-28T10:00:00Z");
+    expect(md).toContain("**Attachments:**");
+    expect(md).toContain("- log.txt");
+    expect(md).not.toContain("status_changed");
+  });
+
+  it("falls back when description is empty and labels are missing", () => {
+    const md = buildIssueMarkdown({
+      issue: { ...baseIssue, description: null },
+      timeline: [],
+      getActorName,
+    });
+    expect(md).toContain("- **Labels:** —");
+    expect(md).toContain("_(no description)_");
+  });
+
+  it("renders explicit labels argument", () => {
+    const labels: Label[] = [
+      { id: "l1", workspace_id: "ws-1", name: "bug", color: "#ff0000", created_at: "", updated_at: "" },
+      { id: "l2", workspace_id: "ws-1", name: "ui", color: "#00ff00", created_at: "", updated_at: "" },
+    ];
+    const md = buildIssueMarkdown({
+      issue: baseIssue,
+      timeline: [],
+      labels,
+      getActorName,
+    });
+    expect(md).toContain("- **Labels:** bug, ui");
+  });
+
+  it("handles missing assignee", () => {
+    const md = buildIssueMarkdown({
+      issue: { ...baseIssue, assignee_type: null, assignee_id: null },
+      timeline: [],
+      getActorName,
+    });
+    expect(md).toContain("- **Assignee:** —");
+  });
+});

--- a/packages/views/issues/utils/build-issue-markdown.ts
+++ b/packages/views/issues/utils/build-issue-markdown.ts
@@ -1,0 +1,109 @@
+import type {
+  Attachment,
+  Issue,
+  Label,
+  TimelineEntry,
+} from "@multica/core/types";
+
+export interface BuildIssueMarkdownInput {
+  issue: Issue;
+  timeline: TimelineEntry[];
+  labels?: Label[];
+  projectName?: string | null;
+  getActorName: (type: string, id: string) => string;
+}
+
+function formatActor(
+  type: string | null | undefined,
+  id: string | null | undefined,
+  getActorName: BuildIssueMarkdownInput["getActorName"],
+): string {
+  if (!type || !id) return "—";
+  const name = getActorName(type, id);
+  return `${name} (${type})`;
+}
+
+function formatAttachments(attachments: Attachment[] | undefined): string[] {
+  if (!attachments || attachments.length === 0) return [];
+  return attachments.map((a) => `- ${a.filename}`);
+}
+
+export function buildIssueMarkdown({
+  issue,
+  timeline,
+  labels,
+  projectName,
+  getActorName,
+}: BuildIssueMarkdownInput): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${issue.identifier}: ${issue.title}`);
+  lines.push("");
+
+  const labelNames = (labels ?? issue.labels ?? []).map((l) => l.name);
+
+  const metaRows: [string, string][] = [
+    ["Status", issue.status],
+    ["Priority", issue.priority],
+    ["Assignee", formatActor(issue.assignee_type, issue.assignee_id, getActorName)],
+    ["Creator", formatActor(issue.creator_type, issue.creator_id, getActorName)],
+    ["Project", projectName ?? "—"],
+    ["Labels", labelNames.length > 0 ? labelNames.join(", ") : "—"],
+    ["Start date", issue.start_date ?? "—"],
+    ["Due date", issue.due_date ?? "—"],
+    ["Created", issue.created_at],
+    ["Updated", issue.updated_at],
+  ];
+
+  for (const [k, v] of metaRows) {
+    lines.push(`- **${k}:** ${v}`);
+  }
+
+  lines.push("");
+  lines.push("## Description");
+  lines.push("");
+  lines.push(issue.description?.trim() ? issue.description : "_(no description)_");
+  lines.push("");
+
+  const comments = timeline
+    .filter((e) => e.type === "comment")
+    .slice()
+    .sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  lines.push("## Comments");
+  lines.push("");
+
+  if (comments.length === 0) {
+    lines.push("_(no comments)_");
+    lines.push("");
+  } else {
+    for (const c of comments) {
+      const author = formatActor(c.actor_type, c.actor_id, getActorName);
+      lines.push(`### ${author} — ${c.created_at}`);
+      lines.push("");
+      const body = (c.content ?? "").trim();
+      lines.push(body.length > 0 ? body : "_(empty comment)_");
+      const attachLines = formatAttachments(c.attachments);
+      if (attachLines.length > 0) {
+        lines.push("");
+        lines.push("**Attachments:**");
+        for (const line of attachLines) lines.push(line);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n").replace(/\n+$/, "\n");
+}
+
+export function downloadMarkdown(filename: string, markdown: string): void {
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -219,7 +219,11 @@
     "link_copy_failed": "Failed to copy link",
     "workdir_path_copied": "Workdir path copied",
     "workdir_path_copy_failed": "Failed to copy workdir path",
-    "workdir_path_unavailable": "No local workdir yet — issue has not been run by a local agent"
+    "workdir_path_unavailable": "No local workdir yet — issue has not been run by a local agent",
+    "export_copy_markdown": "Copy conversation as Markdown",
+    "export_download_markdown": "Download conversation as Markdown",
+    "export_copy_success": "Conversation copied as Markdown",
+    "export_copy_failed": "Failed to copy conversation"
   },
   "timeline": {
     "loading": "Loading..."

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -217,7 +217,11 @@
     "link_copy_failed": "复制链接失败",
     "workdir_path_copied": "已复制本地 workdir 路径",
     "workdir_path_copy_failed": "复制本地 workdir 路径失败",
-    "workdir_path_unavailable": "暂无本地 workdir — 这个 issue 还没被本地 agent 运行过"
+    "workdir_path_unavailable": "暂无本地 workdir — 这个 issue 还没被本地 agent 运行过",
+    "export_copy_markdown": "复制对话为 Markdown",
+    "export_download_markdown": "下载对话为 Markdown",
+    "export_copy_success": "已复制对话为 Markdown",
+    "export_copy_failed": "复制对话失败"
   },
   "timeline": {
     "loading": "加载中…"


### PR DESCRIPTION
## Summary

Adds two Activity header actions on the issue detail surface that let a user copy or download the full fetched issue conversation as Markdown — issue metadata, description, and every comment in chronological order.

- **Copy as Markdown** — writes the conversation to the clipboard.
- **Download as Markdown** — triggers a `<identifier>.md` file download.

## Implementation notes

- Frontend-only. No new API call: the buttons serialize from the timeline already loaded by `useIssueTimeline` and the issue / labels / project caches already on the page.
- New pure helper `packages/views/issues/utils/build-issue-markdown.ts` with unit tests — chronological ordering, attachment enumeration by filename, fallbacks for missing assignee / labels / description.
- Activity entries are intentionally excluded from the body — the export is the human conversation, not the audit log. Comments include attachment filenames so referenced files survive the export.
- New locale strings under `detail.export_*` in both `en` and `zh-Hans`.

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views test` (842 passed, including 5 new unit tests for `build-issue-markdown`)
- [x] `pnpm --filter @multica/views lint` (no new errors / warnings introduced)
- [ ] Manual: visually confirm the two Activity-header buttons render, copy populates the clipboard, download writes `<identifier>.md`.

Implements AND-5157 (parent AND-5026).