### PR TITLE
feat(cli): add --mcp-config and --mcp-config-file flags to agent create and update

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -164,6 +164,8 @@ func init() {
 	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to set an empty map.")
 	agentCreateCmd.Flags().Bool("custom-env-stdin", false, "Read the --custom-env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
 	agentCreateCmd.Flags().String("custom-env-file", "", "Read the --custom-env JSON object from a file path (suggested mode: 0600). Mutually exclusive with --custom-env and --custom-env-stdin.")
+	agentCreateCmd.Flags().String("mcp-config", "", "MCP server config as JSON string (e.g. '{\"mcpServers\":{...}}'). Pass '{}' to clear. Values on the command line are visible to shell history and 'ps'; prefer --mcp-config-file for secrets.")
+	agentCreateCmd.Flags().String("mcp-config-file", "", "Read the MCP server config JSON from a file path (suggested mode: 0600). Mutually exclusive with --mcp-config.")
 	agentCreateCmd.Flags().String("visibility", "private", "Visibility: private or workspace")
 	agentCreateCmd.Flags().Int32("max-concurrent-tasks", 6, "Maximum concurrent tasks")
 	agentCreateCmd.Flags().String("output", "json", "Output format: table or json")
@@ -179,6 +181,8 @@ func init() {
 	// custom_env is intentionally NOT part of `agent update`. Use
 	// `multica agent env set <id>` — that path is owner/admin-only,
 	// denies agent actors, and writes a persisted audit trail.
+	agentUpdateCmd.Flags().String("mcp-config", "", "New MCP server config as JSON string. Pass '{}' to clear. Values on the command line are visible to shell history and 'ps'; prefer --mcp-config-file for secrets.")
+	agentUpdateCmd.Flags().String("mcp-config-file", "", "Read the new MCP server config JSON from a file path (suggested mode: 0600). Mutually exclusive with --mcp-config.")
 	agentUpdateCmd.Flags().String("visibility", "", "New visibility: private or workspace")
 	agentUpdateCmd.Flags().String("status", "", "New status")
 	agentUpdateCmd.Flags().Int32("max-concurrent-tasks", 0, "New max concurrent tasks")
@@ -448,6 +452,11 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 	} else if ok {
 		body["custom_env"] = ce
 	}
+	if mc, ok, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if ok {
+		body["mcp_config"] = mc
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -578,13 +587,18 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("status")
 		body["status"] = v
 	}
+	if mc, ok, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if ok {
+		body["mcp_config"] = mc
+	}
 	if cmd.Flags().Changed("max-concurrent-tasks") {
 		v, _ := cmd.Flags().GetInt32("max-concurrent-tasks")
 		body["max_concurrent_tasks"] = v
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --mcp-config, --mcp-config-file, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -1026,6 +1040,68 @@ func resolveCustomEnv(cmd *cobra.Command) (map[string]string, bool, error) {
 		return nil, false, err
 	}
 	return ce, true, nil
+}
+
+// parseMcpConfig parses the --mcp-config flag value (any valid JSON) into a
+// raw message for the request body. Type validation is left to the server since
+// the MCP config schema is server-owned. Error messages are kept content-free
+// to avoid leaking sensitive config fragments through json error messages.
+func parseMcpConfig(raw string) (json.RawMessage, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("--mcp-config: empty input; pass '{}' to clear")
+	}
+	if !json.Valid([]byte(raw)) {
+		return nil, fmt.Errorf("--mcp-config must be valid JSON")
+	}
+	return json.RawMessage(raw), nil
+}
+
+// resolveMcpConfig collects the --mcp-config and --mcp-config-file flags and
+// returns the parsed raw message, a bool indicating whether the caller
+// supplied either, and any error. The two channels are mutually exclusive.
+// File input is recommended for keeping secrets out of shell history and 'ps'.
+func resolveMcpConfig(cmd *cobra.Command) (json.RawMessage, bool, error) {
+	inline := cmd.Flags().Changed("mcp-config")
+	filePath, _ := cmd.Flags().GetString("mcp-config-file")
+	fromFile := cmd.Flags().Changed("mcp-config-file")
+
+	count := 0
+	if inline {
+		count++
+	}
+	if fromFile {
+		count++
+	}
+	switch {
+	case count == 0:
+		return nil, false, nil
+	case count > 1:
+		return nil, false, fmt.Errorf("--mcp-config and --mcp-config-file are mutually exclusive; pick one")
+	}
+
+	var raw string
+	switch {
+	case inline:
+		raw, _ = cmd.Flags().GetString("mcp-config")
+	case fromFile:
+		if filePath == "" {
+			return nil, false, fmt.Errorf("--mcp-config-file: path must not be empty")
+		}
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, false, fmt.Errorf("read --mcp-config-file: %w", err)
+		}
+		raw = string(buf)
+		if strings.TrimSpace(raw) == "" {
+			return nil, false, fmt.Errorf("--mcp-config-file %q: empty contents; pass '{}' to clear", filePath)
+		}
+	}
+
+	mc, err := parseMcpConfig(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return mc, true, nil
 }
 
 func strVal(m map[string]any, key string) string {

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -210,6 +210,8 @@ func TestAgentUpdateNoFieldsErrorPointsAtEnvCommand(t *testing.T) {
 	cmd.Flags().String("runtime-config", "", "")
 	cmd.Flags().String("model", "", "")
 	cmd.Flags().String("custom-args", "", "")
+	cmd.Flags().String("mcp-config", "", "")
+	cmd.Flags().String("mcp-config-file", "", "")
 	cmd.Flags().String("visibility", "", "")
 	cmd.Flags().String("status", "", "")
 	cmd.Flags().Int32("max-concurrent-tasks", 0, "")
@@ -223,6 +225,9 @@ func TestAgentUpdateNoFieldsErrorPointsAtEnvCommand(t *testing.T) {
 	msg := err.Error()
 	if !strings.Contains(msg, "multica agent env set") {
 		t.Fatalf("no-fields error must direct users to `multica agent env set`; got: %q", msg)
+	}
+	if !strings.Contains(msg, "--mcp-config") {
+		t.Fatalf("no-fields error must mention --mcp-config; got: %q", msg)
 	}
 }
 
@@ -851,6 +856,186 @@ func TestAgentAvatarSizeBoundary(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "file too large") {
 			t.Fatalf("expected 'file too large' error, got: %v", err)
+		}
+	})
+}
+
+// freshAgentMcpCmd returns a standalone cobra.Command with the two
+// --mcp-config* flags registered, so resolveMcpConfig-shaped tests can
+// mutate flag state without leaking across subtests.
+func freshAgentMcpCmd() *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	c.Flags().String("mcp-config", "", "")
+	c.Flags().String("mcp-config-file", "", "")
+	return c
+}
+
+// TestParseMcpConfigErrorSanitization guards against future changes that
+// re-introduce %w wrapping of json error messages. Those errors can surface
+// short fragments of the input, which for a config that may carry secret
+// material (env blocks in MCP server definitions) must not appear in
+// user-visible output.
+func TestParseMcpConfigErrorSanitization(t *testing.T) {
+	secretish := `{"mcpServers":{"loom":{"command":"node","env":{"SECRET_TOKEN":verySensitiveValue}}}}`
+	_, err := parseMcpConfig(secretish)
+	if err == nil {
+		t.Fatal("expected parse error for invalid JSON")
+	}
+	msg := err.Error()
+	for _, leak := range []string{"SECRET_TOKEN", "verySensitiveValue", "loom", "mcpServers"} {
+		if strings.Contains(msg, leak) {
+			t.Fatalf("parseMcpConfig error leaked input fragment %q: %q", leak, msg)
+		}
+	}
+}
+
+// TestAgentCreateAndUpdateExposeMcpConfigFlags ensures both commands expose the
+// --mcp-config and --mcp-config-file flags so agents and users can set MCP
+// server config without requiring direct database access.
+func TestAgentCreateAndUpdateExposeMcpConfigFlags(t *testing.T) {
+	for _, flag := range []string{"mcp-config", "mcp-config-file"} {
+		if agentCreateCmd.Flag(flag) == nil {
+			t.Fatalf("agent create must expose --%s", flag)
+		}
+		if agentUpdateCmd.Flag(flag) == nil {
+			t.Fatalf("agent update must expose --%s", flag)
+		}
+	}
+}
+
+// TestResolveMcpConfig exercises the input-channel resolver: inline flag,
+// file, mutual exclusion, empty path, non-existent file, and the "not
+// supplied" path.
+func TestResolveMcpConfig(t *testing.T) {
+	t.Run("not supplied", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || ok || got != nil {
+			t.Fatalf("unset flags: got=%v ok=%v err=%v", got, ok, err)
+		}
+	})
+
+	t.Run("inline flag: valid JSON object", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		raw := `{"mcpServers":{"loom":{"command":"node","args":["/path/to/index.js"],"type":"stdio"}}}`
+		if err := cmd.Flags().Set("mcp-config", raw); err != nil {
+			t.Fatal(err)
+		}
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("inline: ok=%v err=%v", ok, err)
+		}
+		if string(got) != raw {
+			t.Fatalf("inline: got %s, want %s", got, raw)
+		}
+	})
+
+	t.Run("inline flag: clear with empty object", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		if err := cmd.Flags().Set("mcp-config", "{}"); err != nil {
+			t.Fatal(err)
+		}
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("inline {}: ok=%v err=%v", ok, err)
+		}
+		if string(got) != "{}" {
+			t.Fatalf("inline {}: got %s, want {}", got)
+		}
+	})
+
+	t.Run("file: valid JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		raw := `{"mcpServers":{"loom":{"command":"node","args":["/path/to/index.js"],"type":"stdio"}}}`
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshAgentMcpCmd()
+		if err := cmd.Flags().Set("mcp-config-file", path); err != nil {
+			t.Fatal(err)
+		}
+		got, ok, err := resolveMcpConfig(cmd)
+		if err != nil || !ok {
+			t.Fatalf("file: ok=%v err=%v", ok, err)
+		}
+		if string(got) != raw {
+			t.Fatalf("file: got %s, want %s", got, raw)
+		}
+	})
+
+	t.Run("mutually exclusive: inline + file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config", "{}")
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+
+	t.Run("file: empty path errors instead of being silently swallowed", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config-file", "")
+		if !cmd.Flags().Changed("mcp-config-file") {
+			t.Fatal("setup: expected mcp-config-file flag to be marked Changed")
+		}
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") {
+			t.Fatalf("expected --mcp-config-file empty-path error, got %v", err)
+		}
+	})
+
+	t.Run("file: non-existent path surfaces filesystem error", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config-file", filepath.Join(t.TempDir(), "does-not-exist.json"))
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") {
+			t.Fatalf("expected --mcp-config-file error, got %v", err)
+		}
+	})
+
+	t.Run("file: empty contents errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.json")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") || !strings.Contains(err.Error(), "{}") {
+			t.Fatalf("expected --mcp-config-file empty-contents error mentioning '{}', got %v", err)
+		}
+	})
+
+	t.Run("inline: empty string errors", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config", "")
+		got, ok, err := resolveMcpConfig(cmd)
+		// Empty string is a Changed flag with empty value — parseMcpConfig rejects it.
+		if err == nil {
+			t.Fatalf("expected error for empty --mcp-config, got ok=%v got=%v", ok, got)
+		}
+		if !strings.Contains(err.Error(), "--mcp-config") {
+			t.Fatalf("error must mention --mcp-config, got: %v", err)
+		}
+	})
+
+	t.Run("inline: invalid JSON errors without leaking content", func(t *testing.T) {
+		cmd := freshAgentMcpCmd()
+		_ = cmd.Flags().Set("mcp-config", `not-valid-json`)
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+		if strings.Contains(err.Error(), "not-valid-json") {
+			t.Fatalf("error must not leak input content, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## What

Adds `--mcp-config` and `--mcp-config-file` flags to both `multica agent create` and `multica agent update`, mirroring the existing `--runtime-config` / `--custom-env-file` interface convention.

**`multica agent create` and `multica agent update`:**
- `--mcp-config <json>` — inline JSON string. Useful for scripting; note that values on the command line are visible to shell history and `ps`.
- `--mcp-config-file <path>` — read JSON from a file (suggested mode: 0600). The recommended channel for anything containing OAuth tokens or API keys.

The two flags are mutually exclusive. Validation keeps error messages content-free to avoid leaking secret material (OAuth tokens, API keys are commonly nested inside `env` or `headers` blocks). Type validation is left to the server — the schema is server-owned.

## Why

Agents using per-agent MCP config (Gmail, Calendar, Slack connectors, etc.) could previously only be wired by direct API calls or the web UI. This gap blocked scripted agent provisioning and CLI-first workflows. The `--mcp-config`/`--mcp-config-file` pair closes it for both create and update paths, consistent with the pattern already established by `--runtime-config` and `--custom-env-file`.

## Relation to open PR #2387

PR #2387 (`feat(cli,agents): expose mcp_config via agent update + redact on read`) addresses `agent update` with `--mcp-config-file`, `--mcp-config-stdin`, and `--mcp-config-clear`, plus server-side validation and redaction. This PR:
- Covers `agent create` (not in #2387)
- Uses `--mcp-config` as the inline flag name (vs stdin-only in #2387)
- Does not include `--mcp-config-stdin` or `--mcp-config-clear`
- Does not include server-side validation changes

Maintainers may prefer to close this in favor of landing #2387 first and then extending `agent create` separately. Either path is fine; flagging the overlap explicitly.

## Changes

- `server/cmd/multica/cmd_agent.go` — flag registration on both commands + `resolveMcpConfig` helper + `parseMcpConfig` validator
- `server/cmd/multica/cmd_agent_test.go` — test coverage for flag exposure, resolver logic, and error-sanitization guarantee

## Test coverage

- `TestAgentCreateAndUpdateExposeMcpConfigFlags` — both commands expose the flags
- `TestResolveMcpConfig` — inline flag, file path, mutual exclusion, empty path, non-existent file, empty file, invalid JSON
- `TestParseMcpConfigErrorSanitization` — verifies error messages never echo input fragments (guards against future `%w` wrapping of json parse errors)
- `TestAgentUpdateNoFieldsErrorPointsAtEnvCommand` — updated to include `--mcp-config` in the no-fields error hint