### PR TITLE
fix(skill): canonicalize reserved SKILL.md path check across daemon + API (MUL-2928)

### DIFF
--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 )
 
 // writeContextFiles renders and writes .agent_context/issue_context.md and
@@ -368,9 +370,13 @@ func writeSkillFiles(skillsDir string, skills []SkillContextForEnv, manifest *si
 		//
 		// One common data bug is storing SKILL.md as both the primary
 		// content (skill.Content) and as a supporting file. Skip the
-		// duplicate so the agent still gets every unique file.
+		// duplicate so the agent still gets every unique file. The check
+		// is canonical (see skillpkg.IsReservedContentPath) so a
+		// non-canonical spelling like "./SKILL.md" — which filepath.Join
+		// resolves onto the same dir/SKILL.md we just wrote — is caught
+		// too, instead of colliding and failing prep with errPathPreExists.
 		for _, f := range skill.Files {
-			if strings.EqualFold(f.Path, "SKILL.md") {
+			if skillpkg.IsReservedContentPath(f.Path) {
 				continue
 			}
 			fpath := filepath.Join(dir, f.Path)

--- a/server/internal/daemon/execenv/reserved_skill_path_test.go
+++ b/server/internal/daemon/execenv/reserved_skill_path_test.go
@@ -1,0 +1,65 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteSkillFilesIgnoresBundledSkillMd is the daemon-side regression guard
+// for #3489 / MUL-2928. A skill whose Files include the skill's own SKILL.md
+// (stored as a supporting file by older builds or direct create/update API
+// calls) used to fail task prep with errPathPreExists: writeSkillFiles writes
+// the primary content to dir/SKILL.md first, then the supporting-files loop
+// tried to write the duplicate over it. The non-canonical "./SKILL.md"
+// spelling resolves onto the same path and must be skipped too. Every
+// non-codex provider hit this; codex is unaffected because it writes with a
+// nil manifest (plain os.WriteFile, no refuse-to-overwrite).
+func TestWriteSkillFilesIgnoresBundledSkillMd(t *testing.T) {
+	t.Parallel()
+	skillsDir := filepath.Join(t.TempDir(), ".claude", "skills")
+
+	skills := []SkillContextForEnv{
+		{
+			Name:    "Issue Review",
+			Content: "Primary skill body.",
+			Files: []SkillFileContextForEnv{
+				{Path: "README.md", Content: "readme"},
+				{Path: "SKILL.md", Content: "duplicate primary, must be skipped"},
+				{Path: "./SKILL.md", Content: "non-canonical duplicate, must be skipped"},
+				{Path: "helper.go", Content: "package main"},
+			},
+		},
+	}
+
+	// A non-nil manifest is the production Prepare path: recordWriteFile
+	// enforces refuse-to-overwrite, so a duplicate SKILL.md would error here
+	// if it were not skipped.
+	manifest := &sidecarManifest{}
+	if err := writeSkillFiles(skillsDir, skills, manifest); err != nil {
+		t.Fatalf("writeSkillFiles errored on a bundled SKILL.md: %v", err)
+	}
+
+	skillDir := filepath.Join(skillsDir, "issue-review")
+
+	// SKILL.md must hold the primary content, never a bundled duplicate.
+	got, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(got), "Primary skill body.") {
+		t.Errorf("SKILL.md = %q, want primary content", string(got))
+	}
+	if strings.Contains(string(got), "must be skipped") {
+		t.Error("SKILL.md was overwritten by a bundled duplicate")
+	}
+
+	// Unique supporting files are still written — this also proves the loop
+	// continued past the skipped duplicates instead of aborting on them.
+	for _, name := range []string{"README.md", "helper.go"} {
+		if _, err := os.Stat(filepath.Join(skillDir, name)); err != nil {
+			t.Errorf("expected supporting file %s to be written: %v", name, err)
+		}
+	}
+}

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/multica-ai/multica/server/internal/skill"
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -459,7 +459,7 @@ func (h *Handler) UpdateSkill(w http.ResponseWriter, r *http.Request) {
 		fileResps = make([]SkillFileResponse, 0, len(req.Files))
 		for _, f := range req.Files {
 			// SKILL.md is reserved for the primary skill content (skill.Content).
-			if strings.EqualFold(f.Path, "SKILL.md") {
+			if skillpkg.IsReservedContentPath(f.Path) {
 				continue
 			}
 			sf, err := qtx.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
@@ -1004,7 +1004,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	if skillMdBody == nil {
 		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
 		if err == nil {
-			if name, _ := skill.ParseSkillFrontmatter(string(body)); name == skillName {
+			if name, _ := skillpkg.ParseSkillFrontmatter(string(body)); name == skillName {
 				skillMdBody = body
 				skillDir = ""
 			}
@@ -1018,7 +1018,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	}
 
 	// Parse name and description from YAML frontmatter
-	name, description := skill.ParseSkillFrontmatter(string(skillMdBody))
+	name, description := skillpkg.ParseSkillFrontmatter(string(skillMdBody))
 	if name == "" {
 		name = skillName
 	}
@@ -1290,7 +1290,7 @@ func findMatchingSkillDirByFrontmatter(httpClient *http.Client, rawPrefix, skill
 			slog.Warn("github import: fallback SKILL.md fetch failed", "path", skillPath, "error", err)
 			continue
 		}
-		name, _ := skill.ParseSkillFrontmatter(string(body))
+		name, _ := skillpkg.ParseSkillFrontmatter(string(body))
 		if name == skillName {
 			return skillDirFromSkillFilePath(skillPath), body, true
 		}
@@ -1578,7 +1578,7 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 			skillMdPath, spec.owner, spec.repo, spec.ref, err)
 	}
 
-	name, description := skill.ParseSkillFrontmatter(string(skillMdBody))
+	name, description := skillpkg.ParseSkillFrontmatter(string(skillMdBody))
 	if name == "" {
 		if spec.skillDir != "" {
 			name = filepath.Base(spec.skillDir)
@@ -1848,7 +1848,7 @@ func (h *Handler) UpsertSkillFile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid file path")
 		return
 	}
-	if strings.EqualFold(req.Path, "SKILL.md") {
+	if skillpkg.IsReservedContentPath(req.Path) {
 		writeError(w, http.StatusBadRequest, "SKILL.md is reserved for the primary skill content")
 		return
 	}

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -3,9 +3,9 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -49,7 +49,7 @@ func createSkillWithFilesInTx(ctx context.Context, qtx *db.Queries, input skillC
 	for _, f := range input.Files {
 		// SKILL.md is reserved for the primary skill content (skill.Content).
 		// Supporting files must carry additional assets, not duplicate the main file.
-		if strings.EqualFold(f.Path, "SKILL.md") {
+		if skillpkg.IsReservedContentPath(f.Path) {
 			continue
 		}
 		sf, err := qtx.UpsertSkillFile(ctx, db.UpsertSkillFileParams{

--- a/server/internal/skill/reserved.go
+++ b/server/internal/skill/reserved.go
@@ -1,0 +1,27 @@
+package skill
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ContentFilename is the canonical filename of a skill's primary content
+// (the Content field). The daemon writes Content to this path itself when
+// preparing the execution environment, so it is reserved: a supporting file
+// may not also claim it.
+const ContentFilename = "SKILL.md"
+
+// IsReservedContentPath reports whether p targets the reserved primary
+// content file (SKILL.md).
+//
+// The path is cleaned before comparison so non-canonical spellings like
+// "./SKILL.md" or "sub/../SKILL.md" — which filepath.Join still resolves onto
+// the very SKILL.md the daemon writes itself — are caught too. An exact
+// string match would let them slip through both the API guards and the daemon
+// guard, and the duplicate write would then fail task prep with
+// errPathPreExists (or, on the nil-manifest path, clobber the primary
+// content). Comparison is case-insensitive to match the rest of the SKILL.md
+// handling in this package and the daemon.
+func IsReservedContentPath(p string) bool {
+	return strings.EqualFold(filepath.Clean(p), ContentFilename)
+}

--- a/server/internal/skill/reserved_test.go
+++ b/server/internal/skill/reserved_test.go
@@ -1,0 +1,31 @@
+package skill
+
+import "testing"
+
+func TestIsReservedContentPath(t *testing.T) {
+	reserved := []string{
+		"SKILL.md",        // canonical
+		"skill.md",        // case-insensitive
+		"SKILL.MD",        // case-insensitive
+		"./SKILL.md",      // non-canonical, resolves to SKILL.md
+		"foo/../SKILL.md", // non-canonical, resolves to SKILL.md
+	}
+	for _, p := range reserved {
+		if !IsReservedContentPath(p) {
+			t.Errorf("IsReservedContentPath(%q) = false, want true", p)
+		}
+	}
+
+	notReserved := []string{
+		"README.md",
+		"docs/SKILL.md", // genuine nested file, will not collide with the primary
+		"skills/SKILL.md",
+		"SKILL.md.bak",
+		"",
+	}
+	for _, p := range notReserved {
+		if IsReservedContentPath(p) {
+			t.Errorf("IsReservedContentPath(%q) = true, want false", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #3526 (the emergency fix for #3489). #3526 stopped a duplicate `SKILL.md` supporting file from bricking task prep on non-codex local runtimes, but its guard used an exact match `strings.EqualFold(path, "SKILL.md")`. The stored path is **not** canonicalized, so a non-canonical spelling like `./SKILL.md` or `sub/../SKILL.md` slips past every guard while `filepath.Join` still resolves it onto the same `SKILL.md` the daemon writes itself — meaning prep can still fail with `errPathPreExists` (or, on the nil-manifest path, clobber the primary content).

## What changed

- New shared helper `skill.IsReservedContentPath(path)` — cleans the path (`filepath.Clean`) before a case-insensitive compare against `SKILL.md`. Lives in `server/internal/skill` (the package whose stated purpose is "shared utilities for working with SKILL.md files").
- Reuses it at all **four** guard sites, replacing the duplicated inline checks:
  - `server/internal/daemon/execenv/context.go` — `writeSkillFiles` (load-bearing daemon guard)
  - `server/internal/handler/skill_create.go` — create
  - `server/internal/handler/skill.go` — update + single-file upsert
- Imported as `skillpkg` where a local `skill` variable would otherwise shadow the package.

## Tests

- `TestWriteSkillFilesIgnoresBundledSkillMd` (execenv) — the daemon guard previously had **only API-layer coverage**; this drives `writeSkillFiles` with a non-nil manifest and a bundled `SKILL.md` in both `SKILL.md` and `./SKILL.md` spellings, asserting prep succeeds, the primary content survives, and unique supporting files are still written.
- `TestIsReservedContentPath` (skill) — unit coverage for the canonical/case-insensitive matching, including negative cases (`docs/SKILL.md`, `SKILL.md.bak`).

Verified locally: `go build ./...`, `go vet`, and the affected packages (`./internal/skill`, `./internal/daemon/execenv`) pass.

## Notes

- Existing poisoned `skill_file` rows are intentionally left in place (the daemon now skips them at prep) per the decision on MUL-2928 — no data migration.
- Supersedes #3560, which targeted the same daemon logic with a cleaned-path approach; that PR's `TestWriteSkillFilesIgnoresBundledSkillMd` idea is incorporated here.

Follow-up to #3526.

MUL-2928
