### PR TITLE
fix(issues): move agent live bar back into the activity section

### DIFF
--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -292,7 +292,7 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
     // thread scrolls under it. One bordered container in every state: the
     // single row, the collapsed summary, and the expanded list all share it,
     // so the bar reads at one consistent width.
-    <div className="mb-4 sticky top-4 z-10 rounded-lg bg-background/80 supports-[backdrop-filter]:bg-background/55 backdrop-blur-md">
+    <div className="mt-4 sticky top-4 z-10 rounded-lg bg-background/80 supports-[backdrop-filter]:bg-background/55 backdrop-blur-md">
       <div className="overflow-hidden rounded-lg border border-info/20 bg-info/5">
         {isMulti ? (
           <>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1728,14 +1728,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           className="relative flex-1 overflow-y-auto"
         >
         <div className="mx-auto w-full max-w-4xl px-8 py-8">
-          {/* Agent live status — sticky bar at the top of the main content,
-              above the editable title. Keyed by issue id so switching issues
-              remounts and clears in-flight task state from the previous
-              issue. A single active task is directly actionable (Logs +
-              Stop); multiple collapse into a click-to-open popover. The full
-              execution log lives in the right panel via ExecutionLogSection —
-              this bar is just the "is anyone working?" anchor. */}
-          <AgentLiveCard key={id} issueId={id} />
           <TitleEditor
             key={`title-${id}`}
             defaultValue={issue.title}
@@ -1945,6 +1937,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             </div>
 
             <LocalDirectoryHint projectId={issue?.project_id} />
+
+            {/* Agent live output — sticky banner in the activity section,
+                keyed by issue id so switching issues remounts the card and
+                clears any in-flight task state from the previous issue.
+                The execution log itself (per-task timeline + past runs)
+                lives in the right panel via ExecutionLogSection — this
+                card is just a header-style "agent is working" anchor. */}
+            <AgentLiveCard key={id} issueId={id} />
 
             {/* Timeline entries — virtualized via react-virtuoso to keep
                 first-paint cost O(viewport) instead of O(N). On a 500-comment


### PR DESCRIPTION
## What

Restore the **AgentLiveCard** (the "agent is working" bar) to its original placement in the **activity section** — after `LocalDirectoryHint`, above the timeline — undoing the relocation introduced by #3517.

## Why

#3517 moved the bar to a sticky slot **above the editable title** at the top of the main content. We're putting it back where it was.

## Scope

Reverts **only** the position change. Everything else from #3517 is kept:

- single-container multi-agent accordion (no more N detached boxes)
- cancel-confirmation dialog lifted to `AgentLiveCard`
- dropped redundant parked/running background variant

## Changes

- `issue-detail.tsx` — exact reverse of #3517's two relocation hunks (the `issue-detail.tsx` blob hash matches the pre-#3517 state).
- `agent-live-card.tsx` — container margin `mb-4` → `mt-4`, reverting the spacing tweak #3517 made for the top slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)