### PR TITLE
feat(lark): deliver inbox notifications as direct cards

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -223,6 +223,11 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				h.LarkAPIClient = larkClient
 				patcher := lark.NewPatcher(queries, installSvc, larkClient, lark.PatcherConfig{})
 				patcher.Register(bus)
+				inboxNotifier := lark.NewInboxNotifier(queries, installSvc, larkClient, lark.InboxNotifierConfig{
+					Logger:    slog.Default(),
+					PublicURL: strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_PUBLIC_URL")), "/"),
+				})
+				inboxNotifier.Register(bus)
 
 				// Typing indicator: shows a "processing" reaction on the user's
 				// message while the agent is working, then removes it before the

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -30,6 +30,11 @@ type APIClient interface {
 	// target the same card.
 	SendInteractiveCard(ctx context.Context, p SendCardParams) (string, error)
 
+	// SendDirectInteractiveCard posts an interactive card to a Lark user by
+	// open_id. Used for member-targeted notifications where there is no
+	// existing Lark chat_id yet.
+	SendDirectInteractiveCard(ctx context.Context, p SendDirectCardParams) (string, error)
+
 	// PatchInteractiveCard replaces the body of a previously-sent card.
 	// The throttling decision belongs to the caller; this method just
 	// performs the network call.
@@ -200,6 +205,13 @@ type SendCardParams struct {
 	CardJSON string
 }
 
+type SendDirectCardParams struct {
+	InstallationID InstallationCredentials
+	OpenID         OpenID
+	// CardJSON is the raw Lark interactive card JSON body.
+	CardJSON string
+}
+
 // PatchCardParams is the input shape for updating an existing card.
 type PatchCardParams struct {
 	InstallationID    InstallationCredentials
@@ -317,6 +329,11 @@ func (s *stubAPIClient) IsConfigured() bool { return false }
 
 func (s *stubAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParams) (string, error) {
 	s.log.Warn("lark stub client: SendInteractiveCard called", "chat_id", string(p.ChatID))
+	return "", ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) SendDirectInteractiveCard(ctx context.Context, p SendDirectCardParams) (string, error) {
+	s.log.Warn("lark stub client: SendDirectInteractiveCard called", "open_id", string(p.OpenID))
 	return "", ErrAPIClientNotConfigured
 }
 

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -238,16 +238,30 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	if p.CardJSON == "" {
 		return "", errors.New("lark http client: missing card json")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	return c.sendInteractiveCard(ctx, p.InstallationID, "chat_id", string(p.ChatID), p.CardJSON)
+}
+
+func (c *httpAPIClient) SendDirectInteractiveCard(ctx context.Context, p SendDirectCardParams) (string, error) {
+	if p.OpenID == "" {
+		return "", errors.New("lark http client: missing open_id")
+	}
+	if p.CardJSON == "" {
+		return "", errors.New("lark http client: missing card json")
+	}
+	return c.sendInteractiveCard(ctx, p.InstallationID, "open_id", string(p.OpenID), p.CardJSON)
+}
+
+func (c *httpAPIClient) sendInteractiveCard(ctx context.Context, creds InstallationCredentials, receiveIDType, receiveID, cardJSON string) (string, error) {
+	token, err := c.tenantAccessToken(ctx, creds)
 	if err != nil {
 		return "", err
 	}
 	q := url.Values{}
-	q.Set("receive_id_type", "chat_id")
+	q.Set("receive_id_type", receiveIDType)
 	body := map[string]string{
-		"receive_id": string(p.ChatID),
+		"receive_id": receiveID,
 		"msg_type":   "interactive",
-		"content":    p.CardJSON,
+		"content":    cardJSON,
 	}
 	var resp struct {
 		Code int    `json:"code"`
@@ -257,12 +271,12 @@ func (c *httpAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 		} `json:"data"`
 	}
 	path := "/open-apis/im/v1/messages?" + q.Encode()
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send interactive card: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
 		if isTokenError(resp.Code) {
-			c.invalidateToken(p.InstallationID.AppID)
+			c.invalidateToken(creds.AppID)
 		}
 		return "", fmt.Errorf("lark http client: send interactive card: code=%d msg=%q", resp.Code, resp.Msg)
 	}
@@ -282,21 +296,25 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if p.Text == "" {
 		return "", errors.New("lark http client: missing text")
 	}
-	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	return c.sendText(ctx, p.InstallationID, "chat_id", string(p.ChatID), p.Text)
+}
+
+func (c *httpAPIClient) sendText(ctx context.Context, creds InstallationCredentials, receiveIDType, receiveID, text string) (string, error) {
+	token, err := c.tenantAccessToken(ctx, creds)
 	if err != nil {
 		return "", err
 	}
 	// Lark's `text` msg_type expects content = JSON-encoded {"text": "..."}.
 	// json.Marshal handles the escape of newlines / quotes / unicode so
 	// the agent's reply round-trips intact.
-	contentBytes, err := json.Marshal(map[string]string{"text": p.Text})
+	contentBytes, err := json.Marshal(map[string]string{"text": text})
 	if err != nil {
 		return "", fmt.Errorf("lark http client: encode text content: %w", err)
 	}
 	q := url.Values{}
-	q.Set("receive_id_type", "chat_id")
+	q.Set("receive_id_type", receiveIDType)
 	body := map[string]string{
-		"receive_id": string(p.ChatID),
+		"receive_id": receiveID,
 		"msg_type":   "text",
 		"content":    string(contentBytes),
 	}
@@ -308,12 +326,12 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 		} `json:"data"`
 	}
 	path := "/open-apis/im/v1/messages?" + q.Encode()
