### PR TITLE
fix(chat): improve history row interactions MUL-2845

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -3,8 +3,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { motion } from "motion/react";
-import { Minus, Maximize2, Minimize2, ChevronDown, ChevronRight, Plus, Check, Trash2, Pencil } from "lucide-react";
+import { Minus, Maximize2, Minimize2, ChevronDown, ChevronRight, Plus, Check, Trash2, Pencil, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import {
   DropdownMenu,
@@ -16,15 +17,10 @@ import {
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@multica/ui/components/ui/alert-dialog";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@multica/ui/components/ui/popover";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useAuthStore } from "@multica/core/auth";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
@@ -60,7 +56,7 @@ import {
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatResize } from "./use-chat-resize";
 import { createLogger } from "@multica/core/logger";
-import type { Agent, ChatMessage, ChatPendingTask, ChatSession } from "@multica/core/types";
+import type { Agent, ChatMessage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { useT } from "../../i18n";
 
 const uiLogger = createLogger("chat.ui");
@@ -730,8 +726,14 @@ function SessionDropdown({
     return { active, archived };
   }, [sessions]);
 
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
-  const [pendingDelete, setPendingDelete] = useState<ChatSession | null>(null);
+  const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null);
+  const [confirmingStopId, setConfirmingStopId] = useState<string | null>(null);
+  const [stoppingTaskId, setStoppingTaskId] = useState<string | null>(null);
+  const [completedFlashIds, setCompletedFlashIds] = useState<Set<string>>(() => new Set());
+  const previousInFlightRef = useRef<Set<string>>(new Set());
+  const completedFlashTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // Inline rename: only one row can be in edit mode at a time. We track the
   // session id (not the full session) so a stale closure can't overwrite a
   // newer rename pulled in via WS.
@@ -739,16 +741,64 @@ function SessionDropdown({
   const deleteSession = useDeleteChatSession();
   const updateSession = useUpdateChatSession();
   const setActiveSession = useChatStore((s) => s.setActiveSession);
+  const queryClient = useQueryClient();
   const formatTimeAgo = useFormatTimeAgo();
 
   // Aggregate "which sessions have an in-flight task right now". Reuses
   // the same workspace-scoped query the FAB consumes, so toggling the chat
   // window doesn't fire a second request — TanStack dedupes by key.
   const { data: pending } = useQuery(pendingChatTasksOptions(wsId));
-  const inFlightSessionIds = useMemo(
-    () => new Set((pending?.tasks ?? []).map((t) => t.chat_session_id)),
+  const pendingTaskBySessionId = useMemo(
+    () => new Map((pending?.tasks ?? []).map((task) => [task.chat_session_id, task])),
     [pending],
   );
+  const inFlightSessionIds = useMemo(
+    () => new Set(pendingTaskBySessionId.keys()),
+    [pendingTaskBySessionId],
+  );
+
+  useEffect(() => {
+    const previous = previousInFlightRef.current;
+    const unreadSessionIds = new Set(sessions.filter((s) => s.has_unread).map((s) => s.id));
+
+    for (const sessionId of previous) {
+      if (inFlightSessionIds.has(sessionId) || !unreadSessionIds.has(sessionId)) continue;
+
+      setCompletedFlashIds((current) => {
+        if (current.has(sessionId)) return current;
+        return new Set(current).add(sessionId);
+      });
+
+      const existingTimer = completedFlashTimersRef.current.get(sessionId);
+      if (existingTimer) clearTimeout(existingTimer);
+
+      const timer = setTimeout(() => {
+        setCompletedFlashIds((current) => {
+          if (!current.has(sessionId)) return current;
+          const next = new Set(current);
+          next.delete(sessionId);
+          return next;
+        });
+        completedFlashTimersRef.current.delete(sessionId);
+      }, 1600);
+      completedFlashTimersRef.current.set(sessionId, timer);
+    }
+
+    previousInFlightRef.current = inFlightSessionIds;
+  }, [inFlightSessionIds, sessions]);
+
+  useEffect(() => {
+    const timers = completedFlashTimersRef.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!confirmingStopId || pendingTaskBySessionId.has(confirmingStopId)) return;
+    setConfirmingStopId(null);
+  }, [confirmingStopId, pendingTaskBySessionId]);
 
   // Cross-session aggregate signal for the closed-dropdown trigger.
   // "Active" here means there's something interesting happening in a
@@ -763,16 +813,18 @@ function SessionDropdown({
     (s) => s.id !== activeSessionId && s.has_unread,
   );
 
-  const handleConfirmDelete = () => {
-    if (!pendingDelete) return;
-    const sessionId = pendingDelete.id;
+  const handleConfirmDelete = (session: ChatSession) => {
+    const sessionId = session.id;
+    const isDeletingCurrent = activeSessionId === sessionId;
     // Eager local clear when the user is deleting the session they're
     // currently looking at — otherwise messages / pendingTask queries
     // keep rendering the now-deleted session until chat:session_deleted
     // arrives over WS (~50–200ms gap).
-    if (activeSessionId === sessionId) setActiveSession(null);
+    if (isDeletingCurrent) {
+      setActiveSession(null);
+    }
     deleteSession.mutate(sessionId, {
-      onSettled: () => setPendingDelete(null),
+      onSettled: () => setConfirmingDeleteId(null),
     });
   };
 
@@ -787,26 +839,91 @@ function SessionDropdown({
     updateSession.mutate({ sessionId, title: trimmed });
   };
 
+  const handleSelectSession = (session: ChatSession) => {
+    onSelectSession(session);
+    setIsHistoryOpen(false);
+  };
+
+  const handleConfirmStop = (session: ChatSession, task: PendingChatTasksResponse["tasks"][number]) => {
+    setStoppingTaskId(task.task_id);
+    previousInFlightRef.current = new Set(
+      [...previousInFlightRef.current].filter((sessionId) => sessionId !== session.id),
+    );
+
+    // Same optimistic behavior as the active chat Stop button: remove the
+    // running affordance immediately, then let task:cancelled / refetches
+    // converge every open surface on the server truth.
+    queryClient.setQueryData<PendingChatTasksResponse>(chatKeys.pendingTasks(wsId), (current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        tasks: current.tasks.filter((item) => item.task_id !== task.task_id),
+      };
+    });
+    queryClient.setQueryData(chatKeys.pendingTask(session.id), {});
+    queryClient.invalidateQueries({ queryKey: chatKeys.messages(session.id) });
+
+    api.cancelTaskById(task.task_id).then(
+      () => apiLogger.info("cancelTask.success (history row)", { taskId: task.task_id, sessionId: session.id }),
+      (err) =>
+        apiLogger.warn("cancelTask.error (history row; task may have already finished)", {
+          taskId: task.task_id,
+          sessionId: session.id,
+          err,
+        }),
+    ).finally(() => {
+      queryClient.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+      queryClient.invalidateQueries({ queryKey: chatKeys.pendingTask(session.id) });
+      setStoppingTaskId(null);
+      setConfirmingStopId(null);
+    });
+  };
+
   const renderRow = (session: ChatSession) => {
     const isCurrent = session.id === activeSessionId;
     const agent = agentById.get(session.agent_id) ?? null;
-    const isRunning = inFlightSessionIds.has(session.id);
+    const pendingTask = pendingTaskBySessionId.get(session.id);
+    const isRunning = !!pendingTask;
+    const showCompleted = completedFlashIds.has(session.id) && !isCurrent;
+    const showUnread = session.has_unread && !isCurrent;
     const isRenaming = renamingId === session.id;
+    const isConfirmingDelete = confirmingDeleteId === session.id;
+    const isConfirmingStop = confirmingStopId === session.id && !!pendingTask;
+    const isConfirmingAction = isConfirmingDelete || isConfirmingStop;
+    const titleText = session.title?.trim() || t(($) => $.window.untitled);
+    const trailingStatus = isRunning
+      ? t(($) => $.session_history.row_subtitle.working)
+      : showCompleted
+        ? t(($) => $.session_history.row_subtitle.completed)
+        : showUnread
+          ? t(($) => $.session_history.row_subtitle.new_reply)
+          : session.status === "archived"
+            ? t(($) => $.session_history.row_subtitle.archived_label)
+            : formatTimeAgo(session.updated_at);
+
     return (
-      <DropdownMenuItem
+      <div
         key={session.id}
-        // While renaming we don't want a row click to select the session
-        // OR close the menu — the user is editing text, not navigating.
-        // closeOnClick=false keeps the dropdown open across input clicks
-        // / button clicks inside the row; the normal "click row → switch
-        // session → close menu" flow is unchanged when isRenaming=false.
-        closeOnClick={!isRenaming}
+        aria-current={isCurrent ? "true" : undefined}
+        tabIndex={0}
         onClick={() => {
-          if (isRenaming) return;
-          onSelectSession(session);
+          if (isRenaming || isConfirmingAction) return;
+          handleSelectSession(session);
         }}
-        className="group flex min-w-0 items-center gap-2"
+        onKeyDown={(e) => {
+          if (isRenaming || isConfirmingAction) return;
+          if (e.key !== "Enter" && e.key !== " ") return;
+          e.preventDefault();
+          handleSelectSession(session);
+        }}
+        className={cn(
+          "group/history-row relative flex min-h-11 min-w-0 cursor-default items-center gap-2 overflow-hidden rounded-md py-1.5 pl-2 pr-2 outline-none transition-colors hover:bg-accent/60 focus-visible:bg-accent/60 focus-visible:ring-1 focus-visible:ring-ring",
+          isCurrent && "bg-accent/70",
+          isConfirmingAction && "bg-destructive/5 hover:bg-destructive/5",
+          session.status === "archived" && "opacity-75",
+        )}
       >
+        {isCurrent && <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-brand" />}
         {agent ? (
           <ActorAvatar
             actorType="agent"
@@ -818,93 +935,189 @@ function SessionDropdown({
         ) : (
           <span className="size-6 shrink-0" />
         )}
-        <div className="min-w-0 flex-1">
+        <div className={cn("min-w-0 flex-1", !isRenaming && !isConfirmingAction && "pr-28")}>
           {isRenaming ? (
             <SessionRenameInput
               initialValue={session.title ?? ""}
               onSubmit={(value) => handleSubmitRename(session.id, value)}
               onCancel={() => setRenamingId(null)}
             />
+          ) : isConfirmingDelete ? (
+            <div className="truncate text-sm font-medium text-destructive">
+              {t(($) => $.session_history.delete_dialog.title)}
+            </div>
+          ) : isConfirmingStop ? (
+            <div className="truncate text-sm font-medium text-destructive">
+              {t(($) => $.session_history.stop_dialog.title)}
+            </div>
           ) : (
-            <>
-              <div className="truncate text-sm">
-                {session.title?.trim() || t(($) => $.window.untitled)}
-              </div>
-              <div className="truncate text-xs text-muted-foreground/70">
-                {formatTimeAgo(session.updated_at)}
-              </div>
-            </>
+            <div
+              className={cn("truncate text-sm", (showUnread || showCompleted) && !isRunning && "font-medium")}
+              style={{
+                maskImage: "linear-gradient(to right, black calc(100% - 18px), transparent)",
+                WebkitMaskImage: "linear-gradient(to right, black calc(100% - 18px), transparent)",
+              }}
+            >
+              {titleText}
+            </div>
           )}
         </div>
-        {/* Right-edge status pip: in-flight wins over unread because
-         *  "still working" is more actionable than "has reply" — and
-         *  the two rarely coexist in practice (the unread flag fires
-         *  on chat_message write, by which point the task has just
-         *  finished). Same pip shape as unread for visual rhythm,
-         *  amber + pulse to read as activity.
-         *
-         *  Hidden while renaming so the inline input has room to
-         *  breathe and trailing pips don't visually trail off-screen
-         *  next to the editor caret. */}
-        {!isRenaming && isRunning ? (
-          <span
-            aria-label={t(($) => $.window.running)}
-            title={t(($) => $.window.running)}
-            className="size-1.5 shrink-0 rounded-full bg-amber-500 animate-pulse"
-          />
-        ) : !isRenaming && session.has_unread ? (
-          <span
-            aria-label={t(($) => $.window.unread)}
-            title={t(($) => $.window.unread)}
-            className="size-1.5 shrink-0 rounded-full bg-brand"
-          />
-        ) : null}
-        {!isRenaming && isCurrent && (
-          <Check className="size-3.5 text-muted-foreground shrink-0" />
-        )}
         {!isRenaming && (
-          <>
-            <button
-              type="button"
-              // preventDefault is what tells Base UI's Menu.Item to skip
-              // its close-on-click; stopPropagation prevents the row's
-              // onClick from also firing (which would switch sessions).
-              // onPointerDown is stopped too so the menu's typeahead /
-              // focus tracking doesn't pre-empt the click.
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setRenamingId(session.id);
-              }}
-              className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-              aria-label={t(($) => $.session_history.row_rename_aria)}
-              title={t(($) => $.session_history.row_rename_aria)}
-            >
-              <Pencil className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setPendingDelete(session);
-              }}
-              className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
-              aria-label={t(($) => $.session_history.row_delete_aria)}
-            >
-              <Trash2 className="size-3.5" />
-            </button>
-          </>
+          isConfirmingDelete ? (
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setConfirmingDeleteId(null);
+                }}
+                disabled={deleteSession.isPending}
+                className="inline-flex h-7 items-center rounded px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+              >
+                {t(($) => $.session_history.delete_dialog.cancel)}
+              </button>
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  handleConfirmDelete(session);
+                }}
+                disabled={deleteSession.isPending}
+                className="inline-flex h-7 items-center rounded px-2 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
+              >
+                {deleteSession.isPending
+                  ? t(($) => $.session_history.delete_dialog.confirming)
+                  : t(($) => $.session_history.delete_dialog.confirm)}
+              </button>
+            </div>
+          ) : isConfirmingStop && pendingTask ? (
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setConfirmingStopId(null);
+                }}
+                disabled={stoppingTaskId === pendingTask.task_id}
+                className="inline-flex h-7 items-center rounded px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+              >
+                {t(($) => $.session_history.stop_dialog.cancel)}
+              </button>
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  handleConfirmStop(session, pendingTask);
+                }}
+                disabled={stoppingTaskId === pendingTask.task_id}
+                className="inline-flex h-7 items-center rounded px-2 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
+              >
+                {stoppingTaskId === pendingTask.task_id
+                  ? t(($) => $.session_history.stop_dialog.confirming)
+                  : t(($) => $.session_history.stop_dialog.confirm)}
+              </button>
+            </div>
+          ) : (
+            <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
+              <div className="flex h-7 min-w-16 items-center justify-end gap-1.5 text-xs text-muted-foreground transition-opacity group-hover/history-row:opacity-0 group-focus-within/history-row:opacity-0">
+                {isRunning && <Loader2 className="size-3 animate-spin" />}
+                {showCompleted && !isRunning && <Check className="size-3 text-emerald-500" />}
+                {showUnread && !isRunning && !showCompleted && (
+                  <span
+                    aria-label={t(($) => $.window.unread)}
+                    title={t(($) => $.window.unread)}
+                    className="size-1.5 rounded-full bg-brand"
+                  />
+                )}
+                <span className={cn("truncate", (showUnread || showCompleted || isRunning) && "font-medium text-foreground")}>{trailingStatus}</span>
+              </div>
+              <div className="absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover/history-row:opacity-100 group-focus-within/history-row:opacity-100">
+                {isRunning && pendingTask && (
+                  <button
+                    type="button"
+                    onPointerDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      setConfirmingStopId(session.id);
+                    }}
+                    className="inline-flex h-7 items-center gap-1 rounded px-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
+                    aria-label={t(($) => $.session_history.row_stop_aria)}
+                    title={t(($) => $.session_history.row_stop_aria)}
+                  >
+                    <Square className="size-2.5 fill-current" />
+                    {t(($) => $.session_history.stop_action)}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setRenamingId(session.id);
+                  }}
+                  className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
+                  aria-label={t(($) => $.session_history.row_rename_aria)}
+                  title={t(($) => $.session_history.row_rename_aria)}
+                >
+                  <Pencil className="size-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setConfirmingDeleteId(session.id);
+                  }}
+                  className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
+                  aria-label={t(($) => $.session_history.row_delete_aria)}
+                  title={t(($) => $.session_history.row_delete_aria)}
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
+            </div>
+          )
         )}
