### PR TITLE
fix(runtimes): consolidate out-of-band (WSL2) local daemon under LOCAL (MUL-2799)

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -15,7 +15,7 @@ import {
   type StatsListener,
 } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, hostname } from "os";
 import type { DaemonStatus, DaemonPrefs } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
 import { decideVersionAction } from "./version-decision";
@@ -864,6 +864,11 @@ export function setupDaemonManager(
   ipcMain.handle("daemon:stop", () => withGuard(() => stopDaemon()));
   ipcMain.handle("daemon:restart", () => withGuard(() => restartDaemon()));
   ipcMain.handle("daemon:get-status", () => fetchHealth());
+  // The host's OS name, available regardless of daemon state. The Runtimes
+  // page uses it as a fallback identity for "this machine" when no
+  // app-managed daemon is reporting a device name (e.g. the daemon runs
+  // out-of-band in WSL2). See desktop-runtimes-page.tsx.
+  ipcMain.handle("daemon:get-host-name", () => hostname());
   ipcMain.handle(
     "daemon:sync-token",
     (_event, token: string, userId: string) => syncToken(token, userId),

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -95,6 +95,7 @@ interface DaemonAPI {
   stop: () => Promise<{ success: boolean; error?: string }>;
   restart: () => Promise<{ success: boolean; error?: string }>;
   getStatus: () => Promise<DaemonStatus>;
+  getHostName: () => Promise<string>;
   onStatusChange: (callback: (status: DaemonStatus) => void) => () => void;
   setTargetApiUrl: (url: string) => Promise<void>;
   syncToken: (token: string, userId: string) => Promise<void>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -185,6 +185,8 @@ const daemonAPI = {
     ipcRenderer.invoke("daemon:restart"),
   getStatus: (): Promise<DaemonStatus> =>
     ipcRenderer.invoke("daemon:get-status"),
+  getHostName: (): Promise<string> =>
+    ipcRenderer.invoke("daemon:get-host-name"),
   onStatusChange: (callback: (status: DaemonStatus) => void) => {
     const handler = (_: unknown, status: DaemonStatus) => callback(status);
     ipcRenderer.on("daemon:status", handler);

--- a/apps/desktop/src/renderer/src/components/desktop-runtimes-page.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-runtimes-page.tsx
@@ -28,6 +28,11 @@ export function DesktopRuntimesPage() {
     daemonId: string | null;
     deviceName: string | null;
   }>({ daemonId: null, deviceName: null });
+  // The host's OS hostname, independent of any daemon. Used as the last
+  // fallback for the local machine name so consolidation still works when
+  // the app doesn't manage the running daemon (e.g. it lives in WSL2) and
+  // thus never reports a device name.
+  const [hostName, setHostName] = useState<string | null>(null);
 
   useEffect(() => {
     const apply = (s: DaemonStatus) => {
@@ -40,6 +45,7 @@ export function DesktopRuntimesPage() {
       }
     };
     window.daemonAPI.getStatus().then(apply);
+    window.daemonAPI.getHostName().then((name) => setHostName(name || null));
     return window.daemonAPI.onStatusChange(apply);
   }, []);
 
@@ -51,7 +57,7 @@ export function DesktopRuntimesPage() {
   return (
     <RuntimesPage
       localDaemonId={status.daemonId ?? lastIdentity.daemonId}
-      localMachineName={status.deviceName ?? lastIdentity.deviceName}
+      localMachineName={status.deviceName ?? lastIdentity.deviceName ?? hostName}
       localMachineActions={<DaemonRuntimeActions />}
       // Desktop owns a local machine for the lifetime of the app, even
       // while the daemon is stopped or hasn't registered yet. The shared

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -37,7 +37,7 @@
     "section_local": "Local",
     "section_remote": "Remote",
     "section_cloud": "Cloud",
-    "this_machine": "This Mac",
+    "this_machine": "This device",
     "local_badge": "Local · this machine",
     "runtime_count_one": "{{count}} runtime",
     "runtime_count_other": "{{count}} runtimes",

--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -170,6 +170,7 @@ describe("runtime machine grouping", () => {
         now: NOW,
         localDaemonId: "daemon-uuid",
         localMachineName: "my laptop",
+        currentUserId: "user-1",
         ensureLocalMachine: true,
       },
     );
@@ -199,6 +200,7 @@ describe("runtime machine grouping", () => {
         now: NOW,
         localDaemonId: "daemon-uuid",
         localMachineName: "my laptop",
+        currentUserId: "user-1",
         ensureLocalMachine: true,
       },
     );
@@ -216,6 +218,69 @@ describe("runtime machine grouping", () => {
       section: "local",
       runtimes: [],
     });
+  });
+
+  it("consolidates an out-of-band local daemon (WSL2) by host name and suppresses the placeholder", () => {
+    // The desktop doesn't manage this daemon (it runs in WSL2), so
+    // localDaemonId never matches. localMachineName falls back to the OS
+    // hostname, and the runtime is owned by the viewing user — so it must
+    // consolidate into the local section, and no empty placeholder appears.
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-wsl2",
+          daemon_id: "wsl2-daemon-uuid",
+          name: "Claude (KIKI-PC)",
+          device_info: "KIKI-PC · claude 1.0.0",
+          owner_id: "user-1",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "desktop-daemon-uuid",
+        localMachineName: "KIKI-PC",
+        currentUserId: "user-1",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      title: "KIKI-PC",
+      section: "local",
+      isCurrent: true,
+      daemonId: "wsl2-daemon-uuid",
+    });
+  });
+
+  it("does not claim another user's identically-named machine as current", () => {
+    // Same host name, but the runtime belongs to a different user. Device-name
+    // consolidation must NOT fire, so it stays remote and the placeholder for
+    // this machine is still synthesized.
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-other",
+          daemon_id: "other-daemon-uuid",
+          name: "Claude (KIKI-PC)",
+          device_info: "KIKI-PC · claude 1.0.0",
+          owner_id: "user-2",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: "desktop-daemon-uuid",
+        localMachineName: "KIKI-PC",
+        currentUserId: "user-1",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(2);
+    const other = machines.find((m) => m.id === "local:other-daemon-uuid");
+    expect(other).toMatchObject({ section: "remote", isCurrent: false });
+    const local = machines.find((m) => m.isCurrent);
+    expect(local).toMatchObject({ section: "local", runtimes: [] });
   });
 
   it("keeps cloud runtimes as cloud workers when they have no daemon", () => {

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -34,6 +34,14 @@ interface RuntimeMachineOptions {
   now: number;
   localDaemonId?: string | null;
   localMachineName?: string | null;
+  /**
+   * The viewing user's id. Used to scope the device-name consolidation
+   * below: the runtime list is workspace-wide (every member's runtimes),
+   * so matching purely on a host name could promote another member's
+   * identically-named machine to "this machine". Only a local runtime
+   * OWNED by the current user may be consolidated by device name.
+   */
+  currentUserId?: string | null;
   workloadByRuntimeId?: Map<string, RuntimeWorkloadSummary>;
   /**
    * When true, guarantee that the result contains a machine flagged
@@ -173,16 +181,21 @@ function finalizeRuntimeMachine(
   );
   const first = runtimes[0];
   const providerNames = Array.from(new Set(runtimes.map((r) => r.provider))).sort();
+  // Device-name consolidation is only safe for the current user's own
+  // local runtimes — the list spans the whole workspace, so a host-name
+  // match alone could claim another member's identically-named machine.
+  const ownsLocalRuntime =
+    !!options.currentUserId &&
+    runtimes.some((r) => r.owner_id === options.currentUserId);
+  const matchesLocalName = (value: string | null | undefined): boolean =>
+    !!value && value.toLowerCase() === options.localMachineName?.toLowerCase();
   const isCurrent =
     (!!options.localDaemonId && draft.daemonId === options.localDaemonId) ||
     (draft.mode === "local" &&
       !!options.localMachineName &&
-      (draft.daemonId?.toLowerCase() === options.localMachineName.toLowerCase() ||
-        runtimes.some(
-          (r) =>
-            runtimeDeviceName(r)?.toLowerCase() ===
-            options.localMachineName?.toLowerCase(),
-        )));
+      ownsLocalRuntime &&
+      (matchesLocalName(draft.daemonId) ||
+        runtimes.some((r) => matchesLocalName(runtimeDeviceName(r)))));
   const title = machineTitle(runtimes, {
     isCurrent,
     localMachineName: options.localMachineName,

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -90,6 +90,7 @@ export function RuntimesPage({
   cloudRuntimeEnabled = false,
 }: RuntimesPageProps = {}) {
   const isLoading = useAuthStore((s) => s.isLoading);
+  const currentUserId = useAuthStore((s) => s.user?.id);
   const wsId = useWorkspaceId();
   const qc = useQueryClient();
   const [machineFilter, setMachineFilter] =
@@ -138,6 +139,7 @@ export function RuntimesPage({
         now,
         localDaemonId,
         localMachineName,
+        currentUserId,
         workloadByRuntimeId: workloadIndex,
         ensureLocalMachine: hasLocalMachine,
       }),
@@ -146,6 +148,7 @@ export function RuntimesPage({
       now,
       localDaemonId,
       localMachineName,
+      currentUserId,
       workloadIndex,
       hasLocalMachine,
     ],


### PR DESCRIPTION
## Summary

Fixes #3473 (MUL-2799). On a Windows host with the daemon running out-of-band in WSL2, the Runtimes page showed an empty `LOCAL → This machine · Offline · 0 runtimes` placeholder while the real local runtimes were misclassified under `REMOTE`. The #3336 device-name consolidation never fired in this configuration.

**Root cause:** the desktop derived `localMachineName` / `localDaemonId` *only* from the daemon it manages itself (`window.daemonAPI.getStatus()` → the bundled daemon's `/health`). When the real daemon runs out-of-band (WSL2), the app never learns a device name, so the `#3336` branch in `finalizeRuntimeMachine` short-circuits on `!!localMachineName`: the `runtime_mode: local` runtime falls into the `remote` section and `ensureLocalMachine` synthesizes the empty placeholder. The matching `KIKI-PC` hostnames were never compared because the desktop never read the host OS hostname.

## Changes

**1. Host-identity fallback (desktop)** — the app now always knows its own OS hostname, independent of daemon state.
- `daemon-manager.ts`: new `daemon:get-host-name` IPC returning `os.hostname()`.
- `preload/index.ts` (+ `.d.ts`): `daemonAPI.getHostName()`.
- `desktop-runtimes-page.tsx`: `localMachineName = status.deviceName ?? lastIdentity.deviceName ?? hostName` (daemon-reported name still preferred).

**2. Owner-scoped consolidation (shared, core fix)** — the runtime list is workspace-wide (every member's runtimes), so a host-name match alone could claim another member's identically-named machine as "this machine".
- `runtime-machines.ts`: added `currentUserId` to options; the device-name branch of `isCurrent` now also requires the machine to have a local runtime owned by the current user (`owner_id === currentUserId`).
- `runtimes-page.tsx`: passes `currentUserId` from `useAuthStore`.

Once the real runtime classifies as current it moves into `LOCAL`, and the empty placeholder is no longer synthesized (`buildRuntimeMachines` only adds it when no machine `isCurrent`).

**3. Cosmetic label fix** (separate commit) — the current-machine badge was hard-coded to `"This Mac"` (en) and rendered incorrectly on Windows/Linux; changed to OS-neutral `"This device"` (zh-Hans already used `本机`).

## Notes / boundaries

- **Hostname-match boundary:** consolidation requires the Windows `os.hostname()` to equal the WSL2 daemon's reported device name (true in #3473: both `KIKI-PC`). If they differ, the runtime stays under REMOTE — the inherent limit of host-name heuristics.
- **Fail-safe degradation:** if `owner_id` is null (older backend) or `currentUserId` is unavailable, the device-name branch simply doesn't fire — no false merge, falls back to current behavior. Consistent with the repo's API-compatibility rules.

## Testing

- `pnpm --filter @multica/views exec vitest run runtimes/components/runtime-machines.test.ts` — 12 passed. Added a WSL2-consolidation case and a cross-user safety case (same hostname, different `owner_id` → stays remote, placeholder kept); updated the two existing #3336 tests to pass `currentUserId`.
- `pnpm --filter @multica/views typecheck` and `pnpm --filter @multica/desktop typecheck` — clean.
- `pnpm --filter @multica/views lint` and `pnpm --filter @multica/desktop lint` — 0 errors.