-	if err := c.doJSON(ctx, c.resolveBaseURL(p.InstallationID), http.MethodPost, path, token, body, &resp); err != nil {
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodPost, path, token, body, &resp); err != nil {
 		return "", fmt.Errorf("lark http client: send text message: %w", err)
 	}
 	if resp.Code != 0 || resp.Data.MessageID == "" {
 		if isTokenError(resp.Code) {
-			c.invalidateToken(p.InstallationID.AppID)
+			c.invalidateToken(creds.AppID)
 		}
 		return "", fmt.Errorf("lark http client: send text message: code=%d msg=%q", resp.Code, resp.Msg)
 	}

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -352,6 +352,48 @@ func TestHTTPClient_SendInteractiveCard_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPClient_SendDirectInteractiveCard_HappyPath(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_direct_card", 7200)
+	fake.stubSend(
+		map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]string{"message_id": "om_direct_card_1"},
+		},
+		func(r *http.Request, body map[string]string) {
+			if got := r.URL.Query().Get("receive_id_type"); got != "open_id" {
+				t.Errorf("receive_id_type: got %q want open_id", got)
+			}
+			if body["receive_id"] != "ou_user_1" {
+				t.Errorf("receive_id: got %q", body["receive_id"])
+			}
+			if body["msg_type"] != "interactive" {
+				t.Errorf("msg_type: got %q want interactive", body["msg_type"])
+			}
+			if !strings.Contains(body["content"], "\"tag\"") {
+				t.Errorf("content not a card body: %q", body["content"])
+			}
+		},
+	)
+
+	c := newTestClient(fake, time.Now)
+	msgID, err := c.SendDirectInteractiveCard(context.Background(), SendDirectCardParams{
+		InstallationID: testCreds(),
+		OpenID:         OpenID("ou_user_1"),
+		CardJSON:       `{"tag":"div","text":"hi"}`,
+	})
+	if err != nil {
+		t.Fatalf("send direct card: %v", err)
+	}
+	if msgID != "om_direct_card_1" {
+		t.Errorf("message id: got %q want om_direct_card_1", msgID)
+	}
+	if got := fake.lastAuth(); got != "Bearer tok_direct_card" {
+		t.Errorf("Authorization header: got %q want Bearer tok_direct_card", got)
+	}
+}
+
 // TestHTTPClient_SendTextMessage_HappyPath pins the wire shape of the
 // plain text outbound used for chat replies + /issue confirmations.
 // Path, query, bearer auth, msg_type, and the double-JSON-encoded
@@ -960,8 +1002,8 @@ func TestHTTPClient_GetBotInfo_HappyPath(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"bot": map[string]any{
-				"open_id":   "ou_bot_42",
-				"app_name":  "PersonalAgent",
+				"open_id":    "ou_bot_42",
+				"app_name":   "PersonalAgent",
 				"avatar_url": "https://example/avatar.png",
 			},
 		})

