### PR TITLE
fix: unwrap OpenClaw completion envelopes in task comments

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -132,6 +132,61 @@ func isTrivialDoneOutput(output string) bool {
 	return false
 }
 
+type openclawCompletionEnvelope struct {
+	Result struct {
+		Payloads []struct {
+			Text string `json:"text"`
+		} `json:"payloads"`
+	} `json:"result"`
+	Payloads []struct {
+		Text string `json:"text"`
+	} `json:"payloads"`
+}
+
+// normalizeAgentVisibleOutput strips OpenClaw completion envelopes that can
+// arrive as literal text in task output. Without this guard, Multica publishes
+// the whole JSON wrapper as a fallback issue comment instead of the user's
+// visible assistant text.
+func normalizeAgentVisibleOutput(output string) string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" || trimmed[0] != '{' {
+		return output
+	}
+
+	var envelope openclawCompletionEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return output
+	}
+
+	payloads := envelope.Result.Payloads
+	if len(payloads) == 0 {
+		payloads = envelope.Payloads
+	}
+	if len(payloads) == 0 {
+		return output
+	}
+
+	var parts []string
+	for _, payload := range payloads {
+		text := strings.TrimSpace(payload.Text)
+		if text == "" || isTechnicalOpenclawPayload(text) {
+			continue
+		}
+		parts = append(parts, text)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func isTechnicalOpenclawPayload(text string) bool {
+	return strings.HasPrefix(text, "⚠️") ||
+		strings.HasPrefix(text, "🛠️") ||
+		strings.Contains(text, " failed`") ||
+		strings.Contains(text, "` failed")
+}
+
 func (s *TaskService) captureTaskQueued(ctx context.Context, task db.AgentTaskQueue) {
 	s.captureTaskEvent(ctx, analytics.AgentTaskQueued(s.taskAnalyticsContext(ctx, task)))
 }
@@ -1117,8 +1172,14 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					// emit literal `\n` 4-char sequences (Python/JSON-style) get them
 					// decoded into real newlines before the comment hits the DB. See
 					// util.UnescapeBackslashEscapes for the exact contract.
-					body := util.UnescapeBackslashEscapes(payload.Output)
-					if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
+					body := normalizeAgentVisibleOutput(util.UnescapeBackslashEscapes(payload.Output))
+					if body == "" {
+						slog.Warn("suppressing empty normalized fallback output",
+							"task_id", util.UUIDToString(task.ID),
+							"issue_id", util.UUIDToString(task.IssueID),
+							"agent_id", util.UUIDToString(task.AgentID),
+						)
+					} else if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
 						slog.Warn("suppressing trivial comment-trigger fallback output",
 							"task_id", util.UUIDToString(task.ID),
 							"issue_id", util.UUIDToString(task.IssueID),
@@ -1151,7 +1212,7 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 			// Same unescape as the issue-comment path above: literal `\n` from
 			// agent stdout becomes a real newline so the chat panel renders
 			// paragraph breaks instead of one wall of prose.
-			body := util.UnescapeBackslashEscapes(payload.Output)
+			body := normalizeAgentVisibleOutput(util.UnescapeBackslashEscapes(payload.Output))
 			row, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
 				ChatSessionID: task.ChatSessionID,
 				Role:          "assistant",

--- a/server/internal/service/trivial_done_test.go
+++ b/server/internal/service/trivial_done_test.go
@@ -30,3 +30,68 @@ func TestIsTrivialDoneOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeAgentVisibleOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text unchanged",
+			in:   "Done with details",
+			want: "Done with details",
+		},
+		{
+			name: "openclaw nested result payload",
+			in: `{
+				"runId": "run-1",
+				"status": "ok",
+				"result": {
+					"payloads": [
+						{"text": "Готово. Posted artifact comment."},
+						{"text": "⚠️ 🛠️ multica issue get VID-1 --output json failed"}
+					]
+				}
+			}`,
+			want: "Готово. Posted artifact comment.",
+		},
+		{
+			name: "legacy payloads",
+			in: `{
+				"payloads": [
+					{"text": "First"},
+					{"text": "Second"}
+				],
+				"meta": {"durationMs": 10}
+			}`,
+			want: "First\n\nSecond",
+		},
+		{
+			name: "technical only suppresses",
+			in: `{
+				"result": {
+					"payloads": [
+						{"text": "⚠️ 🛠️ tool failed"}
+					]
+				}
+			}`,
+			want: "",
+		},
+		{
+			name: "non envelope json unchanged",
+			in:   `{"artifact_name":"qc-report.md"}`,
+			want: `{"artifact_name":"qc-report.md"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeAgentVisibleOutput(tt.in); got != tt.want {
+				t.Fatalf("normalizeAgentVisibleOutput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- unwrap OpenClaw completion envelopes before synthesizing fallback issue/chat output
- suppress technical tool-warning payloads from fallback comments
- add regression coverage for nested OpenClaw result payloads and legacy payloads

## Test
- go test ./internal/service

## Context
Observed in the new UMCA Video Production workspace smoke: OpenClaw runtime agents posted clean artifact comments, but Multica also synthesized fallback comments containing the raw JSON completion envelope. This keeps issue timelines readable while preserving normal non-envelope JSON artifact text.