### PR TITLE
feat(cli): per-status error copy with actionable hints (PR2, MUL-3104)

### DIFF
--- a/server/cmd/multica/cmd_config.go
+++ b/server/cmd/multica/cmd_config.go
@@ -80,7 +80,6 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-
 func valueOrDefault(v, fallback string) string {
 	if v == "" {
 		return fallback

--- a/server/cmd/multica/cmd_version.go
+++ b/server/cmd/multica/cmd_version.go
@@ -24,12 +24,12 @@ func runVersion(cmd *cobra.Command, _ []string) error {
 
 	if output == "json" {
 		info := map[string]string{
-			"version":   version,
-			"commit":    commit,
-			"date":      date,
-			"go":        runtime.Version(),
-			"os":        runtime.GOOS,
-			"arch":      runtime.GOARCH,
+			"version": version,
+			"commit":  commit,
+			"date":    date,
+			"go":      runtime.Version(),
+			"os":      runtime.GOOS,
+			"arch":    runtime.GOARCH,
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/server/cmd/multica/help.go
+++ b/server/cmd/multica/help.go
@@ -35,7 +35,6 @@ func exactArgs(n int) cobra.PositionalArgs {
 	}
 }
 
-
 // initHelp configures the root command to use gh-style help output.
 func initHelp(root *cobra.Command) {
 	root.SetHelpTemplate(rootHelpTemplate)

--- a/server/internal/cli/errors.go
+++ b/server/internal/cli/errors.go
@@ -63,6 +63,42 @@ func (k ErrorKind) IsNetwork() bool {
 	}
 }
 
+// String returns a stable, snake_case identifier for the kind. It is used in
+// --debug output and is safe to log or branch on; it is not user-facing copy
+// (see kindMessages / messageFor for that).
+func (k ErrorKind) String() string {
+	switch k {
+	case KindNetworkTimeout:
+		return "network_timeout"
+	case KindNetworkDNS:
+		return "network_dns"
+	case KindNetworkRefused:
+		return "network_refused"
+	case KindNetworkTLS:
+		return "network_tls"
+	case KindNetworkOffline:
+		return "network_offline"
+	case KindAuthRequired:
+		return "auth_required"
+	case KindForbidden:
+		return "forbidden"
+	case KindNotFound:
+		return "not_found"
+	case KindConflict:
+		return "conflict"
+	case KindValidation:
+		return "validation"
+	case KindRateLimited:
+		return "rate_limited"
+	case KindServerError:
+		return "server_error"
+	case KindUnknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("ErrorKind(%d)", int(k))
+	}
+}
+
 // NetworkError wraps a transport-layer error (the error returned by
 // http.Client.Do, before any HTTP status is available). It strips the raw
 // URL out of the user-facing message while preserving the original error for
@@ -235,32 +271,32 @@ var kindMessages = map[ErrorKind][2]string{
 		"无法访问 Multica 服务器。请检查网络连接。",
 	},
 	KindAuthRequired: {
-		"Your session has expired or you are not signed in. Run `multica login` to sign in again.",
-		"登录已过期或尚未登录。请运行 `multica login` 重新登录。",
+		"Your session has expired or you are not signed in. Run `multica login` to sign in again. On a self-hosted or non-OAuth setup, ask your administrator for valid credentials.",
+		"登录已过期或尚未登录。请运行 `multica login` 重新登录。自托管或非 OAuth 场景请联系管理员获取有效凭证。",
 	},
 	KindForbidden: {
-		"You do not have permission to access this resource.",
-		"无权访问该资源。",
+		"You do not have permission to access this resource. Check that you are in the right workspace, or ask an administrator to grant access.",
+		"无权访问该资源。请确认当前 workspace 是否正确，或联系管理员授予权限。",
 	},
 	KindNotFound: {
-		"The requested resource was not found. The ID may not exist or may belong to a different workspace.",
-		"未找到请求的资源。该 ID 可能不存在，或不属于当前 workspace。",
+		"The requested resource was not found. Check the ID, or run the matching `list` command to see what exists in this workspace.",
+		"未找到请求的资源。请核对 ID，或运行对应的 list 命令查看当前 workspace 中已有的内容。",
 	},
 	KindConflict: {
-		"The request conflicts with the current state of the resource.",
-		"请求与资源的当前状态冲突。",
+		"The request conflicts with the current state of the resource (it may already exist or have changed since you last fetched it). Re-fetch the latest state and try again.",
+		"请求与资源的当前状态冲突（可能已存在，或自上次获取后已被修改）。请重新获取最新状态后再试。",
 	},
 	KindValidation: {
-		"The request was invalid.",
-		"请求无效。",
+		"The request was invalid. Check the values you provided; run the command with --help to see the expected format.",
+		"请求无效。请检查所填写的参数；可用 --help 查看期望的格式。",
 	},
 	KindRateLimited: {
-		"Too many requests. Please wait a moment and try again.",
-		"请求过于频繁。请稍后重试。",
+		"Too many requests. Please wait a moment and try again; if this keeps happening, reduce how frequently you call the API.",
+		"请求过于频繁。请稍候重试；若持续出现，请降低 API 调用频率。",
 	},
 	KindServerError: {
-		"The Multica service is temporarily unavailable. Please try again later; contact support if the problem persists.",
-		"Multica 服务暂时不可用。请稍后重试，如持续出现请联系支持。",
+		"The Multica service is temporarily unavailable (server error). Please try again later; if it persists, contact support. Re-run with --debug to see the raw server response.",
+		"Multica 服务暂时不可用（服务器错误）。请稍后重试；若持续出现请联系支持。可加 --debug 查看服务器原始响应。",
 	},
 	KindUnknown: {
 		"An unexpected error occurred.",
@@ -363,7 +399,7 @@ func debugDetail(err error) string {
 
 	var netErr *NetworkError
 	if errors.As(err, &netErr) {
-		fmt.Fprintf(&sb, "\n[debug] network: op=%q kind=%d cause=%v", netErr.Op, netErr.Kind, netErr.Err)
+		fmt.Fprintf(&sb, "\n[debug] network: op=%q kind=%s cause=%v", netErr.Op, netErr.Kind, netErr.Err)
 	}
 	var httpErr *HTTPError
 	if errors.As(err, &httpErr) {

--- a/server/internal/cli/errors_test.go
+++ b/server/internal/cli/errors_test.go
@@ -317,6 +317,8 @@ func TestFormatErrorActionableHints(t *testing.T) {
 		{403, []string{"permission", "workspace"}, []string{"无权", "workspace"}},
 		{404, []string{"not found", "list"}, []string{"未找到", "list"}},
 		{409, []string{"conflict", "again"}, []string{"冲突", "重新获取"}},
+		{400, []string{"--help", "expected format"}, []string{"--help", "格式", "参数"}},
+		{422, []string{"--help", "expected format"}, []string{"--help", "格式", "参数"}},
 		{429, []string{"Too many requests"}, []string{"过于频繁"}},
 		{500, []string{"temporarily unavailable", "--debug"}, []string{"暂时不可用", "--debug"}},
 	}

--- a/server/internal/cli/errors_test.go
+++ b/server/internal/cli/errors_test.go
@@ -271,3 +271,72 @@ func withLang(t *testing.T, lang string) {
 	t.Setenv("LC_MESSAGES", "")
 	t.Setenv("LANG", lang)
 }
+
+func TestErrorKindString(t *testing.T) {
+	cases := map[ErrorKind]string{
+		KindNetworkTimeout: "network_timeout",
+		KindNetworkDNS:     "network_dns",
+		KindNetworkRefused: "network_refused",
+		KindNetworkTLS:     "network_tls",
+		KindNetworkOffline: "network_offline",
+		KindAuthRequired:   "auth_required",
+		KindForbidden:      "forbidden",
+		KindNotFound:       "not_found",
+		KindConflict:       "conflict",
+		KindValidation:     "validation",
+		KindRateLimited:    "rate_limited",
+		KindServerError:    "server_error",
+		KindUnknown:        "unknown",
+	}
+	seen := map[string]ErrorKind{}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("ErrorKind(%d).String() = %q, want %q", int(k), got, want)
+		}
+		if prev, dup := seen[k.String()]; dup {
+			t.Errorf("duplicate String() %q for kinds %d and %d", k.String(), int(prev), int(k))
+		}
+		seen[k.String()] = k
+	}
+	// Out-of-range value gets a stable fallback rather than an empty string.
+	if got := ErrorKind(999).String(); got != "ErrorKind(999)" {
+		t.Errorf("unexpected fallback String(): %q", got)
+	}
+}
+
+// TestFormatErrorActionableHints locks in the per-status actionable hints
+// refined in PR2, in both languages, so a future copy edit can't silently drop
+// the actionable guidance.
+func TestFormatErrorActionableHints(t *testing.T) {
+	cases := []struct {
+		status int
+		enWant []string
+		zhWant []string
+	}{
+		{401, []string{"multica login", "self-hosted", "administrator"}, []string{"multica login", "自托管", "管理员"}},
+		{403, []string{"permission", "workspace"}, []string{"无权", "workspace"}},
+		{404, []string{"not found", "list"}, []string{"未找到", "list"}},
+		{409, []string{"conflict", "again"}, []string{"冲突", "重新获取"}},
+		{429, []string{"Too many requests"}, []string{"过于频繁"}},
+		{500, []string{"temporarily unavailable", "--debug"}, []string{"暂时不可用", "--debug"}},
+	}
+	for _, tc := range cases {
+		httpErr := &HTTPError{Method: "GET", Path: "/api/x", StatusCode: tc.status}
+
+		withLang(t, "en_US.UTF-8")
+		en := FormatError(httpErr, false)
+		for _, sub := range tc.enWant {
+			if !strings.Contains(en, sub) {
+				t.Errorf("EN %d: %q missing %q", tc.status, en, sub)
+			}
+		}
+
+		withLang(t, "zh_CN.UTF-8")
+		zh := FormatError(httpErr, false)
+		for _, sub := range tc.zhWant {
+			if !strings.Contains(zh, sub) {
+				t.Errorf("ZH %d: %q missing %q", tc.status, zh, sub)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR2 of the CLI error-message overhaul (MUL-3104), building on the PR1 translation layer (#3892, merged). This pass refines the per-status user-facing copy so each one carries an **actionable next step**, in both English and Chinese.

## Per-status copy (EN + ZH)

| Status | Actionable hint added |
| --- | --- |
| 401 | run `multica login`; **plus a self-hosted / non-OAuth fallback** telling the user to ask their administrator for valid credentials |
| 403 | check you're in the right workspace, or ask an admin to grant access |
| 404 | check the ID, or run the matching `list` command |
| 409 | re-fetch the latest state and retry |
| 422 | check the values; run with `--help` for the expected format (server-provided validation message is still surfaced when present) |
| 429 | wait and retry; reduce call frequency if it persists |
| 5xx | retry, contact support, and re-run with `--debug` for the raw server response |

Network-layer copy (timeout/DNS/refused/TLS/offline) is unchanged from PR1.

## Also in this PR

- **`ErrorKind.String()`** — stable snake_case identifiers (`auth_required`, `not_found`, …) for every kind, now used in `--debug` output instead of the raw int. Safe to log/branch on; not user-facing copy.
- **Eve's nits** — cleared the pre-existing gofmt dirt she flagged in `cmd_config.go`, `cmd_version.go`, and `help.go` (stray blank lines, map-literal alignment).

## Testing

- `TestErrorKindString` — every kind maps to the expected id, ids are unique, and an out-of-range value gets a stable fallback.
- `TestFormatErrorActionableHints` — locks the per-status hints in both EN and ZH so a future copy edit can't silently drop the actionable guidance.
- Existing PR1 tests (classification, exit codes, integration, timeout) still green.
- `go build ./...`, `go test ./internal/cli/ ./cmd/multica/` (`-count=1`), `go vet`, `gofmt -l` all clean.

## Notes

- Do **not** merge yet — holding for @张大彪's review.
- PR3 (per-command custom copy in cmd_id_resolver.go / cmd_auth.go / docs) still to come.
