### PR TITLE
修复：支持筛选已取消的 Issue (MUL-3987)

### DIFF
--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -9,6 +9,7 @@ import {
   PROJECT_GANTT_MAX_ISSUES,
   PROJECT_GANTT_PAGE_LIMIT,
   childrenByParentsOptions,
+  issueListOptions,
   issueKeys,
   projectGanttIssuesOptions,
 } from "./queries";
@@ -136,6 +137,34 @@ describe("projectGanttIssuesOptions", () => {
   it("uses the project-scoped Gantt cache key", () => {
     const options = projectGanttIssuesOptions(WS_ID, PROJECT_ID);
     expect(options.queryKey).toEqual(issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+});
+
+describe("issueListOptions", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the cancelled bucket so cancelled issues stay discoverable", async () => {
+    const listIssues = vi
+      .fn<(params?: ListIssuesParams) => Promise<ListIssuesResponse>>()
+      .mockResolvedValue({ issues: [], total: 0 });
+    installFakeApi(listIssues);
+
+    await qc.fetchQuery(issueListOptions(WS_ID));
+
+    expect(listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "cancelled" }),
+    );
   });
 });
 

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -8,7 +8,7 @@ import type {
   ListIssuesParams,
   ListIssuesCache,
 } from "../types";
-import { BOARD_STATUSES } from "./config";
+import { ALL_STATUSES } from "./config";
 
 export interface IssueSortParam {
   sort_by?: ListIssuesParams["sort_by"];
@@ -96,8 +96,8 @@ export type AssigneeGroupedIssuesFilter = Omit<
 /** Page size per status column. */
 export const ISSUE_PAGE_SIZE = 50;
 
-/** Statuses the issues/my-issues pages paginate. Cancelled is intentionally excluded — it has never been surfaced in the list/board views. */
-export const PAGINATED_STATUSES: readonly IssueStatus[] = BOARD_STATUSES;
+/** Statuses the issues/my-issues pages paginate. Keep terminal statuses here so explicit filters can surface them. */
+export const PAGINATED_STATUSES: readonly IssueStatus[] = ALL_STATUSES;
 
 /** Flatten a bucketed response to a single Issue[] for consumers that want the whole list. */
 export function flattenIssueBuckets(data: ListIssuesCache) {

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -5,7 +5,7 @@ import { useStore } from "zustand";
 import { ListTodo, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { BOARD_STATUSES, STATUS_ORDER } from "@multica/core/issues/config";
 import {
   childIssueProgressOptions,
   myIssueListOptions,
@@ -138,7 +138,7 @@ export function ActorIssuesPanel({
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0) {
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+      return STATUS_ORDER.filter((s) => statusFilters.includes(s));
     }
     return BOARD_STATUSES;
   }, [statusFilters]);

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -10,7 +10,7 @@ import { useIssueViewStore, useClearFiltersOnWorkspaceChange } from "@multica/co
 import { useIssuesScopeStore } from "@multica/core/issues/stores/issues-scope-store";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { filterIssues } from "../utils/filter";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { BOARD_STATUSES, STATUS_ORDER } from "@multica/core/issues/config";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
@@ -143,7 +143,7 @@ export function IssuesPage() {
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+      return STATUS_ORDER.filter((s) => statusFilters.includes(s));
     return BOARD_STATUSES;
   }, [statusFilters]);
 

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useAuthStore } from "@multica/core/auth";
 import { useQuery } from "@tanstack/react-query";
 import { filterIssues } from "../../issues/utils/filter";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { BOARD_STATUSES, STATUS_ORDER } from "@multica/core/issues/config";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BoardView } from "../../issues/components/board-view";
@@ -166,7 +166,7 @@ export function MyIssuesPage() {
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+      return STATUS_ORDER.filter((s) => statusFilters.includes(s));
     return BOARD_STATUSES;
   }, [statusFilters]);
 

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -31,7 +31,7 @@ import { useRecentContextStore } from "@multica/core/chat";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { PROJECT_STATUS_ORDER, PROJECT_STATUS_CONFIG, PROJECT_PRIORITY_ORDER } from "@multica/core/projects/config";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { BOARD_STATUSES, STATUS_ORDER } from "@multica/core/issues/config";
 import { createIssueViewStore } from "@multica/core/issues/stores/view-store";
 import { ViewStoreProvider, useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { filterIssues } from "../../issues/utils/filter";
@@ -182,7 +182,7 @@ function ProjectIssuesContent({
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+      return STATUS_ORDER.filter((s) => statusFilters.includes(s));
     return BOARD_STATUSES;
   }, [statusFilters]);
 


### PR DESCRIPTION
## Summary

- Fetch cancelled issue buckets in the shared issue list query.
- Keep default board columns unchanged while allowing explicit `Cancelled` filters to render.
- Add a regression test for cancelled issue discoverability.

Fixes #3786.

## Root Cause

`PAGINATED_STATUSES` reused `BOARD_STATUSES`, and `BOARD_STATUSES` excludes `cancelled`. The UI also derived selected visible statuses by filtering through `BOARD_STATUSES`, so an explicit `Cancelled` status filter could produce no visible status group.

## Validation

- `pnpm --filter @multica/core exec vitest run issues/queries.test.ts`
- `pnpm --filter @multica/views exec vitest run issues/components/issues-page.test.tsx projects/components/project-issue-filters.test.ts`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`