### PR TITLE
docs(docs): add docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_fix.yml
+++ b/.github/ISSUE_TEMPLATE/docs_fix.yml
@@ -1,0 +1,31 @@
+name: "Docs fix"
+description: Report a documentation problem, typo, or stale page.
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: page-url
+    attributes:
+      label: Page URL
+      description: Which documentation page needs attention?
+      placeholder: https://github.com/multica-ai/multica/blob/main/README.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong?
+      description: Describe the typo, stale content, missing information, or confusing text.
+      placeholder: |
+        This page says...
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: If you know the change that would help, describe it here.
+      placeholder: |
+        It should say...


### PR DESCRIPTION
Closes AND-5252

Documentation typo and stale-page reports currently have to use the bug or feature request forms, which adds triage noise. This adds a lightweight dedicated docs issue form that captures the affected page, the problem, and an optional suggested fix.

The change is limited to GitHub issue template YAML and leaves the existing template config unchanged.

Verification:
- `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/docs_fix.yml'))"`
- Confirmed `.github/ISSUE_TEMPLATE/` contains `bug_report.yml`, `config.yml`, `feature_request.yml`, and the new `docs_fix.yml`
- `make check-main` not run; issue explicitly marks it unnecessary for this pure GitHub form YAML change.
