### PR TITLE
MUL-3240: fix(desktop): Cmd+W closes active tab first, then window

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -204,10 +204,14 @@ function createWindow(): void {
 
   // Window-level keyboard shortcuts. Calling preventDefault here prevents
   // both the renderer keydown AND the application menu accelerator, so
-  // anything we own here (reload-block, zoom) is the sole handler for
-  // that combination — no double-fire with the macOS default View menu.
+  // anything we own here (reload-block, zoom, tab-close) is the sole handler
+  // for that combination — no double-fire with the macOS default View menu.
   window.webContents.on("before-input-event", (event, input) => {
-    if (handleAppShortcut(input, window.webContents)) {
+    const result = handleAppShortcut(input, window.webContents);
+    if (result === "close-tab") {
+      event.preventDefault();
+      window.webContents.send("tab:close-active");
+    } else if (result) {
       event.preventDefault();
     }
   });
@@ -368,6 +372,11 @@ if (!gotTheLock) {
     // false configuration.
     ipcMain.handle("shell:openExternal", (_event, url: string) => {
       return openExternalSafely(url);
+    });
+
+    // Renderer requests window close (e.g. Cmd+W on last tab).
+    ipcMain.on("window:close", () => {
+      mainWindow?.close();
     });
 
     ipcMain.handle("file:download-url", (_event, url: string) => {

--- a/apps/desktop/src/main/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.test.ts
@@ -150,3 +150,26 @@ describe("handleAppShortcut — unrelated keys pass through", () => {
     expect(handleAppShortcut(key("k", { meta: true }), wc, "darwin")).toBe(false);
   });
 });
+
+describe("handleAppShortcut — close tab (Cmd/Ctrl+W)", () => {
+  it('returns "close-tab" on Cmd+W (macOS)', () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("w", { meta: true }), wc, "darwin")).toBe("close-tab");
+  });
+
+  it('returns "close-tab" on Cmd+W uppercase', () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("W", { meta: true }), wc, "darwin")).toBe("close-tab");
+  });
+
+  it('returns "close-tab" on Ctrl+W (Linux/Windows)', () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("w", { control: true }), wc, "linux")).toBe("close-tab");
+    expect(handleAppShortcut(key("w", { control: true }), wc, "win32")).toBe("close-tab");
+  });
+
+  it("does not trigger without Cmd/Ctrl modifier", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("w"), wc, "darwin")).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.test.ts
@@ -14,13 +14,14 @@ function makeWc(initialLevel = 0) {
 
 function key(
   k: string,
-  mods: Partial<Pick<ShortcutInput, "control" | "meta">> = {},
+  mods: Partial<Pick<ShortcutInput, "control" | "meta" | "shift">> = {},
 ): ShortcutInput {
   return {
     type: "keyDown",
     key: k,
     control: false,
     meta: false,
+    shift: false,
     ...mods,
   };
 }
@@ -171,5 +172,15 @@ describe("handleAppShortcut — close tab (Cmd/Ctrl+W)", () => {
   it("does not trigger without Cmd/Ctrl modifier", () => {
     const wc = makeWc();
     expect(handleAppShortcut(key("w"), wc, "darwin")).toBe(false);
+  });
+
+  it("does not trigger on Cmd+Shift+W (reserved for close-window)", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("W", { meta: true, shift: true }), wc, "darwin")).toBe(false);
+  });
+
+  it("does not trigger on Ctrl+Shift+W (reserved for close-window)", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("W", { control: true, shift: true }), wc, "linux")).toBe(false);
   });
 });

--- a/apps/desktop/src/main/keyboard-shortcuts.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.ts
@@ -34,11 +34,19 @@ const ZOOM_MAX = 4.5;
  * Handling the shortcuts here gives identical behavior on every platform
  * and every layout.
  */
