### PR TITLE
feat(lark): acknowledge ingested messages with reaction

### DIFF
--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -60,6 +60,11 @@ type APIClient interface {
 	// Lark's card schema.
 	SendBindingPromptCard(ctx context.Context, p BindingPromptParams) error
 
+	// AddMessageReaction adds an emoji reaction to an existing Lark
+	// message. Used as a low-noise acknowledgement that the bot has
+	// received a user request and is working on it.
+	AddMessageReaction(ctx context.Context, p AddReactionParams) error
+
 	// GetBotInfo returns the Bot's per-installation `open_id` (the
 	// `bot_open_id` we persist on lark_installation). RegistrationService
 	// is the only caller — after the device-flow registration returns
@@ -233,6 +238,12 @@ type BindingPromptParams struct {
 	BindURL string
 }
 
+type AddReactionParams struct {
+	InstallationID InstallationCredentials
+	MessageID      string
+	EmojiType      string
+}
+
 // InstallationCredentials is the per-installation transport context the
 // client needs to authenticate against Lark on behalf of a workspace's
 // bot. Passing these explicitly to each call (rather than constructing
@@ -311,6 +322,11 @@ func (s *stubAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 
 func (s *stubAPIClient) SendBindingPromptCard(ctx context.Context, p BindingPromptParams) error {
 	s.log.Warn("lark stub client: SendBindingPromptCard called", "open_id", string(p.OpenID))
+	return ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) AddMessageReaction(ctx context.Context, p AddReactionParams) error {
+	s.log.Warn("lark stub client: AddMessageReaction called", "message_id", p.MessageID, "emoji_type", p.EmojiType)
 	return ErrAPIClientNotConfigured
 }
 

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -465,6 +465,39 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 	return nil
 }
 
+func (c *httpAPIClient) AddMessageReaction(ctx context.Context, p AddReactionParams) error {
+	if p.MessageID == "" {
+		return errors.New("lark http client: missing message_id")
+	}
+	if p.EmojiType == "" {
+		return errors.New("lark http client: missing emoji_type")
+	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return err
+	}
+	body := map[string]any{
+		"reaction_type": map[string]string{
+			"emoji_type": p.EmojiType,
+		},
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	path := "/open-apis/im/v1/messages/" + url.PathEscape(p.MessageID) + "/reactions"
+	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+		return fmt.Errorf("lark http client: add message reaction: %w", err)
+	}
+	if resp.Code != 0 {
+		if isTokenError(resp.Code) {
+			c.invalidateToken(p.InstallationID.AppID)
+		}
+		return fmt.Errorf("lark http client: add message reaction: code=%d msg=%q", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
 // GetBotInfo calls /open-apis/bot/v3/info to learn the Bot's
 // per-installation `open_id` and then /open-apis/contact/v3/users/
 // {open_id}?user_id_type=open_id to resolve its stable `union_id`.

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -27,6 +27,7 @@ type larkFakeServer struct {
 	sendN   atomic.Int32
 	patchN  atomic.Int32
 	bindN   atomic.Int32
+	reactN  atomic.Int32
 	authObs atomic.Value // last Authorization header seen across all paths
 }
 
@@ -125,6 +126,31 @@ func (f *larkFakeServer) stubPatch(resp map[string]any, verify func(r *http.Requ
 		}
 		if verify != nil {
 			verify(r, id, body)
+		}
+		writeJSON(w, resp)
+	})
+}
+
+func (f *larkFakeServer) stubReaction(resp map[string]any, verify func(r *http.Request, id string, body map[string]any)) {
+	const suffix = "/reactions"
+	f.mux.HandleFunc("/open-apis/im/v1/messages/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, suffix) {
+			f.t.Errorf("reaction: unexpected path %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			f.t.Errorf("reaction: want POST, got %s", r.Method)
+		}
+		f.reactN.Add(1)
+		rawID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/open-apis/im/v1/messages/"), suffix)
+		if rawID == "" {
+			f.t.Errorf("reaction: missing message id")
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			f.t.Errorf("reaction: decode body: %v", err)
+		}
+		if verify != nil {
+			verify(r, rawID, body)
 		}
 		writeJSON(w, resp)
 	})
@@ -353,6 +379,38 @@ func TestHTTPClient_SendTextMessage_HappyPath(t *testing.T) {
 	}
 	if got := fake.lastAuth(); got != "Bearer tok_text" {
 		t.Errorf("Authorization header: got %q want Bearer tok_text", got)
+	}
+}
+
+func TestHTTPClient_AddMessageReaction_HappyPath(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_react", 7200)
+	fake.stubReaction(map[string]any{"code": 0, "msg": "success"}, func(r *http.Request, id string, body map[string]any) {
+		if id != "om_user_msg_1" {
+			t.Errorf("message id: got %q want om_user_msg_1", id)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok_react" {
+			t.Errorf("Authorization=%q want Bearer tok_react", got)
+		}
+		reactionType, ok := body["reaction_type"].(map[string]any)
+		if !ok {
+			t.Fatalf("reaction_type missing or wrong shape: %v", body)
+		}
+		if got := reactionType["emoji_type"]; got != "OnIt" {
+			t.Errorf("emoji_type=%v want OnIt", got)
+		}
+	})
+
+	c := newTestClient(fake, time.Now)
+	if err := c.AddMessageReaction(context.Background(), AddReactionParams{
+		InstallationID: testCreds(),
+		MessageID:      "om_user_msg_1",
+		EmojiType:      "OnIt",
+	}); err != nil {
+		t.Fatalf("AddMessageReaction: %v", err)
+	}
+	if got := fake.reactN.Load(); got != 1 {
+		t.Fatalf("reaction endpoint calls=%d want 1", got)
 	}
 }
 
@@ -818,8 +876,8 @@ func TestHTTPClient_GetBotInfo_HappyPath(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"bot": map[string]any{
-				"open_id":   "ou_bot_42",
-				"app_name":  "PersonalAgent",
+				"open_id":    "ou_bot_42",
+				"app_name":   "PersonalAgent",
 				"avatar_url": "https://example/avatar.png",
 			},
 		})

