### PR TITLE
docs: fix worktree port parsing examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,7 +361,7 @@ make dev
 Wait for the backend to be healthy:
 
 ```bash
-PORT=$(grep '^PORT=' .env.worktree 2>/dev/null || grep '^PORT=' .env | head -1 | cut -d= -f2)
+PORT=$({ grep '^PORT=' .env.worktree 2>/dev/null || grep '^PORT=' .env; } | head -1 | cut -d= -f2)
 PORT=${PORT:-8080}
 SERVER="http://localhost:${PORT}"
 
@@ -410,7 +410,7 @@ HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
 OFFSET=$((HASH % 1000))
 PROFILE="dev-${SLUG}-${OFFSET}"
 
-FRONTEND_PORT=$(grep '^FRONTEND_PORT=' .env.worktree 2>/dev/null || grep '^FRONTEND_PORT=' .env | head -1 | cut -d= -f2)
+FRONTEND_PORT=$({ grep '^FRONTEND_PORT=' .env.worktree 2>/dev/null || grep '^FRONTEND_PORT=' .env; } | head -1 | cut -d= -f2)
 FRONTEND_PORT=${FRONTEND_PORT:-3000}
 
 CONFIG_DIR="$HOME/.multica/profiles/$PROFILE"


### PR DESCRIPTION
Closes AND-5225

This fixes the CONTRIBUTING.md worktree examples that read PORT and FRONTEND_PORT so the fallback grep is grouped before piping to head/cut. Without grouping, the pipeline only applied to the .env fallback side, which could leave the .env.worktree path returning an unparsed assignment string.

The change keeps the documented workflow intact and only adjusts the shell examples.

Verification:
- git apply --check /tmp/multica-patches/AND-5225-contributing.patch
- Reviewed diff: CONTRIBUTING.md only, 2 insertions / 2 deletions
- Full make check-main not run; docs-only patch from reviewed source issue and current runtime does not have the required full toolchain guarantee.