### PR TITLE
fix(agents): surface archived status for retired agents (MUL-2892)

### DIFF
--- a/apps/mobile/components/ui/presence-dot.tsx
+++ b/apps/mobile/components/ui/presence-dot.tsx
@@ -29,6 +29,9 @@ const DOT_CLASS: Record<AgentAvailability, string> = {
   online: "bg-success",
   unstable: "bg-warning",
   offline: "bg-muted-foreground/40",
+  // Retired agent (agent.archived_at set) — gray, mirrors web's archived dot
+  // in packages/views/agents/presence.ts.
+  archived: "bg-muted-foreground/40",
 };
 
 export function PresenceDot({ availability, size = 8 }: Props) {

--- a/packages/core/agents/derive-presence.test.ts
+++ b/packages/core/agents/derive-presence.test.ts
@@ -345,6 +345,24 @@ describe("deriveAgentPresenceDetail", () => {
     });
     expect(detail.capacity).toBe(3);
   });
+
+  it("reports archived over any runtime/task signal for an archived agent", () => {
+    // Archived wins over presence: a leftover online runtime and a running
+    // task must never make a retired agent read as live. Availability
+    // collapses to "archived" and workload is forced idle with zero counts
+    // so no consumer (dot, hover card, list row) can surface "Online" or
+    // "Working" for an archived agent.
+    const detail = deriveAgentPresenceDetail({
+      agent: makeAgent({ archived_at: "2026-04-27T10:00:00Z" }),
+      runtime: makeRuntime(),
+      tasks: [makeTask({ status: "running" })],
+      now: NOW,
+    });
+    expect(detail.availability).toBe("archived");
+    expect(detail.workload).toBe("idle");
+    expect(detail.runningCount).toBe(0);
+    expect(detail.queuedCount).toBe(0);
+  });
 });
 
 describe("buildPresenceMap", () => {

--- a/packages/core/agents/derive-presence.ts
+++ b/packages/core/agents/derive-presence.ts
@@ -94,6 +94,20 @@ interface DerivePresenceInput {
 }
 
 export function deriveAgentPresenceDetail(input: DerivePresenceInput): AgentPresenceDetail {
+  // Archived wins over every runtime/task signal — a retired agent must
+  // never read as live anywhere. Short-circuit before deriving runtime
+  // health or workload so a leftover online runtime row or a stale snapshot
+  // task can't leak "Online" / "Working" into any consumer.
+  if (input.agent.archived_at) {
+    return {
+      availability: "archived",
+      workload: "idle",
+      runningCount: 0,
+      queuedCount: 0,
+      capacity: input.agent.max_concurrent_tasks,
+    };
+  }
+
   const availability = deriveAgentAvailability(input.runtime, input.now);
   const detail = deriveWorkloadDetail(input.tasks);
 

--- a/packages/core/agents/types.ts
+++ b/packages/core/agents/types.ts
@@ -27,10 +27,19 @@
 // during the runtime sweeper's grace window (offline < 5 min); it decays
 // into `offline` with no new server data, hence the 30s presence tick on
 // the consuming hooks.
+//
+// `archived` is the one non-runtime value: it reflects the agent's lifecycle
+// (agent.archived_at is set), not its runtime. It is the top-priority state —
+// derived BEFORE runtime health in deriveAgentPresenceDetail — so a retired
+// agent with a leftover online runtime row never reads as live. Every dot /
+// label that maps from this union (availabilityConfig) renders it for free;
+// it is intentionally NOT in availabilityOrder (archived agents have their
+// own list view, not an availability filter chip).
 export type AgentAvailability =
   | "online" // 🟢 runtime online and reachable
   | "unstable" // 🟡 runtime recently_lost (< 5 min) — transient
-  | "offline"; // ⚫ runtime long offline / missing / never registered
+  | "offline" // ⚫ runtime long offline / missing / never registered
+  | "archived"; // ⚫ agent.archived_at set — retired, wins over runtime health
 
 // Current task load on this agent. Three states — never historical,
 // never an error predictor (Inbox + Recent Work handle that):

--- a/packages/core/types/squad.ts
+++ b/packages/core/types/squad.ts
@@ -85,12 +85,17 @@ export interface CreateSquadActivityLogRequest {
   details?: unknown;
 }
 
-// SquadMemberStatus mirrors the four-way bucket the back-end derives in
+// SquadMemberStatus mirrors the five-way bucket the back-end derives in
 // handler/squad.go::deriveSquadMemberStatus. Kept as a string union here
 // (rather than re-derived from snapshot data) so the squad page can render
 // the freshest server-side judgement without re-fetching the agent
-// snapshot / runtime list.
-export type SquadMemberStatusValue = "working" | "idle" | "offline" | "unstable";
+// snapshot / runtime list. `archived` wins over every runtime/task signal.
+export type SquadMemberStatusValue =
+  | "working"
+  | "idle"
+  | "offline"
+  | "unstable"
+  | "archived";
 
 export interface SquadActiveIssueBrief {
   issue_id: string;

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -650,6 +650,10 @@ function PresenceBadge({
   presence: AgentPresenceDetail | null | undefined;
 }) {
   const { t } = useT("agents");
+  // Archived is carried by the unified presence (deriveAgentPresenceDetail
+  // sets availability="archived" before any runtime/task scan), so the
+  // normal path below renders the gray "Archived" badge with no special
+  // case here — same single source of truth as every other status surface.
   if (!presence) {
     return (
       <span className="inline-flex h-5 w-20 animate-pulse rounded-md bg-muted" />

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -374,7 +374,7 @@ function DetailHeader({
       leaf={
         <>
           <h1 className="min-w-0 truncate text-sm font-medium text-foreground">{agent.name}</h1>
-          {!isArchived && av && presence && (
+          {av && presence && (
             <span
               className={`inline-flex shrink-0 items-center gap-1.5 rounded-md border px-1.5 py-0.5 text-xs ${av.textClass}`}
             >

--- a/packages/views/agents/components/agent-live-peek-card.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.tsx
@@ -16,7 +16,7 @@ import type { AgentTask } from "@multica/core/types";
 import { AlertTriangle } from "lucide-react";
 import { AppLink } from "../../navigation";
 import { useT, useTimeAgo } from "../../i18n";
-import { workloadConfig } from "../presence";
+import { availabilityConfig, workloadConfig } from "../presence";
 
 interface AgentLivePeekCardProps {
   agentId: string;
@@ -73,8 +73,14 @@ export function AgentLivePeekCard({ agentId }: AgentLivePeekCardProps) {
     .toUpperCase()
     .slice(0, 2);
 
+  // Archived wins over workload — a retired agent reads "Archived", never
+  // "Idle"/"Working". availability is the unified signal (see
+  // deriveAgentPresenceDetail); for archived it's set before any task scan.
+  const isArchived =
+    presence !== "loading" && presence.availability === "archived";
   const workload = presence === "loading" ? null : presence.workload;
   const workloadVisual = workload ? workloadConfig[workload] : null;
+  const archivedVisual = availabilityConfig.archived;
 
   return (
     <div className="flex flex-col gap-3 text-left">
@@ -91,7 +97,16 @@ export function AgentLivePeekCard({ agentId }: AgentLivePeekCardProps) {
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold">{agent.name}</p>
           <div className="mt-0.5 inline-flex items-center gap-1.5">
-            {workloadVisual ? (
+            {isArchived ? (
+              <>
+                <archivedVisual.icon
+                  className={`h-3 w-3 shrink-0 ${archivedVisual.textClass}`}
+                />
+                <span className={`text-xs ${archivedVisual.textClass}`}>
+                  {t(($) => $.availability.archived)}
+                </span>
+              </>
+            ) : workloadVisual ? (
               <>
                 <workloadVisual.icon
                   className={`h-3 w-3 shrink-0 ${workloadVisual.textClass}`}

--- a/packages/views/agents/components/agent-presence-indicator.tsx
+++ b/packages/views/agents/components/agent-presence-indicator.tsx
@@ -82,7 +82,9 @@ export function AgentPresenceIndicator({
           All three workload states render here for symmetry: idle gets
           its own "Idle" label so the difference between "no presence
           data" (no chip at all) and "agent is idle" (explicit Idle chip)
-          is visible. */}
+          is visible. Archived agents skip the workload chip entirely —
+          "Archived" already says everything; "Archived · Idle" is noise. */}
+      {detail.availability !== "archived" && (
       <span className="inline-flex items-center gap-1">
         <span className="text-xs text-muted-foreground">·</span>
         <span
@@ -111,6 +113,7 @@ export function AgentPresenceIndicator({
           </span>
         )}
       </span>
+      )}
     </span>
   );
 }

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -367,6 +367,9 @@ export function AgentsPage({
       online: 0,
       unstable: 0,
       offline: 0,
+      // Active-view scope excludes archived agents, so this bucket stays 0
+      // here; present only to satisfy the exhaustive availability Record.
+      archived: 0,
     };
     for (const a of inScopeOnMachine) {
       const detail = presenceMap.get(a.id);

--- a/packages/views/agents/presence.ts
+++ b/packages/views/agents/presence.ts
@@ -1,5 +1,6 @@
 import {
   AlertCircle,
+  Archive,
   CircleDot,
   CircleSlash,
   Clock,
@@ -61,6 +62,15 @@ export const availabilityConfig: Record<AgentAvailability, AvailabilityVisual> =
     dotClass: "bg-muted-foreground/40",
     textClass: "text-muted-foreground",
     icon: CircleSlash,
+  },
+  // Lifecycle state, not a runtime state — a retired agent. Gray like
+  // offline (it can't take work) but labelled distinctly so the user reads
+  // "this agent is archived", not "temporarily unreachable".
+  archived: {
+    label: "Archived",
+    dotClass: "bg-muted-foreground/40",
+    textClass: "text-muted-foreground",
+    icon: Archive,
   },
 };
 

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -25,7 +25,8 @@
     "all": "All",
     "online": "Online",
     "unstable": "Unstable",
-    "offline": "Offline"
+    "offline": "Offline",
+    "archived": "Archived"
   },
   "workload": {
     "working": "Working",

--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -53,6 +53,7 @@
     "status_idle": "Idle",
     "status_offline": "Offline",
     "status_unstable": "Unstable",
+    "status_archived": "Archived",
     "issue_status_blocked": "blocked",
     "active_issue_more": "and {{count}} more",
     "last_active_label": "last active {{time}}"

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -25,7 +25,8 @@
     "all": "전체",
     "online": "온라인",
     "unstable": "불안정",
-    "offline": "오프라인"
+    "offline": "오프라인",
+    "archived": "보관됨"
   },
   "workload": {
     "working": "작업 중",

--- a/packages/views/locales/ko/squads.json
+++ b/packages/views/locales/ko/squads.json
@@ -53,6 +53,7 @@
     "status_idle": "유휴",
     "status_offline": "오프라인",
     "status_unstable": "불안정",
+    "status_archived": "보관됨",
     "issue_status_blocked": "막힘",
     "active_issue_more": "외 {{count}}개",
     "last_active_label": "마지막 활동 {{time}}"

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -25,7 +25,8 @@
     "all": "全部",
     "online": "在线",
     "unstable": "不稳定",
-    "offline": "离线"
+    "offline": "离线",
+    "archived": "已归档"
   },
   "workload": {
     "working": "处理中",

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -53,6 +53,7 @@
     "status_idle": "空闲",
     "status_offline": "离线",
     "status_unstable": "不稳定",
+    "status_archived": "已归档",
     "issue_status_blocked": "已阻塞",
     "active_issue_more": "还有 {{count}} 个",
     "last_active_label": "最近活动 {{time}}"

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -60,7 +60,7 @@ import {
 } from "../../issues/components/pickers/property-picker";
 import { ChevronDown, UserPlus } from "lucide-react";
 import { toast } from "sonner";
-import type { Squad, SquadMember, SquadMemberStatus, Agent, CreateAgentRequest, MemberWithUser } from "@multica/core/types";
+import type { Squad, SquadMember, SquadMemberStatus, SquadMemberStatusValue, Agent, CreateAgentRequest, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
@@ -212,6 +212,8 @@ export function SquadDetailPage() {
   const availableAgents = agents.filter((a: Agent) => !a.archived_at && !members.some((m) => m.member_type === "agent" && m.member_id === a.id));
   const availableMembers = wsMembers.filter((m) => !members.some((sm) => sm.member_type === "member" && sm.member_id === m.user_id));
   const isLeader = (m: SquadMember) => m.member_type === "agent" && squad.leader_id === m.member_id;
+  const isArchived = (m: SquadMember) =>
+    m.member_type === "agent" && !!agents.find((a: Agent) => a.id === m.member_id)?.archived_at;
 
   const initials = squad.name
     .split(" ")
@@ -258,6 +260,7 @@ export function SquadDetailPage() {
           members={members}
           memberStatusById={memberStatusById}
           isLeader={isLeader}
+          isArchived={isArchived}
           getEntityName={getEntityName}
           onAddMemberClick={() => setShowAddMember(true)}
           onCreateAgentClick={isWorkspaceAdmin ? () => setShowCreateAgent(true) : undefined}
@@ -1001,6 +1004,7 @@ function SquadOverviewPane({
   members,
   memberStatusById,
   isLeader,
+  isArchived,
   getEntityName,
   onAddMemberClick,
   onCreateAgentClick,
@@ -1014,6 +1018,7 @@ function SquadOverviewPane({
   members: SquadMember[];
   memberStatusById: Map<string, SquadMemberStatus>;
   isLeader: (m: SquadMember) => boolean;
+  isArchived: (m: SquadMember) => boolean;
   getEntityName: (type: string, id: string) => string;
   onAddMemberClick: () => void;
   // Optional — only passed when the current user can manage the squad
@@ -1072,6 +1077,7 @@ function SquadOverviewPane({
               members={members}
               memberStatusById={memberStatusById}
               isLeader={isLeader}
+              isArchived={isArchived}
               getEntityName={getEntityName}
               onAddMemberClick={onAddMemberClick}
               onCreateAgentClick={onCreateAgentClick}
@@ -1121,11 +1127,12 @@ function SquadOverviewPane({
 // Unknown / null statuses (human members, server-side enum drift) render as
 // a neutral muted pill; this is the "downgrade, don't crash" defense from
 // CLAUDE.md > API Response Compatibility.
-const SQUAD_STATUS_DOT_CLASS: Record<"working" | "idle" | "offline" | "unstable", string> = {
+const SQUAD_STATUS_DOT_CLASS: Record<SquadMemberStatusValue, string> = {
   working: "bg-success",
   idle: "bg-muted-foreground/40",
   offline: "bg-muted-foreground/40",
   unstable: "bg-warning",
+  archived: "bg-muted-foreground/40",
 };
 
 // Members tab body — re-uses the existing list/role editing patterns.
@@ -1133,6 +1140,7 @@ function SquadMembersTab({
   members,
   memberStatusById,
   isLeader,
+  isArchived,
   getEntityName,
   onAddMemberClick,
   onCreateAgentClick,
@@ -1144,6 +1152,7 @@ function SquadMembersTab({
   members: SquadMember[];
   memberStatusById: Map<string, SquadMemberStatus>;
   isLeader: (m: SquadMember) => boolean;
+  isArchived: (m: SquadMember) => boolean;
   getEntityName: (type: string, id: string) => string;
   onAddMemberClick: () => void;
   // Hidden for non-admins — see SquadOverviewPane.
@@ -1192,6 +1201,7 @@ function SquadMembersTab({
               : statusValue === "idle" ? t(($) => $.members_tab.status_idle)
               : statusValue === "offline" ? t(($) => $.members_tab.status_offline)
               : statusValue === "unstable" ? t(($) => $.members_tab.status_unstable)
+              : statusValue === "archived" ? t(($) => $.members_tab.status_archived)
               : null;
           const activeIssues = status?.active_issues ?? [];
           const primaryIssue = activeIssues[0];
@@ -1280,7 +1290,7 @@ function SquadMembersTab({
                   </TooltipContent>
                 </Tooltip>
               )}
-              {m.member_type === "agent" && !isLeader(m) && (
+              {m.member_type === "agent" && !isLeader(m) && !isArchived(m) && (
                 <Tooltip>
                   <TooltipTrigger
                     render={

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -474,9 +474,11 @@ type SquadMemberStatusListResponse struct {
 // last_seen_at is within the last 5 minutes is reported as "unstable" so
 // the squad UI surfaces transient drops the same way the agent dot does.
 //
-// Archived agents always report `offline` regardless of any leftover
+// Archived agents always report `archived` regardless of any leftover
 // runtime row or task — they should appear in the list but never look
-// like they're still working. Per the RFC decision (see MUL-2319), we
+// like they're still working or merely offline (a leftover online
+// runtime row would otherwise read as "offline" and hide the fact that
+// the agent has been archived). Per the RFC decision (see MUL-2319), we
 // surface archived agents in this endpoint rather than filtering them
 // out in the SQL.
 func deriveSquadMemberStatus(
@@ -487,7 +489,7 @@ func deriveSquadMemberStatus(
 	now time.Time,
 ) string {
 	if archived {
-		return "offline"
+		return "archived"
 	}
 	if hasActiveTask {
 		return "working"

--- a/server/internal/handler/squad_member_status_test.go
+++ b/server/internal/handler/squad_member_status_test.go
@@ -33,12 +33,12 @@ func TestDeriveSquadMemberStatus(t *testing.T) {
 		{"offline runtime, stale heartbeat", false, offline, tsAgo(2 * time.Hour), false, "offline"},
 		{"offline runtime, no heartbeat", false, offline, tsNone, false, "offline"},
 		{"no runtime row", false, missing, tsNone, false, "offline"},
-		// Archived agents always report offline regardless of any leftover
+		// Archived agents always report archived regardless of any leftover
 		// runtime row or task — they should appear in the squad listing
-		// but never look like they're still working.
-		{"archived agent with active task", true, online, tsAgo(time.Second), true, "offline"},
-		{"archived agent with online runtime", true, online, tsAgo(time.Second), false, "offline"},
-		{"archived agent already offline", true, offline, tsAgo(time.Hour), false, "offline"},
+		// but never look like they're still working or merely offline.
+		{"archived agent with active task", true, online, tsAgo(time.Second), true, "archived"},
+		{"archived agent with online runtime", true, online, tsAgo(time.Second), false, "archived"},
+		{"archived agent already offline", true, offline, tsAgo(time.Hour), false, "archived"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What does this PR do?

Retired agents (`agent.archived_at` set) previously read as **Offline** across the agent presence dot, live peek card, detail badge, and squad member list — and because status was derived from runtime health, a leftover online runtime row or a stale snapshot task could make a retired agent read as **Online / Working**, i.e. still live.

This PR adds a dedicated **`archived`** presence/status value that is derived *before* any runtime/task scan, so it wins over every runtime signal. A retired agent now consistently reads "Archived" everywhere and can never surface as live or merely offline.

## Related Issue

Closes #3607

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/core/agents/types.ts` — add `archived` to the `AgentAvailability` union (top-priority, lifecycle not runtime).
- `packages/core/agents/derive-presence.ts` — short-circuit `deriveAgentPresenceDetail` when `archived_at` is set: returns `availability: "archived"`, `workload: "idle"`, zero counts.
- `packages/core/types/squad.ts` — add `archived` to `SquadMemberStatusValue` (five-way bucket).
- `server/internal/handler/squad.go` — `deriveSquadMemberStatus` returns `"archived"` instead of `"offline"` for archived agents.
- `packages/views/agents/presence.ts` — `availabilityConfig.archived` gray dot/label with `Archive` icon.
- `packages/views/agents/components/*` — render archived in peek card, detail badge, presence indicator (skips redundant workload chip); `agents-page` exhaustive bucket.
- `packages/views/squads/components/squad-detail-page.tsx` — archived dot, status label, and hide reassign affordance for archived members.
- `apps/mobile/components/ui/presence-dot.tsx` — archived dot (mirrors web).
- `packages/views/locales/{en,ko,zh-Hans}/{agents,squads}.json` — `Archived` strings.
- Tests: `derive-presence.test.ts` and `squad_member_status_test.go` assert archived wins over an online runtime + running task.

## How to Test

1. Create an agent, bring its runtime online (or give it an in-flight task).
2. Archive the agent.
3. Open the Agents page, agent detail, and the squad member list.
4. Verify the agent reads **Archived** (gray, archive icon) everywhere — never Online/Working/Offline — and the reassign affordance is hidden in the squad list.
5. `pnpm --filter @multica/core --filter @multica/views typecheck`, `pnpm --filter @multica/mobile typecheck`, and `go test ./internal/handler/ -run TestDeriveSquadMemberStatus` all pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Implemented a dedicated `archived` presence/status that short-circuits before runtime derivation on both the TS presence pipeline and the Go squad-status handler, with matching tests and a security review of the diff.
