### PR TITLE
feat(issue): optional human-only "done" transition policy

### DIFF
--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -17,6 +17,7 @@ export type InboxItemType =
   | "task_failed"
   | "agent_blocked"
   | "agent_completed"
+  | "agent_done_blocked"
   | "reaction_added"
   | "quick_create_done"
   | "quick_create_failed";

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -230,6 +230,39 @@ describe("ReadonlyContent code styling", () => {
     expect(blockCode?.textContent?.trim()).toBe(token);
   });
 
+  it("copies the raw snippet to the clipboard via the code block copy button", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const { container } = render(
+      <ReadonlyContent
+        content={["```bash", literalCode, "```"].join("\n")}
+      />,
+    );
+
+    const button = container.querySelector(
+      ".code-block-wrapper button",
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button!);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(literalCode);
+    });
+  });
+
+  it("does not render a copy button for inline code", () => {
+    const { container } = render(
+      <ReadonlyContent content={`Run \`${literalCode}\` now`} />,
+    );
+    // Inline code never reaches the `pre` renderer, so no copy chrome.
+    expect(container.querySelector(".code-block-wrapper")).toBeNull();
+  });
+
   it("keeps editor code literal by disabling font ligatures", () => {
     const codeCss = readFileSync("editor/styles/code.css", "utf8");
 

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -16,7 +16,8 @@
  * - Rendering mentions with the same IssueMentionCard component and .mention class
  */
 
-import { isValidElement, memo, useMemo, useRef } from "react";
+import { isValidElement, memo, useMemo, useRef, useState } from "react";
+import { Copy, Check } from "lucide-react";
 import ReactMarkdown, {
   defaultUrlTransform,
   type Components,
@@ -30,6 +31,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { createLowlight, common } from "lowlight";
 import { toHtml } from "hast-util-to-html";
 import { cn } from "@multica/ui/lib/utils";
+import { useT } from "../i18n";
 import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
 import type { Attachment } from "@multica/core/types";
 import { useNavigation } from "../navigation";
@@ -58,6 +60,73 @@ const lowlight = createLowlight(common);
 // Anchored to whole class tokens so `language-htmlbars` / `language-mermaidx`
 // don't accidentally match and lose their <pre> wrapper.
 const PRE_UNWRAP_RE = /(^|\s)language-(html|mermaid)(\s|$)/;
+
+// ---------------------------------------------------------------------------
+// Copyable code block — wraps the rendered <pre> with a hover copy button.
+// Mirrors the editor's CodeBlockView chrome (`.code-block-wrapper` +
+// `.code-block-header`) so a code snippet looks identical whether it appears
+// in the editor or in a readonly comment / description.
+// ---------------------------------------------------------------------------
+
+// Recursively concatenate the raw text of a hast node. The `pre` renderer
+// receives the unrendered `<pre><code>` AST (highlighted output is injected
+// via dangerouslySetInnerHTML downstream, so the rendered children no longer
+// hold the plain text) — walking the node tree is the reliable source.
+function collectNodeText(node: unknown): string {
+  if (!node || typeof node !== "object") return "";
+  const n = node as { type?: string; value?: string; children?: unknown[] };
+  if (n.type === "text") return n.value ?? "";
+  if (Array.isArray(n.children)) return n.children.map(collectNodeText).join("");
+  return "";
+}
+
+function CodeBlockWithCopy({
+  code,
+  children,
+}: {
+  code: string;
+  children: React.ReactNode;
+}) {
+  const { t } = useT("editor");
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (insecure context / denied permission) — no-op.
+    }
+  };
+
+  return (
+    <div className="code-block-wrapper group/code relative">
+      <div
+        contentEditable={false}
+        className="code-block-header absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100"
+      >
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          title={t(($) => $.code_block.copy_code)}
+          aria-label={t(($) => $.code_block.copy_code)}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      <pre>{children}</pre>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Sanitization schema — extends GitHub defaults to allow file-card data attrs
@@ -275,7 +344,7 @@ function buildComponents(): Partial<Components> {
     // renderer above so the outer `<pre>` does not wrap them — this is the
     // standard two-layer pattern used to escape react-markdown's default
     // `<pre><code>` envelope.
-    pre: ({ children }) => {
+    pre: ({ children, node }) => {
       // react-markdown calls `pre` BEFORE invoking the `code` renderer —
       // `children` is the unrendered `<code>` element from the AST. So we
       // identify "this block was meant to be unwrapped" by inspecting the
@@ -291,7 +360,11 @@ function buildComponents(): Partial<Components> {
           return <>{children}</>;
         }
       }
-      return <pre>{children}</pre>;
+      // Real code block — wrap with a hover copy button. The raw snippet text
+      // comes from the AST node (trailing newline trimmed to match the `code`
+      // renderer), since highlighted output is injected as raw HTML.
+      const code = collectNodeText(node).replace(/\n$/, "");
+      return <CodeBlockWithCopy code={code}>{children}</CodeBlockWithCopy>;
     },
   };
 }

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -27,6 +27,7 @@ export function useTypeLabels(): Record<InboxItemType, string> {
     task_failed: t(($) => $.types.task_failed),
     agent_blocked: t(($) => $.types.agent_blocked),
     agent_completed: t(($) => $.types.agent_completed),
+    agent_done_blocked: t(($) => $.types.agent_done_blocked),
     reaction_added: t(($) => $.types.reaction_added),
     quick_create_done: t(($) => $.types.quick_create_done),
     quick_create_failed: t(($) => $.types.quick_create_failed),

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -42,6 +42,7 @@
     "task_failed": "Task failed",
     "agent_blocked": "Agent blocked",
     "agent_completed": "Agent completed",
+    "agent_done_blocked": "Agent blocked from done",
     "reaction_added": "Reacted",
     "quick_create_done": "Created with agent",
     "quick_create_failed": "Create with agent failed"

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -42,6 +42,7 @@
     "task_failed": "タスク失敗",
     "agent_blocked": "エージェントがブロック",
     "agent_completed": "エージェントが完了",
+    "agent_done_blocked": "エージェントは完了にできません",
     "reaction_added": "リアクションあり",
     "quick_create_done": "エージェントで作成",
     "quick_create_failed": "エージェントでの作成に失敗"

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -42,6 +42,7 @@
     "task_failed": "작업 실패함",
     "agent_blocked": "에이전트 막힘",
     "agent_completed": "에이전트 완료됨",
+    "agent_done_blocked": "에이전트가 완료로 변경할 수 없음",
     "reaction_added": "반응 추가됨",
     "quick_create_done": "에이전트로 생성됨",
     "quick_create_failed": "에이전트 생성 실패"

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -42,6 +42,7 @@
     "task_failed": "task 失败",
     "agent_blocked": "智能体被阻塞",
     "agent_completed": "智能体已完成",
+    "agent_done_blocked": "智能体不可标记为完成",
     "reaction_added": "添加了表情反应",
     "quick_create_done": "通过智能体创建",
     "quick_create_failed": "通过智能体创建失败"

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -139,6 +139,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		TrustedProxies:           parseTrustedProxies(os.Getenv("MULTICA_TRUSTED_PROXIES")),
 		CloudRuntimeFleetURL:     cloudRuntimeFleetURLFromEnv(),
 		CloudRuntimeFleetTimeout: envDuration("MULTICA_CLOUD_FLEET_TIMEOUT", 35*time.Second),
+		RequireHumanDone:         os.Getenv("MULTICA_REQUIRE_HUMAN_DONE") == "true",
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	if opts.DaemonWakeup != nil {

--- a/server/internal/handler/actor_guards.go
+++ b/server/internal/handler/actor_guards.go
@@ -95,14 +95,30 @@ import (
 // human-equivalent or machine-equivalent.
 func RequireHumanActor(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// X-Actor-Source is server-set only. The auth middleware
-		// strips any client-supplied value before stamping its own,
-		// so a non-empty value here is authoritative.
-		switch r.Header.Get("X-Actor-Source") {
-		case "task_token", "cloud_pat":
+		if isMachineActor(r) {
 			writeError(w, http.StatusForbidden, "this endpoint is only available to human actors")
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isMachineActor reports whether the request authenticated via a machine
+// credential — a mat_ task token or mcn_ cloud-node PAT (i.e. an agent process
+// or a cloud-runtime node acting on its owner's behalf) — rather than a human
+// (JWT cookie / mul_ PAT, which leave X-Actor-Source empty).
+//
+// It keys off the server-set X-Actor-Source header. The auth middleware
+// deletes any client-supplied value before stamping its own (see auth.go's
+// `r.Header.Del("X-Actor-Source")`), so a non-empty value here is
+// authoritative — checking it is the single-source-of-truth, no-DB way to
+// classify the credential kind. RequireHumanActor and the human-only-done
+// policy (enforceHumanDone) both gate on this helper; keep the denylist in
+// lockstep with the machine-credential branches in auth.go / daemon_auth.go.
+func isMachineActor(r *http.Request) bool {
+	switch r.Header.Get("X-Actor-Source") {
+	case "task_token", "cloud_pat":
+		return true
+	}
+	return false
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -80,6 +80,17 @@ type Config struct {
 	// return 503 instead of attempting to dial a hard-coded private service.
 	CloudRuntimeFleetURL     string
 	CloudRuntimeFleetTimeout time.Duration
+	// RequireHumanDone, when true, forbids machine actors (mat_ task tokens
+	// and mcn_ cloud-node PATs — i.e. agents and cloud runtimes) from moving
+	// an issue into `done`. The transition into `done` becomes a human-only
+	// action; an agent that finishes its work leaves the issue for a human to
+	// close. A blocked attempt returns 403 and drops an inbox notification for
+	// the owning human. Off by default (opt-in via MULTICA_REQUIRE_HUMAN_DONE)
+	// so existing instances keep the "agent and human are interchangeable"
+	// contract unless an operator opts in. Enforcement lives in
+	// enforceHumanDone (see issue_done_guard.go); it is server-side only, so
+	// it cannot be bypassed by calling the API directly instead of the CLI.
+	RequireHumanDone bool
 }
 
 type cloudRuntimeProxy interface {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2002,6 +2002,13 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		priority = "none"
 	}
 
+	// Human-only-done policy: a machine actor may not create an issue that is
+	// already `done` when MULTICA_REQUIRE_HUMAN_DONE is on. prevStatus is ""
+	// (no prior state), so a `done` target counts as a transition.
+	if h.enforceHumanDone(w, r, wsUUID, pgtype.UUID{}, req.Title, "", status) {
+		return
+	}
+
 	var assigneeType pgtype.Text
 	var assigneeID pgtype.UUID
 	if req.AssigneeType != nil {
@@ -2317,6 +2324,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// Track which fields were explicitly present in JSON (even if null)
 	var rawFields map[string]json.RawMessage
 	json.Unmarshal(bodyBytes, &rawFields)
+
+	// Human-only-done policy: block a machine actor from transitioning this
+	// issue into `done` when MULTICA_REQUIRE_HUMAN_DONE is on. Checked before
+	// any DB write so the status never lands.
+	if req.Status != nil && h.enforceHumanDone(w, r, prevIssue.WorkspaceID, prevIssue.ID, prevIssue.Title, prevIssue.Status, *req.Status) {
+		return
+	}
 
 	// Pre-fill nullable fields (bare sqlc.narg) with current values
 	params := db.UpdateIssueParams{
@@ -2840,6 +2854,15 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+
+	// Human-only-done policy: reject the whole batch up front when a machine
+	// actor tries to bulk-set `done` and MULTICA_REQUIRE_HUMAN_DONE is on. The
+	// gate is independent of any single issue's prior status, so it is checked
+	// once here rather than mid-loop (which would leave a partial batch).
+	if req.Updates.Status != nil && h.enforceHumanDone(w, r, wsUUID, pgtype.UUID{}, "Bulk status update", "", *req.Updates.Status) {
+		return
+	}
+
 	updated := 0
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)

--- a/server/internal/handler/issue_done_guard.go
+++ b/server/internal/handler/issue_done_guard.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// inboxTypeAgentDoneBlocked is the inbox notification type raised when the
+// human-only-done policy (Config.RequireHumanDone) rejects a machine actor's
+// attempt to move an issue into `done`. The matching frontend union member
+// lives in packages/core/types/inbox.ts — keep the two in sync.
+const inboxTypeAgentDoneBlocked = "agent_done_blocked"
+
+// enforceHumanDone applies the optional "only humans may mark issues done"
+// policy (Config.RequireHumanDone). When the policy is on and a machine actor
+// (mat_ task token or mcn_ cloud-node PAT) attempts to transition an issue
+// INTO `done`, it notifies the owning human via the inbox, writes a 403, and
+// returns true. Callers MUST `return` when it returns true — the response has
+// already been written.
+//
+// Only the transition into `done` is gated. Re-saving an already-done issue,
+// or setting any other status, is always allowed so an agent can still update
+// unrelated fields (description, assignee, in_review, …) without tripping the
+// gate.
+//
+// prevStatus is the issue's current status; pass "" for issue creation (no
+// prior state, so a `done` target counts as a transition). issueID may be the
+// zero UUID for creation / batch, where there is no single row to link the
+// notification to.
+func (h *Handler) enforceHumanDone(w http.ResponseWriter, r *http.Request, ws, issueID pgtype.UUID, issueTitle, prevStatus, newStatus string) bool {
+	if !h.cfg.RequireHumanDone {
+		return false
+	}
+	if newStatus != "done" || prevStatus == "done" {
+		return false
+	}
+	if !isMachineActor(r) {
+		return false
+	}
+	h.notifyAgentDoneBlocked(r.Context(), r, ws, issueID, issueTitle)
+	writeError(w, http.StatusForbidden, "issues can only be marked done by a human")
+	return true
+}
+
+// notifyAgentDoneBlocked drops an inbox row for the human who owns the agent
+// whose `done` transition was just denied. The recipient is the request's
+// X-User-ID, which for a mat_/mcn_ credential is the OWNING human (see
+// middleware/auth.go) — exactly the person who should review the work and
+// close the issue themselves.
+//
+// Best-effort: the 403 is the authoritative outcome, so a failed inbox write
+// is logged and swallowed rather than surfaced.
+func (h *Handler) notifyAgentDoneBlocked(ctx context.Context, r *http.Request, ws, issueID pgtype.UUID, issueTitle string) {
+	ownerID := requestUserID(r)
+	recipientID, err := util.ParseUUID(ownerID)
+	if err != nil {
+		return
+	}
+
+	actorType, actorID := h.resolveActor(r, ownerID, uuidToString(ws))
+	var actorUUID pgtype.UUID
+	if id, err := util.ParseUUID(actorID); err == nil {
+		actorUUID = id
+	}
+
+	details, _ := json.Marshal(map[string]string{"attempted_status": "done"})
+
+	if _, err := h.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   ws,
+		RecipientType: "member",
+		RecipientID:   recipientID,
+		Type:          inboxTypeAgentDoneBlocked,
+		Severity:      "attention",
+		IssueID:       issueID,
+		Title:         issueTitle,
+		Body:          util.StrToText("An agent tried to mark this issue done. Only a human can move an issue to done — review the work and close it yourself."),
+		ActorType:     util.StrToText(actorType),
+		ActorID:       actorUUID,
+		Details:       details,
+	}); err != nil {
+		slog.Warn("agent done blocked: inbox write failed",
+			"error", err,
+			"workspace_id", uuidToString(ws),
+			"issue_id", uuidToString(issueID))
+	}
+}

--- a/server/internal/handler/issue_done_guard_test.go
+++ b/server/internal/handler/issue_done_guard_test.go
@@ -1,0 +1,182 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// withRequireHumanDone flips the human-only-done policy on for the duration of
+// a test and restores it afterwards. cfg is a value field on the shared
+// testHandler; handler tests run sequentially (no t.Parallel here), so the
+// mutate-and-restore is safe.
+func withRequireHumanDone(t *testing.T, on bool) {
+	t.Helper()
+	prev := testHandler.cfg.RequireHumanDone
+	testHandler.cfg.RequireHumanDone = on
+	t.Cleanup(func() { testHandler.cfg.RequireHumanDone = prev })
+}
+
+// createDoneGuardIssue creates an issue in the given status and registers
+// cleanup. Returns the decoded response.
+func createDoneGuardIssue(t *testing.T, status string) IssueResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "done-guard " + time.Now().Format(time.RFC3339Nano),
+		"status": status,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create issue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issue.ID)
+	})
+	return issue
+}
+
+// asMachineActor stamps the request as if it arrived on a mat_ task token —
+// the authoritative shape the auth middleware produces for an agent. X-User-ID
+// stays the owning human (set by newRequest), mirroring production.
+func asMachineActor(req *http.Request, agentID string) *http.Request {
+	req.Header.Set("X-Actor-Source", "task_token")
+	if agentID != "" {
+		req.Header.Set("X-Agent-ID", agentID)
+	}
+	return req
+}
+
+func putStatus(t *testing.T, issueID, status string, asMachine bool, agentID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": status})
+	if asMachine {
+		req = asMachineActor(req, agentID)
+	}
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	return w
+}
+
+func issueStatusInDB(t *testing.T, issueID string) string {
+	t.Helper()
+	var status string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT status FROM issue WHERE id = $1`, issueID).Scan(&status); err != nil {
+		t.Fatalf("read issue status: %v", err)
+	}
+	return status
+}
+
+func countAgentDoneBlockedInbox(t *testing.T, recipientUserID, issueID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM inbox_item
+		   WHERE recipient_id = $1 AND issue_id = $2 AND type = 'agent_done_blocked'`,
+		recipientUserID, issueID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count agent_done_blocked inbox: %v", err)
+	}
+	return n
+}
+
+// TestRequireHumanDone_BlocksMachineActor — with the policy on, a machine
+// actor's done transition is rejected with 403, the status is left untouched,
+// and the owning human gets an agent_done_blocked inbox row.
+func TestRequireHumanDone_BlocksMachineActor(t *testing.T) {
+	withRequireHumanDone(t, true)
+	agentID := createHandlerTestAgent(t, "done-guard agent "+time.Now().Format(time.RFC3339Nano), []byte("[]"))
+	issue := createDoneGuardIssue(t, "in_progress")
+
+	w := putStatus(t, issue.ID, "done", true, agentID)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusInDB(t, issue.ID); got != "in_progress" {
+		t.Fatalf("status must stay unchanged, got %q", got)
+	}
+	if n := countAgentDoneBlockedInbox(t, testUserID, issue.ID); n != 1 {
+		t.Fatalf("expected exactly 1 agent_done_blocked inbox row, got %d", n)
+	}
+}
+
+// TestRequireHumanDone_AllowsHumanActor — with the policy on, a human (no
+// X-Actor-Source) can still mark an issue done.
+func TestRequireHumanDone_AllowsHumanActor(t *testing.T) {
+	withRequireHumanDone(t, true)
+	issue := createDoneGuardIssue(t, "in_progress")
+
+	w := putStatus(t, issue.ID, "done", false, "")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusInDB(t, issue.ID); got != "done" {
+		t.Fatalf("expected status done, got %q", got)
+	}
+}
+
+// TestRequireHumanDone_AllowsMachineNonDone — the gate is scoped to the `done`
+// transition only; a machine actor may still move an issue to any other
+// status (e.g. in_review, the natural agent handoff).
+func TestRequireHumanDone_AllowsMachineNonDone(t *testing.T) {
+	withRequireHumanDone(t, true)
+	agentID := createHandlerTestAgent(t, "done-guard agent "+time.Now().Format(time.RFC3339Nano), []byte("[]"))
+	issue := createDoneGuardIssue(t, "in_progress")
+
+	w := putStatus(t, issue.ID, "in_review", true, agentID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusInDB(t, issue.ID); got != "in_review" {
+		t.Fatalf("expected status in_review, got %q", got)
+	}
+}
+
+// TestRequireHumanDone_DisabledAllowsMachine — with the policy off (default),
+// a machine actor marks done exactly as before. Guards against the flag
+// leaking into the default contract.
+func TestRequireHumanDone_DisabledAllowsMachine(t *testing.T) {
+	withRequireHumanDone(t, false)
+	agentID := createHandlerTestAgent(t, "done-guard agent "+time.Now().Format(time.RFC3339Nano), []byte("[]"))
+	issue := createDoneGuardIssue(t, "in_progress")
+
+	w := putStatus(t, issue.ID, "done", true, agentID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := issueStatusInDB(t, issue.ID); got != "done" {
+		t.Fatalf("expected status done, got %q", got)
+	}
+}
+
+// TestRequireHumanDone_BlocksMachineCreateAsDone — creating an issue already
+// in `done` is the same loophole as transitioning into it, so it is gated too.
+func TestRequireHumanDone_BlocksMachineCreateAsDone(t *testing.T) {
+	withRequireHumanDone(t, true)
+	agentID := createHandlerTestAgent(t, "done-guard agent "+time.Now().Format(time.RFC3339Nano), []byte("[]"))
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "done-guard create " + time.Now().Format(time.RFC3339Nano),
+		"status": "done",
+	})
+	req = asMachineActor(req, agentID)
+	testHandler.CreateIssue(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## What

Adds an opt-in policy so that **only humans can move an issue into `done`** — agents (local daemon `task_token` and cloud `cloud_pat`) are blocked.

Controlled by a new env var **`MULTICA_REQUIRE_HUMAN_DONE`** (off by default, so existing instances keep the current "agent and human are interchangeable" contract).

When the policy is on and a machine actor attempts a `done` transition:
- the request returns **403** (`"issues can only be marked done by a human"`)
- the **owning human gets an `agent_done_blocked` inbox notification** (severity `attention`) prompting them to review the work and close the issue themselves

Other status changes by agents (`in_review`, `in_progress`, …) are unaffected — only the transition **into `done`** is gated.

## How

- Enforced **server-side** across `UpdateIssue`, `CreateIssue` (create-as-done) and `BatchUpdateIssues`, so it cannot be bypassed by calling the API directly instead of the CLI.
- Actor classification keys off the server-set `X-Actor-Source` header via a new `isMachineActor()` helper, extracted from and shared with the existing `RequireHumanActor` guard (infalsifiable — the auth middleware strips any client-supplied value).
- Notification recipient is `X-User-ID`, which for a machine credential is the **owning human** — exactly the person who should close the issue.
- The notification is intentionally **always delivered** (a policy signal), so it is left out of `notifTypeToGroup` (which would make it mutable).

## Tests

New `issue_done_guard_test.go` covers:
- machine actor blocked → 403, status unchanged, inbox row created
- human actor still allowed → 200
- machine actor non-`done` status → allowed
- policy off → machine actor allowed (default contract preserved)
- machine create-as-`done` → blocked

Verified: `go build ./...`, `go vet`, the new Go tests + `TestRequireHumanActor*`, `pnpm typecheck` (core + views), and the inbox Vitest suite all pass.

## Enabling

Set `MULTICA_REQUIRE_HUMAN_DONE=true` in the server environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)