### PR TITLE
MUL-2785: clarify thread-scoped comment delta

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3441,7 +3441,9 @@ func TestInjectRuntimeConfigCommentTriggerResumedNoDeltaRead(t *testing.T) {
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Do not re-read comment history by default",
+		"Current-thread delta: 0 additional comments beyond the triggering comment",
+		"This is scoped to the triggering thread, not the whole issue",
+		"Do not re-read the triggering thread by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread " + triggerID + " --tail 30 --output json",
 	} {
@@ -3617,10 +3619,10 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			want: withSection,
 		},
 		{
-			name:                "assignment_triggered",
-			ctx:                 TaskContextForEnv{IssueID: "issue-md-2"},
-			provider:            "claude",
-			filename:            "CLAUDE.md",
+			name:     "assignment_triggered",
+			ctx:      TaskContextForEnv{IssueID: "issue-md-2"},
+			provider: "claude",
+			filename: "CLAUDE.md",
 			workflowStepPresent: []string{
 				"multica issue metadata list issue-md-2 --output json",
 				"See the `## Issue Metadata` section above",

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -42,16 +42,20 @@ func BuildNewCommentsHint(issueID, triggerCommentID, newCommentsSince string, ne
 // BuildResumedCommentsHint returns the comment-reading pointer for the WARM
 // no-delta path: the daemon is resuming a prior provider session and the
 // triggering comment body has already been injected into the per-turn prompt.
-// In that shape, reading the triggering thread's last 30 replies is duplicate
-// context by default. Keep the bounded thread read as an explicit fallback for
-// missing context instead of making it the first action.
+// In that shape, the zero-delta statement must be explicitly scoped to the
+// triggering thread, not the whole issue. Reading the triggering thread's last
+// 30 replies is duplicate context by default, so keep the bounded thread read
+// as an explicit fallback for missing context instead of making it the first
+// action.
 func BuildResumedCommentsHint(issueID, triggerCommentID string) string {
 	if issueID == "" || triggerCommentID == "" {
 		return ""
 	}
 	return fmt.Sprintf(
 		"You're resuming the prior session, and the triggering comment is already included above. "+
-			"Do not re-read comment history by default. "+
+			"Current-thread delta: 0 additional comments beyond the triggering comment. "+
+			"This is scoped to the triggering thread, not the whole issue. "+
+			"Do not re-read the triggering thread by default. "+
 			"Only if the resumed session is missing thread context, pull the triggering conversation: "+
 			"`multica issue comment list %s --thread %s --tail 30 --output json`.\n\n",
 		issueID, triggerCommentID,

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -235,7 +235,9 @@ func TestCommentTriggeredBriefResumedNoDeltaSkipsDefaultThreadRead(t *testing.T)
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Do not re-read comment history by default",
+		"Current-thread delta: 0 additional comments beyond the triggering comment",
+		"This is scoped to the triggering thread, not the whole issue",
+		"Do not re-read the triggering thread by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread trigger-1 --tail 30 --output json",
 	} {

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -381,7 +381,9 @@ func TestBuildPromptResumedNoDeltaDoesNotForceThreadRead(t *testing.T) {
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Do not re-read comment history by default",
+		"Current-thread delta: 0 additional comments beyond the triggering comment",
+		"This is scoped to the triggering thread, not the whole issue",
+		"Do not re-read the triggering thread by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread trigger-1 --tail 30 --output json",
 	} {


### PR DESCRIPTION
## Summary
- remove the cross-thread/other-comment awareness signal from the prompt path
- keep comment deltas scoped to the triggering thread only
- clarify the warm resumed no-delta prompt so 0 means current/triggering-thread delta, not whole-issue delta
- keep cross-thread reads available only as agent-initiated fallback through existing CLI guidance

## Tests
- go test ./internal/daemon/... -count=1
- go build ./...
- git diff --check