### PR TITLE
fix(issues): confine inbox deep-link scroll to the timeline container (#3929)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -303,11 +303,14 @@ vi.mock("@multica/core/issues/stores", () => ({
 // compute a 0-height viewport and render nothing. The mock renders every item
 // inline so id="comment-..." nodes are always present in the DOM — this
 // matches the production cold-path where `initialItemCount` force-mounts
-// items[0..targetIdx], giving the native scrollIntoView a real target.
+// items[0..targetIdx], giving the deep-link effect a real target node.
 //
-// scrollIntoViewSpy: we spy on Element.prototype.scrollIntoView (jsdom no-ops
-// it by default) so tests can assert the deep-link effect dispatched a
-// native scroll on the target node.
+// scrollIntoViewSpy: the deep-link effect no longer calls native
+// scrollIntoView (it drives the timeline container's scrollTop directly to
+// avoid scrolling ancestor overflow:hidden boxes — see issue-detail.tsx). We
+// keep a no-op stub on the prototype so any stray scrollIntoView call from
+// other components doesn't throw; deep-link tests assert the highlight ring
+// instead, which is mechanism-independent and observable without layout.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("react-virtuoso", () => ({
@@ -317,7 +320,8 @@ vi.mock("react-virtuoso", () => ({
   ) {
     useImperativeHandle(ref, () => ({
       // Real Virtuoso ref methods are not exercised by tests in this file
-      // since the cold-path uses native scrollIntoView on the DOM node.
+      // since the deep-link cold-path drives the container's scrollTop on the
+      // real DOM node, not Virtuoso's imperative API.
       scrollIntoView: vi.fn(),
       scrollToIndex: vi.fn(),
     }));
@@ -974,22 +978,23 @@ describe("IssueDetail (shared)", () => {
         ).not.toBeNull();
       });
 
-      // The deep-link useLayoutEffect calls native scrollIntoView on the
-      // target node ({block: 'center'}).
+      // The deep-link effect lands on AND highlights the target comment: it
+      // drives the timeline container's scrollTop directly (jsdom has no
+      // layout, so the scroll itself isn't observable here) and applies the
+      // brand highlight ring. Assert the user-facing highlight.
       await waitFor(() => {
-        expect(scrollIntoViewSpy).toHaveBeenCalled();
+        expect(
+          document.getElementById("comment-comment-2")?.querySelector(".ring-2"),
+        ).not.toBeNull();
       });
-      expect(scrollIntoViewSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ block: "center" }),
-      );
     });
 
     it("still scrolls when the timeline is ready before the issue (regression for inbox click)", async () => {
       // Reproduces the inbox-click race: timeline data is in the cache
       // before the issue resolves. While loading is true, IssueDetail
-      // renders the loading skeleton (Virtuoso never mounts), so no
-      // scroll can fire. After the issue resolves, Virtuoso mounts and
-      // the useLayoutEffect dispatches the native scroll.
+      // renders the loading skeleton (the timeline never mounts), so no
+      // scroll/highlight can fire. After the issue resolves, the timeline
+      // mounts and the deep-link effect lands on + highlights the comment.
       let resolveIssue: (value: Issue) => void = () => {};
       const issuePromise = new Promise<Issue>((resolve) => {
         resolveIssue = resolve;
@@ -1001,7 +1006,8 @@ describe("IssueDetail (shared)", () => {
       expect(
         document.getElementById("comment-comment-2"),
       ).toBeNull();
-      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+      // Nothing highlighted while the loading skeleton is up.
+      expect(document.querySelector(".ring-2")).toBeNull();
 
       resolveIssue(mockIssue);
 
@@ -1011,9 +1017,9 @@ describe("IssueDetail (shared)", () => {
         ).not.toBeNull();
       });
       await waitFor(() => {
-        expect(scrollIntoViewSpy).toHaveBeenCalledWith(
-          expect.objectContaining({ block: "center" }),
-        );
+        expect(
+          document.getElementById("comment-comment-2")?.querySelector(".ring-2"),
+        ).not.toBeNull();
       });
     });
 
@@ -1061,16 +1067,18 @@ describe("IssueDetail (shared)", () => {
       );
 
       // After expansion, the reply must appear in the DOM (inside the now
-      // -unfolded CommentCard) and the deep-link effect must scroll to it.
+      // -unfolded CommentCard) and the deep-link effect must land on + highlight
+      // it. The reply highlight renders as a bg tint on its row (see
+      // CommentCard's reply branch), so assert the row carries the brand tint.
       await waitFor(() => {
         expect(
           document.getElementById("comment-reply-1"),
         ).not.toBeNull();
       });
       await waitFor(() => {
-        expect(scrollIntoViewSpy).toHaveBeenCalledWith(
-          expect.objectContaining({ block: "center" }),
-        );
+        expect(
+          document.getElementById("comment-reply-1")?.className,
+        ).toMatch(/bg-brand/);
       });
     });
   });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1096,14 +1096,48 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
 
     const el = document.getElementById(`comment-${highlightCommentId}`);
