### PR TITLE
fix: interrupt daemon tasks on terminal server status

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2048,10 +2048,11 @@ func newTaskSlotSemaphore(maxConcurrentTasks int) chan int {
 // trivially testable; the polling goroutine in watchTaskCancellation is just
 // I/O around it.
 //
-// Two cases trigger cancellation:
+// Two signal families trigger cancellation:
 //
-//  1. status == "cancelled" — the server moved the task to cancelled
-//     (issue reassigned, user cancel, ...).
+//  1. Any non-active server status means the server has already moved the task
+//     out of the execution window, so the local agent should stop instead of
+//     spending more tokens and later failing its terminal callback.
 //  2. err is a 404 with "task not found" — the task row was deleted while
 //     the agent was running. Without this we'd let the local agent keep
 //     emitting tool calls against a dead task for its full timeout window.
@@ -2063,7 +2064,12 @@ func shouldInterruptAgent(status string, err error) bool {
 	if err != nil {
 		return isTaskNotFoundError(err)
 	}
-	return status == "cancelled"
+	switch status {
+	case "", "dispatched", "waiting_local_directory", "running":
+		return false
+	default:
+		return true
+	}
 }
 
 // watchTaskCancellation polls the server for the task's status on the given

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -703,7 +703,14 @@ func TestShouldInterruptAgent(t *testing.T) {
 		want   bool
 	}{
 		{name: "status cancelled", status: "cancelled", err: nil, want: true},
+		{name: "status failed", status: "failed", err: nil, want: true},
+		{name: "status completed", status: "completed", err: nil, want: true},
+		{name: "status skipped", status: "skipped", err: nil, want: true},
+		{name: "status queued is no longer active for a local runner", status: "queued", err: nil, want: true},
+		{name: "unknown status is not active", status: "archived", err: nil, want: true},
 		{name: "task deleted (404)", status: "", err: notFound, want: true},
+		{name: "dispatched is active", status: "dispatched", err: nil, want: false},
+		{name: "waiting local directory is active", status: "waiting_local_directory", err: nil, want: false},
 		{name: "running normally", status: "running", err: nil, want: false},
 		{name: "transient 5xx is not a cancel signal", status: "", err: transient, want: false},
 		{name: "no information yet", status: "", err: nil, want: false},
@@ -715,6 +722,34 @@ func TestShouldInterruptAgent(t *testing.T) {
 				t.Fatalf("shouldInterruptAgent(%q, %v) = %v, want %v", tc.status, tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestWatchTaskCancellation_StatusFailed ensures the daemon stops local work
+// when the server has already moved the task to a terminal failure state.
+func TestWatchTaskCancellation_StatusFailed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/status") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"failed"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cancelled := d.watchTaskCancellation(ctx, "task-failed", 10*time.Millisecond, slog.Default())
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchTaskCancellation did not signal cancellation when status=failed")
 	}
 }
 


### PR DESCRIPTION
Summary
- Treat every non-active task status from GetTaskStatus as a daemon interruption signal.
- Keep transient HTTP errors non-fatal.
- Add coverage for failed, completed, skipped, queued and unknown statuses.

Tests
- go test ./internal/daemon -run 'TestShouldInterruptAgent|TestWatchTaskCancellation'\n