### PR TITLE
fix(agent): standardize model-discovery timeouts to 15s + stop caching empty results (MUL-2977, #3729)

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -182,6 +182,15 @@ func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
 		return nil, err
 	}
 
+	// Don't cache an empty result. Zero models is almost always a transient
+	// failure (discovery CLI timeout, not-logged-in, network blip) rather than
+	// a runtime that genuinely has no models; caching it would keep the picker
+	// blank for the full TTL even after the cause clears. Skipping the cache
+	// lets the next request retry immediately. See #3729.
+	if len(models) == 0 {
+		return models, nil
+	}
+
 	modelCacheMu.Lock()
 	modelCache[key] = modelCacheEntry{models: models, expiresAt: time.Now().Add(modelCacheTTL)}
 	modelCacheMu.Unlock()
@@ -563,7 +572,13 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	if _, err := exec.LookPath(executablePath); err != nil {
 		return []Model{}, nil
 	}
-	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// Newer pi fetches its catalog from each configured provider over the
+	// network, so discovery time scales with provider count — a multi-provider
+	// setup measured ~4.6-4.8s, right at the old 5s cap. When jitter pushed it
+	// over, the daemon killed the command before it printed anything and the
+	// model picker came back empty while the runtime stayed online. 15s matches
+	// the opencode discovery cap (see #3729, same class as #3627).
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
 	hideAgentWindow(cmd)

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -994,7 +994,10 @@ func discoverCursorModels(ctx context.Context, executablePath string) ([]Model, 
 	if _, err := exec.LookPath(executablePath); err != nil {
 		return cursorStaticModels(), nil
 	}
-	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// 15s to match the other network-backed discovery paths (pi/opencode/ACP);
+	// cursor-agent fetches its frequently-changing catalog, so a tight cap can
+	// time out and fall back to the minimal static list. See #3729.
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
 	hideAgentWindow(cmd)

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -407,6 +407,44 @@ exit 1
 	}
 }
 
+// TestCachedDiscoveryDoesNotCacheEmpty verifies that an empty discovery result
+// is not cached, so a transient failure (e.g. a `pi --list-models` timeout)
+// doesn't keep the model picker blank for the full TTL. A non-empty result is
+// still cached. See #3729.
+func TestCachedDiscoveryDoesNotCacheEmpty(t *testing.T) {
+	emptyCalls := 0
+	empty := func() ([]Model, error) {
+		emptyCalls++
+		return []Model{}, nil
+	}
+	for i := 0; i < 2; i++ {
+		got, err := cachedDiscovery("test-cache-empty", empty)
+		if err != nil {
+			t.Fatalf("cachedDiscovery: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty result, got %+v", got)
+		}
+	}
+	if emptyCalls != 2 {
+		t.Fatalf("empty result must not be cached: expected fn called 2x, got %d", emptyCalls)
+	}
+
+	nonEmptyCalls := 0
+	nonEmpty := func() ([]Model, error) {
+		nonEmptyCalls++
+		return []Model{{ID: "provider/model"}}, nil
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := cachedDiscovery("test-cache-nonempty", nonEmpty); err != nil {
+			t.Fatalf("cachedDiscovery: %v", err)
+		}
+	}
+	if nonEmptyCalls != 1 {
+		t.Fatalf("non-empty result must be cached: expected fn called 1x, got %d", nonEmptyCalls)
+	}
+}
+
 func TestParsePiModels(t *testing.T) {
 	input := `openai:gpt-4o
 anthropic:claude-opus-4-7

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -412,13 +412,26 @@ exit 1
 // doesn't keep the model picker blank for the full TTL. A non-empty result is
 // still cached. See #3729.
 func TestCachedDiscoveryDoesNotCacheEmpty(t *testing.T) {
+	const emptyKey, nonEmptyKey = "test-cache-empty", "test-cache-nonempty"
+	// modelCache is a package-level global; clear our keys up front and on
+	// cleanup so the test stays hermetic under `go test -count=N` (a leftover
+	// non-empty entry from a prior run would otherwise skip the callback).
+	resetCache := func() {
+		modelCacheMu.Lock()
+		delete(modelCache, emptyKey)
+		delete(modelCache, nonEmptyKey)
+		modelCacheMu.Unlock()
+	}
+	resetCache()
+	t.Cleanup(resetCache)
+
 	emptyCalls := 0
 	empty := func() ([]Model, error) {
 		emptyCalls++
 		return []Model{}, nil
 	}
 	for i := 0; i < 2; i++ {
-		got, err := cachedDiscovery("test-cache-empty", empty)
+		got, err := cachedDiscovery(emptyKey, empty)
 		if err != nil {
 			t.Fatalf("cachedDiscovery: %v", err)
 		}
@@ -436,7 +449,7 @@ func TestCachedDiscoveryDoesNotCacheEmpty(t *testing.T) {
 		return []Model{{ID: "provider/model"}}, nil
 	}
 	for i := 0; i < 2; i++ {
-		if _, err := cachedDiscovery("test-cache-nonempty", nonEmpty); err != nil {
+		if _, err := cachedDiscovery(nonEmptyKey, nonEmpty); err != nil {
 			t.Fatalf("cachedDiscovery: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #3748 for #3729 (MUL-2977). The reporter retested on the build with #3748 and the Pi model picker was **still empty** — a **different root cause** than #3748 fixed.

#3748 covered the *non-zero-exit* path. The reporter's `pi --list-models` exits **0** and prints the table to **stderr** (the daemon already falls back to stderr there), so it should have worked. The real problem is a **timeout**:

- The daemon ran `pi --list-models` with a **5s** cap.
- Newer pi (0.78.0) fetches its catalog from each configured provider over the **network**, so discovery time scales with provider count.
- The reporter timed five consecutive runs: **4.811 / 4.652 / 4.637 / 4.776 / 4.784 s** — right at the 5s cap. Network jitter tips it over, the daemon kills the command before it prints anything, and the picker comes back empty while the runtime stays online.

This is the **same class as the opencode timeout in #3627** (fixed in #3689 by raising that path to 15s). pi (and cursor) were never raised.

## Changes

- **Standardize the model-list discovery timeouts to 15s.** `discoverPiModels` and `discoverCursorModels` were still **5s**; raised both to **15s** to match `discoverOpenCodeModels` and the ACP path (hermes/kimi/kiro/copilot). `discoverOpenclawAgents` is intentionally **left at 30s** — it sequentially tries several `openclaw` invocations (multiple JSON flag variants + a text fallback), so lowering it would risk the very empty-list timeout this change prevents elsewhere.
- `cachedDiscovery`: **don't cache an empty result.** Zero models is almost always a transient failure (timeout, not-logged-in, network blip); caching it kept the picker blank for the full 60s TTL even after the cause cleared — which is why the reporter saw no change from restarting/clicking around. Empty now retries on the next request; non-empty results are still cached.

## Testing

- New `TestCachedDiscoveryDoesNotCacheEmpty` (empty result re-runs discovery; non-empty is cached).
- `go test ./pkg/agent/...` passes; `gofmt`/`go vet` clean.

## Notes

Root cause is confirmed by the reporter's own timing data (~4.7s vs a 5s cap), so this should resolve their case; they've offered to retest once a build ships.
