### PR TITLE
fix(views): left-align picker item rows

### DIFF
--- a/packages/views/chat/components/chat-window.agent-dropdown.test.tsx
+++ b/packages/views/chat/components/chat-window.agent-dropdown.test.tsx
@@ -109,6 +109,18 @@ describe("AgentDropdown", () => {
     expect(screen.queryByText("Others")).not.toBeInTheDocument();
   });
 
+  it("left-aligns agent picker rows", async () => {
+    renderDropdown();
+
+    const dialog = await screen.findByRole("dialog");
+    const alphaRow = Array.from(
+      dialog.querySelectorAll<HTMLButtonElement>("button[data-picker-item]"),
+    ).find((row) => row.textContent?.includes("Alpha"));
+
+    expect(alphaRow).toBeDefined();
+    expect(alphaRow).toHaveClass("text-left");
+  });
+
   it("keeps the current agent marked and selects another agent", async () => {
     const { onSelect } = renderDropdown();
 

--- a/packages/views/issues/components/pickers/property-picker.tsx
+++ b/packages/views/issues/components/pickers/property-picker.tsx
@@ -217,7 +217,7 @@ export function PickerItem({
       data-picker-item
       disabled={disabled}
       onClick={onClick}
-      className={`flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-sm ${disabled ? "opacity-50 cursor-not-allowed" : hoverClassName ?? "hover:bg-accent"} transition-colors`}
+      className={`flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left text-sm ${disabled ? "opacity-50 cursor-not-allowed" : hoverClassName ?? "hover:bg-accent"} transition-colors`}
     >
       {/* min-w-0 lets long children (like truncated label names) shrink
           inside the flex row instead of pushing the selected checkmark off


### PR DESCRIPTION
## Summary
- Add `text-left` to the shared `PickerItem` button class.
- Add an agent dropdown regression test asserting picker rows carry `text-left`.

## Test Plan
- `corepack pnpm --filter @multica/views exec vitest run chat/components/chat-window.agent-dropdown.test.tsx`
- `corepack pnpm --filter @multica/views typecheck`
- `corepack pnpm --filter @multica/views lint` (passes with existing warnings)

Fixes the visual alignment regression from #3709.
