### PR TITLE
fix(security): redact agent instructions + skill content for non-admin members

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -147,6 +147,20 @@ export interface Agent {
   name: string;
   description: string;
   instructions: string;
+  /**
+   * True when the requester is not allowed to view this agent's instructions
+   * (system prompt). The `instructions` field is then an empty string. Same
+   * access model as the (server-side) canViewAgentSecrets — owner / admin /
+   * agent owner see the full body; members see a redacted placeholder.
+   * Instructions are methodology rather than credentials, so this is tracked
+   * separately from the existing mcp_config_redacted flag. See server-side
+   * `canViewAgentInstructions` for the gate.
+   *
+   * Optional in the type so older backends (pre-fix) that omit the field
+   * don't crash the renderer; downstream code should treat `undefined` as
+   * `false` (no redaction).
+   */
+  instructions_redacted?: boolean;
   avatar_url: string | null;
   runtime_mode: AgentRuntimeMode;
   runtime_config: Record<string, unknown>;

--- a/packages/views/agents/components/tabs/instructions-tab.tsx
+++ b/packages/views/agents/components/tabs/instructions-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2, Save } from "lucide-react";
+import { Loader2, Lock, Save } from "lucide-react";
 import type { Agent } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor } from "../../../editor/content-editor";
@@ -20,6 +20,23 @@ export function InstructionsTab({
   const [value, setValue] = useState(agent.instructions ?? "");
   const [saving, setSaving] = useState(false);
   const isDirty = value !== (agent.instructions ?? "");
+
+  // When instructions are redacted (server-side, due to viewer role), render
+  // a lock placeholder instead of the editor. Without this gate the editor
+  // would render an empty editable surface and let members save edits over
+  // an empty value, effectively wiping the instructions. See server-side
+  // canViewAgentInstructions in handler/agent.go.
+  if (agent.instructions_redacted) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+        <Lock className="h-8 w-8 text-muted-foreground" />
+        <p className="max-w-md text-sm text-muted-foreground">
+          Agent instructions are only visible to workspace owners, admins,
+          and the agent owner.
+        </p>
+      </div>
+    );
+  }
 
   // Sync when switching between agents.
   useEffect(() => {

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -52,7 +52,16 @@ type AgentResponse struct {
 	HasCustomEnv       bool   `json:"has_custom_env"`
 	CustomEnvKeyCount  int    `json:"custom_env_key_count"`
 	McpConfigRedacted  bool   `json:"mcp_config_redacted"`
-	Visibility         string `json:"visibility"`
+	// InstructionsRedacted is set to true when the caller is not allowed to
+	// view the agent's instructions (system prompt). The `instructions`
+	// field is then empty. See canViewAgentInstructions for the role-based
+	// logic. Instructions often encode methodology — multi-paragraph
+	// system prompts, prompt templates, brand-voice rules, infrastructure
+	// references — so members get a redacted placeholder instead of the
+	// full body. Agent actors are also denied (analogous to the
+	// mcp_config policy in MUL-2600) to prevent lateral-movement.
+	InstructionsRedacted bool   `json:"instructions_redacted"`
+	Visibility           string `json:"visibility"`
 	Status             string `json:"status"`
 	MaxConcurrentTasks int32  `json:"max_concurrent_tasks"`
 	Model              string `json:"model"`
@@ -508,6 +517,13 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		if actorType == "agent" || alwaysRedact || !canViewAgentSecrets(a, userID, member.Role) {
 			redactMcpConfig(&resp)
 		}
+		// Instructions (system prompt) gating is independent of alwaysRedact
+		// (which is a secrets policy) but follows the same lateral-movement
+		// rationale as mcp_config: agent actors never see another agent's
+		// instructions even when their host PAT would normally qualify.
+		if actorType == "agent" || !canViewAgentInstructions(a, userID, member.Role) {
+			redactInstructions(&resp)
+		}
 		visible = append(visible, resp)
 	}
 
@@ -556,6 +572,16 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 	} else if member, ok := ctxMember(r.Context()); ok {
 		if !canViewAgentSecrets(agent, userID, member.Role) {
 			redactMcpConfig(&resp)
+		}
+	}
+	// Instructions gating — see ListAgents for the rationale (agent-actor
+	// + role-based, independent of always_redact_secrets which is
+	// credentials-only).
+	if actorType == "agent" {
+		redactInstructions(&resp)
+	} else if member, ok := ctxMember(r.Context()); ok {
+		if !canViewAgentInstructions(agent, userID, member.Role) {
+			redactInstructions(&resp)
 		}
 	}
 
@@ -827,6 +853,20 @@ func canViewAgentSecrets(agent db.Agent, userID string, memberRole string) bool 
 	return uuidToString(agent.OwnerID) == userID
 }
 
