### PR TITLE
Fix stale sidebar working status reconciliation

### DIFF
--- a/packages/core/agents/use-workspace-presence-prefetch.test.ts
+++ b/packages/core/agents/use-workspace-presence-prefetch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { AgentTask } from "../types";
+import { hasActiveAgentTasks } from "./use-workspace-presence-prefetch";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "rt-1",
+    issue_id: "issue-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-05-27T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("hasActiveAgentTasks", () => {
+  it("returns false for an empty or missing snapshot", () => {
+    expect(hasActiveAgentTasks(undefined)).toBe(false);
+    expect(hasActiveAgentTasks([])).toBe(false);
+  });
+
+  it("returns true while a snapshot contains queued, dispatched, running, or waiting tasks", () => {
+    expect(hasActiveAgentTasks([makeTask({ status: "queued" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "dispatched" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "running" })])).toBe(true);
+    expect(hasActiveAgentTasks([makeTask({ status: "waiting_local_directory" })])).toBe(true);
+  });
+
+  it("returns false once the authoritative snapshot only contains terminal tasks", () => {
+    expect(
+      hasActiveAgentTasks([
+        makeTask({ id: "completed", status: "completed" }),
+        makeTask({ id: "failed", status: "failed" }),
+        makeTask({ id: "cancelled", status: "cancelled" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("keeps polling when active tasks coexist with the latest terminal rows", () => {
+    expect(
+      hasActiveAgentTasks([
+        makeTask({ id: "completed", status: "completed" }),
+        makeTask({ id: "running", status: "running" }),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/core/agents/use-workspace-presence-prefetch.ts
+++ b/packages/core/agents/use-workspace-presence-prefetch.ts
@@ -4,6 +4,22 @@ import { useQuery } from "@tanstack/react-query";
 import { agentListOptions, squadListOptions } from "../workspace/queries";
 import { runtimeListOptions } from "../runtimes/queries";
 import { agentTaskSnapshotOptions } from "./queries";
+import type { AgentTask } from "../types";
+
+const ACTIVE_AGENT_TASK_STATUSES = new Set<AgentTask["status"]>([
+  "queued",
+  "dispatched",
+  "running",
+  "waiting_local_directory",
+]);
+
+const ACTIVE_TASK_REFETCH_INTERVAL_MS = 15_000;
+
+export function hasActiveAgentTasks(
+  snapshot: readonly AgentTask[] | undefined,
+): boolean {
+  return snapshot?.some((task) => ACTIVE_AGENT_TASK_STATUSES.has(task.status)) ?? false;
+}
 
 // Subscribe to the queries that power agent presence and the @mention
 // suggestion list so they're warm by the time any hover card / inline
@@ -24,6 +40,13 @@ import { agentTaskSnapshotOptions } from "./queries";
 export function useWorkspacePresencePrefetch(wsId: string | undefined): void {
   useQuery({ ...agentListOptions(wsId ?? ""), enabled: !!wsId });
   useQuery({ ...runtimeListOptions(wsId ?? ""), enabled: !!wsId });
-  useQuery({ ...agentTaskSnapshotOptions(wsId ?? ""), enabled: !!wsId });
+  useQuery({
+    ...agentTaskSnapshotOptions(wsId ?? ""),
+    enabled: !!wsId,
+    refetchInterval: (query) =>
+      hasActiveAgentTasks(query.state.data)
+        ? ACTIVE_TASK_REFETCH_INTERVAL_MS
+        : false,
+  });
   useQuery({ ...squadListOptions(wsId ?? ""), enabled: !!wsId });
 }


### PR DESCRIPTION
## What does this PR do?

Fixes stale `working` status on sidebar agents in hosted Multica workspaces. After a run/session ends, agents could remain badged as `working` indefinitely until a user opened a direct chat (which forced a reconcile). This change adds a defensive refetch path on the workspace presence prefetch so the sidebar status reconciles itself when realtime task-completion events are missed.

## Related Issue

Closes #1463

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/agents/use-workspace-presence-prefetch.ts` — `useWorkspacePresencePrefetch` now passes `refetchInterval` to the `agentTaskSnapshotOptions` query. While the cached snapshot still has any task in `queued`, `dispatched`, `running`, or `waiting_local_directory`, the snapshot refetches every 15s. Once the authoritative snapshot returns only terminal tasks (or none), `refetchInterval` returns `false` and polling stops.
- Exported `hasActiveAgentTasks(snapshot)` as the active-vs-terminal detector so it can be unit tested in isolation.
- `packages/core/agents/use-workspace-presence-prefetch.test.ts` — new regression coverage for `hasActiveAgentTasks` (empty/undefined snapshot, each active status, all-terminal, and mixed active+terminal).

## How to Test

Repro of the original bug (manual):
1. Open a hosted Multica workspace with at least one agent that has just finished an issue run.
2. Observe the sidebar still showing the agent as `working` even though no run/chat is active.
3. With this change applied, the sidebar resolves to idle within ~15s once the authoritative task snapshot reports only terminal tasks — without opening a direct chat.

Automated coverage:
1. `corepack pnpm install` (root workspace install).
2. `corepack pnpm --filter @multica/core exec vitest run agents/use-workspace-presence-prefetch.test.ts` — four cases covering empty, active, terminal-only, and mixed snapshots.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no visual change — only the timing of an existing status update)
- [ ] I have updated relevant documentation to reflect my changes (no user-facing API or doc impact)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A — internal fix)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (N/A — no copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risk notes

- The new polling only runs while `hasActiveAgentTasks(snapshot)` is true, so a workspace with no active agent work pays zero extra requests.
- `agentTaskSnapshotOptions` is the same query the rest of the presence flow already consumes; this only adds a `refetchInterval` and stops once the snapshot is terminal-only.

## Local Verification

Sandbox executed:

- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm install --ignore-scripts` — installed root workspace deps (scripts ignored because the sandbox cannot write `~/.cache/electron` for the optional desktop pre/post install hooks).
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core exec vitest run agents/use-workspace-presence-prefetch.test.ts` — passed (4/4 tests).
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core typecheck` — passed.
- `COREPACK_HOME=/tmp/corepack XDG_DATA_HOME=/tmp/xdg-data XDG_CACHE_HOME=/tmp/xdg-cache corepack pnpm --filter @multica/core lint` — passed with 1 pre-existing warning in `packages/core/platform/auth-initializer.tsx` (unrelated to this PR).

`make check-main` was **not** executed end-to-end in this sandbox because the runner does not have Docker, PostgreSQL, Go, or a Playwright browser available — `make check-main` boots Postgres via Docker Compose, runs Go tests, and runs Playwright E2E. The TypeScript portion of that pipeline (typecheck + vitest for the changed package) was exercised directly via the commands above. Project CI on the previous head of this branch (PR #3396) ran the full pipeline green before that PR was closed for template fields; this PR is the same single commit (`3fd7c9c2 Fix stale workspace presence polling`).

## AI Disclosure

**AI tool used:** Multica Agent (`release-ops` worker) running on Claude Opus 4.7, dispatched from Multica issue AND-4764 / linked triage AND-5151.

**Prompt / approach:**

The fix was produced through the Multica agent runtime. The chain was:

1. The original bug was filed as multica-ai/multica#1463 and mirrored into Multica as issue AND-4764 ("Reconcile stale sidebar working status when no run is active").
2. A frontend/realtime engineer agent inspected `packages/core/agents/use-workspace-presence-prefetch.ts` and the `agentTaskSnapshotOptions` query, identified that the prefetch only ran once on mount with no defensive refetch when realtime completion events were missed, and proposed gating a 15s `refetchInterval` on a status-aware active-task check.
3. A reviewer agent flagged that early handoffs claimed a regression test that was not actually tracked in the branch; the implementing agent then re-applied the fix and added `use-workspace-presence-prefetch.test.ts` so the active-vs-terminal detector is unit-covered.
4. `release-ops` (this agent) opened the original PR (#3396, closed by maintainer for missing PR template fields), and is now opening this re-submitted PR with the full PR template, AI Disclosure section, and explicit local-verification accounting per upstream `CONTRIBUTING.md`.

No production behavior was altered beyond the documented `refetchInterval`. All committed code was reviewed by the agent before push.
