### PR TITLE
fix(editor): wrap tables in tableWrapper so wide tables scroll locally

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -180,7 +180,12 @@ export function createEditorExtensions(
     // markdownPaste's handlePaste is a catch-all that returns true.
     LinkExtension,
     ImageExtension,
-    Table.configure({ resizable: false }),
+    // renderWrapper wraps the table in `<div class="tableWrapper">` (the same
+    // wrapper the resizable NodeView emits), which prose.css styles with
+    // `overflow-x: auto`. Without it a wide table is a bare <table> that can't
+    // shrink below min-content, so the horizontal scrollbar lands on the
+    // page-level scroll container instead of the table itself.
+    Table.configure({ resizable: false, renderWrapper: true }),
     TableRow,
     TableHeader,
     TableCell,


### PR DESCRIPTION
## Problem

A wide table in an issue description forces a horizontal scrollbar on the entire issue detail scroll container (`issue-detail.tsx` page scroller) instead of scrolling within the table itself.

## Root cause

`Table.configure({ resizable: false })` leaves TipTap's `renderWrapper` at its default `false`, so tables render as bare `<table>` elements. The `.tableWrapper { overflow-x: auto }` rule in `packages/views/editor/styles/prose.css` targets a wrapper div that never exists in the DOM, so it never applies. A bare table can't shrink below its min-content width, and the overflow propagates to the nearest scroll container — the page-level `overflow-y-auto` div.

## Fix

Enable `renderWrapper: true` — TipTap then emits the same `<div class="tableWrapper">` wrapper that the resizable NodeView uses ([official docs](https://tiptap.dev/docs/editor/extensions/nodes/table): "maintaining layout consistency with the node view used for resizable tables"). The existing prose.css wrapper styles (overflow-x scroll, border, radius) take effect immediately, in both editable and readonly modes since both share this extension list.

This matches the industry-standard approach (Bootstrap `.table-responsive`, [tiptap#4872](https://github.com/ueberdosis/tiptap/issues/4872)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)