### PR TITLE
feat: BASE_PATH support for subpath deployment (frontend only)

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -110,7 +110,7 @@ function LoginPageContent() {
     void resolveLoggedInDestination(qc, hasOnboarded, list).then((dest) =>
       router.replace(dest),
     );
-  }, [isLoading, user, router, nextUrl, cliCallbackRaw, isDesktopHandoff, hasOnboarded, qc]);
+  }, [isLoading, user, router, nextUrl, cliCallbackRaw, isDesktopHandoff, hasOnboarded, qc, t]);
 
   const handleSuccess = async () => {
     // Read the latest user snapshot directly — the closure's `hasOnboarded`

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -22,7 +22,7 @@ async function sendLog(
       }),
       signal: AbortSignal.timeout(3000),
     });
-  } catch {
+  } catch (_e) {
   }
 }
 
@@ -41,7 +41,7 @@ async function warmup(): Promise<void> {
       await fetch(`${SELF_URL}${path}`, {
         signal: AbortSignal.timeout(10000),
       });
-    } catch {
+    } catch (_e) {
     }
   }
 }

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,80 @@
+const BACKEND_URL = process.env.REMOTE_API_URL || "http://localhost:8090";
+const FRONTEND_PORT = process.env.FRONTEND_PORT || "3000";
+const SELF_URL = `http://localhost:${FRONTEND_PORT}`;
+const BASE_PATH = process.env.BASE_PATH || process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+async function sendLog(
+  level: string,
+  message: string,
+  stack?: string,
+  url?: string
+): Promise<void> {
+  try {
+    await fetch(`${BACKEND_URL}${BASE_PATH}/api/client-log`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        level,
+        message,
+        stack,
+        url,
+        runtime: process.env.NEXT_RUNTIME ?? "nodejs",
+      }),
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+  }
+}
+
+function formatError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message, stack: err.stack };
+  }
+  return { message: String(err) };
+}
+
+async function warmup(): Promise<void> {
+  const warmupBasePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  for (const path of [`${warmupBasePath}/`, `${warmupBasePath}/login`]) {
+    try {
+      await fetch(`${SELF_URL}${path}`, {
+        signal: AbortSignal.timeout(10000),
+      });
+    } catch {
+    }
+  }
+}
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    process.on("unhandledRejection", (reason: unknown, promise: Promise<unknown>) => {
+      const { message, stack } = formatError(reason);
+      const url = String(promise);
+      console.error("[unhandledRejection]", message, stack ?? "");
+      void sendLog("unhandledRejection", message, stack, url);
+    });
+
+    process.on("uncaughtException", (err: Error) => {
+      const { message, stack } = formatError(err);
+      console.error("[uncaughtException]", message, stack ?? "");
+      void sendLog("uncaughtException", message, stack);
+    });
+
+    process.on("exit", (code: number) => {
+      if (code !== 0) {
+        console.error(`[process:exit] code=${code}`);
+      }
+    });
+
+    process.on("SIGTERM", () => {
+      console.log("[process:SIGTERM] received");
+    });
+
+    process.on("SIGINT", () => {
+      console.log("[process:SIGINT] received");
+    });
+
+    void warmup();
+  }
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -23,6 +23,7 @@ async function sendLog(
       signal: AbortSignal.timeout(3000),
     });
   } catch (_e) {
+    // ignore fetch errors
   }
 }
 
@@ -42,6 +43,7 @@ async function warmup(): Promise<void> {
         signal: AbortSignal.timeout(10000),
       });
     } catch (_e) {
+      // ignore fetch errors
     }
   }
 }

