### PR TITLE
VEN-994: fix autopilot stale issue run recovery

### DIFF
--- a/server/cmd/server/autopilot_failure_monitor_test.go
+++ b/server/cmd/server/autopilot_failure_monitor_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -157,6 +159,98 @@ func TestAutopilotFailureMonitor_PausesOffenderAndNotifiesCreator(t *testing.T) 
 	}
 	if !found {
 		t.Fatalf("expected an autopilot_paused inbox_item in DB for user %s", testUserID)
+	}
+}
+
+func TestDispatchAutopilotFailsStaleIssueCreatedRunsBeforeNewRun(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	agentID := pickFixtureAgent(t)
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Dispatch stale issue run",
+		AssigneeType:       "agent",
+		AssigneeID:         agentID,
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{String: "Dispatch stale issue run follow-up", Valid: true},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE origin_id = $1`, ap.ID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, description, status, priority,
+			assignee_type, assignee_id, creator_type, creator_id,
+			number, position, origin_type, origin_id
+		)
+		VALUES ($1, 'Stale autopilot issue', '', 'todo', 'none',
+			'agent', $2, 'agent', $2,
+			(SELECT COALESCE(MAX(number), 82649) + 1 FROM issue WHERE workspace_id = $1),
+			0, 'autopilot', $3)
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), agentID, ap.ID).Scan(&issueID); err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	var runID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, source, status, issue_id, created_at, triggered_at)
+		VALUES ($1, 'schedule', 'issue_created', $2, now() - interval '2 hours', now() - interval '2 hours')
+		RETURNING id::text
+	`, ap.ID, issueID).Scan(&runID); err != nil {
+		t.Fatalf("seed autopilot_run: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			completed_at, failure_reason, error, attempt, max_attempts
+		)
+		SELECT $1, runtime_id, $2, 'failed', 0,
+		       now() - interval '90 minutes', 'codex_semantic_inactivity',
+		       'codex app-server no progress timeout after 30s', 2, 2
+		FROM agent
+		WHERE id = $1
+	`, agentID, issueID); err != nil {
+		t.Fatalf("seed failed task: %v", err)
+	}
+
+	newRun, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if newRun == nil || newRun.Status != "issue_created" {
+		t.Fatalf("new run = %+v, want issue_created", newRun)
+	}
+
+	run, err := queries.GetAutopilotRun(ctx, parseUUID(runID))
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if run.Status != "failed" {
+		t.Fatalf("stale run status = %q, want failed", run.Status)
+	}
+	if !run.CompletedAt.Valid {
+		t.Fatal("stale run completed_at is invalid, want set")
+	}
+	if !run.FailureReason.Valid || !strings.Contains(run.FailureReason.String, "stale issue_created run") {
+		t.Fatalf("stale run failure_reason = %q, want stale issue_created run", run.FailureReason.String)
 	}
 }
 

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -39,6 +39,10 @@ type AutopilotService struct {
 // when computing next run times.
 const DefaultAutopilotTriggerTimezone = "UTC"
 
+const staleCreateIssueRunAge = 30 * time.Minute
+
+const staleCreateIssueRunFailureReason = "stale issue_created run: linked issue has failed tasks and no active task"
+
 func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *TaskService) *AutopilotService {
 	return &AutopilotService{Queries: q, TxStarter: tx, Bus: bus, TaskSvc: taskSvc}
 }
@@ -63,6 +67,8 @@ func (s *AutopilotService) DispatchAutopilot(
 	source string,
 	payload []byte,
 ) (*db.AutopilotRun, error) {
+	s.failStaleIssueCreatedRuns(ctx, autopilot)
+
 	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
 		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason)
 	}
@@ -485,6 +491,32 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 		FailureReason: pgtype.Text{String: reason, Valid: true},
 	}); err != nil {
 		slog.Warn("failed to mark autopilot run as failed", "run_id", util.UUIDToString(runID), "error", err)
+	}
+}
+
+func (s *AutopilotService) failStaleIssueCreatedRuns(ctx context.Context, ap db.Autopilot) {
+	staleBefore := time.Now().Add(-staleCreateIssueRunAge)
+	runs, err := s.Queries.FailStaleIssueCreatedAutopilotRunsForAutopilot(ctx, db.FailStaleIssueCreatedAutopilotRunsForAutopilotParams{
+		AutopilotID:   ap.ID,
+		CreatedBefore: pgtype.Timestamptz{Time: staleBefore, Valid: true},
+		FailureReason: pgtype.Text{String: staleCreateIssueRunFailureReason, Valid: true},
+	})
+	if err != nil {
+		slog.Warn("autopilot stale run recovery failed",
+			"autopilot_id", util.UUIDToString(ap.ID),
+			"error", err,
+		)
+		return
+	}
+	for _, run := range runs {
+		slog.Warn("autopilot stale issue_created run failed",
+			"autopilot_id", util.UUIDToString(ap.ID),
+			"run_id", util.UUIDToString(run.ID),
+			"issue_id", util.UUIDToString(run.IssueID),
+			"reason", staleCreateIssueRunFailureReason,
+		)
+		s.captureAutopilotRunFailed(ap, run, run.Source, staleCreateIssueRunFailureReason)
+		s.publishRunDone(util.UUIDToString(ap.WorkspaceID), run, "failed")
 	}
 }
 

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -51,15 +51,20 @@ func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *
 // It creates a run and either creates an issue or enqueues a direct agent task
 // depending on execution_mode.
 //
-// Before any work is queued we run an admission check against the assignee
+// Before run_only work is queued we run an admission check against the assignee
 // agent's runtime: if it is not online, we record a `skipped` run with a
 // failure_reason and return without enqueueing. This is the "触发时准入" gate
 // from MUL-1899 — without it a paused laptop / offline daemon causes scheduled
 // autopilots to pile thousands of doomed tasks onto agent_task_queue.
 //
+// create_issue mode is different: its primary contract is a durable audit
+// trail. If the assignee has a runtime but that runtime is merely offline,
+// dispatch still creates the issue and issue task so the work is visible and
+// can be claimed when the runtime returns.
+//
 // When assignee_type='squad' the gate runs against the squad leader (Path A
-// from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), so an offline or
-// archived leader produces the same skip behaviour as an offline solo agent.
+// from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), with the same
+// create_issue audit-trail exception for a merely offline leader runtime.
 func (s *AutopilotService) DispatchAutopilot(
 	ctx context.Context,
 	autopilot db.Autopilot,
@@ -67,10 +72,144 @@ func (s *AutopilotService) DispatchAutopilot(
 	source string,
 	payload []byte,
 ) (*db.AutopilotRun, error) {
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, pgtype.Timestamptz{})
+}
+
+// DispatchAutopilotForPlan is the entry point for scheduled triggers that
+// already know the canonical UTC plan_time of the occurrence they are
+// firing. The plan_time is persisted on autopilot_run.planned_at, and the
+// (trigger_id, planned_at) partial unique index — combined with this
+// method's idempotent lookup — guarantees that the SAME planned occurrence
+// cannot produce two SUCCESSFUL runs even if a stale-steal in
+// sys_cron_executions re-enters this method after a prior attempt.
+//
+// Semantics for an already-existing run at (trigger_id, planned_at):
+//
+//   - If the existing run is COMPLETE (terminal status, or in-flight
+//     with the appropriate downstream linkage — issue_id for
+//     create_issue, task_id for run_only), it is returned unchanged.
+//     The handler then writes SUCCESS in sys_cron_executions; no
+//     duplicate issue/task is produced.
+//   - If the existing run is in a PARTIAL state (a prior attempt
+//     wrote the run row but crashed before creating its downstream
+//     issue/task), it is marked FAILED with a recovery reason and
+//     its planned_at is cleared, releasing the partial-unique slot.
+//     Dispatch then proceeds normally and creates a fresh run at the
+//     same plan_time. Without this branch, a crash-during-dispatch
+//     would let a subsequent retry see the in-flight run, return it
+//     unchanged, and let the scheduler mark the occurrence SUCCESS
+//     without an actual issue/task ever being created (#4443 review).
+//
+// triggerID and plannedAt MUST both be valid; passing zero values
+// would silently disable the idempotency guard. Manual / webhook /
+// api callers should use DispatchAutopilot instead.
+func (s *AutopilotService) DispatchAutopilotForPlan(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	plannedAt time.Time,
+) (*db.AutopilotRun, error) {
+	if !triggerID.Valid {
+		return nil, fmt.Errorf("dispatch for plan: trigger_id is required")
+	}
+	if plannedAt.IsZero() {
+		return nil, fmt.Errorf("dispatch for plan: planned_at is required")
+	}
+	plannedTS := pgtype.Timestamptz{Time: plannedAt.UTC(), Valid: true}
+
+	// Fast path: prior attempt already created a run for this exact
+	// occurrence. The partial unique index uq_autopilot_run_trigger_planned
+	// would also reject a duplicate INSERT, but doing the lookup up
+	// front lets us short-circuit on a complete run and gives us a
+	// chance to recover a partial run before retrying.
+	existing, err := s.Queries.GetAutopilotRunByTriggerAndPlanned(ctx, db.GetAutopilotRunByTriggerAndPlannedParams{
+		TriggerID: triggerID,
+		PlannedAt: plannedTS,
+	})
+	switch {
+	case err == nil && isAutopilotRunComplete(existing):
+		// A prior attempt produced a complete run. Hand it back so the
+		// handler can record SUCCESS in sys_cron_executions without
+		// duplicating any downstream side effect.
+		return &existing, nil
+
+	case err == nil:
+		// Partial-state run from a crashed attempt. Mark it failed
+		// (with a recovery reason) and release its partial-unique
+		// slot so the fresh dispatch below can create a new row.
+		slog.Warn("autopilot dispatch for plan: recovering partial run",
+			"run_id", util.UUIDToString(existing.ID),
+			"trigger_id", util.UUIDToString(triggerID),
+			"planned_at", plannedAt.UTC().Format(time.RFC3339),
+			"status", existing.Status,
+			"issue_set", existing.IssueID.Valid,
+			"task_set", existing.TaskID.Valid,
+		)
+		if err := s.Queries.RecoverPartialAutopilotRun(ctx, existing.ID); err != nil {
+			return nil, fmt.Errorf("dispatch for plan: recover partial run: %w", err)
+		}
+		// Fall through to a fresh dispatch below.
+
+	case !errors.Is(err, pgx.ErrNoRows):
+		return nil, fmt.Errorf("dispatch for plan: lookup existing run: %w", err)
+	}
+
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, plannedTS)
+}
+
+// isAutopilotRunComplete decides whether an existing autopilot_run row
+// for (trigger_id, planned_at) is safe to reuse on a stale-steal retry.
+//
+// A run is "complete" if either:
+//
+//   - It is in a terminal state (completed / failed / skipped). Nothing
+//     more to do downstream; the caller can return it as-is.
+//
+//   - It is in-flight in a state whose downstream side effect is
+//     observable:
+//
+//   - issue_created with a valid issue_id — the issue exists and
+//     the issue-event listener owns task creation from here.
+//
+//   - running with a valid task_id — the task is queued, the
+//     listener will close the run when the task terminates.
+//
+// Anything else — most importantly issue_created/running with NULL
+// issue_id/task_id, or the brief 'pending' state — is a partial run:
+// the run row was inserted before the dispatch path could create the
+// downstream resource, and a stale-steal retry MUST NOT treat it as
+// complete (#4443 review).
+func isAutopilotRunComplete(run db.AutopilotRun) bool {
+	switch run.Status {
+	case "completed", "failed", "skipped":
+		return true
+	case "issue_created":
+		return run.IssueID.Valid
+	case "running":
+		return run.TaskID.Valid
+	default:
+		return false
+	}
+}
+
+// dispatchAutopilot is the shared core of the two public Dispatch entry
+// points. plannedAt is the canonical UTC plan_time for scheduled triggers;
+// for manual / webhook / api dispatch it is the zero pgtype.Timestamptz and
+// the resulting autopilot_run row has planned_at IS NULL.
+func (s *AutopilotService) dispatchAutopilot(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	plannedAt pgtype.Timestamptz,
+) (*db.AutopilotRun, error) {
 	s.failStaleIssueCreatedRuns(ctx, autopilot)
 
 	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
-		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason)
+		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, reason)
 	}
 
 	// Determine initial status based on execution mode.
@@ -86,6 +225,7 @@ func (s *AutopilotService) DispatchAutopilot(
 		Status:         initialStatus,
 		TriggerPayload: payload,
 		SquadID:        autopilotSquadAttribution(autopilot),
+		PlannedAt:      plannedAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create run: %w", err)
@@ -203,6 +343,25 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 		return fmt.Errorf("create issue: %w", err)
 	}
 
+	// Fan out the default subscriber template inside the same tx as the
+	// issue insert, before EventIssueCreated fires — so notification
+	// listeners see the full subscriber set on the first event instead of
+	// racing the listener that would otherwise hydrate the template.
+	templateSubs, err := qtx.ListAutopilotSubscribers(ctx, ap.ID)
+	if err != nil {
+		return fmt.Errorf("list autopilot subscribers: %w", err)
+	}
+	for _, sub := range templateSubs {
+		if err := qtx.AddIssueSubscriber(ctx, db.AddIssueSubscriberParams{
+			IssueID:  issue.ID,
+			UserType: sub.UserType,
+			UserID:   sub.UserID,
+			Reason:   "autopilot",
+		}); err != nil {
+			return fmt.Errorf("add autopilot subscriber to issue: %w", err)
+		}
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
@@ -233,18 +392,30 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 	})
 	s.captureIssueCreatedFromAutopilot(ap, run, issue, leader.ID)
 
+	// The issue:created notification listener only handles handler.IssueResponse
+	// payloads and only direct-notifies the assignee + @mentions; subscribers
+	// don't get an inbox at creation time on the manual path because there are
+	// none yet. The autopilot path is different: the template subscribers were
+	// fanned out into issue_subscriber inside the tx above, so they exist at the
+	// moment of creation and OQ3 says they should receive the same subscription
+	// events as reason='manual'. Issue creation is one such event — so write
+	// the inbox rows directly here. Done after commit so a failure here doesn't
+	// roll back the issue itself.
+	s.notifyAutopilotSubscribersOnCreate(ctx, ap, issue, leader.ID, templateSubs)
+
 	// Enqueue agent task via the existing flow. Squad-assigned autopilots
 	// route to the resolved leader as the executing agent (Path A from
 	// MUL-2429); agent-assigned autopilots go through the standard issue
 	// path. Both code paths land in agent_task_queue with agent_id = leader.
 	if ap.AssigneeType == "squad" {
-		// Fail-closed private-leader gate: if the leader is private, verify
-		// the autopilot creator still has access. This catches illegitimate
-		// configs that were saved before the save-time gate was added.
-		if leader.Visibility == "private" && !s.canCreatorAccessPrivateLeader(ctx, ap, leader) {
+		// Fail-closed invocation gate: verify the autopilot creator may still
+		// invoke the leader under the permission model. Catches configs that
+		// predate the save-time gate, and admin-created configs that no longer
+		// pass (MUL-3963).
+		if !s.canCreatorInvokeAgent(ctx, ap, leader) {
 			return fmt.Errorf("autopilot creator cannot access private squad leader")
 		}
-		if _, err := s.TaskSvc.EnqueueTaskForSquadLeader(ctx, issue, leader.ID, pgtype.UUID{}); err != nil {
+		if _, err := s.TaskSvc.EnqueueTaskForSquadLeader(ctx, issue, leader.ID, ap.AssigneeID, pgtype.UUID{}); err != nil {
 			return fmt.Errorf("enqueue squad leader task: %w", err)
 		}
 	} else {
@@ -261,6 +432,85 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 		"run_id", util.UUIDToString(run.ID),
 	)
 	return nil
+}
+
+// notifyAutopilotSubscribersOnCreate writes an inbox_item for each template
+// subscriber of an autopilot-created issue and broadcasts an inbox:new event
+// so the recipient's inbox updates in real time. Mirrors the inbox payload
+// shape from notification_listeners.go so the WS consumer sees the same fields
+// the listener-driven path produces. Failures are logged, not propagated:
+// the issue and its subscriber rows are already committed, and an inbox-write
+// hiccup must not bubble up as a dispatch failure.
+func (s *AutopilotService) notifyAutopilotSubscribersOnCreate(
+	ctx context.Context,
+	ap db.Autopilot,
+	issue db.Issue,
+	leaderID pgtype.UUID,
+	subscribers []db.AutopilotSubscriber,
+) {
+	if len(subscribers) == 0 {
+		return
+	}
+	details, _ := json.Marshal(map[string]string{
+		"autopilot_id": util.UUIDToString(ap.ID),
+		"reason":       "autopilot",
+	})
+	for _, sub := range subscribers {
+		// Autopilot subscribers are restricted to user_type='member' at the
+		// handler boundary; defend in case that constraint is ever relaxed
+		// (agents don't have inbox).
+		if sub.UserType != "member" {
+			continue
+		}
+		item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+			WorkspaceID:   ap.WorkspaceID,
+			RecipientType: "member",
+			RecipientID:   sub.UserID,
+			Type:          "issue_subscribed",
+			Severity:      "info",
+			IssueID:       issue.ID,
+			Title:         issue.Title,
+			Body:          pgtype.Text{},
+			ActorType:     pgtype.Text{String: "agent", Valid: true},
+			ActorID:       leaderID,
+			Details:       details,
+		})
+		if err != nil {
+			slog.Error("autopilot subscriber inbox write failed",
+				"autopilot_id", util.UUIDToString(ap.ID),
+				"issue_id", util.UUIDToString(issue.ID),
+				"recipient_id", util.UUIDToString(sub.UserID),
+				"error", err,
+			)
+			continue
+		}
+		s.Bus.Publish(events.Event{
+			Type:        protocol.EventInboxNew,
+			WorkspaceID: util.UUIDToString(ap.WorkspaceID),
+			ActorType:   "agent",
+			ActorID:     util.UUIDToString(leaderID),
+			Payload: map[string]any{
+				"item": map[string]any{
+					"id":             util.UUIDToString(item.ID),
+					"workspace_id":   util.UUIDToString(item.WorkspaceID),
+					"recipient_type": item.RecipientType,
+					"recipient_id":   util.UUIDToString(item.RecipientID),
+					"type":           item.Type,
+					"severity":       item.Severity,
+					"issue_id":       util.UUIDToPtr(item.IssueID),
+					"issue_status":   issue.Status,
+					"title":          item.Title,
+					"body":           util.TextToPtr(item.Body),
+					"read":           item.Read,
+					"archived":       item.Archived,
+					"created_at":     util.TimestampToString(item.CreatedAt),
+					"actor_type":     util.TextToPtr(item.ActorType),
+					"actor_id":       util.UUIDToPtr(item.ActorID),
+					"details":        json.RawMessage(item.Details),
+				},
+			},
+		})
+	}
 }
 
 // errDispatchSkipped wraps a readiness failure encountered after the
@@ -306,8 +556,8 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 		return &errDispatchSkipped{reason: formatAdmissionReason(ap, reason)}
 	}
 
-	// Fail-closed private-leader gate for squad autopilots.
-	if ap.AssigneeType == "squad" && agent.Visibility == "private" && !s.canCreatorAccessPrivateLeader(ctx, ap, agent) {
+	// Fail-closed invocation gate for squad autopilots.
+	if ap.AssigneeType == "squad" && !s.canCreatorInvokeAgent(ctx, ap, agent) {
 		return &errDispatchSkipped{reason: formatAdmissionReason(ap, "creator cannot access private squad leader")}
 	}
 
@@ -444,6 +694,79 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 	}
 }
 
+// SyncRunFromLinkedIssueTask fails a create_issue autopilot run when its
+// linked issue task fails terminally before the issue itself reaches a
+// terminal status. create_issue tasks are linked through issue_id rather than
+// autopilot_run_id, so SyncRunFromTask cannot see them directly. Without this
+// the run would hang in `issue_created` forever — and because the failure-rate
+// auto-pause monitor excludes issue_created/running runs, a consistently
+// failing autopilot would never trip the auto-pause either.
+//
+// "Terminal" means no task is still active for the issue. FailTask enqueues an
+// auto-retry for infra-shaped failures (timeout, runtime offline/recovery,
+// codex no-progress) BEFORE it broadcasts the failure event, so an active task
+// here means another attempt is already in flight — we wait for it instead of
+// failing the run prematurely. Once retries are exhausted (or the failure was
+// never retryable in the first place), the run fails carrying the task's reason.
+func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task db.AgentTaskQueue) {
+	if task.AutopilotRunID.Valid || !task.IssueID.Valid || task.Status != "failed" {
+		return
+	}
+	// Only create_issue runs link through issue_id (and their linked issue is
+	// always origin_type=autopilot by construction), so a hit here both
+	// identifies an in-flight create_issue run and bails the common case of
+	// ordinary issue/chat task failures after a single query.
+	run, err := s.Queries.GetAutopilotRunByIssue(ctx, task.IssueID)
+	if err != nil {
+		return // no active run linked to this issue
+	}
+	// A still-active task — typically the auto-retry FailTask just enqueued —
+	// means the dispatch isn't terminal yet; wait for the final attempt.
+	hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+	if err != nil {
+		slog.Warn("failed to check active tasks for autopilot issue failure",
+			"issue_id", util.UUIDToString(task.IssueID),
+			"task_id", util.UUIDToString(task.ID),
+			"error", err,
+		)
+		return
+	}
+	if hasActive {
+		return
+	}
+	autopilot, err := s.Queries.GetAutopilot(ctx, run.AutopilotID)
+	if err != nil {
+		return
+	}
+
+	reason := taskFailureReasonForAutopilotRun(task)
+	updatedRun, err := s.Queries.UpdateAutopilotRunFailed(ctx, db.UpdateAutopilotRunFailedParams{
+		ID:            run.ID,
+		FailureReason: pgtype.Text{String: reason, Valid: reason != ""},
+	})
+	if err != nil {
+		slog.Warn("failed to fail autopilot run from linked issue task",
+			"run_id", util.UUIDToString(run.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+			"task_id", util.UUIDToString(task.ID),
+			"error", err,
+		)
+		return
+	}
+	s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
+	s.publishRunDone(util.UUIDToString(autopilot.WorkspaceID), updatedRun, "failed")
+}
+
+func taskFailureReasonForAutopilotRun(task db.AgentTaskQueue) string {
+	if task.Error.Valid && strings.TrimSpace(task.Error.String) != "" {
+		return task.Error.String
+	}
+	if task.FailureReason.Valid && strings.TrimSpace(task.FailureReason.String) != "" {
+		return task.FailureReason.String
+	}
+	return "task failed"
+}
+
 // handleDispatchSkip recognises an errDispatchSkipped returned from a
 // dispatch function and rewrites the in-flight run to `skipped` (instead of
 // `failed`). Returns the updated run on a real skip, nil otherwise — callers
@@ -498,7 +821,7 @@ func (s *AutopilotService) failStaleIssueCreatedRuns(ctx context.Context, ap db.
 	staleBefore := time.Now().Add(-staleCreateIssueRunAge)
 	runs, err := s.Queries.FailStaleIssueCreatedAutopilotRunsForAutopilot(ctx, db.FailStaleIssueCreatedAutopilotRunsForAutopilotParams{
 		AutopilotID:   ap.ID,
-		CreatedBefore: pgtype.Timestamptz{Time: staleBefore, Valid: true},
+		CreatedAt:     pgtype.Timestamptz{Time: staleBefore, Valid: true},
 		FailureReason: pgtype.Text{String: staleCreateIssueRunFailureReason, Valid: true},
 	})
 	if err != nil {
@@ -583,33 +906,24 @@ func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopil
 		return "", false
 	}
 	if !ready {
-		return formatAdmissionReason(ap, reason), true
-	}
-	// Private-agent gate at the autopilot layer. Caller identity = the
-	// autopilot's creator: if the creator no longer has access to the
-	// (now-private) target agent, the dispatch is recorded as `skipped`.
-	// Agent-created autopilots bypass the gate to preserve A2A
-	// collaboration. Errors loading the workspace member fail closed —
-	// without an authoritative role the gate cannot grant access.
-	//
-	// For squad autopilots the gate runs against the resolved leader.
-	// Leader visibility is the right thing to check — if the human creator
-	// can no longer reach the leader, the autopilot would silently fail
-	// even though the squad itself looks intact.
-	if agent.Visibility == "private" && ap.CreatedByType == "member" {
-		creatorID := util.UUIDToString(ap.CreatedByID)
-		if util.UUIDToString(agent.OwnerID) != creatorID {
-			member, err := s.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
-				UserID:      ap.CreatedByID,
-				WorkspaceID: ap.WorkspaceID,
-			})
-			if err != nil {
-				return "autopilot creator no longer in workspace", true
-			}
-			if member.Role != "owner" && member.Role != "admin" {
-				return "autopilot creator lacks access to private assignee agent", true
-			}
+		if ap.ExecutionMode == "create_issue" && strings.HasPrefix(reason, "agent runtime is ") {
+			slog.Info("autopilot admission: allowing create_issue dispatch for offline runtime",
+				"autopilot_id", util.UUIDToString(ap.ID),
+				"runtime_id", util.UUIDToString(agent.RuntimeID),
+				"reason", reason,
+			)
+		} else {
+			return formatAdmissionReason(ap, reason), true
 		}
+	}
+	// Invocation gate at the autopilot layer (MUL-3963). Effective user = the
+	// autopilot's creator: if the creator may not invoke the target agent
+	// under the permission model, the dispatch is recorded as `skipped`.
+	// Admins do NOT bypass a private agent they do not own; agent-created
+	// autopilots are judged as workspace principals. For squad autopilots the
+	// gate runs against the resolved leader.
+	if !s.canCreatorInvokeAgent(ctx, ap, agent) {
+		return "autopilot creator lacks access to private assignee agent", true
 	}
 	return "", false
 }
@@ -708,6 +1022,7 @@ func (s *AutopilotService) recordSkippedRun(
 	triggerID pgtype.UUID,
 	source string,
 	payload []byte,
+	plannedAt pgtype.Timestamptz,
 	reason string,
 ) (*db.AutopilotRun, error) {
 	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
@@ -717,6 +1032,7 @@ func (s *AutopilotService) recordSkippedRun(
 		Status:         "skipped",
 		TriggerPayload: payload,
 		SquadID:        autopilotSquadAttribution(autopilot),
+		PlannedAt:      plannedAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create skipped run: %w", err)
@@ -1089,24 +1405,53 @@ func (s *AutopilotService) getIssuePrefix(workspaceID pgtype.UUID) string {
 	return ws.IssuePrefix
 }
 
-// canCreatorAccessPrivateLeader checks whether the autopilot's creator still
-// has access to a private leader agent. Mirrors handler.canAccessPrivateAgent
-// logic: agent creators always pass; member creators must be the agent owner
-// or a workspace owner/admin. Returns false (fail-closed) on any lookup error.
-func (s *AutopilotService) canCreatorAccessPrivateLeader(ctx context.Context, ap db.Autopilot, leader db.Agent) bool {
-	if ap.CreatedByType == "agent" {
-		return true
-	}
+// canCreatorInvokeAgent checks whether the autopilot's creator may invoke the
+// target agent under the invocation-permission model (MUL-3963). It mirrors
+// handler.canInvokeAgent with the autopilot creator as the effective user:
+//   - member creator who owns the agent -> always
+//   - private agent -> only the owner (NO admin bypass, NO agent-created bypass)
+//   - public_to agent -> workspace target admits any workspace-member creator
+//     (and agent-created autopilots as workspace principals); member target
+//     admits the matching creator; team targets are inert.
+//
+// Fail-closed on any lookup error.
+func (s *AutopilotService) canCreatorInvokeAgent(ctx context.Context, ap db.Autopilot, agent db.Agent) bool {
 	creatorID := util.UUIDToString(ap.CreatedByID)
-	if util.UUIDToString(leader.OwnerID) == creatorID {
+	if ap.CreatedByType == "member" && util.UUIDToString(agent.OwnerID) == creatorID {
 		return true
 	}
-	member, err := s.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
-		UserID:      ap.CreatedByID,
-		WorkspaceID: ap.WorkspaceID,
-	})
+	if agent.PermissionMode != "public_to" {
+		// private (or unknown mode): deny-by-default; only the owner branch
+		// above passes. Admins and agent-created autopilots do not bypass.
+		return false
+	}
+	targets, err := s.Queries.ListAgentInvocationTargets(ctx, agent.ID)
 	if err != nil {
 		return false
 	}
-	return member.Role == "owner" || member.Role == "admin"
+	// Agent-created autopilots are workspace-internal principals: a workspace
+	// target admits them. Member creators must be workspace members.
+	workspaceBroad := ap.CreatedByType == "agent"
+	isWorkspaceMember := false
+	if ap.CreatedByType == "member" {
+		if _, err := s.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+			UserID:      ap.CreatedByID,
+			WorkspaceID: ap.WorkspaceID,
+		}); err == nil {
+			isWorkspaceMember = true
+		}
+	}
+	for _, t := range targets {
+		switch t.TargetType {
+		case "workspace":
+			if isWorkspaceMember || workspaceBroad {
+				return true
+			}
+		case "member":
+			if ap.CreatedByType == "member" && util.UUIDToString(t.TargetID) == creatorID {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -369,6 +369,82 @@ func (q *Queries) FailAutopilotRunsByIssue(ctx context.Context, issueID pgtype.U
 	return err
 }
 
+const failStaleIssueCreatedAutopilotRunsForAutopilot = `-- name: FailStaleIssueCreatedAutopilotRunsForAutopilot :many
+WITH stale_runs AS (
+    SELECT ar.id
+    FROM autopilot_run ar
+    JOIN issue i ON i.id = ar.issue_id
+    WHERE ar.autopilot_id = $1
+      AND ar.status = 'issue_created'
+      AND ar.created_at < $2
+      AND i.status NOT IN ('in_review', 'done', 'blocked', 'cancelled')
+      AND EXISTS (
+          SELECT 1
+          FROM agent_task_queue failed
+          WHERE failed.issue_id = ar.issue_id
+            AND failed.status = 'failed'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM agent_task_queue active
+          WHERE active.issue_id = ar.issue_id
+            AND active.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+      )
+)
+UPDATE autopilot_run ar
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = $3
+FROM stale_runs
+WHERE ar.id = stale_runs.id
+RETURNING ar.id, ar.autopilot_id, ar.trigger_id, ar.source, ar.status, ar.issue_id, ar.task_id, ar.triggered_at, ar.completed_at, ar.failure_reason, ar.trigger_payload, ar.result, ar.created_at, ar.squad_id
+`
+
+type FailStaleIssueCreatedAutopilotRunsForAutopilotParams struct {
+	AutopilotID   pgtype.UUID        `json:"autopilot_id"`
+	CreatedBefore pgtype.Timestamptz `json:"created_before"`
+	FailureReason pgtype.Text        `json:"failure_reason"`
+}
+
+// Fails old create_issue runs whose linked issue has no active task but does
+// have at least one failed task. This is the recovery guard for scheduled
+// autopilots whose issue task exhausts retries and leaves the run stuck in
+// issue_created until the next scheduled tick.
+func (q *Queries) FailStaleIssueCreatedAutopilotRunsForAutopilot(ctx context.Context, arg FailStaleIssueCreatedAutopilotRunsForAutopilotParams) ([]AutopilotRun, error) {
+	rows, err := q.db.Query(ctx, failStaleIssueCreatedAutopilotRunsForAutopilot, arg.AutopilotID, arg.CreatedBefore, arg.FailureReason)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AutopilotRun{}
+	for rows.Next() {
+		var i AutopilotRun
+		if err := rows.Scan(
+			&i.ID,
+			&i.AutopilotID,
+			&i.TriggerID,
+			&i.Source,
+			&i.Status,
+			&i.IssueID,
+			&i.TaskID,
+			&i.TriggeredAt,
+			&i.CompletedAt,
+			&i.FailureReason,
+			&i.TriggerPayload,
+			&i.Result,
+			&i.CreatedAt,
+			&i.SquadID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAutopilot = `-- name: GetAutopilot :one
 SELECT id, workspace_id, title, description, assignee_id, status, execution_mode, issue_title_template, created_by_type, created_by_id, last_run_at, created_at, updated_at, assignee_type, project_id FROM autopilot
 WHERE id = $1

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -11,6 +11,58 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const addAutopilotCollaborator = `-- name: AddAutopilotCollaborator :one
+INSERT INTO autopilot_collaborator (autopilot_id, user_type, user_id, granted_by)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (autopilot_id, user_type, user_id)
+    DO UPDATE SET granted_by = EXCLUDED.granted_by
+RETURNING autopilot_id, user_type, user_id, granted_by, created_at
+`
+
+type AddAutopilotCollaboratorParams struct {
+	AutopilotID pgtype.UUID `json:"autopilot_id"`
+	UserType    string      `json:"user_type"`
+	UserID      pgtype.UUID `json:"user_id"`
+	GrantedBy   pgtype.UUID `json:"granted_by"`
+}
+
+// Re-granting an existing collaborator is a no-op that refreshes granted_by,
+// so the call is idempotent from the API boundary.
+func (q *Queries) AddAutopilotCollaborator(ctx context.Context, arg AddAutopilotCollaboratorParams) (AutopilotCollaborator, error) {
+	row := q.db.QueryRow(ctx, addAutopilotCollaborator,
+		arg.AutopilotID,
+		arg.UserType,
+		arg.UserID,
+		arg.GrantedBy,
+	)
+	var i AutopilotCollaborator
+	err := row.Scan(
+		&i.AutopilotID,
+		&i.UserType,
+		&i.UserID,
+		&i.GrantedBy,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const addAutopilotSubscriber = `-- name: AddAutopilotSubscriber :exec
+INSERT INTO autopilot_subscriber (autopilot_id, user_type, user_id)
+VALUES ($1, $2, $3)
+ON CONFLICT (autopilot_id, user_type, user_id) DO NOTHING
+`
+
+type AddAutopilotSubscriberParams struct {
+	AutopilotID pgtype.UUID `json:"autopilot_id"`
+	UserType    string      `json:"user_type"`
+	UserID      pgtype.UUID `json:"user_id"`
+}
+
+func (q *Queries) AddAutopilotSubscriber(ctx context.Context, arg AddAutopilotSubscriberParams) error {
+	_, err := q.db.Exec(ctx, addAutopilotSubscriber, arg.AutopilotID, arg.UserType, arg.UserID)
+	return err
+}
+
 const advanceTriggerNextRun = `-- name: AdvanceTriggerNextRun :exec
 UPDATE autopilot_trigger
 SET next_run_at = $2,
@@ -27,81 +79,6 @@ type AdvanceTriggerNextRunParams struct {
 func (q *Queries) AdvanceTriggerNextRun(ctx context.Context, arg AdvanceTriggerNextRunParams) error {
 	_, err := q.db.Exec(ctx, advanceTriggerNextRun, arg.ID, arg.NextRunAt)
 	return err
-}
-
-const claimDueScheduleTriggers = `-- name: ClaimDueScheduleTriggers :many
-
-UPDATE autopilot_trigger t
-SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
-  AND a.status = 'active'
-RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
-`
-
-type ClaimDueScheduleTriggersRow struct {
-	ID                   pgtype.UUID        `json:"id"`
-	AutopilotID          pgtype.UUID        `json:"autopilot_id"`
-	Kind                 string             `json:"kind"`
-	Enabled              bool               `json:"enabled"`
-	CronExpression       pgtype.Text        `json:"cron_expression"`
-	Timezone             pgtype.Text        `json:"timezone"`
-	NextRunAt            pgtype.Timestamptz `json:"next_run_at"`
-	WebhookToken         pgtype.Text        `json:"webhook_token"`
-	Label                pgtype.Text        `json:"label"`
-	LastFiredAt          pgtype.Timestamptz `json:"last_fired_at"`
-	CreatedAt            pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt            pgtype.Timestamptz `json:"updated_at"`
-	Provider             string             `json:"provider"`
-	SigningSecret        pgtype.Text        `json:"signing_secret"`
-	EventFilters         []byte             `json:"event_filters"`
-	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
-}
-
-// =====================
-// Scheduler Queries
-// =====================
-// Atomically claim all due schedule triggers to prevent concurrent execution.
-// Joins the autopilot table to ensure only active autopilots are fired.
-func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueScheduleTriggersRow, error) {
-	rows, err := q.db.Query(ctx, claimDueScheduleTriggers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ClaimDueScheduleTriggersRow{}
-	for rows.Next() {
-		var i ClaimDueScheduleTriggersRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.AutopilotID,
-			&i.Kind,
-			&i.Enabled,
-			&i.CronExpression,
-			&i.Timezone,
-			&i.NextRunAt,
-			&i.WebhookToken,
-			&i.Label,
-			&i.LastFiredAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.Provider,
-			&i.SigningSecret,
-			&i.EventFilters,
-			&i.AutopilotWorkspaceID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const createAutopilot = `-- name: CreateAutopilot :one
@@ -168,20 +145,21 @@ func (q *Queries) CreateAutopilot(ctx context.Context, arg CreateAutopilotParams
 const createAutopilotRun = `-- name: CreateAutopilotRun :one
 
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at
 ) VALUES (
     $1, $4, $2, $3, $5,
-    $6
-) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+    $6, $7
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type CreateAutopilotRunParams struct {
-	AutopilotID    pgtype.UUID `json:"autopilot_id"`
-	Source         string      `json:"source"`
-	Status         string      `json:"status"`
-	TriggerID      pgtype.UUID `json:"trigger_id"`
-	TriggerPayload []byte      `json:"trigger_payload"`
-	SquadID        pgtype.UUID `json:"squad_id"`
+	AutopilotID    pgtype.UUID        `json:"autopilot_id"`
+	Source         string             `json:"source"`
+	Status         string             `json:"status"`
+	TriggerID      pgtype.UUID        `json:"trigger_id"`
+	TriggerPayload []byte             `json:"trigger_payload"`
+	SquadID        pgtype.UUID        `json:"squad_id"`
+	PlannedAt      pgtype.Timestamptz `json:"planned_at"`
 }
 
 // =====================
@@ -191,6 +169,13 @@ type CreateAutopilotRunParams struct {
 // parent autopilot has assignee_type='squad', NULL otherwise. The executing
 // agent_id on agent_task_queue still records who actually ran the work
 // (the squad leader); squad_id lets reports group by squad without a join.
+//
+// planned_at carries the canonical UTC fire time for scheduled triggers
+// (source='schedule'); it stays NULL for manual / webhook / api sources
+// which have no canonical occurrence. Combined with the partial unique
+// index uq_autopilot_run_trigger_planned, this gives dispatch-layer
+// idempotency: a stale-steal retry at the same plan_time cannot create
+// a second run for the same (trigger_id, planned_at) pair (MUL-3551).
 func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRunParams) (AutopilotRun, error) {
 	row := q.db.QueryRow(ctx, createAutopilotRun,
 		arg.AutopilotID,
@@ -199,6 +184,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		arg.TriggerID,
 		arg.TriggerPayload,
 		arg.SquadID,
+		arg.PlannedAt,
 	)
 	var i AutopilotRun
 	err := row.Scan(
@@ -216,6 +202,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -224,7 +211,7 @@ const createAutopilotTask = `-- name: CreateAutopilotTask :one
 
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id, trigger_summary)
 VALUES ($1, $2, NULL, 'queued', $3, $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps
 `
 
 type CreateAutopilotTaskParams struct {
@@ -274,6 +261,15 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		&i.ForceFreshSession,
 		&i.IsLeaderTask,
 		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.SquadID,
+		&i.RuntimeMcpOverlay,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+		&i.OriginatorUserID,
+		&i.RuntimeConnectedApps,
 	)
 	return i, err
 }
@@ -346,6 +342,44 @@ func (q *Queries) DeleteAutopilot(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
+const deleteAutopilotCollaborator = `-- name: DeleteAutopilotCollaborator :exec
+DELETE FROM autopilot_collaborator
+WHERE autopilot_id = $1 AND user_type = $2 AND user_id = $3
+`
+
+type DeleteAutopilotCollaboratorParams struct {
+	AutopilotID pgtype.UUID `json:"autopilot_id"`
+	UserType    string      `json:"user_type"`
+	UserID      pgtype.UUID `json:"user_id"`
+}
+
+func (q *Queries) DeleteAutopilotCollaborator(ctx context.Context, arg DeleteAutopilotCollaboratorParams) error {
+	_, err := q.db.Exec(ctx, deleteAutopilotCollaborator, arg.AutopilotID, arg.UserType, arg.UserID)
+	return err
+}
+
+const deleteAutopilotCollaboratorsForAutopilot = `-- name: DeleteAutopilotCollaboratorsForAutopilot :exec
+DELETE FROM autopilot_collaborator
+WHERE autopilot_id = $1
+`
+
+// Application-layer cleanup run inside the autopilot delete transaction.
+func (q *Queries) DeleteAutopilotCollaboratorsForAutopilot(ctx context.Context, autopilotID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAutopilotCollaboratorsForAutopilot, autopilotID)
+	return err
+}
+
+const deleteAutopilotSubscribersForAutopilot = `-- name: DeleteAutopilotSubscribersForAutopilot :exec
+DELETE FROM autopilot_subscriber
+WHERE autopilot_id = $1
+`
+
+// Paired with a re-insert loop to implement full-replace PATCH semantics.
+func (q *Queries) DeleteAutopilotSubscribersForAutopilot(ctx context.Context, autopilotID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAutopilotSubscribersForAutopilot, autopilotID)
+	return err
+}
+
 const deleteAutopilotTrigger = `-- name: DeleteAutopilotTrigger :exec
 DELETE FROM autopilot_trigger WHERE id = $1
 `
@@ -397,12 +431,12 @@ SET status = 'failed',
     failure_reason = $3
 FROM stale_runs
 WHERE ar.id = stale_runs.id
-RETURNING ar.id, ar.autopilot_id, ar.trigger_id, ar.source, ar.status, ar.issue_id, ar.task_id, ar.triggered_at, ar.completed_at, ar.failure_reason, ar.trigger_payload, ar.result, ar.created_at, ar.squad_id
+RETURNING ar.id, ar.autopilot_id, ar.trigger_id, ar.source, ar.status, ar.issue_id, ar.task_id, ar.triggered_at, ar.completed_at, ar.failure_reason, ar.trigger_payload, ar.result, ar.created_at, ar.squad_id, ar.planned_at
 `
 
 type FailStaleIssueCreatedAutopilotRunsForAutopilotParams struct {
 	AutopilotID   pgtype.UUID        `json:"autopilot_id"`
-	CreatedBefore pgtype.Timestamptz `json:"created_before"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	FailureReason pgtype.Text        `json:"failure_reason"`
 }
 
@@ -411,7 +445,7 @@ type FailStaleIssueCreatedAutopilotRunsForAutopilotParams struct {
 // autopilots whose issue task exhausts retries and leaves the run stuck in
 // issue_created until the next scheduled tick.
 func (q *Queries) FailStaleIssueCreatedAutopilotRunsForAutopilot(ctx context.Context, arg FailStaleIssueCreatedAutopilotRunsForAutopilotParams) ([]AutopilotRun, error) {
-	rows, err := q.db.Query(ctx, failStaleIssueCreatedAutopilotRunsForAutopilot, arg.AutopilotID, arg.CreatedBefore, arg.FailureReason)
+	rows, err := q.db.Query(ctx, failStaleIssueCreatedAutopilotRunsForAutopilot, arg.AutopilotID, arg.CreatedAt, arg.FailureReason)
 	if err != nil {
 		return nil, err
 	}
@@ -434,6 +468,7 @@ func (q *Queries) FailStaleIssueCreatedAutopilotRunsForAutopilot(ctx context.Con
 			&i.Result,
 			&i.CreatedAt,
 			&i.SquadID,
+			&i.PlannedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -507,7 +542,7 @@ func (q *Queries) GetAutopilotInWorkspace(ctx context.Context, arg GetAutopilotI
 }
 
 const getAutopilotRun = `-- name: GetAutopilotRun :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE id = $1
 `
 
@@ -529,13 +564,14 @@ func (q *Queries) GetAutopilotRun(ctx context.Context, id pgtype.UUID) (Autopilo
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
 
 const getAutopilotRunByIssue = `-- name: GetAutopilotRunByIssue :one
 
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE issue_id = $1 AND status IN ('issue_created', 'running')
 LIMIT 1
 `
@@ -561,6 +597,50 @@ func (q *Queries) GetAutopilotRunByIssue(ctx context.Context, issueID pgtype.UUI
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
+	)
+	return i, err
+}
+
+const getAutopilotRunByTriggerAndPlanned = `-- name: GetAutopilotRunByTriggerAndPlanned :one
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
+WHERE trigger_id = $1
+  AND planned_at = $2
+LIMIT 1
+`
+
+type GetAutopilotRunByTriggerAndPlannedParams struct {
+	TriggerID pgtype.UUID        `json:"trigger_id"`
+	PlannedAt pgtype.Timestamptz `json:"planned_at"`
+}
+
+// Idempotent lookup used by DispatchAutopilotForPlan to detect a
+// crash-during-dispatch retry: if a row already exists for this
+// (trigger_id, planned_at), the caller reuses it instead of creating a
+// duplicate. The partial unique index covers the same key, so a race
+// between "look up then insert" still resolves to a single row — this
+// query is just the fast path that lets us skip the INSERT when we
+// can see the prior row clearly. Returns no rows for the (much more
+// common) first-time dispatch.
+func (q *Queries) GetAutopilotRunByTriggerAndPlanned(ctx context.Context, arg GetAutopilotRunByTriggerAndPlannedParams) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getAutopilotRunByTriggerAndPlanned, arg.TriggerID, arg.PlannedAt)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -649,8 +729,90 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 	return i, err
 }
 
+const isAutopilotCollaborator = `-- name: IsAutopilotCollaborator :one
+SELECT EXISTS (
+    SELECT 1 FROM autopilot_collaborator
+    WHERE autopilot_id = $1 AND user_type = 'member' AND user_id = $2
+) AS is_collaborator
+`
+
+type IsAutopilotCollaboratorParams struct {
+	AutopilotID pgtype.UUID `json:"autopilot_id"`
+	UserID      pgtype.UUID `json:"user_id"`
+}
+
+func (q *Queries) IsAutopilotCollaborator(ctx context.Context, arg IsAutopilotCollaboratorParams) (bool, error) {
+	row := q.db.QueryRow(ctx, isAutopilotCollaborator, arg.AutopilotID, arg.UserID)
+	var is_collaborator bool
+	err := row.Scan(&is_collaborator)
+	return is_collaborator, err
+}
+
+const listAutopilotCollaborators = `-- name: ListAutopilotCollaborators :many
+
+SELECT autopilot_id, user_type, user_id, granted_by, created_at FROM autopilot_collaborator
+WHERE autopilot_id = $1
+ORDER BY created_at ASC, user_id ASC
+`
+
+// =====================
+// Autopilot Collaborators
+// =====================
+// ORDER BY created_at keeps row rendering stable across refreshes.
+func (q *Queries) ListAutopilotCollaborators(ctx context.Context, autopilotID pgtype.UUID) ([]AutopilotCollaborator, error) {
+	rows, err := q.db.Query(ctx, listAutopilotCollaborators, autopilotID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AutopilotCollaborator{}
+	for rows.Next() {
+		var i AutopilotCollaborator
+		if err := rows.Scan(
+			&i.AutopilotID,
+			&i.UserType,
+			&i.UserID,
+			&i.GrantedBy,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAutopilotIDsForCollaborator = `-- name: ListAutopilotIDsForCollaborator :many
+SELECT autopilot_id FROM autopilot_collaborator
+WHERE user_type = 'member' AND user_id = $1
+`
+
+// Powers the per-row can_write flag on the list endpoint without an N+1.
+func (q *Queries) ListAutopilotIDsForCollaborator(ctx context.Context, userID pgtype.UUID) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listAutopilotIDsForCollaborator, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var autopilot_id pgtype.UUID
+		if err := rows.Scan(&autopilot_id); err != nil {
+			return nil, err
+		}
+		items = append(items, autopilot_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAutopilotRuns = `-- name: ListAutopilotRuns :many
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -686,6 +848,43 @@ func (q *Queries) ListAutopilotRuns(ctx context.Context, arg ListAutopilotRunsPa
 			&i.Result,
 			&i.CreatedAt,
 			&i.SquadID,
+			&i.PlannedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAutopilotSubscribers = `-- name: ListAutopilotSubscribers :many
+
+SELECT autopilot_id, user_type, user_id, created_at FROM autopilot_subscriber
+WHERE autopilot_id = $1
+ORDER BY created_at ASC, user_id ASC
+`
+
+// =====================
+// Autopilot Subscribers
+// =====================
+// ORDER BY created_at keeps chip rendering stable across refreshes.
+func (q *Queries) ListAutopilotSubscribers(ctx context.Context, autopilotID pgtype.UUID) ([]AutopilotSubscriber, error) {
+	rows, err := q.db.Query(ctx, listAutopilotSubscribers, autopilotID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AutopilotSubscriber{}
+	for rows.Next() {
+		var i AutopilotSubscriber
+		if err := rows.Scan(
+			&i.AutopilotID,
+			&i.UserType,
+			&i.UserID,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -745,10 +944,29 @@ func (q *Queries) ListAutopilotTriggers(ctx context.Context, autopilotID pgtype.
 
 const listAutopilots = `-- name: ListAutopilots :many
 
-SELECT id, workspace_id, title, description, assignee_id, status, execution_mode, issue_title_template, created_by_type, created_by_id, last_run_at, created_at, updated_at, assignee_type, project_id FROM autopilot
-WHERE workspace_id = $1
-  AND ($2::text IS NULL OR status = $2)
-ORDER BY created_at DESC
+SELECT
+  a.id, a.workspace_id, a.title, a.description, a.assignee_id, a.status, a.execution_mode, a.issue_title_template, a.created_by_type, a.created_by_id, a.last_run_at, a.created_at, a.updated_at, a.assignee_type, a.project_id,
+  (
+    SELECT array_agg(DISTINCT t.kind ORDER BY t.kind)
+    FROM autopilot_trigger t
+    WHERE t.autopilot_id = a.id AND t.enabled
+  )::text[] AS trigger_kinds,
+  (
+    SELECT min(t.next_run_at)
+    FROM autopilot_trigger t
+    WHERE t.autopilot_id = a.id AND t.enabled AND t.kind = 'schedule'
+  )::timestamptz AS next_run_at,
+  COALESCE((
+    SELECT r.status
+    FROM autopilot_run r
+    WHERE r.autopilot_id = a.id
+    ORDER BY r.triggered_at DESC
+    LIMIT 1
+  ), '')::text AS last_run_status
+FROM autopilot a
+WHERE a.workspace_id = $1
+  AND ($2::text IS NULL OR a.status = $2)
+ORDER BY a.created_at DESC
 `
 
 type ListAutopilotsParams struct {
@@ -756,34 +974,50 @@ type ListAutopilotsParams struct {
 	Status      pgtype.Text `json:"status"`
 }
 
+type ListAutopilotsRow struct {
+	Autopilot     Autopilot          `json:"autopilot"`
+	TriggerKinds  []string           `json:"trigger_kinds"`
+	NextRunAt     pgtype.Timestamptz `json:"next_run_at"`
+	LastRunStatus string             `json:"last_run_status"`
+}
+
 // =====================
 // Autopilot CRUD
 // =====================
-func (q *Queries) ListAutopilots(ctx context.Context, arg ListAutopilotsParams) ([]Autopilot, error) {
+// List rows carry three derived columns the list UI needs (trigger badges,
+// next run, last-run outcome) so the page never has to N+1 into the detail
+// endpoint. trigger_kinds/next_run_at only consider ENABLED triggers — the
+// columns answer "how does this fire today", not "what is configured".
+// last_run_status is COALESCEd to ” (never ran) because sqlc cannot infer
+// nullability through a scalar subquery; the handler maps ” back to omitted.
+func (q *Queries) ListAutopilots(ctx context.Context, arg ListAutopilotsParams) ([]ListAutopilotsRow, error) {
 	rows, err := q.db.Query(ctx, listAutopilots, arg.WorkspaceID, arg.Status)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Autopilot{}
+	items := []ListAutopilotsRow{}
 	for rows.Next() {
-		var i Autopilot
+		var i ListAutopilotsRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.WorkspaceID,
-			&i.Title,
-			&i.Description,
-			&i.AssigneeID,
-			&i.Status,
-			&i.ExecutionMode,
-			&i.IssueTitleTemplate,
-			&i.CreatedByType,
-			&i.CreatedByID,
-			&i.LastRunAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.AssigneeType,
-			&i.ProjectID,
+			&i.Autopilot.ID,
+			&i.Autopilot.WorkspaceID,
+			&i.Autopilot.Title,
+			&i.Autopilot.Description,
+			&i.Autopilot.AssigneeID,
+			&i.Autopilot.Status,
+			&i.Autopilot.ExecutionMode,
+			&i.Autopilot.IssueTitleTemplate,
+			&i.Autopilot.CreatedByType,
+			&i.Autopilot.CreatedByID,
+			&i.Autopilot.LastRunAt,
+			&i.Autopilot.CreatedAt,
+			&i.Autopilot.UpdatedAt,
+			&i.Autopilot.AssigneeType,
+			&i.Autopilot.ProjectID,
+			&i.TriggerKinds,
+			&i.NextRunAt,
+			&i.LastRunStatus,
 		); err != nil {
 			return nil, err
 		}
@@ -795,69 +1029,67 @@ func (q *Queries) ListAutopilots(ctx context.Context, arg ListAutopilotsParams) 
 	return items, nil
 }
 
-const recoverLostTriggers = `-- name: RecoverLostTriggers :many
+const listSchedulableAutopilotTriggers = `-- name: ListSchedulableAutopilotTriggers :many
 
-SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
+SELECT t.id, t.autopilot_id, t.cron_expression, t.timezone, t.created_at, t.last_fired_at
 FROM autopilot_trigger t
-JOIN autopilot a ON t.autopilot_id = a.id
+JOIN autopilot a ON a.id = t.autopilot_id
 WHERE t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NULL
-  AND t.cron_expression IS NOT NULL
+  AND t.enabled = TRUE
   AND a.status = 'active'
+  AND t.cron_expression IS NOT NULL
+  AND t.cron_expression <> ''
+ORDER BY t.id
 `
 
-type RecoverLostTriggersRow struct {
-	ID                   pgtype.UUID        `json:"id"`
-	AutopilotID          pgtype.UUID        `json:"autopilot_id"`
-	Kind                 string             `json:"kind"`
-	Enabled              bool               `json:"enabled"`
-	CronExpression       pgtype.Text        `json:"cron_expression"`
-	Timezone             pgtype.Text        `json:"timezone"`
-	NextRunAt            pgtype.Timestamptz `json:"next_run_at"`
-	WebhookToken         pgtype.Text        `json:"webhook_token"`
-	Label                pgtype.Text        `json:"label"`
-	LastFiredAt          pgtype.Timestamptz `json:"last_fired_at"`
-	CreatedAt            pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt            pgtype.Timestamptz `json:"updated_at"`
-	Provider             string             `json:"provider"`
-	SigningSecret        pgtype.Text        `json:"signing_secret"`
-	EventFilters         []byte             `json:"event_filters"`
-	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
+type ListSchedulableAutopilotTriggersRow struct {
+	ID             pgtype.UUID        `json:"id"`
+	AutopilotID    pgtype.UUID        `json:"autopilot_id"`
+	CronExpression pgtype.Text        `json:"cron_expression"`
+	Timezone       pgtype.Text        `json:"timezone"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	LastFiredAt    pgtype.Timestamptz `json:"last_fired_at"`
 }
 
 // =====================
-// Scheduler Recovery
+// Scheduler Queries
 // =====================
-// Finds schedule triggers that were claimed (next_run_at = NULL) but never
-// advanced — typically due to a scheduler crash. Returns them so the scheduler
-// can recompute next_run_at.
-func (q *Queries) RecoverLostTriggers(ctx context.Context) ([]RecoverLostTriggersRow, error) {
-	rows, err := q.db.Query(ctx, recoverLostTriggers)
+// Lists every schedule trigger the autopilot_schedule_dispatch JobSpec
+// should consider this tick. Returns just the columns the scheduler's
+// scope provider + PlansForScope hook need; the full trigger row is
+// re-loaded by the handler so a trigger update between scope-list and
+// handler-run sees the latest enabled / cron values.
+//
+// last_fired_at is read so the planner hook can anchor cold-start
+// enumeration on the most recent successful fire (set by either the
+// legacy goroutine before the new scheduler took over, or the new
+// scheduler's own post-dispatch advance — AdvanceTriggerNextRun, falling
+// back to TouchAutopilotTriggerFiredAt on a cron parse error). Without it,
+// a trigger that was created days ago and fired by the legacy code
+// looks like a brand-new trigger to the new scheduler on first tick
+// and the half-open `(created_at, now]` enumeration replays the most
+// recent already-fired occurrence — exactly the post-deploy
+// spurious-fire reported on MUL-3551 dev.
+//
+// Filters out webhook / api triggers, disabled triggers, paused/archived
+// autopilots, and any trigger missing its cron expression. ORDER BY id
+// keeps the per-tick scope list stable across replicas.
+func (q *Queries) ListSchedulableAutopilotTriggers(ctx context.Context) ([]ListSchedulableAutopilotTriggersRow, error) {
+	rows, err := q.db.Query(ctx, listSchedulableAutopilotTriggers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []RecoverLostTriggersRow{}
+	items := []ListSchedulableAutopilotTriggersRow{}
 	for rows.Next() {
-		var i RecoverLostTriggersRow
+		var i ListSchedulableAutopilotTriggersRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.AutopilotID,
-			&i.Kind,
-			&i.Enabled,
 			&i.CronExpression,
 			&i.Timezone,
-			&i.NextRunAt,
-			&i.WebhookToken,
-			&i.Label,
-			&i.LastFiredAt,
 			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.Provider,
-			&i.SigningSecret,
-			&i.EventFilters,
-			&i.AutopilotWorkspaceID,
+			&i.LastFiredAt,
 		); err != nil {
 			return nil, err
 		}
@@ -867,6 +1099,30 @@ func (q *Queries) RecoverLostTriggers(ctx context.Context) ([]RecoverLostTrigger
 		return nil, err
 	}
 	return items, nil
+}
+
+const recoverPartialAutopilotRun = `-- name: RecoverPartialAutopilotRun :exec
+UPDATE autopilot_run
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = 'recovered partial dispatch (crashed before downstream creation)',
+    planned_at = NULL
+WHERE id = $1
+`
+
+// Recovers a partial-state autopilot_run from a crashed first attempt
+// (the runner wrote the run row but died before creating the downstream
+// issue/task) so that a subsequent DispatchAutopilotForPlan call can
+// create a fresh run at the same (trigger_id, planned_at).
+//
+// Setting planned_at = NULL clears the partial-unique slot held by
+// uq_autopilot_run_trigger_planned, letting the new INSERT proceed.
+// The row stays in autopilot_run as a FAILED record (with a recovery
+// reason) so ops still see the abandoned attempt in the run history —
+// it is not silently deleted.
+func (q *Queries) RecoverPartialAutopilotRun(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, recoverPartialAutopilotRun, id)
+	return err
 }
 
 const rotateAutopilotTriggerWebhookToken = `-- name: RotateAutopilotTriggerWebhookToken :one
@@ -1198,7 +1454,7 @@ const updateAutopilotRunCompleted = `-- name: UpdateAutopilotRunCompleted :one
 UPDATE autopilot_run
 SET status = 'completed', completed_at = now(), result = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunCompletedParams struct {
@@ -1224,6 +1480,7 @@ func (q *Queries) UpdateAutopilotRunCompleted(ctx context.Context, arg UpdateAut
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1232,7 +1489,7 @@ const updateAutopilotRunFailed = `-- name: UpdateAutopilotRunFailed :one
 UPDATE autopilot_run
 SET status = 'failed', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunFailedParams struct {
@@ -1258,6 +1515,7 @@ func (q *Queries) UpdateAutopilotRunFailed(ctx context.Context, arg UpdateAutopi
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1266,7 +1524,7 @@ const updateAutopilotRunIssueCreated = `-- name: UpdateAutopilotRunIssueCreated 
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunIssueCreatedParams struct {
@@ -1292,6 +1550,7 @@ func (q *Queries) UpdateAutopilotRunIssueCreated(ctx context.Context, arg Update
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1300,7 +1559,7 @@ const updateAutopilotRunRunning = `-- name: UpdateAutopilotRunRunning :one
 UPDATE autopilot_run
 SET status = 'running', task_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunRunningParams struct {
@@ -1326,6 +1585,7 @@ func (q *Queries) UpdateAutopilotRunRunning(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1334,7 +1594,7 @@ const updateAutopilotRunSkipped = `-- name: UpdateAutopilotRunSkipped :one
 UPDATE autopilot_run
 SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunSkippedParams struct {
@@ -1366,6 +1626,7 @@ func (q *Queries) UpdateAutopilotRunSkipped(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1377,7 +1638,7 @@ SET status = 'skipped',
     failure_reason = $2,
     result = $3
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunSkippedWithResultParams struct {
@@ -1404,6 +1665,7 @@ func (q *Queries) UpdateAutopilotRunSkippedWithResult(ctx context.Context, arg U
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -267,6 +267,40 @@ SET status = 'failed', completed_at = now(), failure_reason = 'linked issue was 
 WHERE issue_id = $1
   AND status IN ('issue_created', 'running');
 
+-- name: FailStaleIssueCreatedAutopilotRunsForAutopilot :many
+-- Fails old create_issue runs whose linked issue has no active task but does
+-- have at least one failed task. This is the recovery guard for scheduled
+-- autopilots whose issue task exhausts retries and leaves the run stuck in
+-- issue_created until the next scheduled tick.
+WITH stale_runs AS (
+    SELECT ar.id
+    FROM autopilot_run ar
+    JOIN issue i ON i.id = ar.issue_id
+    WHERE ar.autopilot_id = $1
+      AND ar.status = 'issue_created'
+      AND ar.created_at < $2
+      AND i.status NOT IN ('in_review', 'done', 'blocked', 'cancelled')
+      AND EXISTS (
+          SELECT 1
+          FROM agent_task_queue failed
+          WHERE failed.issue_id = ar.issue_id
+            AND failed.status = 'failed'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM agent_task_queue active
+          WHERE active.issue_id = ar.issue_id
+            AND active.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+      )
+)
+UPDATE autopilot_run ar
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = $3
+FROM stale_runs
+WHERE ar.id = stale_runs.id
+RETURNING ar.*;
+
 -- =====================
 -- Scheduler Recovery
 -- =====================

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -3,10 +3,35 @@
 -- =====================
 
 -- name: ListAutopilots :many
-SELECT * FROM autopilot
-WHERE workspace_id = $1
-  AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status'))
-ORDER BY created_at DESC;
+-- List rows carry three derived columns the list UI needs (trigger badges,
+-- next run, last-run outcome) so the page never has to N+1 into the detail
+-- endpoint. trigger_kinds/next_run_at only consider ENABLED triggers — the
+-- columns answer "how does this fire today", not "what is configured".
+-- last_run_status is COALESCEd to '' (never ran) because sqlc cannot infer
+-- nullability through a scalar subquery; the handler maps '' back to omitted.
+SELECT
+  sqlc.embed(a),
+  (
+    SELECT array_agg(DISTINCT t.kind ORDER BY t.kind)
+    FROM autopilot_trigger t
+    WHERE t.autopilot_id = a.id AND t.enabled
+  )::text[] AS trigger_kinds,
+  (
+    SELECT min(t.next_run_at)
+    FROM autopilot_trigger t
+    WHERE t.autopilot_id = a.id AND t.enabled AND t.kind = 'schedule'
+  )::timestamptz AS next_run_at,
+  COALESCE((
+    SELECT r.status
+    FROM autopilot_run r
+    WHERE r.autopilot_id = a.id
+    ORDER BY r.triggered_at DESC
+    LIMIT 1
+  ), '')::text AS last_run_status
+FROM autopilot a
+WHERE a.workspace_id = $1
+  AND (sqlc.narg('status')::text IS NULL OR a.status = sqlc.narg('status'))
+ORDER BY a.created_at DESC;
 
 -- name: GetAutopilot :one
 SELECT * FROM autopilot
@@ -161,12 +186,51 @@ RETURNING *;
 -- parent autopilot has assignee_type='squad', NULL otherwise. The executing
 -- agent_id on agent_task_queue still records who actually ran the work
 -- (the squad leader); squad_id lets reports group by squad without a join.
+--
+-- planned_at carries the canonical UTC fire time for scheduled triggers
+-- (source='schedule'); it stays NULL for manual / webhook / api sources
+-- which have no canonical occurrence. Combined with the partial unique
+-- index uq_autopilot_run_trigger_planned, this gives dispatch-layer
+-- idempotency: a stale-steal retry at the same plan_time cannot create
+-- a second run for the same (trigger_id, planned_at) pair (MUL-3551).
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at
 ) VALUES (
     $1, sqlc.narg('trigger_id'), $2, $3, sqlc.narg('trigger_payload'),
-    sqlc.narg('squad_id')
+    sqlc.narg('squad_id'), sqlc.narg('planned_at')
 ) RETURNING *;
+
+-- name: GetAutopilotRunByTriggerAndPlanned :one
+-- Idempotent lookup used by DispatchAutopilotForPlan to detect a
+-- crash-during-dispatch retry: if a row already exists for this
+-- (trigger_id, planned_at), the caller reuses it instead of creating a
+-- duplicate. The partial unique index covers the same key, so a race
+-- between "look up then insert" still resolves to a single row — this
+-- query is just the fast path that lets us skip the INSERT when we
+-- can see the prior row clearly. Returns no rows for the (much more
+-- common) first-time dispatch.
+SELECT * FROM autopilot_run
+WHERE trigger_id = $1
+  AND planned_at = $2
+LIMIT 1;
+
+-- name: RecoverPartialAutopilotRun :exec
+-- Recovers a partial-state autopilot_run from a crashed first attempt
+-- (the runner wrote the run row but died before creating the downstream
+-- issue/task) so that a subsequent DispatchAutopilotForPlan call can
+-- create a fresh run at the same (trigger_id, planned_at).
+--
+-- Setting planned_at = NULL clears the partial-unique slot held by
+-- uq_autopilot_run_trigger_planned, letting the new INSERT proceed.
+-- The row stays in autopilot_run as a FAILED record (with a recovery
+-- reason) so ops still see the abandoned attempt in the run history —
+-- it is not silently deleted.
+UPDATE autopilot_run
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = 'recovered partial dispatch (crashed before downstream creation)',
+    planned_at = NULL
+WHERE id = $1;
 
 -- name: GetAutopilotRun :one
 SELECT * FROM autopilot_run
@@ -227,19 +291,36 @@ RETURNING *;
 -- Scheduler Queries
 -- =====================
 
--- name: ClaimDueScheduleTriggers :many
--- Atomically claim all due schedule triggers to prevent concurrent execution.
--- Joins the autopilot table to ensure only active autopilots are fired.
-UPDATE autopilot_trigger t
-SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
+-- name: ListSchedulableAutopilotTriggers :many
+-- Lists every schedule trigger the autopilot_schedule_dispatch JobSpec
+-- should consider this tick. Returns just the columns the scheduler's
+-- scope provider + PlansForScope hook need; the full trigger row is
+-- re-loaded by the handler so a trigger update between scope-list and
+-- handler-run sees the latest enabled / cron values.
+--
+-- last_fired_at is read so the planner hook can anchor cold-start
+-- enumeration on the most recent successful fire (set by either the
+-- legacy goroutine before the new scheduler took over, or the new
+-- scheduler's own post-dispatch advance — AdvanceTriggerNextRun, falling
+-- back to TouchAutopilotTriggerFiredAt on a cron parse error). Without it,
+-- a trigger that was created days ago and fired by the legacy code
+-- looks like a brand-new trigger to the new scheduler on first tick
+-- and the half-open `(created_at, now]` enumeration replays the most
+-- recent already-fired occurrence — exactly the post-deploy
+-- spurious-fire reported on MUL-3551 dev.
+--
+-- Filters out webhook / api triggers, disabled triggers, paused/archived
+-- autopilots, and any trigger missing its cron expression. ORDER BY id
+-- keeps the per-tick scope list stable across replicas.
+SELECT t.id, t.autopilot_id, t.cron_expression, t.timezone, t.created_at, t.last_fired_at
+FROM autopilot_trigger t
+JOIN autopilot a ON a.id = t.autopilot_id
+WHERE t.kind = 'schedule'
+  AND t.enabled = TRUE
   AND a.status = 'active'
-RETURNING t.*, a.workspace_id AS autopilot_workspace_id;
+  AND t.cron_expression IS NOT NULL
+  AND t.cron_expression <> ''
+ORDER BY t.id;
 
 -- =====================
 -- Task Queue (run_only mode)
@@ -302,23 +383,6 @@ WHERE ar.id = stale_runs.id
 RETURNING ar.*;
 
 -- =====================
--- Scheduler Recovery
--- =====================
-
--- name: RecoverLostTriggers :many
--- Finds schedule triggers that were claimed (next_run_at = NULL) but never
--- advanced — typically due to a scheduler crash. Returns them so the scheduler
--- can recompute next_run_at.
-SELECT t.*, a.workspace_id AS autopilot_workspace_id
-FROM autopilot_trigger t
-JOIN autopilot a ON t.autopilot_id = a.id
-WHERE t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NULL
-  AND t.cron_expression IS NOT NULL
-  AND a.status = 'active';
-
--- =====================
 -- Failure-rate auto-pause
 -- =====================
 
@@ -362,3 +426,62 @@ UPDATE autopilot
 SET status = 'paused', updated_at = now()
 WHERE id = $1 AND status = 'active'
 RETURNING *;
+
+-- =====================
+-- Autopilot Subscribers
+-- =====================
+
+-- name: ListAutopilotSubscribers :many
+-- ORDER BY created_at keeps chip rendering stable across refreshes.
+SELECT * FROM autopilot_subscriber
+WHERE autopilot_id = $1
+ORDER BY created_at ASC, user_id ASC;
+
+-- name: AddAutopilotSubscriber :exec
+INSERT INTO autopilot_subscriber (autopilot_id, user_type, user_id)
+VALUES ($1, $2, $3)
+ON CONFLICT (autopilot_id, user_type, user_id) DO NOTHING;
+
+-- name: DeleteAutopilotSubscribersForAutopilot :exec
+-- Paired with a re-insert loop to implement full-replace PATCH semantics.
+DELETE FROM autopilot_subscriber
+WHERE autopilot_id = $1;
+
+-- =====================
+-- Autopilot Collaborators
+-- =====================
+
+-- name: ListAutopilotCollaborators :many
+-- ORDER BY created_at keeps row rendering stable across refreshes.
+SELECT * FROM autopilot_collaborator
+WHERE autopilot_id = $1
+ORDER BY created_at ASC, user_id ASC;
+
+-- name: AddAutopilotCollaborator :one
+-- Re-granting an existing collaborator is a no-op that refreshes granted_by,
+-- so the call is idempotent from the API boundary.
+INSERT INTO autopilot_collaborator (autopilot_id, user_type, user_id, granted_by)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (autopilot_id, user_type, user_id)
+    DO UPDATE SET granted_by = EXCLUDED.granted_by
+RETURNING *;
+
+-- name: DeleteAutopilotCollaborator :exec
+DELETE FROM autopilot_collaborator
+WHERE autopilot_id = $1 AND user_type = $2 AND user_id = $3;
+
+-- name: DeleteAutopilotCollaboratorsForAutopilot :exec
+-- Application-layer cleanup run inside the autopilot delete transaction.
+DELETE FROM autopilot_collaborator
+WHERE autopilot_id = $1;
+
+-- name: IsAutopilotCollaborator :one
+SELECT EXISTS (
+    SELECT 1 FROM autopilot_collaborator
+    WHERE autopilot_id = $1 AND user_type = 'member' AND user_id = $2
+) AS is_collaborator;
+
+-- name: ListAutopilotIDsForCollaborator :many
+-- Powers the per-row can_write flag on the list endpoint without an N+1.
+SELECT autopilot_id FROM autopilot_collaborator
+WHERE user_type = 'member' AND user_id = $1;


### PR DESCRIPTION
## Summary
- fail stale `create_issue` autopilot runs before dispatching a new run for the same autopilot
- detect linked issues with failed tasks and no active task, then mark the old run failed with a visible reason
- add an integration regression covering a stale `issue_created` run before a new scheduled dispatch

## Root Cause
Scheduled `create_issue` autopilots could leave a run in `issue_created` when the linked issue task exhausted retries without the issue reaching a terminal status. The next scheduled run then created another daily issue while the prior run remained invisible to terminal-run failure monitoring.

## Multica Links
Closes VEN-349
Closes VEN-994

## Validation
- `go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate`
- `go test ./internal/service -count=1`
- `go test ./cmd/server -run TestDispatchAutopilotFailsStaleIssueCreatedRunsBeforeNewRun -count=1`
- `go test ./internal/handler -run TestScheduledAutopilotAllowsActiveDuplicateIssue -count=1`
- `go build ./...`
- `go test -race ./cmd/server ./internal/service ./internal/handler`
- `git diff --check`

## Current Maintainer Note
This PR still needs a maintainer token with GitHub `workflow` scope, or an upstream-branch push path, to update the PR branch with current `main`. The available token only has `repo` scope, and GitHub rejects pushes that bring in upstream commits touching `.github/workflows/ci.yml`.

`go test -race ./...` was also attempted locally and failed in unrelated `server/pkg/agent` local-environment/timing tests:
- `TestLoadConfig_SkipsMulticaHooksShadowingAgentBinaries`
- `TestLoadConfig_SkipsMulticaHooksFromLoginShellFallback`
- `TestLoadConfig_UsesCodexDesktopAppBundleFallback`
- `TestExecuteAndDrain_IdleWatchdog_FiresOnInactivity`
- `TestWatchTaskCancellation_RunningTaskNotInterrupted`
