### PR TITLE
feat(daemon): per-tool-call timeout to stop multi-hour hangs on poll/frozen calls

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -31,7 +31,27 @@ const (
 	// daemon-visible activity — see MUL-2300. 30 min keeps the safety net for
 	// truly stuck runs (dockerd hang) while leaving headroom for long writes.
 	// Set MULTICA_AGENT_IDLE_WATCHDOG=0 to disable.
-	DefaultAgentIdleWatchdog       = 30 * time.Minute
+	DefaultAgentIdleWatchdog = 30 * time.Minute
+	// DefaultMaxToolCallDuration is the per-tool-call hard cap. The idle
+	// watchdog above deliberately treats an in-flight tool call (a tool_use
+	// with no matching tool_result yet) as forward progress and never fires
+	// while one is outstanding — long `npm install` / `docker build` calls
+	// emit no messages for minutes and must not be killed mid-build. The
+	// blind spot: a tool call that hangs forever (a `sleep`/`until` poll loop
+	// on a CI/deploy, a frozen network call, an MCP server that never
+	// answers) is also "in-flight", so the idle watchdog can never catch it.
+	// It then sits at "running" until the coarse DefaultAgentTimeout (2 h),
+	// burning the dispatch slot and 50-200k tokens of accumulated context per
+	// hung run — the single largest token cost from failed runs in the whole
+	// catalogue. This cap force-stops any single tool call that stays
+	// in-flight longer than the limit, so a hung call dies in minutes instead
+	// of hours. 30 min sits far below the 2 h ceiling (catches every truly
+	// stuck call early) while leaving headroom above almost every legitimate
+	// long call — including a full `make check` (typecheck + unit + Go + e2e)
+	// on a cold checkout. Deployments with genuinely longer single calls
+	// (e.g. a 40-min build) raise it via MULTICA_MAX_TOOL_CALL_DURATION;
+	// set 0 to disable.
+	DefaultMaxToolCallDuration     = 30 * time.Minute
 	DefaultRuntimeName             = "Local Agent"
 	DefaultWorkspaceSyncInterval   = 30 * time.Second
 	DefaultHealthPort              = 19514
@@ -79,6 +99,7 @@ type Config struct {
 	AgentTimeout                   time.Duration
 	CodexSemanticInactivityTimeout time.Duration
 	AgentIdleWatchdog              time.Duration // force-stop a run when the backend goes silent this long with an empty queue (0 = disabled)
+	MaxToolCallDuration            time.Duration // force-stop a run when a single tool call stays in-flight (tool_use with no tool_result) longer than this (0 = disabled)
 	ClaudeArgs                     []string
 	CodexArgs                      []string
 }
@@ -280,6 +301,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
+	// MULTICA_MAX_TOOL_CALL_DURATION=0 disables the per-tool-call hard cap.
+	// Routed through durationFromEnv so an operator with genuinely long single
+	// calls can raise it (or disable it) without patching the binary; any
+	// positive duration overrides DefaultMaxToolCallDuration.
+	maxToolCallDuration, err := durationFromEnv("MULTICA_MAX_TOOL_CALL_DURATION", DefaultMaxToolCallDuration)
+	if err != nil {
+		return Config{}, err
+	}
+
 	maxConcurrentTasks, err := intFromEnv("MULTICA_DAEMON_MAX_CONCURRENT_TASKS", DefaultMaxConcurrentTasks)
 	if err != nil {
 		return Config{}, err
@@ -428,6 +458,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		AgentTimeout:                   agentTimeout,
 		CodexSemanticInactivityTimeout: codexSemanticInactivityTimeout,
 		AgentIdleWatchdog:              agentIdleWatchdog,
+		MaxToolCallDuration:            maxToolCallDuration,
 		ClaudeArgs:                     claudeArgs,
 		CodexArgs:                      codexArgs,
 	}, nil

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -240,6 +240,47 @@ func stageFakeAgent(t *testing.T) string {
 	return binDir
 }
 
+// TestLoadConfig_MaxToolCallDuration covers the per-tool-call cap (FIR-2610):
+// the default, an explicit env override (e.g. a deployment with genuinely long
+// single calls raising it), and the 0 = disabled opt-out.
+func TestLoadConfig_MaxToolCallDuration(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_MAX_TOOL_CALL_DURATION", "")
+		cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MaxToolCallDuration != DefaultMaxToolCallDuration {
+			t.Fatalf("MaxToolCallDuration = %s, want default %s", cfg.MaxToolCallDuration, DefaultMaxToolCallDuration)
+		}
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_MAX_TOOL_CALL_DURATION", "45m")
+		cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MaxToolCallDuration != 45*time.Minute {
+			t.Fatalf("MaxToolCallDuration = %s, want 45m", cfg.MaxToolCallDuration)
+		}
+	})
+
+	t.Run("disabled with zero", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_MAX_TOOL_CALL_DURATION", "0")
+		cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.MaxToolCallDuration != 0 {
+			t.Fatalf("MaxToolCallDuration = %s, want 0 (disabled)", cfg.MaxToolCallDuration)
+		}
+	})
+}
+
 // TestLoadConfig_AutoUpdateDefault_SelfHostOff is the regression guard for
 // MUL-2381: a daemon pointed at any non-cloud server URL must default
 // AutoUpdateEnabled to false, because self-host operators frequently run a

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2975,6 +2975,26 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			FailureReason: "idle_watchdog",
 			Usage:         usageEntries,
 		}, nil
