### PR TITLE
fix(autopilot): fail create-issue runs on any terminal task failure (MUL-3164)

### DIFF
--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -122,7 +122,22 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 	}
 }
 
-func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
+// linkedIssueAutopilotFixture is the starting state every create_issue
+// linked-issue listener test shares: a dispatched create_issue run sitting in
+// issue_created with exactly one issue task that carries no autopilot_run_id
+// (so it must be reached via the issue_id lookup, not SyncRunFromTask).
+type linkedIssueAutopilotFixture struct {
+	taskSvc *service.TaskService
+	queries *db.Queries
+	run     *db.AutopilotRun
+	taskID  pgtype.UUID
+}
+
+// dispatchCreateIssueAutopilot creates an active create_issue autopilot,
+// dispatches it, and returns the linked run plus its single issue task.
+// Cleanup (autopilot, issue, tasks, comments) is registered on t.
+func dispatchCreateIssueAutopilot(t *testing.T, title string) linkedIssueAutopilotFixture {
+	t.Helper()
 	ctx := context.Background()
 	queries := db.New(testPool)
 	bus := events.New()
@@ -140,13 +155,13 @@ func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
 
 	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
 		WorkspaceID:        parseUUID(testWorkspaceID),
-		Title:              "Create-issue no-progress listener",
-		Description:        pgtype.Text{String: "VEN-661 regression test", Valid: true},
+		Title:              title,
+		Description:        pgtype.Text{String: "VEN-661 / VEN-662 regression test", Valid: true},
 		AssigneeType:       "agent",
 		AssigneeID:         parseUUID(agentID),
 		Status:             "active",
 		ExecutionMode:      "create_issue",
-		IssueTitleTemplate: pgtype.Text{String: "No-progress issue", Valid: true},
+		IssueTitleTemplate: pgtype.Text{String: "Linked issue", Valid: true},
 		CreatedByType:      "member",
 		CreatedByID:        parseUUID(testUserID),
 	})
@@ -177,7 +192,6 @@ func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
 	if len(tasks) != 1 {
 		t.Fatalf("expected one issue task, got %d", len(tasks))
 	}
-	taskID := tasks[0].ID
 	if tasks[0].AutopilotRunID.Valid {
 		t.Fatal("create_issue issue task unexpectedly has autopilot_run_id; test must exercise linked issue lookup")
 	}
@@ -185,23 +199,42 @@ func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
 		t.Fatalf("expected pre-failure run status issue_created, got %q", run.Status)
 	}
 
