### PR TITLE
fix(web): keep API proxy target off Next's clobbered PORT in dev

### DIFF
--- a/scripts/local-env.sh
+++ b/scripts/local-env.sh
@@ -5,6 +5,12 @@ POSTGRES_USER="${POSTGRES_USER:-multica}"
 POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 
 PORT="${BACKEND_PORT:-${API_PORT:-${SERVER_PORT:-${PORT:-8080}}}}"
+# `next dev --port <frontend>` overwrites process.env.PORT with the frontend
+# port inside the web process, which would poison the API-proxy target in
+# apps/web/config/runtime-urls.ts (it falls back to PORT). Pin BACKEND_PORT to
+# the resolved backend port — the resolver prefers it over PORT and Next never
+# touches it — so the same-origin /api proxy resolves correctly.
+BACKEND_PORT="${PORT}"
 FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 FRONTEND_ORIGIN="${FRONTEND_ORIGIN:-http://localhost:${FRONTEND_PORT}}"
 
@@ -15,6 +21,6 @@ LOCAL_UPLOAD_BASE_URL="${LOCAL_UPLOAD_BASE_URL:-http://localhost:${PORT}}"
 PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL:-${FRONTEND_ORIGIN}}"
 
 export POSTGRES_DB POSTGRES_USER POSTGRES_PORT
-export PORT FRONTEND_PORT FRONTEND_ORIGIN
+export PORT BACKEND_PORT FRONTEND_PORT FRONTEND_ORIGIN
 export MULTICA_APP_URL GOOGLE_REDIRECT_URI MULTICA_SERVER_URL LOCAL_UPLOAD_BASE_URL
 export PLAYWRIGHT_BASE_URL

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,9 @@
   "globalEnv": [
     "DATABASE_URL",
     "PORT",
+    "BACKEND_PORT",
+    "API_PORT",
+    "SERVER_PORT",
     "FRONTEND_PORT",
     "FRONTEND_ORIGIN",
     "NEXT_PUBLIC_API_URL",


### PR DESCRIPTION
`next dev --port <frontend>` overwrites process.env.PORT with the frontend port inside the web process, so resolveRemoteApiUrl (apps/web/config/runtime-urls.ts) resolved the /api proxy target to localhost:3000 — a self-loop that 500'd every API call on main checkouts (worktrees escaped it via NEXT_PUBLIC_API_URL).

Fix at the env layer: export BACKEND_PORT (resolver-preferred, untouched by Next) pinned to the resolved backend port in local-env.sh, and add BACKEND_PORT/API_PORT/SERVER_PORT to turbo.json globalEnv so the value survives Turbo's strict env filtering and reaches next.config.ts.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
