### PR TITLE
feat(transcript): add timestamps to run transcript entries (MUL-3174)

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -306,6 +306,7 @@ export const TaskMessagePayloadSchema: z.ZodType<TaskMessagePayload> = z.object(
   content: z.string().optional(),
   input: z.record(z.string(), z.unknown()).optional(),
   output: z.string().optional(),
+  created_at: z.string().optional(),
 }).loose();
 
 export const TaskMessageListSchema = z.array(TaskMessagePayloadSchema).default([]);

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -64,6 +64,7 @@ export interface ChatTimelineItem {
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  created_at?: string;
 }
 
 export interface ChatState {

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -223,6 +223,7 @@ export interface TaskMessagePayload {
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  created_at?: string;
 }
 
 export interface TaskQueuedPayload {

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -729,6 +729,10 @@ const TranscriptEventRow = ({
   const color = getEventColor(item);
   const label = getEventLabel(item);
   const summary = getEventSummary(item);
+  const date = useMemo(
+    () => (item.created_at ? new Date(item.created_at) : null),
+    [item.created_at],
+  );
 
   const hasDetail =
     (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
@@ -787,9 +791,9 @@ const TranscriptEventRow = ({
           </span>
 
           {/* Timestamp */}
-          {item.created_at && (
-            <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1" title={new Date(item.created_at).toLocaleString()}>
-              {new Date(item.created_at).toLocaleTimeString(undefined, {
+          {date && (
+            <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1" title={date.toLocaleString()}>
+              {date.toLocaleTimeString(undefined, {
                 hour: "2-digit",
                 minute: "2-digit",
                 second: "2-digit",

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -785,6 +785,17 @@ const TranscriptEventRow = ({
           <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1">
             #{item.seq}
           </span>
+
+          {/* Timestamp */}
+          {item.created_at && (
+            <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1" title={new Date(item.created_at).toLocaleString()}>
+              {new Date(item.created_at).toLocaleTimeString(undefined, {
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+              })}
+            </span>
+          )}
         </div>
 
         {/* Expanded detail */}

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -27,6 +27,7 @@ export function coalesceTimelineItems(items: TimelineItem[]): TimelineItem[] {
       out[out.length - 1] = {
         ...prev,
         content: `${prev.content ?? ""}${item.content ?? ""}`,
+        created_at: item.created_at ?? prev.created_at,
       };
       continue;
     }

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -9,6 +9,7 @@ export interface TimelineItem {
   content?: string;
   input?: Record<string, unknown>;
   output?: string;
+  created_at?: string;
 }
 
 function canMergeStreamingText(prev: TimelineItem, next: TimelineItem): boolean {
@@ -58,6 +59,7 @@ export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
       content: msg.content,
       input: msg.input,
       output: msg.output,
+      created_at: msg.created_at,
     });
   }
   return redactTimelineItems(coalesceTimelineItems(items));

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2089,10 +2089,15 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 			Input:   inputJSON,
 			Output:  pgtype.Text{String: msg.Output, Valid: msg.Output != ""},
 		})
+		if createErr != nil {
+			slog.Error("failed to create task message", "task_id", taskID, "seq", msg.Seq, "error", createErr)
+			writeError(w, http.StatusInternalServerError, "failed to persist task message")
+			return
+		}
 
 		if workspaceID != "" {
 			createdAt := ""
-			if createErr == nil && created.CreatedAt.Valid {
+			if created.CreatedAt.Valid {
 				createdAt = created.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
 			}
 			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID, protocol.TaskMessagePayload{
@@ -2110,6 +2115,28 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func taskMessageToPayload(m db.TaskMessage, taskID, issueID string) protocol.TaskMessagePayload {
+	var input map[string]any
+	if m.Input != nil {
+		json.Unmarshal(m.Input, &input)
+	}
+	createdAt := ""
+	if m.CreatedAt.Valid {
+		createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+	}
+	return protocol.TaskMessagePayload{
+		TaskID:    taskID,
+		IssueID:   issueID,
+		Seq:       int(m.Seq),
+		Type:      m.Type,
+		Tool:      m.Tool.String,
+		Content:   m.Content.String,
+		Input:     input,
+		Output:    m.Output.String,
+		CreatedAt: createdAt,
+	}
 }
 
 // ListTaskMessages returns the persisted messages for a task (for catch-up after reconnect).
@@ -2148,25 +2175,7 @@ func (h *Handler) ListTaskMessages(w http.ResponseWriter, r *http.Request) {
 
 	resp := make([]protocol.TaskMessagePayload, len(messages))
 	for i, m := range messages {
-		var input map[string]any
-		if m.Input != nil {
-			json.Unmarshal(m.Input, &input)
-		}
-		createdAt := ""
-		if m.CreatedAt.Valid {
-			createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
-		}
-		resp[i] = protocol.TaskMessagePayload{
-			TaskID:    taskID,
-			IssueID:   issueID,
-			Seq:       int(m.Seq),
-			Type:      m.Type,
-			Tool:      m.Tool.String,
-			Content:   m.Content.String,
-			Input:     input,
-			Output:    m.Output.String,
-			CreatedAt: createdAt,
-		}
+		resp[i] = taskMessageToPayload(m, taskID, issueID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -2296,25 +2305,7 @@ func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request)
 
 	resp := make([]protocol.TaskMessagePayload, len(messages))
 	for i, m := range messages {
-		var input map[string]any
-		if m.Input != nil {
-			json.Unmarshal(m.Input, &input)
-		}
-		createdAt := ""
-		if m.CreatedAt.Valid {
-			createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
-		}
-		resp[i] = protocol.TaskMessagePayload{
-			TaskID:    taskID,
-			IssueID:   issueID,
-			Seq:       int(m.Seq),
-			Type:      m.Type,
-			Tool:      m.Tool.String,
-			Content:   m.Content.String,
-			Input:     input,
-			Output:    m.Output.String,
-			CreatedAt: createdAt,
-		}
+		resp[i] = taskMessageToPayload(m, taskID, issueID)
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2080,7 +2080,7 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		if msg.Input != nil {
 			inputJSON, _ = json.Marshal(msg.Input)
 		}
-		h.Queries.CreateTaskMessage(r.Context(), db.CreateTaskMessageParams{
+		created, createErr := h.Queries.CreateTaskMessage(r.Context(), db.CreateTaskMessageParams{
 			TaskID:  parseUUID(taskID),
 			Seq:     int32(msg.Seq),
 			Type:    msg.Type,
@@ -2091,15 +2091,20 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		})
 
 		if workspaceID != "" {
+			createdAt := ""
+			if createErr == nil && created.CreatedAt.Valid {
+				createdAt = created.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+			}
 			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID, protocol.TaskMessagePayload{
-				TaskID:  taskID,
-				IssueID: uuidToString(task.IssueID),
-				Seq:     msg.Seq,
-				Type:    msg.Type,
-				Tool:    msg.Tool,
-				Content: msg.Content,
-				Input:   msg.Input,
-				Output:  msg.Output,
+				TaskID:    taskID,
+				IssueID:   uuidToString(task.IssueID),
+				Seq:       msg.Seq,
+				Type:      msg.Type,
+				Tool:      msg.Tool,
+				Content:   msg.Content,
+				Input:     msg.Input,
+				Output:    msg.Output,
+				CreatedAt: createdAt,
 			})
 		}
 	}
@@ -2147,15 +2152,20 @@ func (h *Handler) ListTaskMessages(w http.ResponseWriter, r *http.Request) {
 		if m.Input != nil {
 			json.Unmarshal(m.Input, &input)
 		}
+		createdAt := ""
+		if m.CreatedAt.Valid {
+			createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+		}
 		resp[i] = protocol.TaskMessagePayload{
-			TaskID:  taskID,
-			IssueID: issueID,
-			Seq:     int(m.Seq),
-			Type:    m.Type,
-			Tool:    m.Tool.String,
-			Content: m.Content.String,
-			Input:   input,
-			Output:  m.Output.String,
+			TaskID:    taskID,
+			IssueID:   issueID,
+			Seq:       int(m.Seq),
+			Type:      m.Type,
+			Tool:      m.Tool.String,
+			Content:   m.Content.String,
+			Input:     input,
+			Output:    m.Output.String,
+			CreatedAt: createdAt,
 		}
 	}
 
@@ -2290,15 +2300,20 @@ func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request)
 		if m.Input != nil {
 			json.Unmarshal(m.Input, &input)
 		}
+		createdAt := ""
+		if m.CreatedAt.Valid {
+			createdAt = m.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+		}
 		resp[i] = protocol.TaskMessagePayload{
-			TaskID:  taskID,
-			IssueID: issueID,
-			Seq:     int(m.Seq),
-			Type:    m.Type,
-			Tool:    m.Tool.String,
-			Content: m.Content.String,
-			Input:   input,
-			Output:  m.Output.String,
+			TaskID:    taskID,
+			IssueID:   issueID,
+			Seq:       int(m.Seq),
+			Type:      m.Type,
+			Tool:      m.Tool.String,
+			Content:   m.Content.String,
+			Input:     input,
+			Output:    m.Output.String,
+			CreatedAt: createdAt,
 		}
 	}
 

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -40,14 +40,15 @@ type TaskCompletedPayload struct {
 
 // TaskMessagePayload represents a single agent execution message (tool call, text, etc.)
 type TaskMessagePayload struct {
-	TaskID  string         `json:"task_id"`
-	IssueID string         `json:"issue_id,omitempty"`
-	Seq     int            `json:"seq"`
-	Type    string         `json:"type"`              // "text", "tool_use", "tool_result", "error"
-	Tool    string         `json:"tool,omitempty"`    // tool name for tool_use/tool_result
-	Content string         `json:"content,omitempty"` // text content
-	Input   map[string]any `json:"input,omitempty"`   // tool input (tool_use only)
-	Output  string         `json:"output,omitempty"`  // tool output (tool_result only)
+	TaskID    string         `json:"task_id"`
+	IssueID   string         `json:"issue_id,omitempty"`
+	Seq       int            `json:"seq"`
+	Type      string         `json:"type"`              // "text", "tool_use", "tool_result", "error"
+	Tool      string         `json:"tool,omitempty"`    // tool name for tool_use/tool_result
+	Content   string         `json:"content,omitempty"` // text content
+	Input     map[string]any `json:"input,omitempty"`   // tool input (tool_use only)
+	Output    string         `json:"output,omitempty"`  // tool output (tool_result only)
+	CreatedAt string         `json:"created_at,omitempty"`
 }
 
 // DaemonRegisterPayload is sent from daemon to server on connection.


### PR DESCRIPTION
## What does this PR do?

Adds per-entry timestamps to the agent run transcript so users can identify stalled runs at a glance and manually stop them.

The `task_message.created_at` column already existed in the database — it was just stripped at every layer before reaching the frontend. This change threads it through the full stack: Go wire payload → REST/WS handlers → TypeScript types → transcript dialog UI.

## Related Issue


## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Backend (Go)
- `server/pkg/protocol/messages.go` — added `CreatedAt` field to `TaskMessagePayload`
- `server/internal/handler/daemon.go` — `ReportTaskMessages` captures DB-returned timestamp for WS broadcast; `ListTaskMessages` and `ListTaskMessagesByUser` populate `CreatedAt` from DB rows; extracted `taskMessageToPayload()` helper to deduplicate mapping; returns 500 on DB insert failure instead of silently continuing with empty `created_at`

### Frontend (TypeScript)
- `packages/core/types/events.ts` — added `created_at?: string` to `TaskMessagePayload`
- `packages/core/chat/store.ts` — added `created_at?: string` to `ChatTimelineItem`
- `packages/views/common/task-transcript/build-timeline.ts` — passes `created_at` through to `TimelineItem`; coalescing carries latest timestamp (`item.created_at ?? prev.created_at`) so merged rows reflect the most recent activity
- `packages/views/common/task-transcript/agent-transcript-dialog.tsx` — each event row shows `HH:MM:SS` next to `#seq`, with full datetime on hover tooltip; `Date` construction memoized via `useMemo`

### Mobile
- `apps/mobile/data/schemas.ts` — added `created_at: z.string().optional()` to `TaskMessagePayloadSchema`

## How to Test

1. Start a task that produces transcript entries (any agent run)
2. Open the transcript dialog (click the transcript icon on the task)
3. Verify each event row shows a timestamp (HH:MM:SS) next to the `#seq` number
4. Hover over the timestamp to see the full datetime
5. Verify timestamps adapt to locale automatically

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against conventions
- [ ] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Feature request: "Add timestamp to entries in run transcript. To know if a run is stalled and we can manually stop." Implemented by threading the existing `task_message.created_at` column through the full stack. Code review addressed 5 points (coalescing timestamps, error handling, deduplication, mobile schema, date memoization).

## Screenshots (optional)
Before
<img width="1230" height="337" alt="image" src="https://github.com/user-attachments/assets/8d9b062e-81cf-447d-992b-6e4a53189ce9" />

After
<img width="1230" height="337" alt="image" src="https://github.com/user-attachments/assets/971fcde2-aa34-447c-921d-8050f5066e18" />