-      </DropdownMenuItem>
+      </div>
     );
   };
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger className="flex max-w-96 min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-accent aria-expanded:bg-accent">
+      <Popover open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+        <PopoverTrigger className="flex max-w-96 min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-accent data-[popup-open]:bg-accent data-open:bg-accent">
           {triggerAgent && (
             <ActorAvatar
               actorType="agent"
@@ -916,10 +1129,9 @@ function SessionDropdown({
           )}
           <span className="min-w-0 truncate text-sm font-medium">{title}</span>
           {otherSessionRunning ? (
-            <span
+            <Loader2
               aria-label={t(($) => $.window.another_running)}
-              title={t(($) => $.window.another_running)}
-              className="size-1.5 shrink-0 rounded-full bg-amber-500 animate-pulse"
+              className="size-3.5 shrink-0 animate-spin text-muted-foreground"
             />
           ) : otherSessionUnread ? (
             <span
@@ -929,10 +1141,11 @@ function SessionDropdown({
             />
           ) : null}
           <ChevronDown className="size-3 text-muted-foreground shrink-0" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
+        </PopoverTrigger>
+        <PopoverContent
           align="start"
-          className="max-h-96 w-auto min-w-[max(16rem,var(--anchor-width,16rem))] max-w-96 overflow-y-auto"
+          className="max-h-96 w-auto min-w-[max(16rem,var(--anchor-width,16rem))] max-w-96 gap-0 overflow-y-auto p-1"
+          onClick={(e) => e.stopPropagation()}
         >
           {sessions.length === 0 ? (
             <div className="px-2 py-1.5 text-xs text-muted-foreground">
@@ -941,20 +1154,24 @@ function SessionDropdown({
           ) : (
             <>
               {active.length > 0 && (
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>{t(($) => $.window.active_group)}</DropdownMenuLabel>
+                <div role="group" aria-label={t(($) => $.window.active_group)}>
+                  <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">
+                    {t(($) => $.window.active_group)}
+                  </div>
                   {active.map(renderRow)}
-                </DropdownMenuGroup>
+                </div>
               )}
               {archived.length > 0 && (
                 <>
-                  {active.length > 0 && <DropdownMenuSeparator />}
-                  <DropdownMenuItem
+                  {active.length > 0 && <div className="-mx-1 my-1 h-px bg-border" />}
+                  <button
+                    type="button"
                     onClick={(e) => {
                       e.preventDefault();
                       setShowArchived((v) => !v);
                     }}
-                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                    className="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-xs text-muted-foreground outline-none transition-colors hover:bg-accent/60 focus-visible:bg-accent/60 focus-visible:ring-1 focus-visible:ring-ring"
+                    aria-expanded={showArchived}
                   >
                     {showArchived ? (
                       <ChevronDown className="size-3" />
@@ -964,54 +1181,18 @@ function SessionDropdown({
                     <span>
                       {t(($) => $.window.archived_group, { count: archived.length })}
                     </span>
-                  </DropdownMenuItem>
+                  </button>
                   {showArchived && (
-                    <DropdownMenuGroup>
+                    <div role="group" aria-label={t(($) => $.window.archived_group, { count: archived.length })}>
                       {archived.map(renderRow)}
-                    </DropdownMenuGroup>
+                    </div>
                   )}
                 </>
               )}
             </>
           )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <AlertDialog
-        open={!!pendingDelete}
-        onOpenChange={(open) => {
-          if (!open && !deleteSession.isPending) setPendingDelete(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t(($) => $.session_history.delete_dialog.title)}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {pendingDelete?.title
-                ? t(($) => $.session_history.delete_dialog.description_with_title, {
-                    title: pendingDelete.title,
-                  })
-                : t(($) => $.session_history.delete_dialog.description_default)}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteSession.isPending}>
-              {t(($) => $.session_history.delete_dialog.cancel)}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              disabled={deleteSession.isPending}
-              className="bg-destructive text-white hover:bg-destructive/90"
-            >
-              {deleteSession.isPending
-                ? t(($) => $.session_history.delete_dialog.confirming)
-                : t(($) => $.session_history.delete_dialog.confirm)}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        </PopoverContent>
+      </Popover>
     </>
   );
 }
@@ -1022,13 +1203,10 @@ function SessionDropdown({
  * into the existing text. Enter commits, Escape cancels, a real click
  * outside the input also commits.
  *
- * We do NOT commit on the input's `blur` event: Base UI's Menu uses
- * focus-follows-cursor (hovering a sibling row drags DOM focus there),
- * so a blur handler would fire on every mouse-move and "save" the user's
- * half-typed title without them clicking anywhere. Instead a document-
- * level `pointerdown` listener — registered in capture phase so it runs
- * before Base UI's outside-click close handler — commits when the user
- * actually clicks outside the input.
+ * We do NOT commit on the input's `blur` event: the history popover can
+ * move focus to sibling rows and nested actions while the user is still
+ * interacting with the panel. Instead a document-level `pointerdown`
+ * listener commits only when the user actually clicks outside the input.
  */
 function SessionRenameInput({
   initialValue,
@@ -1061,9 +1239,8 @@ function SessionRenameInput({
       if (input.contains(e.target as Node)) return;
       onSubmitRef.current(valueRef.current);
     };
-    // Capture phase — Base UI registers its own outside-click handler in
-    // bubble; running first lets us commit before the menu starts to
-    // close (and unmount this component).
+    // Capture phase — commit before outside-click handling can close the
+    // popover and unmount this component.
     document.addEventListener("pointerdown", handlePointerDown, true);
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown, true);
@@ -1081,7 +1258,8 @@ function SessionRenameInput({
       onClick={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       onKeyDown={(e) => {
-        // Stop the menu from stealing arrow / typeahead / space input.
+        // Keep editing keys inside the input instead of letting the row
+        // selection keyboard handler consume them.
         e.stopPropagation();
         if (e.key === "Enter") {
           e.preventDefault();

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -38,6 +38,22 @@
     },
     "row_delete_aria": "Delete chat session",
     "row_rename_aria": "Rename chat session",
+    "row_stop_aria": "Stop current run",
+    "stop_action": "Stop",
+    "row_subtitle": {
+      "working": "Working",
+      "completed": "Completed",
+      "new_reply": "New reply",
+      "archived_label": "Archived"
+    },
+    "stop_dialog": {
+      "title": "Stop this run?",
+      "description_with_title": "This will cancel the current agent task in \"{{title}}\". Partial output will stay in the chat.",
+      "description_default": "This will cancel the current agent task. Partial output will stay in the chat.",
+      "cancel": "Keep running",
+      "confirm": "Stop run",
+      "confirming": "Stopping..."
+    },
     "delete_dialog": {
       "title": "Delete chat session",
       "description_with_title": "\"{{title}}\" and its messages will be permanently removed. This action cannot be undone.",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -38,6 +38,22 @@
     },
     "row_delete_aria": "채팅 세션 삭제",
     "row_rename_aria": "채팅 세션 이름 변경",
+    "row_stop_aria": "현재 실행 중지",
+    "stop_action": "중지",
+    "row_subtitle": {
+      "working": "작업 중",
+      "completed": "완료됨",
+      "new_reply": "새 답변",
+      "archived_label": "보관됨"
+    },
+    "stop_dialog": {
+      "title": "이 실행을 중지할까요?",
+      "description_with_title": "\"{{title}}\"의 현재 에이전트 작업을 취소합니다. 이미 생성된 내용은 채팅에 남습니다.",
+      "description_default": "현재 에이전트 작업을 취소합니다. 이미 생성된 내용은 채팅에 남습니다.",
+      "cancel": "계속 실행",
+      "confirm": "실행 중지",
+      "confirming": "중지하는 중..."
+    },
     "delete_dialog": {
       "title": "채팅 세션 삭제",
       "description_with_title": "\"{{title}}\"과(와) 메시지가 영구 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -35,6 +35,22 @@
     },
     "row_delete_aria": "删除对话",
     "row_rename_aria": "重命名对话",
+    "row_stop_aria": "停止当前运行",
+    "stop_action": "停止",
+    "row_subtitle": {
+      "working": "运行中",
+      "completed": "已完成",
+      "new_reply": "新回复",
+      "archived_label": "已归档"
+    },
+    "stop_dialog": {
+      "title": "停止这次运行？",
+      "description_with_title": "这会取消 \"{{title}}\" 里的当前智能体任务。已产生的内容会保留在对话里。",
+      "description_default": "这会取消当前智能体任务。已产生的内容会保留在对话里。",
+      "cancel": "继续运行",
+      "confirm": "停止运行",
+      "confirming": "停止中..."
+    },
     "delete_dialog": {
       "title": "删除对话",
       "description_with_title": "\"{{title}}\" 及其消息会被永久删除，无法撤销。",


### PR DESCRIPTION
## Summary
- Rebuild the chat history selector as a stable popover with compact single-line rows
- Show working/new reply/completed/time in the row trailing slot and replace it with actions on hover/focus
- Keep current selection as visual state only; preserve legacy archived display without adding archive actions
- Move delete/stop confirmation inline and add stop handling from history rows

## Review
- Independent code review passed after fixing stale stop confirmation and popover close regressions
- No unsupported archive/unarchive API actions added
- Static security scan found no findings

## Test Plan
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views lint
- git diff --check -- packages/views/chat/components/chat-window.tsx packages/views/locales/en/chat.json packages/views/locales/zh-Hans/chat.json packages/views/locales/ko/chat.json
