### PR TITLE
feat(agent): add Claude Opus 4.8 to model catalog & pricing

### DIFF
--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -158,6 +158,7 @@ const MODEL_PRICING: Record<
   "claude-opus-4-5":    { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
   "claude-opus-4-6":    { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
   "claude-opus-4-7":    { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
+  "claude-opus-4-8":    { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
 
   // -- Anthropic: pre-4.5 Opus (legacy, still served at original price tier) --
   "claude-opus-4-1":    { input: 15,   output: 75,   cacheRead: 1.50, cacheWrite: 18.75 },

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -197,6 +197,7 @@ func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
 func claudeStaticModels() []Model {
 	return []Model{
 		{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Provider: "anthropic", Default: true},
+		{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Provider: "anthropic"},
 		{ID: "claude-opus-4-7", Label: "Claude Opus 4.7", Provider: "anthropic"},
 		{ID: "claude-haiku-4-5-20251001", Label: "Claude Haiku 4.5", Provider: "anthropic"},
 		{ID: "claude-opus-4-6", Label: "Claude Opus 4.6", Provider: "anthropic"},

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -102,6 +102,7 @@ var claudeEffortLabel = map[string]string{
 var claudeModelEffortAllow = map[string]map[string]bool{
 	// Opus is the only model that publicly supports xhigh; the help
 	// list still includes it for Sonnet / Haiku so we filter here.
+	"claude-opus-4-8":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-opus-4-7":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-opus-4-6":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-sonnet-4-6":         {"low": true, "medium": true, "high": true, "max": true},


### PR DESCRIPTION
## Summary

Claude Code now supports **Claude Opus 4.8** (`claude-opus-4-8`). This adds it to the three places in the repo that enumerate Claude models, so the model picker, thinking-level catalog, and usage cost estimates all recognize the new model.

- `server/pkg/agent/models.go` — `claudeStaticModels()`: list **Claude Opus 4.8** as the newest Opus (Sonnet 4.6 remains the default pick).
- `server/pkg/agent/thinking.go` — `claudeModelEffortAllow`: Opus supports the full `low..max` effort set including `xhigh`.
- `packages/views/runtimes/utils.ts` — `MODEL_PRICING`: `claude-opus-4-8` at the current-gen Opus tier: **$5** input / **$25** output, **$0.50** cache read, **$6.25** 5m cache write per MTok.

Pricing was confirmed against Anthropic's official table (the `Next Opus` row is priced identically to Opus 4.5/4.6/4.7): https://platform.claude.com/docs/en/about-claude/pricing

> Note: Copilot's static fallback list (`copilotStaticModels()`) is intentionally left untouched — that catalog is discovered live from the user's GitHub account, and the static list is only a safety net.

## Testing

- `go test ./pkg/agent/` (catalog + thinking-level tests) — pass
- `pnpm --filter @multica/views exec vitest run runtimes/utils.test.ts` — 51/51 pass

Relates to MUL-2797.