### PR TITLE
MUL-2785: fix(comments): revert since-delta to issue-wide, steer to parent thread first

### DIFF
--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -59,7 +59,7 @@ type PrepareParams struct {
 type TaskContextForEnv struct {
 	IssueID                 string
 	TriggerCommentID        string // comment that triggered this task (empty for on_assign)
-	NewCommentCount         int    // non-injected comments in the trigger thread since this agent's last run (excludes its own)
+	NewCommentCount         int    // issue-wide comments since this agent's last run (excludes its own and the injected trigger)
 	NewCommentsSince        string // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	PriorSessionResumed     bool   // true when the daemon will resume an existing provider session for this task
 	AgentID                 string // unique ID of the dispatched agent

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3441,15 +3441,17 @@ func TestInjectRuntimeConfigCommentTriggerResumedNoDeltaRead(t *testing.T) {
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Current-thread delta: 0 additional comments beyond the triggering comment",
-		"This is scoped to the triggering thread, not the whole issue",
-		"Do not re-read the triggering thread by default",
+		"No other new comments on this issue since your last run",
+		"Do not re-read comment history by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread " + triggerID + " --tail 30 --output json",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("comment-triggered resumed Workflow missing %q\n---\n%s", want, s)
 		}
+	}
+	if strings.Contains(s, "scoped to the triggering thread") {
+		t.Errorf("resumed Workflow must not claim the delta is thread-scoped\n---\n%s", s)
 	}
 	if strings.Contains(s, "Read the triggering conversation first") {
 		t.Errorf("resumed workflow must not force the cold-start thread read\n---\n%s", s)

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -4,58 +4,68 @@ import "fmt"
 
 // BuildNewCommentsHint returns the comment-reading pointer for the WARM path —
 // the agent ran on this issue before, so there is a since-anchor. The server
-// count is scoped to the triggering thread and excludes the triggering comment
-// itself because that body is already injected into the prompt. It ships only
-// the COUNT and the cursor — never the comment bodies — so the server stays
-// cheap and the agent pulls details on demand.
+// count is ISSUE-WIDE (every thread, not just the triggering one) and excludes
+// the triggering comment itself because that body is already injected into the
+// prompt. It ships only the COUNT and the cursor — never the comment bodies —
+// so the server stays cheap and the agent pulls details on demand.
+//
+// The agent is told the full issue-wide volume but steered to read the
+// triggering (parent) thread FIRST instead of blindly catching up on every
+// thread. The issue-wide `--since` catch-up is kept as an explicit
+// "only if you need it" fallback.
 //
 // Both the per-turn prompt (daemon.buildCommentPrompt) and the CLAUDE.md
 // workflow (InjectRuntimeConfig) call this so the two surfaces cannot drift
 // (hard requirement from PR #2816).
 //
 // Renders nothing on cold start (no prior run → newCommentsSince empty) or when
-// there are no additional thread comments (newCommentCount <= 0) or required
-// IDs are empty. In those cases the caller falls back to BuildResumedCommentsHint
-// (when a prior session is active) or BuildColdCommentsHint.
+// there are no new comments (newCommentCount <= 0) or issueID is empty. In those
+// cases the caller falls back to BuildResumedCommentsHint (when a prior session
+// is active) or BuildColdCommentsHint.
 func BuildNewCommentsHint(issueID, triggerCommentID, newCommentsSince string, newCommentCount int) string {
-	if newCommentCount <= 0 || newCommentsSince == "" || issueID == "" || triggerCommentID == "" {
+	if newCommentCount <= 0 || newCommentsSince == "" || issueID == "" {
 		return ""
 	}
-	hint := fmt.Sprintf(
-		"%d other new comment(s) in this thread since your last run. "+
-			"The triggering comment is already included above. "+
-			"To inspect the raw thread delta (which may include the injected trigger and agent-authored rows), run: "+
-			"`multica issue comment list %s --thread %s --since %s --output json`.\n\n",
-		newCommentCount, issueID, triggerCommentID, newCommentsSince,
+	// When we know the triggering thread, steer the agent to read THAT thread
+	// first rather than blindly pulling every new comment issue-wide. The
+	// issue-wide --since catch-up is demoted to an only-if-needed fallback.
+	if triggerCommentID != "" {
+		return fmt.Sprintf(
+			"%d new comment(s) on this issue since your last run — don't read them all blindly. "+
+				"Start with the thread your triggering comment is in: "+
+				"`multica issue comment list %s --thread %s --since %s --output json` "+
+				"(swap `--since` for `--tail 30` if you need the full thread, not just the delta). "+
+				"Only if you need context from the other threads, catch up issue-wide: "+
+				"`multica issue comment list %s --since %s --output json`.\n\n",
+			newCommentCount, issueID, triggerCommentID, newCommentsSince, issueID, newCommentsSince,
+		)
+	}
+	// Defensive: comment triggers always carry a trigger id, but if one is
+	// missing there is no thread to anchor on, so fall back to the plain
+	// issue-wide catch-up.
+	return fmt.Sprintf(
+		"%d new comment(s) on this issue since your last run. Catch up: "+
+			"`multica issue comment list %s --since %s --output json`.\n\n",
+		newCommentCount, issueID, newCommentsSince,
 	)
-	// --thread + --since is still only a delta: it covers new rows in the
-	// triggering thread, not older pre-anchor context. Keep a bounded fallback
-	// when the older conversation context is missing.
-	hint += fmt.Sprintf(
-		"If older thread context before %s is missing, pull the triggering conversation: "+
-			"`multica issue comment list %s --thread %s --tail 30 --output json`.\n\n",
-		newCommentsSince, issueID, triggerCommentID,
-	)
-	return hint
 }
 
 // BuildResumedCommentsHint returns the comment-reading pointer for the WARM
 // no-delta path: the daemon is resuming a prior provider session and the
 // triggering comment body has already been injected into the per-turn prompt.
-// In that shape, the zero-delta statement must be explicitly scoped to the
-// triggering thread, not the whole issue. Reading the triggering thread's last
-// 30 replies is duplicate context by default, so keep the bounded thread read
-// as an explicit fallback for missing context instead of making it the first
-// action.
+// newCommentCount == 0 here means no new comments arrived issue-wide since the
+// last run (beyond the injected trigger and the agent's own replies), so
+// re-reading comment history is duplicate work by default. Keep the bounded
+// triggering-thread read as an explicit fallback for missing context instead of
+// making it the first action.
 func BuildResumedCommentsHint(issueID, triggerCommentID string) string {
 	if issueID == "" || triggerCommentID == "" {
 		return ""
 	}
 	return fmt.Sprintf(
 		"You're resuming the prior session, and the triggering comment is already included above. "+
-			"Current-thread delta: 0 additional comments beyond the triggering comment. "+
-			"This is scoped to the triggering thread, not the whole issue. "+
-			"Do not re-read the triggering thread by default. "+
+			"No other new comments on this issue since your last run. "+
+			"Do not re-read comment history by default. "+
 			"Only if the resumed session is missing thread context, pull the triggering conversation: "+
 			"`multica issue comment list %s --thread %s --tail 30 --output json`.\n\n",
 		issueID, triggerCommentID,

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -156,7 +156,7 @@ func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	}
 }
 
-// The CLAUDE.md workflow surface must carry the same thread-scoped since-delta
+// The CLAUDE.md workflow surface must carry the same issue-wide since-delta
 // new-comment hint as the per-turn prompt. PR #2816 requires the two surfaces
 // stay in sync.
 func TestCommentTriggeredBriefCarriesNewCommentsHint(t *testing.T) {
@@ -173,22 +173,23 @@ func TestCommentTriggeredBriefCarriesNewCommentsHint(t *testing.T) {
 	}
 	out := buildMetaSkillContent("claude", ctx)
 
-	if !strings.Contains(out, "4 other new comment(s) in this thread since your last run") {
-		t.Errorf("comment brief must report the new-comment count, got:\n%s", out)
+	// Issue-wide count.
+	if !strings.Contains(out, "4 new comment(s) on this issue since your last run") {
+		t.Errorf("comment brief must report the issue-wide new-comment count, got:\n%s", out)
 	}
+	if !strings.Contains(out, "blindly") {
+		t.Errorf("comment brief must discourage blindly reading every new comment, got:\n%s", out)
+	}
+	// Parent thread first.
 	if !strings.Contains(out, "--thread reply-abc --since "+since+" --output json") {
-		t.Errorf("comment brief must point at the thread-scoped --since catch-up read, got:\n%s", out)
+		t.Errorf("comment brief must point at the triggering (parent) thread --since read first, got:\n%s", out)
 	}
-	if !strings.Contains(out, "raw thread delta") {
-		t.Errorf("comment brief must not imply the CLI output exactly matches the count, got:\n%s", out)
+	if !strings.Contains(out, "--tail 30") {
+		t.Errorf("comment brief must offer the full-thread (--tail 30) option, got:\n%s", out)
 	}
-	if strings.Contains(out, "resumed session is missing older thread context") {
-		t.Errorf("comment brief warm fallback wording must not assume a resumed session, got:\n%s", out)
-	}
-	// Warm path also keeps a bounded full-thread pointer for the triggering
-	// thread's pre-anchor history that --since cannot cover.
-	if !strings.Contains(out, "--thread reply-abc --tail 30 --output json") {
-		t.Errorf("warm brief must also point at the triggering thread, got:\n%s", out)
+	// Issue-wide catch-up demoted to an only-if-needed fallback.
+	if !strings.Contains(out, "multica issue comment list "+issueID+" --since "+since+" --output json") {
+		t.Errorf("comment brief must keep the issue-wide --since catch-up fallback, got:\n%s", out)
 	}
 	// The removed resolve step must not reappear.
 	if strings.Contains(out, "multica comment resolve") {
@@ -235,15 +236,17 @@ func TestCommentTriggeredBriefResumedNoDeltaSkipsDefaultThreadRead(t *testing.T)
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Current-thread delta: 0 additional comments beyond the triggering comment",
-		"This is scoped to the triggering thread, not the whole issue",
-		"Do not re-read the triggering thread by default",
+		"No other new comments on this issue since your last run",
+		"Do not re-read comment history by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread trigger-1 --tail 30 --output json",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("resumed/no-delta brief missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "scoped to the triggering thread") {
+		t.Errorf("resumed/no-delta brief must not claim the delta is thread-scoped, got:\n%s", out)
 	}
 	if strings.Contains(out, "Read the triggering conversation first") {
 		t.Errorf("resumed/no-delta brief must not use the cold-start forced-read wording, got:\n%s", out)

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -159,11 +159,12 @@ func buildCommentPrompt(task Task, provider string) string {
 		}
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
-	// Comment-reading pointer. Warm path with additional thread comments:
-	// thread-scoped since-delta. Warm resumed path with no additional thread
-	// comments: the trigger is already injected, so don't force a duplicate
-	// thread read. Cold path: read the triggering thread, not the flat timeline.
-	// Final fallback (no trigger id, shouldn't happen here): plain read.
+	// Comment-reading pointer. Warm path with new comments: issue-wide
+	// since-delta count, but steer the agent to read the triggering thread
+	// first. Warm resumed path with no new comments: the trigger is already
+	// injected, so don't force a duplicate thread read. Cold path: read the
+	// triggering thread, not the flat timeline. Final fallback (no trigger id,
+	// shouldn't happen here): plain read.
 	if hint := execenv.BuildNewCommentsHint(task.IssueID, task.TriggerCommentID, task.NewCommentsSince, task.NewCommentCount); hint != "" {
 		b.WriteString(hint)
 	} else if task.PriorSessionID != "" {

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -299,8 +299,9 @@ func TestBuildPromptNonSquadLeaderNoRule(t *testing.T) {
 
 // TestBuildPromptNewCommentsHint pins that a comment-triggered task whose agent
 // ran before on this issue (NewCommentsSince set, NewCommentCount > 0) gets the
-// since-delta hint scoped to the triggering thread, so the agent does not pull
-// unrelated thread updates by default.
+// since-delta hint with the ISSUE-WIDE new-comment count, but is steered to read
+// the triggering (parent) thread first rather than blindly pulling every new
+// comment.
 func TestBuildPromptNewCommentsHint(t *testing.T) {
 	const (
 		issueID = "issue-new-1"
@@ -316,22 +317,24 @@ func TestBuildPromptNewCommentsHint(t *testing.T) {
 	}
 	out := BuildPrompt(task, "claude")
 
-	if !strings.Contains(out, "3 other new comment(s) in this thread since your last run") {
-		t.Errorf("hint must report the new-comment count, got:\n%s", out)
+	// Issue-wide count (reverted from the thread-scoped wording).
+	if !strings.Contains(out, "3 new comment(s) on this issue since your last run") {
+		t.Errorf("hint must report the issue-wide new-comment count, got:\n%s", out)
 	}
+	// Don't-blindly-read-all guidance.
+	if !strings.Contains(out, "blindly") {
+		t.Errorf("hint must discourage blindly reading every new comment, got:\n%s", out)
+	}
+	// Parent thread first: the --thread <trigger> read is the prioritized action.
 	if !strings.Contains(out, "multica issue comment list "+issueID+" --thread trigger-1 --since "+since+" --output json") {
-		t.Errorf("hint must point at the thread-scoped --since catch-up read, got:\n%s", out)
+		t.Errorf("hint must point at the triggering (parent) thread --since read first, got:\n%s", out)
 	}
-	if !strings.Contains(out, "raw thread delta") {
-		t.Errorf("hint must not imply the CLI output exactly matches the count, got:\n%s", out)
+	if !strings.Contains(out, "--tail 30") {
+		t.Errorf("hint must offer the full-thread (--tail 30) option, got:\n%s", out)
 	}
-	if strings.Contains(out, "resumed session is missing older thread context") {
-		t.Errorf("warm delta fallback wording must not assume a resumed session, got:\n%s", out)
-	}
-	// Warm path also keeps a bounded full-thread pointer: thread-scoped --since
-	// can still miss the triggering thread's pre-anchor history.
-	if !strings.Contains(out, "multica issue comment list "+issueID+" --thread trigger-1 --tail 30 --output json") {
-		t.Errorf("warm hint must also point at the triggering thread, got:\n%s", out)
+	// Issue-wide catch-up is demoted to an only-if-needed fallback.
+	if !strings.Contains(out, "multica issue comment list "+issueID+" --since "+since+" --output json") {
+		t.Errorf("hint must keep the issue-wide --since catch-up as a fallback, got:\n%s", out)
 	}
 	// The old cursor-heavy paragraph must be gone.
 	if strings.Contains(out, "Next reply cursor") || strings.Contains(out, "--before-id") {
@@ -381,15 +384,19 @@ func TestBuildPromptResumedNoDeltaDoesNotForceThreadRead(t *testing.T) {
 
 	for _, want := range []string{
 		"triggering comment is already included above",
-		"Current-thread delta: 0 additional comments beyond the triggering comment",
-		"This is scoped to the triggering thread, not the whole issue",
-		"Do not re-read the triggering thread by default",
+		"No other new comments on this issue since your last run",
+		"Do not re-read comment history by default",
 		"Only if the resumed session is missing thread context",
 		"multica issue comment list " + issueID + " --thread trigger-1 --tail 30 --output json",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("resumed/no-delta prompt missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+	// The stale thread-scoped wording (since-delta used to be thread-scoped)
+	// must not reappear.
+	if strings.Contains(out, "scoped to the triggering thread") {
+		t.Errorf("resumed/no-delta prompt must not claim the delta is thread-scoped, got:\n%s", out)
 	}
 	if strings.Contains(out, "Read the triggering conversation first") {
 		t.Errorf("resumed/no-delta prompt must not use the cold-start forced-read wording, got:\n%s", out)

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -55,7 +55,7 @@ type Task struct {
 	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
 	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind for the triggering comment
 	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	NewCommentCount         int                   `json:"new_comment_count,omitempty"`         // non-injected comments in the trigger thread since this agent's last run (excludes its own); 0/omitted for old daemons or cold start
+	NewCommentCount         int                   `json:"new_comment_count,omitempty"`         // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
 	NewCommentsSince        string                `json:"new_comments_since,omitempty"`        // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
 	ChatMessage             string                `json:"chat_message,omitempty"`              // user message content for chat tasks

--- a/server/internal/handler/comment_list_test.go
+++ b/server/internal/handler/comment_list_test.go
@@ -1320,12 +1320,13 @@ func resolveCommentRow(t *testing.T, commentID string) {
 	}
 }
 
-// TestCountNewCommentsSince_ThreadScopedExcludesAgentOwnAndTrigger pins the
-// claim-side count query: it counts comments created after the given anchor only
-// within the triggering thread, excludes the triggering comment because it is
-// injected into the prompt, and excludes the agent's own comments so a chatty
-// agent does not inflate its own new-comment count.
-func TestCountNewCommentsSince_ThreadScopedExcludesAgentOwnAndTrigger(t *testing.T) {
+// TestCountNewCommentsSince_IssueWideExcludesAgentOwnAndTrigger pins the
+// claim-side count query: it counts comments created after the given anchor
+// ACROSS THE WHOLE ISSUE (every thread, not just the triggering one), excludes
+// the triggering comment because it is injected into the prompt, and excludes
+// the agent's own comments so a chatty agent does not inflate its own
+// new-comment count.
+func TestCountNewCommentsSince_IssueWideExcludesAgentOwnAndTrigger(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -1341,9 +1342,10 @@ func TestCountNewCommentsSince_ThreadScopedExcludesAgentOwnAndTrigger(t *testing
 
 	ctx := context.Background()
 
-	// Anchor after r1a: root1/r1a are stale, r1b is the only non-trigger,
-	// non-agent comment in the triggering thread. r1b1 is the trigger and root2's
-	// whole thread is unrelated noise.
+	// Anchor after r1a: root1/r1a are stale. Newer than the anchor are r1b
+	// (trigger thread), r1b1 (the trigger itself — excluded), the agent reply
+	// (excluded), and root2's whole thread root2/r2a/r2b (unrelated thread, now
+	// counted because the count is issue-wide). So r1b + root2 + r2a + r2b = 4.
 	got, err := testHandler.Queries.CountNewCommentsSince(ctx, db.CountNewCommentsSinceParams{
 		AnchorID:    parseUUID(fx.R1b1),
 		IssueID:     parseUUID(fx.IssueID),
@@ -1354,8 +1356,8 @@ func TestCountNewCommentsSince_ThreadScopedExcludesAgentOwnAndTrigger(t *testing
 	if err != nil {
 		t.Fatalf("count new since anchor: %v", err)
 	}
-	if got != 1 {
-		t.Fatalf("expected only r1b to count, got %d", got)
+	if got != 4 {
+		t.Fatalf("expected issue-wide count of 4 (r1b + root2 + r2a + r2b), got %d", got)
 	}
 
 	// Anchor in the future: nothing is newer.

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1269,15 +1269,15 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
-				// Count non-injected comments that arrived in the triggering
-				// thread since this agent's last run, so the daemon can tell it up
-				// front instead of forcing an issue-wide catch-up. Anchor = the
-				// prior task's started_at (never completed_at: a long run would
-				// miss comments posted while it ran). Cold start (no prior task) →
-				// no anchor → no hint. Excludes the agent's own comments and the
-				// triggering comment itself because that body is already injected
-				// into the prompt. Best-effort: any DB error or zero count leaves
-				// the hint suppressed.
+				// Count comments that arrived issue-wide since this agent's last
+				// run, so the daemon can tell it the full catch-up volume up front
+				// (the prompt then steers it to read the triggering thread first).
+				// Anchor = the prior task's started_at (never completed_at: a long
+				// run would miss comments posted while it ran). Cold start (no prior
+				// task) → no anchor → no hint. Excludes the agent's own comments and
+				// the triggering comment itself because that body is already
+				// injected into the prompt. Best-effort: any DB error or zero count
+				// leaves the hint suppressed.
 				if startedAt, err := h.Queries.GetLastTaskStartedAtForIssueAndAgent(r.Context(), db.GetLastTaskStartedAtForIssueAndAgentParams{
 					AgentID: task.AgentID,
 					IssueID: comment.IssueID,

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3497,12 +3497,13 @@ func claimCommentTask(t *testing.T, runtimeID, daemonID string) claimCommentTask
 	return resp
 }
 
-// TestClaimTaskByRuntime_CommentTaskPopulatesThreadScopedNewCommentCount
+// TestClaimTaskByRuntime_CommentTaskPopulatesNewCommentCount
 // verifies the claim response carries new_comment_count + new_comments_since for
-// a comment task when the agent ran before: the count is scoped to the
-// triggering thread, excludes the injected trigger comment, excludes the
-// agent's own comments, and the since anchor is the prior run's started_at.
-func TestClaimTaskByRuntime_CommentTaskPopulatesThreadScopedNewCommentCount(t *testing.T) {
+// a comment task when the agent ran before: the count is ISSUE-WIDE (covers
+// every thread, not just the triggering one), excludes the injected trigger
+// comment, excludes the agent's own comments, and the since anchor is the prior
+// run's started_at.
+func TestClaimTaskByRuntime_CommentTaskPopulatesNewCommentCount(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -3562,8 +3563,10 @@ func TestClaimTaskByRuntime_CommentTaskPopulatesThreadScopedNewCommentCount(t *t
 	if resp.Task.NewCommentsSince == "" {
 		t.Errorf("new_comments_since must be set when a prior run exists, got empty")
 	}
-	if resp.Task.NewCommentCount != 1 {
-		t.Errorf("new_comment_count = %d, want 1 (same-thread context only)", resp.Task.NewCommentCount)
+	// Issue-wide: the same-thread context comment AND the unrelated-thread root
+	// both count; only the agent's own reply and the injected trigger are excluded.
+	if resp.Task.NewCommentCount != 2 {
+		t.Errorf("new_comment_count = %d, want 2 (issue-wide: same-thread + unrelated thread)", resp.Task.NewCommentCount)
 	}
 }
 

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -29,54 +29,36 @@ func (q *Queries) CountComments(ctx context.Context, arg CountCommentsParams) (i
 }
 
 const countNewCommentsSince = `-- name: CountNewCommentsSince :one
-WITH RECURSIVE root_of AS (
-    SELECT c.id, c.parent_id
-    FROM comment c
-    WHERE c.id = $1 AND c.issue_id = $2 AND c.workspace_id = $3
-    UNION ALL
-    SELECT p.id, p.parent_id
-    FROM comment p
-    JOIN root_of r ON p.id = r.parent_id
-    WHERE p.issue_id = $2 AND p.workspace_id = $3
-),
-thread_root AS (
-    SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
-),
-descendants AS (
-    SELECT c.id, c.created_at, c.author_type, c.author_id
-    FROM comment c
-    JOIN thread_root tr ON c.id = tr.id
-    UNION
-    SELECT c.id, c.created_at, c.author_type, c.author_id
-    FROM comment c
-    JOIN descendants d ON c.parent_id = d.id
-    WHERE c.issue_id = $2 AND c.workspace_id = $3
-)
-SELECT count(*) FROM descendants
-WHERE created_at > $4
-  AND id <> $1
+SELECT count(*) FROM comment
+WHERE issue_id = $1
+  AND workspace_id = $2
+  AND created_at > $3
+  AND id <> $4
   AND NOT (author_type = 'agent' AND author_id = $5)
 `
 
 type CountNewCommentsSinceParams struct {
-	AnchorID    pgtype.UUID        `json:"anchor_id"`
 	IssueID     pgtype.UUID        `json:"issue_id"`
 	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Since       pgtype.Timestamptz `json:"since"`
+	AnchorID    pgtype.UUID        `json:"anchor_id"`
 	AuthorID    pgtype.UUID        `json:"author_id"`
 }
 
-// Counts non-injected comments in the thread containing @anchor_id created
-// strictly after @since, excluding any authored by the given agent
-// (@author_id). The triggering comment body is already injected into the
-// prompt, so @anchor_id itself is excluded from the count. Feeds the daemon
-// claim response without shipping comment bodies.
+// Counts comments on an issue created strictly after @since, ACROSS THE WHOLE
+// ISSUE (every thread, not just the triggering one). Excludes the triggering
+// comment itself (@anchor_id — its body is already injected into the prompt)
+// and any authored by the given agent (@author_id), so a chatty agent does not
+// inflate its own new-comment count. The agent is steered to read the
+// triggering thread first (see BuildNewCommentsHint), but the count is
+// issue-wide so it knows the full catch-up volume. Feeds the daemon claim
+// response without shipping comment bodies.
 func (q *Queries) CountNewCommentsSince(ctx context.Context, arg CountNewCommentsSinceParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countNewCommentsSince,
-		arg.AnchorID,
 		arg.IssueID,
 		arg.WorkspaceID,
 		arg.Since,
+		arg.AnchorID,
 		arg.AuthorID,
 	)
 	var count int64

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -298,39 +298,18 @@ SELECT count(*) FROM comment
 WHERE issue_id = $1 AND workspace_id = $2;
 
 -- name: CountNewCommentsSince :one
--- Counts non-injected comments in the thread containing @anchor_id created
--- strictly after @since, excluding any authored by the given agent
--- (@author_id). The triggering comment body is already injected into the
--- prompt, so @anchor_id itself is excluded from the count. Feeds the daemon
--- claim response without shipping comment bodies.
-WITH RECURSIVE root_of AS (
-    -- Scope is enforced on both the anchor seed and recursive walk-up; keep
-    -- these predicates together so future parent/thread changes cannot cross
-    -- issue or workspace boundaries.
-    SELECT c.id, c.parent_id
-    FROM comment c
-    WHERE c.id = @anchor_id AND c.issue_id = @issue_id AND c.workspace_id = @workspace_id
-    UNION ALL
-    SELECT p.id, p.parent_id
-    FROM comment p
-    JOIN root_of r ON p.id = r.parent_id
-    WHERE p.issue_id = @issue_id AND p.workspace_id = @workspace_id
-),
-thread_root AS (
-    SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1
-),
-descendants AS (
-    SELECT c.id, c.created_at, c.author_type, c.author_id
-    FROM comment c
-    JOIN thread_root tr ON c.id = tr.id
-    UNION
-    SELECT c.id, c.created_at, c.author_type, c.author_id
-    FROM comment c
-    JOIN descendants d ON c.parent_id = d.id
-    WHERE c.issue_id = @issue_id AND c.workspace_id = @workspace_id
-)
-SELECT count(*) FROM descendants
-WHERE created_at > @since
+-- Counts comments on an issue created strictly after @since, ACROSS THE WHOLE
+-- ISSUE (every thread, not just the triggering one). Excludes the triggering
+-- comment itself (@anchor_id — its body is already injected into the prompt)
+-- and any authored by the given agent (@author_id), so a chatty agent does not
+-- inflate its own new-comment count. The agent is steered to read the
+-- triggering thread first (see BuildNewCommentsHint), but the count is
+-- issue-wide so it knows the full catch-up volume. Feeds the daemon claim
+-- response without shipping comment bodies.
+SELECT count(*) FROM comment
+WHERE issue_id = @issue_id
+  AND workspace_id = @workspace_id
+  AND created_at > @since
   AND id <> @anchor_id
   AND NOT (author_type = 'agent' AND author_id = @author_id);
 


### PR DESCRIPTION
## What

#3509/#3523 scoped the comment-trigger since-delta count to the **triggering thread only**, so an agent resuming a busy issue saw "+N in this thread" and lost sight of new comments in other threads.

Per request on MUL-2785, this reverts the count to **issue-wide** and reshapes the prompt to steer the agent to read the **parent (triggering) thread first** instead of blindly catching up everywhere.

## Changes

- **SQL** `CountNewCommentsSince`: dropped the per-thread recursive scoping → plain issue-wide `count(*)`. Kept the trigger-comment (`@anchor_id`) and agent-own exclusions, so the number still means "new comments you haven't seen." sqlc regenerated.
- **Warm-path hint** (`BuildNewCommentsHint`): now reports the issue-wide volume, points at `--thread <trigger> --since` (or `--tail 30`) as the **first** action, and demotes the issue-wide `--since` catch-up to an only-if-needed fallback ("don't read them all blindly").
- **Resumed no-delta hint** (`BuildResumedCommentsHint`): fixed the now-stale "scoped to the triggering thread" wording → issue-wide zero.
- Updated doc comments on the claim contract fields and the handler.

Did **not** do the per-thread `+count` breakdown that was floated earlier — the user explicitly scoped that out.

## Tests

- `TestCountNewCommentsSince_IssueWideExcludesAgentOwnAndTrigger` — SQL now counts across threads (4 in the fixture).
- `TestClaimTaskByRuntime_CommentTaskPopulatesNewCommentCount` — claim count is 2 (both threads), trigger + agent-own still excluded.
- `TestClaimTaskByRuntime_CommentTaskOmitsDeltaWhenOnlyTriggerIsNew` — still 0 when only the injected trigger is new.
- Warm / resumed hint assertions updated in `prompt_test.go`, `runtime_config_test.go`, `execenv_test.go`.

`go build ./...`, `go test ./internal/daemon/...`, and the affected handler tests (live DB) all pass; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)