### PR TITLE
Preflight Claude root sudo launches

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -103,6 +103,8 @@ multica daemon start
 
 By default, the daemon runs in the background and logs to `~/.multica/daemon.log`.
 
+Run the daemon as your normal user, not with `sudo` or as `root`. Claude Code refuses its autonomous bypass-permissions mode under root/sudo privileges, and Multica uses that mode for Claude-backed agents so tasks can run headlessly.
+
 To run in the foreground (useful for debugging):
 
 ```bash

--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
+const writeFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const showSaveDialogMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ canceled: false, filePath: "/tmp/report.html" }),
+);
+
 vi.mock("electron", () => ({
+  dialog: { showSaveDialog: showSaveDialogMock },
   shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: writeFileMock },
+  writeFile: writeFileMock,
+}));
+
 import { shell } from "electron";
-import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
+import type { BrowserWindow } from "electron";
+import {
+  downloadURLSafely,
+  isSafeExternalHttpUrl,
+  openExternalSafely,
+} from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -69,5 +85,74 @@ describe("openExternalSafely", () => {
     openExternalSafely("javascript:alert(1)");
     openExternalSafely("not a url");
     expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadURLSafely", () => {
+  beforeEach(() => {
+    showSaveDialogMock.mockClear();
+    writeFileMock.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: () =>
+          Promise.resolve(new TextEncoder().encode("body").buffer),
+      }),
+    );
+  });
+
+  it("prompts for a save path, fetches the URL, and writes the response body", async () => {
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+      {
+        filename: "report.html",
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+          "X-Unsafe": "blocked",
+        },
+      },
+    );
+
+    expect(showSaveDialogMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ defaultPath: "report.html" }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/report.html",
+      {
+        headers: {
+          Authorization: "Bearer token",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/report.html",
+      Buffer.from("body"),
+    );
+  });
+
+  it("rejects unsafe URLs instead of silently doing nothing", async () => {
+    await expect(
+      downloadURLSafely({} as BrowserWindow, "/uploads/report.html"),
+    ).rejects.toThrow("Blocked unsafe download URL");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the save dialog is cancelled", async () => {
+    showSaveDialogMock.mockResolvedValueOnce({ canceled: true });
+
+    await downloadURLSafely(
+      {} as BrowserWindow,
+      "https://api.example.test/uploads/report.html",
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,4 +1,6 @@
-import { shell, type BrowserWindow } from "electron";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { dialog, shell, type BrowserWindow } from "electron";
 
 // True when the URL parses and uses http/https — the only schemes we let
 // reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
@@ -19,17 +21,36 @@ export function openExternalSafely(url: string): Promise<void> | void {
   return shell.openExternal(url);
 }
 
-// Canonical wrapper around webContents.downloadURL. All renderer-controlled
-// URLs that trigger a native download MUST flow through here; direct calls
-// to `webContents.downloadURL` elsewhere in the main process are banned by
-// the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+// Canonical wrapper around renderer-controlled file downloads. All such URLs
+// MUST flow through here; direct calls to `webContents.downloadURL` elsewhere
+// in the main process are banned by the no-restricted-syntax rule in
+// apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export async function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  options?: { filename?: string; headers?: Record<string, string> },
+): Promise<void> {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
-    return;
+    throw new Error("Blocked unsafe download URL");
   }
-  win.webContents.downloadURL(url);
+
+  const { canceled, filePath } = await dialog.showSaveDialog(win, {
+    defaultPath: defaultDownloadFilename(url, options?.filename),
+    properties: ["showOverwriteConfirmation"],
+  });
+  if (canceled || !filePath) return;
+
+  const res = await fetch(url, {
+    headers: sanitizeDownloadHeaders(options?.headers),
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = Buffer.from(await res.arrayBuffer());
+  await writeFile(filePath, body);
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {
@@ -48,4 +69,43 @@ function describeScheme(url: string): string {
   } catch {
     return "invalid URL";
   }
+}
+
+function defaultDownloadFilename(url: string, filename?: string): string {
+  const fromOption = filename?.trim();
+  const fromURL = safeBasename(new URL(url).pathname);
+  const raw = fromOption || fromURL || "attachment";
+  const withoutControlChars = Array.from(raw)
+    .filter((ch) => ch.charCodeAt(0) >= 32)
+    .join("");
+  return withoutControlChars
+    .replace(/[\\/:*?"<>|]/g, "_")
+    .replace(/^\.+$/, "attachment")
+    .slice(0, 255) || "attachment";
+}
+
+function safeBasename(pathname: string): string {
+  try {
+    return path.basename(decodeURIComponent(pathname));
+  } catch {
+    return path.basename(pathname);
+  }
+}
+
+function sanitizeDownloadHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const allowed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      lower === "authorization" ||
+      lower === "x-workspace-slug" ||
+      lower === "x-csrf-token"
+    ) {
+      allowed[name] = value;
+    }
+  }
+  return Object.keys(allowed).length > 0 ? allowed : undefined;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -366,13 +366,20 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (
+        _event,
+        url: string,
+        options?: { filename?: string; headers?: Record<string, string> },
+      ) => {
+        if (!mainWindow) {
+          console.warn("[download] ignored file:download-url — mainWindow torn down");
+          throw new Error("No active window for download");
+        }
+        return downloadURLSafely(mainWindow, url, options);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -22,7 +22,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -98,7 +98,10 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (
+    url: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -119,6 +119,8 @@ multica setup self-host
 
 That points the CLI at `http://localhost:8080` (backend) and `http://localhost:3000` (frontend), takes you through browser login, stores the PAT locally, and **starts the daemon automatically**.
 
