### PR TITLE
fix(mobile): render workspace logos and use English copy in workspace switcher (MUL-3096)

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/switch-workspace.tsx
+++ b/apps/mobile/app/(app)/[workspace]/switch-workspace.tsx
@@ -30,6 +30,7 @@ import { router } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import type { Workspace } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
+import { WorkspaceAvatar } from "@/components/workspace/workspace-avatar";
 import { workspaceListOptions } from "@/data/queries/workspaces";
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { useColorScheme } from "@/lib/use-color-scheme";
@@ -45,12 +46,12 @@ export default function SwitchWorkspaceRoute() {
   const onSelect = (ws: Workspace) => {
     if (ws.slug === activeSlug) return;
     Alert.alert(
-      "切换工作区",
-      `确定切换到 "${ws.name}"?`,
+      "Switch workspace",
+      `Switch to "${ws.name}"?`,
       [
-        { text: "取消", style: "cancel" },
+        { text: "Cancel", style: "cancel" },
         {
-          text: "切换",
+          text: "Switch",
           onPress: () => {
             router.dismiss();
             router.replace(`/${ws.slug}/inbox`);
@@ -64,7 +65,7 @@ export default function SwitchWorkspaceRoute() {
     <View className="flex-1">
       <View className="px-4 pt-4 pb-3">
         <Text className="text-base font-semibold text-foreground">
-          切换工作区
+          Switch workspace
         </Text>
       </View>
       {isLoading ? (
@@ -80,7 +81,6 @@ export default function SwitchWorkspaceRoute() {
               active={ws.slug === activeSlug}
               onPress={() => onSelect(ws)}
               iconTint={t.foreground}
-              mutedIconTint={t.mutedForeground}
             />
           ))}
         </ScrollView>
@@ -94,13 +94,11 @@ function WorkspaceRow({
   active,
   onPress,
   iconTint,
-  mutedIconTint,
 }: {
   workspace: Workspace;
   active: boolean;
   onPress: () => void;
   iconTint: string;
-  mutedIconTint: string;
 }) {
   return (
     <Pressable
@@ -108,18 +106,18 @@ function WorkspaceRow({
       disabled={active}
       accessibilityLabel={
         active
-          ? `${workspace.name}, 当前工作区`
-          : `切换到 ${workspace.name}`
+          ? `${workspace.name}, current workspace`
+          : `Switch to ${workspace.name}`
       }
       className={cn(
         "flex-row items-center gap-3 px-4 py-3 active:bg-secondary",
         active && "opacity-100",
       )}
     >
-      <ExpoImage
-        source="sf:building.2"
-        tintColor={active ? iconTint : mutedIconTint}
-        style={{ width: 18, height: 18 }}
+      <WorkspaceAvatar
+        name={workspace.name}
+        avatarUrl={workspace.avatar_url}
+        size={24}
       />
       <Text
         className={cn(

--- a/apps/mobile/components/nav/more-tab-dropdown.tsx
+++ b/apps/mobile/components/nav/more-tab-dropdown.tsx
@@ -50,6 +50,7 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { Text } from "@/components/ui/text";
+import { WorkspaceAvatar } from "@/components/workspace/workspace-avatar";
 import { workspaceListOptions } from "@/data/queries/workspaces";
 import { useAuthStore } from "@/data/auth-store";
 import { useWorkspaceStore } from "@/data/workspace-store";
@@ -138,10 +139,10 @@ export function MoreTabDropdownAnchor({
 
           <WorkspaceCard
             currentWorkspaceName={currentWorkspace?.name}
+            currentWorkspaceAvatarUrl={currentWorkspace?.avatar_url}
             onPress={() =>
               slug && router.push(`/${slug}/switch-workspace`)
             }
-            iconTint={t.foreground}
             chevronTint={t.mutedForeground}
           />
 
@@ -247,13 +248,13 @@ function UserCard({
  */
 function WorkspaceCard({
   currentWorkspaceName,
+  currentWorkspaceAvatarUrl,
   onPress,
-  iconTint,
   chevronTint,
 }: {
   currentWorkspaceName: string | undefined;
+  currentWorkspaceAvatarUrl: string | null | undefined;
   onPress: () => void;
-  iconTint: string;
   chevronTint: string;
 }) {
   const { data } = useQuery(workspaceListOptions());
@@ -265,16 +266,14 @@ function WorkspaceCard({
       disabled={!canSwitch}
       className="h-12 gap-3"
       accessibilityLabel={
-        canSwitch ? "切换工作区" : currentWorkspaceName ?? "Workspace"
+        canSwitch ? "Switch workspace" : currentWorkspaceName ?? "Workspace"
       }
     >
-      <View className="size-8 rounded-md bg-muted items-center justify-center">
-        <ExpoImage
-          source="sf:building.2"
-          tintColor={iconTint}
-          style={{ width: 16, height: 16 }}
-        />
-      </View>
+      <WorkspaceAvatar
+        name={currentWorkspaceName ?? "Workspace"}
+        avatarUrl={currentWorkspaceAvatarUrl}
+        size={32}
+      />
       <View className="flex-1 min-w-0">
         <Text
           className="text-sm font-medium text-foreground"

--- a/apps/mobile/components/workspace/workspace-avatar.tsx
+++ b/apps/mobile/components/workspace/workspace-avatar.tsx
@@ -1,0 +1,57 @@
+/**
+ * Mobile WorkspaceAvatar. Mirrors packages/views/workspace/workspace-avatar.tsx:
+ * a resolved avatar_url renders as a rounded-square logo image; otherwise the
+ * workspace's initial letter sits in a muted tile. Same fallback semantics as
+ * web/desktop so a workspace looks identical across clients (apps/mobile/CLAUDE.md
+ * behavioral-parity rule).
+ *
+ * URL resolution goes through resolveAttachmentUrl — the mobile mirror of
+ * core's resolvePublicFileUrl — because avatar_url comes back as a server-
+ * relative path on self-hosted backends without a CDN signer, which RN's
+ * <Image> can't load without an absolute origin.
+ */
+import { View } from "react-native";
+import { Image as ExpoImage } from "expo-image";
+import { Text } from "@/components/ui/text";
+import { resolveAttachmentUrl } from "@/lib/attachment-url";
+import { cn } from "@/lib/utils";
+
+export function WorkspaceAvatar({
+  name,
+  avatarUrl,
+  size = 24,
+  className,
+}: {
+  name: string;
+  avatarUrl: string | null | undefined;
+  size?: number;
+  className?: string;
+}) {
+  const resolved = resolveAttachmentUrl(avatarUrl);
+  const borderRadius = Math.round(size / 4);
+
+  if (resolved) {
+    return (
+      <ExpoImage
+        source={{ uri: resolved }}
+        contentFit="cover"
+        accessibilityLabel={name}
+        style={{ width: size, height: size, borderRadius }}
+      />
+    );
+  }
+
+  return (
+    <View
+      className={cn("items-center justify-center bg-muted border border-border", className)}
+      style={{ width: size, height: size, borderRadius }}
+    >
+      <Text
+        className="font-semibold text-muted-foreground"
+        style={{ fontSize: Math.round(size * 0.48) }}
+      >
+        {name.charAt(0).toUpperCase()}
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes two visible bugs in the mobile (iOS) workspace switcher:

1. **Workspace logos never rendered.** Every workspace showed a generic `sf:building.2` glyph; `workspace.avatar_url` was ignored entirely, so all workspaces looked identical.
2. **Hardcoded Chinese strings.** The switch sheet title, the confirm dialog, the row accessibility labels, and the More-tab entry row shipped Chinese copy. Mobile is English-only today (no i18n infra yet — see the inline notes in `components/inbox/detail-label.tsx` and `more/settings/notifications.tsx`), so these were untranslated literals, not a localization path.

Approach mirrors the existing web/desktop implementation rather than inventing a mobile-only shape, per the mobile behavioral-parity rules in `apps/mobile/CLAUDE.md`.

## Related Issue

Closes #3840

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- **`apps/mobile/components/workspace/workspace-avatar.tsx`** (new) — mobile `WorkspaceAvatar`, mirroring `packages/views/workspace/workspace-avatar.tsx`: a resolved `avatar_url` renders as a rounded-square logo; otherwise the workspace's initial letter sits in a muted tile (same fallback semantics as web). URL resolution reuses the existing `resolveAttachmentUrl` helper (the mobile mirror of core's `resolvePublicFileUrl`), so self-hosted/relative `avatar_url` paths resolve correctly.
- **`apps/mobile/app/(app)/[workspace]/switch-workspace.tsx`** — render `WorkspaceAvatar` per row instead of the static building glyph; English copy for the title, the `Alert` confirm (`Switch to "X"?` / `Cancel` / `Switch`), and the row accessibility labels. Dropped the now-unused `mutedIconTint` prop.
- **`apps/mobile/components/nav/more-tab-dropdown.tsx`** — the collapsed workspace entry row now shows the current workspace's logo via `WorkspaceAvatar` (threading `avatar_url` through from the already-loaded workspace object); English accessibility label. Dropped the now-unused `iconTint` prop.

## How to Test

1. Sign in on iOS with an account in **2+ workspaces**, at least one of which has an uploaded logo.
2. Open the **More** tab → the entry row shows the current workspace's logo (or its initial if none), not the generic office icon.
3. Tap it to open the **Switch workspace** sheet → each row shows that workspace's logo / initial; all copy is English.
4. Tap a different workspace → the confirm dialog reads `Switch to "<name>"?` with `Cancel` / `Switch`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`tsc --noEmit` + eslint on the changed files)
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — N/A: this PR *removes* hardcoded Chinese in favor of English (mobile has no i18n layer yet)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Reproduced both bugs on a physical device, then traced the web/desktop source of truth (`packages/views/workspace/workspace-avatar.tsx`, `packages/core/workspace/avatar-url.ts`) and mirrored it on mobile using the existing `resolveAttachmentUrl` helper rather than adding a new primitive — following the parity and "mirror, don't import" rules in `apps/mobile/CLAUDE.md`.

## Screenshots (optional)

Intentionally omitted — device screenshots would expose private workspace names/logos. The visual change is: generic office glyph → real workspace logo (initial-letter fallback), and Chinese switcher copy → English.
