### PR TITLE
feat(runtimes): add Droid runtime support

### DIFF
--- a/packages/views/onboarding/steps/step-welcome.tsx
+++ b/packages/views/onboarding/steps/step-welcome.tsx
@@ -281,6 +281,7 @@ type ProviderName =
   | "hermes"
   | "kimi"
   | "kiro"
+  | "droid"
   | "pi"
   | "copilot"
   | "cursor";

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -177,6 +177,23 @@ function KiroLogo({ className }: { className: string }) {
   );
 }
 
+function DroidLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <rect width="24" height="24" rx="6" fill="#111827" />
+      <path
+        d="M6 12c0-3.3 2.7-6 6-6s6 2.7 6 6-2.7 6-6 6-6-2.7-6-6Z"
+        fill="#F8FAFC"
+      />
+      <path
+        d="M9.25 9.5h2.5c1.8 0 3 1.1 3 2.5s-1.2 2.5-3 2.5h-2.5v-5Zm2.35 3.4c.9 0 1.45-.35 1.45-.9s-.55-.9-1.45-.9h-.65v1.8h.65Z"
+        fill="#111827"
+      />
+      <path d="M12 3.5v2.2" stroke="#F8FAFC" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function ProviderLogo({
   provider,
   className = "h-4 w-4",
@@ -205,6 +222,8 @@ export function ProviderLogo({
       return <KimiLogo className={className} />;
     case "kiro":
       return <KiroLogo className={className} />;
+    case "droid":
+      return <DroidLogo className={className} />;
     case "gemini":
       return <GeminiLogo className={className} />;
     default:

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
-	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro
+	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, droid
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
@@ -201,8 +201,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if e, ok := probe("MULTICA_KIRO_PATH", "kiro-cli", "MULTICA_KIRO_MODEL"); ok {
 		agents["kiro"] = e
 	}
+	if e, ok := probe("MULTICA_DROID_PATH", "droid", "MULTICA_DROID_MODEL"); ok {
+		agents["droid"] = e
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, kiro-cli, or droid and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
@@ -537,7 +540,7 @@ func shellArgsFromEnv(name string) ([]string, error) {
 // invocation, instead of paying the cost-per-miss.
 var defaultAgentCommandNames = []string{
 	"claude", "codex", "opencode", "openclaw", "hermes",
-	"gemini", "pi", "cursor-agent", "copilot", "kimi", "kiro-cli",
+	"gemini", "pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "droid",
 }
 
 // loginShellResolveTimeout caps how long the daemon will wait for the user's

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -89,6 +89,38 @@ func TestBuildLoginShellResolveScript_ShapeAndContent(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDetectsDroid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell not available on Windows")
+	}
+	binDir := t.TempDir()
+	fake := filepath.Join(binDir, "droid")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake droid: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("MULTICA_DAEMON_ID", "11111111-1111-1111-1111-111111111111")
+	t.Setenv("MULTICA_DROID_MODEL", "gpt-5.5")
+
+	cfg, err := LoadConfig(Overrides{
+		ServerURL:      "http://localhost:8080",
+		WorkspacesRoot: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	agent, ok := cfg.Agents["droid"]
+	if !ok {
+		t.Fatalf("expected droid agent to be detected, got %#v", cfg.Agents)
+	}
+	if agent.Path != "droid" {
+		t.Fatalf("expected droid path, got %q", agent.Path)
+	}
+	if agent.Model != "gpt-5.5" {
+		t.Fatalf("expected droid model from env, got %q", agent.Model)
+	}
+}
+
 // TestResolveAgentsViaLoginShell_ResolvesViaInteractiveShell verifies the
 // motivating bug scenario: a binary that lives in a directory which is NOT on
 // the daemon's PATH but IS added to PATH by the user's interactive shell rc

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2194,7 +2194,7 @@ func gcMetaForTask(task Task) (execenv.GCMeta, bool) {
 
 func providerNeedsInlineSystemPrompt(provider string) bool {
 	switch provider {
-	case "openclaw", "kiro", "kimi":
+	case "openclaw", "kiro", "kimi", "droid":
 		return true
 	default:
 		return false

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -190,6 +190,7 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 		// can trip upstream provider safety filters on otherwise harmless tasks.
 		{provider: "hermes", want: false},
 		{provider: "kiro", want: true},
+		{provider: "droid", want: true},
 		{provider: "kimi", want: true},
 		{provider: "codex", want: false},
 		{provider: "claude", want: false},

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -21,6 +21,7 @@ import (
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
 // Kiro:     skills → {workDir}/.kiro/skills/{name}/SKILL.md  (native discovery)
+// Droid:    skills → {workDir}/.factory/skills/{name}/SKILL.md  (native discovery)
 // Default:  skills → {workDir}/.agent_context/skills/{name}/SKILL.md
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 	contextDir := filepath.Join(workDir, ".agent_context")
@@ -163,6 +164,9 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 		// Kiro CLI auto-discovers project-level skills from .kiro/skills/
 		// in the workdir.
 		skillsDir = filepath.Join(workDir, ".kiro", "skills")
+	case "droid":
+		// Droid auto-discovers project-level skills from .factory/skills/.
+		skillsDir = filepath.Join(workDir, ".factory", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		skillsDir = filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1009,6 +1009,33 @@ func TestWriteContextFilesKiroNativeSkills(t *testing.T) {
 	}
 }
 
+func TestWriteContextFilesDroidNativeSkills(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "droid-skill-test",
+		AgentSkills: []SkillContextForEnv{
+			{Name: "Go Conventions", Content: "Follow Go conventions."},
+		},
+	}
+
+	if err := writeContextFiles(dir, "droid", ctx); err != nil {
+		t.Fatalf("writeContextFiles failed: %v", err)
+	}
+
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".factory", "skills", "go-conventions", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read .factory/skills/go-conventions/SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
+		t.Error("SKILL.md missing content")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
+		t.Error("expected .agent_context/skills/ to NOT exist for Droid provider")
+	}
+}
+
 func TestInjectRuntimeConfigOpencode(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -98,13 +98,14 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
 // For Kimi:     writes {workDir}/AGENTS.md  (Kimi Code CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
 // For Kiro:     writes {workDir}/AGENTS.md  (Kiro CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
+// For Droid:    writes {workDir}/AGENTS.md  (Droid reads AGENTS.md natively; skills auto-discovered from .factory/skills/)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (string, error) {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return content, os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "droid":
 		return content, os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return content, os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -398,8 +399,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro":
-			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, and Kiro discover skills
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro", "droid":
+			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, Kiro, and Droid discover skills
 			// natively from their respective paths. For OpenClaw, the daemon also writes a
 			// per-task openclaw-config.json (exported via OPENCLAW_CONFIG_PATH) that pins
 			// agents.defaults.workspace to the task workdir so the CLI's scanner picks up

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -47,6 +47,7 @@ type runtimeLocalSkillBundle struct {
 //   - Cursor: official forum guidance referencing the built-in /create-skill flow
 //     (https://forum.cursor.com/t/cursor-doesnt-know-new-skills-arens-saved/158507)
 //   - Kiro: project and user-level .kiro/skills directories discovered by Kiro CLI
+//   - Droid: project and user-level .factory/skills directories discovered by Droid
 //
 // Longer-term this mapping would be better colocated with the provider
 // definitions under server/pkg/agent so adding a new runtime can't silently
@@ -78,6 +79,8 @@ func localSkillRootForProvider(provider string) (string, bool, error) {
 		return filepath.Join(home, ".cursor", "skills"), true, nil
 	case "kiro":
 		return filepath.Join(home, ".kiro", "skills"), true, nil
+	case "droid":
+		return filepath.Join(home, ".factory", "skills"), true, nil
 	default:
 		return "", false, nil
 	}

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -99,6 +99,35 @@ func TestListRuntimeLocalSkills_Kiro(t *testing.T) {
 	}
 }
 
+func TestListRuntimeLocalSkills_Droid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeTestLocalSkill(t, filepath.Join(home, ".factory", "skills"), "review-helper", map[string]string{
+		"SKILL.md": "---\nname: Droid Review\ndescription: Review code with Droid\n---\n# Droid Review\n",
+	})
+
+	skills, supported, err := listRuntimeLocalSkills("droid")
+	if err != nil {
+		t.Fatalf("listRuntimeLocalSkills: %v", err)
+	}
+	if !supported {
+		t.Fatal("droid should be supported")
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	if skills[0].Key != "review-helper" {
+		t.Fatalf("key = %q, want review-helper", skills[0].Key)
+	}
+	if skills[0].Name != "Droid Review" {
+		t.Fatalf("name = %q, want Droid Review", skills[0].Name)
+	}
+	if skills[0].SourcePath != "~/.factory/skills/review-helper" {
+		t.Fatalf("source_path = %q", skills[0].SourcePath)
+	}
+}
+
 // Skill installers (for example lark-cli) place every skill at a shared
 // location like ~/.agents/skills/<name> and symlink each one into the
 // runtime root (~/.claude/skills/<name>). The previous filepath.WalkDir

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, Droid). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -101,13 +101,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
+	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli, droid)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "droid".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -136,8 +136,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "droid":
+		return &droidBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, droid)", agentType)
 	}
 }
 
@@ -164,6 +166,7 @@ var launchHeaders = map[string]string{
 	"pi":       "pi (json mode)",
 	"kimi":     "kimi acp",
 	"kiro":     "kiro-cli acp",
+	"droid":    "droid exec (stream-json)",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -72,7 +72,7 @@ func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	// entry to launchHeaders in agent.go and extend this list.
 	supported := []string{
 		"claude", "codex", "copilot", "cursor", "gemini",
-		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi",
+		"droid", "hermes", "kimi", "kiro", "openclaw", "opencode", "pi",
 	}
 	for _, t_ := range supported {
 		if header := LaunchHeader(t_); header == "" {

--- a/server/pkg/agent/droid.go
+++ b/server/pkg/agent/droid.go
@@ -1,0 +1,234 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type droidBackend struct {
+	cfg Config
+}
+
+func (b *droidBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "droid"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("droid executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	args := buildDroidArgs(prompt, opts, b.cfg.Logger)
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
+	cmd.WaitDelay = 10 * time.Second
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("droid stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[droid:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start droid: %w", err)
+	}
+
+	b.cfg.Logger.Info("droid started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		<-runCtx.Done()
+		_ = stdout.Close()
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		scanResult := b.processEvents(stdout, msgCh)
+		exitErr := cmd.Wait()
+		duration := time.Since(startTime)
+
+		if runCtx.Err() == context.DeadlineExceeded {
+			scanResult.status = "timeout"
+			scanResult.errMsg = fmt.Sprintf("droid timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			scanResult.status = "aborted"
+			scanResult.errMsg = "execution cancelled"
+		} else if exitErr != nil && scanResult.status == "completed" {
+			scanResult.status = "failed"
+			scanResult.errMsg = fmt.Sprintf("droid exited with error: %v", exitErr)
+		}
+
+		b.cfg.Logger.Info("droid finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())
+
+		resCh <- Result{
+			Status:     scanResult.status,
+			Output:     scanResult.output,
+			Error:      scanResult.errMsg,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  scanResult.sessionID,
+			Usage:      scanResult.usage,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+type droidEventResult struct {
+	status    string
+	errMsg    string
+	output    string
+	sessionID string
+	usage     map[string]TokenUsage
+}
+
+func (b *droidBackend) processEvents(r io.Reader, ch chan<- Message) droidEventResult {
+	result := droidEventResult{
+		status: "completed",
+		usage:  map[string]TokenUsage{},
+	}
+	var output strings.Builder
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var evt droidStreamEvent
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			continue
+		}
+		if evt.SessionID != "" {
+			result.sessionID = evt.SessionID
+		}
+
+		switch evt.Type {
+		case "system":
+			if evt.Subtype == "init" {
+				trySend(ch, Message{Type: MessageStatus, Status: "running", SessionID: result.sessionID})
+			}
+		case "message":
+			if evt.Role == "assistant" && evt.Text != "" {
+				output.WriteString(evt.Text)
+				trySend(ch, Message{Type: MessageText, Content: evt.Text})
+			}
+		case "completion":
+			if evt.FinalText != "" {
+				result.output = evt.FinalText
+			}
+			if evt.Usage != nil {
+				result.usage["droid"] = TokenUsage{
+					InputTokens:      evt.Usage.InputTokens,
+					OutputTokens:     evt.Usage.OutputTokens,
+					CacheReadTokens:  evt.Usage.CacheReadInputTokens,
+					CacheWriteTokens: evt.Usage.CacheCreationInputTokens,
+				}
+			}
+		case "error":
+			result.status = "failed"
+			result.errMsg = evt.Message
+			trySend(ch, Message{Type: MessageError, Content: evt.Message})
+		}
+	}
+
+	if result.output == "" {
+		result.output = output.String()
+	}
+	return result
+}
+
+type droidStreamEvent struct {
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype,omitempty"`
+	Role      string `json:"role,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Message   string `json:"message,omitempty"`
+	FinalText string `json:"finalText,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Usage     *struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	} `json:"usage,omitempty"`
+}
+
+var droidBlockedArgs = map[string]blockedArgMode{
+	"-o":                       blockedWithValue,
+	"--output-format":          blockedWithValue,
+	"--auto":                   blockedWithValue,
+	"--skip-permissions-unsafe": blockedStandalone,
+	"--cwd":                    blockedWithValue,
+	"-w":                       blockedWithValue,
+	"--worktree":               blockedWithValue,
+	"--worktree-dir":           blockedWithValue,
+	"-m":                       blockedWithValue,
+	"--model":                  blockedWithValue,
+	"-r":                       blockedWithValue,
+	"--reasoning-effort":       blockedWithValue,
+	"-s":                       blockedWithValue,
+	"--session-id":             blockedWithValue,
+	"--fork":                   blockedWithValue,
+	"--append-system-prompt":   blockedWithValue,
+	"--use-spec":               blockedStandalone,
+	"--mission":                blockedStandalone,
+}
+
+func buildDroidArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{
+		"exec",
+		"-o", "stream-json",
+		"--auto", "medium",
+	}
+	if opts.Cwd != "" {
+		args = append(args, "--cwd", opts.Cwd)
+	}
+	if opts.Model != "" {
+		args = append(args, "-m", opts.Model)
+	}
+	if opts.ThinkingLevel != "" {
+		args = append(args, "-r", opts.ThinkingLevel)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--session-id", opts.ResumeSessionID)
+	}
+	if opts.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", opts.SystemPrompt)
+	}
+	if opts.MaxTurns > 0 {
+		logger.Warn("droid does not support --max-turns; ignoring", "maxTurns", opts.MaxTurns)
+	}
+	if len(opts.McpConfig) > 0 {
+		logger.Warn("droid does not support per-run MCP config injection; ignoring")
+	}
+	args = append(args, filterCustomArgs(opts.CustomArgs, droidBlockedArgs, logger)...)
+	args = append(args, prompt)
+	return args
+}

--- a/server/pkg/agent/droid_test.go
+++ b/server/pkg/agent/droid_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewReturnsDroidBackend(t *testing.T) {
+	t.Parallel()
+
+	b, err := New("droid", Config{ExecutablePath: "/nonexistent/droid"})
+	if err != nil {
+		t.Fatalf("New(droid) error: %v", err)
+	}
+	if _, ok := b.(*droidBackend); !ok {
+		t.Fatalf("expected *droidBackend, got %T", b)
+	}
+}
+
+func TestBuildDroidArgsBaseline(t *testing.T) {
+	t.Parallel()
+
+	args := buildDroidArgs("fix the bug", ExecOptions{}, slog.Default())
+	expected := []string{
+		"exec",
+		"-o", "stream-json",
+		"--auto", "medium",
+		"fix the bug",
+	}
+
+	if strings.Join(args, "\x00") != strings.Join(expected, "\x00") {
+		t.Fatalf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestBuildDroidArgsWithOptions(t *testing.T) {
+	t.Parallel()
+
+	args := buildDroidArgs("continue", ExecOptions{
+		Cwd:             "/tmp/work",
+		Model:           "gpt-5.5",
+		ThinkingLevel:   "high",
+		ResumeSessionID: "ses_123",
+		SystemPrompt:    "follow Multica instructions",
+	}, slog.Default())
+
+	wantPairs := map[string]string{
+		"--cwd":                  "/tmp/work",
+		"-m":                     "gpt-5.5",
+		"-r":                     "high",
+		"--session-id":           "ses_123",
+		"--append-system-prompt": "follow Multica instructions",
+	}
+	for flag, want := range wantPairs {
+		found := false
+		for i, arg := range args {
+			if arg == flag {
+				if i+1 >= len(args) || args[i+1] != want {
+					t.Fatalf("expected %s followed by %q, got %v", flag, want, args)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected %s in args, got %v", flag, args)
+		}
+	}
+	if got := args[len(args)-1]; got != "continue" {
+		t.Fatalf("expected prompt to stay last, got %q in %v", got, args)
+	}
+}
+
+func TestBuildDroidArgsFiltersBlockedCustomArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildDroidArgs("hi", ExecOptions{
+		CustomArgs: []string{"-o", "json", "--enabled-tools", "ApplyPatch"},
+	}, slog.Default())
+
+	for i, arg := range args {
+		if arg == "-o" && i+1 < len(args) && args[i+1] == "json" {
+			t.Fatalf("blocked -o json should have been filtered: %v", args)
+		}
+	}
+	var foundEnabledTools bool
+	for i, arg := range args {
+		if arg == "--enabled-tools" && i+1 < len(args) && args[i+1] == "ApplyPatch" {
+			foundEnabledTools = true
+		}
+	}
+	if !foundEnabledTools {
+		t.Fatalf("expected --enabled-tools ApplyPatch to pass through, got %v", args)
+	}
+	if got := args[len(args)-1]; got != "hi" {
+		t.Fatalf("expected prompt to stay last, got %q in %v", got, args)
+	}
+}
+
+func TestDroidProcessEvents(t *testing.T) {
+	t.Parallel()
+
+	backend := &droidBackend{cfg: Config{Logger: slog.Default()}}
+	input := strings.NewReader(strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"ses_1"}`,
+		`{"type":"message","role":"assistant","text":"Working","session_id":"ses_1"}`,
+		`{"type":"completion","finalText":"Done","durationMs":42,"session_id":"ses_1","usage":{"input_tokens":10,"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}`,
+	}, "\n"))
+	ch := make(chan Message, 8)
+
+	result := backend.processEvents(input, ch)
+	close(ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed status, got %q", result.status)
+	}
+	if result.output != "Done" {
+		t.Fatalf("expected final output Done, got %q", result.output)
+	}
+	if result.sessionID != "ses_1" {
+		t.Fatalf("expected session ID ses_1, got %q", result.sessionID)
+	}
+	usage := result.usage["droid"]
+	if usage.InputTokens != 10 || usage.OutputTokens != 2 || usage.CacheReadTokens != 3 || usage.CacheWriteTokens != 4 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+
+	var sawText bool
+	for msg := range ch {
+		if msg.Type == MessageText && msg.Content == "Working" {
+			sawText = true
+		}
+	}
+	if !sawText {
+		t.Fatalf("expected assistant text message to be emitted")
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -122,6 +122,8 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
+	case "droid":
+		return droidStaticModels(), nil
 	case "opencode":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)
@@ -201,6 +203,12 @@ func codexStaticModels() []Model {
 		{ID: "gpt-5", Label: "GPT-5", Provider: "openai"},
 		{ID: "o3", Label: "o3", Provider: "openai"},
 		{ID: "o3-mini", Label: "o3-mini", Provider: "openai"},
+	}
+}
+
+func droidStaticModels() []Model {
+	return []Model{
+		{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Provider: "factory", Default: true},
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListModelsStaticProviders(t *testing.T) {
 	ctx := context.Background()
-	for _, provider := range []string{"claude", "codex", "gemini", "cursor"} {
+	for _, provider := range []string{"claude", "codex", "droid", "gemini", "cursor"} {
 		got, err := ListModels(ctx, provider, "")
 		if err != nil {
 			t.Fatalf("ListModels(%q) error: %v", provider, err)
@@ -120,6 +120,20 @@ func TestCodexStaticModelsExposesGPT55(t *testing.T) {
 	}
 	if defaults != 1 {
 		t.Errorf("expected exactly one default Codex entry, got %d", defaults)
+	}
+}
+
+func TestDroidStaticModelsExposesDefaultModel(t *testing.T) {
+	models := droidStaticModels()
+	if len(models) == 0 {
+		t.Fatal("expected Droid model catalog to be non-empty")
+	}
+	first := models[0]
+	if first.ID == "" || first.Label == "" {
+		t.Fatalf("expected Droid default model to have ID and label, got %+v", first)
+	}
+	if !first.Default {
+		t.Fatalf("expected first Droid model to be marked default, got %+v", first)
 	}
 }
 
@@ -248,6 +262,7 @@ func TestStaticCatalogsHaveAtMostOneDefault(t *testing.T) {
 	catalogs := map[string][]Model{
 		"claude":  claudeStaticModels(),
 		"codex":   codexStaticModels(),
+		"droid":   droidStaticModels(),
 		"gemini":  geminiStaticModels(),
 		"cursor":  cursorStaticModels(),
 		"copilot": copilotStaticModels(),


### PR DESCRIPTION
## Summary
- Add a Droid backend that runs tasks through `droid exec -o stream-json --auto medium`.
- Detect local Droid installs via `droid` / `MULTICA_DROID_PATH` and wire `MULTICA_DROID_MODEL`.
- Register Droid model metadata, launch header, AGENTS.md/skill wiring, inline runtime prompts, and provider UI logo handling.
- Add unit coverage for Droid argument building, stream parsing, config detection, skills paths, and model catalog behavior.

## Test plan
- [x] `cd server && go test ./...`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (passes with existing warnings)
- [x] `pnpm test`
- [x] `git diff --check`