### PR TITLE
fix(daemon/execenv): skip bundled SKILL.md so a stale dup can't brick agent startup

### DIFF
--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -366,6 +366,13 @@ func writeSkillFiles(skillsDir string, skills []SkillContextForEnv, manifest *si
 		// at the same path — that's an upstream data bug, not a
 		// user-content collision, and we surface it.
 		for _, f := range skill.Files {
+			// A bundled file at the canonical SKILL.md path is redundant with
+			// the skill's content (written above). Skip the duplicate instead
+			// of colliding — otherwise a skill that ships a stale SKILL.md in
+			// its files list bricks startup for every agent that has it.
+			if filepath.Clean(f.Path) == "SKILL.md" {
+				continue
+			}
 			fpath := filepath.Join(dir, f.Path)
 			if err := recordMkdirAll(filepath.Dir(fpath), 0o755, manifest); err != nil {
 				return err

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -512,6 +512,44 @@ func TestWriteContextFilesClaudeNativeSkills(t *testing.T) {
 	}
 }
 
+// TestWriteSkillFilesIgnoresBundledSkillMd verifies that a skill whose bundled
+// supporting files include a redundant SKILL.md entry does not collide with the
+// canonical SKILL.md written from Content. Without the guard this fails with
+// "refuse to overwrite pre-existing path" and bricks startup for every agent
+// that has such a skill.
+func TestWriteSkillFilesIgnoresBundledSkillMd(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "skillmd-collision-test",
+		AgentSkills: []SkillContextForEnv{
+			{
+				Name:    "Example Skill",
+				Content: "canonical body",
+				Files: []SkillFileContextForEnv{
+					{Path: "SKILL.md", Content: "stale duplicate"},
+				},
+			},
+		},
+	}
+
+	if err := writeContextFiles(dir, "claude", ctx, nil); err != nil {
+		t.Fatalf("writeContextFiles must tolerate a bundled SKILL.md, got: %v", err)
+	}
+
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "example-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMd), "canonical body") {
+		t.Errorf("SKILL.md must come from Content, got %q", string(skillMd))
+	}
+	if strings.Contains(string(skillMd), "stale duplicate") {
+		t.Error("bundled SKILL.md must be skipped, not overwrite canonical content")
+	}
+}
+
 func TestCleanupPreservesLogs(t *testing.T) {
 	t.Parallel()
 	workspacesRoot := t.TempDir()


### PR DESCRIPTION
A skill's SKILL.md body lives in the Content field. writeSkillFiles writes it to <dir>/SKILL.md, then iterates bundled supporting files. When a supporting file's path is also SKILL.md (a stale duplicate from an older skill version), the second write collides with the sidecar manifest's errPathPreExists guard and Prepare fails with 'execenv: refuse to overwrite pre-existing path' â bricking startup for every agent that has the skill. Fix: skip any bundled file whose cleaned path is SKILL.md (Content already owns it); genuine double-listed non-SKILL.md paths still surface. Adds a regression test.