+// canViewAgentInstructions checks whether the requesting user is allowed
+// to see the agent's instructions (system prompt). Same access model as
+// canViewAgentSecrets — owner / admin / agent owner — but tracked
+// separately because instructions are methodology rather than
+// credentials. They commonly contain multi-paragraph system prompts
+// encoding processes, prompt templates, brand-voice rules, and
+// infrastructure references. For everyone else the field is redacted.
+func canViewAgentInstructions(agent db.Agent, userID string, memberRole string) bool {
+	if roleAllowed(memberRole, "owner", "admin") {
+		return true
+	}
+	return uuidToString(agent.OwnerID) == userID
+}
+
 // broadcastAgentResponse strips secret-bearing fields from an
 // AgentResponse before it goes onto the WebSocket bus. Mutation
 // handlers call this when fanning out create/update/archive/restore
@@ -839,7 +879,24 @@ func canViewAgentSecrets(agent db.Agent, userID string, memberRole string) bool 
 func broadcastAgentResponse(resp AgentResponse) AgentResponse {
 	out := resp
 	redactMcpConfig(&out)
+	// Same rationale as redactMcpConfig: WS subscribers (including agent
+	// processes) must not learn another agent's instructions via a
+	// fan-out broadcast that bypassed the read-path redaction. Recipients
+	// can still hit GET /api/agents/{id} to receive the canonical role-
+	// gated form.
+	redactInstructions(&out)
 	return out
+}
+
+// redactInstructions removes the instructions value from the response when
+// the caller is not authorised to view it. The field is set to empty;
+// InstructionsRedacted is set to true so callers (and the UI) know an
+// instructions body exists without seeing its contents.
+func redactInstructions(resp *AgentResponse) {
+	if resp.Instructions != "" {
+		resp.Instructions = ""
+		resp.InstructionsRedacted = true
+	}
 }
 
 // redactMcpConfig removes the mcp_config value from the response when the caller is not

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -41,10 +41,17 @@ type SkillResponse struct {
 	Name        string  `json:"name"`
 	Description string  `json:"description"`
 	Content     string  `json:"content"`
-	Config      any     `json:"config"`
-	CreatedBy   *string `json:"created_by"`
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	// ContentRedacted is set to true when the caller is not allowed to view
+	// the skill body. The `content` field is then empty and `files` is nil
+	// (in SkillWithFilesResponse). See canViewSkillContent. Members without
+	// owner/admin role (and who are not the skill creator) get a placeholder
+	// so they know the skill exists without seeing its (often proprietary)
+	// process/prompt content.
+	ContentRedacted bool    `json:"content_redacted"`
+	Config          any     `json:"config"`
+	CreatedBy       *string `json:"created_by"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
 }
 
 // SkillSummaryResponse is the list-endpoint shape: everything SkillResponse
@@ -241,10 +248,25 @@ func (h *Handler) GetSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files, err := h.Queries.ListSkillFiles(r.Context(), skill.ID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list skill files")
-		return
+	resp := skillToResponse(skill)
+
+	// Role-based content gating — skill content + files are methodology/IP
+	// (process docs, prompt templates, brand-voice rules). Members without
+	// owner/admin role (and who are not the skill creator) get a redacted
+	// placeholder so they see the skill exists but not its body. Same
+	// rationale as canViewAgentInstructions in agent.go.
+	var files []db.SkillFile
+	userID := requestUserID(r)
+	if member, mok := ctxMember(r.Context()); mok && !canViewSkillContent(skill, userID, member.Role) {
+		resp.Content = ""
+		resp.ContentRedacted = true
+	} else {
+		var err error
+		files, err = h.Queries.ListSkillFiles(r.Context(), skill.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list skill files")
+			return
+		}
 	}
 
 	fileResps := make([]SkillFileResponse, len(files))
@@ -253,9 +275,22 @@ func (h *Handler) GetSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, SkillWithFilesResponse{
-		SkillResponse: skillToResponse(skill),
+		SkillResponse: resp,
 		Files:         fileResps,
 	})
+}
+
+// canViewSkillContent checks whether the requesting user is allowed to see
+// the skill's body content + files. Only the skill creator or workspace
+// owner/admin may view them. Skill bodies often contain IP/methodology
+// (process docs, prompt templates, brand-voice rules). For everyone else
+// the content is replaced with an empty string and Files is returned as
+// an empty list, with ContentRedacted=true.
+func canViewSkillContent(skill db.Skill, userID string, memberRole string) bool {
+	if roleAllowed(memberRole, "owner", "admin") {
+		return true
+	}
+	return uuidToString(skill.CreatedBy) == userID
 }
 
 func (h *Handler) CreateSkill(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

`GET /api/agents`, `GET /api/agents/{id}` and `GET /api/skills/{id}` return the full `instructions` (system prompt) and skill `content` to every workspace member regardless of role. These fields commonly contain proprietary methodology — multi-paragraph system prompts encoding processes, prompt templates, brand-voice rules, infrastructure references.

The existing `canViewAgentSecrets` + `redactMcpConfig` path (MUL-2600) covers credentials, but the parallel concern about **methodology** in `instructions` and skill `content` was not gated.

This PR adds the missing role gate, mirroring the existing secrets pattern exactly.

## Discovery context

Found during a pre-launch security audit of a multi-tenant fork before inviting a third-party member (vermittler workflow). A workspace `admin` role — typical for a customer-side collaborator — could call `GET /api/agents/{id}` and receive the full 15K-char system prompt of every agent in the workspace, plus the full content of every skill via `GET /api/skills/{id}`.

Cross-workspace isolation is **unaffected** — `RequireWorkspaceMember` middleware + SQL workspace_id scoping work correctly. Only the intra-workspace role gate was missing.

## What this PR does

### 1. `server/internal/handler/agent.go`
- New `canViewAgentInstructions()` mirroring `canViewAgentSecrets`
- New `redactInstructions()` + `InstructionsRedacted bool` on `AgentResponse`
- Applied in `ListAgents`, `GetAgent`, and `broadcastAgentResponse` (so WS fan-out is also gated)
- Agent-actor tokens never see another agent's instructions — same lateral-movement rationale as `mcp_config` in MUL-2600

### 2. `server/internal/handler/skill.go`
- New `canViewSkillContent()` (owner / admin / skill creator)
- `GetSkill` returns `ContentRedacted=true` + empty Content + empty Files for non-permitted members
- Skips the `ListSkillFiles` DB query when redacted (small perf win)
- `ListSkills` was already safe (uses `SkillSummaryResponse` with no body)

### 3. `packages/core/types/agent.ts`
- New optional `instructions_redacted?: boolean` field on `Agent`
- Documented as "treat undefined as false" so older clients don't crash against pre-fix backends

### 4. `packages/views/agents/components/tabs/instructions-tab.tsx`
- Lock-placeholder when `agent.instructions_redacted === true`
- **Critical UX fix:** without this gate, the empty editor with a Save button would let members save-over the real prompt with an empty string

## Role model after this PR

| Role | sees `instructions` | sees skill `content` |
|---|---|---|
| owner | ✅ | ✅ |
| admin | ✅ | ✅ |
| agent owner / skill creator | ✅ (own) | ✅ (own) |
| member | redacted placeholder | redacted placeholder |
| agent actor | redacted (lateral-movement) | n/a |

## Tests

```
go build ./...                          ← clean
go test ./internal/handler/... -count=1 ← clean (0.4s)
pnpm --filter @multica/core typecheck   ← clean
pnpm --filter @multica/views typecheck  ← clean
```

No new test cases added — the new redaction follows the exact `canViewAgentSecrets` / `redactMcpConfig` pattern already covered by the test suite. Happy to add explicit `TestCanViewAgentInstructions` + `TestCanViewSkillContent` permutation tests if reviewers want them — see "follow-up" below.

## Recommended follow-up (out of scope here, happy to do as a separate PR)

- **i18n** — `instructions-tab.tsx` uses a hardcoded EN string; the redacted-member placeholder should land in the i18n schema next to `tab_body.instructions.intro`
- **Squad.instructions** — `packages/core/types/squad.ts:10` likely has the same gap; same pattern fix
- **Permutation tests** — explicit per-role unit tests for `canViewAgentInstructions` + `canViewSkillContent`
- **Audit of other potentially-leaky fields** — `Agent.custom_args` (CLI flags, could leak provider hints), `Agent.runtime_config` (usually safe but worth a sweep)

## Test plan

- [ ] Manual: log in as `member`, open Agent detail → instructions tab shows lock placeholder
- [ ] Manual: log in as `owner` → instructions tab shows editor
- [ ] Manual: same for `GET /api/skills/{id}` body content
- [ ] WebSocket: subscribe as agent actor, trigger an agent update → broadcast event has redacted instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)