### PR TITLE
fix(agents): center avatar images in picker with object-center

### DIFF
--- a/packages/views/agents/components/avatar-picker.tsx
+++ b/packages/views/agents/components/avatar-picker.tsx
@@ -88,7 +88,7 @@ export function AvatarPicker({ value, onChange, size = 56 }: AvatarPickerProps) 
           <img
             src={resolvePublicFileUrl(value) ?? undefined}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full object-cover object-center"
             onError={() => setPreviewError(true)}
           />
         ) : (


### PR DESCRIPTION
Fix: Center avatar images in picker to avoid off-center cropping

Closes #3789

Problem
When users upload non-square images (landscape/portrait) as agent avatars, the preview is cropped from the top-left corner instead of the center, making the subject appear off-center or cut off.

Root Cause
The img tag in AvatarPicker had object-cover but no object-center, so browsers default to object-position: 0% 0% (top-left).

Solution
Add object-center (Tailwind for object-position: center) to centre the crop.

Changes
- packages/views/agents/components/avatar-picker.tsx: added object-center class

Testing
- Landscape image (1920x1080) -> centred crop
- Portrait image (1080x1920) -> centred crop
- Square image (512x512) -> unchanged
- Clear and re-upload -> consistent behaviour

Risk
Low — CSS-only change, affects only the avatar picker preview.