### PR TITLE
fix(chat): limit running history actions

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1070,40 +1070,44 @@ function SessionDropdown({
                     {t(($) => $.session_history.stop_action)}
                   </button>
                 )}
-                <button
-                  type="button"
-                  onPointerDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    setRenamingId(session.id);
-                  }}
-                  className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
-                  aria-label={t(($) => $.session_history.row_rename_aria)}
-                  title={t(($) => $.session_history.row_rename_aria)}
-                >
-                  <Pencil className="size-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onPointerDown={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    setConfirmingDeleteId(session.id);
-                  }}
-                  className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
-                  aria-label={t(($) => $.session_history.row_delete_aria)}
-                  title={t(($) => $.session_history.row_delete_aria)}
-                >
-                  <Trash2 className="size-3.5" />
-                </button>
+                {!isRunning && (
+                  <>
+                    <button
+                      type="button"
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        setRenamingId(session.id);
+                      }}
+                      className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none"
+                      aria-label={t(($) => $.session_history.row_rename_aria)}
+                      title={t(($) => $.session_history.row_rename_aria)}
+                    >
+                      <Pencil className="size-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        setConfirmingDeleteId(session.id);
+                      }}
+                      className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none"
+                      aria-label={t(($) => $.session_history.row_delete_aria)}
+                      title={t(($) => $.session_history.row_delete_aria)}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           )


### PR DESCRIPTION
## Summary
- Show only Stop when hovering a running chat history row
- Keep Rename/Delete available for non-running rows, including new-reply/completed/idle/archived states
- Preserve inline stop confirmation behavior

## Test Plan
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views lint
- git diff --check -- packages/views/chat/components/chat-window.tsx