### PR TITLE
MUL-2863: durable autopilot cron dispatch when agent runtime is offline

### DIFF
--- a/apps/docs/content/docs/autopilots.mdx
+++ b/apps/docs/content/docs/autopilots.mdx
@@ -240,8 +240,13 @@ your provider's webhook-retry machinery doesn't keep hammering the URL:
 
 - `{"status":"accepted","run_id":"…","autopilot_id":"…","trigger_id":"…"}`
   — a run was dispatched.
-- `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}`
-  — the assignee's runtime is offline; recorded as a `skipped` run.
+- `{"status":"pending_runtime","run_id":"…","reason":"agent runtime is offline at dispatch time"}`
+  — the assignee's runtime is offline; the run is parked and will be
+  auto-dispatched when the runtime/daemon comes back online (MUL-2863).
+  The work is not lost.
+- `{"status":"skipped","run_id":"…","reason":"…"}`
+  — the cron was deliberately dropped (assignee agent hard-deleted, squad
+  archived, etc.). The reason in `failure_reason` explains why.
 - `{"status":"ignored","reason":"trigger_disabled"}` — the trigger is disabled.
 - `{"status":"ignored","reason":"autopilot_paused"}` — the autopilot is paused.
 - `{"status":"ignored","reason":"autopilot_archived"}` — the autopilot is archived.
@@ -270,9 +275,11 @@ Every trigger produces a **run record**, visible on the "History" tab of the aut
 
 - Trigger source (`schedule` / `manual` / `webhook`)
 - Start time, completion time
-- Status (`issue_created` / `running` / `completed` / `failed` / `skipped`)
+- Status (`issue_created` / `running` / `completed` / `failed` / `skipped` / `pending_runtime`)
 - The linked issue (create issue mode) or `task` (run-only mode)
 - Failure reason (if failed or skipped)
+- For `pending_runtime` runs, the runtime the run is queued behind; the
+  server re-dispatches automatically when the runtime comes back online.
 
 ## What happens when an autopilot fails
 

--- a/packages/core/types/autopilot.ts
+++ b/packages/core/types/autopilot.ts
@@ -14,9 +14,18 @@ export type AutopilotTriggerKind = "schedule" | "webhook" | "api";
 // (assignee runtime offline at dispatch time, MUL-1899). The frontend MUST
 // handle it explicitly — falling through to a generic case used to show
 // the run as still-pending which masked the no-op.
+//
+// `pending_runtime` (MUL-2863) is the durable-dispatch outcome: the cron
+// fired but the assignee agent's runtime is offline, so the run is parked
+// with status='pending_runtime' and pending_runtime_id set. The
+// runtime-comes-online hook on the server drains the queue and dispatches
+// the parked run at the next opportunity. The frontend surfaces this as
+// "Waiting for agent runtime to come online" so the user knows the run
+// is durable, not lost.
 export type AutopilotRunStatus =
   | "issue_created"
   | "running"
+  | "pending_runtime"
   | "completed"
   | "failed"
   | "skipped";
@@ -83,6 +92,12 @@ export interface AutopilotRun {
   triggered_at: string;
   completed_at: string | null;
   failure_reason: string | null;
+  // pending_runtime_id is the runtime the run is parked behind when
+  // status='pending_runtime' (MUL-2863). Null for every other status;
+  // cleared on the runtime-comes-online re-dispatch. The frontend uses
+  // this to render "Waiting for runtime <name>" alongside the failure
+  // reason in the run history.
+  pending_runtime_id?: string | null;
   trigger_payload: unknown;
   result: unknown;
   created_at: string;

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -70,11 +70,23 @@ function formatDate(date: string): string {
   });
 }
 
