### PR TITLE
docs: add streamlined PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,60 +1,26 @@
-## What does this PR do?
+## Summary
 
-<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
+<!-- Describe this PR in 1-2 sentences. -->
 
-
-
-## Related Issue
-
-<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
+## Related issue
 
 Closes #
 
-## Type of Change
+## Changes
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Refactor / code improvement (no behavior change)
-- [ ] Documentation update
-- [ ] Tests (adding or improving test coverage)
-- [ ] CI / infrastructure
+- <!-- List notable changes. -->
 
-## Changes Made
+## Test plan
 
-<!-- List the specific changes. Include file paths for code changes. -->
+- [ ] `make check-main`
+- [ ] Other: <!-- note any targeted checks or why full verification is not applicable -->
 
--
+## Screenshots / recordings
 
-## How to Test
-
-<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
-
-1.
-2.
-3.
+<!-- If this changes UI, add screenshots or recordings. Otherwise, write "Not applicable." -->
 
 ## Checklist
 
-- [ ] I have included a thinking path that traces from project context to this change
-- [ ] I have run tests locally and they pass
-- [ ] I have added or updated tests where applicable
-- [ ] If this change affects the UI, I have included before/after screenshots
-- [ ] I have updated relevant documentation to reflect my changes
-- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
-- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
-- [ ] I have considered and documented any risks above
-- [ ] I will address all reviewer comments before requesting merge
-
-## AI Disclosure
-
-<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->
-
-**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->
-
-**Prompt / approach:**
-<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->
-
-
-## Screenshots (optional)
-
-<!-- If applicable, add screenshots showing the change in action. -->
+- [ ] I have read `CONTRIBUTING.md`
+- [ ] `make check-main` is green
+- [ ] No secrets committed


### PR DESCRIPTION
## Summary
- Updates the GitHub pull request template to the reviewer-approved community-health structure.
- Keeps the template short and focused on summary, linked issue, changes, test plan, UI evidence, and contributor checklist.

## Validation
- Confirmed upstream already had an older `.github/PULL_REQUEST_TEMPLATE.md`; updated that single file to the sealed spec.
- Ran `git diff --check`.
- `make check-main` not run: markdown-only change and waived by issue spec.