### PR TITLE
fix(ui): ensure avatar images are properly centered and cropped [MUL-3196]

### DIFF
--- a/packages/ui/components/common/actor-avatar.tsx
+++ b/packages/ui/components/common/actor-avatar.tsx
@@ -50,7 +50,7 @@ function ActorAvatar({
         <img
           src={avatarUrl}
           alt={name}
-          className="h-full w-full object-cover"
+          className="h-full w-full object-cover object-center"
           onError={() => setImgError(true)}
         />
       ) : isSystem ? (

--- a/packages/views/workspace/workspace-avatar.tsx
+++ b/packages/views/workspace/workspace-avatar.tsx
@@ -21,7 +21,11 @@ function WorkspaceAvatar({ name, avatarUrl, size = "sm", className }: WorkspaceA
       <img
         src={resolvedUrl}
         alt={name}
-        className={cn("inline-block shrink-0 border object-cover", sizeMap[size], className)}
+        className={cn(
+          "inline-block shrink-0 border aspect-square overflow-hidden object-cover object-center",
+          sizeMap[size],
+          className,
+        )}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Fix avatar/image centering and cropping in WorkspaceAvatar and ActorAvatar components
- Add aspect-square, overflow-hidden, and object-center to ensure proper centering

## Root Cause
WorkspaceAvatar used object-cover without object-center or aspect-square. ActorAvatar lacked explicit object-center.

## Changes
| File | Change |
|------|--------|
| packages/views/workspace/workspace-avatar.tsx | Add aspect-square, overflow-hidden, object-center |
| packages/ui/components/common/actor-avatar.tsx | Add object-center |

Fixes #3789