+	case "tool_timeout":
+		// The tool-call watchdog force-stopped the run because a single tool
+		// call stayed in-flight past MaxToolCallDuration (a hung poll loop,
+		// frozen network call, or unresponsive MCP server). Route through the
+		// blocked path with a dedicated failure_reason so the run leaves
+		// "running" state and operators can tell a hung tool call apart from a
+		// silent backend (idle_watchdog) or a real overall timeout.
+		comment := result.Error
+		if comment == "" {
+			comment = maxToolCallReason(d.cfg.MaxToolCallDuration)
+		}
+		return TaskResult{
+			Status:        "blocked",
+			Comment:       comment,
+			SessionID:     result.SessionID,
+			WorkDir:       env.WorkDir,
+			EnvRoot:       env.RootDir,
+			FailureReason: "tool_timeout",
+			Usage:         usageEntries,
+		}, nil
 	case "cancelled":
 		// Server cancelled the task (e.g. issue reassignment, user cancel).
 		// handleTask's cancelledByPoll branch already discards this result,
@@ -3067,10 +3087,18 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	// that may run far longer than the idle window without emitting any
 	// message — so the watchdog must not interpret that silence as a hang.
 	var inFlightTools atomic.Int32
+	// oldestInFlightAt records (as unix nanos) when the in-flight tool set last
+	// became non-empty, re-stamped on each tool_result that still leaves a tool
+	// outstanding. The tool-call watchdog reads it to cap how long any single
+	// tool call may sit in-flight (tool_use with no tool_result) — the gap the
+	// idle watchdog deliberately ignores. 0 means no tool is in-flight.
+	var oldestInFlightAt atomic.Int64
 	var idleWatchdogFired atomic.Bool
+	var toolTimeoutFired atomic.Bool
 	idleWindow := d.cfg.AgentIdleWatchdog
