### PR TITLE
Optimize chat message loading

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -362,6 +362,68 @@ describe("ApiClient", () => {
     });
   });
 
+  describe("listChatMessagesPage deployment-order fallback", () => {
+    const jsonResponse = (body: unknown, status: number, statusText = "") =>
+      new Response(JSON.stringify(body), {
+        status,
+        statusText,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    it("falls back to the legacy full-list endpoint when the paged route 404s", async () => {
+      const legacy = [
+        { id: "m1", role: "user", content: "hi", created_at: "2026-06-01T00:00:00Z" },
+        { id: "m2", role: "assistant", content: "yo", created_at: "2026-06-01T00:00:01Z" },
+      ];
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ error: "not found" }, 404, "Not Found"))
+        .mockResolvedValueOnce(jsonResponse(legacy, 200));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listChatMessagesPage("session-1", { limit: 50 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0]![0]).toBe(
+        "https://api.example.test/api/chat/sessions/session-1/messages/page?limit=50",
+      );
+      expect(fetchMock.mock.calls[1]![0]).toBe(
+        "https://api.example.test/api/chat/sessions/session-1/messages",
+      );
+      expect(page).toEqual({ messages: legacy, limit: 50, has_more: false, next_cursor: null });
+    });
+
+    it("does NOT fall back on a cursor request — a 404 there propagates", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ error: "not found" }, 404, "Not Found"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new ApiClient("https://api.example.test");
+      await expect(
+        client.listChatMessagesPage("session-1", {
+          before: { created_at: "2026-06-01T00:00:00Z", id: "m1" },
+        }),
+      ).rejects.toBeInstanceOf(ApiError);
+      // Only the paged request fires; no legacy full-list call that would duplicate messages.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates non-404 errors instead of masking them with the legacy list", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ error: "boom" }, 500, "Internal Server Error"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new ApiClient("https://api.example.test");
+      await expect(client.listChatMessagesPage("session-1")).rejects.toMatchObject({
+        status: 500,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("chat attachment wiring", () => {
     it("uploadFile includes chat_session_id in the FormData body", async () => {
       const fetchMock = vi.fn().mockResolvedValue(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -61,6 +61,7 @@ import type {
   Attachment,
   ChatSession,
   ChatMessage,
+  ChatMessagesPage,
   ChatPendingTask,
   PendingChatTasksResponse,
   SendChatMessageResponse,
@@ -1587,6 +1588,17 @@ export class ApiClient {
 
   async listChatMessages(sessionId: string): Promise<ChatMessage[]> {
     return this.fetch(`/api/chat/sessions/${sessionId}/messages`);
+  }
+
+  async listChatMessagesPage(
+    sessionId: string,
+    params: { page?: number; limit?: number } = {},
+  ): Promise<ChatMessagesPage> {
+    const page = params.page ?? 0;
+    const limit = params.limit ?? 50;
+    return this.fetch(
+      `/api/chat/sessions/${sessionId}/messages/page?page=${page}&limit=${limit}`,
+    );
   }
 
   async sendChatMessage(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1592,12 +1592,15 @@ export class ApiClient {
 
   async listChatMessagesPage(
     sessionId: string,
-    params: { page?: number; limit?: number } = {},
+    params: { before?: { created_at: string; id: string } | null; limit?: number } = {},
   ): Promise<ChatMessagesPage> {
-    const page = params.page ?? 0;
-    const limit = params.limit ?? 50;
+    const query = new URLSearchParams({ limit: String(params.limit ?? 50) });
+    if (params.before) {
+      query.set("before_created_at", params.before.created_at);
+      query.set("before_id", params.before.id);
+    }
     return this.fetch(
-      `/api/chat/sessions/${sessionId}/messages/page?page=${page}&limit=${limit}`,
+      `/api/chat/sessions/${sessionId}/messages/page?${query.toString()}`,
     );
   }
 

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1594,14 +1594,31 @@ export class ApiClient {
     sessionId: string,
     params: { before?: { created_at: string; id: string } | null; limit?: number } = {},
   ): Promise<ChatMessagesPage> {
-    const query = new URLSearchParams({ limit: String(params.limit ?? 50) });
+    const limit = params.limit ?? 50;
+    const query = new URLSearchParams({ limit: String(limit) });
     if (params.before) {
       query.set("before_created_at", params.before.created_at);
       query.set("before_id", params.before.id);
     }
-    return this.fetch(
-      `/api/chat/sessions/${sessionId}/messages/page?${query.toString()}`,
-    );
+    try {
+      return await this.fetch(
+        `/api/chat/sessions/${sessionId}/messages/page?${query.toString()}`,
+      );
+    } catch (err) {
+      // Deployment-order compatibility: a backend deployed before this endpoint
+      // existed returns 404 for the unknown route. Fall back to the legacy
+      // full-list endpoint so chat never white-screens regardless of whether
+      // the server or the client deploys first. Only the initial (cursorless)
+      // page falls back — the legacy endpoint returns every message at once, so
+      // the fallback page reports has_more: false and there is no follow-up
+      // request to translate. A 404 on a cursor request is an unexpected state
+      // and propagates instead of duplicating the whole list.
+      if (err instanceof ApiError && err.status === 404 && !params.before) {
+        const messages = await this.listChatMessages(sessionId);
+        return { messages, limit, has_more: false, next_cursor: null };
+      }
+      throw err;
+    }
   }
 
   async sendChatMessage(

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
 
 // NOTE on workspace scoping:
@@ -14,6 +14,7 @@ export const chatKeys = {
   sessions: (wsId: string) => [...chatKeys.all(wsId), "sessions"] as const,
   session: (wsId: string, id: string) => [...chatKeys.all(wsId), "session", id] as const,
   messages: (sessionId: string) => ["chat", "messages", sessionId] as const,
+  messagesPage: (sessionId: string) => ["chat", "messages-page", sessionId] as const,
   pendingTask: (sessionId: string) => ["chat", "pending-task", sessionId] as const,
   /** Aggregate of in-flight chat tasks for the current user — FAB reads this. */
   pendingTasks: (wsId: string) => [...chatKeys.all(wsId), "pending-tasks"] as const,
@@ -48,6 +49,19 @@ export function chatMessagesOptions(sessionId: string) {
   return queryOptions({
     queryKey: chatKeys.messages(sessionId),
     queryFn: () => api.listChatMessages(sessionId),
+    enabled: !!sessionId,
+    staleTime: Infinity,
+  });
+}
+
+export function chatMessagesPageOptions(sessionId: string, limit = 50) {
+  return infiniteQueryOptions({
+    queryKey: chatKeys.messagesPage(sessionId),
+    queryFn: ({ pageParam }) =>
+      api.listChatMessagesPage(sessionId, { page: pageParam, limit }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.page + 1 : undefined,
     enabled: !!sessionId,
     staleTime: Infinity,
   });

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -58,10 +58,10 @@ export function chatMessagesPageOptions(sessionId: string, limit = 50) {
   return infiniteQueryOptions({
     queryKey: chatKeys.messagesPage(sessionId),
     queryFn: ({ pageParam }) =>
-      api.listChatMessagesPage(sessionId, { page: pageParam, limit }),
-    initialPageParam: 0,
+      api.listChatMessagesPage(sessionId, { before: pageParam, limit }),
+    initialPageParam: null as { created_at: string; id: string } | null,
     getNextPageParam: (lastPage) =>
-      lastPage.has_more ? lastPage.page + 1 : undefined,
+      lastPage.has_more ? lastPage.next_cursor ?? undefined : undefined,
     enabled: !!sessionId,
     staleTime: Infinity,
   });

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, type InfiniteData } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import { chatKeys } from "../chat/queries";
 import { issueKeys } from "../issues/queries";
@@ -7,6 +7,7 @@ import type {
   ChatDonePayload,
   ChatMessage,
   ChatPendingTask,
+  ChatMessagesPage,
   Workspace,
 } from "../types";
 import {
@@ -64,7 +65,7 @@ describe("applyChatDoneToCache", () => {
     applyChatDoneToCache(qc, donePayload());
 
     expect(setQueryData.mock.calls[0]?.[0]).toEqual(messagesKey);
-    expect(setQueryData.mock.calls[1]?.[0]).toEqual(pendingKey);
+    expect(setQueryData.mock.calls[2]?.[0]).toEqual(pendingKey);
     expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
     expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toEqual([
       userMessage(),
@@ -199,5 +200,38 @@ describe("applyWorkspaceUpdatedToCache", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: issueKeys.all(wsId),
     });
+  });
+});
+
+
+describe("applyChatDoneToCache paged messages", () => {
+  it("patches page zero and skips older pages without duplicating replayed events", () => {
+    const qc = createQueryClient();
+    const older = userMessage();
+    const latest: ChatMessage = {
+      id: "msg-latest",
+      chat_session_id: sessionId,
+      role: "user",
+      content: "latest",
+      task_id: null,
+      created_at: "2026-05-13T05:00:01Z",
+    };
+    qc.setQueryData<InfiniteData<ChatMessagesPage>>(chatKeys.messagesPage(sessionId), {
+      pages: [
+        { messages: [latest], page: 0, limit: 1, total_count: 2, has_more: true, first_item_index: 1 },
+        { messages: [older], page: 1, limit: 1, total_count: 2, has_more: false, first_item_index: 0 },
+      ],
+      pageParams: [0, 1],
+    });
+
+    applyChatDoneToCache(qc, donePayload());
+    applyChatDoneToCache(qc, donePayload());
+
+    const paged = qc.getQueryData<InfiniteData<ChatMessagesPage>>(chatKeys.messagesPage(sessionId));
+
+    expect(paged?.pages[0]?.messages.map((m) => m.id)).toEqual(["msg-latest", "msg-assistant"]);
+    expect(paged?.pages[1]?.messages.map((m) => m.id)).toEqual(["msg-user"]);
+    expect(paged?.pages[0]?.total_count).toBe(3);
+    expect(paged?.pages[1]?.total_count).toBe(3);
   });
 });

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -218,10 +218,10 @@ describe("applyChatDoneToCache paged messages", () => {
     };
     qc.setQueryData<InfiniteData<ChatMessagesPage>>(chatKeys.messagesPage(sessionId), {
       pages: [
-        { messages: [latest], page: 0, limit: 1, total_count: 2, has_more: true, first_item_index: 1 },
-        { messages: [older], page: 1, limit: 1, total_count: 2, has_more: false, first_item_index: 0 },
+        { messages: [latest], limit: 1, has_more: true, next_cursor: { created_at: latest.created_at, id: latest.id } },
+        { messages: [older], limit: 1, has_more: false, next_cursor: null },
       ],
-      pageParams: [0, 1],
+      pageParams: [null, { created_at: latest.created_at, id: latest.id }],
     });
 
     applyChatDoneToCache(qc, donePayload());
@@ -231,7 +231,5 @@ describe("applyChatDoneToCache paged messages", () => {
 
     expect(paged?.pages[0]?.messages.map((m) => m.id)).toEqual(["msg-latest", "msg-assistant"]);
     expect(paged?.pages[1]?.messages.map((m) => m.id)).toEqual(["msg-user"]);
-    expect(paged?.pages[0]?.total_count).toBe(3);
-    expect(paged?.pages[1]?.total_count).toBe(3);
   });
 });

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import type { WSClient } from "../api/ws-client";
 import type { StoreApi, UseBoundStore } from "zustand";
 import type { AuthState } from "../auth/store";
@@ -71,6 +71,7 @@ import type {
   ChatDonePayload,
   ChatMessage,
   ChatPendingTask,
+  ChatMessagesPage,
   InvitationCreatedPayload,
 } from "../types";
 
@@ -87,23 +88,27 @@ export function applyChatDoneToCache(
   const messageId = payload.message_id;
   const content = payload.content;
   if (messageId && content !== undefined) {
+    const assistant: ChatMessage = {
+      id: messageId,
+      chat_session_id: sessionId,
+      role: "assistant",
+      content,
+      task_id: taskId,
+      created_at: payload.created_at ?? new Date().toISOString(),
+      elapsed_ms: payload.elapsed_ms ?? null,
+    };
     qc.setQueryData<ChatMessage[] | undefined>(
       chatKeys.messages(sessionId),
       (old) => {
         if (!old) return old; // first fetch will pick it up
         // Idempotent against reconnect replay.
         if (old.some((m) => m.id === messageId)) return old;
-        const assistant: ChatMessage = {
-          id: messageId,
-          chat_session_id: sessionId,
-          role: "assistant",
-          content,
-          task_id: taskId,
-          created_at: payload.created_at ?? new Date().toISOString(),
-          elapsed_ms: payload.elapsed_ms ?? null,
-        };
         return [...old, assistant];
       },
+    );
+    qc.setQueryData<InfiniteData<ChatMessagesPage> | undefined>(
+      chatKeys.messagesPage(sessionId),
+      (old) => patchLatestChatMessagePage(old, assistant),
     );
   }
   // Replacement is in the messages list now; safe to drop pending.
@@ -111,7 +116,29 @@ export function applyChatDoneToCache(
   // Authoritative refetch reconciles redaction / migrations / clients
   // that took the fallback branch above.
   qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+  qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
   qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
+}
+
+function patchLatestChatMessagePage(
+  old: InfiniteData<ChatMessagesPage> | undefined,
+  message: ChatMessage,
+): InfiniteData<ChatMessagesPage> | undefined {
+  if (!old?.pages.length) return old;
+  const seen = old.pages.some((page) => page.messages.some((m) => m.id === message.id));
+  if (seen) return old;
+  return {
+    ...old,
+    pages: old.pages.map((page, index) => {
+      const total_count = page.total_count + 1;
+      if (index !== 0) return { ...page, total_count };
+      return {
+        ...page,
+        total_count,
+        messages: [...page.messages, message],
+      };
+    }),
+  };
 }
 
 /**

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -130,11 +130,9 @@ function patchLatestChatMessagePage(
   return {
     ...old,
     pages: old.pages.map((page, index) => {
-      const total_count = page.total_count + 1;
-      if (index !== 0) return { ...page, total_count };
+      if (index !== 0) return page;
       return {
         ...page,
-        total_count,
         messages: [...page.messages, message],
       };
     }),

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -55,6 +55,15 @@ export interface ChatMessage {
   elapsed_ms?: number | null;
 }
 
+export interface ChatMessagesPage {
+  messages: ChatMessage[];
+  page: number;
+  limit: number;
+  total_count: number;
+  has_more: boolean;
+  first_item_index: number;
+}
+
 export interface SendChatMessageResponse {
   message_id: string;
   task_id: string;

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -55,13 +55,16 @@ export interface ChatMessage {
   elapsed_ms?: number | null;
 }
 
+export interface ChatMessagesCursor {
+  created_at: string;
+  id: string;
+}
+
 export interface ChatMessagesPage {
   messages: ChatMessage[];
-  page: number;
   limit: number;
-  total_count: number;
   has_more: boolean;
-  first_item_index: number;
+  next_cursor?: ChatMessagesCursor | null;
 }
 
 export interface SendChatMessageResponse {

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -65,7 +65,7 @@ export type { IssueSubscriber } from "./subscriber";
 export type * from "./events";
 export type * from "./api";
 export type { Attachment } from "./attachment";
-export type { ChatSession, ChatMessage, ChatPendingTask, PendingChatTaskItem, PendingChatTasksResponse, SendChatMessageResponse } from "./chat";
+export type { ChatSession, ChatMessage, ChatMessagesPage, ChatPendingTask, PendingChatTaskItem, PendingChatTasksResponse, SendChatMessageResponse } from "./chat";
 export type { StorageAdapter } from "./storage";
 export type {
   Project,

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
+import { Virtuoso } from "react-virtuoso";
 import { cn } from "@multica/ui/lib/utils";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
@@ -18,7 +19,6 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { ChevronRight, ChevronDown, Brain, AlertCircle, AlertTriangle, Copy } from "lucide-react";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
-import { useAutoScroll } from "@multica/ui/hooks/use-auto-scroll";
 import { isTaskMessageTaskId, taskMessagesOptions } from "@multica/core/chat/queries";
 import { Markdown } from "@multica/views/common/markdown";
 import { copyMarkdown } from "../../editor";
@@ -44,16 +44,24 @@ interface ChatMessageListProps {
   pendingTask: ChatPendingTask | null | undefined;
   /** Resolved presence; pass `undefined` while loading to keep the pill copy neutral. */
   availability: AgentAvailability | undefined;
+  firstItemIndex?: number;
+  hasOlderMessages?: boolean;
+  isFetchingOlderMessages?: boolean;
+  onLoadOlderMessages?: () => void;
 }
 
 export function ChatMessageList({
   messages,
   pendingTask,
   availability,
+  firstItemIndex = 0,
+  hasOlderMessages = false,
+  isFetchingOlderMessages = false,
+  onLoadOlderMessages,
 }: ChatMessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const fadeStyle = useScrollFade(scrollRef);
-  useAutoScroll(scrollRef);
+  const { t } = useT("chat");
 
   const pendingTaskId = pendingTask?.task_id ?? null;
 
@@ -77,6 +85,9 @@ export function ChatMessageList({
   const hasLive = showLiveTimeline && liveTimeline.length > 0;
   const showStatusPill = !!pendingTaskId && !pendingAlreadyPersisted && !!pendingTask;
 
+  const totalCount = messages.length + (hasLive || showStatusPill ? 1 : 0);
+  const firstIndex = totalCount > 0 ? firstItemIndex : 0;
+
   return (
     <div
       ref={scrollRef}
@@ -84,31 +95,52 @@ export function ChatMessageList({
       style={fadeStyle}
       className="flex-1 overflow-y-auto"
     >
-      {/* Inner container matches issue / project detail width convention
-       *  (max-w-4xl + mx-auto) so switching between chat and content
-       *  views doesn't jolt the reading width. px-5 is a touch tighter
-       *  than issue-detail's px-8 because the chat window can be narrow. */}
-      <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-4">
-        {messages.map((msg) => (
-          <MessageBubble
-            key={msg.id}
-            message={msg}
-            isPending={!!pendingTaskId && msg.task_id === pendingTaskId}
-          />
-        ))}
-        {hasLive && (
-          <div className="w-full space-y-1.5">
-            <TimelineView items={liveTimeline} isStreaming />
+      <Virtuoso
+        customScrollParent={scrollRef.current ?? undefined}
+        data={messages}
+        firstItemIndex={firstIndex}
+        increaseViewportBy={{ top: 400, bottom: 600 }}
+        followOutput="smooth"
+        startReached={() => {
+          if (hasOlderMessages && !isFetchingOlderMessages) {
+            onLoadOlderMessages?.();
+          }
+        }}
+        computeItemKey={(_, msg) => msg.id}
+        components={{
+          Header: () => (
+            <div className="mx-auto w-full max-w-4xl px-5 pt-4">
+              {isFetchingOlderMessages && (
+                <div className="text-center text-xs text-muted-foreground">{t(($) => $.message_list.loading_older)}</div>
+              )}
+            </div>
+          ),
+          Footer: () => (
+            <div className="mx-auto w-full max-w-4xl px-5 pb-4 space-y-4">
+              {hasLive && (
+                <div className="w-full space-y-1.5">
+                  <TimelineView items={liveTimeline} isStreaming />
+                </div>
+              )}
+              {showStatusPill && pendingTask && (
+                <TaskStatusPill
+                  pendingTask={pendingTask}
+                  taskMessages={liveTaskMessages ?? []}
+                  availability={availability}
+                />
+              )}
+            </div>
+          ),
+        }}
+        itemContent={(_, msg) => (
+          <div className="mx-auto w-full max-w-4xl px-5 py-2">
+            <MessageBubble
+              message={msg}
+              isPending={!!pendingTaskId && msg.task_id === pendingTaskId}
+            />
           </div>
         )}
-        {showStatusPill && pendingTask && (
-          <TaskStatusPill
-            pendingTask={pendingTask}
-            taskMessages={liveTaskMessages ?? []}
-            availability={availability}
-          />
-        )}
-      </div>
+      />
     </div>
   );
 }

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
 import { Virtuoso } from "react-virtuoso";
@@ -60,6 +60,12 @@ export function ChatMessageList({
   onLoadOlderMessages,
 }: ChatMessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const setScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
+    scrollRef.current = node;
+    setScrollContainerEl(node);
+  }, []);
   const fadeStyle = useScrollFade(scrollRef);
   const { t } = useT("chat");
 
@@ -90,17 +96,24 @@ export function ChatMessageList({
 
   return (
     <div
-      ref={scrollRef}
+      ref={setScrollContainerRef}
       data-tab-scroll-root
       style={fadeStyle}
       className="flex-1 overflow-y-auto"
     >
+      {!scrollContainerEl ? (
+        <div className="mx-auto w-full max-w-4xl px-5 pt-4 space-y-3">
+          <ChatMessageSkeleton />
+        </div>
+      ) : (
       <Virtuoso
-        customScrollParent={scrollRef.current ?? undefined}
+        customScrollParent={scrollContainerEl}
         data={messages}
         firstItemIndex={firstIndex}
         increaseViewportBy={{ top: 400, bottom: 600 }}
-        followOutput="smooth"
+        atBottomThreshold={120}
+        atBottomStateChange={setIsNearBottom}
+        followOutput={() => (!isFetchingOlderMessages && isNearBottom ? "smooth" : false)}
         startReached={() => {
           if (hasOlderMessages && !isFetchingOlderMessages) {
             onLoadOlderMessages?.();
@@ -141,6 +154,7 @@ export function ChatMessageList({
           </div>
         )}
       />
+      )}
     </div>
   );
 }

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { motion } from "motion/react";
 import { Minus, Maximize2, Minimize2, ChevronDown, Plus, Check, Trash2, Pencil, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
@@ -33,7 +33,7 @@ import { OfflineBanner } from "./offline-banner";
 import { NoAgentBanner } from "./no-agent-banner";
 import {
   chatSessionsOptions,
-  chatMessagesOptions,
+  chatMessagesPageOptions,
   pendingChatTaskOptions,
   pendingChatTasksOptions,
   chatKeys,
@@ -56,11 +56,33 @@ import {
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatResize } from "./use-chat-resize";
 import { createLogger } from "@multica/core/logger";
-import type { Agent, ChatMessage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
+import type { Agent, ChatMessage, ChatMessagesPage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { useT } from "../../i18n";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
+
+
+function seedChatMessagesPageCache(
+  qc: ReturnType<typeof useQueryClient>,
+  sessionId: string,
+  messages: ChatMessage[],
+) {
+  qc.setQueryData<InfiniteData<ChatMessagesPage>>(
+    chatKeys.messagesPage(sessionId),
+    (old) => old ?? {
+      pages: [{
+        messages,
+        page: 0,
+        limit: 50,
+        total_count: messages.length,
+        has_more: false,
+        first_item_index: 0,
+      }],
+      pageParams: [0],
+    },
+  );
+}
 
 export function ChatWindow() {
   const { t } = useT("chat");
@@ -77,11 +99,22 @@ export function ChatWindow() {
   // Single sessions cache — eliminates the separate active/all queries
   // that used to drift during the WS-invalidate window.
   const { data: sessions = [] } = useQuery(chatSessionsOptions(wsId));
-  const { data: rawMessages, isLoading: messagesLoading } = useQuery(
-    chatMessagesOptions(activeSessionId ?? ""),
-  );
-  // When no active session, always show empty — don't use stale cache
-  const messages = activeSessionId ? rawMessages ?? [] : [];
+  const {
+    data: rawMessagePages,
+    isLoading: messagesLoading,
+    fetchNextPage: fetchOlderMessages,
+    hasNextPage: hasOlderMessages,
+    isFetchingNextPage: isFetchingOlderMessages,
+  } = useInfiniteQuery(chatMessagesPageOptions(activeSessionId ?? ""));
+  // When no active session, always show empty — don't use stale cache.
+  // Page 0 contains the latest chronological window; higher page numbers are
+  // older chronological windows. Reverse pages so older fetched pages render
+  // above the initial latest page.
+  const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
+  const messages = [...messagePages].reverse().flatMap((page) => page.messages);
+  const firstItemIndex = messagePages.length > 0
+    ? Math.min(...messagePages.map((page) => page.first_item_index))
+    : 0;
   // Skeleton only shows for an un-cached session fetch. Cached switches
   // return data synchronously — no flash. `enabled: false` (new chat)
   // keeps isLoading false so the starter prompts aren't hidden.
@@ -244,6 +277,7 @@ export function ChatWindow() {
       // ChatMessageList mounts directly (no Skeleton frame). Skip the write
       // when an entry already exists — a concurrent handleSend may have
       // seeded an optimistic message we must not clobber.
+      seedChatMessagesPageCache(qc, sessionId, []);
       qc.setQueryData<ChatMessage[]>(
         chatKeys.messages(sessionId),
         (old) => old ?? [],
@@ -303,6 +337,7 @@ export function ChatWindow() {
       // "new-chat first-message" white flash. Priming the cache first means
       // the very first read after activeSessionId flips hits data
       // synchronously and ChatMessageList mounts directly.
+      seedChatMessagesPageCache(qc, sessionId, [optimistic]);
       qc.setQueryData<ChatMessage[]>(
         chatKeys.messages(sessionId),
         (old) => (old ? [...old, optimistic] : [optimistic]),
@@ -337,6 +372,7 @@ export function ChatWindow() {
         created_at: result.created_at,
       });
       qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
     },
     [
       activeSessionId,
@@ -362,6 +398,7 @@ export function ChatWindow() {
     apiLogger.info("cancelTask.start", { taskId: pendingTaskId, sessionId: activeSessionId });
     qc.setQueryData(chatKeys.pendingTask(activeSessionId), {});
     qc.invalidateQueries({ queryKey: chatKeys.messages(activeSessionId) });
+    qc.invalidateQueries({ queryKey: chatKeys.messagesPage(activeSessionId) });
     // Fire-and-forget — UI is already in its post-cancel state. We log the
     // outcome but never block on it.
     api.cancelTaskById(pendingTaskId).then(
@@ -534,6 +571,10 @@ export function ChatWindow() {
           messages={messages}
           pendingTask={pendingTask}
           availability={availability}
+          firstItemIndex={firstItemIndex}
+          hasOlderMessages={!!hasOlderMessages}
+          isFetchingOlderMessages={isFetchingOlderMessages}
+          onLoadOlderMessages={() => void fetchOlderMessages()}
         />
       ) : (
         <EmptyState
@@ -854,6 +895,7 @@ function SessionDropdown({
     });
     queryClient.setQueryData(chatKeys.pendingTask(session.id), {});
     queryClient.invalidateQueries({ queryKey: chatKeys.messages(session.id) });
+    queryClient.invalidateQueries({ queryKey: chatKeys.messagesPage(session.id) });
 
     api.cancelTaskById(task.task_id).then(
       () => apiLogger.info("cancelTask.success (history row)", { taskId: task.task_id, sessionId: session.id }),

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -61,7 +61,7 @@ import { useT } from "../../i18n";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
-
+const CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX = 1_000_000;
 
 function seedChatMessagesPageCache(
   qc: ReturnType<typeof useQueryClient>,
@@ -73,13 +73,11 @@ function seedChatMessagesPageCache(
     (old) => old ?? {
       pages: [{
         messages,
-        page: 0,
         limit: 50,
-        total_count: messages.length,
         has_more: false,
-        first_item_index: 0,
+        next_cursor: null,
       }],
-      pageParams: [0],
+      pageParams: [null],
     },
   );
 }
@@ -107,13 +105,16 @@ export function ChatWindow() {
     isFetchingNextPage: isFetchingOlderMessages,
   } = useInfiniteQuery(chatMessagesPageOptions(activeSessionId ?? ""));
   // When no active session, always show empty — don't use stale cache.
-  // Page 0 contains the latest chronological window; higher page numbers are
+  // Page 0 contains the latest chronological window; later cursor pages are
   // older chronological windows. Reverse pages so older fetched pages render
-  // above the initial latest page.
+  // above the initial latest page. The Virtuoso firstItemIndex is client-owned:
+  // it starts from a large stable base and only subtracts the count of loaded
+  // prepended rows, so concurrent server inserts cannot drift the scroll anchor.
   const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
   const messages = [...messagePages].reverse().flatMap((page) => page.messages);
-  const firstItemIndex = messagePages.length > 0
-    ? Math.min(...messagePages.map((page) => page.first_item_index))
+  const olderMessageCount = messagePages.slice(1).reduce((sum, page) => sum + page.messages.length, 0);
+  const firstItemIndex = messages.length > 0
+    ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
     : 0;
   // Skeleton only shows for an un-cached session fetch. Cached switches
   // return data synchronously — no flash. `enabled: false` (new chat)

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -569,6 +569,7 @@ export function ChatWindow() {
         <ChatMessageSkeleton />
       ) : hasMessages ? (
         <ChatMessageList
+          key={activeSessionId}
           messages={messages}
           pendingTask={pendingTask}
           availability={availability}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -26,7 +26,8 @@
     "process_steps_other": "{{count}} steps",
     "copy_action": "Copy",
     "copied_toast": "Copied",
-    "copy_failed_toast": "Copy failed"
+    "copy_failed_toast": "Copy failed",
+    "loading_older": "Loading older messages…"
   },
   "session_history": {
     "untitled": "Untitled",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -23,7 +23,8 @@
     "process_steps_other": "ステップ {{count}}個",
     "copy_action": "コピー",
     "copied_toast": "コピーしました",
-    "copy_failed_toast": "コピーに失敗しました"
+    "copy_failed_toast": "コピーに失敗しました",
+    "loading_older": "古いメッセージを読み込み中…"
   },
   "session_history": {
     "untitled": "無題",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -26,7 +26,8 @@
     "process_steps_other": "단계 {{count}}개",
     "copy_action": "복사",
     "copied_toast": "복사했습니다",
-    "copy_failed_toast": "복사 실패"
+    "copy_failed_toast": "복사 실패",
+    "loading_older": "이전 메시지를 불러오는 중…"
   },
   "session_history": {
     "untitled": "제목 없음",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -23,7 +23,8 @@
     "process_steps_other": "{{count}} 步",
     "copy_action": "复制",
     "copied_toast": "已复制",
-    "copy_failed_toast": "复制失败"
+    "copy_failed_toast": "复制失败",
+    "loading_older": "正在加载更早的消息…"
   },
   "session_history": {
     "untitled": "无标题",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -707,6 +707,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Delete("/", h.DeleteChatSession)
 					r.Post("/messages", h.SendChatMessage)
 					r.Get("/messages", h.ListChatMessages)
+					r.Get("/messages/page", h.ListChatMessagesPage)
 					r.Get("/pending-task", h.GetPendingChatTask)
 					r.Post("/read", h.MarkChatSessionRead)
 				})

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -500,6 +501,35 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type ChatMessagesPageResponse struct {
+	Messages       []ChatMessageResponse `json:"messages"`
+	Page           int                   `json:"page"`
+	Limit          int                   `json:"limit"`
+	TotalCount     int64                 `json:"total_count"`
+	HasMore        bool                  `json:"has_more"`
+	FirstItemIndex int64                 `json:"first_item_index"`
+}
+
+func parseChatMessagesPageParams(r *http.Request) (int, int, error) {
+	page := 0
+	limit := 50
+	if raw := r.URL.Query().Get("page"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			return 0, 0, errors.New("invalid page")
+		}
+		page = parsed
+	}
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 100 {
+			return 0, 0, errors.New("invalid limit")
+		}
+		limit = parsed
+	}
+	return page, limit, nil
+}
+
 func (h *Handler) ListChatMessages(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -530,6 +560,71 @@ func (h *Handler) ListChatMessages(w http.ResponseWriter, r *http.Request) {
 		resp[i] = chatMessageToResponse(m, groupedAtt[uuidToString(m.ID)])
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) ListChatMessagesPage(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	sessionID := chi.URLParam(r, "sessionId")
+
+	session, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
+		return
+	}
+
+	page, limit, err := parseChatMessagesPageParams(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	offset := page * limit
+
+	totalCount, err := h.Queries.CountChatMessages(r.Context(), session.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count chat messages")
+		return
+	}
+	messages, err := h.Queries.ListChatMessagesPage(r.Context(), db.ListChatMessagesPageParams{
+		ChatSessionID: session.ID,
+		Limit:         int32(limit),
+		Offset:        int32(offset),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list chat messages")
+		return
+	}
+	// SQL fetches newest windows first so page=0 opens at the recent tail.
+	// Reverse each page before serializing to keep message order chronological
+	// within the viewport.
+	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+		messages[i], messages[j] = messages[j], messages[i]
+	}
+	firstItemIndex := totalCount - int64(offset) - int64(len(messages))
+	if firstItemIndex < 0 {
+		firstItemIndex = 0
+	}
+
+	messageIDs := make([]pgtype.UUID, len(messages))
+	for i, m := range messages {
+		messageIDs[i] = m.ID
+	}
+	groupedAtt := h.groupChatMessageAttachments(r.Context(), workspaceID, messageIDs)
+
+	resp := make([]ChatMessageResponse, len(messages))
+	for i, m := range messages {
+		resp[i] = chatMessageToResponse(m, groupedAtt[uuidToString(m.ID)])
+	}
+	writeJSON(w, http.StatusOK, ChatMessagesPageResponse{
+		Messages:       resp,
+		Page:           page,
+		Limit:          limit,
+		TotalCount:     totalCount,
+		HasMore:        int64(offset+len(messages)) < totalCount,
+		FirstItemIndex: firstItemIndex,
+	})
 }
 
 // PendingChatTaskResponse is returned by GetPendingChatTask — either the

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -501,33 +503,45 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-type ChatMessagesPageResponse struct {
-	Messages       []ChatMessageResponse `json:"messages"`
-	Page           int                   `json:"page"`
-	Limit          int                   `json:"limit"`
-	TotalCount     int64                 `json:"total_count"`
-	HasMore        bool                  `json:"has_more"`
-	FirstItemIndex int64                 `json:"first_item_index"`
+type ChatMessagesCursorResponse struct {
+	CreatedAt string `json:"created_at"`
+	ID        string `json:"id"`
 }
 
-func parseChatMessagesPageParams(r *http.Request) (int, int, error) {
-	page := 0
+type ChatMessagesPageResponse struct {
+	Messages   []ChatMessageResponse       `json:"messages"`
+	Limit      int                         `json:"limit"`
+	HasMore    bool                        `json:"has_more"`
+	NextCursor *ChatMessagesCursorResponse `json:"next_cursor,omitempty"`
+}
+
+func parseChatMessagesPageParams(r *http.Request) (int, pgtype.Timestamptz, pgtype.UUID, error) {
 	limit := 50
-	if raw := r.URL.Query().Get("page"); raw != "" {
-		parsed, err := strconv.Atoi(raw)
-		if err != nil || parsed < 0 {
-			return 0, 0, errors.New("invalid page")
-		}
-		page = parsed
-	}
 	if raw := r.URL.Query().Get("limit"); raw != "" {
 		parsed, err := strconv.Atoi(raw)
 		if err != nil || parsed < 1 || parsed > 100 {
-			return 0, 0, errors.New("invalid limit")
+			return 0, pgtype.Timestamptz{}, pgtype.UUID{}, errors.New("invalid limit")
 		}
 		limit = parsed
 	}
-	return page, limit, nil
+
+	rawBeforeCreatedAt := r.URL.Query().Get("before_created_at")
+	rawBeforeID := r.URL.Query().Get("before_id")
+	if rawBeforeCreatedAt == "" && rawBeforeID == "" {
+		return limit, pgtype.Timestamptz{}, pgtype.UUID{}, nil
+	}
+	if rawBeforeCreatedAt == "" || rawBeforeID == "" {
+		return 0, pgtype.Timestamptz{}, pgtype.UUID{}, errors.New("invalid cursor")
+	}
+	beforeTime, err := time.Parse(time.RFC3339Nano, rawBeforeCreatedAt)
+	if err != nil {
+		return 0, pgtype.Timestamptz{}, pgtype.UUID{}, errors.New("invalid cursor")
+	}
+	beforeID, err := util.ParseUUID(rawBeforeID)
+	if err != nil {
+		return 0, pgtype.Timestamptz{}, pgtype.UUID{}, errors.New("invalid cursor")
+	}
+	return limit, pgtype.Timestamptz{Time: beforeTime, Valid: true}, beforeID, nil
 }
 
 func (h *Handler) ListChatMessages(w http.ResponseWriter, r *http.Request) {
@@ -575,36 +589,39 @@ func (h *Handler) ListChatMessagesPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	page, limit, err := parseChatMessagesPageParams(r)
+	limit, beforeCreatedAt, beforeID, err := parseChatMessagesPageParams(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	offset := page * limit
 
-	totalCount, err := h.Queries.CountChatMessages(r.Context(), session.ID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to count chat messages")
-		return
-	}
 	messages, err := h.Queries.ListChatMessagesPage(r.Context(), db.ListChatMessagesPageParams{
-		ChatSessionID: session.ID,
-		Limit:         int32(limit),
-		Offset:        int32(offset),
+		ChatSessionID:   session.ID,
+		Limit:           int32(limit + 1),
+		BeforeCreatedAt: beforeCreatedAt,
+		BeforeID:        beforeID,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list chat messages")
 		return
 	}
-	// SQL fetches newest windows first so page=0 opens at the recent tail.
-	// Reverse each page before serializing to keep message order chronological
-	// within the viewport.
+	hasMore := len(messages) > limit
+	if hasMore {
+		messages = messages[:limit]
+	}
+	var nextCursor *ChatMessagesCursorResponse
+	if hasMore && len(messages) > 0 {
+		oldest := messages[len(messages)-1]
+		nextCursor = &ChatMessagesCursorResponse{
+			CreatedAt: oldest.CreatedAt.Time.Format(time.RFC3339Nano),
+			ID:        uuidToString(oldest.ID),
+		}
+	}
+	// SQL fetches newest windows first so the empty cursor opens at the recent
+	// tail. Reverse each cursor page before serializing to keep message order
+	// chronological within the viewport.
 	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
 		messages[i], messages[j] = messages[j], messages[i]
-	}
-	firstItemIndex := totalCount - int64(offset) - int64(len(messages))
-	if firstItemIndex < 0 {
-		firstItemIndex = 0
 	}
 
 	messageIDs := make([]pgtype.UUID, len(messages))
@@ -618,12 +635,10 @@ func (h *Handler) ListChatMessagesPage(w http.ResponseWriter, r *http.Request) {
 		resp[i] = chatMessageToResponse(m, groupedAtt[uuidToString(m.ID)])
 	}
 	writeJSON(w, http.StatusOK, ChatMessagesPageResponse{
-		Messages:       resp,
-		Page:           page,
-		Limit:          limit,
-		TotalCount:     totalCount,
-		HasMore:        int64(offset+len(messages)) < totalCount,
-		FirstItemIndex: firstItemIndex,
+		Messages:   resp,
+		Limit:      limit,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
 	})
 }
 

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -194,3 +194,74 @@ func TestSendChatMessage_InvalidAttachmentIDs(t *testing.T) {
 		t.Fatalf("expected 0 chat_message rows after rejected send, got %d", count)
 	}
 }
+
+func TestListChatMessagesPage_PaginatesWithoutChangingLegacyList(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatPaginationAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	for i, content := range []string{"oldest", "middle", "newest"} {
+		_, err := testPool.Exec(
+			context.Background(),
+			`INSERT INTO chat_message (chat_session_id, role, content, created_at)
+			 VALUES ($1, 'user', $2, timestamp '2026-01-01 00:00:00' + ($3::int * interval '1 second'))`,
+			sessionID,
+			content,
+			i,
+		)
+		if err != nil {
+			t.Fatalf("insert chat message %d: %v", i, err)
+		}
+	}
+
+	legacyReq := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages", nil)
+	legacyReq.Header.Set("X-User-ID", testUserID)
+	legacyReq = withURLParam(legacyReq, "sessionId", sessionID)
+	legacyReq = withChatTestWorkspaceCtx(t, legacyReq)
+	legacyW := httptest.NewRecorder()
+	testHandler.ListChatMessages(legacyW, legacyReq)
+	if legacyW.Code != http.StatusOK {
+		t.Fatalf("ListChatMessages: expected 200, got %d: %s", legacyW.Code, legacyW.Body.String())
+	}
+	var legacy []ChatMessageResponse
+	if err := json.Unmarshal(legacyW.Body.Bytes(), &legacy); err != nil {
+		t.Fatalf("decode legacy messages: %v", err)
+	}
+	if len(legacy) != 3 || legacy[0].Content != "oldest" || legacy[2].Content != "newest" {
+		t.Fatalf("legacy messages = %#v", legacy)
+	}
+
+	pageReq := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages/page?page=0&limit=2", nil)
+	pageReq.Header.Set("X-User-ID", testUserID)
+	pageReq = withURLParam(pageReq, "sessionId", sessionID)
+	pageReq = withChatTestWorkspaceCtx(t, pageReq)
+	pageW := httptest.NewRecorder()
+	testHandler.ListChatMessagesPage(pageW, pageReq)
+	if pageW.Code != http.StatusOK {
+		t.Fatalf("ListChatMessagesPage: expected 200, got %d: %s", pageW.Code, pageW.Body.String())
+	}
+	var page ChatMessagesPageResponse
+	if err := json.Unmarshal(pageW.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page messages: %v", err)
+	}
+	if page.Page != 0 || page.Limit != 2 || page.TotalCount != 3 || !page.HasMore {
+		t.Fatalf("page metadata = %#v", page)
+	}
+	if page.FirstItemIndex != 1 || len(page.Messages) != 2 || page.Messages[0].Content != "middle" || page.Messages[1].Content != "newest" {
+		t.Fatalf("page messages = %#v", page)
+	}
+}
+
+func TestListChatMessagesPage_RejectsInvalidLimit(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatPaginationBadLimitAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages/page?page=0&limit=0", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withURLParam(req, "sessionId", sessionID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w := httptest.NewRecorder()
+	testHandler.ListChatMessagesPage(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("ListChatMessagesPage invalid limit: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -195,8 +196,30 @@ func TestSendChatMessage_InvalidAttachmentIDs(t *testing.T) {
 	}
 }
 
-func TestListChatMessagesPage_PaginatesWithoutChangingLegacyList(t *testing.T) {
-	agentID := createHandlerTestAgent(t, "ChatPaginationAgent", []byte("[]"))
+func fetchChatMessagesPageForTest(t *testing.T, sessionID string, params url.Values) ChatMessagesPageResponse {
+	t.Helper()
+	target := "/api/chat/sessions/" + sessionID + "/messages/page"
+	if encoded := params.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withURLParam(req, "sessionId", sessionID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w := httptest.NewRecorder()
+	testHandler.ListChatMessagesPage(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChatMessagesPage: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var page ChatMessagesPageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page messages: %v", err)
+	}
+	return page
+}
+
+func TestListChatMessagesPage_UsesCursorWithoutChangingLegacyList(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatCursorPaginationAgent", []byte("[]"))
 	sessionID := createHandlerTestChatSession(t, agentID)
 
 	for i, content := range []string{"oldest", "middle", "newest"} {
@@ -230,24 +253,90 @@ func TestListChatMessagesPage_PaginatesWithoutChangingLegacyList(t *testing.T) {
 		t.Fatalf("legacy messages = %#v", legacy)
 	}
 
-	pageReq := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages/page?page=0&limit=2", nil)
-	pageReq.Header.Set("X-User-ID", testUserID)
-	pageReq = withURLParam(pageReq, "sessionId", sessionID)
-	pageReq = withChatTestWorkspaceCtx(t, pageReq)
-	pageW := httptest.NewRecorder()
-	testHandler.ListChatMessagesPage(pageW, pageReq)
-	if pageW.Code != http.StatusOK {
-		t.Fatalf("ListChatMessagesPage: expected 200, got %d: %s", pageW.Code, pageW.Body.String())
+	latest := fetchChatMessagesPageForTest(t, sessionID, url.Values{"limit": {"2"}})
+	if latest.Limit != 2 || !latest.HasMore || latest.NextCursor == nil {
+		t.Fatalf("latest page metadata = %#v", latest)
 	}
-	var page ChatMessagesPageResponse
-	if err := json.Unmarshal(pageW.Body.Bytes(), &page); err != nil {
-		t.Fatalf("decode page messages: %v", err)
+	if len(latest.Messages) != 2 || latest.Messages[0].Content != "middle" || latest.Messages[1].Content != "newest" {
+		t.Fatalf("latest page messages = %#v", latest)
 	}
-	if page.Page != 0 || page.Limit != 2 || page.TotalCount != 3 || !page.HasMore {
-		t.Fatalf("page metadata = %#v", page)
+
+	older := fetchChatMessagesPageForTest(t, sessionID, url.Values{
+		"limit":             {"2"},
+		"before_created_at": {latest.NextCursor.CreatedAt},
+		"before_id":         {latest.NextCursor.ID},
+	})
+	if older.HasMore || older.NextCursor != nil {
+		t.Fatalf("older page metadata = %#v", older)
 	}
-	if page.FirstItemIndex != 1 || len(page.Messages) != 2 || page.Messages[0].Content != "middle" || page.Messages[1].Content != "newest" {
-		t.Fatalf("page messages = %#v", page)
+	if len(older.Messages) != 1 || older.Messages[0].Content != "oldest" {
+		t.Fatalf("older page messages = %#v", older)
+	}
+}
+
+func TestListChatMessagesPage_CursorTieBreaksSameTimestampWithoutDupesOrGaps(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatCursorTieBreakAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	contents := []string{"a", "b", "c", "d", "e"}
+	for _, content := range contents {
+		_, err := testPool.Exec(
+			context.Background(),
+			`INSERT INTO chat_message (chat_session_id, role, content, created_at)
+			 VALUES ($1, 'user', $2, timestamp '2026-01-01 00:00:00')`,
+			sessionID,
+			content,
+		)
+		if err != nil {
+			t.Fatalf("insert chat message %q: %v", content, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	var ordered []string
+	params := url.Values{"limit": {"2"}}
+	for {
+		page := fetchChatMessagesPageForTest(t, sessionID, params)
+		for _, msg := range page.Messages {
+			if seen[msg.ID] {
+				t.Fatalf("duplicate message id %s across cursor pages", msg.ID)
+			}
+			seen[msg.ID] = true
+			ordered = append(ordered, msg.Content)
+		}
+		if !page.HasMore {
+			if page.NextCursor != nil {
+				t.Fatalf("terminal page has next cursor: %#v", page.NextCursor)
+			}
+			break
+		}
+		if page.NextCursor == nil {
+			t.Fatalf("has_more page missing next cursor: %#v", page)
+		}
+		params = url.Values{
+			"limit":             {"2"},
+			"before_created_at": {page.NextCursor.CreatedAt},
+			"before_id":         {page.NextCursor.ID},
+		}
+	}
+
+	if len(ordered) != len(contents) {
+		t.Fatalf("expected %d messages across pages, got %d: %v", len(contents), len(ordered), ordered)
+	}
+	// Pages are newest-window first and chronological within each page. With all
+	// timestamps equal, the id tie-break must still produce a deterministic,
+	// gap-free traversal.
+	for _, content := range contents {
+		found := false
+		for _, got := range ordered {
+			if got == content {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing content %q across cursor pages: %v", content, ordered)
+		}
 	}
 }
 
@@ -255,7 +344,7 @@ func TestListChatMessagesPage_RejectsInvalidLimit(t *testing.T) {
 	agentID := createHandlerTestAgent(t, "ChatPaginationBadLimitAgent", []byte("[]"))
 	sessionID := createHandlerTestChatSession(t, agentID)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages/page?page=0&limit=0", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/chat/sessions/"+sessionID+"/messages/page?limit=0", nil)
 	req.Header.Set("X-User-ID", testUserID)
 	req = withURLParam(req, "sessionId", sessionID)
 	req = withChatTestWorkspaceCtx(t, req)

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -11,6 +11,18 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countChatMessages = `-- name: CountChatMessages :one
+SELECT count(*) FROM chat_message
+WHERE chat_session_id = $1
+`
+
+func (q *Queries) CountChatMessages(ctx context.Context, chatSessionID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatMessages, chatSessionID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createChatMessage = `-- name: CreateChatMessage :one
 INSERT INTO chat_message (chat_session_id, role, content, task_id, failure_reason, elapsed_ms)
 VALUES ($1, $2, $3, $4, $5, $6)
@@ -369,6 +381,48 @@ ORDER BY created_at ASC
 
 func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUID) ([]ChatMessage, error) {
 	rows, err := q.db.Query(ctx, listChatMessages, chatSessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ChatMessage{}
+	for rows.Next() {
+		var i ChatMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatSessionID,
+			&i.Role,
+			&i.Content,
+			&i.TaskID,
+			&i.CreatedAt,
+			&i.FailureReason,
+			&i.ElapsedMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChatMessagesPage = `-- name: ListChatMessagesPage :many
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
+WHERE chat_session_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListChatMessagesPageParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	Limit         int32       `json:"limit"`
+	Offset        int32       `json:"offset"`
+}
+
+func (q *Queries) ListChatMessagesPage(ctx context.Context, arg ListChatMessagesPageParams) ([]ChatMessage, error) {
+	rows, err := q.db.Query(ctx, listChatMessagesPage, arg.ChatSessionID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -11,18 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const countChatMessages = `-- name: CountChatMessages :one
-SELECT count(*) FROM chat_message
-WHERE chat_session_id = $1
-`
-
-func (q *Queries) CountChatMessages(ctx context.Context, chatSessionID pgtype.UUID) (int64, error) {
-	row := q.db.QueryRow(ctx, countChatMessages, chatSessionID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
 const createChatMessage = `-- name: CreateChatMessage :one
 INSERT INTO chat_message (chat_session_id, role, content, task_id, failure_reason, elapsed_ms)
 VALUES ($1, $2, $3, $4, $5, $6)
@@ -411,18 +399,28 @@ func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUI
 const listChatMessagesPage = `-- name: ListChatMessagesPage :many
 SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
 WHERE chat_session_id = $1
-ORDER BY created_at DESC
-LIMIT $2 OFFSET $3
+  AND (
+    $3::timestamptz IS NULL
+    OR (created_at, id) < ($3::timestamptz, $4::uuid)
+  )
+ORDER BY created_at DESC, id DESC
+LIMIT $2
 `
 
 type ListChatMessagesPageParams struct {
-	ChatSessionID pgtype.UUID `json:"chat_session_id"`
-	Limit         int32       `json:"limit"`
-	Offset        int32       `json:"offset"`
+	ChatSessionID   pgtype.UUID        `json:"chat_session_id"`
+	Limit           int32              `json:"limit"`
+	BeforeCreatedAt pgtype.Timestamptz `json:"before_created_at"`
+	BeforeID        pgtype.UUID        `json:"before_id"`
 }
 
 func (q *Queries) ListChatMessagesPage(ctx context.Context, arg ListChatMessagesPageParams) ([]ChatMessage, error) {
-	rows, err := q.db.Query(ctx, listChatMessagesPage, arg.ChatSessionID, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, listChatMessagesPage,
+		arg.ChatSessionID,
+		arg.Limit,
+		arg.BeforeCreatedAt,
+		arg.BeforeID,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -83,6 +83,16 @@ SELECT * FROM chat_message
 WHERE chat_session_id = $1
 ORDER BY created_at ASC;
 
+-- name: CountChatMessages :one
+SELECT count(*) FROM chat_message
+WHERE chat_session_id = $1;
+
+-- name: ListChatMessagesPage :many
+SELECT * FROM chat_message
+WHERE chat_session_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3;
+
 -- name: GetChatMessage :one
 SELECT * FROM chat_message
 WHERE id = $1;

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -83,15 +83,15 @@ SELECT * FROM chat_message
 WHERE chat_session_id = $1
 ORDER BY created_at ASC;
 
--- name: CountChatMessages :one
-SELECT count(*) FROM chat_message
-WHERE chat_session_id = $1;
-
 -- name: ListChatMessagesPage :many
 SELECT * FROM chat_message
 WHERE chat_session_id = $1
-ORDER BY created_at DESC
-LIMIT $2 OFFSET $3;
+  AND (
+    sqlc.narg('before_created_at')::timestamptz IS NULL
+    OR (created_at, id) < (sqlc.narg('before_created_at')::timestamptz, sqlc.narg('before_id')::uuid)
+  )
+ORDER BY created_at DESC, id DESC
+LIMIT $2;
 
 -- name: GetChatMessage :one
 SELECT * FROM chat_message


### PR DESCRIPTION
## Summary
- add paginated chat message API while preserving the legacy `/messages` endpoint
- load chat messages with an infinite query and virtualized rendering
- keep realtime `chat:done` updates in sync for both legacy and paged caches

## Verification
- `go test ./internal/handler -run 'TestListChatMessages'`
- `pnpm -C packages/core typecheck`
- `pnpm -C packages/core lint`
- `pnpm -C packages/core test -- realtime/use-realtime-sync.test.ts`
- `pnpm -C packages/views typecheck`
- `pnpm -C packages/views lint` (passes with existing warnings)
- `pnpm -C packages/views test -- chat/components/chat-input.test.tsx` (passes with existing React act warnings)
- `git diff --check`

## Known risks
- `go test ./...` still fails on existing fixture/schema issues unrelated to this change (`avatar_url` missing, workspace slug resolution, webhook PR link tests, daemon workspace setup).
- Virtualized chat now relies on `react-virtuoso` already present in the repo dependency graph.
