### PR TITLE
contrib: multi-user Feishu/Lark OAuth sidecar reference

### DIFF
--- a/contrib/feishu-oauth-sidecar/README.md
+++ b/contrib/feishu-oauth-sidecar/README.md
@@ -1,0 +1,118 @@
+# Multi-user Feishu / Lark OAuth Sidecar for Multica
+
+> A reference integration that lets **each Multica user act with their own Feishu/Lark
+> identity** when an agent performs Feishu operations (send messages, read docs, manage
+> calendar/wiki) — without storing any user OAuth token in the Multica server database.
+
+This is a community contribution / reference pattern. It is **not** part of Multica core;
+it runs as a small companion sidecar next to your Multica daemon.
+
+## Problem
+
+Multica agents often need to act on a user's behalf in an external SaaS (here: Feishu/Lark).
+The naive approach — one shared bot token for the whole workspace — means every agent speaks
+as the same identity, which breaks per-user attribution, permissions, and audit.
+
+What we want: when user *A* creates an issue and an agent handles it, the Feishu action runs
+as *A*'s own Feishu identity; when user *B* does the same, it runs as *B*.
+
+## Approach: HOME-isolation sidecar
+
+The [`lark-cli`](https://www.npmjs.com/package/@larksuite/lark-cli) tool stores OAuth
+credentials under `$HOME`. We exploit that: each Multica user gets an isolated `HOME`
+directory holding only their own encrypted Feishu token. A small Go sidecar:
+
+1. runs the OAuth **device flow** (RFC 8628) per user and writes the token into that user's
+   isolated HOME (`mc-user-<multica_user_id>/`)
+2. exposes a tiny HTTP API (`/start`, `/status`, `/complete`, `/force-restart`) + a single-page
+   `oauth-ui.html` for scanning the QR code
+3. ships a wrapper script (`05_agent_spawn.sh`) the agent calls to run any `lark-cli` command
+   **as a specific user**, by pointing `HOME` at that user's isolated dir
+
+No user token ever touches the Multica server DB. Tokens live only on the daemon host,
+encrypted, one HOME per user.
+
+```
+Multica issue (creator = user A)
+   │  agent picks it up, needs to do a Feishu action
+   ▼
+agent loads the "feishu-as-user" skill (skill/SKILL.md)
+   │  1. resolve A's multica_user_id from the issue (fallback chain, see skill)
+   │  2. GET sidecar /status?multica_user_id=A   → bound? token valid? lark_open_id?
+   │  3. bash scripts/05_agent_spawn.sh A im +messages-send --user-id <open_id> ...
+   ▼
+05_agent_spawn.sh  →  env HOME=<homes>/mc-user-A  lark-cli <cmd>
+   ▼
+Feishu API responds as user A's identity
+```
+
+## Components
+
+| Path | What |
+|------|------|
+| `sidecar/` | Go HTTP sidecar (device-flow OAuth + status + force-restart + token-expiry watcher). Self-contained, ~700 LOC, unit-tested. |
+| `sidecar/oauth-ui.html` | Single-page QR scan UI (no framework, no external CDN). Auto-detects the current Multica user via `/api/me`. |
+| `scripts/01..05_*.sh` | Provisioning + OAuth lifecycle: init → provision per-user HOME → device-flow start → complete → agent spawn wrapper. |
+| `skill/SKILL.md` | The agent skill that teaches the LLM the full flow: identity resolution, token check, error classification, anti-hallucination rules. |
+| `deploy/*.plist.example` | launchd template (macOS) to run the sidecar as a service. |
+
+## Quick start
+
+> Prerequisites: Go 1.23+, Node (for `lark-cli`), a Feishu/Lark custom app with the scopes
+> you need, and a Multica daemon already running on the same host.
+
+```bash
+# 1. configure (env vars, all have sane defaults — see scripts headers)
+export MULTICA_USER_HOMES_DIR="$HOME/multica-user-homes"
+export LARK_BIN="$(command -v lark-cli)"
+
+# 2. one-time host init (copies app config + master key into the homes base dir)
+bash scripts/01_mini_init.sh
+
+# 3. build + run the sidecar
+cd sidecar && go build -o feishu-oauth-sidecar . && \
+  PORT=18090 MAPPING_FILE="$MULTICA_USER_HOMES_DIR/user_mapping.json" ./feishu-oauth-sidecar
+
+# 4. open the OAuth UI, scan, done
+#    http://localhost:18090/oauth-ui?multica_user_id=<your-multica-user-id>
+```
+
+Wire the skill into any agent that should be able to act as a user in Feishu (assign the
+skill in Multica, or drop `skill/SKILL.md` into the agent's skill set). Then the agent can
+run Feishu operations on behalf of whoever created the issue.
+
+## The agent skill (identity resolution + safety)
+
+`skill/SKILL.md` is the heart of the integration. Key design points learned in production:
+
+- **Identity fallback chain** — resolve the acting user from, in order: explicit
+  `issue.metadata.feishu_user_id` → `creator_id` (if creator is a member) → parent issue
+  (if creator is an agent) → `agent.owner_id`. Covers human-created and agent/autopilot-created
+  issues alike. Private issues (`metadata.private_to`) require an explicit id and skip all fallback.
+- **Authoritative open_id only** — the `--user-id` for a message must come from the sidecar
+  `/status` response field `lark_user_open_id`. The skill forbids hand-typing any UUID/`ou_`/`oc_`
+  string, because LLMs mis-copy long hex ids (`c↔f`, `0↔o`, `1↔l`) and the Feishu API returns
+  `200 OK` + a fake message_id for a non-existent user — silently delivering to the wrong person.
+- **Error classification** — distinguishes real OAuth expiry (re-auth) from transient errors
+  (retry ≤2) from business errors (report) — so a flaky network never gets misattributed as
+  "token expired".
+
+## Security model
+
+- User tokens never leave the daemon host; never stored in the Multica server DB.
+- One isolated `HOME` per user; the spawn wrapper scrubs the environment (`env -i` + allowlist)
+  so the host's own agent-runtime context can't leak into a user's `lark-cli` invocation.
+- Workspace issues are visible to all members by default (Multica's model); the skill enforces
+  a `metadata.private_to` convention as an additional guard for sensitive issues.
+
+## Placeholders in this package
+
+All host/identity specifics are placeholders — replace before use:
+`multica.example.com`, `relay.example.com`, `RELAY_PUBLIC_IP`, `SERVER_LAN_IP`, `LAN_IP`,
+`00000000-0000-0000-0000-000000000000` (a Multica user id), `ou_EXAMPLE_OPEN_ID`,
+`oc_EXAMPLE_CHAT_ID`, `your-org`.
+
+## Status
+
+Battle-tested in a small (≤10 user) self-hosted Multica deployment. Contributed as a reference
+pattern; adapt the scripts/sidecar to your host and Feishu app before relying on it.

--- a/contrib/feishu-oauth-sidecar/README.md
+++ b/contrib/feishu-oauth-sidecar/README.md
@@ -81,6 +81,19 @@ Wire the skill into any agent that should be able to act as a user in Feishu (as
 skill in Multica, or drop `skill/SKILL.md` into the agent's skill set). Then the agent can
 run Feishu operations on behalf of whoever created the issue.
 
+> **Registering the skill in Multica — set the body via `content`, never as a `SKILL.md` file.**
+> When creating the skill, pass the SKILL.md body to the skill's **content** field:
+> ```bash
+> multica skill create --name feishu-as-user --content "$(cat skill/SKILL.md)"
+> ```
+> Do **not** add the body as a supporting file named `SKILL.md` (e.g. via
+> `multica skill files upsert --path SKILL.md`). The daemon's execenv writes the skill's
+> `content` to `<workdir>/.../skills/<slug>/SKILL.md` and then writes each supporting file;
+> a supporting file also named `SKILL.md` produces a second write to the same path, which the
+> sidecar-manifest guard rejects (`refuse to overwrite pre-existing path`), breaking execenv
+> setup for **every** agent assigned the skill. Keep `files` for real bundled assets
+> (scripts/templates) only. (Learned the hard way in a self-hosted deployment.)
+
 ## The agent skill (identity resolution + safety)
 
 `skill/SKILL.md` is the heart of the integration. Key design points learned in production:

--- a/contrib/feishu-oauth-sidecar/deploy/com.multica.feishu-oauth.plist.example
+++ b/contrib/feishu-oauth-sidecar/deploy/com.multica.feishu-oauth.plist.example
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.multica.feishu-oauth</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>__USER_HOME__/feishu-oauth-sidecar/feishu-oauth-sidecar</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PORT</key>
+      <string>18090</string>
+      <key>SCRIPTS_DIR</key>
+      <string>__USER_HOME__/lark_multi_user</string>
+      <key>MAPPING_FILE</key>
+      <string>__USER_HOME__/multica-user-homes/user_mapping.json</string>
+      <key>PATH</key>
+      <string>__USER_HOME__/.nvm/versions/node/v22.12.0/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/feishu-oauth-sidecar.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/feishu-oauth-sidecar.log</string>
+  </dict>
+</plist>

--- a/contrib/feishu-oauth-sidecar/scripts/01_mini_init.sh
+++ b/contrib/feishu-oauth-sidecar/scripts/01_mini_init.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USER_HOMES_DIR="${MULTICA_USER_HOMES_DIR:-$HOME/multica-user-homes}"
+EXPECTED_OWNER="$(id -un)"
+
+err() {
+  echo "$*" >&2
+}
+
+emit_json() {
+  local payload="$1"
+  echo "$payload" | jq -e . >/dev/null
+  printf '%s\n' "$payload"
+}
+
+default_home() {
+  local user home_line
+  user="$(id -un)"
+  if home_line="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null)"; then
+    printf '%s\n' "${home_line##* }"
+    return
+  fi
+  printf '%s\n' "$HOME"
+}
+
+mkdir -p "$USER_HOMES_DIR"
+chmod 700 "$USER_HOMES_DIR"
+
+if id "$EXPECTED_OWNER" >/dev/null 2>&1; then
+  chown "$EXPECTED_OWNER" "$USER_HOMES_DIR"
+fi
+
+DEFAULT_HOME="$(default_home)"
+APP_SUPPORT_DIR="${DEFAULT_HOME}/Library/Application Support/lark-cli"
+MASTER_KEY_FILE="${APP_SUPPORT_DIR}/master.key.file"
+CONFIG_FILE="${DEFAULT_HOME}/.lark-cli/config.json"
+
+if [ ! -f "$MASTER_KEY_FILE" ]; then
+  err "请先在 Terminal.app 跑 lark-cli config keychain-downgrade"
+  exit 1
+fi
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  err "未找到 ${CONFIG_FILE}，请先完成 lark-cli 初始化与登录"
+  exit 1
+fi
+
+APP_ID="$(jq -r '(.apps[0].appId // .appId // .app_id) // empty' "$CONFIG_FILE")"
+if [ -z "$APP_ID" ]; then
+  err "config.json 中未找到 app_id"
+  exit 1
+fi
+
+APP_SECRET_ENC_FILE="${APP_SUPPORT_DIR}/appsecret_${APP_ID}.enc"
+if [ ! -f "$APP_SECRET_ENC_FILE" ]; then
+  err "未找到 app secret 文件：${APP_SECRET_ENC_FILE}"
+  exit 1
+fi
+
+payload="$(jq -n \
+  --arg app_id "$APP_ID" \
+  --arg user_homes_dir "$USER_HOMES_DIR" \
+  --arg master_key_file "$MASTER_KEY_FILE" \
+  --arg appsecret_enc_file "$APP_SECRET_ENC_FILE" \
+  --arg default_home "$DEFAULT_HOME" \
+  '{ok:true,app_id:$app_id,user_homes_dir:$user_homes_dir,master_key_file:$master_key_file,appsecret_enc_file:$appsecret_enc_file,default_home:$default_home}')"
+
+emit_json "$payload"

--- a/contrib/feishu-oauth-sidecar/scripts/02_user_provision.sh
+++ b/contrib/feishu-oauth-sidecar/scripts/02_user_provision.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="${MULTICA_USER_HOMES_DIR:-$HOME/multica-user-homes}"
+
+err() {
+  echo "$*" >&2
+}
+
+emit_json() {
+  local payload="$1"
+  echo "$payload" | jq -e . >/dev/null
+  printf '%s\n' "$payload"
+}
+
+default_home() {
+  local user home_line
+  user="$(id -un)"
+  if home_line="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null)"; then
+    printf '%s\n' "${home_line##* }"
+    return
+  fi
+  printf '%s\n' "$HOME"
+}
+
+if [ "${1:-}" = "" ]; then
+  err "用法：$0 <multica_user_id>"
+  exit 1
+fi
+
+USER_ID="$1"
+if ! printf '%s' "$USER_ID" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  err "multica_user_id 格式非法：仅允许字母数字._-"
+  exit 1
+fi
+
+USER_HOME="${BASE_DIR}/mc-user-${USER_ID}"
+
+DEFAULT_HOME="$(default_home)"
+SRC_APP_DIR="${DEFAULT_HOME}/Library/Application Support/lark-cli"
+SRC_CONFIG="${DEFAULT_HOME}/.lark-cli/config.json"
+SRC_MASTER_KEY="${SRC_APP_DIR}/master.key.file"
+
+if [ ! -d "$BASE_DIR" ]; then
+  err "未找到 ${BASE_DIR}，请先运行 01_mini_init.sh"
+  exit 1
+fi
+
+if [ ! -f "$SRC_CONFIG" ] || [ ! -f "$SRC_MASTER_KEY" ]; then
+  err "默认 HOME 下缺少 lark-cli 配置或 master.key.file，请先运行 01_mini_init.sh"
+  exit 1
+fi
+
+if [ -d "$USER_HOME" ]; then
+  token_count="$(find "$USER_HOME/Library/Application Support/lark-cli" -type f -name '*.enc' 2>/dev/null | grep -v '/appsecret_' || true | wc -l | tr -d ' ')"
+  if [ "${token_count:-0}" -gt 0 ]; then
+    payload="$(jq -n --arg user_id "$USER_ID" --arg home "$USER_HOME" '{ok:true,user_id:$user_id,home:$home,ready_for_oauth:true,already_provisioned:true}')"
+    emit_json "$payload"
+    exit 0
+  fi
+fi
+
+mkdir -p "$USER_HOME/.lark-cli"
+mkdir -p "$USER_HOME/Library/Application Support/lark-cli"
+chmod 700 "$USER_HOME" "$USER_HOME/.lark-cli" "$USER_HOME/Library" "$USER_HOME/Library/Application Support" "$USER_HOME/Library/Application Support/lark-cli" 2>/dev/null || true
+
+cp "$SRC_MASTER_KEY" "$USER_HOME/Library/Application Support/lark-cli/master.key.file"
+
+shopt -s nullglob
+APPSECRET_FILES=("${SRC_APP_DIR}"/appsecret_*.enc)
+shopt -u nullglob
+if [ "${#APPSECRET_FILES[@]}" -eq 0 ]; then
+  err "默认 HOME 下未找到 appsecret_*.enc"
+  exit 1
+fi
+
+for f in "${APPSECRET_FILES[@]}"; do
+  cp "$f" "$USER_HOME/Library/Application Support/lark-cli/"
+done
+
+cp "$SRC_CONFIG" "$USER_HOME/.lark-cli/config.json"
+
+payload="$(jq -n --arg user_id "$USER_ID" --arg home "$USER_HOME" '{ok:true,user_id:$user_id,home:$home,ready_for_oauth:true}')"
+emit_json "$payload"

--- a/contrib/feishu-oauth-sidecar/scripts/03_user_oauth_start.sh
+++ b/contrib/feishu-oauth-sidecar/scripts/03_user_oauth_start.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="${MULTICA_USER_HOMES_DIR:-$HOME/multica-user-homes}"
+
+err() {
+  echo "$*" >&2
+}
+
+emit_json() {
+  local payload="$1"
+  echo "$payload" | jq -e . >/dev/null
+  printf '%s\n' "$payload"
+}
+
+if [ "${1:-}" = "" ]; then
+  err "用法：$0 <multica_user_id>"
+  exit 1
+fi
+
+USER_ID="$1"
+if ! printf '%s' "$USER_ID" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  err "multica_user_id 格式非法：仅允许字母数字._-"
+  exit 1
+fi
+
+USER_HOME="${BASE_DIR}/mc-user-${USER_ID}"
+TARGET_APP_DIR="${USER_HOME}/Library/Application Support/lark-cli"
+TARGET_CONFIG="${USER_HOME}/.lark-cli/config.json"
+
+if [ ! -d "$USER_HOME" ] || [ ! -f "$TARGET_CONFIG" ] || [ ! -f "$TARGET_APP_DIR/master.key.file" ]; then
+  err "USER_HOME 未 provision，请先运行 02_user_provision.sh"
+  exit 1
+fi
+
+shopt -s nullglob
+APPSECRET_FILES=("${TARGET_APP_DIR}"/appsecret_*.enc)
+shopt -u nullglob
+if [ "${#APPSECRET_FILES[@]}" -eq 0 ]; then
+  err "USER_HOME 缺少 appsecret_*.enc，请重新 provision"
+  exit 1
+fi
+
+login_json="$(HOME="$USER_HOME" lark-cli auth login --no-wait --json --domain im,calendar,contact)"
+echo "$login_json" | jq -e . >/dev/null
+
+device_code="$(echo "$login_json" | jq -r '.device_code // .deviceCode // empty')"
+verification_url="$(echo "$login_json" | jq -r '.verification_url // .verificationUrl // .verification_uri // empty')"
+user_code="$(echo "$login_json" | jq -r '.user_code // .userCode // empty')"
+expires_in="$(echo "$login_json" | jq -r '.expires_in // .expiresIn // 0')"
+
+if [ -z "$device_code" ] || [ -z "$verification_url" ]; then
+  err "auth login 返回缺少 device_code 或 verification_url"
+  exit 1
+fi
+
+qr_ascii_raw="$(HOME="$USER_HOME" lark-cli auth qrcode "$verification_url" --ascii)"
+qr_ascii_b64="$(printf '%s' "$qr_ascii_raw" | base64 | tr -d '\n')"
+
+payload="$(jq -n \
+  --arg user_id "$USER_ID" \
+  --arg device_code "$device_code" \
+  --arg verification_url "$verification_url" \
+  --arg user_code "$user_code" \
+  --arg qr_ascii "$qr_ascii_b64" \
+  --argjson expires_in "$expires_in" \
+  '{ok:true,user_id:$user_id,device_code:$device_code,verification_url:$verification_url,user_code:$user_code,expires_in:$expires_in,qr_ascii:$qr_ascii}')"
+
+emit_json "$payload"

--- a/contrib/feishu-oauth-sidecar/scripts/04_user_oauth_complete.sh
+++ b/contrib/feishu-oauth-sidecar/scripts/04_user_oauth_complete.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="${MULTICA_USER_HOMES_DIR:-$HOME/multica-user-homes}"
+MAPPING_FILE="${MULTICA_USER_MAPPING_FILE:-$HOME/multica-user-homes/user_mapping.json}"
+LARK_BIN="${LARK_BIN:-$HOME/.nvm/versions/node/v22.12.0/bin/lark-cli}"
+TIMEOUT_SECONDS=180
+
+err() { echo "$*" >&2; }
+emit_json() {
+  local payload="$1"
+  echo "$payload" | jq -e . >/dev/null
+  printf '%s\n' "$payload"
+}
+
+# === 参数校验 ===
+if [ "${1:-}" = "" ] || [ "${2:-}" = "" ]; then
+  err "用法：$0 <multica_user_id> <device_code>"
+  exit 1
+fi
+USER_ID="$1"
+DEVICE_CODE="$2"
+if ! printf '%s' "$USER_ID" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  err "multica_user_id 格式非法：仅允许字母数字._-"
+  exit 1
+fi
+
+USER_HOME="${BASE_DIR}/mc-user-${USER_ID}"
+if [ ! -d "$USER_HOME" ] || [ ! -f "$USER_HOME/.lark-cli/config.json" ]; then
+  err "USER_HOME 未 provision，请先运行 02_user_provision.sh"
+  exit 1
+fi
+
+# === 临时文件 + trap (cover tmp_map 残留 — Gemini 建议 #2) ===
+tmp_out="$(mktemp)"
+tmp_err="$(mktemp)"
+tmp_map=""
+cleanup() {
+  rm -f "$tmp_out" "$tmp_err" "${tmp_map:-}"
+}
+trap cleanup EXIT
+
+# === polling (subshell + 等 token 落地, 不依赖 lark-cli 子进程 exit code) ===
+# 历史 bug: lark-cli auth login --device-code 拿到 token 后还会做 ~3min 额外清理操作才 exit
+# 子进程 exit 1 但 token 早已落地。直接 watch token enc 文件出现就视为成功 (类似 self-heal 思路)
+TOKEN_ENC_DIR="$USER_HOME/Library/Application Support/lark-cli"
+
+# 记录 polling 前的 enc 文件 (排除 appsecret_) — 之后多出的就是 user token
+enc_before="$(find "$TOKEN_ENC_DIR" -type f -name '*.enc' 2>/dev/null | grep -v '/appsecret_' || true)"
+enc_before_count="$(printf '%s\n' "$enc_before" | grep -c . || true)"
+
+(
+  HOME="$USER_HOME" "$LARK_BIN" auth login --device-code "$DEVICE_CODE" --json >"$tmp_out" 2>"$tmp_err"
+) &
+pid=$!
+
+start_ts="$(date +%s)"
+token_landed=0
+while kill -0 "$pid" 2>/dev/null; do
+  now_ts="$(date +%s)"
+  if [ $((now_ts - start_ts)) -ge "$TIMEOUT_SECONDS" ]; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    err "auth login polling 超时（${TIMEOUT_SECONDS}s）"
+    exit 1
+  fi
+  # 每秒检测 token enc 文件 — 落地立即跳出循环 (kill lark-cli 子进程节省时间)
+  enc_now_count="$(find "$TOKEN_ENC_DIR" -type f -name '*.enc' 2>/dev/null | grep -v '/appsecret_' | wc -l | tr -d ' ' || echo 0)"
+  if [ "$enc_now_count" -gt "$enc_before_count" ]; then
+    token_landed=1
+    # 优雅 kill: 给 lark-cli 1s flush 时间再 kill
+    sleep 1
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    break
+  fi
+  sleep 1
+done
+
+# 如果 lark-cli 自然退出且 token 没落地 → 真失败 (用户取消授权 / 网络中断)
+if [ "$token_landed" -ne 1 ]; then
+  enc_now_count="$(find "$TOKEN_ENC_DIR" -type f -name '*.enc' 2>/dev/null | grep -v '/appsecret_' | wc -l | tr -d ' ' || echo 0)"
+  if [ "$enc_now_count" -le "$enc_before_count" ]; then
+    err "lark-cli 退出但 token 未落地 (stderr: $(cat "$tmp_err" | head -c 300))"
+    exit 1
+  fi
+  token_landed=1
+fi
+
+# token 已落地。读 tmp_out 看 lark-cli 是否输出了 scope (可能因 kill 早退没输出,降级用空)
+poll_json="$(cat "$tmp_out" 2>/dev/null || echo '{}')"
+if ! echo "$poll_json" | jq -e . >/dev/null 2>&1; then
+  poll_json='{}'
+fi
+scopes_json="$(echo "$poll_json" | jq -c '.scope // .scopes // []' 2>/dev/null || echo '[]')"
+
+# === 拿 user 信息 (root cause 修复点 — 不用 --json flag,默认就是 JSON) ===
+# 之前 bug: lark-cli auth status 没有 --json flag, 用 --json 触发 exit 1 + 输出 Usage 到 stdout
+# `|| fallback` 让 $(...) 把 Usage + JSON 拼接,jq 解析失败
+status_raw="$(HOME="$USER_HOME" "$LARK_BIN" auth status 2>/dev/null || true)"
+
+if [ -z "$status_raw" ] || ! echo "$status_raw" | jq -e . >/dev/null 2>&1; then
+  err "lark-cli auth status 没返回合法 JSON,无法拿 user_open_id (head=$(printf %s "$status_raw" | head -c 100))"
+  exit 1
+fi
+
+# 兼容 v1.0.41 nested + 顶层 + snake_case
+lark_user_open_id="$(echo "$status_raw" | jq -r '.identities.user.openId // .userOpenId // .user_open_id // .open_id // .user.open_id // empty')"
+lark_user_name="$(echo "$status_raw" | jq -r '.identities.user.userName // .userName // .lark_user_name // .user_name // .name // .user.name // empty')"
+
+if [ -z "$lark_user_open_id" ] || [ -z "$lark_user_name" ]; then
+  err "无法从 auth status 提取 user_open_id 或 user_name (head=$(printf %s "$status_raw" | head -c 200))"
+  exit 1
+fi
+
+# === Mapping 写入 (加 flock 防并发覆盖 — Gemini 建议 #1) ===
+mapping_dir="$(dirname "$MAPPING_FILE")"
+mkdir -p "$mapping_dir"
+
+# macOS 默认无 flock,用 mkdir 原子操作做 mutex
+# 最多等 30s 拿锁,超时报错(避免死锁)
+lock_dir="$MAPPING_FILE.lock.d"
+lock_acquired=0
+for _ in $(seq 1 30); do
+  if mkdir "$lock_dir" 2>/dev/null; then
+    lock_acquired=1
+    break
+  fi
+  sleep 1
+done
+if [ "$lock_acquired" -ne 1 ]; then
+  err "mapping 文件锁拿不到 (30s timeout, lock_dir=$lock_dir 可能残留)"
+  exit 1
+fi
+# 增强 trap: cleanup 时一并释放锁
+cleanup_with_lock() {
+  rmdir "$lock_dir" 2>/dev/null || true
+  cleanup
+}
+trap cleanup_with_lock EXIT
+
+if [ ! -f "$MAPPING_FILE" ]; then
+  printf '[]\n' > "$MAPPING_FILE"
+fi
+
+if ! jq -e . "$MAPPING_FILE" >/dev/null 2>&1; then
+  err "mapping 文件不是合法 JSON：$MAPPING_FILE"
+  exit 1
+fi
+
+now_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+tmp_map="$(mktemp "${mapping_dir}/user_mapping.json.tmp.XXXXXX")"
+
+jq --arg uid "$USER_ID" \
+   --arg openid "$lark_user_open_id" \
+   --arg uname "$lark_user_name" \
+   --arg home "$USER_HOME" \
+   --arg now "$now_iso" \
+   '
+   (map(select(.multica_user_id != $uid)))
+   + [
+       {
+         multica_user_id: $uid,
+         lark_user_open_id: $openid,
+         lark_user_name: $uname,
+         home: $home,
+         provisioned_at: $now
+       }
+     ]
+   ' "$MAPPING_FILE" > "$tmp_map"
+
+mv "$tmp_map" "$MAPPING_FILE"
+tmp_map=""  # 防 cleanup 再删
+# 锁会在 EXIT trap 里释放
+
+payload="$(jq -n \
+  --arg multica_user_id "$USER_ID" \
+  --arg lark_user_open_id "$lark_user_open_id" \
+  --arg lark_user_name "$lark_user_name" \
+  --argjson scopes "$scopes_json" \
+  '{ok:true,multica_user_id:$multica_user_id,lark_user_open_id:$lark_user_open_id,lark_user_name:$lark_user_name,scopes:$scopes}')"
+
+emit_json "$payload"

--- a/contrib/feishu-oauth-sidecar/scripts/05_agent_spawn.sh
+++ b/contrib/feishu-oauth-sidecar/scripts/05_agent_spawn.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 关键: 确保 PATH 含 lark-cli 安装位置 (multica daemon spawn 时 PATH 可能缺 nvm)
+export PATH="$HOME/.nvm/versions/node/v22.12.0/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+BASE_DIR="${MULTICA_USER_HOMES_DIR:-${HOME}/multica-user-homes}"
+MAPPING_FILE="${MULTICA_USER_MAPPING_FILE:-${HOME}/multica-user-homes/user_mapping.json}"
+LARK_BIN="${LARK_BIN:-${HOME}/.nvm/versions/node/v22.12.0/bin/lark-cli}"
+
+err() { echo "$*" >&2; }
+emit_json() {
+  local payload="$1"
+  echo "$payload" | jq -e . >/dev/null
+  printf '%s\n' "$payload"
+}
+
+if [ ! -x "$LARK_BIN" ]; then
+  emit_json "$(jq -n --arg p "$LARK_BIN" '{ok:false,error:"lark_cli_not_executable",hint:"check LARK_BIN path",lark_bin:$p}')"
+  exit 127
+fi
+
+if [ "${1:-}" = "" ] || [ "${2:-}" = "" ]; then
+  err "用法: $0 <multica_user_id> <lark-cli-cmd...>"
+  exit 1
+fi
+
+USER_ID="$1"
+shift
+
+if ! printf '%s' "$USER_ID" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  err "multica_user_id 格式非法: 仅允许字母数字._-"
+  exit 1
+fi
+
+USER_HOME="${BASE_DIR}/mc-user-${USER_ID}"
+if [ ! -d "$USER_HOME" ]; then
+  emit_json "$(jq -n --arg uid "$USER_ID" '{ok:false,error:"home_not_found",multica_user_id:$uid}')"
+  exit 1
+fi
+
+if [ ! -f "$MAPPING_FILE" ] || ! jq -e . "$MAPPING_FILE" >/dev/null 2>&1; then
+  emit_json "$(jq -n '{ok:false,error:"mapping_missing_or_invalid"}')"
+  exit 1
+fi
+
+if ! jq -e --arg uid "$USER_ID" 'map(select(.multica_user_id == $uid)) | length > 0' "$MAPPING_FILE" >/dev/null; then
+  emit_json "$(jq -n --arg uid "$USER_ID" '{ok:false,error:"binding_not_found",multica_user_id:$uid,hint:"user must complete oauth"}')"
+  exit 1
+fi
+
+# 关键改进 (V2): 不再做 lark-cli 输出 string match 预检查 (V1 误判源)
+# 直接 exec lark-cli, 让真实 OAuth 错误码透传给上层 skill (V2) 分类
+#
+# V4 修 (2026-05-30, 完整版): env -i 清空 + 只保留必要 env
+#
+# 根因 (实测追踪): multica hermes runtime spawn 子进程时会自动注入大量 hermes
+# 上下文标识 env (NODE / npm_config_* / HERMES_HOME / OPENCLAW_HOME / LARK_CHANNEL 等),
+# lark-cli detection 任一命中 → 强制走 "bind required" 路径, 报 exit 3
+# "hermes context detected but lark-cli is not bound to it"。
+# 单纯 unset 几个不可靠 (multica daemon 注入清单未文档化, 可能新增),
+# 用 env -i 整体清空 env, 只显式保留 wrapper 真正需要的几个,
+# lark-cli 在干净 env 里走 user-default 路径。
+exec env -i \
+  HOME="$USER_HOME" \
+  PATH="$HOME/.nvm/versions/node/v22.12.0/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TERM="${TERM:-xterm}" \
+  LANG="${LANG:-en_US.UTF-8}" \
+  LC_ALL="${LC_ALL:-en_US.UTF-8}" \
+  USER="${USER:-multica}" \
+  LOGNAME="${LOGNAME:-multica}" \
+  "$LARK_BIN" "$@"

--- a/contrib/feishu-oauth-sidecar/sidecar/.gitignore
+++ b/contrib/feishu-oauth-sidecar/sidecar/.gitignore
@@ -1,0 +1,2 @@
+feishu-oauth-sidecar
+*.test

--- a/contrib/feishu-oauth-sidecar/sidecar/expiry_watcher.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/expiry_watcher.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ExpiryWatcher 周期扫所有 mapping,token 距 refresh expiry < threshold 时发飞书通知.
+//
+// 防止重复打扰: notify 状态文件 notified.json 记录每个 user 最近通知时间,
+// 同一 user 24h 内不重复发通知.
+//
+// 复用 05_agent_spawn.sh 作为 lark-cli wrapper (HOME 隔离已在 wrapper 内做了),
+// 不直接 exec lark-cli,避免重复实现 HOME 切换/proxy 注入逻辑.
+type ExpiryWatcher struct {
+	runner          ScriptRunner
+	logger          *slog.Logger
+	mappingFile     string
+	stateFile       string
+	scanInterval    time.Duration // 多久跑一次 scan, 默认 1h
+	warnThreshold   time.Duration // token 距 expiry 多少时间触发通知, 默认 24h
+	notifyCooldown  time.Duration // 同 user 多久内不重复通知, 默认 24h
+	scriptTimeout   time.Duration // 单次 lark-cli 调用超时, 默认 30s
+	notifyTextTpl   string        // 通知文案模板, %s = 剩余时间
+	now             func() time.Time
+	mu              sync.Mutex // 守护 notify 状态文件
+}
+
+// notifyState 是 stateFile 序列化结构.
+type notifyState struct {
+	NotifiedAt map[string]time.Time `json:"notified_at"` // key = multica_user_id, val = last notify time
+}
+
+// authStatusOutput 解析 lark-cli auth status 输出. 字段名都是 wrapper / lark-cli 已稳定的.
+type authStatusOutput struct {
+	TokenStatus      string `json:"tokenStatus"`
+	ExpiresAt        string `json:"expiresAt"`
+	RefreshExpiresAt string `json:"refreshExpiresAt"`
+	// 嵌套结构 fallback: lark-cli 部分版本把字段塞 identities.user 下
+	Identities struct {
+		User struct {
+			ExpiresAt        string `json:"expiresAt"`
+			RefreshExpiresAt string `json:"refreshExpiresAt"`
+			TokenStatus      string `json:"tokenStatus"`
+		} `json:"user"`
+	} `json:"identities"`
+}
+
+// NewExpiryWatcher 构造 watcher. 配置项走显式参数避免 surprise.
+func NewExpiryWatcher(runner ScriptRunner, logger *slog.Logger, mappingFile, stateFile string) *ExpiryWatcher {
+	return &ExpiryWatcher{
+		runner:         runner,
+		logger:         logger,
+		mappingFile:    mappingFile,
+		stateFile:      stateFile,
+		scanInterval:   time.Hour,
+		warnThreshold:  24 * time.Hour,
+		notifyCooldown: 24 * time.Hour,
+		scriptTimeout:  30 * time.Second,
+		notifyTextTpl:  "⚠️ 飞书授权将在约 %s 后过期,请打开 https://multica.example.com/oauth-ui 重新扫码授权,以免 multica 任务被中断。",
+		now:            time.Now,
+	}
+}
+
+// Start 启动后台 ticker, ctx 取消即退出. 不阻塞调用方.
+func (w *ExpiryWatcher) Start(ctx context.Context) {
+	go func() {
+		// 启动后等 30s 让 daemon/runner 完全 ready, 再做第一次扫描
+		select {
+		case <-time.After(30 * time.Second):
+		case <-ctx.Done():
+			return
+		}
+		w.RunOnce(ctx)
+		ticker := time.NewTicker(w.scanInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.RunOnce(ctx)
+			}
+		}
+	}()
+}
+
+// RunOnce 同步跑一次完整扫描. 测试 / 手动触发都走这.
+// 返回 (扫描人数, 通知人数, 错误数).
+func (w *ExpiryWatcher) RunOnce(ctx context.Context) (scanned, notified, errs int) {
+	entries, err := loadMappings(w.mappingFile)
+	if err != nil {
+		w.logger.Warn("expiry-watcher: load mapping failed", "error", err.Error())
+		return 0, 0, 1
+	}
+	state, err := w.loadState()
+	if err != nil {
+		w.logger.Warn("expiry-watcher: load state failed (continue with empty)", "error", err.Error())
+		state = notifyState{NotifiedAt: map[string]time.Time{}}
+	}
+
+	for _, entry := range entries {
+		scanned++
+		if entry.MulticaUserID == "" || entry.LarkUserOpenID == "" {
+			continue
+		}
+		expireAt, status, err := w.fetchExpiry(ctx, entry.MulticaUserID)
+		if err != nil {
+			errs++
+			w.logger.Warn("expiry-watcher: fetch expiry failed", "user_id", entry.MulticaUserID, "error", err.Error())
+			continue
+		}
+		if expireAt.IsZero() {
+			// 无 refreshExpiresAt 也无 expiresAt — lark-cli 输出格式异常, 跳过避免误报
+			w.logger.Debug("expiry-watcher: no expiry field", "user_id", entry.MulticaUserID, "token_status", status)
+			continue
+		}
+		remaining := expireAt.Sub(w.now())
+		if remaining > w.warnThreshold {
+			continue
+		}
+		// 已通知过且未到冷却期 → skip
+		if last, ok := state.NotifiedAt[entry.MulticaUserID]; ok {
+			if w.now().Sub(last) < w.notifyCooldown {
+				continue
+			}
+		}
+		if err := w.notify(ctx, entry, remaining); err != nil {
+			errs++
+			w.logger.Warn("expiry-watcher: notify failed", "user_id", entry.MulticaUserID, "error", err.Error())
+			continue
+		}
+		state.NotifiedAt[entry.MulticaUserID] = w.now()
+		notified++
+		w.logger.Info("expiry-watcher: notify sent",
+			"user_id", entry.MulticaUserID,
+			"lark_user_open_id", entry.LarkUserOpenID,
+			"remaining", remaining.String(),
+		)
+	}
+	if notified > 0 {
+		if err := w.saveState(state); err != nil {
+			w.logger.Warn("expiry-watcher: save state failed", "error", err.Error())
+			errs++
+		}
+	}
+	w.logger.Info("expiry-watcher: scan done", "scanned", scanned, "notified", notified, "errors", errs)
+	return scanned, notified, errs
+}
+
+// fetchExpiry 通过 05_agent_spawn.sh 调 lark-cli auth status 拿 refresh expiry.
+// 优先用 refreshExpiresAt (~30 天有效); 没有就 fallback expiresAt (~2 小时, lark-cli 自动 refresh).
+func (w *ExpiryWatcher) fetchExpiry(ctx context.Context, userID string) (time.Time, string, error) {
+	ctx2, cancel := context.WithTimeout(ctx, w.scriptTimeout)
+	defer cancel()
+	res, err := w.runner.Run(ctx2, "05_agent_spawn.sh", userID, "auth", "status")
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	clean := stripWarnLines(res.Stdout)
+	// 去掉头尾非 JSON
+	first := strings.Index(clean, "{")
+	last := strings.LastIndex(clean, "}")
+	if first < 0 || last <= first {
+		return time.Time{}, "", fmt.Errorf("auth status: no JSON object (head=%q)", truncate(res.Stdout, 200))
+	}
+	var out authStatusOutput
+	if err := json.Unmarshal([]byte(clean[first:last+1]), &out); err != nil {
+		return time.Time{}, "", fmt.Errorf("auth status unmarshal: %w", err)
+	}
+	status := out.TokenStatus
+	if status == "" {
+		status = out.Identities.User.TokenStatus
+	}
+	pick := func(vals ...string) string {
+		for _, v := range vals {
+			if strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	expStr := pick(out.RefreshExpiresAt, out.Identities.User.RefreshExpiresAt, out.ExpiresAt, out.Identities.User.ExpiresAt)
+	if expStr == "" {
+		return time.Time{}, status, nil
+	}
+	t, err := parseFlexibleTime(expStr)
+	if err != nil {
+		return time.Time{}, status, fmt.Errorf("parse expiry %q: %w", expStr, err)
+	}
+	return t, status, nil
+}
+
+// parseFlexibleTime 接受 RFC3339 / RFC3339 含偏移 / 秒级 unix 数字字符串.
+func parseFlexibleTime(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05-0700", "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	// fallback: 数字 unix 秒
+	if n := parseUnixSeconds(s); n > 0 {
+		return time.Unix(n, 0).UTC(), nil
+	}
+	return time.Time{}, errors.New("unrecognized time format")
+}
+
+func parseUnixSeconds(s string) int64 {
+	var n int64
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		n = n*10 + int64(ch-'0')
+	}
+	// 1e9 (2001 年) ~ 1e10 (2286 年) 之间才像合理 unix 秒
+	if n < 1_000_000_000 || n > 99_999_999_999 {
+		return 0
+	}
+	return n
+}
+
+// notify 调 lark-cli im messages-send 给 user 自己发消息.
+// 文本里写剩余时间 (向下取整到小时), 避免显示 "0h 12m" 这种太精确造成假紧迫感.
+func (w *ExpiryWatcher) notify(ctx context.Context, entry MappingEntry, remaining time.Duration) error {
+	ctx2, cancel := context.WithTimeout(ctx, w.scriptTimeout)
+	defer cancel()
+	humanRemain := formatRemaining(remaining)
+	text := fmt.Sprintf(w.notifyTextTpl, humanRemain)
+	_, err := w.runner.Run(ctx2, "05_agent_spawn.sh", entry.MulticaUserID, "im", "+messages-send",
+		"--user-id", entry.LarkUserOpenID, "--text", text)
+	return err
+}
+
+func formatRemaining(d time.Duration) string {
+	if d <= 0 {
+		return "0 小时 (已过期)"
+	}
+	hours := int(d.Hours())
+	if hours >= 24 {
+		days := hours / 24
+		return fmt.Sprintf("%d 天", days)
+	}
+	if hours >= 1 {
+		return fmt.Sprintf("%d 小时", hours)
+	}
+	return fmt.Sprintf("%d 分钟", int(d.Minutes()))
+}
+
+// ---- state file (notified.json) ----
+
+func (w *ExpiryWatcher) loadState() (notifyState, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	empty := notifyState{NotifiedAt: map[string]time.Time{}}
+	b, err := os.ReadFile(w.stateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return empty, nil
+		}
+		return empty, err
+	}
+	if len(strings.TrimSpace(string(b))) == 0 {
+		return empty, nil
+	}
+	var s notifyState
+	if err := json.Unmarshal(b, &s); err != nil {
+		return empty, err
+	}
+	if s.NotifiedAt == nil {
+		s.NotifiedAt = map[string]time.Time{}
+	}
+	return s, nil
+}
+
+func (w *ExpiryWatcher) saveState(s notifyState) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(w.stateFile)
+	if dir != "" && dir != "." {
+		_ = os.MkdirAll(dir, 0o700)
+	}
+	tmp, err := os.CreateTemp(dir, "notified.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, w.stateFile)
+}

--- a/contrib/feishu-oauth-sidecar/sidecar/expiry_watcher_test.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/expiry_watcher_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// frozenRunner: 按 callKey 派发 stdout/err,记录所有调用方便断言.
+type frozenRunner struct {
+	mu    sync.Mutex
+	resp  map[string]mockResp
+	calls []string
+}
+
+func (r *frozenRunner) Run(ctx context.Context, script string, args ...string) (RunResult, error) {
+	key := callKey(script, args...)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, key)
+	if got, ok := r.resp[key]; ok {
+		return RunResult{Stdout: got.stdout, Stderr: got.stderr}, got.err
+	}
+	// 未配置 → 当成 lark-cli 调用成功但空输出,避免 panic; 显式声明 unknown
+	return RunResult{Stdout: `{"ok":true}`}, nil
+}
+
+func (r *frozenRunner) callsCopy() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func newTestWatcher(t *testing.T, runner ScriptRunner, mappingJSON string, now time.Time) (*ExpiryWatcher, string) {
+	t.Helper()
+	dir := t.TempDir()
+	mapping := filepath.Join(dir, "user_mapping.json")
+	if err := os.WriteFile(mapping, []byte(mappingJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(dir, "notified.json")
+	w := NewExpiryWatcher(runner, slog.New(slog.NewTextHandler(io.Discard, nil)), mapping, stateFile)
+	w.now = func() time.Time { return now }
+	w.scriptTimeout = 2 * time.Second
+	return w, stateFile
+}
+
+func TestExpiryWatcher_NotifyAboutToExpire(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	expireIn10h := now.Add(10 * time.Hour).Format(time.RFC3339)
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","lark_user_name":"alice","home":"/h/u1","provisioned_at":"2026-05-01T00:00:00Z"}]`
+	runner := &frozenRunner{resp: map[string]mockResp{
+		callKey("05_agent_spawn.sh", "u1", "auth", "status"): {
+			stdout: `{"tokenStatus":"valid","refreshExpiresAt":"` + expireIn10h + `","expiresAt":"` + expireIn10h + `"}`,
+		},
+		callKey("05_agent_spawn.sh", "u1", "im", "+messages-send",
+			"--user-id", "ou_1", "--text",
+			"⚠️ 飞书授权将在约 10 小时 后过期,请打开 https://multica.example.com/oauth-ui 重新扫码授权,以免 multica 任务被中断。"): {
+			stdout: `{"ok":true}`,
+		},
+	}}
+	w, stateFile := newTestWatcher(t, runner, mapping, now)
+
+	scanned, notified, errs := w.RunOnce(context.Background())
+	if scanned != 1 || notified != 1 || errs != 0 {
+		t.Fatalf("want 1/1/0 got %d/%d/%d, calls=%v", scanned, notified, errs, runner.callsCopy())
+	}
+
+	// 状态文件必须含 u1 的 notified_at
+	raw, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var st notifyState
+	if err := json.Unmarshal(raw, &st); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if _, ok := st.NotifiedAt["u1"]; !ok {
+		t.Fatalf("state missing u1: %s", raw)
+	}
+}
+
+func TestExpiryWatcher_NoNotifyWhenFresh(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	expireIn5d := now.Add(5 * 24 * time.Hour).Format(time.RFC3339)
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","home":"/h/u1","provisioned_at":"2026-05-01T00:00:00Z"}]`
+	runner := &frozenRunner{resp: map[string]mockResp{
+		callKey("05_agent_spawn.sh", "u1", "auth", "status"): {
+			stdout: `{"tokenStatus":"valid","refreshExpiresAt":"` + expireIn5d + `"}`,
+		},
+	}}
+	w, stateFile := newTestWatcher(t, runner, mapping, now)
+	_, notified, errs := w.RunOnce(context.Background())
+	if notified != 0 || errs != 0 {
+		t.Fatalf("want notified=0 errs=0, got %d/%d, calls=%v", notified, errs, runner.callsCopy())
+	}
+	// 没通知 → 状态文件不该被创建
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Fatalf("state file should not exist, err=%v", err)
+	}
+	// 也不该有 im +messages-send 调用
+	for _, c := range runner.callsCopy() {
+		if strings.Contains(c, "messages-send") {
+			t.Fatalf("unexpected messages-send call: %s", c)
+		}
+	}
+}
+
+func TestExpiryWatcher_CooldownPreventsDoubleNotify(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	expireIn10h := now.Add(10 * time.Hour).Format(time.RFC3339)
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","home":"/h/u1","provisioned_at":"2026-05-01T00:00:00Z"}]`
+	runner := &frozenRunner{resp: map[string]mockResp{
+		callKey("05_agent_spawn.sh", "u1", "auth", "status"): {
+			stdout: `{"tokenStatus":"valid","refreshExpiresAt":"` + expireIn10h + `"}`,
+		},
+		// 任意 messages-send 调用 — 这里 stdout 写空给默认 success
+	}}
+	w, stateFile := newTestWatcher(t, runner, mapping, now)
+
+	// 第一次: 应通知
+	_, notified1, _ := w.RunOnce(context.Background())
+	if notified1 != 1 {
+		t.Fatalf("first run want notified=1 got %d, calls=%v", notified1, runner.callsCopy())
+	}
+	// 第二次同一时刻: cooldown 24h 应抑制
+	_, notified2, _ := w.RunOnce(context.Background())
+	if notified2 != 0 {
+		t.Fatalf("second run want notified=0 (cooldown) got %d", notified2)
+	}
+	// 推进时间 25h: cooldown 过, 又应通知
+	w.now = func() time.Time { return now.Add(25 * time.Hour) }
+	// 更新 expiry 到 now+25h+10h, 让它仍在 24h threshold 内
+	expireLater := now.Add(25 * time.Hour).Add(10 * time.Hour).Format(time.RFC3339)
+	runner.mu.Lock()
+	runner.resp[callKey("05_agent_spawn.sh", "u1", "auth", "status")] = mockResp{
+		stdout: `{"tokenStatus":"valid","refreshExpiresAt":"` + expireLater + `"}`,
+	}
+	runner.mu.Unlock()
+	_, notified3, _ := w.RunOnce(context.Background())
+	if notified3 != 1 {
+		t.Fatalf("third run want notified=1 (cooldown elapsed) got %d", notified3)
+	}
+	// 状态文件应该被 update 过
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("state file missing after notify: %v", err)
+	}
+}
+
+func TestExpiryWatcher_SkipEntryWithMissingOpenID(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"","home":"/h/u1"}]`
+	runner := &frozenRunner{resp: map[string]mockResp{}}
+	w, _ := newTestWatcher(t, runner, mapping, now)
+	scanned, notified, errs := w.RunOnce(context.Background())
+	if scanned != 1 || notified != 0 || errs != 0 {
+		t.Fatalf("want 1/0/0 got %d/%d/%d", scanned, notified, errs)
+	}
+	// 不应该调任何 lark-cli
+	if len(runner.callsCopy()) != 0 {
+		t.Fatalf("should skip without lark-cli calls, got %v", runner.callsCopy())
+	}
+}
+
+func TestExpiryWatcher_FetchExpiryParsesNestedIdentities(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	expireIn8h := now.Add(8 * time.Hour).Format(time.RFC3339)
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","home":"/h/u1"}]`
+	// 用嵌套 identities.user.refreshExpiresAt 测 fallback 解析路径
+	nestedJSON := `{"identities":{"user":{"tokenStatus":"valid","refreshExpiresAt":"` + expireIn8h + `"}}}`
+	runner := &frozenRunner{resp: map[string]mockResp{
+		callKey("05_agent_spawn.sh", "u1", "auth", "status"): {stdout: nestedJSON},
+	}}
+	w, _ := newTestWatcher(t, runner, mapping, now)
+	_, notified, errs := w.RunOnce(context.Background())
+	if notified != 1 || errs != 0 {
+		t.Fatalf("want notified=1 errs=0 got %d/%d, calls=%v", notified, errs, runner.callsCopy())
+	}
+}
+
+func TestExpiryWatcher_StripsWarnLinesFromAuthOutput(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	expireIn5h := now.Add(5 * time.Hour).Format(time.RFC3339)
+	noisyOut := "[WARN] proxy detected\n[lark-cli] using HOME=/h/u1\n" +
+		`{"tokenStatus":"valid","refreshExpiresAt":"` + expireIn5h + `"}` + "\n"
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","home":"/h/u1"}]`
+	runner := &frozenRunner{resp: map[string]mockResp{
+		callKey("05_agent_spawn.sh", "u1", "auth", "status"): {stdout: noisyOut},
+	}}
+	w, _ := newTestWatcher(t, runner, mapping, now)
+	_, notified, errs := w.RunOnce(context.Background())
+	if notified != 1 || errs != 0 {
+		t.Fatalf("want notified=1 errs=0 got %d/%d", notified, errs)
+	}
+}
+
+func TestExpiryWatcher_FormatRemaining(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{-time.Hour, "0 小时 (已过期)"},
+		{30 * time.Minute, "30 分钟"},
+		{90 * time.Minute, "1 小时"},
+		{23 * time.Hour, "23 小时"},
+		{72 * time.Hour, "3 天"},
+	}
+	for _, c := range cases {
+		if got := formatRemaining(c.d); got != c.want {
+			t.Errorf("formatRemaining(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestExpiryWatcher_ParseFlexibleTime(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"2026-05-30T20:46:09+08:00", false},
+		{"2026-05-30T12:46:09Z", false},
+		{"2026-05-30 20:46:09", false},
+		{"1748520369", false}, // unix sec ~2025
+		{"", true},
+		{"not-a-time", true},
+	}
+	for _, c := range cases {
+		_, err := parseFlexibleTime(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parseFlexibleTime(%q): err=%v, wantErr=%v", c.in, err, c.wantErr)
+		}
+	}
+}

--- a/contrib/feishu-oauth-sidecar/sidecar/go.mod
+++ b/contrib/feishu-oauth-sidecar/sidecar/go.mod
@@ -1,0 +1,5 @@
+module feishu-oauth-sidecar
+
+go 1.23
+
+require github.com/go-chi/chi/v5 v5.1.0

--- a/contrib/feishu-oauth-sidecar/sidecar/go.sum
+++ b/contrib/feishu-oauth-sidecar/sidecar/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/contrib/feishu-oauth-sidecar/sidecar/handlers.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/handlers.go
@@ -1,0 +1,730 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+var userIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+//go:embed oauth-ui.html
+var oauthUIFS embed.FS
+
+type Config struct {
+	Port           string
+	ScriptsDir     string
+	MappingFile    string
+	UserHomesDir   string
+	AllowedOrigins []string
+	Version        string
+}
+
+type MappingEntry struct {
+	MulticaUserID  string    `json:"multica_user_id"`
+	LarkUserOpenID string    `json:"lark_user_open_id"`
+	LarkUserName   string    `json:"lark_user_name"`
+	Home           string    `json:"home"`
+	ProvisionedAt  time.Time `json:"provisioned_at"`
+}
+
+type Server struct {
+	cfg         Config
+	runner      ScriptRunner
+	logger      *slog.Logger
+	rateLimiter *IPRateLimiter
+	corsAllow   map[string]struct{}
+	allowAll    bool
+}
+
+type IPRateLimiter struct {
+	mu     sync.Mutex
+	window time.Duration
+	limit  int
+	hits   map[string][]time.Time
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+type jsonResponse map[string]any
+
+type TokenStatus struct {
+	TokenStatus string   `json:"tokenStatus"`
+	ExpiresAt   string   `json:"expiresAt"`
+	Scopes      []string `json:"scopes"`
+}
+
+func NewIPRateLimiter(limit int, window time.Duration) *IPRateLimiter {
+	return &IPRateLimiter{limit: limit, window: window, hits: make(map[string][]time.Time)}
+}
+
+func (l *IPRateLimiter) Allow(ip string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	start := now.Add(-l.window)
+	times := l.hits[ip]
+	k := 0
+	for _, t := range times {
+		if t.After(start) {
+			times[k] = t
+			k++
+		}
+	}
+	times = times[:k]
+	if len(times) >= l.limit {
+		l.hits[ip] = times
+		return false
+	}
+	times = append(times, now)
+	l.hits[ip] = times
+	return true
+}
+
+func NewServer(cfg Config, runner ScriptRunner, logger *slog.Logger) *Server {
+	allowAll := len(cfg.AllowedOrigins) == 0
+	allowSet := map[string]struct{}{}
+	for _, origin := range cfg.AllowedOrigins {
+		o := strings.TrimSpace(origin)
+		if o == "" {
+			continue
+		}
+		if o == "*" {
+			allowAll = true
+		}
+		allowSet[o] = struct{}{}
+	}
+	if len(allowSet) == 0 {
+		allowAll = true
+	}
+
+	return &Server{
+		cfg:         cfg,
+		runner:      runner,
+		logger:      logger,
+		rateLimiter: NewIPRateLimiter(60, time.Minute),
+		corsAllow:   allowSet,
+		allowAll:    allowAll,
+	}
+}
+
+func (s *Server) Router() http.Handler {
+	r := chi.NewRouter()
+	r.Use(s.corsMiddleware)
+	r.Use(s.rateLimitMiddleware)
+	r.Use(s.requestLogMiddleware)
+
+	r.Get("/healthz", s.healthzHandler)
+	r.Get("/oauth-ui", s.serveOAuthUI)
+	r.Get("/settings", s.serveOAuthUI) // 别名: multica web 入口可链 /settings, UI 自适应展示
+	r.Post("/api/feishu/device/start", s.startHandler)
+	r.Post("/api/feishu/device/complete", s.completeHandler)
+	r.Get("/api/feishu/device/status", s.statusHandler)
+	r.Post("/api/feishu/device/force-restart", s.forceRestartHandler) // V4: 清旧 mapping/home 强制重授权
+	return r
+}
+
+func (sr *statusRecorder) WriteHeader(status int) {
+	sr.status = status
+	sr.ResponseWriter.WriteHeader(status)
+}
+
+func (s *Server) requestLogMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		duration := time.Since(start)
+		s.logger.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"user_id", requestUserID(r),
+			"duration_ms", duration.Milliseconds(),
+			"status", rec.status,
+		)
+	})
+}
+
+func (s *Server) corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if s.allowAll {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+		} else if origin != "" {
+			if _, ok := s.corsAllow[origin]; ok {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+		}
+		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,Authorization")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) rateLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r)
+		if !s.rateLimiter.Allow(ip, time.Now()) {
+			writeJSON(w, http.StatusTooManyRequests, jsonResponse{"ok": false, "error": "rate limit exceeded"})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) healthzHandler(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	writeJSON(w, http.StatusOK, jsonResponse{"ok": true, "version": s.cfg.Version})
+}
+
+func (s *Server) serveOAuthUI(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	body, err := oauthUIFS.ReadFile("oauth-ui.html")
+	if err != nil {
+		s.logger.Error("read oauth-ui failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, jsonResponse{"ok": false, "error": "oauth ui unavailable"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+func (s *Server) startHandler(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	var req struct {
+		MulticaUserID string `json:"multica_user_id"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+	if err := validateUserID(req.MulticaUserID); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+
+	if _, err := s.runScriptJSON(ctx, "02_user_provision.sh", req.MulticaUserID); err != nil {
+		s.writeExecError(w, "provision failed", err, http.StatusInternalServerError)
+		return
+	}
+	data, err := s.runScriptJSON(ctx, "03_user_oauth_start.sh", req.MulticaUserID)
+	if err != nil {
+		s.writeExecError(w, "oauth start failed", err, http.StatusInternalServerError)
+		return
+	}
+
+	deviceCode := stringVal(data, "device_code", "deviceCode")
+
+	// fire-and-forget 后台 polling: oauth-ui 前端只轮询 /status, 不主动调 /complete
+	// 04 脚本完成后会写 mapping + token 落到 user HOME, /status 自然检测到 bound=true
+	if deviceCode != "" {
+		uid := req.MulticaUserID
+		go func() {
+			bgCtx, bgCancel := context.WithTimeout(context.Background(), 200*time.Second)
+			defer bgCancel()
+			if _, err := s.runScriptJSON(bgCtx, "04_user_oauth_complete.sh", uid, deviceCode); err != nil {
+				s.logger.Warn("background oauth polling failed", "user_id", uid, "error", err.Error())
+			} else {
+				s.logger.Info("background oauth polling succeeded", "user_id", uid)
+			}
+		}()
+	}
+
+	writeJSON(w, http.StatusOK, jsonResponse{
+		"ok":               true,
+		"multica_user_id":  req.MulticaUserID,
+		"device_code":      deviceCode,
+		"verification_url": stringVal(data, "verification_url", "verificationUrl"),
+		"user_code":        stringVal(data, "user_code", "userCode"),
+		"expires_in":       intVal(data, "expires_in", "expiresIn"),
+		"qr_ascii":         stringVal(data, "qr_ascii", "qrAscii"),
+	})
+}
+
+func (s *Server) completeHandler(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	ctx, cancel := context.WithTimeout(r.Context(), 200*time.Second)
+	defer cancel()
+
+	var req struct {
+		MulticaUserID string `json:"multica_user_id"`
+		DeviceCode    string `json:"device_code"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(req.MulticaUserID) == "" || strings.TrimSpace(req.DeviceCode) == "" {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": "multica_user_id and device_code are required"})
+		return
+	}
+
+	type result struct {
+		data map[string]any
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := s.runScriptJSON(ctx, "04_user_oauth_complete.sh", req.MulticaUserID, req.DeviceCode)
+		ch <- result{data: data, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": "oauth complete timeout"})
+		return
+	case r := <-ch:
+		if r.err != nil {
+			s.writeExecError(w, "oauth complete failed", r.err, http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, jsonResponse{
+			"ok":                true,
+			"multica_user_id":   stringVal(r.data, "multica_user_id", "multicaUserId"),
+			"lark_user_open_id": stringVal(r.data, "lark_user_open_id", "larkUserOpenId", "userOpenId"),
+			"lark_user_name":    stringVal(r.data, "lark_user_name", "larkUserName", "userName"),
+			"scopes":            sliceStringVal(r.data, "scopes"),
+		})
+	}
+}
+
+func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	userID := strings.TrimSpace(r.URL.Query().Get("multica_user_id"))
+	if err := validateUserID(userID); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+
+	entries, err := loadMappings(s.cfg.MappingFile)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, jsonResponse{"ok": false, "error": fmt.Sprintf("load mapping failed: %v", err)})
+		return
+	}
+
+	entry, ok := findMapping(entries, userID)
+	if !ok {
+		// self-heal: mapping 缺但 token enc 已落地 (例如 04 polling 成功但脚本最后 exit 失败)
+		// → 查 lark-cli auth status 拿 openId+userName 补写 mapping,避免用户重新扫码
+		userHome := filepath.Join(s.cfg.UserHomesDir, "mc-user-"+userID)
+		if st, err := os.Stat(userHome); err == nil && st.IsDir() {
+			rec, healErr := s.tryHealMapping(ctx, userID, userHome)
+			if healErr != nil {
+				s.logger.Warn("self-heal try failed", "user_id", userID, "error", healErr.Error())
+			}
+			if healErr == nil && rec != nil {
+				entries = append(entries, *rec)
+				if saveErr := saveMappings(s.cfg.MappingFile, entries); saveErr != nil {
+					s.logger.Warn("self-heal save mapping failed", "user_id", userID, "error", saveErr.Error())
+				} else {
+					s.logger.Info("self-heal mapping written", "user_id", userID, "lark_user_open_id", rec.LarkUserOpenID)
+					entry = *rec
+					ok = true
+				}
+			}
+		}
+		if !ok {
+			homeFound := false
+			if st, err := os.Stat(userHome); err == nil && st.IsDir() {
+				homeFound = true
+			}
+			status := "no_token"
+			if homeFound {
+				status = "not_authorized"
+			}
+			writeJSON(w, http.StatusOK, jsonResponse{
+				"ok":              true,
+				"multica_user_id": userID,
+				"bound":           false,
+				"token_status":    status,
+			})
+			return
+		}
+	}
+
+	result, err := s.runner.Run(ctx, "05_agent_spawn.sh", userID, "auth", "status")
+	if err != nil {
+		s.writeExecError(w, "auth status failed", err, http.StatusInternalServerError)
+		return
+	}
+	tokenInfo, err := parseTokenStatus(result.Stdout)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, jsonResponse{"ok": false, "error": fmt.Sprintf("parse auth status failed: %v", err)})
+		return
+	}
+	writeJSON(w, http.StatusOK, jsonResponse{
+		"ok":                true,
+		"multica_user_id":   userID,
+		"bound":             true,
+		"lark_user_open_id": entry.LarkUserOpenID,
+		"lark_user_name":    entry.LarkUserName,
+		"token_status":      tokenInfo.TokenStatus,
+		"expires_at":        tokenInfo.ExpiresAt,
+		"scopes":            tokenInfo.Scopes,
+	})
+}
+
+// forceRestartHandler V4: 用户在 oauth-ui 触发"强制重新授权" 时调用,
+// 清理本机的 (mapping entry + user home dir),然后 oauth-ui 应跳回 device start 重走流程。
+//
+// 适用场景:
+// - 用户在另一台机器扫码授权了,本机 mapping 缺
+// - 本机 token enc 损坏 / refresh 失败 / auth.json 格式漂移
+// - 用户想换飞书账号绑定 (旧 mapping 必须先清)
+//
+// 安全考虑:
+// - 仅接受 POST + multica_user_id (cors + rate limit 自动覆盖)
+// - 不能跨 multica_user_id 操作 (user 只能清自己的, 通过 URL 参数自证)
+// - 不真的删 home 目录里 user 数据,只删 .hermes/.lark-cli 等 token 凭据 (避免误删)
+func (s *Server) forceRestartHandler(w http.ResponseWriter, r *http.Request) {
+	defer s.recoverPanic(w, r)
+	var req struct {
+		MulticaUserID string `json:"multica_user_id"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+	userID := strings.TrimSpace(req.MulticaUserID)
+	if err := validateUserID(userID); err != nil {
+		writeJSON(w, http.StatusBadRequest, jsonResponse{"ok": false, "error": err.Error()})
+		return
+	}
+
+	// 1. 删 mapping entry (如果存在)
+	entries, err := loadMappings(s.cfg.MappingFile)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, jsonResponse{"ok": false, "error": fmt.Sprintf("load mapping: %v", err)})
+		return
+	}
+	cleaned := make([]MappingEntry, 0, len(entries))
+	removed := 0
+	for _, e := range entries {
+		if e.MulticaUserID == userID {
+			removed++
+			continue
+		}
+		cleaned = append(cleaned, e)
+	}
+	if removed > 0 {
+		if saveErr := saveMappings(s.cfg.MappingFile, cleaned); saveErr != nil {
+			s.logger.Warn("force-restart save mapping failed", "user_id", userID, "error", saveErr.Error())
+		}
+	}
+
+	// 2. 删 user home 里的 token 凭据 (但保留 home 目录本身, 避免误删用户其他数据)
+	userHome := filepath.Join(s.cfg.UserHomesDir, "mc-user-"+userID)
+	cleanedPaths := []string{}
+	if _, err := os.Stat(userHome); err == nil {
+		// 安全清单: 只清这些已知 token 文件 / 目录
+		tokenPaths := []string{
+			filepath.Join(userHome, ".lark-cli"),
+			filepath.Join(userHome, ".hermes", "auth.json"),
+			filepath.Join(userHome, ".config", "lark"),
+		}
+		for _, p := range tokenPaths {
+			if _, err := os.Stat(p); err == nil {
+				if err := os.RemoveAll(p); err == nil {
+					cleanedPaths = append(cleanedPaths, p)
+				} else {
+					s.logger.Warn("force-restart remove failed", "path", p, "error", err.Error())
+				}
+			}
+		}
+	}
+
+	s.logger.Info("force-restart done", "user_id", userID, "mapping_removed", removed, "paths_cleaned", len(cleanedPaths))
+	writeJSON(w, http.StatusOK, jsonResponse{
+		"ok":              true,
+		"multica_user_id": userID,
+		"mapping_removed": removed,
+		"paths_cleaned":   cleanedPaths,
+		"next_step":       "请重新点击「开始飞书授权」走完整 device flow",
+	})
+}
+
+func (s *Server) runScriptJSON(ctx context.Context, script string, args ...string) (map[string]any, error) {
+	res, err := s.runner.Run(ctx, script, args...)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := parseJSONObject(res.Stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse json failed: %w", err)
+	}
+	if ok, exists := payload["ok"]; exists {
+		if bv, isBool := ok.(bool); isBool && !bv {
+			return nil, errors.New(stringVal(payload, "error", "message"))
+		}
+	}
+	return payload, nil
+}
+
+func (s *Server) recoverPanic(w http.ResponseWriter, _ *http.Request) {
+	if rec := recover(); rec != nil {
+		s.logger.Error("panic", "error", rec)
+		writeJSON(w, http.StatusInternalServerError, jsonResponse{"ok": false, "error": "internal server error"})
+	}
+}
+
+func (s *Server) writeExecError(w http.ResponseWriter, msg string, err error, code int) {
+	var execErr *ExecError
+	if errors.As(err, &execErr) {
+		s.logger.Error(msg,
+			"script", execErr.Script,
+			"exit_code", execErr.ExitCode,
+			"timeout", execErr.Timeout,
+			"stderr", strings.TrimSpace(execErr.Stderr),
+		)
+		if execErr.Timeout {
+			writeJSON(w, code, jsonResponse{"ok": false, "error": msg + ": timeout"})
+			return
+		}
+		writeJSON(w, code, jsonResponse{"ok": false, "error": fmt.Sprintf("%s: exit=%d", msg, execErr.ExitCode)})
+		return
+	}
+	s.logger.Error(msg, "error", err)
+	writeJSON(w, code, jsonResponse{"ok": false, "error": msg})
+}
+
+func decodeJSON(r *http.Request, out any) error {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("invalid json: %w", err)
+	}
+	return nil
+}
+
+func validateUserID(userID string) error {
+	if strings.TrimSpace(userID) == "" {
+		return errors.New("multica_user_id is required")
+	}
+	if !userIDPattern.MatchString(userID) {
+		return errors.New("multica_user_id contains invalid characters")
+	}
+	return nil
+}
+
+func loadMappings(path string) ([]MappingEntry, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	trim := strings.TrimSpace(string(b))
+	if trim == "" {
+		return []MappingEntry{}, nil
+	}
+	var entries []MappingEntry
+	if err := json.Unmarshal(b, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func findMapping(items []MappingEntry, userID string) (MappingEntry, bool) {
+	for _, item := range items {
+		if item.MulticaUserID == userID {
+			return item, true
+		}
+	}
+	return MappingEntry{}, false
+}
+
+func saveMappings(path string, entries []MappingEntry) error {
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		_ = os.MkdirAll(dir, 0o700)
+	}
+	tmp, err := os.CreateTemp(dir, "user_mapping.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// tryHealMapping: token enc 已落地但 mapping 缺时,直接 exec lark-cli auth status (绕过 05_spawn 的 mapping 检查) 补出 MappingEntry
+func (s *Server) tryHealMapping(ctx context.Context, userID, userHome string) (*MappingEntry, error) {
+	larkBin := os.Getenv("LARK_BIN")
+	if larkBin == "" {
+		// fallback to common nvm path; same default as wrapper
+		larkBin = filepath.Join(os.Getenv("HOME"), ".nvm/versions/node/v22.12.0/bin/lark-cli")
+	}
+	cmd := exec.CommandContext(ctx, larkBin, "auth", "status")
+	cmd.Env = append(os.Environ(), "HOME="+userHome)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("exec lark-cli (bin=%s home=%s): %w stderr=%s", larkBin, userHome, err, strings.TrimSpace(stderr.String()))
+	}
+	obj, err := parseJSONObject(string(stdout))
+	if err != nil {
+		return nil, fmt.Errorf("parse lark-cli stdout (head=%q): %w", truncate(string(stdout), 200), err)
+	}
+	// lark-cli auth status 输出 .identities.user.{openId,userName,tokenStatus}
+	openID := ""
+	userName := ""
+	if ids, ok := obj["identities"].(map[string]any); ok {
+		if u, ok := ids["user"].(map[string]any); ok {
+			openID = stringVal(u, "openId", "open_id")
+			userName = stringVal(u, "userName", "user_name")
+		}
+	}
+	if openID == "" {
+		// fallback: 顶层有 userOpenId
+		openID = stringVal(obj, "userOpenId", "user_open_id")
+		userName = stringVal(obj, "userName", "user_name")
+	}
+	if openID == "" {
+		return nil, errors.New("auth status missing user openId")
+	}
+	return &MappingEntry{
+		MulticaUserID:  userID,
+		LarkUserOpenID: openID,
+		LarkUserName:   userName,
+		Home:           userHome,
+		ProvisionedAt:  time.Now().UTC(),
+	}, nil
+}
+
+func parseTokenStatus(out string) (TokenStatus, error) {
+	obj, err := parseJSONObject(out)
+	if err != nil {
+		return TokenStatus{}, err
+	}
+	return TokenStatus{
+		TokenStatus: stringVal(obj, "tokenStatus", "token_status"),
+		ExpiresAt:   stringVal(obj, "expiresAt", "expires_at"),
+		Scopes:      sliceStringVal(obj, "scopes"),
+	}, nil
+}
+
+func parseJSONObject(raw string) (map[string]any, error) {
+	clean := stripWarnLines(raw)
+	first := strings.Index(clean, "{")
+	last := strings.LastIndex(clean, "}")
+	if first < 0 || last < 0 || last <= first {
+		return nil, errors.New("json object not found")
+	}
+	clean = clean[first : last+1]
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(clean), &obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func stripWarnLines(raw string) string {
+	lines := strings.Split(raw, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trim := strings.TrimSpace(line)
+		if trim == "" {
+			continue
+		}
+		if strings.HasPrefix(trim, "[WARN]") || strings.HasPrefix(trim, "[lark-cli]") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+func stringVal(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func intVal(m map[string]any, keys ...string) int {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			switch n := v.(type) {
+			case float64:
+				return int(n)
+			case int:
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+func sliceStringVal(m map[string]any, key string) []string {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, status int, body jsonResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/contrib/feishu-oauth-sidecar/sidecar/handlers_test.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/handlers_test.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type mockResp struct {
+	stdout string
+	stderr string
+	err    error
+	delay  time.Duration
+}
+
+type mockRunner struct {
+	mu    sync.Mutex
+	resp  map[string]mockResp
+	calls []string
+}
+
+func (m *mockRunner) Run(ctx context.Context, script string, args ...string) (RunResult, error) {
+	key := callKey(script, args...)
+	m.mu.Lock()
+	r, ok := m.resp[key]
+	m.calls = append(m.calls, key)
+	m.mu.Unlock()
+	if !ok {
+		return RunResult{}, errors.New("unexpected call: " + key)
+	}
+	if r.delay > 0 {
+		select {
+		case <-time.After(r.delay):
+		case <-ctx.Done():
+			return RunResult{}, &ExecError{Script: script, Args: args, Timeout: true, ExitCode: -1, Cause: ctx.Err()}
+		}
+	}
+	return RunResult{Stdout: r.stdout, Stderr: r.stderr}, r.err
+}
+
+func callKey(script string, args ...string) string {
+	return script + "|" + strings.Join(args, "\x1f")
+}
+
+func newTestHandler(t *testing.T, runner ScriptRunner, mappingContent string, withUserHome string) http.Handler {
+	t.Helper()
+	return newTestHandlerWithMapping(t, runner, mappingContent, withUserHome).router
+}
+
+// testEnv 抓住 mapping 文件路径,方便测试断言 self-heal 后磁盘已写入.
+type testEnv struct {
+	router       http.Handler
+	mappingFile  string
+	userHomesDir string
+}
+
+func newTestHandlerWithMapping(t *testing.T, runner ScriptRunner, mappingContent string, withUserHome string) testEnv {
+	t.Helper()
+	dir := t.TempDir()
+	mapping := filepath.Join(dir, "user_mapping.json")
+	if err := os.WriteFile(mapping, []byte(mappingContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userHomes := filepath.Join(dir, "homes")
+	if err := os.MkdirAll(userHomes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if withUserHome != "" {
+		// statusHandler 期望 mc-user-<id> 目录名 (handlers.go:336),
+		// 所以测试同样用 mc-user-<id> 而不是裸 <id>
+		if err := os.MkdirAll(filepath.Join(userHomes, "mc-user-"+withUserHome), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := Config{
+		Port:           "18090",
+		ScriptsDir:     "/tmp/scripts",
+		MappingFile:    mapping,
+		UserHomesDir:   userHomes,
+		AllowedOrigins: []string{"*"},
+		Version:        "test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewServer(cfg, runner, logger)
+	return testEnv{router: s.Router(), mappingFile: mapping, userHomesDir: userHomes}
+}
+
+// writeFakeLarkBin 创建一个 mock lark-cli 脚本,固定输出指定 JSON 后 0 退出.
+// 用 t.Setenv 把 LARK_BIN 指过去,让 tryHealMapping 不需要真 lark-cli.
+func writeFakeLarkBin(t *testing.T, jsonOut string, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "lark-cli-fake")
+	// 用 heredoc 避免在 shell 里 escape 嵌套引号
+	script := "#!/bin/sh\ncat <<'JSON_EOF'\n" + jsonOut + "\nJSON_EOF\n"
+	if exitCode != 0 {
+		script += "exit " + itoa(exitCode) + "\n"
+	}
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func parseBody(t *testing.T, rr *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestStartEndpoint(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("02_user_provision.sh", "u1"): {stdout: `{"ok":true}`},
+			callKey("03_user_oauth_start.sh", "u1"): {
+				stdout: "[WARN] proxy detected\n" + `{"ok":true,"device_code":"dc","verification_url":"https://x","user_code":"uc","expires_in":600,"qr_ascii":"b64"}`,
+			},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/start", strings.NewReader(`{"multica_user_id":"u1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if body["device_code"] != "dc" {
+			t.Fatalf("unexpected device_code: %v", body["device_code"])
+		}
+	})
+
+	t.Run("missing param", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/start", strings.NewReader(`{"multica_user_id":""}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+
+	t.Run("script fail", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("02_user_provision.sh", "u1"): {err: &ExecError{Script: "02_user_provision.sh", ExitCode: 1}},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/start", strings.NewReader(`{"multica_user_id":"u1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500 got %d", rr.Code)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("02_user_provision.sh", "u1"): {err: &ExecError{Script: "02_user_provision.sh", Timeout: true, ExitCode: -1}},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/start", strings.NewReader(`{"multica_user_id":"u1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500 got %d", rr.Code)
+		}
+	})
+}
+
+func TestCompleteEndpoint(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("04_user_oauth_complete.sh", "u1", "dc"): {stdout: `{"ok":true,"multicaUserId":"u1","larkUserOpenId":"ou_1","larkUserName":"bob","scopes":["im:message"]}`},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/complete", strings.NewReader(`{"multica_user_id":"u1","device_code":"dc"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+	})
+
+	t.Run("missing param", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/complete", strings.NewReader(`{"multica_user_id":"u1"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+
+	t.Run("script fail", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("04_user_oauth_complete.sh", "u1", "dc"): {err: &ExecError{Script: "04_user_oauth_complete.sh", ExitCode: 2}},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/complete", strings.NewReader(`{"multica_user_id":"u1","device_code":"dc"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("04_user_oauth_complete.sh", "u1", "dc"): {err: &ExecError{Script: "04_user_oauth_complete.sh", Timeout: true, ExitCode: -1}},
+		}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/complete", strings.NewReader(`{"multica_user_id":"u1","device_code":"dc"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	mapping := `[{"multica_user_id":"u1","lark_user_open_id":"ou_1","lark_user_name":"bob","home":"/h/u1","provisioned_at":"2026-05-27T10:46:09Z"}]`
+
+	t.Run("happy", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("05_agent_spawn.sh", "u1", "auth", "status"): {stdout: `{"tokenStatus":"valid","expiresAt":"2026-05-27T20:46:09+08:00","scopes":["im:message"]}`},
+		}}
+		h := newTestHandler(t, r, mapping, "")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u1", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if body["bound"] != true {
+			t.Fatalf("want bound true got %v", body["bound"])
+		}
+	})
+
+	t.Run("missing param", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, mapping, "")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+
+	t.Run("script fail", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("05_agent_spawn.sh", "u1", "auth", "status"): {err: &ExecError{Script: "05_agent_spawn.sh", ExitCode: 3}},
+		}}
+		h := newTestHandler(t, r, mapping, "")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u1", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500 got %d", rr.Code)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("05_agent_spawn.sh", "u1", "auth", "status"): {err: &ExecError{Script: "05_agent_spawn.sh", Timeout: true, ExitCode: -1}},
+		}}
+		h := newTestHandler(t, r, mapping, "")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u1", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500 got %d", rr.Code)
+		}
+	})
+
+	t.Run("no mapping but home exists self heal fails", func(t *testing.T) {
+		// home 存在但 lark-cli 假 binary 报错 → 应该 fallback 返回 not_authorized
+		t.Setenv("LARK_BIN", "/usr/bin/false")
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, "[]", "u2")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u2", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if body["bound"] != false {
+			t.Fatalf("want bound false got %v", body["bound"])
+		}
+		if body["token_status"] != "not_authorized" {
+			t.Fatalf("unexpected token_status: %v", body["token_status"])
+		}
+	})
+
+	t.Run("no mapping no home returns no_token", func(t *testing.T) {
+		// mapping 空且 home 不存在 → no_token (跟 not_authorized 区分)
+		t.Setenv("LARK_BIN", "/usr/bin/false")
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=ughost", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if body["token_status"] != "no_token" {
+			t.Fatalf("want no_token got %v", body["token_status"])
+		}
+	})
+
+	t.Run("self heal happy path", func(t *testing.T) {
+		// home 存在 + lark-cli 返回 valid openId → tryHealMapping 写 mapping → 后续 05_agent_spawn 拿 token status
+		fakeLark := writeFakeLarkBin(t, `{"identities":{"user":{"openId":"ou_healed_3","userName":"alice"}}}`, 0)
+		t.Setenv("LARK_BIN", fakeLark)
+
+		r := &mockRunner{resp: map[string]mockResp{
+			callKey("05_agent_spawn.sh", "u3", "auth", "status"): {
+				stdout: `{"tokenStatus":"valid","expiresAt":"2026-05-30T20:46:09+08:00","scopes":["im:message"]}`,
+			},
+		}}
+		env := newTestHandlerWithMapping(t, r, "[]", "u3")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u3", nil)
+		rr := httptest.NewRecorder()
+		env.router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d body=%s", rr.Code, rr.Body.String())
+		}
+		body := parseBody(t, rr)
+		if body["bound"] != true {
+			t.Fatalf("want bound true got %v", body["bound"])
+		}
+		if body["lark_user_open_id"] != "ou_healed_3" {
+			t.Fatalf("want ou_healed_3 got %v", body["lark_user_open_id"])
+		}
+		if body["token_status"] != "valid" {
+			t.Fatalf("want token_status valid got %v", body["token_status"])
+		}
+
+		// 验证: self-heal 已把新 entry 持久化到 mapping 文件
+		raw, err := os.ReadFile(env.mappingFile)
+		if err != nil {
+			t.Fatalf("read mapping after heal: %v", err)
+		}
+		var entries []map[string]any
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			t.Fatalf("unmarshal mapping: %v", err)
+		}
+		if len(entries) != 1 || entries[0]["multica_user_id"] != "u3" || entries[0]["lark_user_open_id"] != "ou_healed_3" {
+			t.Fatalf("mapping not self-healed correctly: %v", entries)
+		}
+	})
+
+	t.Run("self heal fails when lark output missing openId", func(t *testing.T) {
+		// lark-cli 返回 JSON 但没 openId → tryHealMapping 应失败 → fallback not_authorized,且 mapping 不该写
+		fakeLark := writeFakeLarkBin(t, `{"identities":{"user":{"userName":"orphan"}}}`, 0)
+		t.Setenv("LARK_BIN", fakeLark)
+		r := &mockRunner{resp: map[string]mockResp{}}
+		env := newTestHandlerWithMapping(t, r, "[]", "u4")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/feishu/device/status?multica_user_id=u4", nil)
+		rr := httptest.NewRecorder()
+		env.router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if body["token_status"] != "not_authorized" {
+			t.Fatalf("want not_authorized got %v", body["token_status"])
+		}
+		// mapping 文件应该保持 [] 不被脏写
+		raw, _ := os.ReadFile(env.mappingFile)
+		if strings.TrimSpace(string(raw)) != "[]" {
+			t.Fatalf("mapping should remain empty, got: %s", raw)
+		}
+	})
+}
+
+func TestForceRestartEndpoint(t *testing.T) {
+	t.Run("missing user id", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{}}
+		h := newTestHandler(t, r, "[]", "")
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/force-restart", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("want 400 got %d", rr.Code)
+		}
+	})
+
+	t.Run("removes mapping entry", func(t *testing.T) {
+		mapping := `[
+			{"multica_user_id":"alice","lark_user_open_id":"ou_a","lark_user_name":"Alice","home":"/h/a","provisioned_at":"2026-05-27T10:46:09Z"},
+			{"multica_user_id":"bob","lark_user_open_id":"ou_b","lark_user_name":"Bob","home":"/h/b","provisioned_at":"2026-05-27T10:46:09Z"}
+		]`
+		r := &mockRunner{resp: map[string]mockResp{}}
+		env := newTestHandlerWithMapping(t, r, mapping, "")
+
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/force-restart", strings.NewReader(`{"multica_user_id":"alice"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		env.router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d body=%s", rr.Code, rr.Body.String())
+		}
+		body := parseBody(t, rr)
+		if body["ok"] != true {
+			t.Fatalf("want ok true got %v", body["ok"])
+		}
+		if mr, _ := body["mapping_removed"].(float64); mr != 1 {
+			t.Fatalf("want mapping_removed=1 got %v", body["mapping_removed"])
+		}
+
+		// 验证 alice 已删, bob 还在
+		raw, _ := os.ReadFile(env.mappingFile)
+		var remaining []map[string]any
+		if err := json.Unmarshal(raw, &remaining); err != nil {
+			t.Fatal(err)
+		}
+		if len(remaining) != 1 || remaining[0]["multica_user_id"] != "bob" {
+			t.Fatalf("expect only bob remaining, got: %v", remaining)
+		}
+	})
+
+	t.Run("cleans token files in user home", func(t *testing.T) {
+		r := &mockRunner{resp: map[string]mockResp{}}
+		env := newTestHandlerWithMapping(t, r, "[]", "u_clean")
+
+		// 在 home 下放假 token files
+		homeDir := filepath.Join(env.userHomesDir, "mc-user-u_clean")
+		larkCliDir := filepath.Join(homeDir, ".lark-cli")
+		if err := os.MkdirAll(larkCliDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(larkCliDir, "tokens.json"), []byte(`{"x":1}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		hermesDir := filepath.Join(homeDir, ".hermes")
+		if err := os.MkdirAll(hermesDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(hermesDir, "auth.json"), []byte(`{"y":2}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// 留一个不该被删的: 用户其他数据
+		userDataDir := filepath.Join(homeDir, "my-notes")
+		if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/force-restart", strings.NewReader(`{"multica_user_id":"u_clean"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		env.router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+
+		// 验证 token files 删了, my-notes 还在
+		if _, err := os.Stat(larkCliDir); !os.IsNotExist(err) {
+			t.Fatalf(".lark-cli should be removed")
+		}
+		if _, err := os.Stat(filepath.Join(hermesDir, "auth.json")); !os.IsNotExist(err) {
+			t.Fatalf(".hermes/auth.json should be removed")
+		}
+		if _, err := os.Stat(userDataDir); err != nil {
+			t.Fatalf("my-notes (user data) should NOT be removed, got %v", err)
+		}
+	})
+
+	t.Run("idempotent when no mapping no home", func(t *testing.T) {
+		// 没 mapping 没 home 也应该 200 OK 而不是 500, 让 UI 能重复点
+		r := &mockRunner{resp: map[string]mockResp{}}
+		env := newTestHandlerWithMapping(t, r, "[]", "")
+
+		req := httptest.NewRequest(http.MethodPost, "/api/feishu/device/force-restart", strings.NewReader(`{"multica_user_id":"ghost"}`))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		env.router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("want 200 got %d", rr.Code)
+		}
+		body := parseBody(t, rr)
+		if mr, _ := body["mapping_removed"].(float64); mr != 0 {
+			t.Fatalf("want mapping_removed=0 got %v", body["mapping_removed"])
+		}
+	})
+}
+
+func TestOAuthUIEndpoint(t *testing.T) {
+	r := &mockRunner{resp: map[string]mockResp{}}
+	h := newTestHandler(t, r, "[]", "")
+	req := httptest.NewRequest(http.MethodGet, "/oauth-ui", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Type"); !strings.Contains(got, "text/html") {
+		t.Fatalf("unexpected content-type: %s", got)
+	}
+	if got := rr.Header().Get("Cache-Control"); !strings.Contains(got, "max-age=300") {
+		t.Fatalf("unexpected cache-control: %s", got)
+	}
+	if !strings.Contains(rr.Body.String(), "飞书扫码授权") {
+		t.Fatalf("unexpected body")
+	}
+}

