### PR TITLE
fix(issues): clean execution log active rows

### DIFF
--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -19,18 +19,6 @@ import { failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { useT } from "../../i18n";
 import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
 
-// Mask gradient that fades the trigger-summary text into transparency at
-// the right edge. Mirrors the pattern used by the desktop tab bar
-// (apps/desktop/.../tab-bar.tsx) and the sidebar pin item
-// (packages/views/layout/app-sidebar.tsx) — gives the row a smooth
-// visual ramp toward the trailing actions instead of a hard truncate +
-// ellipsis cut.
-const TRIGGER_MASK_STYLE: React.CSSProperties = {
-  maskImage: "linear-gradient(to right, black calc(100% - 12px), transparent)",
-  WebkitMaskImage:
-    "linear-gradient(to right, black calc(100% - 12px), transparent)",
-};
-
 // Right-panel section that lists every agent run for this issue. Active
 // runs sit at the top (always visible when present); past runs (terminal
 // statuses) collapse behind a "Show past runs (N)" toggle.
@@ -418,7 +406,7 @@ function RowShell({
   // `relative` so the absolute-positioned RowActions slot anchors to this
   // row instead of an outer container.
   return (
-    <div className="group relative flex items-center gap-2 overflow-hidden rounded px-1 py-1.5 transition-colors hover:bg-accent/40">
+    <div className="group/execution-log-row relative flex items-center gap-2 overflow-hidden rounded px-1 py-1.5 transition-colors hover:bg-accent/40">
       {task.agent_id ? (
         <ActorAvatar
           actorType="agent"
@@ -441,8 +429,12 @@ function RowShell({
 function TriggerText({ text }: { text: string }) {
   return (
     <span
-      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap pr-24 text-xs text-muted-foreground"
-      style={TRIGGER_MASK_STYLE}
+      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap pr-36 text-xs text-muted-foreground"
+      style={{
+        maskImage: "linear-gradient(to right, black calc(100% - 28px), transparent)",
+        WebkitMaskImage:
+          "linear-gradient(to right, black calc(100% - 28px), transparent)",
+      }}
     >
       {text}
     </span>
@@ -462,7 +454,7 @@ function RowStatus({
   return (
     <div
       title={title}
-      className="pointer-events-none absolute right-1 top-1/2 flex h-7 max-w-24 -translate-y-1/2 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover:opacity-0"
+      className="pointer-events-none absolute right-1 top-1/2 flex h-7 w-28 -translate-y-1/2 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover/execution-log-row:opacity-0"
     >
       {children}
     </div>
@@ -482,7 +474,7 @@ function RowActions({ children }: { children: React.ReactNode }) {
         // from the right and fades to transparent on the left, so the
         // status text underneath is dimmed gracefully rather than cut.
         "bg-gradient-to-l from-accent/95 via-accent/80 to-transparent",
-        "group-hover:pointer-events-auto group-hover:opacity-100",
+        "group-hover/execution-log-row:pointer-events-auto group-hover/execution-log-row:opacity-100",
       ].join(" ")}
     >
       {children}

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -422,14 +422,14 @@ function RowShell({
   );
 }
 
-// Trigger description with a mask-gradient right edge — text fades into
-// transparency in the trailing 12px for the same reason desktop tab /
-// sidebar pin do it: avoids a hard truncate cut against neighbouring
-// content.
+// Trigger description leaves a real layout gutter before the absolute
+// trailing slot. Padding is not enough here: text can still visually paint
+// under an overlaid status. The right margin makes the text column end
+// before status/actions begin.
 function TriggerText({ text }: { text: string }) {
   return (
     <span
-      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap pr-36 text-xs text-muted-foreground"
+      className="mr-32 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs text-muted-foreground"
       style={{
         maskImage: "linear-gradient(to right, black calc(100% - 28px), transparent)",
         WebkitMaskImage:
@@ -454,7 +454,7 @@ function RowStatus({
   return (
     <div
       title={title}
-      className="pointer-events-none absolute right-1 top-1/2 flex h-7 w-28 -translate-y-1/2 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover/execution-log-row:opacity-0"
+      className="pointer-events-none absolute inset-y-0 right-1 flex w-28 items-center justify-end gap-1 overflow-hidden whitespace-nowrap bg-gradient-to-l from-background via-background/95 to-transparent pl-4 text-xs transition-opacity group-hover/execution-log-row:opacity-0"
     >
       {children}
     </div>

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Loader2, RotateCcw, Square } from "lucide-react";
+import { Ban, CheckCircle2, ChevronRight, Loader2, RotateCcw, Square, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { issueKeys } from "@multica/core/issues/queries";
@@ -28,14 +28,12 @@ import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
 //     (sticky card stays as a header-only banner)
 //   - the standalone <TaskRunHistory> below the main content
 //
-// Row layout — two visual columns, with an overlaid trailing slot:
+// Row layout — simple left/right flex:
 //   1. Agent avatar (no status dot — agent availability is not the
 //      story here; the row's right column carries the task status)
-//   2. Trigger description (e.g. "From comment", "Autopilot", "Retry"),
-//      masked before the fixed trailing zone
-//   3. Fixed right trailing zone: status by default, hover actions on top.
-//      Status never participates in flex layout, otherwise long terminal
-//      labels create invisible hover gaps and squeeze the trigger text.
+//   2. Trigger description flexes and truncates
+//   3. Status is a normal shrink-0 right column; hover actions overlay that
+//      same right edge. Do not use masks/padding gymnastics here.
 //
 // One query (`listTasksByIssue`) drives both buckets — the back-end
 // returns every status, the front-end filters into active vs past on the
@@ -273,7 +271,7 @@ function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <RowStatus>
+      <RowStatus title={label}>
         {task.status === "running" && <Loader2 className="h-3 w-3 animate-spin text-info" />}
         <span className={tone}>{label}</span>
       </RowStatus>
@@ -327,7 +325,6 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const [retrying, setRetrying] = useState(false);
-  const tone = STATUS_TONE[task.status];
   const label = useStatusLabel(task.status);
   const trigger = useTriggerText(task);
   const time = task.completed_at ? timeAgo(task.completed_at) : "—";
@@ -361,9 +358,9 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <RowStatus title={failureLabel ?? undefined}>
-        <span className={tone}>{label}</span>
-        <span className="text-muted-foreground"> · {time}</span>
+      <RowStatus title={failureLabel ?? label}>
+        <TaskStatusIcon status={task.status} />
+        <span className="text-muted-foreground">{time}</span>
       </RowStatus>
       <RowActions>
         <TranscriptButton task={task} agentName="" title={t(($) => $.execution_log.transcript_tooltip)} />
@@ -422,28 +419,10 @@ function RowShell({
   );
 }
 
-// Trigger description leaves a real layout gutter before the absolute
-// trailing slot. Padding is not enough here: text can still visually paint
-// under an overlaid status. The right margin makes the text column end
-// before status/actions begin.
 function TriggerText({ text }: { text: string }) {
-  return (
-    <span
-      className="mr-32 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs text-muted-foreground"
-      style={{
-        maskImage: "linear-gradient(to right, black calc(100% - 28px), transparent)",
-        WebkitMaskImage:
-          "linear-gradient(to right, black calc(100% - 28px), transparent)",
-      }}
-    >
-      {text}
-    </span>
-  );
+  return <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{text}</span>;
 }
 
-// Fixed trailing status slot. This deliberately does NOT sit in flex layout:
-// terminal rows can have longer status/time text, but that text must not
-// reserve a huge invisible gap when hover actions fade in.
 function RowStatus({
   children,
   title,
@@ -454,22 +433,33 @@ function RowStatus({
   return (
     <div
       title={title}
-      className="pointer-events-none absolute inset-y-0 right-1 flex w-28 items-center justify-end gap-1 overflow-hidden whitespace-nowrap bg-gradient-to-l from-background via-background/95 to-transparent pl-4 text-xs transition-opacity group-hover/execution-log-row:opacity-0"
+      className="flex h-7 w-20 shrink-0 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover/execution-log-row:opacity-0"
     >
       {children}
     </div>
   );
 }
 
+function TaskStatusIcon({ status }: { status: AgentTask["status"] }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="h-3.5 w-3.5 text-success" />;
+    case "failed":
+      return <XCircle className="h-3.5 w-3.5 text-destructive" />;
+    case "cancelled":
+      return <Ban className="h-3.5 w-3.5 text-muted-foreground" />;
+    default:
+      return null;
+  }
+}
+
 // Hover-only action slot — absolute-positioned over the row's right edge.
-// Default trailing status and hover actions share the same fixed right zone,
-// so the row never reflows and long status text never steals trigger width.
-// Mirrors the compact Chat History / desktop tab / sidebar pin pattern.
+// It covers the normal right status column only on hover.
 function RowActions({ children }: { children: React.ReactNode }) {
   return (
     <div
       className={[
-        "pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 pl-6 opacity-0 transition-opacity",
+        "pointer-events-none absolute inset-y-0 right-1 flex w-20 items-center justify-end gap-0.5 opacity-0 transition-opacity",
         // The gradient backdrop blends the row's hover background (accent/40)
         // from the right and fades to transparent on the left, so the
         // status text underneath is dimmed gracefully rather than cut.

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -40,14 +40,14 @@ const TRIGGER_MASK_STYLE: React.CSSProperties = {
 //     (sticky card stays as a header-only banner)
 //   - the standalone <TaskRunHistory> below the main content
 //
-// Row layout — three columns, left to right:
+// Row layout — two visual columns, with an overlaid trailing slot:
 //   1. Agent avatar (no status dot — agent availability is not the
 //      story here; the row's right column carries the task status)
 //   2. Trigger description (e.g. "From comment", "Autopilot", "Retry"),
-//      truncated with ellipsis when narrow
-//   3. Status, swapped to hover actions (cancel / transcript) in the same
-//      trailing zone. Active rows do not show relative time; the live status
-//      is the useful signal.
+//      masked before the fixed trailing zone
+//   3. Fixed right trailing zone: status by default, hover actions on top.
+//      Status never participates in flex layout, otherwise long terminal
+//      labels create invisible hover gaps and squeeze the trigger text.
 //
 // One query (`listTasksByIssue`) drives both buckets — the back-end
 // returns every status, the front-end filters into active vs past on the
@@ -285,10 +285,10 @@ function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+      <RowStatus>
         {task.status === "running" && <Loader2 className="h-3 w-3 animate-spin text-info" />}
         <span className={tone}>{label}</span>
-      </span>
+      </RowStatus>
       <RowActions>
         {showTranscript && (
           <TranscriptButton
@@ -373,10 +373,10 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <span className="shrink-0 whitespace-nowrap text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-        <span className={tone}>{failureLabel ?? label}</span>
+      <RowStatus title={failureLabel ?? undefined}>
+        <span className={tone}>{label}</span>
         <span className="text-muted-foreground"> · {time}</span>
-      </span>
+      </RowStatus>
       <RowActions>
         <TranscriptButton task={task} agentName="" title={t(($) => $.execution_log.transcript_tooltip)} />
         {canRetry && (
@@ -418,7 +418,7 @@ function RowShell({
   // `relative` so the absolute-positioned RowActions slot anchors to this
   // row instead of an outer container.
   return (
-    <div className="group relative flex items-center gap-2 rounded px-1 py-1.5 transition-colors hover:bg-accent/40">
+    <div className="group relative flex items-center gap-2 overflow-hidden rounded px-1 py-1.5 transition-colors hover:bg-accent/40">
       {task.agent_id ? (
         <ActorAvatar
           actorType="agent"
@@ -441,7 +441,7 @@ function RowShell({
 function TriggerText({ text }: { text: string }) {
   return (
     <span
-      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap text-xs text-muted-foreground"
+      className="min-w-0 flex-1 overflow-hidden whitespace-nowrap pr-24 text-xs text-muted-foreground"
       style={TRIGGER_MASK_STYLE}
     >
       {text}
@@ -449,10 +449,30 @@ function TriggerText({ text }: { text: string }) {
   );
 }
 
+// Fixed trailing status slot. This deliberately does NOT sit in flex layout:
+// terminal rows can have longer status/time text, but that text must not
+// reserve a huge invisible gap when hover actions fade in.
+function RowStatus({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
+  return (
+    <div
+      title={title}
+      className="pointer-events-none absolute right-1 top-1/2 flex h-7 max-w-24 -translate-y-1/2 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover:opacity-0"
+    >
+      {children}
+    </div>
+  );
+}
+
 // Hover-only action slot — absolute-positioned over the row's right edge.
-// Default trailing status stays anchored in the layout; on hover it fades out
-// and the action buttons fade into the same trailing zone, so the row never
-// reflows. Mirrors the compact Chat History / desktop tab / sidebar pin pattern.
+// Default trailing status and hover actions share the same fixed right zone,
+// so the row never reflows and long status text never steals trigger width.
+// Mirrors the compact Chat History / desktop tab / sidebar pin pattern.
 function RowActions({ children }: { children: React.ReactNode }) {
   return (
     <div
@@ -463,7 +483,6 @@ function RowActions({ children }: { children: React.ReactNode }) {
         // status text underneath is dimmed gracefully rather than cut.
         "bg-gradient-to-l from-accent/95 via-accent/80 to-transparent",
         "group-hover:pointer-events-auto group-hover:opacity-100",
-        "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
       ].join(" ")}
     >
       {children}

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -273,7 +273,7 @@ function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
       <TriggerText text={trigger} />
       <RowStatus title={label}>
         {task.status === "running" && <Loader2 className="h-3 w-3 animate-spin text-info" />}
-        <span className={tone}>{label}</span>
+        <span className={`${tone} min-w-0 truncate`}>{label}</span>
       </RowStatus>
       <RowActions>
         {showTranscript && (
@@ -360,6 +360,7 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
       <TriggerText text={trigger} />
       <RowStatus title={failureLabel ?? label}>
         <TaskStatusIcon status={task.status} />
+        <span className="sr-only">{failureLabel ?? label}</span>
         <span className="text-muted-foreground">{time}</span>
       </RowStatus>
       <RowActions>
@@ -433,7 +434,7 @@ function RowStatus({
   return (
     <div
       title={title}
-      className="flex h-7 w-20 shrink-0 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover/execution-log-row:opacity-0"
+      className="flex h-7 w-20 shrink-0 items-center justify-end gap-1 overflow-hidden whitespace-nowrap text-xs transition-opacity group-hover/execution-log-row:opacity-0 group-focus-within/execution-log-row:opacity-0"
     >
       {children}
     </div>
@@ -443,11 +444,11 @@ function RowStatus({
 function TaskStatusIcon({ status }: { status: AgentTask["status"] }) {
   switch (status) {
     case "completed":
-      return <CheckCircle2 className="h-3.5 w-3.5 text-success" />;
+      return <CheckCircle2 aria-hidden="true" className="h-3.5 w-3.5 text-success" />;
     case "failed":
-      return <XCircle className="h-3.5 w-3.5 text-destructive" />;
+      return <XCircle aria-hidden="true" className="h-3.5 w-3.5 text-destructive" />;
     case "cancelled":
-      return <Ban className="h-3.5 w-3.5 text-muted-foreground" />;
+      return <Ban aria-hidden="true" className="h-3.5 w-3.5 text-muted-foreground" />;
     default:
       return null;
   }
@@ -465,6 +466,7 @@ function RowActions({ children }: { children: React.ReactNode }) {
         // status text underneath is dimmed gracefully rather than cut.
         "bg-gradient-to-l from-accent/95 via-accent/80 to-transparent",
         "group-hover/execution-log-row:pointer-events-auto group-hover/execution-log-row:opacity-100",
+        "group-focus-within/execution-log-row:pointer-events-auto group-focus-within/execution-log-row:opacity-100",
       ].join(" ")}
     >
       {children}

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -45,8 +45,9 @@ const TRIGGER_MASK_STYLE: React.CSSProperties = {
 //      story here; the row's right column carries the task status)
 //   2. Trigger description (e.g. "From comment", "Autopilot", "Retry"),
 //      truncated with ellipsis when narrow
-//   3. Status + relative time, swapped to hover actions (cancel /
-//      transcript) on hover
+//   3. Status, swapped to hover actions (cancel / transcript) in the same
+//      trailing zone. Active rows do not show relative time; the live status
+//      is the useful signal.
 //
 // One query (`listTasksByIssue`) drives both buckets — the back-end
 // returns every status, the front-end filters into active vs past on the
@@ -214,22 +215,6 @@ const STATUS_TONE: Record<AgentTask["status"], string> = {
   cancelled: "text-muted-foreground",
 };
 
-// Time anchor depends on status. Active rows want "Started 2m ago" /
-// "Queued 30s ago" — what's happening now. Past rows want "5m ago" — when
-// the verdict landed.
-function activeTimeText(task: AgentTask, timeAgo: (dateStr: string) => string): string {
-  if (task.status === "running" && task.started_at) {
-    return timeAgo(task.started_at);
-  }
-  if (
-    (task.status === "dispatched" || task.status === "waiting_local_directory") &&
-    task.dispatched_at
-  ) {
-    return timeAgo(task.dispatched_at);
-  }
-  return timeAgo(task.created_at);
-}
-
 // ─── Active row ────────────────────────────────────────────────────────────
 
 import { stripMentionMarkdown } from "../utils/strip-mention-markdown";
@@ -270,13 +255,11 @@ function useStatusLabel(status: AgentTask["status"]): string {
 
 function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const { t } = useT("issues");
-  const timeAgo = useTimeAgo();
   const [cancelling, setCancelling] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const tone = STATUS_TONE[task.status];
   const label = useStatusLabel(task.status);
   const trigger = useTriggerText(task);
-  const time = activeTimeText(task, timeAgo);
 
   // Transcript only meaningful once messages exist — pure-queued and
   // waiting_local_directory tasks haven't streamed any agent output yet.
@@ -302,11 +285,9 @@ function ActiveRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      {/* Status + time always visible — actions append on hover, never
-          replace. Same pattern as desktop tab bar / sidebar pins. */}
-      <span className="shrink-0 whitespace-nowrap text-xs">
+      <span className="flex shrink-0 items-center gap-1 whitespace-nowrap text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+        {task.status === "running" && <Loader2 className="h-3 w-3 animate-spin text-info" />}
         <span className={tone}>{label}</span>
-        <span className="text-muted-foreground"> · {time}</span>
       </span>
       <RowActions>
         {showTranscript && (
@@ -392,7 +373,7 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <span className="shrink-0 whitespace-nowrap text-xs">
+      <span className="shrink-0 whitespace-nowrap text-xs transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
         <span className={tone}>{failureLabel ?? label}</span>
         <span className="text-muted-foreground"> · {time}</span>
       </span>
@@ -469,11 +450,9 @@ function TriggerText({ text }: { text: string }) {
 }
 
 // Hover-only action slot — absolute-positioned over the row's right edge.
-// Status + time stay anchored in the layout; on hover the action buttons
-// fade in on top of them with a left-fading gradient backdrop, so the
-// status copy is gracefully covered (not hard-clipped) and the row
-// content never reflows. Mirrors the "actions sticky over content" idiom
-// used by GitHub PR rows, Linear issue rows, etc.
+// Default trailing status stays anchored in the layout; on hover it fades out
+// and the action buttons fade into the same trailing zone, so the row never
+// reflows. Mirrors the compact Chat History / desktop tab / sidebar pin pattern.
 function RowActions({ children }: { children: React.ReactNode }) {
   return (
     <div


### PR DESCRIPTION
## Summary
- Remove relative time from active Execution Log rows so live rows show only their status
- Add a compact running spinner for active running tasks
- Fade default trailing status out when row actions appear, matching Chat History / tab / pin interaction
- Keep past rows showing verdict time, but use the same trailing replace behavior on hover

## Test Plan
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views lint
- git diff --check -- packages/views/issues/components/execution-log-section.tsx