### PR TITLE
Add artifact relay update override

### DIFF
--- a/docs/nanjing-vps-artifact-relay.md
+++ b/docs/nanjing-vps-artifact-relay.md
@@ -1,0 +1,99 @@
+# Nanjing VPS Artifact Relay
+
+Use this workflow when a mainland China VPS should keep domestic-agent
+workloads but must update Multica without direct GitHub release access.
+
+This is not a general proxy. The relay caches verified Multica release
+artifacts on a local Mac, US server, or other host that can reach GitHub, then
+serves only cached release metadata and cached asset files from `127.0.0.1`.
+
+## Relay Host
+
+Run these commands on the local Mac, US server, or other relay host:
+
+```bash
+python3 scripts/artifact-relay.py --sync
+python3 scripts/artifact-relay.py --serve --port 9876
+```
+
+For a one-shot start:
+
+```bash
+python3 scripts/artifact-relay.py --all --port 9876
+```
+
+The script downloads release metadata, `checksums.txt`, and release assets,
+then verifies asset SHA-256 values before serving the cache.
+
+## Nanjing VPS
+
+Create a tunnel from the Nanjing VPS to the relay host:
+
+```bash
+ssh -N -L 9876:127.0.0.1:9876 youruser@relay-host
+```
+
+Configure the Multica updater to use the relay:
+
+```bash
+export MULTICA_UPDATE_GH_API_BASE=http://localhost:9876
+export MULTICA_UPDATE_GH_DOWNLOAD_BASE=http://localhost:9876/assets
+multica daemon restart
+```
+
+Test relay connectivity before updating:
+
+```bash
+curl -s http://localhost:9876/repos/multica-ai/multica/releases/latest | python3 -m json.tool | head
+```
+
+## Safe Codex Removal
+
+Do discovery first. Do not delete paths until the real installation and config
+locations are listed and reviewed.
+
+```bash
+command -v codex
+codex --version 2>/dev/null
+npm list -g @openai/codex 2>/dev/null
+npm list -g @anthropic/codex 2>/dev/null
+brew list --formula 2>/dev/null | grep -i codex
+echo "MULTICA_CODEX_PATH=${MULTICA_CODEX_PATH:-<unset>}"
+find ~/.npm -maxdepth 8 -path '*/@openai/codex' -type d 2>/dev/null
+find ~/.npm -maxdepth 8 -path '*/@anthropic/codex' -type d 2>/dev/null
+ls -la ~/.codex/ 2>/dev/null
+ls -la ~/.config/codex/ 2>/dev/null
+ls -la ~/.cache/codex/ 2>/dev/null
+```
+
+If config or session data should be preserved, back it up before uninstalling:
+
+```bash
+tar czf ~/codex-backup-$(date +%Y%m%d).tar.gz \
+  ~/.codex/ ~/.config/codex/ ~/.cache/codex/ 2>/dev/null
+```
+
+After reviewing the discovery output and backup, uninstall Codex:
+
+```bash
+npm uninstall -g @openai/codex 2>/dev/null
+npm uninstall -g @anthropic/codex 2>/dev/null
+brew uninstall codex 2>/dev/null
+```
+
+Only after confirming the backup is no longer needed, optionally clear Codex
+state:
+
+```bash
+rm -rf ~/.codex/
+rm -rf ~/.config/codex/
+rm -rf ~/.cache/codex/
+```
+
+Restart and verify:
+
+```bash
+multica daemon restart
+command -v codex
+multica daemon show 2>&1 | grep -i codex
+```