--- a/contrib/feishu-oauth-sidecar/sidecar/main.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const version = "0.1.0"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := loadConfig()
+	runner := &CommandRunner{ScriptsDir: cfg.ScriptsDir}
+
+	if err := initMini(logger, runner); err != nil {
+		logger.Error("init failed", "error", err)
+		os.Exit(1)
+	}
+
+	srv := NewServer(cfg, runner, logger)
+	httpServer := &http.Server{
+		Addr:         ":" + cfg.Port,
+		Handler:      srv.Router(),
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 210 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// expiry watcher 后台 goroutine: 每 1h 扫一次,token 距 refresh expiry <24h 发飞书提醒,
+	// 24h cooldown 防止重复打扰. ctx 在 main 退出时取消.
+	watcherCtx, watcherCancel := context.WithCancel(context.Background())
+	defer watcherCancel()
+	stateFile := filepath.Join(filepath.Dir(cfg.MappingFile), "notified.json")
+	watcher := NewExpiryWatcher(runner, logger, cfg.MappingFile, stateFile)
+	watcher.Start(watcherCtx)
+
+	go func() {
+		logger.Info("server start", "addr", httpServer.Addr, "expiry_watcher", "enabled")
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	<-stop
+	watcherCancel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(ctx); err != nil {
+		logger.Error("shutdown failed", "error", err)
+	}
+	logger.Info("server stopped")
+}
+
+func loadConfig() Config {
+	mapping := expandHome(getEnv("MAPPING_FILE", "~/multica-user-homes/user_mapping.json"))
+	return Config{
+		Port:           getEnv("PORT", "18090"),
+		ScriptsDir:     expandHome(getEnv("SCRIPTS_DIR", "~/lark_multi_user")),
+		MappingFile:    mapping,
+		UserHomesDir:   expandHome(getEnv("USER_HOMES_DIR", filepath.Dir(mapping))),
+		AllowedOrigins: splitCSV(getEnv("ALLOWED_ORIGINS", "*")),
+		Version:        version,
+	}
+}
+
+func initMini(logger *slog.Logger, runner ScriptRunner) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := runner.Run(ctx, "01_mini_init.sh")
+	if err != nil {
+		return err
+	}
+	logger.Info("init done", "stdout", strings.TrimSpace(res.Stdout))
+	if strings.TrimSpace(res.Stderr) != "" {
+		logger.Warn("init stderr", "stderr", strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func getEnv(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func expandHome(p string) string {
+	if !strings.HasPrefix(p, "~/") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, p[2:])
+}
+
+func requestUserID(r *http.Request) string {
+	if r.Method == http.MethodGet {
+		return r.URL.Query().Get("multica_user_id")
+	}
+	return ""
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/contrib/feishu-oauth-sidecar/sidecar/oauth-ui.html
+++ b/contrib/feishu-oauth-sidecar/sidecar/oauth-ui.html
@@ -1,0 +1,437 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>飞书扫码授权 | Multica</title>
+<style>
+/* ====== 基础变量 ====== */
+:root { --bg:#0a0a0a; --bg2:#111; --card:#141414; --elev:#1b1b1b; --text:#f5f5f5; --sub:#b3b3b3; --muted:#8a8a8a; --blue:#3370ff; --blue-soft:rgba(51,112,255,.2); --danger:#ff5f57; --border:rgba(255,255,255,.12); --border2:rgba(255,255,255,.2); }
+/* ====== Reset ====== */
+*{box-sizing:border-box}
+html,body{margin:0;min-height:100%;background:radial-gradient(circle at 15% 10%,rgba(51,112,255,.18),transparent 40%),radial-gradient(circle at 85% 85%,rgba(51,112,255,.08),transparent 45%),linear-gradient(180deg,#090909 0%,#0f0f0f 100%);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"PingFang SC","Segoe UI",sans-serif}
+body{display:flex;justify-content:center;align-items:center;padding:24px 16px 40px}
+/* ====== 布局 ====== */
+.shell{width:100%;max-width:480px}
+.title-wrap{text-align:center;margin-bottom:14px}
+.title{margin:0;font-size:28px;font-weight:700}
+.subtitle{margin:8px 0 0;color:var(--sub);font-size:15px;line-height:1.45}
+.card{border-radius:18px;padding:1px;background:linear-gradient(140deg,rgba(255,255,255,.28),rgba(255,255,255,.04));box-shadow:0 18px 44px rgba(0,0,0,.45)}
+.card-inner{background:linear-gradient(180deg,rgba(18,18,18,.96),rgba(14,14,14,.96));border-radius:17px;min-height:530px;padding:24px}
+/* ====== 状态切换 ====== */
+.state{display:none}
+.state.active{display:block}
+/* ====== 表单 ====== */
+.field-label{display:block;margin-bottom:8px;color:var(--sub);font-size:14px}
+.id-input{width:100%;border:1px solid var(--border);background:var(--elev);color:var(--text);border-radius:12px;padding:13px 14px;font-size:15px;outline:none}
+.id-input:focus{border-color:var(--blue);box-shadow:0 0 0 3px var(--blue-soft)}
+.hint{margin-top:8px;color:var(--muted);font-size:13px;line-height:1.5}
+.primary-btn,.ghost-btn{border:none;border-radius:12px;padding:12px 16px;font-size:15px;font-weight:600;cursor:pointer}
+.primary-btn{width:100%;background:linear-gradient(180deg,#4d7dff,#3370ff);color:#fff;margin-top:16px}
+.primary-btn:disabled{opacity:.55;cursor:not-allowed}
+.ghost-btn{background:rgba(255,255,255,.08);color:var(--text);border:1px solid var(--border)}
+/* ====== Loading ====== */
+.loading{min-height:300px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px}
+.spinner{width:44px;height:44px;border:3px solid rgba(255,255,255,.15);border-top-color:var(--blue);border-radius:999px;animation:spin .85s linear infinite}
+@keyframes spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}
+.loading-text{margin:0;font-size:16px;font-weight:600}
+/* ====== 错误面板 ====== */
+.error-panel{margin-top:12px;border:1px solid rgba(255,95,87,.4);background:rgba(255,95,87,.12);border-radius:12px;padding:12px;display:none}
+.error-panel.visible{display:block}
+.error-msg{margin:0;color:#ffd4d2;font-size:14px;line-height:1.45;white-space:pre-wrap;word-break:break-word}
+.error-action{margin-top:10px}
+/* ====== 二维码区 ====== */
+.qr-wrap{text-align:center}
+.qr-box{width:300px;height:300px;margin:0 auto;border-radius:16px;background:#fff;display:flex;align-items:center;justify-content:center;padding:6px;overflow:hidden}
+.qr-box canvas,.qr-box img{max-width:100%;max-height:100%}
+.qr-box pre.qr-ascii{margin:0;font-family:"SF Mono",Menlo,Consolas,monospace;font-size:13px;line-height:11px;letter-spacing:-0.5px;color:#111;background:#fff;white-space:pre;font-weight:700;text-align:center}
+.qr-fallback{display:none;color:#222;font-size:14px;line-height:1.4;text-align:center}
+.qr-fallback.visible{display:block}
+.verify-link{margin:16px 0 0;font-size:14px;color:var(--sub);line-height:1.5}
+.verify-link a{color:#8ab0ff;word-break:break-all}
+.user-code{margin-top:12px;color:var(--sub);font-size:14px;font-variant-numeric:tabular-nums}
+.countdown{margin-top:14px}
+.countdown-label{margin:0;color:var(--muted);font-size:13px}
+.countdown-time{margin:6px 0 0;font-size:30px;font-weight:700;color:#dbe6ff;letter-spacing:1px;font-variant-numeric:tabular-nums}
+.status-tip{margin-top:14px;color:var(--muted);font-size:13px}
+/* ====== 成功 / 过期 ====== */
+.success-wrap,.expired-wrap{min-height:360px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:14px}
+.success-icon{width:76px;height:76px;border-radius:999px;background:rgba(43,195,107,.18);border:1px solid rgba(43,195,107,.45);display:grid;place-items:center;color:#7ff0a8;font-size:42px;font-weight:700}
+.success-title{margin:0;font-size:28px}
+.profile{width:100%;border:1px solid var(--border);background:rgba(255,255,255,.04);border-radius:14px;padding:14px;text-align:left}
+.profile-item{margin:0 0 10px;color:var(--sub);font-size:14px;line-height:1.45;word-break:break-all}
+.profile-item:last-child{margin-bottom:0}
+.profile strong{color:#f6f8ff;margin-right:6px}
+.copy-row{display:flex;gap:10px;flex-wrap:wrap;justify-content:center}
+.expired-icon{font-size:40px;color:var(--danger)}
+.expired-title{margin:0;font-size:24px}
+.expired-subtitle{margin:0;color:var(--sub);font-size:15px;line-height:1.5}
+/* ====== Toast ====== */
+.toast{position:fixed;left:50%;bottom:30px;transform:translateX(-50%);border-radius:10px;border:1px solid var(--border2);background:rgba(17,17,17,.96);color:var(--text);padding:10px 14px;font-size:13px;box-shadow:0 10px 28px rgba(0,0,0,.35);display:none;max-width:calc(100vw - 32px);text-align:center}
+.toast.visible{display:block}
+/* ====== 手机适配 ====== */
+@media (max-width:560px){body{align-items:flex-start;padding-top:16px}.title{font-size:24px}.card-inner{min-height:auto;padding:20px 16px}.qr-box{width:min(300px,calc(100vw - 76px));height:min(300px,calc(100vw - 76px))}.countdown-time{font-size:27px}}
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="title-wrap">
+    <h1 class="title">飞书扫码授权</h1>
+    <p class="subtitle">用于将当前 Multica 用户绑定到飞书账号，仅需一次授权。</p>
+  </div>
+  <div class="card"><div class="card-inner">
+    <section id="state-input" class="state active">
+      <label for="userIdInput" class="field-label">Multica 用户 ID</label>
+      <input id="userIdInput" class="id-input" type="text" placeholder="例如: user-123-abc" autocomplete="off" spellcheck="false">
+      <div class="hint">如未自动检测到，请先在另一标签页登录 <a href="https://multica.example.com" target="_blank" rel="noopener" style="color:#8ab0ff">multica</a> 后刷新本页。或直接在 multica CLI 跑 <code style="background:#1a1a1a;padding:2px 6px;border-radius:4px">multica user profile get</code> 拿 <code style="background:#1a1a1a;padding:2px 6px;border-radius:4px">id</code> 字段。</div>
+      <button id="startBtn" class="primary-btn">开始飞书授权</button>
+
+      <details style="margin-top:18px;border-top:1px solid var(--border);padding-top:14px">
+        <summary style="color:var(--sub);font-size:13px;cursor:pointer;user-select:none">遇到问题？ 诊断 / 强制重置 ▾</summary>
+        <div style="margin-top:12px;color:var(--muted);font-size:13px;line-height:1.55">
+          <p style="margin:0 0 8px"><strong style="color:var(--text)">什么时候用强制重置？</strong></p>
+          <ul style="margin:0 0 12px;padding-left:18px">
+            <li>授权扫码后页面卡住、长时间不切到"成功"</li>
+            <li>已绑定但 multica 操作仍报"飞书授权失效"</li>
+            <li>想换飞书账号（清旧绑定后重新扫码）</li>
+            <li>在另一台机器扫码了，本机没同步</li>
+          </ul>
+          <p style="margin:0 0 8px"><strong style="color:var(--text)">强制重置会做什么？</strong></p>
+          <ul style="margin:0 0 12px;padding-left:18px">
+            <li>清除当前 multica 用户的飞书 token 凭据</li>
+            <li>清除 mapping (本机数据库的飞书身份记录)</li>
+            <li>保留你的其他用户数据 (只删 .lark-cli / .hermes/auth.json / .config/lark)</li>
+            <li>之后请点上方"开始飞书授权"重走扫码流程</li>
+          </ul>
+          <button id="forceRestartBtn" class="ghost-btn" style="width:100%;border-color:rgba(255,95,87,.4);color:#ffd4d2">强制重置当前 multica 用户的飞书绑定</button>
+          <p id="forceRestartResult" style="margin:10px 0 0;color:var(--muted);font-size:12px;line-height:1.5"></p>
+        </div>
+      </details>
+    </section>
+
+    <section id="state-loading" class="state">
+      <div class="loading">
+        <div class="spinner" aria-hidden="true"></div>
+        <p id="loadingText" class="loading-text">正在生成授权链接...</p>
+      </div>
+      <div id="startErrorPanel" class="error-panel" role="alert">
+        <p id="startErrorMsg" class="error-msg"></p>
+        <div class="error-action"><button id="retryStartBtn" class="ghost-btn">重试</button></div>
+      </div>
+    </section>
+
+    <section id="state-authorize" class="state">
+      <div class="qr-wrap">
+        <div id="qrBox" class="qr-box" aria-label="授权二维码"><div id="qrFallback" class="qr-fallback">二维码加载失败，请使用下方链接继续授权。</div></div>
+        <p class="verify-link">授权完成，点这里手动完成：<a id="verifyLink" href="#" target="_blank" rel="noopener noreferrer">打开飞书授权页</a></p>
+        <p id="userCodeLine" class="user-code"></p>
+        <div class="countdown"><p class="countdown-label">二维码剩余有效时间</p><p id="countdownText" class="countdown-time">10:00</p></div>
+        <p id="statusTip" class="status-tip">等待你扫码并确认授权，页面会自动刷新状态。</p>
+      </div>
+    </section>
+
+    <section id="state-success" class="state">
+      <div class="success-wrap">
+        <div class="success-icon" aria-hidden="true">✓</div>
+        <h2 class="success-title">授权成功</h2>
+        <div class="profile">
+          <p class="profile-item"><strong>飞书用户名:</strong><span id="successName">-</span></p>
+          <p class="profile-item"><strong>Open ID:</strong><span id="successOpenID">-</span></p>
+        </div>
+        <div class="copy-row">
+          <button id="copyOpenIdBtn" class="ghost-btn">复制 Open ID</button>
+          <button id="closeBtn" class="primary-btn">完成，关闭此页面</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="state-expired" class="state">
+      <div class="expired-wrap">
+        <div class="expired-icon">⚠</div>
+        <h2 class="expired-title">授权链接已过期</h2>
+        <p class="expired-subtitle">10 分钟内未完成扫码，请重新开始授权流程。</p>
+        <button id="restartBtn" class="primary-btn">重新开始</button>
+      </div>
+    </section>
+  </div></div>
+</div>
+<div id="toast" class="toast" role="status"></div>
+
+<script>
+(function(){
+  /*
+   * 使用说明:
+   * 1. 正常访问 /oauth-ui 会显示输入框。
+   * 2. 访问 /oauth-ui?multica_user_id=xxx 会自动开始授权。
+   * 3. /start 返回 verification_url 后，页面绘制二维码并启动倒计时。
+   * 4. 页面每 3 秒调用 /status，直到 token 可用。
+   * 5. valid / needs_refresh 都视为授权成功。
+   * 6. 倒计时结束后切换过期页面并允许重新开始。
+   *
+   * 约束:
+   * - 无第三方框架，仅原生 HTML/CSS/JS。
+   * - 唯一外部 CDN 为 qrcode.min.js。
+   * - 所有错误都以页面提示呈现，不依赖控制台日志。
+   * - 轮询网络抖动不终止流程，只展示状态提示。
+   * - 复制 Open ID 使用 navigator.clipboard，失败时提示手动复制。
+   * - 页面可在手机上操作，二维码区域自适应宽度。
+   */
+
+  /*
+   * 页面状态机:
+   * 1) input     输入 multica_user_id
+   * 2) loading   调 /start 生成二维码
+   * 3) authorize 展示二维码 + 倒计时 + 轮询 /status
+   * 4) success   授权成功显示飞书身份
+   * 5) expired   超时过期，可重试
+   *
+   * 错误策略:
+   * - /start 失败: 显示错误面板 + 重试按钮
+   * - /status 轮询失败: 不中断流程，提示网络波动并继续轮询
+   * - 二维码 CDN 异常: 显示文本链接作为 fallback
+   */
+
+  // DOM 缓存
+  var els={
+    inputState:document.getElementById("state-input"),
+    loadingState:document.getElementById("state-loading"),
+    authorizeState:document.getElementById("state-authorize"),
+    successState:document.getElementById("state-success"),
+    expiredState:document.getElementById("state-expired"),
+    userIdInput:document.getElementById("userIdInput"),
+    startBtn:document.getElementById("startBtn"),
+    retryStartBtn:document.getElementById("retryStartBtn"),
+    startErrorPanel:document.getElementById("startErrorPanel"),
+    startErrorMsg:document.getElementById("startErrorMsg"),
+    loadingText:document.getElementById("loadingText"),
+    verifyLink:document.getElementById("verifyLink"),
+    qrBox:document.getElementById("qrBox"),
+    qrFallback:document.getElementById("qrFallback"),
+    userCodeLine:document.getElementById("userCodeLine"),
+    countdownText:document.getElementById("countdownText"),
+    statusTip:document.getElementById("statusTip"),
+    successName:document.getElementById("successName"),
+    successOpenID:document.getElementById("successOpenID"),
+    copyOpenIdBtn:document.getElementById("copyOpenIdBtn"),
+    closeBtn:document.getElementById("closeBtn"),
+    restartBtn:document.getElementById("restartBtn"),
+    toast:document.getElementById("toast"),
+    forceRestartBtn:document.getElementById("forceRestartBtn"),
+    forceRestartResult:document.getElementById("forceRestartResult")
+  };
+  // 状态节点映射
+  var states={input:els.inputState,loading:els.loadingState,authorize:els.authorizeState,success:els.successState,expired:els.expiredState};
+  // 运行态变量
+  var pollTimer=null,countdownTimer=null,remainingSeconds=0,currentUserID="",currentOpenID="",pollingInFlight=false,toastTimer=null;
+
+  // ====== UI 基础方法 ======
+  function setState(name){Object.keys(states).forEach(function(k){states[k].classList.toggle("active",k===name);});}
+  function showToast(msg){if(!msg)return;els.toast.textContent=msg;els.toast.classList.add("visible");if(toastTimer)clearTimeout(toastTimer);toastTimer=setTimeout(function(){els.toast.classList.remove("visible");},2600);}
+  function clearStartError(){els.startErrorPanel.classList.remove("visible");els.startErrorMsg.textContent="";}
+  function showStartError(msg){els.startErrorMsg.textContent=msg||"授权启动失败，请稍后重试。";els.startErrorPanel.classList.add("visible");}
+  function stopTimers(){if(pollTimer){clearInterval(pollTimer);pollTimer=null;}if(countdownTimer){clearInterval(countdownTimer);countdownTimer=null;}}
+  function sanitizeUserID(raw){return(raw||"").trim();}
+  function formatTime(total){var safe=Math.max(0,total),mm=String(Math.floor(safe/60)).padStart(2,"0"),ss=String(safe%60).padStart(2,"0");return mm+":"+ss;}
+
+  // ====== 倒计时 ======
+  function beginCountdown(seconds){
+    remainingSeconds=Number.isFinite(seconds)&&seconds>0?Math.floor(seconds):600;
+    els.countdownText.textContent=formatTime(remainingSeconds);
+    if(countdownTimer)clearInterval(countdownTimer);
+    countdownTimer=setInterval(function(){
+      remainingSeconds-=1;
+      if(remainingSeconds<=0){remainingSeconds=0;els.countdownText.textContent="00:00";stopTimers();setState("expired");return;}
+      els.countdownText.textContent=formatTime(remainingSeconds);
+    },1000);
+  }
+
+  // ====== 网络请求 ======
+  async function postJSON(url,payload){
+    var res=await fetch(url,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(payload)});
+    var data=null;try{data=await res.json();}catch(_){data=null;}
+    if(!res.ok)throw new Error(data&&(data.error||data.message)?(data.error||data.message):"请求失败");
+    return data;
+  }
+
+  async function getJSON(url){var res=await fetch(url,{method:"GET"});if(!res.ok)throw new Error("请求失败");return res.json();}
+
+  // ====== QR 渲染（用 sidecar 返回的 ASCII，零外部 CDN 依赖）======
+  function renderQRCode(qrAsciiBase64){
+    els.qrFallback.classList.remove("visible");
+    els.qrBox.innerHTML="";
+    els.qrBox.appendChild(els.qrFallback);
+    if(!qrAsciiBase64){els.qrFallback.classList.add("visible");return;}
+    try{
+      // sidecar 返回的 qr_ascii 是 base64-encoded UTF-8 (含 ▀▄█ 块字符)
+      var decoded=decodeURIComponent(escape(atob(qrAsciiBase64)));
+      var pre=document.createElement("pre");
+      pre.className="qr-ascii";
+      pre.textContent=decoded;
+      els.qrBox.appendChild(pre);
+    }catch(e){els.qrFallback.classList.add("visible");}
+  }
+
+  // ====== 授权状态判断 ======
+  function shouldTreatAsSuccess(statusData){
+    if(!statusData||statusData.bound!==true)return false;
+    var token=String(statusData.token_status||"").toLowerCase();
+    return token==="valid"||token==="needs_refresh";
+  }
+
+  // ====== 成功态渲染 ======
+  function enterSuccess(statusData){
+    stopTimers();
+    els.successName.textContent=statusData.lark_user_name||"未返回";
+    currentOpenID=statusData.lark_user_open_id||"";
+    els.successOpenID.textContent=currentOpenID||"未返回";
+    setState("success");
+  }
+
+  // ====== 轮询 /status ======
+  async function pollStatus(){
+    if(!currentUserID||pollingInFlight)return;
+    pollingInFlight=true;
+    try{
+      var data=await getJSON("/api/feishu/device/status?multica_user_id="+encodeURIComponent(currentUserID));
+      if(data&&data.ok&&shouldTreatAsSuccess(data)){enterSuccess(data);return;}
+      if(data&&data.ok&&data.bound===false&&String(data.token_status||"")==="not_authorized"){els.statusTip.textContent="已生成二维码，等待扫码确认...";}
+    }catch(_){els.statusTip.textContent="网络轻微波动，正在自动重试...";}
+    finally{pollingInFlight=false;}
+  }
+
+  function startPolling(){if(pollTimer)clearInterval(pollTimer);pollTimer=setInterval(pollStatus,3000);}
+
+  // ====== 授权页面渲染 ======
+  function fillAuthorizeUI(data){
+    var verificationURL=data.verification_url||"";
+    els.verifyLink.href=verificationURL||"#";
+    els.verifyLink.textContent=verificationURL||"打开飞书授权页";
+    els.userCodeLine.textContent=data.user_code?("用户验证码："+data.user_code):"";
+    els.statusTip.textContent="等待你扫码并确认授权，页面会自动刷新状态。";
+    renderQRCode(data.qr_ascii||"");
+  }
+
+  // ====== 开始授权流程 ======
+  async function beginFlow(multicaUserID){
+    currentUserID=multicaUserID;
+    stopTimers();
+    clearStartError();
+    setState("loading");
+    els.loadingText.textContent="正在生成授权链接...";
+    try{
+      var data=await postJSON("/api/feishu/device/start",{multica_user_id:multicaUserID});
+      if(!data||data.ok!==true)throw new Error((data&&(data.error||data.message))||"授权启动失败");
+      fillAuthorizeUI(data);
+      setState("authorize");
+      beginCountdown(Number(data.expires_in));
+      startPolling();
+      pollStatus();
+    }catch(err){
+      setState("loading");
+      els.loadingText.textContent="生成授权链接失败";
+      showStartError(err&&err.message?err.message:"网络异常，请稍后重试");
+    }
+  }
+
+  // ====== 输入态动作 ======
+  function handleStart(){
+    var id=sanitizeUserID(els.userIdInput.value);
+    if(!id){showToast("请先输入 multica_user_id");els.userIdInput.focus();return;}
+    beginFlow(id);
+  }
+
+  // ====== 重置到输入态 ======
+  function resetToInput(){stopTimers();pollingInFlight=false;currentOpenID="";clearStartError();els.userIdInput.value="";setState("input");els.userIdInput.focus();}
+
+  // ====== 复制 open_id ======
+  async function copyOpenID(){
+    if(!currentOpenID){showToast("当前没有可复制的 Open ID");return;}
+    try{await navigator.clipboard.writeText(currentOpenID);showToast("Open ID 已复制");}
+    catch(_){showToast("复制失败，请手动复制");}
+  }
+
+  // ====== Query 参数自动发起 (优先级 1) ======
+  // ====== /api/me 自动检测 multica 当前登录用户 (优先级 2, 同域 cookie 自动带过去) ======
+  async function autoDetectFromMulticaSession(){
+    try{
+      var res=await fetch("/api/me",{method:"GET",credentials:"include",headers:{"Accept":"application/json"}});
+      if(!res.ok)return null;
+      var data=await res.json();
+      var id=sanitizeUserID(data&&data.id);
+      return id||null;
+    }catch(_){return null;}
+  }
+
+  async function initFromQuery(){
+    var params=new URLSearchParams(window.location.search);
+    var queryID=sanitizeUserID(params.get("multica_user_id"));
+    if(queryID){els.userIdInput.value=queryID;beginFlow(queryID);return;}
+
+    // 自动检测 multica 当前登录用户
+    setState("input");
+    els.userIdInput.value="";
+    els.userIdInput.placeholder="正在自动检测 multica 当前登录用户...";
+    els.userIdInput.disabled=true;
+    els.startBtn.disabled=true;
+    var detectedID=await autoDetectFromMulticaSession();
+    els.userIdInput.disabled=false;
+    els.startBtn.disabled=false;
+    if(detectedID){
+      els.userIdInput.value=detectedID;
+      els.userIdInput.placeholder="例如: user-123-abc";
+      beginFlow(detectedID);
+      return;
+    }
+    // 自动检测失败 → fallback 手动输入
+    els.userIdInput.placeholder="例如: 00000000-0000-0000-0000-000000000000";
+    els.userIdInput.focus();
+  }
+
+  // ====== V4 强制重置: 调 /api/feishu/device/force-restart ======
+  // 适用场景: 卡死 / 跨机器扫码 / 换账号 / token 文件损坏
+  // 服务端会清 mapping entry + .lark-cli / .hermes/auth.json / .config/lark (保留用户其他数据)
+  async function handleForceRestart(){
+    var raw=sanitizeUserID(els.userIdInput.value);
+    if(!raw){showToast("请先填入 Multica 用户 ID");els.userIdInput.focus();return;}
+    if(!els.forceRestartBtn||!els.forceRestartResult)return;
+    if(!window.confirm("强制重置当前 user 的飞书绑定?\n这会清掉旧的 token + mapping,然后你需要重新扫码授权。\n确定继续吗?"))return;
+    els.forceRestartBtn.disabled=true;
+    els.forceRestartBtn.textContent="正在重置...";
+    els.forceRestartResult.textContent="";
+    try{
+      var data=await postJSON("/api/feishu/device/force-restart",{multica_user_id:raw});
+      var removed=data&&typeof data.mapping_removed==="number"?data.mapping_removed:0;
+      var cleaned=Array.isArray(data&&data.paths_cleaned)?data.paths_cleaned.length:0;
+      els.forceRestartResult.textContent="✓ 已清理: mapping "+removed+" 条, token 文件 "+cleaned+" 个. 请点上方「开始飞书授权」重走扫码。";
+      els.forceRestartResult.style.color="#7ff0a8";
+      showToast("重置成功,请重新授权");
+    }catch(err){
+      els.forceRestartResult.textContent="✗ 重置失败: "+(err&&err.message?err.message:"未知错误");
+      els.forceRestartResult.style.color="#ffd4d2";
+    }finally{
+      els.forceRestartBtn.disabled=false;
+      els.forceRestartBtn.textContent="强制重置当前 multica 用户的飞书绑定";
+    }
+  }
+
+  // ====== 事件绑定 ======
+  // 触发点:
+  // - 点击开始按钮
+  // - 输入框回车
+  // - 重试 / 重新开始
+  // - 强制重置 (V4)
+  // - 页面卸载时清理定时器
+  els.startBtn.addEventListener("click",handleStart);
+  els.retryStartBtn.addEventListener("click",function(){if(currentUserID)beginFlow(currentUserID);else handleStart();});
+  els.userIdInput.addEventListener("keydown",function(evt){if(evt.key==="Enter"){evt.preventDefault();handleStart();}});
+  els.copyOpenIdBtn.addEventListener("click",copyOpenID);
+  els.closeBtn.addEventListener("click",function(){window.close();showToast("可直接关闭此页面");});
+  els.restartBtn.addEventListener("click",resetToInput);
+  if(els.forceRestartBtn){els.forceRestartBtn.addEventListener("click",handleForceRestart);}
+  window.addEventListener("beforeunload",stopTimers);
+  // 启动
+  initFromQuery();
+})();
+</script>
+</body>
+</html>

--- a/contrib/feishu-oauth-sidecar/sidecar/runner.go
+++ b/contrib/feishu-oauth-sidecar/sidecar/runner.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type ScriptRunner interface {
+	Run(ctx context.Context, script string, args ...string) (RunResult, error)
+}
+
+type RunResult struct {
+	Stdout string
+	Stderr string
+}
+
+type CommandRunner struct {
+	ScriptsDir string
+}
+
+type ExecError struct {
+	Script   string
+	Args     []string
+	ExitCode int
+	Stderr   string
+	Timeout  bool
+	Cause    error
+}
+
+func (e *ExecError) Error() string {
+	if e.Timeout {
+		return fmt.Sprintf("script %s timed out", e.Script)
+	}
+	if e.ExitCode != 0 {
+		return fmt.Sprintf("script %s exited with code %d", e.Script, e.ExitCode)
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("script %s failed: %v", e.Script, e.Cause)
+	}
+	return fmt.Sprintf("script %s failed", e.Script)
+}
+
+func (r *CommandRunner) Run(ctx context.Context, script string, args ...string) (RunResult, error) {
+	cmd := exec.CommandContext(ctx, "bash", append([]string{scriptPath(r.ScriptsDir, script)}, args...)...)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	result := RunResult{Stdout: outBuf.String(), Stderr: errBuf.String()}
+	if err == nil {
+		return result, nil
+	}
+
+	execErr := &ExecError{Script: script, Args: args, Stderr: result.Stderr, Cause: err, ExitCode: -1}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		execErr.Timeout = true
+		return result, execErr
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		execErr.ExitCode = exitErr.ExitCode()
+	}
+	return result, execErr
+}
+
+func scriptPath(dir, script string) string {
+	return strings.TrimRight(dir, "/") + "/" + script
+}

--- a/contrib/feishu-oauth-sidecar/skill/SKILL.md
+++ b/contrib/feishu-oauth-sidecar/skill/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: 飞书代理操作-zh
+description: 以当前 issue 创建者 (multica user) 的飞书身份执行 lark-cli 操作 — 发消息/查日历/读文档/管理 wiki 等。V6 反 hallucination:禁手敲 UUID/open_id,只允许 bash 变量引用 + sidecar /status 权威字段。V5 完整 fallback 链:metadata → member creator_id → agent parent.creator → agent.owner_id。私密 issue 禁 fallback。区分 OAuth 失效 vs 临时错误,错误分类四档 + retry max 2。永不伪造结果。
+language: zh-CN
+---
+
+# 飞书代理操作员 (V6)
+
+## 何时使用
+
+issue 描述里出现以下任一意图时，**必须**用这个 skill，**禁止**自己造 lark-cli 命令：
+
+- 发飞书消息（im send / chat-create / reply / forward）
+- 读/写飞书日历（calendar event create/read/update）
+- 操作飞书文档（docs / docx / wiki）
+- 任何飞书操作（任何 `lark-cli <module>` 命令）
+
+## 操作流程（必须严格按顺序）
+
+### 步骤 0 (V3): 私密 issue 隔离检查 — 防身份误用
+
+multica 当前 workspace 内所有 issue 互看 (没 per-issue ACL),但 `metadata.private_to` 是 issue 创建者标记的"只允许这个 multica user 名下的飞书身份执行"约定。**先拿 ISSUE 完整 JSON,一次解析全部字段**:
+
+```bash
+ISSUE_JSON=$(multica issue get $ISSUE_ID --output json)
+PRIVATE_TO=$(echo "$ISSUE_JSON" | jq -r '.metadata.private_to // empty')
+FEISHU_USER_ID_META=$(echo "$ISSUE_JSON" | jq -r '.metadata.feishu_user_id // empty')
+CREATOR_ID=$(echo "$ISSUE_JSON" | jq -r '.creator_id // empty')
+CREATOR_TYPE=$(echo "$ISSUE_JSON" | jq -r '.creator_type // empty')
+PARENT_ISSUE_ID=$(echo "$ISSUE_JSON" | jq -r '.parent_issue_id // empty')
+```
+
+**判定铁律 — 私密 issue (违反 = 安全事故)**:
+
+- `private_to` 为空 → 公开 issue, 跳过本步走步骤 1+ 的常规校验 (会自动走 V4 fallback)
+- `private_to` 非空 → **必须**显式 `metadata.feishu_user_id`, 严格校验 `private_to == feishu_user_id`:
+  - 自洽 → 放行,**禁止用 V4 fallback** (私密 issue 不允许猜身份)
+  - `feishu_user_id` 为空 → 拒绝:
+    > 🔒 此 issue 标了 `private_to=$PRIVATE_TO` (私密),但缺 `metadata.feishu_user_id`,**拒绝执行**。请 issue 创建者补 `metadata.feishu_user_id=$PRIVATE_TO` 后 rerun。私密 issue 不允许 fallback。
+  - 不一致 → 拒绝:
+    > 🔒 私密 issue: `metadata.private_to=$PRIVATE_TO`, 但 `metadata.feishu_user_id=$FEISHU_USER_ID_META` 不一致,**拒绝执行**。
+
+**不允许的反模式 (私密 issue 场景)**:
+- ❌ 把 `private_to` 解释成"软提示",硬跑
+- ❌ 私密 issue 用 V4 fallback 推导 `creator_id` 当 `feishu_user_id` — 违反"必须显式"原则
+- ❌ 用 owner 身份 / workspace 默认身份替代
+
+### 步骤 1 (V5 升级): 决定 FEISHU_USER_ID — 完整 fallback 推导链
+
+按以下**优先级顺序**决定 `FEISHU_USER_ID`,**私密 issue (private_to 非空) 跳过所有 fallback,必须显式 metadata**:
+
+```
+1. metadata.feishu_user_id 非空 → 直接用 (尊重显式注入)
+2. creator_type=member + creator_id 非空 → 用 creator_id (V4 fallback)
+3. creator_type=agent + parent_issue_id 非空 → 递归看 parent (找 user 起源)
+4. creator_type=agent + 无 parent → 用 agent.owner_id (V5 fallback,覆盖 autopilot 直派 issue)
+5. 都不行 → 错误引导
+```
+
+**Bash 实现**:
+
+```bash
+FEISHU_USER_ID=""
+FEISHU_SOURCE=""
+
+if [ -n "$FEISHU_USER_ID_META" ]; then
+  # 1. 显式 metadata
+  FEISHU_USER_ID="$FEISHU_USER_ID_META"
+  FEISHU_SOURCE="metadata.feishu_user_id (显式)"
+elif [ "$CREATOR_TYPE" = "member" ] && [ -n "$CREATOR_ID" ]; then
+  # 2. V4: member 创建的 issue 用 creator_id
+  FEISHU_USER_ID="$CREATOR_ID"
+  FEISHU_SOURCE="issue.creator_id (V4 fallback, member 创建)"
+elif [ "$CREATOR_TYPE" = "agent" ]; then
+  # 3 + 4: agent 创建的 issue — 先看 parent, 否则取 agent.owner_id
+  if [ -n "$PARENT_ISSUE_ID" ]; then
+    # 递归查 parent (V5a) — 最多向上 5 层避免循环
+    P_JSON=$(multica issue get $PARENT_ISSUE_ID --output json)
+    P_CREATOR_TYPE=$(echo "$P_JSON" | jq -r '.creator_type // empty')
+    P_CREATOR_ID=$(echo "$P_JSON" | jq -r '.creator_id // empty')
+    P_META=$(echo "$P_JSON" | jq -r '.metadata.feishu_user_id // empty')
+    if [ -n "$P_META" ]; then
+      FEISHU_USER_ID="$P_META"
+      FEISHU_SOURCE="parent issue.metadata (V5a)"
+    elif [ "$P_CREATOR_TYPE" = "member" ] && [ -n "$P_CREATOR_ID" ]; then
+      FEISHU_USER_ID="$P_CREATOR_ID"
+      FEISHU_SOURCE="parent issue.creator_id (V5a, member 起源)"
+    fi
+    # 仍空 → 落到 owner_id (V5b)
+  fi
+  if [ -z "$FEISHU_USER_ID" ]; then
+    # V5b: agent 没 parent (或 parent 也是 agent), 取 agent.owner_id
+    AGENT_JSON=$(multica agent get $CREATOR_ID --output json)
+    OWNER_ID=$(echo "$AGENT_JSON" | jq -r '.owner_id // empty')
+    if [ -n "$OWNER_ID" ]; then
+      FEISHU_USER_ID="$OWNER_ID"
+      FEISHU_SOURCE="agent.owner_id (V5b fallback, 适用 autopilot 直派 issue)"
+    fi
+  fi
+fi
+```
+
+**V4/V5 fallback 适用前提**:
+- 目标 multica user (member 或 agent owner) 已通过 oauth-ui 扫码绑定飞书
+- 步骤 2 调 sidecar `/status` 自动验证, bound:false 时给清晰错误
+- **私密 issue (private_to 非空) 仍强制显式 metadata, 不允许 fallback** (安全边界)
+
+**FEISHU_USER_ID 为空时的错误处理**:
+
+> ❌ 无法确定 issue 对应的飞书身份:
+> - `metadata.feishu_user_id` 为空 (未显式注入)
+> - `creator_type=$CREATOR_TYPE` / `creator_id=$CREATOR_ID`
+> - V5 fallback 链全部走完仍未拿到 user id
+>
+> 请 issue 创建者:
+> 1. 补 `metadata.feishu_user_id=<你的 multica user id>` 后 rerun
+> 2. 或前往 https://multica.example.com/settings 飞书绑定完成后由本人 (或本人创建的 agent) 重新派单
+
+### 步骤 2 (V6 强化): 检查 token + 拿权威 lark_user_open_id
+
+**[V6 关键]** 不要从 issue 描述 / 历史 comment / 训练记忆 / Contact API 自己搜 open_id。**sidecar /status 返回的 `lark_user_open_id` 字段是唯一权威源**,直接 jq 提取使用,**禁止手敲任何 UUID/ou_/oc_ 字符串**。
+
+```bash
+FEISHU_USER_ID="<step1 输出>"   # 已经通过 V5 fallback 链推导出的权威值
+STATUS_JSON=$(curl -sS "http://localhost:18090/api/feishu/device/status?multica_user_id=$FEISHU_USER_ID")
+echo "$STATUS_JSON" | jq .
+
+# V6: 直接 jq 提取权威 open_id, 不许手敲
+LARK_OPEN_ID=$(echo "$STATUS_JSON" | jq -r '.lark_user_open_id // empty')
+BOUND=$(echo "$STATUS_JSON" | jq -r '.bound // false')
+TOKEN_STATUS=$(echo "$STATUS_JSON" | jq -r '.token_status // empty')
+```
+
+**仅当 sidecar 明确返回 `bound:false` 或 `token_status != "valid"`** → 立即停止，issue comment 回：
+> ❌ multica user `$FEISHU_USER_ID` 的飞书授权已过期/未授权 (sidecar 返回 token_status: `<status>`)。请访问 https://multica.example.com/settings 重新扫码授权。
+
+**注意**：以下情况**不算** token 失效，不要错误归因：
+- sidecar `/status` 返回网络错误（curl timeout）→ 临时问题，retry sidecar 一次
+- lark-cli 后续命令失败（步骤 3）→ 看错误码分类（见下），不要直接判定 token 失效
+
+**V6 反 hallucination 自检** (步骤 3 前必做):
+- $FEISHU_USER_ID 必须是 step 1 bash 变量传递, **不许在新命令里重新手敲 UUID 字符串**
+- $LARK_OPEN_ID 必须是 step 2 sidecar /status 返回的字段, **不许从 Contact API / 历史 issue / 记忆里搜其他 ou_xxx 替代**
+
+### 步骤 3 (V6 强化): 用 05_agent_spawn.sh 发送, 强制变量引用不许手敲
+
+```bash
+# ✅ 正确: bash 变量引用, 一字不差传递
+RESPONSE=$(bash ~/lark_multi_user/05_agent_spawn.sh "$FEISHU_USER_ID" im +messages-send --user-id "$LARK_OPEN_ID" --text "$MESSAGE")
+
+# ❌ 严禁: 手敲 UUID/open_id (会出 c→f 一字 hallucination 把消息发到错的人)
+# bash ~/lark_multi_user/05_agent_spawn.sh 00000000-0000-0000-0000-000000000000 ...
+#                                                                          ↑ 这里一字之差送错人, 飞书 API 不验证存在性
+
+EXIT_CODE=$?
+echo "$RESPONSE"
+```
+
+**判定结果（严格按顺序，禁止跳级）**：
+
+#### 3.1 成功路径
+若 RESPONSE 是合法 JSON 且 `.ok == true` → 操作成功，按"输出规范"回 issue comment。
+
+#### 3.2 OAuth 失效路径（仅这类才停掉走授权流程）
+若 RESPONSE 含以下任一信号 → 真实 token 失效：
+- `code: 99991671` / `99991673` / `99991668`（飞书 access_token 类错误码）
+- HTTP 401 / 403 状态
+- 显式提示 `invalid_token` / `token_expired` / `access_token_invalid`
+- 含 `"error": "token_invalid"` 关键字（来自 wrapper）
+
+→ 走步骤 2 的"已过期"分支提示 user 重新扫码。
+
+#### 3.3 lark-cli 临时错误路径（必须 retry max 2 次）
+若 RESPONSE 含以下信号 → 临时错误：
+- HTTP 5xx / `internal server error` / `service unavailable`
+- 网络类错误 `connection refused` / `timeout` / `EOF` / `read tcp`
+- 飞书限流 `code: 99991400` / `frequency limit`
+- lark-cli stderr 含 `proxy` 字样但 stdout 空（proxy 抖动）
+
+→ `sleep 2 && retry` 重试 1 次，再失败 `sleep 5 && retry` 第 2 次。仍失败按"业务失败"返回。
+
+#### 3.4 业务参数错误路径（不重试，立即报错）
+若 RESPONSE 含以下信号 → 业务错误（参数不对/权限不够）：
+- HTTP 400 + clear validation error
+- 飞书 code `99991400` 含 `invalid params` 字样
+- 权限不足 `permission denied` / `not authorized for this scope`
+
+→ 不重试，按"输出规范"返回错误（含原始 error 给 user 看，便于修参数）。
+
+#### 3.5 未知错误（保守归类为业务失败，不轻易触发授权流程）
+任何 3.2-3.4 都不匹配的错误 → 报"未知错误"，**禁止**默认归类为 token 失效，**禁止**编造 sidecar 状态。
+
+## 输出规范
+
+### 成功
+```
+✅ 飞书操作完成
+- 执行人 (multica user): $FEISHU_USER_ID
+- 身份来源: $FEISHU_SOURCE  ← V4 标注 (metadata 显式 vs creator_id fallback)
+- 飞书身份: <step2 status 输出的 lark_user_name>
+- 操作: <命令简述>
+- 结果: <message_id 或其他证据，从 RESPONSE.data 提取>
+- 重试次数: <0/1/2>
+```
+
+### Token 失效
+```
+❌ 飞书授权已过期，需重新扫码
+- multica user: $FEISHU_USER_ID
+- 检测来源: <sidecar status / lark-cli OAuth code>
+- 重新授权链接: https://multica.example.com/oauth-ui?multica_user_id=$FEISHU_USER_ID
+```
+
+### 临时错误（已 retry 仍失败）
+```
+⚠️ 飞书 API 临时不可用 (已重试 2 次)
+- multica user: $FEISHU_USER_ID  
+- 错误: <RESPONSE 原文摘要>
+- 建议: 等待 5-10 分钟后 rerun 此 issue
+```
+
+### 业务错误
+```
+❌ 飞书操作业务失败
+- multica user: $FEISHU_USER_ID
+- 错误: <RESPONSE.error 原文>
+- 修复方向: <根据错误码给的建议>
+```
+
+## 铁律（违反一律视为流程失败）
+
+1. **绝不**自己造 lark-cli 命令绕过 wrapper(`05_agent_spawn.sh`)
+2. **绝不**用 workspace owner 的飞书身份执行别人的 issue
+3. **绝不**在 sidecar `/status` 明确返回 `bound:false / token_status != valid` 时硬跑
+4. **绝不**把 lark-cli 偶发错误（网络/限流/proxy）归因到 token 失效 — 必须按 3.2-3.4 错误分类判断
+5. **绝不**伪造 message_id / chat_id / 其他证据 — 不知道就说"未知"
+6. **必须**每次操作前调 sidecar `/status` 拿最新 token 状态（token 长任务期可能失效）
+7. **必须**临时错误 retry max 2 次 + 间隔 2s/5s
+8. **必须**报告 retry 次数让 user 看到完整经历
+9. **V3 必须**: `metadata.private_to` 非空时按步骤 0 严判,不一致一律拒绝,不要尝试"猜对意图"
+10. **V4 必须**: 公开 issue 缺 `metadata.feishu_user_id` 时走 `creator_id` fallback (前提 `creator_type=member`); 私密 issue (private_to 非空) **禁止** fallback, 必须显式 metadata
+11. **V4/V5 必须**: 成功 comment 标注 `身份来源` 字段, 让审计能区分"显式 vs fallback 各档"
+12. **V5 必须**: agent 创建的 issue (`creator_type=agent`) 按 parent → owner_id 链回溯找 user; agent 自己**不是** user, 不允许把 agent_id 当 feishu_user_id 用
+13. **V6 必须 (反 hallucination)**: $FEISHU_USER_ID / $LARK_OPEN_ID 只能 bash 变量引用传递, **禁止**在 lark-cli 命令里手敲 UUID 字符串。LLM 复制 UUID 时会出 c→f / 0→o 类一字之差,飞书 API 不验存在性所以**会返回 OK + 错误 message_id**, 但消息送到错的人 = 严重隐私事故 (FUT-61 教训)
+14. **V6 必须**: 只能用 sidecar /status 返回的 `lark_user_open_id` 字段作为 --user-id 参数。**禁止**从 issue 描述 / 历史 comment / 训练记忆 / Contact API 搜来的 ou_xxx 或 oc_xxx 替代 (oc_ 是群 chat_id 不是 user id, 用错会更隐蔽地失败)
+
+## 常见 lark-cli 命令速查
+
+| 操作 | 命令 |
+|------|------|
+| 发消息给用户 | `im +messages-send --user-id ou_xxx --text "..."` |
+| 发消息到群 | `im +messages-send --chat-id oc_xxx --text "..."` |
+| 创建日历事件 | `calendar +event-create --summary "..." --start-time "2026-..." --end-time "..."` |
+| 读 wiki 节点 | `wiki +node-content-get --node-token wiki_xxx` |
+| 搜员工 | `contact +user-search --query "张三"` |
+
+详细参数：`bash ~/lark_multi_user/05_agent_spawn.sh $FEISHU_USER_ID <module> +<cmd> --help`
+
+## V6 变更（vs V5，2026-05-30 晚）
+
+**根因 (FUT-61 实战暴露)**: 飞书代理 agent 报告说"已发送 message_id=om_x100b6e9f6c83013cb..."但owner**没收到**。调查发现:
+- agent 没用步骤 1 拿到的 $FEISHU_USER_ID, 而是**自己在 lark-cli 命令里手敲 UUID**: `00000000-0000-0000-0000-000000000000` (注意 `cf` 这字符)
+- 但 sidecar mapping 里owner真实 user id 是 `00000000-0000-0000-0000-000000000000` (`cd` 这字符)
+- 一字之差 (d→f) 让 sidecar 返 not_authorized → agent 编了个"oc_EXAMPLE_CHAT_ID... 失效"借口 → 又"通过 Contact API"瞎搜了 `ou_EXAMPLE_OPEN_ID`
+- 飞书 API 不验证 user 存在性 → 返回 message_id (假成功) → 消息送到错误用户那里 = 隐私事故
+
+**V6 加强**:
+- **铁律 #13/#14** 显式禁止手敲 UUID / 复用历史 ou_xxx 字符串, 只能 bash 变量引用 + sidecar /status 权威字段
+- 步骤 2 加 `LARK_OPEN_ID=$(echo "$STATUS_JSON" | jq -r '.lark_user_open_id')` 明示提取方式
+- 步骤 3 用 `"$FEISHU_USER_ID"` 和 `"$LARK_OPEN_ID"` 强制引用, 注释里给"反面教材"展示一字之差怎么发到错的人
+
+**为什么这是高频陷阱**:
+- LLM 在长 prompt 里复制 UUID 高概率出错 (尤其字符 c/f, 0/o, 1/l)
+- 飞书 API 对 user_id 存在性是 fuzzy 的, 错的 ID 经常返回 200 OK + 假 message_id
+- agent 看到 "ok:true" 会自信 "成功",不知道送错人
+
+## V5 变更（vs V4，2026-05-30）
+
+**根因**: V4 只覆盖 `creator_type=member`,但 autopilot / coordinator agent (如「example-agent 4.3」) 自己派的 issue `creator_type=agent`,V4 fallback 不生效 → 飞书代理操作员仍报"读不到 feishu_user_id"(FUT-54 实战暴露)。
+
+**V5 加强 fallback 链** (公开 issue,私密 issue 仍禁 fallback):
+
+1. metadata.feishu_user_id 非空 → 用
+2. creator_type=member → 用 creator_id (V4)
+3. **V5a**: creator_type=agent + 有 parent_issue_id → 递归查 parent (找 user 起源,最多 5 层)
+4. **V5b**: creator_type=agent + 无 parent → 用 `agent.owner_id` (创建该 agent 的 user, 覆盖 autopilot 直派 issue)
+
+**为什么 agent.owner_id 是合理 fallback**:
+- multica agent 创建时必须指定 owner (一个 multica user)
+- agent 派的 issue 本质是"代表 owner 执行" — owner 是真实负责人
+- autopilot / scheduler 触发的 agent 也都有 owner (谁创建的 agent)
+- 实测:owner所有 agent 的 owner_id 都是同一个 user (`00000000-...`),fallback 自洽
+
+**新增铁律 #12**: agent 自己**不是** user,不允许把 agent_id 当 feishu_user_id 用 (会撞 sidecar 404)。
+
+## V4 变更（vs V3，2026-05-29）
+
+- **核心**: 公开 issue 缺 `metadata.feishu_user_id` 时,**自动 fallback 用 `issue.creator_id`** 作为 `FEISHU_USER_ID` (前提 `creator_type=member`)
+- **理由**: multica 没 issue.created webhook,无法 server-side 自动注入 `metadata.feishu_user_id`。但 multica `user_id` 和 sidecar 用的 `multica_user_id` 本就同一个 id,所以只要用户绑定过飞书,`creator_id` 就能直接当 `feishu_user_id` 用 — **99% 普通 issue 不再报"缺 metadata"错**
+- **新增 `身份来源` 字段**: 成功 comment 区分"显式 metadata vs creator_id fallback",可审计
+- **私密 issue 限制**: `metadata.private_to` 非空时**禁止** fallback,必须显式 `metadata.feishu_user_id` (保安全边界)
+- 新增**铁律 #10/#11**: V4 fallback 适用条件 + 标注审计字段
+- 实施: 步骤 0 已经拿 `creator_id` `creator_type`,fallback 是纯 bash 逻辑,无额外 API 调用
+
+## V3 变更（vs V2，2026-05-28）
+
+- 新增**步骤 0 私密 issue 隔离检查**: `metadata.private_to` 非空时严判 `private_to == feishu_user_id`,不一致拒绝执行
+- 新增**铁律 #9**: 不允许猜测对齐意图,只能让 issue 创建者手动改 metadata 后 rerun
+- 安全模型: workspace 内 issue 公开 (没 per-issue ACL,by design),敏感场景靠 `private_to` metadata + skill 严判 + agent 调飞书身份独立隔离三层防护
+- 实施: 步骤 0 + 步骤 1 共用一次 `multica issue get` 调用,无额外延迟
+
+## V2 变更（vs V1）
+
+- 加错误分类四档：OAuth 失效 / 临时错误 retry / 业务错误 / 未知（保守不归 token）
+- 加重试机制：临时错误 max 2 次，2s/5s 间隔
+- 加 V1 反模式禁令：不要把 lark-cli 偶发错误归因到 token（FUT-15 教训）
+- 输出加"重试次数"字段，可追溯
+- 提示 user 用授权 web UI（B 路径产出）而不是 sidecar /start API


### PR DESCRIPTION
## What

Adds a self-contained **community reference integration** under `contrib/feishu-oauth-sidecar/` that lets **each Multica user act with their own Feishu/Lark identity** when an agent performs Feishu operations (send messages, read docs, calendar/wiki) — **without storing any user OAuth token in the Multica server database**.

This is **not** core; it runs as a small companion sidecar next to the daemon. Opening as a **draft** to gather maintainer feedback on whether `contrib/` is the right home (vs `docs/integrations/`, an `examples/` dir, or a separate repo).

## Why

The naive approach — one shared bot token per workspace — makes every agent speak as the same identity, breaking per-user attribution, permissions and audit. This pattern gives per-user identity instead.

## How — HOME-isolation sidecar

`lark-cli` stores OAuth creds under `$HOME`. Each Multica user gets an isolated `HOME` holding only their own encrypted token. A small Go sidecar runs the OAuth **device flow** (RFC 8628) per user, exposes a tiny HTTP API + single-page QR UI, and ships a spawn wrapper the agent calls to run `lark-cli` **as a specific user**.

```
issue (creator = user A) → agent loads skill → resolve A's id → sidecar /status (token? open_id?)
  → 05_agent_spawn.sh A ... → env HOME=<homes>/mc-user-A lark-cli <cmd> → Feishu acts as A
```

## Contents

| Path | What |
|------|------|
| `sidecar/` | Go HTTP service (device-flow OAuth, status, force-restart, token-expiry watcher). Unit-tested, ~700 LOC. |
| `scripts/01..05_*.sh` | provisioning + OAuth lifecycle |
| `skill/SKILL.md` | agent skill: identity fallback chain + error classification + anti-hallucination rules |
| `deploy/*.plist.example` | launchd template |
| `README.md` | integration guide + security model |

## Notes

- All host/identity values are placeholders (`multica.example.com`, `RELAY_PUBLIC_IP`, `00000000-...`, `ou_EXAMPLE_OPEN_ID`, etc.).
- `sidecar/` builds and passes `go test ./...` standalone.
- Battle-tested in a small (≤10 user) self-hosted deployment.

Happy to relocate/restructure per maintainer preference.