### PR TITLE
fix(db): drop FK on agent_task_queue.initiator_user_id (MUL-2645)

### DIFF
--- a/server/migrations/117_agent_task_queue_initiator_user_id.up.sql
+++ b/server/migrations/117_agent_task_queue_initiator_user_id.up.sql
@@ -8,5 +8,12 @@
 -- NULL for non-chat tasks and for chat tasks queued before this column existed;
 -- the brief simply omits the `## Task Initiator` section in that case. See
 -- MUL-2645.
+--
+-- Plain UUID, no FK to "user": adding a foreign key here also takes a lock on
+-- the (hot) "user" table at migration time, which made this ALTER time out on a
+-- busy production deploy. The column only feeds a best-effort name/email lookup
+-- at claim time (a stale id just yields no initiator section), so referential
+-- integrity is not load-bearing. Migration 118 drops the FK on environments
+-- that already applied the original constraint-bearing version of this file.
 ALTER TABLE agent_task_queue
-    ADD COLUMN initiator_user_id UUID REFERENCES "user"(id) ON DELETE SET NULL;
+    ADD COLUMN initiator_user_id UUID;

--- a/server/migrations/118_agent_task_queue_initiator_user_id_drop_fk.down.sql
+++ b/server/migrations/118_agent_task_queue_initiator_user_id_drop_fk.down.sql
@@ -1,0 +1,7 @@
+-- Intentionally empty. The up is a convergence step ("ensure no FK on
+-- initiator_user_id") whose effect is conditional (DROP CONSTRAINT IF EXISTS),
+-- so it has no single inverse: on a database first migrated with the FK-free
+-- 117 there was never a constraint to restore, and re-adding the FK on rollback
+-- would reintroduce the exact lock-on-"user" timeout this migration removed.
+-- The FK is non-essential, so leaving the column FK-less on rollback is correct.
+-- Full rollback drops the column via 117's down migration.

--- a/server/migrations/118_agent_task_queue_initiator_user_id_drop_fk.up.sql
+++ b/server/migrations/118_agent_task_queue_initiator_user_id_drop_fk.up.sql
@@ -1,0 +1,13 @@
+-- Converge environments that already applied the original constraint-bearing
+-- version of migration 117 (which added `initiator_user_id` with a foreign key
+-- to "user"). Those environments skip the now-edited 117 by version, so the FK
+-- still exists there; this drops it so every environment ends up with a plain
+-- `initiator_user_id` column and no FK.
+--
+-- The FK to the hot "user" table is what made 117 time out on a busy deploy, and
+-- the column only feeds a best-effort name/email lookup at claim time, so the
+-- constraint is not needed. DROP CONSTRAINT only touches catalog metadata (a
+-- brief lock on agent_task_queue, no table scan, no lock on "user"). IF EXISTS
+-- makes this a no-op where 117 already ran in its FK-free form. See MUL-2645.
+ALTER TABLE agent_task_queue
+    DROP CONSTRAINT IF EXISTS agent_task_queue_initiator_user_id_fkey;


### PR DESCRIPTION
## Summary

Follow-up to #3899. The `agent_task_queue.initiator_user_id` column (migration 117) was added with a foreign key to the `user` table. Adding that FK also takes a lock on the **hot `user` table** at migration time. Per the issue discussion, the FK is dropped — a plain `UUID` column is enough.

The column only feeds a best-effort name/email lookup at claim time (a stale id just yields no `## Task Initiator` section), so referential integrity here is not load-bearing.

## Why both an edit and a new migration

The migrate runner tracks applied migrations by **version only** (no checksum). Prod's earlier deploy timed out and **never recorded 117** (verified: `schema_migrations` still at 116, column absent on prod). So:

- **Edit 117** → plain `ADD COLUMN initiator_user_id UUID` (no FK). Prod re-runs it (it was never recorded) and now gets the FK-free version; fresh databases also get the right schema.
- **Add 118** → `ALTER TABLE agent_task_queue DROP CONSTRAINT IF EXISTS agent_task_queue_initiator_user_id_fkey` for environments that already applied the constraint-bearing 117 (they skip the edited 117 by version). `IF EXISTS` makes it a no-op where the FK was never created.

All environments converge to a plain, FK-free column. `118.down` is intentionally empty (the up is a conditional convergence step with no single inverse; re-adding the FK on rollback would reintroduce the very lock-timeout this fixes).

## ⚠️ Deploy note (lock, not data volume)

This is a metadata-only `ADD COLUMN`, so it does not depend on row count. But it still needs a brief `ACCESS EXCLUSIVE` lock on `agent_task_queue`, which conflicts with any in-flight query holding `AccessShareLock` on that table. Prod currently has a multi-hour `reader` SELECT holding such a lock, which is the likely cause of the original timeout. **Before deploying, make sure no long-running query is holding `agent_task_queue`** (cancel it if so), or run during a quiet window — otherwise the `ALTER` will wait again. Removing the FK does not change this; it only removes the additional lock on the `user` table.

## No code change

Dropping the FK does not change the Go column type — `sqlc generate` produces no diff, and the service/handler/dispatcher logic is untouched.

## Testing
- Verified on a DB that had the constraint-bearing 117: `migrate up` runs 118, the FK is dropped, and the `initiator_user_id uuid` column is retained.
- `sqlc generate` → no diff in `pkg/db/generated`.
- `go build ./...`, `go vet`, and the initiator tests (`internal/handler`, `internal/integrations/lark`) pass.

MUL-2645