-    if (!el) return;
+    const container = scrollContainerEl;
+    if (!el || !container) return;
 
     didHighlightRef.current = highlightCommentId;
-    el.scrollIntoView({ block: "center" });
+
+    // Center the target comment WITHIN its own scroll container by driving the
+    // container's scrollTop directly — never native scrollIntoView. Native
+    // scrollIntoView is spec'd to scroll EVERY scrollable ancestor: on a cold
+    // mount where the timeline is still growing (streaming agent), the inner
+    // scroller can't satisfy centering on its own, so the scroll propagates up
+    // and moves the desktop shell's `overflow:hidden` wrapper — shoving the
+    // whole page, header included, off the top with no scrollbar to recover,
+    // until a resize reflows it (#3929). Scoping the scroll to `container`
+    // keeps it contained; re-centering across frames lands the comment
+    // precisely once async heights (markdown, code highlight, streamed replies)
+    // settle, instead of leaning on the ancestor scroll the way native did.
+    let rafId = 0;
+    let frames = 0;
+    let last = -1;
+    const center = () => {
+      const c = container.getBoundingClientRect();
+      const e = el.getBoundingClientRect();
+      const target = Math.max(
+        0,
+        container.scrollTop + (e.top - c.top) - (container.clientHeight - e.height) / 2,
+      );
+      container.scrollTop = target;
+      // Content is still laying out → the centered offset keeps shifting; keep
+      // re-centering until it stabilizes (within 1px) or we hit ~0.5s of frames.
+      if (Math.abs(target - last) > 1 && ++frames < 30) {
+        last = target;
+        rafId = requestAnimationFrame(center);
+      }
+    };
+    rafId = requestAnimationFrame(center);
 
     setHighlightedId(highlightCommentId);
     const fade = window.setTimeout(() => setHighlightedId(null), 2500);
-    return () => clearTimeout(fade);
+    return () => {
+      cancelAnimationFrame(rafId);
+      clearTimeout(fade);
+    };
   }, [highlightCommentId, items, targetIdx, scrollContainerEl, replyToRoot, toggleResolvedExpand]);
 
   // Cmd-F / Ctrl-F on a virtualized timeline only searches what's mounted in


### PR DESCRIPTION
Fixes #3929.

## Symptom

On desktop, opening an inbox comment notification for an issue that has a **running agent** shoved the entire page — title bar included — off the top. Scrolling the content didn't help; only clicking the right sidebar open and closed again restored it.

## Root cause

The deep-link landing calls native `scrollIntoView({ block: "center" })` on the target comment (`issue-detail.tsx`). Native `scrollIntoView` is spec'd to scroll **every** scrollable ancestor. When all of these line up:

- **is-working** — the timeline is still streaming/growing,
- **deep-link cold mount** — heights not settled,
- **right sidebar collapsed** — the panel group's first layout isn't stable,

the inner timeline scroller can't center the target on its own, so the scroll **propagates up** and scrolls the desktop shell's `overflow:hidden` wrapper (`desktop-layout.tsx`). That wrapper has no scrollbar and doesn't auto-clamp, so the page stays shoved up until a resize (the sidebar toggle) reflows it.

Desktop-only: web renders the same page in a document-scroll context with a real scrollbar that self-corrects.

## Fix

Drive the timeline container's `scrollTop` directly and re-center across `requestAnimationFrame` frames until async heights settle, instead of leaning on the ancestor scroll. The scroll never touches an ancestor, so the header can no longer be pushed off-screen, and the comment still lands centered once the streaming content settles.

## Tests

The 3 deep-link tests now assert the user-facing contract (lands on + highlights the target comment) rather than the scroll mechanism, which jsdom can't lay out. All 24 tests in the file pass.

## Note (out of scope)

Two other `scrollIntoView` call sites have the same latent ancestor-propagation risk and may want the same treatment later: `agent-transcript-dialog.tsx` and `chat-message-list.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)