### PR TITLE
feat(views): add thinking level picker to create-agent dialog

### DIFF
--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -31,6 +31,23 @@ vi.mock("./model-dropdown", () => ({
   ModelDropdown: () => null,
 }));
 
+const mockModelsData = vi.hoisted(() => ({
+  current: null as { models: Array<{ id: string; label: string; provider?: string; default?: boolean; thinking?: { supported_levels: Array<{ value: string; label: string; description?: string }>; default_level?: string } }>; supported: boolean } | null,
+}));
+
+vi.mock("@multica/core/runtimes", () => ({
+  runtimeModelsOptions: () => ({
+    queryKey: ["runtimes", "models", "test"],
+    queryFn: () => {
+      if (mockModelsData.current) return Promise.resolve(mockModelsData.current);
+      return Promise.resolve({ models: [], supported: true });
+    },
+    enabled: true,
+    staleTime: 60_000,
+    retry: false,
+  }),
+}));
+
 // Provider logos don't matter for these assertions but they pull in SVGs.
 vi.mock("../../runtimes/components/provider-logo", () => ({
   ProviderLogo: () => null,
@@ -283,5 +300,203 @@ describe("CreateAgentDialog runtime visibility gate", () => {
       .find((b) => b.textContent === "Create");
     expect(createBtn).toBeDefined();
     expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("CreateAgentDialog thinking level", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockModelsData.current = null;
+  });
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    mockModelsData.current = null;
+  });
+
+  it("shows thinking picker when model has supported_levels", async () => {
+    mockModelsData.current = {
+      models: [
+        {
+          id: "claude-sonnet-4",
+          label: "Claude Sonnet 4",
+          provider: "anthropic",
+          default: true,
+          thinking: {
+            supported_levels: [
+              { value: "low", label: "Low" },
+              { value: "medium", label: "Medium" },
+              { value: "high", label: "High" },
+            ],
+            default_level: "medium",
+          },
+        },
+      ],
+      supported: true,
+    };
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME, visibility: "private" });
+    renderDialog([mine]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Thinking")).toBeInTheDocument();
+    });
+  });
+
+  it("hides thinking picker when model has no supported_levels", async () => {
+    mockModelsData.current = {
+      models: [
+        {
+          id: "gpt-4",
+          label: "GPT-4",
+          provider: "openai",
+          default: true,
+        },
+      ],
+      supported: true,
+    };
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME, visibility: "private" });
+    renderDialog([mine]);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText("Thinking")).toBeNull();
+  });
+
+  it("includes thinking_level in create payload", async () => {
+    mockModelsData.current = {
+      models: [
+        {
+          id: "claude-sonnet-4",
+          label: "Claude Sonnet 4",
+          provider: "anthropic",
+          default: true,
+          thinking: {
+            supported_levels: [
+              { value: "low", label: "Low" },
+              { value: "high", label: "High" },
+            ],
+          },
+        },
+      ],
+      supported: true,
+    };
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME, visibility: "private" });
+    const { onCreate } = renderDialog([mine]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Thinking")).toBeInTheDocument();
+    });
+
+    // Click the thinking picker trigger to open the popover
+    const pickerTrigger = screen.getByRole("button", { name: /Thinking/i });
+    fireEvent.click(pickerTrigger);
+
+    // Select "High"
+    await vi.waitFor(() => {
+      expect(screen.getByText("High")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("High"));
+
+    // Fill in a name and submit
+    const nameInput = screen.getByPlaceholderText("e.g. Deep Research Agent");
+    fireEvent.change(nameInput, { target: { value: "Test Agent" } });
+    fireEvent.click(screen.getByText("Create"));
+
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(onCreate.mock.calls[0]?.[0].thinking_level).toBe("high");
+  });
+
+  it("does not submit stale thinking_level when discovery is unavailable (offline runtime)", async () => {
+    // Simulate: duplicating an agent with thinking_level=high, but runtime
+    // is offline so discovery never fires and picker stays hidden.
+    mockModelsData.current = null;
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      visibility: "private",
+      status: "offline",
+    });
+    const template = makeTemplate("rt-mine");
+    template.thinking_level = "high";
+    const { onCreate } = renderDialog([mine], template);
+
+    await new Promise((r) => setTimeout(r, 50));
+    // Thinking picker must not be visible
+    expect(screen.queryByText("Thinking")).toBeNull();
+
+    // Submit the form — the stale thinking_level must NOT be in the payload
+    fireEvent.click(screen.getByText("Create"));
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(onCreate.mock.calls[0]?.[0].thinking_level).toBeUndefined();
+  });
+
+  it("does not submit stale thinking_level when model does not support thinking", async () => {
+    // Simulate: duplicating an agent with thinking_level=high onto a model
+    // that has no thinking levels (e.g. GPT-4).
+    mockModelsData.current = {
+      models: [
+        {
+          id: "gpt-4",
+          label: "GPT-4",
+          provider: "openai",
+          default: true,
+        },
+      ],
+      supported: true,
+    };
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME, visibility: "private" });
+    const template = makeTemplate("rt-mine");
+    template.thinking_level = "high";
+    const { onCreate } = renderDialog([mine], template);
+
+    await new Promise((r) => setTimeout(r, 50));
+    // Thinking picker must not be visible (model has no thinking levels)
+    expect(screen.queryByText("Thinking")).toBeNull();
+
+    // Submit
+    fireEvent.click(screen.getByText("Create"));
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(onCreate.mock.calls[0]?.[0].thinking_level).toBeUndefined();
+  });
+
+  it("pre-fills thinking_level in duplicate mode when model supports it", async () => {
+    mockModelsData.current = {
+      models: [
+        {
+          id: "claude-sonnet-4",
+          label: "Claude Sonnet 4",
+          provider: "anthropic",
+          default: true,
+          thinking: {
+            supported_levels: [
+              { value: "low", label: "Low" },
+              { value: "high", label: "High" },
+            ],
+          },
+        },
+      ],
+      supported: true,
+    };
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME, visibility: "private" });
+    const template = makeTemplate("rt-mine");
+    template.thinking_level = "high";
+    const { onCreate } = renderDialog([mine], template);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Thinking")).toBeInTheDocument();
+    });
+
+    // Submit without changing anything — should carry the pre-filled value
+    fireEvent.click(screen.getByText("Create"));
+    await vi.waitFor(() => {
+      expect(onCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(onCreate.mock.calls[0]?.[0].thinking_level).toBe("high");
   });
 });

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Globe, Lock } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ModelDropdown } from "./model-dropdown";
 import { RuntimePicker, isRuntimeUsableForUser } from "./runtime-picker";
 import { InstructionsEditor } from "./instructions-editor";
 import { SkillMultiSelect } from "./skill-multi-select";
 import { AvatarPicker } from "./avatar-picker";
