### PR TITLE
MUL-2792 fix(agent): preserve skills in update/archive/restore response

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -532,20 +533,9 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 	// AgentSkillSummary only needs id/name/description, and reading large
 	// SKILL.md bodies just to discard them is the exact regression we fixed
 	// in #2174.
-	skills, err := h.Queries.ListAgentSkillSummaries(r.Context(), agent.ID)
-	if err != nil {
+	if err := h.attachAgentSkills(r.Context(), &resp, agent.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
 		return
-	}
-	if len(skills) > 0 {
-		resp.Skills = make([]AgentSkillSummary, len(skills))
-		for i, s := range skills {
-			resp.Skills[i] = AgentSkillSummary{
-				ID:          uuidToString(s.ID),
-				Name:        s.Name,
-				Description: s.Description,
-			}
-		}
 	}
 
 	// mcp_config redaction (custom_env was removed from this response shape
@@ -1081,12 +1071,46 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := agentToResponse(updated)
+	// agentToResponse always initialises Skills as []; junction-table rows
+	// are untouched by the SQL update, so we reload them here to keep the
+	// response (and the broadcast that mirrors it) in sync with reality.
+	// Without this, callers see "skills": [] after every metadata-only
+	// update and assume their bindings were cleared — see #3459.
+	if err := h.attachAgentSkills(r.Context(), &resp, updated.ID); err != nil {
+		slog.Warn("load agent skills after update failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+		return
+	}
 	slog.Info("agent updated", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", uuidToString(updated.WorkspaceID))...)
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, uuidToString(updated.WorkspaceID))
 	h.publish(protocol.EventAgentStatus, uuidToString(updated.WorkspaceID), actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})
 	redactAgentResponseForActor(&resp, actorType)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// attachAgentSkills populates resp.Skills from the agent_skill junction
+// table for the given agent. agentToResponse zeros the field; mutation
+// handlers that don't refresh it would otherwise serve a misleading
+// empty array on every successful response (#3459).
+func (h *Handler) attachAgentSkills(ctx context.Context, resp *AgentResponse, agentID pgtype.UUID) error {
+	skills, err := h.Queries.ListAgentSkillSummaries(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	if len(skills) == 0 {
+		return nil
+	}
+	out := make([]AgentSkillSummary, len(skills))
+	for i, s := range skills {
+		out[i] = AgentSkillSummary{
+			ID:          uuidToString(s.ID),
+			Name:        s.Name,
+			Description: s.Description,
+		}
+	}
+	resp.Skills = out
+	return nil
 }
 
 // resolveAgentProvider returns the provider name for the runtime that
@@ -1142,6 +1166,11 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 	wsID := uuidToString(archived.WorkspaceID)
 	slog.Info("agent archived", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", wsID)...)
 	resp := agentToResponse(archived)
+	if err := h.attachAgentSkills(r.Context(), &resp, archived.ID); err != nil {
+		slog.Warn("load agent skills after archive failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+		return
+	}
 	actorType, actorID := h.resolveActor(r, userID, wsID)
 	h.publish(protocol.EventAgentArchived, wsID, actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})
 	redactAgentResponseForActor(&resp, actorType)
@@ -1172,6 +1201,11 @@ func (h *Handler) RestoreAgent(w http.ResponseWriter, r *http.Request) {
 	wsID := uuidToString(restored.WorkspaceID)
 	slog.Info("agent restored", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", wsID)...)
 	resp := agentToResponse(restored)
+	if err := h.attachAgentSkills(r.Context(), &resp, restored.ID); err != nil {
+		slog.Warn("load agent skills after restore failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+		return
+	}
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, wsID)
 	h.publish(protocol.EventAgentRestored, wsID, actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})

--- a/server/internal/handler/agent_env.go
+++ b/server/internal/handler/agent_env.go
@@ -228,8 +228,15 @@ func (h *Handler) UpdateAgentEnv(w http.ResponseWriter, r *http.Request) {
 
 	// Broadcast an agent:status update so connected clients refresh the
 	// "N variables configured" indicator. Payload is the redacted
-	// AgentResponse — no env values are sent.
+	// AgentResponse — no env values are sent. Skills are reloaded so the
+	// broadcast doesn't tell subscribers the agent has no skills (#3459).
 	resp := agentToResponse(updated)
+	if err := h.attachAgentSkills(r.Context(), &resp, updated.ID); err != nil {
+		slog.Warn("load agent skills after env update failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(updated.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+		return
+	}
 	workspaceID := uuidToString(updated.WorkspaceID)
 	h.publish(protocol.EventAgentStatus, workspaceID, "member", uuidToString(member.UserID), map[string]any{"agent": broadcastAgentResponse(resp)})
 

--- a/server/internal/handler/agent_template.go
+++ b/server/internal/handler/agent_template.go
@@ -540,6 +540,16 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 	}
 
 	resp := agentToResponse(agent)
+	// Templates attach skills via AddAgentSkill above, so the freshly built
+	// AgentResponse must reload them — otherwise the create response (and
+	// the agent:created broadcast) would tell clients the agent has no
+	// skills despite the template having just imported them (#3459).
+	if err := h.attachAgentSkills(r.Context(), &resp, agent.ID); err != nil {
+		slog.Warn("load agent skills after template create failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
+		return
+	}
 	actorType, actorID := h.resolveActor(r, ownerID, workspaceID)
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -773,6 +773,143 @@ func TestUpdateAgent_KeepsMcpConfigForMemberActor(t *testing.T) {
 	}
 }
 
+// TestUpdateAgent_PreservesSkillsInResponse is the regression for #3459:
+// updating only description/instructions used to return "skills": []
+// because the handler skipped the skill reload that GetAgent does. The
+// DB row was always preserved; the response just lied about it, which
+// scared users into manually re-running `agent skills set` and risked
+// scripted clients writing the empty set back. We assert (a) the
+// response carries the bound skills, (b) the DB row is unchanged, and
+// (c) GetAgent reports the same shape so the two endpoints don't drift.
+func TestUpdateAgent_PreservesSkillsInResponse(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "update-preserves-skills-agent", nil)
+	skillA := insertHandlerTestSkill(t, "update-preserve-a", "alpha body")
+	skillB := insertHandlerTestSkill(t, "update-preserve-b", "beta body")
+	for _, sid := range []string{skillA, skillB} {
+		if _, err := testPool.Exec(ctx,
+			`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+			agentID, sid,
+		); err != nil {
+			t.Fatalf("attach skill %s: %v", sid, err)
+		}
+	}
+
+	req := newRequest(http.MethodPut, "/api/agents/"+agentID, map[string]any{
+		"description": "metadata-only update",
+	})
+	req = withURLParam(req, "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	gotIDs := map[string]bool{}
+	for _, s := range resp.Skills {
+		gotIDs[s.ID] = true
+	}
+	for _, want := range []string{skillA, skillB} {
+		if !gotIDs[want] {
+			t.Errorf("UpdateAgent response missing skill %s; got %+v", want, resp.Skills)
+		}
+	}
+
+	// Defence in depth: the junction table must be untouched too. Without
+	// this check a future regression that DOES wipe agent_skill rows but
+	// reloads them into the response would silently pass.
+	var rowCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM agent_skill WHERE agent_id = $1`,
+		agentID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count agent_skill: %v", err)
+	}
+	if rowCount != 2 {
+		t.Errorf("agent_skill row count: expected 2, got %d", rowCount)
+	}
+
+	// GetAgent must agree with UpdateAgent on the skill list — otherwise
+	// CLI users will see one shape from the mutation and a different one
+	// on the very next read.
+	getReq := newRequest(http.MethodGet, "/api/agents/"+agentID, nil)
+	getReq = withURLParam(getReq, "id", agentID)
+	getW := httptest.NewRecorder()
+	testHandler.GetAgent(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetAgent: expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+	var getResp AgentResponse
+	if err := json.NewDecoder(getW.Body).Decode(&getResp); err != nil {
+		t.Fatalf("decode GetAgent: %v", err)
+	}
+	if len(getResp.Skills) != len(resp.Skills) {
+		t.Errorf("GetAgent skill count %d != UpdateAgent skill count %d",
+			len(getResp.Skills), len(resp.Skills))
+	}
+}
+
+// TestArchiveRestoreAgent_PreservesSkillsInResponse is the sister
+// regression for #3459: ArchiveAgent / RestoreAgent share the same
+// agentToResponse path as UpdateAgent and previously also returned
+// "skills": [] regardless of what was in the junction table. The
+// archive/restore broadcasts are the only place where mobile clients
+// learn about state flips, so an empty skills array there would propagate
+// to every connected client until the next refetch.
+func TestArchiveRestoreAgent_PreservesSkillsInResponse(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "archive-preserves-skills-agent", nil)
+	skillID := insertHandlerTestSkill(t, "archive-preserve", "body")
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+		agentID, skillID,
+	); err != nil {
+		t.Fatalf("attach skill: %v", err)
+	}
+
+	archiveReq := newRequest(http.MethodPost, "/api/agents/"+agentID+"/archive", nil)
+	archiveReq = withURLParam(archiveReq, "id", agentID)
+	archiveW := httptest.NewRecorder()
+	testHandler.ArchiveAgent(archiveW, archiveReq)
+	if archiveW.Code != http.StatusOK {
+		t.Fatalf("ArchiveAgent: expected 200, got %d: %s", archiveW.Code, archiveW.Body.String())
+	}
+	var archived AgentResponse
+	if err := json.NewDecoder(archiveW.Body).Decode(&archived); err != nil {
+		t.Fatalf("decode archive: %v", err)
+	}
+	if len(archived.Skills) != 1 || archived.Skills[0].ID != skillID {
+		t.Errorf("ArchiveAgent: expected 1 skill %s, got %+v", skillID, archived.Skills)
+	}
+
+	restoreReq := newRequest(http.MethodPost, "/api/agents/"+agentID+"/restore", nil)
+	restoreReq = withURLParam(restoreReq, "id", agentID)
+	restoreW := httptest.NewRecorder()
+	testHandler.RestoreAgent(restoreW, restoreReq)
+	if restoreW.Code != http.StatusOK {
+		t.Fatalf("RestoreAgent: expected 200, got %d: %s", restoreW.Code, restoreW.Body.String())
+	}
+	var restored AgentResponse
+	if err := json.NewDecoder(restoreW.Body).Decode(&restored); err != nil {
+		t.Fatalf("decode restore: %v", err)
+	}
+	if len(restored.Skills) != 1 || restored.Skills[0].ID != skillID {
+		t.Errorf("RestoreAgent: expected 1 skill %s, got %+v", skillID, restored.Skills)
+	}
+}
+
 // insertHandlerTestTask creates an in_progress task for the given
 // agent so resolveActor's GetAgentTask lookup succeeds without
 // dragging the full TaskService into the test.


### PR DESCRIPTION
Closes #3459 · Related: [MUL-2792](https://github.com/multica-ai/multica/issues/3459)

## Summary

- `agentToResponse` always returns `Skills: []`; only `GetAgent` and `ListAgents` reload the junction table after building the response. `UpdateAgent` / `ArchiveAgent` / `RestoreAgent` skipped that step, so every successful response (and its WS broadcast) showed `"skills": []` regardless of what the agent actually had bound.
- Two further sites caught in review and folded into this PR: the `agent:status` broadcast in `UpdateAgentEnv` and the create response + `agent:created` broadcast in `CreateAgentFromTemplate` had the same shape — they reused `agentToResponse` without reloading skills.
- The DB write path was never wrong — `agent_skill` rows are untouched by these handlers, so skills weren't really deleted. But the lying response scared users into manually re-running `agent skills set` (per the bug report) and risks scripted callers writing the empty set back as truth.
- Extracted the existing `GetAgent` reload block into a small `attachAgentSkills` helper and called it from every affected site, always before the broadcast so the WS payload stays consistent with the HTTP response.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] New unit tests: `TestUpdateAgent_PreservesSkillsInResponse` and `TestArchiveRestoreAgent_PreservesSkillsInResponse` — assert the response carries the bound skills, the `agent_skill` row count is unchanged, and `GetAgent` agrees with `UpdateAgent`. CI runs them against the workflow's Postgres service (local Docker wasn't available in the dev env, so they only get exercised in CI).
- [x] The env/template follow-up sites use the same helper as the tested handlers — the fix pattern is identical and inherits confidence from those tests. No dedicated test added because there is no existing broadcast assertion harness in this package, and the template handler has no test fixtures yet.
- [ ] Manual repro of the original bug after backend deploy: bind skills → `multica agent update --description ...` → confirm response no longer reports `"skills": []`.