### PR TITLE
docs(self-hosting): document WebSocket Origin allowlist requirement

### DIFF
--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -112,7 +112,7 @@ The `Secure` flag on session cookies is derived automatically from the scheme of
 | `PORT` | `8080` | Backend server port |
 | `METRICS_ADDR` | empty | Optional Prometheus metrics listener, for example `127.0.0.1:9090` |
 | `FRONTEND_PORT` | `3000` | Frontend port |
-| `CORS_ALLOWED_ORIGINS` | Value of `FRONTEND_ORIGIN` | Comma-separated list of allowed origins |
+| `CORS_ALLOWED_ORIGINS` | Value of `FRONTEND_ORIGIN` | Comma-separated list of allowed origins. Governs **both** the HTTP CORS allowlist **and** the WebSocket `Origin` check. A browser origin that isn't listed here (and isn't `localhost`) has its real-time WebSocket upgrade rejected with `403`, so live updates stop working until a manual refresh. |
 | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 
 ### CLI / Daemon
@@ -337,6 +337,8 @@ multica.example.com {
 }
 ```
 
+> Even on a single domain, set `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS` to that public origin (e.g. `https://multica.example.com`) on the backend. The backend's default origin allowlist is `localhost` only, so without this it rejects the WebSocket upgrade from the public URL with `403` and real-time updates silently stop working. See [LAN / Non-localhost Access](#lan--non-localhost-access).
+
 **Separate-domain layout** — frontend and backend on different hostnames:
 
 ```
@@ -455,6 +457,8 @@ HTTP requests (issues, comments, uploads) work on LAN out of the box — Next.js
    ```
 
    `NEXT_PUBLIC_WS_URL` is a build-time variable (see `Dockerfile.web`), so setting it only in `environment:` on the pre-built image has no effect — you must use the `selfhost.build.yml` override that rebuilds the image.
+
+**Also required: allowlist the browser origin.** The two options above fix the WebSocket *upgrade proxying*, but a second, independent setting gates the connection: the backend validates the WebSocket `Origin` header against an allowlist that defaults to `localhost` only. When you open Multica from any other origin — a LAN IP **or a public domain behind a reverse proxy** — set `CORS_ALLOWED_ORIGINS` (or `FRONTEND_ORIGIN`) on the backend to that exact origin and restart, exactly as shown under [LAN / Non-localhost Access](#lan--non-localhost-access) above. Otherwise the upgrade is refused with `403`: the backend logs `websocket: request origin not allowed by Upgrader.CheckOrigin` and the browser console loops `disconnected, reconnecting in 3s`, while HTTP requests (and manual page refreshes) keep working because they are same-origin to the page. The single value covers both HTTP CORS and the WebSocket origin check.
 
 > **Note:** If you need to hard-code a different public API / WebSocket endpoint into the web image for any other reason, use the same source-build override: `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build`.
 


### PR DESCRIPTION
## Summary

Documents the backend's **WebSocket `Origin` allowlist** as a self-hosting requirement. The docs already covered the WebSocket *upgrade-proxy* failure mode (Next.js rewrites don't forward the `Upgrade` handshake), but not the second, independent gate: the backend validates the WS `Origin` against an allowlist that defaults to `localhost` only and rejects anything else with a `403`. Self-hosters accessing Multica from a non-localhost origin therefore lose all real-time updates until they set `CORS_ALLOWED_ORIGINS` / `FRONTEND_ORIGIN` — but nothing pointed them there from the WebSocket troubleshooting path.

Reported in #3677 (and tracked as MUL-2945): chat replies and live issue/running-bar updates only appeared after a manual page refresh. Root cause was exactly this — the backend logged `websocket: request origin not allowed by Upgrader.CheckOrigin` and the browser looped `disconnected, reconnecting in 3s`. Setting `CORS_ALLOWED_ORIGINS` to the external origin fixed it; the reporter confirmed.

## Changes (docs-only, `SELF_HOSTING_ADVANCED.md`)

1. **Env-var table** — clarify that `CORS_ALLOWED_ORIGINS` governs **both** the HTTP CORS allowlist **and** the WebSocket `Origin` check (it was described as CORS-only).
2. **Single-domain Caddy example** — add a callout that even single-domain self-hosters must set `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS` to their public origin (the separate-domain example already showed these vars; the single-domain one didn't).
3. **"WebSocket for LAN / Non-localhost Access" section** — add an "Also required: allowlist the browser origin" callout describing this failure mode independently of the upgrade-proxy one, including the exact backend error string and the browser-console symptom so it's searchable.

## Why it matters

The fix was technically derivable from the existing "LAN / Non-localhost Access" section, but that section is framed around LAN IPs and never mentions WebSockets — so a user debugging broken real-time updates would land on the WebSocket section, follow the proxy advice (which they may already have), and still be stuck. These edits connect the symptom (WS `403` / no live updates) to the fix (`CORS_ALLOWED_ORIGINS`).

## Testing / Verification

Docs-only change — no code paths touched. Reviewed the rendered Markdown and confirmed the relative anchor link (`#lan--non-localhost-access`) resolves to the existing `## LAN / Non-localhost Access` heading. The documented error string and env-var behavior were verified against the backend source (`server/internal/realtime/hub.go` `checkOrigin` / `loadAllowedOrigins`, `server/cmd/server/router.go` `SetAllowedOrigins`).
