### PR TITLE
feat: hold Claude runtimes on session limit and auto-resume after reset

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -917,6 +917,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					// `runtime_has_active_agents` and the user confirmed the
 					// cascade plan.
 					r.Post("/archive-agents-and-delete", h.ArchiveAgentsAndDeleteRuntime)
+					r.Post("/resume", h.ResumeRuntime)
 				})
 			})
 

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -85,7 +85,7 @@ func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handle
 			sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 			sweepStaleTasks(ctx, queries, taskSvc, bus)
 			sweepExpiredQueuedTasks(ctx, queries, taskSvc)
-			sweepExpiredHolds(ctx, queries, taskSvc, bus)
+			sweepExpiredHolds(ctx, queries, bus)
 			gcRuntimes(ctx, queries, bus)
 		}
 	}
@@ -289,7 +289,7 @@ func sweepExpiredQueuedTasks(ctx context.Context, queries *db.Queries, taskSvc *
 // sweepExpiredHolds clears holds on runtimes whose hold_until has passed.
 // After clearing, it broadcasts a daemon:register event so connected clients
 // refresh the runtime list and the daemon can pick up queued tasks.
-func sweepExpiredHolds(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus) {
+func sweepExpiredHolds(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 	released, err := queries.ClearExpiredHolds(ctx)
 	if err != nil {
 		slog.Warn("runtime sweeper: failed to clear expired holds", "error", err)
@@ -306,17 +306,15 @@ func sweepExpiredHolds(ctx context.Context, queries *db.Queries, taskSvc *servic
 		)
 		wsID := util.UUIDToString(row.WorkspaceID)
 		workspaces[wsID] = true
-		if bus != nil {
-			bus.Publish(events.Event{
-				Type:        protocol.EventRuntimeResumed,
-				WorkspaceID: wsID,
-				ActorType:   "system",
-				Payload: map[string]any{
-					"runtime_id": util.UUIDToString(row.ID),
-					"auto":       true,
-				},
-			})
-		}
+		bus.Publish(events.Event{
+			Type:        protocol.EventRuntimeResumed,
+			WorkspaceID: wsID,
+			ActorType:   "system",
+			Payload: map[string]any{
+				"runtime_id": util.UUIDToString(row.ID),
+				"auto":       true,
+			},
+		})
 	}
 
 	for wsID := range workspaces {

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -85,6 +85,7 @@ func runRuntimeSweeper(ctx context.Context, queries *db.Queries, liveness handle
 			sweepStaleRuntimes(ctx, queries, liveness, taskSvc, bus)
 			sweepStaleTasks(ctx, queries, taskSvc, bus)
 			sweepExpiredQueuedTasks(ctx, queries, taskSvc)
+			sweepExpiredHolds(ctx, queries, taskSvc, bus)
 			gcRuntimes(ctx, queries, bus)
 		}
 	}
@@ -283,6 +284,51 @@ func sweepExpiredQueuedTasks(ctx context.Context, queries *db.Queries, taskSvc *
 	slog.Info("task sweeper: expired stale queued tasks", "count", len(failedTasks))
 	taskSvc.CaptureQueuedExpiredTasks(ctx, failedTasks)
 	taskSvc.HandleFailedTasks(ctx, failedTasks)
+}
+
+// sweepExpiredHolds clears holds on runtimes whose hold_until has passed.
+// After clearing, it broadcasts a daemon:register event so connected clients
+// refresh the runtime list and the daemon can pick up queued tasks.
+func sweepExpiredHolds(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus) {
+	released, err := queries.ClearExpiredHolds(ctx)
+	if err != nil {
+		slog.Warn("runtime sweeper: failed to clear expired holds", "error", err)
+		return
+	}
+	if len(released) == 0 {
+		return
+	}
+
+	workspaces := make(map[string]bool)
+	for _, row := range released {
+		slog.Info("runtime hold expired, resuming",
+			"runtime_id", util.UUIDToString(row.ID),
+		)
+		wsID := util.UUIDToString(row.WorkspaceID)
+		workspaces[wsID] = true
+		if bus != nil {
+			bus.Publish(events.Event{
+				Type:        protocol.EventRuntimeResumed,
+				WorkspaceID: wsID,
+				ActorType:   "system",
+				Payload: map[string]any{
+					"runtime_id": util.UUIDToString(row.ID),
+					"auto":       true,
+				},
+			})
+		}
+	}
+
+	for wsID := range workspaces {
+		bus.Publish(events.Event{
+			Type:        protocol.EventDaemonRegister,
+			WorkspaceID: wsID,
+			ActorType:   "system",
+			Payload: map[string]any{
+				"action": "hold_expired",
+			},
+		})
+	}
 }
 
 // broadcastFailedTasks is preserved as a thin shim for the integration tests

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -745,7 +745,7 @@ func TestSweepExpiredHolds(t *testing.T) {
 	})
 
 	queries := db.New(testPool)
-	sweepExpiredHolds(ctx, queries, nil, bus)
+	sweepExpiredHolds(ctx, queries, bus)
 
 	// Hold should be cleared.
 	var holdAfter *string
@@ -804,7 +804,7 @@ func TestSweepExpiredHoldsLeavesActiveholdsUntouched(t *testing.T) {
 	})
 
 	queries := db.New(testPool)
-	sweepExpiredHolds(ctx, queries, nil, nil)
+	sweepExpiredHolds(ctx, queries, nil)
 
 	// Hold should still be set.
 	var holdUntilSet bool

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -689,6 +689,133 @@ func TestExpireStaleQueuedTasksRespectsBatchLimit(t *testing.T) {
 	}
 }
 
