### PR TITLE
feat(lark): unbind affordance on the agent connected badge (MUL-3090)

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -248,6 +248,7 @@
     "agent_bot_connected_label": "Connected to Lark",
     "agent_bot_manage_link": "Manage in Lark",
     "agent_bot_manage_tooltip": "Open this Bot's app page in Lark — manage scopes, edit display name, request additional permissions.",
+    "agent_bot_disconnect_tooltip": "Unbind this Lark Bot from the Agent. The Bot will stop receiving Lark messages.",
     "install_dialog_title": "Bind to Lark",
     "install_dialog_description": "Open Lark on your phone and scan the code below to create a PersonalAgent Bot.",
     "install_dialog_description_for_agent": "Open Lark on your phone and scan the code below to create a Bot for {{agent}}.",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -248,6 +248,7 @@
     "agent_bot_connected_label": "Lark に接続済み",
     "agent_bot_manage_link": "Lark で管理",
     "agent_bot_manage_tooltip": "Lark のデベロッパーコンソールでこのボットのアプリページを開き、スコープ管理 / 名称変更 / 追加権限の申請ができます。",
+    "agent_bot_disconnect_tooltip": "この Lark ボットとエージェントの連携を解除します。ボットは Lark メッセージの受信を停止します。",
     "install_dialog_title": "Lark に接続",
     "install_dialog_description": "Lark を開き、以下のコードをスキャンして PersonalAgent ボットを作成してください。",
     "install_dialog_description_for_agent": "Lark を開き、以下のコードをスキャンして {{agent}} 用のボットを作成してください。",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -325,6 +325,7 @@
     "agent_bot_connected_label": "Lark에 연결됨",
     "agent_bot_manage_link": "Lark에서 관리",
     "agent_bot_manage_tooltip": "Lark 개발자 콘솔에서 이 봇의 앱 페이지를 열어 스코프 관리, 이름 변경, 추가 권한 신청을 할 수 있어요.",
+    "agent_bot_disconnect_tooltip": "이 Lark 봇과 에이전트 연결을 해제합니다. 봇은 Lark 메시지 수신을 중단합니다.",
     "install_dialog_title": "Lark에 연결",
     "install_dialog_description": "휴대폰에서 Lark를 열고 아래 코드를 스캔해 PersonalAgent 봇을 만드세요.",
     "install_dialog_description_for_agent": "휴대폰에서 Lark를 열고 아래 코드를 스캔해 {{agent}}용 봇을 만드세요.",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -248,6 +248,7 @@
     "agent_bot_connected_label": "已连接到飞书",
     "agent_bot_manage_link": "在飞书中管理",
     "agent_bot_manage_tooltip": "打开飞书开发者控制台中该 Bot 的应用页面——管理权限、修改名称、申请新的权限范围。",
+    "agent_bot_disconnect_tooltip": "将该飞书 Bot 与智能体解绑，Bot 将停止接收飞书消息。",
     "install_dialog_title": "绑定到飞书",
     "install_dialog_description": "用飞书扫描下方二维码，创建一个 PersonalAgent Bot。",
     "install_dialog_description_for_agent": "用飞书扫描下方二维码，为 {{agent}} 创建一个 Bot。",

--- a/packages/views/settings/components/lark-tab.test.tsx
+++ b/packages/views/settings/components/lark-tab.test.tsx
@@ -146,6 +146,7 @@ vi.mock("react-qr-code", () => {
 });
 
 import { LarkAgentBindButton, LarkTab } from "./lark-tab";
