### PR TITLE
feat(lark): split agent integration UI into inspector status + tab actions

### DIFF
--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -69,6 +69,12 @@ interface InspectorProps {
    */
   canEdit: boolean;
   onUpdate: (id: string, data: Record<string, unknown>) => Promise<void>;
+  /**
+   * Focus the overview pane's Integrations tab. The inspector's Lark status
+   * row is read-only and deep-links here; Manage / Disconnect live in the
+   * tab so the destructive action exists in exactly one place.
+   */
+  onShowIntegrations: () => void;
 }
 
 /**
@@ -92,6 +98,7 @@ export function AgentDetailInspector({
   currentUserId,
   canEdit,
   onUpdate,
+  onShowIntegrations,
 }: InspectorProps) {
   const { t } = useT("agents");
   const timeAgo = useTimeAgo();
@@ -223,7 +230,11 @@ export function AgentDetailInspector({
             </span>
           </div>
           <div className="flex flex-wrap gap-2">
-            <LarkAgentBindButton agentId={agent.id} agentName={agent.name} />
+            <LarkAgentBindButton
+              agentId={agent.id}
+              agentName={agent.name}
+              onShowConnectedDetails={onShowIntegrations}
+            />
           </div>
         </div>
       )}

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -48,7 +48,7 @@ import { BreadcrumbHeader } from "../../layout/breadcrumb-header";
 import { PageHeader } from "../../layout/page-header";
 import { availabilityConfig } from "../presence";
 import { AgentDetailInspector } from "./agent-detail-inspector";
-import { AgentOverviewPane } from "./agent-overview-pane";
+import { AgentOverviewPane, type DetailTab } from "./agent-overview-pane";
 import { useT } from "../../i18n";
 
 interface AgentDetailPageProps {
@@ -100,6 +100,10 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
   const { canEdit } = useAgentPermissions(agent, wsId);
 
   const [confirmArchive, setConfirmArchive] = useState(false);
+
+  // One-shot channel: the inspector's compact Lark status row asks the
+  // overview pane to focus a tab. The pane clears it after consuming.
+  const [tabNavIntent, setTabNavIntent] = useState<DetailTab | null>(null);
 
   const handleUpdate = async (id: string, data: Record<string, unknown>) => {
     // Optimistic update: patch the matching agent in the cached list
@@ -290,12 +294,15 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
           currentUserId={currentUser?.id ?? null}
           canEdit={canEdit.allowed}
           onUpdate={handleUpdate}
+          onShowIntegrations={() => setTabNavIntent("integrations")}
         />
 
         <AgentOverviewPane
           agent={agent}
           runtimes={runtimes}
           onUpdate={handleUpdate}
+          navIntent={tabNavIntent}
+          onNavIntentHandled={() => setTabNavIntent(null)}
         />
       </div>
 

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Activity,
   BookOpenText,
@@ -36,7 +36,7 @@ import { IntegrationsTab } from "./tabs/integrations-tab";
 import { ActorIssuesPanel } from "../../common/actor-issues-panel";
 import { useT } from "../../i18n";
 
-type DetailTab =
+export type DetailTab =
   | "activity"
   | "tasks"
   | "instructions"
@@ -75,6 +75,14 @@ interface AgentOverviewPaneProps {
   agent: Agent;
   runtimes: AgentRuntime[];
   onUpdate: (id: string, data: Record<string, unknown>) => Promise<void>;
+  /**
+   * One-shot request from a sibling (the inspector's compact Lark status
+   * row) to focus a specific tab. Routed through the same `requestTabChange`
+   * the tab buttons use, so the unsaved-changes guard still fires. The pane
+   * calls `onNavIntentHandled` to clear it after consuming.
+   */
+  navIntent?: DetailTab | null;
+  onNavIntentHandled?: () => void;
 }
 
 /**
@@ -104,6 +112,8 @@ export function AgentOverviewPane({
   agent,
   runtimes,
   onUpdate,
+  navIntent,
+  onNavIntentHandled,
 }: AgentOverviewPaneProps) {
   const { t } = useT("agents");
   const wsId = useWorkspaceId();
@@ -172,6 +182,17 @@ export function AgentOverviewPane({
       setPendingTab(null);
     }
   };
+
+  // Consume a one-shot tab-focus request from a sibling. Routing through
+  // `requestTabChange` (rather than `setActiveTab`) keeps the unsaved-changes
+  // guard honored even when the request originates outside the tab strip. The
+  // effect body is a no-op while `navIntent` is null, so the unstable
+  // `requestTabChange`/`onNavIntentHandled` identities can't loop it.
+  useEffect(() => {
+    if (navIntent == null) return;
+    requestTabChange(navIntent);
+    onNavIntentHandled?.();
+  }, [navIntent, requestTabChange, onNavIntentHandled]);
 
   return (
     // On mobile the parent stacks the inspector and overview and scrolls the

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { ExternalLink, RefreshCw, Trash2 } from "lucide-react";
+import { ChevronRight, ExternalLink, RefreshCw, Trash2 } from "lucide-react";
 // Named import, NOT default: react-qr-code is CJS, and electron-vite's
 // dep-optimizer default-import interop handed back the module namespace
 // object instead of the component, throwing "Element type is invalid …
@@ -287,10 +287,20 @@ export function LarkAgentBindButton({
   agentId,
   agentName,
   className,
+  onShowConnectedDetails,
 }: {
   agentId: string;
   agentName?: string;
   className?: string;
+  /**
+   * When set, the connected state renders as a compact read-only status
+   * row that invokes this callback on click instead of the full badge with
+   * inline Manage / Disconnect actions. The agent inspector passes a
+   * "jump to the Integrations tab" handler so the left column stays a
+   * glanceable summary and the management actions live in one place (the
+   * tab). The tab itself omits this prop and gets the full badge.
+   */
+  onShowConnectedDetails?: () => void;
 }) {
   const { t } = useT("settings");
   const wsId = useWorkspaceId();
@@ -324,7 +334,13 @@ export function LarkAgentBindButton({
     (inst) => inst.agent_id === agentId && inst.status === "active",
   );
   if (existing) {
-    return (
+    return onShowConnectedDetails ? (
+      <LarkAgentBotStatusRow
+        installation={existing}
+        onClick={onShowConnectedDetails}
+        className={className}
+      />
+    ) : (
       <LarkAgentBotConnectedBadge installation={existing} className={className} />
     );
   }
@@ -358,12 +374,52 @@ export function LarkAgentBindButton({
   );
 }
 
-// LarkAgentBotConnectedBadge is the "already connected" affordance the
-// agent inspector renders in place of the Bind button when this agent
-// has an active Lark installation. It surfaces three things side by
-// side: a green-dot status pill, a "Manage in Lark" link to the Bot's
-// dev console page (new tab), and an Unbind/Disconnect action that
-// removes the installation after a confirm dialog.
+// LarkAgentBotStatusRow is the compact, read-only connected affordance the
+// agent inspector (left column) renders instead of the full badge. It shows
+// only the status — green dot, Feishu/Lark region chip, "Connected to Lark"
+// — and is a single full-width button that deep-links into the Integrations
+// tab, where Manage / Disconnect live. Keeping the destructive action out of
+// the always-visible sidebar means it exists in exactly one place.
+function LarkAgentBotStatusRow({
+  installation,
+  onClick,
+  className,
+}: {
+  installation: LarkInstallation;
+  onClick: () => void;
+  className?: string;
+}) {
+  const { t } = useT("settings");
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        className,
+      )}
+      data-testid="lark-agent-bot-status"
+    >
+      <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
+      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+        {installation.region === "lark"
+          ? t(($) => $.lark.region_lark)
+          : t(($) => $.lark.region_feishu)}
+      </span>
+      <span className="truncate">{t(($) => $.lark.agent_bot_connected_label)}</span>
+      <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0" />
+    </button>
+  );
+}
+
+// LarkAgentBotConnectedBadge is the full "already connected" affordance the
+// Integrations tab renders in place of the Bind button when this agent has
+// an active Lark installation. (The inspector's left column uses the compact
+// LarkAgentBotStatusRow instead, which deep-links here.) It lays out as two
+// rows: row 1 pairs a green-dot status (with the Feishu/Lark region chip) on
+// the left with a soft-destructive Disconnect button on the right; row 2
+// carries the secondary "Manage in Lark" link to the Bot's dev console page
+// (new tab). Disconnect removes the installation after a confirm dialog.
 //
 // Visibility rules carry over from the parent `LarkAgentBindButton`:
 // only owners and admins ever reach this component, so the unbind
