### PR TITLE
test: cover issue board project filters

### DIFF
--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -486,6 +486,12 @@ describe("IssuesPage (shared)", () => {
     mockViewState.grouping = "status";
     mockViewState.statusFilters = [];
     mockViewState.priorityFilters = [];
+    mockViewState.assigneeFilters = [];
+    mockViewState.includeNoAssignee = false;
+    mockViewState.creatorFilters = [];
+    mockViewState.projectFilters = [];
+    mockViewState.includeNoProject = false;
+    mockViewState.labelFilters = [];
     mockScope = "all";
   });
 
@@ -557,6 +563,50 @@ describe("IssuesPage (shared)", () => {
       }),
     );
     expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("applies project filters to status-board issue cards", async () => {
+    mockViewState.viewMode = "board";
+    mockViewState.grouping = "status";
+    mockViewState.projectFilters = ["project-a"];
+    const issuesWithProjects = [
+      { ...mockIssues[0]!, project_id: "project-a" },
+      { ...mockIssues[1]!, project_id: "project-b" },
+      { ...mockIssues[2]!, project_id: null },
+      { ...mockIssues[3]!, project_id: "project-a" },
+    ];
+    mockListIssues.mockImplementation((params: any) =>
+      Promise.resolve({
+        issues: issuesWithProjects.filter((i) => i.status === params?.status),
+        total: issuesWithProjects.filter((i) => i.status === params?.status).length,
+      }),
+    );
+
+    renderWithQuery(<IssuesPage />);
+
+    await screen.findByText("Implement auth");
+    expect(screen.getByText("Squad task")).toBeInTheDocument();
+    expect(screen.queryByText("Design landing page")).not.toBeInTheDocument();
+    expect(screen.queryByText("Write tests")).not.toBeInTheDocument();
+  });
+
+  it("forwards project filters to assignee-grouped board queries", async () => {
+    mockViewState.viewMode = "board";
+    mockViewState.grouping = "assignee";
+    mockViewState.projectFilters = ["project-a", "project-b"];
+    mockViewState.includeNoProject = true;
+    mockListGroupedIssues.mockResolvedValue(mockAssigneeGroups(mockIssues));
+
+    renderWithQuery(<IssuesPage />);
+
+    await screen.findByText("Implement auth");
+    expect(mockListGroupedIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        group_by: "assignee",
+        project_ids: ["project-a", "project-b"],
+        include_no_project: true,
+      }),
+    );
   });
 
   it("shows the 'Issues' section header without a workspace prefix", async () => {


### PR DESCRIPTION
## Summary
- add regression coverage for project filters on the shared Issues status-board view
- assert the assignee-grouped board forwards `project_ids` and `include_no_project` to the grouped issues API

## Notes
- regression-only PR; no production behavior or API/DB/runtime contracts changed
- supports investigation of GitHub issue #3870 while keeping that issue open for repro details

## Verification
- `pnpm --filter @multica/views exec vitest run issues/components/issues-page.test.tsx issues/utils/filter.test.ts`
- `pnpm --filter @multica/views typecheck`