-	if idleWindow > 0 {
-		go d.runIdleWatchdog(agentCtx, idleWindow, &lastActivityAt, &inFlightTools, &idleWatchdogFired, agentCancel, session.Messages, taskLog, taskID)
+	maxToolWindow := d.cfg.MaxToolCallDuration
+	if idleWindow > 0 || maxToolWindow > 0 {
+		go d.runIdleWatchdog(agentCtx, idleWindow, maxToolWindow, &lastActivityAt, &inFlightTools, &oldestInFlightAt, &idleWatchdogFired, &toolTimeoutFired, agentCancel, session.Messages, taskLog, taskID)
 	}
 
 	go func() {
@@ -3163,7 +3191,14 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 					}
 				case agent.MessageToolUse:
 					n := toolCount.Add(1)
-					inFlightTools.Add(1)
+					// Stamp the in-flight clock only on the 0->1 transition so
+					// the tool-call watchdog measures from when the first
+					// outstanding call started. Parallel tool_use messages in
+					// the same batch share that start. Message processing is
+					// single-goroutine, so the load-then-store is race-free.
+					if inFlightTools.Add(1) == 1 {
+						oldestInFlightAt.Store(time.Now().UnixNano())
+					}
 					taskLog.Info(fmt.Sprintf("tool #%d: %s", n, msg.Tool))
 					if msg.CallID != "" {
 						mu.Lock()
@@ -3193,6 +3228,16 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 						if inFlightTools.CompareAndSwap(cur, cur-1) {
 							break
 						}
+					}
+					// A tool_result is forward progress. Clear the in-flight
+					// clock when nothing is outstanding, otherwise re-stamp it
+					// so a remaining call gets a fresh window rather than
+					// inheriting a sibling's elapsed time — we only kill a call
+					// that produces no result at all for the full window.
+					if inFlightTools.Load() == 0 {
+						oldestInFlightAt.Store(0)
+					} else {
+						oldestInFlightAt.Store(time.Now().UnixNano())
 					}
 					s := seq.Add(1)
 					output := msg.Output
@@ -3249,7 +3294,16 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 
 	select {
 	case result := <-session.Result:
-		if idleWatchdogFired.Load() {
+		if toolTimeoutFired.Load() {
+			// A single tool call exceeded MaxToolCallDuration. Re-tag the
+			// SIGKILL-induced "aborted" as "tool_timeout" so runTask routes
+			// it through a dedicated failure_reason instead of the generic
+			// agent_error bucket.
+			result.Status = "tool_timeout"
+			if result.Error == "" {
+				result.Error = maxToolCallReason(maxToolWindow)
+			}
+		} else if idleWatchdogFired.Load() {
 			// The backend's wait goroutine (e.g. claude.go) translates the
 			// SIGKILL we delivered via agentCancel into Status="aborted".
 			// Re-tag it as "idle_watchdog" so runTask routes the
@@ -3266,6 +3320,12 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		// context.Canceled. Check this BEFORE the generic cancelled/timeout
 		// classifiers so a watchdog-induced stop isn't misreported as
 		// "task cancelled by server".
+		if toolTimeoutFired.Load() {
+			return agent.Result{
+				Status: "tool_timeout",
+				Error:  maxToolCallReason(maxToolWindow),
+			}, toolCount.Load(), nil
+		}
 		if idleWatchdogFired.Load() {
 			return agent.Result{
 				Status: "idle_watchdog",
@@ -3297,31 +3357,52 @@ func idleWatchdogReason(window time.Duration) string {
 	return fmt.Sprintf("agent produced no new messages for %s and message queue was empty; force-stopped by idle watchdog", window)
 }
 
-// runIdleWatchdog ticks until either agentCtx is cancelled or the backend has
-// been silent for at least window with no in-flight tool call. On firing, it
-// sets fired and calls cancel, which propagates to the agent subprocess (via
-// the ctx passed to backend.Execute) and to drainCtx. The check requires:
+// maxToolCallReason formats the human-facing explanation surfaced on
+// tool_timeout dispositions, when a single tool call stayed in-flight longer
+// than MaxToolCallDuration with no tool_result.
+func maxToolCallReason(window time.Duration) string {
+	return fmt.Sprintf("tool call exceeded MaxToolCallDuration (%s) with no result; force-stopped by tool-call watchdog", window)
+}
+
+// runIdleWatchdog ticks until either agentCtx is cancelled or one of two
+// safety nets fires. On firing it sets the matching flag and calls cancel,
+// which propagates to the agent subprocess (via the ctx passed to
+// backend.Execute) and to drainCtx. The two nets are complementary — they
+// cover the two distinct ways a run can stall:
 //
-//  1. inFlightTools == 0 — the backend has emitted a tool_use whose
-//     matching tool_result hasn't arrived yet, meaning a real tool (e.g.
-//     `npm install`, `docker build`) is legitimately running. Long tool
-//     calls produce no messages between use and result; killing here would
-//     yank the agent mid-build. AND
-//  2. time since lastActivityAt exceeds window — the drain loop is single
-//     reader, so a stale stamp means no message has actually arrived; AND
-//  3. session.Messages buffer is empty — defensive against a hypothetical
-//     drain stall where unprocessed messages would still imply progress.
+//  1. Idle watchdog (window = idleWindow > 0). Fires when the backend has gone
+//     silent for at least idleWindow AND no tool call is in-flight AND the
+//     message buffer is empty. This is the "backend died mid-thought" case.
+//     It deliberately stands down while a tool call is in-flight: a long
+//     `npm install` / `docker build` produces no messages between tool_use and
+//     tool_result, so killing there would yank the agent mid-build.
 //
-// Tick interval is window/2 (floored at 30 s in production, but the floor only
-// kicks in for windows >= 1 min so tests can pass tiny windows like 50 ms and
-// see the watchdog fire within a few ticks).
-func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger, taskID string) {
-	interval := window / 2
-	if window >= time.Minute && interval < 30*time.Second {
+//  2. Tool-call watchdog (maxToolWindow > 0). Covers the blind spot of (1):
+//     a single tool call that hangs forever (a `sleep`/`until` poll loop, a
+//     frozen network call, an MCP server that never answers) is "in-flight",
+//     so the idle watchdog never catches it and the run sits at "running"
+//     until the 2 h DefaultAgentTimeout. This net fires when a tool call has
+//     stayed in-flight (oldestInFlightAt) longer than maxToolWindow with no
+//     tool_result, killing a hung call in minutes instead of hours.
+//
+// Either window may be 0 (disabled); the caller starts the goroutine when at
+// least one is positive. Tick interval is half the smallest active window
+// (floored at 30 s in production, but the floor only kicks in for windows
+// >= 1 min so tests can pass tiny windows like 50 ms and see a fire within a
+// few ticks).
+func (d *Daemon) runIdleWatchdog(agentCtx context.Context, idleWindow, maxToolWindow time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, oldestInFlightAt *atomic.Int64, fired *atomic.Bool, toolFired *atomic.Bool, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger, taskID string) {
+	// Drive the ticker off the smallest active window so neither net is
+	// checked later than roughly half its own window.
+	tickBase := idleWindow
+	if maxToolWindow > 0 && (tickBase == 0 || maxToolWindow < tickBase) {
+		tickBase = maxToolWindow
+	}
+	interval := tickBase / 2
+	if tickBase >= time.Minute && interval < 30*time.Second {
 		interval = 30 * time.Second
 	}
 	if interval <= 0 {
-		interval = window
+		interval = tickBase
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -3330,16 +3411,37 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window time.Duration,
 		case <-agentCtx.Done():
 			return
 		case <-ticker.C:
-			// In-flight tool call: the agent has emitted tool_use and
-			// the corresponding tool_result hasn't landed yet. A long
-			// build/install/test can sit here silently for many minutes
-			// — that is forward progress, not a hang.
+			// In-flight tool call: the agent has emitted tool_use and the
+			// corresponding tool_result hasn't landed yet. A long
+			// build/install/test can sit here silently for many minutes —
+			// that is forward progress, not a hang — so the idle watchdog
+			// stands down. But an in-flight call that never returns is the
+			// 2 h-hang we must catch, so apply the per-tool-call hard cap.
 			if inFlightTools.Load() > 0 {
+				if maxToolWindow > 0 {
+					if startedNanos := oldestInFlightAt.Load(); startedNanos > 0 {
+						if inFlightFor := time.Since(time.Unix(0, startedNanos)); inFlightFor >= maxToolWindow {
+							taskLog.Warn("tool-call watchdog firing: in-flight tool exceeded max duration, force-stopping run",
+								"task", shortID(taskID),
+								"in_flight_for", inFlightFor.Round(time.Second).String(),
+								"threshold", maxToolWindow.String(),
+							)
+							toolFired.Store(true)
+							cancel()
+							return
+						}
+					}
+				}
+				continue
+			}
+			if idleWindow <= 0 {
+				// Idle watchdog disabled; only the tool-call cap is active and
+				// there is no in-flight call to cap right now.
 				continue
 			}
 			last := time.Unix(0, lastActivityAt.Load())
 			idleFor := time.Since(last)
-			if idleFor < window {
+			if idleFor < idleWindow {
 				continue
 			}
 			// A buffered-but-undrained message means the drain loop is
@@ -3351,7 +3453,7 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window time.Duration,
 			taskLog.Warn("idle watchdog firing: no agent activity, force-stopping run",
 				"task", shortID(taskID),
 				"idle_for", idleFor.Round(time.Second).String(),
-				"threshold", window.String(),
+				"threshold", idleWindow.String(),
 			)
 			fired.Store(true)
 			cancel()

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1318,6 +1318,109 @@ func TestExecuteAndDrain_IdleWatchdog_FiresAfterToolResultIfBackendStaysSilent(t
 	}
 }
 
+// TestExecuteAndDrain_ToolCallWatchdog_FiresOnHungToolCall is the core of the
+// per-tool-call timeout (FIR-2610). It models the exact blind spot the idle
+// watchdog can never catch: a single tool call (a `sleep`/`until` poll loop, a
+// frozen network call, an unresponsive MCP server) that emits tool_use and
+// then never returns a tool_result. The idle watchdog stands down while a tool
+// is in-flight, so before this fix the run sat at "running" until the 2 h
+// DefaultAgentTimeout. With MaxToolCallDuration set, it must be force-stopped
+// in a few ticks — minutes, not hours.
+func TestExecuteAndDrain_ToolCallWatchdog_FiresOnHungToolCall(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	// Idle watchdog deliberately DISABLED to prove the tool-call cap stands on
+	// its own. The tool stays in-flight far longer than the cap.
+	d.cfg.AgentIdleWatchdog = 0
+	d.cfg.MaxToolCallDuration = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	result, _, err := d.executeAndDrain(
+		ctx,
+		longToolCallBackend{toolSilence: 10 * time.Second},
+		"p",
+		agent.ExecOptions{},
+		slog.Default(),
+		"t-hung-tool",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "tool_timeout" {
+		t.Fatalf("expected status=tool_timeout for a hung in-flight tool call, got %q (err=%q)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "MaxToolCallDuration") {
+		t.Fatalf("expected error to mention MaxToolCallDuration, got %q", result.Error)
+	}
+	// The whole point: it must fire on the cap, not sit for the 10 s tool
+	// silence (let alone the 2 h ceiling). 1 s is generous against slow CI.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("tool-call watchdog took too long to fire: %s (cap=%s)", elapsed, d.cfg.MaxToolCallDuration)
+	}
+}
+
+// TestExecuteAndDrain_ToolCallWatchdog_DoesNotFireForToolWithinCap guards the
+// done-criterion that legitimate long single calls are not killed: a tool call
+// that finishes inside MaxToolCallDuration must complete normally.
+func TestExecuteAndDrain_ToolCallWatchdog_DoesNotFireForToolWithinCap(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	d.cfg.AgentIdleWatchdog = 0
+	// Cap comfortably larger than the tool's silence.
+	d.cfg.MaxToolCallDuration = 2 * time.Second
+
+	result, _, err := d.executeAndDrain(
+		context.Background(),
+		longToolCallBackend{toolSilence: 50 * time.Millisecond},
+		"p",
+		agent.ExecOptions{},
+		slog.Default(),
+		"t-tool-within-cap",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("expected status=completed for a tool call within the cap, got %q (err=%q)", result.Status, result.Error)
+	}
+}
+
+// TestExecuteAndDrain_ToolCallWatchdog_FiresWhileIdleWatchdogStandsDown proves
+// the two nets are complementary: with BOTH enabled and a hung in-flight tool,
+// the idle watchdog (shorter window) correctly stands down because a tool is
+// in-flight, and the tool-call cap is what actually stops the run — tagged
+// tool_timeout, not idle_watchdog.
+func TestExecuteAndDrain_ToolCallWatchdog_FiresWhileIdleWatchdogStandsDown(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	d.cfg.AgentIdleWatchdog = 50 * time.Millisecond
+	d.cfg.MaxToolCallDuration = 150 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	result, _, err := d.executeAndDrain(
+		ctx,
+		longToolCallBackend{toolSilence: 10 * time.Second},
+		"p",
+		agent.ExecOptions{},
+		slog.Default(),
+		"t-hung-tool-both",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "tool_timeout" {
+		t.Fatalf("expected status=tool_timeout (idle watchdog must stand down for an in-flight tool), got %q (err=%q)", result.Status, result.Error)
+	}
+}
+
 // ensureRepoReady must refresh `workspaceState.settings` on every checkout —
 // even when the repo cache already holds the URL. The /repo/checkout handler
 // reads `workspaceCoAuthoredByEnabled` right after, and the 30s workspace


### PR DESCRIPTION
## Problem

The daemon's idle watchdog deliberately stands down while a tool call is **in-flight** (a `tool_use` with no matching `tool_result` yet) — a long `npm install` / `docker build` emits no messages and must not be killed mid-build. The blind spot: a single tool call that **hangs forever** is also "in-flight", so the idle watchdog can never catch it:

- a `sleep`/`until` poll loop on a CI/deploy that never converges
- a frozen network call
- an MCP server / child process that never answers

Such a run sits at `running` until the coarse 2h `DefaultAgentTimeout`, holding a dispatch slot and burning a large amount of accumulated context per hung run.

## Fix

Add `MaxToolCallDuration` (`MULTICA_MAX_TOOL_CALL_DURATION`, default **30m**, `0` to disable), enforced **per tool call** inside the existing watchdog goroutine — exactly in the branch that currently `continue`s on an in-flight tool. When a tool stays in-flight past the cap with no result, the run is force-stopped with a dedicated `tool_timeout` disposition and a clear error: `tool call exceeded MaxToolCallDuration`.

A hung call now dies in **minutes instead of hours**. Legitimate long single calls are not killed — 30m sits far below the 2h ceiling yet above almost every real long call; deployments with genuinely longer single calls raise the limit explicitly (or set `0` to disable).

### Mechanics
- The watchdog goroutine now starts when **either** the idle window or the tool-call cap is positive; the tick interval is driven by the smaller active window.
- The in-flight clock is stamped on the `0->1` tool transition and re-stamped on each `tool_result` that still leaves a call outstanding, so a single non-returning call is measured from its own start while genuine progress resets it.
- `tool_timeout` routes through the same blocked path as `idle_watchdog`, with its own `failure_reason` so operators can tell a hung tool call apart from a silent backend or a real overall timeout.

## Tests
- fires on a hung in-flight tool (with the idle watchdog disabled, proving the cap stands alone)
- does **not** fire for a tool that completes within the cap
- fires while the idle watchdog correctly stands down (both enabled)
- config default / env-override / disable parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)