--- a/server/internal/integrations/lark/inbound_enricher_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_test.go
@@ -74,6 +74,9 @@ func (f *enricherFakeClient) BatchGetUsers(ctx context.Context, creds Installati
 func (f *enricherFakeClient) SendInteractiveCard(context.Context, SendCardParams) (string, error) {
 	return "", nil
 }
+func (f *enricherFakeClient) SendDirectInteractiveCard(context.Context, SendDirectCardParams) (string, error) {
+	return "", nil
+}
 func (f *enricherFakeClient) PatchInteractiveCard(context.Context, PatchCardParams) error { return nil }
 func (f *enricherFakeClient) SendTextMessage(context.Context, SendTextParams) (string, error) {
 	return "", nil

--- a/server/internal/integrations/lark/inbox_notifier.go
+++ b/server/internal/integrations/lark/inbox_notifier.go
@@ -1,0 +1,495 @@
+package lark
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const inboxNotifyTimeout = 10 * time.Second
+
+type InboxNotifierQueries interface {
+	DeleteLarkInboxNotificationDelivery(ctx context.Context, arg db.DeleteLarkInboxNotificationDeliveryParams) error
+	GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error)
+	GetNotificationPreference(ctx context.Context, arg db.GetNotificationPreferenceParams) (db.NotificationPreference, error)
+	GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error)
+	ClaimLarkInboxNotificationDelivery(ctx context.Context, arg db.ClaimLarkInboxNotificationDeliveryParams) (bool, error)
+	ListActiveLarkUserBindingsByMember(ctx context.Context, arg db.ListActiveLarkUserBindingsByMemberParams) ([]db.ListActiveLarkUserBindingsByMemberRow, error)
+}
+
+type InboxNotifier struct {
+	queries     InboxNotifierQueries
+	credentials CredentialsResolver
+	client      APIClient
+	log         *slog.Logger
+	publicURL   string
+}
+
+type InboxNotifierConfig struct {
+	Logger    *slog.Logger
+	PublicURL string
+}
+
+func NewInboxNotifier(queries InboxNotifierQueries, credentials CredentialsResolver, client APIClient, cfg InboxNotifierConfig) *InboxNotifier {
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	return &InboxNotifier{
+		queries:     queries,
+		credentials: credentials,
+		client:      client,
+		log:         log,
+		publicURL:   strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+	}
+}
+
+func (n *InboxNotifier) Register(bus *events.Bus) {
+	if bus == nil {
+		return
+	}
+	bus.Subscribe(protocol.EventInboxNew, func(e events.Event) {
+		go n.handleEvent(e)
+	})
+}
+
+func (n *InboxNotifier) handleEvent(e events.Event) {
+	ctx, cancel := context.WithTimeout(context.Background(), inboxNotifyTimeout)
+	defer cancel()
+	if err := n.notify(ctx, e.Payload); err != nil {
+		n.log.Warn("lark inbox notifier: notify failed", "err", err.Error())
+	}
+}
+
+func (n *InboxNotifier) notify(ctx context.Context, payload any) error {
+	if n.queries == nil || n.credentials == nil || n.client == nil {
+		return errors.New("notifier not configured")
+	}
+	item, ok := inboxNotificationItemFromPayload(payload)
+	if !ok {
+		return errors.New("missing inbox item payload")
+	}
+	if item.RecipientType != "member" {
+		return nil
+	}
+	itemID, err := scanUUID(item.ID)
+	if err != nil {
+		return fmt.Errorf("parse inbox item id: %w", err)
+	}
+	workspaceID, err := scanUUID(item.WorkspaceID)
+	if err != nil {
+		return fmt.Errorf("parse workspace_id: %w", err)
+	}
+	recipientID, err := scanUUID(item.RecipientID)
+	if err != nil {
+		return fmt.Errorf("parse recipient_id: %w", err)
+	}
+	muted, err := n.isMuted(ctx, workspaceID, recipientID, item.Type)
+	if err != nil {
+		n.log.Warn("lark inbox notifier: preference lookup failed", "err", err.Error())
+	} else if muted {
+		return nil
+	}
+	rows, err := n.queries.ListActiveLarkUserBindingsByMember(ctx, db.ListActiveLarkUserBindingsByMemberParams{
+		WorkspaceID:   workspaceID,
+		MulticaUserID: recipientID,
+	})
+	if err != nil {
+		return fmt.Errorf("lookup lark binding: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	row, ok := selectInboxNotificationBinding(ctx, n.queries, rows, item)
+	if !ok {
+		return nil
+	}
+	claimed, err := n.queries.ClaimLarkInboxNotificationDelivery(ctx, db.ClaimLarkInboxNotificationDeliveryParams{
+		InboxItemID:    itemID,
+		InstallationID: row.LarkInstallation.ID,
+		LarkOpenID:     row.LarkUserBinding.LarkOpenID,
+	})
+	if err != nil {
+		return fmt.Errorf("claim lark inbox notification delivery: %w", err)
+	}
+	if !claimed {
+		return nil
+	}
+	claimArg := db.DeleteLarkInboxNotificationDeliveryParams{
+		InboxItemID:    itemID,
+		InstallationID: row.LarkInstallation.ID,
+		LarkOpenID:     row.LarkUserBinding.LarkOpenID,
+	}
+	creds, err := n.installationCredentials(row.LarkInstallation)
+	if err != nil {
+		n.releaseDeliveryClaim(claimArg)
+		return err
+	}
+	cardJSON, err := n.renderInboxNotificationCard(ctx, workspaceID, item)
+	if err != nil {
+		n.releaseDeliveryClaim(claimArg)
+		return fmt.Errorf("render inbox card: %w", err)
+	}
+	if _, err := n.client.SendDirectInteractiveCard(ctx, SendDirectCardParams{
+		InstallationID: creds,
+		OpenID:         OpenID(row.LarkUserBinding.LarkOpenID),
+		CardJSON:       cardJSON,
+	}); err != nil {
+		n.releaseDeliveryClaim(claimArg)
+		return fmt.Errorf("send inbox dm: %w", err)
+	}
+	return nil
+}
+
+func (n *InboxNotifier) releaseDeliveryClaim(arg db.DeleteLarkInboxNotificationDeliveryParams) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := n.queries.DeleteLarkInboxNotificationDelivery(ctx, arg); err != nil {
+		n.log.Warn("lark inbox notifier: release delivery claim failed", "err", err.Error())
+	}
+}
+
+func (n *InboxNotifier) installationCredentials(inst db.LarkInstallation) (InstallationCredentials, error) {
+	secret, err := n.credentials.DecryptAppSecret(inst)
+	if err != nil {
+		return InstallationCredentials{}, fmt.Errorf("decrypt app_secret: %w", err)
+	}
+	creds := InstallationCredentials{
+		AppID:     inst.AppID,
+		AppSecret: secret,
+		Region:    RegionOrDefault(inst.Region),
+	}
+	if inst.TenantKey.Valid {
+		creds.TenantKey = inst.TenantKey.String
+	}
+	return creds, nil
+}
+
+var inboxNotificationTypeToGroup = map[string]string{
+	"issue_assigned":      "assignments",
+	"unassigned":          "assignments",
+	"assignee_changed":    "assignments",
+	"status_changed":      "status_changes",
+	"new_comment":         "comments",
+	"mentioned":           "comments",
+	"priority_changed":    "updates",
+	"start_date_changed":  "updates",
+	"due_date_changed":    "updates",
+	"task_completed":      "agent_activity",
+	"task_failed":         "agent_activity",
+	"agent_blocked":       "agent_activity",
+	"agent_completed":     "agent_activity",
+	"quick_create_done":   "agent_activity",
+	"quick_create_failed": "agent_activity",
+}
+
+func (n *InboxNotifier) isMuted(ctx context.Context, workspaceID, userID pgtype.UUID, notificationType string) (bool, error) {
+	group, ok := inboxNotificationTypeToGroup[notificationType]
+	if !ok {
+		return false, nil
+	}
+	pref, err := n.queries.GetNotificationPreference(ctx, db.GetNotificationPreferenceParams{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	var prefs map[string]string
+	if err := json.Unmarshal(pref.Preferences, &prefs); err != nil {
+		return false, nil
+	}
+	return prefs[group] == "muted", nil
+}
+
+type inboxNotificationItem struct {
+	ID            string          `json:"id"`
+	WorkspaceID   string          `json:"workspace_id"`
+	RecipientType string          `json:"recipient_type"`
+	RecipientID   string          `json:"recipient_id"`
+	Type          string          `json:"type"`
+	Severity      string          `json:"severity"`
+	IssueID       *string         `json:"issue_id"`
+	Title         string          `json:"title"`
+	Body          *string         `json:"body"`
+	ActorType     *string         `json:"actor_type"`
+	ActorID       *string         `json:"actor_id"`
+	Details       json.RawMessage `json:"details"`
+}
+
+func inboxNotificationItemFromPayload(payload any) (inboxNotificationItem, bool) {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return inboxNotificationItem{}, false
+	}
+	raw, ok := m["item"]
+	if !ok {
+		return inboxNotificationItem{}, false
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return inboxNotificationItem{}, false
+	}
+	var item inboxNotificationItem
+	if err := json.Unmarshal(b, &item); err != nil {
+		return inboxNotificationItem{}, false
+	}
+	return item, item.WorkspaceID != "" && item.RecipientID != ""
+}
+
+func selectInboxNotificationBinding(ctx context.Context, queries InboxNotifierQueries, rows []db.ListActiveLarkUserBindingsByMemberRow, item inboxNotificationItem) (db.ListActiveLarkUserBindingsByMemberRow, bool) {
+	if item.ActorType != nil && *item.ActorType == "agent" && item.ActorID != nil {
+		if actorID, err := scanUUID(*item.ActorID); err == nil {
+			if row, ok := selectInboxNotificationBindingByAgent(rows, actorID); ok {
+				return row, true
+			}
+		}
+	}
+	if item.IssueID != nil && queries != nil {
+		if issueID, err := scanUUID(*item.IssueID); err == nil {
+			if issue, err := queries.GetIssue(ctx, issueID); err == nil &&
+				issue.AssigneeType.Valid && issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid {
+				if row, ok := selectInboxNotificationBindingByAgent(rows, issue.AssigneeID); ok {
+					return row, true
+				}
+			}
+		}
+	}
+	return db.ListActiveLarkUserBindingsByMemberRow{}, false
+}
+
+func selectInboxNotificationBindingByAgent(rows []db.ListActiveLarkUserBindingsByMemberRow, agentID pgtype.UUID) (db.ListActiveLarkUserBindingsByMemberRow, bool) {
+	for _, row := range rows {
+		if row.LarkInstallation.AgentID == agentID {
+			return row, true
+		}
+	}
+	return db.ListActiveLarkUserBindingsByMemberRow{}, false
+}
+
+func (n *InboxNotifier) renderInboxNotificationCard(ctx context.Context, workspaceID pgtype.UUID, item inboxNotificationItem) (string, error) {
+	issue, workspace := n.inboxNotificationContext(ctx, workspaceID, item)
+	identifier := inboxIssueIdentifier(issue, workspace)
+	headerTitle := inboxNotificationHeaderTitle(identifier, item.Title)
+	bodyMD := inboxNotificationMarkdown(item)
+	if bodyMD == "" {
+		bodyMD = headerTitle
+	}
+	card := map[string]any{
+		"config": map[string]any{"wide_screen_mode": true},
+		"header": map[string]any{
+			"template": inboxNotificationTemplate(item),
+			"title": map[string]any{
+				"tag":     "plain_text",
+				"content": headerTitle,
+			},
+		},
+		"elements": []any{
+			map[string]any{
+				"tag": "div",
+				"text": map[string]any{
+					"tag":     "lark_md",
+					"content": bodyMD,
+				},
+			},
+		},
+	}
+	if issueURL := n.issueURL(workspace, item); issueURL != "" {
+		card["elements"] = append(card["elements"].([]any),
+			map[string]any{"tag": "hr"},
+			map[string]any{
+				"tag": "action",
+				"actions": []any{
+					map[string]any{
+						"tag":  "button",
+						"text": map[string]any{"tag": "plain_text", "content": "View in Multica"},
+						"url":  issueURL,
+						"type": "primary",
+					},
+				},
+			},
+		)
+	}
+	raw, err := json.Marshal(card)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (n *InboxNotifier) inboxNotificationContext(ctx context.Context, workspaceID pgtype.UUID, item inboxNotificationItem) (*db.Issue, *db.Workspace) {
+	var issue *db.Issue
+	if item.IssueID != nil {
+		if issueID, err := scanUUID(*item.IssueID); err == nil {
+			if row, err := n.queries.GetIssue(ctx, issueID); err == nil {
+				issue = &row
+			}
+		}
+	}
+	var workspace *db.Workspace
+	if row, err := n.queries.GetWorkspace(ctx, workspaceID); err == nil {
+		workspace = &row
+	}
+	return issue, workspace
+}
+
+func inboxIssueIdentifier(issue *db.Issue, workspace *db.Workspace) string {
+	if issue == nil || issue.Number == 0 {
+		return ""
+	}
+	if workspace != nil && strings.TrimSpace(workspace.IssuePrefix) != "" {
+		return fmt.Sprintf("%s-%d", strings.TrimSpace(workspace.IssuePrefix), issue.Number)
+	}
+	return fmt.Sprintf("#%d", issue.Number)
+}
+
+func inboxNotificationHeaderTitle(identifier, title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		title = "Inbox"
+	}
+	if identifier != "" {
+		title = fmt.Sprintf("[%s] %s", identifier, title)
+	}
+	return truncateRunes(title, 80)
+}
+
+func inboxNotificationMarkdown(item inboxNotificationItem) string {
+	body := ""
+	if item.Body != nil {
+		body = strings.TrimSpace(*item.Body)
+	}
+	switch item.Type {
+	case "new_comment":
+		if body == "" {
+			return ""
+		}
+		return fmt.Sprintf("**%s commented**\n\n%s", inboxActorLabel(item), truncateRunes(body, 700))
+	case "status_changed":
+		from, to := inboxStatusChange(item)
+		if from != "" || to != "" {
+			return fmt.Sprintf("**Status changed**\n\n`%s` -> `%s`", statusLabelForInbox(from), statusLabelForInbox(to))
+		}
+		return "**Status changed**"
+	case "quick_create_failed", "task_failed":
+		if body != "" {
+			return fmt.Sprintf("**Agent task failed**\n\n%s", truncateRunes(body, 700))
+		}
+		return "**Agent task failed**"
+	case "quick_create_done":
+		return "**Issue created**"
+	default:
+		if body != "" {
+			return truncateRunes(body, 700)
+		}
+		return ""
+	}
+}
+
+func inboxNotificationTemplate(item inboxNotificationItem) string {
+	switch item.Type {
+	case "new_comment":
+		return "wathet"
+	case "quick_create_failed", "task_failed":
+		return "red"
+	case "quick_create_done":
+		return "green"
+	case "status_changed":
+		_, to := inboxStatusChange(item)
+		switch to {
+		case "done":
+			return "green"
+		case "blocked", "cancelled":
+			return "red"
+		case "in_review":
+			return "yellow"
+		case "in_progress":
+			return "blue"
+		}
+	}
+	return "blue"
+}
+
+func inboxActorLabel(item inboxNotificationItem) string {
+	if item.ActorType != nil && *item.ActorType == "agent" {
+		return "Agent"
+	}
+	return "Someone"
+}
+
+func inboxStatusChange(item inboxNotificationItem) (string, string) {
+	var details struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if len(item.Details) == 0 {
+		return "", ""
+	}
+	if err := json.Unmarshal(item.Details, &details); err != nil {
+		return "", ""
+	}
+	return details.From, details.To
+}
+
+func statusLabelForInbox(s string) string {
+	switch s {
+	case "backlog":
+		return "Backlog"
+	case "todo":
+		return "Todo"
+	case "in_progress":
+		return "In progress"
+	case "in_review":
+		return "In review"
+	case "blocked":
+		return "Blocked"
+	case "done":
+		return "Done"
+	case "cancelled":
+		return "Cancelled"
+	case "":
+		return "Unknown"
+	default:
+		return s
+	}
+}
+
+func (n *InboxNotifier) issueURL(workspace *db.Workspace, item inboxNotificationItem) string {
+	if n.publicURL == "" || workspace == nil || workspace.Slug == "" || item.IssueID == nil || *item.IssueID == "" {
+		return ""
+	}
+	return n.publicURL + "/" + url.PathEscape(workspace.Slug) + "/issues/" + url.PathEscape(*item.IssueID)
+}
+
+func scanUUID(s string) (pgtype.UUID, error) {
+	var id pgtype.UUID
+	if err := id.Scan(s); err != nil {
+		return pgtype.UUID{}, err
+	}
+	return id, nil
+}
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}

--- a/server/internal/integrations/lark/inbox_notifier_test.go
+++ b/server/internal/integrations/lark/inbox_notifier_test.go
@@ -1,0 +1,526 @@
+package lark
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type fakeInboxNotifierQueries struct {
+	rows         []db.ListActiveLarkUserBindingsByMemberRow
+	err          error
+	arg          db.ListActiveLarkUserBindingsByMemberParams
+	issue        db.Issue
+	issueErr     error
+	issueArg     pgtype.UUID
+	workspace    db.Workspace
+	workspaceErr error
+	workspaceArg pgtype.UUID
+	pref         db.NotificationPreference
+	prefErr      error
+	prefArg      db.GetNotificationPreferenceParams
+	claims       map[string]bool
+	claimCalls   int
+	claimArg     db.ClaimLarkInboxNotificationDeliveryParams
+	deleteCalls  int
+	deleteArg    db.DeleteLarkInboxNotificationDeliveryParams
+	deleteCtxErr error
+}
+
+func (f *fakeInboxNotifierQueries) GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error) {
+	f.issueArg = id
+	if f.issueErr != nil {
+		return db.Issue{}, f.issueErr
+	}
+	return f.issue, nil
+}
+
+func (f *fakeInboxNotifierQueries) GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error) {
+	f.workspaceArg = id
+	if f.workspaceErr != nil {
+		return db.Workspace{}, f.workspaceErr
+	}
+	return f.workspace, nil
+}
+
+func (f *fakeInboxNotifierQueries) GetNotificationPreference(ctx context.Context, arg db.GetNotificationPreferenceParams) (db.NotificationPreference, error) {
+	f.prefArg = arg
+	if f.prefErr != nil {
+		return db.NotificationPreference{}, f.prefErr
+	}
+	return f.pref, nil
+}
+
+func (f *fakeInboxNotifierQueries) ListActiveLarkUserBindingsByMember(ctx context.Context, arg db.ListActiveLarkUserBindingsByMemberParams) ([]db.ListActiveLarkUserBindingsByMemberRow, error) {
+	f.arg = arg
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}
+
+func (f *fakeInboxNotifierQueries) ClaimLarkInboxNotificationDelivery(ctx context.Context, arg db.ClaimLarkInboxNotificationDeliveryParams) (bool, error) {
+	f.claimCalls++
+	f.claimArg = arg
+	if f.claims == nil {
+		f.claims = map[string]bool{}
+	}
+	key := uuidString(arg.InboxItemID) + "|" + uuidString(arg.InstallationID) + "|" + arg.LarkOpenID
+	if f.claims[key] {
+		return false, nil
+	}
+	f.claims[key] = true
+	return true, nil
+}
+
+func (f *fakeInboxNotifierQueries) DeleteLarkInboxNotificationDelivery(ctx context.Context, arg db.DeleteLarkInboxNotificationDeliveryParams) error {
+	f.deleteCalls++
+	f.deleteArg = arg
+	f.deleteCtxErr = ctx.Err()
+	if f.claims != nil {
+		key := uuidString(arg.InboxItemID) + "|" + uuidString(arg.InstallationID) + "|" + arg.LarkOpenID
+		delete(f.claims, key)
+	}
+	return nil
+}
+
+func TestInboxNotifierSendsDMViaActorAgentBot(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	otherAgentID := mustUUID("33333333-3333-3333-3333-333333333333")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, otherAgentID, "cli_other", "ou_other"),
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		prefErr: pgx.ErrNoRows,
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "quick_create_failed",
+			"severity":       "action_required",
+			"title":          "Quick create failed",
+			"body":           "agent exited with code 1",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if q.arg.WorkspaceID != workspaceID || q.arg.MulticaUserID != userID {
+		t.Fatalf("binding lookup arg = %+v", q.arg)
+	}
+	if q.claimCalls != 1 || q.claimArg.LarkOpenID != "ou_actor" {
+		t.Fatalf("unexpected delivery claim calls=%d arg=%+v", q.claimCalls, q.claimArg)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("expected one direct card send, got %d", len(api.directCardsOut))
+	}
+	got := api.directCardsOut[0]
+	if got.OpenID != "ou_actor" {
+		t.Fatalf("OpenID = %q, want actor bot binding recipient ou_actor", got.OpenID)
+	}
+	if got.InstallationID.AppID != "cli_actor" {
+		t.Fatalf("AppID = %q, want cli_actor", got.InstallationID.AppID)
+	}
+	if got.InstallationID.Region != RegionLark {
+		t.Fatalf("Region = %q, want %q", got.InstallationID.Region, RegionLark)
+	}
+	if !strings.Contains(got.CardJSON, `"title":{"content":"Quick create failed"`) ||
+		!strings.Contains(got.CardJSON, `"tag":"lark_md"`) ||
+		!strings.Contains(got.CardJSON, "Quick create failed") ||
+		!strings.Contains(got.CardJSON, "agent exited with code 1") {
+		t.Fatalf("unexpected notification card: %q", got.CardJSON)
+	}
+}
+
+func TestInboxNotifierSkipsDuplicateDeliveryClaim(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	itemID := "55555555-5555-5555-5555-555555555555"
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		prefErr: pgx.ErrNoRows,
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+	payload := map[string]any{
+		"item": map[string]any{
+			"id":             itemID,
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "quick_create_failed",
+			"severity":       "action_required",
+			"title":          "Quick create failed",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	}
+
+	if err := notifier.notify(context.Background(), payload); err != nil {
+		t.Fatalf("first notify: %v", err)
+	}
+	if err := notifier.notify(context.Background(), payload); err != nil {
+		t.Fatalf("duplicate notify: %v", err)
+	}
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("duplicate delivery claim should send one card, got %d", len(api.directCardsOut))
+	}
+	if q.claimCalls != 2 {
+		t.Fatalf("expected both attempts to claim delivery, got %d", q.claimCalls)
+	}
+}
+
+func TestInboxNotifierHonorsMutedEventPreference(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		pref: db.NotificationPreference{
+			WorkspaceID: workspaceID,
+			UserID:      userID,
+			Preferences: []byte(`{"agent_activity":"muted"}`),
+		},
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "task_failed",
+			"severity":       "action_required",
+			"title":          "Task failed",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if q.arg.WorkspaceID.Valid {
+		t.Fatalf("muted notification should not query Lark bindings")
+	}
+	if q.claimCalls != 0 {
+		t.Fatalf("muted notification should not claim delivery, got %d calls", q.claimCalls)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 0 {
+		t.Fatalf("muted notification should not send cards, got %d", len(api.directCardsOut))
+	}
+}
+
+func TestInboxNotifierPreferenceLookupFailureFallsThrough(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		prefErr: errors.New("preference db unavailable"),
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "task_failed",
+			"severity":       "action_required",
+			"title":          "Task failed",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("preference lookup failure should not drop notification, got %d sends", len(api.directCardsOut))
+	}
+}
+
+func TestInboxNotifierReleasesClaimWhenSendFails(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		prefErr: pgx.ErrNoRows,
+	}
+	api := &stubAPIClientWithRecorder{configured: true, sendErr: errors.New("lark 5xx")}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+	payload := map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "task_failed",
+			"severity":       "action_required",
+			"title":          "Task failed",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := notifier.notify(ctx, payload); err == nil {
+		t.Fatal("expected send failure")
+	}
+	if q.deleteCalls != 1 {
+		t.Fatalf("send failure should release delivery claim, got %d deletes", q.deleteCalls)
+	}
+	if q.deleteCtxErr != nil {
+		t.Fatalf("release claim should use a fresh context, got ctx err %v", q.deleteCtxErr)
+	}
+	api.sendErr = nil
+	if err := notifier.notify(context.Background(), payload); err != nil {
+		t.Fatalf("retry notify: %v", err)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("retry after released claim should send one card, got %d", len(api.directCardsOut))
+	}
+}
+
+func TestInboxNotifierFallsBackToAssigneeAgentBot(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	otherAgentID := mustUUID("33333333-3333-3333-3333-333333333333")
+	assigneeAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	issueID := mustUUID("55555555-5555-5555-5555-555555555555")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, otherAgentID, "cli_other", "ou_other"),
+			inboxBindingRow(workspaceID, userID, assigneeAgentID, "cli_assignee", "ou_assignee"),
+		},
+		prefErr: pgx.ErrNoRows,
+		issue: db.Issue{
+			ID:           issueID,
+			AssigneeType: pgtype.Text{String: "agent", Valid: true},
+			AssigneeID:   assigneeAgentID,
+		},
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "66666666-6666-6666-6666-666666666666",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "status_changed",
+			"severity":       "info",
+			"issue_id":       uuidString(issueID),
+			"title":          "Synced status changed",
+			"actor_type":     "system",
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if q.issueArg != issueID {
+		t.Fatalf("GetIssue arg = %v, want %v", q.issueArg, issueID)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("expected one direct card send, got %d", len(api.directCardsOut))
+	}
+	got := api.directCardsOut[0]
+	if got.OpenID != "ou_assignee" {
+		t.Fatalf("OpenID = %q, want assignee bot binding recipient ou_assignee", got.OpenID)
+	}
+	if got.InstallationID.AppID != "cli_assignee" {
+		t.Fatalf("AppID = %q, want cli_assignee", got.InstallationID.AppID)
+	}
+}
+
+func TestInboxNotifierSkipsWhenNoAgentBotMatches(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	otherAgentID := mustUUID("33333333-3333-3333-3333-333333333333")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, otherAgentID, "cli_other", "ou_other"),
+		},
+		prefErr: pgx.ErrNoRows,
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "quick_create_failed",
+			"severity":       "action_required",
+			"title":          "Quick create failed",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 0 {
+		t.Fatalf("expected no direct card send for unmatched agent bot, got %d", len(api.directCardsOut))
+	}
+}
+
+func TestInboxNotifierSkipsNonMemberRecipients(t *testing.T) {
+	q := &fakeInboxNotifierQueries{}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"workspace_id":   "11111111-1111-1111-1111-111111111111",
+			"recipient_type": "agent",
+			"recipient_id":   "22222222-2222-2222-2222-222222222222",
+			"title":          "Ignored",
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if q.arg.WorkspaceID.Valid {
+		t.Fatalf("non-member recipient should not query bindings")
+	}
+}
+
+func TestInboxNotifierSendsNewCommentAsMarkdownCard(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	actorAgentID := mustUUID("44444444-4444-4444-4444-444444444444")
+	q := &fakeInboxNotifierQueries{
+		rows: []db.ListActiveLarkUserBindingsByMemberRow{
+			inboxBindingRow(workspaceID, userID, actorAgentID, "cli_actor", "ou_actor"),
+		},
+		workspace: db.Workspace{ID: workspaceID, Slug: "tide-server", IssuePrefix: "TID"},
+		prefErr:   pgx.ErrNoRows,
+	}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{
+		PublicURL: "https://multica.test",
+	})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"id":             "55555555-5555-5555-5555-555555555555",
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"type":           "new_comment",
+			"severity":       "info",
+			"issue_id":       "66666666-6666-6666-6666-666666666666",
+			"title":          "Issue updated",
+			"body":           "**Result**\n- Cleaned up\n- Kept `tide`",
+			"actor_type":     "agent",
+			"actor_id":       uuidString(actorAgentID),
+		},
+	})
+	if err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.directCardsOut) != 1 {
+		t.Fatalf("expected one direct card send for new_comment, got %d", len(api.directCardsOut))
+	}
+	card := api.directCardsOut[0].CardJSON
+	for _, want := range []string{`"tag":"lark_md"`, "**Agent commented**", "**Result**", "View in Multica", "https://multica.test/tide-server/issues/66666666-6666-6666-6666-666666666666"} {
+		if !strings.Contains(card, want) {
+			t.Fatalf("new_comment card missing %q: %s", want, card)
+		}
+	}
+}
+
+func TestInboxNotifierRejectsMissingInboxItemID(t *testing.T) {
+	workspaceID := mustUUID("11111111-1111-1111-1111-111111111111")
+	userID := mustUUID("22222222-2222-2222-2222-222222222222")
+	q := &fakeInboxNotifierQueries{}
+	api := &stubAPIClientWithRecorder{configured: true}
+	notifier := NewInboxNotifier(q, stubCredentialsResolver{secret: "secret"}, api, InboxNotifierConfig{})
+
+	err := notifier.notify(context.Background(), map[string]any{
+		"item": map[string]any{
+			"workspace_id":   uuidString(workspaceID),
+			"recipient_type": "member",
+			"recipient_id":   uuidString(userID),
+			"title":          "Missing id",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing inbox item id error")
+	}
+	if q.arg.WorkspaceID.Valid {
+		t.Fatalf("missing inbox item id should not query bindings")
+	}
+}
+
+func inboxBindingRow(workspaceID, userID, agentID pgtype.UUID, appID, openID string) db.ListActiveLarkUserBindingsByMemberRow {
+	return db.ListActiveLarkUserBindingsByMemberRow{
+		LarkUserBinding: db.LarkUserBinding{
+			WorkspaceID:    workspaceID,
+			MulticaUserID:  userID,
+			InstallationID: mustUUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			LarkOpenID:     openID,
+		},
+		LarkInstallation: db.LarkInstallation{
+			ID:          mustUUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+			WorkspaceID: workspaceID,
+			AgentID:     agentID,
+			AppID:       appID,
+			Status:      string(InstallationActive),
+			Region:      string(RegionLark),
+		},
+	}
+}

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -92,6 +92,9 @@ func (f *fakeAPIClient) SendInteractiveCard(ctx context.Context, p SendCardParam
 	f.sent = append(f.sent, p)
 	return f.sendReturn, f.sendErr
 }
+func (f *fakeAPIClient) SendDirectInteractiveCard(ctx context.Context, p SendDirectCardParams) (string, error) {
+	return "", nil
+}
 func (f *fakeAPIClient) PatchInteractiveCard(ctx context.Context, p PatchCardParams) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -22,7 +22,9 @@ type stubAPIClientWithRecorder struct {
 	configured     bool
 	bindingCalls   []BindingPromptParams
 	interactiveOut []SendCardParams
+	directCardsOut []SendDirectCardParams
 	textOut        []SendTextParams
+	reactions      []AddReactionParams
 	sendErr        error
 	textErr        error
 	bindingErr     error
@@ -38,6 +40,16 @@ func (s *stubAPIClientWithRecorder) SendInteractiveCard(ctx context.Context, p S
 	}
 	s.interactiveOut = append(s.interactiveOut, p)
 	return "lark-msg-id", nil
+}
+
+func (s *stubAPIClientWithRecorder) SendDirectInteractiveCard(ctx context.Context, p SendDirectCardParams) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sendErr != nil {
+		return "", s.sendErr
+	}
+	s.directCardsOut = append(s.directCardsOut, p)
+	return "lark-direct-card-msg-id", nil
 }
 
 func (s *stubAPIClientWithRecorder) PatchInteractiveCard(ctx context.Context, p PatchCardParams) error {

--- a/server/internal/integrations/lark/typing_indicator_test.go
+++ b/server/internal/integrations/lark/typing_indicator_test.go
@@ -36,6 +36,9 @@ func (f *fakeTypingAPIClient) IsConfigured() bool { return true }
 func (f *fakeTypingAPIClient) SendInteractiveCard(context.Context, SendCardParams) (string, error) {
 	return "", nil
 }
+func (f *fakeTypingAPIClient) SendDirectInteractiveCard(context.Context, SendDirectCardParams) (string, error) {
+	return "", nil
+}
 func (f *fakeTypingAPIClient) PatchInteractiveCard(context.Context, PatchCardParams) error {
 	return nil
 }

--- a/server/migrations/118_lark_inbox_notification_delivery.down.sql
+++ b/server/migrations/118_lark_inbox_notification_delivery.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS lark_inbox_notification_delivery;

--- a/server/migrations/118_lark_inbox_notification_delivery.up.sql
+++ b/server/migrations/118_lark_inbox_notification_delivery.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE lark_inbox_notification_delivery (
+    inbox_item_id UUID NOT NULL REFERENCES inbox_item(id) ON DELETE CASCADE,
+    installation_id UUID NOT NULL REFERENCES lark_installation(id) ON DELETE CASCADE,
+    lark_open_id TEXT NOT NULL,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (inbox_item_id, installation_id, lark_open_id)
+);

--- a/server/pkg/db/generated/lark.sql.go
+++ b/server/pkg/db/generated/lark.sql.go
@@ -149,6 +149,36 @@ func (q *Queries) ClaimLarkInboundDedup(ctx context.Context, arg ClaimLarkInboun
 	return i, err
 }
 
+const claimLarkInboxNotificationDelivery = `-- name: ClaimLarkInboxNotificationDelivery :one
+WITH ins AS (
+    INSERT INTO lark_inbox_notification_delivery (
+        inbox_item_id,
+        installation_id,
+        lark_open_id
+    ) VALUES ($1, $2, $3)
+    ON CONFLICT DO NOTHING
+    RETURNING true AS claimed
+)
+SELECT COALESCE((SELECT claimed FROM ins), false)::boolean AS claimed
+`
+
+type ClaimLarkInboxNotificationDeliveryParams struct {
+	InboxItemID    pgtype.UUID `json:"inbox_item_id"`
+	InstallationID pgtype.UUID `json:"installation_id"`
+	LarkOpenID     string      `json:"lark_open_id"`
+}
+
+// Claims one outbound Lark inbox notification delivery. This is intentionally
+// keyed by the durable inbox_item row plus the concrete bot installation and
+// recipient open_id so repeated inbox:new events, duplicate bus subscribers,
+// or multi-replica handling cannot send duplicate DMs.
+func (q *Queries) ClaimLarkInboxNotificationDelivery(ctx context.Context, arg ClaimLarkInboxNotificationDeliveryParams) (bool, error) {
+	row := q.db.QueryRow(ctx, claimLarkInboxNotificationDelivery, arg.InboxItemID, arg.InstallationID, arg.LarkOpenID)
+	var claimed bool
+	err := row.Scan(&claimed)
+	return claimed, err
+}
+
 const consumeLarkBindingToken = `-- name: ConsumeLarkBindingToken :one
 UPDATE lark_binding_token
 SET consumed_at = now()
@@ -448,6 +478,24 @@ func (q *Queries) CreateLarkUserBinding(ctx context.Context, arg CreateLarkUserB
 	return i, err
 }
 
+const deleteLarkInboxNotificationDelivery = `-- name: DeleteLarkInboxNotificationDelivery :exec
+DELETE FROM lark_inbox_notification_delivery
+WHERE inbox_item_id = $1
+  AND installation_id = $2
+  AND lark_open_id = $3
+`
+
+type DeleteLarkInboxNotificationDeliveryParams struct {
+	InboxItemID    pgtype.UUID `json:"inbox_item_id"`
+	InstallationID pgtype.UUID `json:"installation_id"`
+	LarkOpenID     string      `json:"lark_open_id"`
+}
+
+func (q *Queries) DeleteLarkInboxNotificationDelivery(ctx context.Context, arg DeleteLarkInboxNotificationDeliveryParams) error {
+	_, err := q.db.Exec(ctx, deleteLarkInboxNotificationDelivery, arg.InboxItemID, arg.InstallationID, arg.LarkOpenID)
+	return err
+}
+
 const deleteLarkUserBinding = `-- name: DeleteLarkUserBinding :exec
 DELETE FROM lark_user_binding WHERE id = $1
 `
@@ -722,6 +770,73 @@ func (q *Queries) ListActiveLarkInstallations(ctx context.Context) ([]LarkInstal
 			&i.UpdatedAt,
 			&i.BotUnionID,
 			&i.Region,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActiveLarkUserBindingsByMember = `-- name: ListActiveLarkUserBindingsByMember :many
+SELECT lub.id, lub.workspace_id, lub.multica_user_id, lub.installation_id, lub.lark_open_id, lub.union_id, lub.bound_at, li.id, li.workspace_id, li.agent_id, li.app_id, li.app_secret_encrypted, li.tenant_key, li.bot_open_id, li.installer_user_id, li.status, li.ws_lease_token, li.ws_lease_expires_at, li.installed_at, li.created_at, li.updated_at, li.bot_union_id, li.region
+FROM lark_user_binding lub
+JOIN lark_installation li ON li.id = lub.installation_id
+WHERE lub.workspace_id = $1
+  AND lub.multica_user_id = $2
+  AND li.workspace_id = lub.workspace_id
+  AND li.status = 'active'
+ORDER BY lub.bound_at DESC
+`
+
+type ListActiveLarkUserBindingsByMemberParams struct {
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
+	MulticaUserID pgtype.UUID `json:"multica_user_id"`
+}
+
+type ListActiveLarkUserBindingsByMemberRow struct {
+	LarkUserBinding  LarkUserBinding  `json:"lark_user_binding"`
+	LarkInstallation LarkInstallation `json:"lark_installation"`
+}
+
+// Outbound notification path: find the recipient's bound Lark accounts in
+// this workspace, with the active bot installation needed for credentials.
+func (q *Queries) ListActiveLarkUserBindingsByMember(ctx context.Context, arg ListActiveLarkUserBindingsByMemberParams) ([]ListActiveLarkUserBindingsByMemberRow, error) {
+	rows, err := q.db.Query(ctx, listActiveLarkUserBindingsByMember, arg.WorkspaceID, arg.MulticaUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListActiveLarkUserBindingsByMemberRow{}
+	for rows.Next() {
+		var i ListActiveLarkUserBindingsByMemberRow
+		if err := rows.Scan(
+			&i.LarkUserBinding.ID,
+			&i.LarkUserBinding.WorkspaceID,
+			&i.LarkUserBinding.MulticaUserID,
+			&i.LarkUserBinding.InstallationID,
+			&i.LarkUserBinding.LarkOpenID,
+			&i.LarkUserBinding.UnionID,
+			&i.LarkUserBinding.BoundAt,
+			&i.LarkInstallation.ID,
+			&i.LarkInstallation.WorkspaceID,
+			&i.LarkInstallation.AgentID,
+			&i.LarkInstallation.AppID,
+			&i.LarkInstallation.AppSecretEncrypted,
+			&i.LarkInstallation.TenantKey,
+			&i.LarkInstallation.BotOpenID,
+			&i.LarkInstallation.InstallerUserID,
+			&i.LarkInstallation.Status,
+			&i.LarkInstallation.WsLeaseToken,
+			&i.LarkInstallation.WsLeaseExpiresAt,
+			&i.LarkInstallation.InstalledAt,
+			&i.LarkInstallation.CreatedAt,
+			&i.LarkInstallation.UpdatedAt,
+			&i.LarkInstallation.BotUnionID,
+			&i.LarkInstallation.Region,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -446,6 +446,13 @@ type LarkInboundMessageDedup struct {
 	ClaimToken     pgtype.UUID        `json:"claim_token"`
 }
 
+type LarkInboxNotificationDelivery struct {
+	InboxItemID    pgtype.UUID        `json:"inbox_item_id"`
+	InstallationID pgtype.UUID        `json:"installation_id"`
+	LarkOpenID     string             `json:"lark_open_id"`
+	ClaimedAt      pgtype.Timestamptz `json:"claimed_at"`
+}
+
 type LarkInstallation struct {
 	ID                 pgtype.UUID        `json:"id"`
 	WorkspaceID        pgtype.UUID        `json:"workspace_id"`

--- a/server/pkg/db/queries/lark.sql
+++ b/server/pkg/db/queries/lark.sql
@@ -192,6 +192,18 @@ SELECT * FROM lark_user_binding
 WHERE installation_id = $1
 ORDER BY bound_at DESC;
 
+-- name: ListActiveLarkUserBindingsByMember :many
+-- Outbound notification path: find the recipient's bound Lark accounts in
+-- this workspace, with the active bot installation needed for credentials.
+SELECT sqlc.embed(lub), sqlc.embed(li)
+FROM lark_user_binding lub
+JOIN lark_installation li ON li.id = lub.installation_id
+WHERE lub.workspace_id = $1
+  AND lub.multica_user_id = $2
+  AND li.workspace_id = lub.workspace_id
+  AND li.status = 'active'
+ORDER BY lub.bound_at DESC;
+
 -- name: DeleteLarkUserBinding :exec
 DELETE FROM lark_user_binding WHERE id = $1;
 
@@ -221,6 +233,28 @@ WHERE installation_id = $1 AND lark_chat_id = $2;
 -- to PATCH when an agent emits a stream event for this session.
 SELECT * FROM lark_chat_session_binding
 WHERE chat_session_id = $1;
+
+-- name: ClaimLarkInboxNotificationDelivery :one
+-- Claims one outbound Lark inbox notification delivery. This is intentionally
+-- keyed by the durable inbox_item row plus the concrete bot installation and
+-- recipient open_id so repeated inbox:new events, duplicate bus subscribers,
+-- or multi-replica handling cannot send duplicate DMs.
+WITH ins AS (
+    INSERT INTO lark_inbox_notification_delivery (
+        inbox_item_id,
+        installation_id,
+        lark_open_id
+    ) VALUES ($1, $2, $3)
+    ON CONFLICT DO NOTHING
+    RETURNING true AS claimed
+)
+SELECT COALESCE((SELECT claimed FROM ins), false)::boolean AS claimed;
+
+-- name: DeleteLarkInboxNotificationDelivery :exec
+DELETE FROM lark_inbox_notification_delivery
+WHERE inbox_item_id = $1
+  AND installation_id = $2
+  AND lark_open_id = $3;
 
 -- =====================
 -- lark_inbound_message_dedup


### PR DESCRIPTION
## Summary

Fixes #3918.

This keeps Lark/Feishu bot workflows inside IM after an agent starts work. When an `inbox:new` item targets a member who has a bound Lark account, Multica now sends a direct bot card for useful agent/result notifications instead of requiring the user to switch back to web or desktop to discover the outcome.

## Changes

- Add a Lark inbox notifier subscribed to `inbox:new` events.
- Resolve the recipient bound Lark account and pick the bot installation associated with the actor agent, falling back to the issue assignee agent.
- Send direct interactive cards for useful inbox events such as comments, status changes, quick-create completion, and task failures.
- Add `lark_inbox_notification_delivery` to deduplicate sends by inbox item, bot installation, and recipient open_id.
- Add direct interactive-card transport support for open_id recipients.
- Wire the notifier when the Lark integration is enabled, using `MULTICA_PUBLIC_URL` for optional deep links back to Multica.

## Notes

This intentionally does not change browser/desktop system notifications. It is a separate Lark/Feishu IM notification channel for users who already start work through the bot.

## Testing

- `go test ./internal/integrations/lark`
- `go test ./cmd/server`
- `go test ./...`