### PR TITLE
docs(squad): correct stale "four status buckets" comments to five (MUL-2892)

### DIFF
--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -1121,7 +1121,7 @@ function SquadOverviewPane({
   );
 }
 
-// Visual config for the four squad member status buckets. Mirrors
+// Visual config for the five squad member status buckets. Mirrors
 // availabilityConfig + workloadConfig in packages/views/agents/presence.ts —
 // same semantic tokens so a status dot here matches the agent page's dot.
 // Unknown / null statuses (human members, server-side enum drift) render as

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -463,7 +463,7 @@ type SquadMemberStatusListResponse struct {
 	Members []SquadMemberStatusResponse `json:"members"`
 }
 
-// deriveSquadMemberStatus collapses runtime + task signals into the four
+// deriveSquadMemberStatus collapses runtime + task signals into the five
 // status buckets used by the squad UI. Mirrors the workload+availability
 // split in packages/core/agents/derive-presence.ts: working wins over
 // runtime health (an agent that is in the middle of dispatched/running


### PR DESCRIPTION
## What does this PR do?

Follow-up doc nit after #3608, which added the dedicated `archived` status (making it a five-way bucket). Two comments still said "four status buckets" — corrected to "five".

- `server/internal/handler/squad.go` — `deriveSquadMemberStatus` docstring: "four" → "five".
- `packages/views/squads/components/squad-detail-page.tsx` — `SQUAD_STATUS_DOT_CLASS` comment: "four" → "five".

No logic change — comments only. The `SquadMemberStatusValue` union and the `Record<SquadMemberStatusValue, …>` map already reflect all five buckets (`working`, `idle`, `offline`, `unstable`, `archived`).

## Type of Change

- [x] Documentation / comment fix (non-functional)

## How to Test

Comment-only change; nothing to run. `go vet` and `pnpm typecheck` are unaffected.

Related: MUL-2892
