### PR TITLE
MAG-307 fix Close autopilot failures

### DIFF
--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -268,6 +268,176 @@ func TestAutopilotCreateIssueBatchFailureBlocksIssueWithResultComment(t *testing
 	}
 }
 
+func TestAutopilotCreateIssueBatchFailureLinksContinuationIssue(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text, runtime_id::text
+		FROM agent
+		WHERE workspace_id = $1 AND runtime_id IS NOT NULL
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("load fixture agent/runtime: %v", err)
+	}
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Continuation-link autopilot {{date}}",
+		Description:        pgtype.Text{String: "MAG-307 continuation regression", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{String: "Continuation-link autopilot {{date}}", Valid: true},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	oldNumber, err := queries.IncrementIssueCounter(ctx, parseUUID(testWorkspaceID))
+	if err != nil {
+		t.Fatalf("IncrementIssueCounter old: %v", err)
+	}
+	nextNumber, err := queries.IncrementIssueCounter(ctx, parseUUID(testWorkspaceID))
+	if err != nil {
+		t.Fatalf("IncrementIssueCounter next: %v", err)
+	}
+
+	var oldIssueID, continuationIssueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority,
+			creator_type, creator_id, assignee_type, assignee_id,
+			origin_type, origin_id, number, position, created_at
+		)
+		VALUES ($1, 'Continuation old window', 'in_progress', 'none',
+			'agent', $2, 'agent', $2, 'autopilot', $3, $4, 0, now() - interval '2 hours')
+		RETURNING id::text
+	`, testWorkspaceID, agentID, ap.ID, oldNumber).Scan(&oldIssueID); err != nil {
+		t.Fatalf("create old autopilot issue: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority,
+			creator_type, creator_id, assignee_type, assignee_id,
+			origin_type, origin_id, number, position, created_at
+		)
+		VALUES ($1, 'Continuation follow-up window', 'in_progress', 'none',
+			'agent', $2, 'agent', $2, 'autopilot', $3, $4, 0, now() - interval '1 hour')
+		RETURNING id::text
+	`, testWorkspaceID, agentID, ap.ID, nextNumber).Scan(&continuationIssueID); err != nil {
+		t.Fatalf("create continuation autopilot issue: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`, oldIssueID, continuationIssueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id IN ($1, $2)`, oldIssueID, continuationIssueID)
+	})
+
+	oldRun, err := queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID: ap.ID,
+		Source:      "schedule",
+		Status:      "issue_created",
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotRun old: %v", err)
+	}
+	oldRun, err = queries.UpdateAutopilotRunIssueCreated(ctx, db.UpdateAutopilotRunIssueCreatedParams{
+		ID:      oldRun.ID,
+		IssueID: parseUUID(oldIssueID),
+	})
+	if err != nil {
+		t.Fatalf("UpdateAutopilotRunIssueCreated old: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE autopilot_run
+		SET created_at = now() - interval '2 hours',
+		    triggered_at = now() - interval '2 hours'
+		WHERE id = $1
+	`, oldRun.ID); err != nil {
+		t.Fatalf("backdate old run: %v", err)
+	}
+
+	nextRun, err := queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID: ap.ID,
+		Source:      "schedule",
+		Status:      "issue_created",
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotRun next: %v", err)
+	}
+	nextRun, err = queries.UpdateAutopilotRunIssueCreated(ctx, db.UpdateAutopilotRunIssueCreatedParams{
+		ID:      nextRun.ID,
+		IssueID: parseUUID(continuationIssueID),
+	})
+	if err != nil {
+		t.Fatalf("UpdateAutopilotRunIssueCreated next: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE autopilot_run
+		SET created_at = now() - interval '1 hour',
+		    triggered_at = now() - interval '1 hour'
+		WHERE id = $1
+	`, nextRun.ID); err != nil {
+		t.Fatalf("backdate next run: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			dispatched_at, started_at, completed_at,
+			error, failure_reason, attempt, max_attempts
+		)
+		VALUES ($1, $2, $3, 'failed', 0,
+			now() - interval '3 minutes',
+			now() - interval '2 minutes',
+			now(),
+			'runtime went offline while task was running',
+			'runtime_offline',
+			2, 2)
+		RETURNING id::text
+	`, agentID, runtimeID, oldIssueID).Scan(&taskID); err != nil {
+		t.Fatalf("create failed task: %v", err)
+	}
+
+	task, err := queries.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatalf("GetAgentTask: %v", err)
+	}
+	if got := taskSvc.HandleFailedTasks(ctx, []db.AgentTaskQueue{task}); got != 0 {
+		t.Fatalf("HandleFailedTasks retried %d tasks, want 0", got)
+	}
+
+	var comment string
+	if err := testPool.QueryRow(ctx, `
+		SELECT content FROM comment
+		WHERE issue_id = $1 AND type = 'system'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, oldIssueID).Scan(&comment); err != nil {
+		t.Fatalf("load result comment: %v", err)
+	}
+	if !strings.Contains(comment, "continuation_issue:") ||
+		!strings.Contains(comment, "mention://issue/"+continuationIssueID) {
+		t.Fatalf("result comment missing continuation link to %s:\n%s", continuationIssueID, comment)
+	}
+	if strings.Contains(comment, "No continuation issue was identified automatically") {
+		t.Fatalf("result comment should not claim no continuation when one exists:\n%s", comment)
+	}
+}
+
 // TestAutopilotDispatchSkipsWhenRuntimeOffline locks in the MUL-1899
 // admission gate: when the assignee agent's runtime is not online we must
 // record a `skipped` autopilot_run with a failure_reason and NOT enqueue an

