### PR TITLE
feat(cli): add --all and --latest flags to runtime update command

### DIFF
--- a/server/cmd/multica/cmd_runtime.go
+++ b/server/cmd/multica/cmd_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -37,9 +38,9 @@ var runtimeActivityCmd = &cobra.Command{
 }
 
 var runtimeUpdateCmd = &cobra.Command{
-	Use:   "update <runtime-id>",
+	Use:   "update [runtime-id]",
 	Short: "Initiate a CLI update on a runtime",
-	Args:  exactArgs(1),
+	Args:  maximumNArgs(1),
 	RunE:  runRuntimeUpdate,
 }
 
@@ -60,9 +61,11 @@ func init() {
 	runtimeActivityCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// runtime update
-	runtimeUpdateCmd.Flags().String("target-version", "", "Target version to update to (required)")
+	runtimeUpdateCmd.Flags().String("target-version", "", "Target version to update to (required without --latest)")
 	runtimeUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 	runtimeUpdateCmd.Flags().Bool("wait", false, "Wait for update to complete (poll until done)")
+	runtimeUpdateCmd.Flags().Bool("latest", false, "Fetch the latest release from GitHub and use it as target version")
+	runtimeUpdateCmd.Flags().Bool("all", false, "Update all runtimes in the workspace (mutually exclusive with runtime-id)")
 }
 
 // ---------------------------------------------------------------------------
