### PR TITLE
fix(runtime): pause autopilots inside the runtime-delete teardown transaction

### DIFF
--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -587,25 +587,6 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pause autopilots pointing at the archived agents BEFORE we delete
-	// them. Migration 096 dropped the autopilot.assignee_id agent FK, so a
-	// hard-delete here would otherwise leave dangling rows that subsequent
-	// scheduler ticks would skip with "assignee agent no longer exists" —
-	// quiet, but burning a run record every tick until an operator notices.
-	// Pausing makes the breakage visible in the autopilot list so the owner
-	// can re-point or delete the row instead.
-	archivedAgentIDs, err := h.Queries.ListArchivedAgentIDsByRuntime(r.Context(), rt.ID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to enumerate archived agents")
-		return
-	}
-	if len(archivedAgentIDs) > 0 {
-		if err := h.Queries.PauseAutopilotsByAgentAssignees(r.Context(), archivedAgentIDs); err != nil {
-			slog.Warn("pause autopilots for archived agents failed",
-				"runtime_id", uuidToString(rt.ID), "error", err)
-		}
-	}
-
 	tx, err := h.TxStarter.Begin(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete runtime")
@@ -613,6 +594,27 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback(r.Context())
 	qtx := h.Queries.WithTx(tx)
+
+	// Pause autopilots pointing at the archived agents BEFORE we delete
+	// them. Migration 096 dropped the autopilot.assignee_id agent FK, so a
+	// hard-delete here would otherwise leave dangling rows that subsequent
+	// scheduler ticks would skip with "assignee agent no longer exists" —
+	// quiet, but burning a run record every tick until an operator notices.
+	// Pausing makes the breakage visible in the autopilot list so the owner
+	// can re-point or delete the row instead. This runs inside the teardown
+	// transaction so a pause that lands but is followed by a failed delete
+	// rolls back with everything else, matching ArchiveAgentsAndDeleteRuntime.
+	archivedAgentIDs, err := qtx.ListArchivedAgentIDsByRuntime(r.Context(), rt.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to enumerate archived agents")
+		return
+	}
+	if len(archivedAgentIDs) > 0 {
+		if err := qtx.PauseAutopilotsByAgentAssignees(r.Context(), archivedAgentIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to pause autopilots")
+			return
+		}
+	}
 
 	// Remove archived squads whose leader is an archived agent on this runtime
 	// so the RESTRICT FK on squad.leader_id won't block the subsequent agent


### PR DESCRIPTION
## What does this PR do?

Moves the autopilot-pause step in `DeleteAgentRuntime` **inside** the runtime-teardown transaction.

Follow-up to #2955 (which wrapped the archived-squad / archived-agent / runtime deletes in a transaction). The autopilot pause was left just outside that transaction and was best-effort (`slog.Warn` on error, then continue):

```go
// before: outside the tx, warn-only
archivedAgentIDs, _ := h.Queries.ListArchivedAgentIDsByRuntime(...)
h.Queries.PauseAutopilotsByAgentAssignees(...)   // best-effort

tx, _ := h.TxStarter.Begin(...)
qtx := h.Queries.WithTx(tx)
// ... deletes via qtx ... commit
```

So if the pause succeeded but a later delete in the transaction failed and rolled back, the autopilots stayed paused while the runtime survived — a side effect that did not roll back with the rest of the teardown.

This window predates #2955 (that PR only added the transaction around the deletes, not the pause), so it's fixed separately here.

## Change

Run `ListArchivedAgentIDsByRuntime` + `PauseAutopilotsByAgentAssignees` through `qtx` inside the transaction, and treat a pause error as a hard failure (500 → rollback) instead of warn-and-continue. This matches the sibling teardown handler `ArchiveAgentsAndDeleteRuntime` in the same file, which already pauses inside its transaction. A failed `Exec` would poison the pgx transaction anyway, so warn-and-continue is not a valid option once the call is inside the tx.

## How tested

- `go vet ./internal/handler/` — clean
- `gofmt` — clean
- `go test ./internal/handler/ -run 'TestDeleteAgentRuntime|TestDeleteSquadsByArchivedAgentsOnRuntime_Query'` — pass (existing teardown tests exercise the moved pause on the happy path)

No behavior change on the success path; the only observable difference is that a teardown that rolls back no longer leaves autopilots paused.

MUL-3105