--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -122,6 +122,152 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 	}
 }
 
+func TestAutopilotCreateIssueBatchFailureBlocksIssueWithResultComment(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text, runtime_id::text
+		FROM agent
+		WHERE workspace_id = $1 AND runtime_id IS NOT NULL
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("load fixture agent/runtime: %v", err)
+	}
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Batch failure create_issue autopilot",
+		Description:        pgtype.Text{String: "MAG-307 regression", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	issueNumber, err := queries.IncrementIssueCounter(ctx, parseUUID(testWorkspaceID))
+	if err != nil {
+		t.Fatalf("IncrementIssueCounter: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority,
+			creator_type, creator_id, assignee_type, assignee_id,
+			origin_type, origin_id, number, position
+		)
+		VALUES ($1, 'MAG-307 autopilot failure fixture', 'in_progress', 'none',
+			'agent', $2, 'agent', $2, 'autopilot', $3, $4, 0)
+		RETURNING id::text
+	`, testWorkspaceID, agentID, ap.ID, issueNumber).Scan(&issueID); err != nil {
+		t.Fatalf("create autopilot issue: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	run, err := queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID: ap.ID,
+		Source:      "schedule",
+		Status:      "issue_created",
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotRun: %v", err)
+	}
+	run, err = queries.UpdateAutopilotRunIssueCreated(ctx, db.UpdateAutopilotRunIssueCreatedParams{
+		ID:      run.ID,
+		IssueID: parseUUID(issueID),
+	})
+	if err != nil {
+		t.Fatalf("UpdateAutopilotRunIssueCreated: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			dispatched_at, started_at, completed_at,
+			error, failure_reason, attempt, max_attempts
+		)
+		VALUES ($1, $2, $3, 'failed', 0,
+			now() - interval '3 minutes',
+			now() - interval '2 minutes',
+			now(),
+			'runtime went offline while task was running',
+			'runtime_offline',
+			2, 2)
+		RETURNING id::text
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("create failed task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+	})
+
+	task, err := queries.GetAgentTask(ctx, parseUUID(taskID))
+	if err != nil {
+		t.Fatalf("GetAgentTask: %v", err)
+	}
+	if got := taskSvc.HandleFailedTasks(ctx, []db.AgentTaskQueue{task}); got != 0 {
+		t.Fatalf("HandleFailedTasks retried %d tasks, want 0", got)
+	}
+
+	updatedIssue, err := queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if updatedIssue.Status != "blocked" {
+		t.Fatalf("issue status = %q, want blocked", updatedIssue.Status)
+	}
+
+	var comment string
+	if err := testPool.QueryRow(ctx, `
+		SELECT content FROM comment
+		WHERE issue_id = $1 AND type = 'system'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, issueID).Scan(&comment); err != nil {
+		t.Fatalf("load result comment: %v", err)
+	}
+	for _, want := range []string{
+		"failure_reason: runtime_offline",
+		"attempts: 2/2",
+		"runtime_id: " + runtimeID,
+		"No continuation issue was identified automatically",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("result comment missing %q:\n%s", want, comment)
+		}
+	}
+
+	updatedRun, err := queries.GetAutopilotRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updatedRun.Status != "failed" {
+		t.Fatalf("run status = %q, want failed", updatedRun.Status)
+	}
+	if !updatedRun.FailureReason.Valid || updatedRun.FailureReason.String != "runtime_offline" {
+		t.Fatalf("run failure_reason = %+v, want runtime_offline", updatedRun.FailureReason)
+	}
+}
+
 // TestAutopilotDispatchSkipsWhenRuntimeOffline locks in the MUL-1899
 // admission gate: when the assignee agent's runtime is not online we must
 // record a `skipped` autopilot_run with a failure_reason and NOT enqueue an

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1104,6 +1104,17 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if failed, ferr := h.failAutopilotClaimWhenExecutionIdentityUnresolved(r.Context(), runtime, *task); failed {
+		if ferr != nil {
+			outcome = "error_execution_identity"
+			writeError(w, http.StatusInternalServerError, "failed to close out task execution identity failure")
+			return
+		}
+		outcome = "execution_identity_unresolved"
+		writeJSON(w, http.StatusOK, map[string]any{"task": nil})
+		return
+	}
+
 	outcome = "claimed"
 	buildStart = time.Now()
 
