### PR TITLE
fix(daemon): skip duplicate SKILL.md in supporting files to prevent task prep failures

### DIFF
--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -365,7 +365,14 @@ func writeSkillFiles(skillsDir string, skills []SkillContextForEnv, manifest *si
 		// it would mean the skill's bundled files list two entries
 		// at the same path — that's an upstream data bug, not a
 		// user-content collision, and we surface it.
+		//
+		// One common data bug is storing SKILL.md as both the primary
+		// content (skill.Content) and as a supporting file. Skip the
+		// duplicate so the agent still gets every unique file.
 		for _, f := range skill.Files {
+			if strings.EqualFold(f.Path, "SKILL.md") {
+				continue
+			}
 			fpath := filepath.Join(dir, f.Path)
 			if err := recordMkdirAll(filepath.Dir(fpath), 0o755, manifest); err != nil {
 				return err

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -3280,3 +3280,199 @@ func TestAgentExplicitMentionStillTriggers(t *testing.T) {
 		t.Fatalf("expected 0 tasks for Agent A (no self-trigger on own mention), got %d", got)
 	}
 }
+
+func TestCreateSkillSkipsSkillMdFile(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+
+	body, _ := json.Marshal(CreateSkillRequest{
+		Name:    "test-skill-create-skip-skillmd",
+		Content: "# SKILL.md content",
+		Files: []CreateSkillFileRequest{
+			{Path: "README.md", Content: "readme"},
+			{Path: "SKILL.md", Content: "should be skipped"},
+			{Path: "helper.go", Content: "package main"},
+		},
+	})
+
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	testHandler.CreateSkill(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp SkillWithFilesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	// Should only have README.md and helper.go, not SKILL.md
+	if len(resp.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(resp.Files))
+	}
+	for _, f := range resp.Files {
+		if strings.EqualFold(f.Path, "SKILL.md") {
+			t.Fatalf("SKILL.md should not be in response files")
+		}
+	}
+
+	// Verify DB state directly
+	ctx := context.Background()
+	rows, err := testPool.Query(ctx, "SELECT path FROM skill_file WHERE skill_id = $1", resp.ID)
+	if err != nil {
+		t.Fatalf("query skill_file: %v", err)
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan path: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 rows in skill_file, got %d", len(paths))
+	}
+	for _, p := range paths {
+		if strings.EqualFold(p, "SKILL.md") {
+			t.Fatalf("SKILL.md should not be stored in skill_file")
+		}
+	}
+}
+
+func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+
+	// Create a skill first
+	body, _ := json.Marshal(CreateSkillRequest{
+		Name:    "test-skill-update-skip-skillmd",
+		Content: "# SKILL.md content",
+		Files: []CreateSkillFileRequest{
+			{Path: "README.md", Content: "readme"},
+		},
+	})
+
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	testHandler.CreateSkill(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create skill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var createResp SkillWithFilesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+
+	// Update with SKILL.md in files
+	updateBody, _ := json.Marshal(UpdateSkillRequest{
+		Name:    strPtr("updated-name"),
+		Content: strPtr("updated content"),
+		Files: []CreateSkillFileRequest{
+			{Path: "README.md", Content: "updated readme"},
+			{Path: "SKILL.md", Content: "should be skipped"},
+			{Path: "new.go", Content: "package main"},
+		},
+	})
+
+	updateReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID, bytes.NewReader(updateBody))
+	updateReq = withURLParam(updateReq, "skillID", createResp.ID)
+	updateRec := httptest.NewRecorder()
+	testHandler.UpdateSkill(updateRec, updateReq)
+
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("update skill: expected 200, got %d: %s", updateRec.Code, updateRec.Body.String())
+	}
+
+	var updateResp SkillWithFilesResponse
+	if err := json.Unmarshal(updateRec.Body.Bytes(), &updateResp); err != nil {
+		t.Fatalf("unmarshal update response: %v", err)
+	}
+
+	if len(updateResp.Files) != 2 {
+		t.Fatalf("expected 2 files after update, got %d", len(updateResp.Files))
+	}
+	for _, f := range updateResp.Files {
+		if strings.EqualFold(f.Path, "SKILL.md") {
+			t.Fatalf("SKILL.md should not be in updated response files")
+		}
+	}
+
+	// Verify DB state
+	ctx := context.Background()
+	rows, err := testPool.Query(ctx, "SELECT path FROM skill_file WHERE skill_id = $1", createResp.ID)
+	if err != nil {
+		t.Fatalf("query skill_file: %v", err)
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			t.Fatalf("scan path: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 rows in skill_file after update, got %d", len(paths))
+	}
+	for _, p := range paths {
+		if strings.EqualFold(p, "SKILL.md") {
+			t.Fatalf("SKILL.md should not be stored in skill_file after update")
+		}
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database available")
+	}
+
+	// Create a skill first
+	body, _ := json.Marshal(CreateSkillRequest{
+		Name:    "test-skill-upsert-reject-skillmd",
+		Content: "# SKILL.md content",
+	})
+
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	testHandler.CreateSkill(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create skill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var createResp SkillWithFilesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+
+	// Try to upsert SKILL.md
+	upsertBody, _ := json.Marshal(CreateSkillFileRequest{
+		Path:    "SKILL.md",
+		Content: "should be rejected",
+	})
+
+	upsertReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID+"/files", bytes.NewReader(upsertBody))
+	upsertReq = withURLParam(upsertReq, "skillID", createResp.ID)
+	upsertRec := httptest.NewRecorder()
+	testHandler.UpsertSkillFile(upsertRec, upsertReq)
+
+	if upsertRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", upsertRec.Code, upsertRec.Body.String())
+	}
+	if !strings.Contains(upsertRec.Body.String(), "SKILL.md is reserved") {
+		t.Fatalf("expected error message about reserved SKILL.md, got: %s", upsertRec.Body.String())
+	}
+}

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -3286,7 +3286,7 @@ func TestCreateSkillSkipsSkillMdFile(t *testing.T) {
 		t.Skip("no database available")
 	}
 
