### PR TITLE
fix(agent): stop stripping user-facing CLAUDE_CODE_* config from child env

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -593,22 +593,27 @@ func mergeEnv(base []string, extra map[string]string) []string {
 // isFilteredChildEnvKey reports whether an inherited env var is an internal
 // Claude Code runtime/session marker that must NOT leak into the spawned child
 // (otherwise the child mistakes itself for a nested or resumed session, or
-// reuses the parent's temp dir / exec path).
+// inherits the parent's exec path / transport).
 //
 // It must NOT strip the user-facing CLAUDE_CODE_* configuration namespace
 // (CLAUDE_CODE_GIT_BASH_PATH, CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX,
-// CLAUDE_CODE_MAX_OUTPUT_TOKENS, ...): users set those deliberately and the
-// child needs them. Blanket-stripping the whole prefix is what broke Windows —
-// CLAUDE_CODE_GIT_BASH_PATH was silently removed, so Claude Code could not find
-// bash.exe and exited immediately. Strip internal markers by exact name and let
-// every other CLAUDE_CODE_* var through.
+// CLAUDE_CODE_MAX_OUTPUT_TOKENS, CLAUDE_CODE_TMPDIR, ...): users set those
+// deliberately and the child needs them. Blanket-stripping the whole prefix is
+// what broke Windows — CLAUDE_CODE_GIT_BASH_PATH was silently removed, so Claude
+// Code could not find bash.exe and exited immediately. Strip internal markers by
+// exact name and let every other CLAUDE_CODE_* var through.
+//
+// The denylist holds only undocumented, per-process runtime markers. Anything in
+// the public env-vars reference (https://code.claude.com/docs/en/env-vars) is
+// user config and stays out of this list — including CLAUDE_CODE_TMPDIR, a
+// documented temp-dir override under which Claude Code creates its own
+// per-session subdir, so inheriting it is harmless.
 func isFilteredChildEnvKey(key string) bool {
 	switch key {
 	case "CLAUDECODE", // "1" when running inside Claude Code
 		"CLAUDE_CODE_ENTRYPOINT", // entrypoint marker (cli/sdk-cli/...)
 		"CLAUDE_CODE_EXECPATH",   // path to the running CLI binary
 		"CLAUDE_CODE_SESSION_ID", // per-session identifier
-		"CLAUDE_CODE_TMPDIR",     // per-session temp dir
 		"CLAUDE_CODE_SSE_PORT":   // IDE-extension transport port
 		return true
 	}

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -590,10 +590,31 @@ func mergeEnv(base []string, extra map[string]string) []string {
 	return env
 }
 
+// isFilteredChildEnvKey reports whether an inherited env var is an internal
+// Claude Code runtime/session marker that must NOT leak into the spawned child
+// (otherwise the child mistakes itself for a nested or resumed session, or
+// reuses the parent's temp dir / exec path).
+//
+// It must NOT strip the user-facing CLAUDE_CODE_* configuration namespace
+// (CLAUDE_CODE_GIT_BASH_PATH, CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX,
+// CLAUDE_CODE_MAX_OUTPUT_TOKENS, ...): users set those deliberately and the
+// child needs them. Blanket-stripping the whole prefix is what broke Windows —
+// CLAUDE_CODE_GIT_BASH_PATH was silently removed, so Claude Code could not find
+// bash.exe and exited immediately. Strip internal markers by exact name and let
+// every other CLAUDE_CODE_* var through.
 func isFilteredChildEnvKey(key string) bool {
-	return key == "CLAUDECODE" ||
-		strings.HasPrefix(key, "CLAUDECODE_") ||
-		strings.HasPrefix(key, "CLAUDE_CODE_")
+	switch key {
+	case "CLAUDECODE", // "1" when running inside Claude Code
+		"CLAUDE_CODE_ENTRYPOINT", // entrypoint marker (cli/sdk-cli/...)
+		"CLAUDE_CODE_EXECPATH",   // path to the running CLI binary
+		"CLAUDE_CODE_SESSION_ID", // per-session identifier
+		"CLAUDE_CODE_TMPDIR",     // per-session temp dir
+		"CLAUDE_CODE_SSE_PORT":   // IDE-extension transport port
+		return true
+	}
+	// CLAUDECODE_* (no underscore between CLAUDE and CODE) is wholly internal;
+	// keep stripping it. The user-facing config namespace is CLAUDE_CODE_*.
+	return strings.HasPrefix(key, "CLAUDECODE_")
 }
 
 // blockedArgMode specifies whether a blocked arg takes a value or is standalone.

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -419,21 +419,20 @@ func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
 		"CLAUDE_CODE_ENTRYPOINT=cli",
 		"CLAUDE_CODE_EXECPATH=/opt/claude",
 		"CLAUDE_CODE_SESSION_ID=abc123",
-		"CLAUDE_CODE_TMPDIR=/tmp/claude-x",
 		"CLAUDE_CODE_SSE_PORT=9999",
 		"CLAUDECODEX=keep-me",
 		"CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe",
 		"CLAUDE_CODE_USE_BEDROCK=1",
+		"CLAUDE_CODE_TMPDIR=/custom/tmp",
 	}, map[string]string{"FOO": "bar"})
 
 	// Internal runtime/session markers must be stripped so the child does not
