### PR TITLE
fix(daemon): bind runtime claim access to runtime identity

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -92,6 +92,28 @@ func (h *Handler) requireDaemonRuntimeAccess(w http.ResponseWriter, r *http.Requ
 	return rt, true
 }
 
+// requireDaemonRuntimeIdentityAccess verifies the caller is bound to the
+// specific runtime, not merely to the runtime's workspace. Bound daemon tokens
+// can only operate the daemon_id they were minted for; PAT/JWT fallback is
+// accepted only for the runtime owner. Legacy runtimes without owner/daemon_id
+// keep the existing workspace-scoped fallback until they are backfilled.
+func (h *Handler) requireDaemonRuntimeIdentityAccess(w http.ResponseWriter, r *http.Request, rt db.AgentRuntime) bool {
+	if h.verifyDaemonRuntimeIdentityAccess(r, rt) {
+		return true
+	}
+	writeError(w, http.StatusNotFound, "runtime not found")
+	return false
+}
+
+func (h *Handler) verifyDaemonRuntimeIdentityAccess(r *http.Request, rt db.AgentRuntime) bool {
+	if daemonID := middleware.DaemonIDFromContext(r.Context()); daemonID != "" {
+		return !rt.DaemonID.Valid || rt.DaemonID.String == daemonID
+	}
+
+	userID := requestUserID(r)
+	return userID != "" && (!rt.OwnerID.Valid || uuidToString(rt.OwnerID) == userID)
+}
+
 // requireDaemonTaskAccess looks up a task and verifies the caller owns its workspace.
 func (h *Handler) requireDaemonTaskAccess(w http.ResponseWriter, r *http.Request, taskID string) (db.AgentTaskQueue, bool) {
 	task, _, ok := h.requireDaemonTaskAccessWithWorkspace(w, r, taskID)
@@ -1083,6 +1105,10 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	// runtime_id (defense-in-depth against upstream routing bugs).
 	runtime, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID)
 	if !ok {
+		return
+	}
+	if !h.requireDaemonRuntimeIdentityAccess(w, r, runtime) {
+		outcome = "runtime_identity_denied"
 		return
 	}
 	runtimeWorkspaceID := uuidToString(runtime.WorkspaceID)

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -307,6 +307,151 @@ func TestClaimTaskByRuntime_DoesNotReclaimDifferentRuntimeTask(t *testing.T) {
 	}
 }
 
+func TestClaimTaskByRuntime_RejectsSameWorkspaceMemberForForeignRuntime(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	attackerUserID, _ := createEphemeralMember(t, testWorkspaceID, "runtime-claim-attacker", "member")
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider,
+			status, device_info, metadata, owner_id, last_seen_at, visibility
+		)
+		VALUES ($1, 'victim-daemon-' || gen_random_uuid()::text, 'Victim Runtime',
+		        'local', 'handler_test_runtime', 'online', 'victim device', '{}'::jsonb, $2, now(), 'private')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("setup: create victim runtime: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID) })
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, owner_id, visibility, max_concurrent_tasks
+		)
+		VALUES ($1, 'Victim Agent', '', 'local', '{}'::jsonb, $2, $3, 'private', 1)
+		RETURNING id
+	`, testWorkspaceID, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("setup: create victim agent: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'Foreign runtime claim fixture', 'todo', 'none', $2, 'member', 81299, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newRequestAsUser(attackerUserID, "POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("ClaimTaskByRuntime as same-workspace non-owner: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&status); err != nil {
+		t.Fatalf("query task status: %v", err)
+	}
+	if status != "queued" {
+		t.Fatalf("foreign runtime claim must leave task queued, got status %q", status)
+	}
+}
+
+func TestClaimTaskByRuntime_AllowsRuntimeOwnerPATFallback(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider,
+			status, device_info, metadata, owner_id, last_seen_at, visibility
+		)
+		VALUES ($1, 'owner-daemon-' || gen_random_uuid()::text, 'Owner Runtime',
+		        'local', 'handler_test_runtime', 'online', 'owner device', '{}'::jsonb, $2, now(), 'private')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("setup: create owner runtime: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID) })
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, owner_id, visibility, max_concurrent_tasks
+		)
+		VALUES ($1, 'Owner Agent', '', 'local', '{}'::jsonb, $2, $3, 'private', 1)
+		RETURNING id
+	`, testWorkspaceID, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("setup: create owner agent: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID) })
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'Owner runtime claim fixture', 'todo', 'none', $2, 'member', 81300, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime as runtime owner: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Task *AgentTaskResponse `json:"task"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode claim response: %v", err)
+	}
+	if resp.Task == nil || resp.Task.ID != taskID {
+		t.Fatalf("expected owner to claim task %s, got %#v body=%s", taskID, resp.Task, w.Body.String())
+	}
+}
+
 // TestClaimTaskByRuntime_PopulatesWorkspaceContext verifies the claim
 // response carries workspace.context so the daemon can inject the
 // workspace-level system prompt into every agent brief. Regression coverage


### PR DESCRIPTION
## Summary

Bind daemon task claim authorization to the runtime identity when identity metadata is available.

This keeps the existing workspace-level daemon access check, then adds a claim-time runtime identity check so a caller with workspace access cannot claim a task for another bound runtime. For compatibility, legacy runtimes that do not yet have `owner_id` or `daemon_id` metadata continue to use the existing workspace-scoped fallback.

## Why

The daemon claim response carries the execution payload for the selected runtime, including the agent configuration and a task-scoped auth token. Workspace membership alone is too broad for that response once a runtime is associated with a concrete owner or daemon id.

The narrower check is applied at the task claim boundary rather than to every daemon endpoint, which preserves existing heartbeat/register behavior and avoids breaking legacy runtime rows while still tightening the sensitive response path.

## Changes

- Add a runtime identity authorization helper for daemon-token and PAT/JWT fallback paths.
- Require `ClaimTaskByRuntime` callers to match the runtime owner or daemon id when the runtime row has that metadata.
- Return 404 on mismatch to keep the existing not-found behavior and avoid exposing runtime existence.
- Add regression coverage for non-owner claim rejection and owner PAT fallback.

## Test Plan

- `DATABASE_URL=postgres://multica:multica@127.0.0.1:15432/multica_task3?sslmode=disable GOCACHE=/tmp/multica-go-cache GOPATH=/tmp/multica-go-path /usr/local/go/bin/go test ./internal/handler -run 'TestClaimTaskByRuntime_(RejectsSameWorkspaceMemberForForeignRuntime|AllowsRuntimeOwnerPATFallback)' -count=1 -v`
- `DATABASE_URL=postgres://multica:multica@127.0.0.1:15432/multica_task3?sslmode=disable GOCACHE=/tmp/multica-go-cache GOPATH=/tmp/multica-go-path /usr/local/go/bin/go test ./internal/handler -run 'TestDaemonHeartbeat|TestDaemonRegister|TestClaimTaskByRuntime' -count=1 -v`