@@ -1636,6 +1647,56 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID)
 	writeJSON(w, http.StatusOK, map[string]any{"task": resp})
+}
+
+func (h *Handler) failAutopilotClaimWhenExecutionIdentityUnresolved(ctx context.Context, runtime db.AgentRuntime, task db.AgentTaskQueue) (bool, error) {
+	reason := h.autopilotClaimExecutionIdentityFailureReason(ctx, runtime, task)
+	if reason == "" {
+		return false, nil
+	}
+	failed, err := h.TaskService.FailTask(ctx, task.ID, reason, "", "", "execution_identity_unresolved")
+	if err != nil {
+		slog.Warn("task claim: failed to close out unresolved autopilot execution identity",
+			"task_id", uuidToString(task.ID),
+			"runtime_id", uuidToString(runtime.ID),
+			"error", err,
+		)
+		return true, err
+	}
+	slog.Warn("task claim: autopilot execution identity unresolved; task failed before start",
+		"task_id", uuidToString(failed.ID),
+		"issue_id", uuidToString(failed.IssueID),
+		"runtime_id", uuidToString(runtime.ID),
+		"reason", reason,
+	)
+	return true, nil
+}
+
+func (h *Handler) autopilotClaimExecutionIdentityFailureReason(ctx context.Context, runtime db.AgentRuntime, task db.AgentTaskQueue) string {
+	if !task.IssueID.Valid {
+		return ""
+	}
+
+	issue, err := h.Queries.GetIssue(ctx, task.IssueID)
+	if err != nil {
+		return ""
+	}
+	if issue.WorkspaceID != runtime.WorkspaceID {
+		return ""
+	}
+	if !issue.OriginType.Valid || issue.OriginType.String != "autopilot" || issue.CreatorType != "agent" {
+		return ""
+	}
+	if !runtime.OwnerID.Valid {
+		return "current_user_id could not be determined uniquely: task-bound runtime has no owner_id; bind a runtime owner workspace member before rerunning this autopilot issue"
+	}
+	if _, err := h.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+		UserID:      runtime.OwnerID,
+		WorkspaceID: issue.WorkspaceID,
+	}); err != nil {
+		return "current_user_id could not be determined uniquely: task-bound runtime owner is not a workspace member; restore membership or bind a deterministic execution owner before rerunning this autopilot issue"
+	}
+	return ""
 }
 
 // ListPendingTasksByRuntime returns queued/dispatched tasks for a runtime.

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -219,6 +220,143 @@ func TestClaimTaskByRuntime_ReclaimsStaleDispatchedTask(t *testing.T) {
 	}
 	if !refreshed {
 		t.Fatal("expected reclaimed task to refresh dispatched_at")
+	}
+}
+
+func TestClaimTaskByRuntime_AutopilotCreateIssueExecutionIdentityUnresolvedBlocksIssue(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	queries := db.New(testPool)
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Autopilot unresolved identity runtime")
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, 'autopilot-unresolved-identity-agent', '', 'cloud', '{}'::jsonb, $2, 'workspace', 1, $3)
+		RETURNING id::text
+	`, testWorkspaceID, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Autopilot unresolved identity",
+		Description:        pgtype.Text{String: "MAG-307 execution identity regression", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "agent",
+		CreatedByID:        parseUUID(agentID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if !run.IssueID.Valid {
+		t.Fatal("create_issue dispatch did not link an issue")
+	}
+	issueID := uuidToString(run.IssueID)
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	createdIssue, err := queries.GetIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("GetIssue before claim: %v", err)
+	}
+	if createdIssue.CreatorType != "agent" || uuidToString(createdIssue.CreatorID) != agentID {
+		t.Fatalf("creator = %s/%s, want agent/%s", createdIssue.CreatorType, uuidToString(createdIssue.CreatorID), agentID)
+	}
+
+	var queuedTaskID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, issueID, agentID).Scan(&queuedTaskID); err != nil {
+		t.Fatalf("load queued autopilot task: %v", err)
+	}
+
+	task, body := claimTaskByRuntimeForTest(t, runtimeID)
+	if task != nil {
+		t.Fatalf("claim should fail closed before returning a runnable task, got %s body=%s", task.ID, body)
+	}
+
+	var taskStatus string
+	var taskStartedAt pgtype.Timestamptz
+	var failureReason string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, started_at, failure_reason
+		FROM agent_task_queue
+		WHERE id = $1
+	`, queuedTaskID).Scan(&taskStatus, &taskStartedAt, &failureReason); err != nil {
+		t.Fatalf("load failed task: %v", err)
+	}
+	if taskStatus != "failed" {
+		t.Fatalf("task status = %q, want failed", taskStatus)
+	}
+	if taskStartedAt.Valid {
+		t.Fatalf("task should not have started, started_at=%v", taskStartedAt.Time)
+	}
+	if failureReason != "execution_identity_unresolved" {
+		t.Fatalf("failure_reason = %q, want execution_identity_unresolved", failureReason)
+	}
+
+	updatedIssue, err := queries.GetIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("GetIssue after claim: %v", err)
+	}
+	if updatedIssue.Status != "blocked" {
+		t.Fatalf("issue status = %q, want blocked", updatedIssue.Status)
+	}
+
+	var comment string
+	if err := testPool.QueryRow(ctx, `
+		SELECT content FROM comment
+		WHERE issue_id = $1 AND type = 'system'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, issueID).Scan(&comment); err != nil {
+		t.Fatalf("load close-out comment: %v", err)
+	}
+	for _, want := range []string{
+		"failure_reason: execution_identity_unresolved",
+		"current_user_id could not be determined uniquely",
+		"bind a deterministic execution member/runtime owner",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("close-out comment missing %q:\n%s", want, comment)
+		}
+	}
+
+	updatedRun, err := queries.GetAutopilotRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updatedRun.Status != "failed" {
+		t.Fatalf("run status = %q, want failed", updatedRun.Status)
+	}
+	if !updatedRun.FailureReason.Valid || updatedRun.FailureReason.String != "execution_identity_unresolved" {
+		t.Fatalf("run failure_reason = %+v, want execution_identity_unresolved", updatedRun.FailureReason)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1352,8 +1352,23 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// Skip the per-failure system comment when we'll immediately retry —
 	// the new task will surface its own status to the user, and we don't
 	// want to spam the issue with "task timed out" messages on every
-	// daemon hiccup.
-	if errMsg != "" && task.IssueID.Valid && retried == nil {
+	// daemon hiccup. Autopilot-created issues get a stronger terminal
+	// close-out below: structured result comment + blocked status.
+	closedAutopilotIssue := false
+	if task.IssueID.Valid && retried == nil {
+		if issue, loadErr := s.Queries.GetIssue(ctx, task.IssueID); loadErr == nil {
+			hasActive, checkErr := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+			if checkErr != nil {
+				slog.Warn("fail task: active check failed before autopilot issue close-out",
+					"issue_id", util.UUIDToString(task.IssueID),
+					"error", checkErr,
+				)
+			} else if !hasActive {
+				closedAutopilotIssue = s.closeOutAutopilotIssueFailure(ctx, task, issue, failureReason, errMsg)
+			}
+		}
+	}
+	if errMsg != "" && task.IssueID.Valid && retried == nil && !closedAutopilotIssue {
 		s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(errMsg), "system", task.TriggerCommentID)
 	}
 
@@ -1646,8 +1661,11 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 				workspaceID = util.UUIDToString(issue.WorkspaceID)
 				// Reset stuck in_progress issues only when no other active
 				// task exists for the issue and no retry was just enqueued.
+				// Autopilot-created issues are terminal deliverables: when the
+				// final attempt fails, close them out as blocked with a result
+				// comment instead of silently putting them back in todo.
 				issueKey := util.UUIDToString(t.IssueID)
-				if issue.Status == "in_progress" && !processedIssues[issueKey] && !retriedIssues[issueKey] {
+				if !processedIssues[issueKey] && !retriedIssues[issueKey] {
 					processedIssues[issueKey] = true
 					hasActive, checkErr := s.Queries.HasActiveTaskForIssue(ctx, t.IssueID)
 					if checkErr != nil {
@@ -1656,15 +1674,21 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 							"error", checkErr,
 						)
 					} else if !hasActive {
-						if _, updateErr := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-							ID:          t.IssueID,
-							Status:      "todo",
-							WorkspaceID: issue.WorkspaceID,
-						}); updateErr != nil {
-							slog.Warn("handle failed tasks: reset stuck issue failed",
-								"issue_id", issueKey,
-								"error", updateErr,
-							)
+						errMsg := ""
+						if t.Error.Valid {
+							errMsg = t.Error.String
+						}
+						if !s.closeOutAutopilotIssueFailure(ctx, t, issue, failureReason, errMsg) && issue.Status == "in_progress" {
+							if _, updateErr := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+								ID:          t.IssueID,
+								Status:      "todo",
+								WorkspaceID: issue.WorkspaceID,
+							}); updateErr != nil {
+								slog.Warn("handle failed tasks: reset stuck issue failed",
+									"issue_id", issueKey,
+									"error", updateErr,
+								)
+							}
 						}
 					}
 				}
@@ -1696,6 +1720,132 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 		s.ReconcileAgentStatus(ctx, agentID)
 	}
 	return retried
+}
+
+func isOpenAutopilotIssue(issue db.Issue) bool {
+	if !issue.OriginType.Valid || issue.OriginType.String != "autopilot" || !issue.OriginID.Valid {
+		return false
+	}
+	return issue.Status == "todo" || issue.Status == "in_progress" || issue.Status == "blocked"
+}
+
+func normalizeAutopilotIssueFailureReason(failureReason, errMsg string) string {
+	combined := strings.ToLower(failureReason + " " + errMsg)
+	if strings.Contains(combined, "execution_identity_unresolved") ||
+		strings.Contains(combined, "current_user_id could not be determined uniquely") {
+		return "execution_identity_unresolved"
+	}
+	if strings.TrimSpace(failureReason) != "" {
+		return strings.TrimSpace(failureReason)
+	}
+	if strings.TrimSpace(errMsg) != "" {
+		return taskfailure.Classify(errMsg).String()
+	}
+	return "agent_error"
+}
+
+func formatTaskFailureTime(ts pgtype.Timestamptz, empty string) string {
+	if !ts.Valid {
+		return empty
+	}
+	return ts.Time.UTC().Format(time.RFC3339)
+}
+
+func formatTaskFailureUUID(id pgtype.UUID, empty string) string {
+	if !id.Valid {
+		return empty
+	}
+	return util.UUIDToString(id)
+}
+
+func buildAutopilotIssueFailureComment(task db.AgentTaskQueue, failureReason, errMsg string) string {
+	var b strings.Builder
+	b.WriteString("Autopilot run failed and this issue was moved to blocked.\n\n")
+	b.WriteString("- failure_reason: ")
+	b.WriteString(failureReason)
+	b.WriteString("\n- attempts: ")
+	b.WriteString(strconv.Itoa(int(task.Attempt)))
+	b.WriteString("/")
+	b.WriteString(strconv.Itoa(int(task.MaxAttempts)))
+	b.WriteString("\n- task_id: ")
+	b.WriteString(util.UUIDToString(task.ID))
+	b.WriteString("\n- runtime_id: ")
+	b.WriteString(formatTaskFailureUUID(task.RuntimeID, "none"))
+	b.WriteString("\n- last_started_at: ")
+	b.WriteString(formatTaskFailureTime(task.StartedAt, "not started"))
+	b.WriteString("\n- last_completed_at: ")
+	b.WriteString(formatTaskFailureTime(task.CompletedAt, "not completed"))
+	if strings.TrimSpace(errMsg) != "" {
+		b.WriteString("\n- error: ")
+		b.WriteString(truncateForSummary(errMsg, 600))
+	}
+	b.WriteString("\n\n")
+	if failureReason == "execution_identity_unresolved" {
+		b.WriteString("Next step: bind a deterministic execution member/runtime owner for the task-bound agent identity, then rerun this issue. The issue creator remains the agent for audit purposes.")
+	} else {
+		b.WriteString("Next step: fix the runtime or task failure and rerun this issue. No continuation issue was identified automatically; link a follow-up issue if this reporting window was superseded.")
+	}
+	return b.String()
+}
+
+func (s *TaskService) closeOutAutopilotIssueFailure(ctx context.Context, task db.AgentTaskQueue, issue db.Issue, failureReason, errMsg string) bool {
+	if !isOpenAutopilotIssue(issue) {
+		return false
+	}
+	if issue.Status == "blocked" {
+		return true
+	}
+
+	reason := normalizeAutopilotIssueFailureReason(failureReason, errMsg)
+	body := buildAutopilotIssueFailureComment(task, reason, errMsg)
+	s.createAgentComment(ctx, issue.ID, task.AgentID, redact.Text(body), "system", task.TriggerCommentID)
+
+	if run, err := s.Queries.GetAutopilotRunByIssue(ctx, issue.ID); err == nil {
+		updatedRun, updateErr := s.Queries.UpdateAutopilotRunFailed(ctx, db.UpdateAutopilotRunFailedParams{
+			ID:            run.ID,
+			FailureReason: pgtype.Text{String: reason, Valid: true},
+		})
+		if updateErr != nil {
+			slog.Warn("autopilot issue close-out: failed to mark run failed",
+				"run_id", util.UUIDToString(run.ID),
+				"issue_id", util.UUIDToString(issue.ID),
+				"error", updateErr,
+			)
+		} else if s.Bus != nil {
+			s.Bus.Publish(events.Event{
+				Type:        protocol.EventAutopilotRunDone,
+				WorkspaceID: util.UUIDToString(issue.WorkspaceID),
+				ActorType:   "system",
+				Payload: map[string]any{
+					"run_id":       util.UUIDToString(updatedRun.ID),
+					"autopilot_id": util.UUIDToString(updatedRun.AutopilotID),
+					"status":       "failed",
+				},
+			})
+		}
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		slog.Warn("autopilot issue close-out: failed to load linked run",
+			"issue_id", util.UUIDToString(issue.ID),
+			"error", err,
+		)
+	}
+
+	updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+		ID:          issue.ID,
+		Status:      "blocked",
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		slog.Warn("autopilot issue close-out: failed to block issue",
+			"issue_id", util.UUIDToString(issue.ID),
+			"error", err,
+		)
+		return true
+	}
+	if s.Bus != nil {
+		s.broadcastIssueUpdated(updatedIssue)
+	}
+	return true
 }
 
 // runInTx executes fn inside a single DB transaction. If TxStarter is nil

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1758,17 +1758,21 @@ func formatTaskFailureUUID(id pgtype.UUID, empty string) string {
 	return util.UUIDToString(id)
 }
 
-func buildAutopilotIssueFailureComment(task db.AgentTaskQueue, failureReason, errMsg string) string {
+func buildAutopilotIssueFailureComment(task db.AgentTaskQueue, failureReason, errMsg, continuationIssue string) string {
 	var b strings.Builder
 	b.WriteString("Autopilot run failed and this issue was moved to blocked.\n\n")
 	b.WriteString("- failure_reason: ")
 	b.WriteString(failureReason)
-	b.WriteString("\n- attempts: ")
-	b.WriteString(strconv.Itoa(int(task.Attempt)))
-	b.WriteString("/")
-	b.WriteString(strconv.Itoa(int(task.MaxAttempts)))
+	if task.ID.Valid {
+		b.WriteString("\n- attempts: ")
+		b.WriteString(strconv.Itoa(int(task.Attempt)))
+		b.WriteString("/")
+		b.WriteString(strconv.Itoa(int(task.MaxAttempts)))
+	} else {
+		b.WriteString("\n- attempts: not started")
+	}
 	b.WriteString("\n- task_id: ")
-	b.WriteString(util.UUIDToString(task.ID))
+	b.WriteString(formatTaskFailureUUID(task.ID, "not enqueued"))
 	b.WriteString("\n- runtime_id: ")
 	b.WriteString(formatTaskFailureUUID(task.RuntimeID, "none"))
 	b.WriteString("\n- last_started_at: ")
@@ -1779,13 +1783,79 @@ func buildAutopilotIssueFailureComment(task db.AgentTaskQueue, failureReason, er
 		b.WriteString("\n- error: ")
 		b.WriteString(truncateForSummary(errMsg, 600))
 	}
+	if continuationIssue != "" {
+		b.WriteString("\n- continuation_issue: ")
+		b.WriteString(continuationIssue)
+	}
 	b.WriteString("\n\n")
-	if failureReason == "execution_identity_unresolved" {
+	if continuationIssue != "" {
+		b.WriteString("Next step: follow the continuation issue linked above; this failed issue has been blocked so radar does not need to re-read run messages.")
+	} else if failureReason == "execution_identity_unresolved" {
 		b.WriteString("Next step: bind a deterministic execution member/runtime owner for the task-bound agent identity, then rerun this issue. The issue creator remains the agent for audit purposes.")
 	} else {
 		b.WriteString("Next step: fix the runtime or task failure and rerun this issue. No continuation issue was identified automatically; link a follow-up issue if this reporting window was superseded.")
 	}
 	return b.String()
+}
+
+func autopilotRunWindowKey(run db.AutopilotRun) string {
+	return autopilotRunTriggeredAt(run).UTC().Format("2006-01-02")
+}
+
+func (s *TaskService) formatIssueMention(ctx context.Context, issue db.Issue) string {
+	label := "#" + strconv.Itoa(int(issue.Number))
+	if ws, err := s.Queries.GetWorkspace(ctx, issue.WorkspaceID); err == nil && strings.TrimSpace(ws.IssuePrefix) != "" {
+		label = ws.IssuePrefix + "-" + strconv.Itoa(int(issue.Number))
+	}
+	return "[" + label + "](mention://issue/" + util.UUIDToString(issue.ID) + ")"
+}
+
+func (s *TaskService) findAutopilotContinuationIssue(ctx context.Context, failedIssue db.Issue, failedRun db.AutopilotRun) string {
+	if !failedRun.AutopilotID.Valid || !failedIssue.ID.Valid {
+		return ""
+	}
+	failedWindow := autopilotRunWindowKey(failedRun)
+	failedAt := autopilotRunTriggeredAt(failedRun)
+
+	runs, err := s.Queries.ListAutopilotRuns(ctx, db.ListAutopilotRunsParams{
+		AutopilotID: failedRun.AutopilotID,
+		Limit:       50,
+		Offset:      0,
+	})
+	if err != nil {
+		slog.Warn("autopilot issue close-out: failed to scan continuation runs",
+			"issue_id", util.UUIDToString(failedIssue.ID),
+			"autopilot_id", util.UUIDToString(failedRun.AutopilotID),
+			"error", err,
+		)
+		return ""
+	}
+
+	for _, candidateRun := range runs {
+		if !candidateRun.IssueID.Valid || candidateRun.IssueID == failedIssue.ID {
+			continue
+		}
+		if autopilotRunWindowKey(candidateRun) != failedWindow {
+			continue
+		}
+		if !autopilotRunTriggeredAt(candidateRun).After(failedAt) && !candidateRun.CreatedAt.Time.After(failedRun.CreatedAt.Time) {
+			continue
+		}
+		candidateIssue, err := s.Queries.GetIssue(ctx, candidateRun.IssueID)
+		if err != nil {
+			slog.Warn("autopilot issue close-out: failed to load continuation issue",
+				"issue_id", util.UUIDToString(candidateRun.IssueID),
+				"failed_issue_id", util.UUIDToString(failedIssue.ID),
+				"error", err,
+			)
+			continue
+		}
+		if candidateIssue.WorkspaceID != failedIssue.WorkspaceID || candidateIssue.Status == "cancelled" {
+			continue
+		}
+		return s.formatIssueMention(ctx, candidateIssue)
+	}
+	return ""
 }
 
 func (s *TaskService) closeOutAutopilotIssueFailure(ctx context.Context, task db.AgentTaskQueue, issue db.Issue, failureReason, errMsg string) bool {
@@ -1797,10 +1867,13 @@ func (s *TaskService) closeOutAutopilotIssueFailure(ctx context.Context, task db
 	}
 
 	reason := normalizeAutopilotIssueFailureReason(failureReason, errMsg)
-	body := buildAutopilotIssueFailureComment(task, reason, errMsg)
-	s.createAgentComment(ctx, issue.ID, task.AgentID, redact.Text(body), "system", task.TriggerCommentID)
+	continuationIssue := ""
 
 	if run, err := s.Queries.GetAutopilotRunByIssue(ctx, issue.ID); err == nil {
+		continuationIssue = s.findAutopilotContinuationIssue(ctx, issue, run)
+		body := buildAutopilotIssueFailureComment(task, reason, errMsg, continuationIssue)
+		s.createAgentComment(ctx, issue.ID, task.AgentID, redact.Text(body), "system", task.TriggerCommentID)
+
 		updatedRun, updateErr := s.Queries.UpdateAutopilotRunFailed(ctx, db.UpdateAutopilotRunFailedParams{
 			ID:            run.ID,
 			FailureReason: pgtype.Text{String: reason, Valid: true},
@@ -1828,6 +1901,11 @@ func (s *TaskService) closeOutAutopilotIssueFailure(ctx context.Context, task db
 			"issue_id", util.UUIDToString(issue.ID),
 			"error", err,
 		)
+		body := buildAutopilotIssueFailureComment(task, reason, errMsg, continuationIssue)
+		s.createAgentComment(ctx, issue.ID, task.AgentID, redact.Text(body), "system", task.TriggerCommentID)
+	} else {
+		body := buildAutopilotIssueFailureComment(task, reason, errMsg, continuationIssue)
+		s.createAgentComment(ctx, issue.ID, task.AgentID, redact.Text(body), "system", task.TriggerCommentID)
 	}
 
 	updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{


### PR DESCRIPTION
Implements MAG-307 autopilot failure close-out: terminal failed autopilot-created issues now get a structured result comment, move to blocked, and mark the linked run failed. Adds a regression test for create_issue autopilot batch failure close-out. Verification: git diff --check; go test ./cmd/server -run 'TestAutopilot(CreateIssueBatchFailureBlocksIssueWithResultComment|RunOnlyTaskTerminalEventsUpdateRun)'; go test ./internal/service.