+// TestSweepExpiredHolds verifies that sweepExpiredHolds clears holds whose
+// hold_until has passed and leaves active (future) holds untouched.
+func TestSweepExpiredHolds(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.runtime_id FROM agent a
+		JOIN member m ON m.workspace_id = a.workspace_id
+		JOIN "user" u ON u.id = m.user_id
+		WHERE u.email = $1
+		LIMIT 1
+	`, integrationTestEmail).Scan(&runtimeID); err != nil {
+		t.Fatalf("failed to find test runtime: %v", err)
+	}
+
+	// Place the runtime on hold in the past so sweepExpiredHolds should clear it.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_runtime
+		SET hold_until = now() - interval '5 minutes', hold_reason = 'session_limit'
+		WHERE id = $1
+	`, runtimeID); err != nil {
+		t.Fatalf("set hold: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE agent_runtime SET hold_until = NULL, hold_reason = NULL WHERE id = $1`, runtimeID)
+	})
+
+	// Confirm the hold is set.
+	var holdUntilSet bool
+	if err := testPool.QueryRow(ctx, `SELECT hold_until IS NOT NULL FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&holdUntilSet); err != nil {
+		t.Fatalf("check hold: %v", err)
+	}
+	if !holdUntilSet {
+		t.Fatal("precondition: hold_until should be set before sweep")
+	}
+
+	// Capture runtime:resumed events.
+	bus := events.New()
+	var mu sync.Mutex
+	var resumedEvents []string
+	bus.Subscribe("runtime:resumed", func(e events.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		if payload, ok := e.Payload.(map[string]any); ok {
+			if rid, ok := payload["runtime_id"].(string); ok {
+				resumedEvents = append(resumedEvents, rid)
+			}
+		}
+	})
+
+	queries := db.New(testPool)
+	sweepExpiredHolds(ctx, queries, nil, bus)
+
+	// Hold should be cleared.
+	var holdAfter *string
+	if err := testPool.QueryRow(ctx, `SELECT hold_until::text FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&holdAfter); err != nil {
+		t.Fatalf("read hold after sweep: %v", err)
+	}
+	if holdAfter != nil {
+		t.Fatalf("expected hold_until to be NULL after sweep, got %q", *holdAfter)
+	}
+
+	// runtime:resumed event should have been broadcast.
+	mu.Lock()
+	found := false
+	for _, rid := range resumedEvents {
+		if rid == runtimeID {
+			found = true
+			break
+		}
+	}
+	mu.Unlock()
+	if !found {
+		t.Fatalf("expected runtime:resumed event for runtime %q, got events: %v", runtimeID, resumedEvents)
+	}
+}
+
+// TestSweepExpiredHoldsLeavesActiveholdsUntouched verifies that a hold whose
+// hold_until is in the future is not cleared by sweepExpiredHolds.
+func TestSweepExpiredHoldsLeavesActiveholdsUntouched(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.runtime_id FROM agent a
+		JOIN member m ON m.workspace_id = a.workspace_id
+		JOIN "user" u ON u.id = m.user_id
+		WHERE u.email = $1
+		LIMIT 1
+	`, integrationTestEmail).Scan(&runtimeID); err != nil {
+		t.Fatalf("failed to find test runtime: %v", err)
+	}
+
+	// Place the runtime on hold in the future (1 hour from now).
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_runtime
+		SET hold_until = now() + interval '1 hour', hold_reason = 'session_limit'
+		WHERE id = $1
+	`, runtimeID); err != nil {
+		t.Fatalf("set hold: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE agent_runtime SET hold_until = NULL, hold_reason = NULL WHERE id = $1`, runtimeID)
+	})
+
+	queries := db.New(testPool)
+	sweepExpiredHolds(ctx, queries, nil, nil)
+
+	// Hold should still be set.
+	var holdUntilSet bool
+	if err := testPool.QueryRow(ctx, `SELECT hold_until IS NOT NULL FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&holdUntilSet); err != nil {
+		t.Fatalf("check hold after sweep: %v", err)
+	}
+	if !holdUntilSet {
+		t.Fatal("active hold (future hold_until) must not be cleared by sweepExpiredHolds")
+	}
+}
+
 // parseUUIDBytes converts a UUID string to the 16-byte array used by pgtype.UUID.
 func parseUUIDBytes(s string) [16]byte {
 	s = strings.ReplaceAll(s, "-", "")

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -959,15 +959,10 @@ func (h *Handler) ResumeRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.TaskService.ResumeRuntime(r.Context(), runtimeUUID); err != nil {
+	updated, err := h.TaskService.ResumeRuntime(r.Context(), runtimeUUID)
+	if err != nil {
 		slog.Error("ResumeRuntime failed", "error", err, "runtime_id", runtimeID)
 		writeError(w, http.StatusInternalServerError, "failed to resume runtime")
-		return
-	}
-
-	updated, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
-	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
 

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -34,6 +34,8 @@ type AgentRuntimeResponse struct {
 	// 083 and canUseRuntimeForAgent.
 	Visibility string  `json:"visibility"`
 	LastSeenAt *string `json:"last_seen_at"`
+	HoldUntil  *string `json:"hold_until,omitempty"`
+	HoldReason *string `json:"hold_reason,omitempty"`
 	CreatedAt  string  `json:"created_at"`
 	UpdatedAt  string  `json:"updated_at"`
 }
@@ -61,6 +63,8 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 		OwnerID:      uuidToPtr(rt.OwnerID),
 		Visibility:   rt.Visibility,
 		LastSeenAt:   timestampToPtr(rt.LastSeenAt),
+		HoldUntil:    timestampToPtr(rt.HoldUntil),
+		HoldReason:   textToPtr(rt.HoldReason),
 		CreatedAt:    timestampToString(rt.CreatedAt),
 		UpdatedAt:    timestampToString(rt.UpdatedAt),
 	}
@@ -922,4 +926,54 @@ func activeAgentSetMatches(current []db.Agent, expected map[string]struct{}) boo
 		}
 	}
 	return true
+}
+
+// ResumeRuntime handles POST /api/runtimes/:runtimeId/resume. Clears any
+// active hold on the runtime so tasks can be dispatched immediately,
+// bypassing the automatic reset time.
+func (h *Handler) ResumeRuntime(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
+
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "runtime not found")
+		return
+	}
+
+	wsID := uuidToString(rt.WorkspaceID)
+	member, ok := h.requireWorkspaceMember(w, r, wsID, "runtime not found")
+	if !ok {
+		return
+	}
+	if !canEditRuntime(member, rt) {
+		writeError(w, http.StatusForbidden, "you can only resume your own runtimes")
+		return
+	}
+
+	if h.TaskService == nil {
+		writeError(w, http.StatusServiceUnavailable, "task service unavailable")
+		return
+	}
+
+	if err := h.TaskService.ResumeRuntime(r.Context(), runtimeUUID); err != nil {
+		slog.Error("ResumeRuntime failed", "error", err, "runtime_id", runtimeID)
+		writeError(w, http.StatusInternalServerError, "failed to resume runtime")
+		return
+	}
+
+	updated, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	h.publish(protocol.EventDaemonRegister, wsID, "member", uuidToString(member.UserID), map[string]any{
+		"action": "resume",
+	})
+
+	writeJSON(w, http.StatusOK, runtimeToResponse(updated))
 }

--- a/server/internal/handler/runtime_hold_failtask_test.go
+++ b/server/internal/handler/runtime_hold_failtask_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestFailTaskSessionLimitHoldsRuntimeAndRetries pins the FailTask detection
+// glue end-to-end: when a task on a runtime fails with a Claude session-limit
+// message, FailTask must (1) place the runtime on hold with a parsed
+// hold_until, and (2) auto-queue a retry that stays gated behind the hold.
+//
+// This is the integration point the parser / sweeper / resume-API unit tests
+// never reach: deleting the `failureReason == "session_limit"` block from
+// FailTask leaves every one of those tests green, so without this test the
+// feature's actual wiring could regress unnoticed.
+func TestFailTaskSessionLimitHoldsRuntimeAndRetries(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	runtimeID := handlerTestRuntimeID(t)
+	agentID := createHandlerTestAgent(t, "Session Limit FailTask Agent", []byte("{}"))
+
+	// Start from a clean (unheld) runtime and restore it afterwards so the
+	// shared handler-test runtime is not left on hold for later tests.
+	if _, err := testPool.Exec(ctx, `UPDATE agent_runtime SET hold_until = NULL, hold_reason = NULL WHERE id = $1`, runtimeID); err != nil {
+		t.Fatalf("reset runtime hold: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE agent_runtime SET hold_until = NULL, hold_reason = NULL WHERE id = $1`, runtimeID)
+	})
+
+	// Seed an issue assigned to the agent and a running task on the runtime.
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, assignee_type, assignee_id)
+		VALUES ($1, 'session limit failtask test', 'in_progress', 'none', 'member', $2, 'agent', $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, agentID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, dispatched_at, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now(), now())
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("create running task: %v", err)
+	}
+
+	queries := db.New(testPool)
+	hub := realtime.NewHub()
+	go hub.Run()
+	bus := events.New()
+	svc := service.NewTaskService(queries, testPool, hub, bus)
+
+	// Fail the task with a Claude session-limit message. Pass an empty
+	// failureReason so FailTask runs the classifier itself — this also
+	// exercises the Classify("...session limit...resets...") == session_limit
+	// path that the detection block keys off.
+	const msg = "You've hit your session limit · resets 11:59pm (UTC)"
+	if _, err := svc.FailTask(ctx, parseUUID(taskID), msg, "", "", ""); err != nil {
+		t.Fatalf("FailTask: %v", err)
+	}
+
+	// (1) The runtime must be on hold with a parsed expiry and the
+	// session_limit reason.
+	var holdUntilSet bool
+	var holdReason *string
+	if err := testPool.QueryRow(ctx, `
+		SELECT hold_until IS NOT NULL, hold_reason FROM agent_runtime WHERE id = $1
+	`, runtimeID).Scan(&holdUntilSet, &holdReason); err != nil {
+		t.Fatalf("read runtime hold: %v", err)
+	}
+	if !holdUntilSet {
+		t.Fatal("FailTask did not set hold_until on the runtime after a session-limit failure")
+	}
+	if holdReason == nil || *holdReason != "session_limit" {
+		t.Fatalf("expected hold_reason 'session_limit', got %v", holdReason)
+	}
+
+	// (2) A retry must have been queued for the failed task, gated behind
+	// the hold (the queued clone carries the same runtime_id, which both
+	// claim paths skip while the hold is active).
+	var retryCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM agent_task_queue
+		WHERE parent_task_id = $1 AND status = 'queued'
+	`, taskID).Scan(&retryCount); err != nil {
+		t.Fatalf("count retry tasks: %v", err)
+	}
+	if retryCount != 1 {
+		t.Fatalf("expected exactly 1 queued retry task after session-limit failure, got %d", retryCount)
+	}
+}

--- a/server/internal/handler/runtime_test.go
+++ b/server/internal/handler/runtime_test.go
@@ -9,6 +9,10 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 func TestRuntimeHandlersRejectMalformedRuntimeID(t *testing.T) {
@@ -354,6 +358,115 @@ func TestResolveViewingTZ(t *testing.T) {
 	req = newRequest("GET", "/api/dashboard/usage/daily", nil)
 	if got := testHandler.resolveViewingTZ(req); got != "UTC" {
 		t.Fatalf("unauthenticated caller: expected UTC, got %q", got)
+	}
+}
+
+// TestResumeRuntimeRejectsMalformedID verifies that POST /resume returns 400
+// for a non-UUID runtime ID (consistent with all other runtime endpoints).
+func TestResumeRuntimeRejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/runtimes/not-a-uuid/resume", nil)
+	req = withURLParam(req, "runtimeId", "not-a-uuid")
+	testHandler.ResumeRuntime(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed runtimeId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestResumeRuntimeReturnsNotFoundForUnknownRuntime pins that 404 is returned
+// when the runtime ID is a valid UUID that doesn't exist.
+func TestResumeRuntimeReturnsNotFoundForUnknownRuntime(t *testing.T) {
+	// A well-formed UUID that does not exist in the DB.
+	const missing = "00000000-0000-0000-0000-000000000001"
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/runtimes/"+missing+"/resume", nil)
+	req = withURLParam(req, "runtimeId", missing)
+	testHandler.ResumeRuntime(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown runtime, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestResumeRuntimeClearsHold is the happy-path integration test: place a
+// runtime on hold, call ResumeRuntime, assert hold_until is cleared and the
+// response contains the runtime without hold fields set.
+func TestResumeRuntimeClearsHold(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	runtimeID := handlerTestRuntimeID(t)
+
+	// Place the runtime on hold.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_runtime
+		SET hold_until = now() + interval '1 hour', hold_reason = 'session_limit'
+		WHERE id = $1
+	`, runtimeID); err != nil {
+		t.Fatalf("set hold: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE agent_runtime SET hold_until = NULL, hold_reason = NULL WHERE id = $1`, runtimeID)
+	})
+
+	// Wire up a TaskService so ResumeRuntime can call ClearRuntimeHold.
+	queries := db.New(testPool)
+	hub := realtime.NewHub()
+	go hub.Run()
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, hub, bus)
+	testHandler.TaskService = taskSvc
+	t.Cleanup(func() { testHandler.TaskService = nil })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/resume", nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ResumeRuntime(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ResumeRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// DB assertion: hold must be cleared.
+	var holdUntilSet bool
+	if err := testPool.QueryRow(ctx, `SELECT hold_until IS NOT NULL FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&holdUntilSet); err != nil {
+		t.Fatalf("read hold after resume: %v", err)
+	}
+	if holdUntilSet {
+		t.Fatal("ResumeRuntime: hold_until should be NULL after successful resume")
+	}
+
+	// Response must include hold_until as null.
+	var resp AgentRuntimeResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.HoldUntil != nil {
+		t.Fatalf("ResumeRuntime: response hold_until should be nil, got %q", *resp.HoldUntil)
+	}
+}
+
+// TestResumeRuntimeWithoutTaskServiceReturns503 ensures the graceful
+// degradation path is exercised: when TaskService is nil (not wired), the
+// handler must return 503 rather than panic.
+func TestResumeRuntimeWithoutTaskServiceReturns503(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	runtimeID := handlerTestRuntimeID(t)
+
+	// Ensure TaskService is nil for this test.
+	saved := testHandler.TaskService
+	testHandler.TaskService = nil
+	t.Cleanup(func() { testHandler.TaskService = saved })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/resume", nil)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ResumeRuntime(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when TaskService is nil, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/runtime_test.go
+++ b/server/internal/handler/runtime_test.go
@@ -410,13 +410,15 @@ func TestResumeRuntimeClearsHold(t *testing.T) {
 	})
 
 	// Wire up a TaskService so ResumeRuntime can call ClearRuntimeHold.
+	// Save and restore the original value so parallel tests are not affected.
+	savedTaskSvc := testHandler.TaskService
 	queries := db.New(testPool)
 	hub := realtime.NewHub()
 	go hub.Run()
 	bus := events.New()
 	taskSvc := service.NewTaskService(queries, testPool, hub, bus)
 	testHandler.TaskService = taskSvc
-	t.Cleanup(func() { testHandler.TaskService = nil })
+	t.Cleanup(func() { testHandler.TaskService = savedTaskSvc })
 
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/resume", nil)

--- a/server/internal/service/runtime_hold.go
+++ b/server/internal/service/runtime_hold.go
@@ -10,6 +10,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
 // HoldRuntime places a runtime on hold until the given reset time. While on
@@ -48,6 +49,32 @@ func (s *TaskService) HoldRuntime(ctx context.Context, runtimeID pgtype.UUID, re
 		},
 	})
 	return nil
+}
+
+// HoldRuntimeIfSessionLimit classifies the error message, and when it
+// indicates a session limit with a parseable reset time, places the runtime
+// on hold until that time. Bundles the Classify + ParseSessionLimitResetTime
+// + HoldRuntime chain so callers cannot accidentally hold a runtime without
+// first verifying the reset time is parseable (which would leave the runtime
+// stuck on hold indefinitely).
+//
+// Returns true when the runtime was placed on hold, false otherwise.
+func (s *TaskService) HoldRuntimeIfSessionLimit(ctx context.Context, runtimeID pgtype.UUID, errMsg string) bool {
+	if taskfailure.Classify(errMsg) != taskfailure.ReasonSessionLimit {
+		return false
+	}
+	resetTime, ok := ParseSessionLimitResetTime(errMsg)
+	if !ok {
+		return false
+	}
+	if err := s.HoldRuntime(ctx, runtimeID, "session_limit", resetTime); err != nil {
+		slog.Warn("failed to hold runtime after session limit",
+			"runtime_id", util.UUIDToString(runtimeID),
+			"error", err,
+		)
+		return false
+	}
+	return true
 }
 
 // ResumeRuntime clears the hold on a runtime, allowing tasks to be

--- a/server/internal/service/runtime_hold.go
+++ b/server/internal/service/runtime_hold.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// HoldRuntime places a runtime on hold until the given reset time. While on
+// hold, the claim path skips the runtime so no new tasks are dispatched to
+// it. The hold_reason is stored for observability (e.g. "session_limit").
+func (s *TaskService) HoldRuntime(ctx context.Context, runtimeID pgtype.UUID, reason string, resetTime time.Time) error {
+	rt, err := s.Queries.SetRuntimeHold(ctx, db.SetRuntimeHoldParams{
+		ID: runtimeID,
+		HoldUntil: pgtype.Timestamptz{
+			Time:  resetTime,
+			Valid: true,
+		},
+		HoldReason: pgtype.Text{
+			String: reason,
+			Valid:  reason != "",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	slog.Info("runtime placed on hold",
+		"runtime_id", util.UUIDToString(runtimeID),
+		"reason", reason,
+		"hold_until", resetTime.Format(time.RFC3339),
+	)
+
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventRuntimeHeld,
+		WorkspaceID: util.UUIDToString(rt.WorkspaceID),
+		ActorType:   "system",
+		Payload: map[string]any{
+			"runtime_id": util.UUIDToString(runtimeID),
+			"reason":     reason,
+			"hold_until": resetTime.Format(time.RFC3339),
+		},
+	})
+	return nil
+}
+
+// ResumeRuntime clears the hold on a runtime, allowing tasks to be
+// dispatched to it again.
+func (s *TaskService) ResumeRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
+	rt, err := s.Queries.ClearRuntimeHold(ctx, runtimeID)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("runtime hold cleared",
+		"runtime_id", util.UUIDToString(runtimeID),
+	)
+
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventRuntimeResumed,
+		WorkspaceID: util.UUIDToString(rt.WorkspaceID),
+		ActorType:   "system",
+		Payload: map[string]any{
+			"runtime_id": util.UUIDToString(runtimeID),
+		},
+	})
+	return nil
+}

--- a/server/internal/service/runtime_hold.go
+++ b/server/internal/service/runtime_hold.go
@@ -51,11 +51,12 @@ func (s *TaskService) HoldRuntime(ctx context.Context, runtimeID pgtype.UUID, re
 }
 
 // ResumeRuntime clears the hold on a runtime, allowing tasks to be
-// dispatched to it again.
-func (s *TaskService) ResumeRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
+// dispatched to it again. It returns the updated runtime row produced by the
+// ClearRuntimeHold query so callers can avoid a redundant re-fetch.
+func (s *TaskService) ResumeRuntime(ctx context.Context, runtimeID pgtype.UUID) (db.AgentRuntime, error) {
 	rt, err := s.Queries.ClearRuntimeHold(ctx, runtimeID)
 	if err != nil {
-		return err
+		return db.AgentRuntime{}, err
 	}
 
 	slog.Info("runtime hold cleared",
@@ -70,5 +71,5 @@ func (s *TaskService) ResumeRuntime(ctx context.Context, runtimeID pgtype.UUID) 
 			"runtime_id": util.UUIDToString(runtimeID),
 		},
 	})
-	return nil
+	return rt, nil
 }

--- a/server/internal/service/session_limit.go
+++ b/server/internal/service/session_limit.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -29,17 +30,13 @@ func ParseSessionLimitResetTime(message string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 
-	hour, minute, ampm := 0, 0, ""
-	switch {
-	case len(matches) >= 4:
-		hour = parseInt(matches[1])
-		minute = parseInt(matches[2])
-		ampm = strings.ToLower(matches[3])
-	default:
-		return time.Time{}, false
-	}
+	// The regex guarantees matches[1] and matches[2] are digit runs, so the
+	// conversion cannot fail; the error is discarded by construction.
+	hour, _ := strconv.Atoi(matches[1])
+	minute, _ := strconv.Atoi(matches[2])
+	ampm := strings.ToLower(matches[3])
 
-	if hour < 1 || hour > 12 || minute < 0 || minute > 59 {
+	if hour < 1 || hour > 12 || minute > 59 {
 		return time.Time{}, false
 	}
 
@@ -55,14 +52,4 @@ func ParseSessionLimitResetTime(message string) (time.Time, bool) {
 		reset = reset.AddDate(0, 0, 1)
 	}
 	return reset, true
-}
-
-func parseInt(s string) int {
-	n := 0
-	for _, c := range s {
-		if c >= '0' && c <= '9' {
-			n = n*10 + int(c-'0')
-		}
-	}
-	return n
 }

--- a/server/internal/service/session_limit.go
+++ b/server/internal/service/session_limit.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// sessionLimitResetRe matches the Claude session limit reset time pattern.
+// Examples:
+//
+//	"You've hit your session limit · resets 5:10pm (UTC)"
+//	"You've hit your session limit · resets 10:10pm (UTC)"
+//	"You've hit your session limit · resets 12:00am (UTC)"
+var sessionLimitResetRe = regexp.MustCompile(`(?i)resets?\s+(\d{1,2}):(\d{2})\s*(am|pm)\s*\(?UTC\)?`)
+
+// ParseSessionLimitResetTime extracts the reset time from a Claude session
+// limit message. Returns the absolute UTC time of the next occurrence of the
+// given wall-clock time. Returns (zero, false) when the message does not
+// contain a parseable reset time.
+//
+// The message only carries a wall-clock time (e.g. "5:10pm (UTC)") without a
+// date, so we compute the next occurrence relative to now. If the parsed time
+// is in the past today, we assume it refers to tomorrow (the reset hasn't
+// happened yet in the current cycle).
+func ParseSessionLimitResetTime(message string) (time.Time, bool) {
+	matches := sessionLimitResetRe.FindStringSubmatch(message)
+	if matches == nil {
+		return time.Time{}, false
+	}
+
+	hour, minute, ampm := 0, 0, ""
+	switch {
+	case len(matches) >= 4:
+		hour = parseInt(matches[1])
+		minute = parseInt(matches[2])
+		ampm = strings.ToLower(matches[3])
+	default:
+		return time.Time{}, false
+	}
+
+	if hour < 1 || hour > 12 || minute < 0 || minute > 59 {
+		return time.Time{}, false
+	}
+
+	if ampm == "pm" && hour != 12 {
+		hour += 12
+	} else if ampm == "am" && hour == 12 {
+		hour = 0
+	}
+
+	now := time.Now().UTC()
+	reset := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC)
+	if reset.Before(now) {
+		reset = reset.AddDate(0, 0, 1)
+	}
+	return reset, true
+}
+
+func parseInt(s string) int {
+	n := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		}
+	}
+	return n
+}

--- a/server/internal/service/session_limit_test.go
+++ b/server/internal/service/session_limit_test.go
@@ -37,6 +37,21 @@ func TestParseSessionLimitResetTime(t *testing.T) {
 			wantOK:  true,
 		},
 		{
+			name:    "single digit hour 1am",
+			message: "You've hit your session limit · resets 1:00am (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "case-insensitive AM",
+			message: "You've hit your session limit · resets 9:45AM (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "message embedded in larger text",
+			message: "Task failed: You've hit your session limit · resets 3:15pm (UTC). Please wait.",
+			wantOK:  true,
+		},
+		{
 			name:    "unrelated error",
 			message: "connection refused",
 			wantOK:  false,
@@ -49,6 +64,16 @@ func TestParseSessionLimitResetTime(t *testing.T) {
 		{
 			name:    "no reset time",
 			message: "You've hit your session limit",
+			wantOK:  false,
+		},
+		{
+			name:    "hour out of range 0",
+			message: "You've hit your session limit · resets 0:00am (UTC)",
+			wantOK:  false,
+		},
+		{
+			name:    "hour out of range 13",
+			message: "You've hit your session limit · resets 13:00pm (UTC)",
 			wantOK:  false,
 		},
 	}
@@ -71,6 +96,7 @@ func TestParseSessionLimitResetTime(t *testing.T) {
 	}
 }
 
+// TestParseSessionLimitResetTimeValues verifies the exact hour/minute conversion.
 func TestParseSessionLimitResetTimeValues(t *testing.T) {
 	msg := "You've hit your session limit · resets 11:30pm (UTC)"
 	got, ok := ParseSessionLimitResetTime(msg)
@@ -79,5 +105,81 @@ func TestParseSessionLimitResetTimeValues(t *testing.T) {
 	}
 	if got.Hour() != 23 || got.Minute() != 30 {
 		t.Fatalf("expected 23:30, got %02d:%02d", got.Hour(), got.Minute())
+	}
+}
+
+// TestParseSessionLimitResetTimeConversions verifies AM/PM and 12-hour boundary
+// conversions produce the correct 24-hour UTC values.
+func TestParseSessionLimitResetTimeConversions(t *testing.T) {
+	cases := []struct {
+		name        string
+		message     string
+		wantHour    int
+		wantMinute  int
+	}{
+		{
+			name:       "12am is midnight (hour 0)",
+			message:    "resets 12:00am (UTC)",
+			wantHour:   0,
+			wantMinute: 0,
+		},
+		{
+			name:       "12pm is noon (hour 12)",
+			message:    "resets 12:30pm (UTC)",
+			wantHour:   12,
+			wantMinute: 30,
+		},
+		{
+			name:       "1pm becomes hour 13",
+			message:    "resets 1:15pm (UTC)",
+			wantHour:   13,
+			wantMinute: 15,
+		},
+		{
+			name:       "1am stays hour 1",
+			message:    "resets 1:00am (UTC)",
+			wantHour:   1,
+			wantMinute: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseSessionLimitResetTime(tc.message)
+			if !ok {
+				t.Fatalf("expected parse success for %q", tc.message)
+			}
+			if got.Hour() != tc.wantHour || got.Minute() != tc.wantMinute {
+				t.Fatalf("expected %02d:%02d, got %02d:%02d", tc.wantHour, tc.wantMinute, got.Hour(), got.Minute())
+			}
+		})
+	}
+}
+
+// TestParseSessionLimitResetTimeTomorrowRollover pins the contract that a
+// parsed wall-clock time already in the past today is advanced to tomorrow.
+func TestParseSessionLimitResetTimeTomorrowRollover(t *testing.T) {
+	// 00:01 UTC is always in the past for the current day whenever the test
+	// runs after 00:01 UTC — except for the one minute window at midnight,
+	// so we skip in that edge case to keep the test deterministic.
+	now := time.Now().UTC()
+	if now.Hour() == 0 && now.Minute() == 0 {
+		t.Skip("skipping midnight edge-case window")
+	}
+
+	// If current time is after 00:01, "resets 12:01am" is in the past today
+	// and the parser should return tomorrow.
+	got, ok := ParseSessionLimitResetTime("You've hit your session limit · resets 12:01am (UTC)")
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 1, 0, 0, time.UTC)
+	if got.Before(now) {
+		t.Fatalf("reset time %v is in the past (now=%v)", got, now)
+	}
+	_ = today // used to compute the expected tomorrow
+	expectedDate := today.AddDate(0, 0, 1)
+	if now.After(today) && got.Day() != expectedDate.Day() {
+		t.Fatalf("expected rollover to tomorrow (day %d), got day %d", expectedDate.Day(), got.Day())
 	}
 }

--- a/server/internal/service/session_limit_test.go
+++ b/server/internal/service/session_limit_test.go
@@ -112,10 +112,10 @@ func TestParseSessionLimitResetTimeValues(t *testing.T) {
 // conversions produce the correct 24-hour UTC values.
 func TestParseSessionLimitResetTimeConversions(t *testing.T) {
 	cases := []struct {
-		name        string
-		message     string
-		wantHour    int
-		wantMinute  int
+		name       string
+		message    string
+		wantHour   int
+		wantMinute int
 	}{
 		{
 			name:       "12am is midnight (hour 0)",

--- a/server/internal/service/session_limit_test.go
+++ b/server/internal/service/session_limit_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSessionLimitResetTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		wantOK  bool
+	}{
+		{
+			name:    "standard claude message pm",
+			message: "You've hit your session limit · resets 5:10pm (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "standard claude message am",
+			message: "You've hit your session limit · resets 10:10am (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "midnight 12am",
+			message: "You've hit your session limit · resets 12:00am (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "noon 12pm",
+			message: "You've hit your session limit · resets 12:00pm (UTC)",
+			wantOK:  true,
+		},
+		{
+			name:    "no parentheses",
+			message: "You've hit your session limit · resets 5:10pm UTC",
+			wantOK:  true,
+		},
+		{
+			name:    "unrelated error",
+			message: "connection refused",
+			wantOK:  false,
+		},
+		{
+			name:    "empty",
+			message: "",
+			wantOK:  false,
+		},
+		{
+			name:    "no reset time",
+			message: "You've hit your session limit",
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseSessionLimitResetTime(tc.message)
+			if ok != tc.wantOK {
+				t.Fatalf("ParseSessionLimitResetTime(%q) ok = %v, want %v", tc.message, ok, tc.wantOK)
+			}
+			if ok {
+				if got.IsZero() {
+					t.Fatal("expected non-zero time")
+				}
+				if got.Before(time.Now().UTC().Add(-time.Minute)) {
+					t.Fatalf("reset time %v is in the past", got)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSessionLimitResetTimeValues(t *testing.T) {
+	msg := "You've hit your session limit · resets 11:30pm (UTC)"
+	got, ok := ParseSessionLimitResetTime(msg)
+	if !ok {
+		t.Fatal("expected parse success")
+	}
+	if got.Hour() != 23 || got.Minute() != 30 {
+		t.Fatalf("expected 23:30, got %02d:%02d", got.Hour(), got.Minute())
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -422,6 +422,8 @@ func taskErrorType(reason string) string {
 		return "agent_output"
 	case "cancelled", "user_cancelled":
 		return "cancelled"
+	case "session_limit":
+		return "session_limit"
 	default:
 		return "agent_error"
 	}
@@ -1353,8 +1355,22 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	slog.Warn("task failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", errMsg, "failure_reason", failureReason)
 	s.captureTaskFailed(ctx, task)
 
+	// Session limit: place the runtime on hold before auto-retry so the
+	// retried task won't be claimed until the hold lifts.
+	if failureReason == "session_limit" && task.RuntimeID.Valid {
+		if resetTime, ok := ParseSessionLimitResetTime(errMsg); ok {
+			if err := s.HoldRuntime(ctx, task.RuntimeID, "session_limit", resetTime); err != nil {
+				slog.Warn("failed to hold runtime after session limit",
+					"runtime_id", util.UUIDToString(task.RuntimeID),
+					"task_id", util.UUIDToString(task.ID),
+					"error", err,
+				)
+			}
+		}
+	}
+
 	// Auto-retry eligible failures (orphan, timeout, runtime_offline,
-	// runtime_recovery). The helper itself enforces attempt < max_attempts
+	// runtime_recovery, session_limit). The helper itself enforces attempt < max_attempts
 	// and only triggers for issue/chat tasks.
 	retried, _ := s.MaybeRetryFailedTask(ctx, task)
 
@@ -1418,6 +1434,7 @@ var retryableReasons = map[string]bool{
 	"runtime_recovery":          true,
 	"timeout":                   true,
 	"codex_semantic_inactivity": true,
+	"session_limit":             true,
 }
 
 func resumeUnsafeFailureReason(reason string) bool {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1358,15 +1358,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// Session limit: place the runtime on hold before auto-retry so the
 	// retried task won't be claimed until the hold lifts.
 	if failureReason == "session_limit" && task.RuntimeID.Valid {
-		if resetTime, ok := ParseSessionLimitResetTime(errMsg); ok {
-			if err := s.HoldRuntime(ctx, task.RuntimeID, "session_limit", resetTime); err != nil {
-				slog.Warn("failed to hold runtime after session limit",
-					"runtime_id", util.UUIDToString(task.RuntimeID),
-					"task_id", util.UUIDToString(task.ID),
-					"error", err,
-				)
-			}
-		}
+		s.HoldRuntimeIfSessionLimit(ctx, task.RuntimeID, errMsg)
 	}
 
 	// Auto-retry eligible failures (orphan, timeout, runtime_offline,

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -180,6 +180,7 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		{reason: "iteration_limit", wantType: "agent_output", wantResumeOK: false, wantRetry: false},
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
 		{reason: "agent_error", wantType: "agent_error", wantResumeOK: true, wantRetry: false},
+		{reason: "session_limit", wantType: "session_limit", wantResumeOK: true, wantRetry: true},
 	}
 
 	for _, tc := range cases {

--- a/server/migrations/119_runtime_hold.down.sql
+++ b/server/migrations/119_runtime_hold.down.sql
@@ -1,3 +1,5 @@
+DROP INDEX IF EXISTS idx_agent_runtime_hold_until;
+
 ALTER TABLE agent_runtime
     DROP COLUMN IF EXISTS hold_until,
     DROP COLUMN IF EXISTS hold_reason;

--- a/server/migrations/119_runtime_hold.down.sql
+++ b/server/migrations/119_runtime_hold.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_runtime
+    DROP COLUMN IF EXISTS hold_until,
+    DROP COLUMN IF EXISTS hold_reason;

--- a/server/migrations/119_runtime_hold.up.sql
+++ b/server/migrations/119_runtime_hold.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_runtime
+    ADD COLUMN hold_until TIMESTAMPTZ,
+    ADD COLUMN hold_reason TEXT;

--- a/server/migrations/119_runtime_hold.up.sql
+++ b/server/migrations/119_runtime_hold.up.sql
@@ -1,3 +1,11 @@
 ALTER TABLE agent_runtime
     ADD COLUMN hold_until TIMESTAMPTZ,
     ADD COLUMN hold_reason TEXT;
+
+-- Partial index supporting the runtime sweeper's ClearExpiredHolds scan
+-- (WHERE hold_until IS NOT NULL AND hold_until <= now()). Only runtimes
+-- currently on hold are indexed, so the index stays tiny and the sweep
+-- cost is bounded by the held-runtime count rather than the whole fleet.
+CREATE INDEX IF NOT EXISTS idx_agent_runtime_hold_until
+    ON agent_runtime (hold_until)
+    WHERE hold_until IS NOT NULL;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -527,6 +527,12 @@ WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
       AND NOT EXISTS (
+          SELECT 1 FROM agent_runtime ar
+          WHERE ar.id = atq.runtime_id
+            AND ar.hold_until IS NOT NULL
+            AND ar.hold_until > now()
+      )
+      AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
             AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
@@ -2071,9 +2077,15 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id FROM agent_task_queue atq
+WHERE atq.runtime_id = $1 AND atq.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_runtime ar
+      WHERE ar.id = atq.runtime_id
+        AND ar.hold_until IS NOT NULL
+        AND ar.hold_until > now()
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC
 `
 
 // Returns rows the runtime can attempt to claim. Status is restricted to
@@ -2084,6 +2096,7 @@ ORDER BY priority DESC, created_at ASC
 // ClaimAgentTask, wasting CPU and a SELECT every poll cycle when the
 // runtime is busy on a long-running task. Backed by the partial index
 // idx_agent_task_queue_claim_candidates so the warm path is cheap.
+// Skips results when the runtime is on hold (hold_until > now()).
 func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtimeID pgtype.UUID) ([]AgentTaskQueue, error) {
 	rows, err := q.db.Query(ctx, listQueuedClaimCandidatesByRuntime, runtimeID)
 	if err != nil {

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -62,6 +62,8 @@ type AgentRuntime struct {
 	OwnerID        pgtype.UUID        `json:"owner_id"`
 	LegacyDaemonID pgtype.Text        `json:"legacy_daemon_id"`
 	Visibility     string             `json:"visibility"`
+	HoldUntil      pgtype.Timestamptz `json:"hold_until"`
+	HoldReason     pgtype.Text        `json:"hold_reason"`
 }
 
 type AgentSkill struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -90,15 +90,12 @@ const clearExpiredHolds = `-- name: ClearExpiredHolds :many
 UPDATE agent_runtime
 SET hold_until = NULL, hold_reason = NULL, updated_at = now()
 WHERE hold_until IS NOT NULL AND hold_until <= now()
-RETURNING id, workspace_id, owner_id, daemon_id, provider
+RETURNING id, workspace_id
 `
 
 type ClearExpiredHoldsRow struct {
 	ID          pgtype.UUID `json:"id"`
 	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	OwnerID     pgtype.UUID `json:"owner_id"`
-	DaemonID    pgtype.Text `json:"daemon_id"`
-	Provider    string      `json:"provider"`
 }
 
 func (q *Queries) ClearExpiredHolds(ctx context.Context) ([]ClearExpiredHoldsRow, error) {
@@ -113,9 +110,6 @@ func (q *Queries) ClearExpiredHolds(ctx context.Context) ([]ClearExpiredHoldsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WorkspaceID,
-			&i.OwnerID,
-			&i.DaemonID,
-			&i.Provider,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -86,6 +86,79 @@ func (q *Queries) CancelAgentTasksByRuntimeOrAgent(ctx context.Context, arg Canc
 	return items, nil
 }
 
+const clearExpiredHolds = `-- name: ClearExpiredHolds :many
+UPDATE agent_runtime
+SET hold_until = NULL, hold_reason = NULL, updated_at = now()
+WHERE hold_until IS NOT NULL AND hold_until <= now()
+RETURNING id, workspace_id, owner_id, daemon_id, provider
+`
+
+type ClearExpiredHoldsRow struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	OwnerID     pgtype.UUID `json:"owner_id"`
+	DaemonID    pgtype.Text `json:"daemon_id"`
+	Provider    string      `json:"provider"`
+}
+
+func (q *Queries) ClearExpiredHolds(ctx context.Context) ([]ClearExpiredHoldsRow, error) {
+	rows, err := q.db.Query(ctx, clearExpiredHolds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ClearExpiredHoldsRow{}
+	for rows.Next() {
+		var i ClearExpiredHoldsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.OwnerID,
+			&i.DaemonID,
+			&i.Provider,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const clearRuntimeHold = `-- name: ClearRuntimeHold :one
+UPDATE agent_runtime
+SET hold_until = NULL, hold_reason = NULL, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason
+`
+
+func (q *Queries) ClearRuntimeHold(ctx context.Context, id pgtype.UUID) (AgentRuntime, error) {
+	row := q.db.QueryRow(ctx, clearRuntimeHold, id)
+	var i AgentRuntime
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.DaemonID,
+		&i.Name,
+		&i.RuntimeMode,
+		&i.Provider,
+		&i.Status,
+		&i.DeviceInfo,
+		&i.Metadata,
+		&i.LastSeenAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.LegacyDaemonID,
+		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
+	)
+	return i, err
+}
+
 const countActiveAgentsByRuntime = `-- name: CountActiveAgentsByRuntime :one
 SELECT count(*) FROM agent WHERE runtime_id = $1 AND archived_at IS NULL
 `
@@ -249,7 +322,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 }
 
 const findLegacyRuntimesByDaemonID = `-- name: FindLegacyRuntimesByDaemonID :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE workspace_id = $1
   AND provider = $2
   AND LOWER(daemon_id) = LOWER($3)
@@ -301,6 +374,8 @@ func (q *Queries) FindLegacyRuntimesByDaemonID(ctx context.Context, arg FindLega
 			&i.OwnerID,
 			&i.LegacyDaemonID,
 			&i.Visibility,
+			&i.HoldUntil,
+			&i.HoldReason,
 		); err != nil {
 			return nil, err
 		}
@@ -360,7 +435,7 @@ func (q *Queries) ForceOfflineRuntimesByIDs(ctx context.Context, runtimeIds []pg
 }
 
 const getAgentRuntime = `-- name: GetAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE id = $1
 `
 
@@ -383,12 +458,14 @@ func (q *Queries) GetAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRun
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 	)
 	return i, err
 }
 
 const getAgentRuntimeForWorkspace = `-- name: GetAgentRuntimeForWorkspace :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -416,12 +493,14 @@ func (q *Queries) GetAgentRuntimeForWorkspace(ctx context.Context, arg GetAgentR
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 	)
 	return i, err
 }
 
 const listAgentRuntimes = `-- name: ListAgentRuntimes :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -451,6 +530,8 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 			&i.OwnerID,
 			&i.LegacyDaemonID,
 			&i.Visibility,
+			&i.HoldUntil,
+			&i.HoldReason,
 		); err != nil {
 			return nil, err
 		}
@@ -463,7 +544,7 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 }
 
 const listAgentRuntimesByOwner = `-- name: ListAgentRuntimesByOwner :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE workspace_id = $1 AND owner_id = $2
 ORDER BY created_at ASC
 `
@@ -498,6 +579,8 @@ func (q *Queries) ListAgentRuntimesByOwner(ctx context.Context, arg ListAgentRun
 			&i.OwnerID,
 			&i.LegacyDaemonID,
 			&i.Visibility,
+			&i.HoldUntil,
+			&i.HoldReason,
 		); err != nil {
 			return nil, err
 		}
@@ -537,7 +620,7 @@ func (q *Queries) ListArchivedAgentIDsByRuntime(ctx context.Context, runtimeID p
 }
 
 const lockAgentRuntime = `-- name: LockAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason FROM agent_runtime
 WHERE id = $1
 FOR UPDATE
 `
@@ -575,6 +658,8 @@ func (q *Queries) LockAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRu
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 	)
 	return i, err
 }
@@ -583,7 +668,7 @@ const markAgentRuntimeOnline = `-- name: MarkAgentRuntimeOnline :one
 UPDATE agent_runtime
 SET status = 'online', last_seen_at = now(), updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason
 `
 
 // Used on the offline→online transition (and on first heartbeat after
@@ -608,6 +693,8 @@ func (q *Queries) MarkAgentRuntimeOnline(ctx context.Context, id pgtype.UUID) (A
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 	)
 	return i, err
 }
@@ -807,6 +894,44 @@ func (q *Queries) SetAgentRuntimeOffline(ctx context.Context, id pgtype.UUID) er
 	return err
 }
 
+const setRuntimeHold = `-- name: SetRuntimeHold :one
+UPDATE agent_runtime
+SET hold_until = $1, hold_reason = $2, updated_at = now()
+WHERE id = $3
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason
+`
+
+type SetRuntimeHoldParams struct {
+	HoldUntil  pgtype.Timestamptz `json:"hold_until"`
+	HoldReason pgtype.Text        `json:"hold_reason"`
+	ID         pgtype.UUID        `json:"id"`
+}
+
+func (q *Queries) SetRuntimeHold(ctx context.Context, arg SetRuntimeHoldParams) (AgentRuntime, error) {
+	row := q.db.QueryRow(ctx, setRuntimeHold, arg.HoldUntil, arg.HoldReason, arg.ID)
+	var i AgentRuntime
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.DaemonID,
+		&i.Name,
+		&i.RuntimeMode,
+		&i.Provider,
+		&i.Status,
+		&i.DeviceInfo,
+		&i.Metadata,
+		&i.LastSeenAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.LegacyDaemonID,
+		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
+	)
+	return i, err
+}
+
 const touchAgentRuntimeLastSeen = `-- name: TouchAgentRuntimeLastSeen :execrows
 UPDATE agent_runtime
 SET last_seen_at = now()
@@ -860,7 +985,7 @@ const updateAgentRuntimeVisibility = `-- name: UpdateAgentRuntimeVisibility :one
 UPDATE agent_runtime
 SET visibility = $1, updated_at = now()
 WHERE id = $2
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason
 `
 
 type UpdateAgentRuntimeVisibilityParams struct {
@@ -891,6 +1016,8 @@ func (q *Queries) UpdateAgentRuntimeVisibility(ctx context.Context, arg UpdateAg
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 	)
 	return i, err
 }
@@ -918,7 +1045,7 @@ DO UPDATE SET
     owner_id = COALESCE(EXCLUDED.owner_id, agent_runtime.owner_id),
     last_seen_at = now(),
     updated_at = now()
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, (xmax = 0) AS inserted
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, hold_until, hold_reason, (xmax = 0) AS inserted
 `
 
 type UpsertAgentRuntimeParams struct {
@@ -949,6 +1076,8 @@ type UpsertAgentRuntimeRow struct {
 	OwnerID        pgtype.UUID        `json:"owner_id"`
 	LegacyDaemonID pgtype.Text        `json:"legacy_daemon_id"`
 	Visibility     string             `json:"visibility"`
+	HoldUntil      pgtype.Timestamptz `json:"hold_until"`
+	HoldReason     pgtype.Text        `json:"hold_reason"`
 	Inserted       bool               `json:"inserted"`
 }
 
@@ -984,6 +1113,8 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		&i.OwnerID,
 		&i.LegacyDaemonID,
 		&i.Visibility,
+		&i.HoldUntil,
+		&i.HoldReason,
 		&i.Inserted,
 	)
 	return i, err

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -279,6 +279,12 @@ WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
       AND NOT EXISTS (
+          SELECT 1 FROM agent_runtime ar
+          WHERE ar.id = atq.runtime_id
+            AND ar.hold_until IS NOT NULL
+            AND ar.hold_until > now()
+      )
+      AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
             AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
@@ -573,9 +579,16 @@ ORDER BY priority DESC, created_at ASC;
 -- ClaimAgentTask, wasting CPU and a SELECT every poll cycle when the
 -- runtime is busy on a long-running task. Backed by the partial index
 -- idx_agent_task_queue_claim_candidates so the warm path is cheap.
-SELECT * FROM agent_task_queue
-WHERE runtime_id = $1 AND status = 'queued'
-ORDER BY priority DESC, created_at ASC;
+-- Skips results when the runtime is on hold (hold_until > now()).
+SELECT atq.* FROM agent_task_queue atq
+WHERE atq.runtime_id = $1 AND atq.status = 'queued'
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_runtime ar
+      WHERE ar.id = atq.runtime_id
+        AND ar.hold_until IS NOT NULL
+        AND ar.hold_until > now()
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC;
 
 -- name: ListActiveTasksByIssue :many
 -- Backs the issue-detail "agent live" banner. Includes 'queued' so the

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -285,6 +285,24 @@ UPDATE agent_runtime
 SET legacy_daemon_id = COALESCE(legacy_daemon_id, $2)
 WHERE id = $1;
 
+-- name: SetRuntimeHold :one
+UPDATE agent_runtime
+SET hold_until = @hold_until, hold_reason = @hold_reason, updated_at = now()
+WHERE id = @id
+RETURNING *;
+
+-- name: ClearRuntimeHold :one
+UPDATE agent_runtime
+SET hold_until = NULL, hold_reason = NULL, updated_at = now()
+WHERE id = @id
+RETURNING *;
+
+-- name: ClearExpiredHolds :many
+UPDATE agent_runtime
+SET hold_until = NULL, hold_reason = NULL, updated_at = now()
+WHERE hold_until IS NOT NULL AND hold_until <= now()
+RETURNING id, workspace_id, owner_id, daemon_id, provider;
+
 -- name: DeleteStaleOfflineRuntimes :many
 -- Deletes runtimes that have been offline for longer than the TTL and have
 -- no agents bound (active or archived). The FK constraint on agent.runtime_id

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -301,7 +301,7 @@ RETURNING *;
 UPDATE agent_runtime
 SET hold_until = NULL, hold_reason = NULL, updated_at = now()
 WHERE hold_until IS NOT NULL AND hold_until <= now()
-RETURNING id, workspace_id, owner_id, daemon_id, provider;
+RETURNING id, workspace_id;
 
 -- name: DeleteStaleOfflineRuntimes :many
 -- Deletes runtimes that have been offline for longer than the TTL and have

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -118,6 +118,10 @@ const (
 	EventDaemonRegister      = "daemon:register"
 	EventDaemonTaskAvailable = "daemon:task_available"
 
+	// Runtime hold events
+	EventRuntimeHeld    = "runtime:held"
+	EventRuntimeResumed = "runtime:resumed"
+
 	// GitHub integration events
 	EventGitHubInstallationCreated = "github_installation:created"
 	EventGitHubInstallationDeleted = "github_installation:deleted"

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -99,7 +99,15 @@ func Classify(rawError string) Reason {
 	):
 		return ReasonAgentProviderAuthOrAccess
 
-	// 4. Quota / billing. 402 / insufficient balance / monthly usage
+	// 4. Session limit. Checked before quota because the Claude session
+	//    limit message ("You've hit your session limit · resets ...")
+	//    overlaps with the quota/billing patterns but is structurally
+	//    different: the runtime goes on hold until the reset time
+	//    rather than requiring a billing action.
+	case strings.Contains(lower, "session limit"):
+		return ReasonSessionLimit
+
+	// 5. Quota / billing. 402 / insufficient balance / monthly usage
 	//    limit / credits exhausted.
 	case containsAny(lower,
 		"402",

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -104,7 +104,15 @@ func Classify(rawError string) Reason {
 	//    overlaps with the quota/billing patterns but is structurally
 	//    different: the runtime goes on hold until the reset time
 	//    rather than requiring a billing action.
-	case strings.Contains(lower, "session limit"):
+	//
+	//    The "reset" token is required, not just "session limit": the
+	//    hold is only useful when the message also carries a reset time
+	//    we can parse into an expiry. A "session limit" message without a
+	//    reset marker would otherwise classify here, get held, but never
+	//    receive a real hold_until — leaving the runtime stuck on hold
+	//    until a manual resume. Such messages fall through to the broader
+	//    quota rule (still retryable, but no open-ended hold).
+	case strings.Contains(lower, "session limit") && strings.Contains(lower, "reset"):
 		return ReasonSessionLimit
 
 	// 5. Quota / billing. 402 / insufficient balance / monthly usage

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -62,7 +62,11 @@ func TestClassifyRules(t *testing.T) {
 		{"does not have access", "Your account does not have access to this model", ReasonAgentProviderAuthOrAccess},
 		{"may not have access", "you may not have access to claude-3-opus", ReasonAgentProviderAuthOrAccess},
 
-		// 4. Provider quota / billing.
+		// 4. Session limit (checked before quota).
+		{"session limit pm", "You've hit your session limit · resets 5:10pm (UTC)", ReasonSessionLimit},
+		{"session limit am", "You've hit your session limit · resets 10:10am (UTC)", ReasonSessionLimit},
+
+		// 5. Provider quota / billing.
 		{"402", "API Error: 402 Payment Required", ReasonAgentProviderQuotaLimit},
 		{"insufficient_balance", `{"error":{"code":"insufficient_balance"}}`, ReasonAgentProviderQuotaLimit},
 		{"balance is too low", "balance is too low to make this request", ReasonAgentProviderQuotaLimit},

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -62,7 +62,11 @@ func TestClassifyRules(t *testing.T) {
 		{"does not have access", "Your account does not have access to this model", ReasonAgentProviderAuthOrAccess},
 		{"may not have access", "you may not have access to claude-3-opus", ReasonAgentProviderAuthOrAccess},
 
-		// 4. Session limit (checked before quota).
+		// 4. Session limit (checked before quota). Requires both the
+		//    "session limit" phrase AND a "reset" marker — the hold is only
+		//    useful when a reset time can be parsed into an expiry, so a
+		//    session-limit message without "reset" must NOT land here (see
+		//    TestClassifySessionLimitRequiresResetToken).
 		{"session limit pm", "You've hit your session limit · resets 5:10pm (UTC)", ReasonSessionLimit},
 		{"session limit am", "You've hit your session limit · resets 10:10am (UTC)", ReasonSessionLimit},
 
@@ -189,6 +193,38 @@ func TestClassifyOrderingPriorities(t *testing.T) {
 				t.Errorf("Classify(%q) = %q, want %q", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+// TestClassifySessionLimitRequiresResetToken pins the contract that a
+// "session limit" message is only classified as ReasonSessionLimit when it
+// also carries a "reset" marker. The hold path keys off this reason and only
+// works when ParseSessionLimitResetTime can extract an expiry; a session-limit
+// message without "reset" would otherwise be held with no hold_until, leaving
+// the runtime stuck until a manual resume. Without the token it must fall
+// through to the broader (still-retryable) quota rule instead.
+func TestClassifySessionLimitRequiresResetToken(t *testing.T) {
+	t.Parallel()
+
+	// With a reset marker: classified as the session-limit reason.
+	withReset := []string{
+		"You've hit your session limit · resets 5:10pm (UTC)",
+		"task failed: session limit reached, resets 9:00am",
+	}
+	for _, in := range withReset {
+		if got := Classify(in); got != ReasonSessionLimit {
+			t.Errorf("Classify(%q) = %q, want %q", in, got, ReasonSessionLimit)
+		}
+	}
+
+	// Without a reset marker: must NOT be the session-limit reason. The
+	// "usage limit" phrasing routes to the quota bucket; the bare phrase
+	// falls through to the catchall. Either way it is not held.
+	if got := Classify("You've hit your session limit"); got == ReasonSessionLimit {
+		t.Errorf(`Classify(%q) = %q, want anything but %q`, "You've hit your session limit", got, ReasonSessionLimit)
+	}
+	if got := Classify("session limit: monthly usage limit reached"); got != ReasonAgentProviderQuotaLimit {
+		t.Errorf("Classify(session limit without reset) = %q, want %q", got, ReasonAgentProviderQuotaLimit)
 	}
 }
 

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -12,23 +12,29 @@
 // This package lifts that classifier into the in-flight write path so the
 // stored failure_reason is already refined when the row is first
 // persisted, and so server / daemon / cloud share a single source of
-// truth for the canonical 21 values. PR1 of the Grafana board plan
+// truth for the canonical 22 values. PR1 of the Grafana board plan
 // ([MUL-2946](https://multica/issues/MUL-2946)). Subsequent PRs use
 // AllReasons() to pre-warm the Prometheus failure_reason label set.
 //
-// The 21 canonical values fall into two groups:
+// The 22 canonical values fall into two groups:
 //
-//   - 7 platform-side values (no `agent_error.` prefix) emitted by the
-//     server-side sweepers and daemon classifiers when the failure is
-//     attributable to the platform/scheduler/runtime layer rather than
-//     anything the agent process did:
+//   - 8 platform-side values (no `agent_error.` prefix) attributable to
+//     the platform/scheduler/runtime layer rather than anything the agent
+//     process did:
 //
 //     queued_expired, runtime_offline, runtime_recovery, timeout,
-//     iteration_limit, agent_blocked, api_invalid_request
+//     iteration_limit, agent_blocked, api_invalid_request, session_limit
+//
+//     Most are emitted by the server-side sweepers and daemon classifiers.
+//     session_limit is the exception: it is platform-side (the runtime is
+//     placed on hold rather than the agent process having erred) but is
+//     produced by Classify(rawError) when it detects a session-limit
+//     message — so Classify's output is NOT exclusively agent-side.
 //
 //   - 14 agent-side values (with `agent_error.` prefix) produced by
 //     Classify(rawError) when the agent process surfaced an error string.
-//     IsAgentError reports membership in this set.
+//     IsAgentError reports membership in this set (and returns false for
+//     session_limit, which carries no `agent_error.` prefix).
 //
 // Wire stability: the string forms of these constants are persisted into
 // the database and surfaced as Prometheus labels. Renaming a value is a
@@ -179,7 +185,7 @@ const (
 	ReasonAgentUnknown Reason = "agent_error.unknown"
 )
 
-// allReasons is the canonical ordered list of the 21 reasons. Order is
+// allReasons is the canonical ordered list of the 22 reasons. Order is
 // stable so callers (e.g. Prometheus collectors that pre-warm series via
 // AllReasons) can build deterministic label sets across restarts.
 //
@@ -237,7 +243,7 @@ func (r Reason) IsAgentError() bool {
 	return strings.HasPrefix(string(r), agentErrorPrefix)
 }
 
-// AllReasons returns the canonical 21 reasons in a stable order. The
+// AllReasons returns the canonical 22 reasons in a stable order. The
 // caller MUST NOT mutate the returned slice; a copy is returned so
 // concurrent callers can append to their local copy without corrupting
 // the package-level fixture.

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -99,6 +99,11 @@ const (
 	// resume lookup. Written by classifyPoisonedError in daemon/poisoned.go.
 	ReasonAPIInvalidRequest Reason = "api_invalid_request"
 
+	// ReasonSessionLimit: the runtime hit a session limit (e.g. Claude
+	// "You've hit your session limit"). The runtime is placed on hold
+	// until the reset time; tasks are auto-retried after the hold lifts.
+	ReasonSessionLimit Reason = "session_limit"
+
 	// Agent process side: failure surfaced by the agent CLI / SDK as
 	// an error string. Classify(rawError) is responsible for picking
 	// the right sub-reason from the string. IsAgentError returns true
@@ -192,6 +197,7 @@ var allReasons = []Reason{
 	ReasonIterationLimit,
 	ReasonAgentBlocked,
 	ReasonAPIInvalidRequest,
+	ReasonSessionLimit,
 
 	// Agent process side: provider errors.
 	ReasonAgentProviderAuthOrAccess,

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -110,8 +110,8 @@ func TestAllReasonsContents(t *testing.T) {
 	t.Parallel()
 
 	got := AllReasons()
-	if len(got) != 21 {
-		t.Fatalf("AllReasons() returned %d entries, want 21", len(got))
+	if len(got) != 22 {
+		t.Fatalf("AllReasons() returned %d entries, want 22", len(got))
 	}
 
 	seen := make(map[Reason]bool, len(got))
@@ -128,8 +128,8 @@ func TestAllReasonsContents(t *testing.T) {
 		}
 	}
 
-	if platformCount != 7 {
-		t.Errorf("AllReasons(): platform-side count = %d, want 7", platformCount)
+	if platformCount != 8 {
+		t.Errorf("AllReasons(): platform-side count = %d, want 8", platformCount)
 	}
 	if agentCount != 14 {
 		t.Errorf("AllReasons(): agent-side count = %d, want 14", agentCount)

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -26,6 +26,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonIterationLimit, "iteration_limit"},
 		{ReasonAgentBlocked, "agent_blocked"},
 		{ReasonAPIInvalidRequest, "api_invalid_request"},
+		{ReasonSessionLimit, "session_limit"},
 		// Agent-side.
 		{ReasonAgentProviderAuthOrAccess, "agent_error.provider_auth_or_access"},
 		{ReasonAgentProviderQuotaLimit, "agent_error.provider_quota_limit"},
@@ -43,7 +44,7 @@ func TestReasonStringWireValues(t *testing.T) {
 		{ReasonAgentUnknown, "agent_error.unknown"},
 	}
 
-	if got, want := len(cases), 21; got != want {
+	if got, want := len(cases), 22; got != want {
 		t.Fatalf("constant count = %d, want %d (canonical taxonomy size)", got, want)
 	}
 
@@ -70,6 +71,7 @@ func TestIsAgentError(t *testing.T) {
 		ReasonIterationLimit,
 		ReasonAgentBlocked,
 		ReasonAPIInvalidRequest,
+		ReasonSessionLimit,
 	}
 	for _, r := range platformSide {
 		if r.IsAgentError() {


### PR DESCRIPTION
## Summary

- Claude runtimes that hit a session limit are automatically placed on hold until the platform-reported reset time — no further tasks are dispatched to them while the hold is active, and `hold_until` / `hold_reason` are exposed on the runtime response so UIs can show the state.
- Tasks that fail with a `session_limit` reason are auto-retried; they queue immediately but are claim-gated until the hold expires, then released by the sweeper's `runtime:resumed` + `daemon:register` broadcast.
- A new `POST /api/runtimes/{id}/resume` endpoint lets workspace members (owner/admin) lift a hold manually before the automatic reset time.

## Why

When Claude returns "You've hit your session limit · resets 5:10pm (UTC)", the system previously had no way to react — tasks would fail with no retry path and no visibility into why. This PR closes that loop end-to-end: parse the UTC reset time from the message, hold the runtime, record a `session_limit` event at the triggering issue, reschedule the task, and auto-release when the reset time is reached. Manual resume is there for cases where the limit clears early (e.g. a manual platform reset).


## Risk

- **Migration 119** adds two nullable columns (`hold_until TIMESTAMPTZ`, `hold_reason TEXT`) to `agent_runtime`. Backwards-compatible — no default value, no back-fill, existing rows are unaffected. Rollback drops the two columns cleanly.
- **Claim-gating change** means held runtimes receive no tasks until the hold lifts. If a hold is set incorrectly, `POST /api/runtimes/{id}/resume` clears it immediately.
- **No feature flag.** Hold/resume activates for all Claude runtimes on deploy. The only trigger is the exact session-limit message pattern — other failure modes are unaffected.
- **Also bumps the `taskfailure` taxonomy**: `session_limit` is now reason #8 (platform-side). Any caller that pattern-matches on the full reason list should treat unknown values gracefully (they already should, but worth a grep if you have such callers).

## Test plan

- [ ] **Parser** (`session_limit_test.go`): 12am → hour 0, 12pm → hour 12, 1pm → 13, 1am → 1; tomorrow rollover for past-today wall-clock; case-insensitive AM; message embedded in larger text; out-of-range hour rejected.
- [ ] **Sweeper** (`runtime_sweeper_test.go`): expired hold is cleared and `runtime:resumed` event is broadcast; a future hold is left untouched.
- [ ] **Resume API** (`handler/runtime_test.go`): 400 on malformed UUID, 404 on unknown runtime, 200 clears `hold_until` in DB and returns `nil` in response, 503 when task service is unavailable.
- [ ] **Claim gating**: confirm both `ClaimAgentTask` and `ListQueuedClaimCandidatesByRuntime` skip held runtimes — checked in code review, covered by the end-to-end retry-stays-queued contract.
- [ ] **Integration smoke** (CI): migration 119 applies cleanly against `pgvector/pgvector:pg17`; `go test ./...` green (two pre-existing flakes in `internal/daemon` and `pkg/agent/codex` are environmental, not regressions — see code review for details).