### PR TITLE
fix(quick-create): persist project selection immediately on pick

### DIFF
--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -495,7 +495,11 @@ export function AgentCreatePanel({
         <div className="flex items-center gap-1.5 px-4 pb-2 shrink-0 flex-wrap">
           <ProjectPicker
             projectId={projectId}
-            onUpdate={(u) => setProjectId(u.project_id ?? null)}
+            onUpdate={(u) => {
+              const newProjectId = u.project_id ?? null;
+              setProjectId(newProjectId);
+              setLastProjectId(newProjectId);
+            }}
             triggerRender={<PillButton />}
             align="start"
           />


### PR DESCRIPTION
## Summary

- When issue creation fails in the quick-create dialog, the selected project was only persisted to `lastProjectId` on **successful** submission
- If the user closed the dialog after a failure and reopened it ("重新创建"), the project field would revert to the previous successfully-created project instead of the one just selected
- Fix: persist `lastProjectId` immediately when the user picks a project in the `ProjectPicker`, not just on submit success

## Root cause

In `packages/views/modals/quick-create-issue.tsx`, `setLastProjectId` was only called in the success path (`setLastProjectId(projectId)` at submit). The `ProjectPicker.onUpdate` callback only updated local component state, so the selection was lost when the component unmounted on dialog close.

## Fix

Added `setLastProjectId(newProjectId)` call inside the `ProjectPicker.onUpdate` callback so the selection is persisted to the workspace-scoped store as soon as the user picks it.

## Test plan

- [ ] Open quick-create dialog, select a project, submit → creation fails
- [ ] Close the dialog and reopen → project field is pre-filled with the selected project
- [ ] Successful creation flow still works correctly
- [ ] Switching projects before submit correctly persists the new selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)