### PR TITLE
fix(agent): raise opencode model-discovery timeout to 15s

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -342,7 +342,11 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 	if _, err := exec.LookPath(executablePath); err != nil {
 		return []Model{}, nil
 	}
-	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// Newer opencode (1.15+) syncs its hosted free-model catalog over the
+	// network on `opencode models`, which can take ~6s; the previous 5s cap
+	// timed out and returned an empty list, so the runtime showed online but
+	// the model picker was empty. See multica-ai/multica#3627.
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "models")
 	hideAgentWindow(cmd)


### PR DESCRIPTION
## Summary

Raises the OpenCode model-discovery timeout in the daemon from **5s to 15s**.

Newer OpenCode (1.15+) synchronizes its hosted free-model catalog over the network when `opencode models` runs, which can take ~6s. The previous 5s cap killed the command before it finished; `discoverOpenCodeModels` then returned an empty list (with a nil error), and the daemon reported it as a *successful empty result*. The net effect: the runtime showed **online** but the model picker was empty ("暂无可用模型"), with no error surfaced.

Confirmed against issue #3627 — the reporter's `opencode --version` is `1.15.13` and their `opencode models` takes ~6s, while a setup on `1.14.41` (which finishes under 5s) lists models correctly. The command output itself is well-formed and parses fine; the only problem was the timeout.

This is the minimal, targeted fix requested. Scope is limited to the OpenCode discovery timeout — the identical 5s cap on other runtimes (e.g. `pi`) is intentionally left untouched.

## Changes

- `server/pkg/agent/models.go` — `discoverOpenCodeModels`: timeout `5s → 15s`, with a comment explaining the network-sync latency.

## Testing

- `gofmt -l` / `go vet ./pkg/agent/` — clean
- `go test ./pkg/agent/` — pass (incl. `TestParseOpenCodeModels`)

## Notes

Related follow-ups identified during review but intentionally **out of scope** for this minimal fix (can be tracked separately if desired):
- A timed-out/failed discovery is cached as an empty result for 60s (`cachedDiscovery`).
- A discovery timeout is reported as `completed` (empty) rather than `failed`, so the UI cannot distinguish "discovery failed" from "genuinely no models".

MUL-2888
Fixes #3627
