### PR TITLE
MUL-3123 fix(realtime): support X-Forwarded-Host in WebSocket checkOrigin

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -205,6 +205,11 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	// Share allowed origins with WebSocket origin checker.
 	realtime.SetAllowedOrigins(origins)
 
+	// Share the same trusted-proxy CIDRs (MULTICA_TRUSTED_PROXIES) so the
+	// WebSocket origin check honors X-Forwarded-Host only from trusted proxies,
+	// using one config source instead of a parallel one.
+	realtime.SetTrustedProxies(signupConfig.TrustedProxies)
+
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   origins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -40,9 +40,11 @@ type ScopeAuthorizer interface {
 }
 
 var allowedWSOrigins atomic.Value // holds []string
+var trustedProxies atomic.Value   // holds []string
 
 func init() {
 	allowedWSOrigins.Store(loadAllowedOrigins())
+	trustedProxies.Store(loadTrustedProxies())
 }
 
 func loadAllowedOrigins() []string {
@@ -72,9 +74,50 @@ func loadAllowedOrigins() []string {
 	return origins
 }
 
+func loadTrustedProxies() []string {
+	raw := strings.TrimSpace(os.Getenv("TRUSTED_PROXIES"))
+	if raw == "" {
+		// Default: trust localhost and private networks in development
+		return []string{"127.0.0.1", "::1"}
+	}
+	parts := strings.Split(raw, ",")
+	proxies := make([]string, 0, len(parts))
+	for _, part := range parts {
+		proxy := strings.TrimSpace(part)
+		if proxy != "" {
+			proxies = append(proxies, proxy)
+		}
+	}
+	return proxies
+}
+
 // SetAllowedOrigins overrides the WebSocket origin whitelist.
 func SetAllowedOrigins(origins []string) {
 	allowedWSOrigins.Store(origins)
+}
+
+// SetTrustedProxies overrides the trusted proxy list.
+func SetTrustedProxies(proxies []string) {
+	trustedProxies.Store(proxies)
+}
+
+// isTrustedProxy checks if the remote address is in the trusted proxy list.
+func isTrustedProxy(remoteAddr string) bool {
+	// Extract IP from "IP:port" format
+	host := remoteAddr
+	if idx := strings.LastIndex(remoteAddr, ":"); idx != -1 {
+		host = remoteAddr[:idx]
+	}
+	// Remove IPv6 brackets if present
+	host = strings.Trim(host, "[]")
+
+	proxies := trustedProxies.Load().([]string)
+	for _, trusted := range proxies {
+		if host == trusted {
+			return true
+		}
+	}
+	return false
 }
 
 func checkOrigin(r *http.Request) bool {
@@ -92,13 +135,23 @@ func checkOrigin(r *http.Request) bool {
 	if u, err := url.Parse(origin); err == nil && strings.EqualFold(u.Host, r.Host) {
 		return true
 	}
+	// Reverse-proxy support: when sitting behind a proxy the Host header
+	// contains the internal address. X-Forwarded-Host carries the original
+	// public host seen by the client, so we treat a matching origin as
+	// same-origin in that case too. SECURITY: Only trust X-Forwarded-Host
+	// if the request comes from a trusted proxy to prevent header spoofing.
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" && isTrustedProxy(r.RemoteAddr) {
+		if u, err := url.Parse(origin); err == nil && strings.EqualFold(u.Host, fwdHost) {
+			return true
+		}
+	}
 	origins := allowedWSOrigins.Load().([]string)
 	for _, allowed := range origins {
 		if origin == allowed {
 			return true
 		}
 	}
-	slog.Warn("ws: rejected origin", "origin", origin)
+	slog.Warn("ws: rejected origin", "origin", origin, "remote_addr", r.RemoteAddr)
 	return false
 }
 

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"strings"
@@ -40,7 +42,7 @@ type ScopeAuthorizer interface {
 }
 
 var allowedWSOrigins atomic.Value // holds []string
-var trustedProxies atomic.Value   // holds []string
+var trustedProxies atomic.Value   // holds []netip.Prefix
 
 func init() {
 	allowedWSOrigins.Store(loadAllowedOrigins())
@@ -74,21 +76,31 @@ func loadAllowedOrigins() []string {
 	return origins
 }
 
-func loadTrustedProxies() []string {
-	raw := strings.TrimSpace(os.Getenv("TRUSTED_PROXIES"))
+// loadTrustedProxies reads the same MULTICA_TRUSTED_PROXIES env var the rest of
+// the server uses (see cmd/server/router.go and handler.Config.TrustedProxies),
+// parsing it as a comma-separated list of CIDR prefixes. Invalid entries are
+// dropped with a warn-line rather than crashing. Empty input returns nil, which
+// means "trust no proxy" — X-Forwarded-Host is then never honored. The router
+// overrides this at startup via SetTrustedProxies so both share one config.
+func loadTrustedProxies() []netip.Prefix {
+	raw := strings.TrimSpace(os.Getenv("MULTICA_TRUSTED_PROXIES"))
 	if raw == "" {
-		// Default: trust localhost and private networks in development
-		return []string{"127.0.0.1", "::1"}
+		return nil
 	}
-	parts := strings.Split(raw, ",")
-	proxies := make([]string, 0, len(parts))
-	for _, part := range parts {
-		proxy := strings.TrimSpace(part)
-		if proxy != "" {
-			proxies = append(proxies, proxy)
+	var prefixes []netip.Prefix
+	for _, part := range strings.Split(raw, ",") {
+		s := strings.TrimSpace(part)
+		if s == "" {
+			continue
 		}
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			slog.Warn("ws: ignoring invalid trusted proxy CIDR", "value", s, "error", err)
+			continue
+		}
+		prefixes = append(prefixes, p)
 	}
-	return proxies
+	return prefixes
 }
 
 // SetAllowedOrigins overrides the WebSocket origin whitelist.
@@ -96,28 +108,51 @@ func SetAllowedOrigins(origins []string) {
 	allowedWSOrigins.Store(origins)
 }
 
-// SetTrustedProxies overrides the trusted proxy list.
-func SetTrustedProxies(proxies []string) {
+// SetTrustedProxies overrides the trusted proxy CIDR list. The server wires the
+// shared MULTICA_TRUSTED_PROXIES value in here at startup.
+func SetTrustedProxies(proxies []netip.Prefix) {
 	trustedProxies.Store(proxies)
 }
 
-// isTrustedProxy checks if the remote address is in the trusted proxy list.
+// isTrustedProxy reports whether the request's remote address falls within one
+// of the configured trusted proxy CIDRs.
 func isTrustedProxy(remoteAddr string) bool {
-	// Extract IP from "IP:port" format
-	host := remoteAddr
-	if idx := strings.LastIndex(remoteAddr, ":"); idx != -1 {
-		host = remoteAddr[:idx]
+	proxies := trustedProxies.Load().([]netip.Prefix)
+	if len(proxies) == 0 {
+		return false
 	}
-	// Remove IPv6 brackets if present
-	host = strings.Trim(host, "[]")
-
-	proxies := trustedProxies.Load().([]string)
-	for _, trusted := range proxies {
-		if host == trusted {
+	addr, err := netip.ParseAddr(remoteHost(remoteAddr))
+	if err != nil {
+		return false
+	}
+	addr = addr.Unmap()
+	for _, p := range proxies {
+		if p.Contains(addr) {
 			return true
 		}
 	}
 	return false
+}
+
+// remoteHost extracts the host/IP from an http.Request.RemoteAddr, which is
+// normally "host:port". It handles bracketed IPv6 ("[::1]:443") via
+// net.SplitHostPort and falls back to the raw value (sans brackets) when no
+// port is present.
+func remoteHost(remoteAddr string) string {
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return strings.Trim(remoteAddr, "[]")
+}
+
+// firstForwardedHost returns the first host from a (possibly comma-separated)
+// X-Forwarded-Host header. Proxy chains append values left-to-right, so the
+// first entry is the original client-facing host we compare against Origin.
+func firstForwardedHost(h string) string {
+	if i := strings.IndexByte(h, ','); i >= 0 {
+		h = h[:i]
+	}
+	return strings.TrimSpace(h)
 }
 
 func checkOrigin(r *http.Request) bool {
@@ -140,7 +175,7 @@ func checkOrigin(r *http.Request) bool {
 	// public host seen by the client, so we treat a matching origin as
 	// same-origin in that case too. SECURITY: Only trust X-Forwarded-Host
 	// if the request comes from a trusted proxy to prevent header spoofing.
-	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" && isTrustedProxy(r.RemoteAddr) {
+	if fwdHost := firstForwardedHost(r.Header.Get("X-Forwarded-Host")); fwdHost != "" && isTrustedProxy(r.RemoteAddr) {
 		if u, err := url.Parse(origin); err == nil && strings.EqualFold(u.Host, fwdHost) {
 			return true
 		}

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"sync"
 	"testing"
@@ -360,17 +361,21 @@ func TestCheckOrigin(t *testing.T) {
 	})
 	t.Cleanup(func() { SetAllowedOrigins(prev) })
 
-	prevProxies := trustedProxies.Load().([]string)
-	SetTrustedProxies([]string{"127.0.0.1", "10.0.0.1"})
+	prevProxies := trustedProxies.Load().([]netip.Prefix)
+	SetTrustedProxies([]netip.Prefix{
+		netip.MustParsePrefix("127.0.0.1/32"),
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("::1/128"),
+	})
 	t.Cleanup(func() { SetTrustedProxies(prevProxies) })
 
 	cases := []struct {
-		name        string
-		host        string
-		origin      string
-		fwdHost     string
-		remoteAddr  string
-		want        bool
+		name       string
+		host       string
+		origin     string
+		fwdHost    string
+		remoteAddr string
+		want       bool
 	}{
 		{"empty origin allowed", "api.multica.ai", "", "", "1.2.3.4:5678", true},
 		{"same-origin allowed (native client default)", "localhost:8080", "http://localhost:8080", "", "1.2.3.4:5678", true},
@@ -386,6 +391,10 @@ func TestCheckOrigin(t *testing.T) {
 		{"X-Forwarded-Host from trusted proxy but evil origin rejected", "internal.proxy", "https://evil.com", "multica.ai", "127.0.0.1:5678", false},
 		{"X-Forwarded-Host present but origin matches direct Host", "multica.ai", "https://multica.ai", "other.host", "1.2.3.4:5678", true},
 		{"X-Forwarded-Host spoofed by attacker rejected", "internal.proxy", "https://evil.com", "evil.com", "1.2.3.4:5678", false},
+		{"X-Forwarded-Host from trusted CIDR range matches origin", "internal.proxy", "https://multica.ai", "multica.ai", "10.5.6.7:5678", true},
+		{"X-Forwarded-Host from trusted IPv6 proxy matches origin", "internal.proxy", "https://multica.ai", "multica.ai", "[::1]:5678", true},
+		{"X-Forwarded-Host comma list uses first (client-facing) value", "internal.proxy", "https://multica.ai", "multica.ai, proxy.internal", "127.0.0.1:5678", true},
+		{"X-Forwarded-Host comma list ignores trailing values", "internal.proxy", "https://app.multica.ai", "proxy.internal, app.multica.ai", "127.0.0.1:5678", false},
 	}
 
 	for _, tc := range cases {

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -360,31 +360,47 @@ func TestCheckOrigin(t *testing.T) {
 	})
 	t.Cleanup(func() { SetAllowedOrigins(prev) })
 
+	prevProxies := trustedProxies.Load().([]string)
+	SetTrustedProxies([]string{"127.0.0.1", "10.0.0.1"})
+	t.Cleanup(func() { SetTrustedProxies(prevProxies) })
+
 	cases := []struct {
-		name   string
-		host   string
-		origin string
-		want   bool
+		name        string
+		host        string
+		origin      string
+		fwdHost     string
+		remoteAddr  string
+		want        bool
 	}{
-		{"empty origin allowed", "api.multica.ai", "", true},
-		{"same-origin allowed (native client default)", "localhost:8080", "http://localhost:8080", true},
-		{"same-origin allowed (https)", "api.multica.ai", "https://api.multica.ai", true},
-		{"same-origin allowed (case-insensitive host, RFC 7230)", "API.Multica.AI", "https://api.multica.ai", true},
-		{"whitelisted origin allowed (web cross-origin)", "localhost:8080", "http://localhost:3000", true},
-		{"whitelisted origin allowed (prod web)", "api.multica.ai", "https://multica.ai", true},
-		{"unknown origin rejected (CSWSH defense)", "api.multica.ai", "https://evil.com", false},
-		{"different port rejected", "localhost:8080", "http://localhost:9999", false},
+		{"empty origin allowed", "api.multica.ai", "", "", "1.2.3.4:5678", true},
+		{"same-origin allowed (native client default)", "localhost:8080", "http://localhost:8080", "", "1.2.3.4:5678", true},
+		{"same-origin allowed (https)", "api.multica.ai", "https://api.multica.ai", "", "1.2.3.4:5678", true},
+		{"same-origin allowed (case-insensitive host, RFC 7230)", "API.Multica.AI", "https://api.multica.ai", "", "1.2.3.4:5678", true},
+		{"whitelisted origin allowed (web cross-origin)", "localhost:8080", "http://localhost:3000", "", "1.2.3.4:5678", true},
+		{"whitelisted origin allowed (prod web)", "api.multica.ai", "https://multica.ai", "", "1.2.3.4:5678", true},
+		{"unknown origin rejected (CSWSH defense)", "api.multica.ai", "https://evil.com", "", "1.2.3.4:5678", false},
+		{"different port rejected", "localhost:8080", "http://localhost:9999", "", "1.2.3.4:5678", false},
+		{"X-Forwarded-Host from trusted proxy matches origin", "internal.proxy", "https://multica.ai", "multica.ai", "127.0.0.1:5678", true},
+		{"X-Forwarded-Host from trusted proxy case-insensitive", "internal.proxy", "https://Multica.AI", "multica.ai", "10.0.0.1:5678", true},
+		{"X-Forwarded-Host from untrusted source rejected", "internal.proxy", "https://example.com", "example.com", "1.2.3.4:5678", false},
+		{"X-Forwarded-Host from trusted proxy but evil origin rejected", "internal.proxy", "https://evil.com", "multica.ai", "127.0.0.1:5678", false},
+		{"X-Forwarded-Host present but origin matches direct Host", "multica.ai", "https://multica.ai", "other.host", "1.2.3.4:5678", true},
+		{"X-Forwarded-Host spoofed by attacker rejected", "internal.proxy", "https://evil.com", "evil.com", "1.2.3.4:5678", false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodGet, "/ws", nil)
 			r.Host = tc.host
+			r.RemoteAddr = tc.remoteAddr
 			if tc.origin != "" {
 				r.Header.Set("Origin", tc.origin)
 			}
+			if tc.fwdHost != "" {
+				r.Header.Set("X-Forwarded-Host", tc.fwdHost)
+			}
 			if got := checkOrigin(r); got != tc.want {
-				t.Fatalf("checkOrigin(host=%q, origin=%q) = %v, want %v", tc.host, tc.origin, got, tc.want)
+				t.Fatalf("checkOrigin(host=%q, origin=%q, X-Forwarded-Host=%q, remoteAddr=%q) = %v, want %v", tc.host, tc.origin, tc.fwdHost, tc.remoteAddr, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What does this PR do?**

修复通过反向代理访问时 WebSocket checkOrigin 校验失败的问题。请求的 Host 头为代理地址而非公开域名，导致 WS 连接被拒绝。新增对 X-Forwarded-Host 头的检查，并引入可信代理验证机制（TrustedProxies），使反向代理场景下可正常建立连接，同时防止 X-Forwarded-Host 头伪造攻击。

## Type of Change

- Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/realtime/hub.go`：checkOrigin 新增对 X-Forwarded-Host 头的检查；新增 `loadTrustedProxies`/`isTrustedProxy` 机制，仅在请求来自可信代理时采纳 X-Forwarded-Host，防止头伪造绕过同源校验
- `server/internal/realtime/hub_test.go`：新增测试覆盖 X-Forwarded-Host 场景（匹配允许、大小写不敏感、不匹配拒绝、可信代理校验）
- `server/cmd/server/listeners_frame_test.go`：补充相关测试

## How to Test

1. 配置反向代理（如 nginx），将请求转发到应用，设置 X-Forwarded-Host 头为公开域名；将代理 IP 加入 `TRUSTED_PROXIES` 环境变量
2. 通过反向代理访问应用，尝试建立 WebSocket 连接
3. 验证 WS 连接成功建立（不再被 checkOrigin 拒绝）
4. 运行新增单元测试，验证 X-Forwarded-Host 头被正确校验：

```bash
cd server
go test ./internal/realtime/...
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica AI Agent
**Prompt / approach:** 分析反向代理场景下 WS 连接被拒绝的问题，定位到 checkOrigin 只校验 Host 头而未检查 X-Forwarded-Host，新增对 X-Forwarded-Host 的校验逻辑；结合审核员意见新增 TrustedProxies 机制，避免裸部署场景下 X-Forwarded-Host 被伪造绕过同源校验

