### PR TITLE
fix(agent): normalise colon-separated model IDs in opencode discovery (MUL-3198)

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -451,6 +452,28 @@ func parseOpenCodeModelIDLine(line string) string {
 	id := fields[0]
 	if strings.HasPrefix(id, `"`) || strings.HasPrefix(id, "{") || strings.HasPrefix(id, "[") {
 		return ""
+	}
+	// Normalize the first colon to slash so that model IDs emitted by
+	// opencode in provider:model format (e.g. "custom:lfm2.5:8b") are
+	// treated the same as provider/model. Subsequent colons (as in the
+	// model segment "lfm2.5:8b") are preserved.  This mirrors the
+	// normalisation applied by parsePiModels for the pi backend.
+	// Guard: only normalise colon to slash when the line looks like a
+	// table-format model row (fields[0] is the model ID, the rest are
+	// context/max_out numbers) or a bare model ID. Skip multi-word noise
+	// like "panic: catalog sync failed" where subsequent tokens contain
+	// letters.
+	if strings.Contains(id, ":") && !strings.Contains(id, "/") {
+		isTableRow := true
+		for _, f := range fields[1:] {
+			if _, err := strconv.Atoi(strings.TrimSpace(f)); err != nil {
+				isTableRow = false
+				break
+			}
+		}
+		if isTableRow {
+			id = strings.Replace(id, ":", "/", 1)
+		}
 	}
 	if !strings.Contains(id, "/") {
 		return ""

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -310,6 +310,33 @@ nonprefixed-line
 	}
 }
 
+func TestParseOpenCodeModelsColonProvider(t *testing.T) {
+	// opencode may emit local/custom models as "provider:model"
+	// (e.g. "custom:lfm2.5:8b"). The first colon should be
+	// normalised to a slash so the model is not silently dropped.
+	input := `PROVIDER/MODEL                     CONTEXT  MAX_OUT
+custom:lfm2.5:8b                   32768    4096
+custom:qwen3:4b                    131072   8192
+openai/gpt-4o                      128000   16384
+`
+	models := parseOpenCodeModels(input)
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models (colon normalised), got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "custom/lfm2.5:8b" {
+		t.Errorf("custom:lfm2.5:8b not normalised, got %q", models[0].ID)
+	}
+	if models[0].Provider != "custom" {
+		t.Errorf("expected provider custom, got %q", models[0].Provider)
+	}
+	if models[1].ID != "custom/qwen3:4b" {
+		t.Errorf("custom:qwen3:4b not normalised, got %q", models[1].ID)
+	}
+	if models[2].ID != "openai/gpt-4o" {
+		t.Errorf("expected openai/gpt-4o, got %q", models[2].ID)
+	}
+}
+
 func TestParseOpenCodeModelsVerboseVariants(t *testing.T) {
 	input := `openai/gpt-5
 {


### PR DESCRIPTION
## Summary
- Normalise the first colon in model IDs to a slash in `parseOpenCodeModelIDLine()`, matching the existing behaviour of `parsePiModels()`
- Fixes detection of local/custom models emitted by opencode in `provider:model` format (e.g. `custom:lfm2.5:8b` → `custom/lfm2.5:8b`)

## Changes
| File | Change |
|------|--------|
| `server/pkg/agent/models.go` | Guard colon normalisation to table-format rows; add structural backstop to drop single-token colon noise; remove redundant TrimSpace |
| `server/pkg/agent/models_test.go` | Add `TestParseOpenCodeModelsColonProvider` for colon normalisation and `TestParseOpenCodeModelsColonNoiseAndBare` for noise-line backstop |

## Test Plan
- [x] `TestParseOpenCodeModelsColonProvider` validates `custom:lfm2.5:8b` → `custom/lfm2.5:8b`
- [x] `TestParseOpenCodeModelsColonNoiseAndBare` validates noise lines (Error:, custom:, etc.) are dropped by structural backstop
- [x] Existing tests continue to pass

Related to #3945