-	if _, err := testPool.Exec(ctx,
-		`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now(), max_attempts = 1 WHERE id = $1`,
-		taskID,
+	return linkedIssueAutopilotFixture{taskSvc: taskSvc, queries: queries, run: run, taskID: tasks[0].ID}
+}
+
+// runTaskWithBudget marks the issue task dispatched with the given attempt
+// budget and transitions it to running, mirroring the daemon claim → start
+// flow so FailTask sees a realistic row (and so the auto-retry budget is
+// whatever the test wants).
+func runTaskWithBudget(t *testing.T, queries *db.Queries, taskID pgtype.UUID, maxAttempts int) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now(), max_attempts = $2 WHERE id = $1`,
+		taskID, maxAttempts,
 	); err != nil {
 		t.Fatalf("mark task dispatched: %v", err)
 	}
-	task, err := queries.StartAgentTask(ctx, taskID)
-	if err != nil {
+	if _, err := queries.StartAgentTask(context.Background(), taskID); err != nil {
 		t.Fatalf("StartAgentTask: %v", err)
 	}
+}
+
+// TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun is the original
+// VEN-661 regression: a Codex no-progress failure with no retries left fails
+// the linked run.
+func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
+	ctx := context.Background()
+	f := dispatchCreateIssueAutopilot(t, "Create-issue no-progress listener")
+
+	// max_attempts = 1 means the failed attempt has no retry budget left.
+	runTaskWithBudget(t, f.queries, f.taskID, 1)
 
 	const errMsg = "codex app-server no progress timeout after 30s"
-	if _, err := taskSvc.FailTask(ctx, task.ID, errMsg, "", "", "codex_semantic_inactivity"); err != nil {
+	if _, err := f.taskSvc.FailTask(ctx, f.taskID, errMsg, "", "", "codex_semantic_inactivity"); err != nil {
 		t.Fatalf("FailTask: %v", err)
 	}
 
-	updatedRun, err := queries.GetAutopilotRun(ctx, run.ID)
+	updatedRun, err := f.queries.GetAutopilotRun(ctx, f.run.ID)
 	if err != nil {
 		t.Fatalf("GetAutopilotRun: %v", err)
 	}
@@ -210,6 +243,68 @@ func TestAutopilotCreateIssueTaskNoProgressFailureUpdatesRun(t *testing.T) {
 	}
 	if !updatedRun.FailureReason.Valid || !strings.Contains(updatedRun.FailureReason.String, "no progress timeout") {
 		t.Fatalf("expected no-progress failure reason, got %+v", updatedRun.FailureReason)
+	}
+}
+
+// TestAutopilotCreateIssueTaskAgentErrorFailureUpdatesRun covers the VEN-662
+// generalization: an ordinary, non-retryable agent failure must also close the
+// linked run instead of leaving it stuck in issue_created.
+func TestAutopilotCreateIssueTaskAgentErrorFailureUpdatesRun(t *testing.T) {
+	ctx := context.Background()
+	f := dispatchCreateIssueAutopilot(t, "Create-issue agent-error listener")
+
+	runTaskWithBudget(t, f.queries, f.taskID, 1)
+
+	// agent_error is not in retryableReasons, so the first terminal failure is
+	// final — the run must fail carrying the agent's error text.
+	const errMsg = "build failed: ./pkg/foo: undefined: Bar"
+	if _, err := f.taskSvc.FailTask(ctx, f.taskID, errMsg, "", "", "agent_error"); err != nil {
+		t.Fatalf("FailTask: %v", err)
+	}
+
+	updatedRun, err := f.queries.GetAutopilotRun(ctx, f.run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updatedRun.Status != "failed" {
+		t.Fatalf("expected run status failed, got %q", updatedRun.Status)
+	}
+	if !updatedRun.FailureReason.Valid || !strings.Contains(updatedRun.FailureReason.String, "build failed") {
+		t.Fatalf("expected agent-error failure reason, got %+v", updatedRun.FailureReason)
+	}
+}
+
+// TestAutopilotCreateIssueTaskRetryPendingKeepsRunOpen locks in the wait guard:
+// when FailTask auto-retries a retryable failure (attempt budget remaining), an
+// active retry task still exists for the issue, so the run must stay open until
+// the final attempt resolves.
+func TestAutopilotCreateIssueTaskRetryPendingKeepsRunOpen(t *testing.T) {
+	ctx := context.Background()
+	f := dispatchCreateIssueAutopilot(t, "Create-issue retry-pending listener")
+
+	// max_attempts = 2 with attempt = 1 leaves budget for one auto-retry.
+	runTaskWithBudget(t, f.queries, f.taskID, 2)
+
+	// timeout is retryable, so FailTask enqueues a fresh attempt before it
+	// broadcasts the failure event.
+	if _, err := f.taskSvc.FailTask(ctx, f.taskID, "runtime went offline", "", "", "timeout"); err != nil {
+		t.Fatalf("FailTask: %v", err)
+	}
+
+	hasActive, err := f.queries.HasActiveTaskForIssue(ctx, f.run.IssueID)
+	if err != nil {
+		t.Fatalf("HasActiveTaskForIssue: %v", err)
+	}
+	if !hasActive {
+		t.Fatal("expected an active retry task for the issue after a retryable failure")
+	}
+
+	updatedRun, err := f.queries.GetAutopilotRun(ctx, f.run.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotRun: %v", err)
+	}
+	if updatedRun.Status != "issue_created" {
+		t.Fatalf("expected run to stay issue_created while a retry is pending, got %q", updatedRun.Status)
 	}
 }
 

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -438,17 +438,34 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 	}
 }
 
-// SyncRunFromLinkedIssueTask closes a create_issue autopilot run when the
-// issue task fails before producing agent progress. create_issue tasks are
-// linked through issue_id rather than autopilot_run_id, so SyncRunFromTask
-// cannot see them directly.
+// SyncRunFromLinkedIssueTask fails a create_issue autopilot run when its
+// linked issue task fails terminally before the issue itself reaches a
+// terminal status. create_issue tasks are linked through issue_id rather than
+// autopilot_run_id, so SyncRunFromTask cannot see them directly. Without this
+// the run would hang in `issue_created` forever — and because the failure-rate
+// auto-pause monitor excludes issue_created/running runs, a consistently
+// failing autopilot would never trip the auto-pause either.
+//
+// "Terminal" means no task is still active for the issue. FailTask enqueues an
+// auto-retry for infra-shaped failures (timeout, runtime offline/recovery,
+// codex no-progress) BEFORE it broadcasts the failure event, so an active task
+// here means another attempt is already in flight — we wait for it instead of
+// failing the run prematurely. Once retries are exhausted (or the failure was
+// never retryable in the first place), the run fails carrying the task's reason.
 func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task db.AgentTaskQueue) {
 	if task.AutopilotRunID.Valid || !task.IssueID.Valid || task.Status != "failed" {
 		return
 	}
-	if !isNoProgressTaskFailure(task) {
-		return
+	// Only create_issue runs link through issue_id (and their linked issue is
+	// always origin_type=autopilot by construction), so a hit here both
+	// identifies an in-flight create_issue run and bails the common case of
+	// ordinary issue/chat task failures after a single query.
+	run, err := s.Queries.GetAutopilotRunByIssue(ctx, task.IssueID)
+	if err != nil {
+		return // no active run linked to this issue
 	}
+	// A still-active task — typically the auto-retry FailTask just enqueued —
+	// means the dispatch isn't terminal yet; wait for the final attempt.
 	hasActive, err := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
 	if err != nil {
 		slog.Warn("failed to check active tasks for autopilot issue failure",
@@ -459,15 +476,6 @@ func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task 
 		return
 	}
 	if hasActive {
-		return
-	}
-
-	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
-	if err != nil || !issue.OriginType.Valid || issue.OriginType.String != "autopilot" {
-		return
-	}
-	run, err := s.Queries.GetAutopilotRunByIssue(ctx, issue.ID)
-	if err != nil {
 		return
 	}
 	autopilot, err := s.Queries.GetAutopilot(ctx, run.AutopilotID)
@@ -483,26 +491,14 @@ func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task 
 	if err != nil {
 		slog.Warn("failed to fail autopilot run from linked issue task",
 			"run_id", util.UUIDToString(run.ID),
-			"issue_id", util.UUIDToString(issue.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
 			"task_id", util.UUIDToString(task.ID),
 			"error", err,
 		)
 		return
 	}
 	s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
-	s.publishRunDone(util.UUIDToString(issue.WorkspaceID), updatedRun, "failed")
-}
-
-func isNoProgressTaskFailure(task db.AgentTaskQueue) bool {
-	if task.FailureReason.Valid && task.FailureReason.String == "codex_semantic_inactivity" {
-		return true
-	}
-	if !task.Error.Valid {
-		return false
-	}
-	errText := strings.ToLower(task.Error.String)
-	return strings.Contains(errText, "codex app-server no progress timeout") ||
-		strings.Contains(errText, "codex semantic inactivity timeout")
+	s.publishRunDone(util.UUIDToString(autopilot.WorkspaceID), updatedRun, "failed")
 }
 
 func taskFailureReasonForAutopilotRun(task db.AgentTaskQueue) string {
@@ -512,7 +508,7 @@ func taskFailureReasonForAutopilotRun(task db.AgentTaskQueue) string {
 	if task.FailureReason.Valid && strings.TrimSpace(task.FailureReason.String) != "" {
 		return task.FailureReason.String
 	}
-	return "task failed before agent progress"
+	return "task failed"
 }
 
 // handleDispatchSkip recognises an errDispatchSkipped returned from a

--- a/server/internal/service/autopilot_test.go
+++ b/server/internal/service/autopilot_test.go
@@ -26,47 +26,39 @@ func TestAutopilotErrorType(t *testing.T) {
 	}
 }
 
-func TestIsNoProgressTaskFailure(t *testing.T) {
+func TestTaskFailureReasonForAutopilotRun(t *testing.T) {
 	cases := []struct {
 		name string
 		task db.AgentTaskQueue
-		want bool
+		want string
 	}{
 		{
-			name: "classified codex semantic inactivity",
+			name: "prefers raw error text",
 			task: db.AgentTaskQueue{
+				Error:         pgtype.Text{String: "tests failed", Valid: true},
+				FailureReason: pgtype.Text{String: "agent_error", Valid: true},
+			},
+			want: "tests failed",
+		},
+		{
+			name: "falls back to classified reason when error is blank",
+			task: db.AgentTaskQueue{
+				Error:         pgtype.Text{String: "   ", Valid: true},
 				FailureReason: pgtype.Text{String: "codex_semantic_inactivity", Valid: true},
 			},
-			want: true,
+			want: "codex_semantic_inactivity",
 		},
 		{
-			name: "codex app-server no progress marker",
-			task: db.AgentTaskQueue{
-				Error: pgtype.Text{String: "codex app-server no progress timeout after 30s", Valid: true},
-			},
-			want: true,
-		},
-		{
-			name: "codex semantic inactivity marker",
-			task: db.AgentTaskQueue{
-				Error: pgtype.Text{String: "codex semantic inactivity timeout after 5m", Valid: true},
-			},
-			want: true,
-		},
-		{
-			name: "ordinary agent failure",
-			task: db.AgentTaskQueue{
-				FailureReason: pgtype.Text{String: "agent_error", Valid: true},
-				Error:         pgtype.Text{String: "tests failed", Valid: true},
-			},
-			want: false,
+			name: "generic default when nothing is set",
+			task: db.AgentTaskQueue{},
+			want: "task failed",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isNoProgressTaskFailure(tc.task); got != tc.want {
-				t.Fatalf("isNoProgressTaskFailure() = %v, want %v", got, tc.want)
+			if got := taskFailureReasonForAutopilotRun(tc.task); got != tc.want {
+				t.Fatalf("taskFailureReasonForAutopilotRun() = %q, want %q", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
VEN-661 / VEN-662 / MUL-3164

Follow-up to #3927.

## Summary
- Generalize `SyncRunFromLinkedIssueTask` beyond Codex no-progress: **any** terminal create-issue task failure now fails the linked autopilot run, so it can no longer hang in `issue_created`. Because the failure-rate auto-pause monitor (`SelectAutopilotsExceedingFailureThreshold`) excludes `issue_created`/`running` runs, a consistently-failing autopilot would otherwise never trip auto-pause.
- The wait-for-retry guard is unchanged in spirit and now does the heavy lifting for all failures: `FailTask` enqueues an auto-retry (for retryable, infra-shaped reasons) *before* broadcasting the failure event, so an active task on the issue means another attempt is in flight and we wait. The run only fails once retries are exhausted (or the failure was never retryable).

## Review nits from #3927
- Removed the `isNoProgressTaskFailure` classifier, which duplicated the `pkg/agent` marker strings — generalizing subsumes it, so there is nothing left to drift.
- Dropped the redundant `GetIssue`/origin-type lookup: the linked issue of a create-issue run is always `origin_type=autopilot` by construction. `GetAutopilotRunByIssue` now leads and short-circuits the common case (ordinary issue/chat task failures) in a single query; `WorkspaceID` comes from the autopilot row.

## Behavior (before → after)
- **Before:** only Codex no-progress / semantic-inactivity failures closed a stuck create-issue run; an `agent_error`, `iteration_limit`, `api_invalid_request`, or exhausted-retry `timeout`/`runtime_offline` left the run pinned at `issue_created` indefinitely and invisible to auto-pause.
- **After:** every terminal task failure (no retry pending) closes the run with the task's failure reason.

## Tests
- Keep the no-progress regression.
- Add an `agent_error` (non-retryable) case proving an ordinary failure now fails the run.
- Add a retry-pending case proving the run stays `issue_created` while an auto-retry is in flight.
- Replace the deleted classifier's unit test with one for `taskFailureReasonForAutopilotRun`.

## Verification
- `go build ./...`, `go vet ./internal/service ./cmd/server`, and the pure `internal/service` unit tests pass locally. The DB-backed listener tests run in CI (local Postgres unavailable).
