### PR TITLE
fix(daemon): add opencode export fallback for empty output

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3599,18 +3599,34 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	case "completed":
 		if result.Output == "" {
 			// The agent completed successfully but produced no text output.
-			// This is valid — the agent may have done all its work via tool
-			// calls (e.g. posting comments via CLI, pushing code). Treat as
-			// a normal completion so the task is not incorrectly marked as
-			// blocked.
-			return TaskResult{
-				Status:    "completed",
-				Comment:   "",
-				SessionID: result.SessionID,
-				WorkDir:   env.WorkDir,
-				EnvRoot:   env.RootDir,
-				Usage:     usageEntries,
-			}, nil
+			// Before treating this as a valid empty completion, attempt an
+			// export fallback for backends that support SessionExporter (opencode).
+			// may not stream text events over NDJSON even though the
+			// response is stored in the session DB. See #3922.
+			if result.SessionID != "" {
+				if exporter, ok := backend.(agent.SessionExporter); ok {
+					exported, exportErr := exporter.ExportSession(ctx, result.SessionID)
+					if exportErr != nil {
+						taskLog.Warn("session export fallback failed", "error", exportErr, "session_id", result.SessionID)
+					} else if exported != "" {
+						taskLog.Info("session export fallback recovered output", "bytes", len(exported), "session_id", result.SessionID)
+						result.Output = exported
+					}
+				}
+			}
+			if result.Output == "" {
+				// Still empty after fallback (or not an opencode backend).
+				// This is valid — the agent may have done all its work via
+				// tool calls (e.g. posting comments via CLI, pushing code).
+				return TaskResult{
+					Status:    "completed",
+					Comment:   "",
+					SessionID: result.SessionID,
+					WorkDir:   env.WorkDir,
+					EnvRoot:   env.RootDir,
+					Usage:     usageEntries,
+				}, nil
+			}
 		}
 		// Detect "poisoned" terminal output: the agent didn't reach a real
 		// conclusion but emitted a known fallback marker (iteration limit,

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -20,6 +20,15 @@ type Backend interface {
 	Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error)
 }
 
+// SessionExporter is an optional interface that backends may implement to
+// support recovering output from a completed session when the primary
+// streaming path produced no text (e.g. opencode run --format json emitting
+// only step_start events). The daemon checks for this interface when
+// result.Output is empty but a session ID is available.
+type SessionExporter interface {
+	ExportSession(ctx context.Context, sessionID string) (string, error)
+}
+
 // ExecOptions configures a single execution.
 type ExecOptions struct {
 	Cwd   string

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -201,6 +201,58 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
+// ExportSession runs `opencode export <sessionID>` and returns the
+// concatenated text output from the session database. This is the
+// fallback path when `opencode run --format json` completes with
+// status=completed but output_bytes=0 — opencode v1.16.2 and later
+// may not stream text/reasoning events over NDJSON, even though the
+// response is stored in the session DB and retrievable via export.
+// See #3922.
+func (b *opencodeBackend) ExportSession(ctx context.Context, sessionID string) (string, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "opencode"
+	}
+	resolved, err := exec.LookPath(execPath)
+	if err != nil {
+		return "", fmt.Errorf("opencode executable not found: %w", err)
+	}
+
+	exportCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(exportCtx, resolved, "export", sessionID)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("opencode export fallback", "session_id", sessionID)
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("opencode export %s: %w", sessionID, err)
+	}
+
+	// Parse the export output: each line is a JSON object with type and text fields.
+	var texts []string
+	scanner := bufio.NewScanner(strings.NewReader(string(stdout)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Type == "text" && entry.Text != "" {
+			texts = append(texts, entry.Text)
+		}
+	}
+	return strings.Join(texts, ""), nil
+}
+
 // ── Event handlers ──
 
 // eventResult holds the accumulated state from processing the event stream.


### PR DESCRIPTION
## Summary
- When opencode run --format json completes with output_bytes=0 but a session ID is available, fall back to opencode export sessionID to recover the response from the session database
- Adds SessionExporter optional interface to the agent package for backend-agnostic export support

## Root Cause
opencode v1.16.2 with --format json only emits step_start events on stdout. Text and reasoning output is stored in the session database but never reaches stdout.

## Changes
| File | Change |
|------|--------|
| server/pkg/agent/agent.go | Add SessionExporter optional interface |
| server/pkg/agent/opencode.go | Add ExportSession() method |
| server/internal/daemon/daemon.go | Attempt export fallback when result.Output is empty |

Fixes #3922