-	body, _ := json.Marshal(CreateSkillRequest{
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", CreateSkillRequest{
 		Name:    "test-skill-create-skip-skillmd",
 		Content: "# SKILL.md content",
 		Files: []CreateSkillFileRequest{
@@ -3295,13 +3295,11 @@ func TestCreateSkillSkipsSkillMdFile(t *testing.T) {
 			{Path: "helper.go", Content: "package main"},
 		},
 	})
-
-	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	testHandler.CreateSkill(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	var resp SkillWithFilesResponse
@@ -3351,19 +3349,17 @@ func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
 	}
 
 	// Create a skill first
-	body, _ := json.Marshal(CreateSkillRequest{
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", CreateSkillRequest{
 		Name:    "test-skill-update-skip-skillmd",
 		Content: "# SKILL.md content",
 		Files: []CreateSkillFileRequest{
 			{Path: "README.md", Content: "readme"},
 		},
 	})
-
-	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	testHandler.CreateSkill(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("create skill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create skill: expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	var createResp SkillWithFilesResponse
@@ -3372,7 +3368,7 @@ func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
 	}
 
 	// Update with SKILL.md in files
-	updateBody, _ := json.Marshal(UpdateSkillRequest{
+	updateReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID, UpdateSkillRequest{
 		Name:    strPtr("updated-name"),
 		Content: strPtr("updated content"),
 		Files: []CreateSkillFileRequest{
@@ -3381,9 +3377,7 @@ func TestUpdateSkillSkipsSkillMdFile(t *testing.T) {
 			{Path: "new.go", Content: "package main"},
 		},
 	})
-
-	updateReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID, bytes.NewReader(updateBody))
-	updateReq = withURLParam(updateReq, "skillID", createResp.ID)
+	updateReq = withURLParam(updateReq, "id", createResp.ID)
 	updateRec := httptest.NewRecorder()
 	testHandler.UpdateSkill(updateRec, updateReq)
 
@@ -3441,16 +3435,14 @@ func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
 	}
 
 	// Create a skill first
-	body, _ := json.Marshal(CreateSkillRequest{
+	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", CreateSkillRequest{
 		Name:    "test-skill-upsert-reject-skillmd",
 		Content: "# SKILL.md content",
 	})
-
-	req := newRequest(http.MethodPost, "/api/workspaces/"+testWorkspaceID+"/skills", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	testHandler.CreateSkill(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("create skill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create skill: expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
 
 	var createResp SkillWithFilesResponse
@@ -3459,13 +3451,11 @@ func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
 	}
 
 	// Try to upsert SKILL.md
-	upsertBody, _ := json.Marshal(CreateSkillFileRequest{
+	upsertReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID+"/files", CreateSkillFileRequest{
 		Path:    "SKILL.md",
 		Content: "should be rejected",
 	})
-
-	upsertReq := newRequest(http.MethodPut, "/api/skills/"+createResp.ID+"/files", bytes.NewReader(upsertBody))
-	upsertReq = withURLParam(upsertReq, "skillID", createResp.ID)
+	upsertReq = withURLParam(upsertReq, "id", createResp.ID)
 	upsertRec := httptest.NewRecorder()
 	testHandler.UpsertSkillFile(upsertRec, upsertReq)
 

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -396,6 +396,10 @@ func (h *Handler) UpdateSkill(w http.ResponseWriter, r *http.Request) {
 		}
 		fileResps = make([]SkillFileResponse, 0, len(req.Files))
 		for _, f := range req.Files {
+			// SKILL.md is reserved for the primary skill content (skill.Content).
+			if strings.EqualFold(f.Path, "SKILL.md") {
+				continue
+			}
 			sf, err := qtx.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
 				SkillID: skill.ID,
 				Path:    sanitizeNullBytes(f.Path),
@@ -1708,6 +1712,10 @@ func (h *Handler) UpsertSkillFile(w http.ResponseWriter, r *http.Request) {
 
 	if !validateFilePath(req.Path) {
 		writeError(w, http.StatusBadRequest, "invalid file path")
+		return
+	}
+	if strings.EqualFold(req.Path, "SKILL.md") {
+		writeError(w, http.StatusBadRequest, "SKILL.md is reserved for the primary skill content")
 		return
 	}
 

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -46,6 +47,11 @@ func createSkillWithFilesInTx(ctx context.Context, qtx *db.Queries, input skillC
 
 	fileResps := make([]SkillFileResponse, 0, len(input.Files))
 	for _, f := range input.Files {
+		// SKILL.md is reserved for the primary skill content (skill.Content).
+		// Supporting files must carry additional assets, not duplicate the main file.
+		if strings.EqualFold(f.Path, "SKILL.md") {
+			continue
+		}
 		sf, err := qtx.UpsertSkillFile(ctx, db.UpsertSkillFileParams{
 			SkillID: skill.ID,
 			Path:    sanitizeNullBytes(f.Path),


### PR DESCRIPTION
Some skills store SKILL.md as both the primary content (skill.Content) and as a supporting file (skill.Files). When the daemon prepares the execution environment, it writes skill.Content as SKILL.md first, then tries to write supporting files. A duplicate SKILL.md entry causes recordWriteFile to return errPathPreExists, which fails the entire task with:



This skip is defensive — the import code already excludes SKILL.md for GitHub/skills.sh imports, but skills created via older builds or manual API calls may still carry the duplicate. Skipping the duplicate allows the agent to still get every unique supporting file without crashing on data inconsistencies.

### Related
- Fixes tasks failing when skills have SKILL.md stored as both content and a supporting file.
- Fixes #3489

MUL-2928
