### PR TITLE
[codex] recover stale codex executable path

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -68,6 +68,8 @@ type codexTimeoutDiagnostic struct {
 	CodexVersion string
 }
 
+var codexLookPath = exec.LookPath
+
 // codexBackend implements Backend by spawning `codex app-server --listen stdio://`
 // and communicating via JSON-RPC 2.0 over stdin/stdout.
 type codexBackend struct {
@@ -490,12 +492,9 @@ func isCodexBareTomlKey(s string) bool {
 }
 
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
-	execPath := b.cfg.ExecutablePath
-	if execPath == "" {
-		execPath = "codex"
-	}
-	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("codex executable not found at %q: %w", execPath, err)
+	execPath, err := resolveCodexExecPath(b.cfg.ExecutablePath)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := opts.Timeout
@@ -865,6 +864,23 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func resolveCodexExecPath(configured string) (string, error) {
+	execPath := strings.TrimSpace(configured)
+	if execPath == "" {
+		execPath = "codex"
+	}
+	resolved, err := codexLookPath(execPath)
+	if err == nil {
+		return resolved, nil
+	}
+	if configured != "" && filepath.Base(execPath) == "codex" {
+		if fallback, fallbackErr := codexLookPath("codex"); fallbackErr == nil {
+			return fallback, nil
+		}
+	}
+	return "", fmt.Errorf("codex executable not found at %q: %w", execPath, err)
 }
 
 // startOrResumeThread picks between Codex's thread/resume and thread/start

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1131,6 +1131,31 @@ func TestCodexExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
 	}
 }
 
+func TestResolveCodexExecPathFallsBackToPathWhenConfiguredCodexPathIsStale(t *testing.T) {
+	stalePath := filepath.Join(t.TempDir(), "codex")
+	fallbackPath := filepath.Join(t.TempDir(), "bin", "codex")
+	oldLookPath := codexLookPath
+	codexLookPath = func(file string) (string, error) {
+		switch file {
+		case stalePath:
+			return "", os.ErrNotExist
+		case "codex":
+			return fallbackPath, nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	defer func() { codexLookPath = oldLookPath }()
+
+	got, err := resolveCodexExecPath(stalePath)
+	if err != nil {
+		t.Fatalf("resolveCodexExecPath: %v", err)
+	}
+	if got != fallbackPath {
+		t.Fatalf("expected fallback path %q, got %q", fallbackPath, got)
+	}
+}
+
 func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary
- Adds a Codex executable resolver that validates the configured path first.
- Falls back to `PATH` only when the configured executable basename is `codex`, covering stale absolute Codex paths such as `/usr/local/bin/codex`.
- Keeps unrelated explicit executable paths failing normally and adds a focused regression test for the fallback.

## Context
VEN-352 / VEN-351 follow-up. Review Artifact Repair Engineer failed with `codex executable not found at /usr/local/bin/codex` after Codex moved on the host.

## Verification
- RED: `cd server && go test ./pkg/agent -run TestResolveCodexExecPathFallsBackToPathWhenConfiguredCodexPathIsStale -count=1` failed before production code with undefined resolver symbols.
- GREEN: `cd server && go test ./pkg/agent -run TestResolveCodexExecPathFallsBackToPathWhenConfiguredCodexPathIsStale -count=1` passed: `ok github.com/multica-ai/multica/server/pkg/agent 0.469s`.
- Broader check: `cd server && go test ./pkg/agent -count=1` still fails in existing Codex timeout tests under package-wide load: `TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress`, `TestCodexExecuteSemanticInactivityAllowsContinuousMessages`, and `TestCodexExecuteLegacyFirstTurnMessageSatisfiesProgress`.

## Risk
Low. The fallback path is limited to configured executables whose basename is exactly `codex`; non-Codex explicit paths continue to surface the original lookup error.