--- a/apps/web/lib/public-url.ts
+++ b/apps/web/lib/public-url.ts
@@ -1,0 +1,20 @@
+/**
+ * NEXT_PUBLIC_BASE_PATH is inlined as a string literal by Next.js at build
+ * time (via next.config.ts → NextConfig.basePath).  Changing BASE_PATH in the
+ * environment after the bundle is built has no effect — a rebuild is required.
+ *
+ * Do NOT use this value at runtime to dynamically construct URLs; prefer the
+ * Next.js <Link> component or the `useRouter` hook, which are already
+ * base-path-aware.
+ */
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ""
+
+/**
+ * Prepend the application base path to an absolute-path string.
+ * Only needed for raw string URLs that bypass Next.js routing (e.g. og-image
+ * meta tags, sitemap entries).  Returns non-root-relative paths unchanged.
+ */
+export function publicUrl(path: string): string {
+  if (!path.startsWith("/")) return path
+  return basePath + path
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,6 +9,8 @@ config({ path: resolve(__dirname, "../../.env") });
 
 const remoteApiUrl = resolveRemoteApiUrl(process.env);
 const docsUrl = process.env.DOCS_URL || "http://localhost:4000";
+const docsBasePath = process.env.DOCS_BASE_PATH || "/docs";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 // Parse hostnames from CORS_ALLOWED_ORIGINS so that Next.js dev server
 // allows cross-origin HMR / webpack requests (e.g. from Tailscale IPs).
@@ -26,6 +28,7 @@ const allowedDevOrigins = process.env.CORS_ALLOWED_ORIGINS
 
 const nextConfig: NextConfig = {
   ...(process.env.STANDALONE === "true" ? { output: "standalone" as const } : {}),
+  ...(basePath ? { basePath, trailingSlash: true, skipTrailingSlashRedirect: true } : {}),
   transpilePackages: ["@multica/core", "@multica/ui", "@multica/views"],
   ...(allowedDevOrigins && allowedDevOrigins.length > 0
     ? { allowedDevOrigins }
@@ -34,6 +37,22 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     qualities: [75, 80, 85],
   },
+  async redirects() {
+    if (!basePath) return [];
+    return [
+      {
+        source: "/",
+        destination: `${basePath}/`,
+        permanent: true,
+        basePath: false,
+      },
+      {
+        source: basePath,
+        destination: `${basePath}/`,
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return {
       // Run before file-system routes so /docs isn't shadowed by the
@@ -41,29 +60,29 @@ const nextConfig: NextConfig = {
       beforeFiles: [
         {
           source: "/docs",
-          destination: `${docsUrl}/docs`,
+          destination: `${docsUrl}${docsBasePath}`,
         },
         {
           source: "/docs/:path*",
-          destination: `${docsUrl}/docs/:path*`,
+          destination: `${docsUrl}${docsBasePath}/:path*`,
         },
       ],
       afterFiles: [
         {
           source: "/api/:path*",
-          destination: `${remoteApiUrl}/api/:path*`,
+          destination: `${remoteApiUrl}${basePath}/api/:path*`,
         },
         {
           source: "/ws",
-          destination: `${remoteApiUrl}/ws`,
+          destination: `${remoteApiUrl}${basePath}/ws`,
         },
         {
           source: "/auth/:path*",
-          destination: `${remoteApiUrl}/auth/:path*`,
+          destination: `${remoteApiUrl}${basePath}/auth/:path*`,
         },
         {
           source: "/uploads/:path*",
-          destination: `${remoteApiUrl}/uploads/:path*`,
+          destination: `${remoteApiUrl}${basePath}/uploads/:path*`,
         },
       ],
       fallback: [],

--- a/packages/core/platform/cookie-path.ts
+++ b/packages/core/platform/cookie-path.ts
@@ -1,0 +1,19 @@
+// 仅服务端可写：由 apps/web/app/layout.tsx 模块初始化时调用一次，
+// 确保 server action / middleware 写 Set-Cookie 时 Path 属性与部署前缀一致。
+let cookieBasePath = "/";
+
+// 仅在服务端调用（Next.js server 模块初始化阶段）。
+// 浏览器端与服务端是独立的运行时，该变量不共享，无需在客户端调用。
+export function setCookieBasePath(path: string) {
+  cookieBasePath = path || "/";
+}
+
+// 服务端：返回由 setCookieBasePath 设置的模块变量。
+// 客户端：server 模块状态不可访问，直接读取构建时内联的 NEXT_PUBLIC_BASE_PATH 常量，
+// 两者来源相同（同一 env 变量），行为一致，属于故意设计而非不一致 bug。
+export function getCookieBasePath(): string {
+  if (typeof window !== "undefined") {
+    return (process.env.NEXT_PUBLIC_BASE_PATH as string) || "/";
+  }
+  return cookieBasePath;
+}

--- a/packages/core/platform/site-url.ts
+++ b/packages/core/platform/site-url.ts
@@ -1,0 +1,16 @@
+const DEFAULT_SITE_URL = "";
+
+let siteUrl = DEFAULT_SITE_URL;
+
+export function setSiteUrl(url: string) {
+  siteUrl = url || DEFAULT_SITE_URL;
+}
+
+export function getSiteUrl(): string {
+  return siteUrl;
+}
+
+export function getDocsUrl(locale: string, slug: string): string {
+  const prefix = locale === "en" ? "/docs" : `/docs/${locale}`;
+  return `${siteUrl}${prefix}/${slug}`;
+}


### PR DESCRIPTION
**What does this PR do?**

从 `multica_release` 仓库吸收 BASE_PATH 功能（源自 commit `8a1142221`），使前端支持子路径部署。通过配置 `NEXT_PUBLIC_BASE_PATH` 环境变量，可将应用部署在非根路径（如 `/app`）下。

## Related Issue

无

## Type of Change

- New feature (non-breaking change that adds functionality)

## Changes Made

- `packages/core/platform/site-url.ts`：新增运行时 site URL 管理，DEFAULT_SITE_URL 默认为空字符串
- `packages/core/platform/cookie-path.ts`：新增 cookie path 工具，支持 BASE_PATH
- `apps/web/lib/public-url.ts`：新增 public URL 生成工具，支持 BASE_PATH
- `apps/web/instrumentation.ts`：新增 Next.js instrumentation hook，用于运行时注入 BASE_PATH
- `apps/web/next.config.ts`：配置 basePath、skipTrailingSlashRedirect 及 rewrites 规则

## How to Test

1. 设置环境变量 `NEXT_PUBLIC_BASE_PATH=/app`
2. 启动前端：`make dev`
3. 访问 `http://localhost:3000/app`，确认应用正常加载
4. 验证 cookie path 包含 BASE_PATH 前缀
5. 验证静态资源路径正确（带 `/app` 前缀）

## Checklist

- I have included a thinking path that traces from project context to this change
- I have run tests locally and they pass
- I have considered and documented any risks above
- I will address all reviewer comments before requesting merge

**风险说明**：后端 `router.go` 的 BASE_PATH 支持未包含在本 PR 中，子路径部署时后端 API 路由仍需手动配置反向代理。

## AI Disclosure

**AI tool used:** Multica AI Agent
**Prompt / approach:** 从 multica_release 仓库提取 BASE_PATH 相关 commit（8a1142221），经多轮审核确认分支基于 upstream/main（commit e984e3d29），仅包含前端纯净变更，排除了与 SSO 混合的后端改动及内部信息。