### PR TITLE
fix(projects): apply working filter in project issues

### DIFF
--- a/packages/views/issues/components/issues-header.test.tsx
+++ b/packages/views/issues/components/issues-header.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStore } from "zustand/vanilla";
+import { I18nProvider } from "@multica/core/i18n/react";
+import {
+  useIssueViewStore,
+  viewStoreSlice,
+  type IssueViewState,
+} from "@multica/core/issues/stores/view-store";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+import { IssuesHeader } from "./issues-header";
+
+vi.mock("@multica/core/issues/stores/issues-scope-store", () => ({
+  useIssuesScopeStore: (selector: any) =>
+    selector({ scope: "all", setScope: vi.fn() }),
+}));
+
+vi.mock("./workspace-agent-working-chip", () => ({
+  WorkspaceAgentWorkingChip: ({
+    value,
+    onToggle,
+  }: {
+    value: boolean;
+    onToggle: () => void;
+  }) => (
+    <button
+      type="button"
+      data-active={String(value)}
+      data-testid="working-chip"
+      onClick={onToggle}
+    >
+      Working
+    </button>
+  ),
+}));
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+function createTestViewStore() {
+  return createStore<IssueViewState>()((set) => viewStoreSlice(set));
+}
+
+function renderHeader(store = createTestViewStore()) {
+  return {
+    store,
+    user: userEvent.setup(),
+    ...render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <ViewStoreProvider store={store}>
+          <IssuesHeader scopedIssues={[]} />
+        </ViewStoreProvider>
+      </I18nProvider>,
+    ),
+  };
+}
+
+describe("IssuesHeader", () => {
+  it("toggles the working filter on the current view store", async () => {
+    const store = createTestViewStore();
+    store.setState({ agentRunningFilter: false });
+    useIssueViewStore.setState({ agentRunningFilter: false });
+
+    const { user } = renderHeader(store);
+
+    expect(screen.getByTestId("working-chip")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+
+    await user.click(screen.getByTestId("working-chip"));
+
+    expect(store.getState().agentRunningFilter).toBe(true);
+    expect(useIssueViewStore.getState().agentRunningFilter).toBe(false);
+    expect(screen.getByTestId("working-chip")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+  });
+});

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -73,7 +73,6 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import type { Issue } from "@multica/core/types";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
-import { useIssueViewStore } from "@multica/core/issues/stores/view-store";
 import { WorkspaceAgentWorkingChip } from "./workspace-agent-working-chip";
 
 // ---------------------------------------------------------------------------
@@ -508,11 +507,11 @@ export function IssuesHeader({
   const { t } = useT("issues");
   const scope = useIssuesScopeStore((s) => s.scope);
   const setScope = useIssuesScopeStore((s) => s.setScope);
-  // Bind the workspace agents-working chip to the global /issues view
-  // store. Subscribing here keeps the chip presentational and lets
-  // /my-issues bind its own store via a sibling header.
-  const agentRunningFilter = useIssueViewStore((s) => s.agentRunningFilter);
-  const toggleAgentRunningFilter = useIssueViewStore(
+  // Bind the workspace agents-working chip to the current view store.
+  // /issues and project detail both provide their own store through
+  // ViewStoreProvider; /my-issues binds its own store via a sibling header.
+  const agentRunningFilter = useViewStore((s) => s.agentRunningFilter);
+  const toggleAgentRunningFilter = useViewStore(
     (s) => s.toggleAgentRunningFilter,
   );
   // Scope the chip to whatever issues this page is currently showing.

--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { Issue, Project } from "@multica/core/types";
+import type { IssueViewState } from "@multica/core/issues/stores/view-store";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+import enProjects from "../../locales/en/projects.json";
+import { ProjectDetail } from "./project-detail";
+
+const apiMocks = vi.hoisted(() => ({
+  getProject: vi.fn(),
+  listIssues: vi.fn(),
+  listGroupedIssues: vi.fn(),
+  getAgentTaskSnapshot: vi.fn(),
+  getChildIssueProgress: vi.fn(),
+  listMembers: vi.fn(),
+  listAgents: vi.fn(),
+  listProjects: vi.fn(),
+  listPins: vi.fn(),
+  updateIssue: vi.fn(),
+}));
+
+const projectStoreRef = vi.hoisted(() => ({
+  store: null as StoreApi<IssueViewState> | null,
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    getProject: (...args: any[]) => apiMocks.getProject(...args),
+    listIssues: (...args: any[]) => apiMocks.listIssues(...args),
+    listGroupedIssues: (...args: any[]) =>
+      apiMocks.listGroupedIssues(...args),
+    getAgentTaskSnapshot: (...args: any[]) =>
+      apiMocks.getAgentTaskSnapshot(...args),
+    getChildIssueProgress: (...args: any[]) =>
+      apiMocks.getChildIssueProgress(...args),
+    listMembers: (...args: any[]) => apiMocks.listMembers(...args),
+    listAgents: (...args: any[]) => apiMocks.listAgents(...args),
+    listProjects: (...args: any[]) => apiMocks.listProjects(...args),
+    listPins: (...args: any[]) => apiMocks.listPins(...args),
+    updateIssue: (...args: any[]) => apiMocks.updateIssue(...args),
+  },
+}));
+
+vi.mock("@multica/core/issues/stores/view-store", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/issues/stores/view-store")>(
+      "@multica/core/issues/stores/view-store",
+    );
+
+  return {
+    ...actual,
+    createIssueViewStore: () => {
+      const store = createStore<IssueViewState>()((set) =>
+        actual.viewStoreSlice(set),
+      );
+      projectStoreRef.store = store;
+      return store;
+    },
+  };
+});
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useWorkspacePaths: () => actual.paths.workspace("test"),
+  };
+});
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: any) => selector({ user: null }),
+}));
+
+vi.mock("../../navigation", () => ({
+  useNavigation: () => ({ push: vi.fn(), pathname: "/test/projects/proj-1" }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Someone" }),
+}));
+
+vi.mock("../../layout/breadcrumb-header", () => ({
+  BreadcrumbHeader: ({ leaf, actions }: any) => (
+    <div>
+      {leaf}
+      {actions}
+    </div>
+  ),
+}));
+
+vi.mock("../../editor", () => ({
+  TitleEditor: ({ defaultValue }: any) => (
+    <div data-testid="title-editor">{defaultValue}</div>
+  ),
+  ContentEditor: () => null,
+}));
+
+vi.mock("./project-resources-section", () => ({
+  ProjectResourcesSection: () => null,
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+vi.mock("../../issues/components/issues-header", () => ({
+  IssuesHeader: () => null,
+}));
+
+vi.mock("../../issues/components/board-view", () => ({
+  BoardView: ({ issues, assigneeGroups }: any) => {
+    const renderedIssues = assigneeGroups
+      ? assigneeGroups.flatMap((group: any) => group.issues)
+      : issues;
+
+    return (
+      <div data-testid="board-view">
+        <div data-testid="board-rendered-issues">
+          {renderedIssues.map((issue: Issue) => issue.title).join(",")}
+        </div>
+        {assigneeGroups?.map((group: any) => (
+          <div key={group.id} data-testid="assignee-group">
+            {group.issues.map((issue: Issue) => issue.title).join(",")}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+vi.mock("../../issues/components/list-view", () => ({
+  ListView: () => null,
+}));
+
+vi.mock("../../issues/components/gantt-view", () => ({
+  GanttView: () => null,
+}));
+
+vi.mock("../../issues/components/swimlane-view", () => ({
+  SwimLaneView: () => null,
+}));
+
+vi.mock("../../issues/components/batch-action-toolbar", () => ({
+  BatchActionToolbar: () => null,
+}));
+
+vi.mock("@multica/ui/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: any) => <div>{children}</div>,
+  ResizablePanel: ({ children }: any) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+
+vi.mock("react-resizable-panels", () => ({
+  useDefaultLayout: () => ({
+    defaultLayout: undefined,
+    onLayoutChanged: vi.fn(),
+  }),
+  usePanelRef: () => ({
+    current: {
+      isCollapsed: () => false,
+      collapse: vi.fn(),
+      expand: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, issues: enIssues, projects: enProjects },
+};
+
+const project: Project = {
+  id: "proj-1",
+  workspace_id: "ws-1",
+  title: "Project One",
+  description: null,
+  icon: null,
+  status: "in_progress",
+  priority: "medium",
+  lead_type: null,
+  lead_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  issue_count: 2,
+  done_count: 0,
+  resource_count: 0,
+};
+
+function makeIssue(id: string, title: string): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: id.toUpperCase(),
+    title,
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: "agent",
+    assignee_id: "agent-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: "proj-1",
+    position: 0,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function renderProjectDetail() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={qc}>
+        <ProjectDetail projectId="proj-1" />
+      </QueryClientProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("ProjectDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const runningIssue = makeIssue("issue-running", "Running issue");
+    const idleIssue = makeIssue("issue-idle", "Idle issue");
+
+    apiMocks.getProject.mockResolvedValue(project);
+    apiMocks.listIssues.mockResolvedValue({ issues: [], total: 0 });
+    apiMocks.listGroupedIssues.mockResolvedValue({
+      groups: [
+        {
+          id: "assignee:agent:agent-1",
+          assignee_type: "agent",
+          assignee_id: "agent-1",
+          issues: [runningIssue, idleIssue],
+          total: 2,
+        },
+      ],
+    });
+    apiMocks.getAgentTaskSnapshot.mockResolvedValue([
+      {
+        id: "task-1",
+        agent_id: "agent-1",
+        runtime_id: "runtime-1",
+        issue_id: "issue-running",
+        status: "running",
+      },
+    ]);
+    apiMocks.getChildIssueProgress.mockResolvedValue({ progress: [] });
+    apiMocks.listMembers.mockResolvedValue([]);
+    apiMocks.listAgents.mockResolvedValue([]);
+    apiMocks.listProjects.mockResolvedValue({ projects: [], total: 0 });
+    apiMocks.listPins.mockResolvedValue([]);
+
+    projectStoreRef.store?.setState({
+      viewMode: "board",
+      grouping: "assignee",
+      agentRunningFilter: true,
+      statusFilters: [],
+      priorityFilters: [],
+      assigneeFilters: [],
+      includeNoAssignee: false,
+      creatorFilters: [],
+      labelFilters: [],
+    });
+  });
+
+  it("filters assignee-grouped project boards by running issues", async () => {
+    renderProjectDetail();
+
+    await screen.findByTestId("board-view");
+
+    expect(screen.getByTestId("board-rendered-issues")).toHaveTextContent(
+      "Running issue",
+    );
+    expect(screen.getByTestId("board-rendered-issues")).not.toHaveTextContent(
+      "Idle issue",
+    );
+    expect(screen.getByTestId("assignee-group")).toHaveTextContent(
+      "Running issue",
+    );
+    expect(screen.getByTestId("assignee-group")).not.toHaveTextContent(
+      "Idle issue",
+    );
+  });
+});

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -23,6 +23,7 @@ import {
 } from "@multica/core/issues/queries";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useModalStore } from "@multica/core/modals";
+import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
@@ -119,6 +120,8 @@ function ProjectIssuesContent({
   filter,
   sort,
   ganttIssues,
+  agentRunningFilter,
+  runningIssueIds,
 }: {
   projectId: string;
   projectIssues: Issue[];
@@ -129,6 +132,8 @@ function ProjectIssuesContent({
   filter: MyIssuesFilter;
   sort?: IssueSortParam;
   ganttIssues: Issue[];
+  agentRunningFilter: boolean;
+  runningIssueIds: ReadonlySet<string>;
 }) {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
@@ -141,22 +146,87 @@ function ProjectIssuesContent({
   const labelFilters = useViewStore((s) => s.labelFilters);
 
   const issues = useMemo(
-    () => filterIssues(projectIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
-    [projectIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
+    () =>
+      filterIssues(projectIssues, {
+        statusFilters,
+        priorityFilters,
+        assigneeFilters,
+        includeNoAssignee,
+        creatorFilters,
+        projectFilters: [],
+        includeNoProject: false,
+        labelFilters,
+        agentRunningFilter,
+        runningIssueIds,
+      }),
+    [
+      projectIssues,
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      labelFilters,
+      agentRunningFilter,
+      runningIssueIds,
+    ],
   );
 
   // Status-unfiltered companion for Swimlane.
   const swimlaneIssues = useMemo(
-    () => filterIssues(projectIssues, { statusFilters: [], priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
-    [projectIssues, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
+    () =>
+      filterIssues(projectIssues, {
+        statusFilters: [],
+        priorityFilters,
+        assigneeFilters,
+        includeNoAssignee,
+        creatorFilters,
+        projectFilters: [],
+        includeNoProject: false,
+        labelFilters,
+        agentRunningFilter,
+        runningIssueIds,
+      }),
+    [
+      projectIssues,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      labelFilters,
+      agentRunningFilter,
+      runningIssueIds,
+    ],
   );
 
   // Gantt rides its own dedicated query (scheduled-only) so it doesn't have
   // to wait for every status bucket to paginate in. View-store filters still
   // apply so toggling priority / assignee / label hides the same bars.
   const filteredGanttIssues = useMemo(
-    () => filterIssues(ganttIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
-    [ganttIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
+    () =>
+      filterIssues(ganttIssues, {
+        statusFilters,
+        priorityFilters,
+        assigneeFilters,
+        includeNoAssignee,
+        creatorFilters,
+        projectFilters: [],
+        includeNoProject: false,
+        labelFilters,
+        agentRunningFilter,
+        runningIssueIds,
+      }),
+    [
+      ganttIssues,
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      labelFilters,
+      agentRunningFilter,
+      runningIssueIds,
+    ],
   );
 
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
@@ -171,6 +241,43 @@ function ProjectIssuesContent({
     () => BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s)),
     [visibleStatuses],
   );
+
+  const filteredAssigneeGroups = useMemo(() => {
+    if (!assigneeGroups) return undefined;
+
+    return assigneeGroups
+      .map((group) => {
+        const groupIssues = filterIssues(group.issues, {
+          statusFilters,
+          priorityFilters,
+          assigneeFilters,
+          includeNoAssignee,
+          creatorFilters,
+          projectFilters: [],
+          includeNoProject: false,
+          labelFilters,
+          agentRunningFilter,
+          runningIssueIds,
+        });
+
+        return {
+          ...group,
+          issues: groupIssues,
+          total: groupIssues.length,
+        };
+      })
+      .filter((group) => group.issues.length > 0);
+  }, [
+    assigneeGroups,
+    statusFilters,
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    labelFilters,
+    agentRunningFilter,
+    runningIssueIds,
+  ]);
 
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
@@ -222,7 +329,7 @@ function ProjectIssuesContent({
       {viewMode === "board" && (
         <BoardView
           issues={assigneeGroups ? projectIssues : issues}
-          assigneeGroups={assigneeGroups}
+          assigneeGroups={filteredAssigneeGroups}
           assigneeGroupQueryKey={assigneeGroupQueryKey}
           assigneeGroupFilter={assigneeGroupFilter}
           visibleStatuses={visibleStatuses}
@@ -276,6 +383,18 @@ function ProjectIssuesSurface({
   filter: MyIssuesFilter;
 }) {
   const wsId = useWorkspaceId();
+  const agentRunningFilter = useViewStore((s) => s.agentRunningFilter);
+
+  const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
+  const runningIssueIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const task of snapshot) {
+      if (task.status === "running" && task.issue_id) {
+        ids.add(task.issue_id);
+      }
+    }
+    return ids;
+  }, [snapshot]);
   const viewMode = useViewStore((s) => s.viewMode);
   const grouping = useViewStore((s) => s.grouping);
   const sortBy = useViewStore((s) => s.sortBy);
@@ -360,6 +479,8 @@ function ProjectIssuesSurface({
         filter={filter}
         sort={sort}
         ganttIssues={ganttIssues}
+        agentRunningFilter={agentRunningFilter}
+        runningIssueIds={runningIssueIds}
       />
       <BatchActionToolbar />
     </>


### PR DESCRIPTION
## What does this PR do?

Fixes the project issues Working filter so the project detail issue views use the current project view store and apply the existing running-task filter.

The Working chip was reading the global `/issues` view store, while project detail owns its own `projectViewStore`. This meant clicking Working in a project header did not drive the project page’s filtering state. This PR binds the shared `IssuesHeader` to the active `ViewStoreProvider` and wires project issues through the existing `filterIssues` running-task path.

## Design Notes

The fix keeps the existing frontend filtering design instead of adding a new API/backend filter. The Working state is derived from `agentTaskSnapshotOptions`, converted into `runningIssueIds`, and then passed into the existing `filterIssues` utility.

For assignee-grouped project boards, `BoardView` renders from `assigneeGroups` rather than the top-level `issues` prop. Because of that, this PR applies the same `filterIssues` rules inside each group and passes:

```tsx
assigneeGroups={filteredAssigneeGroups}
```
At the same time, the existing board data-source shape is preserved:

```tsx
issues={assigneeGroups ? projectIssues : issues}
```

This keeps the original assignee-grouped board semantics while ensuring the loaded group issues also respect the Working filter. A backend-level running filter could make grouped totals and pagination fully authoritative in the future, but that would be a broader API/query-key change and is intentionally kept out of this bug fix.

## Related
Closes #3431

## Type of Change
Bug fix, non-breaking

## Changes Made
Bind IssuesHeader Working chip to the current ViewStoreProvider store instead of the global /issues store
Fetch the workspace agent task snapshot in project issue surface
Derive runningIssueIds from running agent tasks
Pass agentRunningFilter and runningIssueIds into project issue filtering
Apply the same Working filter to project board/list/swimlane/gantt issue data
Filter assignee-grouped board issues inside each assigneeGroups[].issues
Preserve the existing top-level BoardView issues data-source behavior for assignee-grouped boards
Add regression coverage for the shared header context store behavior
Add regression coverage for assignee-grouped project boards with the Working filter enabled

## How to Test
Open a project with at least two issues.
Ensure one issue has a running agent task and another does not.
Open the project detail page.
Click the Working filter in the project issues header.
Confirm only the issue with the running task remains visible.
Switch to the assignee-grouped board view.
Confirm the assignee group only shows the running issue and idle issues are hidden.
Turn off the Working filter and confirm the hidden issues return.

## Verification
pnpm --filter @multica/views test
pnpm --filter @multica/views typecheck
pnpm --filter @multica/views exec eslint issues/components/issues-header.tsx issues/components/issues-header.test.tsx projects/components/project-detail.tsx projects/components/project-detail.test.tsx
git diff --check

## Checklist
I have run tests locally and they pass
I have added or updated tests where applicable
I have manually verified the project Working filter and assignee-grouped board flow

## AI Disclosure
AI tool used: Codex

Prompt / approach: Collaborated on root-cause analysis, traced the project issues view-store and rendering hierarchy, reviewed the assignee-grouped board data path, and added regression tests for the context-store binding and assignee-grouped Working filter behavior.
