### PR TITLE
fix(board): live cross-column preview for non-manual kanban drag

### DIFF
--- a/packages/views/issues/components/board-view.test.tsx
+++ b/packages/views/issues/components/board-view.test.tsx
@@ -63,17 +63,21 @@ vi.mock("@multica/core/issues/mutations", () => ({
   useLoadMoreByAssigneeGroup: () => useLoadMoreByStatusMock(),
 }));
 
-// Capture the drag handlers so tests can drive drag-end directly.
+// Capture the drag handlers so tests can drive drag-over / drag-end directly.
 let lastOnDragEnd: ((event: unknown) => void) | null = null;
+let lastOnDragOver: ((event: unknown) => void) | null = null;
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({
     children,
     onDragEnd,
+    onDragOver,
   }: {
     children: React.ReactNode;
     onDragEnd: (event: unknown) => void;
+    onDragOver: (event: unknown) => void;
   }) => {
     lastOnDragEnd = onDragEnd;
+    lastOnDragOver = onDragOver;
     return children;
   },
   DragOverlay: () => null,
@@ -160,6 +164,7 @@ describe("BoardView non-manual ordering", () => {
     mockViewState.sortBy = "position";
     mockViewState.sortDirection = "asc";
     lastOnDragEnd = null;
+    lastOnDragOver = null;
   });
 
   it("orders cards within a column by the active non-position sort", () => {
@@ -244,6 +249,48 @@ describe("BoardView non-manual ordering", () => {
     const inProgress = within(getByTestId("col-status:in_progress")).getAllByTestId(
       "card",
     );
+    expect(inProgress.map((c) => c.textContent)).toEqual([
+      "stay-urgent",
+      "mover",
+      "stay-low",
+    ]);
+  });
+
+  it("previews a non-manual cross-column drag in the target's sorted slot (no drop)", () => {
+    // The smoothness fix: during the drag (onDragOver, before any drop) the card
+    // must already sit in its sorted slot in the target column. Without this it
+    // stays glued to the source column and teleports on release.
+    mockViewState.sortBy = "priority";
+    const mover = makeIssue({ id: "mover", status: "todo", priority: "high" });
+    const issues = [
+      mover,
+      makeIssue({ id: "stay-urgent", status: "in_progress", priority: "urgent" }),
+      makeIssue({ id: "stay-low", status: "in_progress", priority: "low" }),
+    ];
+
+    const { getByTestId } = renderBoard(
+      <BoardView
+        issues={issues}
+        visibleStatuses={[...VISIBLE]}
+        hiddenStatuses={[]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    // Drag (not drop) "mover" over the in_progress column.
+    act(() => {
+      lastOnDragOver?.({
+        active: { id: "mover" },
+        over: { id: "status:in_progress" },
+      });
+    });
+
+    const todo = within(getByTestId("col-status:todo")).queryAllByTestId("card");
+    expect(todo.map((c) => c.textContent)).toEqual([]);
+    const inProgress = within(
+      getByTestId("col-status:in_progress"),
+    ).getAllByTestId("card");
+    // Sorted by priority: urgent, then the dragged high, then low.
     expect(inProgress.map((c) => c.textContent)).toEqual([
       "stay-urgent",
       "mover",

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -295,18 +295,40 @@ export function BoardView({
         const overCol = findColumn(prev, overId, groupIds);
         if (!activeCol || !overCol || activeCol === overCol) return prev;
 
-        if (sortBy !== "position") return prev;
-
         recentlyMovedRef.current = true;
         const oldIds = prev[activeCol]!.filter((id) => id !== activeId);
-        const newIds = [...prev[overCol]!];
-        const overIndex = newIds.indexOf(overId);
-        const insertIndex = overIndex >= 0 ? overIndex : newIds.length;
-        newIds.splice(insertIndex, 0, activeId);
-        return { ...prev, [activeCol]: oldIds, [overCol]: newIds };
+
+        if (sortBy === "position") {
+          // Manual: drop the card at the hovered slot — the user picks the order.
+          const newIds = [...prev[overCol]!];
+          const overIndex = newIds.indexOf(overId);
+          const insertIndex = overIndex >= 0 ? overIndex : newIds.length;
+          newIds.splice(insertIndex, 0, activeId);
+          return { ...prev, [activeCol]: oldIds, [overCol]: newIds };
+        }
+
+        // Non-manual: the cursor can't choose the slot — the sort does. Preview
+        // the card in the target column at its sorted slot so the live drag
+        // mirrors where the optimistic move lands. Without this the card stays
+        // glued to the source column and teleports to its sorted slot on drop.
+        // The card's sort field (priority/date/title) is unchanged by a
+        // cross-column move, so this preview slot is exactly where it settles.
+        const map = issueMapRef.current;
+        const activeIssue = map.get(activeId);
+        if (!activeIssue) return prev;
+        const targetIssues = prev[overCol]!
+          .filter((id) => id !== activeId)
+          .map((id) => map.get(id))
+          .filter((issue): issue is Issue => issue !== undefined);
+        const sortedTarget = sortIssues(
+          [...targetIssues, activeIssue],
+          sortBy,
+          sortDirection,
+        ).map((issue) => issue.id);
+        return { ...prev, [activeCol]: oldIds, [overCol]: sortedTarget };
       });
     },
-    [groupIds, sortBy],
+    [groupIds, sortBy, sortDirection],
   );
 
   const handleDragEnd = useCallback(
@@ -369,10 +391,11 @@ export function BoardView({
           resetColumns();
           return;
         }
-        // No settle gate here: the optimistic cache patch flows straight through
-        // the (now sorted) buildColumns effect, so the card lands in its correct
-        // sorted slot in the target column in one frame — no "stuck in source
-        // column then jump" lag. The settle gate is only needed for manual
+        // No settle gate here. onDragOver already previewed the card in its
+        // sorted slot in the target column, and the optimistic cache patch
+        // rebuilds the same arrangement through the (now sorted) buildColumns
+        // effect — preview and committed state agree in one frame, so there is
+        // no teleport on drop. The settle gate is only needed for manual
         // (position) reorders, which keep a hand-built local order below.
         onMoveIssue(activeId, getMoveUpdates(finalGroup, currentIssue.position));
         return;


### PR DESCRIPTION
## Problem
After #3514 added client-side sort, non-manual kanban drag (Priority / date / title) **still jumps on drop** — the card stays glued to the source column for the whole drag and teleports to its sorted slot only on release.

## Root cause
`onDragOver` bailed out for non-position sorts:

```ts
if (sortBy !== "position") return prev;
```

So the manual path got live cross-column movement (you see the card slot in as you drag) while non-manual got nothing — no live preview, the card snaps into place on drop. #3514's client-side sort fixed the *settle double-jump* but left this teleport untouched, because they're different layers: sort fixes the rebuild order, this fixes the in-drag preview.

## Fix
Make non-manual drag behave like the manual path. `onDragOver` now moves the card into the target column at its **sorted slot** during the drag:

- Manual (`position`): unchanged — drop at the hovered slot, the user picks the order.
- Non-manual: the cursor can't pick the slot (the sort does), so insert the card and re-run `sortIssues`. The card's sort field (priority/date/title) is unchanged by a cross-column move, so the preview slot is exactly where the optimistic move settles → preview and committed state agree in one frame, no teleport.

## Tests
New `board-view.test.tsx` case: a non-manual cross-column **drag-over** (no drop, no settle) already places the card in its sorted slot in the target column. All 4 board-view tests pass.

## Scope
`list-view.tsx` shares the same dnd machinery and has the same latent behavior; left untouched to keep this scoped to the board — worth a follow-up (same note as #3514).

> Stacked on #3514 (base `agent/matt/eb55cd5c`) — this fix relies on its client-side sort. GitHub will retarget to `main` once #3514 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)