### PR TITLE
fix(attachments): render description images on Desktop (bind via contentReferencesAttachment)

### DIFF
--- a/packages/core/types/attachment-url.test.ts
+++ b/packages/core/types/attachment-url.test.ts
@@ -96,4 +96,26 @@ describe("contentReferencesAttachment", () => {
     const md = `![file](${attachmentDownloadPath(ID)})`;
     expect(contentReferencesAttachment(md, { id: ID, url: "" })).toBe(true);
   });
+
+  // Regression — issue DESCRIPTION editor binding (Desktop image render).
+  //
+  // The editor persists the durable `markdown_url`
+  // (`<MULTICA_PUBLIC_URL>/api/attachments/<id>/download`) into the body,
+  // NOT the raw storage `a.url`. The description composer used to bind
+  // pending uploads with `md.includes(a.url)`, which never matched this
+  // shape, so the upload was never linked via `attachment_ids`. After a
+  // reload the attachment was absent from `issueAttachments`, the renderer
+  // couldn't resolve it to a freshly-signed `download_url`, and the
+  // auth-gated endpoint failed to load as a native <img> on Desktop/Electron
+  // (cross-origin, no cookies). `contentReferencesAttachment` matches the
+  // absolute-host download URL via its stable-path substring, so the
+  // attachment now binds the same way comments do.
+  it("matches the absolute-host markdown_url the editor actually persists", () => {
+    const markdownUrl = `https://multica-api.copilothub.ai/api/attachments/${ID}/download`;
+    const md = `body\n\n![pasted](${markdownUrl})\n`;
+    // The raw storage url is NOT present in the body — the old
+    // `md.includes(a.url)` check would have returned false here.
+    expect(md.includes(att.url)).toBe(false);
+    expect(contentReferencesAttachment(md, att)).toBe(true);
+  });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -43,6 +43,7 @@ import { AvatarGroup, AvatarGroupCount } from "@multica/ui/components/ui/avatar"
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PropRow } from "../../common/prop-row";
 import type { Attachment, Issue, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
+import { contentReferencesAttachment } from "@multica/core/types";
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { formatDateOnly } from "@multica/core/issues/date";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
@@ -1847,8 +1848,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 // Bind any pending uploads still referenced in the markdown
                 // so they appear in `issueAttachments` after refresh and the
                 // editor's text/code preview keeps working past reload.
+                //
+                // Match with `contentReferencesAttachment`, NOT `md.includes(a.url)`:
+                // the editor persists the durable `markdownLink`
+                // (`/api/attachments/<id>/download` / `markdown_url`) into the
+                // body, never the raw storage `a.url`. A bare `md.includes(a.url)`
+                // therefore never matches, so the upload is never linked via
+                // `attachment_ids`. After reload it's absent from
+                // `issueAttachments`, the renderer can't resolve it to a
+                // freshly-signed `download_url`, and the persisted auth-gated
+                // download endpoint fails to load as a native <img> on clients
+                // whose origin isn't the API host (Desktop/Electron, mobile
+                // webview) — while still working on web via the cookie/proxy.
+                // This mirrors the comment/reply/chat composers, which already
+                // bind via `contentReferencesAttachment` (MUL-3130 / MUL-3192).
                 const ids = descPendingAttachments
-                  .filter((a) => md.includes(a.url))
+                  .filter((a) => contentReferencesAttachment(md, a))
                   .map((a) => a.id);
                 handleUpdateField({ description: md, attachment_ids: ids.length > 0 ? ids : undefined });
               }}


### PR DESCRIPTION
## Summary

Web-uploaded **issue description** images render fine on web but break on **Desktop/Electron**, and their copy-link returns the bare `https://<api-host>/api/attachments/<id>/download` endpoint — while comment images resolve to a signed CDN URL. This unifies the two.

### Root cause

Each attachment has three URL fields with different lifetimes:
- `url` — raw storage URL (may be private)
- `download_url` — per-response, signed CDN URL (short TTL, must not persist)
- `markdown_url` — durable persisted URL = `MULTICA_PUBLIC_URL + /api/attachments/<id>/download` (auth-gated)

The body persists `markdown_url`; the renderer upgrades it to a freshly-signed `download_url` at render time **only when it can resolve the attachment record** via `AttachmentDownloadProvider`.

The description editor bound pending uploads with `md.includes(a.url)`, but the editor writes the durable `markdownLink` (the download path), **never** the raw `a.url`. So the filter never matched → uploads were never linked via `attachment_ids` → after reload they were absent from `issueAttachments` → the renderer fell back to the auth-gated endpoint.

- **Web**: loads (same-site cookie / `/api` proxy).
- **Desktop/Electron** (`file://` renderer): cross-origin `<img>` carries no auth header and SameSite blocks the cookie → 401/404 → broken image.

Comments already bind via `contentReferencesAttachment` (which matches both the stable download path and `a.url`), so they resolve to the signed CDN URL and render everywhere.

### Fix

Switch the description editor's binding to `contentReferencesAttachment(md, a)`, matching the comment/reply/chat composers. Description images now resolve to the signed CDN URL on every client; copy-link becomes consistent too.

## Changes
- `packages/views/issues/components/issue-detail.tsx` — bind description uploads via `contentReferencesAttachment`.
- `packages/core/types/attachment-url.test.ts` — regression test for the absolute-host `markdown_url` shape.

## Testing
- `pnpm typecheck` — 6/6 packages pass
- `packages/core/types/attachment-url.test.ts` — 17/17 (incl. new test)
- `packages/views` `issues/components/issue-detail.test.tsx` — 24/24

## Notes
- Mobile (`apps/mobile/components/issue/comment-attachment-list.tsx`) uses the same `content.includes(a.url)` pattern and likely double-renders web-authored inline images; intentionally left out of scope here.