### PR TITLE
fix(agent): fail Codex RPC fast after app-server exit instead of hanging

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1133,6 +1133,18 @@ type codexClient struct {
 
 	turnErrorMu sync.Mutex
 	turnError   string // captured from turn/completed status=failed or terminal error notifications
+
+	// closed latches true once the reader goroutine observes the app-server's
+	// stdout close (the process exited or stopped emitting). Guarded by mu and
+	// set by closeAllPending. While the reader is alive it delivers responses
+	// and, on EOF, fails every in-flight request; but once it has exited no
+	// goroutine remains to complete a freshly-registered request. Without this
+	// latch such a request — e.g. the thread/start fallback after a
+	// thread/resume that killed the app-server — would block on its context
+	// until the task timeout (hours), pinning the runtime and bypassing the
+	// daemon's "resume failed, retry with a fresh session" recovery.
+	closed   bool
+	closeErr error
 }
 
 func (c *codexClient) setTurnError(msg string) {
@@ -1164,6 +1176,17 @@ type rpcResult struct {
 
 func (c *codexClient) request(ctx context.Context, method string, params any) (json.RawMessage, error) {
 	c.mu.Lock()
+	if c.closed {
+		// The app-server is gone; no goroutine will ever complete this
+		// request. Fail fast with the exit error instead of blocking on ctx
+		// (the task timeout) so callers like startOrResumeThread surface the
+		// failure promptly. The mu/closed handshake makes this race-free: a
+		// request that registered before closeAllPending ran is failed by it
+		// via the pending map; one arriving after is caught here.
+		closeErr := c.closeErr
+		c.mu.Unlock()
+		return nil, closeErr
+	}
 	c.nextID++
 	id := c.nextID
 	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: method}
@@ -1244,9 +1267,20 @@ func (c *codexClient) respondError(id int, code int, message string) {
 	_, _ = c.stdin.Write(data)
 }
 
+// closeAllPending fails every in-flight request and latches the client closed
+// so that any request() issued afterwards fails fast instead of blocking on its
+// context. It is called once, when the reader goroutine sees the app-server's
+// stdout close. The latch is what rescues the thread/start fallback in
+// startOrResumeThread: once the process is gone, no goroutine remains to deliver
+// an RPC response, so a fresh request would otherwise wait out the whole task
+// timeout rather than surfacing the failure for the daemon to retry fresh.
 func (c *codexClient) closeAllPending(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if !c.closed {
+		c.closed = true
+		c.closeErr = err
+	}
 	for id, pr := range c.pending {
 		pr.ch <- rpcResult{err: err}
 		delete(c.pending, id)

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -710,6 +710,46 @@ func TestCodexCloseAllPending(t *testing.T) {
 	}
 }
 
+// TestCodexRequestAfterProcessExitFailsFast guards the transport-level hang
+// behind a stuck Codex resume: when the app-server's stdout closes, the reader
+// goroutine calls closeAllPending and exits, so a request issued afterwards —
+// e.g. the thread/start fallback after a thread/resume that killed the process
+// — has no goroutine left to complete it. It must fail fast rather than block
+// on ctx (the task's multi-hour timeout), so startOrResumeThread can surface a
+// failed result and the daemon's fresh-session retry can take over.
+func TestCodexRequestAfterProcessExitFailsFast(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+
+	// Reader goroutine observed stdout EOF.
+	c.closeAllPending(fmt.Errorf("codex process exited"))
+
+	// A long-lived context stands in for the task timeout: the request must
+	// not depend on it firing. Before the closed latch this call blocked here
+	// until ctx, pinning the runtime for the whole task timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.request(ctx, "thread/start", map[string]any{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected request after process exit to fail, got nil")
+		}
+		if !strings.Contains(err.Error(), "codex process exited") {
+			t.Fatalf("expected process-exit error, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request after process exit hung; expected fast failure")
+	}
+}
+
 func TestCodexHandleInvalidJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

A Codex-backed task can hang in `status=running` with **zero output for hours**,
pinning its runtime, when a `thread/resume` kills the app-server. The hang also
**silently bypasses the daemon's existing "resume failed → retry with a fresh
session" recovery**. This change makes the transport layer fail fast on
app-server exit so that recovery actually runs — turning a multi-hour hung,
runtime-pinning task into a sub-second failover that succeeds on a fresh session.

Reproduced on a self-hosted deployment (daemon `multica 0.3.14`,
`codex-cli 0.135.0`): a follow-up comment triggered a `resume_session=true` run;
`thread/resume` returned `codex process exited`; the task then sat ~42 min with
no activity (and would have run to the 2h task timeout) holding the Codex
runtime and blocking every task queued behind it. Manually cancelling and
re-running fresh succeeded immediately — which is exactly what the daemon's own
retry path is supposed to do automatically.

## Root cause

`codexClient.request()` blocks on `select { case <-pr.ch; case <-ctx.Done() }`.
`pr.ch` is fed only by `handleResponse` (a stdout line) or `closeAllPending`. The
reader goroutine calls `closeAllPending("codex process exited")` **exactly once**,
when codex's stdout closes, and then exits (`codex.go`, reader goroutine).

Sequence:

1. `thread/resume` is in flight → the app-server's stdout closes → the reader
   calls `closeAllPending` (which fails the in-flight resume request) and
   **exits**.
2. `startOrResumeThread` falls back to `thread/start` → `request()` registers a
   **new** pending entry. The reader is already gone, so nothing will ever
   complete it. It blocks until `ctx.Done()` — the task timeout (hours).

Because `Execute` is stuck inside `startOrResumeThread`, it is *before* the
turn-level first-turn-no-progress / semantic-inactivity watchdogs arm, so neither
watchdog applies. Worse, `Execute` never returns the `failed` result that the
daemon's fresh-session retry keys on:

```go
// daemon.go — already present
if result.Status == "failed" && task.PriorSessionID != "" && result.SessionID == "" {
    execOpts.ResumeSessionID = ""           // retry with a fresh session
    retryResult, ... := d.executeAndDrain(ctx, backend, prompt, execOpts, ...)
}
```

So the bug doesn't merely hang — it disables Multica's own recovery for resume
failures.

## Fix

Make the client process-death-aware:

- `closeAllPending` latches `closed`/`closeErr` under `mu`.
- `request()` short-circuits with the exit error when already closed.

Any RPC issued after the app-server is gone now fails fast instead of blocking on
`ctx`. `startOrResumeThread` returns promptly → `Execute` reports `failed` with no
session → the **existing** fresh-session retry runs → the task recovers on a new
session and the runtime is freed in seconds.

The `mu`/`closed` handshake is race-free: a request registered before
`closeAllPending` runs is failed by it via the pending map; one arriving after is
caught by the entry check. Transport-only — no daemon or classifier changes.

## Test

`TestCodexRequestAfterProcessExitFailsFast`: after `closeAllPending`, a
`request()` on a **non-expiring** context must return the exit error within 2s.
It hangs (failing the 2s guard) before the fix and passes after.

## Relation to #3262

Same end-symptom family ("Codex app-server stuck at `status=running`, no output")
but a **distinct** trigger. #3262 is a *cold-first-turn* no-output case
(model-catalog / provider), already partially handled by the first-turn
no-progress watchdog added in #3291. This is the *resume-failure fallback* path,
which runs **before** any turn starts — so #3291's watchdog never arms here.
Independent fix; complementary, not a duplicate.

## Follow-ups (not in this PR)

- `hermes.go` shares the same `closeAllPending`-once transport shape (request
  selects only on `pr.ch` / `ctx.Done()`), so it likely has the same latent hang;
  `kiro.go` / `kimi.go` look similar. Happy to extend the same latch to those
  backends in this PR or a follow-up, whichever you prefer.

## Verification

`gofmt` clean · `go vet ./pkg/agent/` clean · `go build ./...` · `go test ./pkg/agent/`
(58 pass, incl. the new test). Built with the repo's pinned Go 1.26.1 toolchain.
