### PR TITLE
feat(lark): pre-fill PersonalAgent bot name as "<agent> - Multica" (MUL-2823)

### DIFF
--- a/server/internal/integrations/lark/registration.go
+++ b/server/internal/integrations/lark/registration.go
@@ -211,7 +211,14 @@ func (e *RegistrationError) Error() string {
 // (mainland) domain. Lark may surface a Lark-international tenant on
 // the FIRST poll — we don't try to predict it here; the polling loop
 // in RegistrationService handles the domain swap.
-func (c *RegistrationClient) Begin(ctx context.Context) (*BeginResult, error) {
+//
+// namePreset pre-fills the bot/app name on Lark's "create a
+// PersonalAgent" form so the installed bot defaults to e.g.
+// "<agent> - Multica" instead of Lark's auto-generated
+// "{用户姓名}的智能助手". It is a user-editable default (the user can
+// still change it on the form), and it rides on the QR URL — not the
+// begin POST body, which has no name field. Empty omits the pre-fill.
+func (c *RegistrationClient) Begin(ctx context.Context, namePreset string) (*BeginResult, error) {
 	var resp struct {
 		DeviceCode              string `json:"device_code"`
 		VerificationURIComplete string `json:"verification_uri_complete"`
@@ -240,7 +247,7 @@ func (c *RegistrationClient) Begin(ctx context.Context) (*BeginResult, error) {
 	if resp.VerificationURIComplete == "" {
 		return nil, &RegistrationError{Code: "invalid_response", Description: "verification_uri_complete is empty"}
 	}
-	qr, err := decorateQRCodeURL(resp.VerificationURIComplete, c.cfg.Source)
+	qr, err := decorateQRCodeURL(resp.VerificationURIComplete, c.cfg.Source, namePreset)
 	if err != nil {
 		return nil, &RegistrationError{Code: "invalid_response", Description: "verification_uri_complete is not a URL: " + err.Error()}
 	}
@@ -385,7 +392,13 @@ func (c *RegistrationClient) doForm(ctx context.Context, domain string, form url
 // on the QR-image URL. Without `from=sdk&tp=sdk&source=<src>` the
 // scanner UI on the user's phone shows a less polished prompt and Lark
 // cannot attribute installs back to Multica in their analytics.
-func decorateQRCodeURL(raw, source string) (string, error) {
+//
+// namePreset, when non-empty, is appended as `name=<...>` to pre-fill
+// the bot/app name on Lark's "create a PersonalAgent" form. This
+// mirrors the upstream SDK's AppPreset.Name: Lark reads it from the
+// verification/QR URL (the begin POST body carries no name field) and
+// treats it as a user-editable default, not a locked final name.
+func decorateQRCodeURL(raw, source, namePreset string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "", err
@@ -394,6 +407,9 @@ func decorateQRCodeURL(raw, source string) (string, error) {
 	q.Set("from", "sdk")
 	q.Set("tp", "sdk")
 	q.Set("source", "go-sdk/"+source)
+	if namePreset != "" {
+		q.Set("name", namePreset)
+	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/server/internal/integrations/lark/registration_service.go
+++ b/server/internal/integrations/lark/registration_service.go
@@ -271,14 +271,19 @@ func (s *RegistrationService) BeginInstall(ctx context.Context, p BeginInstallPa
 	// by guessing the UUID, and the device_code minted against Lark
 	// would still produce credentials. The handler does the same
 	// check; doing it here too keeps the service self-defending.
-	if _, err := s.authQueries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+	//
+	// We keep the agent: its name pre-fills the bot name on Lark's
+	// PersonalAgent creation form (see botNamePreset) so the installed
+	// bot reads "<agent> - Multica" instead of "{用户姓名}的智能助手".
+	agent, err := s.authQueries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
 		ID:          p.AgentID,
 		WorkspaceID: p.WorkspaceID,
-	}); err != nil {
+	})
+	if err != nil {
 		return BeginInstallResult{}, fmt.Errorf("lark registration: agent not in workspace: %w", err)
 	}
 
-	begin, err := s.client.Begin(ctx)
+	begin, err := s.client.Begin(ctx, botNamePreset(agent.Name))
 	if err != nil {
 		return BeginInstallResult{}, fmt.Errorf("lark registration: begin: %w", err)
 	}
@@ -545,6 +550,21 @@ func uuidEqual(a, b pgtype.UUID) bool {
 		return false
 	}
 	return a.Bytes == b.Bytes
+}
+
+// botNamePreset builds the display name we pre-fill on Lark's
+// PersonalAgent creation form so the installed bot reads
+// "<agent> - Multica" instead of Lark's auto-generated
+// "{用户姓名}的智能助手". Lark treats this as a default the installer can
+// still edit; we never get to lock the final name. A blank agent name
+// (defensive — Agent.Name is NOT NULL in schema) degrades to plain
+// "Multica" rather than a dangling " - Multica".
+func botNamePreset(agentName string) string {
+	name := strings.TrimSpace(agentName)
+	if name == "" {
+		return "Multica"
+	}
+	return name + " - Multica"
 }
 
 // uuidString is the package-local UUID-to-string helper defined in

--- a/server/internal/integrations/lark/registration_service_test.go
+++ b/server/internal/integrations/lark/registration_service_test.go
@@ -68,6 +68,24 @@ func TestRegistrationServiceConstructorValidatesDeps(t *testing.T) {
 	}
 }
 
+// TestBotNamePreset pins the bot-name pre-fill format that rides on the
+// QR URL: "<agent> - Multica", with a blank agent name degrading to
+// plain "Multica" rather than a dangling " - Multica".
+func TestBotNamePreset(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Ada", "Ada - Multica"},
+		{"  Ada  ", "Ada - Multica"},
+		{"产品助手", "产品助手 - Multica"},
+		{"", "Multica"},
+		{"   ", "Multica"},
+	}
+	for _, tc := range cases {
+		if got := botNamePreset(tc.in); got != tc.want {
+			t.Errorf("botNamePreset(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestRegistrationGetSessionNotFound pins both halves of the
 // not-found path: unknown session id, and (the security-critical one)
 // known session id but from a different workspace. Both must surface

--- a/server/internal/integrations/lark/registration_test.go
+++ b/server/internal/integrations/lark/registration_test.go
@@ -81,7 +81,7 @@ func TestRegistrationClient_Begin_HappyPath(t *testing.T) {
 	})
 
 	c := NewRegistrationClient(RegistrationConfig{Domain: fake.URL()})
-	res, err := c.Begin(context.Background())
+	res, err := c.Begin(context.Background(), "Ada - Multica")
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -113,6 +113,37 @@ func TestRegistrationClient_Begin_HappyPath(t *testing.T) {
 	if !strings.HasPrefix(q.Get("source"), "go-sdk/multica") {
 		t.Errorf("qr source=%q want go-sdk/multica", q.Get("source"))
 	}
+	// The name preset pre-fills the Lark PersonalAgent creation form so
+	// the bot defaults to "<agent> - Multica" rather than the
+	// auto-generated "{用户姓名}的智能助手".
+	if q.Get("name") != "Ada - Multica" {
+		t.Errorf("qr name=%q want %q", q.Get("name"), "Ada - Multica")
+	}
+}
+
+// TestRegistrationClient_Begin_OmitsNameWhenPresetEmpty pins that an
+// empty preset leaves the `name` param off the QR URL entirely (rather
+// than emitting name= and pre-filling a blank), so the begin path is
+// unchanged when no preset is supplied.
+func TestRegistrationClient_Begin_OmitsNameWhenPresetEmpty(t *testing.T) {
+	fake := newRegistrationFake(t)
+	fake.stubBegin(map[string]any{
+		"device_code":               "dc_noname",
+		"verification_uri_complete": "https://accounts.feishu.cn/oauth/v1/qrcode?code=abc",
+	})
+
+	c := NewRegistrationClient(RegistrationConfig{Domain: fake.URL()})
+	res, err := c.Begin(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	u, err := url.Parse(res.QRCodeURL)
+	if err != nil {
+		t.Fatalf("QRCodeURL: %v", err)
+	}
+	if _, ok := u.Query()["name"]; ok {
+		t.Errorf("qr URL should omit name when preset empty, got %q", res.QRCodeURL)
+	}
 }
 
 func TestRegistrationClient_Begin_DefaultsWhenServerOmitsTimers(t *testing.T) {
@@ -128,7 +159,7 @@ func TestRegistrationClient_Begin_DefaultsWhenServerOmitsTimers(t *testing.T) {
 	})
 
 	c := NewRegistrationClient(RegistrationConfig{Domain: fake.URL()})
-	res, err := c.Begin(context.Background())
+	res, err := c.Begin(context.Background(), "")
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -147,7 +178,7 @@ func TestRegistrationClient_Begin_LarkError(t *testing.T) {
 		"error_description": "missing archetype",
 	})
 	c := NewRegistrationClient(RegistrationConfig{Domain: fake.URL()})
-	_, err := c.Begin(context.Background())
+	_, err := c.Begin(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error from Lark error response")
 	}
@@ -167,7 +198,7 @@ func TestRegistrationClient_Begin_HTTPNon2xx(t *testing.T) {
 		_, _ = w.Write([]byte("server boom"))
 	})
 	c := NewRegistrationClient(RegistrationConfig{Domain: fake.URL()})
-	_, err := c.Begin(context.Background())
+	_, err := c.Begin(context.Background(), "")
 	if err == nil {
 		t.Fatal("want error on 500")
 	}


### PR DESCRIPTION
Stacked on #3277 (base = `feat/lark-bot-mvp-migration-and-service-boundary`) so the diff is just the pre-fill. Implements the spike conclusion from MUL-2823.

## What
After the PersonalAgent device-flow install, the bot kept Lark's auto-generated name **「{用户姓名}的智能助手」**. This pre-fills the bot name on Lark's "create a PersonalAgent" form so it defaults to **`<agent> - Multica`** instead.

Mechanism: Lark's registration scene reads an optional `name` query param off the **verification/QR URL** (this mirrors the upstream `oapi-sdk-go` `AppPreset.Name`). The `begin` POST body has no name field, so the name rides on the QR URL via `decorateQRCodeURL`.

## Changes
- `RegistrationClient.Begin(ctx, namePreset)` — new `namePreset` arg; empty omits the param.
- `decorateQRCodeURL(...)` — appends `name=<preset>` when non-empty.
- `BeginInstall` — already loads the agent for its ownership check; now keeps it and passes `botNamePreset(agent.Name)`.
- `botNamePreset` — builds `"<agent> - Multica"`; blank name degrades to `"Multica"`.

## Important caveats
- **User-editable default, not a locked name.** Lark shows this as the default on the creation form; the installer can still change it. There is no way to force the final name.
- **Undocumented on open.feishu.cn** — the `name` pre-fill is SDK-sourced (only in `oapi-sdk-go/-java/-python` source, not the public docs). **It should be verified against one live PersonalAgent registration** before we rely on it: confirm (a) Lark honors `name`, (b) the created bot keeps it rather than falling back to「…的智能助手」, (c) any length/char limits.
- **No post-install rename path exists** (`bot/v3` is read-only; no `bot/v3/update`; `application/v6` PATCH has no name field), so install-time pre-fill is the only programmatic lever.

## Testing
- `go build ./...`, `go vet ./internal/integrations/lark/...` clean.
- `go test ./internal/integrations/lark/` passes, incl. new `TestRegistrationClient_Begin_OmitsNameWhenPresetEmpty` (param omitted when blank), a `name`-param assertion in the happy-path test, and `TestBotNamePreset` (format + blank degradation).
- gofmt: only pre-existing struct-alignment nits on the base branch remain; this diff is gofmt-clean.

Not folded into #3277 to keep that PR's review scope intact (MUL-2823 explicitly kept the rename out of the smoke fix). Happy to squash it into #3277 instead if you'd prefer.
