### PR TITLE
docs(packages): add package agent guidance

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,28 @@
+# Package Guidelines
+
+This directory contains shared TypeScript workspaces used by the web and desktop apps.
+
+> **Single source of truth:** Root `../CLAUDE.md` defines the authoritative package
+> boundaries, commands, and coding rules. Read it before changing package code.
+
+## Package Map
+
+- `core/` - headless business logic, API clients, React Query hooks, platform adapters, and shared Zustand stores.
+- `ui/` - atomic UI components and shared styles only; no product data or business logic.
+- `views/` - reusable business views and page-level components shared across web and desktop.
+- `tsconfig/` - shared TypeScript configuration.
+- `eslint-config/` - shared lint configuration.
+
+## Boundary Rules
+
+- Keep `core/` free of `react-dom`, browser globals such as `localStorage`, and `process.env`.
+- Keep `ui/` free of `@multica/core` imports.
+- Keep `views/` free of `next/*`, `react-router-dom`, and Zustand stores; route through the navigation adapter.
+- Put web/desktop-shared behavior in `core/`, `ui/`, or `views/` instead of duplicating it in both apps.
+- Declare every directly imported external package in the workspace's own `package.json`.
+
+## Verification
+
+Use the root `CLAUDE.md` command list for checks. For package-only TypeScript changes,
+the relevant checks are normally the Turborepo `pnpm typecheck`, `pnpm lint`, and
+`pnpm test` flows, or a narrower package-filtered Vitest command when appropriate.


### PR DESCRIPTION
Closes AND-5230.

This adds package-scoped agent guidance for the shared TypeScript workspaces. The new `packages/AGENTS.md` points back to the root `CLAUDE.md`, summarizes the package map, and repeats the key package boundary rules agents need before editing shared package code.

Fix approach: add a focused docs-only file under `packages/` with no runtime code changes.

Verification:
- `git apply --check /tmp/AND-5230-packages-agents.patch`
- `wc -l packages/AGENTS.md`
- `LC_ALL=C grep -n '[^ -~]' packages/AGENTS.md` (no non-ASCII output)
- `git diff --cached --stat`
- `git diff --cached --check`

Full `make check-main` was not run in this runtime because required prerequisites are missing: `pnpm` not found, `go` not found, and `docker` not found.