+import { toast } from "sonner";
 
 const TEST_RESOURCES = {
   en: { common: enCommon, settings: enSettings },
@@ -239,11 +240,13 @@ describe("LarkAgentBindButton (CTA gate)", () => {
         updated_at: "2026-06-03T00:00:00Z",
       },
     ];
-    const { container } = render(
+    render(
       <LarkAgentBindButton agentId="agent-1" agentName="Bot" />,
       { wrapper: I18nWrapper },
     );
-    expect(container.querySelector("button")).toBeNull();
+    // The Bind CTA must be gone — re-scanning would orphan the
+    // PersonalAgent (see badge comment in lark-tab.tsx).
+    expect(screen.queryByRole("button", { name: /Bind to Lark/i })).toBeNull();
     expect(screen.getByText(/Connected to Lark/i)).toBeTruthy();
     const link = screen.getByRole("link", { name: /Manage in Lark/i }) as HTMLAnchorElement;
     expect(link.href).toBe("https://open.feishu.cn/app/cli_existing_app");
@@ -319,11 +322,13 @@ describe("LarkAgentBindButton (CTA gate)", () => {
         updated_at: "2026-06-03T00:00:00Z",
       },
     ];
-    const { container } = render(
+    render(
       <LarkAgentBindButton agentId="agent-1" agentName="Bot" />,
       { wrapper: I18nWrapper },
     );
-    expect(container.querySelector("button")).toBeNull();
+    // The Bind CTA must be gone even when install_supported=false,
+    // since the existing-installation check runs first.
+    expect(screen.queryByRole("button", { name: /Bind to Lark/i })).toBeNull();
     expect(screen.getByText(/Connected to Lark/i)).toBeTruthy();
     expect(
       screen.getByRole("link", { name: /Manage in Lark/i }),
@@ -349,6 +354,147 @@ describe("LarkAgentBindButton (CTA gate)", () => {
       wrapper: I18nWrapper,
     });
     expect(screen.getByRole("button", { name: /Bind to Lark/i })).toBeTruthy();
+  });
+});
+
+// The Connected badge surfaces an Unbind affordance for owners/admins
+// (parent gate keeps non-admins out of this component entirely). The
+// disconnect path is the recovery handle for the install_supported=false
+// re-scan zombie-bot trap and the dual-bot conflict — these tests pin
+// the contract: confirm gating, deleteLarkInstallation wiring, cache
+// invalidation, and toast feedback on success / failure.
+describe("LarkAgentBotConnectedBadge (Unbind / Disconnect)", () => {
+  beforeEach(() => {
+    resetFixtures();
+    installationsRef.current.installations = [
+      {
+        id: "inst-1",
+        workspace_id: "ws-1",
+        agent_id: "agent-1",
+        app_id: "cli_existing_app",
+        bot_open_id: "ou_existing_bot",
+        installer_user_id: "user-1",
+        status: "active",
+        installed_at: "2026-06-03T00:00:00Z",
+        created_at: "2026-06-03T00:00:00Z",
+        updated_at: "2026-06-03T00:00:00Z",
+      },
+    ];
+  });
+
+  it("renders a Disconnect affordance alongside the Manage link when the agent is bound", () => {
+    render(<LarkAgentBindButton agentId="agent-1" agentName="Bot" />, {
+      wrapper: I18nWrapper,
+    });
+    // The badge surfaces three siblings: the green-dot status pill,
+    // the Manage link, and the Unbind action. We assert by test-id so
+    // we don't trip over /Disconnect/i copy that also appears in the
+    // (closed) AlertDialog.
+    expect(screen.getByTestId("lark-agent-bot-disconnect")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Manage in Lark/i })).toBeTruthy();
+  });
+
+  it("opens the confirm dialog and does NOT call the API until the user confirms", async () => {
+    const user = userEvent.setup();
+    render(<LarkAgentBindButton agentId="agent-1" agentName="Bot" />, {
+      wrapper: I18nWrapper,
+    });
+    await user.click(screen.getByTestId("lark-agent-bot-disconnect"));
+    // Confirm dialog must mount with the correct copy.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Disconnect this Lark bot\?/i),
+      ).toBeTruthy();
+    });
+    // Critically: clicking the trigger alone must NOT have deleted the
+    // installation — confirmation is mandatory.
+    expect(mockDeleteInstallation).not.toHaveBeenCalled();
+  });
+
+  it("calls deleteLarkInstallation with (workspaceId, installationId), invalidates the cache, and toasts on confirm", async () => {
+    mockDeleteInstallation.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<LarkAgentBindButton agentId="agent-1" agentName="Bot" />, {
+      wrapper: I18nWrapper,
+    });
+    await user.click(screen.getByTestId("lark-agent-bot-disconnect"));
+    // Wait for the dialog to mount, then click the destructive action
+    // (the AlertDialogAction's accessible name is the same "Disconnect"
+    // label as the trigger button — but we're now inside the dialog
+    // role, so role+name is unambiguous).
+    const confirmButton = await screen.findByRole("button", {
+      name: /^Disconnect$/i,
+    });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockDeleteInstallation).toHaveBeenCalledTimes(1);
+    });
+    expect(mockDeleteInstallation).toHaveBeenCalledWith("workspace-1", "inst-1");
+    // Listings cache must be invalidated so the parent re-renders the
+    // Bind CTA in place of the now-stale Connected badge.
+    expect(mockInvalidate).toHaveBeenCalledWith({
+      queryKey: ["lark", "installations", "workspace-1"],
+    });
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("toasts an error and keeps the badge mounted when the API call rejects", async () => {
+    mockDeleteInstallation.mockRejectedValue(
+      new Error("upstream 500"),
+    );
+    const user = userEvent.setup();
+    render(<LarkAgentBindButton agentId="agent-1" agentName="Bot" />, {
+      wrapper: I18nWrapper,
+    });
+    await user.click(screen.getByTestId("lark-agent-bot-disconnect"));
+    const confirmButton = await screen.findByRole("button", {
+      name: /^Disconnect$/i,
+    });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+    // Cache must NOT be invalidated on failure — invalidating would
+    // round-trip a refetch, momentarily flicker the row away even
+    // though the install is still active server-side.
+    expect(mockInvalidate).not.toHaveBeenCalled();
+    // Badge stays mounted so the user can retry.
+    expect(screen.getByTestId("lark-agent-bot-connected")).toBeTruthy();
+  });
+
+  it("disables the Cancel button while the request is in-flight (prevents racing the close)", async () => {
+    let resolveDelete: () => void = () => {};
+    mockDeleteInstallation.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    render(<LarkAgentBindButton agentId="agent-1" agentName="Bot" />, {
+      wrapper: I18nWrapper,
+    });
+    await user.click(screen.getByTestId("lark-agent-bot-disconnect"));
+    const confirmButton = await screen.findByRole("button", {
+      name: /^Disconnect$/i,
+    });
+    await user.click(confirmButton);
+
+    // Cancel is disabled while disconnecting — closing mid-flight
+    // would orphan the in-flight invalidate + toast.
+    const cancel = screen.getByRole("button", { name: /Cancel/i });
+    await waitFor(() => {
+      expect((cancel as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    // Resolve and let the request finish so jsdom doesn't carry a
+    // dangling promise into the next test.
+    resolveDelete();
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -12,6 +12,7 @@ import { ExternalLink, RefreshCw, Trash2 } from "lucide-react";
 // was fine. The named export maps straight to `exports.QRCode` and
 // resolves correctly under both bundlers.
 import { QRCode } from "react-qr-code";
+import { cn } from "@multica/ui/lib/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import {
@@ -359,10 +360,16 @@ export function LarkAgentBindButton({
 
 // LarkAgentBotConnectedBadge is the "already connected" affordance the
 // agent inspector renders in place of the Bind button when this agent
-// has an active Lark installation. The badge is non-interactive (just
-// a status pill), the Manage link opens the Bot's dev console page in
-// a new tab so the user can manage scopes / display name / additional
-// permissions without re-scanning the QR.
+// has an active Lark installation. It surfaces three things side by
+// side: a green-dot status pill, a "Manage in Lark" link to the Bot's
+// dev console page (new tab), and an Unbind/Disconnect action that
+// removes the installation after a confirm dialog.
+//
+// Visibility rules carry over from the parent `LarkAgentBindButton`:
+// only owners and admins ever reach this component, so the unbind
+// affordance is unconditionally shown — the backend gates DELETE on
+// the same role and would 403 anyone else, which makes a redundant
+// `canManage` check here dead code.
 //
 // The dev-console host depends on which Lark cloud the bot lives on:
 // Feishu (mainland) bots are managed at open.feishu.cn, Lark
@@ -384,9 +391,43 @@ function LarkAgentBotConnectedBadge({
   className?: string;
 }) {
   const { t } = useT("settings");
+  const wsId = useWorkspaceId();
+  const qc = useQueryClient();
   const manageHref = `${larkDevConsoleHost(installation.region)}/app/${encodeURIComponent(installation.app_id)}`;
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  async function handleDisconnect() {
+    if (disconnecting) return;
+    setDisconnecting(true);
+    try {
+      await api.deleteLarkInstallation(wsId, installation.id);
+      // Invalidate before closing the dialog: the badge unmounts when
+      // the listings query updates (the parent swaps to the Bind CTA),
+      // so leaving the open state behind is fine — but doing the
+      // network call before the close prevents a flash of "stale
+      // connected" state.
+      await qc.invalidateQueries({ queryKey: larkKeys.installations(wsId) });
+      toast.success(t(($) => $.lark.toast_disconnected));
+      setConfirmOpen(false);
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : t(($) => $.lark.toast_disconnect_failed),
+      );
+    } finally {
+      setDisconnecting(false);
+    }
+  }
+
   return (
-    <div className={className} data-testid="lark-agent-bot-connected">
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-3 gap-y-1",
+        className,
+      )}
+      data-testid="lark-agent-bot-connected"
+    >
       <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
         <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
         {t(($) => $.lark.agent_bot_connected_label)}
@@ -395,12 +436,64 @@ function LarkAgentBotConnectedBadge({
         href={manageHref}
         target="_blank"
         rel="noopener noreferrer"
-        className="ml-3 inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
+        className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
         title={t(($) => $.lark.agent_bot_manage_tooltip)}
       >
         <ExternalLink className="h-3 w-3" />
         {t(($) => $.lark.agent_bot_manage_link)}
       </a>
+      {/* Unbind affordance — kept visually quieter than the primary
+          "Manage in Lark" link so it doesn't compete for attention,
+          but still discoverable. Confirmation is mandatory: the
+          backend disconnect tears down the WebSocket and stops
+          message delivery, and this is the user-facing recovery path
+          for the install_supported=false / re-scan zombie-bot trap
+          (server/internal/handler/lark.go). */}
+      <button
+        type="button"
+        onClick={() => setConfirmOpen(true)}
+        disabled={disconnecting}
+        className="inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-destructive focus-visible:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30 disabled:cursor-not-allowed disabled:opacity-50"
+        title={t(($) => $.lark.agent_bot_disconnect_tooltip)}
+        aria-label={t(($) => $.lark.disconnect)}
+        data-testid="lark-agent-bot-disconnect"
+      >
+        <Trash2 className="h-3 w-3" />
+        {disconnecting
+          ? t(($) => $.lark.disconnecting)
+          : t(($) => $.lark.disconnect)}
+      </button>
+
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={(v) => {
+          if (!v && !disconnecting) setConfirmOpen(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t(($) => $.lark.disconnect_confirm_title)}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t(($) => $.lark.disconnect_confirm_description)}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={disconnecting}>
+              {t(($) => $.lark.disconnect_confirm_cancel)}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+            >
+              {disconnecting
+                ? t(($) => $.lark.disconnecting)
+                : t(($) => $.lark.disconnect)}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Surface a Disconnect/Unbind action on `LarkAgentBotConnectedBadge` so workspace owners and admins can remove a Lark Bot binding directly from the agent inspector's INTEGRATIONS section — no detour to Settings.

The new affordance sits beside the existing **Manage in Lark** link and is rendered as a quieter muted-foreground control with a hover-destructive accent — discoverable but not competing visually with the primary Manage link.

| Before | After |
| --- | --- |
| ● Connected to Lark    ↗ Manage in Lark | ● Connected to Lark    ↗ Manage in Lark    🗑 Disconnect |

## Behaviour

- Confirmation is mandatory: a small `AlertDialog` reuses the existing `lark.disconnect_confirm_*` i18n strings (no new copy needed for the dialog body).
- A new tooltip key `lark.agent_bot_disconnect_tooltip` is added in en / zh-Hans / ja / ko.
- On confirm: `api.deleteLarkInstallation(wsId, installation.id)` → invalidates `larkKeys.installations(wsId)` so the parent re-renders the Bind CTA → success toast.
- On error: `toast.error(...)`, **no** cache invalidation (avoids flickering the row away while the install is still active server-side), badge stays mounted so the user can retry.
- `Cancel` is disabled while the request is in-flight to prevent racing the close.

## Why visibility is not gated again here

The parent `LarkAgentBindButton` already returns `null` for non-admin/non-owner viewers (matches the backend role gate on `DELETE /workspaces/:id/lark/installations/:id`), so this component only ever renders for users who can also action the disconnect. A redundant `canManage` check would be dead code.

## Tests

Updated 2 existing assertions that tested "the badge has no buttons" (it now has the disconnect button), and added 5 new tests in `packages/views/settings/components/lark-tab.test.tsx`:

1. Disconnect button is rendered alongside the Manage link when bound.
2. Clicking the trigger opens the confirm dialog and does **not** call the API until confirmed.
3. Confirming calls `deleteLarkInstallation('workspace-1', 'inst-1')`, invalidates the listings cache, and toasts success.
4. Error path: `toast.error` is fired, the listings cache is **not** invalidated, the badge stays mounted.
5. Cancel is disabled while the request is in-flight.

## Verification

- `pnpm --filter @multica/views typecheck` ✅
- `pnpm --filter @multica/views test` ✅  (1201 passed, was 1196)
- `pnpm --filter @multica/views lint settings/components/lark-tab.tsx settings/components/lark-tab.test.tsx` ✅ (0 warnings, 0 errors for modified files)

## Related

- Issue: MUL-3090
