### PR TITLE
feat(server): attribute issue creation on behalf of a workspace member

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -259,6 +259,13 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 	if taskID := os.Getenv("MULTICA_TASK_ID"); taskID != "" {
 		client.TaskID = taskID
 	}
+	// Act-as-member: same env->header plumbing as MULTICA_AGENT_ID above, but a
+	// distinct server path (the member branch of resolveActor, not the agent
+	// branch). The server honors it only for an owner/admin caller whose target
+	// is a workspace member; otherwise it falls back to the token owner.
+	if onBehalfOf := os.Getenv("MULTICA_ON_BEHALF_OF"); onBehalfOf != "" {
+		client.OnBehalfOf = onBehalfOf
+	}
 	return client, nil
 }
 

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -52,6 +52,7 @@ type APIClient struct {
 	Token       string
 	AgentID     string // When set, requests are attributed to this agent instead of the user.
 	TaskID      string // When set, sent as X-Task-ID for agent-task validation.
+	OnBehalfOf  string // When set, a privileged token attributes the action to this member (X-On-Behalf-Of).
 	HTTPClient  *http.Client
 
 	// Identity overrides. Empty values fall back to the package-level
@@ -173,6 +174,9 @@ func (c *APIClient) setHeaders(req *http.Request) {
 	}
 	if c.TaskID != "" {
 		req.Header.Set("X-Task-ID", c.TaskID)
+	}
+	if c.OnBehalfOf != "" {
+		req.Header.Set("X-On-Behalf-Of", c.OnBehalfOf)
 	}
 
 	platform := c.Platform

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -382,3 +382,35 @@ func TestNormalizeGOOS(t *testing.T) {
 		}
 	}
 }