+/**
+ * Result of handleAppShortcut:
+ * - `false`: not handled, let Electron continue
+ * - `true`: handled (preventDefault), no further action
+ * - `"close-tab"`: Cmd/Ctrl+W intercepted — caller should send IPC to renderer
+ */
+export type ShortcutResult = boolean | "close-tab";
+
 export function handleAppShortcut(
   input: ShortcutInput,
   webContents: ZoomTarget,
   platform: NodeJS.Platform = process.platform,
-): boolean {
+): ShortcutResult {
   if (input.type !== "keyDown") return false;
   const cmdOrCtrl = platform === "darwin" ? input.meta : input.control;
 
@@ -68,6 +76,12 @@ export function handleAppShortcut(
   if (input.key === "0") {
     webContents.setZoomLevel(0);
     return true;
+  }
+
+  // Cmd/Ctrl + W → close active tab (or window if last tab).
+  // Return a signal so the caller can send IPC to the renderer.
+  if (input.key.toLowerCase() === "w") {
+    return "close-tab";
   }
 
   return false;

--- a/apps/desktop/src/main/keyboard-shortcuts.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.ts
@@ -8,6 +8,7 @@ export type ShortcutInput = {
   key: string;
   control: boolean;
   meta: boolean;
+  shift: boolean;
 };
 
 // Subset of WebContents the zoom handler needs. Keeps the test mock tiny.
@@ -79,8 +80,9 @@ export function handleAppShortcut(
   }
 
   // Cmd/Ctrl + W → close active tab (or window if last tab).
+  // Cmd/Ctrl + Shift + W is reserved for "close window" — do not intercept.
   // Return a signal so the caller can send IPC to the renderer.
-  if (input.key.toLowerCase() === "w") {
+  if (input.key.toLowerCase() === "w" && !input.shift) {
     return "close-tab";
   }
 

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -71,6 +71,11 @@ interface DesktopAPI {
       | "error";
     error?: string;
   }>;
+  /** Listen for Cmd/Ctrl+W tab-close requests from the main process.
+   *  Returns an unsubscribe function. */
+  onCloseActiveTab: (callback: () => void) => () => void;
+  /** Ask the main process to close the window. */
+  closeWindow: () => void;
 }
 
 interface DaemonStatus {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -162,6 +162,18 @@ const desktopAPI = {
   /** Validate that a path is an existing readable+writable directory. */
   validateLocalDirectory: (path: string) =>
     ipcRenderer.invoke("local-directory:validate", path),
+  /** Listen for Cmd/Ctrl+W tab-close requests from the main process.
+   *  The renderer should close the active tab; if it was the last tab,
+   *  call `closeWindow()` to dismiss the window. Returns an unsubscribe fn. */
+  onCloseActiveTab: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on("tab:close-active", handler);
+    return () => {
+      ipcRenderer.removeListener("tab:close-active", handler);
+    };
+  },
+  /** Ask the main process to close the window (used after closing the last tab). */
+  closeWindow: () => ipcRenderer.send("window:close"),
 };
 
 interface DaemonStatus {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -34,10 +34,44 @@ const HTML_LANG: Record<SupportedLocale, string> = {
 };
 
 
+/**
+ * Cmd/Ctrl+W: close the active tab. When the last real tab is closed
+ * (or no tabs/workspace exist — e.g. login page), close the window.
+ *
+ * Mounted in AppContent (not DesktopShell) so every app state — login,
+ * loading, onboarding — has a working Cmd+W handler. Without this,
+ * non-DesktopShell states would swallow the shortcut and do nothing.
+ */
+function useCmdWCloseTab() {
+  useEffect(() => {
+    return window.desktopAPI.onCloseActiveTab(() => {
+      const store = useTabStore.getState();
+      const { activeWorkspaceSlug, byWorkspace } = store;
+      if (!activeWorkspaceSlug) {
+        // No workspace — nothing to close, dismiss the window.
+        window.desktopAPI.closeWindow();
+        return;
+      }
+      const group = byWorkspace[activeWorkspaceSlug];
+      if (!group || group.tabs.length <= 1) {
+        // Last tab (or no tabs) — close the window.
+        window.desktopAPI.closeWindow();
+        return;
+      }
+      // Multiple tabs — close the active one.
+      store.closeActiveTab();
+    });
+  }, []);
+}
+
 function AppContent() {
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
   const qc = useQueryClient();
+
+  // Cmd/Ctrl+W handler — lives here (not DesktopShell) so login page,
+  // loading screen, and onboarding all get a working close shortcut.
+  useCmdWCloseTab();
   // Deep-link login runs loginWithToken → syncToken → listWorkspaces →
   // setQueryData sequentially. loginWithToken sets user+isLoading=false
   // as soon as getMe resolves, which would cause DesktopShell to mount

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -71,32 +71,6 @@ function useNativeNavigationGestures() {
   }, [goBack, goForward]);
 }
 
-/**
- * Cmd/Ctrl+W: close the active tab. When the last real tab is closed
- * (tab-store reseeds a default), close the window instead.
- */
-function useCmdWCloseTab() {
-  useEffect(() => {
-    return window.desktopAPI.onCloseActiveTab(() => {
-      const store = useTabStore.getState();
-      const { activeWorkspaceSlug, byWorkspace } = store;
-      if (!activeWorkspaceSlug) {
-        // No workspace — nothing to close, dismiss the window.
-        window.desktopAPI.closeWindow();
-        return;
-      }
-      const group = byWorkspace[activeWorkspaceSlug];
-      if (!group || group.tabs.length <= 1) {
-        // Last tab (or no tabs) — close the window.
-        window.desktopAPI.closeWindow();
-        return;
-      }
-      // Multiple tabs — close the active one.
-      store.closeActiveTab();
-    });
-  }, []);
-}
-
 // The main area's top bar doubles as a window drag region. When the sidebar
 // is not occupying main-flow width — either user-collapsed (offcanvas) or
 // auto-hidden in mobile mode (<768px, becomes a sheet drawer) — we pad the
@@ -188,7 +162,6 @@ export function DesktopShell() {
   useInternalLinkHandler();
   useActiveTitleSync();
   useNativeNavigationGestures();
-  useCmdWCloseTab();
 
   // Reactive read of current workspace slug from the platform singleton.
   // On first mount, slug is null until WorkspaceRouteLayout (inside the tab

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -71,6 +71,32 @@ function useNativeNavigationGestures() {
   }, [goBack, goForward]);
 }
 
+/**
+ * Cmd/Ctrl+W: close the active tab. When the last real tab is closed
+ * (tab-store reseeds a default), close the window instead.
+ */
+function useCmdWCloseTab() {
+  useEffect(() => {
+    return window.desktopAPI.onCloseActiveTab(() => {
+      const store = useTabStore.getState();
+      const { activeWorkspaceSlug, byWorkspace } = store;
+      if (!activeWorkspaceSlug) {
+        // No workspace — nothing to close, dismiss the window.
+        window.desktopAPI.closeWindow();
+        return;
+      }
+      const group = byWorkspace[activeWorkspaceSlug];
+      if (!group || group.tabs.length <= 1) {
+        // Last tab (or no tabs) — close the window.
+        window.desktopAPI.closeWindow();
+        return;
+      }
+      // Multiple tabs — close the active one.
+      store.closeActiveTab();
+    });
+  }, []);
+}
+
 // The main area's top bar doubles as a window drag region. When the sidebar
 // is not occupying main-flow width — either user-collapsed (offcanvas) or
 // auto-hidden in mobile mode (<768px, becomes a sheet drawer) — we pad the
@@ -162,6 +188,7 @@ export function DesktopShell() {
   useInternalLinkHandler();
   useActiveTitleSync();
   useNativeNavigationGestures();
+  useCmdWCloseTab();
 
   // Reactive read of current workspace slug from the platform singleton.
   // On first mount, slug is null until WorkspaceRouteLayout (inside the tab


### PR DESCRIPTION
## Problem

Pressing **Cmd+W** (macOS) / **Ctrl+W** (Win/Linux) immediately closes the entire Electron window. In a tabbed app, users expect it to close the active tab first.

Closes #3987

## Solution

Intercept Cmd/Ctrl+W in the `before-input-event` handler and route it through IPC:

1. **Main process** (`keyboard-shortcuts.ts`): intercept Cmd+W, return `"close-tab"` signal
2. **Main process** (`index.ts`): on signal, send `tab:close-active` IPC to renderer + add `window:close` handler
3. **Preload**: expose `onCloseActiveTab()` listener + `closeWindow()` sender
4. **Renderer** (`desktop-layout.tsx`): `useCmdWCloseTab` hook — close active tab if multiple, close window if last

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Cmd+W with 3 tabs | Window closes | Active tab closes, sibling activates |
| Cmd+W with 1 tab | Window closes | Window closes (unchanged) |
| Cmd+W with no workspace | Window closes | Window closes (unchanged) |

## Testing

- 4 new unit tests in `keyboard-shortcuts.test.ts` (all 23 pass)
- Manual: open 3 tabs → Cmd+W closes tabs one by one → last tab closes window