@@ -184,57 +187,191 @@ func runRuntimeUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	targetVersion, _ := cmd.Flags().GetString("target-version")
-	if targetVersion == "" {
-		return fmt.Errorf("--target-version is required")
+	latest, _ := cmd.Flags().GetBool("latest")
+	all, _ := cmd.Flags().GetBool("all")
+
+	// Resolve target version.
+	if latest {
+		rel, err := cli.FetchLatestRelease()
+		if err != nil {
+			return fmt.Errorf("fetch latest release: %w", err)
+		}
+		targetVersion = rel.TagName
+	} else if targetVersion == "" {
+		return fmt.Errorf("one of --target-version or --latest is required")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
-	defer cancel()
+	// Collect runtime IDs.
+	var runtimeIDs []string
+	if all {
+		if len(args) == 1 {
+			return fmt.Errorf("--all is mutually exclusive with specifying a runtime-id")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 
-	body := map[string]any{
-		"target_version": targetVersion,
-	}
+		var runtimes []map[string]any
+		if err := client.GetJSON(ctx, "/api/runtimes", &runtimes); err != nil {
+			return fmt.Errorf("list runtimes: %w", err)
+		}
 
-	var update map[string]any
-	if err := client.PostJSON(ctx, "/api/runtimes/"+args[0]+"/update", body, &update); err != nil {
-		return fmt.Errorf("initiate update: %w", err)
+		for _, rt := range runtimes {
+			id, ok := rt["id"].(string)
+			if !ok || id == "" {
+				continue
+			}
+			runtimeIDs = append(runtimeIDs, id)
+		}
+
+		if len(runtimeIDs) == 0 {
+			fmt.Fprintln(os.Stderr, "No runtimes found in workspace.")
+			return nil
+		}
+	} else {
+		if len(args) != 1 {
+			return fmt.Errorf("exactly one runtime-id is required when not using --all")
+		}
+		runtimeIDs = append(runtimeIDs, args[0])
 	}
 
 	wait, _ := cmd.Flags().GetBool("wait")
-	if !wait {
-		output, _ := cmd.Flags().GetString("output")
-		if output == "json" {
-			return cli.PrintJSON(os.Stdout, update)
+	output, _ := cmd.Flags().GetString("output")
+
+	// Track updates across all runtimes for --wait mode.
+	type updateInfo struct {
+		runtimeID string
+		updateID  string
+		update    map[string]any
+	}
+
+	var pending []updateInfo
+	results := make([]updateInfo, 0, len(runtimeIDs))
+
+	for _, rtID := range runtimeIDs {
+		postCtx, postCancel := context.WithTimeout(context.Background(), 150*time.Second)
+		body := map[string]any{
+			"target_version": strings.TrimPrefix(targetVersion, "v"),
 		}
-		fmt.Printf("Update initiated: %s (status: %s)\n", strVal(update, "id"), strVal(update, "status"))
+
+		var update map[string]any
+		if err := client.PostJSON(postCtx, "/api/runtimes/"+rtID+"/update", body, &update); err != nil {
+			postCancel()
+			results = append(results, updateInfo{runtimeID: rtID, update: map[string]any{"error": err.Error()}})
+			continue
+		}
+		postCancel()
+
+		updateID := strVal(update, "id")
+
+		if !wait {
+			results = append(results, updateInfo{runtimeID: rtID, updateID: updateID, update: update})
+		} else {
+			pending = append(pending, updateInfo{runtimeID: rtID, updateID: updateID, update: update})
+		}
+	}
+
+	// Poll updates in --wait mode.
+	if wait && len(pending) > 0 {
+		pollCtx, pollCancel := context.WithTimeout(context.Background(), 150*time.Second)
+		defer pollCancel()
+
+		var completed, failed, timedOut int
+		done := make(map[string]bool)
+
+		for len(done) < len(pending) {
+			select {
+			case <-pollCtx.Done():
+				// Mark remaining as timed out.
+				for _, u := range pending {
+					if !done[u.updateID] {
+						timedOut++
+						u.update["status"] = "timeout"
+						u.update["error"] = "timed out waiting for update"
+						done[u.updateID] = true
+						results = append(results, u)
+					}
+				}
+				break
+			case <-time.After(2 * time.Second):
+				for _, u := range pending {
+					if done[u.updateID] {
+						continue
+					}
+
+					var update map[string]any
+					if err := client.GetJSON(pollCtx, "/api/runtimes/"+u.runtimeID+"/update/"+u.updateID, &update); err != nil {
+						// Polling failed, try next round.
+						continue
+					}
+
+					status := strVal(update, "status")
+					if status == "completed" || status == "failed" || status == "timeout" {
+						done[u.updateID] = true
+						if status == "completed" {
+							completed++
+						} else if status == "failed" {
+							failed++
+						} else {
+							timedOut++
+						}
+						results = append(results, updateInfo{runtimeID: u.runtimeID, updateID: u.updateID, update: update})
+					}
+				}
+			}
+		}
+
+		// Print summary.
+		if output == "json" {
+			type summaryEntry struct {
+				RuntimeID string `json:"runtime_id"`
+				UpdateID  string `json:"update_id"`
+				Status    string `json:"status"`
+				Output    string `json:"output,omitempty"`
+				Error     string `json:"error,omitempty"`
+			}
+			entries := make([]summaryEntry, 0, len(results))
+			for _, r := range results {
+				entries = append(entries, summaryEntry{
+					RuntimeID: r.runtimeID,
+					UpdateID:  r.updateID,
+					Status:    strVal(r.update, "status"),
+					Output:    strVal(r.update, "output"),
+					Error:     strVal(r.update, "error"),
+				})
+			}
+			return cli.PrintJSON(os.Stdout, map[string]any{
+				"completed": completed,
+				"failed":    failed,
+				"timed_out": timedOut,
+				"results":   entries,
+			})
+		}
+
+		fmt.Printf("Update summary: %d completed, %d failed, %d timed out (target: %s)\n",
+			completed, failed, timedOut, targetVersion)
+		for _, r := range results {
+			status := strVal(r.update, "status")
+			if status == "completed" {
+				fmt.Printf("  %s: completed — %s\n", r.runtimeID, strVal(r.update, "output"))
+			} else {
+				fmt.Printf("  %s: %s — %s\n", r.runtimeID, status, strVal(r.update, "error"))
+			}
+		}
 		return nil
 	}
 
-	// Poll until completed/failed/timeout.
-	updateID := strVal(update, "id")
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for update (last status: %s)", strVal(update, "status"))
-		case <-time.After(2 * time.Second):
+	// Non-wait mode output.
+	if output == "json" {
+		var allResults []map[string]any
+		for _, r := range results {
+			allResults = append(allResults, r.update)
 		}
-
-		if err := client.GetJSON(ctx, "/api/runtimes/"+args[0]+"/update/"+updateID, &update); err != nil {
-			return fmt.Errorf("get update status: %w", err)
-		}
-
-		status := strVal(update, "status")
-		if status == "completed" || status == "failed" || status == "timeout" {
-			output, _ := cmd.Flags().GetString("output")
-			if output == "json" {
-				return cli.PrintJSON(os.Stdout, update)
-			}
-			if status == "completed" {
-				fmt.Printf("Update completed: %s\n", strVal(update, "output"))
-			} else {
-				fmt.Printf("Update %s: %s\n", status, strVal(update, "error"))
-			}
-			return nil
-		}
+		return cli.PrintJSON(os.Stdout, allResults)
 	}
+
+	for _, r := range results {
+		fmt.Printf("Runtime %s: update %s (status: %s)\n",
+			r.runtimeID, strVal(r.update, "id"), strVal(r.update, "status"))
+	}
+	return nil
 }

--- a/server/cmd/multica/cmd_runtime.go
+++ b/server/cmd/multica/cmd_runtime.go
@@ -12,6 +12,10 @@ import (
 	"github.com/multica-ai/multica/server/internal/cli"
 )
 
+// fetchLatestReleaseFn is the function used to fetch the latest GitHub release.
+// Exported as a variable so tests can replace it with a mock.
+var fetchLatestReleaseFn = cli.FetchLatestRelease
+
 var runtimeCmd = &cobra.Command{
 	Use:   "runtime",
 	Short: "Work with agent runtimes",
@@ -192,7 +196,7 @@ func runRuntimeUpdate(cmd *cobra.Command, args []string) error {
 
 	// Resolve target version.
 	if latest {
-		rel, err := cli.FetchLatestRelease()
+		rel, err := fetchLatestReleaseFn()
 		if err != nil {
 			return fmt.Errorf("fetch latest release: %w", err)
 		}
@@ -278,21 +282,22 @@ func runRuntimeUpdate(cmd *cobra.Command, args []string) error {
 		var completed, failed, timedOut int
 		done := make(map[string]bool)
 
-		for len(done) < len(pending) {
-			select {
-			case <-pollCtx.Done():
-				// Mark remaining as timed out.
-				for _, u := range pending {
-					if !done[u.updateID] {
-						timedOut++
-						u.update["status"] = "timeout"
-						u.update["error"] = "timed out waiting for update"
-						done[u.updateID] = true
-						results = append(results, u)
-					}
+	pollLoop:
+	for len(done) < len(pending) {
+		select {
+		case <-pollCtx.Done():
+			// Mark remaining as timed out.
+			for _, u := range pending {
+				if !done[u.updateID] {
+					timedOut++
+					u.update["status"] = "timeout"
+					u.update["error"] = "timed out waiting for update"
+					done[u.updateID] = true
+					results = append(results, u)
 				}
-				break
-			case <-time.After(2 * time.Second):
+			}
+			break pollLoop
+		case <-time.After(2 * time.Second):
 				for _, u := range pending {
 					if done[u.updateID] {
 						continue
@@ -362,6 +367,9 @@ func runRuntimeUpdate(cmd *cobra.Command, args []string) error {
 
 	// Non-wait mode output.
 	if output == "json" {
+		if len(results) == 1 && !all {
+			return cli.PrintJSON(os.Stdout, results[0].update)
+		}
 		var allResults []map[string]any
 		for _, r := range results {
 			allResults = append(allResults, r.update)

--- a/server/cmd/multica/cmd_runtime_test.go
+++ b/server/cmd/multica/cmd_runtime_test.go
@@ -1,0 +1,501 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+func newRuntimeUpdateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("target-version", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().Bool("wait", false, "")
+	cmd.Flags().Bool("latest", false, "")
+	cmd.Flags().Bool("all", false, "")
+	cmd.PersistentFlags().String("profile", "", "")
+	return cmd
+}
+
+func captureStdoutRuntime(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	runErr := fn()
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("close stdout writer: %v", cerr)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(out), runErr
+}
+
+func TestRuntimeUpdate_MissingVersion(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:0")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+
+	err := runRuntimeUpdate(cmd, []string{"rt-1"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--target-version") || !strings.Contains(err.Error(), "--latest") {
+		t.Fatalf("error should mention --target-version or --latest, got: %v", err)
+	}
+}
+
+func TestRuntimeUpdate_MutuallyExclusiveAllAndRuntimeID(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:0")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("all", "true")
+
+	err := runRuntimeUpdate(cmd, []string{"rt-1"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error should mention mutual exclusivity, got: %v", err)
+	}
+}
+
+func TestRuntimeUpdate_MissingRuntimeIDWithoutAll(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:0")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+
+	err := runRuntimeUpdate(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "runtime-id") {
+		t.Fatalf("error should mention runtime-id, got: %v", err)
+	}
+}
+
+func TestRuntimeUpdate_LatestResolvesVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes/rt-1/update" {
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			// The target_version should NOT have the "v" prefix.
+			tv, ok := body["target_version"].(string)
+			if !ok {
+				t.Fatalf("target_version missing from body")
+			}
+			if strings.HasPrefix(tv, "v") {
+				t.Fatalf("target_version should not have 'v' prefix, got: %s", tv)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-1",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	// Mock FetchLatestRelease
+	orig := fetchLatestReleaseFn
+	defer func() { fetchLatestReleaseFn = orig }()
+	fetchLatestReleaseFn = func() (*cli.GitHubRelease, error) {
+		return &cli.GitHubRelease{TagName: "v2.0.0"}, nil
+	}
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("latest", "true")
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode stdout JSON %q: %v", out, err)
+	}
+	if result["status"] != "pending" {
+		t.Fatalf("status = %v, want pending", result["status"])
+	}
+}
+
+func TestRuntimeUpdate_SingleRuntimeReturnsBareObject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes/rt-1/update" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-1",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	// Verify it's a bare object, not an array.
+	trimmed := strings.TrimSpace(out)
+	if strings.HasPrefix(trimmed, "[") {
+		t.Fatalf("single-runtime JSON should be a bare object, not an array: %s", out)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode stdout JSON %q: %v", out, err)
+	}
+	if result["id"] != "upd-1" {
+		t.Fatalf("id = %v, want upd-1", result["id"])
+	}
+}
+
+func TestRuntimeUpdate_AllReturnsArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/runtimes":
+			if r.Method == http.MethodGet {
+				json.NewEncoder(w).Encode([]map[string]any{
+					{"id": "rt-1", "status": "active"},
+					{"id": "rt-2", "status": "active"},
+					{"id": "rt-3", "status": "offline"},
+				})
+			} else {
+				http.NotFound(w, r)
+			}
+		case "/api/runtimes/rt-1/update", "/api/runtimes/rt-2/update", "/api/runtimes/rt-3/update":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-" + strings.TrimPrefix(r.URL.Path, "/api/runtimes/"),
+				"status": "pending",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("all", "true")
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	trimmed := strings.TrimSpace(out)
+	if !strings.HasPrefix(trimmed, "[") {
+		t.Fatalf("--all JSON should be an array, got: %s", out)
+	}
+
+	var results []map[string]any
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatalf("decode stdout JSON %q: %v", out, err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+}
+
+func TestRuntimeUpdate_NoRuntimesForAllExitsGracefully(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes" {
+			json.NewEncoder(w).Encode([]map[string]any{})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("all", "true")
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	defer func() { os.Stderr = oldStderr }()
+
+	err := runRuntimeUpdate(cmd, []string{})
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("close stderr writer: %v", cerr)
+	}
+	out, _ := io.ReadAll(r)
+
+	if err != nil {
+		t.Fatalf("expected nil error for empty runtime list, got: %v", err)
+	}
+	if !strings.Contains(string(out), "No runtimes found") {
+		t.Fatalf("stderr should mention 'No runtimes found', got: %s", string(out))
+	}
+}
+
+func TestRuntimeUpdate_AllSkipsEmptyIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes" {
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "rt-good", "status": "active"},
+				{"id": "", "status": "bad"},
+				{"status": "no-id-key"},
+			})
+		} else if strings.Contains(r.URL.Path, "/update") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-good",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("all", "true")
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	var results []map[string]any
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatalf("decode stdout JSON %q: %v", out, err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (skipping empty/missing IDs), got %d", len(results))
+	}
+}
+
+func TestRuntimeUpdate_PostFailureIncludedInResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, `{"error":"server error"}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode stdout JSON %q: %v", out, err)
+	}
+	if _, ok := result["error"]; !ok {
+		t.Fatalf("result should contain error key: %s", out)
+	}
+}
+
+func TestRuntimeUpdate_TargetVersionStripsVPrefix(t *testing.T) {
+	var receivedVersion string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes/rt-1/update" {
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			receivedVersion = body["target_version"].(string)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-1",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "v1.5.0")
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	if receivedVersion != "1.5.0" {
+		t.Fatalf("target_version sent to server = %q, want %q", receivedVersion, "1.5.0")
+	}
+}
+
+func TestRuntimeUpdate_TableOutputForSingleRuntime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes/rt-1/update" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-1",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("output", "table")
+
+	out, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+
+	if !strings.Contains(out, "rt-1") {
+		t.Fatalf("table output should contain runtime ID: %s", out)
+	}
+	if !strings.Contains(out, "upd-1") {
+		t.Fatalf("table output should contain update ID: %s", out)
+	}
+}
+
+func TestRuntimeUpdate_LatestAndTargetVersionBoth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/runtimes/rt-1/update" {
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			tv := body["target_version"].(string)
+			// --latest takes precedence, so version should come from the mock, not the flag.
+			if tv != "3.0.0" {
+				t.Fatalf("target_version = %q, want 3.0.0 from --latest (should override --target-version)", tv)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "upd-1",
+				"status": "pending",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	orig := fetchLatestReleaseFn
+	defer func() { fetchLatestReleaseFn = orig }()
+	fetchLatestReleaseFn = func() (*cli.GitHubRelease, error) {
+		return &cli.GitHubRelease{TagName: "v3.0.0"}, nil
+	}
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("latest", "true")
+	_ = cmd.Flags().Set("target-version", "1.0.0")
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdoutRuntime(t, func() error {
+		return runRuntimeUpdate(cmd, []string{"rt-1"})
+	})
+	if err != nil {
+		t.Fatalf("runRuntimeUpdate: %v", err)
+	}
+}
+
+func TestRuntimeUpdate_LatestFetchFails(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:0")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	orig := fetchLatestReleaseFn
+	defer func() { fetchLatestReleaseFn = orig }()
+	fetchLatestReleaseFn = func() (*cli.GitHubRelease, error) {
+		return nil, fmt.Errorf("GitHub API unavailable")
+	}
+
+	cmd := newRuntimeUpdateTestCmd()
+	_ = cmd.Flags().Set("latest", "true")
+
+	err := runRuntimeUpdate(cmd, []string{"rt-1"})
+	if err == nil {
+		t.Fatal("expected error when --latest fetch fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch latest release") {
+		t.Fatalf("error should mention 'fetch latest release', got: %v", err)
+	}
+}

--- a/server/cmd/multica/help.go
+++ b/server/cmd/multica/help.go
@@ -35,6 +35,17 @@ func exactArgs(n int) cobra.PositionalArgs {
 	}
 }
 
+func maximumNArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > n {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: accepts at most %d arg, received %d\n\n", n, len(args))
+			cmd.Help()
+			return errSilent
+		}
+		return nil
+	}
+}
+
 
 // initHelp configures the root command to use gh-style help output.
 func initHelp(root *cobra.Command) {


### PR DESCRIPTION
## Summary

- **`--all`**: update every runtime instead of a single one
- **`--latest`**: resolve target version from the latest GitHub release
- Runtime-id positional arg is now optional when using `--all`
- Added `maximumNArgs(n)` helper for optional positional arg validation

## Example usage

```
multica runtime update --latest              # all runtimes → latest
multica runtime update <runtime-id> --latest  # one runtime → latest
multica runtime update --all --target-version 2.0.0
```