-	// inherit the parent's identity, temp dir, or transport.
+	// inherit the parent's identity or transport.
 	filteredOut := []string{
 		"CLAUDECODE=1",
 		"CLAUDE_CODE_ENTRYPOINT=cli",
 		"CLAUDE_CODE_EXECPATH=/opt/claude",
 		"CLAUDE_CODE_SESSION_ID=abc123",
-		"CLAUDE_CODE_TMPDIR=/tmp/claude-x",
 		"CLAUDE_CODE_SSE_PORT=9999",
 	}
 	for _, entry := range env {
@@ -462,6 +461,11 @@ func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
 	}
 	if !found["CLAUDE_CODE_USE_BEDROCK=1"] {
 		t.Fatalf("expected CLAUDE_CODE_USE_BEDROCK to be preserved, got %v", env)
+	}
+	// CLAUDE_CODE_TMPDIR is a documented user-configurable temp-dir override, not
+	// an internal per-session marker, so it must reach the child.
+	if !found["CLAUDE_CODE_TMPDIR=/custom/tmp"] {
+		t.Fatalf("expected CLAUDE_CODE_TMPDIR to be preserved, got %v", env)
 	}
 	if !found["FOO=bar"] {
 		t.Fatalf("expected extra env var to be appended, got %v", env)

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -417,12 +417,30 @@ func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
 		"PATH=/usr/bin",
 		"CLAUDECODE=1",
 		"CLAUDE_CODE_ENTRYPOINT=cli",
+		"CLAUDE_CODE_EXECPATH=/opt/claude",
+		"CLAUDE_CODE_SESSION_ID=abc123",
+		"CLAUDE_CODE_TMPDIR=/tmp/claude-x",
+		"CLAUDE_CODE_SSE_PORT=9999",
 		"CLAUDECODEX=keep-me",
+		"CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe",
+		"CLAUDE_CODE_USE_BEDROCK=1",
 	}, map[string]string{"FOO": "bar"})
 
+	// Internal runtime/session markers must be stripped so the child does not
+	// inherit the parent's identity, temp dir, or transport.
+	filteredOut := []string{
+		"CLAUDECODE=1",
+		"CLAUDE_CODE_ENTRYPOINT=cli",
+		"CLAUDE_CODE_EXECPATH=/opt/claude",
+		"CLAUDE_CODE_SESSION_ID=abc123",
+		"CLAUDE_CODE_TMPDIR=/tmp/claude-x",
+		"CLAUDE_CODE_SSE_PORT=9999",
+	}
 	for _, entry := range env {
-		if entry == "CLAUDECODE=1" || entry == "CLAUDE_CODE_ENTRYPOINT=cli" {
-			t.Fatalf("expected CLAUDECODE vars to be filtered, got %v", env)
+		for _, banned := range filteredOut {
+			if entry == banned {
+				t.Fatalf("expected internal Claude Code marker %q to be filtered, got %v", banned, env)
+			}
 		}
 	}
 
@@ -436,6 +454,14 @@ func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
 	}
 	if !found["CLAUDECODEX=keep-me"] {
 		t.Fatalf("expected unrelated env vars to be preserved, got %v", env)
+	}
+	// User-facing CLAUDE_CODE_* config must reach the child — stripping
+	// CLAUDE_CODE_GIT_BASH_PATH is what broke Claude Code on Windows (#3671).
+	if !found["CLAUDE_CODE_GIT_BASH_PATH=C:\\Program Files\\Git\\bin\\bash.exe"] {
+		t.Fatalf("expected CLAUDE_CODE_GIT_BASH_PATH to be preserved, got %v", env)
+	}
+	if !found["CLAUDE_CODE_USE_BEDROCK=1"] {
+		t.Fatalf("expected CLAUDE_CODE_USE_BEDROCK to be preserved, got %v", env)
 	}
 	if !found["FOO=bar"] {
 		t.Fatalf("expected extra env var to be appended, got %v", env)


### PR DESCRIPTION
## Summary

`isFilteredChildEnvKey` (`server/pkg/agent/claude.go`) blanket-stripped **every** `CLAUDE_CODE_*` variable from the spawned Claude Code child's environment. The filter's intent is only to stop the daemon's internal session markers from leaking into the child — but `CLAUDE_CODE_*` is also Anthropic's **user-facing configuration namespace**.

On Windows this removed the user-set `CLAUDE_CODE_GIT_BASH_PATH`, so Claude Code could not locate `bash.exe`, exited immediately, and every task failed with:

```
write claude input: write |1: The pipe has been ended.
```

(The pipe error is downstream — the child had already exited.)

## Fix

Switch from prefix-matching the whole `CLAUDE_CODE_` namespace to an **exact-name denylist** of the internal runtime/session markers, while still blanket-stripping the wholly-internal `CLAUDECODE_*` namespace (no underscore between `CLAUDE` and `CODE`):

- `CLAUDECODE`
- `CLAUDE_CODE_ENTRYPOINT`
- `CLAUDE_CODE_EXECPATH`
- `CLAUDE_CODE_SESSION_ID`
- `CLAUDE_CODE_TMPDIR`
- `CLAUDE_CODE_SSE_PORT`

Every other `CLAUDE_CODE_*` var (`GIT_BASH_PATH`, `USE_BEDROCK`, `USE_VERTEX`, `MAX_OUTPUT_TOKENS`, ...) now reaches the child. The internal-marker set was confirmed against the live Claude Code runtime, not guessed — `SESSION_ID`, `TMPDIR`, and `EXECPATH` are session-specific state that genuinely must not leak (a child inheriting the parent's `SESSION_ID` would mistake itself for a resumed session).

This fixes the whole class, not just git-bash: Bedrock/Vertex and other user config were silently dropped the same way.

## Testing

- Extended `TestMergeEnvFiltersClaudeCodeVars` to assert the six internal markers are still stripped **and** that `CLAUDE_CODE_GIT_BASH_PATH` / `CLAUDE_CODE_USE_BEDROCK` are now preserved.
- `go test ./pkg/agent/` passes; `gofmt` and `go vet` clean.

Closes #3671

MUL-2940
