### PR TITLE
feat: implement agent task failure escalation hook (MIN-76)

### DIFF
--- a/server/internal/daemon/local_directory.go
+++ b/server/internal/daemon/local_directory.go
@@ -214,14 +214,17 @@ func isBlacklistedLocalPath(absPath string) (reason string, blocked bool) {
 	if isDriveRoot(cleaned) {
 		return fmt.Sprintf("path is a drive root %q", cleaned), true
 	}
-	for _, banned := range systemRootBlacklist() {
-		if cleaned == banned {
-			return fmt.Sprintf("path is a protected system root %q", banned), true
-		}
-	}
+	// Check home directory before system roots so that $HOME paths that
+	// also happen to be in the system-root blacklist (e.g. /root when
+	// running as root) produce the more specific "home directory" message.
 	if home, err := os.UserHomeDir(); err == nil {
 		if cleaned == filepath.Clean(home) {
 			return "path is the user's home directory", true
+		}
+	}
+	for _, banned := range systemRootBlacklist() {
+		if cleaned == banned {
+			return fmt.Sprintf("path is a protected system root %q", banned), true
 		}
 	}
 	return "", false
@@ -240,17 +243,9 @@ func isBlacklistedRealPath(realPath string) (reason string, blocked bool) {
 	if isDriveRoot(realClean) {
 		return fmt.Sprintf("path is a drive root %q", realClean), true
 	}
-	for _, banned := range systemRootBlacklist() {
-		bannedClean := filepath.Clean(banned)
-		if realClean == bannedClean {
-			return fmt.Sprintf("path is a protected system root %q", banned), true
-		}
-		if r, err := filepath.EvalSymlinks(banned); err == nil {
-			if filepath.Clean(r) == realClean {
-				return fmt.Sprintf("path is a protected system root %q", banned), true
-			}
-		}
-	}
+	// Check home directory before system roots so that $HOME paths that
+	// also happen to be in the system-root blacklist (e.g. /root when
+	// running as root) produce the more specific "home directory" message.
 	if home, err := os.UserHomeDir(); err == nil {
 		homeClean := filepath.Clean(home)
 		if realClean == homeClean {
@@ -259,6 +254,17 @@ func isBlacklistedRealPath(realPath string) (reason string, blocked bool) {
 		if r, err := filepath.EvalSymlinks(home); err == nil {
 			if filepath.Clean(r) == realClean {
 				return "path is the user's home directory", true
+			}
+		}
+	}
+	for _, banned := range systemRootBlacklist() {
+		bannedClean := filepath.Clean(banned)
+		if realClean == bannedClean {
+			return fmt.Sprintf("path is a protected system root %q", banned), true
+		}
+		if r, err := filepath.EvalSymlinks(banned); err == nil {
+			if filepath.Clean(r) == realClean {
+				return fmt.Sprintf("path is a protected system root %q", banned), true
 			}
 		}
 	}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1266,6 +1266,12 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// and only triggers for issue/chat tasks.
 	retried, _ := s.MaybeRetryFailedTask(ctx, task)
 
+	// Escalate to next handler when no auto-retry is pending. The helper
+	// itself handles dedup (metadata check, later-success guard, etc.).
+	if task.IssueID.Valid && retried == nil {
+		s.escalateTaskFailure(ctx, task)
+	}
+
 	// Skip the per-failure system comment when we'll immediately retry —
 	// the new task will surface its own status to the user, and we don't
 	// want to spam the issue with "task timed out" messages on every
@@ -1544,11 +1550,19 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 	for _, t := range tasks {
 		// Auto-retry first so the issue stays in_progress rather than
 		// flapping todo → in_progress within a tick.
-		if child, _ := s.MaybeRetryFailedTask(ctx, t); child != nil {
+		child, _ := s.MaybeRetryFailedTask(ctx, t)
+		if child != nil {
 			retried++
 			if t.IssueID.Valid {
 				retriedIssues[util.UUIDToString(t.IssueID)] = true
 			}
+		}
+
+		// Escalate to next handler when no auto-retry is pending.
+		// This covers batch paths (orphan recovery, sweeper, timeout, etc.)
+		// that FailTask does not reach.
+		if child == nil && t.IssueID.Valid {
+			s.escalateTaskFailure(ctx, t)
 		}
 
 		failureReason := "agent_error"

--- a/server/internal/service/task_escalation.go
+++ b/server/internal/service/task_escalation.go
@@ -1,0 +1,376 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/multica-ai/multica/server/pkg/redact"
+)
+
+// escalateTaskFailure is the shared escalation entry point for a single
+// failed task. It is safe to call multiple times for the same task —
+// metadata-level dedup prevents duplicate comments and dispatches.
+//
+// Must only be called after the auto-retry decision has settled (i.e.
+// retried == nil), otherwise a transient failure that will be retried
+// would incorrectly trigger escalation.
+func (s *TaskService) escalateTaskFailure(ctx context.Context, task db.AgentTaskQueue) {
+	if !task.IssueID.Valid {
+		// Chat-only and quick-create tasks do not get issue escalation.
+		return
+	}
+
+	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
+	if err != nil {
+		slog.Warn("escalation: failed to load issue",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+			"error", err,
+		)
+		return
+	}
+
+	// Skip done / cancelled issues — no point escalating historical failures.
+	if issue.Status == "done" || issue.Status == "cancelled" {
+		return
+	}
+
+	failureReason := taskFailureReason(task)
+
+	// --- Dedup: check metadata for prior escalation of the same task ---
+	meta := parseIssueMetadata(issue.Metadata)
+	if priorTaskID, ok := meta["failure_escalated_task_id"].(string); ok && priorTaskID == util.UUIDToString(task.ID) {
+		slog.Debug("escalation skipped: already escalated for this task",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+		)
+		return
+	}
+
+	// --- Suppress escalation when a later completed task exists ---
+	// A failure that was overtaken by a successful task (e.g. the agent
+	// produced valid output before an idle_watchdog killed the runner)
+	// should not produce an escalation comment.
+	if s.hasCompletedTaskAfter(ctx, task) {
+		slog.Debug("escalation skipped: later completed task exists",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+		)
+		return
+	}
+
+	// --- Build escalation comment ---
+	errSummary := ""
+	if task.Error.Valid && task.Error.String != "" {
+		errSummary = redact.Text(task.Error.String)
+	}
+	commentBody := s.buildEscalationComment(task, issue, failureReason, errSummary)
+
+	// Sanitise user-controlled fields (issue title, error text) against
+	// mention injection so a malicious title or error cannot trigger
+	// side-effect agent mentions.
+	commentBody = stripMentionInjections(commentBody)
+
+	// --- Create system comment ---
+	// Use author_type="system" with a zero UUID so the comment is not
+	// attributed to any agent. This matches the pattern established in
+	// issue_child_done.go / migration 107.
+	comment, err := s.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true}, // zero UUID
+		Content:     commentBody,
+		Type:        "system",
+		ParentID:    pgtype.UUID{}, // top-level
+	})
+	if err != nil {
+		slog.Warn("escalation: create system comment failed",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+			"error", err,
+		)
+		return
+	}
+
+	// --- Write escalation metadata for dedup ---
+	metaPayload := map[string]string{
+		"failure_escalated_task_id":     util.UUIDToString(task.ID),
+		"failure_escalated_reason":      failureReason,
+		"failure_escalated_agent_id":    util.UUIDToString(task.AgentID),
+		"failure_escalation_comment_id": util.UUIDToString(comment.ID),
+		"failure_escalation_status":     "notified_leader",
+	}
+	for k, v := range metaPayload {
+		valBytes, err := json.Marshal(v)
+		if err != nil {
+			slog.Warn("escalation: marshal metadata value failed",
+				"key", k, "error", err,
+			)
+			continue
+		}
+		if _, err := s.Queries.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+			ID:          issue.ID,
+			WorkspaceID: issue.WorkspaceID,
+			Key:         k,
+			Value:       valBytes,
+		}); err != nil {
+			slog.Warn("escalation: set metadata key failed",
+				"key", k, "error", err,
+			)
+		}
+	}
+
+	// --- Broadcast the comment event ---
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventCommentCreated,
+		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"comment": map[string]any{
+				"id":          util.UUIDToString(comment.ID),
+				"issue_id":    util.UUIDToString(comment.IssueID),
+				"author_type": comment.AuthorType,
+				"author_id":   util.UUIDToString(comment.AuthorID),
+				"content":     comment.Content,
+				"type":        comment.Type,
+				"parent_id":   util.UUIDToPtr(comment.ParentID),
+				"created_at":  comment.CreatedAt.Time.Format("2006-01-02T15:04:05Z"),
+			},
+			"issue_title":  issue.Title,
+			"issue_status": issue.Status,
+		},
+	})
+
+	// --- Explicit dispatch to next handler ---
+	s.dispatchEscalationTarget(ctx, issue, task, failureReason)
+
+	slog.Info("task failure escalated",
+		"task_id", util.UUIDToString(task.ID),
+		"issue_id", util.UUIDToString(task.IssueID),
+		"agent_id", util.UUIDToString(task.AgentID),
+		"reason", failureReason,
+		"comment_id", util.UUIDToString(comment.ID),
+	)
+}
+
+// buildEscalationComment constructs the diagnostic comment body for a
+// task failure escalation.
+func (s *TaskService) buildEscalationComment(task db.AgentTaskQueue, issue db.Issue, failureReason, errSummary string) string {
+	agentName := s.lookupAgentName(task.AgentID)
+	taskID := util.UUIDToString(task.ID)
+	agentID := util.UUIDToString(task.AgentID)
+	route := recommendRoute(failureReason)
+	nextHandler := recommendNextHandler(failureReason)
+
+	var b strings.Builder
+	b.WriteString("**Task Failure Escalation**\n\n")
+	b.WriteString(fmt.Sprintf("- **Failed Agent**: %s (%s)\n", agentName, agentID))
+	b.WriteString(fmt.Sprintf("- **Task ID**: %s\n", taskID))
+	b.WriteString(fmt.Sprintf("- **Failure Reason**: `%s`\n", failureReason))
+	b.WriteString(fmt.Sprintf("- **Issue Status**: %s\n", issue.Status))
+	if task.Attempt > 0 {
+		b.WriteString(fmt.Sprintf("- **Attempt**: %d / %d\n", task.Attempt, task.MaxAttempts))
+	}
+	if errSummary != "" {
+		// Limit error summary to 500 characters so the comment stays readable.
+		if len(errSummary) > 500 {
+			errSummary = errSummary[:500] + "…"
+		}
+		b.WriteString(fmt.Sprintf("- **Error**: %s\n", errSummary))
+	}
+	b.WriteString(fmt.Sprintf("\n**Recommended Next Step**: %s\n", route))
+	b.WriteString(fmt.Sprintf("**Suggested Handler**: %s\n", nextHandler))
+	b.WriteString("\n> This is an automated escalation. No daemon restart was performed. ")
+	b.WriteString("If daemon/runtime restart is needed, a human must explicitly approve it. ")
+	b.WriteString("Do not @mention the failed agent back — their next run requires explicit rerun or reassignment.")
+
+	return b.String()
+}
+
+// lookupAgentName returns the agent's name, or "unknown" if the lookup fails.
+func (s *TaskService) lookupAgentName(agentID pgtype.UUID) string {
+	if s.Queries == nil {
+		return "unknown"
+	}
+	agent, err := s.Queries.GetAgent(context.Background(), agentID)
+	if err != nil {
+		return "unknown"
+	}
+	return agent.Name
+}
+
+
+// hasCompletedTaskAfter returns true when another task for the same issue
+// completed after this one failed — the failure was overtaken by success
+// and escalation should be suppressed.
+func (s *TaskService) hasCompletedTaskAfter(ctx context.Context, task db.AgentTaskQueue) bool {
+	if !task.IssueID.Valid || !task.CompletedAt.Valid {
+		return false
+	}
+	count, err := s.Queries.CountCompletedTasksForIssueAfter(ctx, db.CountCompletedTasksForIssueAfterParams{
+		IssueID:     task.IssueID,
+		CompletedAt: task.CompletedAt,
+	})
+	if err != nil {
+		slog.Warn("escalation: count completed tasks failed",
+			"task_id", util.UUIDToString(task.ID),
+			"error", err,
+		)
+		return false
+	}
+	return count > 0
+}
+
+// dispatchEscalationTarget enqueues a follow-up task for the escalation
+// target based on the failure reason and issue assignee.
+func (s *TaskService) dispatchEscalationTarget(ctx context.Context, issue db.Issue, task db.AgentTaskQueue, failureReason string) {
+	// Determine target agent for the escalation follow-up.
+	targetID, isLeader := s.resolveEscalationTarget(ctx, issue, task, failureReason)
+	if targetID == nil {
+		return
+	}
+
+	// Do not dispatch back to the agent that just failed — that would
+	// create a no-op re-trigger loop.
+	if util.UUIDToString(*targetID) == util.UUIDToString(task.AgentID) {
+		slog.Debug("escalation dispatch skipped: target is the failed agent",
+			"task_id", util.UUIDToString(task.ID),
+			"agent_id", util.UUIDToString(task.AgentID),
+		)
+		return
+	}
+
+	if isLeader {
+		if _, err := s.EnqueueTaskForSquadLeader(ctx, issue, *targetID, pgtype.UUID{}); err != nil {
+			slog.Warn("escalation dispatch: enqueue squad leader failed",
+				"task_id", util.UUIDToString(task.ID),
+				"leader_id", util.UUIDToString(*targetID),
+				"error", err,
+			)
+		}
+	} else {
+		if _, err := s.EnqueueTaskForMention(ctx, issue, *targetID, pgtype.UUID{}); err != nil {
+			slog.Warn("escalation dispatch: enqueue mention task failed",
+				"task_id", util.UUIDToString(task.ID),
+				"agent_id", util.UUIDToString(*targetID),
+				"error", err,
+			)
+		}
+	}
+}
+
+// resolveEscalationTarget returns the agent ID and whether they should be
+// dispatched as a squad leader, or nil if no suitable target is found.
+func (s *TaskService) resolveEscalationTarget(ctx context.Context, issue db.Issue, task db.AgentTaskQueue, failureReason string) (_ *pgtype.UUID, isLeader bool) {
+	// 1. If the issue is assigned to a squad, route to the squad leader.
+	if issue.AssigneeType.Valid && issue.AssigneeType.String == "squad" && issue.AssigneeID.Valid {
+		squad, err := s.Queries.GetSquad(ctx, issue.AssigneeID)
+		if err == nil && squad.LeaderID.Valid {
+			return &squad.LeaderID, true
+		}
+	}
+
+	// 2. If the issue has a specific agent assignee (different from the
+	//    failed agent), route to that assignee.
+	if issue.AssigneeType.Valid && issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid {
+		if util.UUIDToString(issue.AssigneeID) != util.UUIDToString(task.AgentID) {
+			return &issue.AssigneeID, false
+		}
+	}
+
+	// 3. Fall back to the failed agent's owner if set.
+	failedAgent, err := s.Queries.GetAgent(ctx, task.AgentID)
+	if err == nil && failedAgent.OwnerID.Valid {
+		ownerAgent, err := s.Queries.GetAgent(ctx, failedAgent.OwnerID)
+		if err == nil && !ownerAgent.ArchivedAt.Valid && ownerAgent.RuntimeID.Valid {
+			return &failedAgent.OwnerID, false
+		}
+	}
+
+	return nil, false
+}
+
+// recommendRoute returns a human-readable recommendation for the next
+// action based on the failure reason.
+func recommendRoute(failureReason string) string {
+	switch failureReason {
+	case "idle_watchdog", "codex_semantic_inactivity":
+		return "Check if valid results exist from previous attempts. If so, have QA/owner review. Otherwise, reassign to an alternative agent or use a more stable runtime."
+	case "timeout":
+		return "Auto-retry may have been attempted. If retries are exhausted, reassign to a different agent or break the task into smaller units."
+	case "runtime_offline", "runtime_recovery", "queued_expired":
+		return "Runtime infrastructure issue. Route to DevOps for investigation."
+	case "provider_error":
+		return "Provider/model error. Route to runtime QA / DevOps to check provider configuration, quotas, and model availability."
+	case "permission_error", "sandbox_error":
+		return "Permission or sandbox restriction. Route to DevOps for access review. Do not auto-elevate permissions."
+	case "qa_fail", "needs_fix":
+		return "QA failure or fix needed. Route to the implementation owner or parent issue owner."
+	case "block":
+		return "Task is blocked. Route to team lead for decision on issue status."
+	case "cancelled":
+		return "Task was cancelled (non-user action). Route to team lead for review."
+	case "agent_error":
+		fallthrough
+	default:
+		return "Unknown agent error. Route to Spark preflight or QA for log review."
+	}
+}
+
+// recommendNextHandler returns a human-readable suggested handler role.
+func recommendNextHandler(failureReason string) string {
+	switch failureReason {
+	case "idle_watchdog", "codex_semantic_inactivity":
+		return "QA / Issue Owner"
+	case "timeout":
+		return "Team Lead"
+	case "runtime_offline", "runtime_recovery", "queued_expired":
+		return "DevOps"
+	case "provider_error":
+		return "Runtime QA / DevOps"
+	case "permission_error", "sandbox_error":
+		return "DevOps"
+	case "qa_fail", "needs_fix":
+		return "Implementation Owner"
+	case "block":
+		return "Team Lead"
+	case "cancelled":
+		return "Team Lead"
+	default:
+		return "Spark Preflight / QA"
+	}
+}
+
+// stripMentionInjections removes mention://agent, mention://member, and
+// mention://squad markdown links from a string to prevent side-effect
+// agent mentions. mention://issue links are preserved.
+func stripMentionInjections(s string) string {
+	// Replace mention links for agent/member/squad types by inserting a space
+	// before the closing parenthesis so the mention regex no longer matches.
+	result := strings.ReplaceAll(s, "](mention://agent/", "] (mention://agent/")
+	result = strings.ReplaceAll(result, "](mention://member/", "] (mention://member/")
+	result = strings.ReplaceAll(result, "](mention://squad/", "] (mention://squad/")
+	return result
+}
+
+// parseIssueMetadata decodes JSONB metadata bytes into a map.
+func parseIssueMetadata(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}