--- a/server/internal/integrations/lark/inbound_enricher_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_test.go
@@ -84,6 +84,9 @@ func (f *enricherFakeClient) SendMarkdownCard(context.Context, SendMarkdownCardP
 func (f *enricherFakeClient) SendBindingPromptCard(context.Context, BindingPromptParams) error {
 	return nil
 }
+func (f *enricherFakeClient) AddMessageReaction(context.Context, AddReactionParams) error {
+	return nil
+}
 func (f *enricherFakeClient) GetBotInfo(context.Context, InstallationCredentials) (BotInfo, error) {
 	return BotInfo{}, nil
 }

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -116,6 +116,9 @@ func (f *fakeAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 	f.bindingSent = append(f.bindingSent, p)
 	return nil
 }
+func (f *fakeAPIClient) AddMessageReaction(ctx context.Context, p AddReactionParams) error {
+	return nil
+}
 func (f *fakeAPIClient) GetBotInfo(ctx context.Context, creds InstallationCredentials) (BotInfo, error) {
 	return BotInfo{}, nil
 }

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -13,6 +13,8 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+const processingReactionEmoji = "OnIt"
+
 // OutcomeReplier reacts to the Dispatcher's verdict by posting the
 // appropriate Lark-side reply card. This is the outbound half of the
 // `EventEmitter` contract in hub.go: NeedsBinding sends the binding
@@ -172,6 +174,14 @@ func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst db.LarkInstallation
 			)
 		}
 	case OutcomeIngested:
+		if err := r.addProcessingReaction(ctx, inst, msg); err != nil {
+			r.log.Warn("lark outcome replier: processing reaction failed",
+				"installation_id", uuidString(inst.ID),
+				"chat_id", string(msg.ChatID),
+				"message_id", msg.MessageID,
+				"err", err.Error(),
+			)
+		}
 		// The agent's chat reply itself goes through the Patcher (text
 		// message on ChatDone). But /issue does NOT block on the
 		// agent — the user expects an immediate "Created [MUL-42]"
