### PR TITLE
MUL-2922 helm: gate uploads PVC behind backend.uploads.persistence.enabled

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -144,7 +144,7 @@ If you already run a Kubernetes cluster, you can deploy Multica there instead of
 The chart creates the following resources in the target namespace:
 
 - `multica-postgres` — `pgvector/pgvector:pg17` backed by a 10Gi PVC
-- `multica-backend` — Go API/WS server backed by a 5Gi uploads PVC
+- `multica-backend` — Go API/WS server. Backed by a 5Gi `ReadWriteOnce` uploads PVC by default; set `backend.uploads.persistence.enabled=false` when you have configured S3 (`backend.config.s3Bucket`) and don't want the chart to declare the PVC at all.
 - `multica-frontend` — Next.js standalone server
 - Two `Ingress` resources: one for the web host, one for the backend host
 - `multica-config` ConfigMap (rendered from `values.yaml`)

--- a/deploy/helm/multica/templates/backend.yaml
+++ b/deploy/helm/multica/templates/backend.yaml
@@ -1,4 +1,5 @@
 {{- $backendImageTag := default .Chart.AppVersion .Values.images.backend.tag -}}
+{{- if .Values.backend.uploads.persistence.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -7,7 +8,8 @@ metadata:
     {{- include "multica.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
 spec:
-  accessModes: [ReadWriteOnce]
+  accessModes:
+    {{- toYaml .Values.backend.uploads.persistence.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.backend.uploads.persistence.size | quote }}
@@ -15,6 +17,7 @@ spec:
   storageClassName: {{ . | quote }}
   {{- end }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,9 +69,11 @@ spec:
           env:
             - name: DATABASE_URL
               value: {{ include "multica.databaseUrl" . | quote }}
+          {{- if .Values.backend.uploads.persistence.enabled }}
           volumeMounts:
             - name: uploads
               mountPath: /app/data/uploads
+          {{- end }}
           # The entrypoint runs `./migrate up` before serving traffic. On a
           # cold cluster (Postgres still coming up) this can take minutes. The
           # startupProbe holds off liveness/readiness until /healthz is OK,
@@ -95,10 +100,12 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- if .Values.backend.uploads.persistence.enabled }}
       volumes:
         - name: uploads
           persistentVolumeClaim:
             claimName: {{ include "multica.backend.fullname" . }}-uploads
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -59,8 +59,29 @@ backend:
   replicas: 1
   uploads:
     persistence:
+      # When true (default) the chart provisions a PersistentVolumeClaim for
+      # /app/data/uploads and mounts it into the backend pod. The backend only
+      # uses this directory when S3 is NOT configured (`backend.config.s3Bucket`
+      # empty) — see server/cmd/server/router.go for the storage selection.
+      #
+      # Set to false when you have configured S3/CloudFront and don't want the
+      # chart to declare the uploads PVC at all. The default access mode is
+      # ReadWriteOnce, which prevents `backend.replicas > 1` from scheduling a
+      # second pod (Multi-Attach error); disabling persistence — or switching
+      # accessModes to a ReadWriteMany class — removes that constraint on the
+      # storage side. Note: backend startup migrations are not yet serialized
+      # across pods, so multi-replica still requires care beyond the chart.
+      enabled: true
       size: 5Gi
+      # Leave empty to use the cluster's default StorageClass.
       storageClass: ""
+      # PVC accessModes. Defaults to [ReadWriteOnce] to match the typical
+      # local-path / hostPath / EBS StorageClass on a single-node setup. Switch
+      # to [ReadWriteMany] (with a compatible StorageClass such as NFS, EFS,
+      # CephFS) if you intend to share the uploads volume across multiple
+      # backend replicas without S3.
+      accessModes:
+        - ReadWriteOnce
   # All non-secret backend env. Secret values come from `existingSecret`.
   config:
     appEnv: production


### PR DESCRIPTION
## Summary

Closes #3646 on the chart side: the uploads PersistentVolumeClaim, the backend container's `volumeMount`, and the pod-spec `volume` are now gated behind a new value `backend.uploads.persistence.enabled` (default `true`, so existing installs keep working unchanged). The PVC `accessModes` is also exposed as a value (default `[ReadWriteOnce]`).

The chart previously declared the uploads PVC unconditionally with hardcoded `[ReadWriteOnce]`, even when the operator had configured `S3_BUCKET` and the backend never wrote to `/app/data/uploads`. With this change, an operator running on S3 can set `backend.uploads.persistence.enabled=false` and the chart will not declare the PVC at all — removing the `ReadWriteOnce` Multi-Attach blocker on the storage side for `backend.replicas > 1`.

> Scope note: this PR only fixes the **storage-side** blocker. It does not claim that multi-replica backend is fully supported — the backend entrypoint still runs `./migrate up` per pod with no advisory lock, so concurrent startup migrations remain a separate concern that should be addressed in a follow-up. This PR's intent is narrow: when running on S3, the chart should not pin the deployment to a single ReadWriteOnce PVC.

## Changes

- `deploy/helm/multica/values.yaml`: add `backend.uploads.persistence.enabled` (default `true`) and `backend.uploads.persistence.accessModes` (default `[ReadWriteOnce]`), with comments explaining when to flip them.
- `deploy/helm/multica/templates/backend.yaml`: wrap the PVC, `volumeMounts` block, and `volumes` block in `{{- if .Values.backend.uploads.persistence.enabled }}`. Render `accessModes` from values.
- `SELF_HOSTING.md`: update the chart resource bullet to mention the new toggle.

## Verification

`helm lint deploy/helm/multica` passes. `helm template` was run in three configurations:

1. **Default (enabled, `[ReadWriteOnce]`)** — PVC `multica-backend-uploads`, backend `volumeMount`, and pod `volume` all render exactly as before.
2. **Disabled (`backend.uploads.persistence.enabled=false`, `replicas=2`, `s3Bucket=my-bucket`)** — no PVC; the backend Deployment renders with no `volumeMounts` and no `volumes` block; the resulting pod spec is clean YAML.
3. **`accessModes=[ReadWriteMany]` with a custom storageClass** — PVC renders with `accessModes: - ReadWriteMany` and `storageClassName: "nfs-client"`.

## Backward compatibility

No values were renamed. `backend.uploads.persistence.enabled` defaults to `true`, so existing `values.yaml` files keep producing the same manifests they did before.

## Related

- Issue: https://github.com/multica-ai/multica/issues/3646