@@ -422,47 +478,56 @@ function LarkAgentBotConnectedBadge({
 
   return (
     <div
-      className={cn(
-        "flex flex-wrap items-center gap-x-3 gap-y-1",
-        className,
-      )}
+      className={cn("space-y-2", className)}
       data-testid="lark-agent-bot-connected"
     >
-      <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-        <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
-        {t(($) => $.lark.agent_bot_connected_label)}
-      </span>
+      {/* Row 1: connection status (left) and the destructive unbind
+          action (right). The Disconnect uses the soft-tinted
+          `destructive` button variant — it reads dangerous without the
+          loud solid-red, and stays visible because it is the user-facing
+          recovery path for the install_supported=false / re-scan
+          zombie-bot trap (server/internal/handler/lark.go). Confirmation
+          is mandatory: the backend disconnect tears down the WebSocket
+          and stops message delivery. */}
+      <div className="flex items-center justify-between gap-3">
+        <span className="inline-flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            {installation.region === "lark"
+              ? t(($) => $.lark.region_lark)
+              : t(($) => $.lark.region_feishu)}
+          </span>
+          <span className="truncate">{t(($) => $.lark.agent_bot_connected_label)}</span>
+        </span>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={() => setConfirmOpen(true)}
+          disabled={disconnecting}
+          title={t(($) => $.lark.agent_bot_disconnect_tooltip)}
+          aria-label={t(($) => $.lark.disconnect)}
+          data-testid="lark-agent-bot-disconnect"
+        >
+          <Trash2 className="h-3 w-3" />
+          {disconnecting
+            ? t(($) => $.lark.disconnecting)
+            : t(($) => $.lark.disconnect)}
+        </Button>
+      </div>
+
+      {/* Row 2: secondary "Manage in Lark" link to the Bot's dev-console
+          app page. Demoted below the status row so it no longer competes
+          with the primary connect/disconnect intents. */}
       <a
         href={manageHref}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
         title={t(($) => $.lark.agent_bot_manage_tooltip)}
       >
         <ExternalLink className="h-3 w-3" />
         {t(($) => $.lark.agent_bot_manage_link)}
       </a>
-      {/* Unbind affordance — kept visually quieter than the primary
-          "Manage in Lark" link so it doesn't compete for attention,
-          but still discoverable. Confirmation is mandatory: the
-          backend disconnect tears down the WebSocket and stops
-          message delivery, and this is the user-facing recovery path
-          for the install_supported=false / re-scan zombie-bot trap
-          (server/internal/handler/lark.go). */}
-      <button
-        type="button"
-        onClick={() => setConfirmOpen(true)}
-        disabled={disconnecting}
-        className="inline-flex items-center gap-1 rounded text-xs text-muted-foreground transition-colors hover:text-destructive focus-visible:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30 disabled:cursor-not-allowed disabled:opacity-50"
-        title={t(($) => $.lark.agent_bot_disconnect_tooltip)}
-        aria-label={t(($) => $.lark.disconnect)}
-        data-testid="lark-agent-bot-disconnect"
-      >
-        <Trash2 className="h-3 w-3" />
-        {disconnecting
-          ? t(($) => $.lark.disconnecting)
-          : t(($) => $.lark.disconnect)}
-      </button>
 
       <AlertDialog
         open={confirmOpen}


### PR DESCRIPTION
## Summary
The agent Lark binding showed the same connect/disconnect affordance twice on one page — the left inspector's INTEGRATIONS section and the right pane's Integrations tab both rendered the full `LarkAgentBindButton`, so the destructive **Disconnect** lived in two spots. This splits the two surfaces by role.

- **Inspector (left column)** — now a compact, read-only status row: green dot + Feishu/Lark region chip + "Connected to Lark", as a single full-width button that deep-links into the Integrations tab. New `LarkAgentBotStatusRow`, opted into via `LarkAgentBindButton`'s `onShowConnectedDetails` prop.
- **Integrations tab (right pane)** — keeps the full badge and is now the single home for **Manage / Disconnect**. The badge is reworked to a two-row layout: status (left) + soft `destructive`-variant **Disconnect** (right) on row 1; **Manage in Lark** demoted to a muted secondary link on row 2.

## Cross-sibling navigation
The inspector and the tab strip are siblings under `AgentDetailPage`. A one-shot `navIntent` channel on `AgentOverviewPane` lets the inspector focus the Integrations tab. It is consumed through the existing `requestTabChange`, **not** a raw `setActiveTab`, so the unsaved-changes guard still fires when you jump from the inspector while another tab is dirty.

## Files
- `lark-tab.tsx` — `LarkAgentBotStatusRow` (new), `onShowConnectedDetails` prop, two-row `LarkAgentBotConnectedBadge`.
- `agent-overview-pane.tsx` — export `DetailTab`; `navIntent` / `onNavIntentHandled` props + consuming effect.
- `agent-detail-page.tsx` — one-shot intent state wiring both siblings.
- `agent-detail-inspector.tsx` — `onShowIntegrations` prop, passed through.

## Notes
- The tab path passes no `onShowConnectedDetails`, so it still renders the full badge — existing `lark-tab.test.tsx` assertions are unaffected.
- **Out of scope:** the inspector's *not-connected* state still shows the inline Bind button (QR dialog); only the connected state was changed to deep-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)