### PR TITLE
MUL-2996 Teach default PR handoff in issue skill

### DIFF
--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -48,6 +48,28 @@ close the issue on merge. A closing keyword immediately adjacent to the issue ke
 records close intent; on merge, that close intent can move the linked issue to
 `done`.
 
+### Default for code-changing issue work
+
+When an issue run changes code in a checked-out GitHub repo, the default handoff
+is to open or update a PR before posting the final Multica issue comment, unless
+the user explicitly asked for a local-only change or no PR. This is a default, not
+an unconditional command: if no code changed, say no PR is needed; if PR creation
+is blocked by auth, failing tests, or missing remote state, report that blocker
+instead of pretending the run is complete.
+
+Use a routable issue key in the PR title, body, or branch so the webhook can link
+the PR back to the issue. If the PR should close the issue on merge, put the key
+immediately after a closing keyword in the title or body, for example:
+
+```text
+MUL-2759: fix login redirect        # links only
+Closes MUL-2759                     # links and records close intent
+```
+
+In the final issue comment, include the PR URL when a PR exists. If the task did
+not produce a PR because no code changed or the user asked not to create one, say
+that explicitly.
+
 ## Reading a linked PR's real state
 
 When a step depends on PR state, query Multica's link table — do not infer it

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -175,6 +175,11 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 	// shifts a line cannot rot this test into pinning a stale lie.
 	mustContain := []string{
 		"multica issue pull-requests <issue-id> --output json",
+		"Default for code-changing issue work",
+		"open or update a PR before posting the final Multica issue comment",
+		"This is a default, not",
+		"Use a routable issue key in the PR title, body, or branch",
+		"include the PR URL when a PR exists",
 		"Closes MUL-2759",
 		"--status backlog",
 		"pr_url",


### PR DESCRIPTION
Closes MUL-2996

## Summary
- Move PR handoff guidance out of the daemon-generated assignment workflow.
- Teach the default behavior in the built-in `multica-working-on-issues` skill: code-changing issue work should normally open/update a PR before the final Multica issue comment, but it is explicitly a default, not an unconditional command.
- Require final issue comments to include the PR URL when one exists, or explain why no PR was produced.
- Add built-in skill canary coverage for the new guidance.

## Tests
- go test ./internal/daemon/execenv ./internal/service