### PR TITLE
fix(mobile): border + className passthrough on WorkspaceAvatar logo branch (MUL-3096)

### DIFF
--- a/apps/mobile/components/workspace/workspace-avatar.tsx
+++ b/apps/mobile/components/workspace/workspace-avatar.tsx
@@ -9,6 +9,14 @@
  * core's resolvePublicFileUrl — because avatar_url comes back as a server-
  * relative path on self-hosted backends without a CDN signer, which RN's
  * <Image> can't load without an absolute origin.
+ *
+ * Both branches render a `border border-border` tile and thread `className`
+ * through, matching web's <img>/<span> (both carry `border` + `className`).
+ * The logo sits inside an overflow-hidden View rather than styling the
+ * <ExpoImage> directly: NativeWind has no cssInterop for expo-image, so
+ * className/border utilities are silently dropped on <ExpoImage>. The wrapper
+ * View is how the rest of the app borders/rounds an expo-image — see
+ * lib/markdown/markdown-image.tsx.
  */
 import { View } from "react-native";
 import { Image as ExpoImage } from "expo-image";
@@ -32,12 +40,17 @@ export function WorkspaceAvatar({
 
   if (resolved) {
     return (
-      <ExpoImage
-        source={{ uri: resolved }}
-        contentFit="cover"
-        accessibilityLabel={name}
+      <View
+        className={cn("overflow-hidden border border-border", className)}
         style={{ width: size, height: size, borderRadius }}
-      />
+      >
+        <ExpoImage
+          source={{ uri: resolved }}
+          contentFit="cover"
+          accessibilityLabel={name}
+          style={{ width: "100%", height: "100%" }}
+        />
+      </View>
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

Small follow-up to #3839 closing the two non-blocking review nits on the new mobile `WorkspaceAvatar`. Brings the **logo (resolved `avatar_url`) branch** to full parity with the initial-letter fallback and with web's `<img>`:

1. **Adds the missing border.** The fallback tile renders `border border-border`; web's `<img>` renders `border object-cover`. The logo branch had neither, so a light logo on a light surface lost its edge. It now carries `border border-border`.
2. **Threads `className` through the logo branch.** Previously `className` only reached the fallback `<View>`, so a caller passing `className` to style a logo was silently ignored. Both branches now thread it, matching web (its `<img>` and `<span>` both take `className`).

### Why a wrapper `View` instead of styling `<ExpoImage>` directly

NativeWind has no `cssInterop` registered for `expo-image`, so `className` / `border` utilities are **silently dropped** on `<ExpoImage>` (same class of issue noted in `components/issue/mention-suggestion-bar.tsx` for `Animated.View`). The logo therefore sits inside an `overflow-hidden` `View` that carries the border + `className` — which is exactly how the rest of the app borders/rounds an expo-image (see `lib/markdown/markdown-image.tsx`). No new primitive, no new dependency.

## Related Issue

Follow-up to #3839 (which closed #3840). Tracked in Multica as MUL-3096.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [ ] Tests
- [ ] CI / infrastructure

## Changes Made

- **`apps/mobile/components/workspace/workspace-avatar.tsx`** — wrap the logo `<ExpoImage>` in an `overflow-hidden border border-border` `View` that threads `className`; image fills it (`contentFit="cover"`, `100%`×`100%`). Fallback branch unchanged. Header comment documents why the wrapper exists (expo-image has no NativeWind cssInterop).

## How to Test

1. iOS app, account in **2+ workspaces**, at least one with an uploaded logo.
2. Open **More** tab → **Switch workspace**: each logo now shows a 1px themed border (matches the initial-letter tiles) in both light and dark mode.
3. Workspaces without a logo are unchanged (initial-letter tile).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass — relying on the Mobile Verify CI (typecheck/lint/test on `apps/mobile/**`); deps not installed in this checkout
- [ ] I have added or updated tests where applicable — N/A, pure visual parity tweak
- [ ] If this change affects the UI, I have included before/after screenshots — omitted; would expose private workspace logos. Visual delta: logo gains the same 1px `border-border` edge the fallback tile already has
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` — N/A, no copy change
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Claude Code (agent J)

**Prompt / approach:** Traced web source of truth (`packages/views/workspace/workspace-avatar.tsx` — both branches carry `border` + `className`), confirmed NativeWind drops className on `<ExpoImage>` (no cssInterop in this repo; every mobile `ExpoImage` styles via `style`), and mirrored the in-repo `markdown-image.tsx` wrapper pattern rather than inventing a new one — per the parity and "existing pattern first" rules in `apps/mobile/CLAUDE.md`.