@@ -194,6 +204,21 @@ func (r *LarkOutcomeReplier) Reply(ctx context.Context, inst db.LarkInstallation
 	case OutcomeDropped:
 		// OutcomeDropped is informational; no user-visible reply.
 	}
+}
+
+func (r *LarkOutcomeReplier) addProcessingReaction(ctx context.Context, inst db.LarkInstallation, msg InboundMessage) error {
+	if msg.MessageID == "" {
+		return errors.New("missing message_id")
+	}
+	creds, err := r.installationCredentials(inst)
+	if err != nil {
+		return err
+	}
+	return r.client.AddMessageReaction(ctx, AddReactionParams{
+		InstallationID: creds,
+		MessageID:      msg.MessageID,
+		EmojiType:      processingReactionEmoji,
+	})
 }
 
 func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst db.LarkInstallation, res DispatchResult) error {

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -23,9 +23,11 @@ type stubAPIClientWithRecorder struct {
 	bindingCalls   []BindingPromptParams
 	interactiveOut []SendCardParams
 	textOut        []SendTextParams
+	reactions      []AddReactionParams
 	sendErr        error
 	textErr        error
 	bindingErr     error
+	reactionErr    error
 }
 
 func (s *stubAPIClientWithRecorder) IsConfigured() bool { return s.configured }
@@ -65,6 +67,16 @@ func (s *stubAPIClientWithRecorder) SendBindingPromptCard(ctx context.Context, p
 		return s.bindingErr
 	}
 	s.bindingCalls = append(s.bindingCalls, p)
+	return nil
+}
+
+func (s *stubAPIClientWithRecorder) AddMessageReaction(ctx context.Context, p AddReactionParams) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.reactionErr != nil {
+		return s.reactionErr
+	}
+	s.reactions = append(s.reactions, p)
 	return nil
 }
 
@@ -225,10 +237,7 @@ func TestLarkOutcomeReplierAgentArchivedSendsCard(t *testing.T) {
 	}
 }
 
-// TestLarkOutcomeReplierIngestedAndDroppedAreSilent asserts that the
-// replier does NOT call the APIClient on outcomes owned elsewhere
-// (Patcher handles Ingested; Dropped is informational only).
-func TestLarkOutcomeReplierIngestedAndDroppedAreSilent(t *testing.T) {
+func TestLarkOutcomeReplierIngestedAddsProcessingReaction(t *testing.T) {
 	t.Parallel()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	stub := &stubAPIClientWithRecorder{configured: true}
@@ -240,11 +249,19 @@ func TestLarkOutcomeReplierIngestedAndDroppedAreSilent(t *testing.T) {
 		PublicURL:   "https://multica.test",
 		Logger:      log,
 	})
-	msg := InboundMessage{ChatID: "oc_x"}
+	msg := InboundMessage{ChatID: "oc_x", MessageID: "om_user_1"}
 	rep.Reply(context.Background(), db.LarkInstallation{}, msg, DispatchResult{Outcome: OutcomeIngested})
 	rep.Reply(context.Background(), db.LarkInstallation{}, msg, DispatchResult{Outcome: OutcomeDropped, DropReason: DropReasonDuplicate})
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.reactions) != 1 {
+		t.Fatalf("ingested message should get one processing reaction; got %d", len(stub.reactions))
+	}
+	if got := stub.reactions[0]; got.MessageID != "om_user_1" || got.EmojiType != processingReactionEmoji {
+		t.Fatalf("reaction = %+v, want message om_user_1 emoji %s", got, processingReactionEmoji)
+	}
 	if len(stub.interactiveOut) != 0 || len(stub.bindingCalls) != 0 {
-		t.Errorf("Ingested/Dropped should not trigger any APIClient call; got interactive=%d binding=%d",
+		t.Errorf("Ingested/Dropped should not trigger card/binding calls; got interactive=%d binding=%d",
 			len(stub.interactiveOut), len(stub.bindingCalls))
 	}
 }
@@ -307,6 +324,7 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	inst := db.LarkInstallation{AppID: "cli_x"}
 	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
 	msg := InboundMessage{ChatID: "oc_chat_42", SenderOpenID: "ou_user"}
