### PR TITLE
cmd/multica: suppress pagination cursor output in json mode (MUL-2877)

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -1030,17 +1030,19 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 	// to dig into the raw HTTP response. Label depends on which paging mode
 	// the caller is in — under --recent the cursor is a thread cursor;
 	// under --thread + --tail it is a reply cursor inside that thread.
-	if nb := respHeaders.Get("X-Multica-Next-Before"); nb != "" {
-		if nbid := respHeaders.Get("X-Multica-Next-Before-Id"); nbid != "" {
-			label := "Next thread cursor"
-			if thread != "" && tailSet {
-				label = "Next reply cursor"
+	output, _ := cmd.Flags().GetString("output")
+	if output != "json" {
+		if nb := respHeaders.Get("X-Multica-Next-Before"); nb != "" {
+			if nbid := respHeaders.Get("X-Multica-Next-Before-Id"); nbid != "" {
+				label := "Next thread cursor"
+				if thread != "" && tailSet {
+					label = "Next reply cursor"
+				}
+				fmt.Fprintf(os.Stderr, "%s: --before %s --before-id %s\n", label, nb, nbid)
 			}
-			fmt.Fprintf(os.Stderr, "%s: --before %s --before-id %s\n", label, nb, nbid)
 		}
 	}
 
-	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {
 		return cli.PrintJSON(os.Stdout, comments)
 	}

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -1550,7 +1550,7 @@ func TestIssueSubscriberMutationBody(t *testing.T) {
 // daemon init path.
 func newIssueCommentListTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "list"}
-	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("output", "table", "")
 	cmd.Flags().String("since", "", "")
 	cmd.Flags().Bool("roots-only", false, "")
 	cmd.Flags().Bool("summary", false, "")
@@ -1924,17 +1924,16 @@ func TestRunIssueCommentList_DoesNotPrintShowingPreamble(t *testing.T) {
 			})
 			return
 		}
+		w.Header().Set("X-Multica-Next-Before", "2026-01-01T00:00:00.000000001Z")
+		w.Header().Set("X-Multica-Next-Before-Id", "00000000-0000-0000-0000-000000000999")
 		w.Write([]byte(`[{"id":"c1"},{"id":"c2"}]`))
 	}))
 	defer srv.Close()
-
 	t.Setenv("MULTICA_SERVER_URL", srv.URL)
 	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
 	t.Setenv("MULTICA_TOKEN", "test-token")
-
 	stderr := captureStderr(t)
 	defer stderr.restore()
-
 	cmd := newIssueCommentListTestCmd()
 	if err := cmd.Flags().Set("output", "json"); err != nil {
 		t.Fatalf("set output: %v", err)
@@ -1942,11 +1941,15 @@ func TestRunIssueCommentList_DoesNotPrintShowingPreamble(t *testing.T) {
 	if err := runIssueCommentList(cmd, []string{"MUL-1"}); err != nil {
 		t.Fatalf("runIssueCommentList: %v", err)
 	}
-
-	if got := stderr.read(); strings.Contains(got, "Showing") {
+	got := stderr.read()
+	if strings.Contains(got, "Showing") {
 		t.Errorf("stderr must not contain a 'Showing ...' preamble, got: %q", got)
 	}
+	if strings.Contains(got, "Next") {
+		t.Errorf("stderr must not contain next-cursor lines in json mode, got: %q", got)
+	}
 }
+
 
 func TestValidIssueStatuses(t *testing.T) {
 	expected := map[string]bool{


### PR DESCRIPTION
### Summary
This PR fixes a bug where `multica issue comment list --output json` prepends the plain-text pagination cursor (`Next reply cursor: ...`) to standard output. This pollutes the output stream and causes JSON parsing errors for automated tools (like agents, jq, and CI tasks) that capture combined stdout/stderr.

### Changes
- Wrapped the pagination cursor logging in `server/cmd/multica/cmd_issue.go` with a check to ensure it is suppressed when `--output json` is requested.
- Updated the test command helper `newIssueCommentListTestCmd` in `server/cmd/multica/cmd_issue_test.go` to default to `table` mode (matching production behavior) so the tests verify real CLI execution.
- Added assertions to `TestRunIssueCommentList_DoesNotPrintShowingPreamble` to verify that cursor lines are completely suppressed in JSON mode.

### Verification
- Verified manually using a local Python mock server that the command returns strictly valid JSON without prepended text when `--output json` is set.
- All Go unit tests in `cmd_issue_test.go` pass successfully.

Closes #3303