### PR TITLE
fix(agents): show MCP tab for ACP runtimes

### DIFF
--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -6,7 +6,14 @@
 // per-task wrapper preparer in `server/internal/daemon/execenv/` which
 // materialises `mcp.servers` into the synthesised config rather than going
 // through ExecOptions.
-const MCP_SUPPORTED_PROVIDERS = new Set(["claude", "codex", "openclaw"]);
+const MCP_SUPPORTED_PROVIDERS = new Set([
+  "claude",
+  "codex",
+  "hermes",
+  "kimi",
+  "kiro",
+  "openclaw",
+]);
 
 export function providerSupportsMcpConfig(provider: string | undefined | null): boolean {
   if (!provider) return false;

--- a/packages/views/agents/components/agent-overview-pane.test.tsx
+++ b/packages/views/agents/components/agent-overview-pane.test.tsx
@@ -98,22 +98,15 @@ function renderPane(runtimes: AgentRuntime[]) {
 }
 
 describe("AgentOverviewPane MCP tab visibility", () => {
-  it("renders the MCP tab when the agent runs on the Claude runtime", () => {
-    renderPane([makeRuntime("claude")]);
-    expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
-  });
-
-  it("renders the MCP tab when the agent runs on the Codex runtime", () => {
-    // Codex now reads mcp_config too — must not be hidden from the tab strip.
-    renderPane([makeRuntime("codex")]);
-    expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
-  });
-
-  it("renders the MCP tab when the agent runs on the OpenClaw runtime", () => {
-    // OpenClaw materialises mcp_config via the per-task wrapper config
-    // (OPENCLAW_CONFIG_PATH) rather than ExecOptions, but the Tab must still
-    // surface so admins can save the managed set.
-    renderPane([makeRuntime("openclaw")]);
+  it.each([
+    ["Claude", "claude"],
+    ["Codex", "codex"],
+    ["Hermes", "hermes"],
+    ["Kimi", "kimi"],
+    ["Kiro", "kiro"],
+    ["OpenClaw", "openclaw"],
+  ])("renders the MCP tab when the agent runs on the %s runtime", (_label, provider) => {
+    renderPane([makeRuntime(provider)]);
     expect(screen.getByRole("button", { name: /^MCP$/i })).toBeInTheDocument();
   });
 

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -296,7 +296,7 @@
       "save_failed_toast": "Failed to save custom arguments"
     },
     "mcp_config": {
-      "intro": "MCP server configuration forwarded to the runtime CLI (Claude via --mcp-config, Codex via $CODEX_HOME/config.toml, OpenClaw via the per-task config wrapper). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default. For OpenClaw HTTP/SSE entries use OpenClaw's own field name (e.g. \"transport\": \"streamable-http\") instead of Claude's \"type\".",
+      "intro": "MCP server configuration forwarded to the runtime CLI (Claude via --mcp-config, Codex via $CODEX_HOME/config.toml, Hermes/Kimi/Kiro via ACP mcpServers, OpenClaw via the per-task config wrapper). Stored verbatim and may contain secrets — only the agent owner and workspace admins can read it. Leave empty to fall back to the CLI's own default. For OpenClaw HTTP/SSE entries use OpenClaw's own field name (e.g. \"transport\": \"streamable-http\") instead of Claude's \"type\".",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP config JSON editor",
       "clear_action": "Clear",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -296,7 +296,7 @@
       "save_failed_toast": "사용자 지정 인자를 저장하지 못했습니다"
     },
     "mcp_config": {
-      "intro": "런타임 CLI로 전달되는 MCP server configuration입니다(Claude는 --mcp-config, Codex는 $CODEX_HOME/config.toml, OpenClaw는 task별 config wrapper). 그대로 저장되며 secret이 포함될 수 있으므로 에이전트 소유자와 워크스페이스 관리자만 읽을 수 있습니다. 비워두면 CLI 자체 기본값을 사용합니다. OpenClaw HTTP/SSE 항목은 Claude의 \"type\" 대신 OpenClaw의 필드명(예: \"transport\": \"streamable-http\")을 사용하세요.",
+      "intro": "런타임 CLI로 전달되는 MCP server configuration입니다(Claude는 --mcp-config, Codex는 $CODEX_HOME/config.toml, Hermes/Kimi/Kiro는 ACP mcpServers, OpenClaw는 task별 config wrapper). 그대로 저장되며 secret이 포함될 수 있으므로 에이전트 소유자와 워크스페이스 관리자만 읽을 수 있습니다. 비워두면 CLI 자체 기본값을 사용합니다. OpenClaw HTTP/SSE 항목은 Claude의 \"type\" 대신 OpenClaw의 필드명(예: \"transport\": \"streamable-http\")을 사용하세요.",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP config JSON editor",
       "clear_action": "지우기",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -290,7 +290,7 @@
       "save_failed_toast": "保存自定义参数失败"
     },
     "mcp_config": {
-      "intro": "转发给运行时 CLI 的 MCP 服务器配置（Claude 通过 --mcp-config，Codex 通过 $CODEX_HOME/config.toml，OpenClaw 通过每个任务的配置 wrapper）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。OpenClaw 的 HTTP/SSE 条目需要使用 OpenClaw 自己的字段名（例如 \"transport\": \"streamable-http\"），而不是 Claude 的 \"type\"。",
+      "intro": "转发给运行时 CLI 的 MCP 服务器配置（Claude 通过 --mcp-config，Codex 通过 $CODEX_HOME/config.toml，Hermes/Kimi/Kiro 通过 ACP mcpServers，OpenClaw 通过每个任务的配置 wrapper）。原样保存，可能包含密钥 —— 只有智能体所有者和工作区管理员可以读取。留空则回退到 CLI 自身的默认设置。OpenClaw 的 HTTP/SSE 条目需要使用 OpenClaw 自己的字段名（例如 \"transport\": \"streamable-http\"），而不是 Claude 的 \"type\"。",
       "placeholder": "{\n  \"mcpServers\": {\n    \"fetch\": {\n      \"command\": \"uvx\",\n      \"args\": [\"mcp-server-fetch\"]\n    }\n  }\n}",
       "editor_aria": "MCP 配置 JSON 编辑器",
       "clear_action": "清空",


### PR DESCRIPTION
## Summary

- Add Hermes, Kimi, and Kiro to the frontend MCP config provider allowlist.
- Expand the agent overview tab visibility test to cover all MCP-consuming runtimes.
- Update MCP tab intro copy in English, Simplified Chinese, and Korean so the newly-visible ACP runtimes are documented in-product.

## Test plan

- `pnpm --filter @multica/views test -- agents/components/agent-overview-pane.test.tsx locales/parity.test.ts`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (passes with pre-existing warnings outside touched files)

Refs MUL-2833 and GitHub issue #2385.