+import { ThinkingPicker } from "./inspector/thinking-picker";
+import { pickModelEntry } from "./inspector/thinking-prop-row";
 import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { runtimeModelsOptions } from "@multica/core/runtimes";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type {
   Agent,
@@ -87,6 +90,7 @@ export function CreateAgentDialog({
     template?.visibility ?? "workspace",
   );
   const [model, setModel] = useState(template?.model ?? "");
+  const [thinkingLevel, setThinkingLevel] = useState(template?.thinking_level ?? "");
   const [instructions, setInstructions] = useState(template?.instructions ?? "");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(template?.avatar_url ?? null);
   const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(
@@ -117,6 +121,27 @@ export function CreateAgentDialog({
   const selectedRuntimeLocked =
     selectedRuntime != null &&
     !isRuntimeUsableForUser(selectedRuntime, currentUserId);
+
+  const modelsQuery = useQuery(
+    runtimeModelsOptions(
+      selectedRuntime?.status === "online" ? selectedRuntime.id : null,
+    ),
+  );
+  const models = useMemo(
+    () => modelsQuery.data?.models ?? [],
+    [modelsQuery.data],
+  );
+  const thinkingEntry = pickModelEntry(models, model);
+  const thinkingLevels = thinkingEntry?.thinking?.supported_levels ?? [];
+
+  useEffect(() => {
+    if (!thinkingLevel || !modelsQuery.data) return;
+    if (thinkingLevels.length === 0) {
+      setThinkingLevel("");
+    } else if (!thinkingLevels.some((l) => l.value === thinkingLevel)) {
+      setThinkingLevel("");
+    }
+  }, [thinkingLevels, thinkingLevel, modelsQuery.data]);
 
   // Shared squad-join follow-up. Returns nothing — the caller has
   // already shown its create-success toast; we only need to surface a
@@ -162,6 +187,8 @@ export function CreateAgentDialog({
         model: model.trim() || undefined,
         instructions: trimmedInstructions || undefined,
         avatar_url: avatarUrl ?? undefined,
+        thinking_level:
+          thinkingLevels.length > 0 ? thinkingLevel || undefined : undefined,
       };
       if (template) {
         // Duplicate path: forward the hidden config fields the source
@@ -341,6 +368,26 @@ export function CreateAgentDialog({
               onChange={setModel}
               disabled={!selectedRuntime}
             />
+
+            {thinkingLevels.length > 0 && (
+              <div className="flex flex-col min-w-0">
+                <div className="flex h-6 items-center">
+                  <Label className="text-xs text-muted-foreground">
+                    {t(($) => $.create_dialog.thinking_label)}
+                  </Label>
+                </div>
+                <div className="mt-1.5 flex items-center rounded-lg border border-border bg-background px-3 py-2.5">
+                  <ThinkingPicker
+                    value={thinkingLevel}
+                    levels={thinkingLevels}
+                    onChange={(next) => setThinkingLevel(next)}
+                  />
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t(($) => $.create_dialog.thinking_help)}
+                </p>
+              </div>
+            )}
 
             {/* --- Optional sections (instructions / skills) ---
                 Collapsed by default so quick-create stays fast.

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -62,7 +62,7 @@ export function ThinkingPropRow({
   );
 }
 
-function pickModelEntry(
+export function pickModelEntry(
   models: RuntimeModel[],
   model: string,
 ): RuntimeModel | undefined {

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -209,6 +209,7 @@
     "environment": "Environment",
     "custom_args": "Custom Args",
     "mcp_config": "MCP",
+    "integrations": "Integrations",
     "discard_dialog_title": "Discard unsaved changes?",
     "discard_dialog_description": "You have unsaved changes in this tab. Leaving now will discard them.",
     "discard_keep": "Keep editing",
@@ -340,6 +341,10 @@
       "add_dialog_confirm_other": "Add {{count}} skills",
       "add_dialog_cancel": "Cancel",
       "add_failed_toast": "Failed to add skill"
+    },
+    "integrations": {
+      "intro": "Connect this agent to external chat platforms so people can work with it where they already are.",
+      "members_note": "Only workspace owners and admins can bind a Lark Bot to an agent. You can view connected bots in Settings → Integrations."
     },
     "activity": {
       "section_now": "Now",

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -209,7 +209,6 @@
     "environment": "Environment",
     "custom_args": "Custom Args",
     "mcp_config": "MCP",
-    "integrations": "Integrations",
     "discard_dialog_title": "Discard unsaved changes?",
     "discard_dialog_description": "You have unsaved changes in this tab. Leaving now will discard them.",
     "discard_keep": "Keep editing",
@@ -240,6 +239,8 @@
     "create_failed_toast": "Failed to create agent",
     "skill_attach_failed_toast": "Agent created, but failed to attach skills: {{error}}",
     "squad_join_failed_toast": "Agent \"{{name}}\" was created but couldn't join the squad: {{error}}. You can add it manually from Members.",
+    "thinking_label": "Thinking",
+    "thinking_help": "Override reasoning effort for this agent",
     "instructions": {
       "label": "Instructions",
       "placeholder_blank": "Click to write instructions…",
@@ -339,10 +340,6 @@
       "add_dialog_confirm_other": "Add {{count}} skills",
       "add_dialog_cancel": "Cancel",
       "add_failed_toast": "Failed to add skill"
-    },
-    "integrations": {
-      "intro": "Connect this agent to external chat platforms so people can work with it where they already are.",
-      "members_note": "Only workspace owners and admins can bind a Lark Bot to an agent. You can view connected bots in Settings → Integrations."
     },
     "activity": {
       "section_now": "Now",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -196,6 +196,7 @@
     "environment": "環境",
     "custom_args": "カスタム引数",
     "mcp_config": "MCP",
+    "integrations": "連携",
     "discard_dialog_title": "保存していない変更を破棄しますか？",
     "discard_dialog_description": "このタブに保存していない変更があります。今移動すると変更は破棄されます。",
     "discard_keep": "編集を続ける",
@@ -324,6 +325,10 @@
       "add_dialog_confirm_other": "スキル {{count}} 件を追加",
       "add_dialog_cancel": "キャンセル",
       "add_failed_toast": "スキルを追加できませんでした"
+    },
+    "integrations": {
+      "intro": "このエージェントを外部のチャットプラットフォームに接続し、普段使っているツールから直接やり取りできるようにします。",
+      "members_note": "エージェントに Lark Bot を紐付けできるのはワークスペースのオーナーと管理者のみです。接続済みの Bot は「設定 → 連携」で確認できます。"
     },
     "activity": {
       "section_now": "現在",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -196,7 +196,6 @@
     "environment": "環境",
     "custom_args": "カスタム引数",
     "mcp_config": "MCP",
-    "integrations": "連携",
     "discard_dialog_title": "保存していない変更を破棄しますか？",
     "discard_dialog_description": "このタブに保存していない変更があります。今移動すると変更は破棄されます。",
     "discard_keep": "編集を続ける",
@@ -227,6 +226,8 @@
     "create_failed_toast": "エージェントを作成できませんでした",
     "skill_attach_failed_toast": "エージェントは作成されましたが、スキルを追加できませんでした: {{error}}",
     "squad_join_failed_toast": "エージェント \"{{name}}\" は作成されましたが、スクワッドに参加できませんでした: {{error}}。メンバーから手動で追加できます。",
+    "thinking_label": "思考",
+    "thinking_help": "このエージェントの推論レベルをオーバーライドします",
     "instructions": {
       "label": "指示",
       "placeholder_blank": "クリックして指示を作成...",
@@ -323,10 +324,6 @@
       "add_dialog_confirm_other": "スキル {{count}} 件を追加",
       "add_dialog_cancel": "キャンセル",
       "add_failed_toast": "スキルを追加できませんでした"
-    },
-    "integrations": {
-      "intro": "このエージェントを外部のチャットプラットフォームに接続し、普段使っているツールから直接やり取りできるようにします。",
-      "members_note": "エージェントに Lark Bot を紐付けできるのはワークスペースのオーナーと管理者のみです。接続済みの Bot は「設定 → 連携」で確認できます。"
     },
     "activity": {
       "section_now": "現在",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -209,7 +209,6 @@
     "environment": "환경",
     "custom_args": "사용자 지정 인자",
     "mcp_config": "MCP",
-    "integrations": "연동",
     "discard_dialog_title": "저장하지 않은 변경사항을 버릴까요?",
     "discard_dialog_description": "이 탭에 저장하지 않은 변경사항이 있습니다. 지금 나가면 변경사항이 사라집니다.",
     "discard_keep": "계속 편집",
@@ -240,6 +239,8 @@
     "create_failed_toast": "에이전트를 만들지 못했습니다",
     "skill_attach_failed_toast": "에이전트는 만들었지만 스킬을 연결하지 못했습니다: {{error}}",
     "squad_join_failed_toast": "에이전트 \"{{name}}\"은(는) 만들었지만 스쿼드에 참가하지 못했습니다: {{error}}. 멤버에서 직접 추가할 수 있습니다.",
+    "thinking_label": "사고",
+    "thinking_help": "이 에이전트의 추론 수준을 오버라이드합니다",
     "instructions": {
       "label": "지침",
       "placeholder_blank": "클릭해서 지침 작성...",
@@ -339,10 +340,6 @@
       "add_dialog_confirm_other": "스킬 {{count}}개 추가",
       "add_dialog_cancel": "취소",
       "add_failed_toast": "스킬을 추가하지 못했습니다"
-    },
-    "integrations": {
-      "intro": "이 에이전트를 외부 채팅 플랫폼에 연결해 팀원이 평소 사용하는 도구에서 바로 함께 작업할 수 있도록 합니다.",
-      "members_note": "에이전트에 Lark 봇을 연결할 수 있는 사람은 워크스페이스 소유자와 관리자뿐입니다. 연결된 봇은 설정 → 연동에서 확인할 수 있습니다."
     },
     "activity": {
       "section_now": "현재",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -209,6 +209,7 @@
     "environment": "환경",
     "custom_args": "사용자 지정 인자",
     "mcp_config": "MCP",
+    "integrations": "연동",
     "discard_dialog_title": "저장하지 않은 변경사항을 버릴까요?",
     "discard_dialog_description": "이 탭에 저장하지 않은 변경사항이 있습니다. 지금 나가면 변경사항이 사라집니다.",
     "discard_keep": "계속 편집",
@@ -340,6 +341,10 @@
       "add_dialog_confirm_other": "스킬 {{count}}개 추가",
       "add_dialog_cancel": "취소",
       "add_failed_toast": "스킬을 추가하지 못했습니다"
+    },
+    "integrations": {
+      "intro": "이 에이전트를 외부 채팅 플랫폼에 연결해 팀원이 평소 사용하는 도구에서 바로 함께 작업할 수 있도록 합니다.",
+      "members_note": "에이전트에 Lark 봇을 연결할 수 있는 사람은 워크스페이스 소유자와 관리자뿐입니다. 연결된 봇은 설정 → 연동에서 확인할 수 있습니다."
     },
     "activity": {
       "section_now": "현재",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -204,7 +204,6 @@
     "environment": "环境变量",
     "custom_args": "自定义参数",
     "mcp_config": "MCP",
-    "integrations": "集成",
     "discard_dialog_title": "放弃未保存的修改？",
     "discard_dialog_description": "当前 tab 有未保存的修改，离开会丢弃这些修改。",
     "discard_keep": "继续编辑",
@@ -235,6 +234,8 @@
     "create_failed_toast": "创建智能体失败",
     "skill_attach_failed_toast": "智能体已创建，但 skill 关联失败：{{error}}",
     "squad_join_failed_toast": "智能体「{{name}}」已创建，但加入小队失败：{{error}}。你可以在 Members 标签里手动添加。",
+    "thinking_label": "思考",
+    "thinking_help": "为此智能体覆盖推理级别",
     "instructions": {
       "label": "指令",
       "placeholder_blank": "点击撰写指令…",
@@ -331,10 +332,6 @@
       "add_dialog_confirm_other": "添加 {{count}} 个 skill",
       "add_dialog_cancel": "取消",
       "add_failed_toast": "添加 skill 失败"
-    },
-    "integrations": {
-      "intro": "把这个智能体连接到外部聊天平台，让大家在自己熟悉的工具里直接与它协作。",
-      "members_note": "只有工作区的所有者和管理员才能为智能体绑定飞书 Bot。你可以在「设置 → 集成」中查看已连接的 Bot。"
     },
     "activity": {
       "section_now": "当前",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -204,6 +204,7 @@
     "environment": "环境变量",
     "custom_args": "自定义参数",
     "mcp_config": "MCP",
+    "integrations": "集成",
     "discard_dialog_title": "放弃未保存的修改？",
     "discard_dialog_description": "当前 tab 有未保存的修改，离开会丢弃这些修改。",
     "discard_keep": "继续编辑",
@@ -332,6 +333,10 @@
       "add_dialog_confirm_other": "添加 {{count}} 个 skill",
       "add_dialog_cancel": "取消",
       "add_failed_toast": "添加 skill 失败"
+    },
+    "integrations": {
+      "intro": "把这个智能体连接到外部聊天平台，让大家在自己熟悉的工具里直接与它协作。",
+      "members_note": "只有工作区的所有者和管理员才能为智能体绑定飞书 Bot。你可以在「设置 → 集成」中查看已连接的 Bot。"
     },
     "activity": {
       "section_now": "当前",


### PR DESCRIPTION
Add a ThinkingLevel selector to the create/duplicate agent dialog, placed between Model and Instructions. The picker shows only when the selected model exposes supported_levels via runtime discovery.

Key behaviors:
- Only submits thinking_level when picker is visible (discovery resolved and model supports thinking), preventing silent submission of stale template values when runtime is offline or model changes.
- Duplicate mode pre-fills from template.thinking_level when compatible; clears automatically when the new model/runtime is incompatible.
- Runtime/model changes trigger re-evaluation; invalid selections are cleared via useEffect after modelsQuery resolves.

Changes:
- create-agent-dialog.tsx: add thinkingLevel state, model discovery query, ThinkingPicker UI, and guarded payload submission
- thinking-prop-row.tsx: export pickModelEntry for reuse
- i18n: add thinking_label/thinking_help to en/zh-Hans/ko/ja
- Tests: 6 new cases covering show/hide, payload inclusion, offline/incompatible duplicate, and compatible pre-fill

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
