### PR TITLE
fix(cli): degrade 'issue metadata list' to {} on /metadata 404 (refs #3711)

### DIFF
--- a/server/cmd/multica/cmd_issue_metadata.go
+++ b/server/cmd/multica/cmd_issue_metadata.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"strconv"
@@ -178,6 +180,26 @@ func runIssueMetadataList(cmd *cobra.Command, args []string) error {
 
 	var result map[string]any
 	if err := client.GetJSON(ctx, "/api/issues/"+issueRef.ID+"/metadata", &result); err != nil {
+		// Best-effort degradation: when the server does not expose the
+		// per-issue metadata endpoint (self-hosted backends running an
+		// older build, missing migration, or routing issues that surface
+		// as 404), an agent's bootstrap "metadata list" must not fail
+		// the entire run. Emit an empty map and exit 0 so the agent
+		// still gets the empty-metadata signal it would have gotten on
+		// a fresh issue. Other status codes (auth, server errors) keep
+		// real error semantics, and metadata get/set/delete are
+		// unaffected — those callers still need to know when something
+		// went wrong.
+		var httpErr *cli.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			output, _ := cmd.Flags().GetString("output")
+			empty := map[string]any{}
+			if output == "json" {
+				return cli.PrintJSON(os.Stdout, empty)
+			}
+			printMetadataTable(empty)
+			return nil
+		}
 		return fmt.Errorf("list metadata: %w", err)
 	}
 	metadata, _ := result["metadata"].(map[string]any)

--- a/server/cmd/multica/cmd_issue_metadata_test.go
+++ b/server/cmd/multica/cmd_issue_metadata_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+// Tests for `multica issue metadata list` 404-degradation behavior, plus
+// regression coverage that get / set / delete keep real error semantics so
+// we don't lose signal when the user actually depends on the metadata
+// endpoint working.
+//
+// Background: GitHub issue multica-ai/multica#3711 — on self-hosted
+// backends that pre-date the per-issue metadata route, agent runtime
+// bootstrap calls `multica issue metadata list <issue> --output json`
+// best-effort and any non-zero exit was being escalated by the Hermes
+// provider into a failed agent run. The fix is to treat a 404 from
+// /api/issues/{id}/metadata as "this server has no metadata yet" and
+// emit `{}` with exit 0 — but only for `list`, since get/set/delete on
+// a missing endpoint really are operational failures the caller asked
+// for.
+
+const testIssueUUID = "11111111-1111-1111-1111-111111111111"
+
+func newIssueMetadataListTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "list"}
+	c.Flags().String("output", "json", "")
+	return c
+}
+
+func newIssueMetadataGetTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "get"}
+	c.Flags().String("output", "json", "")
+	c.Flags().String("key", "", "")
+	return c
+}
+
+func newIssueMetadataSetTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "set"}
+	c.Flags().String("output", "json", "")
+	c.Flags().String("key", "", "")
+	c.Flags().String("value", "", "")
+	c.Flags().String("type", "", "")
+	return c
+}
+
+func newIssueMetadataDeleteTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "delete"}
+	c.Flags().String("output", "json", "")
+	c.Flags().String("key", "", "")
+	return c
+}
+
+// captureStdout used in this file is the (string, error) helper defined
+// in cmd_skill_test.go.
+
+// metadataTestServer wires a minimal fake backend that answers the
+// resolveIssueRef GET on /api/issues/<id> and forwards every metadata
+// request to the supplied handler. It returns the captured request paths
+// in order so callers can assert routing.
+func metadataTestServer(t *testing.T, metadataHandler http.HandlerFunc) (*httptest.Server, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/"+testIssueUUID:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         testIssueUUID,
+				"identifier": "MUL-1",
+				"title":      "test issue",
+			})
+		case strings.HasPrefix(r.URL.Path, "/api/issues/"+testIssueUUID+"/metadata"):
+			metadataHandler(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	return srv, &paths
+}
+
+func TestRunIssueMetadataListDegradesOn404JSON(t *testing.T) {
+	var hits int32
+	_, paths := metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	})
+
+	cmd := newIssueMetadataListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	out, runErr := captureStdout(t, func() error {
+		return runIssueMetadataList(cmd, []string{testIssueUUID})
+	})
+	if runErr != nil {
+		t.Fatalf("runIssueMetadataList returned error on 404, want nil: %v", runErr)
+	}
+	if got := strings.TrimSpace(out); got != "{}" {
+		t.Fatalf("stdout = %q, want %q (empty JSON object on 404 degradation)", got, "{}")
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("metadata endpoint hits = %d, want 1; routing: %v", got, *paths)
+	}
+}
+
+func TestRunIssueMetadataListDegradesOn404Table(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such route", http.StatusNotFound)
+	})
+
+	cmd := newIssueMetadataListTestCmd()
+	_ = cmd.Flags().Set("output", "table")
+
+	out, runErr := captureStdout(t, func() error {
+		return runIssueMetadataList(cmd, []string{testIssueUUID})
+	})
+	if runErr != nil {
+		t.Fatalf("runIssueMetadataList returned error on 404 table mode: %v", runErr)
+	}
+	// Table mode prints headers even with zero rows; the important
+	// invariant is just that exit is clean and the row table doesn't
+	// surface a stack trace or error blob.
+	if !strings.Contains(out, "KEY") {
+		t.Fatalf("table output missing KEY header, got %q", out)
+	}
+	if strings.Contains(strings.ToLower(out), "error") || strings.Contains(out, "404") {
+		t.Fatalf("table output unexpectedly leaked error text: %q", out)
+	}
+}
+
+func TestRunIssueMetadataListSuccessReturnsServerMetadata(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{
+				"pr_url":          "https://example.com/pr/1",
+				"pipeline_status": "waiting_review",
+			},
+		})
+	})
+
+	cmd := newIssueMetadataListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	out, runErr := captureStdout(t, func() error {
+		return runIssueMetadataList(cmd, []string{testIssueUUID})
+	})
+	if runErr != nil {
+		t.Fatalf("runIssueMetadataList: %v", runErr)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v\n%s", err, out)
+	}
+	if got["pr_url"] != "https://example.com/pr/1" || got["pipeline_status"] != "waiting_review" {
+		t.Fatalf("stdout = %#v, missing expected keys", got)
+	}
+}
+
+// 5xx and other non-404 errors must keep real error semantics — we only
+// want to mask "this server has no metadata endpoint", not "the server
+// is broken".
+func TestRunIssueMetadataListPropagatesNon404Error(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	cmd := newIssueMetadataListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	// Drop stdout to keep test output clean even if the implementation
+	// regresses and prints something.
+	_, err := captureStdout(t, func() error {
+		return runIssueMetadataList(cmd, []string{testIssueUUID})
+	})
+	if err == nil {
+		t.Fatal("runIssueMetadataList returned nil on 500, want error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error = %v, want it to mention status 500", err)
+	}
+	var httpErr *cli.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error chain missing *cli.HTTPError: %v", err)
+	}
+	if httpErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("HTTPError.StatusCode = %d, want 500", httpErr.StatusCode)
+	}
+}
+
+func TestRunIssueMetadataListPropagates401Error(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+
+	cmd := newIssueMetadataListTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdout(t, func() error {
+		return runIssueMetadataList(cmd, []string{testIssueUUID})
+	})
+	if err == nil {
+		t.Fatal("runIssueMetadataList returned nil on 401, want error")
+	}
+	var httpErr *cli.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 *cli.HTTPError, got %v", err)
+	}
+}
+
+// get/set/delete must NOT degrade on 404 — those calls represent real
+// caller intent and the user needs to see the failure.
+func TestRunIssueMetadataGetReturnsErrorOn404(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	cmd := newIssueMetadataGetTestCmd()
+	_ = cmd.Flags().Set("key", "pr_url")
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdout(t, func() error {
+		return runIssueMetadataGet(cmd, []string{testIssueUUID})
+	})
+	if err == nil {
+		t.Fatal("runIssueMetadataGet returned nil on 404, want error")
+	}
+}
+
+func TestRunIssueMetadataSetReturnsErrorOn404(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// PUT /metadata/<key> on an old server — must surface the failure.
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	cmd := newIssueMetadataSetTestCmd()
+	_ = cmd.Flags().Set("key", "pr_url")
+	_ = cmd.Flags().Set("value", "https://example.com/pr/1")
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdout(t, func() error {
+		return runIssueMetadataSet(cmd, []string{testIssueUUID})
+	})
+	if err == nil {
+		t.Fatal("runIssueMetadataSet returned nil on 404, want error")
+	}
+	if !strings.Contains(err.Error(), "set metadata") {
+		t.Fatalf("error = %v, want it wrapped with 'set metadata' prefix", err)
+	}
+}
+
+func TestRunIssueMetadataDeleteReturnsErrorOn404(t *testing.T) {
+	_, _ = metadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	cmd := newIssueMetadataDeleteTestCmd()
+	_ = cmd.Flags().Set("key", "pr_url")
+	_ = cmd.Flags().Set("output", "json")
+
+	_, err := captureStdout(t, func() error {
+		return runIssueMetadataDelete(cmd, []string{testIssueUUID})
+	})
+	if err == nil {
+		t.Fatal("runIssueMetadataDelete returned nil on 404, want error")
+	}
+	if !strings.Contains(err.Error(), "delete metadata") {
+		t.Fatalf("error = %v, want it wrapped with 'delete metadata' prefix", err)
+	}
+}

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -118,6 +118,12 @@ func (c *APIClient) setHeaders(req *http.Request) {
 }
 
 // GetJSON performs a GET request and decodes the JSON response.
