### PR TITLE
fix: swimlane view filters (MUL-3072)

### DIFF
--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -137,6 +137,26 @@ export function IssuesPage() {
     [scopedIssues, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, agentRunningFilter, runningIssueIds],
   );
 
+  const activeFilters = useMemo(() => ({
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    projectFilters,
+    includeNoProject,
+    labelFilters,
+    agentRunningFilter,
+  }), [
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    projectFilters,
+    includeNoProject,
+    labelFilters,
+    agentRunningFilter,
+  ]);
+
   // Fetch sub-issue progress from the backend so counts are accurate
   // regardless of client-side pagination or filtering of done issues.
   const { data: childProgressMap = EMPTY_CHILD_PROGRESS } = useQuery(childIssueProgressOptions(wsId));
@@ -222,6 +242,7 @@ export function IssuesPage() {
               <SwimLaneView
                 issues={issues}
                 unfilteredIssues={swimlaneIssues}
+                activeFilters={activeFilters}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -154,6 +154,14 @@ const mockViewState: {
   toggleSwimlaneCollapsed: (key: string) => void;
   hideStatus: (s: string) => void;
   showStatus: (s: string) => void;
+  priorityFilters?: string[];
+  assigneeFilters?: any[];
+  includeNoAssignee?: boolean;
+  creatorFilters?: any[];
+  projectFilters?: string[];
+  includeNoProject?: boolean;
+  labelFilters?: string[];
+  agentRunningFilter?: boolean;
 } = {
   sortBy: "position",
   sortDirection: "asc",
@@ -166,6 +174,14 @@ const mockViewState: {
   toggleSwimlaneCollapsed: vi.fn(),
   hideStatus: vi.fn(),
   showStatus: vi.fn(),
+  priorityFilters: [],
+  assigneeFilters: [],
+  includeNoAssignee: false,
+  creatorFilters: [],
+  projectFilters: [],
+  includeNoProject: false,
+  labelFilters: [],
+  agentRunningFilter: false,
 };
 const mockSetSwimlaneOrder = mockViewState.setSwimlaneOrder as ReturnType<typeof vi.fn>;
 const mockToggleSwimlaneCollapsed = mockViewState.toggleSwimlaneCollapsed as ReturnType<typeof vi.fn>;
@@ -1344,5 +1360,92 @@ describe("SwimLaneView", () => {
     });
 
     expect(mockOnMoveIssue).not.toHaveBeenCalled();
+  });
+
+  it("filters batch-fetched children using active filters", async () => {
+    mockViewState.swimlaneGrouping = "parent";
+
+    const grandparent: Issue = {
+      id: "gp-2",
+      workspace_id: "ws-1",
+      number: 20,
+      identifier: "PROJ-20",
+      title: "Grandparent 2",
+      description: null,
+      status: "todo",
+      priority: "high",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 10,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const parent: Issue = {
+      ...grandparent,
+      id: "p-2",
+      number: 21,
+      identifier: "PROJ-21",
+      title: "Parent 2",
+      parent_issue_id: "gp-2",
+      position: 11,
+    };
+    const matchingGrandchild: Issue = {
+      ...grandparent,
+      id: "gc-matching",
+      number: 22,
+      identifier: "PROJ-22",
+      title: "Matching Child (High Priority)",
+      status: "in_progress",
+      priority: "high",
+      parent_issue_id: "p-2",
+      position: 12,
+    };
+    const nonMatchingGrandchild: Issue = {
+      ...grandparent,
+      id: "gc-non-matching",
+      number: 23,
+      identifier: "PROJ-23",
+      title: "Non-matching Child (Low Priority)",
+      status: "in_progress",
+      priority: "low",
+      parent_issue_id: "p-2",
+      position: 13,
+    };
+
+    (mockViewState as any).priorityFilters = ["high"];
+
+    mockListChildrenByParents.mockResolvedValueOnce({
+      issues: [matchingGrandchild, nonMatchingGrandchild],
+    });
+
+    const childProgressMap = new Map<string, { done: number; total: number }>([
+      ["p-2", { done: 0, total: 2 }],
+    ]);
+
+    renderWithI18n(
+      <SwimLaneView
+        issues={[grandparent, parent]}
+        childProgressMap={childProgressMap}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockListChildrenByParents).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Matching Child (High Priority)")).toBeInTheDocument();
+      expect(screen.queryByText("Non-matching Child (Low Priority)")).toBeNull();
+    });
+
+    (mockViewState as any).priorityFilters = [];
   });
 });

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -19,9 +19,18 @@ vi.mock("@multica/core/hooks", () => ({
 const mockListChildrenByParents = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ issues: [] }),
 );
