### PR TITLE
fix: surface cancelled issues in list filter

### DIFF
--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -96,8 +96,14 @@ export type AssigneeGroupedIssuesFilter = Omit<
 /** Page size per status column. */
 export const ISSUE_PAGE_SIZE = 50;
 
-/** Statuses the issues/my-issues pages paginate. Cancelled is intentionally excluded — it has never been surfaced in the list/board views. */
-export const PAGINATED_STATUSES: readonly IssueStatus[] = BOARD_STATUSES;
+/** Statuses the issues/my-issues pages paginate. Includes cancelled so the
+ *  client cache, flatten, and WS helpers can surface it when the user
+ *  explicitly filters Status = Cancelled in List view. Default board/list
+ *  columns still come from BOARD_STATUSES / visibleStatuses. */
+export const PAGINATED_STATUSES: readonly IssueStatus[] = [
+  ...BOARD_STATUSES,
+  "cancelled",
+];
 
 /** Flatten a bucketed response to a single Issue[] for consumers that want the whole list. */
 export function flattenIssueBuckets(data: ListIssuesCache) {

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -10,7 +10,7 @@ import { useIssueViewStore, useClearFiltersOnWorkspaceChange } from "@multica/co
 import { useIssuesScopeStore } from "@multica/core/issues/stores/issues-scope-store";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { filterIssues } from "../utils/filter";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { ALL_STATUSES, BOARD_STATUSES } from "@multica/core/issues/config";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
@@ -142,10 +142,12 @@ export function IssuesPage() {
   const { data: childProgressMap = EMPTY_CHILD_PROGRESS } = useQuery(childIssueProgressOptions(wsId));
 
   const visibleStatuses = useMemo(() => {
-    if (statusFilters.length > 0)
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+    if (statusFilters.length > 0) {
+      const pool = viewMode === "list" ? ALL_STATUSES : BOARD_STATUSES;
+      return pool.filter((s) => statusFilters.includes(s));
+    }
     return BOARD_STATUSES;
-  }, [statusFilters]);
+  }, [statusFilters, viewMode]);
 
   const hiddenStatuses = useMemo(() => {
     return BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s));

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useAuthStore } from "@multica/core/auth";
 import { useQuery } from "@tanstack/react-query";
 import { filterIssues } from "../../issues/utils/filter";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { ALL_STATUSES, BOARD_STATUSES } from "@multica/core/issues/config";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BoardView } from "../../issues/components/board-view";
@@ -165,10 +165,12 @@ export function MyIssuesPage() {
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
 
   const visibleStatuses = useMemo(() => {
-    if (statusFilters.length > 0)
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+    if (statusFilters.length > 0) {
+      const pool = viewMode === "list" ? ALL_STATUSES : BOARD_STATUSES;
+      return pool.filter((s) => statusFilters.includes(s));
+    }
     return BOARD_STATUSES;
-  }, [statusFilters]);
+  }, [statusFilters, viewMode]);
 
   const hiddenStatuses = useMemo(() => {
     return BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s));


### PR DESCRIPTION
## Summary

Addresses #3786.

Makes cancelled issues discoverable from the Issues and My Issues List views when users explicitly filter by Cancelled status.

## Changes

- Include `cancelled` in paginated issue statuses so cancelled issues are loaded into the list cache.
- Allow List view status groups to include `cancelled` when a status filter is active.
- Keep default visible statuses unchanged by continuing to use `BOARD_STATUSES` when no status filter is active.
- Keep Board and Swimlane workflow columns unchanged to avoid changing their default layout semantics.

## Verification

- Ran `pnpm --filter @multica/core typecheck`.
- Ran `pnpm --filter @multica/views typecheck`.
- Opened Issues in List view.
- Applied Status = Cancelled.
- Confirmed cancelled issues are visible under the Cancelled group.
- Repeated the same validation in My Issues List view.
- Confirmed default views do not show Cancelled unless explicitly filtered in List view.

## Notes

This PR intentionally scopes the fix to List views. Board and Swimlane status column behavior is left unchanged to avoid expanding this bug fix into a broader workflow layout change.