### PR TITLE
feat(editor): text highlight (==text==) in description & comments [MUL-2934]

### DIFF
--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -56,6 +56,7 @@ import {
   Italic,
   Strikethrough,
   Code,
+  Highlighter,
   Link2,
   List,
   ListOrdered,
@@ -92,13 +93,14 @@ function shouldShowBubbleMenu(editor: Editor): boolean {
 // Mark Toggle Button
 // ---------------------------------------------------------------------------
 
-type InlineMark = "bold" | "italic" | "strike" | "code";
+type InlineMark = "bold" | "italic" | "strike" | "code" | "highlight";
 
 const toggleMarkActions: Record<InlineMark, (editor: Editor) => void> = {
   bold: (e) => e.chain().focus().toggleBold().run(),
   italic: (e) => e.chain().focus().toggleItalic().run(),
   strike: (e) => e.chain().focus().toggleStrike().run(),
   code: (e) => e.chain().focus().toggleCode().run(),
+  highlight: (e) => e.chain().focus().toggleHighlight().run(),
 };
 
 function MarkButton({
@@ -471,6 +473,7 @@ function EditorBubbleMenu({
       italic: e.isActive("italic"),
       strike: e.isActive("strike"),
       code: e.isActive("code"),
+      highlight: e.isActive("highlight"),
       link: e.isActive("link"),
       blockquote: e.isActive("blockquote"),
       bulletList: e.isActive("bulletList"),
@@ -591,6 +594,7 @@ function EditorBubbleMenu({
             <MarkButton editor={editor} mark="italic" icon={Italic} label={t(($) => $.bubble_menu.italic)} shortcut={`${modKey}+I`} isActive={fmt.italic} />
             <MarkButton editor={editor} mark="strike" icon={Strikethrough} label={t(($) => $.bubble_menu.strikethrough)} shortcut={`${modKey}+Shift+S`} isActive={fmt.strike} />
             <MarkButton editor={editor} mark="code" icon={Code} label={t(($) => $.bubble_menu.code)} shortcut={`${modKey}+E`} isActive={fmt.code} />
+            <MarkButton editor={editor} mark="highlight" icon={Highlighter} label={t(($) => $.bubble_menu.highlight)} shortcut={`${modKey}+Shift+H`} isActive={fmt.highlight} />
             <Separator orientation="vertical" className="mx-0.5 h-5" />
             <Tooltip>
               <TooltipTrigger render={

--- a/packages/views/editor/extensions/highlight.test.ts
+++ b/packages/views/editor/extensions/highlight.test.ts
@@ -61,4 +61,24 @@ describe("HighlightExtension — markdown serialization (cross-process protocol)
   it("does not treat == inside inline code as a highlight", () => {
     expect(roundTrip("`a ==b== c`")).toBe("`a ==b== c`");
   });
+
+  // Boundary regressions (Emacs review, PR #3661).
+
+  it("does not let a == inside inline code close the highlight", () => {
+    const e = makeEditor("==a `b==c` d==");
+    const html = e.getHTML();
+    // whole span highlighted; inner `==` stays inside an inline <code>
+    expect(html).toContain("<mark");
+    expect(html).toContain("<code");
+    expect(html).toContain("b==c");
+    // must NOT have stopped at the code's `==`
+    expect(html).not.toMatch(/<mark[^>]*>a\s*$/);
+    expect(e.getMarkdown().trim()).toBe("==a `b==c` d==");
+  });
+
+  it("does not highlight across a blank line (two literal paragraphs)", () => {
+    const e = makeEditor("==a\n\nb==");
+    expect(e.getHTML()).not.toContain("<mark");
+    expect(e.getMarkdown().trim()).toBe("==a\n\nb==");
+  });
 });

--- a/packages/views/editor/extensions/highlight.test.ts
+++ b/packages/views/editor/extensions/highlight.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "@tiptap/markdown";
+import { HighlightExtension } from "./highlight";
+
+let editor: Editor | null = null;
+
+function makeEditor(markdown: string): Editor {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  editor = new Editor({
+    element,
+    extensions: [StarterKit, Markdown, HighlightExtension],
+  });
+  editor.commands.setContent(markdown, { contentType: "markdown" });
+  return editor;
+}
+
+/** Round-trip: load markdown → serialize back to markdown. */
+function roundTrip(markdown: string): string {
+  return makeEditor(markdown).getMarkdown().trim();
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe("HighlightExtension — markdown serialization (cross-process protocol)", () => {
+  it("round-trips a basic highlight as ==text==", () => {
+    expect(roundTrip("==hi==")).toBe("==hi==");
+  });
+
+  it("round-trips a highlight embedded in a sentence", () => {
+    expect(roundTrip("before ==mid== after")).toBe("before ==mid== after");
+  });
+
+  it("parses ==text== into a highlight mark (<mark> in HTML)", () => {
+    const html = makeEditor("==hi==").getHTML();
+    expect(html).toContain("<mark");
+    expect(html).toContain("hi");
+  });
+
+  it("preserves inner formatting inside a highlight", () => {
+    // bold nested inside highlight must survive the round-trip
+    expect(roundTrip("==**bold**==")).toBe("==**bold**==");
+  });
+
+  it("serializes a highlight applied via the toggleHighlight command", () => {
+    const e = makeEditor("hello");
+    e.commands.selectAll();
+    e.commands.toggleHighlight();
+    expect(e.getMarkdown().trim()).toBe("==hello==");
+  });
+
+  it("leaves a lone == (comparison) untouched", () => {
+    expect(roundTrip("if a == b")).toBe("if a == b");
+  });
+
+  it("does not treat == inside inline code as a highlight", () => {
+    expect(roundTrip("`a ==b== c`")).toBe("`a ==b== c`");
+  });
+});

--- a/packages/views/editor/extensions/highlight.test.ts
+++ b/packages/views/editor/extensions/highlight.test.ts
@@ -81,4 +81,14 @@ describe("HighlightExtension — markdown serialization (cross-process protocol)
     expect(e.getHTML()).not.toContain("<mark");
     expect(e.getMarkdown().trim()).toBe("==a\n\nb==");
   });
+
+  it("does not highlight across a CRLF blank line", () => {
+    const e = makeEditor("==a\r\n\r\nb==");
+    expect(e.getHTML()).not.toContain("<mark");
+  });
+
+  it("still highlights across a CRLF soft line break", () => {
+    const e = makeEditor("==a\r\nb==");
+    expect(e.getHTML()).toContain("<mark");
+  });
 });

--- a/packages/views/editor/extensions/highlight.ts
+++ b/packages/views/editor/extensions/highlight.ts
@@ -1,0 +1,53 @@
+import Highlight from "@tiptap/extension-highlight";
+
+/**
+ * HighlightExtension — text highlight mark (`==text==` ⇄ <mark>).
+ *
+ * Builds on @tiptap/extension-highlight, which already supplies the `<mark>`
+ * parseHTML/renderHTML, the `==text==` input/paste rules, the
+ * setHighlight/toggleHighlight/unsetHighlight commands, and the Mod-Shift-H
+ * shortcut. On top of that we add @tiptap/markdown serialization so highlights
+ * round-trip through the stored Markdown as `==text==`:
+ *
+ *   - renderMarkdown: highlight mark → `==…==`. @tiptap/markdown renders marks by
+ *     calling renderMarkdown with a placeholder child and splitting the result
+ *     into opening/closing fences, so wrapping the placeholder in `==` yields a
+ *     `==` open and `==` close.
+ *   - markdownTokenizer + parseMarkdown: `==text==` in stored Markdown → highlight
+ *     mark. inlineTokens keeps inner inline formatting (e.g. `==**bold**==`).
+ *
+ * Single colour (yellow) for now — `multicolor` stays off. A future multicolour
+ * variant would need a syntax that can carry a colour (`==text==` cannot), so it
+ * is intentionally out of scope here (see MUL-2934).
+ *
+ * BOUNDARY RULES — must stay in sync with the read-only renderer's regex in
+ * utils/highlight-markdown.ts so the editor and the read-only view agree on what
+ * counts as a highlight:
+ *   - no whitespace directly inside the fences (`==x==` highlights, `== x ==` does not)
+ *   - non-empty content (`====` stays literal text)
+ */
+const HIGHLIGHT_TOKEN_RE = /^==(?!\s)([\s\S]*?[^\s])==/;
+
+export const HighlightExtension = Highlight.extend({
+  markdownTokenizer: {
+    name: "highlight",
+    level: "inline" as const,
+    start(src: string) {
+      return src.indexOf("==");
+    },
+    tokenize(src: string, _tokens: unknown, helpers: any) {
+      const match = HIGHLIGHT_TOKEN_RE.exec(src);
+      if (!match) return undefined;
+      return {
+        type: "highlight",
+        raw: match[0],
+        tokens: helpers.inlineTokens(match[1]),
+      };
+    },
+  },
+
+  parseMarkdown: (token: any, helpers: any) =>
+    helpers.applyMark("highlight", helpers.parseInline(token.tokens)),
+
+  renderMarkdown: (_node: any, helpers: any) => `==${helpers.renderChildren()}==`,
+}).configure({ multicolor: false });

--- a/packages/views/editor/extensions/highlight.ts
+++ b/packages/views/editor/extensions/highlight.ts
@@ -1,4 +1,5 @@
 import Highlight from "@tiptap/extension-highlight";
+import { matchHighlightAt } from "../utils/highlight-match";
 
 /**
  * HighlightExtension — text highlight mark (`==text==` ⇄ <mark>).
@@ -20,13 +21,15 @@ import Highlight from "@tiptap/extension-highlight";
  * variant would need a syntax that can carry a colour (`==text==` cannot), so it
  * is intentionally out of scope here (see MUL-2934).
  *
- * BOUNDARY RULES — must stay in sync with the read-only renderer's regex in
- * utils/highlight-markdown.ts so the editor and the read-only view agree on what
- * counts as a highlight:
- *   - no whitespace directly inside the fences (`==x==` highlights, `== x ==` does not)
+ * BOUNDARY RULES live in utils/highlight-match.ts and are shared with the
+ * read-only renderer (utils/highlight-markdown.ts) so the editor and the
+ * read-only view can never disagree on what counts as a highlight:
+ *   - no whitespace directly inside the fences (`==x==` highlights, `== x ==` not)
  *   - non-empty content (`====` stays literal text)
+ *   - neither fence may sit inside code/math (a `==` inside `` `code` `` / `$math$`
+ *     is literal), so ``==a `b==c` d==`` highlights the whole span, not `a `b`
+ *   - a highlight may not cross a blank line / block boundary
  */
-const HIGHLIGHT_TOKEN_RE = /^==(?!\s)([\s\S]*?[^\s])==/;
 
 export const HighlightExtension = Highlight.extend({
   markdownTokenizer: {
@@ -36,12 +39,12 @@ export const HighlightExtension = Highlight.extend({
       return src.indexOf("==");
     },
     tokenize(src: string, _tokens: unknown, helpers: any) {
-      const match = HIGHLIGHT_TOKEN_RE.exec(src);
+      const match = matchHighlightAt(src, 0);
       if (!match) return undefined;
       return {
         type: "highlight",
-        raw: match[0],
-        tokens: helpers.inlineTokens(match[1]),
+        raw: src.slice(0, match.end),
+        tokens: helpers.inlineTokens(match.inner),
       };
     },
   },

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -50,6 +50,7 @@ import { createFileUploadExtension } from "./file-upload";
 import { FileCardExtension } from "./file-card";
 import { ImageView } from "./image-view";
 import { BlockMathExtension, InlineMathExtension } from "./math";
+import { HighlightExtension } from "./highlight";
 
 const lowlight = createLowlight(common);
 
@@ -144,6 +145,7 @@ export function createEditorExtensions(
     TableCell,
     BlockMathExtension,
     InlineMathExtension,
+    HighlightExtension,
     // 3-space indent so nested ordered lists survive CommonMark in ReadonlyContent.
     Markdown.configure({ indentation: { style: "space", size: 3 } }),
     // Make Cmd+C / Cmd+X / drag write Markdown source to clipboard text/plain

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -147,6 +147,22 @@ describe("ReadonlyContent highlight Markdown", () => {
     expect(container.querySelector("mark")).toBeNull();
     expect(container.querySelector("code")?.textContent).toBe("a ==b== c");
   });
+
+  // Boundary regressions (Emacs review, PR #3661).
+
+  it("wraps the whole span when an inner == lives in inline code", () => {
+    const { container } = render(<ReadonlyContent content={"==a `b==c` d=="} />);
+    const mark = container.querySelector("mark");
+    expect(mark).not.toBeNull();
+    // inner `==` stays inside the code, not consumed as the closing fence
+    expect(mark?.querySelector("code")?.textContent).toBe("b==c");
+    expect(mark?.textContent).toBe("a b==c d");
+  });
+
+  it("does not highlight across a blank line", () => {
+    const { container } = render(<ReadonlyContent content={"==a\n\nb=="} />);
+    expect(container.querySelector("mark")).toBeNull();
+  });
 });
 
 describe("ReadonlyContent issue mention Markdown", () => {

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -126,6 +126,29 @@ describe("ReadonlyContent line breaks", () => {
   });
 });
 
+describe("ReadonlyContent highlight Markdown", () => {
+  // `==text==` is lowered to a raw <mark> by highlightToHtml; rehype-raw turns
+  // it into an element and the sanitize schema must whitelist <mark> or it gets
+  // stripped. These guard both halves of that contract.
+  it("renders ==text== as a <mark> element", () => {
+    const { container } = render(<ReadonlyContent content={"a ==hi== b"} />);
+    const mark = container.querySelector("mark");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe("hi");
+  });
+
+  it("keeps inner Markdown formatting inside a highlight", () => {
+    const { container } = render(<ReadonlyContent content={"==**bold**=="} />);
+    expect(container.querySelector("mark strong")).not.toBeNull();
+  });
+
+  it("does not highlight == inside inline code", () => {
+    const { container } = render(<ReadonlyContent content={"`a ==b== c`"} />);
+    expect(container.querySelector("mark")).toBeNull();
+    expect(container.querySelector("code")?.textContent).toBe("a ==b== c");
+  });
+});
+
 describe("ReadonlyContent issue mention Markdown", () => {
   it("renders an issue mention inside a task list as an issue mention card", () => {
     const { container, getByTestId } = render(

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -38,6 +38,7 @@ import { useLinkHover, LinkHoverCard } from "./link-hover-card";
 import { openLink, isMentionHref } from "./utils/link-handler";
 import { isAllowedFileCardHref } from "@multica/ui/markdown";
 import { preprocessMarkdown } from "./utils/preprocess";
+import { highlightToHtml } from "./utils/highlight-markdown";
 import { MermaidDiagram } from "./mermaid-diagram";
 import { HtmlBlockPreview } from "./html-block-preview";
 import { AttachmentDownloadProvider } from "./attachment-download-context";
@@ -64,6 +65,9 @@ const PRE_UNWRAP_RE = /(^|\s)language-(html|mermaid)(\s|$)/;
 
 const sanitizeSchema = {
   ...defaultSchema,
+  // Allow <mark> (text highlight) — emitted by highlightToHtml from `==text==`.
+  // It carries no attributes, so only the tag name needs whitelisting.
+  tagNames: [...(defaultSchema.tagNames ?? []), "mark"],
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "mention", "slash"],
@@ -322,7 +326,10 @@ export const ReadonlyContent = memo(function ReadonlyContent({
   className,
   attachments,
 }: ReadonlyContentProps) {
-  const processed = useMemo(() => preprocessMarkdown(content), [content]);
+  const processed = useMemo(
+    () => highlightToHtml(preprocessMarkdown(content)),
+    [content],
+  );
   const wrapperRef = useRef<HTMLDivElement>(null);
   const hover = useLinkHover(wrapperRef);
 

--- a/packages/views/editor/styles/prose.css
+++ b/packages/views/editor/styles/prose.css
@@ -284,3 +284,16 @@
   text-decoration: line-through;
   color: var(--muted-foreground);
 }
+
+/* Text highlight (`==text==` → <mark>). Single yellow tint that stays legible
+   in both light and dark themes; `color: inherit` keeps the underlying text
+   color so highlighted links/code remain readable. box-decoration-break clones
+   the background across wrapped lines (same approach as inline code above). */
+.rich-text-editor mark {
+  background-color: color-mix(in srgb, #facc15 45%, transparent);
+  color: inherit;
+  border-radius: 0.2em;
+  padding: 0 0.15em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}

--- a/packages/views/editor/utils/highlight-markdown.test.ts
+++ b/packages/views/editor/utils/highlight-markdown.test.ts
@@ -51,4 +51,28 @@ describe("highlightToHtml", () => {
   it("does not treat a == b (comparison) as a highlight", () => {
     expect(highlightToHtml("if a == b then")).toBe("if a == b then");
   });
+
+  // Boundary regressions (Emacs review, PR #3661).
+
+  it("does not let a == inside inline code close the highlight", () => {
+    // The inner `==` lives in inline code; the highlight must wrap the whole
+    // span, not stop at the code's `==`.
+    expect(highlightToHtml("==a `b==c` d==")).toBe(
+      "<mark>a `b==c` d</mark>",
+    );
+  });
+
+  it("does not let a == inside inline math close the highlight", () => {
+    expect(highlightToHtml("==a $b==c$ d==")).toBe(
+      "<mark>a $b==c$ d</mark>",
+    );
+  });
+
+  it("does not highlight across a blank line / block boundary", () => {
+    expect(highlightToHtml("==a\n\nb==")).toBe("==a\n\nb==");
+  });
+
+  it("still highlights across a soft line break within a block", () => {
+    expect(highlightToHtml("==a\nb==")).toBe("<mark>a\nb</mark>");
+  });
 });

--- a/packages/views/editor/utils/highlight-markdown.test.ts
+++ b/packages/views/editor/utils/highlight-markdown.test.ts
@@ -75,4 +75,12 @@ describe("highlightToHtml", () => {
   it("still highlights across a soft line break within a block", () => {
     expect(highlightToHtml("==a\nb==")).toBe("<mark>a\nb</mark>");
   });
+
+  it("does not highlight across a CRLF blank line", () => {
+    expect(highlightToHtml("==a\r\n\r\nb==")).toBe("==a\r\n\r\nb==");
+  });
+
+  it("still highlights across a CRLF soft line break", () => {
+    expect(highlightToHtml("==a\r\nb==")).toBe("<mark>a\r\nb</mark>");
+  });
 });

--- a/packages/views/editor/utils/highlight-markdown.test.ts
+++ b/packages/views/editor/utils/highlight-markdown.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { highlightToHtml } from "./highlight-markdown";
+
+describe("highlightToHtml", () => {
+  it("lowers a basic highlight to <mark>", () => {
+    expect(highlightToHtml("a ==hi== b")).toBe("a <mark>hi</mark> b");
+  });
+
+  it("keeps inner markdown intact for nested formatting", () => {
+    expect(highlightToHtml("==**bold**==")).toBe("<mark>**bold**</mark>");
+  });
+
+  it("handles multiple highlights on one line", () => {
+    expect(highlightToHtml("==a== and ==b==")).toBe(
+      "<mark>a</mark> and <mark>b</mark>",
+    );
+  });
+
+  it("requires non-space directly inside the fences", () => {
+    expect(highlightToHtml("== spaced ==")).toBe("== spaced ==");
+  });
+
+  it("does not match empty fences", () => {
+    expect(highlightToHtml("====")).toBe("====");
+  });
+
+  it("is a no-op when there is no ==", () => {
+    const md = "plain **bold** _italic_ text";
+    expect(highlightToHtml(md)).toBe(md);
+  });
+
+  it("ignores == inside inline code", () => {
+    expect(highlightToHtml("`a ==b== c`")).toBe("`a ==b== c`");
+  });
+
+  it("ignores == inside fenced code blocks", () => {
+    const md = "```\nx ==y== z\n```";
+    expect(highlightToHtml(md)).toBe(md);
+  });
+
+  it("ignores == inside inline math", () => {
+    expect(highlightToHtml("$a ==b== c$")).toBe("$a ==b== c$");
+  });
+
+  it("highlights outside code while leaving code untouched", () => {
+    expect(highlightToHtml("==hi== `x ==y==`")).toBe(
+      "<mark>hi</mark> `x ==y==`",
+    );
+  });
+
+  it("does not treat a == b (comparison) as a highlight", () => {
+    expect(highlightToHtml("if a == b then")).toBe("if a == b then");
+  });
+});

--- a/packages/views/editor/utils/highlight-markdown.ts
+++ b/packages/views/editor/utils/highlight-markdown.ts
@@ -6,52 +6,16 @@
  * notion of `==` highlight syntax, so we lower it to a raw `<mark>` element here.
  * readonly-content.tsx already runs `rehype-raw` (so the raw `<mark>` becomes a
  * real element) and whitelists `mark` in its sanitize schema. Because the inner
- * text is left untouched, nested Markdown inside a highlight (e.g. `==**bold**==`)
- * is still parsed by remark — matching the editor, which keeps inner formatting
- * via inlineTokens.
+ * text is left untouched, nested Markdown inside a highlight (e.g. `==**bold**==`
+ * or an inline `` `code` ``) is still parsed by remark — matching the editor.
  *
- * The match rules mirror HighlightExtension's HIGHLIGHT_TOKEN_RE so the two
- * renderers agree on what is a highlight:
- *   - no whitespace directly inside the fences (`==x==` highlights, `== x ==` not)
- *   - non-empty content (`====` stays literal)
- *
- * `==` inside code (fenced blocks, inline code) and math (`$…$`, `$$…$$`) is left
- * untouched — those are literal contexts where `==` must not become a highlight.
+ * The matching rules live in highlight-match.ts and are shared with the editor
+ * tokenizer, so the storage ↔ editor ↔ read-only boundary can never drift:
+ * fences may not sit inside code/math, and a highlight may not cross a blank
+ * line / block boundary.
  */
 
-const HIGHLIGHT_RE = /==(?!\s)([\s\S]*?[^\s])==/g;
-
-interface Range {
-  start: number;
-  end: number;
-}
-
-/**
- * Spans where `==` must NOT be interpreted as highlight syntax: fenced code,
- * inline code, and inline/display math. Mirrors the code-range scan in
- * @multica/ui/markdown's linkify so highlight and autolink skip the same
- * literal contexts.
- */
-function findLiteralRanges(text: string): Range[] {
-  const ranges: Range[] = [];
-  const add = (re: RegExp) => {
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(text)) !== null) {
-      const start = m.index;
-      if (ranges.some((r) => start >= r.start && start < r.end)) continue;
-      ranges.push({ start, end: start + m[0].length });
-    }
-  };
-  add(/```[\s\S]*?```/g); // fenced code
-  add(/\$\$[\s\S]*?\$\$/g); // display math
-  add(/(?<!\$)\$(?!\$)[^$\n]+\$(?!\$)/g); // inline math
-  add(/(?<!`)`(?!`)[^`\n]+`(?!`)/g); // inline code
-  return ranges;
-}
-
-function isInside(pos: number, ranges: Range[]): boolean {
-  return ranges.some((r) => pos >= r.start && pos < r.end);
-}
+import { findLiteralRanges, matchHighlightAt } from "./highlight-match";
 
 /**
  * Lower `==text==` highlight syntax to raw `<mark>` for the react-markdown
@@ -59,18 +23,23 @@ function isInside(pos: number, ranges: Range[]): boolean {
  */
 export function highlightToHtml(markdown: string): string {
   if (!markdown.includes("==")) return markdown;
-  const literalRanges = findLiteralRanges(markdown);
+  const ranges = findLiteralRanges(markdown);
 
   let result = "";
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-  HIGHLIGHT_RE.lastIndex = 0;
-  while ((match = HIGHLIGHT_RE.exec(markdown)) !== null) {
-    if (isInside(match.index, literalRanges)) continue;
-    result += markdown.slice(lastIndex, match.index);
-    result += `<mark>${match[1]}</mark>`;
-    lastIndex = match.index + match[0].length;
+  let cursor = 0;
+  let i = markdown.indexOf("==");
+  while (i !== -1) {
+    const match = matchHighlightAt(markdown, i, ranges);
+    if (match) {
+      result += markdown.slice(cursor, i);
+      result += `<mark>${match.inner}</mark>`;
+      cursor = match.end;
+      i = markdown.indexOf("==", match.end);
+    } else {
+      // Not a highlight here — advance past this `==` and keep looking.
+      i = markdown.indexOf("==", i + 2);
+    }
   }
-  result += markdown.slice(lastIndex);
+  result += markdown.slice(cursor);
   return result;
 }

--- a/packages/views/editor/utils/highlight-markdown.ts
+++ b/packages/views/editor/utils/highlight-markdown.ts
@@ -1,0 +1,76 @@
+/**
+ * highlight-markdown — read-only `==text==` → `<mark>text</mark>` transform.
+ *
+ * The editor (Tiptap) parses `==text==` natively via the HighlightExtension's
+ * markdownTokenizer. The read-only surface uses react-markdown, which has no
+ * notion of `==` highlight syntax, so we lower it to a raw `<mark>` element here.
+ * readonly-content.tsx already runs `rehype-raw` (so the raw `<mark>` becomes a
+ * real element) and whitelists `mark` in its sanitize schema. Because the inner
+ * text is left untouched, nested Markdown inside a highlight (e.g. `==**bold**==`)
+ * is still parsed by remark — matching the editor, which keeps inner formatting
+ * via inlineTokens.
+ *
+ * The match rules mirror HighlightExtension's HIGHLIGHT_TOKEN_RE so the two
+ * renderers agree on what is a highlight:
+ *   - no whitespace directly inside the fences (`==x==` highlights, `== x ==` not)
+ *   - non-empty content (`====` stays literal)
+ *
+ * `==` inside code (fenced blocks, inline code) and math (`$…$`, `$$…$$`) is left
+ * untouched — those are literal contexts where `==` must not become a highlight.
+ */
+
+const HIGHLIGHT_RE = /==(?!\s)([\s\S]*?[^\s])==/g;
+
+interface Range {
+  start: number;
+  end: number;
+}
+
+/**
+ * Spans where `==` must NOT be interpreted as highlight syntax: fenced code,
+ * inline code, and inline/display math. Mirrors the code-range scan in
+ * @multica/ui/markdown's linkify so highlight and autolink skip the same
+ * literal contexts.
+ */
+function findLiteralRanges(text: string): Range[] {
+  const ranges: Range[] = [];
+  const add = (re: RegExp) => {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const start = m.index;
+      if (ranges.some((r) => start >= r.start && start < r.end)) continue;
+      ranges.push({ start, end: start + m[0].length });
+    }
+  };
+  add(/```[\s\S]*?```/g); // fenced code
+  add(/\$\$[\s\S]*?\$\$/g); // display math
+  add(/(?<!\$)\$(?!\$)[^$\n]+\$(?!\$)/g); // inline math
+  add(/(?<!`)`(?!`)[^`\n]+`(?!`)/g); // inline code
+  return ranges;
+}
+
+function isInside(pos: number, ranges: Range[]): boolean {
+  return ranges.some((r) => pos >= r.start && pos < r.end);
+}
+
+/**
+ * Lower `==text==` highlight syntax to raw `<mark>` for the react-markdown
+ * read-only pipeline. No-op when the text contains no `==`.
+ */
+export function highlightToHtml(markdown: string): string {
+  if (!markdown.includes("==")) return markdown;
+  const literalRanges = findLiteralRanges(markdown);
+
+  let result = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  HIGHLIGHT_RE.lastIndex = 0;
+  while ((match = HIGHLIGHT_RE.exec(markdown)) !== null) {
+    if (isInside(match.index, literalRanges)) continue;
+    result += markdown.slice(lastIndex, match.index);
+    result += `<mark>${match[1]}</mark>`;
+    lastIndex = match.index + match[0].length;
+  }
+  result += markdown.slice(lastIndex);
+  return result;
+}

--- a/packages/views/editor/utils/highlight-match.test.ts
+++ b/packages/views/editor/utils/highlight-match.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { matchHighlightAt, findLiteralRanges } from "./highlight-match";
+
+/** Convenience: match at the first `==` and return the inner text, or null. */
+function inner(text: string): string | null {
+  const i = text.indexOf("==");
+  if (i === -1) return null;
+  const m = matchHighlightAt(text, i);
+  return m ? m.inner : null;
+}
+
+describe("matchHighlightAt", () => {
+  it("matches a basic highlight at the opening fence", () => {
+    const m = matchHighlightAt("==hi==", 0);
+    expect(m).toEqual({ end: 6, inner: "hi" });
+  });
+
+  it("returns null when the opening fence is not at i", () => {
+    expect(matchHighlightAt("x==hi==", 0)).toBeNull();
+  });
+
+  it("rejects whitespace directly inside the fences", () => {
+    expect(inner("== x ==")).toBeNull();
+  });
+
+  it("rejects empty content", () => {
+    expect(inner("====")).toBeNull();
+  });
+
+  it("skips a closing == that sits inside inline code", () => {
+    // ==a `b==c` d== → inner is the whole `a `b==c` d`, not `a `b`
+    expect(inner("==a `b==c` d==")).toBe("a `b==c` d");
+  });
+
+  it("skips a closing == that sits inside inline math", () => {
+    expect(inner("==a $b==c$ d==")).toBe("a $b==c$ d");
+  });
+
+  it("does not open a highlight whose opening == is inside inline code", () => {
+    expect(inner("`x==y==z`")).toBeNull();
+  });
+
+  it("does not cross a blank line", () => {
+    expect(inner("==a\n\nb==")).toBeNull();
+  });
+
+  it("allows a soft line break inside a block", () => {
+    expect(inner("==a\nb==")).toBe("a\nb");
+  });
+
+  it("matches the nearest valid closing fence", () => {
+    // first valid close wins; trailing == is left over
+    expect(matchHighlightAt("==a==b==", 0)).toEqual({ end: 5, inner: "a" });
+  });
+});
+
+describe("findLiteralRanges", () => {
+  it("treats == inside a fenced block as literal", () => {
+    const text = "```\n==x==\n```";
+    const ranges = findLiteralRanges(text);
+    const fencePos = text.indexOf("==x==");
+    expect(ranges.some((r) => fencePos >= r.start && fencePos < r.end)).toBe(true);
+  });
+});

--- a/packages/views/editor/utils/highlight-match.test.ts
+++ b/packages/views/editor/utils/highlight-match.test.ts
@@ -48,6 +48,14 @@ describe("matchHighlightAt", () => {
     expect(inner("==a\nb==")).toBe("a\nb");
   });
 
+  it("does not cross a CRLF blank line", () => {
+    expect(inner("==a\r\n\r\nb==")).toBeNull();
+  });
+
+  it("allows a CRLF soft line break inside a block", () => {
+    expect(inner("==a\r\nb==")).toBe("a\r\nb");
+  });
+
   it("matches the nearest valid closing fence", () => {
     // first valid close wins; trailing == is left over
     expect(matchHighlightAt("==a==b==", 0)).toEqual({ end: 5, inner: "a" });

--- a/packages/views/editor/utils/highlight-match.ts
+++ b/packages/views/editor/utils/highlight-match.ts
@@ -20,8 +20,12 @@ export interface Range {
   end: number;
 }
 
-/** A blank line: a newline, optional spaces/tabs, then another newline. */
-const BLANK_LINE_RE = /\n[ \t]*\n/;
+/**
+ * A blank line: a line break, optional spaces/tabs, then another line break.
+ * Handles both LF and CRLF (Windows / pasted) line endings so the boundary
+ * rule holds regardless of how the content was stored.
+ */
+const BLANK_LINE_RE = /\r?\n[ \t]*\r?\n/;
 
 /**
  * Spans where `==` must NOT be interpreted as highlight syntax: fenced code,

--- a/packages/views/editor/utils/highlight-match.ts
+++ b/packages/views/editor/utils/highlight-match.ts
@@ -1,0 +1,88 @@
+/**
+ * highlight-match — the single source of truth for what `==text==` highlight
+ * spans look like. BOTH the editor tokenizer (extensions/highlight.ts) and the
+ * read-only lowering (utils/highlight-markdown.ts) use this so the storage ↔
+ * editor ↔ read-only boundary rules can never drift.
+ *
+ * Rules for a highlight `==INNER==`:
+ *   - no whitespace directly inside the fences (`==x==` ok, `== x ==` not)
+ *   - INNER is non-empty (`====` stays literal)
+ *   - neither fence may sit inside a code/math literal span — a `==` inside
+ *     inline code/math or a fenced/`$$` block is literal and must not open or
+ *     close a highlight (so ``==a `b==c` d=="`` highlights the whole thing, the
+ *     inner `==` stays code)
+ *   - INNER may not cross a blank line / block boundary (`==a\n\nb==` is two
+ *     literal paragraphs, matching how the editor lexes it)
+ */
+
+export interface Range {
+  start: number;
+  end: number;
+}
+
+/** A blank line: a newline, optional spaces/tabs, then another newline. */
+const BLANK_LINE_RE = /\n[ \t]*\n/;
+
+/**
+ * Spans where `==` must NOT be interpreted as highlight syntax: fenced code,
+ * inline code, and inline/display math. Mirrors the code-range scan in
+ * @multica/ui/markdown's linkify so highlight and autolink skip the same
+ * literal contexts. Earlier (block-level) ranges win so a `==`/backtick inside
+ * a fenced block is not also counted as inline.
+ */
+export function findLiteralRanges(text: string): Range[] {
+  const ranges: Range[] = [];
+  const add = (re: RegExp) => {
+    let m: RegExpExecArray | null;
+    re.lastIndex = 0;
+    while ((m = re.exec(text)) !== null) {
+      const start = m.index;
+      if (ranges.some((r) => start >= r.start && start < r.end)) continue;
+      ranges.push({ start, end: start + m[0].length });
+    }
+  };
+  add(/```[\s\S]*?```/g); // fenced code
+  add(/\$\$[\s\S]*?\$\$/g); // display math
+  add(/(?<!\$)\$(?!\$)[^$\n]+\$(?!\$)/g); // inline math
+  add(/(?<!`)`(?!`)[^`\n]+`(?!`)/g); // inline code
+  return ranges;
+}
+
+function isInside(pos: number, ranges: Range[]): boolean {
+  return ranges.some((r) => pos >= r.start && pos < r.end);
+}
+
+/**
+ * Try to match a highlight whose opening `==` begins at `i`. Returns the
+ * exclusive end offset (just past the closing `==`) and the inner text, or
+ * null if no valid highlight starts here.
+ *
+ * `ranges` may be passed in when the caller already computed literal ranges for
+ * the whole text (read-only path); otherwise they are computed from `text`.
+ */
+export function matchHighlightAt(
+  text: string,
+  i: number,
+  ranges?: Range[],
+): { end: number; inner: string } | null {
+  if (text[i] !== "=" || text[i + 1] !== "=") return null;
+  const innerStart = i + 2;
+  // Non-empty and no whitespace directly after the opening fence.
+  if (innerStart >= text.length) return null;
+  if (/\s/.test(text[innerStart]!)) return null;
+
+  const r = ranges ?? findLiteralRanges(text);
+  if (isInside(i, r)) return null; // opening fence is literal (inside code/math)
+
+  // INNER may not cross a blank line: cap the scan at the first one.
+  const blankRel = text.slice(innerStart).search(BLANK_LINE_RE);
+  const scanLimit = blankRel === -1 ? text.length : innerStart + blankRel;
+
+  for (let j = innerStart + 1; j <= scanLimit && j + 1 < text.length; j++) {
+    if (text[j] !== "=" || text[j + 1] !== "=") continue;
+    if (isInside(j, r)) continue; // closing fence is literal — keep scanning
+    if (/\s/.test(text[j - 1]!)) continue; // no whitespace directly before fence
+    return { end: j + 2, inner: text.slice(innerStart, j) };
+  }
+  return null;
+}

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -4,6 +4,7 @@
     "italic": "Italic",
     "strikethrough": "Strikethrough",
     "code": "Code",
+    "highlight": "Highlight",
     "link": "Link",
     "list": "List",
     "quote": "Quote",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -4,6 +4,7 @@
     "italic": "斜体",
     "strikethrough": "取り消し線",
     "code": "コード",
+    "highlight": "ハイライト",
     "link": "リンク",
     "list": "リスト",
     "quote": "引用",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -4,6 +4,7 @@
     "italic": "기울임",
     "strikethrough": "취소선",
     "code": "코드",
+    "highlight": "강조",
     "link": "링크",
     "list": "목록",
     "quote": "인용",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -4,6 +4,7 @@
     "italic": "斜体",
     "strikethrough": "删除线",
     "code": "代码",
+    "highlight": "高亮",
     "link": "链接",
     "list": "列表",
     "quote": "引用",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -63,6 +63,7 @@
     "@tiptap/core": "^3.22.1",
     "@tiptap/extension-code-block-lowlight": "^3.22.1",
     "@tiptap/extension-document": "^3.22.1",
+    "@tiptap/extension-highlight": "3.22.1",
     "@tiptap/extension-image": "^3.22.1",
     "@tiptap/extension-link": "^3.22.1",
     "@tiptap/extension-list": "^3.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,6 +972,9 @@ importers:
       '@tiptap/extension-document':
         specifier: ^3.22.1
         version: 3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))
+      '@tiptap/extension-highlight':
+        specifier: 3.22.1
+        version: 3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))
       '@tiptap/extension-image':
         specifier: ^3.22.1
         version: 3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))
@@ -4056,6 +4059,11 @@ packages:
 
   '@tiptap/extension-heading@3.22.1':
     resolution: {integrity: sha512-EaIihzrOfXUHQlL6fFyJCkDrjgg0e/eD4jpkjhKpeuJDcqf7eJ1c0E2zcNRAiZkeXdN/hTQFaXKsSyNUE7T7Sg==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.1
+
+  '@tiptap/extension-highlight@3.22.1':
+    resolution: {integrity: sha512-3XH0HWViJVzr+FUZY/HQn2vasOgOssVlOjdirKck9AmHoDFUceJbAygSJIdj2fZF3RQl0ohjMGi+OpGMVJ83sw==}
     peerDependencies:
       '@tiptap/core': ^3.22.1
 
@@ -14157,6 +14165,10 @@ snapshots:
       '@tiptap/core': 3.22.1(@tiptap/pm@3.22.1)
 
   '@tiptap/extension-heading@3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))':
+    dependencies:
+      '@tiptap/core': 3.22.1(@tiptap/pm@3.22.1)
+
+  '@tiptap/extension-highlight@3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))':
     dependencies:
       '@tiptap/core': 3.22.1(@tiptap/pm@3.22.1)
 


### PR DESCRIPTION
## What

Adds a single-color (yellow) **text highlight** mark to the shared rich-text editor used by issue **description** and **comments**, per MUL-2934. Highlights round-trip through the stored Markdown as `==text==`.

## Why

`description` / `comment` are stored as plain Markdown. There was no `<mark>` / highlight support. Jiayuan chose option ① (text highlight mark + a quick-edit button); single color now, no multicolor.

## Four touchpoints

1. **Editor mark** — `extensions/highlight.ts`: `@tiptap/extension-highlight` (gives `<mark>` parse/render, `==text==` input rule, `toggleHighlight`, `Mod-Shift-H`) extended with `@tiptap/markdown` hooks (`markdownTokenizer` + `parseMarkdown` + `renderMarkdown`) so `==text==` ⇄ highlight mark round-trips. Inner inline formatting (`==**bold**==`) preserved via `inlineTokens`.
2. **`==text==` serialization** — handled by the markdown hooks above. Verified end-to-end through the real `@tiptap/markdown` serializer (see `highlight.test.ts`).
3. **Read-only renderer** — `utils/highlight-markdown.ts` lowers `==text==` → `<mark>` (skips code/math spans); `readonly-content.tsx` sanitize schema whitelists `<mark>`. Nested Markdown inside a highlight still parses via the existing `rehype-raw` step.
4. **Bubble / quick-edit menu** — highlight toggle button (Highlighter icon, `Mod+Shift+H`), i18n added to all 4 locales.

Plus `prose.css` `<mark>` styling (single yellow, light/dark legible).

## Dependency note

Pinned `@tiptap/extension-highlight` to **exact `3.22.1`** to match `@tiptap/core@3.22.1` — `>=3.23` imports a `getStyleProperty` export that core 3.22.1 doesn't provide.

## Scope / follow-up

**Web + desktop only.** Mobile uses native `react-native-enriched-markdown` (md4c), which can't parse `==` and forbids custom leaf renderers, so mobile highlight needs its own native investigation — split into a follow-up sub-task.

## Cross-process protocol ⚠️

`==text==` serialization is a cross-process protocol. Per workflow rule it needs **Lambda + Emacs end-to-end verification** in addition to review.

## Tests

- `extensions/highlight.test.ts` — editor Markdown round-trip (the serialization protocol), `toggleHighlight`, code/comparison `==` left alone.
- `utils/highlight-markdown.test.ts` — `==`→`<mark>` transform incl. code/inline-code/math skip, nesting, boundary rules.
- `readonly-content.test.tsx` — `<mark>` renders through the full react-markdown + sanitize pipeline, nested formatting, code untouched.

`pnpm --filter @multica/views exec tsc --noEmit` clean; all 288 editor-dir tests pass.