+const mockGetAgentTaskSnapshot = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([]),
+);
 vi.mock("@multica/core/api", () => ({
-  api: { listChildrenByParents: mockListChildrenByParents },
-  getApi: () => ({ listChildrenByParents: mockListChildrenByParents }),
+  api: {
+    listChildrenByParents: mockListChildrenByParents,
+    getAgentTaskSnapshot: mockGetAgentTaskSnapshot,
+  },
+  getApi: () => ({
+    listChildrenByParents: mockListChildrenByParents,
+    getAgentTaskSnapshot: mockGetAgentTaskSnapshot,
+  }),
   setApiInstance: vi.fn(),
 }));
 
@@ -334,7 +343,16 @@ describe("SwimLaneView", () => {
     mockViewState.swimlaneGrouping = "parent";
     mockViewState.swimlaneOrders = { parent: [], project: [], assignee: [] };
     mockViewState.collapsedSwimlanes = { parent: [], project: [], assignee: [] };
+    mockViewState.priorityFilters = [];
+    mockViewState.assigneeFilters = [];
+    mockViewState.includeNoAssignee = false;
+    mockViewState.creatorFilters = [];
+    mockViewState.projectFilters = [];
+    mockViewState.includeNoProject = false;
+    mockViewState.labelFilters = [];
+    mockViewState.agentRunningFilter = false;
     mockListChildrenByParents.mockResolvedValue({ issues: [] });
+    mockGetAgentTaskSnapshot.mockResolvedValue([]);
     useLoadMoreByStatusMock.mockImplementation(() => ({
       total: 0,
       loaded: 0,
@@ -1419,8 +1437,6 @@ describe("SwimLaneView", () => {
       position: 13,
     };
 
-    (mockViewState as any).priorityFilters = ["high"];
-
     mockListChildrenByParents.mockResolvedValueOnce({
       issues: [matchingGrandchild, nonMatchingGrandchild],
     });
@@ -1432,6 +1448,16 @@ describe("SwimLaneView", () => {
     renderWithI18n(
       <SwimLaneView
         issues={[grandparent, parent]}
+        activeFilters={{
+          priorityFilters: ["high"],
+          assigneeFilters: [],
+          includeNoAssignee: false,
+          creatorFilters: [],
+          projectFilters: [],
+          includeNoProject: false,
+          labelFilters: [],
+          agentRunningFilter: false,
+        }}
         childProgressMap={childProgressMap}
         onMoveIssue={vi.fn()}
       />,
@@ -1445,7 +1471,100 @@ describe("SwimLaneView", () => {
       expect(screen.getByText("Matching Child (High Priority)")).toBeInTheDocument();
       expect(screen.queryByText("Non-matching Child (Low Priority)")).toBeNull();
     });
+  });
 
-    (mockViewState as any).priorityFilters = [];
+  it("filters batch-fetched children using working filter", async () => {
+    mockViewState.swimlaneGrouping = "parent";
+
+    const grandparent: Issue = {
+      id: "gp-3",
+      workspace_id: "ws-1",
+      number: 30,
+      identifier: "PROJ-30",
+      title: "Grandparent 3",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 10,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const parent: Issue = {
+      ...grandparent,
+      id: "p-3",
+      number: 31,
+      identifier: "PROJ-31",
+      title: "Parent 3",
+      parent_issue_id: "gp-3",
+      position: 11,
+    };
+    const runningGrandchild: Issue = {
+      ...grandparent,
+      id: "gc-running",
+      number: 32,
+      identifier: "PROJ-32",
+      title: "Running Child",
+      status: "in_progress",
+      parent_issue_id: "p-3",
+      position: 12,
+    };
+    const nonRunningGrandchild: Issue = {
+      ...grandparent,
+      id: "gc-non-running",
+      number: 33,
+      identifier: "PROJ-33",
+      title: "Non-running Child",
+      status: "in_progress",
+      parent_issue_id: "p-3",
+      position: 13,
+    };
+
+    mockGetAgentTaskSnapshot.mockResolvedValueOnce([
+      { id: "task-1", status: "running", issue_id: "gc-running" },
+    ]);
+
+    mockListChildrenByParents.mockResolvedValueOnce({
+      issues: [runningGrandchild, nonRunningGrandchild],
+    });
+
+    const childProgressMap = new Map<string, { done: number; total: number }>([
+      ["p-3", { done: 0, total: 2 }],
+    ]);
+
+    renderWithI18n(
+      <SwimLaneView
+        issues={[grandparent, parent]}
+        activeFilters={{
+          priorityFilters: [],
+          assigneeFilters: [],
+          includeNoAssignee: false,
+          creatorFilters: [],
+          projectFilters: [],
+          includeNoProject: false,
+          labelFilters: [],
+          agentRunningFilter: true,
+        }}
+        childProgressMap={childProgressMap}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockListChildrenByParents).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Running Child")).toBeInTheDocument();
+      expect(screen.queryByText("Non-running Child")).toBeNull();
+    });
   });
 });

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -28,7 +28,7 @@ import type {
 } from "@multica/core/types";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
-import { filterIssues } from "../utils/filter";
+import { filterIssues, type IssueFilters } from "../utils/filter";
 import type { SwimlaneGrouping } from "@multica/core/issues/stores/view-store";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -444,6 +444,7 @@ function buildAssigneeLanes(
 export function SwimLaneView({
   issues,
   unfilteredIssues,
+  activeFilters: activeFiltersProp,
   visibleStatuses = BOARD_STATUSES,
   hiddenStatuses = [],
   onMoveIssue,
@@ -463,6 +464,7 @@ export function SwimLaneView({
    * a parent in a hidden status still surfaces its label correctly.
    */
   unfilteredIssues?: Issue[];
+  activeFilters?: Omit<IssueFilters, "statusFilters" | "runningIssueIds">;
   visibleStatuses?: IssueStatus[];
   hiddenStatuses?: IssueStatus[];
   onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
@@ -483,15 +485,6 @@ export function SwimLaneView({
   const swimlaneOrders = useViewStore((s) => s.swimlaneOrders);
   const swimlaneOrder = swimlaneOrders[swimlaneGrouping];
 
-  const priorityFilters = useViewStore((s) => s.priorityFilters);
-  const assigneeFilters = useViewStore((s) => s.assigneeFilters);
-  const includeNoAssignee = useViewStore((s) => s.includeNoAssignee);
-  const creatorFilters = useViewStore((s) => s.creatorFilters);
-  const projectFilters = useViewStore((s) => s.projectFilters);
-  const includeNoProject = useViewStore((s) => s.includeNoProject);
-  const labelFilters = useViewStore((s) => s.labelFilters);
-  const agentRunningFilter = useViewStore((s) => s.agentRunningFilter);
-
   const wsId = useWorkspaceId();
 
   const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
@@ -504,27 +497,18 @@ export function SwimLaneView({
   }, [snapshot]);
 
   const activeFilters = useMemo(() => ({
+    // Status is enforced by visible-column rendering, not by filterIssues
     statusFilters: [],
-    priorityFilters,
-    assigneeFilters,
-    includeNoAssignee,
-    creatorFilters,
-    projectFilters,
-    includeNoProject,
-    labelFilters,
-    agentRunningFilter,
+    priorityFilters: activeFiltersProp?.priorityFilters ?? [],
+    assigneeFilters: activeFiltersProp?.assigneeFilters ?? [],
+    includeNoAssignee: activeFiltersProp?.includeNoAssignee ?? false,
+    creatorFilters: activeFiltersProp?.creatorFilters ?? [],
+    projectFilters: activeFiltersProp?.projectFilters ?? [],
+    includeNoProject: activeFiltersProp?.includeNoProject ?? false,
+    labelFilters: activeFiltersProp?.labelFilters ?? [],
+    agentRunningFilter: activeFiltersProp?.agentRunningFilter ?? false,
     runningIssueIds,
-  }), [
-    priorityFilters,
-    assigneeFilters,
-    includeNoAssignee,
-    creatorFilters,
-    projectFilters,
-    includeNoProject,
-    labelFilters,
-    agentRunningFilter,
-    runningIssueIds,
-  ]);
+  }), [activeFiltersProp, runningIssueIds]);
   const { data: projects = EMPTY_PROJECTS } = useQuery({
     ...projectListOptions(wsId),
     enabled: swimlaneGrouping === "project",

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -27,6 +27,8 @@ import type {
   UpdateIssueRequest,
 } from "@multica/core/types";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
+import { agentTaskSnapshotOptions } from "@multica/core/agents";
+import { filterIssues } from "../utils/filter";
 import type { SwimlaneGrouping } from "@multica/core/issues/stores/view-store";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -481,7 +483,48 @@ export function SwimLaneView({
   const swimlaneOrders = useViewStore((s) => s.swimlaneOrders);
   const swimlaneOrder = swimlaneOrders[swimlaneGrouping];
 
+  const priorityFilters = useViewStore((s) => s.priorityFilters);
+  const assigneeFilters = useViewStore((s) => s.assigneeFilters);
+  const includeNoAssignee = useViewStore((s) => s.includeNoAssignee);
+  const creatorFilters = useViewStore((s) => s.creatorFilters);
+  const projectFilters = useViewStore((s) => s.projectFilters);
+  const includeNoProject = useViewStore((s) => s.includeNoProject);
+  const labelFilters = useViewStore((s) => s.labelFilters);
+  const agentRunningFilter = useViewStore((s) => s.agentRunningFilter);
+
   const wsId = useWorkspaceId();
+
+  const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
+  const runningIssueIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const t of snapshot) {
+      if (t.status === "running" && t.issue_id) ids.add(t.issue_id);
+    }
+    return ids;
+  }, [snapshot]);
+
+  const activeFilters = useMemo(() => ({
+    statusFilters: [],
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    projectFilters,
+    includeNoProject,
+    labelFilters,
+    agentRunningFilter,
+    runningIssueIds,
+  }), [
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    projectFilters,
+    includeNoProject,
+    labelFilters,
+    agentRunningFilter,
+    runningIssueIds,
+  ]);
   const { data: projects = EMPTY_PROJECTS } = useQuery({
     ...projectListOptions(wsId),
     enabled: swimlaneGrouping === "project",
@@ -606,8 +649,9 @@ export function SwimLaneView({
         }
       }
     }
-    return extra.length === 0 ? issues : [...issues, ...extra];
-  }, [swimlaneGrouping, issues, perParentChildrenLists, subscribedParentIds, batchChildrenMap]);
+    const filteredExtra = filterIssues(extra, activeFilters);
+    return filteredExtra.length === 0 ? issues : [...issues, ...filteredExtra];
+  }, [swimlaneGrouping, issues, perParentChildrenLists, subscribedParentIds, batchChildrenMap, activeFilters]);
 
   const laneGroups = useMemo<LaneGroup[]>(() => {
     if (swimlaneGrouping === "project") {

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -162,6 +162,17 @@ export function MyIssuesPage() {
     [myIssues, priorityFilters, agentRunningFilter, runningIssueIds],
   );
 
+  const activeFilters = useMemo(() => ({
+    priorityFilters,
+    assigneeFilters: [],
+    includeNoAssignee: false,
+    creatorFilters: [],
+    projectFilters: [],
+    includeNoProject: false,
+    labelFilters: [],
+    agentRunningFilter,
+  }), [priorityFilters, agentRunningFilter]);
+
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
 
   const visibleStatuses = useMemo(() => {
@@ -269,6 +280,7 @@ export function MyIssuesPage() {
               <SwimLaneView
                 issues={issues}
                 unfilteredIssues={swimlaneIssues}
+                activeFilters={activeFilters}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -165,6 +165,24 @@ function ProjectIssuesContent({
     [projectIssues, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters, agentRunningFilter, runningIssueIds],
   );
 
+  const activeFilters = useMemo(() => ({
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    projectFilters: [],
+    includeNoProject: false,
+    labelFilters,
+    agentRunningFilter,
+  }), [
+    priorityFilters,
+    assigneeFilters,
+    includeNoAssignee,
+    creatorFilters,
+    labelFilters,
+    agentRunningFilter,
+  ]);
+
   // Gantt rides its own dedicated query (scheduled-only) so it doesn't have
   // to wait for every status bucket to paginate in. View-store filters still
   // apply so toggling priority / assignee / label hides the same bars.
@@ -271,6 +289,7 @@ function ProjectIssuesContent({
         <SwimLaneView
           issues={issues}
           unfilteredIssues={swimlaneIssues}
+          activeFilters={activeFilters}
           visibleStatuses={visibleStatuses}
           hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where the **"Working"** quick-filter (and other active view-store filters like priority, assignee, creator, project, and labels) failed to filter child sub-issues when the board view was set to **Swimlane** (specifically under the **Parent** grouping).

## Related Issue

None

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [X] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- **`packages/views/issues/components/swimlane-view.tsx`**:
  - Subscribed to active view-store filters (`priorityFilters`, `assigneeFilters`, `includeNoAssignee`, `creatorFilters`, `projectFilters`, `includeNoProject`, `labelFilters`, `agentRunningFilter`).
  - Utilized `agentTaskSnapshotOptions` to retrieve workspace-scoped `runningIssueIds` lightweight and instantaneously from cache.
  - Filtered batch-fetched child issues (`extra`) using `filterIssues` before merging them into `mergedIssues`.
- **`packages/views/issues/components/swimlane-view.test.tsx`**:
  - Enhanced the `mockViewState` helper to support mock store definitions for all active filters.
  - Added a comprehensive unit test (`"filters batch-fetched children using active filters"`) to assert that non-matching batch-fetched sub-issues are correctly excluded from render under parent lanes.

## How to Test

1. Navigate to the **Issues** page (or **My Issues**) and switch the view to **Swimlane**, grouping by **Parent**.
2. Activate the **"Working"** quick-filter chip (or another filter, such as **Priority: High**).
3. Verify that only sub-issues currently being worked on by an agent (or matching the filter criteria) render on the board, and any other non-matching children are correctly filtered out.

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [X] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [X] I have considered and documented any risks above
- [X] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Opencode

**Prompt / approach:**

I investigated the SwimLaneView rendering pipeline and located where child sub-issues were being fetched on-demand. I identified that mergedIssues combined the original filtered issues with unfiltered batch-fetched extra sub-issues without performing any filtering checks. I updated the component to query active filters, fetch current runningIssueIds from the React Query cache, and execute filterIssues(extra, activeFilters) prior to combining lists. I updated the testing mock structure to prevent test regressions and added a new unit test confirming correct active-filter behaviors in Swimlane view.