+	msg.MessageID = "om_issue_cmd"
 	rep.Reply(context.Background(), inst, msg, DispatchResult{
 		Outcome:         OutcomeIngested,
 		IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
@@ -319,6 +337,12 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	defer stub.mu.Unlock()
 	if len(stub.textOut) != 1 {
 		t.Fatalf("expected one SendTextMessage call, got %d", len(stub.textOut))
+	}
+	if len(stub.reactions) != 1 {
+		t.Fatalf("expected one AddMessageReaction call, got %d", len(stub.reactions))
+	}
+	if got := stub.reactions[0]; got.MessageID != "om_issue_cmd" || got.EmojiType != processingReactionEmoji {
+		t.Fatalf("reaction = %+v, want message om_issue_cmd emoji %s", got, processingReactionEmoji)
 	}
 	got := stub.textOut[0]
 	if got.ChatID != "oc_chat_42" {
@@ -340,12 +364,11 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 	}
 }
 
-// TestLarkOutcomeReplierOutcomeIngestedSilentWithoutIssue pins the
-// silent-by-default behaviour for plain chat messages. The "Created"
-// text is gated on IssueID.Valid; a chat that didn't include /issue
-// must NOT trigger an outbound from the OutcomeReplier (the agent's
-// reply is delivered separately by the Patcher on EventChatDone).
-func TestLarkOutcomeReplierOutcomeIngestedSilentWithoutIssue(t *testing.T) {
+// TestLarkOutcomeReplierOutcomeIngestedWithoutIssueDoesNotSendMessage
+// pins the low-noise plain-chat behaviour: the bot acknowledges with a
+// reaction, while the actual answer is delivered later by the Patcher
+// on EventChatDone.
+func TestLarkOutcomeReplierOutcomeIngestedWithoutIssueDoesNotSendMessage(t *testing.T) {
 	t.Parallel()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	stub := &stubAPIClientWithRecorder{configured: true}
@@ -358,14 +381,46 @@ func TestLarkOutcomeReplierOutcomeIngestedSilentWithoutIssue(t *testing.T) {
 		Logger:      log,
 	})
 
-	rep.Reply(context.Background(), db.LarkInstallation{}, InboundMessage{ChatID: "oc"},
+	rep.Reply(context.Background(), db.LarkInstallation{}, InboundMessage{ChatID: "oc", MessageID: "om_plain"},
 		DispatchResult{Outcome: OutcomeIngested}) // no IssueID
 
 	stub.mu.Lock()
 	defer stub.mu.Unlock()
 	if len(stub.textOut) != 0 || len(stub.interactiveOut) != 0 {
-		t.Errorf("plain chat ingest must be silent at the replier; got text=%d cards=%d",
+		t.Errorf("plain chat ingest must not send messages at the replier; got text=%d cards=%d",
 			len(stub.textOut), len(stub.interactiveOut))
+	}
+	if len(stub.reactions) != 1 {
+		t.Fatalf("plain chat ingest should add a reaction; got %d", len(stub.reactions))
+	}
+}
+
+func TestLarkOutcomeReplierReactionFailureDoesNotBlockIssueConfirmation(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{configured: true, reactionErr: errors.New("missing reaction scope")}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  &BindingTokenService{},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		PublicURL:   "https://multica.test",
+		Logger:      log,
+	})
+
+	rep.Reply(context.Background(), db.LarkInstallation{}, InboundMessage{ChatID: "oc", MessageID: "om"},
+		DispatchResult{
+			Outcome:         OutcomeIngested,
+			IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
+			IssueNumber:     42,
+			IssueIdentifier: "MUL-42",
+			IssueTitle:      "fix login bug",
+		})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.textOut) != 1 {
+		t.Fatalf("issue confirmation must still send when reaction fails; got %d text sends", len(stub.textOut))
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a Lark message reaction API wrapper
- add a processing reaction when a bot-ingested message is accepted
- keep reaction failures non-blocking so ingestion and replies continue normally

## Test plan

- go test ./internal/integrations/lark/
