### PR TITLE
Support per-comment resolve

### DIFF
--- a/apps/mobile/components/issue/comment-card.tsx
+++ b/apps/mobile/components/issue/comment-card.tsx
@@ -15,12 +15,9 @@
  * the targeted bubble's border highlights. See `useCommentLongPress` in
  * `./comment-context-menu.tsx`.
  *
- * Resolved threads render in a collapsed `<ResolvedThreadBar>` by default —
- * mirrors the same state language web uses (`packages/views/issues/
- * components/resolved-thread-bar.tsx`), but the visual is a single-line
- * tap-to-expand bar at iOS section-row scale. Tap expands the bar in place;
- * when expanded the resolved indicator stays at the top of the body so the
- * user keeps the "this thread is resolved" signal even while reading.
+ * Resolved comments render in a collapsed `<ResolvedCommentBar>` at their
+ * own position by default. The compact bubble still groups a root and its
+ * replies, but resolve state is per-comment.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Pressable, View } from "react-native";
@@ -82,13 +79,20 @@ export function CommentCard({
   issueIdentifier,
   highlightedCommentId,
 }: Props) {
-  // Resolved threads default to a single-line bar; tap expands in place for
+  // Resolved comments default to a single-line bar; tap expands in place for
   // the current session. Unmount (scroll out of viewport) resets — same
-  // behavior as iOS Mail's "tap to expand a thread" pattern. Replies cannot
-  // themselves be resolved (server enforces root-only), so the resolved flag
-  // on the root is the single source of truth for this card.
-  const resolved = !!entry.resolved_at;
-  const [expanded, setExpanded] = useState(false);
+  // behavior as iOS Mail's "tap to expand a thread" pattern.
+  const [expandedResolvedIds, setExpandedResolvedIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const setResolvedExpanded = useCallback((entryId: string, expand: boolean) => {
+    setExpandedResolvedIds((prev) => {
+      const next = new Set(prev);
+      if (expand) next.add(entryId);
+      else next.delete(entryId);
+      return next;
+    });
+  }, []);
   // Highlight ring while a long-press action sheet is on screen — child
   // CommentBody flips this via onPressChange so the outer bubble shell can
   // visually bind the sheet to the targeted entry.
@@ -112,28 +116,22 @@ export function CommentCard({
   const isSelectingHere =
     selectingId === entry.id || replies.some((r) => r.id === selectingId);
 
-  // Inbox deep-link target inside a resolved thread expands automatically —
+  // Inbox deep-link target inside a resolved comment expands automatically —
   // otherwise tapping a notification would just reveal a bar with no content
   // and force the user to tap again.
   useEffect(() => {
-    if (!resolved || !highlightedCommentId) return;
-    if (
-      highlightedCommentId === entry.id ||
-      replies.some((r) => r.id === highlightedCommentId)
-    ) {
-      setExpanded(true);
+    if (!highlightedCommentId) return;
+    const target =
+      highlightedCommentId === entry.id
+        ? entry
+        : replies.find((r) => r.id === highlightedCommentId);
+    if (target?.resolved_at) {
+      setResolvedExpanded(target.id, true);
     }
-  }, [resolved, highlightedCommentId, entry.id, replies]);
+  }, [highlightedCommentId, entry, replies, setResolvedExpanded]);
 
-  if (resolved && !expanded) {
-    return (
-      <ResolvedThreadBar
-        entry={entry}
-        replies={replies}
-        onExpand={() => setExpanded(true)}
-      />
-    );
-  }
+  const rootResolved = !!entry.resolved_at;
+  const rootResolvedExpanded = expandedResolvedIds.has(entry.id);
 
   return (
     <View className="px-4">
@@ -154,36 +152,62 @@ export function CommentCard({
         <View
           className={cn(
             "bg-surface-1 rounded-2xl px-4 py-3 gap-3 border-2 border-transparent transition-colors",
-            resolved && "opacity-70",
+            rootResolved && rootResolvedExpanded && "opacity-70",
             isHighlighted && "border-primary/30",
             isSelectingHere && "bg-primary/5 border-primary/30",
           )}
         >
-          {resolved ? (
+          {rootResolved && rootResolvedExpanded ? (
             <ResolvedIndicator
               entry={entry}
-              onCollapse={() => setExpanded(false)}
+              onCollapse={() => setResolvedExpanded(entry.id, false)}
             />
           ) : null}
-          <CommentBody
-            entry={entry}
-            issueId={issueId}
-            issueIdentifier={issueIdentifier}
-            onPressChange={handlePressChange}
-          />
-          {replies.map((reply) => (
-            <View key={reply.id} className="border-t border-border/60 pt-3">
-              <CommentBody
-                entry={reply}
-                issueId={issueId}
-                issueIdentifier={issueIdentifier}
-                onPressChange={handlePressChange}
-              />
-              <ReplyHighlightOverlay
-                active={highlightedCommentId === reply.id}
-              />
-            </View>
-          ))}
+          {rootResolved && !rootResolvedExpanded ? (
+            <ResolvedCommentBar
+              entry={entry}
+              onExpand={() => setResolvedExpanded(entry.id, true)}
+            />
+          ) : (
+            <CommentBody
+              entry={entry}
+              issueId={issueId}
+              issueIdentifier={issueIdentifier}
+              onPressChange={handlePressChange}
+            />
+          )}
+          {replies.map((reply) => {
+            const replyResolved = !!reply.resolved_at;
+            const replyResolvedExpanded = expandedResolvedIds.has(reply.id);
+            return (
+              <View key={reply.id} className="border-t border-border/60 pt-3">
+                {replyResolved && !replyResolvedExpanded ? (
+                  <ResolvedCommentBar
+                    entry={reply}
+                    onExpand={() => setResolvedExpanded(reply.id, true)}
+                  />
+                ) : (
+                  <>
+                    {replyResolved && replyResolvedExpanded ? (
+                      <ResolvedIndicator
+                        entry={reply}
+                        onCollapse={() => setResolvedExpanded(reply.id, false)}
+                      />
+                    ) : null}
+                    <CommentBody
+                      entry={reply}
+                      issueId={issueId}
+                      issueIdentifier={issueIdentifier}
+                      onPressChange={handlePressChange}
+                    />
+                  </>
+                )}
+                <ReplyHighlightOverlay
+                  active={highlightedCommentId === reply.id}
+                />
+              </View>
+            );
+          })}
         </View>
         <RootHighlightOverlay active={highlightedCommentId === entry.id} />
       </View>
@@ -192,84 +216,46 @@ export function CommentCard({
 }
 
 /**
- * Compact "thread is resolved" bar — substitutes the full card when a
- * resolved root is collapsed (default state). Tap anywhere to expand.
- *
- * Mirrors web's `<ResolvedThreadBar>` (`packages/views/issues/components/
- * resolved-thread-bar.tsx`): checkmark + N participant authors + reply
- * count + chevron. On mobile we drop the dedicated <Card> chrome and use
- * the same `bg-surface-1` bubble so the resolved bar reads as the same
- * "row" rhythm as the full card it stands in for.
+ * Compact "comment is resolved" bar — substitutes a single comment body when
+ * collapsed (default state). Tap anywhere to expand.
  */
-function ResolvedThreadBar({
+function ResolvedCommentBar({
   entry,
-  replies,
   onExpand,
 }: {
   entry: TimelineEntry;
-  replies: TimelineEntry[];
   onExpand: () => void;
 }) {
   const { getName } = useActorLookup();
   const { colorScheme } = useColorScheme();
   const mutedFg = THEME[colorScheme].mutedForeground;
-
-  // Unique participant set across root + replies, preserving chronological
-  // order of first appearance. Up to two authors are named; the rest are
-  // rolled into "+N more" so the bar stays a single line on a narrow phone.
-  const authorsLabel = useMemo(() => {
-    const MAX_NAMED = 2;
-    const seen = new Set<string>();
-    const ordered: { type: string | null; id: string | null }[] = [];
-    for (const e of [entry, ...replies]) {
-      const key = `${e.actor_type}:${e.actor_id}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      ordered.push({ type: e.actor_type, id: e.actor_id });
-    }
-    const named = ordered
-      .slice(0, MAX_NAMED)
-      .map((a) =>
-        getName(a.type as "member" | "agent" | null | undefined, a.id),
-      )
-      .join(", ");
-    const remaining = ordered.length - MAX_NAMED;
-    return remaining > 0 ? `${named} +${remaining}` : named;
-  }, [entry, replies, getName]);
-
-  const total = 1 + replies.length;
+  const authorName = getName(
+    entry.actor_type as "member" | "agent" | null | undefined,
+    entry.actor_id,
+  );
 
   return (
-    <View className="px-4">
-      <Pressable
-        onPress={onExpand}
-        className="flex-row items-center gap-2.5 px-4 py-3 rounded-2xl bg-surface-1 active:opacity-70"
-        accessibilityRole="button"
-        accessibilityLabel={`Resolved thread by ${authorsLabel}, ${total} ${total === 1 ? "message" : "messages"}. Tap to expand.`}
+    <Pressable
+      onPress={onExpand}
+      className="flex-row items-center gap-2.5 rounded-xl bg-surface-2 px-3 py-2.5 active:opacity-70"
+      accessibilityRole="button"
+      accessibilityLabel={`Resolved comment by ${authorName}. Tap to expand.`}
+    >
+      <Ionicons name="checkmark-circle" size={18} color={mutedFg} />
+      <Text
+        className="flex-1 text-sm text-muted-foreground"
+        numberOfLines={1}
       >
-        <Ionicons name="checkmark-circle" size={18} color={mutedFg} />
-        <Text
-          className="flex-1 text-sm text-muted-foreground"
-          numberOfLines={1}
-        >
-          Resolved · {total} {total === 1 ? "message" : "messages"} by{" "}
-          {authorsLabel}
-        </Text>
-        <Ionicons name="chevron-down" size={14} color={mutedFg} />
-      </Pressable>
-    </View>
+        Resolved comment by {authorName}
+      </Text>
+      <Ionicons name="chevron-down" size={14} color={mutedFg} />
+    </Pressable>
   );
 }
 
 /**
- * Resolved indicator row that sits at the top of an expanded resolved
- * thread. Carries the "who resolved + when" attribution and a collapse
- * affordance — equivalent to web's "Mark as resolved" header bar
- * (`packages/views/issues/components/comment-card.tsx:519-532`).
- *
- * Tap collapses the thread back to the bar without firing the
- * <CommentBody> long-press action sheet (the row is a self-contained
- * Pressable, sits above CommentBody in the bubble's gap-3 layout).
+ * Resolved indicator row that sits above an expanded resolved comment.
+ * Carries the "who resolved + when" attribution and a collapse affordance.
  */
 function ResolvedIndicator({
   entry,
@@ -291,7 +277,7 @@ function ResolvedIndicator({
       onPress={onCollapse}
       className="flex-row items-center gap-2 active:opacity-60"
       accessibilityRole="button"
-      accessibilityLabel="Collapse resolved thread"
+      accessibilityLabel="Collapse resolved comment"
     >
       <Ionicons name="checkmark-circle" size={14} color={mutedFg} />
       <Text className="text-xs text-muted-foreground flex-1" numberOfLines={1}>
@@ -418,7 +404,10 @@ function CommentBody({
 
   // Reactions live on TimelineEntry.reactions (mirrored from Comment).
   // Pass through to the bar; toggle finds existing match by emoji + actor.
-  const reactions: Reaction[] = (entry.reactions ?? []) as Reaction[];
+  const reactions: Reaction[] = useMemo(
+    () => (entry.reactions ?? []) as Reaction[],
+    [entry.reactions],
+  );
 
   const onToggleReaction = useCallback(
     (emoji: string) => {

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -733,8 +733,7 @@ class ApiClient {
     await this.fetch<void>(`/api/comments/${commentId}`, { method: "DELETE" });
   }
 
-  // POST /api/comments/:id/resolve — marks the thread root resolved; only
-  // meaningful for root comments. Backend mirrors web semantics.
+  // POST /api/comments/:id/resolve — marks an individual comment resolved.
   async resolveComment(commentId: string): Promise<Comment> {
     return this.fetchValidatedWith(
       `/api/comments/${commentId}/resolve`,
@@ -745,7 +744,7 @@ class ApiClient {
     );
   }
 
-  // DELETE /api/comments/:id/resolve — un-resolves the thread.
+  // DELETE /api/comments/:id/resolve — un-resolves an individual comment.
   async unresolveComment(commentId: string): Promise<Comment> {
     return this.fetchValidatedWith(
       `/api/comments/${commentId}/resolve`,

--- a/apps/mobile/data/mutations/issues.ts
+++ b/apps/mobile/data/mutations/issues.ts
@@ -303,8 +303,7 @@ export function useDeleteComment(issueId: string) {
 }
 
 /**
- * Resolve / unresolve a comment thread (root comments only — server rejects
- * the call on a reply). Toggle is driven by the `resolved` boolean param:
+ * Resolve / unresolve an individual comment. Toggle is driven by the `resolved` boolean param:
  * true → POST /resolve, false → DELETE /resolve. Mirrors web
  * `useResolveComment(commentId, resolved)` semantics.
  *

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -132,6 +132,7 @@ import {
   AgentTemplateSummaryListSchema,
   AttachmentResponseSchema,
   ChildIssuesResponseSchema,
+  CommentSchema,
   CommentsListSchema,
   CloudRuntimeNodeListSchema,
   CloudRuntimeNodeSchema,
@@ -146,6 +147,7 @@ import {
   EMPTY_ATTACHMENT,
   EMPTY_CLOUD_RUNTIME_NODE,
   EMPTY_CLOUD_RUNTIME_NODE_LIST,
+  EMPTY_COMMENT,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
   EMPTY_GROUPED_ISSUES_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
@@ -672,11 +674,17 @@ export class ApiClient {
   }
 
   async resolveComment(commentId: string): Promise<Comment> {
-    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "POST" });
+    const raw = await this.fetch<unknown>(`/api/comments/${commentId}/resolve`, { method: "POST" });
+    return parseWithFallback(raw, CommentSchema, EMPTY_COMMENT, {
+      endpoint: "POST /api/comments/:id/resolve",
+    });
   }
 
   async unresolveComment(commentId: string): Promise<Comment> {
-    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "DELETE" });
+    const raw = await this.fetch<unknown>(`/api/comments/${commentId}/resolve`, { method: "DELETE" });
+    return parseWithFallback(raw, CommentSchema, EMPTY_COMMENT, {
+      endpoint: "DELETE /api/comments/:id/resolve",
+    });
   }
 
   async addReaction(commentId: string, emoji: string): Promise<Reaction> {

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -78,6 +78,47 @@ describe("ApiClient schema fallback", () => {
     });
   });
 
+  describe("resolveComment", () => {
+    const commentBody = {
+      id: "comment-1",
+      issue_id: "issue-1",
+      author_type: "member",
+      author_id: "user-1",
+      content: "done",
+      type: "comment",
+      parent_id: "root-1",
+      reactions: [],
+      attachments: [],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    it("defaults missing resolved fields to null for older responses", async () => {
+      stubFetchJson(commentBody);
+      const client = new ApiClient("https://api.example.test");
+      const comment = await client.resolveComment("comment-1");
+      expect(comment.id).toBe("comment-1");
+      expect(comment.parent_id).toBe("root-1");
+      expect(comment.resolved_at).toBeNull();
+      expect(comment.resolved_by_type).toBeNull();
+      expect(comment.resolved_by_id).toBeNull();
+    });
+
+    it("falls back to an empty comment when the response is malformed", async () => {
+      stubFetchJson({ id: 123 });
+      const client = new ApiClient("https://api.example.test");
+      const comment = await client.resolveComment("comment-1");
+      expect(comment).toEqual(
+        expect.objectContaining({
+          id: "",
+          issue_id: "",
+          parent_id: null,
+          resolved_at: null,
+        }),
+      );
+    });
+  });
+
   describe("listIssues", () => {
     it("falls back to an empty list when the response is malformed", async () => {
       // `issues` having the wrong type triggers the fallback. An object

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -10,6 +10,7 @@ import type {
   BillingPriceTier,
   BillingTopupsPage,
   BillingTransactionsPage,
+  Comment,
   CreateAgentFromTemplateResponse,
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
@@ -185,7 +186,27 @@ export const CommentSchema = z.object({
   attachments: z.array(AttachmentSchema).default([]),
   created_at: z.string(),
   updated_at: z.string(),
+  resolved_at: z.string().nullable().default(null),
+  resolved_by_type: z.string().nullable().default(null),
+  resolved_by_id: z.string().nullable().default(null),
 }).loose();
+
+export const EMPTY_COMMENT: Comment = {
+  id: "",
+  issue_id: "",
+  author_type: "member",
+  author_id: "",
+  content: "",
+  type: "comment",
+  parent_id: null,
+  reactions: [],
+  attachments: [],
+  created_at: "",
+  updated_at: "",
+  resolved_at: null,
+  resolved_by_type: null,
+  resolved_by_id: null,
+};
 
 export const CommentsListSchema = z.array(CommentSchema);
 

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -38,6 +38,7 @@ import { ReplyInput } from "./reply-input";
 import type { TimelineEntry, Attachment } from "@multica/core/types";
 import { useCommentCollapseStore, useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
+import { ResolvedCommentBar } from "./resolved-thread-bar";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -67,14 +68,11 @@ interface CommentCardProps {
   onEdit: (commentId: string, content: string, attachmentIds: string[]) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
-  /** Toggle the resolved state on the thread root. Only invoked for root entries. */
+  /** Toggle the resolved state for any comment in this thread. */
   onResolveToggle?: (commentId: string, resolved: boolean) => void;
-  /**
-   * When non-null, the thread root is currently rendered as a resolved-but-
-   * expanded card. Pass a "Collapse" affordance into the header so the user
-   * can fold the thread back to the bar; the parent owns the session state.
-   */
-  onCollapseResolved?: () => void;
+  /** Per-session set of resolved comments the user expanded back to full text. */
+  expandedResolvedIds?: ReadonlySet<string>;
+  onResolvedExpandChange?: (commentId: string, expand: boolean) => void;
   /** ID of the comment to highlight (flash animation). */
   highlightedCommentId?: string | null;
 }
@@ -322,6 +320,9 @@ function CommentRow({
   onEdit,
   onDelete,
   onToggleReaction,
+  onResolveToggle,
+  isResolvedExpanded = false,
+  onResolvedExpandChange,
 }: {
   issueId: string;
   entry: TimelineEntry;
@@ -330,6 +331,9 @@ function CommentRow({
   onEdit: (commentId: string, content: string, attachmentIds: string[]) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
+  onResolveToggle?: (commentId: string, resolved: boolean) => void;
+  isResolvedExpanded?: boolean;
+  onResolvedExpandChange?: (commentId: string, expand: boolean) => void;
 }) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
@@ -345,6 +349,17 @@ function CommentRow({
   const reactions = entry.reactions ?? [];
   const contentText = entry.content ?? "";
   const isLongContent = contentText.length > 500 || contentText.split("\n").length > 8;
+
+  if (entry.resolved_at && !isResolvedExpanded) {
+    return (
+      <div className="py-3">
+        <ResolvedCommentBar
+          entry={entry}
+          onExpand={() => onResolvedExpandChange?.(entry.id, true)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="py-3">
@@ -365,6 +380,17 @@ function CommentRow({
             {new Date(entry.created_at).toLocaleString()}
           </TooltipContent>
         </Tooltip>
+
+        {entry.resolved_at && onResolvedExpandChange && (
+          <button
+            type="button"
+            onClick={() => onResolvedExpandChange(entry.id, false)}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {t(($) => $.comment.resolve.collapse)}
+          </button>
+        )}
 
         <div className="ml-auto flex items-center gap-0.5">
           <QuickEmojiPicker
@@ -387,6 +413,24 @@ function CommentRow({
                 <Copy className="h-3.5 w-3.5" />
                 {t(($) => $.comment.copy_action)}
               </DropdownMenuItem>
+              {onResolveToggle && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => onResolveToggle(entry.id, !entry.resolved_at)}>
+                    {entry.resolved_at ? (
+                      <>
+                        <RotateCcw className="h-3.5 w-3.5" />
+                        {t(($) => $.comment.resolve.unresolve_action)}
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                        {t(($) => $.comment.resolve.resolve_action)}
+                      </>
+                    )}
+                  </DropdownMenuItem>
+                </>
+              )}
               {(canEditEntry || canDeleteEntry) && (
                 <>
                   <DropdownMenuSeparator />
@@ -500,7 +544,8 @@ function CommentCardImpl({
   onDelete,
   onToggleReaction,
   onResolveToggle,
-  onCollapseResolved,
+  expandedResolvedIds,
+  onResolvedExpandChange,
   highlightedCommentId,
 }: CommentCardProps) {
   const { t } = useT("issues");
@@ -527,13 +572,15 @@ function CommentCardImpl({
   const isLongContent = contentText.length > 500 || contentText.split("\n").length > 8;
 
   const isHighlighted = highlightedCommentId === entry.id;
+  const rootResolvedExpanded = !!entry.resolved_at && !!expandedResolvedIds?.has(entry.id);
+  const rootResolvedCollapsed = !!entry.resolved_at && !rootResolvedExpanded;
 
   return (
     <Card className={cn("!py-0 !gap-0 overflow-hidden transition-colors duration-700", isHighlighted && "ring-2 ring-brand/50 bg-brand/5")}>
-      {onCollapseResolved && (
+      {rootResolvedExpanded && onResolvedExpandChange && (
         <button
           type="button"
-          onClick={onCollapseResolved}
+          onClick={() => onResolvedExpandChange(entry.id, false)}
           className="flex w-full items-center justify-between border-b border-border/50 px-4 py-2.5 text-left text-sm text-muted-foreground hover:bg-muted/50 transition-colors"
           aria-label={t(($) => $.comment.resolve.collapse)}
         >
@@ -654,7 +701,14 @@ function CommentCardImpl({
         <CollapsibleContent>
           {/* Parent comment body */}
           <div className="px-4 pb-3">
-            {edit.editing ? (
+            {rootResolvedCollapsed ? (
+              <div className="pl-10">
+                <ResolvedCommentBar
+                  entry={entry}
+                  onExpand={() => onResolvedExpandChange?.(entry.id, true)}
+                />
+              </div>
+            ) : edit.editing ? (
               <div
                 {...edit.dropZoneProps}
                 className="relative pl-10"
@@ -733,6 +787,9 @@ function CommentCardImpl({
                 onEdit={onEdit}
                 onDelete={onDelete}
                 onToggleReaction={onToggleReaction}
+                onResolveToggle={onResolveToggle}
+                isResolvedExpanded={!!expandedResolvedIds?.has(reply.id)}
+                onResolvedExpandChange={onResolvedExpandChange}
               />
             </div>
           ))}

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -200,6 +200,8 @@ const mockApiObj = vi.hoisted(() => ({
   createComment: vi.fn(),
   updateComment: vi.fn(),
   deleteComment: vi.fn(),
+  resolveComment: vi.fn(),
+  unresolveComment: vi.fn(),
   deleteIssue: vi.fn(),
   updateIssue: vi.fn(),
   listIssueSubscribers: vi.fn().mockResolvedValue([]),
@@ -502,6 +504,8 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });
     mockApiObj.listTasksByIssue.mockResolvedValue([]);
+    mockApiObj.resolveComment.mockResolvedValue({ ...mockTimeline[0], issue_id: "issue-1" });
+    mockApiObj.unresolveComment.mockResolvedValue({ ...mockTimeline[0], issue_id: "issue-1" });
     mockApiObj.listMembers.mockResolvedValue([
       { user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" },
     ]);
@@ -529,6 +533,84 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+  });
+
+  it("folds only a resolved root comment and keeps its unresolved replies visible", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      {
+        type: "comment",
+        id: "root-resolved",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "Resolved root content",
+        parent_id: null,
+        created_at: "2026-01-18T00:00:00Z",
+        updated_at: "2026-01-18T00:00:00Z",
+        comment_type: "comment",
+        resolved_at: "2026-01-19T00:00:00Z",
+      },
+      {
+        type: "comment",
+        id: "reply-open",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "Unresolved reply stays visible",
+        parent_id: "root-resolved",
+        created_at: "2026-01-18T01:00:00Z",
+        updated_at: "2026-01-18T01:00:00Z",
+        comment_type: "comment",
+      },
+    ] as TimelineEntry[]);
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("1 resolved comment from Test User")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Resolved root content")).not.toBeInTheDocument();
+    expect(screen.getByText("Unresolved reply stays visible")).toBeInTheDocument();
+  });
+
+  it("folds a resolved reply independently and expands it in place", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      {
+        type: "comment",
+        id: "root-open",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "Open root content",
+        parent_id: null,
+        created_at: "2026-01-18T00:00:00Z",
+        updated_at: "2026-01-18T00:00:00Z",
+        comment_type: "comment",
+      },
+      {
+        type: "comment",
+        id: "reply-resolved",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "Resolved reply content",
+        parent_id: "root-open",
+        created_at: "2026-01-18T01:00:00Z",
+        updated_at: "2026-01-18T01:00:00Z",
+        comment_type: "comment",
+        resolved_at: "2026-01-19T00:00:00Z",
+      },
+    ] as TimelineEntry[]);
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open root content")).toBeInTheDocument();
+    });
+    const foldedReply = screen.getByText("1 resolved comment from Test User");
+    expect(screen.queryByText("Resolved reply content")).not.toBeInTheDocument();
+
+    fireEvent.click(foldedReply);
+
+    await waitFor(() => {
+      expect(screen.getByText("Resolved reply content")).toBeInTheDocument();
+    });
   });
 
   it("renders the issue title leaf as a link to the issue detail page", async () => {
@@ -1017,13 +1099,8 @@ describe("IssueDetail (shared)", () => {
       });
     });
 
-    it("auto-expands a folded resolved thread when deep-link target is a reply inside it", async () => {
-      // Seed a timeline where comment-3 is resolved (so it renders as a
-      // resolved-bar by default) and has a reply, reply-1, whose id is the
-      // deep-link target. The reply is not in the flat items array — only
-      // the resolved-bar root is. The effect must detect this, expand the
-      // thread, then on re-run scroll to the reply's id="comment-reply-1" node.
-      const timelineWithResolvedThread: TimelineEntry[] = [
+    it("auto-expands a folded resolved comment when it is the deep-link target", async () => {
+      const timelineWithResolvedComment: TimelineEntry[] = [
         ...mockTimeline,
         {
           type: "comment",
@@ -1042,30 +1119,26 @@ describe("IssueDetail (shared)", () => {
           id: "reply-1",
           actor_type: "member",
           actor_id: "user-1",
-          content: "Reply inside resolved thread",
+          content: "Reply inside resolved comment group",
           parent_id: "comment-3",
           created_at: "2026-01-18T01:00:00Z",
           updated_at: "2026-01-18T01:00:00Z",
           comment_type: "comment",
         } as TimelineEntry,
       ];
-      mockApiObj.listTimeline.mockResolvedValue(timelineWithResolvedThread);
+      mockApiObj.listTimeline.mockResolvedValue(timelineWithResolvedComment);
 
       const queryClient = createTestQueryClient();
       render(
         <I18nProvider locale="en" resources={TEST_RESOURCES}>
           <QueryClientProvider client={queryClient}>
-            <IssueDetail issueId="issue-1" highlightCommentId="reply-1" />
+            <IssueDetail issueId="issue-1" highlightCommentId="comment-3" />
           </QueryClientProvider>
         </I18nProvider>,
       );
 
-      // After expansion, the reply must appear in the DOM (inside the now
-      // -unfolded CommentCard) and the deep-link effect must scroll to it.
       await waitFor(() => {
-        expect(
-          document.getElementById("comment-reply-1"),
-        ).not.toBeNull();
+        expect(screen.getByText("Resolved root")).toBeInTheDocument();
       });
       await waitFor(() => {
         expect(scrollIntoViewSpy).toHaveBeenCalledWith(

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -53,7 +53,6 @@ import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
-import { ResolvedThreadBar } from "./resolved-thread-bar";
 import { collectThreadReplies } from "./thread-utils";
 import { AgentLiveCard } from "./agent-live-card";
 import { ExecutionLogSection } from "./execution-log-section";
@@ -275,7 +274,7 @@ function formatTokenCount(n: number): string {
 }
 
 // Stable reference for threads with no replies. Inline `[]` would create a
-// new array on every render and bust React.memo on CommentCard / ResolvedThreadBar.
+// new array on every render and bust React.memo on CommentCard.
 const EMPTY_REPLIES: TimelineEntry[] = [];
 
 // ---------------------------------------------------------------------------
@@ -335,7 +334,6 @@ function shallowEqualEntries(a: TimelineEntry[], b: TimelineEntry[]): boolean {
 // the itemContent dispatcher can switch on.
 type TimelineItem =
   | { kind: "comment"; id: string; entry: TimelineEntry }
-  | { kind: "resolved-bar"; id: string; entry: TimelineEntry }
   | { kind: "activity-group"; id: string; entries: TimelineEntry[] };
 
 type RawTimelineGroup = {
@@ -343,21 +341,12 @@ type RawTimelineGroup = {
   entries: TimelineEntry[];
 };
 
-function flattenGroups(
-  groups: ReadonlyArray<RawTimelineGroup>,
-  expandedResolved: ReadonlySet<string>,
-): TimelineItem[] {
+function flattenGroups(groups: ReadonlyArray<RawTimelineGroup>): TimelineItem[] {
   const out: TimelineItem[] = [];
   for (const group of groups) {
     if (group.type === "comment") {
       const entry = group.entries[0]!;
-      const isResolved = !!entry.resolved_at;
-      const isExpanded = expandedResolved.has(entry.id);
-      out.push(
-        isResolved && !isExpanded
-          ? { kind: "resolved-bar", id: entry.id, entry }
-          : { kind: "comment", id: entry.id, entry },
-      );
+      out.push({ kind: "comment", id: entry.id, entry });
     } else {
       out.push({
         kind: "activity-group",
@@ -722,8 +711,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
 
-  // Per-session: which resolved threads the user has temporarily expanded.
-  // Not persisted (matches Linear) — reload collapses everything back to bars.
+  // Per-session: which resolved comments the user has temporarily expanded.
+  // Not persisted (matches Linear) — reload collapses them back to bars.
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(() => new Set());
   const toggleResolvedExpand = useCallback((commentId: string, expand: boolean) => {
     setExpandedResolved((prev) => {
@@ -853,9 +842,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   } = useIssueTimeline(id, user?.id);
 
   // Resolve / unresolve must always clear the per-session expand entry so
-  // re-resolving an already-expanded thread folds it back to the bar (the
+  // re-resolving an already-expanded comment folds it back to the bar (the
   // expand Set is keyed only on commentId, not on resolution state). Without
-  // this wrapper, an expand → unresolve → resolve sequence keeps the thread
+  // this wrapper, an expand → unresolve → resolve sequence keeps the comment
   // visually expanded after the second resolve.
   const handleResolveToggle = useCallback(
     (commentId: string, resolved: boolean) => {
@@ -870,7 +859,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // dedicated `threadReplies` slice per root. Slices are stabilized against
   // the previous render via `prevThreadRepliesRef`: if a thread's flat list
   // is shallow-equal to the previous one, we reuse the previous array so
-  // React.memo on CommentCard / ResolvedThreadBar can short-circuit. Without
+  // React.memo on CommentCard can short-circuit. Without
   // this, every WS event (including reactions, edits, AI streaming on an
   // unrelated thread) hands every card a brand-new prop reference and forces
   // every thread subtree to re-render in lockstep.
@@ -954,13 +943,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [timeline]);
 
   // Flat array consumed by <Virtuoso>. Recomputed when timelineView.groups
-  // changes (timeline events) or expandedResolved flips (user toggles a
-  // resolved thread). Kept in a useMemo so Virtuoso's data identity is stable
-  // across unrelated re-renders.
+  // changes (timeline events). Kept in a useMemo so Virtuoso's data identity
+  // is stable across unrelated re-renders.
   const items = useMemo<TimelineItem[]>(
-    () => flattenGroups(timelineView.groups, expandedResolved),
-    [timelineView.groups, expandedResolved],
+    () => flattenGroups(timelineView.groups),
+    [timelineView.groups],
   );
+
+  const commentsById = useMemo(() => {
+    const map = new Map<string, TimelineEntry>();
+    for (const entry of timeline) {
+      if (entry.type === "comment") {
+        map.set(entry.id, entry);
+      }
+    }
+    return map;
+  }, [timeline]);
 
   // ID of the trailing activity block — the only one expanded by default.
   const lastActivityGroupId = useMemo(() => {
@@ -970,31 +968,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
     return null;
   }, [timelineView.groups]);
-
-  // Map of reply-comment id → root-comment id, so a deep-link to a reply
-  // (which lives inside a CommentCard, not in the flat items array) can fall
-  // back to scrolling the root thread into view. Without this, an inbox
-  // notification on a reply would land at items[-1] and short-circuit.
-  const replyToRoot = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const [rootId, replies] of timelineView.threadReplies) {
-      for (const reply of replies) {
-        map.set(reply.id, rootId);
-      }
-    }
-    return map;
-  }, [timelineView.threadReplies]);
-
-  // Deep-link target index in the flat items array. For root comments this is
-  // a direct findIndex hit; for reply ids we look up the enclosing root.
-  const targetIdx = useMemo(() => {
-    if (!highlightCommentId) return -1;
-    const direct = items.findIndex((it) => it.id === highlightCommentId);
-    if (direct >= 0) return direct;
-    const rootId = replyToRoot.get(highlightCommentId);
-    if (!rootId) return -1;
-    return items.findIndex((it) => it.id === rootId);
-  }, [items, highlightCommentId, replyToRoot]);
 
   const {
     reactions: issueReactions,
@@ -1073,9 +1046,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // virtualization), so every comment id is in the DOM by the time this
   // effect runs after commit.
   //
-  // For a reply inside a folded resolved thread, the reply is not in items
-  // (only the resolved-bar root is). Auto-expand the thread first; the
-  // effect re-runs once items re-flatten.
+  // For a deep link to a folded resolved comment, auto-expand the comment
+  // first so the highlighted target shows the actual comment body instead
+  // of just the folded bar. The effect re-runs after the expand state flips.
   //
   // `scrollContainerEl` is in deps because the component early-returns a
   // loading skeleton while the issue query is pending. The scroll-container
@@ -1085,13 +1058,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     if (!highlightCommentId || items.length === 0) return;
     if (didHighlightRef.current === highlightCommentId) return;
 
-    const rootId = replyToRoot.get(highlightCommentId);
+    const targetComment = commentsById.get(highlightCommentId);
     if (
-      rootId &&
-      rootId !== highlightCommentId &&
-      items[targetIdx]?.kind === "resolved-bar"
+      targetComment?.resolved_at &&
+      !expandedResolved.has(highlightCommentId)
     ) {
-      toggleResolvedExpand(rootId, true);
+      toggleResolvedExpand(highlightCommentId, true);
       return;
     }
 
@@ -1104,7 +1076,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     setHighlightedId(highlightCommentId);
     const fade = window.setTimeout(() => setHighlightedId(null), 2500);
     return () => clearTimeout(fade);
-  }, [highlightCommentId, items, targetIdx, scrollContainerEl, replyToRoot, toggleResolvedExpand]);
+  }, [highlightCommentId, items, scrollContainerEl, commentsById, expandedResolved, toggleResolvedExpand]);
 
   // Cmd-F / Ctrl-F on a virtualized timeline only searches what's mounted in
   // the viewport — off-screen comments are invisible to browser find-in-page.
@@ -1555,19 +1527,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // The wrapper `id="comment-..."` is the deep-link target — equivalent to
   // a native `<a href="#comment-...">` anchor.
   const renderItem = (_i: number, item: TimelineItem): React.ReactElement => {
-    if (item.kind === "resolved-bar") {
-      return (
-        <div className="pb-3" id={`comment-${item.id}`}>
-          <ResolvedThreadBar
-            entry={item.entry}
-            replies={timelineView.threadReplies.get(item.id) ?? EMPTY_REPLIES}
-            onExpand={() => toggleResolvedExpand(item.id, true)}
-          />
-        </div>
-      );
-    }
     if (item.kind === "comment") {
-      const isResolved = !!item.entry.resolved_at;
       return (
         <div className="pb-3" id={`comment-${item.id}`}>
           <CommentCard
@@ -1581,7 +1541,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             onDelete={deleteComment}
             onToggleReaction={handleToggleReaction}
             onResolveToggle={handleResolveToggle}
-            onCollapseResolved={isResolved ? () => toggleResolvedExpand(item.id, false) : undefined}
+            expandedResolvedIds={expandedResolved}
+            onResolvedExpandChange={toggleResolvedExpand}
             highlightedCommentId={highlightedId}
           />
         </div>

--- a/packages/views/issues/components/resolved-thread-bar.tsx
+++ b/packages/views/issues/components/resolved-thread-bar.tsx
@@ -1,37 +1,27 @@
 import { CheckCircle2, ChevronRight } from "lucide-react";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { Card } from "@multica/ui/components/ui/card";
 import type { TimelineEntry } from "@multica/core/types";
 import { useT } from "../../i18n";
 
-interface ResolvedThreadBarProps {
-  /** The resolved root comment. */
+interface ResolvedCommentBarProps {
+  /** The resolved comment represented by this folded row. */
   entry: TimelineEntry;
-  /**
-   * Flat list of every nested reply under this thread root. Precomputed by
-   * `issue-detail.tsx`'s `timelineView` from the same walk that CommentCard
-   * uses, so the count + author list match what the expanded view renders
-   * (direct-children-only would undercount nested replies).
-   */
-  replies: TimelineEntry[];
   onExpand: () => void;
 }
 
 const MAX_NAMED_AUTHORS = 2;
 
-export function ResolvedThreadBar({ entry, replies, onExpand }: ResolvedThreadBarProps) {
+export function ResolvedCommentBar({ entry, onExpand }: ResolvedCommentBarProps) {
   const { t } = useT("issues");
   const { getActorName } = useActorName();
 
   const authorKeys = new Set<string>();
   const authors: Array<{ type: string; id: string }> = [];
-  for (const e of [entry, ...replies]) {
-    const key = `${e.actor_type}:${e.actor_id}`;
-    if (authorKeys.has(key)) continue;
+  const key = `${entry.actor_type}:${entry.actor_id}`;
+  if (!authorKeys.has(key)) {
     authorKeys.add(key);
-    authors.push({ type: e.actor_type, id: e.actor_id });
+    authors.push({ type: entry.actor_type, id: entry.actor_id });
   }
-  const count = 1 + replies.length;
 
   let authorsLabel: string;
   if (authors.length <= MAX_NAMED_AUTHORS) {
@@ -43,20 +33,18 @@ export function ResolvedThreadBar({ entry, replies, onExpand }: ResolvedThreadBa
   }
 
   return (
-    <Card className="!py-0 !gap-0 overflow-hidden">
-      <button
-        type="button"
-        onClick={onExpand}
-        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
-      >
-        <span className="flex items-center gap-2.5 text-sm text-muted-foreground">
-          <CheckCircle2 className="h-4 w-4 shrink-0" />
-          <span className="truncate">
-            {t(($) => $.comment.resolve.bar, { count, authors: authorsLabel })}
-          </span>
+    <button
+      type="button"
+      onClick={onExpand}
+      className="flex w-full items-center justify-between rounded-md bg-muted/45 px-3 py-2.5 text-left transition-colors hover:bg-muted"
+    >
+      <span className="flex min-w-0 items-center gap-2.5 text-sm text-muted-foreground">
+        <CheckCircle2 className="h-4 w-4 shrink-0" />
+        <span className="truncate">
+          {t(($) => $.comment.resolve.bar, { count: 1, authors: authorsLabel })}
         </span>
-        <ChevronRight className="h-3.5 w-3.5 rotate-90 shrink-0 text-muted-foreground" />
-      </button>
-    </Card>
+      </span>
+      <ChevronRight className="h-3.5 w-3.5 rotate-90 shrink-0 text-muted-foreground" />
+    </button>
   );
 }

--- a/packages/views/issues/components/thread-utils.ts
+++ b/packages/views/issues/components/thread-utils.ts
@@ -2,9 +2,8 @@ import type { TimelineEntry } from "@multica/core/types";
 
 /**
  * Walks the parent_id graph rooted at `rootId` and returns every descendant in
- * traversal order. Shared between CommentCard (which renders the expanded
- * thread) and ResolvedThreadBar (which displays the collapsed count + author
- * list) so the two views stay in sync — direct-children-only counts diverge
+ * traversal order. CommentCard uses this to render the expanded thread while
+ * keeping nested reply counts stable — direct-children-only counts diverge
  * once nested replies exist (see Emacs review on PR #2300).
  */
 export function collectThreadReplies(

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -278,15 +278,15 @@
     "expand_tooltip": "Expand",
     "collapse_tooltip": "Collapse",
     "resolve": {
-      "resolve_action": "Resolve thread",
-      "unresolve_action": "Unresolve thread",
+      "resolve_action": "Resolve comment",
+      "unresolve_action": "Unresolve comment",
       "collapse": "Collapse",
       "bar_one": "{{count}} resolved comment from {{authors}}",
       "bar_other": "{{count}} resolved comments from {{authors}}",
       "bar_authors_more_one": "{{names}} and {{count}} other",
       "bar_authors_more_other": "{{names}} and {{count}} others",
-      "resolve_failed": "Failed to resolve thread",
-      "unresolve_failed": "Failed to unresolve thread"
+      "resolve_failed": "Failed to resolve comment",
+      "unresolve_failed": "Failed to unresolve comment"
     }
   },
   "reply": {

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -270,13 +270,13 @@
     "expand_tooltip": "展開",
     "collapse_tooltip": "折りたたむ",
     "resolve": {
-      "resolve_action": "スレッドを解決",
-      "unresolve_action": "スレッドの解決を取り消す",
+      "resolve_action": "コメントを解決",
+      "unresolve_action": "コメントの解決を取り消す",
       "collapse": "折りたたむ",
       "bar_other": "{{authors}} による解決済みコメント {{count}} 件",
       "bar_authors_more_other": "{{names}} 他 {{count}} 名",
-      "resolve_failed": "スレッドを解決できませんでした",
-      "unresolve_failed": "スレッドの解決を取り消せませんでした"
+      "resolve_failed": "コメントを解決できませんでした",
+      "unresolve_failed": "コメントの解決を取り消せませんでした"
     }
   },
   "reply": {

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -278,15 +278,15 @@
     "expand_tooltip": "펼치기",
     "collapse_tooltip": "접기",
     "resolve": {
-      "resolve_action": "스레드 해결",
-      "unresolve_action": "스레드 해결 취소",
+      "resolve_action": "댓글 해결",
+      "unresolve_action": "댓글 해결 취소",
       "collapse": "접기",
       "bar_one": "{{authors}}님의 해결된 댓글 {{count}}개",
       "bar_other": "{{authors}}님의 해결된 댓글 {{count}}개",
       "bar_authors_more_one": "{{names}} 외 {{count}}명",
       "bar_authors_more_other": "{{names}} 외 {{count}}명",
-      "resolve_failed": "스레드를 해결하지 못했습니다",
-      "unresolve_failed": "스레드 해결을 취소하지 못했습니다"
+      "resolve_failed": "댓글을 해결하지 못했습니다",
+      "unresolve_failed": "댓글 해결을 취소하지 못했습니다"
     }
   },
   "reply": {

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -917,11 +917,11 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		"issue_status":        issue.Status,
 	})
 
-	// A reply in a resolved thread re-opens it. Done after CreateComment commits
-	// so the reply is visible regardless of the unresolve outcome. Shared with
-	// the agent task path (TaskService.createAgentComment) — both reply paths
-	// must keep the resolved root in sync.
-	h.TaskService.AutoUnresolveThreadOnReply(r.Context(), rootComment, uuidToString(issue.WorkspaceID), authorType, authorID)
+	// A reply to resolved context re-opens the direct parent comment and, for
+	// compatibility with the previous thread-level behavior, the thread root.
+	// Done after CreateComment commits so the reply is visible regardless of
+	// the unresolve outcome.
+	h.TaskService.AutoUnresolveCommentsOnReply(r.Context(), []*db.Comment{parentComment, rootComment}, uuidToString(issue.WorkspaceID), authorType, authorID)
 
 	h.triggerTasksForComment(r.Context(), issue, comment, parentComment, authorType, authorID)
 
@@ -1365,11 +1365,11 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// loadRootCommentForActor resolves a {commentId} URL param to a root comment in
-// the caller's workspace. Returns the comment, the workspace UUID, the actor
+// loadCommentForActor resolves a {commentId} URL param to a comment in the
+// caller's workspace. Returns the comment, the workspace UUID, the actor
 // identity, and ok. Resolve / unresolve handlers share this scaffolding so the
-// "must be a root comment" rule lives in one place.
-func (h *Handler) loadRootCommentForActor(w http.ResponseWriter, r *http.Request) (db.Comment, string, string, string, bool) {
+// workspace membership and tenant guard stay identical for every comment row.
+func (h *Handler) loadCommentForActor(w http.ResponseWriter, r *http.Request) (db.Comment, string, string, string, bool) {
 	commentId := chi.URLParam(r, "commentId")
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -1395,16 +1395,12 @@ func (h *Handler) loadRootCommentForActor(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, "comment not found")
 		return db.Comment{}, "", "", "", false
 	}
-	if comment.ParentID.Valid {
-		writeError(w, http.StatusBadRequest, "only root comments can be resolved")
-		return db.Comment{}, "", "", "", false
-	}
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 	return comment, workspaceID, actorType, actorID, true
 }
 
 func (h *Handler) ResolveComment(w http.ResponseWriter, r *http.Request) {
-	comment, workspaceID, actorType, actorID, ok := h.loadRootCommentForActor(w, r)
+	comment, workspaceID, actorType, actorID, ok := h.loadCommentForActor(w, r)
 	if !ok {
 		return
 	}
@@ -1441,7 +1437,7 @@ func (h *Handler) ResolveComment(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) UnresolveComment(w http.ResponseWriter, r *http.Request) {
-	comment, workspaceID, actorType, actorID, ok := h.loadRootCommentForActor(w, r)
+	comment, workspaceID, actorType, actorID, ok := h.loadCommentForActor(w, r)
 	if !ok {
 		return
 	}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -871,19 +871,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// entity-encode Markdown syntax characters (>, ", &, <) and corrupt the
 	// source. See issue #1303 / discussion in MUL-1119, MUL-1125.
 
-	// parent_id stores the exact comment being replied to. Thread-level behavior
-	// (for example auto-unresolving a resolved thread) resolves the root
-	// separately so storing a reply-to-reply does not destroy the direct-parent
-	// signal used by trigger decisions.
-	var rootComment *db.Comment
-	if parentID.Valid {
-		if root, err := h.Queries.GetThreadRoot(r.Context(), db.GetThreadRootParams{
-			CommentID:   parentID,
-			WorkspaceID: issue.WorkspaceID,
-		}); err == nil {
-			rootComment = &root
-		}
-	}
+	// parent_id stores the exact comment being replied to. Per-comment
+	// auto-reopen uses only that direct parent so unrelated resolved ancestors
+	// or siblings stay resolved.
 
 	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
 		IssueID:     issue.ID,
@@ -917,11 +907,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		"issue_status":        issue.Status,
 	})
 
-	// A reply to resolved context re-opens the direct parent comment and, for
-	// compatibility with the previous thread-level behavior, the thread root.
+	// A reply to a resolved direct parent re-opens that parent comment.
 	// Done after CreateComment commits so the reply is visible regardless of
 	// the unresolve outcome.
-	h.TaskService.AutoUnresolveCommentsOnReply(r.Context(), []*db.Comment{parentComment, rootComment}, uuidToString(issue.WorkspaceID), authorType, authorID)
+	h.TaskService.AutoUnresolveCommentsOnReply(r.Context(), []*db.Comment{parentComment}, uuidToString(issue.WorkspaceID), authorType, authorID)
 
 	h.triggerTasksForComment(r.Context(), issue, comment, parentComment, authorType, authorID)
 

--- a/server/internal/handler/comment_resolve_test.go
+++ b/server/internal/handler/comment_resolve_test.go
@@ -1,0 +1,160 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func createResolveCommentFixture(t *testing.T) (issueID, rootID, replyID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, "comment resolve fixture").Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'root', 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&rootID); err != nil {
+		t.Fatalf("create root comment: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id)
+		VALUES ($1, $2, 'member', $3, 'reply', 'comment', $4)
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID, rootID).Scan(&replyID); err != nil {
+		t.Fatalf("create reply comment: %v", err)
+	}
+
+	return issueID, rootID, replyID
+}
+
+func TestResolveComment_AllowsReplyComment(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	_, rootID, replyID := createResolveCommentFixture(t)
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPost, "/api/comments/"+replyID+"/resolve", nil)
+	req = withURLParam(req, "commentId", replyID)
+	testHandler.ResolveComment(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ResolveComment reply: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID != replyID {
+		t.Fatalf("resolved id = %q, want reply %q", resp.ID, replyID)
+	}
+	if resp.ParentID == nil || *resp.ParentID != rootID {
+		t.Fatalf("resolved reply parent_id = %v, want %q", resp.ParentID, rootID)
+	}
+	if resp.ResolvedAt == nil || resp.ResolvedByType == nil || resp.ResolvedByID == nil {
+		t.Fatalf("resolved fields not populated: %+v", resp)
+	}
+
+	var rootResolved bool
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT resolved_at IS NOT NULL FROM comment WHERE id = $1
+	`, rootID).Scan(&rootResolved); err != nil {
+		t.Fatalf("query root resolved state: %v", err)
+	}
+	if rootResolved {
+		t.Fatal("resolving a reply must not resolve its thread root")
+	}
+}
+
+func TestUnresolveComment_AllowsReplyComment(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	_, _, replyID := createResolveCommentFixture(t)
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE comment
+		SET resolved_at = now(), resolved_by_type = 'member', resolved_by_id = $2
+		WHERE id = $1
+	`, replyID, testUserID); err != nil {
+		t.Fatalf("seed reply resolved state: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodDelete, "/api/comments/"+replyID+"/resolve", nil)
+	req = withURLParam(req, "commentId", replyID)
+	testHandler.UnresolveComment(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UnresolveComment reply: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID != replyID {
+		t.Fatalf("unresolved id = %q, want reply %q", resp.ID, replyID)
+	}
+	if resp.ResolvedAt != nil || resp.ResolvedByType != nil || resp.ResolvedByID != nil {
+		t.Fatalf("resolved fields should be cleared: %+v", resp)
+	}
+}
+
+func TestCreateComment_AutoUnresolvesResolvedDirectParent(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	issueID, rootID, replyID := createResolveCommentFixture(t)
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE comment
+		SET resolved_at = now(), resolved_by_type = 'member', resolved_by_id = $2
+		WHERE id = $1
+	`, replyID, testUserID); err != nil {
+		t.Fatalf("seed reply resolved state: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{
+		"content":   "re-open direct parent",
+		"parent_id": replyID,
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment reply: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var replyResolved bool
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT resolved_at IS NOT NULL FROM comment WHERE id = $1
+	`, replyID).Scan(&replyResolved); err != nil {
+		t.Fatalf("query reply resolved state: %v", err)
+	}
+	if replyResolved {
+		t.Fatal("replying to a resolved direct parent must reopen that parent comment")
+	}
+
+	var rootResolved bool
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT resolved_at IS NOT NULL FROM comment WHERE id = $1
+	`, rootID).Scan(&rootResolved); err != nil {
+		t.Fatalf("query root resolved state: %v", err)
+	}
+	if rootResolved {
+		t.Fatal("unresolved root should not be changed by direct-parent auto reopen")
+	}
+}

--- a/server/internal/handler/comment_resolve_test.go
+++ b/server/internal/handler/comment_resolve_test.go
@@ -158,3 +158,38 @@ func TestCreateComment_AutoUnresolvesResolvedDirectParent(t *testing.T) {
 		t.Fatal("unresolved root should not be changed by direct-parent auto reopen")
 	}
 }
+
+func TestCreateComment_DoesNotAutoUnresolveResolvedRootWhenReplyingToUnresolvedReply(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	issueID, rootID, replyID := createResolveCommentFixture(t)
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE comment
+		SET resolved_at = now(), resolved_by_type = 'member', resolved_by_id = $2
+		WHERE id = $1
+	`, rootID, testUserID); err != nil {
+		t.Fatalf("seed root resolved state: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", map[string]any{
+		"content":   "reply to unresolved sibling",
+		"parent_id": replyID,
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment reply: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var rootResolved bool
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT resolved_at IS NOT NULL FROM comment WHERE id = $1
+	`, rootID).Scan(&rootResolved); err != nil {
+		t.Fatalf("query root resolved state: %v", err)
+	}
+	if !rootResolved {
+		t.Fatal("replying to an unresolved reply must not reopen a resolved thread root")
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2015,11 +2015,15 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	if err != nil {
 		return
 	}
-	// Resolve the thread root for thread-level side effects without overwriting
-	// parentID. The stored parent_id must remain the exact comment being replied
-	// to; recursive thread reads recover the root when needed.
+	// Resolve the direct parent and thread root for reply side effects without
+	// overwriting parentID. The stored parent_id must remain the exact comment
+	// being replied to; recursive thread reads recover the root when needed.
+	var parentComment *db.Comment
 	var rootComment *db.Comment
 	if parentID.Valid {
+		if parent, err := s.Queries.GetComment(ctx, parentID); err == nil && util.UUIDToString(parent.IssueID) == util.UUIDToString(issueID) {
+			parentComment = &parent
+		}
 		if root, err := s.Queries.GetThreadRoot(ctx, db.GetThreadRootParams{
 			CommentID:   parentID,
 			WorkspaceID: issue.WorkspaceID,
@@ -2061,46 +2065,55 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 			"issue_status": issue.Status,
 		},
 	})
-	s.AutoUnresolveThreadOnReply(ctx, rootComment, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
+	s.AutoUnresolveCommentsOnReply(ctx, []*db.Comment{parentComment, rootComment}, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
 }
 
-// AutoUnresolveThreadOnReply clears resolved_at on the thread root when a
-// reply lands in a resolved thread, and broadcasts comment:unresolved. Shared
-// between the user-facing Handler.CreateComment path and the agent-facing
-// TaskService.createAgentComment path so the resolved-then-replied state can
-// never desync (one of the bugs Emacs flagged on PR #2300). Errors are logged
-// — the reply itself already committed, the desync is recoverable on next read.
-func (s *TaskService) AutoUnresolveThreadOnReply(ctx context.Context, parent *db.Comment, workspaceID, actorType, actorID string) {
-	if parent == nil || !parent.ResolvedAt.Valid {
-		return
-	}
-	updated, err := s.Queries.UnresolveComment(ctx, parent.ID)
-	if err != nil {
-		slog.Warn("auto-unresolve on reply failed", "error", err, "comment_id", util.UUIDToString(parent.ID))
-		return
-	}
-	s.Bus.Publish(events.Event{
-		Type:        protocol.EventCommentUnresolved,
-		WorkspaceID: workspaceID,
-		ActorType:   actorType,
-		ActorID:     actorID,
-		Payload: map[string]any{
-			"comment": map[string]any{
-				"id":               util.UUIDToString(updated.ID),
-				"issue_id":         util.UUIDToString(updated.IssueID),
-				"author_type":      updated.AuthorType,
-				"author_id":        util.UUIDToString(updated.AuthorID),
-				"content":          updated.Content,
-				"type":             updated.Type,
-				"parent_id":        util.UUIDToPtr(updated.ParentID),
-				"created_at":       util.TimestampToString(updated.CreatedAt),
-				"updated_at":       util.TimestampToString(updated.UpdatedAt),
-				"resolved_at":      util.TimestampToPtr(updated.ResolvedAt),
-				"resolved_by_type": util.TextToPtr(updated.ResolvedByType),
-				"resolved_by_id":   util.UUIDToPtr(updated.ResolvedByID),
+// AutoUnresolveCommentsOnReply clears resolved_at on resolved comments that a
+// new reply re-opens, and broadcasts comment:unresolved for each changed row.
+// Callers pass the direct parent plus the thread root: the direct parent is
+// the new per-comment behavior, while the root preserves the old thread-level
+// reopen contract. Errors are logged — the reply itself already committed, the
+// desync is recoverable on next read.
+func (s *TaskService) AutoUnresolveCommentsOnReply(ctx context.Context, comments []*db.Comment, workspaceID, actorType, actorID string) {
+	seen := make(map[string]struct{}, len(comments))
+	for _, comment := range comments {
+		if comment == nil || !comment.ResolvedAt.Valid {
+			continue
+		}
+		commentID := util.UUIDToString(comment.ID)
+		if _, ok := seen[commentID]; ok {
+			continue
+		}
+		seen[commentID] = struct{}{}
+
+		updated, err := s.Queries.UnresolveComment(ctx, comment.ID)
+		if err != nil {
+			slog.Warn("auto-unresolve on reply failed", "error", err, "comment_id", commentID)
+			continue
+		}
+		s.Bus.Publish(events.Event{
+			Type:        protocol.EventCommentUnresolved,
+			WorkspaceID: workspaceID,
+			ActorType:   actorType,
+			ActorID:     actorID,
+			Payload: map[string]any{
+				"comment": map[string]any{
+					"id":               util.UUIDToString(updated.ID),
+					"issue_id":         util.UUIDToString(updated.IssueID),
+					"author_type":      updated.AuthorType,
+					"author_id":        util.UUIDToString(updated.AuthorID),
+					"content":          updated.Content,
+					"type":             updated.Type,
+					"parent_id":        util.UUIDToPtr(updated.ParentID),
+					"created_at":       util.TimestampToString(updated.CreatedAt),
+					"updated_at":       util.TimestampToString(updated.UpdatedAt),
+					"resolved_at":      util.TimestampToPtr(updated.ResolvedAt),
+					"resolved_by_type": util.TextToPtr(updated.ResolvedByType),
+					"resolved_by_id":   util.UUIDToPtr(updated.ResolvedByID),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func issueToMap(issue db.Issue, issuePrefix string) map[string]any {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2015,20 +2015,13 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	if err != nil {
 		return
 	}
-	// Resolve the direct parent and thread root for reply side effects without
-	// overwriting parentID. The stored parent_id must remain the exact comment
-	// being replied to; recursive thread reads recover the root when needed.
+	// Resolve the direct parent for reply side effects without overwriting
+	// parentID. The stored parent_id must remain the exact comment being
+	// replied to; recursive thread reads recover the root when needed.
 	var parentComment *db.Comment
-	var rootComment *db.Comment
 	if parentID.Valid {
 		if parent, err := s.Queries.GetComment(ctx, parentID); err == nil && util.UUIDToString(parent.IssueID) == util.UUIDToString(issueID) {
 			parentComment = &parent
-		}
-		if root, err := s.Queries.GetThreadRoot(ctx, db.GetThreadRootParams{
-			CommentID:   parentID,
-			WorkspaceID: issue.WorkspaceID,
-		}); err == nil {
-			rootComment = &root
 		}
 	}
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
@@ -2065,15 +2058,14 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 			"issue_status": issue.Status,
 		},
 	})
-	s.AutoUnresolveCommentsOnReply(ctx, []*db.Comment{parentComment, rootComment}, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
+	s.AutoUnresolveCommentsOnReply(ctx, []*db.Comment{parentComment}, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
 }
 
 // AutoUnresolveCommentsOnReply clears resolved_at on resolved comments that a
 // new reply re-opens, and broadcasts comment:unresolved for each changed row.
-// Callers pass the direct parent plus the thread root: the direct parent is
-// the new per-comment behavior, while the root preserves the old thread-level
-// reopen contract. Errors are logged — the reply itself already committed, the
-// desync is recoverable on next read.
+// Callers pass the direct parent comment only; unrelated resolved roots or
+// ancestors stay resolved. Errors are logged — the reply itself already
+// committed, the desync is recoverable on next read.
 func (s *TaskService) AutoUnresolveCommentsOnReply(ctx context.Context, comments []*db.Comment, workspaceID, actorType, actorID string) {
 	seen := make(map[string]struct{}, len(comments))
 	for _, comment := range comments {


### PR DESCRIPTION
## Summary
- Allow `POST/DELETE /api/comments/:id/resolve` on any comment row while keeping the existing workspace membership/tenant guard.
- Fold resolved comments independently in Web/Desktop and mobile; resolving a root no longer hides unresolved replies.
- Keep comment list/CLI/agent reads full-fidelity: resolved rows remain returned by default, `--thread`, and `--tail` paths.
- Parse resolve/unresolve comment responses through the core API schema with null defaults for older responses.
- Limit reply auto-reopen to the direct parent comment only, so unrelated resolved roots stay resolved.

## Tests
- `go test ./internal/handler -run 'TestResolveComment_AllowsReplyComment|TestUnresolveComment_AllowsReplyComment|TestCreateComment_AutoUnresolvesResolvedDirectParent|TestCreateComment_DoesNotAutoUnresolveResolvedRootWhenReplyingToUnresolvedReply|TestListComments_DefaultPreservesChronologicalOrder|TestListComments_ThreadTailReturnsRootPlusNewestReplies'`
- `go test ./internal/service`
- `go test ./cmd/multica -run 'TestRunIssueCommentList_RootsOnlyPassesThroughWithSince|TestRunIssueCommentList_ThreadTailPassesThroughAndPrintsReplyCursor|TestRunIssueCommentList_RecentStillLabelsCursorAsThread|TestRunIssueCommentList_DoesNotPrintShowingPreamble'`
- `pnpm --filter @multica/core exec vitest run api/schema.test.ts`
- `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/mobile typecheck`
- `pnpm --filter @multica/core lint`
- `pnpm --filter @multica/views lint` (warnings only in pre-existing unrelated files)
- `pnpm --filter @multica/mobile lint` (warnings only in pre-existing unrelated files)
- `git diff --check`

## Risk / review notes
- Auto-reopen now clears only the direct resolved parent comment. Replying to an unresolved sibling reply no longer reopens a resolved thread root; covered by `TestCreateComment_DoesNotAutoUnresolveResolvedRootWhenReplyingToUnresolvedReply`.
- Notifications remain unchanged: resolve/unresolve only publishes realtime comment events.
- Sticky current comment and analytics are intentionally out of scope for this PR.