--- a/scripts/artifact-relay.py
+++ b/scripts/artifact-relay.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Cache verified Multica release assets and serve them from localhost.
+
+This is an artifact relay, not a network proxy. `--sync` talks to GitHub,
+downloads release metadata, checksums.txt, and release assets, verifies every
+asset that appears in checksums.txt, and stores the result in a local cache.
+`--serve` only serves cached metadata and cached files from 127.0.0.1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+from urllib.parse import urlparse
+
+
+REPO = "multica-ai/multica"
+GITHUB_API = "https://api.github.com"
+DEFAULT_CACHE = Path.home() / ".cache" / "multica-artifact-relay"
+CHECKSUMS_NAME = "checksums.txt"
+HOST = "127.0.0.1"
+
+
+class RelayError(Exception):
+    pass
+
+
+def request_json(url: str) -> dict:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "multica-artifact-relay",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        if resp.status != HTTPStatus.OK:
+            raise RelayError(f"{url} returned HTTP {resp.status}")
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=dest.name + ".", dir=str(dest.parent))
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "multica-artifact-relay"})
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            if resp.status != HTTPStatus.OK:
+                raise RelayError(f"{url} returned HTTP {resp.status}")
+            with tmp.open("wb") as out:
+                shutil.copyfileobj(resp, out)
+        tmp.replace(dest)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def asset_filename(asset: dict) -> str:
+    name = str(asset.get("name") or "").strip()
+    if not name or "/" in name or name in {".", ".."}:
+        raise RelayError(f"invalid release asset name: {name!r}")
+    return name
+
+
+def find_asset(release: dict, name: str) -> dict:
+    for asset in release.get("assets", []):
+        if asset.get("name") == name:
+            return asset
+    raise RelayError(f"release {release.get('tag_name')} has no {name}")
+
+
+def parse_checksums(data: bytes) -> Dict[str, str]:
+    checksums: Dict[str, str] = {}
+    for raw_line in data.decode("utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        checksum, filename = parts[0].lower(), parts[1]
+        if len(checksum) == 64:
+            checksums[filename] = checksum
+    if not checksums:
+        raise RelayError("checksums.txt did not contain any SHA-256 entries")
+    return checksums
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_file(path: Path, expected: str) -> None:
+    actual = sha256_file(path)
+    if actual.lower() != expected.lower():
+        path.unlink(missing_ok=True)
+        raise RelayError(f"checksum mismatch for {path.name}: expected {expected}, got {actual}")
+
+
+def release_dir(cache: Path, tag: str) -> Path:
+    return cache / "releases" / tag
+
+
+def assets_dir(cache: Path, tag: str) -> Path:
+    return release_dir(cache, tag) / "assets"
+
+
+def metadata_path(cache: Path, tag: str) -> Path:
+    return release_dir(cache, tag) / "release.json"
+
+
+def latest_path(cache: Path) -> Path:
+    return cache / "latest.json"
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def rewrite_release_urls(release: dict, public_base: str) -> dict:
+    copied = json.loads(json.dumps(release))
+    for asset in copied.get("assets", []):
+        name = asset.get("name")
+        if name:
+            asset["browser_download_url"] = f"{public_base.rstrip('/')}/assets/{name}"
+    return copied
+
+
+def sync_release(cache: Path, tag: Optional[str]) -> str:
+    if tag:
+        api_url = f"{GITHUB_API}/repos/{REPO}/releases/tags/{tag}"
+    else:
+        api_url = f"{GITHUB_API}/repos/{REPO}/releases/latest"
+    print(f"[sync] Fetching release metadata: {api_url}")
+    release = request_json(api_url)
+    tag_name = release.get("tag_name")
+    if not tag_name:
+        raise RelayError("release metadata is missing tag_name")
+
+    target_assets = assets_dir(cache, tag_name)
+    target_assets.mkdir(parents=True, exist_ok=True)
+
+    checksums_asset = find_asset(release, CHECKSUMS_NAME)
+    checksums_url = checksums_asset.get("browser_download_url")
+    if not checksums_url:
+        raise RelayError("checksums.txt is missing browser_download_url")
+
+    checksums_file = target_assets / CHECKSUMS_NAME
+    print(f"[sync] Downloading {CHECKSUMS_NAME}")
+    download(checksums_url, checksums_file)
+    checksums = parse_checksums(checksums_file.read_bytes())
+
+    for asset in release.get("assets", []):
+        name = asset_filename(asset)
+        if name == CHECKSUMS_NAME:
+            continue
+        expected = checksums.get(name)
+        if not expected:
+            print(f"[sync] Skipping {name}: not present in {CHECKSUMS_NAME}")
+            continue
+        url = asset.get("browser_download_url")
+        if not url:
+            raise RelayError(f"{name} is missing browser_download_url")
+        dest = target_assets / name
+        print(f"[sync] Downloading {name}")
+        download(url, dest)
+        verify_file(dest, expected)
+        print(f"[sync] {name}: verified OK")
+
+    write_json(metadata_path(cache, tag_name), release)
+    write_json(latest_path(cache), release)
+    print(f"[sync] Cached {tag_name} in {release_dir(cache, tag_name)}")
+    return tag_name
+
+
+def safe_asset_path(cache: Path, filename: str) -> Path:
+    if "/" in filename or filename in {"", ".", ".."}:
+        raise RelayError("invalid asset path")
+    latest = read_json(latest_path(cache))
+    tag = latest.get("tag_name")
+    if not tag:
+        raise RelayError("latest release metadata is missing tag_name")
+    path = assets_dir(cache, tag) / filename
+    if not path.is_file():
+        raise FileNotFoundError(filename)
+    return path
+
+
+class RelayHandler(BaseHTTPRequestHandler):
+    cache: Path
+    public_base: str
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("[serve] " + fmt % args + "\n")
+
+    def send_json(self, payload: dict) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def send_error_text(self, status: HTTPStatus, message: str) -> None:
+        data = (message + "\n").encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        try:
+            if path == f"/repos/{REPO}/releases/latest":
+                self.send_json(rewrite_release_urls(read_json(latest_path(self.cache)), self.public_base))
+                return
+
+            prefix = f"/repos/{REPO}/releases/tags/"
+            if path.startswith(prefix):
+                tag = path[len(prefix) :]
+                if "/" in tag or not tag:
+                    self.send_error_text(HTTPStatus.BAD_REQUEST, "invalid tag")
+                    return
+                self.send_json(rewrite_release_urls(read_json(metadata_path(self.cache, tag)), self.public_base))
+                return
+
+            if path.startswith("/assets/"):
+                filename = path[len("/assets/") :]
+                asset = safe_asset_path(self.cache, filename)
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(asset.stat().st_size))
+                self.end_headers()
+                with asset.open("rb") as f:
+                    shutil.copyfileobj(f, self.wfile)
+                return
+
+            self.send_error_text(HTTPStatus.NOT_FOUND, "not found")
+        except FileNotFoundError:
+            self.send_error_text(HTTPStatus.NOT_FOUND, "not found")
+        except RelayError as err:
+            self.send_error_text(HTTPStatus.BAD_REQUEST, str(err))
+
+
+def serve(cache: Path, port: int) -> None:
+    if not latest_path(cache).is_file():
+        raise RelayError(f"{latest_path(cache)} is missing; run --sync first")
+
+    public_base = f"http://{HOST}:{port}"
+
+    class Handler(RelayHandler):
+        pass
+
+    Handler.cache = cache
+    Handler.public_base = public_base
+
+    server = ThreadingHTTPServer((HOST, port), Handler)
+    print(f"[serve] Serving cached artifacts on {public_base}")
+    print("[serve] Configure Multica with:")
+    print(f"        {update_env('MULTICA_UPDATE_GH_API_BASE', public_base)}")
+    print(f"        {update_env('MULTICA_UPDATE_GH_DOWNLOAD_BASE', public_base + '/assets')}")
+    server.serve_forever()
+
+
+def update_env(name: str, value: str) -> str:
+    return f"export {name}={value}"
+
+
+def positive_port(value: str) -> int:
+    port = int(value)
+    if port <= 0 or port > 65535:
+        raise argparse.ArgumentTypeError("port must be between 1 and 65535")
+    return port
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache", type=Path, default=DEFAULT_CACHE, help=f"cache directory (default: {DEFAULT_CACHE})")
+    parser.add_argument("--port", type=positive_port, default=9876, help="localhost port for --serve")
+    parser.add_argument("--tag", help="release tag to sync; default syncs latest")
+    parser.add_argument("--sync", action="store_true", help="download and verify release artifacts")
+    parser.add_argument("--serve", action="store_true", help="serve cached artifacts from 127.0.0.1")
+    parser.add_argument("--all", action="store_true", help="run --sync then --serve")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    if args.all:
+        args.sync = True
+        args.serve = True
+    if not args.sync and not args.serve:
+        print("nothing to do; pass --sync, --serve, or --all", file=sys.stderr)
+        return 2
+
+    cache = args.cache.expanduser().resolve()
+    try:
+        if args.sync:
+            sync_release(cache, args.tag)
+        if args.serve:
+            serve(cache, args.port)
+    except (RelayError, urllib.error.URLError, OSError) as err:
+        print(f"artifact-relay: {err}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/internal/cli/update.go
+++ b/server/internal/cli/update.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	urlpath "path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -28,6 +30,9 @@ import (
 const ChecksumManifestName = "checksums.txt"
 
 const DefaultUpdateDownloadTimeout = 120 * time.Second
+const defaultUpdateAPIBase = "https://api.github.com"
+const updateAPIBaseEnv = "MULTICA_UPDATE_GH_API_BASE"
+const updateDownloadBaseEnv = "MULTICA_UPDATE_GH_DOWNLOAD_BASE"
 
 // GitHubRelease is the subset of the GitHub releases API response we need.
 type GitHubRelease struct {
@@ -122,6 +127,34 @@ func parseReleaseVersion(v string) ([3]int, bool) {
 type GitHubReleaseAsset struct {
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func updateAPIBase() string {
+	base := strings.TrimSpace(os.Getenv(updateAPIBaseEnv))
+	if base == "" {
+		return defaultUpdateAPIBase
+	}
+	return strings.TrimRight(base, "/")
+}
+
+func updateReleaseURL(path string) string {
+	return updateAPIBase() + "/repos/multica-ai/multica/" + strings.TrimLeft(path, "/")
+}
+
+func rewriteAssetDownloadURL(rawURL string) string {
+	base := strings.TrimSpace(os.Getenv(updateDownloadBaseEnv))
+	if base == "" {
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	filename := urlpath.Base(parsed.Path)
+	if filename == "." || filename == "/" || filename == "" {
+		return rawURL
+	}
+	return strings.TrimRight(base, "/") + "/" + filename
 }
 
 func releaseArchiveExtension(goos string) string {
@@ -223,7 +256,7 @@ func verifyAssetSHA256(data []byte, expectedHex, assetName string) error {
 
 func fetchReleaseByTag(tag string) (*GitHubRelease, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/multica-ai/multica/releases/tags/"+tag, nil)
+	req, err := http.NewRequest(http.MethodGet, updateReleaseURL("releases/tags/"+tag), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +282,7 @@ func fetchReleaseByTag(tag string) (*GitHubRelease, error) {
 // FetchLatestRelease fetches the latest release tag from the multica GitHub repo.
 func FetchLatestRelease() (*GitHubRelease, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/multica-ai/multica/releases/latest", nil)
+	req, err := http.NewRequest(http.MethodGet, updateReleaseURL("releases/latest"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -383,14 +416,14 @@ func UpdateViaDownloadWithTimeout(targetVersion string, downloadTimeout time.Dur
 	if err != nil {
 		return "", err
 	}
-	downloadURL := asset.BrowserDownloadURL
+	downloadURL := rewriteAssetDownloadURL(asset.BrowserDownloadURL)
 	assetName := asset.Name
 
 	// Pull the checksum manifest first so a release that is half-published
 	// (archives uploaded but checksums.txt not yet) fails before we eat the
 	// archive's bandwidth.
 	timeout := updateDownloadTimeoutOrDefault(downloadTimeout)
-	manifestData, err := fetchURLBytes(manifestAsset.BrowserDownloadURL, timeout)
+	manifestData, err := fetchURLBytes(rewriteAssetDownloadURL(manifestAsset.BrowserDownloadURL), timeout)
 	if err != nil {
 		return "", fmt.Errorf("download checksum manifest: %w", err)
 	}

--- a/server/internal/cli/update_test.go
+++ b/server/internal/cli/update_test.go
@@ -154,6 +154,96 @@ func TestIsNewerVersion(t *testing.T) {
 	}
 }
 
+func TestUpdateAPIBase(t *testing.T) {
+	t.Run("defaults to GitHub API", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "")
+		if got := updateAPIBase(); got != defaultUpdateAPIBase {
+			t.Fatalf("updateAPIBase() = %q, want %q", got, defaultUpdateAPIBase)
+		}
+	})
+
+	t.Run("uses environment override", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "http://localhost:9876")
+		if got := updateAPIBase(); got != "http://localhost:9876" {
+			t.Fatalf("updateAPIBase() = %q", got)
+		}
+	})
+
+	t.Run("trims whitespace and trailing slashes", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "  http://localhost:9876///  ")
+		if got := updateAPIBase(); got != "http://localhost:9876" {
+			t.Fatalf("updateAPIBase() = %q", got)
+		}
+	})
+
+	t.Run("whitespace falls back to default", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "   ")
+		if got := updateAPIBase(); got != defaultUpdateAPIBase {
+			t.Fatalf("updateAPIBase() = %q, want %q", got, defaultUpdateAPIBase)
+		}
+	})
+}
+
+func TestUpdateReleaseURL(t *testing.T) {
+	t.Run("builds default GitHub release tag URL", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "")
+		want := "https://api.github.com/repos/multica-ai/multica/releases/tags/v1.2.3"
+		if got := updateReleaseURL("releases/tags/v1.2.3"); got != want {
+			t.Fatalf("updateReleaseURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("builds relay latest release URL", func(t *testing.T) {
+		t.Setenv(updateAPIBaseEnv, "http://localhost:9876/")
+		want := "http://localhost:9876/repos/multica-ai/multica/releases/latest"
+		if got := updateReleaseURL("/releases/latest"); got != want {
+			t.Fatalf("updateReleaseURL() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestRewriteAssetDownloadURL(t *testing.T) {
+	original := "https://github.com/multica-ai/multica/releases/download/v1.2.3/multica-cli-1.2.3-linux-amd64.tar.gz"
+
+	t.Run("passes through without override", func(t *testing.T) {
+		t.Setenv(updateDownloadBaseEnv, "")
+		if got := rewriteAssetDownloadURL(original); got != original {
+			t.Fatalf("rewriteAssetDownloadURL() = %q, want passthrough", got)
+		}
+	})
+
+	t.Run("rewrites to relay asset base", func(t *testing.T) {
+		t.Setenv(updateDownloadBaseEnv, "http://localhost:9876/assets")
+		want := "http://localhost:9876/assets/multica-cli-1.2.3-linux-amd64.tar.gz"
+		if got := rewriteAssetDownloadURL(original); got != want {
+			t.Fatalf("rewriteAssetDownloadURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("trims trailing slash from relay base", func(t *testing.T) {
+		t.Setenv(updateDownloadBaseEnv, "http://localhost:9876/assets/")
+		want := "http://localhost:9876/assets/multica-cli-1.2.3-linux-amd64.tar.gz"
+		if got := rewriteAssetDownloadURL(original); got != want {
+			t.Fatalf("rewriteAssetDownloadURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("whitespace override passes through", func(t *testing.T) {
+		t.Setenv(updateDownloadBaseEnv, "   ")
+		if got := rewriteAssetDownloadURL(original); got != original {
+			t.Fatalf("rewriteAssetDownloadURL() = %q, want passthrough", got)
+		}
+	})
+
+	t.Run("empty filename passes through", func(t *testing.T) {
+		t.Setenv(updateDownloadBaseEnv, "http://localhost:9876/assets")
+		raw := "https://github.com/"
+		if got := rewriteAssetDownloadURL(raw); got != raw {
+			t.Fatalf("rewriteAssetDownloadURL() = %q, want passthrough", got)
+		}
+	})
+}
+
 func TestFindChecksumManifestAsset(t *testing.T) {
 	t.Run("finds checksums.txt among assets", func(t *testing.T) {
 		assets := []GitHubReleaseAsset{


### PR DESCRIPTION
## Summary
- add a localhost-only artifact relay script for verified Multica release assets
- allow CLI updater GitHub API/download bases to be overridden by environment variables
- add focused updater helper tests and Nanjing VPS relay/Codex removal docs

## Verification
- git diff --cached --check before commit
- python3 -m py_compile scripts/artifact-relay.py
- python3 scripts/artifact-relay.py --help

Go tests were not run in this runtime because go is not installed (command -v go exits 1).