### PR TITLE
feat(lark): prefetch surrounding group context on @-mention (MUL-3084)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1003,11 +1003,15 @@ func buildLarkConnectorFactory(installSvc *lark.InstallationService, apiClient l
 		}
 		return creds, nil
 	})
-	// Inbound enricher: expands quoted replies / forwarded bundles into
-	// the agent's body via the IM API before dispatch. It shares the
+	// Inbound enricher: expands quoted replies / forwarded bundles AND
+	// prefetches a window of surrounding group history (MUL-3084) into the
+	// agent's body via the IM API before dispatch. It shares the
 	// connector's resolved credentials and runs under the connector's
 	// EnrichTimeout so it cannot overrun the Lark long-conn ACK budget.
-	enricher := lark.NewInboundEnricher(apiClient, lark.InboundEnricherConfig{Logger: slog.Default()})
+	enricher := lark.NewInboundEnricher(apiClient, lark.InboundEnricherConfig{
+		RecentContextSize: lark.DefaultRecentContextSize,
+		Logger:            slog.Default(),
+	})
 	conn, err := lark.NewWSLongConnConnector(lark.WSConnectorConfig{
 		Dialer:              dialer,
 		EndpointFetcher:     endpointFetcher,

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -81,6 +81,31 @@ type APIClient interface {
 	// slice keeps this method a thin transport adapter — flattening and
 	// block assembly are the enricher's job.
 	GetMessage(ctx context.Context, creds InstallationCredentials, messageID string) ([]LarkMessage, error)
+
+	// ListChatMessages fetches the most recent messages in a single chat
+	// via GET /open-apis/im/v1/messages?container_id_type=chat. It powers
+	// the group-context prefetch: when a user @-mentions the Bot in a busy
+	// group, the enricher pulls a bounded window of surrounding messages
+	// so the agent sees the conversation, not just the one @-ed line.
+	//
+	// Results come back newest-first (sort_type=ByCreateTimeDesc), capped
+	// at p.PageSize (Lark hard-caps a page at 50); the caller orders and
+	// trims for rendering. Only a single page is fetched — pagination is
+	// deliberately not exposed so the inbound ACK path's HTTP fan-out
+	// stays a single round-trip. Like GetMessage, this is a thin transport
+	// adapter: flattening and block assembly are the enricher's job.
+	ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error)
+}
+
+// ListMessagesParams selects a bounded, recent window of messages in a
+// single Lark chat for the group-context prefetch. Only the fields the
+// enricher needs today are exposed; start_time/end_time and page_token
+// are intentionally omitted until a caller needs them.
+type ListMessagesParams struct {
+	ChatID ChatID
+	// PageSize is how many of the most-recent messages to fetch. The
+	// client clamps it into Lark's valid 1..50 range.
+	PageSize int
 }
 
 // LarkMessage is the normalized slice of an IM v1 message item the
@@ -278,5 +303,10 @@ func (s *stubAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 
 func (s *stubAPIClient) GetMessage(ctx context.Context, creds InstallationCredentials, messageID string) ([]LarkMessage, error) {
 	s.log.Warn("lark stub client: GetMessage called", "message_id", messageID)
+	return nil, ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
+	s.log.Warn("lark stub client: ListChatMessages called", "chat_id", string(p.ChatID))
 	return nil, ErrAPIClientNotConfigured
 }

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -106,6 +106,12 @@ type ListMessagesParams struct {
 	// PageSize is how many of the most-recent messages to fetch. The
 	// client clamps it into Lark's valid 1..50 range.
 	PageSize int
+	// EndTime, when > 0, caps the window to messages created at or before
+	// this Unix timestamp in SECONDS (Lark's end_time is second-, not
+	// millisecond-, granularity). The enricher sets it to the trigger
+	// message's time so the prefetch is anchored to the @-mention moment
+	// rather than whatever is newest by the time the fetch runs.
+	EndTime int64
 }
 
 // LarkMessage is the normalized slice of an IM v1 message item the

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -99,8 +99,9 @@ type APIClient interface {
 
 // ListMessagesParams selects a bounded, recent window of messages in a
 // single Lark chat for the group-context prefetch. Only the fields the
-// enricher needs today are exposed; start_time/end_time and page_token
-// are intentionally omitted until a caller needs them.
+// enricher needs today are exposed (ChatID, PageSize, EndTime);
+// start_time and page_token are intentionally omitted until a caller
+// needs them.
 type ListMessagesParams struct {
 	ChatID ChatID
 	// PageSize is how many of the most-recent messages to fetch. The

--- a/server/internal/integrations/lark/dispatcher.go
+++ b/server/internal/integrations/lark/dispatcher.go
@@ -40,6 +40,13 @@ type InboundMessage struct {
 	// the dispatcher itself stays msg_type-agnostic and only reads Body.
 	MessageType string
 
+	// CreateTime is the trigger message's creation time (epoch
+	// milliseconds, as Lark sends it). The enricher uses it to anchor the
+	// group recent-context window to the moment of the @-mention — it
+	// fetches the conversation up to this time rather than whatever is
+	// newest when the (slightly later) prefetch HTTP call runs.
+	CreateTime string
+
 	// ParentID is the message_id of the message this one quote-replies
 	// to, taken verbatim from the receive event's `parent_id`. Empty
 	// when the message is not a reply. The enricher fetches it and

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -620,6 +620,9 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 	q.Set("sort_type", "ByCreateTimeDesc")
 	q.Set("page_size", strconv.Itoa(size))
 	q.Set("user_id_type", "open_id")
+	if p.EndTime > 0 {
+		q.Set("end_time", strconv.FormatInt(p.EndTime, 10))
+	}
 	path := "/open-apis/im/v1/messages?" + q.Encode()
 
 	var resp struct {

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -576,6 +577,66 @@ func (c *httpAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 			c.invalidateToken(creds.AppID)
 		}
 		return nil, fmt.Errorf("lark http client: get message: code=%d msg=%q", resp.Code, resp.Msg)
+	}
+
+	out := make([]LarkMessage, 0, len(resp.Data.Items))
+	for _, it := range resp.Data.Items {
+		out = append(out, it.normalize())
+	}
+	return out, nil
+}
+
+// larkListMessagesMaxPageSize is Lark's hard cap on a single
+// im/v1/messages page. We clamp to it so a caller asking for more
+// silently gets the max rather than a 400 from Lark.
+const larkListMessagesMaxPageSize = 50
+
+// ListChatMessages retrieves a bounded, recent window of messages in one
+// chat via GET /open-apis/im/v1/messages?container_id_type=chat. Where
+// GetMessage fetches a single message by id, this lists a conversation;
+// it backs the enricher's group-context prefetch. We pass
+// sort_type=ByCreateTimeDesc so the newest messages come first and a
+// small page_size captures "the last N" without paginating, keeping the
+// inbound ACK path's fan-out to a single round-trip. user_id_type=open_id
+// matches the identifiers the rest of the package keys on; body.content
+// is forwarded verbatim for the enricher's flattener to interpret.
+func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
+	if p.ChatID == "" {
+		return nil, errors.New("lark http client: missing chat_id")
+	}
+	size := p.PageSize
+	if size <= 0 {
+		size = 1
+	} else if size > larkListMessagesMaxPageSize {
+		size = larkListMessagesMaxPageSize
+	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+	q := url.Values{}
+	q.Set("container_id_type", "chat")
+	q.Set("container_id", string(p.ChatID))
+	q.Set("sort_type", "ByCreateTimeDesc")
+	q.Set("page_size", strconv.Itoa(size))
+	q.Set("user_id_type", "open_id")
+	path := "/open-apis/im/v1/messages?" + q.Encode()
+
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			Items []larkRESTMessageItem `json:"items"`
+		} `json:"data"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &resp); err != nil {
+		return nil, fmt.Errorf("lark http client: list chat messages: %w", err)
+	}
+	if resp.Code != 0 {
+		if isTokenError(resp.Code) {
+			c.invalidateToken(creds.AppID)
+		}
+		return nil, fmt.Errorf("lark http client: list chat messages: code=%d msg=%q", resp.Code, resp.Msg)
 	}
 
 	out := make([]LarkMessage, 0, len(resp.Data.Items))

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -632,7 +632,7 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 			Items []larkRESTMessageItem `json:"items"`
 		} `json:"data"`
 	}
-	if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
 		return nil, fmt.Errorf("lark http client: list chat messages: %w", err)
 	}
 	if resp.Code != 0 {

--- a/server/internal/integrations/lark/http_client_listmessages_test.go
+++ b/server/internal/integrations/lark/http_client_listmessages_test.go
@@ -35,6 +35,9 @@ func TestHTTPClient_ListChatMessages(t *testing.T) {
 		if q.Get("user_id_type") != "open_id" {
 			t.Errorf("user_id_type = %q", q.Get("user_id_type"))
 		}
+		if q.Get("end_time") != "1700000000" {
+			t.Errorf("end_time = %q", q.Get("end_time"))
+		}
 		writeJSON(w, map[string]any{
 			"code": 0, "msg": "ok",
 			"data": map[string]any{
@@ -59,7 +62,7 @@ func TestHTTPClient_ListChatMessages(t *testing.T) {
 	})
 
 	c := newTestClient(fake, time.Now)
-	items, err := c.ListChatMessages(context.Background(), testCreds(), ListMessagesParams{ChatID: "oc_chat", PageSize: 20})
+	items, err := c.ListChatMessages(context.Background(), testCreds(), ListMessagesParams{ChatID: "oc_chat", PageSize: 20, EndTime: 1700000000})
 	if err != nil {
 		t.Fatalf("ListChatMessages: %v", err)
 	}
@@ -81,8 +84,11 @@ func TestHTTPClient_ListChatMessagesClampsPageSize(t *testing.T) {
 	fake := newLarkFake(t)
 	fake.stubToken("tok", 7200)
 	var seenSize string
+	var endPresent bool
 	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
-		seenSize = r.URL.Query().Get("page_size")
+		q := r.URL.Query()
+		seenSize = q.Get("page_size")
+		endPresent = q.Has("end_time")
 		writeJSON(w, map[string]any{"code": 0, "msg": "ok", "data": map[string]any{"items": []any{}}})
 	})
 	c := newTestClient(fake, time.Now)
@@ -91,6 +97,10 @@ func TestHTTPClient_ListChatMessagesClampsPageSize(t *testing.T) {
 	}
 	if seenSize != "50" {
 		t.Errorf("page_size = %q, want clamped 50", seenSize)
+	}
+	// With no EndTime set, the end_time param must be omitted entirely.
+	if endPresent {
+		t.Errorf("end_time should be absent when EndTime=0")
 	}
 }
 

--- a/server/internal/integrations/lark/http_client_listmessages_test.go
+++ b/server/internal/integrations/lark/http_client_listmessages_test.go
@@ -1,0 +1,105 @@
+package lark
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestHTTPClient_ListChatMessages exercises the group-context list path:
+// the request carries container_id_type=chat, the chat id, a descending
+// sort, the requested page_size, and user_id_type=open_id; items[] come
+// back normalized verbatim (ordering is the enricher's job, not the
+// transport's).
+func TestHTTPClient_ListChatMessages(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("want GET, got %s", r.Method)
+		}
+		q := r.URL.Query()
+		if q.Get("container_id_type") != "chat" {
+			t.Errorf("container_id_type = %q", q.Get("container_id_type"))
+		}
+		if q.Get("container_id") != "oc_chat" {
+			t.Errorf("container_id = %q", q.Get("container_id"))
+		}
+		if q.Get("sort_type") != "ByCreateTimeDesc" {
+			t.Errorf("sort_type = %q", q.Get("sort_type"))
+		}
+		if q.Get("page_size") != "20" {
+			t.Errorf("page_size = %q", q.Get("page_size"))
+		}
+		if q.Get("user_id_type") != "open_id" {
+			t.Errorf("user_id_type = %q", q.Get("user_id_type"))
+		}
+		writeJSON(w, map[string]any{
+			"code": 0, "msg": "ok",
+			"data": map[string]any{
+				"items": []any{
+					map[string]any{
+						"message_id":  "om_2",
+						"msg_type":    "text",
+						"create_time": "2000",
+						"sender":      map[string]any{"id": "ou_b", "id_type": "open_id", "sender_type": "user"},
+						"body":        map[string]any{"content": `{"text":"second"}`},
+					},
+					map[string]any{
+						"message_id":  "om_1",
+						"msg_type":    "text",
+						"create_time": "1000",
+						"sender":      map[string]any{"id": "ou_a", "id_type": "open_id", "sender_type": "user"},
+						"body":        map[string]any{"content": `{"text":"first"}`},
+					},
+				},
+			},
+		})
+	})
+
+	c := newTestClient(fake, time.Now)
+	items, err := c.ListChatMessages(context.Background(), testCreds(), ListMessagesParams{ChatID: "oc_chat", PageSize: 20})
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if items[0].MessageID != "om_2" || items[0].Content != `{"text":"second"}` || items[0].SenderID != "ou_b" {
+		t.Errorf("items[0] = %+v", items[0])
+	}
+	if a := fake.lastAuth(); a != "Bearer tok" {
+		t.Errorf("auth header = %q", a)
+	}
+}
+
+// TestHTTPClient_ListChatMessagesClampsPageSize pins that an over-cap
+// page_size is clamped to Lark's 50 limit rather than passed through (a
+// raw >50 would earn a 400 from Lark).
+func TestHTTPClient_ListChatMessagesClampsPageSize(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	var seenSize string
+	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		seenSize = r.URL.Query().Get("page_size")
+		writeJSON(w, map[string]any{"code": 0, "msg": "ok", "data": map[string]any{"items": []any{}}})
+	})
+	c := newTestClient(fake, time.Now)
+	if _, err := c.ListChatMessages(context.Background(), testCreds(), ListMessagesParams{ChatID: "oc_chat", PageSize: 999}); err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	if seenSize != "50" {
+		t.Errorf("page_size = %q, want clamped 50", seenSize)
+	}
+}
+
+// TestHTTPClient_ListChatMessagesMissingChatID fails fast (no token, no
+// network call) when the chat id is empty.
+func TestHTTPClient_ListChatMessagesMissingChatID(t *testing.T) {
+	fake := newLarkFake(t)
+	c := newTestClient(fake, time.Now)
+	if _, err := c.ListChatMessages(context.Background(), testCreds(), ListMessagesParams{}); err == nil {
+		t.Fatalf("want error for empty chat id")
+	}
+}

--- a/server/internal/integrations/lark/inbound_enricher.go
+++ b/server/internal/integrations/lark/inbound_enricher.go
@@ -22,6 +22,13 @@ const larkMsgTypeMergeForward = "merge_forward"
 // visible "... (N more truncated)" marker.
 const defaultMaxForwardChildren = 100
 
+// DefaultRecentContextSize is the window the production wiring uses for
+// the group-context prefetch: how many of the most-recent group messages
+// to inline as a <recent_context> block when a user @-mentions the Bot.
+// 20 keeps the agent's prompt meaningfully contextual without bloating it
+// or risking the inbound ACK budget (a single list call, page_size 20).
+const DefaultRecentContextSize = 20
+
 // Enricher expands an inbound message's body with context the user
 // EXPLICITLY attached — a quoted reply or a merged-and-forwarded bundle
 // — by calling back into Lark's IM API. It runs after the (fast,
@@ -37,11 +44,18 @@ type Enricher interface {
 	Enrich(ctx context.Context, msg InboundMessage, creds InstallationCredentials) InboundMessage
 }
 
-// InboundEnricherConfig tunes the enricher. Both fields default.
+// InboundEnricherConfig tunes the enricher. All fields default.
 type InboundEnricherConfig struct {
 	// MaxForwardChildren caps inlined forward children. <=0 uses
 	// defaultMaxForwardChildren.
 	MaxForwardChildren int
+	// RecentContextSize caps how many surrounding group messages the
+	// enricher prefetches and inlines as a <recent_context> block when a
+	// user @-mentions the Bot in a group. <=0 DISABLES the prefetch
+	// entirely (only explicitly-attached quote/forward context is used);
+	// the production wiring sets DefaultRecentContextSize. Values above
+	// Lark's 50-per-page cap are clamped by the client.
+	RecentContextSize int
 	// Logger receives best-effort warnings about fetch failures. Nil
 	// uses slog.Default().
 	Logger *slog.Logger
@@ -50,6 +64,7 @@ type InboundEnricherConfig struct {
 type inboundEnricher struct {
 	client             APIClient
 	maxForwardChildren int
+	recentContextSize  int
 	logger             *slog.Logger
 }
 
@@ -66,22 +81,33 @@ func NewInboundEnricher(client APIClient, cfg InboundEnricherConfig) Enricher {
 	return &inboundEnricher{
 		client:             client,
 		maxForwardChildren: cfg.MaxForwardChildren,
+		recentContextSize:  cfg.RecentContextSize,
 		logger:             cfg.Logger,
 	}
 }
 
-// Enrich rewrites msg.Body to inline any quoted-reply parent and/or
-// forwarded bundle. Composition order matches the product spec: the
-// quoted block is prepended, then the message's own content (or, for a
-// forward, the rendered transcript) follows.
+// Enrich rewrites msg.Body to inline surrounding group context and/or
+// any quoted-reply parent and/or forwarded bundle. Composition order
+// goes broadest-to-narrowest: the surrounding group history first, then
+// the explicitly-quoted parent (a specific reference), then the message's
+// own content (or, for a forward, the rendered transcript).
+//
+//	<recent_context …>…</recent_context>
 //
 //	<quoted_message …>…</quoted_message>
 //
 //	<the user's own message, or the forwarded transcript>
+//
+// The <recent_context> block is only produced for a group message
+// addressed to the Bot, and only when RecentContextSize > 0 — it answers
+// MUL-3084 (the Bot saw only the single @-ed line, never the surrounding
+// conversation). It is the one fetch here NOT triggered by something the
+// user explicitly attached.
 func (e *inboundEnricher) Enrich(ctx context.Context, msg InboundMessage, creds InstallationCredentials) InboundMessage {
 	isForward := msg.MessageType == larkMsgTypeMergeForward
-	if msg.ParentID == "" && !isForward {
-		// Nothing the user explicitly attached — no network call.
+	wantRecent := e.recentContextSize > 0 && msg.ChatType == ChatTypeGroup && msg.AddressedToBot
+	if msg.ParentID == "" && !isForward && !wantRecent {
+		// Nothing to expand and no group prefetch wanted — no network call.
 		return msg
 	}
 	// If the transport isn't wired (stub client on a deployment without
@@ -92,7 +118,15 @@ func (e *inboundEnricher) Enrich(ctx context.Context, msg InboundMessage, creds 
 	}
 
 	var b strings.Builder
+	if wantRecent {
+		if blk := e.renderRecentContext(ctx, creds, msg); blk != "" {
+			b.WriteString(blk)
+		}
+	}
 	if msg.ParentID != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
 		b.WriteString(e.renderQuoted(ctx, creds, msg.ParentID))
 	}
 
@@ -109,6 +143,73 @@ func (e *inboundEnricher) Enrich(ctx context.Context, msg InboundMessage, creds 
 
 	msg.Body = b.String()
 	return msg
+}
+
+// renderRecentContext fetches the most recent messages in the group and
+// renders a <recent_context> block of the surrounding conversation,
+// excluding the triggering message itself and the directly-quoted parent
+// (which gets its own <quoted_message> block, so it isn't duplicated).
+// Messages render oldest-first as "[<speaker>]: <text>" using the same
+// positional speaker labels the forwarded-transcript renderer uses. Any
+// fetch failure degrades to a visible placeholder; like the rest of the
+// enricher it never blocks ingestion. An empty/whitespace window yields
+// "" so Enrich emits no block at all.
+func (e *inboundEnricher) renderRecentContext(ctx context.Context, creds InstallationCredentials, msg InboundMessage) string {
+	items, err := e.client.ListChatMessages(ctx, creds, ListMessagesParams{
+		ChatID:   msg.ChatID,
+		PageSize: e.recentContextSize,
+	})
+	if err != nil {
+		e.logger.Warn("lark enricher: recent context fetch failed",
+			"chat_id", string(msg.ChatID), "err", err)
+		return recentContextErrorBlock()
+	}
+
+	// Drop the trigger and the quoted parent so neither is duplicated
+	// alongside the user's core message / its own <quoted_message> block.
+	exclude := map[string]bool{msg.MessageID: true}
+	if msg.ParentID != "" {
+		exclude[msg.ParentID] = true
+	}
+	kept := make([]LarkMessage, 0, len(items))
+	for _, it := range items {
+		if exclude[it.MessageID] {
+			continue
+		}
+		kept = append(kept, it)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+
+	// The list endpoint returns newest-first; render oldest-first so the
+	// transcript reads top-to-bottom like the chat does.
+	sort.SliceStable(kept, func(i, j int) bool {
+		return parseLarkMillis(kept[i].CreateTime) < parseLarkMillis(kept[j].CreateTime)
+	})
+
+	labeler := newSpeakerLabeler()
+	lines := make([]string, 0, len(kept))
+	for _, m := range kept {
+		label := labeler.label(m)
+		var text string
+		switch {
+		case m.MessageType == larkMsgTypeMergeForward:
+			text = "[merge_forward, expand manually]"
+		default:
+			text = e.flattenMessage(m)
+			if text == "" {
+				text = "[empty message]"
+			}
+		}
+		lines = append(lines, fmt.Sprintf("[%s]: %s", label, text))
+	}
+	return fmt.Sprintf("<recent_context count=\"%d\">\n%s\n</recent_context>",
+		len(kept), strings.Join(lines, "\n"))
+}
+
+func recentContextErrorBlock() string {
+	return "<recent_context type=\"error\">[unable to fetch recent context]</recent_context>"
 }
 
 // renderQuoted fetches the directly-quoted parent and renders a

--- a/server/internal/integrations/lark/inbound_enricher.go
+++ b/server/internal/integrations/lark/inbound_enricher.go
@@ -23,10 +23,13 @@ const larkMsgTypeMergeForward = "merge_forward"
 const defaultMaxForwardChildren = 100
 
 // DefaultRecentContextSize is the window the production wiring uses for
-// the group-context prefetch: how many of the most-recent group messages
-// to inline as a <recent_context> block when a user @-mentions the Bot.
-// 10 keeps the agent's prompt meaningfully contextual without bloating it
-// or risking the inbound ACK budget (a single list call, page_size 10).
+// the group-context prefetch: the page_size of the single list call made
+// when a user @-mentions the Bot in a group. It is a FETCH budget, not a
+// guaranteed rendered count — the trigger message itself and any quoted
+// parent are filtered out of the result, so the <recent_context> block
+// usually renders one or two fewer lines. 10 keeps the agent's prompt
+// meaningfully contextual without bloating it or straining the inbound
+// ACK budget (one list call, page_size 10).
 const DefaultRecentContextSize = 10
 
 // Enricher expands an inbound message's body with context the user
@@ -103,6 +106,16 @@ func NewInboundEnricher(client APIClient, cfg InboundEnricherConfig) Enricher {
 // MUL-3084 (the Bot saw only the single @-ed line, never the surrounding
 // conversation). It is the one fetch here NOT triggered by something the
 // user explicitly attached.
+//
+// Persistence note: like the quoted/forwarded blocks, the rewritten Body
+// is persisted into the addressed turn's chat_message.content downstream
+// (AppendUserMessage). Inlining nearby group messages — including ones
+// from senders who did not address the Bot — into a member's addressed
+// turn is an accepted product decision for MUL-3084. It does NOT relax
+// the MUL-2671 drop-audit invariant: a non-addressed group message still
+// never creates its own session row, and is only ever surfaced as read-
+// context attached to a turn a workspace member explicitly directed at
+// the Bot.
 func (e *inboundEnricher) Enrich(ctx context.Context, msg InboundMessage, creds InstallationCredentials) InboundMessage {
 	isForward := msg.MessageType == larkMsgTypeMergeForward
 	wantRecent := e.recentContextSize > 0 && msg.ChatType == ChatTypeGroup && msg.AddressedToBot

--- a/server/internal/integrations/lark/inbound_enricher.go
+++ b/server/internal/integrations/lark/inbound_enricher.go
@@ -25,9 +25,9 @@ const defaultMaxForwardChildren = 100
 // DefaultRecentContextSize is the window the production wiring uses for
 // the group-context prefetch: how many of the most-recent group messages
 // to inline as a <recent_context> block when a user @-mentions the Bot.
-// 20 keeps the agent's prompt meaningfully contextual without bloating it
-// or risking the inbound ACK budget (a single list call, page_size 20).
-const DefaultRecentContextSize = 20
+// 10 keeps the agent's prompt meaningfully contextual without bloating it
+// or risking the inbound ACK budget (a single list call, page_size 10).
+const DefaultRecentContextSize = 10
 
 // Enricher expands an inbound message's body with context the user
 // EXPLICITLY attached — a quoted reply or a merged-and-forwarded bundle
@@ -158,6 +158,12 @@ func (e *inboundEnricher) renderRecentContext(ctx context.Context, creds Install
 	items, err := e.client.ListChatMessages(ctx, creds, ListMessagesParams{
 		ChatID:   msg.ChatID,
 		PageSize: e.recentContextSize,
+		// Anchor the window to the trigger message's time (Lark sends it
+		// as epoch millis; end_time wants seconds) so we pull the
+		// conversation up to the @-mention, not whatever is newest by the
+		// time this prefetch runs. A missing/unparseable time yields 0,
+		// which the client treats as "no end_time" (newest N).
+		EndTime: parseLarkMillis(msg.CreateTime) / 1000,
 	})
 	if err != nil {
 		e.logger.Warn("lark enricher: recent context fetch failed",

--- a/server/internal/integrations/lark/inbound_enricher_recent_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_recent_test.go
@@ -46,6 +46,7 @@ func TestEnrichRecentContextGroupMention(t *testing.T) {
 		ChatType:       ChatTypeGroup,
 		AddressedToBot: true,
 		Body:           "总结一下",
+		CreateTime:     "3000", // 3000ms -> end_time 3s
 	}
 
 	out := enrich(t, fake, in, groupCfg())
@@ -65,6 +66,14 @@ func TestEnrichRecentContextGroupMention(t *testing.T) {
 	}
 	if len(fake.calls) != 0 {
 		t.Errorf("no GetMessage expected, got %v", fake.calls)
+	}
+	// The window uses the production default size and is anchored to the
+	// trigger's time (millis -> seconds).
+	if got := fake.listParams[0].PageSize; got != DefaultRecentContextSize {
+		t.Errorf("page size = %d, want %d", got, DefaultRecentContextSize)
+	}
+	if got := fake.listParams[0].EndTime; got != 3 {
+		t.Errorf("end_time = %d, want 3 (3000ms -> 3s)", got)
 	}
 }
 

--- a/server/internal/integrations/lark/inbound_enricher_recent_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_recent_test.go
@@ -1,0 +1,209 @@
+package lark
+
+import (
+	"errors"
+	"testing"
+)
+
+// appMsg builds a Bot-sent message (sender_type "app"), so the speaker
+// labeler renders it as "Bot" inside a recent_context transcript.
+func appMsg(id, text, createTime string) LarkMessage {
+	return LarkMessage{
+		MessageID:   id,
+		MessageType: "text",
+		Content:     `{"text":"` + text + `"}`,
+		SenderID:    "cli_bot",
+		SenderType:  "app",
+		CreateTime:  createTime,
+	}
+}
+
+// groupCfg enables the recent-context prefetch with the production window.
+func groupCfg() InboundEnricherConfig {
+	return InboundEnricherConfig{RecentContextSize: DefaultRecentContextSize}
+}
+
+// TestEnrichRecentContextGroupMention is the MUL-3084 core: a bare @-bot
+// mention in a group (no quote, no forward) gets the surrounding
+// conversation inlined as a <recent_context> block ahead of the user's
+// own message. The trigger message is excluded; speakers are labeled
+// positionally with Bot replies labeled "Bot"; oldest-first ordering.
+func TestEnrichRecentContextGroupMention(t *testing.T) {
+	t.Parallel()
+	fake := newEnricherFake()
+	// Lark returns newest-first; include the trigger itself to prove it
+	// is filtered back out.
+	fake.byChat["oc_g"] = []LarkMessage{
+		textMsg("om_trigger", "ou_user", "总结一下", "3000"),
+		appMsg("om_bot", "你好", "2500"),
+		textMsg("om_b", "ou_bob", "明天发布", "2000"),
+		textMsg("om_a", "ou_alice", "我改完了登录页", "1000"),
+	}
+	in := InboundMessage{
+		MessageType:    "text",
+		MessageID:      "om_trigger",
+		ChatID:         "oc_g",
+		ChatType:       ChatTypeGroup,
+		AddressedToBot: true,
+		Body:           "总结一下",
+	}
+
+	out := enrich(t, fake, in, groupCfg())
+
+	want := `<recent_context count="3">
+[User 1]: 我改完了登录页
+[User 2]: 明天发布
+[Bot]: 你好
+</recent_context>
+
+总结一下`
+	if out.Body != want {
+		t.Errorf("body\n got = %q\nwant = %q", out.Body, want)
+	}
+	if len(fake.listCalls) != 1 || fake.listCalls[0] != "oc_g" {
+		t.Errorf("expected one ListChatMessages(oc_g), got %v", fake.listCalls)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("no GetMessage expected, got %v", fake.calls)
+	}
+}
+
+// TestEnrichRecentContextWithQuotedReply composes both expansions: the
+// recent_context block comes first (broadest), then the quoted parent,
+// then the user's prose. The quoted parent is excluded from the
+// recent_context window so it isn't duplicated.
+func TestEnrichRecentContextWithQuotedReply(t *testing.T) {
+	t.Parallel()
+	fake := newEnricherFake()
+	fake.byID["om_parent"] = []LarkMessage{
+		textMsg("om_parent", "ou_alice", "删除按钮加一下", "1000"),
+	}
+	fake.byChat["oc_g"] = []LarkMessage{
+		textMsg("om_trigger", "ou_user", "去做", "3000"),
+		textMsg("om_x", "ou_bob", "顺便看下样式", "2000"),
+		textMsg("om_parent", "ou_alice", "删除按钮加一下", "1000"),
+	}
+	in := InboundMessage{
+		MessageType:    "text",
+		MessageID:      "om_trigger",
+		ChatID:         "oc_g",
+		ChatType:       ChatTypeGroup,
+		AddressedToBot: true,
+		Body:           "去做",
+		ParentID:       "om_parent",
+	}
+
+	out := enrich(t, fake, in, groupCfg())
+
+	want := `<recent_context count="1">
+[User 1]: 顺便看下样式
+</recent_context>
+
+<quoted_message message_id="om_parent" sender="User 1" type="text">
+删除按钮加一下
+</quoted_message>
+
+去做`
+	if out.Body != want {
+		t.Errorf("body\n got = %q\nwant = %q", out.Body, want)
+	}
+	if len(fake.listCalls) != 1 || fake.listCalls[0] != "oc_g" {
+		t.Errorf("expected one ListChatMessages(oc_g), got %v", fake.listCalls)
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "om_parent" {
+		t.Errorf("expected one GetMessage(om_parent), got %v", fake.calls)
+	}
+}
+
+// TestEnrichRecentContextFetchError degrades to a visible placeholder on
+// a list failure, without blocking ingestion or dropping the user's body.
+func TestEnrichRecentContextFetchError(t *testing.T) {
+	t.Parallel()
+	fake := newEnricherFake()
+	fake.errByChat["oc_g"] = errors.New("boom")
+	in := InboundMessage{
+		MessageType:    "text",
+		MessageID:      "om_trigger",
+		ChatID:         "oc_g",
+		ChatType:       ChatTypeGroup,
+		AddressedToBot: true,
+		Body:           "在干嘛",
+	}
+
+	out := enrich(t, fake, in, groupCfg())
+
+	want := `<recent_context type="error">[unable to fetch recent context]</recent_context>
+
+在干嘛`
+	if out.Body != want {
+		t.Errorf("body\n got = %q\nwant = %q", out.Body, want)
+	}
+}
+
+// TestEnrichRecentContextEmptyWindow emits NO block (not an empty one)
+// when the only message in the window is the trigger itself.
+func TestEnrichRecentContextEmptyWindow(t *testing.T) {
+	t.Parallel()
+	fake := newEnricherFake()
+	fake.byChat["oc_g"] = []LarkMessage{
+		textMsg("om_trigger", "ou_user", "在吗", "1000"),
+	}
+	in := InboundMessage{
+		MessageType:    "text",
+		MessageID:      "om_trigger",
+		ChatID:         "oc_g",
+		ChatType:       ChatTypeGroup,
+		AddressedToBot: true,
+		Body:           "在吗",
+	}
+
+	out := enrich(t, fake, in, groupCfg())
+
+	if out.Body != "在吗" {
+		t.Errorf("body = %q, want unchanged %q", out.Body, "在吗")
+	}
+	if len(fake.listCalls) != 1 {
+		t.Errorf("expected one ListChatMessages, got %v", fake.listCalls)
+	}
+}
+
+// TestEnrichRecentContextSkippedCases pins the three conditions under
+// which the prefetch must NOT fire: p2p chats, group messages not
+// addressed to the Bot, and a disabled window (size 0). In all three the
+// body is untouched and no list call is made.
+func TestEnrichRecentContextSkippedCases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		msg  InboundMessage
+		cfg  InboundEnricherConfig
+	}{
+		{
+			name: "p2p chat",
+			msg:  InboundMessage{MessageType: "text", MessageID: "om1", ChatID: "oc_p", ChatType: ChatTypeP2P, AddressedToBot: true, Body: "hi"},
+			cfg:  groupCfg(),
+		},
+		{
+			name: "group but not addressed",
+			msg:  InboundMessage{MessageType: "text", MessageID: "om1", ChatID: "oc_g", ChatType: ChatTypeGroup, AddressedToBot: false, Body: "闲聊"},
+			cfg:  groupCfg(),
+		},
+		{
+			name: "prefetch disabled (size 0)",
+			msg:  InboundMessage{MessageType: "text", MessageID: "om1", ChatID: "oc_g", ChatType: ChatTypeGroup, AddressedToBot: true, Body: "在吗"},
+			cfg:  InboundEnricherConfig{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newEnricherFake()
+			out := enrich(t, fake, tc.msg, tc.cfg)
+			if out.Body != tc.msg.Body {
+				t.Errorf("body = %q, want unchanged %q", out.Body, tc.msg.Body)
+			}
+			if len(fake.listCalls) != 0 {
+				t.Errorf("expected no ListChatMessages, got %v", fake.listCalls)
+			}
+		})
+	}
+}

--- a/server/internal/integrations/lark/inbound_enricher_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_test.go
@@ -16,6 +16,11 @@ type enricherFakeClient struct {
 	byID       map[string][]LarkMessage
 	errByID    map[string]error
 	calls      []string
+
+	// ListChatMessages canned results + recorder, keyed by chat id.
+	byChat    map[ChatID][]LarkMessage
+	errByChat map[ChatID]error
+	listCalls []ChatID
 }
 
 func newEnricherFake() *enricherFakeClient {
@@ -23,6 +28,8 @@ func newEnricherFake() *enricherFakeClient {
 		configured: true,
 		byID:       map[string][]LarkMessage{},
 		errByID:    map[string]error{},
+		byChat:     map[ChatID][]LarkMessage{},
+		errByChat:  map[ChatID]error{},
 	}
 }
 
@@ -33,6 +40,13 @@ func (f *enricherFakeClient) GetMessage(ctx context.Context, creds InstallationC
 		return nil, e
 	}
 	return f.byID[id], nil
+}
+func (f *enricherFakeClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
+	f.listCalls = append(f.listCalls, p.ChatID)
+	if e, ok := f.errByChat[p.ChatID]; ok {
+		return nil, e
+	}
+	return f.byChat[p.ChatID], nil
 }
 
 // Unused-by-enricher methods — present only to satisfy APIClient.

--- a/server/internal/integrations/lark/inbound_enricher_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_test.go
@@ -18,9 +18,10 @@ type enricherFakeClient struct {
 	calls      []string
 
 	// ListChatMessages canned results + recorder, keyed by chat id.
-	byChat    map[ChatID][]LarkMessage
-	errByChat map[ChatID]error
-	listCalls []ChatID
+	byChat     map[ChatID][]LarkMessage
+	errByChat  map[ChatID]error
+	listCalls  []ChatID
+	listParams []ListMessagesParams
 }
 
 func newEnricherFake() *enricherFakeClient {
@@ -43,6 +44,7 @@ func (f *enricherFakeClient) GetMessage(ctx context.Context, creds InstallationC
 }
 func (f *enricherFakeClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
 	f.listCalls = append(f.listCalls, p.ChatID)
+	f.listParams = append(f.listParams, p)
 	if e, ok := f.errByChat[p.ChatID]; ok {
 		return nil, e
 	}

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -122,6 +122,9 @@ func (f *fakeAPIClient) GetBotInfo(ctx context.Context, creds InstallationCreden
 func (f *fakeAPIClient) GetMessage(ctx context.Context, creds InstallationCredentials, messageID string) ([]LarkMessage, error) {
 	return nil, nil
 }
+func (f *fakeAPIClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
+	return nil, nil
+}
 
 func newTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeAPIClient) {
 	t.Helper()

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -75,6 +75,9 @@ func (s *stubAPIClientWithRecorder) GetBotInfo(ctx context.Context, creds Instal
 func (s *stubAPIClientWithRecorder) GetMessage(ctx context.Context, creds InstallationCredentials, messageID string) ([]LarkMessage, error) {
 	return nil, nil
 }
+func (s *stubAPIClientWithRecorder) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
+	return nil, nil
+}
 
 // stubCredentialsResolver returns a fixed plaintext secret.
 type stubCredentialsResolver struct{ secret string }

--- a/server/internal/integrations/lark/ws_frame_decoder.go
+++ b/server/internal/integrations/lark/ws_frame_decoder.go
@@ -75,6 +75,7 @@ func (d *LarkJSONFrameDecoder) Decode(payload []byte, inst db.LarkInstallation) 
 		MessageID:    evt.Message.MessageID,
 		SenderOpenID: OpenID(evt.Sender.SenderID.OpenID),
 		MessageType:  evt.Message.MessageType,
+		CreateTime:   evt.Message.CreateTime,
 		// parent_id / root_id are populated by Lark only in reply
 		// scenarios. The enricher keys quoted-reply expansion off
 		// ParentID (the directly quoted message); RootID is carried for


### PR DESCRIPTION
## Summary

In Feishu/Lark **group** chats the Bot only ever saw the single message that `@`-mentioned it — never the messages before/after it. Root cause (MUL-3084): the inbound enricher only inlined context the user *explicitly attached* (a quoted reply via `parent_id`, or a `merge_forward` bundle), and the Lark API client had no way to list a chat's history at all.

This implements **Option A** from the design discussion: on a group `@`-mention, prefetch a bounded window of recent messages and inline them so the agent sees the surrounding conversation.

### Changes
- **`APIClient.ListChatMessages`** — new method calling `GET /open-apis/im/v1/messages` (`container_id_type=chat`, `sort_type=ByCreateTimeDesc`, `page_size` clamped to Lark's 50 cap, `user_id_type=open_id`). Thin transport adapter mirroring `GetMessage`; reuses the existing token cache / `doJSON` / `larkRESTMessageItem.normalize()`. Added to the stub and all test fakes.
- **Enricher `<recent_context>` block** — for a group message addressed to the Bot (and only when enabled), fetch recent history and prepend a `<recent_context>` block ahead of any `<quoted_message>` and the user's own message (broadest → narrowest). The trigger message and any quoted parent are excluded so nothing is duplicated; speakers are labeled positionally (`User 1` / `User 2` / `Bot`); messages render oldest-first. Fetch failure degrades to a visible placeholder and never blocks ingestion; an empty window emits no block.
- **Config / wiring** — `InboundEnricherConfig.RecentContextSize` (`<=0` disables; default-off for callers that don't set it). Production (`router.go`) wires `DefaultRecentContextSize` (20).

### Design notes
- **ACK budget:** exactly one list call per addressed turn, run under the connector's existing `EnrichTimeout` (single page, no pagination), so it stays within the Lark long-conn ACK window — same envelope as the existing quote/forward fetches.
- **Privacy:** the prefetch only runs for messages addressed to the Bot, consistent with how the enricher already persists an addressed turn's quoted parent. The `not_addressed_in_group` drop policy (MUL-2671 §4.7) is untouched — no new always-on ingestion.
- **Scopes:** the installed PersonalAgent already has the group message-read permission (confirmed by the issue owner), so no scope/registration change is needed.

A follow-up can expose this as an on-demand `multica chat history` tool so the agent can page back further; `ListChatMessages` is the shared foundation for that.

## How tested
- `go build ./...` — clean.
- `go test ./internal/integrations/lark/` — passes, including new tests:
  - `TestEnrichRecentContextGroupMention` (core: bare `@` inlines surrounding history, trigger excluded, Bot label)
  - `TestEnrichRecentContextWithQuotedReply` (recent_context + quoted parent compose; parent de-duped)
  - `TestEnrichRecentContextFetchError` (placeholder on failure)
  - `TestEnrichRecentContextEmptyWindow` (no empty block when only the trigger is returned)
  - `TestEnrichRecentContextSkippedCases` (p2p / not-addressed / disabled → no fetch)
  - `TestHTTPClient_ListChatMessages` + clamp + missing-chat-id transport tests
- `go vet ./internal/integrations/lark/` — clean; touched files are gofmt-clean.