### PR TITLE
feat(issues): add brand border beam to active agent header chip

### DIFF
--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -9,6 +9,7 @@ import {
 } from "@multica/ui/components/ui/popover";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { cn } from "@multica/ui/lib/utils";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import type { AgentTask } from "@multica/core/types";
 import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
@@ -99,7 +100,15 @@ function ActiveChip({ issueId, running, queued }: ActiveChipProps) {
             <button
               type="button"
               aria-label={label}
-              className="flex h-7 max-w-[11rem] items-center gap-1.5 rounded-md px-1.5 text-muted-foreground outline-none transition-colors hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-ring"
+              // While an agent is actively running, the chip wears the
+              // brand border beam — a highlight sweeping around its rounded
+              // edge — so a triggered run is unmistakably "alive" in the
+              // header. Queued-only state stays calm (no beam) to reserve the
+              // motion for work that is genuinely in flight.
+              className={cn(
+                "flex h-7 max-w-[11rem] items-center gap-1.5 rounded-md px-1.5 text-muted-foreground outline-none transition-colors hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-ring",
+                anyRunning && "border-beam bg-brand/5",
+              )}
             />
           }
         >


### PR DESCRIPTION
为 header 中 "agent is working" 指示器添加 beam 流光效果（MUL-3145）。

参考效果：https://beam.jakubantalik.com/

## 改动
当有 agent 正在运行时，header chip 套上品牌色 border beam —— 一道高亮沿圆角边框持续流转，让用户触发的 run 在 header 中明确地 "活着"。仅在真正运行（`anyRunning`）时启用，纯排队状态保持静止，把动效留给真正在进行的工作。

复用已有的 `.border-beam` 工具类（`packages/ui/styles/base.css`，conic-gradient + animated @property angle，且已含 `prefers-reduced-motion` 降级），与 manual create 里 "switch to agent" 的用法一致，零新增 CSS。

## 文件
- `packages/views/issues/components/issue-agent-header-chip.tsx` — 运行时给 chip 按钮加 `border-beam bg-brand/5`