### PR TITLE
refactor(transcript): reuse payload helper + cover coalesce timestamps (MUL-3174)

### DIFF
--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -76,4 +76,29 @@ describe("task transcript timeline", () => {
     expect(items[0]?.content).not.toContain("abc123xyz");
     expect(items[0]?.content).not.toContain("def456");
   });
+
+  it("keeps the latest created_at when coalescing streaming fragments", () => {
+    const items = coalesceTimelineItems([
+      { seq: 1, type: "text", content: "hello ", created_at: "2026-06-09T09:00:00.000Z" },
+      { seq: 2, type: "text", content: "world", created_at: "2026-06-09T09:00:05.000Z" },
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        seq: 1,
+        type: "text",
+        content: "hello world",
+        created_at: "2026-06-09T09:00:05.000Z",
+      }),
+    ]);
+  });
+
+  it("falls back to the previous created_at when the merged fragment has none", () => {
+    const items = coalesceTimelineItems([
+      { seq: 1, type: "text", content: "hello ", created_at: "2026-06-09T09:00:00.000Z" },
+      { seq: 2, type: "text", content: "world" },
+    ]);
+
+    expect(items[0]?.created_at).toBe("2026-06-09T09:00:00.000Z");
+  });
 });

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2096,21 +2096,8 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if workspaceID != "" {
-			createdAt := ""
-			if created.CreatedAt.Valid {
-				createdAt = created.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
-			}
-			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID, protocol.TaskMessagePayload{
-				TaskID:    taskID,
-				IssueID:   uuidToString(task.IssueID),
-				Seq:       msg.Seq,
-				Type:      msg.Type,
-				Tool:      msg.Tool,
-				Content:   msg.Content,
-				Input:     msg.Input,
-				Output:    msg.Output,
-				CreatedAt: createdAt,
-			})
+			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID,
+				taskMessageToPayload(created, taskID, uuidToString(task.IssueID)))
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #3951 (MUL-3174). Applies the two non-blocking nits surfaced while reviewing the run-transcript timestamps feature. They were intentionally kept out of #3951 so they wouldn't hold up the contributor's PR.

1. **Reuse the helper on the WS broadcast path.** `ReportTaskMessages` hand-built a `TaskMessagePayload` for its WebSocket broadcast and duplicated the `created_at` formatting that `taskMessageToPayload()` already performs. It now reuses the helper with the just-inserted DB row (`created`), which carries the same redacted `content`/`output`/`tool` values and the DB-assigned timestamp. Net −13 lines, single mapping path for both the broadcast and the REST list endpoints.
2. **Cover the coalesce-timestamp behavior.** Adds two unit cases to `build-timeline.test.ts` exercising both branches of `item.created_at ?? prev.created_at`: a merged streaming run keeps the *latest* fragment's timestamp, and falls back to the previous timestamp when the newer fragment has none.

No user-facing behavior change — pure refactor + added test coverage.

## Related Issue

MUL-3174. Follows up #3951.

## Type of Change

- [x] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/internal/handler/daemon.go` — `ReportTaskMessages` WS broadcast reuses `taskMessageToPayload(created, taskID, …)` instead of a hand-built payload.
- `packages/views/common/task-transcript/build-timeline.test.ts` — two new coalesce `created_at` cases.

## How to Test

1. `cd server && go build ./... && go vet ./internal/handler/` — compiles clean.
2. `pnpm --filter @multica/views exec vitest run common/task-transcript/build-timeline.test.ts` — the two new cases pass.
3. Functionally unchanged: transcript timestamps still render and still reflect the latest activity after coalescing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass — Go `build`/`vet`/`gofmt` pass locally; frontend `vitest` was **not** run in this checkout (no `node_modules`), so it relies on CI.
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — no UI change.
- [ ] I have updated relevant documentation to reflect my changes — not applicable.
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy and docs — not applicable.
- [ ] If this PR touches Chinese product copy, I checked it against conventions — not applicable.
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:** Follow-up cleanup for the two non-blocking nits raised during review of #3951 — reuse the existing payload helper on the broadcast path, and add unit coverage for the coalesce-timestamp logic. Verified the Go side builds/vets/gofmt-clean locally.
