### PR TITLE
docs(github): normalize self-hosted issue template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
       description: Are you using the Official App (multica.ai) or a self-hosted instance?
       options:
         - Official App
-        - self-host
+        - Self-hosted
     validations:
       required: true
 


### PR DESCRIPTION
Closes AND-5233.

This normalizes the deployment dropdown label in the bug report template. The option now reads `Self-hosted`, matching the capitalization style of `Official App` and the surrounding description's self-hosted wording.

Fix approach: apply the focused docs/config patch to `.github/ISSUE_TEMPLATE/bug_report.yml` only.

Verification:
- `git apply --check /tmp/AND-5233-github-template-deployment-label.patch`
- `git diff --stat`
- `git diff --check`
- `git diff --cached --stat`
- `git diff --cached --check`

Full `make check-main` was not run in this runtime because required prerequisites are missing: `pnpm` not found, `go` not found, and `docker` not found.
