### PR TITLE
feat: add structured completion goals for agent tasks

### DIFF
--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -39,6 +39,7 @@ export interface Issue {
   identifier: string;
   title: string;
   description: string | null;
+  goal_condition?: string | null;
   status: IssueStatus;
   priority: IssuePriority;
   assignee_type: IssueAssigneeType | null;

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -273,6 +273,7 @@ func init() {
 	issueCreateCmd.Flags().String("description", "", "Issue description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueCreateCmd.Flags().Bool("description-stdin", false, "Read issue description from stdin (preserves multi-line content verbatim)")
 	issueCreateCmd.Flags().String("description-file", "", "Read issue description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
+	issueCreateCmd.Flags().String("goal", "", "Structured completion condition for the assigned agent")
 	issueCreateCmd.Flags().String("status", "", "Issue status")
 	issueCreateCmd.Flags().String("priority", "", "Issue priority")
 	issueCreateCmd.Flags().String("assignee", "", "Assignee name (member, agent, or squad; fuzzy match)")
@@ -290,6 +291,7 @@ func init() {
 	issueUpdateCmd.Flags().String("description", "", "New description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueUpdateCmd.Flags().Bool("description-stdin", false, "Read new description from stdin (preserves multi-line content verbatim)")
 	issueUpdateCmd.Flags().String("description-file", "", "Read new description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
+	issueUpdateCmd.Flags().String("goal", "", "New structured completion condition (pass empty string to clear)")
 	issueUpdateCmd.Flags().String("status", "", "New status")
 	issueUpdateCmd.Flags().String("priority", "", "New priority")
 	issueUpdateCmd.Flags().String("assignee", "", "New assignee name (member, agent, or squad; fuzzy match)")
@@ -578,6 +580,9 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	if hasDesc {
 		body["description"] = desc
 	}
+	if v, _ := cmd.Flags().GetString("goal"); v != "" {
+		body["goal_condition"] = util.UnescapeBackslashEscapes(v)
+	}
 	if v, _ := cmd.Flags().GetString("status"); v != "" {
 		body["status"] = v
 	}
@@ -739,6 +744,10 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		body["description"] = desc
+	}
+	if cmd.Flags().Changed("goal") {
+		v, _ := cmd.Flags().GetString("goal")
+		body["goal_condition"] = util.UnescapeBackslashEscapes(v)
 	}
 	if cmd.Flags().Changed("status") {
 		v, _ := cmd.Flags().GetString("status")

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -232,6 +232,7 @@ func newIssueCreateTestCmd() *cobra.Command {
 	cmd.Flags().String("description", "", "")
 	cmd.Flags().Bool("description-stdin", false, "")
 	cmd.Flags().String("description-file", "", "")
+	cmd.Flags().String("goal", "", "")
 	cmd.Flags().String("status", "", "")
 	cmd.Flags().String("priority", "", "")
 	cmd.Flags().String("assignee", "", "")
@@ -1965,5 +1966,119 @@ func TestValidIssueStatuses(t *testing.T) {
 	}
 	if len(validIssueStatuses) != len(expected) {
 		t.Errorf("validIssueStatuses has %d entries, expected %d", len(validIssueStatuses), len(expected))
+	}
+}
+
+// newIssueUpdateTestCmd builds a throwaway cobra.Command carrying the subset
+// of `issue update` flags that runIssueUpdate reads. pflag reports any
+// unregistered flag as not-Changed, so a focused test only registers (and
+// Sets) the flags it exercises.
+func newIssueUpdateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("title", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().Bool("description-stdin", false, "")
+	cmd.Flags().String("description-file", "", "")
+	cmd.Flags().String("goal", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+// issueUpdateBodyForFlags resolves MUL-1 then captures the JSON body that
+// runIssueUpdate PUTs, so the goal_condition plumbing (set / clear / omit)
+// can be asserted without a live server.
+func issueUpdateBodyForFlags(t *testing.T, setFlags func(*cobra.Command)) map[string]any {
+	t.Helper()
+	const issueID = "1881a167-4bb6-4602-944b-f40ce4192fe6"
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/MUL-1":
+			json.NewEncoder(w).Encode(map[string]any{"id": issueID, "identifier": "MUL-1", "title": "T"})
+		case r.URL.Path == "/api/issues/"+issueID:
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{"id": issueID, "identifier": "MUL-1", "title": "T", "status": "todo", "priority": "none"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueUpdateTestCmd()
+	setFlags(cmd)
+	if err := runIssueUpdate(cmd, []string{"MUL-1"}); err != nil {
+		t.Fatalf("runIssueUpdate: %v", err)
+	}
+	return body
+}
+
+func TestRunIssueCreateSendsGoalSeparateFromDescription(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/issues" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "issue-1", "identifier": "MUL-1", "title": "T", "status": "todo", "priority": "none"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Has a goal")
+	_ = cmd.Flags().Set("description", "Do the work described here")
+	_ = cmd.Flags().Set("goal", "Open PR, checks pass, no deploy")
+	if err := runIssueCreate(cmd, nil); err != nil {
+		t.Fatalf("runIssueCreate: %v", err)
+	}
+	if got := body["goal_condition"]; got != "Open PR, checks pass, no deploy" {
+		t.Fatalf("goal_condition = %#v, want the --goal value", got)
+	}
+	if got := body["description"]; got != "Do the work described here" {
+		t.Fatalf("description = %#v, want the --description value (goal must be a separate field)", got)
+	}
+}
+
+func TestRunIssueUpdateSetsGoal(t *testing.T) {
+	body := issueUpdateBodyForFlags(t, func(cmd *cobra.Command) {
+		_ = cmd.Flags().Set("goal", "Ship the PR")
+	})
+	if got := body["goal_condition"]; got != "Ship the PR" {
+		t.Fatalf("goal_condition = %#v, want \"Ship the PR\"", got)
+	}
+}
+
+func TestRunIssueUpdateClearsGoalWithEmptyString(t *testing.T) {
+	body := issueUpdateBodyForFlags(t, func(cmd *cobra.Command) {
+		_ = cmd.Flags().Set("goal", "")
+	})
+	got, ok := body["goal_condition"]
+	if !ok {
+		t.Fatalf("goal_condition key must be present (empty string) to clear, body=%#v", body)
+	}
+	if got != "" {
+		t.Fatalf("goal_condition = %#v, want empty string to signal clear", got)
+	}
+}
+
+func TestRunIssueUpdateOmitsGoalWhenFlagUnset(t *testing.T) {
+	body := issueUpdateBodyForFlags(t, func(cmd *cobra.Command) {
+		_ = cmd.Flags().Set("title", "Only title changes")
+	})
+	if _, ok := body["goal_condition"]; ok {
+		t.Fatalf("goal_condition must be absent when --goal is not passed, body=%#v", body)
 	}
 }

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -208,6 +208,9 @@ func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages
 
 func (c *Client) CompleteTask(ctx context.Context, taskID, output, branchName, sessionID, workDir string) error {
 	body := map[string]any{"output": output}
+	if status := parseGoalStatus(output); status != goalStatusUnknown {
+		body["goal_status"] = string(status)
+	}
 	if branchName != "" {
 		body["branch_name"] = branchName
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2487,6 +2487,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// via `multica repo checkout <url>`.
 	taskCtx := execenv.TaskContextForEnv{
 		IssueID:                          task.IssueID,
+		GoalCondition:                    task.GoalCondition,
 		TriggerCommentID:                 task.TriggerCommentID,
 		NewCommentCount:                  task.NewCommentCount,
 		NewCommentsSince:                 task.NewCommentsSince,

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -392,6 +392,11 @@ func renderIssueContext(provider string, ctx TaskContextForEnv) string {
 
 	b.WriteString("# Task Assignment\n\n")
 	fmt.Fprintf(&b, "**Issue ID:** %s\n\n", ctx.IssueID)
+	if strings.TrimSpace(ctx.GoalCondition) != "" {
+		b.WriteString("**Completion goal:** ")
+		b.WriteString(strings.TrimSpace(ctx.GoalCondition))
+		b.WriteString("\n\n")
+	}
 
 	if ctx.TriggerCommentID != "" {
 		b.WriteString("**Trigger:** Comment Reply\n")

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -58,6 +58,7 @@ type PrepareParams struct {
 // TaskContextForEnv is the subset of task context used for writing context files.
 type TaskContextForEnv struct {
 	IssueID                 string
+	GoalCondition           string
 	TriggerCommentID        string // comment that triggered this task (empty for on_assign)
 	NewCommentCount         int    // issue-wide comments since this agent's last run (excludes its own and the injected trigger)
 	NewCommentsSince        string // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start

--- a/server/internal/daemon/goal.go
+++ b/server/internal/daemon/goal.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type goalStatus string
+
+const (
+	goalStatusUnknown   goalStatus = "unknown"
+	goalStatusSatisfied goalStatus = "satisfied"
+	goalStatusBlocked   goalStatus = "blocked"
+	goalStatusPartial   goalStatus = "partial"
+)
+
+func appendGoalInstruction(prompt, provider, goal string) string {
+	goal = strings.TrimSpace(goal)
+	if goal == "" {
+		return prompt
+	}
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(prompt, "\n"))
+	b.WriteString("\n\n")
+	b.WriteString(compileGoalInstruction(provider, goal))
+	return b.String()
+}
+
+func compileGoalInstruction(provider, goal string) string {
+	var b strings.Builder
+	b.WriteString("## Completion Goal\n\n")
+	fmt.Fprintf(&b, "Multica has stored this task's completion condition as structured data, separate from the issue description:\n\n> %s\n\n", goal)
+
+	switch provider {
+	case "codex":
+		b.WriteString("Codex runtime instruction: keep working until the completion goal is satisfied or a real blocker is encountered. Do not treat a narrative summary or vague 'done' as enough.\n\n")
+	case "openclaw", "claude":
+		b.WriteString("Claude runtime instruction: keep working until the completion goal is satisfied or a real blocker is encountered. Do not depend on slash-command support in non-interactive mode; treat this prompt-level instruction as authoritative.\n\n")
+	default:
+		b.WriteString("Runtime instruction: keep working until the completion goal is satisfied or a real blocker is encountered. Do not treat a narrative summary or vague 'done' as enough.\n\n")
+	}
+
+	b.WriteString("Before your final output, verify the goal and include exactly one of these markers with evidence:\n")
+	b.WriteString("- GOAL_SATISFIED — the completion condition is true.\n")
+	b.WriteString("- BLOCKED — a real blocker prevents satisfying the goal.\n")
+	b.WriteString("- PARTIAL — meaningful progress was made, but the goal is not fully satisfied.\n\n")
+	b.WriteString("Preferred final shape:\n")
+	b.WriteString("```json\n")
+	b.WriteString("{\n  \"goal_status\": \"satisfied|blocked|partial\",\n  \"evidence\": [\"...\"],\n  \"remaining\": [\"...\"]\n}\n")
+	b.WriteString("```\n")
+	return b.String()
+}
+
+func parseGoalStatus(output string) goalStatus {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return goalStatusUnknown
+	}
+
+	if status := parseGoalStatusJSON(trimmed); status != goalStatusUnknown {
+		return status
+	}
+
+	upper := strings.ToUpper(trimmed)
+	switch {
+	case strings.Contains(upper, "GOAL_SATISFIED"):
+		return goalStatusSatisfied
+	case strings.Contains(upper, "BLOCKED"):
+		return goalStatusBlocked
+	case strings.Contains(upper, "PARTIAL"):
+		return goalStatusPartial
+	default:
+		return goalStatusUnknown
+	}
+}
+
+func parseGoalStatusJSON(output string) goalStatus {
+	candidates := []string{output}
+	if start := strings.Index(output, "{"); start >= 0 {
+		if end := strings.LastIndex(output, "}"); end > start {
+			candidates = append(candidates, output[start:end+1])
+		}
+	}
+
+	for _, candidate := range candidates {
+		var payload struct {
+			GoalStatus string `json:"goal_status"`
+		}
+		if err := json.Unmarshal([]byte(candidate), &payload); err != nil {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(payload.GoalStatus)) {
+		case "satisfied", "goal_satisfied", "done", "complete", "completed":
+			return goalStatusSatisfied
+		case "blocked":
+			return goalStatusBlocked
+		case "partial", "partially_satisfied":
+			return goalStatusPartial
+		}
+	}
+	return goalStatusUnknown
+}

--- a/server/internal/daemon/goal_test.go
+++ b/server/internal/daemon/goal_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAppendGoalInstructionCompilesProviderSpecificPrompt(t *testing.T) {
+	base := "Do work.\n"
+	got := appendGoalInstruction(base, "codex", "Open PR and checks pass")
+	if !strings.Contains(got, "## Completion Goal") {
+		t.Fatalf("expected goal section, got %q", got)
+	}
+	if !strings.Contains(got, "Open PR and checks pass") {
+		t.Fatalf("expected goal condition in prompt, got %q", got)
+	}
+	if !strings.Contains(got, "Codex runtime instruction") {
+		t.Fatalf("expected Codex-specific instruction, got %q", got)
+	}
+	if strings.Contains(got, "/goal") {
+		t.Fatalf("prompt should not depend on slash commands: %q", got)
+	}
+}
+
+func TestAppendGoalInstructionSkipsEmptyGoal(t *testing.T) {
+	base := "Do work.\n"
+	if got := appendGoalInstruction(base, "codex", "  "); got != base {
+		t.Fatalf("expected unchanged prompt, got %q", got)
+	}
+}
+
+func TestParseGoalStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want goalStatus
+	}{
+		{name: "marker satisfied", out: "GOAL_SATISFIED\nPR opened", want: goalStatusSatisfied},
+		{name: "marker blocked", out: "BLOCKED: missing credentials", want: goalStatusBlocked},
+		{name: "marker partial", out: "PARTIAL: tests pass but PR not opened", want: goalStatusPartial},
+		{name: "json satisfied", out: `{"goal_status":"satisfied","evidence":["tests passed"]}`, want: goalStatusSatisfied},
+		{name: "json fenced", out: "```json\n{\"goal_status\":\"blocked\"}\n```", want: goalStatusBlocked},
+		{name: "missing", out: "Done, see summary", want: goalStatusUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseGoalStatus(tt.out); got != tt.want {
+				t.Fatalf("parseGoalStatus() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPromptIncludesGoalInstruction(t *testing.T) {
+	task := Task{IssueID: "issue-1", GoalCondition: "Open PR and checks pass"}
+	got := BuildPrompt(task, "codex")
+	if !strings.Contains(got, "## Completion Goal") {
+		t.Fatalf("expected goal section in assignment prompt, got %q", got)
+	}
+	if !strings.Contains(got, "Open PR and checks pass") {
+		t.Fatalf("expected goal condition in prompt, got %q", got)
+	}
+	if !strings.Contains(got, "Codex runtime instruction") {
+		t.Fatalf("expected provider-specific instruction, got %q", got)
+	}
+}
+
+func TestBuildPromptWithoutGoalIsUnchanged(t *testing.T) {
+	task := Task{IssueID: "issue-1"}
+	got := BuildPrompt(task, "codex")
+	if strings.Contains(got, "## Completion Goal") {
+		t.Fatalf("expected no goal section when GoalCondition is empty, got %q", got)
+	}
+}
+
+func TestCompileGoalInstructionProviderVariants(t *testing.T) {
+	if claude := compileGoalInstruction("claude", "ship it"); !strings.Contains(claude, "Claude runtime instruction") {
+		t.Fatalf("expected Claude-specific instruction, got %q", claude)
+	}
+	// Any unmapped provider still gets a generic instruction (never silence).
+	generic := compileGoalInstruction("gemini", "ship it")
+	if strings.Contains(generic, "Claude runtime instruction") || strings.Contains(generic, "Codex runtime instruction") {
+		t.Fatalf("expected generic instruction for unmapped provider, got %q", generic)
+	}
+	for _, p := range []string{"claude", "codex", "gemini", "openclaw"} {
+		if out := compileGoalInstruction(p, "ship it"); strings.Contains(out, "/goal") {
+			t.Fatalf("provider %q instruction must not depend on slash commands: %q", p, out)
+		}
+	}
+}
+
+func TestTaskUnmarshalsGoalCondition(t *testing.T) {
+	var task Task
+	if err := json.Unmarshal([]byte(`{"id":"t1","issue_id":"i1","goal_condition":"Ship the PR"}`), &task); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if task.GoalCondition != "Ship the PR" {
+		t.Fatalf("GoalCondition = %q, want %q", task.GoalCondition, "Ship the PR")
+	}
+}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -19,7 +19,7 @@ func BuildPrompt(task Task, provider string) string {
 		return buildChatPrompt(task)
 	}
 	if task.TriggerCommentID != "" {
-		return buildCommentPrompt(task, provider)
+		return appendGoalInstruction(buildCommentPrompt(task, provider), provider, task.GoalCondition)
 	}
 	if task.AutopilotRunID != "" {
 		return buildAutopilotPrompt(task)
@@ -32,7 +32,7 @@ func BuildPrompt(task Task, provider string) string {
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	fmt.Fprintf(&b, "For comment history, follow the rule in your runtime workflow file (assignment-triggered tasks treat the read as mandatory). `multica issue comment list %s --output json` returns all comments for the issue (server caps at 2000). On long-running issues use `--recent 20 --output json` to read the 20 most recently active threads, then page older threads via the stderr `Next thread cursor: ...` line and the matching `--before` / `--before-id` until you have enough history. `--since <RFC3339>` is still available for incremental polling and may combine with `--recent`.\n", task.IssueID)
-	return b.String()
+	return appendGoalInstruction(b.String(), provider, task.GoalCondition)
 }
 
 // buildQuickCreatePrompt constructs a prompt for quick-create tasks. The
@@ -59,6 +59,8 @@ func buildQuickCreatePrompt(task Task) string {
 	b.WriteString("     CC exception: `multica issue create` has no `--subscriber` flag, and the platform auto-subscribes members whose `[@Name](mention://member/<uuid>)` link appears in the description. When the user wrote \"cc @Y\", strip the verbal \"cc\" wrapper from the User request body and append a final `CC: <mention link(s)>` line to the description so the cc routing still fires.\n\n")
 	b.WriteString("  2. **Context** — include ONLY when the input cited external resources AND you successfully fetched them AND they produced verifiable facts worth recording. Summarize facts only (e.g. \"PR #45 changes auth to JWT\"), not interpretation or unsolicited reference implementations. If you have nothing factual to add, omit the section entirely — never use it as an apology log for resources you could not fetch.\n\n")
 	b.WriteString("  Hard rules: never invent requirements, implementation details, or acceptance criteria the user did not express; never reduce multi-sentence input to a single vague sentence; never echo the title.\n\n")
+
+	b.WriteString("- **goal**: optional. If the user states a clear completion condition distinct from the work description, pass it with `--goal`. Keep it short and outcome-based (for example: `Open PR, checks pass, no deploy`). Do not copy the whole description into the goal, and do not invent a goal when the input only describes context.\n\n")
 
 	// priority
 	b.WriteString("- **priority**: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\" → urgent. If unspecified, omit.\n\n")

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -34,11 +34,12 @@ type ProjectResourceData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID          string `json:"id"`
-	AgentID     string `json:"agent_id"`
-	RuntimeID   string `json:"runtime_id"`
-	IssueID     string `json:"issue_id"`
-	WorkspaceID string `json:"workspace_id"`
+	ID            string `json:"id"`
+	AgentID       string `json:"agent_id"`
+	RuntimeID     string `json:"runtime_id"`
+	IssueID       string `json:"issue_id"`
+	GoalCondition string `json:"goal_condition,omitempty"` // issue's completion goal; empty when unset, compiled per-provider in goal.go
+	WorkspaceID   string `json:"workspace_id"`
 	// WorkspaceContext mirrors workspace.context (the per-workspace system
 	// prompt set in Settings → General). Server populates this on every claim
 	// regardless of task kind so the daemon can inject `## Workspace Context`

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -156,11 +156,12 @@ type ProjectResourceData struct {
 }
 
 type AgentTaskResponse struct {
-	ID          string `json:"id"`
-	AgentID     string `json:"agent_id"`
-	RuntimeID   string `json:"runtime_id"`
-	IssueID     string `json:"issue_id"`
-	WorkspaceID string `json:"workspace_id"`
+	ID            string `json:"id"`
+	AgentID       string `json:"agent_id"`
+	RuntimeID     string `json:"runtime_id"`
+	IssueID       string `json:"issue_id"`
+	WorkspaceID   string `json:"workspace_id"`
+	GoalCondition string `json:"goal_condition,omitempty"`
 	// WorkspaceContext is the workspace-level system prompt set in workspace
 	// settings (`workspace.context` DB column). Injected into the agent brief
 	// as `## Workspace Context` so every agent running in this workspace —

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1167,6 +1167,9 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if task.IssueID.Valid {
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
 			resp.WorkspaceID = uuidToString(issue.WorkspaceID)
+			if issue.GoalCondition.Valid {
+				resp.GoalCondition = strings.TrimSpace(issue.GoalCondition.String)
+			}
 
 			// Squad-leader briefing injection: when the issue is assigned
 			// to a squad and the claiming agent is that squad's current
@@ -1758,10 +1761,11 @@ func (h *Handler) ReportTaskProgress(w http.ResponseWriter, r *http.Request) {
 
 // CompleteTask marks a running task as completed.
 type TaskCompleteRequest struct {
-	PRURL     string `json:"pr_url"`
-	Output    string `json:"output"`
-	SessionID string `json:"session_id"` // Claude session ID for future resumption
-	WorkDir   string `json:"work_dir"`   // working directory used during execution
+	PRURL      string `json:"pr_url"`
+	Output     string `json:"output"`
+	GoalStatus string `json:"goal_status"`
+	SessionID  string `json:"session_id"` // Claude session ID for future resumption
+	WorkDir    string `json:"work_dir"`   // working directory used during execution
 }
 
 func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -34,6 +34,7 @@ type IssueResponse struct {
 	Identifier    string                  `json:"identifier"`
 	Title         string                  `json:"title"`
 	Description   *string                 `json:"description"`
+	GoalCondition *string                 `json:"goal_condition,omitempty"`
 	Status        string                  `json:"status"`
 	Priority      string                  `json:"priority"`
 	AssigneeType  *string                 `json:"assignee_type"`
@@ -71,6 +72,7 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 		Identifier:    identifier,
 		Title:         i.Title,
 		Description:   textToPtr(i.Description),
+		GoalCondition: textToPtr(i.GoalCondition),
 		Status:        i.Status,
 		Priority:      i.Priority,
 		AssigneeType:  textToPtr(i.AssigneeType),
@@ -98,6 +100,7 @@ func issueListRowToResponse(i db.ListIssuesRow, issuePrefix string) IssueRespons
 		Identifier:    identifier,
 		Title:         i.Title,
 		Description:   textToPtr(i.Description),
+		GoalCondition: textToPtr(i.GoalCondition),
 		Status:        i.Status,
 		Priority:      i.Priority,
 		AssigneeType:  textToPtr(i.AssigneeType),
@@ -155,6 +158,7 @@ func openIssueRowToResponse(i db.ListOpenIssuesRow, issuePrefix string) IssueRes
 		Identifier:    identifier,
 		Title:         i.Title,
 		Description:   textToPtr(i.Description),
+		GoalCondition: textToPtr(i.GoalCondition),
 		Status:        i.Status,
 		Priority:      i.Priority,
 		AssigneeType:  textToPtr(i.AssigneeType),
@@ -1942,6 +1946,7 @@ func readRuntimeCLIVersion(metadata []byte) string {
 type CreateIssueRequest struct {
 	Title         string   `json:"title"`
 	Description   *string  `json:"description"`
+	GoalCondition *string  `json:"goal_condition"`
 	Status        string   `json:"status"`
 	Priority      string   `json:"priority"`
 	AssigneeType  *string  `json:"assignee_type"`
@@ -2159,6 +2164,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 			DueDate:       dueDate,
 			Number:        issueNumber,
 			ProjectID:     projectID,
+			GoalCondition: ptrToText(req.GoalCondition),
 			OriginType:    originType,
 			OriginID:      originID,
 		})
@@ -2179,6 +2185,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 			DueDate:       dueDate,
 			Number:        issueNumber,
 			ProjectID:     projectID,
+			GoalCondition: ptrToText(req.GoalCondition),
 		})
 	}
 	if err != nil {
@@ -2273,6 +2280,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 type UpdateIssueRequest struct {
 	Title         *string  `json:"title"`
 	Description   *string  `json:"description"`
+	GoalCondition *string  `json:"goal_condition"`
 	Status        *string  `json:"status"`
 	Priority      *string  `json:"priority"`
 	AssigneeType  *string  `json:"assignee_type"`
@@ -2324,6 +2332,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		DueDate:       prevIssue.DueDate,
 		ParentIssueID: prevIssue.ParentIssueID,
 		ProjectID:     prevIssue.ProjectID,
+		GoalCondition: prevIssue.GoalCondition,
 	}
 
 	// COALESCE fields — only set when explicitly provided
@@ -2341,6 +2350,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Position != nil {
 		params.Position = pgtype.Float8{Float64: *req.Position, Valid: true}
+	}
+	if _, ok := rawFields["goal_condition"]; ok {
+		if req.GoalCondition != nil && strings.TrimSpace(*req.GoalCondition) != "" {
+			params.GoalCondition = pgtype.Text{String: strings.TrimSpace(*req.GoalCondition), Valid: true}
+		} else {
+			params.GoalCondition = pgtype.Text{Valid: false}
+		}
 	}
 	// Nullable fields — only override when explicitly present in JSON
 	if _, ok := rawFields["assignee_type"]; ok {
@@ -2855,6 +2871,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			DueDate:       prevIssue.DueDate,
 			ParentIssueID: prevIssue.ParentIssueID,
 			ProjectID:     prevIssue.ProjectID,
+			GoalCondition: prevIssue.GoalCondition,
 		}
 
 		if req.Updates.Title != nil {

--- a/server/internal/service/goal.go
+++ b/server/internal/service/goal.go
@@ -1,0 +1,12 @@
+package service
+
+import "strings"
+
+func appendMissingGoalStatusNotice(output string) string {
+	output = strings.TrimSpace(output)
+	notice := "Goal condition was present, but the agent finished without declaring GOAL_SATISFIED, BLOCKED, or PARTIAL."
+	if output == "" {
+		return notice
+	}
+	return output + "\n\n" + notice
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1095,6 +1095,16 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// for assignment-triggered tasks it is NULL and the fallback is top-level.
 	// Chat tasks have no IssueID and are handled separately below.
 	if task.IssueID.Valid {
+		goalCondition := ""
+		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil && issue.GoalCondition.Valid {
+			goalCondition = strings.TrimSpace(issue.GoalCondition.String)
+		} else if err != nil {
+			slog.Warn("checking issue goal condition failed",
+				"task_id", util.UUIDToString(task.ID),
+				"issue_id", util.UUIDToString(task.IssueID),
+				"error", err,
+			)
+		}
 		suppressNoActionComment, err := HasSquadLeaderNoActionEvaluationForTask(ctx, s.Queries, task)
 		if err != nil {
 			slog.Warn("checking squad leader no_action evaluation failed",
@@ -1118,6 +1128,9 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					// decoded into real newlines before the comment hits the DB. See
 					// util.UnescapeBackslashEscapes for the exact contract.
 					body := util.UnescapeBackslashEscapes(payload.Output)
+					if goalCondition != "" && strings.TrimSpace(payload.GoalStatus) == "" {
+						body = appendMissingGoalStatusNotice(body)
+					}
 					if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
 						slog.Warn("suppressing trivial comment-trigger fallback output",
 							"task_id", util.UUIDToString(task.ID),

--- a/server/migrations/099_issue_goal_condition.down.sql
+++ b/server/migrations/099_issue_goal_condition.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issue
+    DROP COLUMN IF EXISTS goal_condition;

--- a/server/migrations/099_issue_goal_condition.up.sql
+++ b/server/migrations/099_issue_goal_condition.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issue
+    ADD COLUMN goal_condition TEXT;

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -174,10 +174,10 @@ const createIssue = `-- name: CreateIssue :one
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id
+    parent_issue_id, position, start_date, due_date, number, project_id, goal_condition
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
-) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type CreateIssueParams struct {
@@ -196,6 +196,7 @@ type CreateIssueParams struct {
 	DueDate       pgtype.Timestamptz `json:"due_date"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	GoalCondition pgtype.Text        `json:"goal_condition"`
 }
 
 func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue, error) {
@@ -215,6 +216,7 @@ func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue
 		arg.DueDate,
 		arg.Number,
 		arg.ProjectID,
+		arg.GoalCondition,
 	)
 	var i Issue
 	err := row.Scan(
@@ -241,6 +243,7 @@ func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
@@ -250,12 +253,12 @@ const createIssueWithOrigin = `-- name: CreateIssueWithOrigin :one
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, position, start_date, due_date, number, project_id, goal_condition,
     origin_type, origin_id
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17
-) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+    $17, $18
+) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type CreateIssueWithOriginParams struct {
@@ -274,6 +277,7 @@ type CreateIssueWithOriginParams struct {
 	DueDate       pgtype.Timestamptz `json:"due_date"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	GoalCondition pgtype.Text        `json:"goal_condition"`
 	OriginType    pgtype.Text        `json:"origin_type"`
 	OriginID      pgtype.UUID        `json:"origin_id"`
 }
@@ -295,6 +299,7 @@ func (q *Queries) CreateIssueWithOrigin(ctx context.Context, arg CreateIssueWith
 		arg.DueDate,
 		arg.Number,
 		arg.ProjectID,
+		arg.GoalCondition,
 		arg.OriginType,
 		arg.OriginID,
 	)
@@ -323,6 +328,7 @@ func (q *Queries) CreateIssueWithOrigin(ctx context.Context, arg CreateIssueWith
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
@@ -352,7 +358,7 @@ UPDATE issue SET
     metadata = metadata - $1::text,
     updated_at = now()
 WHERE id = $2 AND workspace_id = $3
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type DeleteIssueMetadataKeyParams struct {
@@ -390,13 +396,14 @@ func (q *Queries) DeleteIssueMetadataKey(ctx context.Context, arg DeleteIssueMet
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const findActiveDuplicateIssue = `-- name: FindActiveDuplicateIssue :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE workspace_id = $1
   AND status NOT IN ('done', 'cancelled')
   AND project_id IS NOT DISTINCT FROM $2::uuid
@@ -445,13 +452,14 @@ func (q *Queries) FindActiveDuplicateIssue(ctx context.Context, arg FindActiveDu
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const getIssue = `-- name: GetIssue :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE id = $1
 `
 
@@ -482,13 +490,14 @@ func (q *Queries) GetIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const getIssueByNumber = `-- name: GetIssueByNumber :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE workspace_id = $1 AND number = $2
 `
 
@@ -524,13 +533,14 @@ func (q *Queries) GetIssueByNumber(ctx context.Context, arg GetIssueByNumberPara
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const getIssueByOrigin = `-- name: GetIssueByOrigin :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE workspace_id = $1
   AND origin_type = $2
   AND origin_id = $3
@@ -575,13 +585,14 @@ func (q *Queries) GetIssueByOrigin(ctx context.Context, arg GetIssueByOriginPara
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const getIssueInWorkspace = `-- name: GetIssueInWorkspace :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -617,13 +628,14 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
 }
 
 const listChildIssues = `-- name: ListChildIssues :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE parent_issue_id = $1
 ORDER BY position ASC, created_at DESC
 `
@@ -661,6 +673,7 @@ func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID
 			&i.OriginID,
 			&i.FirstExecutedAt,
 			&i.StartDate,
+			&i.GoalCondition,
 			&i.Metadata,
 		); err != nil {
 			return nil, err
@@ -674,7 +687,7 @@ func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID
 }
 
 const listChildrenByParents = `-- name: ListChildrenByParents :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id = ANY($2::uuid[])
 ORDER BY parent_issue_id, position ASC, created_at DESC
@@ -723,6 +736,7 @@ func (q *Queries) ListChildrenByParents(ctx context.Context, arg ListChildrenByP
 			&i.OriginID,
 			&i.FirstExecutedAt,
 			&i.StartDate,
+			&i.GoalCondition,
 			&i.Metadata,
 		); err != nil {
 			return nil, err
@@ -738,7 +752,7 @@ func (q *Queries) ListChildrenByParents(ctx context.Context, arg ListChildrenByP
 const listIssues = `-- name: ListIssues :many
 SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.goal_condition, i.metadata
 FROM issue i
 WHERE i.workspace_id = $1
   AND ($4::text IS NULL OR i.status = $4)
@@ -827,6 +841,7 @@ type ListIssuesRow struct {
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	GoalCondition pgtype.Text        `json:"goal_condition"`
 	Metadata      []byte             `json:"metadata"`
 }
 
@@ -877,6 +892,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 			&i.UpdatedAt,
 			&i.Number,
 			&i.ProjectID,
+			&i.GoalCondition,
 			&i.Metadata,
 		); err != nil {
 			return nil, err
@@ -892,7 +908,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 const listOpenIssues = `-- name: ListOpenIssues :many
 SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.goal_condition, i.metadata
 FROM issue i
 WHERE i.workspace_id = $1
   AND i.status NOT IN ('done', 'cancelled')
@@ -967,6 +983,7 @@ type ListOpenIssuesRow struct {
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	GoalCondition pgtype.Text        `json:"goal_condition"`
 	Metadata      []byte             `json:"metadata"`
 }
 
@@ -1009,6 +1026,7 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 			&i.UpdatedAt,
 			&i.Number,
 			&i.ProjectID,
+			&i.GoalCondition,
 			&i.Metadata,
 		); err != nil {
 			return nil, err
@@ -1068,7 +1086,7 @@ UPDATE issue SET
     metadata = jsonb_set(metadata, ARRAY[$1::text], $2::jsonb),
     updated_at = now()
 WHERE id = $3 AND workspace_id = $4
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type SetIssueMetadataKeyParams struct {
@@ -1114,6 +1132,7 @@ func (q *Queries) SetIssueMetadataKey(ctx context.Context, arg SetIssueMetadataK
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
@@ -1132,9 +1151,10 @@ UPDATE issue SET
     due_date = $10,
     parent_issue_id = $11,
     project_id = $12,
+    goal_condition = $13,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type UpdateIssueParams struct {
@@ -1150,6 +1170,7 @@ type UpdateIssueParams struct {
 	DueDate       pgtype.Timestamptz `json:"due_date"`
 	ParentIssueID pgtype.UUID        `json:"parent_issue_id"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	GoalCondition pgtype.Text        `json:"goal_condition"`
 }
 
 func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue, error) {
@@ -1166,6 +1187,7 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 		arg.DueDate,
 		arg.ParentIssueID,
 		arg.ProjectID,
+		arg.GoalCondition,
 	)
 	var i Issue
 	err := row.Scan(
@@ -1192,6 +1214,7 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err
@@ -1202,7 +1225,7 @@ UPDATE issue SET
     status = $2,
     updated_at = now()
 WHERE id = $1 AND workspace_id = $3
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, goal_condition, metadata
 `
 
 type UpdateIssueStatusParams struct {
@@ -1239,6 +1262,7 @@ func (q *Queries) UpdateIssueStatus(ctx context.Context, arg UpdateIssueStatusPa
 		&i.OriginID,
 		&i.FirstExecutedAt,
 		&i.StartDate,
+		&i.GoalCondition,
 		&i.Metadata,
 	)
 	return i, err

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -356,6 +356,7 @@ type Issue struct {
 	OriginID           pgtype.UUID        `json:"origin_id"`
 	FirstExecutedAt    pgtype.Timestamptz `json:"first_executed_at"`
 	StartDate          pgtype.Timestamptz `json:"start_date"`
+	GoalCondition      pgtype.Text        `json:"goal_condition"`
 	Metadata           []byte             `json:"metadata"`
 }
 

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -7,7 +7,7 @@
 -- "Assigned to me"), and the two filters must produce disjoint result sets.
 SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.goal_condition, i.metadata
 FROM issue i
 WHERE i.workspace_id = $1
   AND (sqlc.narg('status')::text IS NULL OR i.status = sqlc.narg('status'))
@@ -73,9 +73,9 @@ WHERE id = $1 AND workspace_id = $2;
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id
+    parent_issue_id, position, start_date, due_date, number, project_id, goal_condition
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
 ) RETURNING *;
 
 -- name: GetIssueByNumber :one
@@ -95,6 +95,7 @@ UPDATE issue SET
     due_date = sqlc.narg('due_date'),
     parent_issue_id = sqlc.narg('parent_issue_id'),
     project_id = sqlc.narg('project_id'),
+    goal_condition = sqlc.narg('goal_condition'),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
@@ -111,10 +112,10 @@ RETURNING *;
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, position, start_date, due_date, number, project_id, goal_condition,
     origin_type, origin_id
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
     sqlc.narg('origin_type'), sqlc.narg('origin_id')
 ) RETURNING *;
 
@@ -144,7 +145,7 @@ DELETE FROM issue WHERE id = $1 AND workspace_id = $2;
 -- filter; member-direct assignment is intentionally excluded).
 SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.goal_condition, i.metadata
 FROM issue i
 WHERE i.workspace_id = $1
   AND i.status NOT IN ('done', 'cancelled')

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -33,9 +33,10 @@ type TaskProgressPayload struct {
 
 // TaskCompletedPayload is sent from daemon to server when a task finishes.
 type TaskCompletedPayload struct {
-	TaskID string `json:"task_id"`
-	PRURL  string `json:"pr_url,omitempty"`
-	Output string `json:"output,omitempty"`
+	TaskID     string `json:"task_id"`
+	PRURL      string `json:"pr_url,omitempty"`
+	Output     string `json:"output,omitempty"`
+	GoalStatus string `json:"goal_status,omitempty"`
 }
 
 // TaskMessagePayload represents a single agent execution message (tool call, text, etc.)


### PR DESCRIPTION
## Summary
- Adds a structured `goal_condition` on issues, separate from `description`, exposed via API, CLI (`--goal`), and the shared TS `Issue` type.
- Passes the goal through the task-claim payload to daemon runtimes.
- Compiles it into provider-specific prompt instructions (Claude/openclaw, Codex, and a generic fallback) with an explicit final-marker contract (`GOAL_SATISFIED` / `BLOCKED` / `PARTIAL`) plus a preferred JSON shape. No slash-command dependency.
- Parses the agent's final output for a goal status, forwards it on task completion, and appends an explicit notice when a goal was set but no marker was emitted (so a vague "done" is not silently treated as success).
- Existing issues with no goal behave exactly as before.

## Why
Issue descriptions can mention desired outcomes, but long-running agent tasks need a separate, durable stop condition. Keeping the work brief and the completion criterion distinct lets each runtime receive provider-specific instructions and lets the server detect "finished without satisfying the goal".

## Changes
- **DB**: migration `099_issue_goal_condition` adds a nullable `goal_condition TEXT` column; sqlc-generated queries/structs regenerated (sqlc v1.31.1, zero drift).
- **API**: `goal_condition` on create/get/list/update responses and requests; update supports explicit clear (empty string -> NULL) and preserve-on-omit.
- **CLI**: `multica issue create --goal "..."` and `multica issue update <ref> --goal "..."` (pass `--goal ""` to clear).
- **Daemon**: `Task.GoalCondition` from the claim payload; prompt + execenv context injection; `goal_status` parsing on completion.

## Runtime behavior
- Claude/openclaw and Codex receive equivalent prompt-level instructions (independent of slash-command support); other providers get a generic instruction with the same marker contract.
- Existing issues with no goal are unchanged.

## Validation
- `go build ./...`, `go vet ./...` — clean (go 1.26.1)
- `go test ./internal/daemon ./cmd/multica` — pass (the pre-existing root-only `TestValidateLocalPath` symlink subtest is skipped; it fails only when run as root because `$HOME=/root` collides with the system-root blacklist, unrelated to this change)
- New tests: goal prompt compilation (provider variants, no slash deps, empty-goal skip), `parseGoalStatus` (markers / JSON / fenced / missing), `Task` JSON unmarshal, `BuildPrompt` with and without a goal, CLI `--goal` create / update / clear / omit
- TS typecheck (`@multica/core`, `@multica/views`) — clean
- CLI `--goal` help smoke on create and update

## Not in this PR
- Live HTTP create/get/update round-trip should run in CI with a dedicated test database (the handler test harness currently defaults to the local DB).
- Goal support is issue-bound (assignment- and comment-triggered tasks). Autopilot / chat / quick-create tasks do not receive the goal instruction in this version.
