### PR TITLE
fix(autopilot): fail no-progress issue runs

### DIFF
--- a/server/cmd/server/autopilot_listeners.go
+++ b/server/cmd/server/autopilot_listeners.go
@@ -68,8 +68,11 @@ func syncRunFromTaskEvent(ctx context.Context, svc *service.AutopilotService, e 
 	if err != nil {
 		return
 	}
-	if !task.AutopilotRunID.Valid {
+	if task.AutopilotRunID.Valid {
+		svc.SyncRunFromTask(ctx, task)
 		return
 	}
-	svc.SyncRunFromTask(ctx, task)
+	if e.Type == protocol.EventTaskFailed {
+		svc.SyncRunFromLinkedIssueTask(ctx, task)
+	}
 }

--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -122,6 +122,97 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 	}
 }
 
+func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Create-issue no-progress listener",
+		Description:        pgtype.Text{String: "VEN-661 regression test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{String: "No-progress issue", Valid: true},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	run, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if !run.IssueID.Valid {
+		t.Fatal("create_issue dispatch did not link an issue")
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, run.IssueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, run.IssueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, run.IssueID)
+	})
+
+	tasks, err := queries.ListTasksByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("ListTasksByIssue: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected one issue task, got %d", len(tasks))
+	}
+	taskID := tasks[0].ID
+	if tasks[0].AutopilotRunID.Valid {
+		t.Fatal("create_issue issue task unexpectedly has autopilot_run_id; test must exercise linked issue lookup")
+	}
+	if run.Status != "issue_created" {
+		t.Fatalf("expected pre-failure run status issue_created, got %q", run.Status)
+	}
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now(), max_attempts = 1 WHERE id = $1`,
+		taskID,
+	); err != nil {
+		t.Fatalf("mark task dispatched: %v", err)
+	}
+	task, err := queries.StartAgentTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("StartAgentTask: %v", err)
+	}
+
+	const errMsg = "codex app-server no progress timeout after 30s"
+	if _, err := taskSvc.FailTask(ctx, task.ID, errMsg, "", "", "codex_semantic_inactivity"); err != nil {
+		t.Fatalf("FailTask: %v", err)
+	}
+
+	updatedRun, err := queries.GetAutopilotRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updatedRun.Status != "failed" {
+		t.Fatalf("expected run status failed, got %q", updatedRun.Status)
+	}
+	if !updatedRun.FailureReason.Valid || !strings.Contains(updatedRun.FailureReason.String, "no progress timeout") {
+		t.Fatalf("expected no-progress failure reason, got %+v", updatedRun.FailureReason)
+	}
+}
+
 // TestAutopilotDispatchSkipsWhenRuntimeOffline locks in the MUL-1899
 // admission gate: when the assignee agent's runtime is not online we must
 // record a `skipped` autopilot_run with a failure_reason and NOT enqueue an

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -438,6 +438,83 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 	}
 }
 
+// SyncRunFromLinkedIssueTask closes a create_issue autopilot run when the
+// issue task fails before producing agent progress. create_issue tasks are
+// linked through issue_id rather than autopilot_run_id, so SyncRunFromTask
+// cannot see them directly.
+func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task db.AgentTaskQueue) {
+	if task.AutopilotRunID.Valid || !task.IssueID.Valid || task.Status != "failed" {
+		return
+	}
+	if !isNoProgressTaskFailure(task) {
+		return
+	}
+	hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+	if err != nil {
+		slog.Warn("failed to check active tasks for autopilot issue failure",
+			"issue_id", util.UUIDToString(task.IssueID),
+			"task_id", util.UUIDToString(task.ID),
+			"error", err,
+		)
+		return
+	}
+	if hasActive {
+		return
+	}
+
+	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
+	if err != nil || !issue.OriginType.Valid || issue.OriginType.String != "autopilot" {
+		return
+	}
+	run, err := s.Queries.GetAutopilotRunByIssue(ctx, issue.ID)
+	if err != nil {
+		return
+	}
+	autopilot, err := s.Queries.GetAutopilot(ctx, run.AutopilotID)
+	if err != nil {
+		return
+	}
+
+	reason := taskFailureReasonForAutopilotRun(task)
+	updatedRun, err := s.Queries.UpdateAutopilotRunFailed(ctx, db.UpdateAutopilotRunFailedParams{
+		ID:            run.ID,
+		FailureReason: pgtype.Text{String: reason, Valid: reason != ""},
+	})
+	if err != nil {
+		slog.Warn("failed to fail autopilot run from linked issue task",
+			"run_id", util.UUIDToString(run.ID),
+			"issue_id", util.UUIDToString(issue.ID),
+			"task_id", util.UUIDToString(task.ID),
+			"error", err,
+		)
+		return
+	}
+	s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
+	s.publishRunDone(util.UUIDToString(issue.WorkspaceID), updatedRun, "failed")
+}
+
+func isNoProgressTaskFailure(task db.AgentTaskQueue) bool {
+	if task.FailureReason.Valid && task.FailureReason.String == "codex_semantic_inactivity" {
+		return true
+	}
+	if !task.Error.Valid {
+		return false
+	}
+	errText := strings.ToLower(task.Error.String)
+	return strings.Contains(errText, "codex app-server no progress timeout") ||
+		strings.Contains(errText, "codex semantic inactivity timeout")
+}
+
+func taskFailureReasonForAutopilotRun(task db.AgentTaskQueue) string {
+	if task.Error.Valid && strings.TrimSpace(task.Error.String) != "" {
+		return task.Error.String
+	}
+	if task.FailureReason.Valid && strings.TrimSpace(task.FailureReason.String) != "" {
+		return task.FailureReason.String
+	}
+	return "task failed before agent progress"
+}
+
 // handleDispatchSkip recognises an errDispatchSkipped returned from a
 // dispatch function and rewrites the in-flight run to `skipped` (instead of
 // `failed`). Returns the updated run on a real skip, nil otherwise — callers

--- a/server/internal/service/autopilot_test.go
+++ b/server/internal/service/autopilot_test.go
@@ -26,6 +26,52 @@ func TestAutopilotErrorType(t *testing.T) {
 	}
 }
 
+func TestIsNoProgressTaskFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		task db.AgentTaskQueue
+		want bool
+	}{
+		{
+			name: "classified codex semantic inactivity",
+			task: db.AgentTaskQueue{
+				FailureReason: pgtype.Text{String: "codex_semantic_inactivity", Valid: true},
+			},
+			want: true,
+		},
+		{
+			name: "codex app-server no progress marker",
+			task: db.AgentTaskQueue{
+				Error: pgtype.Text{String: "codex app-server no progress timeout after 30s", Valid: true},
+			},
+			want: true,
+		},
+		{
+			name: "codex semantic inactivity marker",
+			task: db.AgentTaskQueue{
+				Error: pgtype.Text{String: "codex semantic inactivity timeout after 5m", Valid: true},
+			},
+			want: true,
+		},
+		{
+			name: "ordinary agent failure",
+			task: db.AgentTaskQueue{
+				FailureReason: pgtype.Text{String: "agent_error", Valid: true},
+				Error:         pgtype.Text{String: "tests failed", Valid: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNoProgressTaskFailure(tc.task); got != tc.want {
+				t.Fatalf("isNoProgressTaskFailure() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildIssueDescription_NoTriggerPayload(t *testing.T) {
 	s := &AutopilotService{}
 	ap := db.Autopilot{Description: pgtype.Text{String: "do the thing", Valid: true}}


### PR DESCRIPTION
VEN-661 / VEN-662

## Summary
- route failed create-issue autopilot issue tasks into linked run sync when they have no direct `autopilot_run_id`
- fail linked create-issue autopilot runs only for Codex no-progress / semantic-inactivity task failures
- wait when an active retry task still exists for the issue
- add pure classifier coverage and a DB-backed listener regression for the no-progress failure path

## Verification
- `go test ./internal/service -count=1`
- `go test ./cmd/server -count=1`
- `go test ./cmd/server -run TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun -count=1 -v` reported `ok`, but the DB-backed test was skipped because local Postgres was unreachable on localhost:5432

## Notes
- Direct push to `multica-ai/multica` failed because the current GitHub token has `READ` permission on the upstream repo. This PR is opened from the existing `stevenayl/multica` fork.