+
+func TestSetHeadersOnBehalfOf(t *testing.T) {
+	t.Run("sends X-On-Behalf-Of when set", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if obo := r.Header.Get("X-On-Behalf-Of"); obo != "member-789" {
+				t.Errorf("expected X-On-Behalf-Of member-789, got %q", obo)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"1"}`))
+		}))
+		defer srv.Close()
+		client := NewAPIClient(srv.URL, "ws", "tok")
+		client.OnBehalfOf = "member-789"
+		if err := client.PostJSON(context.Background(), "/t", map[string]string{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("omits header when unset", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := r.Header["X-On-Behalf-Of"]; ok {
+				t.Errorf("did not expect X-On-Behalf-Of header")
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"1"}`))
+		}))
+		defer srv.Close()
+		client := NewAPIClient(srv.URL, "ws", "tok")
+		if err := client.PostJSON(context.Background(), "/t", map[string]string{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -362,7 +362,8 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	}
 	agentID := r.Header.Get("X-Agent-ID")
 	if agentID == "" {
-		return "member", userID
+		// No agent context: optionally honor an act-as-member override.
+		return h.resolveMemberActor(r, userID, workspaceID)
 	}
 	taskID := r.Header.Get("X-Task-ID")
 	if taskID == "" {
@@ -441,6 +442,42 @@ func (h *Handler) workspaceMember(w http.ResponseWriter, r *http.Request, worksp
 		return m, true
 	}
 	return h.requireWorkspaceMember(w, r, workspaceID, "workspace not found")
+}
+
+// resolveMemberActor honors an X-On-Behalf-Of override that lets a privileged
+// (owner/admin) caller attribute an action to another workspace member. Any
+// failure falls back to the authenticated token owner. The auth middleware
+// derives userID from the token, so this header can only redirect attribution,
+// never escalate it.
+func (h *Handler) resolveMemberActor(r *http.Request, userID, workspaceID string) (actorType, actorID string) {
+	onBehalfOf := r.Header.Get("X-On-Behalf-Of")
+	if onBehalfOf == "" || onBehalfOf == userID {
+		return "member", userID
+	}
+
+	caller, err := h.getWorkspaceMember(r.Context(), userID, workspaceID)
+	if err != nil {
+		if !isNotFound(err) {
+			slog.Warn("resolveActor: caller member lookup failed, falling back to token owner", "user_id", userID, "workspace_id", workspaceID, "error", err)
+		}
+		return "member", userID
+	}
+	if !roleAllowed(caller.Role, "owner", "admin") {
+		slog.Debug("resolveActor: X-On-Behalf-Of ignored, caller not owner/admin", "user_id", userID, "workspace_id", workspaceID)
+		return "member", userID
+	}
+
+	if _, err := h.getWorkspaceMember(r.Context(), onBehalfOf, workspaceID); err != nil {
+		if !isNotFound(err) {
+			slog.Warn("resolveActor: target member lookup failed, falling back to token owner", "target_id", onBehalfOf, "workspace_id", workspaceID, "error", err)
+		} else {
+			slog.Debug("resolveActor: X-On-Behalf-Of ignored, target not a workspace member", "target_id", onBehalfOf, "workspace_id", workspaceID)
+		}
+		return "member", userID
+	}
+
+	slog.Info("resolveActor: attributing on behalf of member", "caller", userID, "on_behalf_of", onBehalfOf, "workspace_id", workspaceID)
+	return "member", onBehalfOf
 }
 
 func roleAllowed(role string, roles ...string) bool {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -4003,6 +4003,22 @@ func TestResolveActorActAsMember(t *testing.T) {
 		adminUserID   = "44444444-4444-4444-4444-444444444444"
 	)
 
+	// member.user_id has a FK to "user"(id), so the referenced users must exist
+	// before they can be added to the workspace. nonMemberID is created as a
+	// real user but deliberately NOT added to member, exercising the
+	// "target is a user but not a workspace member" path.
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO "user" (id, name, email) VALUES
+			($1, 'act-as target', 'act-as-target@e2e.test'),
+			($2, 'act-as nonpriv', 'act-as-nonpriv@e2e.test'),
+			($3, 'act-as nonmember', 'act-as-nonmember@e2e.test'),
+			($4, 'act-as admin', 'act-as-admin@e2e.test')
+		ON CONFLICT (id) DO NOTHING`,
+		targetUserID, nonPrivUserID, nonMemberID, adminUserID,
+	); err != nil {
+		t.Fatalf("failed to seed users: %v", err)
+	}
+
 	if _, err := testPool.Exec(ctx,
 		`INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member'), ($1, $3, 'member'), ($1, $4, 'admin')`,
 		testWorkspaceID, targetUserID, nonPrivUserID, adminUserID,
@@ -4010,8 +4026,11 @@ func TestResolveActorActAsMember(t *testing.T) {
 		t.Fatalf("failed to seed members: %v", err)
 	}
 	t.Cleanup(func() {
+		// Delete members first (they FK-reference the users), then the users.
 		testPool.Exec(ctx, `DELETE FROM member WHERE workspace_id = $1 AND user_id = ANY($2)`,
 			testWorkspaceID, []string{targetUserID, nonPrivUserID, adminUserID})
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = ANY($1)`,
+			[]string{targetUserID, nonPrivUserID, nonMemberID, adminUserID})
 	})
 
 	tests := []struct {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -3992,3 +3992,55 @@ func TestUpsertSkillFileRejectsSkillMd(t *testing.T) {
 		t.Fatalf("expected error message about reserved SKILL.md, got: %s", upsertRec.Body.String())
 	}
 }
+
+func TestResolveActorActAsMember(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		targetUserID  = "11111111-1111-1111-1111-111111111111"
+		nonPrivUserID = "22222222-2222-2222-2222-222222222222"
+		nonMemberID   = "33333333-3333-3333-3333-333333333333"
+		adminUserID   = "44444444-4444-4444-4444-444444444444"
+	)
+
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member'), ($1, $3, 'member'), ($1, $4, 'admin')`,
+		testWorkspaceID, targetUserID, nonPrivUserID, adminUserID,
+	); err != nil {
+		t.Fatalf("failed to seed members: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM member WHERE workspace_id = $1 AND user_id = ANY($2)`,
+			testWorkspaceID, []string{targetUserID, nonPrivUserID, adminUserID})
+	})
+
+	tests := []struct {
+		name        string
+		caller      string
+		onBehalfOf  string
+		wantActorID string
+	}{
+		{"owner impersonates member", testUserID, targetUserID, targetUserID},
+		{"admin impersonates member", adminUserID, targetUserID, targetUserID},
+		{"self on-behalf is no-op", testUserID, testUserID, testUserID},
+		{"non-privileged cannot forge", nonPrivUserID, targetUserID, nonPrivUserID},
+		{"non-member target ignored", testUserID, nonMemberID, testUserID},
+		{"absent header keeps caller", testUserID, "", testUserID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newRequest("GET", "/test", nil)
+			if tt.onBehalfOf != "" {
+				req.Header.Set("X-On-Behalf-Of", tt.onBehalfOf)
+			}
+			actorType, actorID := testHandler.resolveActor(req, tt.caller, testWorkspaceID)
+			if actorType != "member" {
+				t.Errorf("actorType = %q, want member", actorType)
+			}
+			if actorID != tt.wantActorID {
+				t.Errorf("actorID = %q, want %q", actorID, tt.wantActorID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds an **act-as-member** path so a privileged (`owner`/`admin`) caller can attribute a created issue to **another workspace member** via an `X-On-Behalf-Of: <member-user-id>` header. This mirrors the existing `X-Agent-ID` agent-impersonation mechanism, for humans.

It solves a real gap: an integration creating issues via the CLI under one service token otherwise records every issue under that token's owner instead of the real requester (our use case is a Discord bot that turns slash commands into Multica issues).

The approach intentionally reuses the existing `resolveActor` seam and its role primitives (`roleAllowed`, `getWorkspaceMember`) rather than introducing a parallel mechanism.

## Related Issue

Closes #3527

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `server/internal/cli/client.go` — add `OnBehalfOf` field; send it as `X-On-Behalf-Of`.
- `server/cmd/multica/cmd_agent.go` — populate it from `MULTICA_ON_BEHALF_OF` (mirrors `MULTICA_AGENT_ID`).
- `server/internal/handler/handler.go` — new `resolveMemberActor`: on the no-agent branch of `resolveActor`, honor `X-On-Behalf-Of` only when the caller is `owner`/`admin` **and** the target is a member of the same workspace; otherwise fall back to the token owner. Successful attribution is logged at INFO; infra lookup errors (`!isNotFound`) are logged at WARN and distinguished from genuine "not a member" denials.
- `server/internal/handler/handler_test.go` — `TestResolveActorActAsMember` (owner/admin impersonate, self no-op, non-privileged denied, non-member ignored, absent header).
- `server/internal/cli/client_test.go` — `TestSetHeadersOnBehalfOf` (header sent when set / omitted when unset).

## How to Test

1. Build + vet: `cd server && go build ./... && go vet ./...`.
2. Unit: `go test ./internal/cli/ -run TestSetHeadersOnBehalfOf` (no DB) and `go test ./internal/handler/ -run TestResolveActorActAsMember` (uses the standard handler test-DB harness).
3. Manual: with an `owner`/`admin` token, `MULTICA_ON_BEHALF_OF=<other-member-user-id> multica issue create --title x` → the issue's `creator_id` is the target member. Repeat without the env (or as a non-privileged caller) → creator is the token owner.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass — `go build ./...`, `go vet`, and `go test ./internal/cli/` pass in a `golang:1.26` container; the handler test is added and runs under the standard test-DB harness (CI).
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (backend only)
- [ ] I have updated relevant documentation to reflect my changes — happy to add `MULTICA_ON_BEHALF_OF` to the docs; point me at the preferred location.
- [ ] If I added a new runtime / coding tool / UI tab — N/A
- [ ] If this PR touches Chinese product copy — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risks / open question

`resolveActor` is shared by other actor-attributed sites (comments, status, reactions, …), so this header is honored there too — but always behind the same `owner`/`admin` gate, so it redirects attribution without granting access the caller didn't already have (e.g. comment edit/delete already allow `owner`/`admin` via `isAdmin`). If you'd prefer to scope it strictly to issue creation, I'm glad to thread it explicitly through the create path instead.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Implemented and reviewed with Claude Code. The agent traced the existing `X-Agent-ID` impersonation path, mirrored it for members behind the existing `roleAllowed`/`getWorkspaceMember` primitives, then ran a multi-agent review (security, silent-failure, tests) — which is why the success path is audited at INFO and infra errors are distinguished from denials. Verified end-to-end against a running instance (DB `creator_id` reflects the on-behalf member; non-privileged/non-member fall back to the token owner).