### PR TITLE
fix(views): defer issue draft description hydration

### DIFF
--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef, useState, type ReactNode } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -140,6 +140,10 @@ vi.mock("../editor", () => {
   const ContentEditor = forwardRef(({ defaultValue, onUpdate, placeholder }: any, ref: any) => {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
+    useEffect(() => {
+      valueRef.current = defaultValue || "";
+      setValue(defaultValue || "");
+    }, [defaultValue]);
     useImperativeHandle(ref, () => ({
       getMarkdown: () => valueRef.current,
       clearContent: () => {
@@ -314,8 +318,14 @@ describe("CreateIssueModal", () => {
     });
     // Reset the shared draft mock so per-test assignee seeding (squad / agent)
     // doesn't leak into the next test in the suite.
+    mockDraftStore.draft.title = "";
+    mockDraftStore.draft.description = "";
+    mockDraftStore.draft.status = "todo";
+    mockDraftStore.draft.priority = "none";
     mockDraftStore.draft.assigneeType = undefined;
     mockDraftStore.draft.assigneeId = undefined;
+    mockDraftStore.draft.startDate = null;
+    mockDraftStore.draft.dueDate = null;
     mockCreateIssue.mockResolvedValue({
       id: "issue-123",
       identifier: "TES-123",
@@ -627,6 +637,20 @@ describe("CreateIssueModal", () => {
     await user.click(picker);
 
     expect(screen.queryByTestId("start-date-picker")).not.toBeInTheDocument();
+  });
+
+  it("defers persisted description hydration until after the dialog can render", async () => {
+    mockDraftStore.draft.title = "Recovered title";
+    mockDraftStore.draft.description = "x".repeat(70 * 1024);
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("Issue title")).toHaveValue("Recovered title");
+    expect(screen.getByPlaceholderText("Add description...")).toHaveValue("");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Add description...")).toHaveValue(mockDraftStore.draft.description);
+    });
   });
 
   // Title + description are packed into the agent prompt on switch; if we

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigation } from "../navigation";
 import {
@@ -100,8 +100,10 @@ export function ManualCreatePanel({
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
 
   const [title, setTitle] = useState(draft.title);
+  const [descriptionDefaultValue, setDescriptionDefaultValue] = useState("");
   const [formResetKey, setFormResetKey] = useState(0);
   const descEditorRef = useRef<ContentEditorRef>(null);
+  const initialDraftDescriptionRef = useRef(draft.description);
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
   });
@@ -149,6 +151,24 @@ export function ManualCreatePanel({
   // File upload — collect attachment IDs so we can link them after issue creation.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
   const { uploadWithToast } = useFileUpload(api);
+
+  useEffect(() => {
+    const initialDescription = initialDraftDescriptionRef.current;
+    if (!initialDescription) return;
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const frameId = requestAnimationFrame(() => {
+      timeoutId = setTimeout(() => {
+        setDescriptionDefaultValue(initialDescription);
+      }, 0);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, []);
+
   const handleUpload = async (file: File) => {
     const result = await uploadWithToast(file);
     if (result) {
@@ -190,6 +210,7 @@ export function ManualCreatePanel({
       startDate: null,
       dueDate: null,
     });
+    setDescriptionDefaultValue("");
     descEditorRef.current?.clearContent();
     setFormResetKey((key) => key + 1);
   };
@@ -477,7 +498,7 @@ export function ManualCreatePanel({
             <div {...descDropZoneProps} className="relative flex flex-1 min-h-0 overflow-y-auto px-5">
               <ContentEditor
                 ref={descEditorRef}
-                defaultValue={draft.description}
+                defaultValue={descriptionDefaultValue}
                 placeholder={t(($) => $.create_issue.description_placeholder)}
                 onUpdate={(md) => setDraft({ description: md })}
                 onUploadFile={handleUpload}


### PR DESCRIPTION
## Summary

Fix the Create Issue dialog freeze caused by hydrating very large persisted manual-mode draft descriptions during the first render pass.

The dialog still restores lightweight draft fields immediately, but defers the expensive description hydration until after the modal has mounted so the initial UI can render and stay responsive.

Fixes #3622.

## Why

Manual-mode issue drafts can persist very large descriptions in local storage. Restoring that value synchronously while the Create Issue dialog opens blocks the modal from rendering, which makes the desktop UI appear frozen before the user can interact with the form.

The description is the expensive field; lightweight metadata such as title, status, and priority can still be restored synchronously without causing the same stall. Deferring only the description keeps draft restoration behavior intact while removing the blocking first-render path.

## Changes

- Defer persisted issue draft description hydration until after the Create Issue dialog can render.
- Preserve immediate restoration for lightweight draft fields such as title, status, and priority.
- Add regression coverage for large persisted manual-mode drafts.

## Test Plan

- `COREPACK_HOME=/tmp/corepack pnpm --filter @multica/views exec vitest run modals/create-issue.test.tsx`
- `COREPACK_HOME=/tmp/corepack pnpm --filter @multica/views typecheck`
- `COREPACK_HOME=/tmp/corepack pnpm --filter @multica/views test`