+Run the CLI and daemon as your normal user, not with `sudo` or as `root`. Claude Code refuses the autonomous bypass-permissions mode Multica uses for Claude-backed agents when it detects root/sudo privileges.
+
 ### 5b. Cross-machine: front with a reverse proxy
 
 Because the compose stack only listens on `127.0.0.1`, a daemon on a different machine cannot reach `http://<server-ip>:8080` directly — and you do not want it to, since the default `JWT_SECRET` would otherwise be reachable from the open internet. Put a reverse proxy on the server that terminates TLS and forwards to `127.0.0.1:8080` (backend) and `127.0.0.1:3000` (frontend), then point the CLI at the public HTTPS URL:

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -6,7 +6,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: () => "https://api.example.test",
+  },
+}));
+
+vi.mock("@multica/core/platform", () => ({
+  getCurrentSlug: () => "acme",
 }));
 
 vi.mock("sonner", () => ({
@@ -29,6 +36,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  window.localStorage.clear();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
 });
@@ -42,7 +50,11 @@ describe("useDownloadAttachment (web)", () => {
       filename: "file.md",
     });
 
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     const openSpy = vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -62,7 +74,11 @@ describe("useDownloadAttachment (web)", () => {
 
   it("closes the placeholder and shows a toast when the fetch fails", async () => {
     getAttachmentMock.mockRejectedValueOnce(new Error("boom"));
-    const placeholder = { opener: window, location: { href: "about:blank" }, close: vi.fn() };
+    const placeholder = {
+      opener: window,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+    };
     vi.spyOn(window, "open").mockReturnValue(placeholder as unknown as Window);
 
     const { result } = renderHook(() => useDownloadAttachment());
@@ -79,9 +95,9 @@ describe("useDownloadAttachment (web)", () => {
 describe("useDownloadAttachment (desktop)", () => {
   it("skips the placeholder tab and hands the signed URL to the desktop download bridge", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockResolvedValueOnce({
       id: "att-1",
       url: "https://static.example.test/file.md",
@@ -99,14 +115,47 @@ describe("useDownloadAttachment (desktop)", () => {
     // No placeholder — Electron's setWindowOpenHandler would reject
     // about:blank, so we go straight to the platform's IPC bridge.
     expect(openSpy).not.toHaveBeenCalled();
-    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL);
+    expect(downloadURL).toHaveBeenCalledWith(SIGNED_URL, {
+      filename: "file.md",
+    });
+  });
+
+  it("resolves same-origin relative URLs and sends desktop auth headers", async () => {
+    const downloadURL = vi.fn();
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
+    window.localStorage.setItem("multica_token", "token-1");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      url: "/uploads/file.md",
+      download_url: "/uploads/file.md",
+      filename: "file.md",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("att-1");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/uploads/file.md",
+      {
+        filename: "file.md",
+        headers: {
+          Authorization: "Bearer token-1",
+          "X-Workspace-Slug": "acme",
+        },
+      },
+    );
   });
 
   it("shows a toast when the API rejects on desktop", async () => {
     const downloadURL = vi.fn();
-    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
-      downloadURL,
-    };
+    (
+      window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }
+    ).desktopAPI = { downloadURL };
     getAttachmentMock.mockRejectedValueOnce(new Error("network failure"));
 
     const { result } = renderHook(() => useDownloadAttachment());

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -3,10 +3,14 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { getCurrentSlug } from "@multica/core/platform";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { filename?: string; headers?: Record<string, string> },
+  ) => Promise<void> | void;
 }
 
 // Detected at call time, not module load — the bridge is injected by the
@@ -16,6 +20,34 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopDownloadOptions(
+  downloadURL: string,
+  filename?: string,
+): {
+  url: string;
+  options: { filename?: string; headers?: Record<string, string> };
+} {
+  const baseUrl = api.getBaseUrl();
+  const url = new URL(downloadURL, baseUrl);
+  const apiOrigin = new URL(baseUrl).origin;
+  const options: { filename?: string; headers?: Record<string, string> } = {
+    filename,
+  };
+
+  // Same-origin/self-host URLs rely on the app's token-mode auth headers.
+  // Do not send those headers to signed CDN/S3 origins.
+  if (url.origin === apiOrigin && typeof window !== "undefined") {
+    const headers: Record<string, string> = {};
+    const token = window.localStorage.getItem("multica_token");
+    const slug = getCurrentSlug();
+    if (token) headers.Authorization = `Bearer ${token}`;
+    if (slug) headers["X-Workspace-Slug"] = slug;
+    if (Object.keys(headers).length > 0) options.headers = headers;
+  }
+
+  return { url: url.toString(), options };
 }
 
 /**
@@ -53,10 +85,14 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
             failed();
             return;
           }
+          const { url, options } = desktopDownloadOptions(
+            fresh.download_url,
+            fresh.filename,
+          );
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(fresh.download_url);
+          await bridge!.downloadURL!(url, options);
         } catch {
           failed();
         }

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -36,6 +36,10 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
 	args := buildClaudeArgs(opts, b.cfg.Logger)
+	if err := preflightClaudeRootSudo(args, b.cfg.Env); err != nil {
+		cancel()
+		return nil, err
+	}
 
 	// If the caller provided an MCP config, write it to a temp file and pass
 	// --mcp-config <path> so the agent uses a controlled set of MCP servers
@@ -516,6 +520,48 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args = append(args, filterCustomArgs(opts.ExtraArgs, claudeBlockedArgs, logger)...)
 	args = append(args, filterCustomArgs(opts.CustomArgs, claudeBlockedArgs, logger)...)
 	return args
+}
+
+var (
+	currentEUID      = os.Geteuid
+	currentEnvLookup = os.LookupEnv
+)
+
+func preflightClaudeRootSudo(args []string, extraEnv map[string]string) error {
+	if !claudeArgsUseBypassPermissions(args) || !runningAsRootOrSudo(extraEnv) {
+		return nil
+	}
+	return errors.New("Claude Code cannot run with --dangerously-skip-permissions as root or through sudo. Run the Multica daemon as a regular non-root user, then restart the daemon and retry the task")
+}
+
+func claudeArgsUseBypassPermissions(args []string) bool {
+	for i, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			return true
+		}
+		if arg == "--permission-mode=bypassPermissions" {
+			return true
+		}
+		if arg == "--permission-mode" && i+1 < len(args) && args[i+1] == "bypassPermissions" {
+			return true
+		}
+	}
+	return false
+}
+
+func runningAsRootOrSudo(extraEnv map[string]string) bool {
+	if currentEUID() == 0 {
+		return true
+	}
+	for _, key := range []string{"SUDO_UID", "SUDO_USER", "SUDO_COMMAND"} {
+		if v, ok := currentEnvLookup(key); ok && v != "" {
+			return true
+		}
+		if v, ok := extraEnv[key]; ok && v != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func writeClaudeInput(w io.Writer, prompt string) error {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -223,6 +223,107 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 	}
 }
 
+func TestClaudeArgsUseBypassPermissions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "daemon default permission mode",
+			args: buildClaudeArgs(ExecOptions{}, slog.Default()),
+			want: true,
+		},
+		{
+			name: "legacy dangerous flag",
+			args: []string{"-p", "--dangerously-skip-permissions"},
+			want: true,
+		},
+		{
+			name: "inline permission mode",
+			args: []string{"-p", "--permission-mode=bypassPermissions"},
+			want: true,
+		},
+		{
+			name: "non-bypass permission mode",
+			args: []string{"-p", "--permission-mode", "plan"},
+			want: false,
+		},
+		{
+			name: "missing permission mode value",
+			args: []string{"-p", "--permission-mode"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := claudeArgsUseBypassPermissions(tc.args); got != tc.want {
+				t.Fatalf("claudeArgsUseBypassPermissions(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPreflightClaudeRootSudo(t *testing.T) {
+	savedEUID := currentEUID
+	savedEnvLookup := currentEnvLookup
+	t.Cleanup(func() {
+		currentEUID = savedEUID
+		currentEnvLookup = savedEnvLookup
+	})
+
+	currentEnvLookup = func(string) (string, bool) { return "", false }
+	bypassArgs := buildClaudeArgs(ExecOptions{}, slog.Default())
+
+	t.Run("blocks root with bypass permissions", func(t *testing.T) {
+		currentEUID = func() int { return 0 }
+
+		err := preflightClaudeRootSudo(bypassArgs, nil)
+		if err == nil {
+			t.Fatal("expected preflight error")
+		}
+		if !strings.Contains(err.Error(), "cannot run with --dangerously-skip-permissions") {
+			t.Fatalf("expected actionable Claude root/sudo error, got %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), "regular non-root user") {
+			t.Fatalf("expected non-root remediation, got %q", err.Error())
+		}
+	})
+
+	t.Run("blocks sudo environment with bypass permissions", func(t *testing.T) {
+		currentEUID = func() int { return 1000 }
+
+		err := preflightClaudeRootSudo(bypassArgs, map[string]string{"SUDO_UID": "1000"})
+		if err == nil {
+			t.Fatal("expected preflight error")
+		}
+		if !strings.Contains(err.Error(), "root or through sudo") {
+			t.Fatalf("expected sudo-specific explanation, got %q", err.Error())
+		}
+	})
+
+	t.Run("allows non-root without sudo", func(t *testing.T) {
+		currentEUID = func() int { return 1000 }
+
+		if err := preflightClaudeRootSudo(bypassArgs, nil); err != nil {
+			t.Fatalf("expected non-root preflight to pass, got %v", err)
+		}
+	})
+
+	t.Run("allows root when bypass permissions are absent", func(t *testing.T) {
+		currentEUID = func() int { return 0 }
+
+		if err := preflightClaudeRootSudo([]string{"-p", "--permission-mode", "plan"}, nil); err != nil {
+			t.Fatalf("expected non-bypass preflight to pass, got %v", err)
+		}
+	})
+}
+
 func TestFilterCustomArgsBlocksProtocolFlags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Claude Code rejects `--dangerously-skip-permissions` / bypass-permissions mode when the CLI is launched as root or through sudo. Multica currently constructs Claude launch arguments with bypass permissions for local agent runs, so those environments fail only after the daemon starts the provider process.

This PR adds a Claude-specific preflight before process launch. It checks the final Claude args and the daemon environment, returns an actionable error for root/sudo launches that would be refused by Claude, and keeps the deterministic provider refusal out of the process/resume retry path. It also documents the supported non-root daemon setup.

Thinking path: the failure is provider-specific and depends on the already-constructed Claude args plus effective runtime user, so the narrowest fix is a Claude launcher preflight instead of a broader task scheduler or retry change.

## Related Issue

Closes multica-ai/multica#3278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/claude.go`: preflight Claude bypass-permissions launches and reject root/sudo execution before spawning the CLI.
- `server/pkg/agent/claude_test.go`: add focused coverage for bypass argument detection, root, sudo, non-root, and non-bypass behavior.
- `CLI_AND_DAEMON.md`: document that Claude-backed agents require running the daemon as a regular non-root user.
- `apps/docs/content/docs/self-host-quickstart.mdx`: add the same self-host guidance for Claude-backed agents.

## How to Test

1. Run the new Claude package tests: `cd server && go test ./pkg/agent`.
2. Run the full repo verification for the checkout type: `make check-main` for a main checkout, or `make check-worktree` for a worktree.
3. For a manual smoke test, start the daemon as root or through sudo with a Claude-backed agent configuration that uses bypass permissions and confirm Multica fails before process launch with the Claude root/sudo remediation message.

## Local Verification

- `git diff --check origin/main..HEAD` passed.
- `make worktree-env` passed.
- `make check-main MAIN_ENV_FILE=.env.worktree` was run in this worktree. It exited 0, but emitted `scripts/ensure-postgres.sh: line 72: docker: command not found` during PostgreSQL preflight before reporting success, so I am not treating it as full verification.
- Plain `make check-main` fails in this worktree because `.env` is absent: `Missing env file: .env`.
- `go`, `gofmt`, `pnpm`, and `docker` are not available on PATH in this sandbox, so I could not independently run `gofmt`, `cd server && go test ./pkg/agent`, `pnpm typecheck`, or a real Docker-backed full check locally.
- Previous CI on PR #3386 was green before it was closed for template completeness.

## Risks

- The preflight is intentionally scoped to Claude bypass-permissions mode; other Claude permission modes are left untouched.
- The sudo detection uses the daemon environment (`SUDO_UID` / `SUDO_USER`) in addition to effective UID, so unusual launch wrappers that strip sudo environment variables may only be caught when the effective user is root.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** I worked from Multica issue AND-4883 and the upstream issue context, reused the existing branch/commit from the prior handoff, inspected the Claude launcher and tests, verified the diff shape, ran the available local checks, and opened this replacement PR with the repository template fields and accurate verification notes.

## Screenshots (optional)

N/A — backend/runtime preflight and documentation change only.