-type RunStatus = "issue_created" | "running" | "skipped" | "completed" | "failed";
+type RunStatus =
+  | "issue_created"
+  | "running"
+  | "pending_runtime"
+  | "completed"
+  | "failed"
+  | "skipped";
 
 const RUN_VISUAL: Record<RunStatus, { color: string; icon: typeof CheckCircle2; spin?: boolean }> = {
   issue_created: { color: "text-blue-500", icon: Clock },
   running: { color: "text-blue-500", icon: Loader2, spin: true },
+  // `pending_runtime` (MUL-2863) is the durable-dispatch outcome: the
+  // cron fired but the runtime was offline, so the run is parked waiting
+  // for the runtime to come back. It is NOT a failure — the row is muted
+  // blue with a small hourglass-like icon so the user reads it as "this
+  // will run later" rather than "this failed silently".
+  pending_runtime: { color: "text-blue-400", icon: Clock },
   // `skipped` (admission check found the assignee runtime offline,
   // MUL-1899) is muted so it doesn't read as a failure-ratio inflator.
   // The row still shows failure_reason which carries the skip context.
@@ -143,6 +155,13 @@ function RunRow({ run, agentId, agentName }: { run: AutopilotRun; agentId: strin
       <span className="flex-1 min-w-0 text-xs text-muted-foreground truncate">
         {run.issue_id ? (
           t(($) => $.run.issue_linked)
+        ) : run.status === "pending_runtime" ? (
+          <span
+            className="text-muted-foreground"
+            title={t(($) => $.run.pending_runtime_tooltip) ?? undefined}
+          >
+            {t(($) => $.run.pending_runtime_reason) ?? run.failure_reason}
+          </span>
         ) : run.failure_reason ? (
           <span className="text-destructive">{run.failure_reason}</span>
         ) : null}
@@ -188,16 +207,78 @@ function RunHistoryList({
   agentId: string;
   agentName: string;
 }) {
-  const visibleRuns = runs.filter((run) => run.status !== "skipped");
+  const activeRuns = runs.filter(
+    (run) => run.status !== "skipped" && run.status !== "pending_runtime",
+  );
+  const pendingRuntimeRuns = runs.filter((run) => run.status === "pending_runtime");
   const skippedRuns = runs.filter((run) => run.status === "skipped");
 
   return (
     <div className="rounded-md border overflow-hidden">
-      {visibleRuns.map((run) => (
+      {activeRuns.map((run) => (
         <RunRow key={run.id} run={run} agentId={agentId} agentName={agentName} />
       ))}
+      {pendingRuntimeRuns.length > 0 && (
+        <PendingRuntimeRunsGroup
+          runs={pendingRuntimeRuns}
+          agentId={agentId}
+          agentName={agentName}
+        />
+      )}
       {skippedRuns.length > 0 && (
         <SkippedRunsGroup runs={skippedRuns} agentId={agentId} agentName={agentName} />
+      )}
+    </div>
+  );
+}
+
+function PendingRuntimeRunsGroup({
+  runs,
+  agentId,
+  agentName,
+}: {
+  runs: AutopilotRun[];
+  agentId: string;
+  agentName: string;
+}) {
+  // MUL-2863: parked-runs group. Sits between active runs and the
+  // collapsed SkippedRunsGroup so the user sees "the cron fired, we're
+  // waiting for the runtime" in the natural reading order — after the
+  // currently-running rows, before the failures.
+  const { t } = useT("autopilots");
+  const [open, setOpen] = useState(false);
+  const latestRun = runs[0];
+  const ToggleIcon = open ? ChevronDown : ChevronRight;
+
+  return (
+    <div className="border-t bg-blue-50/40 dark:bg-blue-950/20">
+      <button
+        type="button"
+        className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent/30 transition-colors"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        title={t(($) => $.run.pending_runtime_tooltip) ?? undefined}
+      >
+        <ToggleIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Clock className="h-4 w-4 shrink-0 text-blue-400" />
+        <span className="w-24 shrink-0 text-xs font-medium text-blue-400">
+          {t(($) => $.run.pending_runtime_group.label)}
+        </span>
+        <span className="flex-1 min-w-0 text-xs text-muted-foreground truncate">
+          {t(($) => $.run.pending_runtime_group.summary, { count: runs.length })}
+        </span>
+        {latestRun && (
+          <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+            {formatDate(latestRun.triggered_at || latestRun.created_at)}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="border-t bg-background">
+          {runs.map((run) => (
+            <RunRow key={run.id} run={run} agentId={agentId} agentName={agentName} />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -96,7 +96,7 @@
     "skipped": "Skipped",
     "completed": "Completed",
     "failed": "Failed",
-    "skipped": "Skipped"
+    "pending_runtime": "Waiting for runtime"
   },
   "run_source": {
     "schedule": "Schedule",
@@ -107,9 +107,15 @@
   "run": {
     "issue_linked": "Issue linked",
     "view_log": "View execution log",
+    "pending_runtime_reason": "Waiting for agent runtime to come online",
+    "pending_runtime_tooltip": "The cron fired but the agent's runtime was offline. The run will be dispatched automatically when the runtime comes back online.",
     "skipped_group": {
       "label": "Skipped",
       "summary": "{{count}} skipped runs"
+    },
+    "pending_runtime_group": {
+      "label": "Waiting for runtime",
+      "summary": "{{count}} runs waiting for runtime"
     }
   },
   "webhook_payload": {

--- a/packages/views/locales/ko/autopilots.json
+++ b/packages/views/locales/ko/autopilots.json
@@ -95,7 +95,8 @@
     "running": "실행 중",
     "skipped": "건너뜀",
     "completed": "완료됨",
-    "failed": "실패함"
+    "failed": "실패함",
+    "pending_runtime": "런타임 대기 중"
   },
   "run_source": {
     "schedule": "일정",
@@ -106,9 +107,15 @@
   "run": {
     "issue_linked": "이슈 연결됨",
     "view_log": "실행 로그 보기",
+    "pending_runtime_reason": "에이전트 런타임이 온라인 상태가 될 때까지 대기 중",
+    "pending_runtime_tooltip": "크론 예약은 이미 실행되었지만 에이전트의 런타임이 오프라인입니다. 런타임이 다시 온라인이 되면 자동으로 실행이 디스패치됩니다.",
     "skipped_group": {
       "label": "건너뜀",
       "summary": "건너뛴 실행 {{count}}개"
+    },
+    "pending_runtime_group": {
+      "label": "런타임 대기 중",
+      "summary": "런타임을 기다리는 실행 {{count}}개"
     }
   },
   "webhook_payload": {

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -96,7 +96,7 @@
     "skipped": "已跳过",
     "completed": "已完成",
     "failed": "失败",
-    "skipped": "已跳过"
+    "pending_runtime": "等待运行时"
   },
   "run_source": {
     "schedule": "时间表",
@@ -107,9 +107,15 @@
   "run": {
     "issue_linked": "已关联 issue",
     "view_log": "查看执行日志",
+    "pending_runtime_reason": "等待智能体运行时上线",
+    "pending_runtime_tooltip": "时间表已触发，但智能体运行时当前离线。运行时恢复在线后，运行会自动派发。",
     "skipped_group": {
       "label": "已跳过",
       "summary": "{{count}} 条跳过的运行"
+    },
+    "pending_runtime_group": {
+      "label": "等待运行时",
+      "summary": "{{count}} 条运行在等待运行时"
     }
   },
   "webhook_payload": {

--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -122,12 +123,20 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 	}
 }
 
-// TestAutopilotDispatchSkipsWhenRuntimeOffline locks in the MUL-1899
-// admission gate: when the assignee agent's runtime is not online we must
-// record a `skipped` autopilot_run with a failure_reason and NOT enqueue an
-// agent_task_queue row. This is the fix for "活跃 schedule 持续给离线 local
-// agent 入队".
-func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
+// TestAutopilotDispatchParksWhenRuntimeOffline locks in the MUL-2863
+// durable-dispatch path. The cron tick must:
+//
+//  1. NOT record a `skipped` run when the runtime is offline — that would
+//     silently drop the cron for any user whose laptop is asleep at the
+//     scheduled time (the canonical bug from MUL-2863).
+//  2. Instead record a `pending_runtime` run with the runtime_id queued
+//     behind and a failure_reason that names the runtime-offline condition.
+//     The runtime-comes-online hook (covered by
+//     TestDispatchPendingRuntimeRunsForRuntime below) will pick this up.
+//  3. NEVER enqueue an agent_task_queue row while the runtime is offline —
+//     the MUL-1899 admission gate's other half ("stop piling doomed tasks
+//     onto the queue") still applies. Durable != "execute now anyway".
+func TestAutopilotDispatchParksWhenRuntimeOffline(t *testing.T) {
 	ctx := context.Background()
 	queries := db.New(testPool)
 	bus := events.New()
@@ -141,7 +150,7 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 		INSERT INTO agent_runtime (
 			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
 		)
-		VALUES ($1, NULL, 'Offline runtime', 'local', 'mul1899_offline_runtime', 'offline', '{}'::jsonb, '{}'::jsonb, now())
+		VALUES ($1, NULL, 'Offline runtime', 'local', 'mul2863_offline_runtime', 'offline', '{}'::jsonb, '{}'::jsonb, now())
 		RETURNING id::text
 	`, parseUUID(testWorkspaceID)).Scan(&runtimeID); err != nil {
 		t.Fatalf("create offline runtime: %v", err)
@@ -155,7 +164,7 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 			workspace_id, name, description, runtime_mode, runtime_config,
 			runtime_id, visibility, max_concurrent_tasks, owner_id
 		)
-		VALUES ($1, 'mul1899-offline-agent', '', 'local', '{}'::jsonb, $2, 'workspace', 1, $3)
+		VALUES ($1, 'mul2863-offline-agent', '', 'local', '{}'::jsonb, $2, 'workspace', 1, $3)
 		RETURNING id::text
 	`, parseUUID(testWorkspaceID), runtimeID, parseUUID(testUserID)).Scan(&agentID); err != nil {
 		t.Fatalf("create offline agent: %v", err)
@@ -167,7 +176,7 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
 		WorkspaceID:        parseUUID(testWorkspaceID),
 		Title:              "Offline-runtime autopilot",
-		Description:        pgtype.Text{String: "MUL-1899 admission test", Valid: true},
+		Description:        pgtype.Text{String: "MUL-2863 durable dispatch test", Valid: true},
 		AssigneeType:       "agent",
 		AssigneeID:         parseUUID(agentID),
 		Status:             "active",
@@ -190,17 +199,29 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 	if run == nil {
 		t.Fatal("expected a run, got nil")
 	}
-	if run.Status != "skipped" {
-		t.Fatalf("expected run status 'skipped', got %q", run.Status)
+	// MUL-2863: status is 'pending_runtime', not 'skipped'. The "the
+	// runtime is offline" admission outcome is durable: the run will
+	// be re-dispatched when the runtime/daemon comes back online.
+	if run.Status != "pending_runtime" {
+		t.Fatalf("expected run status 'pending_runtime', got %q", run.Status)
 	}
 	if !run.FailureReason.Valid || !strings.Contains(run.FailureReason.String, "offline") {
 		t.Fatalf("expected failure reason mentioning 'offline', got %+v", run.FailureReason)
+	}
+	// pending_runtime_id must point at the runtime we're queued behind,
+	// so the runtime-comes-online hook can find this row.
+	if !run.PendingRuntimeID.Valid {
+		t.Fatalf("expected pending_runtime_id to be set, got invalid")
+	}
+	if run.PendingRuntimeID != parseUUID(runtimeID) {
+		t.Fatalf("expected pending_runtime_id=%s, got %s", runtimeID, util.UUIDToString(run.PendingRuntimeID))
 	}
 	if run.TaskID.Valid {
 		t.Fatalf("expected no task to be enqueued, got task_id %v", run.TaskID)
 	}
 
-	// Defensive: confirm at the DB layer that nothing landed on the queue.
+	// Defensive: confirm at the DB layer that nothing landed on the queue
+	// (MUL-1899's "stop piling doomed tasks" half still applies).
 	var taskCount int
 	if err := testPool.QueryRow(ctx,
 		`SELECT count(*) FROM agent_task_queue WHERE agent_id = $1`,
@@ -210,6 +231,211 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 	}
 	if taskCount != 0 {
 		t.Fatalf("expected 0 queued tasks for offline-runtime agent, got %d", taskCount)
+	}
+}
+
+// TestDispatchPendingRuntimeRunsForRuntime exercises the runtime-comes-
+// online hook end-to-end (MUL-2863). The fixture parks a run with
+// status='pending_runtime' (via the same code path the cron scheduler
+// uses), then we flip the runtime to online and assert the run gets
+// dispatched through the standard create_issue / run_only branch —
+// moving to 'running' (run_only) or 'issue_created' (create_issue) and
+// landing a task in agent_task_queue.
+func TestDispatchPendingRuntimeRunsForRuntime(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var runtimeID, agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, 'MUL-2863 hook runtime', 'local', 'mul2863_hook_runtime', 'offline', '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID)).Scan(&runtimeID); err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, 'mul2863-hook-agent', '', 'local', '{}'::jsonb, $2, 'workspace', 1, $3)
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), runtimeID, parseUUID(testUserID)).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "MUL-2863 durable-dispatch autopilot",
+		Description:        pgtype.Text{String: "Durable-dispatch hook test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	// Park a run via the same path the cron scheduler uses.
+	run, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot (offline): %v", err)
+	}
+	if run.Status != "pending_runtime" {
+		t.Fatalf("expected pending_runtime, got %q", run.Status)
+	}
+
+	// No task yet.
+	var taskCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE agent_id = $1`,
+		agentID,
+	).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks before hook: %v", err)
+	}
+	if taskCount != 0 {
+		t.Fatalf("expected 0 queued tasks before hook, got %d", taskCount)
+	}
+
+	// Flip the runtime to online. DispatchPendingRuntimeRunsForRuntime
+	// only fires when the runtime is online; the in-process hook from
+	// recordHeartbeat / DaemonRegister will then drain the queue.
+	if _, err := testPool.Exec(ctx, `UPDATE agent_runtime SET status = 'online' WHERE id = $1`, runtimeID); err != nil {
+		t.Fatalf("flip runtime online: %v", err)
+	}
+
+	if err := autopilotSvc.DispatchPendingRuntimeRunsForRuntime(ctx, parseUUID(runtimeID)); err != nil {
+		t.Fatalf("DispatchPendingRuntimeRunsForRuntime: %v", err)
+	}
+
+	// Run should now be in 'running' (run_only mode) with a task_id set.
+	updated, err := queries.GetAutopilotRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updated.Status != "running" {
+		t.Fatalf("expected run status 'running' after dispatch, got %q", updated.Status)
+	}
+	if !updated.TaskID.Valid {
+		t.Fatalf("expected task_id to be set after dispatch")
+	}
+	// pending_runtime_id should be cleared so future ListPendingRuntimeAutopilotRunsForRuntime
+	// calls do not re-dispatch the same run.
+	if updated.PendingRuntimeID.Valid {
+		t.Fatalf("expected pending_runtime_id to be cleared after dispatch, got %s", util.UUIDToString(updated.PendingRuntimeID))
+	}
+
+	// And the task should have landed on agent_task_queue.
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE agent_id = $1`,
+		agentID,
+	).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks after hook: %v", err)
+	}
+	if taskCount != 1 {
+		t.Fatalf("expected 1 queued task after hook, got %d", taskCount)
+	}
+}
+
+// TestDispatchPendingRuntimeRunsKeepsPendingWhenStillOffline locks in
+// the "still offline" branch of the runtime-comes-online hook. If the
+// runtime flipped offline again between the original parking and the
+// hook call, the run must stay in 'pending_runtime' rather than be
+// marked as a real failure (which would trigger the failure-rate auto-
+// pause monitor for a user who is just running their laptop in cycles).
+func TestDispatchPendingRuntimeRunsKeepsPendingWhenStillOffline(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var runtimeID, agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, 'MUL-2863 still-offline runtime', 'local', 'mul2863_stilloffline_runtime', 'offline', '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID)).Scan(&runtimeID); err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, 'mul2863-stilloffline-agent', '', 'local', '{}'::jsonb, $2, 'workspace', 1, $3)
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), runtimeID, parseUUID(testUserID)).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "MUL-2863 still-offline autopilot",
+		Description:        pgtype.Text{String: "Runtime-comes-online hook still-offline branch", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	run, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+
+	// The runtime is still offline in the DB; the hook should leave
+	// the run in 'pending_runtime' rather than fail it.
+	if err := autopilotSvc.DispatchPendingRuntimeRunsForRuntime(ctx, parseUUID(runtimeID)); err != nil {
+		t.Fatalf("DispatchPendingRuntimeRunsForRuntime: %v", err)
+	}
+
+	updated, err := queries.GetAutopilotRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updated.Status != "pending_runtime" {
+		t.Fatalf("expected run to stay pending_runtime (runtime still offline), got %q", updated.Status)
+	}
+	if !updated.PendingRuntimeID.Valid {
+		t.Fatalf("expected pending_runtime_id to remain set, got invalid")
 	}
 }
 
@@ -295,7 +521,13 @@ func TestManualTriggerDoesNotErrorOnPostAdmissionSkip(t *testing.T) {
 	if run == nil {
 		t.Fatal("expected a run, got nil")
 	}
-	if run.Status != "skipped" {
-		t.Fatalf("expected run status 'skipped', got %q", run.Status)
+	// MUL-2863: a runtime-offline admission outcome is now durable
+	// ('pending_runtime'), not a terminal 'skipped'. The same property
+	// the original PR #2888 fix #2 cared about (no 500 on the manual
+	// trigger) still holds: the function returns (run, nil), the UI
+	// surfaces "Waiting for agent runtime to come online", and the
+	// run will be re-dispatched when the runtime comes back.
+	if run.Status != "pending_runtime" {
+		t.Fatalf("expected run status 'pending_runtime', got %q", run.Status)
 	}
 }

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -96,9 +96,14 @@ type AutopilotRunResponse struct {
 	TriggeredAt    string  `json:"triggered_at"`
 	CompletedAt    *string `json:"completed_at"`
 	FailureReason  *string `json:"failure_reason"`
-	TriggerPayload any     `json:"trigger_payload"`
-	Result         any     `json:"result"`
-	CreatedAt      string  `json:"created_at"`
+	// PendingRuntimeID is the runtime_id the run is queued behind when
+	// status='pending_runtime' (MUL-2863). Null for every other status;
+	// cleared on the runtime-comes-online re-dispatch. Used by the
+	// frontend to render "Waiting for runtime <name>" in the run history.
+	PendingRuntimeID *string `json:"pending_runtime_id,omitempty"`
+	TriggerPayload   any     `json:"trigger_payload"`
+	Result           any     `json:"result"`
+	CreatedAt        string  `json:"created_at"`
 }
 
 // ── Converters ──────────────────────────────────────────────────────────────
@@ -204,19 +209,20 @@ func runToResponse(r db.AutopilotRun) AutopilotRunResponse {
 		json.Unmarshal(r.Result, &result)
 	}
 	return AutopilotRunResponse{
-		ID:             uuidToString(r.ID),
-		AutopilotID:    uuidToString(r.AutopilotID),
-		TriggerID:      uuidToPtr(r.TriggerID),
-		Source:         r.Source,
-		Status:         r.Status,
-		IssueID:        uuidToPtr(r.IssueID),
-		TaskID:         uuidToPtr(r.TaskID),
-		TriggeredAt:    timestampToString(r.TriggeredAt),
-		CompletedAt:    timestampToPtr(r.CompletedAt),
-		FailureReason:  textToPtr(r.FailureReason),
-		TriggerPayload: payload,
-		Result:         result,
-		CreatedAt:      timestampToString(r.CreatedAt),
+		ID:               uuidToString(r.ID),
+		AutopilotID:      uuidToString(r.AutopilotID),
+		TriggerID:        uuidToPtr(r.TriggerID),
+		Source:           r.Source,
+		Status:           r.Status,
+		IssueID:          uuidToPtr(r.IssueID),
+		TaskID:           uuidToPtr(r.TaskID),
+		TriggeredAt:      timestampToString(r.TriggeredAt),
+		CompletedAt:      timestampToPtr(r.CompletedAt),
+		FailureReason:    textToPtr(r.FailureReason),
+		PendingRuntimeID: uuidToPtr(r.PendingRuntimeID),
+		TriggerPayload:   payload,
+		Result:           result,
+		CreatedAt:        timestampToString(r.CreatedAt),
 	}
 }
 

--- a/server/internal/handler/autopilot_webhook.go
+++ b/server/internal/handler/autopilot_webhook.go
@@ -329,9 +329,10 @@ func selectedHeadersJSON(headers http.Header) []byte {
 //     trigger's "last seen" is accurate.
 //
 // Response shapes:
-//   - 200 {"status":"accepted",  "delivery_id", "run_id", "autopilot_id", "trigger_id"}
-//   - 200 {"status":"skipped",   "delivery_id", "run_id", "reason"}
-//   - 200 {"status":"ignored",   "delivery_id", "reason"}
+//   - 200 {"status":"accepted",         "delivery_id", "run_id", "autopilot_id", "trigger_id"}
+//   - 200 {"status":"skipped",          "delivery_id", "run_id", "reason"}
+//   - 200 {"status":"pending_runtime",  "delivery_id", "run_id", "reason"} (MUL-2863)
+//   - 200 {"status":"ignored",          "delivery_id", "reason"}
 //   - 200 {"status":"duplicate", "delivery_id", "run_id?"}
 //   - 400 {"error":"..."}                                          — invalid JSON / scalar / empty
 //   - 401 {"status":"rejected",  "delivery_id", "reason":"..."}    — signature failure
@@ -582,10 +583,12 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 	// The delivery row is always `dispatched` once we reach here: from the
 	// ingress's perspective we handed the payload off to the autopilot
 	// machinery and got a run id back. The autopilot may have skipped the
-	// run (e.g. runtime offline) — that's reflected in the response status
-	// + reason and in the linked run row, not in the delivery status. This
-	// keeps the delivery enum tight and the Deliveries UI unambiguous
-	// (`run.status` is the source of truth for what the run did).
+	// run (e.g. assignee agent hard-deleted) or parked it pending_runtime
+	// (e.g. runtime offline, MUL-2863) — that's reflected in the response
+	// status + reason and in the linked run row, not in the delivery
+	// status. This keeps the delivery enum tight and the Deliveries UI
+	// unambiguous (`run.status` is the source of truth for what the run
+	// did).
 	respBody := map[string]any{
 		"status":       "accepted",
 		"delivery_id":  uuidToString(delivery.ID),
@@ -593,9 +596,10 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 		"autopilot_id": uuidToString(autopilot.ID),
 		"trigger_id":   uuidToString(trigRow.ID),
 	}
-	if run.Status == "skipped" {
+	switch run.Status {
+	case "skipped", "pending_runtime":
 		respBody = map[string]any{
-			"status":      "skipped",
+			"status":      run.Status,
 			"delivery_id": uuidToString(delivery.ID),
 			"run_id":      uuidToString(run.ID),
 		}

--- a/server/internal/handler/autopilot_webhook.go
+++ b/server/internal/handler/autopilot_webhook.go
@@ -61,9 +61,10 @@ const (
 //
 // "Duplicate" is a *response* status, not a delivery status — duplicates
 // don't get their own row; they bump attempt_count on the existing dedupe
-// target. Likewise "skipped" is a *response* status reported when the
-// autopilot service skipped the run (e.g. runtime offline); the delivery
-// row itself records `dispatched` and links the skipped run via
+// target. Likewise "skipped" and "pending_runtime" (MUL-2863) are
+// *response* statuses reported when the autopilot service declined or
+// parked the run (e.g. runtime offline, agent hard-deleted); the delivery
+// row itself records `dispatched` and links the affected run via
 // autopilot_run_id, because from the ingress's perspective we DID hand
 // the payload to the autopilot machinery.
 const (

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -397,6 +397,28 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// MUL-2863: durable dispatch hook. DaemonRegister is the second of
+		// two runtime-comes-online transition points (the first is the
+		// heartbeat path's recordHeartbeat). For a freshly inserted runtime
+		// row the new ID is brand-new — it cannot have pending runs queued
+		// against it — so the hook is a no-op in that case. For an upsert
+		// (daemon reconnect on an existing row that was previously
+		// offline) the same logic as the heartbeat hook applies: drain
+		// any 'pending_runtime' autopilot_run rows that were waiting for
+		// this runtime.
+		//
+		// We always call — the function is idempotent and short-circuits
+		// on an empty pending set — rather than gating on row.Inserted
+		// because a reconnect on an offline runtime is exactly the case
+		// the user is asking us to handle ("my laptop slept, the cron
+		// fired while the daemon was offline, now the daemon came back").
+		if registered.Status == "online" && h.AutopilotService != nil {
+			if err := h.AutopilotService.DispatchPendingRuntimeRunsForRuntime(r.Context(), registered.ID); err != nil {
+				slog.Warn("autopilot dispatch: failed to drain pending_runtime runs on register",
+					"runtime_id", uuidToString(registered.ID), "error", err)
+			}
+		}
+
 		// Seamless migration from the previous hostname-derived identity. The
 		// daemon sends every legacy daemon_id it may have registered under
 		// (e.g. "host.local", "host", "host-staging"); for each match we
@@ -835,7 +857,30 @@ func (h *Handler) recordHeartbeat(ctx context.Context, rt db.AgentRuntime) error
 	// Either bumps last_seen_at on an already-online row (Touch + race
 	// fallback) or flips status from offline to online. The scheduler
 	// chooses sync vs batched per case; see HeartbeatScheduler doc.
-	return h.HeartbeatScheduler.Schedule(ctx, rt)
+	if err := h.HeartbeatScheduler.Schedule(ctx, rt); err != nil {
+		return err
+	}
+
+	// MUL-2863: durable dispatch hook. After a successful DB write on the
+	// heartbeat path (which is the only way a runtime's DB row transitions
+	// from offline to online, since the sweeper only flips the other way),
+	// drain any autopilot_run rows that were parked waiting for this
+	// runtime to come back online. We dispatch the hook from here rather
+	// than from the autopilot listeners so the call site is co-located
+	// with the runtime-online transition itself — the only other flip
+	// point is DaemonRegister, which hooks the same call below.
+	//
+	// Errors are logged, not returned: a failed dispatch drain should not
+	// turn a healthy 200 heartbeat into a 500, and the next beat (or
+	// registration) will retry. The function is itself idempotent and
+	// short-circuits on an empty pending set.
+	if h.AutopilotService != nil {
+		if err := h.AutopilotService.DispatchPendingRuntimeRunsForRuntime(ctx, rt.ID); err != nil {
+			slog.Warn("autopilot dispatch: failed to drain pending_runtime runs on heartbeat",
+				"runtime_id", uuidToString(rt.ID), "error", err)
+		}
+	}
+	return nil
 }
 
 // heartbeatMetrics carries per-stage timings out of processHeartbeat so the

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -47,10 +47,20 @@ func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *
 // depending on execution_mode.
 //
 // Before any work is queued we run an admission check against the assignee
-// agent's runtime: if it is not online, we record a `skipped` run with a
-// failure_reason and return without enqueueing. This is the "触发时准入" gate
-// from MUL-1899 — without it a paused laptop / offline daemon causes scheduled
-// autopilots to pile thousands of doomed tasks onto agent_task_queue.
+// agent's runtime. Two skip outcomes are possible (MUL-1899 + MUL-2863):
+//
+//  1. The runtime is offline. MUL-2863 makes this a *durable* skip: we
+//     persist a `pending_runtime` run with the runtime_id it was waiting
+//     behind, so when the runtime/daemon reappears the
+//     DispatchPendingRuntimeRunsForRuntime hook picks it up and dispatches
+//     the actual work. This is the "the cron should not be silently lost
+//     while my laptop is asleep" fix from MUL-2863.
+//
+//  2. Any other admission failure (agent archived, squad archived, no
+//     runtime bound, private-agent gate, etc.) is a *terminal* skip. The
+//     cron is recorded as `skipped` with a failure_reason, mirroring the
+//     legacy MUL-1899 behaviour. Retrying wouldn't change anything, and
+//     retrying would inflate the failure-rate auto-pause monitor.
 //
 // When assignee_type='squad' the gate runs against the squad leader (Path A
 // from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), so an offline or
@@ -63,6 +73,20 @@ func (s *AutopilotService) DispatchAutopilot(
 	payload []byte,
 ) (*db.AutopilotRun, error) {
 	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
+		if isRuntimeOfflineAdmissionReason(reason) {
+			if run, err := s.recordPendingRuntimeRun(ctx, autopilot, triggerID, source, payload, reason); err == nil {
+				return run, nil
+			} else {
+				// Falling back to a terminal skip keeps a DB error from
+				// silently dropping the cron: the run row still gets
+				// written, the failure reason still surfaces in the UI,
+				// and the next tick gets another chance.
+				slog.Warn("autopilot dispatch: pending_runtime insert failed, falling back to skipped",
+					"autopilot_id", util.UUIDToString(autopilot.ID),
+					"error", err,
+				)
+			}
+		}
 		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason)
 	}
 
@@ -652,6 +676,345 @@ func autopilotSquadAttribution(ap db.Autopilot) pgtype.UUID {
 		return ap.AssigneeID
 	}
 	return pgtype.UUID{}
+}
+
+// isRuntimeOfflineAdmissionReason reports whether a shouldSkipDispatch
+// failure_reason indicates "the assignee agent's runtime is offline". This
+// is the only admission outcome that is durable (MUL-2863): we persist the
+// run as 'pending_runtime' so the runtime-comes-online hook can re-dispatch
+// it. All other admission failures (agent archived, squad archived, no
+// runtime bound, private-agent gate failure) are terminal — retrying the
+// cron would not change anything, so we keep the legacy 'skipped' status.
+//
+// We match on the formatted reason rather than re-running AgentReadiness
+// here: the admission gate has already loaded the runtime row, and the
+// "at dispatch time" suffix is the load-bearing string the MUL-1899
+// failure-monitor alert already groups on. Adding a second reason-string
+// would silently break that alert query.
+func isRuntimeOfflineAdmissionReason(reason string) bool {
+	return strings.HasPrefix(reason, "agent runtime is ") ||
+		strings.HasPrefix(reason, "assignee agent runtime is ") ||
+		strings.HasPrefix(reason, "squad leader agent runtime is ")
+}
+
+// recordPendingRuntimeRun persists a 'pending_runtime' autopilot_run for the
+// MUL-2863 durable-dispatch path. Mirrors recordSkippedRun's contract
+// (returns run + nil error so callers treat this as a successful no-op
+// dispatch), but:
+//   - status='pending_runtime' instead of 'skipped'
+//   - pending_runtime_id is set to the runtime we're queued behind, so the
+//     runtime-comes-online hook can find it
+//   - failure_reason is the admission-gate text (e.g. "agent runtime is
+//     offline at dispatch time") so the UI's existing failure_reason field
+//     can surface "Waiting for agent runtime to come online" without a
+//     schema change. The mapping from "offline at dispatch time" →
+//     "Waiting for agent runtime" lives in the frontend
+//     (AutopilotRunStatus handler) so the wire contract stays text-only.
+//
+// Returns nil run + err on a DB error so the caller can fall back to
+// recordSkippedRun; we deliberately do not propagate a partial state
+// (pending row without a queued runtime id) because that would create the
+// exact "orphaned pending row" the durable path is meant to prevent.
+func (s *AutopilotService) recordPendingRuntimeRun(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	reason string,
+) (*db.AutopilotRun, error) {
+	runtimeID, err := s.resolveAssigneeRuntimeID(ctx, autopilot)
+	if err != nil || !runtimeID.Valid {
+		// Either the assignee agent row is gone, the squad row is archived,
+		// or the agent has no runtime bound. The admission gate already
+		// classified this as a non-runtime-offline skip, so the caller
+		// would have routed to recordSkippedRun — we should never reach
+		// here. If we do (e.g. a race between the gate and this lookup),
+		// bail with no row so the caller falls back to the legacy skip.
+		slog.Warn("autopilot dispatch: cannot resolve runtime for pending run",
+			"autopilot_id", util.UUIDToString(autopilot.ID),
+			"reason", reason,
+			"err", err,
+		)
+		return nil, fmt.Errorf("resolve runtime: %w", err)
+	}
+
+	run, err := s.Queries.CreateAutopilotRunPendingRuntime(ctx, db.CreateAutopilotRunPendingRuntimeParams{
+		AutopilotID:      autopilot.ID,
+		Source:           source,
+		FailureReason:    pgtype.Text{String: reason, Valid: true},
+		PendingRuntimeID: runtimeID,
+		TriggerID:        triggerID,
+		TriggerPayload:   payload,
+		SquadID:          autopilotSquadAttribution(autopilot),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create pending_runtime run: %w", err)
+	}
+
+	// Mirror recordSkippedRun's last_run_at bump + WS event. From the
+	// scheduler's / UI's point of view we *did* evaluate the trigger this
+	// tick; the runtime was just offline, so we parked the run for later.
+	s.Queries.UpdateAutopilotLastRunAt(ctx, autopilot.ID)
+
+	slog.Info("autopilot dispatch parked pending runtime",
+		"autopilot_id", util.UUIDToString(autopilot.ID),
+		"run_id", util.UUIDToString(run.ID),
+		"source", source,
+		"runtime_id", util.UUIDToString(runtimeID),
+		"reason", reason,
+	)
+
+	// Publish the same run-done event the skipped path publishes, but with
+	// status='pending_runtime' so the frontend renders the new "Waiting
+	// for runtime" pill without a new event type.
+	s.publishRunDone(util.UUIDToString(autopilot.WorkspaceID), run, "pending_runtime")
+	return &run, nil
+}
+
+// resolveAssigneeRuntimeID returns the runtime_id bound to the autopilot's
+// resolved leader (the agent for assignee_type='agent', the squad's leader
+// for assignee_type='squad'). Returns an invalid UUID when the agent has
+// no runtime bound so the caller can decide what to do.
+func (s *AutopilotService) resolveAssigneeRuntimeID(ctx context.Context, ap db.Autopilot) (pgtype.UUID, error) {
+	agent, _, err := s.resolveAutopilotLeader(ctx, ap)
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+	return agent.RuntimeID, nil
+}
+
+// maxPendingRuntimeRunsPerSweep caps the number of pending_runtime runs
+// one runtime-online sweep dispatches in a single transaction. Keeps the
+// heartbeat hot path bounded when a long-offline laptop comes back with
+// hundreds of queued cron runs: dispatch the oldest, leave the rest
+// pending for the next beat (or, more likely, the immediate next iteration
+// of the loop after this batch commits).
+const maxPendingRuntimeRunsPerSweep = 50
+
+// DispatchPendingRuntimeRunsForRuntime is the runtime-comes-online hook
+// for MUL-2863. It walks every 'pending_runtime' autopilot_run queued
+// behind the given runtime_id and tries to dispatch each one, oldest first.
+//
+// Per-run dispatch mirrors DispatchAutopilot: re-validate the admission
+// gate (in case the agent was archived, the squad was archived, or the
+// agent was re-bound to a different runtime while we were waiting), then
+// run the standard create_issue / run_only branch. A re-check is necessary
+// because the run may have been parked for hours/days; the world may have
+// moved on.
+//
+// The 3-outcome contract from DispatchAutopilot is preserved:
+//
+//   - success → run is moved to 'issue_created' or 'running' and the
+//     autopilot_run.issue_id / task_id is set by the per-mode dispatcher.
+//   - admission still failing for the same runtime-offline reason →
+//     keep the run as 'pending_runtime' (no row changes). The next time
+//     the runtime goes offline → online, we'll try again. (Defensive
+//     in case the runtime went online briefly and the agent hasn't
+//     heartbeated yet.)
+//   - admission failing for a non-runtime reason (agent archived, etc.) →
+//     rewind the run to 'skipped' with the new failure_reason so it
+//     doesn't sit in pending forever. We treat this as a terminal skip
+//     rather than a failure so it doesn't pollute the failure-rate auto-
+//     pause monitor.
+//
+// The function is safe to call from heartbeat hot paths: it short-circuits
+// on an empty pending set, and the per-row queries are bounded by
+// maxPendingRuntimeRunsPerSweep.
+func (s *AutopilotService) DispatchPendingRuntimeRunsForRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
+	if !runtimeID.Valid {
+		return nil
+	}
+	rows, err := s.Queries.ListPendingRuntimeAutopilotRunsForRuntime(ctx, db.ListPendingRuntimeAutopilotRunsForRuntimeParams{
+		PendingRuntimeID: runtimeID,
+		Limit:            maxPendingRuntimeRunsPerSweep,
+	})
+	if err != nil {
+		return fmt.Errorf("list pending runtime runs: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	slog.Info("autopilot dispatch: runtime came online, draining pending runs",
+		"runtime_id", util.UUIDToString(runtimeID),
+		"pending_count", len(rows),
+	)
+
+	for _, row := range rows {
+		// Re-load the autopilot fresh. The SQL JOIN returned a snapshot
+		// at SELECT time, but the autopilot may have been reassigned,
+		// paused, or archived in the gap between SELECT and this loop
+		// iteration. The post-admission branch (DispatchAutopilot's
+		// `running` path) is idempotent on re-call, so a re-dispatch
+		// of a run that already slipped through is at worst a no-op
+		// double-skip — acceptable for the first version.
+		autopilot, err := s.Queries.GetAutopilot(ctx, row.AutopilotID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				// Autopilot hard-deleted while pending. Mark the run
+				// skipped with a useful reason so the UI doesn't show
+				// a forever-pending row.
+				s.transitionPendingToSkipped(ctx, row.ID, "autopilot was deleted while waiting for runtime")
+				continue
+			}
+			slog.Warn("autopilot dispatch: failed to reload autopilot for pending run",
+				"run_id", util.UUIDToString(row.ID),
+				"autopilot_id", util.UUIDToString(row.AutopilotID),
+				"error", err,
+			)
+			continue
+		}
+		if autopilot.Status != "active" {
+			// The SQL WHERE clause already filters to status='active',
+			// but a race (paused/archived between SELECT and reload)
+			// can still flip it. Re-check defensively.
+			s.transitionPendingToSkipped(ctx, row.ID, "autopilot is no longer active (paused or archived)")
+			continue
+		}
+
+		// Re-run the admission gate. If the runtime is still offline
+		// (e.g. another agent on this runtime is up but the autopilot's
+		// agent is on a different runtime that flapped), leave the run
+		// pending. Any other failure → terminal skip.
+		if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
+			if isRuntimeOfflineAdmissionReason(reason) {
+				// Still offline. Leave as pending; the next time the
+				// runtime comes online we'll re-try. No log line per
+				// pending run per tick — that would be noisy on a
+				// stable-but-offline agent.
+				continue
+			}
+			s.transitionPendingToSkipped(ctx, row.ID, reason)
+			continue
+		}
+
+		// Clear the pending_runtime_id pointer *before* the dispatch,
+		// so a later ListPendingRuntimeAutopilotRunsForRuntime call (in
+		// this same sweep or a concurrent heartbeat) does not double-
+		// dispatch. If dispatch itself fails, the row is left in
+		// 'pending_runtime' via the fallback in DispatchAutopilot and
+		// would re-appear on a subsequent sweep.
+		if _, err := s.Queries.ClearAutopilotRunPendingRuntime(ctx, row.ID); err != nil {
+			slog.Warn("autopilot dispatch: failed to clear pending_runtime_id before re-dispatch",
+				"run_id", util.UUIDToString(row.ID), "error", err)
+			continue
+		}
+
+		// Re-dispatch through the standard entry point. The run row
+		// already exists (we did not create a new one); pass
+		// existing=true semantics via the run pointer in DispatchAutopilot.
+		s.dispatchExistingPendingRun(ctx, autopilot, row)
+	}
+	return nil
+}
+
+// dispatchExistingPendingRun re-dispatches a pre-existing pending_runtime
+// run. It mirrors DispatchAutopilot's per-mode branch but does not create
+// a new autopilot_run row (one was already created when the cron fired
+// and the runtime was offline). The Status transition (pending_runtime
+// → issue_created / running) and the side effects (issue creation, task
+// enqueue) are identical to a fresh dispatch.
+func (s *AutopilotService) dispatchExistingPendingRun(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	row db.ListPendingRuntimeAutopilotRunsForRuntimeRow,
+) {
+	run := db.AutopilotRun{
+		ID:               row.ID,
+		AutopilotID:      row.AutopilotID,
+		TriggerID:        row.TriggerID,
+		Source:           row.Source,
+		Status:           row.Status,
+		IssueID:          row.IssueID,
+		TaskID:           row.TaskID,
+		TriggeredAt:      row.TriggeredAt,
+		CompletedAt:      row.CompletedAt,
+		FailureReason:    row.FailureReason,
+		TriggerPayload:   row.TriggerPayload,
+		Result:           row.Result,
+		CreatedAt:        row.CreatedAt,
+		SquadID:          row.SquadID,
+		PendingRuntimeID: row.PendingRuntimeID,
+	}
+
+	switch autopilot.ExecutionMode {
+	case "create_issue":
+		triggerTimezone := s.resolveAutopilotTriggerTimezone(ctx, run.TriggerID)
+		if err := s.dispatchCreateIssue(ctx, autopilot, &run, triggerTimezone); err != nil {
+			if skipped := s.handleDispatchSkip(ctx, autopilot, &run, err); skipped != nil {
+				return
+			}
+			s.failRun(ctx, run.ID, err.Error())
+			s.captureAutopilotRunFailed(autopilot, run, run.Source, err.Error())
+			return
+		}
+	case "run_only":
+		if err := s.dispatchRunOnly(ctx, autopilot, &run); err != nil {
+			if skipped := s.handleDispatchSkip(ctx, autopilot, &run, err); skipped != nil {
+				return
+			}
+			s.failRun(ctx, run.ID, err.Error())
+			s.captureAutopilotRunFailed(autopilot, run, run.Source, err.Error())
+			return
+		}
+	default:
+		s.failRun(ctx, run.ID, "unknown execution_mode: "+autopilot.ExecutionMode)
+		return
+	}
+
+	// Mirror DispatchAutopilot's last_run_at + WS event so the UI
+	// observes the transition from 'pending_runtime' to 'issue_created'
+	// / 'running' identically to a fresh dispatch.
+	s.Queries.UpdateAutopilotLastRunAt(ctx, autopilot.ID)
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventAutopilotRunStart,
+		WorkspaceID: util.UUIDToString(autopilot.WorkspaceID),
+		ActorType:   "system",
+		Payload: map[string]any{
+			"run_id":       util.UUIDToString(run.ID),
+			"autopilot_id": util.UUIDToString(autopilot.ID),
+			"source":       run.Source,
+			"status":       run.Status,
+			// 'resumed_from_pending_runtime' lets the UI distinguish
+			// "the cron fired now and started work" from "we just
+			// resumed a run that was parked waiting for the runtime".
+			// Both produce a fresh issue / task; the diagnostic value
+			// is in user-facing run history and analytics.
+			"resumed_from": "pending_runtime",
+		},
+	})
+}
+
+// transitionPendingToSkipped rewinds a pending_runtime run to the
+// 'skipped' terminal status. Used by the runtime-comes-online hook when
+// the re-validated admission gate fails for a non-runtime reason (agent
+// archived, autopilot paused/archived/deleted, etc.). Mirrors
+// recordSkippedRun's row finalization but on an existing run id.
+func (s *AutopilotService) transitionPendingToSkipped(ctx context.Context, runID pgtype.UUID, reason string) {
+	updated, err := s.Queries.UpdateAutopilotRunSkipped(ctx, db.UpdateAutopilotRunSkippedParams{
+		ID:            runID,
+		FailureReason: pgtype.Text{String: reason, Valid: true},
+	})
+	if err != nil {
+		slog.Warn("autopilot dispatch: failed to transition pending_runtime to skipped",
+			"run_id", util.UUIDToString(runID), "error", err)
+		return
+	}
+	// Clear the queue pointer so future sweeps don't see this row.
+	if _, err := s.Queries.ClearAutopilotRunPendingRuntime(ctx, runID); err != nil {
+		slog.Warn("autopilot dispatch: failed to clear pending_runtime_id after skip",
+			"run_id", util.UUIDToString(runID), "error", err)
+	}
+	slog.Info("autopilot dispatch: pending_runtime → skipped",
+		"run_id", util.UUIDToString(runID),
+		"reason", reason,
+	)
+	// publishRunDone uses run.WorkspaceID indirectly via autopilot_id;
+	// we don't have the autopilot loaded here, so load it for the event.
+	if ap, err := s.Queries.GetAutopilotByRunID(ctx, runID); err == nil {
+		s.publishRunDone(util.UUIDToString(ap.WorkspaceID), updated, "skipped")
+	}
 }
 
 // recordSkippedRun persists a `skipped` autopilot_run with the given reason

--- a/server/internal/service/autopilot_squad_test.go
+++ b/server/internal/service/autopilot_squad_test.go
@@ -59,6 +59,46 @@ func TestFormatAdmissionReason(t *testing.T) {
 	}
 }
 
+// TestIsRuntimeOfflineAdmissionReason locks in the MUL-2863 reason-string
+// contract that routes a runtime-offline admission outcome to the durable
+// 'pending_runtime' run path. The classifier must:
+//
+//  1. Match every admission reason whose root cause is "the runtime is
+//     offline" — including the prefixed variants produced by
+//     formatAdmissionReason (assignee…, squad leader…) and the legacy
+//     "at dispatch time" suffix. The MUL-1899 alert dashboards group on
+//     "offline at dispatch time" so we cannot rename the suffix.
+//  2. NOT match other admission failures (agent archived, no runtime
+//     bound, private-agent gate, etc.) — those remain terminal skips.
+//     Misclassifying a private-agent failure as runtime-offline would
+//     cause the run to stay pending forever waiting for a runtime that
+//     is already online but blocked by a different gate.
+func TestIsRuntimeOfflineAdmissionReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{"agent runtime offline (legacy format)", "agent runtime is offline at dispatch time", true},
+		{"assignee agent runtime offline (formatted)", "assignee agent runtime is offline at dispatch time", true},
+		{"squad leader agent runtime offline (formatted)", "squad leader agent runtime is offline at dispatch time", true},
+		{"runtime starting", "agent runtime is starting at dispatch time", true},
+		{"runtime unstable", "agent runtime is unstable at dispatch time", true},
+		{"agent archived (terminal skip)", "assignee agent is archived", false},
+		{"agent no runtime (terminal skip)", "assignee agent has no runtime bound", false},
+		{"squad archived (terminal skip)", "assignee squad is archived", false},
+		{"private agent gate (terminal skip)", "autopilot creator lacks access to private assignee agent", false},
+		{"empty reason", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRuntimeOfflineAdmissionReason(tc.reason); got != tc.want {
+				t.Fatalf("isRuntimeOfflineAdmissionReason(%q) = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
 // errDispatchSkipped must be distinguishable via errors.As from a wrapped
 // fmt.Errorf, otherwise DispatchAutopilot's failure-vs-skip switch will treat
 // it as a generic failure and the manual-trigger handler will 500. Locks in

--- a/server/migrations/111_autopilot_pending_runtime_status.down.sql
+++ b/server/migrations/111_autopilot_pending_runtime_status.down.sql
@@ -1,0 +1,25 @@
+-- Down migration for MUL-2863. Drops the pending_runtime-related objects.
+-- Note: any 'pending_runtime' rows are migrated to 'skipped' with a
+-- migration reason so the (post-079) constraint is still satisfied when
+-- we re-tighten it below. This matches the 079 down approach: tighten
+-- the constraint by walking the data through it, not by deleting rows.
+
+UPDATE autopilot_run
+SET status = 'skipped',
+    completed_at = COALESCE(completed_at, now()),
+    failure_reason = COALESCE(failure_reason, 'migrated from pending_runtime status')
+WHERE status = 'pending_runtime';
+
+-- Restore the original in-flight partial index predicate (the
+-- 'pending_runtime' state is no longer valid after this migration lands).
+DROP INDEX IF EXISTS idx_autopilot_run_pending_runtime;
+DROP INDEX IF EXISTS idx_autopilot_run_status;
+CREATE INDEX IF NOT EXISTS idx_autopilot_run_status
+    ON autopilot_run(autopilot_id, status)
+    WHERE status IN ('issue_created', 'running');
+
+ALTER TABLE autopilot_run DROP COLUMN IF EXISTS pending_runtime_id;
+
+ALTER TABLE autopilot_run DROP CONSTRAINT IF EXISTS autopilot_run_status_check;
+ALTER TABLE autopilot_run ADD CONSTRAINT autopilot_run_status_check
+    CHECK (status IN ('issue_created', 'running', 'completed', 'failed', 'skipped'));

--- a/server/migrations/111_autopilot_pending_runtime_status.up.sql
+++ b/server/migrations/111_autopilot_pending_runtime_status.up.sql
@@ -1,0 +1,53 @@
+-- MUL-2863: durable autopilot cron dispatch when the assignee agent's
+-- runtime is offline at dispatch time. Adds a `pending_runtime` terminal-
+-- state-equivalent status for autopilot_run and a column that records which
+-- runtime the run is queued behind.
+--
+-- Without this, the MUL-1899 admission gate records a `skipped` run whenever
+-- the runtime is offline — silently losing scheduled work for any user whose
+-- laptop sleeps, restarts, or loses connectivity at the cron fire time. The
+-- new status lets the cron tick persist a run record that surfaces in the UI
+-- as "Waiting for agent runtime to come online" and is auto-dispatched the
+-- next time the runtime/daemon reappears, instead of being thrown away.
+--
+-- We do NOT change the existing 'skipped' status semantics — it still
+-- represents an admission failure that we are deliberately dropping (e.g.
+-- the assignee agent was hard-deleted, or the squad is archived). 'pending'
+-- from the original 042 schema is reused for the same intent but the
+-- constraint is being tightened to make it explicit.
+
+ALTER TABLE autopilot_run DROP CONSTRAINT IF EXISTS autopilot_run_status_check;
+ALTER TABLE autopilot_run ADD CONSTRAINT autopilot_run_status_check
+    CHECK (status IN ('pending_runtime', 'issue_created', 'running', 'completed', 'failed', 'skipped'));
+
+-- pending_runtime_id records which runtime the run is queued behind. Set
+-- at admission time when we transition the run to 'pending_runtime';
+-- cleared on transition to a non-pending status.
+--
+-- No FK to agent_runtime(id) on purpose: the runtime row can be GC'd
+-- (offlineRuntimeTTLSeconds in cmd/server/runtime_sweeper.go) while a run
+-- is still pending, and the run should keep surfacing in the UI as
+-- "Waiting for runtime" until the user manually re-triggers or the
+-- autopilot is re-pointed. Surfacing it without a runtime row also gives
+-- ops a paper trail for "this autopilot never recovered" cases.
+ALTER TABLE autopilot_run ADD COLUMN IF NOT EXISTS pending_runtime_id UUID;
+
+-- Targeted partial index for the runtime-comes-online dispatch path
+-- (ListPendingRuntimeAutopilotRunsForRuntime). Pending rows are
+-- short-lived relative to completed/failed runs, so the partial
+-- condition keeps the index lean. Oldest-first ordering matches the
+-- queue semantics: when a runtime comes back online we dispatch the
+-- oldest eligible pending run first.
+CREATE INDEX IF NOT EXISTS idx_autopilot_run_pending_runtime
+    ON autopilot_run(pending_runtime_id, triggered_at ASC)
+    WHERE status = 'pending_runtime';
+
+-- Tighten the in-flight partial index from migration 042 to also include
+-- pending_runtime. The existing predicate (pending, issue_created, running)
+-- predates the new status, so a pending run would not show up in the index
+-- the sweeper / dispatcher uses to walk in-flight work. We DROP+CREATE here
+-- rather than ALTER because the predicate changed.
+DROP INDEX IF EXISTS idx_autopilot_run_status;
+CREATE INDEX IF NOT EXISTS idx_autopilot_run_status
+    ON autopilot_run(autopilot_id, status)
+    WHERE status IN ('pending_runtime', 'issue_created', 'running');

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -104,6 +104,45 @@ func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueSched
 	return items, nil
 }
 
+const clearAutopilotRunPendingRuntime = `-- name: ClearAutopilotRunPendingRuntime :one
+UPDATE autopilot_run
+SET pending_runtime_id = NULL
+WHERE id = $1
+  AND status = 'pending_runtime'
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
+`
+
+// MUL-2863: when a 'pending_runtime' run is dispatched (or otherwise
+// transitioned to a non-pending status), clear pending_runtime_id so a
+// stale value can't keep matching future ListPendingRuntimeAutopilotRunsForRuntime
+// calls. Failure_reason and completed_at are deliberately NOT touched
+// here: callers transition the status themselves (UpdateAutopilotRunIssueCreated
+// / UpdateAutopilotRunRunning / UpdateAutopilotRunSkipped) and own those
+// columns. The dispatcher composes the two updates: this one to clear the
+// queue pointer, the status-specific one to finalize.
+func (q *Queries) ClearAutopilotRunPendingRuntime(ctx context.Context, id pgtype.UUID) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, clearAutopilotRunPendingRuntime, id)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PendingRuntimeID,
+	)
+	return i, err
+}
+
 const createAutopilot = `-- name: CreateAutopilot :one
 INSERT INTO autopilot (
     workspace_id, title, description, assignee_type, assignee_id,
@@ -172,7 +211,7 @@ INSERT INTO autopilot_run (
 ) VALUES (
     $1, $4, $2, $3, $5,
     $6
-) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type CreateAutopilotRunParams struct {
@@ -216,6 +255,73 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
+	)
+	return i, err
+}
+
+const createAutopilotRunPendingRuntime = `-- name: CreateAutopilotRunPendingRuntime :one
+INSERT INTO autopilot_run (
+    autopilot_id, trigger_id, source, status, trigger_payload,
+    squad_id, failure_reason, pending_runtime_id
+) VALUES (
+    $1, $5, $2, 'pending_runtime',
+    $6, $7,
+    $3, $4
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
+`
+
+type CreateAutopilotRunPendingRuntimeParams struct {
+	AutopilotID      pgtype.UUID `json:"autopilot_id"`
+	Source           string      `json:"source"`
+	FailureReason    pgtype.Text `json:"failure_reason"`
+	PendingRuntimeID pgtype.UUID `json:"pending_runtime_id"`
+	TriggerID        pgtype.UUID `json:"trigger_id"`
+	TriggerPayload   []byte      `json:"trigger_payload"`
+	SquadID          pgtype.UUID `json:"squad_id"`
+}
+
+// MUL-2863: durable dispatch when the runtime is offline. The cron tick
+// creates a run row in 'pending_runtime' (terminal-state-equivalent) and
+// records which runtime it's queued behind. When the runtime comes back
+// online, the runtime-comes-online hook re-dispatches the oldest pending
+// run. This is the durable alternative to UpdateAutopilotRunSkipped: rather
+// than recording a "we deliberately dropped this" outcome, we record a
+// "we evaluated the trigger and parked it for later" outcome.
+//
+// Mapped to the agent on whose bound runtime we're waiting, so the
+// runtime-comes-online path can fan out across agents on the same
+// runtime without an extra join. NULL is fine (offline agent with no
+// runtime bound — see MUL-1899's "agent has no runtime bound" branch)
+// because the agent-resolution re-check at dispatch time catches that
+// case and fails closed.
+func (q *Queries) CreateAutopilotRunPendingRuntime(ctx context.Context, arg CreateAutopilotRunPendingRuntimeParams) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, createAutopilotRunPendingRuntime,
+		arg.AutopilotID,
+		arg.Source,
+		arg.FailureReason,
+		arg.PendingRuntimeID,
+		arg.TriggerID,
+		arg.TriggerPayload,
+		arg.SquadID,
+	)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -397,6 +503,42 @@ func (q *Queries) GetAutopilot(ctx context.Context, id pgtype.UUID) (Autopilot, 
 	return i, err
 }
 
+const getAutopilotByRunID = `-- name: GetAutopilotByRunID :one
+SELECT a.id, a.workspace_id, a.title, a.description, a.assignee_id, a.status, a.execution_mode, a.issue_title_template, a.created_by_type, a.created_by_id, a.last_run_at, a.created_at, a.updated_at, a.assignee_type, a.project_id
+FROM autopilot a
+JOIN autopilot_run r ON r.autopilot_id = a.id
+WHERE r.id = $1
+`
+
+// MUL-2863: reverse lookup for the runtime-comes-online skip-transition
+// path. The dispatch loop holds a run row and needs the parent autopilot
+// (and its workspace_id) to publish a run:done event; loading the autopilot
+// directly via the run's autopilot_id saves a join. Used only on the
+// transitionPendingToSkipped hot path; happy-path dispatch re-uses the
+// autopilot already loaded in DispatchPendingRuntimeRunsForRuntime.
+func (q *Queries) GetAutopilotByRunID(ctx context.Context, id pgtype.UUID) (Autopilot, error) {
+	row := q.db.QueryRow(ctx, getAutopilotByRunID, id)
+	var i Autopilot
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.Description,
+		&i.AssigneeID,
+		&i.Status,
+		&i.ExecutionMode,
+		&i.IssueTitleTemplate,
+		&i.CreatedByType,
+		&i.CreatedByID,
+		&i.LastRunAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.AssigneeType,
+		&i.ProjectID,
+	)
+	return i, err
+}
+
 const getAutopilotInWorkspace = `-- name: GetAutopilotInWorkspace :one
 SELECT id, workspace_id, title, description, assignee_id, status, execution_mode, issue_title_template, created_by_type, created_by_id, last_run_at, created_at, updated_at, assignee_type, project_id FROM autopilot
 WHERE id = $1 AND workspace_id = $2
@@ -431,7 +573,7 @@ func (q *Queries) GetAutopilotInWorkspace(ctx context.Context, arg GetAutopilotI
 }
 
 const getAutopilotRun = `-- name: GetAutopilotRun :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id FROM autopilot_run
 WHERE id = $1
 `
 
@@ -453,13 +595,14 @@ func (q *Queries) GetAutopilotRun(ctx context.Context, id pgtype.UUID) (Autopilo
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
 
 const getAutopilotRunByIssue = `-- name: GetAutopilotRunByIssue :one
 
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id FROM autopilot_run
 WHERE issue_id = $1 AND status IN ('issue_created', 'running')
 LIMIT 1
 `
@@ -485,6 +628,7 @@ func (q *Queries) GetAutopilotRunByIssue(ctx context.Context, issueID pgtype.UUI
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -574,7 +718,7 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 }
 
 const listAutopilotRuns = `-- name: ListAutopilotRuns :many
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id FROM autopilot_run
 WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -610,6 +754,7 @@ func (q *Queries) ListAutopilotRuns(ctx context.Context, arg ListAutopilotRunsPa
 			&i.Result,
 			&i.CreatedAt,
 			&i.SquadID,
+			&i.PendingRuntimeID,
 		); err != nil {
 			return nil, err
 		}
@@ -708,6 +853,99 @@ func (q *Queries) ListAutopilots(ctx context.Context, arg ListAutopilotsParams) 
 			&i.UpdatedAt,
 			&i.AssigneeType,
 			&i.ProjectID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPendingRuntimeAutopilotRunsForRuntime = `-- name: ListPendingRuntimeAutopilotRunsForRuntime :many
+SELECT r.id, r.autopilot_id, r.trigger_id, r.source, r.status, r.issue_id, r.task_id, r.triggered_at, r.completed_at, r.failure_reason, r.trigger_payload, r.result, r.created_at, r.squad_id, r.pending_runtime_id, a.workspace_id AS autopilot_workspace_id,
+       a.status AS autopilot_status, a.assignee_type, a.assignee_id,
+       a.execution_mode
+FROM autopilot_run r
+JOIN autopilot a ON a.id = r.autopilot_id
+WHERE r.pending_runtime_id = $1
+  AND r.status = 'pending_runtime'
+  AND a.status = 'active'
+ORDER BY r.triggered_at ASC
+LIMIT $2
+`
+
+type ListPendingRuntimeAutopilotRunsForRuntimeParams struct {
+	PendingRuntimeID pgtype.UUID `json:"pending_runtime_id"`
+	Limit            int32       `json:"limit"`
+}
+
+type ListPendingRuntimeAutopilotRunsForRuntimeRow struct {
+	ID                   pgtype.UUID        `json:"id"`
+	AutopilotID          pgtype.UUID        `json:"autopilot_id"`
+	TriggerID            pgtype.UUID        `json:"trigger_id"`
+	Source               string             `json:"source"`
+	Status               string             `json:"status"`
+	IssueID              pgtype.UUID        `json:"issue_id"`
+	TaskID               pgtype.UUID        `json:"task_id"`
+	TriggeredAt          pgtype.Timestamptz `json:"triggered_at"`
+	CompletedAt          pgtype.Timestamptz `json:"completed_at"`
+	FailureReason        pgtype.Text        `json:"failure_reason"`
+	TriggerPayload       []byte             `json:"trigger_payload"`
+	Result               []byte             `json:"result"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	SquadID              pgtype.UUID        `json:"squad_id"`
+	PendingRuntimeID     pgtype.UUID        `json:"pending_runtime_id"`
+	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
+	AutopilotStatus      string             `json:"autopilot_status"`
+	AssigneeType         string             `json:"assignee_type"`
+	AssigneeID           pgtype.UUID        `json:"assignee_id"`
+	ExecutionMode        string             `json:"execution_mode"`
+}
+
+// MUL-2863: when a runtime transitions back to online, the runtime-comes-
+// online hook calls this with the runtime_id to walk the durable queue.
+// Oldest-first (per migration 111's partial index ordering) matches the
+// "oldest eligible run goes first" semantics: if a laptop was offline for
+// 8 hours and the cron was hourly, we dispatch the original 8 missing
+// runs in order rather than the newest, which is what a user looking at
+// the autopilot history would expect.
+//
+// JOIN to autopilot so the caller can re-validate the assignee's runtime
+// at dispatch time without a second round-trip per row, and so a paused
+// / archived autopilot short-circuits cleanly.
+func (q *Queries) ListPendingRuntimeAutopilotRunsForRuntime(ctx context.Context, arg ListPendingRuntimeAutopilotRunsForRuntimeParams) ([]ListPendingRuntimeAutopilotRunsForRuntimeRow, error) {
+	rows, err := q.db.Query(ctx, listPendingRuntimeAutopilotRunsForRuntime, arg.PendingRuntimeID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPendingRuntimeAutopilotRunsForRuntimeRow{}
+	for rows.Next() {
+		var i ListPendingRuntimeAutopilotRunsForRuntimeRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AutopilotID,
+			&i.TriggerID,
+			&i.Source,
+			&i.Status,
+			&i.IssueID,
+			&i.TaskID,
+			&i.TriggeredAt,
+			&i.CompletedAt,
+			&i.FailureReason,
+			&i.TriggerPayload,
+			&i.Result,
+			&i.CreatedAt,
+			&i.SquadID,
+			&i.PendingRuntimeID,
+			&i.AutopilotWorkspaceID,
+			&i.AutopilotStatus,
+			&i.AssigneeType,
+			&i.AssigneeID,
+			&i.ExecutionMode,
 		); err != nil {
 			return nil, err
 		}
@@ -876,13 +1114,14 @@ type SelectAutopilotsExceedingFailureThresholdRow struct {
 // Failure-rate auto-pause
 // =====================
 // Find active autopilots whose recent run failure rate exceeds the threshold.
-// Counts only "real" terminal runs (completed | failed). 'skipped' is
-// excluded from BOTH numerator and denominator: an admission-skipped run
-// (e.g. assignee runtime offline at dispatch time, MUL-1899) is neither a
-// success nor a failure, so it must not dilute the failure ratio (which
-// would let a 100%-failing autopilot mask itself behind a wall of skips)
-// nor inflate it. issue_created/running are still excluded so in-flight
-// work isn't penalised.
+// Counts only "real" terminal runs (completed | failed). 'skipped' and
+// 'pending_runtime' are both excluded from BOTH numerator and denominator:
+// an admission-skipped run (e.g. assignee agent hard-deleted, MUL-1899) and
+// a parked pending_runtime run (assignee runtime offline, MUL-2863) are
+// neither a success nor a failure, so neither must dilute the failure ratio
+// (which would let a 100%-failing autopilot mask itself behind a wall of
+// skips / parked runs) nor inflate it. issue_created/running are still
+// excluded so in-flight work isn't penalised.
 // Used by the failure monitor to auto-pause sustained-failure autopilots
 // (the canonical example from MUL-1336 was an autopilot scheduled every 5 min
 // that 100% failed for days, burning ~1.5k useless tasks per week).
@@ -1122,7 +1361,7 @@ const updateAutopilotRunCompleted = `-- name: UpdateAutopilotRunCompleted :one
 UPDATE autopilot_run
 SET status = 'completed', completed_at = now(), result = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunCompletedParams struct {
@@ -1148,6 +1387,7 @@ func (q *Queries) UpdateAutopilotRunCompleted(ctx context.Context, arg UpdateAut
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -1156,7 +1396,7 @@ const updateAutopilotRunFailed = `-- name: UpdateAutopilotRunFailed :one
 UPDATE autopilot_run
 SET status = 'failed', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunFailedParams struct {
@@ -1182,6 +1422,7 @@ func (q *Queries) UpdateAutopilotRunFailed(ctx context.Context, arg UpdateAutopi
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -1190,7 +1431,7 @@ const updateAutopilotRunIssueCreated = `-- name: UpdateAutopilotRunIssueCreated 
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunIssueCreatedParams struct {
@@ -1216,6 +1457,7 @@ func (q *Queries) UpdateAutopilotRunIssueCreated(ctx context.Context, arg Update
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -1224,7 +1466,7 @@ const updateAutopilotRunRunning = `-- name: UpdateAutopilotRunRunning :one
 UPDATE autopilot_run
 SET status = 'running', task_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunRunningParams struct {
@@ -1250,6 +1492,7 @@ func (q *Queries) UpdateAutopilotRunRunning(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -1258,7 +1501,7 @@ const updateAutopilotRunSkipped = `-- name: UpdateAutopilotRunSkipped :one
 UPDATE autopilot_run
 SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunSkippedParams struct {
@@ -1290,6 +1533,7 @@ func (q *Queries) UpdateAutopilotRunSkipped(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }
@@ -1301,7 +1545,7 @@ SET status = 'skipped',
     failure_reason = $2,
     result = $3
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, pending_runtime_id
 `
 
 type UpdateAutopilotRunSkippedWithResultParams struct {
@@ -1328,6 +1572,7 @@ func (q *Queries) UpdateAutopilotRunSkippedWithResult(ctx context.Context, arg U
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PendingRuntimeID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -134,20 +134,21 @@ type Autopilot struct {
 }
 
 type AutopilotRun struct {
-	ID             pgtype.UUID        `json:"id"`
-	AutopilotID    pgtype.UUID        `json:"autopilot_id"`
-	TriggerID      pgtype.UUID        `json:"trigger_id"`
-	Source         string             `json:"source"`
-	Status         string             `json:"status"`
-	IssueID        pgtype.UUID        `json:"issue_id"`
-	TaskID         pgtype.UUID        `json:"task_id"`
-	TriggeredAt    pgtype.Timestamptz `json:"triggered_at"`
-	CompletedAt    pgtype.Timestamptz `json:"completed_at"`
-	FailureReason  pgtype.Text        `json:"failure_reason"`
-	TriggerPayload []byte             `json:"trigger_payload"`
-	Result         []byte             `json:"result"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	SquadID        pgtype.UUID        `json:"squad_id"`
+	ID               pgtype.UUID        `json:"id"`
+	AutopilotID      pgtype.UUID        `json:"autopilot_id"`
+	TriggerID        pgtype.UUID        `json:"trigger_id"`
+	Source           string             `json:"source"`
+	Status           string             `json:"status"`
+	IssueID          pgtype.UUID        `json:"issue_id"`
+	TaskID           pgtype.UUID        `json:"task_id"`
+	TriggeredAt      pgtype.Timestamptz `json:"triggered_at"`
+	CompletedAt      pgtype.Timestamptz `json:"completed_at"`
+	FailureReason    pgtype.Text        `json:"failure_reason"`
+	TriggerPayload   []byte             `json:"trigger_payload"`
+	Result           []byte             `json:"result"`
+	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	SquadID          pgtype.UUID        `json:"squad_id"`
+	PendingRuntimeID pgtype.UUID        `json:"pending_runtime_id"`
 }
 
 type AutopilotTrigger struct {

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -214,6 +214,80 @@ SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
 RETURNING *;
 
+-- name: CreateAutopilotRunPendingRuntime :one
+-- MUL-2863: durable dispatch when the runtime is offline. The cron tick
+-- creates a run row in 'pending_runtime' (terminal-state-equivalent) and
+-- records which runtime it's queued behind. When the runtime comes back
+-- online, the runtime-comes-online hook re-dispatches the oldest pending
+-- run. This is the durable alternative to UpdateAutopilotRunSkipped: rather
+-- than recording a "we deliberately dropped this" outcome, we record a
+-- "we evaluated the trigger and parked it for later" outcome.
+--
+-- Mapped to the agent on whose bound runtime we're waiting, so the
+-- runtime-comes-online path can fan out across agents on the same
+-- runtime without an extra join. NULL is fine (offline agent with no
+-- runtime bound — see MUL-1899's "agent has no runtime bound" branch)
+-- because the agent-resolution re-check at dispatch time catches that
+-- case and fails closed.
+INSERT INTO autopilot_run (
+    autopilot_id, trigger_id, source, status, trigger_payload,
+    squad_id, failure_reason, pending_runtime_id
+) VALUES (
+    $1, sqlc.narg('trigger_id'), $2, 'pending_runtime',
+    sqlc.narg('trigger_payload'), sqlc.narg('squad_id'),
+    $3, $4
+) RETURNING *;
+
+-- name: ListPendingRuntimeAutopilotRunsForRuntime :many
+-- MUL-2863: when a runtime transitions back to online, the runtime-comes-
+-- online hook calls this with the runtime_id to walk the durable queue.
+-- Oldest-first (per migration 111's partial index ordering) matches the
+-- "oldest eligible run goes first" semantics: if a laptop was offline for
+-- 8 hours and the cron was hourly, we dispatch the original 8 missing
+-- runs in order rather than the newest, which is what a user looking at
+-- the autopilot history would expect.
+--
+-- JOIN to autopilot so the caller can re-validate the assignee's runtime
+-- at dispatch time without a second round-trip per row, and so a paused
+-- / archived autopilot short-circuits cleanly.
+SELECT r.*, a.workspace_id AS autopilot_workspace_id,
+       a.status AS autopilot_status, a.assignee_type, a.assignee_id,
+       a.execution_mode
+FROM autopilot_run r
+JOIN autopilot a ON a.id = r.autopilot_id
+WHERE r.pending_runtime_id = $1
+  AND r.status = 'pending_runtime'
+  AND a.status = 'active'
+ORDER BY r.triggered_at ASC
+LIMIT $2;
+
+-- name: ClearAutopilotRunPendingRuntime :one
+-- MUL-2863: when a 'pending_runtime' run is dispatched (or otherwise
+-- transitioned to a non-pending status), clear pending_runtime_id so a
+-- stale value can't keep matching future ListPendingRuntimeAutopilotRunsForRuntime
+-- calls. Failure_reason and completed_at are deliberately NOT touched
+-- here: callers transition the status themselves (UpdateAutopilotRunIssueCreated
+-- / UpdateAutopilotRunRunning / UpdateAutopilotRunSkipped) and own those
+-- columns. The dispatcher composes the two updates: this one to clear the
+-- queue pointer, the status-specific one to finalize.
+UPDATE autopilot_run
+SET pending_runtime_id = NULL
+WHERE id = $1
+  AND status = 'pending_runtime'
+RETURNING *;
+
+-- name: GetAutopilotByRunID :one
+-- MUL-2863: reverse lookup for the runtime-comes-online skip-transition
+-- path. The dispatch loop holds a run row and needs the parent autopilot
+-- (and its workspace_id) to publish a run:done event; loading the autopilot
+-- directly via the run's autopilot_id saves a join. Used only on the
+-- transitionPendingToSkipped hot path; happy-path dispatch re-uses the
+-- autopilot already loaded in DispatchPendingRuntimeRunsForRuntime.
+SELECT a.*
+FROM autopilot a
+JOIN autopilot_run r ON r.autopilot_id = a.id
+WHERE r.id = $1;
+
 -- name: UpdateAutopilotRunSkippedWithResult :one
 UPDATE autopilot_run
 SET status = 'skipped',
@@ -290,13 +364,14 @@ WHERE t.kind = 'schedule'
 
 -- name: SelectAutopilotsExceedingFailureThreshold :many
 -- Find active autopilots whose recent run failure rate exceeds the threshold.
--- Counts only "real" terminal runs (completed | failed). 'skipped' is
--- excluded from BOTH numerator and denominator: an admission-skipped run
--- (e.g. assignee runtime offline at dispatch time, MUL-1899) is neither a
--- success nor a failure, so it must not dilute the failure ratio (which
--- would let a 100%-failing autopilot mask itself behind a wall of skips)
--- nor inflate it. issue_created/running are still excluded so in-flight
--- work isn't penalised.
+-- Counts only "real" terminal runs (completed | failed). 'skipped' and
+-- 'pending_runtime' are both excluded from BOTH numerator and denominator:
+-- an admission-skipped run (e.g. assignee agent hard-deleted, MUL-1899) and
+-- a parked pending_runtime run (assignee runtime offline, MUL-2863) are
+-- neither a success nor a failure, so neither must dilute the failure ratio
+-- (which would let a 100%-failing autopilot mask itself behind a wall of
+-- skips / parked runs) nor inflate it. issue_created/running are still
+-- excluded so in-flight work isn't penalised.
 -- Used by the failure monitor to auto-pause sustained-failure autopilots
 -- (the canonical example from MUL-1336 was an autopilot scheduled every 5 min
 -- that 100% failed for days, burning ~1.5k useless tasks per week).


### PR DESCRIPTION
Implements multica-ai/multica#3549 — durable dispatch for cron-triggered autopilots when the assignee agent's runtime is offline at the cron fire time.

## Problem
Cron-triggered autopilots were silently dropped when the assignee agent's runtime was offline at the scheduled time, with the message 'agent runtime is offline at dispatch time' and a skipped run row. For users whose laptop sleeps, restarts, or loses connectivity at the cron fire time, this means scheduled work is silently lost.

## Fix
- New pending_runtime status for autopilot_run (with pending_runtime_id tracking which runtime the run is queued behind). Distinguished from the existing skipped status so the user can see 'we did evaluate the trigger and parked it' vs. 'we deliberately dropped it'.
- Service recordPendingRuntimeRun writes a parked run instead of a skipped one when the admission failure is runtime-offline. All other admission failures (agent archived, squad archived, no runtime bound, private-agent gate) still take the legacy skipped path.
- Service DispatchPendingRuntimeRunsForRuntime drains the queue when a runtime comes online, re-validating the admission gate per run, oldest first.
- Hook points in DaemonRegister (new runtime row / upsert on a re-registered runtime) and recordHeartbeat (the offline→online flip path) call the durable-dispatch hook after a successful DB write.
- Webhook ingress surfaces pending_runtime as a distinct response shape ({status: pending_runtime, run_id, reason}).
- Frontend: AutopilotRunStatus union includes pending_runtime. The run history renders a separate PendingRuntimeRunsGroup ('Waiting for runtime') between the active rows and the muted SkippedRunsGroup, so the user reads parked-but-waiting as a first-class state, not a failure.
- i18n: pending_runtime status label + tooltip in en/zh-Hans/ko.
- Tests: durable-dispatch contract locked in (TestAutopilotDispatchParksWhenRuntimeOffline, TestDispatchPendingRuntimeRunsForRuntime, TestDispatchPendingRuntimeRunsKeepsPendingWhenStillOffline); legacy TestAutopilotDispatchSkipsWhenRuntimeOffline renamed and updated to assert the new pending_runtime outcome; helper isRuntimeOfflineAdmissionReason has its own unit test.

## Design notes
- For create_issue autopilots, the issue is not pre-created at the cron fire time; the full issue-creation + task-enqueue happens when the runtime comes back online. This keeps the dispatch path uniform across both execution modes and avoids a 'stuck issue with no task' state during long offline windows.
- Failure-rate auto-pause monitor (SelectAutopilotsExceedingFailureThreshold) already filters to completed | failed runs, so pending_runtime runs do not pollute the failure ratio.
- Manual triggers (handler/autopilot.go) get the same treatment as cron triggers: a manual trigger on an offline-runtime autopilot parks the run instead of returning a 500. PR #2888's 'no 500 on post-admission skip' guarantee still holds.
- No FK on pending_runtime_id → agent_runtime(id): the runtime row can be GC'd while a run is still pending (offlineRuntimeTTLSeconds), and the run should keep surfacing in the UI as 'Waiting for runtime' until the user manually re-triggers.