### PR TITLE
fix(agent): keep resolvable models when CLI discovery exits non-zero (MUL-2977, #3729)

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -360,18 +360,24 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "models", "--verbose")
 	hideAgentWindow(cmd)
-	out, err := cmd.Output()
-	if err != nil {
-		if len(out) == 0 {
-			cmd = exec.CommandContext(runCtx, executablePath, "models")
-			hideAgentWindow(cmd)
-			out, err = cmd.Output()
-			if err != nil && len(out) == 0 {
-				return []Model{}, nil
-			}
-		}
+	// Parse whatever the verbose command printed, even on a non-zero exit — a
+	// stale config entry can make `opencode models` exit non-zero while still
+	// listing the resolvable catalog (mirrors the pi path; see #3729/#3627).
+	out, _ := cmd.Output()
+	models := parseOpenCodeModels(string(out))
+	if len(models) == 0 {
+		// Verbose yielded nothing usable (unsupported flag, error text, or an
+		// empty list). Retry the plain command, which omits the per-model JSON
+		// but still prints the IDs.
+		cmd = exec.CommandContext(runCtx, executablePath, "models")
+		hideAgentWindow(cmd)
+		out, _ = cmd.Output()
+		models = parseOpenCodeModels(string(out))
 	}
-	return parseOpenCodeModels(string(out)), nil
+	if len(models) == 0 {
+		return []Model{}, nil
+	}
+	return models, nil
 }
 
 // parseOpenCodeModels accepts the `opencode models` text output and
@@ -589,6 +595,14 @@ func parsePiModels(output string) []Model {
 		if line == "" {
 			continue
 		}
+		// pi interleaves human-readable diagnostics with the catalog when an
+		// agent config references stale patterns — e.g.
+		//   Warning: No models match pattern "opencode-go/mimo-v2-omni"
+		// Skip them before field-splitting; otherwise prose tokens are coined
+		// into bogus models like `No/models` or `Warning/`. See #3729.
+		if isPiDiscoveryNoise(line) {
+			continue
+		}
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
@@ -608,11 +622,9 @@ func parsePiModels(output string) []Model {
 		} else {
 			continue
 		}
-		// A real row resolves to `provider/model` with both halves present.
-		// Drop anything else — e.g. a stray `Warning: No models match pattern
-		// "..."` line, which pi can interleave with the catalog when an agent
-		// config holds stale patterns (#3729). Without this guard the leading
-		// `Warning:` token becomes a bogus `Warning/` model in the picker.
+		// A real id has a non-empty provider and model on both sides of the
+		// slash. Drop anything that doesn't (e.g. a stray `something:` token),
+		// a cheap structural backstop on top of the diagnostic filter above.
 		if slash := strings.Index(id, "/"); slash <= 0 || slash == len(id)-1 {
 			continue
 		}
@@ -627,6 +639,26 @@ func parsePiModels(output string) []Model {
 		models = append(models, Model{ID: id, Label: id, Provider: provider})
 	}
 	return models
+}
+
+// isPiDiscoveryNoise reports whether a `pi --list-models` line is a diagnostic
+// message rather than a catalog row. pi prints these alongside the table when
+// an agent config references stale provider/model patterns, e.g.
+//
+//	Warning: No models match pattern "opencode-go/mimo-v2-omni"
+//
+// The `Warning:` prefix is not guaranteed across versions, so the unmatched-
+// pattern message is also matched on its own. These are prose, not
+// `provider model` rows; without skipping them the field splitter coins bogus
+// models like `No/models`. See #3729.
+func isPiDiscoveryNoise(line string) bool {
+	lower := strings.ToLower(line)
+	if strings.Contains(lower, "no models match pattern") {
+		return true
+	}
+	return strings.HasPrefix(lower, "warning:") ||
+		strings.HasPrefix(lower, "error:") ||
+		strings.HasPrefix(lower, "info:")
 }
 
 // discoverHermesModels spins up a throwaway `hermes acp` process,

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -362,11 +362,13 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
-		cmd = exec.CommandContext(runCtx, executablePath, "models")
-		hideAgentWindow(cmd)
-		out, err = cmd.Output()
-		if err != nil {
-			return []Model{}, nil
+		if len(out) == 0 {
+			cmd = exec.CommandContext(runCtx, executablePath, "models")
+			hideAgentWindow(cmd)
+			out, err = cmd.Output()
+			if err != nil && len(out) == 0 {
+				return []Model{}, nil
+			}
 		}
 	}
 	return parseOpenCodeModels(string(out)), nil
