### PR TITLE
fix(issues): keep comment trigger preview fresh against live queue state

### DIFF
--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -73,9 +73,13 @@ export const issueKeys = {
   /** Full-issue timeline (single TanStack Query, no cursor). */
   timeline: (issueId: string) =>
     [...issueKeys.timelineAll(), issueId] as const,
+  /** Prefix across all issues — WS task lifecycle events invalidate here so
+   *  an open composer's trigger preview refreshes when an agent's queue
+   *  state changes (the dedup guard makes the answer queue-dependent). */
+  commentTriggerPreviewAll: () => ["issues", "comment-trigger-preview"] as const,
   /** PREFIX for invalidation — the composer hook appends parent + content signature. */
   commentTriggerPreview: (issueId: string) =>
-    ["issues", "comment-trigger-preview", issueId] as const,
+    [...issueKeys.commentTriggerPreviewAll(), issueId] as const,
   reactionsAll: () => ["issues", "reactions"] as const,
   reactions: (issueId: string) =>
     [...issueKeys.reactionsAll(), issueId] as const,

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -504,6 +504,12 @@ export function useRealtimeSync(
         // Squad members-status reads the same task lifecycle to flip
         // working ↔ idle for each agent member.
         invalidateSquadMemberStatusQueries(qc, wsId);
+        // Comment trigger previews answer "who would a send wake right
+        // now" — the pending-task dedup guard makes that answer
+        // queue-dependent, so any task lifecycle change must refresh an
+        // open composer's chips (e.g. an agent finishing its run becomes
+        // triggerable again mid-typing).
+        qc.invalidateQueries({ queryKey: issueKeys.commentTriggerPreviewAll() });
       },
     };
 

--- a/packages/views/issues/hooks/use-comment-trigger-preview.test.ts
+++ b/packages/views/issues/hooks/use-comment-trigger-preview.test.ts
@@ -69,10 +69,14 @@ describe("useCommentTriggerPreview", () => {
     );
   });
 
-  it("uses the TanStack Query cache when the debounced signature repeats", async () => {
+  it("revalidates when the debounced signature repeats — the answer is queue-state dependent", async () => {
     const agentA = "00000000-0000-0000-0000-000000000001";
     const content = `[@A](mention://agent/${agentA})`;
-    const { rerender } = renderHook(
+    const agents = [
+      { id: agentA, name: "A", source: "mention_agent", reason: "" },
+    ];
+    previewCommentTriggers.mockResolvedValue({ agents });
+    const { result, rerender } = renderHook(
       ({ content }) => useCommentTriggerPreview({ issueId: "issue-1", content }),
       {
         wrapper: createWrapper(),
@@ -85,9 +89,13 @@ describe("useCommentTriggerPreview", () => {
 
     rerender({ content: "" });
     rerender({ content });
+    // Cached agents render immediately for the repeated signature (no
+    // flicker)…
     await advancePreviewDebounce();
-
-    expect(previewCommentTriggers).toHaveBeenCalledTimes(1);
+    expect(result.current.agents).toEqual(agents);
+    // …but a background revalidation still fires: an agent finishing its
+    // queued task changes the answer for the very same mention set.
+    expect(previewCommentTriggers).toHaveBeenCalledTimes(2);
   });
 
   it("fetches again when routing mention tokens change", async () => {

--- a/packages/views/issues/hooks/use-comment-trigger-preview.ts
+++ b/packages/views/issues/hooks/use-comment-trigger-preview.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
 import { issueKeys } from "@multica/core/issues/queries";
 import type { CommentTriggerPreviewAgent } from "@multica/core/types";
@@ -77,7 +77,15 @@ export function useCommentTriggerPreview({
     queryFn: () => api.previewCommentTriggers(issueId, contentRef.current, parentId),
     enabled: signature !== "empty" && debouncedSignature !== "empty",
     retry: false,
-    staleTime: Infinity,
+    // The answer depends on live queue state (pending-task dedup), not just
+    // the mention set, so a cached result must revalidate when its signature
+    // reappears — Infinity here once pinned a stale "nobody triggers"
+    // snapshot taken while the agent was still queued.
+    staleTime: 0,
+    // Keep the previous agent list while a new signature is fetching:
+    // without it the in-flight gap renders as "no agents", flickering the
+    // chips and wiping the composer's suppressed-id set.
+    placeholderData: keepPreviousData,
   });
 
   // Loading and errors intentionally surface as "no agents": the preview is


### PR DESCRIPTION
## Summary
The trigger preview's answer depends on **live queue state** (the pending-task dedup guard), not just the mention set. Three staleness bugs around that, all in the frontend (backend verified correct against a real DB for every case):

- **Poisoned cache** — `staleTime: Infinity` permanently pinned a "nobody triggers" snapshot taken while the mentioned agent was still queued. Repro: @ the agent that just replied in the thread → no chip, but sending really does wake it (create always recomputes). → `staleTime: 0`: a repeated signature shows cached agents instantly and revalidates in the background.
- **Suppression wipe + flicker** — on a signature change the in-flight gap rendered as an empty agent list, which both flickered the chips and made the composer's pruning effect wipe the suppressed-id set. → `placeholderData: keepPreviousData`.
- **No live refresh** — nothing told an open composer that an agent's task finished. → the WS `task:` lifecycle handler now also invalidates the new `issueKeys.commentTriggerPreviewAll()` prefix, so chips appear mid-typing the moment the agent becomes triggerable again (per the "WS events invalidate queries" rule).

## Verification
- `pnpm --filter @multica/views exec vitest run issues/hooks/use-comment-trigger-preview.test.ts issues/components/comment-trigger-chips.test.tsx` — 16 passed (the "cache forever" test now asserts the revalidate-on-repeat contract)
- `pnpm --filter @multica/views typecheck` / `pnpm --filter @multica/core typecheck`
- Manual repro in dev: squad-assigned issue, @ the agent right after it replies — chip now appears once its task clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)