--- a/server/internal/service/task_escalation_test.go
+++ b/server/internal/service/task_escalation_test.go
@@ -1,0 +1,230 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestStripMentionInjectionsAgent(t *testing.T) {
+	input := `Error in [Malicious](mention://agent/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	got := stripMentionInjections(input)
+	want := `Error in [Malicious] (mention://agent/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	if got != want {
+		t.Fatalf("stripMentionInjections:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestStripMentionInjectionsMember(t *testing.T) {
+	input := `[Attacker](mention://member/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	got := stripMentionInjections(input)
+	want := `[Attacker] (mention://member/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	if got != want {
+		t.Fatalf("stripMentionInjections:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestStripMentionInjectionsIssue(t *testing.T) {
+	input := `See [MIN-72](mention://issue/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	got := stripMentionInjections(input)
+	if got != input {
+		t.Fatalf("stripMentionInjections should preserve issue mentions:\ngot:  %q\nwant: %q", got, input)
+	}
+}
+
+func TestStripMentionInjectionsSquad(t *testing.T) {
+	input := `[Squad](mention://squad/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	got := stripMentionInjections(input)
+	want := `[Squad] (mention://squad/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee)`
+	if got != want {
+		t.Fatalf("stripMentionInjections:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestParseIssueMetadataNil(t *testing.T) {
+	got := parseIssueMetadata(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}
+
+func TestParseIssueMetadataEmpty(t *testing.T) {
+	got := parseIssueMetadata([]byte{})
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}
+
+func TestParseIssueMetadataValid(t *testing.T) {
+	data := []byte(`{"failure_escalated_task_id": "abc-123"}`)
+	got := parseIssueMetadata(data)
+	if got["failure_escalated_task_id"] != "abc-123" {
+		t.Fatalf("expected abc-123, got %v", got["failure_escalated_task_id"])
+	}
+}
+
+func TestRecommendRoute(t *testing.T) {
+	tests := []struct {
+		reason string
+		check  func(string) bool
+	}{
+		{"idle_watchdog", func(s string) bool { return len(s) > 20 && containsStr(s, "reassign") }},
+		{"timeout", func(s string) bool { return len(s) > 20 && containsStr(s, "retry") }},
+		{"provider_error", func(s string) bool { return len(s) > 20 && containsStr(s, "DevOps") }},
+		{"agent_error", func(s string) bool { return len(s) > 20 && containsStr(s, "Spark") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			got := recommendRoute(tt.reason)
+			if !tt.check(got) {
+				t.Errorf("recommendRoute(%q) = %q, doesn't satisfy predicate", tt.reason, got)
+			}
+		})
+	}
+}
+
+func TestRecommendNextHandler(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   string
+	}{
+		{"idle_watchdog", "QA / Issue Owner"},
+		{"timeout", "Team Lead"},
+		{"provider_error", "Runtime QA / DevOps"},
+		{"permission_error", "DevOps"},
+		{"qa_fail", "Implementation Owner"},
+		{"block", "Team Lead"},
+		{"agent_error", "Spark Preflight / QA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reason, func(t *testing.T) {
+			got := recommendNextHandler(tt.reason)
+			if got != tt.want {
+				t.Errorf("recommendNextHandler(%q) = %q, want %q", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasCompletedTaskAfter(t *testing.T) {
+	t.Run("no issue id returns false", func(t *testing.T) {
+		svc := &TaskService{Bus: events.New()}
+		task := db.AgentTaskQueue{
+			CompletedAt: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		}
+		if svc.hasCompletedTaskAfter(context.Background(), task) {
+			t.Error("expected false when no issue id")
+		}
+	})
+	t.Run("no completed at returns false", func(t *testing.T) {
+		svc := &TaskService{Bus: events.New()}
+		task := db.AgentTaskQueue{
+			IssueID: testUUID(1),
+		}
+		if svc.hasCompletedTaskAfter(context.Background(), task) {
+			t.Error("expected false when no completed_at")
+		}
+	})
+}
+
+func TestBuildEscalationComment(t *testing.T) {
+	svc := &TaskService{}
+
+	now := time.Now()
+	task := db.AgentTaskQueue{
+		ID:            testUUID(1),
+		AgentID:       testUUID(2),
+		IssueID:       testUUID(3),
+		Attempt:       2,
+		MaxAttempts:   3,
+		FailureReason: pgtype.Text{String: "timeout", Valid: true},
+		Error:         pgtype.Text{String: "operation timed out after 30s", Valid: true},
+		CompletedAt:   pgtype.Timestamptz{Time: now, Valid: true},
+	}
+	issue := db.Issue{
+		ID:     testUUID(3),
+		Status: "in_progress",
+		Title:  "Test issue",
+	}
+
+	body := svc.buildEscalationComment(task, issue, "timeout", "operation timed out after 30s")
+
+	checks := []string{
+		"**Task Failure Escalation**",
+		"**Failed Agent**",
+		"**Task ID**",
+		"**Failure Reason**",
+		"`timeout`",
+		"**Attempt**: 2 / 3",
+		"timed out",
+		"**Recommended Next Step**",
+		"Team Lead",
+		"automated escalation",
+		"Do not @mention",
+	}
+	for _, c := range checks {
+		if !containsStr(body, c) {
+			t.Errorf("expected comment body to contain %q", c)
+		}
+	}
+	if containsStr(body, "mention://agent") || containsStr(body, "mention://member") {
+		t.Error("comment body contains raw mention links")
+	}
+}
+
+func TestBuildEscalationCommentTruncatedError(t *testing.T) {
+	svc := &TaskService{}
+
+	longErr := ""
+	for i := 0; i < 600; i++ {
+		longErr += "x"
+	}
+
+	task := db.AgentTaskQueue{
+		ID:      testUUID(1),
+		AgentID: testUUID(2),
+		IssueID: testUUID(3),
+	}
+	issue := db.Issue{ID: testUUID(3), Status: "todo"}
+
+	body := svc.buildEscalationComment(task, issue, "agent_error", longErr)
+
+	if !containsStr(body, "…") {
+		t.Errorf("expected truncated error to end with ...\nbody: %s", body)
+	}
+}
+
+func TestBuildEscalationCommentNoAttempt(t *testing.T) {
+	svc := &TaskService{}
+
+	task := db.AgentTaskQueue{
+		ID:      testUUID(1),
+		AgentID: testUUID(2),
+		IssueID: testUUID(3),
+		Attempt: 0,
+	}
+	issue := db.Issue{ID: testUUID(3), Status: "todo"}
+
+	body := svc.buildEscalationComment(task, issue, "agent_error", "")
+	if containsStr(body, "Attempt") {
+		t.Error("body should not mention attempt when it's zero")
+	}
+}
+
+// containsStr is a simple substring check.
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && stringContains(s, substr)
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1428,6 +1428,26 @@ func (q *Queries) GetLastTaskStartedAtForIssueAndAgent(ctx context.Context, arg 
 	return started_at, err
 }
 
+const countCompletedTasksForIssueAfter = `-- name: CountCompletedTasksForIssueAfter :one
+SELECT count(*)::bigint FROM agent_task_queue
+WHERE issue_id = $1
+  AND status = 'completed'
+  AND completed_at IS NOT NULL
+  AND completed_at > $2
+`
+
+type CountCompletedTasksForIssueAfterParams struct {
+	IssueID     pgtype.UUID `json:"issue_id"`
+	CompletedAt pgtype.Timestamptz `json:"completed_at"`
+}
+
+func (q *Queries) CountCompletedTasksForIssueAfter(ctx context.Context, arg CountCompletedTasksForIssueAfterParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countCompletedTasksForIssueAfter, arg.IssueID, arg.CompletedAt)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getLatestTaskIsLeaderForIssueAndAgent = `-- name: GetLatestTaskIsLeaderForIssueAndAgent :one
 SELECT is_leader_task FROM agent_task_queue
 WHERE issue_id = $1 AND agent_id = $2

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -535,6 +535,16 @@ WHERE issue_id = $1 AND status IN ('queued', 'dispatched');
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
 WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched');
 
+
+-- name: CountCompletedTasksForIssueAfter :one
+-- Returns the number of completed tasks for the same issue that finished
+-- after the given timestamp. Used by the failure-escalation dedup to
+-- suppress an escalation when a subsequent task already succeeded.
+SELECT count(*)\:\:bigint FROM agent_task_queue
+WHERE issue_id = $1
+  AND status = 'completed'
+  AND completed_at IS NOT NULL
+  AND completed_at > $2;
 -- name: GetLatestTaskIsLeaderForIssueAndAgent :one
 -- Returns the is_leader_task flag of the agent's most recent task on this
 -- issue, or NULL if the agent has never had a task on this issue. Used by


### PR DESCRIPTION
## Summary

Implements the Agent failure escalation hook as specified in MIN-72 / MIN-76. When a task fails without a pending auto-retry, the system:

1. Creates a system comment on the issue with diagnostics
2. Writes dedup metadata on the issue
3. Dispatches a follow-up task to the appropriate handler

### Files changed

- `server/internal/service/task_escalation.go` (new)
- `server/internal/service/task_escalation_test.go` (new)
- `server/internal/service/task.go` (modified)
- `server/pkg/db/queries/agent.sql` (modified)
- `server/pkg/db/generated/agent.sql.go` (regenerated)
- `server/internal/daemon/local_directory.go` (home-dir ordering fix)

### Test results

All 23 internal/... packages and 4 pkg/... packages pass.