### PR TITLE
Fix(UI): issue-level attachment rendering in issue detail

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -125,6 +125,11 @@ vi.mock("../../editor", () => ({
     modal: null,
   }),
   isPreviewable: () => false,
+  AttachmentDownloadProvider: ({ children }: any) => <>{children}</>,
+  Attachment: ({ attachment }: any) => {
+    const record = attachment?.kind === "record" ? attachment.attachment : attachment;
+    return <div data-testid="attachment-card">{record?.filename}</div>;
+  },
   ReadonlyContent: ({ content }: { content: string }) => (
     <div data-testid="readonly-content">{content}</div>
   ),
@@ -502,6 +507,7 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });
     mockApiObj.listTasksByIssue.mockResolvedValue([]);
+    mockApiObj.listAttachments.mockResolvedValue([]);
     mockApiObj.listMembers.mockResolvedValue([
       { user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" },
     ]);
@@ -529,6 +535,69 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+  });
+
+  it("renders issue-level attachments below the description", async () => {
+    mockApiObj.getIssue.mockResolvedValue({
+      ...mockIssue,
+      description: "Inline attachment: /uploads/inline.md",
+    });
+    mockApiObj.listAttachments.mockResolvedValue([
+      {
+        id: "issue-att-1",
+        workspace_id: "ws-1",
+        issue_id: "issue-1",
+        comment_id: null,
+        chat_session_id: null,
+        chat_message_id: null,
+        uploader_type: "member",
+        uploader_id: "user-1",
+        filename: "child-task.md",
+        url: "/uploads/child-task.md",
+        download_url: "/api/attachments/issue-att-1/download",
+        content_type: "text/markdown",
+        size_bytes: 10,
+        created_at: "2026-01-16T00:00:00Z",
+      },
+      {
+        id: "issue-att-2",
+        workspace_id: "ws-1",
+        issue_id: "issue-1",
+        comment_id: null,
+        chat_session_id: null,
+        chat_message_id: null,
+        uploader_type: "member",
+        uploader_id: "user-1",
+        filename: "inline.md",
+        url: "/uploads/inline.md",
+        download_url: "/api/attachments/issue-att-2/download",
+        content_type: "text/markdown",
+        size_bytes: 10,
+        created_at: "2026-01-16T00:00:00Z",
+      },
+      {
+        id: "comment-att-1",
+        workspace_id: "ws-1",
+        issue_id: "issue-1",
+        comment_id: "comment-1",
+        chat_session_id: null,
+        chat_message_id: null,
+        uploader_type: "member",
+        uploader_id: "user-1",
+        filename: "dev-handoff.md",
+        url: "/uploads/dev-handoff.md",
+        download_url: "/api/attachments/comment-att-1/download",
+        content_type: "text/markdown",
+        size_bytes: 10,
+        created_at: "2026-01-16T00:00:00Z",
+      },
+    ]);
+
+    renderIssueDetail();
+
+    expect(await screen.findByText("child-task.md")).toBeInTheDocument();
+    expect(screen.queryByText("inline.md")).not.toBeInTheDocument();
+    expect(screen.queryByText("dev-handoff.md")).not.toBeInTheDocument();
   });
 
   it("renders the issue title leaf as a link to the issue detail page", async () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1142,9 +1142,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     : issueAttachments;
   const issueLevelAttachments = useMemo(
     () => (issueAttachments ?? []).filter((a) =>
-      a.issue_id === id && a.comment_id === null && a.chat_message_id === null
+      a.comment_id === null && a.chat_message_id === null
     ),
-    [id, issueAttachments],
+    [issueAttachments],
   );
   const handleDescriptionUpload = useCallback(
     async (file: File) => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -51,7 +51,7 @@ import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, StartDatePicker
 import { IssueActionsDropdown, useIssueActions } from "../actions";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
-import { CommentCard } from "./comment-card";
+import { AttachmentList, CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
 import { ResolvedThreadBar } from "./resolved-thread-bar";
 import { collectThreadReplies } from "./thread-utils";
@@ -1140,6 +1140,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const descEditorAttachments = descPendingAttachments.length > 0
     ? [...(issueAttachments ?? []), ...descPendingAttachments]
     : issueAttachments;
+  const issueLevelAttachments = useMemo(
+    () => (issueAttachments ?? []).filter((a) =>
+      a.issue_id === id && a.comment_id === null && a.chat_message_id === null
+    ),
+    [id, issueAttachments],
+  );
   const handleDescriptionUpload = useCallback(
     async (file: File) => {
       const result = await uploadWithToast(file);
@@ -1790,6 +1796,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               debounceMs={1500}
               currentIssueId={id}
               attachments={descEditorAttachments}
+            />
+            <AttachmentList
+              attachments={issueLevelAttachments}
+              content={issue.description || ""}
+              className="mt-3"
             />
 
             <div className="flex items-center gap-1 mt-3">


### PR DESCRIPTION
## Summary

This fixes issue-level attachments that are persisted on an issue but not visible in the issue detail view. Attachments created through issue creation or manual issue upload are stored with `issue_id` set and `comment_id = null`; previously the detail page only passed those records into the description editor for inline preview/download resolution, but did not render standalone issue attachments below the description.

Changes:
- Render standalone issue-level attachments below the issue description editor.
- Filter the standalone list to attachments for the current issue with no `comment_id` or `chat_message_id`, so comment/chat attachments do not leak into the issue body area.
- Reuse the existing `AttachmentList` behavior so attachments already referenced in the description are not duplicated.
- Add regression coverage for issue-level attachments, inline attachment deduplication, and comment attachment exclusion.

## Verification

- `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
- `pnpm --filter @multica/views typecheck`

## Manual QA Guidance

For a manual check, use one issue with an issue-level attachment where `comment_id = null`:
1. Confirm the attachment exists in issue JSON or attachment JSON.
2. Open the same issue on a build before this fix and observe that the standalone issue attachment is not shown under the description.
3. Open the same issue on this branch and confirm the attachment card appears under the description, while comment attachments remain scoped to their comments.

Before
<img width="1125" height="240" alt="image" src="https://github.com/user-attachments/assets/908f6cd3-aa98-4d6a-b31a-ed2d961d04fd" />
<img width="950" height="630" alt="image" src="https://github.com/user-attachments/assets/0e9085e9-44af-481e-a7cd-949d376efca0" />
After
<img width="961" height="697" alt="image" src="https://github.com/user-attachments/assets/c96bc3f7-cad6-4518-922a-3901f5fda814" />
