### PR TITLE
MUL-3127: reuse submit button in reply input

### DIFF
--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useRef, useState, useCallback, useEffect } from "react";
-import { ArrowUp, Loader2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
+import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -149,23 +149,11 @@ function ReplyInput({
             multiple
             onSelect={(file) => editorRef.current?.uploadFile(file)}
           />
-          <button
-            type="button"
-            disabled={isEmpty || submitting}
+          <SubmitButton
             onClick={handleSubmit}
-            className={cn(
-              "inline-flex h-6 w-6 items-center justify-center rounded-full transition-colors disabled:pointer-events-none disabled:opacity-50",
-              isEmpty
-                ? "text-muted-foreground hover:bg-accent hover:text-foreground"
-                : "bg-primary text-primary-foreground hover:bg-primary/90",
-            )}
-          >
-            {submitting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <ArrowUp className="h-3.5 w-3.5" />
-            )}
-          </button>
+            disabled={isEmpty}
+            loading={submitting}
+          />
         </div>
         {isDragOver && <FileDropOverlay />}
       </div>


### PR DESCRIPTION
## Summary
- Replace the inline `rounded-full` reply send button with the shared `SubmitButton`.
- Keep `reply-input` aligned with the existing composer action-row standard: `FileUploadButton size="sm"` (24px) + `SubmitButton` (`Button size="icon-sm"`, 28px, 8px radius), matching `comment-input` and `chat-input`.
- Keep the empty state on the shared `SubmitButton` primary disabled treatment, also matching `comment-input` and `chat-input`.

## Rendering Evidence
Captured from a local proof page that imports `apps/web/app/globals.css` and renders the actual `FileUploadButton` + `SubmitButton` components.

![Full rendering proof](https://multica-static.copilothub.ai/workspaces/a05b0e10-ee7a-4603-a72d-a548b2390cb2/019ea661-a688-738b-a590-2b52f7321b06.png)

![reply-input empty state](https://multica-static.copilothub.ai/workspaces/a05b0e10-ee7a-4603-a72d-a548b2390cb2/019ea661-a7d4-75e0-9977-0b6e8fbc8003.png)

![reply-input with content](https://multica-static.copilothub.ai/workspaces/a05b0e10-ee7a-4603-a72d-a548b2390cb2/019ea661-a8e0-76ef-b1d7-f44295f88b04.png)

Computed style check from the capture harness:
- Upload button: 24x24.
- Submit button: 28x28, 8px border radius.
- Empty state submit: disabled primary button.
- Content state submit: enabled primary button.

## Verification
- `pnpm --filter @multica/views exec vitest run issues/components/comment-composers.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (passes with existing warnings outside this change)
- Local rendering proof captured with Playwright.

Closes MUL-3127
