### PR TITLE
fix(email): set EHLO hostname for SMTP relay compatibility [MUL-2984]

### DIFF
--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -31,6 +31,7 @@ type EmailService struct {
 	smtpPassword    string
 	smtpTLSInsecure bool
 	smtpTLSImplicit bool
+	smtpEHLOName    string
 }
 
 func NewEmailService() *EmailService {
@@ -48,6 +49,14 @@ func NewEmailService() *EmailService {
 	smtpUsername := os.Getenv("SMTP_USERNAME")
 	smtpPassword := os.Getenv("SMTP_PASSWORD")
 	smtpTLSInsecure := os.Getenv("SMTP_TLS_INSECURE") == "true"
+
+	// EHLO/HELO name. net/smtp defaults to "localhost", which strict relays
+	// (e.g. smtp-relay.gmail.com) reject from a public source. Fall back to the
+	// machine hostname when SMTP_EHLO_NAME is unset.
+	smtpEHLOName := strings.TrimSpace(os.Getenv("SMTP_EHLO_NAME"))
+	if smtpEHLOName == "" {
+		smtpEHLOName, _ = os.Hostname()
+	}
 
 	// SMTP_TLS=implicit forces an immediate TLS handshake on connect (SMTPS).
 	// Required by providers like Aliyun enterprise mail that only offer port 465
@@ -89,6 +98,7 @@ func NewEmailService() *EmailService {
 		smtpPassword:    smtpPassword,
 		smtpTLSInsecure: smtpTLSInsecure,
 		smtpTLSImplicit: smtpTLSImplicit,
+		smtpEHLOName:    smtpEHLOName,
 	}
 }
 
@@ -128,6 +138,15 @@ func (s *EmailService) sendSMTP(to, subject, htmlBody string) error {
 		return fmt.Errorf("smtp client: %w", err)
 	}
 	defer c.Close()
+
+	// Greet with a real hostname before any other command, else net/smtp lazily
+	// EHLOs "localhost" — which strict relays drop, surfacing as an opaque EOF on
+	// a later command rather than at the EHLO itself.
+	if s.smtpEHLOName != "" {
+		if err = c.Hello(s.smtpEHLOName); err != nil {
+			return fmt.Errorf("smtp EHLO %s: %w", s.smtpEHLOName, err)
+		}
+	}
 
 	// STARTTLS upgrade only makes sense when the underlying connection is still
 	// plaintext. Skip when we already dialed with implicit TLS.


### PR DESCRIPTION
## What does this PR do?

`EmailService.sendSMTP` never calls `Client.Hello()`, so Go's `net/smtp` sends `EHLO localhost` (its hardcoded default). Strict relays like Google Workspace's `smtp-relay.gmail.com:587` reject that from a public IP and drop the connection.

The drop doesn't surface at EHLO because `textproto` buffers reads. It shows up later as an opaque `EOF` on the next command (`auth: EOF`, or `MAIL FROM: EOF` without credentials), which is painful to diagnose.

Fix: send a real EHLO name before anything else. Use `SMTP_EHLO_NAME` if set, otherwise the machine hostname.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/service/email.go`:
  - Add `smtpEHLOName`, resolved from `SMTP_EHLO_NAME` or `os.Hostname()`.
  - Call `c.Hello()` right after `smtp.NewClient`, so a rejection surfaces at the EHLO instead of as a later `EOF`. Skipped if the name is empty.

## How to Test

1. Point `SMTP_HOST=smtp-relay.gmail.com`, `SMTP_PORT=587` at a Workspace relay that allows your IP.
2. Trigger a verification or invitation email. Before this change it fails with `smtp auth: EOF`; after, it delivers.
3. Set `SMTP_EHLO_NAME=<your.fqdn>` to override the announced name.

## Checklist

- [x] I have run tests locally and they pass

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Tracked the opaque `EOF` back to `EHLO localhost`, then added the `Client.Hello()` call with an env override and hostname fallback.
