### PR TITLE
MUL-3122 feat(chat): add search filter to agent selector dropdown

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -643,24 +643,27 @@ function AgentDropdown({
   onSelect: (agent: Agent) => void;
 }) {
   const { t } = useT("chat");
-  // Split into the user's own agents and everyone else so the menu groups
-  // them — matches the old AgentSelector layout.
+  const [filter, setFilter] = useState("");
+
   const { mine, others } = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const match = (a: Agent) => !q || a.name.toLowerCase().includes(q);
     const mine: Agent[] = [];
     const others: Agent[] = [];
     for (const a of agents) {
+      if (!match(a)) continue;
       if (a.owner_id === userId) mine.push(a);
       else others.push(a);
     }
     return { mine, others };
-  }, [agents, userId]);
+  }, [agents, userId, filter]);
 
   if (!activeAgent) {
     return <span className="text-xs text-muted-foreground">{t(($) => $.window.no_agents)}</span>;
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => { if (!open) setFilter(""); }}>
       <DropdownMenuTrigger className="flex items-center gap-1.5 rounded-md px-1.5 py-1 -ml-1 cursor-pointer outline-none transition-colors hover:bg-accent aria-expanded:bg-accent">
         <ActorAvatar
           actorType="agent"
@@ -673,6 +676,16 @@ function AgentDropdown({
         <ChevronDown className="size-3 text-muted-foreground shrink-0" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="top" className="max-h-80 w-auto max-w-64">
+        <div className="px-2 py-1.5 border-b">
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            placeholder={t(($) => $.window.filter_placeholder)}
+            className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+          />
+        </div>
         {mine.length > 0 && (
           <DropdownMenuGroup>
             <DropdownMenuLabel>{t(($) => $.window.my_agents)}</DropdownMenuLabel>

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -77,6 +77,7 @@
     "my_agents": "My agents",
     "others": "Others",
     "no_agents": "No agents",
+    "filter_placeholder": "Filter agents...",
     "history_group": "Chat history"
   },
   "empty_state": {

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -74,6 +74,7 @@
     "my_agents": "マイエージェント",
     "others": "その他",
     "no_agents": "エージェントなし",
+    "filter_placeholder": "エージェントを検索...",
     "history_group": "チャット履歴"
   },
   "empty_state": {

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -77,6 +77,7 @@
     "my_agents": "내 에이전트",
     "others": "기타",
     "no_agents": "에이전트 없음",
+    "filter_placeholder": "에이전트 검색...",
     "history_group": "채팅 기록"
   },
   "empty_state": {

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -74,6 +74,7 @@
     "my_agents": "我的智能体",
     "others": "其他",
     "no_agents": "暂无智能体",
+    "filter_placeholder": "搜索智能体...",
     "history_group": "历史对话"
   },
   "empty_state": {


### PR DESCRIPTION
## Summary

- Add a search/filter input to the Chat page's agent selector dropdown, so users can quickly find agents by name when there are many

Closes #3676

## Changes

- `packages/views/chat/components/chat-window.tsx` — add filter state and search input to `AgentDropdown`
- `packages/views/locales/{en,zh-Hans,ja,ko}/chat.json` — add `filter_placeholder` i18n key

## Test plan

- [ ] Open Chat page → click agent selector → search input visible at top
- [ ] Type to filter agents by name
- [ ] Close and reopen dropdown → filter is cleared