### PR TITLE
MAG-229 fix Redact agent env

### DIFF
--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -76,4 +76,32 @@ describe("task transcript timeline", () => {
     expect(items[0]?.content).not.toContain("abc123xyz");
     expect(items[0]?.content).not.toContain("def456");
   });
+
+  it("redacts tool input before transcript summaries can render it", () => {
+    const items = buildTimeline([
+      {
+        task_id: "task-1",
+        issue_id: "issue-1",
+        seq: 1,
+        type: "tool_use",
+        tool: "multica",
+        input: {
+          command: "multica agent list --output json",
+          custom_env: {
+            SECOND_BRAIN_TOKEN: "token-value",
+            SEARCH_API_KEY: "key-value",
+          },
+        },
+      },
+    ]);
+
+    expect(items[0]?.input).toEqual({
+      command: "multica agent list --output json",
+      has_custom_env: true,
+      custom_env_key_count: 2,
+      custom_env_redacted: true,
+    });
+    expect(JSON.stringify(items[0]?.input)).not.toContain("SECOND_BRAIN_TOKEN");
+    expect(JSON.stringify(items[0]?.input)).not.toContain("token-value");
+  });
 });

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -1,5 +1,5 @@
 import type { TaskMessagePayload } from "@multica/core/types/events";
-import { redactSecrets } from "./redact";
+import { redactSecrets, redactValue } from "./redact";
 
 /** A unified timeline entry: tool calls, thinking, text, and errors in chronological order. */
 export interface TimelineItem {
@@ -43,6 +43,7 @@ function redactTimelineItems(items: TimelineItem[]): TimelineItem[] {
   return items.map((item) => ({
     ...item,
     content: item.content ? redactSecrets(item.content) : item.content,
+    input: item.input ? redactValue(item.input) as Record<string, unknown> : item.input,
     output: item.output ? redactSecrets(item.output) : item.output,
   }));
 }

--- a/packages/views/common/task-transcript/redact.test.ts
+++ b/packages/views/common/task-transcript/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { redactSecrets } from "./redact";
+import { redactSecrets, redactValue } from "./redact";
 
 describe("redactSecrets", () => {
   it("redacts AWS access key", () => {
@@ -65,6 +65,64 @@ describe("redactSecrets", () => {
       expect(result).toContain("[REDACTED CREDENTIAL]");
       expect(result).not.toContain("supersecretvalue123");
     }
+  });
+
+  it("redacts custom_env from agent list JSON without dropping routing metadata", () => {
+    const result = redactSecrets(JSON.stringify([
+      {
+        id: "agent-1",
+        name: "Router",
+        status: "online",
+        runtime_mode: "cloud",
+        skills: [{ id: "skill-1", name: "route" }],
+        custom_env: {
+          SECOND_BRAIN_TOKEN: "token-value-123",
+          SEARCH_API_KEY: "key-value-456",
+          DB_PASSWORD: "password-value-789",
+          SESSION_JWT: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        },
+        custom_env_redacted: false,
+      },
+    ]));
+    for (const leak of [
+      "SECOND_BRAIN_TOKEN",
+      "SEARCH_API_KEY",
+      "DB_PASSWORD",
+      "SESSION_JWT",
+      "token-value-123",
+      "key-value-456",
+      "password-value-789",
+      "eyJhbGci",
+    ]) {
+      expect(result).not.toContain(leak);
+    }
+    expect(result).toContain('"id":"agent-1"');
+    expect(result).toContain('"name":"Router"');
+    expect(result).toContain('"status":"online"');
+    expect(result).toContain('"runtime_mode":"cloud"');
+    expect(result).toContain('"skills"');
+    expect(result).toContain('"custom_env_redacted":true');
+    expect(result).toContain('"custom_env_key_count":4');
+  });
+
+  it("redacts nested custom_env values in structured input", () => {
+    const result = redactValue({
+      command: "multica agent list --output json",
+      payload: {
+        name: "Router",
+        custom_env: {
+          API_TOKEN: "token-value",
+          API_KEY: "key-value",
+        },
+      },
+    }) as Record<string, unknown>;
+    const payload = result.payload as Record<string, unknown>;
+    expect(payload.name).toBe("Router");
+    expect(payload.custom_env).toBeUndefined();
+    expect(payload.custom_env_redacted).toBe(true);
+    expect(payload.custom_env_key_count).toBe(2);
+    expect(JSON.stringify(result)).not.toContain("token-value");
+    expect(JSON.stringify(result)).not.toContain("API_TOKEN");
   });
 
   it("redacts multiple secrets in one string", () => {

--- a/packages/views/common/task-transcript/redact.ts
+++ b/packages/views/common/task-transcript/redact.ts
@@ -28,10 +28,87 @@ const patterns: { re: RegExp; replacement: string }[] = [
   { re: /(?:API_KEY|API_SECRET|SECRET_KEY|SECRET|ACCESS_TOKEN|AUTH_TOKEN|PRIVATE_KEY|DATABASE_URL|DB_PASSWORD|DB_URL|REDIS_URL|PASSWORD|TOKEN)\s*[=:]\s*\S+/gi, replacement: "[REDACTED CREDENTIAL]" },
 ];
 
-export function redactSecrets(text: string): string {
+const sensitiveJSONKey =
+  /(^|[_-])(api[_-]?key|api[_-]?secret|secret[_-]?key|secret|access[_-]?token|auth[_-]?token|private[_-]?key|database[_-]?url|db[_-]?password|db[_-]?url|redis[_-]?url|password|token|jwt)($|[_-])/i;
+
+function applyTextPatterns(text: string): string {
   let result = text;
   for (const { re, replacement } of patterns) {
     result = result.replace(re, replacement);
   }
   return result;
+}
+
+function countObjectKeys(value: unknown): number {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? Object.keys(value as Record<string, unknown>).length
+    : 0;
+}
+
+function redactJSONValue(value: unknown): [unknown, boolean] {
+  if (typeof value === "string") {
+    const redacted = applyTextPatterns(value);
+    return [redacted, redacted !== value];
+  }
+  if (Array.isArray(value)) {
+    let changed = false;
+    const out = value.map((item) => {
+      const [redacted, itemChanged] = redactJSONValue(item);
+      changed = changed || itemChanged;
+      return redacted;
+    });
+    return [out, changed];
+  }
+  if (!value || typeof value !== "object") return [value, false];
+
+  const input = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  let changed = false;
+  let customEnvSeen = false;
+  let customEnvKeyCount = 0;
+
+  for (const [key, item] of Object.entries(input)) {
+    if (key.toLowerCase() === "custom_env") {
+      customEnvSeen = true;
+      customEnvKeyCount = countObjectKeys(item);
+      changed = true;
+      continue;
+    }
+    if (sensitiveJSONKey.test(key)) {
+      out[key] = "[REDACTED CREDENTIAL]";
+      changed = true;
+      continue;
+    }
+    const [redacted, itemChanged] = redactJSONValue(item);
+    out[key] = redacted;
+    changed = changed || itemChanged;
+  }
+
+  if (customEnvSeen) {
+    out.has_custom_env = customEnvKeyCount > 0;
+    out.custom_env_key_count = customEnvKeyCount;
+    out.custom_env_redacted = true;
+  }
+
+  return [out, changed];
+}
+
+export function redactValue(value: unknown): unknown {
+  return redactJSONValue(value)[0];
+}
+
+function redactStructuredJSON(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed || (trimmed[0] !== "{" && trimmed[0] !== "[")) return text;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const [redacted, changed] = redactJSONValue(parsed);
+    return changed ? JSON.stringify(redacted) : text;
+  } catch {
+    return text;
+  }
+}
+
+export function redactSecrets(text: string): string {
+  return applyTextPatterns(redactStructuredJSON(text));
 }

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -237,7 +237,12 @@ func TestGetAgent_ResponseHasNoCustomEnv(t *testing.T) {
 	ctx := context.Background()
 
 	agentID := createHandlerTestAgent(t, "noenv-get-agent", nil)
-	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{
+		"SECRET_KEY": "super-secret",
+		"SECOND_BRAIN_TOKEN": "token-secret",
+		"DB_PASSWORD": "password-secret",
+		"SESSION_JWT": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	}' WHERE id = $1`, agentID); err != nil {
 		t.Fatalf("failed to set custom_env: %v", err)
 	}
 
@@ -260,8 +265,11 @@ func TestGetAgent_ResponseHasNoCustomEnv(t *testing.T) {
 	if got, _ := raw["has_custom_env"].(bool); !got {
 		t.Errorf("has_custom_env expected true, got %v", raw["has_custom_env"])
 	}
-	if got, _ := raw["custom_env_key_count"].(float64); got != 1 {
-		t.Errorf("custom_env_key_count expected 1, got %v", raw["custom_env_key_count"])
+	if got, _ := raw["custom_env_key_count"].(float64); got != 4 {
+		t.Errorf("custom_env_key_count expected 4, got %v", raw["custom_env_key_count"])
+	}
+	if raw["id"] != agentID || raw["name"] != "noenv-get-agent" || raw["status"] == "" || raw["runtime_mode"] == "" {
+		t.Errorf("routing metadata should remain present, got id=%v name=%v status=%v runtime_mode=%v", raw["id"], raw["name"], raw["status"], raw["runtime_mode"])
 	}
 
 	// Sanity-check the typed shape too — the struct must not have
@@ -273,8 +281,8 @@ func TestGetAgent_ResponseHasNoCustomEnv(t *testing.T) {
 	if typed.HasCustomEnv != true {
 		t.Errorf("typed.HasCustomEnv expected true")
 	}
-	if typed.CustomEnvKeyCount != 1 {
-		t.Errorf("typed.CustomEnvKeyCount expected 1, got %d", typed.CustomEnvKeyCount)
+	if typed.CustomEnvKeyCount != 4 {
+		t.Errorf("typed.CustomEnvKeyCount expected 4, got %d", typed.CustomEnvKeyCount)
 	}
 }
 
@@ -289,7 +297,12 @@ func TestListAgents_ResponseHasNoCustomEnv(t *testing.T) {
 
 	agentName := "noenv-list-agent"
 	agentID := createHandlerTestAgent(t, agentName, nil)
-	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret", "OTHER": "y"}' WHERE id = $1`, agentID); err != nil {
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{
+		"SECRET_KEY": "super-secret",
+		"SECOND_BRAIN_TOKEN": "token-secret",
+		"DB_PASSWORD": "password-secret",
+		"SESSION_JWT": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	}' WHERE id = $1`, agentID); err != nil {
 		t.Fatalf("failed to set custom_env: %v", err)
 	}
 
@@ -318,11 +331,14 @@ func TestListAgents_ResponseHasNoCustomEnv(t *testing.T) {
 	if _, ok := found["custom_env"]; ok {
 		t.Errorf("custom_env must not appear in list response")
 	}
-	if got, _ := found["custom_env_key_count"].(float64); got != 2 {
-		t.Errorf("custom_env_key_count expected 2, got %v", found["custom_env_key_count"])
+	if got, _ := found["custom_env_key_count"].(float64); got != 4 {
+		t.Errorf("custom_env_key_count expected 4, got %v", found["custom_env_key_count"])
 	}
 	if got, _ := found["has_custom_env"].(bool); !got {
 		t.Errorf("has_custom_env expected true")
+	}
+	if found["id"] != agentID || found["name"] != agentName || found["status"] == "" || found["runtime_mode"] == "" || found["skills"] == nil {
+		t.Errorf("routing metadata should remain present, got %#v", found)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2041,20 +2041,7 @@ func (h *Handler) ListTaskMessages(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]protocol.TaskMessagePayload, len(messages))
 	for i, m := range messages {
-		var input map[string]any
-		if m.Input != nil {
-			json.Unmarshal(m.Input, &input)
-		}
-		resp[i] = protocol.TaskMessagePayload{
-			TaskID:  taskID,
-			IssueID: issueID,
-			Seq:     int(m.Seq),
-			Type:    m.Type,
-			Tool:    m.Tool.String,
-			Content: m.Content.String,
-			Input:   input,
-			Output:  m.Output.String,
-		}
+		resp[i] = taskMessagePayloadFromRow(m, taskID, issueID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -2184,23 +2171,27 @@ func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request)
 
 	resp := make([]protocol.TaskMessagePayload, len(messages))
 	for i, m := range messages {
-		var input map[string]any
-		if m.Input != nil {
-			json.Unmarshal(m.Input, &input)
-		}
-		resp[i] = protocol.TaskMessagePayload{
-			TaskID:  taskID,
-			IssueID: issueID,
-			Seq:     int(m.Seq),
-			Type:    m.Type,
-			Tool:    m.Tool.String,
-			Content: m.Content.String,
-			Input:   input,
-			Output:  m.Output.String,
-		}
+		resp[i] = taskMessagePayloadFromRow(m, taskID, issueID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func taskMessagePayloadFromRow(m db.TaskMessage, taskID, issueID string) protocol.TaskMessagePayload {
+	var input map[string]any
+	if m.Input != nil {
+		json.Unmarshal(m.Input, &input)
+	}
+	return protocol.TaskMessagePayload{
+		TaskID:  taskID,
+		IssueID: issueID,
+		Seq:     int(m.Seq),
+		Type:    m.Type,
+		Tool:    m.Tool.String,
+		Content: redact.Text(m.Content.String),
+		Input:   redact.InputMap(input),
+		Output:  redact.Text(m.Output.String),
+	}
 }
 
 // GetIssueUsage returns aggregated token usage for all tasks belonging to an issue.

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -847,6 +847,111 @@ func TestListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestListTaskMessagesByUser_RedactsHistoricalAgentCustomEnv(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "task-message-redaction-agent", nil)
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type)
+		VALUES ($1, 'Task message redaction issue', 'todo', 'medium', $2, 'member')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	taskID := createHandlerTestTaskForAgentOnIssue(t, agentID, issueID)
+	agentListOutput := `[
+		{
+			"id": "agent-1",
+			"name": "Router",
+			"status": "online",
+			"runtime_mode": "cloud",
+			"skills": [{"id": "skill-1", "name": "route"}],
+			"custom_env": {
+				"SECOND_BRAIN_TOKEN": "token-value-123",
+				"SEARCH_API_KEY": "key-value-456",
+				"DB_PASSWORD": "password-value-789",
+				"SESSION_JWT": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			},
+			"custom_env_redacted": false
+		}
+	]`
+	inputJSON := []byte(`{
+		"command": "multica agent list --output json",
+		"custom_env": {
+			"CLI_TOKEN": "token-in-input",
+			"PRIVATE_KEY": "key-in-input"
+		}
+	}`)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO task_message (task_id, seq, type, tool, content, input, output)
+		VALUES ($1, 1, 'tool_result', 'multica', $2, $3, $4)
+	`, taskID, agentListOutput, inputJSON, agentListOutput); err != nil {
+		t.Fatalf("failed to seed task message: %v", err)
+	}
+	taskRow, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatalf("failed to read seeded task: %v", err)
+	}
+	if wsID := testHandler.TaskService.ResolveTaskWorkspaceID(ctx, taskRow); wsID != testWorkspaceID {
+		t.Fatalf("seeded task workspace = %q, want %q", wsID, testWorkspaceID)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodGet, "/api/tasks/"+taskID+"/messages", nil)
+	req = withURLParams(req, "taskId", taskID)
+	req = req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, db.Member{}))
+	testHandler.ListTaskMessagesByUser(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var messages []protocol.TaskMessagePayload
+	if err := json.NewDecoder(w.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode task messages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	body := w.Body.String()
+	for _, leak := range []string{
+		"SECOND_BRAIN_TOKEN",
+		"SEARCH_API_KEY",
+		"DB_PASSWORD",
+		"SESSION_JWT",
+		"CLI_TOKEN",
+		"PRIVATE_KEY",
+		"token-value-123",
+		"key-value-456",
+		"password-value-789",
+		"token-in-input",
+		"key-in-input",
+		"eyJhbGci",
+	} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("task message response leaked %q: %s", leak, body)
+		}
+	}
+	for _, kept := range []string{`"id":"agent-1"`, `"name":"Router"`, `"status":"online"`, `"runtime_mode":"cloud"`, `"skills"`} {
+		if !strings.Contains(messages[0].Output, kept) {
+			t.Fatalf("routing metadata %q missing from redacted output: %s", kept, messages[0].Output)
+		}
+	}
+	if messages[0].Input["custom_env"] != nil {
+		t.Fatalf("custom_env should not appear in redacted input: %#v", messages[0].Input)
+	}
+	if messages[0].Input["custom_env_redacted"] != true {
+		t.Fatalf("expected input custom_env_redacted=true, got %#v", messages[0].Input)
+	}
+}
+
 // setupForeignWorkspaceFixture creates an isolated workspace (not reachable
 // from testUserID) with its own agent, runtime, issue, and queued task.
 // Returns (issueID, taskID). All rows are cleaned up when the test ends.

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -52,6 +52,11 @@ func TestMain(m *testing.M) {
 		pool.Close()
 		os.Exit(0)
 	}
+	if err := ensureHandlerTestSchema(ctx, pool); err != nil {
+		fmt.Printf("Failed to update handler test schema: %v\n", err)
+		pool.Close()
+		os.Exit(1)
+	}
 
 	queries := db.New(pool)
 	hub := realtime.NewHub()
@@ -86,6 +91,34 @@ func TestMain(m *testing.M) {
 	}
 	pool.Close()
 	os.Exit(code)
+}
+
+func ensureHandlerTestSchema(ctx context.Context, pool *pgxpool.Pool) error {
+	if err := ensureHandlerTestColumn(ctx, pool, "agent_task_queue", "wait_reason", `ALTER TABLE agent_task_queue ADD COLUMN wait_reason TEXT`); err != nil {
+		return err
+	}
+	return ensureHandlerTestColumn(ctx, pool, "issue", "metadata", `ALTER TABLE issue ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}'::jsonb`)
+}
+
+func ensureHandlerTestColumn(ctx context.Context, pool *pgxpool.Pool, tableName, columnName, ddl string) error {
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+				AND table_name = $1
+				AND column_name = $2
+		)
+	`, tableName, columnName).Scan(&exists); err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	_, err := pool.Exec(ctx, ddl)
+	return err
 }
 
 func setupHandlerTestFixture(ctx context.Context, pool *pgxpool.Pool) (string, string, error) {

--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -3,6 +3,9 @@
 package redact
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"os/user"
 	"regexp"
@@ -51,21 +54,22 @@ var patterns = []secretPattern{
 	{regexp.MustCompile(`(?i)(?:API_KEY|API_SECRET|SECRET_KEY|SECRET|ACCESS_TOKEN|AUTH_TOKEN|PRIVATE_KEY|DATABASE_URL|DB_PASSWORD|DB_URL|REDIS_URL|PASSWORD|TOKEN)\s*[=:]\s*\S+`), "[REDACTED CREDENTIAL]"},
 }
 
-// InputMap returns a copy of m with all string values passed through Text.
-// Non-string values are preserved as-is.
+var sensitiveJSONKey = regexp.MustCompile(`(?i)(^|[_-])(api[_-]?key|api[_-]?secret|secret[_-]?key|secret|access[_-]?token|auth[_-]?token|private[_-]?key|database[_-]?url|db[_-]?password|db[_-]?url|redis[_-]?url|password|token|jwt)($|[_-])`)
+
+const redactedCredential = "[REDACTED CREDENTIAL]"
+
+// InputMap returns a copy of m with all string values passed through Text and
+// any nested custom_env object replaced by coarse metadata. Non-string values
+// are preserved unless they are nested inside a secret-bearing key.
 func InputMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil
 	}
-	out := make(map[string]any, len(m))
-	for k, v := range m {
-		if s, ok := v.(string); ok {
-			out[k] = Text(s)
-		} else {
-			out[k] = v
-		}
+	redacted, _ := redactJSONMap(m)
+	if out, ok := redacted.(map[string]any); ok {
+		return out
 	}
-	return out
+	return map[string]any{}
 }
 
 // homeDir is resolved once at init for path redaction.
@@ -83,6 +87,11 @@ func init() {
 // matches with safe placeholders. It also masks the local user's home
 // directory path to prevent leaking the username.
 func Text(s string) string {
+	s = redactStructuredJSON(s)
+	return redactPlainText(s)
+}
+
+func redactPlainText(s string) string {
 	for _, p := range patterns {
 		s = p.re.ReplaceAllString(s, p.replacement)
 	}
@@ -94,4 +103,95 @@ func Text(s string) string {
 	}
 
 	return s
+}
+
+func redactStructuredJSON(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return s
+	}
+
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	dec.UseNumber()
+
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return s
+	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return s
+	}
+
+	redacted, changed := redactJSONValue(value)
+	if !changed {
+		return s
+	}
+	out, err := json.Marshal(redacted)
+	if err != nil {
+		return s
+	}
+	return string(out)
+}
+
+func redactJSONValue(value any) (any, bool) {
+	switch v := value.(type) {
+	case map[string]any:
+		return redactJSONMap(v)
+	case []any:
+		out := make([]any, len(v))
+		changed := false
+		for i, item := range v {
+			redacted, itemChanged := redactJSONValue(item)
+			out[i] = redacted
+			changed = changed || itemChanged
+		}
+		return out, changed
+	case string:
+		redacted := redactPlainText(v)
+		return redacted, redacted != v
+	default:
+		return value, false
+	}
+}
+
+func redactJSONMap(m map[string]any) (any, bool) {
+	out := make(map[string]any, len(m))
+	changed := false
+	customEnvSeen := false
+	customEnvKeyCount := 0
+
+	for k, v := range m {
+		if strings.EqualFold(k, "custom_env") {
+			customEnvSeen = true
+			customEnvKeyCount = countObjectKeys(v)
+			changed = true
+			continue
+		}
+
+		if sensitiveJSONKey.MatchString(k) {
+			out[k] = redactedCredential
+			changed = true
+			continue
+		}
+
+		redacted, valueChanged := redactJSONValue(v)
+		out[k] = redacted
+		changed = changed || valueChanged
+	}
+
+	if customEnvSeen {
+		out["has_custom_env"] = customEnvKeyCount > 0
+		out["custom_env_key_count"] = customEnvKeyCount
+		out["custom_env_redacted"] = true
+	}
+
+	return out, changed
+}
+
+func countObjectKeys(value any) int {
+	if m, ok := value.(map[string]any); ok {
+		return len(m)
+	}
+	return 0
 }

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -162,6 +162,7 @@ func TestRedactPasswordEnvVar(t *testing.T) {
 		{"PASSWORD", "PASSWORD=hunter2"},
 		{"SECRET", "SECRET=mysecretvalue"},
 		{"TOKEN", "TOKEN=abc123xyz"},
+		{"JWT", "AUTH_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signaturepart"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -212,5 +213,81 @@ func TestRedactMultipleSecrets(t *testing.T) {
 	}
 	if strings.Contains(got, "ghp_") {
 		t.Fatal("GitHub token not redacted in multi-secret text")
+	}
+}
+
+func TestRedactAgentListJSONCustomEnv(t *testing.T) {
+	t.Parallel()
+	input := `[
+		{
+			"id": "agent-1",
+			"name": "Router",
+			"status": "online",
+			"runtime_mode": "cloud",
+			"skills": [{"id": "skill-1", "name": "route"}],
+			"custom_env": {
+				"SECOND_BRAIN_TOKEN": "token-value-123",
+				"SEARCH_API_KEY": "key-value-456",
+				"DB_PASSWORD": "password-value-789",
+				"SESSION_JWT": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			},
+			"custom_env_redacted": false
+		}
+	]`
+	got := Text(input)
+	for _, leak := range []string{
+		"SECOND_BRAIN_TOKEN",
+		"SEARCH_API_KEY",
+		"DB_PASSWORD",
+		"SESSION_JWT",
+		"token-value-123",
+		"key-value-456",
+		"password-value-789",
+		"eyJhbGci",
+	} {
+		if strings.Contains(got, leak) {
+			t.Fatalf("custom_env leak %q in redacted JSON: %s", leak, got)
+		}
+	}
+	for _, kept := range []string{`"id":"agent-1"`, `"name":"Router"`, `"status":"online"`, `"runtime_mode":"cloud"`, `"skills"`} {
+		if !strings.Contains(got, kept) {
+			t.Fatalf("routing metadata %q missing from redacted JSON: %s", kept, got)
+		}
+	}
+	if !strings.Contains(got, `"custom_env_redacted":true`) {
+		t.Fatalf("expected custom_env_redacted=true, got: %s", got)
+	}
+	if !strings.Contains(got, `"custom_env_key_count":4`) {
+		t.Fatalf("expected custom_env_key_count=4, got: %s", got)
+	}
+}
+
+func TestInputMapRedactsNestedCustomEnv(t *testing.T) {
+	t.Parallel()
+	got := InputMap(map[string]any{
+		"command": "multica agent list --output json",
+		"payload": map[string]any{
+			"custom_env": map[string]any{
+				"API_TOKEN": "token-value",
+				"API_KEY":   "key-value",
+			},
+			"name": "Router",
+		},
+	})
+	payload, ok := got["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload should remain an object, got %#v", got["payload"])
+	}
+	if _, ok := payload["custom_env"]; ok {
+		t.Fatalf("custom_env should be removed from nested payload: %#v", payload)
+	}
+	if payload["custom_env_redacted"] != true {
+		t.Fatalf("expected custom_env_redacted=true, got %#v", payload)
+	}
+	if payload["custom_env_key_count"] != 2 {
+		t.Fatalf("expected custom_env_key_count=2, got %#v", payload)
+	}
+	if payload["name"] != "Router" {
+		t.Fatalf("non-sensitive metadata changed: %#v", payload)
 	}
 }


### PR DESCRIPTION
## Summary
- redact agent custom_env values from agent list/get and historical task-message readback
- preserve routing metadata while exposing only custom_env coarse metadata
- make the DB-backed historical readback regression execute by updating handler test schema setup

## Verification
- go test ./pkg/redact -count=1
- go test ./internal/handler -run 'Test(GetAgent_ResponseHasNoCustomEnv|ListAgents_ResponseHasNoCustomEnv|ListTaskMessagesByUser_RedactsHistoricalAgentCustomEnv|ListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest)' -count=1 -v
- pnpm --dir packages/views exec vitest run common/task-transcript/redact.test.ts common/task-transcript/build-timeline.test.ts
- pnpm --dir packages/views typecheck
- git diff --check