### PR TITLE
fix(agent): clear stale session id when a resumed ACP session is gone [MUL-3216]

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -299,6 +299,17 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				b.cfg.Logger.Warn("hermes set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// On a resumed session with a model override, the dead
+					// session surfaces here instead of at session/prompt.
+					// Same fix as the prompt path below: clear the id so
+					// the daemon's resume-failure fallback retries fresh.
+					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
+						"backend", "hermes",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 				resCh <- Result{
 					Status:     finalStatus,
 					Error:      finalError,
@@ -645,17 +656,19 @@ func (e *acpRPCError) Error() string {
 }
 
 // isACPSessionNotFound reports whether err is the agent rejecting a
-// session id it no longer knows. Runtimes signal this as JSON-RPC
-// -32603 (Internal error) with wording that varies — Hermes says
-// "Session not found", Kiro puts "No session found with id ..." in
-// `data` — so the code alone is not discriminating and the message
-// text is matched too.
+// session id it no longer knows. Runtimes signal this with codes and
+// wording that vary — Hermes says "Session not found" under -32603
+// (Internal error), Kiro puts "No session found with id ..." in
+// `data` under -32603, and kimi-cli raises invalid_params (-32602)
+// with {"session_id": "Session not found"} in `data` for every
+// unknown-session path (src/kimi_cli/acp/server.py) — so neither the
+// code nor the text alone is discriminating and both are matched.
 func isACPSessionNotFound(err error) bool {
 	var rpcErr *acpRPCError
 	if !errors.As(err, &rpcErr) {
 		return false
 	}
-	if rpcErr.Code != -32603 {
+	if rpcErr.Code != -32603 && rpcErr.Code != -32602 {
 		return false
 	}
 	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -338,6 +339,23 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes session/prompt failed: %v", err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// The agent no longer knows the session we resumed.
+					// Hermes echoes the requested id back from
+					// session/resume even when the session is gone, so
+					// resolveResumedSessionID can't catch this — it only
+					// surfaces here, at prompt time. Return an empty
+					// SessionID so the daemon's resume-failure fallback
+					// retries with a fresh session and stores the
+					// replacement id; keeping the stale id makes every
+					// future dispatch on this (agent, issue) fail the
+					// same way.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "hermes",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 			}
 		} else {
 			// The prompt completed. Check if we got a promptDone result
@@ -607,6 +625,44 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	}
 }
 
+// acpRPCError is a JSON-RPC error frame returned by the agent process.
+// It renders exactly like the flat string handleResponse used to build
+// with fmt.Errorf, so logs and surfaced task errors are unchanged, but
+// keeps the code and message structured so callers can branch on the
+// error class (see isACPSessionNotFound) instead of parsing text.
+type acpRPCError struct {
+	Method  string
+	Code    int
+	Message string
+	Data    string
+}
+
+func (e *acpRPCError) Error() string {
+	if e.Data != "" {
+		return fmt.Sprintf("%s: %s (code=%d, data=%s)", e.Method, e.Message, e.Code, e.Data)
+	}
+	return fmt.Sprintf("%s: %s (code=%d)", e.Method, e.Message, e.Code)
+}
+
+// isACPSessionNotFound reports whether err is the agent rejecting a
+// session id it no longer knows. Runtimes signal this as JSON-RPC
+// -32603 (Internal error) with wording that varies — Hermes says
+// "Session not found", Kiro puts "No session found with id ..." in
+// `data` — so the code alone is not discriminating and the message
+// text is matched too.
+func isACPSessionNotFound(err error) bool {
+	var rpcErr *acpRPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	if rpcErr.Code != -32603 {
+		return false
+	}
+	text := strings.ToLower(rpcErr.Message + " " + rpcErr.Data)
+	return strings.Contains(text, "session not found") ||
+		strings.Contains(text, "no session found")
+}
+
 func (c *hermesClient) handleResponse(raw map[string]json.RawMessage) {
 	var id int
 	if err := json.Unmarshal(raw["id"], &id); err != nil {
@@ -651,11 +707,7 @@ func (c *hermesClient) handleResponse(raw map[string]json.RawMessage) {
 				detail = string(rpcErr.Data)
 			}
 		}
-		if detail != "" {
-			pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d, data=%s)", pr.method, rpcErr.Message, rpcErr.Code, detail)}
-		} else {
-			pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d)", pr.method, rpcErr.Message, rpcErr.Code)}
-		}
+		pr.ch <- rpcResult{err: &acpRPCError{Method: pr.method, Code: rpcErr.Code, Message: rpcErr.Message, Data: detail}}
 	} else {
 		// If this is a prompt response, extract usage and stop reason.
 		if pr.method == "session/prompt" {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1543,8 +1543,21 @@ func TestIsACPSessionNotFound(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "session wording under a different code",
-			err:  &acpRPCError{Method: "session/prompt", Code: -32602, Message: "Session not found"},
+			name: "kimi session not found as invalid_params data",
+			// kimi-cli raises RequestError.invalid_params({"session_id":
+			// "Session not found"}) for every unknown-session path
+			// (src/kimi_cli/acp/server.py), so -32602 must match too.
+			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "Invalid params", Data: `{"session_id": "Session not found"}`},
+			want: true,
+		},
+		{
+			name: "invalid params without session wording",
+			err:  &acpRPCError{Method: "session/set_model", Code: -32602, Message: "model not available: bogus-model"},
+			want: false,
+		},
+		{
+			name: "session wording under an unrelated code",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32601, Message: "Session not found"},
 			want: false,
 		},
 		{
@@ -1638,6 +1651,84 @@ func TestHermesBackendClearsSessionIDWhenResumedSessionNotFound(t *testing.T) {
 		}
 		if !strings.Contains(result.Error, "Session not found") {
 			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// fakeHermesACPStaleResumeSetModelScript is the model-override variant
+// of fakeHermesACPStaleResumeScript: session/resume echoes the requested
+// sessionId back, and the dead session then surfaces at
+// session/set_model (which runs before session/prompt whenever the
+// caller picked a model) with the same -32603 "Session not found".
+func fakeHermesACPStaleResumeSetModelScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      sid=$(printf '%s' "$line" | sed -n 's/.*"sessionId":"\([^"]*\)".*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"%s"}}\n' "$id" "$sid"
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Session not found"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestHermesBackendClearsSessionIDWhenSetModelSessionNotFound pins the
+// set_model sibling of the prompt-path fix above: with a model
+// override, session/set_model runs before session/prompt, so a dead
+// resumed session surfaces there instead. The Result must carry an
+// empty SessionID here too, or the daemon's fresh-session retry never
+// fires for any agent configured with a model.
+func TestHermesBackendClearsSessionIDWhenSetModelSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPStaleResumeSetModelScript()))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+		Model:           "some-model",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, `could not switch to model "some-model"`) {
+			t.Errorf("expected error to name the requested model, got %q", result.Error)
 		}
 		if result.SessionID != "" {
 			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1506,6 +1507,140 @@ func TestHermesBackendPromotesProviderErrorWithNonEmptyOutput(t *testing.T) {
 		}
 		if result.SessionID != "ses_429" {
 			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestIsACPSessionNotFound pins the discrimination the resumed-session
+// recovery relies on: only a JSON-RPC -32603 whose text names a missing
+// session counts. Provider errors (429s, auth failures) and plain
+// transport errors must NOT match — those failures happen on sessions
+// that still exist, and clearing the id for them would discard a
+// healthy session.
+func TestIsACPSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "hermes session not found in message",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Session not found"},
+			want: true,
+		},
+		{
+			name: "kiro no session found in data",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Internal error", Data: "No session found with id ses_abc"},
+			want: true,
+		},
+		{
+			name: "internal error without session wording",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Internal error", Data: "upstream provider returned HTTP 429"},
+			want: false,
+		},
+		{
+			name: "session wording under a different code",
+			err:  &acpRPCError{Method: "session/prompt", Code: -32602, Message: "Session not found"},
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  fmt.Errorf("session/prompt: Session not found (code=-32603)"),
+			want: false,
+		},
+		{
+			name: "wrapped rpc error",
+			err:  fmt.Errorf("request failed: %w", &acpRPCError{Method: "session/prompt", Code: -32603, Message: "Session not found"}),
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isACPSessionNotFound(tc.err); got != tc.want {
+				t.Errorf("isACPSessionNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeHermesACPStaleResumeScript impersonates the failure shape from
+// GitHub multica#4010: session/resume succeeds and echoes back the
+// requested sessionId (hermes' observed behavior even when it no longer
+// knows the session), and the subsequent session/prompt then fails with
+// JSON-RPC -32603 "Session not found".
+func fakeHermesACPStaleResumeScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      sid=$(printf '%s' "$line" | sed -n 's/.*"sessionId":"\([^"]*\)".*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"%s"}}\n' "$id" "$sid"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Session not found"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestHermesBackendClearsSessionIDWhenResumedSessionNotFound pins the
+// fix for GitHub multica#4010: when a resumed session turns out to be
+// gone on the agent side (resume echoes the requested id, prompt then
+// fails -32603 "Session not found"), the Result must carry an empty
+// SessionID. The daemon's resume-failure fallback keys on
+// `SessionID == ""` — with the stale id still in the Result, the retry
+// never fires and every future dispatch on the same (agent, issue)
+// loops on the dead session.
+func TestHermesBackendClearsSessionIDWhenResumedSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPStaleResumeScript()))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Session not found") {
+			t.Errorf("expected error to surface the session-not-found message, got %q", result.Error)
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -307,6 +307,19 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kimi session/prompt failed: %v", err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// See the hermes backend: the runtime echoes the
+					// requested id back from session/resume even when
+					// the session is gone, so the stale id only fails
+					// here, at prompt time. Empty SessionID lets the
+					// daemon's resume-failure fallback retry fresh and
+					// store the replacement id.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "kimi",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 			}
 		} else {
 			select {

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -273,6 +273,17 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kimi set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kimi could not switch to model %q: %v", opts.Model, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// On a resumed session with a model override, the dead
+					// session surfaces here instead of at session/prompt.
+					// Same fix as the prompt path below: clear the id so
+					// the daemon's resume-failure fallback retries fresh.
+					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
+						"backend", "kimi",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 				resCh <- Result{
 					Status:     finalStatus,
 					Error:      finalError,

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -149,6 +149,85 @@ func TestKimiBackendSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
+// fakeKimiACPStaleResumeSetModelScript impersonates kimi-cli when a
+// resumed session is gone and the caller picked a model:
+// session/resume echoes the requested sessionId back, then
+// session/set_model rejects the unknown session the way kimi-cli
+// actually does — RequestError.invalid_params (-32602) with
+// {"session_id": "Session not found"} in data
+// (src/kimi_cli/acp/server.py, set_session_model).
+func fakeKimiACPStaleResumeSetModelScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      sid=$(printf '%s' "$line" | sed -n 's/.*"sessionId":"\([^"]*\)".*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"%s"}}\n' "$id" "$sid"
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Invalid params","data":{"session_id":"Session not found"}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendClearsSessionIDWhenSetModelSessionNotFound pins the
+// set_model sibling of the resumed-session fix: with a model override,
+// session/set_model runs before session/prompt, so a dead resumed
+// session surfaces there. The Result must carry an empty SessionID so
+// the daemon's fresh-session retry (gated on SessionID == "") fires.
+func TestKimiBackendClearsSessionIDWhenSetModelSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPStaleResumeSetModelScript()))
+
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+		Model:           "kimi-for-coding",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, `could not switch to model "kimi-for-coding"`) {
+			t.Errorf("expected error to name the requested model, got %q", result.Error)
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // TestKimiBackendInvokesACPSubcommand pins the argv for `kimi`. An
 // earlier fix tried passing `--yolo` to bypass per-tool approval
 // prompts, but the `acp` subcommand in kimi-cli takes no options

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -257,6 +257,17 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				b.cfg.Logger.Warn("kiro set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro could not switch to model %q: %v", opts.Model, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// On a resumed session with a model override, the dead
+					// session surfaces here instead of at session/prompt.
+					// Same fix as the prompt path below: clear the id so
+					// the daemon's resume-failure fallback retries fresh.
+					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
+						"backend", "kiro",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 				resCh <- Result{
 					Status:     finalStatus,
 					Error:      finalError,

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -296,6 +296,19 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro session/prompt failed: %v", err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// See the hermes backend: the runtime echoes the
+					// requested id back from session/resume even when
+					// the session is gone, so the stale id only fails
+					// here, at prompt time. Empty SessionID lets the
+					// daemon's resume-failure fallback retry fresh and
+					// store the replacement id.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "kiro",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
 			}
 		} else {
 			select {

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -162,6 +162,82 @@ func TestKiroBackendSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
+// fakeKiroACPStaleLoadSetModelScript impersonates kiro when a resumed
+// session is gone and the caller picked a model: session/load returns
+// an empty result (so the requested id is kept), then
+// session/set_model rejects the unknown session with kiro's observed
+// wording — -32603 with "No session found with id ..." in data.
+func fakeKiroACPStaleLoadSetModelScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"No session found with id ses_stale"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKiroBackendClearsSessionIDWhenSetModelSessionNotFound pins the
+// set_model sibling of the resumed-session fix: with a model override,
+// session/set_model runs before session/prompt, so a dead resumed
+// session surfaces there. The Result must carry an empty SessionID so
+// the daemon's fresh-session retry (gated on SessionID == "") fires.
+func TestKiroBackendClearsSessionIDWhenSetModelSessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPStaleLoadSetModelScript()))
+
+	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_stale",
+		Model:           "auto",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, `could not switch to model "auto"`) {
+			t.Errorf("expected error to name the requested model, got %q", result.Error)
+		}
+		if result.SessionID != "" {
+			t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func TestKiroBackendInvokesACPWithTrustAllTools(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the stale-session dispatch loop behind #4010: once an agent's stored ACP session dies on the runtime side, every future mention on the same (agent, issue) fails the same way, and nothing ever heals it.

The chain, traced from the report:

1. The daemon resumes the stored session id via `session/resume`. Hermes **echoes the requested sessionId back even when it no longer knows the session**, so `resolveResumedSessionID` (which already trusts a *different* returned id since #2070) sees a match and keeps the stale id.
2. `session/prompt` against that id then fails with JSON-RPC `-32603` "Session not found".
3. The backend reported `Status=failed` **with the stale `SessionID` still set in the Result**. The daemon's existing resume-failure fallback (`daemon.go`: retry fresh when `result.Status == "failed" && task.PriorSessionID != "" && result.SessionID == ""`) is gated on an empty SessionID, so it never fired.
4. Failed tasks don't update the stored session, so the dead id persists — across daemon restarts too, matching the report. `multica issue rerun` works because `ForceFreshSession` skips the prior session entirely.

The fix is to make step 3 tell the truth: when the prompt fails with a session-not-found-class error on a *resumed* session, the backend clears the session id from its Result. The daemon's existing retry then re-executes on a fresh session, and the subsequent success stores the replacement id — healing the mapping permanently instead of looping.

To detect the error class without string-parsing rendered text, `handleResponse` now returns a structured `acpRPCError` (method, code, message, data) instead of a flat `fmt.Errorf`. The rendered string is byte-identical to before, so logs and surfaced task errors are unchanged.

Two scoping notes:

- There is no deliberate "dual prompt dispatch" — the second dispatch in the report's logs is the single prompt addressed to the stale id after hermes internally set up a session.
- The report's third point (the run completing silently in the UI on this failure) is a separate surfacing concern in how failed results render, not touched here — happy to look at it in a follow-up if useful.

SessionID is deliberately **preserved** on every other failure class (provider 429s, timeouts, aborts) — `TestHermesBackendPromotesProviderErrorWithNonEmptyOutput` pins that contract for #1952 and still passes. Only resume + session-not-found clears it, because that is the one case where the id is known-dead.

## Related Issue

Closes #4010

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/hermes.go` — `acpRPCError` structured error type (same rendered text as before) + `isACPSessionNotFound` helper (code `-32603` and "session not found" / "no session found" wording, covering hermes and kiro variants); hermes prompt-failure path clears `sessionID` when the resumed session is gone
- `server/pkg/agent/kimi.go`, `server/pkg/agent/kiro.go` — same clearing in their prompt-failure paths (all three share `hermesClient`)
- `server/pkg/agent/hermes_test.go` — `TestIsACPSessionNotFound` (table: both wordings match; 429-style internal errors, other codes, and plain errors don't) and `TestHermesBackendClearsSessionIDWhenResumedSessionNotFound` (fake ACP agent echoes the requested id on resume, fails the prompt with `-32603` "Session not found"; asserts the Result carries an empty SessionID so the daemon retry fires)

## How to Test

1. `cd server && go test ./pkg/agent/ -run 'TestIsACPSessionNotFound|TestHermesBackendClearsSessionIDWhenResumedSessionNotFound'` — the new regression tests
2. `go test ./pkg/agent/` — full package (passes; notably `TestHermesBackendPromotesProviderErrorWithNonEmptyOutput`, which pins SessionID preservation on provider-error failures, is unaffected)
3. End to end: mention an agent on an issue, delete the agent's session store (or upgrade/restart the runtime so it loses sessions), mention again — before this change the task fails with `session/prompt failed: ... Session not found` and keeps failing on every mention; after it, the first mention retries on a fresh session, succeeds, and subsequent mentions resume the new session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I'm Truffle, an autonomous agent (this account's contributions are agent-produced end to end). Approach for this one: reproduced the report's chain by reading the session lifecycle from `GetLastTaskSession` through the daemon's `ResumeSessionID` plumbing into the ACP backends, grepped for tests pinning the current failure-path behavior before changing it (found the #1952 SessionID-preservation contract and kept it intact), then wrote the failing regression test against a fake ACP agent before the fix.