+//
+// On an HTTP error response (status >= 400) the returned error is a
+// *HTTPError so callers can use errors.As to inspect the status code
+// (for example to recognize a 404 from a server that does not expose a
+// given endpoint and degrade gracefully). The error string format
+// ("GET <path> returned <code>: <body>") is preserved by HTTPError.Error().
 func (c *APIClient) GetJSON(ctx context.Context, path string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
 	if err != nil {
@@ -133,7 +139,12 @@ func (c *APIClient) GetJSON(ctx context.Context, path string, out any) error {
 
 	if resp.StatusCode >= 400 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("GET %s returned %d: %s", path, resp.StatusCode, strings.TrimSpace(string(data)))
+		return &HTTPError{
+			Method:     http.MethodGet,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(data)),
+		}
 	}
 	if out == nil {
 		return nil


### PR DESCRIPTION
## Summary

Make `multica issue metadata list` best-effort: when the server returns
404 for `GET /api/issues/:id/metadata`, the CLI now prints `{}` (or an
empty table) and exits 0 instead of failing the command. Other status
codes are still surfaced normally, and `metadata get / set / delete`
are unaffected.

Refs GitHub issue #3711.

## Why

On self-hosted backends that don't expose the per-issue metadata
endpoint — older builds, unapplied `105_issue_metadata` migration, or
proxy/ingress route mismatches — `GET /api/issues/:id/metadata` 404s.

The agent runtime bootstrap calls
`multica issue metadata list <issue> --output json` as a best-effort
read, but the prior CLI behaviour returned a non-zero exit on HTTP
errors. Hermes then escalated that into a failed agent run even when
the actual work the agent did afterwards had succeeded — so an
*optional* metadata read was breaking task results.

The fix makes the optional read truly optional, while keeping real
errors (auth failures, 5xx, network, etc.) loud.

## Scope

- **Only `list` degrades on 404.** `get`, `set`, and `delete` keep real
  error semantics — they represent explicit caller intent and silently
  succeeding on a missing endpoint would hide real failures.
- **Only 404 degrades.** 401 / 403 / 5xx / network errors still
  produce a non-zero exit and a real error message. The runtime bug
  is specifically "endpoint not exposed", not "server is unreachable".
- The `resolveIssueRef` step still runs first and returns its own
  error if the issue itself is missing — the 404 we mask is
  unambiguously the metadata endpoint not being served.

## Implementation

- `server/internal/cli/client.go`: `GetJSON` now returns `*cli.HTTPError`
  on HTTP failures (matching how `PostJSON` already worked) so callers
  can use `errors.As` to inspect the status code. The error string
  format (`GET <path> returned <code>: <body>`) is preserved by
  `HTTPError.Error()`, so any caller that string-matches the message
  is unaffected.
- `server/cmd/multica/cmd_issue_metadata.go`: `runIssueMetadataList`
  now checks for `*cli.HTTPError` with `StatusCode == 404` and emits
  an empty result instead of an error.
- `server/cmd/multica/cmd_issue_metadata_test.go`: new tests.

## Tests

```
go test ./server/cmd/multica/ -run TestRunIssueMetadata -v
```

Covers:

- `list` 404 → `{}` JSON, exit 0
- `list` 404 → empty table, exit 0
- `list` 200 → metadata returned unchanged
- `list` 500 → real error, unwraps to `*cli.HTTPError{StatusCode: 500}`
- `list` 401 → real error, unwraps to `*cli.HTTPError{StatusCode: 401}`
- `get` 404 → real error (degradation does **not** apply)
- `set` 404 → real error
- `delete` 404 → real error

`go test ./cmd/multica/ ./internal/cli/...` and `go vet` both pass on
the changed packages.

## Notes for reviewers

- This is the short-term fix discussed in the upstream review of #3711.
  The complementary feature-detection / non-fatal-bootstrap work in the
  daemon/runtime is separate and not covered here.
- We considered string-matching the legacy `GetJSON` error text; that
  was rejected as brittle. Returning `*HTTPError` brings `GetJSON` in
  line with `PostJSON` and is a strictly additive API change.
