### PR TITLE
MUL-2785: surface other comment activity

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2489,6 +2489,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		IssueID:                          task.IssueID,
 		TriggerCommentID:                 task.TriggerCommentID,
 		NewCommentCount:                  task.NewCommentCount,
+		OtherNewCommentCount:             task.OtherNewCommentCount,
 		NewCommentsSince:                 task.NewCommentsSince,
 		PriorSessionResumed:              task.PriorSessionID != "",
 		AgentID:                          agentID,

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -60,6 +60,7 @@ type TaskContextForEnv struct {
 	IssueID                 string
 	TriggerCommentID        string // comment that triggered this task (empty for on_assign)
 	NewCommentCount         int    // non-injected comments in the trigger thread since this agent's last run (excludes its own)
+	OtherNewCommentCount    int    // non-agent comments outside the trigger thread since this agent's last run; awareness only
 	NewCommentsSince        string // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	PriorSessionResumed     bool   // true when the daemon will resume an existing provider session for this task
 	AgentID                 string // unique ID of the dispatched agent

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -5,29 +5,43 @@ import "fmt"
 // BuildNewCommentsHint returns the comment-reading pointer for the WARM path —
 // the agent ran on this issue before, so there is a since-anchor. The server
 // count is scoped to the triggering thread and excludes the triggering comment
-// itself because that body is already injected into the prompt. It ships only
-// the COUNT and the cursor — never the comment bodies — so the server stays
-// cheap and the agent pulls details on demand.
+// itself because that body is already injected into the prompt. The separate
+// other-thread count keeps cross-thread activity visible without making it part
+// of the default read path. It ships only counts and cursors — never comment
+// bodies — so the server stays cheap and the agent pulls details on demand.
 //
 // Both the per-turn prompt (daemon.buildCommentPrompt) and the CLAUDE.md
 // workflow (InjectRuntimeConfig) call this so the two surfaces cannot drift
 // (hard requirement from PR #2816).
 //
-// Renders nothing on cold start (no prior run → newCommentsSince empty) or when
-// there are no additional thread comments (newCommentCount <= 0) or required
-// IDs are empty. In those cases the caller falls back to BuildResumedCommentsHint
-// (when a prior session is active) or BuildColdCommentsHint.
-func BuildNewCommentsHint(issueID, triggerCommentID, newCommentsSince string, newCommentCount int) string {
-	if newCommentCount <= 0 || newCommentsSince == "" || issueID == "" || triggerCommentID == "" {
+// Renders nothing on cold start (no prior run → newCommentsSince empty), when
+// no relevant counts are positive, or when required IDs are empty. In those
+// cases the caller falls back to BuildResumedCommentsHint (when a prior session
+// is active) or BuildColdCommentsHint.
+func BuildNewCommentsHint(issueID, triggerCommentID, newCommentsSince string, newCommentCount, otherNewCommentCount int) string {
+	if (newCommentCount <= 0 && otherNewCommentCount <= 0) || newCommentsSince == "" || issueID == "" || triggerCommentID == "" {
 		return ""
 	}
-	hint := fmt.Sprintf(
-		"%d other new comment(s) in this thread since your last run. "+
-			"The triggering comment is already included above. "+
-			"To inspect the raw thread delta (which may include the injected trigger and agent-authored rows), run: "+
-			"`multica issue comment list %s --thread %s --since %s --output json`.\n\n",
-		newCommentCount, issueID, triggerCommentID, newCommentsSince,
-	)
+	hint := "The triggering comment is already included above. "
+	if newCommentCount > 0 {
+		hint += fmt.Sprintf(
+			"%d other new comment(s) in this thread since your last run. "+
+				"To inspect the raw thread delta (which may include the injected trigger and agent-authored rows), run: "+
+				"`multica issue comment list %s --thread %s --since %s --output json`.\n\n",
+			newCommentCount, issueID, triggerCommentID, newCommentsSince,
+		)
+	} else {
+		hint += "No additional comments in this thread since your last run beyond the triggering comment.\n\n"
+	}
+	if otherNewCommentCount > 0 {
+		hint += fmt.Sprintf(
+			"%d new comment(s) outside this thread since your last run. "+
+				"Treat this as awareness, not required reading. "+
+				"If the triggering request depends on broader discussion, inspect recent issue activity: "+
+				"`multica issue comment list %s --recent 20 --since %s --output json`.\n\n",
+			otherNewCommentCount, issueID, newCommentsSince,
+		)
+	}
 	// --thread + --since is still only a delta: it covers new rows in the
 	// triggering thread, not older pre-anchor context. Keep a bounded fallback
 	// when the older conversation context is missing.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -574,7 +574,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("**This task was triggered by a NEW comment.** Your primary job is to respond to THIS specific comment, even if you have handled similar requests before in this session.\n\n")
 		fmt.Fprintf(&b, "1. Run `multica issue get %s --output json` to understand the issue context\n", ctx.IssueID)
 		fmt.Fprintf(&b, "2. Run `multica issue metadata list %s --output json` to see what prior agents pinned — best-effort, empty `{}` and CLI failures are normal. See the `## Issue Metadata` section above for what to look for.\n", ctx.IssueID)
-		if hint := BuildNewCommentsHint(ctx.IssueID, ctx.TriggerCommentID, ctx.NewCommentsSince, ctx.NewCommentCount); hint != "" {
+		if hint := BuildNewCommentsHint(ctx.IssueID, ctx.TriggerCommentID, ctx.NewCommentsSince, ctx.NewCommentCount, ctx.OtherNewCommentCount); hint != "" {
 			b.WriteString("3. " + hint)
 		} else if ctx.PriorSessionResumed {
 			b.WriteString("3. " + BuildResumedCommentsHint(ctx.IssueID, ctx.TriggerCommentID))

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -166,10 +166,11 @@ func TestCommentTriggeredBriefCarriesNewCommentsHint(t *testing.T) {
 		since   = "2026-05-28T11:00:00Z"
 	)
 	ctx := TaskContextForEnv{
-		IssueID:          issueID,
-		TriggerCommentID: "reply-abc",
-		NewCommentCount:  4,
-		NewCommentsSince: since,
+		IssueID:              issueID,
+		TriggerCommentID:     "reply-abc",
+		NewCommentCount:      4,
+		OtherNewCommentCount: 3,
+		NewCommentsSince:     since,
 	}
 	out := buildMetaSkillContent("claude", ctx)
 
@@ -181,6 +182,15 @@ func TestCommentTriggeredBriefCarriesNewCommentsHint(t *testing.T) {
 	}
 	if !strings.Contains(out, "raw thread delta") {
 		t.Errorf("comment brief must not imply the CLI output exactly matches the count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "3 new comment(s) outside this thread since your last run") {
+		t.Errorf("comment brief must surface cross-thread awareness separately, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Treat this as awareness, not required reading") {
+		t.Errorf("comment brief cross-thread hint must not turn into mandatory reading, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--recent 20 --since "+since+" --output json") {
+		t.Errorf("comment brief must provide an optional recent activity read, got:\n%s", out)
 	}
 	if strings.Contains(out, "resumed session is missing older thread context") {
 		t.Errorf("comment brief warm fallback wording must not assume a resumed session, got:\n%s", out)

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -164,7 +164,7 @@ func buildCommentPrompt(task Task, provider string) string {
 	// comments: the trigger is already injected, so don't force a duplicate
 	// thread read. Cold path: read the triggering thread, not the flat timeline.
 	// Final fallback (no trigger id, shouldn't happen here): plain read.
-	if hint := execenv.BuildNewCommentsHint(task.IssueID, task.TriggerCommentID, task.NewCommentsSince, task.NewCommentCount); hint != "" {
+	if hint := execenv.BuildNewCommentsHint(task.IssueID, task.TriggerCommentID, task.NewCommentsSince, task.NewCommentCount, task.OtherNewCommentCount); hint != "" {
 		b.WriteString(hint)
 	} else if task.PriorSessionID != "" {
 		b.WriteString(execenv.BuildResumedCommentsHint(task.IssueID, task.TriggerCommentID))

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -312,6 +312,7 @@ func TestBuildPromptNewCommentsHint(t *testing.T) {
 		TriggerCommentContent: "please look",
 		TriggerAuthorType:     "member",
 		NewCommentCount:       3,
+		OtherNewCommentCount:  2,
 		NewCommentsSince:      since,
 	}
 	out := BuildPrompt(task, "claude")
@@ -325,6 +326,15 @@ func TestBuildPromptNewCommentsHint(t *testing.T) {
 	if !strings.Contains(out, "raw thread delta") {
 		t.Errorf("hint must not imply the CLI output exactly matches the count, got:\n%s", out)
 	}
+	if !strings.Contains(out, "2 new comment(s) outside this thread since your last run") {
+		t.Errorf("hint must surface cross-thread awareness separately, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Treat this as awareness, not required reading") {
+		t.Errorf("cross-thread hint must not turn into mandatory reading, got:\n%s", out)
+	}
+	if !strings.Contains(out, "multica issue comment list "+issueID+" --recent 20 --since "+since+" --output json") {
+		t.Errorf("cross-thread hint must provide an optional recent activity read, got:\n%s", out)
+	}
 	if strings.Contains(out, "resumed session is missing older thread context") {
 		t.Errorf("warm delta fallback wording must not assume a resumed session, got:\n%s", out)
 	}
@@ -336,6 +346,33 @@ func TestBuildPromptNewCommentsHint(t *testing.T) {
 	// The old cursor-heavy paragraph must be gone.
 	if strings.Contains(out, "Next reply cursor") || strings.Contains(out, "--before-id") {
 		t.Errorf("the old cursor-pagination paragraph must not render, got:\n%s", out)
+	}
+}
+
+func TestBuildPromptOtherNewCommentsHintWithoutThreadDelta(t *testing.T) {
+	const (
+		issueID = "issue-other-1"
+		since   = "2026-05-28T11:00:00Z"
+	)
+	task := Task{
+		IssueID:               issueID,
+		TriggerCommentID:      "trigger-1",
+		TriggerCommentContent: "please look",
+		TriggerAuthorType:     "member",
+		NewCommentCount:       0,
+		OtherNewCommentCount:  5,
+		NewCommentsSince:      since,
+	}
+	out := BuildPrompt(task, "claude")
+
+	if !strings.Contains(out, "No additional comments in this thread since your last run beyond the triggering comment") {
+		t.Errorf("other-only hint must clarify the triggering thread has no extra delta, got:\n%s", out)
+	}
+	if !strings.Contains(out, "5 new comment(s) outside this thread since your last run") {
+		t.Errorf("other-only hint must preserve cross-thread awareness, got:\n%s", out)
+	}
+	if strings.Contains(out, "--thread trigger-1 --since "+since) {
+		t.Errorf("other-only hint must not invent a thread delta read, got:\n%s", out)
 	}
 }
 

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -56,6 +56,7 @@ type Task struct {
 	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind for the triggering comment
 	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
 	NewCommentCount         int                   `json:"new_comment_count,omitempty"`         // non-injected comments in the trigger thread since this agent's last run (excludes its own); 0/omitted for old daemons or cold start
+	OtherNewCommentCount    int                   `json:"other_new_comment_count,omitempty"`   // non-agent comments outside the trigger thread since this agent's last run; awareness only
 	NewCommentsSince        string                `json:"new_comments_since,omitempty"`        // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
 	ChatMessage             string                `json:"chat_message,omitempty"`              // user message content for chat tasks

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -204,6 +204,7 @@ type AgentTaskResponse struct {
 	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
 	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
 	NewCommentCount         int                   `json:"new_comment_count,omitempty"`         // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
+	OtherNewCommentCount    int                   `json:"other_new_comment_count,omitempty"`   // comments outside the trigger thread since last run; awareness only
 	NewCommentsSince        string                `json:"new_comments_since,omitempty"`        // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
 	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
 	ChatMessage             string                `json:"chat_message,omitempty"`              // user message for chat tasks

--- a/server/internal/handler/comment_list_test.go
+++ b/server/internal/handler/comment_list_test.go
@@ -1374,6 +1374,35 @@ func TestCountNewCommentsSince_ThreadScopedExcludesAgentOwnAndTrigger(t *testing
 	}
 }
 
+func TestCountOtherNewCommentsSince_ExcludesTriggerThreadAndAgentOwn(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	fx := newCommentListFixture(t)
+	agentID := createHandlerTestAgent(t, "other-count-agent", []byte("[]"))
+
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, created_at)
+		VALUES ($1, $2, 'agent', $3, 'agent reply elsewhere', 'comment', $4, $5)
+	`, fx.IssueID, testWorkspaceID, agentID, fx.Root2, fx.Base.Add(13*time.Minute)); err != nil {
+		t.Fatalf("insert agent comment: %v", err)
+	}
+
+	got, err := testHandler.Queries.CountOtherNewCommentsSince(context.Background(), db.CountOtherNewCommentsSinceParams{
+		AnchorID:    parseUUID(fx.R1b1),
+		IssueID:     parseUUID(fx.IssueID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Since:       pgtype.Timestamptz{Time: fx.Base.Add(90 * time.Second), Valid: true},
+		AuthorID:    parseUUID(agentID),
+	})
+	if err != nil {
+		t.Fatalf("count other new since anchor: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("expected root2/r2a/r2b to count and current thread + agent own to be excluded, got %d", got)
+	}
+}
+
 // TestCreateCommentNormalizesParentToThreadRoot pins the write-boundary
 // invariant: a reply created through CreateComment is always stored with its
 // parent_id pointing at the THREAD ROOT, never at an interior reply. This keeps

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1269,15 +1269,15 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
-				// Count non-injected comments that arrived in the triggering
-				// thread since this agent's last run, so the daemon can tell it up
-				// front instead of forcing an issue-wide catch-up. Anchor = the
-				// prior task's started_at (never completed_at: a long run would
-				// miss comments posted while it ran). Cold start (no prior task) →
-				// no anchor → no hint. Excludes the agent's own comments and the
-				// triggering comment itself because that body is already injected
-				// into the prompt. Best-effort: any DB error or zero count leaves
-				// the hint suppressed.
+				// Count comments that arrived since this agent's last run.
+				// Anchor = the prior task's started_at (never completed_at: a long
+				// run would miss comments posted while it ran). The trigger-thread
+				// count drives the default catch-up path. The other-thread count is
+				// only an awareness signal, so agents do not mistake a quiet
+				// triggering thread for a quiet issue. Both exclude the agent's own
+				// comments, and the trigger itself is excluded because its body is
+				// already injected into the prompt. Best-effort: DB errors leave
+				// individual counts suppressed.
 				if startedAt, err := h.Queries.GetLastTaskStartedAtForIssueAndAgent(r.Context(), db.GetLastTaskStartedAtForIssueAndAgentParams{
 					AgentID: task.AgentID,
 					IssueID: comment.IssueID,
@@ -1290,6 +1290,17 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 						AuthorID:    task.AgentID,
 					}); err == nil && cnt > 0 {
 						resp.NewCommentCount = int(cnt)
+					}
+					if cnt, err := h.Queries.CountOtherNewCommentsSince(r.Context(), db.CountOtherNewCommentsSinceParams{
+						AnchorID:    task.TriggerCommentID,
+						IssueID:     comment.IssueID,
+						WorkspaceID: comment.WorkspaceID,
+						Since:       startedAt,
+						AuthorID:    task.AgentID,
+					}); err == nil && cnt > 0 {
+						resp.OtherNewCommentCount = int(cnt)
+					}
+					if resp.NewCommentCount > 0 || resp.OtherNewCommentCount > 0 {
 						resp.NewCommentsSince = startedAt.Time.UTC().Format(time.RFC3339)
 					}
 				}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3470,11 +3470,12 @@ func createCommentTriggeredClaimTask(t *testing.T, ctx context.Context, agentID,
 
 type claimCommentTaskResp struct {
 	Task *struct {
-		ID               string `json:"id"`
-		PriorSessionID   string `json:"prior_session_id"`
-		TriggerCommentID string `json:"trigger_comment_id"`
-		NewCommentCount  int    `json:"new_comment_count"`
-		NewCommentsSince string `json:"new_comments_since"`
+		ID                   string `json:"id"`
+		PriorSessionID       string `json:"prior_session_id"`
+		TriggerCommentID     string `json:"trigger_comment_id"`
+		NewCommentCount      int    `json:"new_comment_count"`
+		OtherNewCommentCount int    `json:"other_new_comment_count"`
+		NewCommentsSince     string `json:"new_comments_since"`
 	} `json:"task"`
 }
 
@@ -3565,6 +3566,9 @@ func TestClaimTaskByRuntime_CommentTaskPopulatesThreadScopedNewCommentCount(t *t
 	if resp.Task.NewCommentCount != 1 {
 		t.Errorf("new_comment_count = %d, want 1 (same-thread context only)", resp.Task.NewCommentCount)
 	}
+	if resp.Task.OtherNewCommentCount != 1 {
+		t.Errorf("other_new_comment_count = %d, want 1 (unrelated thread awareness)", resp.Task.OtherNewCommentCount)
+	}
 }
 
 func TestClaimTaskByRuntime_CommentTaskOmitsDeltaWhenOnlyTriggerIsNew(t *testing.T) {
@@ -3596,6 +3600,51 @@ func TestClaimTaskByRuntime_CommentTaskOmitsDeltaWhenOnlyTriggerIsNew(t *testing
 	}
 	if resp.Task.NewCommentsSince != "" {
 		t.Errorf("new_comments_since = %q, want empty when only the injected trigger is new", resp.Task.NewCommentsSince)
+	}
+}
+
+func TestClaimTaskByRuntime_CommentTaskPopulatesOtherNewCommentCountWithoutThreadDelta(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Comment other-count runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Comment other-count agent")
+
+	var priorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at, completed_at)
+		VALUES ($1, $2, $3, 'completed', 0, now() - interval '1 hour', now() - interval '50 minutes')
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&priorTaskID); err != nil {
+		t.Fatalf("insert prior task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, priorTaskID) })
+
+	var otherRootID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'other thread update', 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&otherRootID); err != nil {
+		t.Fatalf("insert other thread root: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, otherRootID) })
+
+	_, triggerID := createCommentTriggeredClaimTask(t, ctx, agentID, runtimeID, issueID, nil)
+
+	resp := claimCommentTask(t, runtimeID, "comment-other-count-claim")
+	if resp.Task.TriggerCommentID != triggerID {
+		t.Fatalf("trigger_comment_id = %s, want %s", resp.Task.TriggerCommentID, triggerID)
+	}
+	if resp.Task.NewCommentCount != 0 {
+		t.Errorf("new_comment_count = %d, want 0 when only the injected trigger is new in its thread", resp.Task.NewCommentCount)
+	}
+	if resp.Task.OtherNewCommentCount != 1 {
+		t.Errorf("other_new_comment_count = %d, want 1 for the other thread update", resp.Task.OtherNewCommentCount)
+	}
+	if resp.Task.NewCommentsSince == "" {
+		t.Errorf("new_comments_since must be set when only other-thread comments changed")
 	}
 }
 

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -30,39 +30,46 @@ func (q *Queries) CountComments(ctx context.Context, arg CountCommentsParams) (i
 
 const countNewCommentsSince = `-- name: CountNewCommentsSince :one
 WITH RECURSIVE root_of AS (
+    -- Scope is enforced on both the anchor seed and recursive walk-up; keep
+    -- these predicates together so future parent/thread changes cannot cross
+    -- issue or workspace boundaries.
     SELECT c.id, c.parent_id
     FROM comment c
-    WHERE c.id = $1 AND c.issue_id = $2 AND c.workspace_id = $3
+    WHERE c.id = $4 AND c.issue_id = $1 AND c.workspace_id = $2
     UNION ALL
     SELECT p.id, p.parent_id
     FROM comment p
     JOIN root_of r ON p.id = r.parent_id
-    WHERE p.issue_id = $2 AND p.workspace_id = $3
+    WHERE p.issue_id = $1 AND p.workspace_id = $2
 ),
 thread_root AS (
     SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
 ),
 descendants AS (
-    SELECT c.id, c.created_at, c.author_type, c.author_id
+    SELECT c.id
     FROM comment c
     JOIN thread_root tr ON c.id = tr.id
     UNION
-    SELECT c.id, c.created_at, c.author_type, c.author_id
+    SELECT c.id
     FROM comment c
     JOIN descendants d ON c.parent_id = d.id
-    WHERE c.issue_id = $2 AND c.workspace_id = $3
+    WHERE c.issue_id = $1 AND c.workspace_id = $2
 )
-SELECT count(*) FROM descendants
-WHERE created_at > $4
-  AND id <> $1
-  AND NOT (author_type = 'agent' AND author_id = $5)
+SELECT count(*) FROM comment c
+WHERE c.issue_id = $1
+  AND c.workspace_id = $2
+  AND c.created_at > $3
+  AND c.id <> $4
+  AND EXISTS (SELECT 1 FROM thread_root)
+  AND NOT (c.author_type = 'agent' AND c.author_id = $5)
+  AND EXISTS (SELECT 1 FROM descendants d WHERE d.id = c.id)
 `
 
 type CountNewCommentsSinceParams struct {
-	AnchorID    pgtype.UUID        `json:"anchor_id"`
 	IssueID     pgtype.UUID        `json:"issue_id"`
 	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Since       pgtype.Timestamptz `json:"since"`
+	AnchorID    pgtype.UUID        `json:"anchor_id"`
 	AuthorID    pgtype.UUID        `json:"author_id"`
 }
 
@@ -73,10 +80,73 @@ type CountNewCommentsSinceParams struct {
 // claim response without shipping comment bodies.
 func (q *Queries) CountNewCommentsSince(ctx context.Context, arg CountNewCommentsSinceParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countNewCommentsSince,
-		arg.AnchorID,
 		arg.IssueID,
 		arg.WorkspaceID,
 		arg.Since,
+		arg.AnchorID,
+		arg.AuthorID,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countOtherNewCommentsSince = `-- name: CountOtherNewCommentsSince :one
+WITH RECURSIVE root_of AS (
+    -- Scope is enforced on both the anchor seed and recursive walk-up; keep
+    -- these predicates together so future parent/thread changes cannot cross
+    -- issue or workspace boundaries.
+    SELECT c.id, c.parent_id
+    FROM comment c
+    WHERE c.id = $4 AND c.issue_id = $1 AND c.workspace_id = $2
+    UNION ALL
+    SELECT p.id, p.parent_id
+    FROM comment p
+    JOIN root_of r ON p.id = r.parent_id
+    WHERE p.issue_id = $1 AND p.workspace_id = $2
+),
+thread_root AS (
+    SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
+),
+descendants AS (
+    SELECT c.id
+    FROM comment c
+    JOIN thread_root tr ON c.id = tr.id
+    UNION
+    SELECT c.id
+    FROM comment c
+    JOIN descendants d ON c.parent_id = d.id
+    WHERE c.issue_id = $1 AND c.workspace_id = $2
+)
+SELECT count(*) FROM comment c
+WHERE c.issue_id = $1
+  AND c.workspace_id = $2
+  AND c.created_at > $3
+  AND c.id <> $4
+  AND EXISTS (SELECT 1 FROM thread_root)
+  AND NOT (c.author_type = 'agent' AND c.author_id = $5)
+  AND NOT EXISTS (SELECT 1 FROM descendants d WHERE d.id = c.id)
+`
+
+type CountOtherNewCommentsSinceParams struct {
+	IssueID     pgtype.UUID        `json:"issue_id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Since       pgtype.Timestamptz `json:"since"`
+	AnchorID    pgtype.UUID        `json:"anchor_id"`
+	AuthorID    pgtype.UUID        `json:"author_id"`
+}
+
+// Counts comments created after @since on the same issue but outside the
+// thread containing @anchor_id. This is an awareness signal only: it lets the
+// agent know the issue has cross-thread activity without making those comments
+// part of the default read path. Agent-authored rows by @author_id are excluded
+// for the same reason as CountNewCommentsSince.
+func (q *Queries) CountOtherNewCommentsSince(ctx context.Context, arg CountOtherNewCommentsSinceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countOtherNewCommentsSince,
+		arg.IssueID,
+		arg.WorkspaceID,
+		arg.Since,
+		arg.AnchorID,
 		arg.AuthorID,
 	)
 	var count int64

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -320,19 +320,64 @@ thread_root AS (
     SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
 ),
 descendants AS (
-    SELECT c.id, c.created_at, c.author_type, c.author_id
+    SELECT c.id
     FROM comment c
     JOIN thread_root tr ON c.id = tr.id
     UNION
-    SELECT c.id, c.created_at, c.author_type, c.author_id
+    SELECT c.id
     FROM comment c
     JOIN descendants d ON c.parent_id = d.id
     WHERE c.issue_id = @issue_id AND c.workspace_id = @workspace_id
 )
-SELECT count(*) FROM descendants
-WHERE created_at > @since
-  AND id <> @anchor_id
-  AND NOT (author_type = 'agent' AND author_id = @author_id);
+SELECT count(*) FROM comment c
+WHERE c.issue_id = @issue_id
+  AND c.workspace_id = @workspace_id
+  AND c.created_at > @since
+  AND c.id <> @anchor_id
+  AND EXISTS (SELECT 1 FROM thread_root)
+  AND NOT (c.author_type = 'agent' AND c.author_id = @author_id)
+  AND EXISTS (SELECT 1 FROM descendants d WHERE d.id = c.id);
+
+-- name: CountOtherNewCommentsSince :one
+-- Counts comments created after @since on the same issue but outside the
+-- thread containing @anchor_id. This is an awareness signal only: it lets the
+-- agent know the issue has cross-thread activity without making those comments
+-- part of the default read path. Agent-authored rows by @author_id are excluded
+-- for the same reason as CountNewCommentsSince.
+WITH RECURSIVE root_of AS (
+    -- Scope is enforced on both the anchor seed and recursive walk-up; keep
+    -- these predicates together so future parent/thread changes cannot cross
+    -- issue or workspace boundaries.
+    SELECT c.id, c.parent_id
+    FROM comment c
+    WHERE c.id = @anchor_id AND c.issue_id = @issue_id AND c.workspace_id = @workspace_id
+    UNION ALL
+    SELECT p.id, p.parent_id
+    FROM comment p
+    JOIN root_of r ON p.id = r.parent_id
+    WHERE p.issue_id = @issue_id AND p.workspace_id = @workspace_id
+),
+thread_root AS (
+    SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
+),
+descendants AS (
+    SELECT c.id
+    FROM comment c
+    JOIN thread_root tr ON c.id = tr.id
+    UNION
+    SELECT c.id
+    FROM comment c
+    JOIN descendants d ON c.parent_id = d.id
+    WHERE c.issue_id = @issue_id AND c.workspace_id = @workspace_id
+)
+SELECT count(*) FROM comment c
+WHERE c.issue_id = @issue_id
+  AND c.workspace_id = @workspace_id
+  AND c.created_at > @since
+  AND c.id <> @anchor_id
+  AND EXISTS (SELECT 1 FROM thread_root)
+  AND NOT (c.author_type = 'agent' AND c.author_id = @author_id)
+  AND NOT EXISTS (SELECT 1 FROM descendants d WHERE d.id = c.id);
 
 -- name: GetComment :one
 SELECT * FROM comment


### PR DESCRIPTION
## Summary
- add an additive other_new_comment_count claim field for comments outside the triggering thread since the agent's last run
- keep new_comment_count scoped to the triggering thread while setting the shared since anchor when either count is positive
- update comment prompts to surface other-thread activity as awareness only, with current-thread reads remaining the default path

## Tests
- go test ./internal/daemon/... -count=1
- go test ./internal/handler -count=1
- go build ./...
- git diff --check