@@ -562,7 +564,7 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
-	if err != nil {
+	if err != nil && len(stdout) == 0 && stderr.Len() == 0 {
 		return []Model{}, nil
 	}
 	text := string(stdout)
@@ -604,6 +606,14 @@ func parsePiModels(output string) []Model {
 		} else if len(fields) >= 2 {
 			id = first + "/" + fields[1]
 		} else {
+			continue
+		}
+		// A real row resolves to `provider/model` with both halves present.
+		// Drop anything else — e.g. a stray `Warning: No models match pattern
+		// "..."` line, which pi can interleave with the catalog when an agent
+		// config holds stale patterns (#3729). Without this guard the leading
+		// `Warning:` token becomes a bogus `Warning/` model in the picker.
+		if slash := strings.Index(id, "/"); slash <= 0 || slash == len(id)-1 {
 			continue
 		}
 		if seen[id] {
@@ -942,7 +952,7 @@ func discoverCursorModels(ctx context.Context, executablePath string) ([]Model, 
 	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
-	if err != nil {
+	if err != nil && len(out) == 0 {
 		return cursorStaticModels(), nil
 	}
 	models := parseCursorModels(string(out))
@@ -1039,7 +1049,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 		cmd := exec.CommandContext(runCtx, executablePath, jsonArgs...)
 		hideAgentWindow(cmd)
 		out, err := cmd.Output()
-		if err != nil {
+		if err != nil && len(out) == 0 {
 			continue
 		}
 		if models, ok := parseOpenclawAgentsJSON(out); ok {
@@ -1053,7 +1063,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 	cmd := exec.CommandContext(runCtx, executablePath, "agents", "list")
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
-	if err != nil {
+	if err != nil && len(out) == 0 {
 		return []Model{}, nil
 	}
 	return parseOpenclawAgents(string(out)), nil

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -447,6 +448,70 @@ bareword-only-line
 	// the legacy `provider:model` form gets colon→slash normalization.
 	if models[3].ID != "opencode/claude-sonnet-4-6:exp" || models[3].Provider != "opencode" {
 		t.Errorf("expected ':' inside table-format model name to be preserved: %+v", models[3])
+	}
+}
+
+// TestDiscoverPiModelsNonZeroExit verifies that discoverPiModels still returns
+// the resolvable catalog when `pi --list-models` exits non-zero. Pi exits
+// non-zero (and warns) when an agent config references stale provider/model
+// patterns that no longer match the local catalog. Before the fix the daemon
+// discarded the populated output on any non-zero exit and returned an empty
+// list, so the UI model picker was blank even though the runtime was online and
+// agents ran fine. See GitHub #3729.
+func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake pi binary is a /bin/sh script")
+	}
+
+	const table = "provider         model        context  max-out  thinking  images\n" +
+		"glm-coding-plan  glm-4.7      202.8K   16.4K    no        no"
+	const warning = `Warning: No models match pattern "opencode-go/mimo-v2-omni"`
+
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{
+			// Newer pi prints the catalog to stdout; the stale-pattern
+			// warning goes to stderr and the process exits non-zero.
+			name: "catalog on stdout",
+			script: "#!/bin/sh\n" +
+				"cat <<'EOF'\n" + table + "\nEOF\n" +
+				"echo " + strconv.Quote(warning) + " >&2\n" +
+				"exit 1\n",
+		},
+		{
+			// Older pi prints the catalog (and the warning) to stderr; same
+			// non-zero exit. The stderr fallback must still parse the catalog.
+			name: "catalog on stderr",
+			script: "#!/bin/sh\n" +
+				"cat >&2 <<'EOF'\n" + table + "\n" + warning + "\nEOF\n" +
+				"exit 1\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakePath := filepath.Join(t.TempDir(), "pi")
+			writeTestExecutable(t, fakePath, []byte(tc.script))
+
+			models, err := discoverPiModels(context.Background(), fakePath)
+			if err != nil {
+				t.Fatalf("discoverPiModels: %v", err)
+			}
+			var found bool
+			for _, m := range models {
+				if m.ID == "glm-coding-plan/glm-4.7" {
+					found = true
+				}
+				if m.ID == "Warning/" || m.Provider == "Warning" {
+					t.Errorf("warning line leaked into the catalog as a bogus model: %+v", m)
+				}
+			}
+			if !found {
+				t.Fatalf("expected glm-coding-plan/glm-4.7 despite non-zero exit, got %+v", models)
+			}
+		})
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -465,7 +465,11 @@ func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
 
 	const table = "provider         model        context  max-out  thinking  images\n" +
 		"glm-coding-plan  glm-4.7      202.8K   16.4K    no        no"
-	const warning = `Warning: No models match pattern "opencode-go/mimo-v2-omni"`
+	// The unmatched-pattern warning, with and without the `Warning:` prefix —
+	// the prefix is not guaranteed across pi versions, and the bare form is
+	// what slips past a naive guard into a bogus `No/models` model.
+	const prefixed = `Warning: No models match pattern "opencode-go/mimo-v2-omni"`
+	const bare = `No models match pattern "opencode-go/mimo-v2-pro"`
 
 	cases := []struct {
 		name   string
@@ -477,15 +481,23 @@ func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
 			name: "catalog on stdout",
 			script: "#!/bin/sh\n" +
 				"cat <<'EOF'\n" + table + "\nEOF\n" +
-				"echo " + strconv.Quote(warning) + " >&2\n" +
+				"echo " + strconv.Quote(prefixed) + " >&2\n" +
 				"exit 1\n",
 		},
 		{
 			// Older pi prints the catalog (and the warning) to stderr; same
 			// non-zero exit. The stderr fallback must still parse the catalog.
-			name: "catalog on stderr",
+			name: "catalog and prefixed warning on stderr",
 			script: "#!/bin/sh\n" +
-				"cat >&2 <<'EOF'\n" + table + "\n" + warning + "\nEOF\n" +
+				"cat >&2 <<'EOF'\n" + table + "\n" + prefixed + "\nEOF\n" +
+				"exit 1\n",
+		},
+		{
+			// Same, but the warning has no `Warning:` prefix — must not leak in
+			// as a `No/models` row.
+			name: "catalog and bare warning on stderr",
+			script: "#!/bin/sh\n" +
+				"cat >&2 <<'EOF'\n" + table + "\n" + bare + "\nEOF\n" +
 				"exit 1\n",
 		},
 	}
@@ -499,19 +511,43 @@ func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
 			if err != nil {
 				t.Fatalf("discoverPiModels: %v", err)
 			}
-			var found bool
-			for _, m := range models {
-				if m.ID == "glm-coding-plan/glm-4.7" {
-					found = true
-				}
-				if m.ID == "Warning/" || m.Provider == "Warning" {
-					t.Errorf("warning line leaked into the catalog as a bogus model: %+v", m)
-				}
-			}
-			if !found {
-				t.Fatalf("expected glm-coding-plan/glm-4.7 despite non-zero exit, got %+v", models)
+			// Exactly the resolvable model — no warning line coined into a
+			// bogus entry, no header row.
+			if len(models) != 1 || models[0].ID != "glm-coding-plan/glm-4.7" {
+				t.Fatalf("expected exactly [glm-coding-plan/glm-4.7] despite non-zero exit, got %+v", models)
 			}
 		})
+	}
+}
+
+// TestDiscoverOpenCodeModelsFallsBackOnVerboseNoise verifies that a non-zero
+// `opencode models --verbose` whose stdout is unparseable noise still falls
+// back to the plain `opencode models` command instead of returning empty. The
+// earlier fix skipped the fallback whenever verbose printed any bytes, which
+// regressed this case. Mirrors the pi hardening in #3729.
+func TestDiscoverOpenCodeModelsFallsBackOnVerboseNoise(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake opencode binary is a /bin/sh script")
+	}
+
+	// `opencode models --verbose` => $2 == "--verbose": emit noise + exit 1.
+	// `opencode models`           => no $2: print the plain catalog.
+	script := "#!/bin/sh\n" +
+		"if [ \"$2\" = \"--verbose\" ]; then\n" +
+		"  echo 'panic: catalog sync failed'\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"echo 'openai/gpt-4o'\n"
+
+	fakePath := filepath.Join(t.TempDir(), "opencode")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	models, err := discoverOpenCodeModels(context.Background(), fakePath)
+	if err != nil {
+		t.Fatalf("discoverOpenCodeModels: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "openai/gpt-4o" {
+		t.Fatalf("expected fallback to plain `opencode models` to yield [openai/gpt-4o], got %+v", models)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3729 (MUL-2977). A user's Pi runtime showed an **empty model picker** in the UI even though the runtime was online and Pi agents ran fine on their configured model.

Model discovery shells out to each runtime's CLI and parses the output:
`pi --list-models`, `opencode models`, `cursor-agent --list-models`,
`openclaw agents list`. The bail-out was gated only on `cmd.Output()`
returning an error — but `cmd.Output()` returns an `*exec.ExitError` on **any
non-zero exit even when stdout is fully populated**. So a non-zero exit threw
away the already-captured catalog and returned an empty list.

Pi exits non-zero (with a `Warning: No models match pattern "..."` line) when an
agent config still references **stale provider/model patterns** that no longer
match the local catalog — exactly the reporter's case (two `opencode-go/mimo-v2-*`
leftovers). The resolvable models (e.g. `glm-coding-plan/glm-4.7`) were on stdout,
but the daemon discarded them, so the picker came back blank. This is *not* the
timeout class from #3627 — Pi responds immediately, just with a non-zero exit.

## Changes

- `discoverPiModels` / `discoverOpenCodeModels` / `discoverCursorModels` /
  `discoverOpenclawAgents`: only treat a non-zero exit as failure when there is
  **also no usable output**, so a partial-but-valid catalog is still parsed
  instead of dropped. This matches the reporter's expectation — "ask Pi what it
  can resolve, drop the non-matching ones, return the rest."
- `parsePiModels`: drop rows that don't resolve to a real `provider/model`
  (both halves present). Older pi prints the catalog to **stderr**, so the
  stale-pattern warning can share the stream with the table; without this guard
  a leading `Warning:` token became a bogus `Warning/` entry in the picker.

## Testing

- New `TestDiscoverPiModelsNonZeroExit` covers both shapes — catalog on
  **stdout** (newer pi) and catalog on **stderr** (older pi) — each with a
  non-zero exit, asserting the real model is returned and no `Warning/` junk
  leaks in.
- `go test ./pkg/agent/...` passes; `gofmt`/`go vet` clean.

## Notes

The exact exit-code behavior of `pi --list-models` on the reporter's host is
being confirmed on the issue, but this hardening is correct regardless of the
precise exit code: when the CLI prints a usable catalog, the daemon now parses
it instead of relying on a zero exit.
