### PR TITLE
fix(issues): header chip shows 'is queued' when no agent is running

### DIFF
--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -27,9 +27,10 @@ import { useT } from "../../i18n";
 // with those surfaces and costs zero extra network.
 //
 // Collapsed display stays intentionally shallow:
-//   - one active agent   → avatar + "{name} is working"
-//   - multiple agents   → avatar stack + "N agents working"
-//   - queued only       → same copy, half-opacity avatars / muted text
+//   - one running agent  → avatar + "{name} is working"
+//   - multiple running   → avatar stack + "N agents working"
+//   - queued only        → "{name} is queued" / "N agents queued",
+//                          half-opacity avatars / muted text (no beam)
 //
 // Click opens a compact Popover card with the same active rows as the right
 // panel. Those rows show necessary status/time and task entry actions, but do
@@ -84,13 +85,23 @@ function ActiveChip({ issueId, running, queued }: ActiveChipProps) {
   const agentIds = [...new Set(activeTasks.map((task) => task.agent_id))];
   const anyRunning = running.length > 0;
   const isSingle = agentIds.length === 1;
+  // Copy must follow the actual state: "is working" only when something is
+  // truly running. With nothing running (queued / dispatched / parked on a
+  // path lock) the chip reads "is queued" so a not-yet-started agent isn't
+  // mislabelled as working.
   const label = isSingle
-    ? t(($) => $.agent_live.is_working, {
-        name: getActorName("agent", agentIds[0] ?? ""),
-      })
-    : t(($) => $.agent_activity.hover_header, {
-        count: agentIds.length,
-      });
+    ? t(
+        ($) =>
+          anyRunning ? $.agent_live.is_working : $.agent_live.is_queued,
+        { name: getActorName("agent", agentIds[0] ?? "") },
+      )
+    : t(
+        ($) =>
+          anyRunning
+            ? $.agent_activity.hover_header
+            : $.agent_activity.hover_header_queued,
+        { count: agentIds.length },
+      );
 
   return (
     <div className="flex items-center gap-1">
@@ -126,9 +137,13 @@ function ActiveChip({ issueId, running, queued }: ActiveChipProps) {
         </PopoverTrigger>
         <PopoverContent align="end" keepMounted className="w-80">
           <div className="text-xs font-medium text-muted-foreground">
-            {t(($) => $.agent_activity.hover_header, {
-              count: agentIds.length,
-            })}
+            {t(
+              ($) =>
+                anyRunning
+                  ? $.agent_activity.hover_header
+                  : $.agent_activity.hover_header_queued,
+              { count: agentIds.length },
+            )}
           </div>
           <div className="flex flex-col gap-0.5">
             {activeTasks.map((task) => (

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -293,6 +293,8 @@
   "agent_activity": {
     "hover_header_one": "{{count}} agent working",
     "hover_header_other": "{{count}} agents working",
+    "hover_header_queued_one": "{{count}} agent queued",
+    "hover_header_queued_other": "{{count}} agents queued",
     "status_running": "Working",
     "status_queued": "Queued",
     "chip_label": "working",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -282,6 +282,7 @@
   },
   "agent_activity": {
     "hover_header_other": "作業中のエージェント {{count}} 件",
+    "hover_header_queued_other": "待機中のエージェント {{count}} 件",
     "status_running": "作業中",
     "status_queued": "待機中",
     "chip_label": "作業中",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -293,6 +293,8 @@
   "agent_activity": {
     "hover_header_one": "작업 중인 에이전트 {{count}}개",
     "hover_header_other": "작업 중인 에이전트 {{count}}개",
+    "hover_header_queued_one": "대기 중인 에이전트 {{count}}개",
+    "hover_header_queued_other": "대기 중인 에이전트 {{count}}개",
     "status_running": "작업 중",
     "status_queued": "대기 중",
     "chip_label": "작업 중",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -287,6 +287,7 @@
   },
   "agent_activity": {
     "hover_header_other": "{{count}} 个智能体正在工作",
+    "hover_header_queued_other": "{{count}} 个智能体排队中",
     "status_running": "正在工作",
     "status_queued": "排队中",
     "chip_label": "工作中",


### PR DESCRIPTION
Follow-up to #3921（beam 已合并）。

## 问题
header 的 "agent is working" chip 不管什么状态都显示 "is working" 文案 —— agent 还在排队（queued / dispatched / 等本地目录锁）、并没有真正开始跑时，也被标成 "is working"，会误导用户。

## 改动
文案按真实状态走：
- **单个 agent**：`anyRunning` 时用 `agent_live.is_working`，否则用已有的 `agent_live.is_queued`（"{name} is queued"）。
- **多个 agent**：新增 `agent_activity.hover_header_queued`（"N agents queued"）四语言文案，排队时 chip 与 popover 标题都走这个。
- 颜色 / 透明度本来就按 running vs queued 区分（灰字 + 半透明头像 + 无 beam），文案补齐后整体一致：**running → "is working" + beam**，**queued → "is queued"、灰字、无 beam**。

i18n key 用法与现有 `hover_header` 完全一致；四个 locale JSON 已校验合法。