### PR TITLE
fix(lark): use named import for react-qr-code to survive electron-vite interop

### DIFF
--- a/packages/views/settings/components/lark-tab.test.tsx
+++ b/packages/views/settings/components/lark-tab.test.tsx
@@ -133,11 +133,17 @@ vi.mock("sonner", () => ({
 // react-qr-code renders SVG that jsdom doesn't fully support — a stub
 // keeps the dialog DOM compact and lets us assert on the surrounding
 // chrome (status text, buttons) without QR mechanics.
-vi.mock("react-qr-code", () => ({
-  default: ({ value }: { value: string }) => (
+// Expose the stub as BOTH the named `QRCode` export (what lark-tab now
+// imports — see the named-import interop fix) and `default`, so the mock
+// stays correct regardless of how the component pulls it in. The stub is
+// defined inside the factory because vi.mock is hoisted above any
+// top-level variable.
+vi.mock("react-qr-code", () => {
+  const QrStub = ({ value }: { value: string }) => (
     <span data-testid="qr-code" data-value={value} />
-  ),
-}));
+  );
+  return { QRCode: QrStub, default: QrStub };
+});
 
 import { LarkAgentBindButton, LarkTab } from "./lark-tab";
 

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -4,7 +4,14 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ExternalLink, RefreshCw, Trash2 } from "lucide-react";
-import QRCode from "react-qr-code";
+// Named import, NOT default: react-qr-code is CJS, and electron-vite's
+// dep-optimizer default-import interop handed back the module namespace
+// object instead of the component, throwing "Element type is invalid …
+// got: object" the moment <QRCode> mounted (the QR step of the install
+// dialog) — desktop white-screened while web (Next.js, different interop)
+// was fine. The named export maps straight to `exports.QRCode` and
+// resolves correctly under both bundlers.
+import { QRCode } from "react-qr-code";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import {


### PR DESCRIPTION
## Symptom

Clicking **Bind** on the agent detail page → Integrations white-screened the **desktop** app at the QR-loading step. Web was unaffected.

Console error:
```
Element type is invalid: expected a string (for built-in components) or a
class/function (for composite components) but got: object.
Check the render method of `LarkInstallDialog`.
```

## Root cause

`react-qr-code` is a **CJS** package. `import QRCode from "react-qr-code"` relies on the bundler's `__esModule` default-interop to unwrap `.default`:

- **Next.js (web)** unwraps it correctly → `QRCode` is the component → renders fine.
- **electron-vite (desktop)** dep-optimizer handed back the whole module namespace object `{ default, QRCode, __esModule }` instead of the component. React got an `object` where it expected a component the instant `<QRCode>` mounted (the `session && status === "pending"` branch) → white screen.

So it was a **desktop-only frontend CJS interop bug** — not a backend / Lark-env / empty-`qr_code_url` issue (those were ruled out: the field is correctly mapped `qr_code_url → qrCodeURL`, and the dep is installed + optimized).

## Fix

Switch the default import to the named import:

```diff
-import QRCode from "react-qr-code";
+import { QRCode } from "react-qr-code";
```

The named export maps straight to `exports.QRCode` and doesn't depend on the flaky default-interop path, so it resolves correctly under **both** bundlers. The package's own `types/index.d.ts` exports both the named class and the default, so it typechecks unchanged.

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] Manual (desktop, after `rm -rf apps/desktop/node_modules/.vite` + restart): Bind → QR renders, no white screen
- [x] Web unchanged (was already working)