### PR TITLE
docs: normalize feature request self-hosted label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
       description: Are you using the Official App (multica.ai) or a self-hosted instance?
       options:
         - Official App
-        - self-host
+        - Self-hosted
     validations:
       required: true
 


### PR DESCRIPTION
Closes AND-5239

The feature request issue template currently labels self-hosted deployments as `self-host`, while the surrounding documentation and companion issue template use user-facing self-hosted terminology. This creates inconsistent wording for contributors filing issues.

This updates the `.github/ISSUE_TEMPLATE/feature_request.yml` deployment dropdown to use `Self-hosted`, matching the intended wording while keeping the change limited to one YAML template line.

Verification:
- `git diff --check` passed
- Confirmed the diff is limited to `.github/ISSUE_TEMPLATE/feature_request.yml`
- `make check-main` was not run because this runtime is missing required prerequisites: `pnpm`, `go`, and `docker` are not installed.