### PR TITLE
MUL-3217: fix: sort execution log past runs by timestamp (newest first)

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/issue/[id]/runs.tsx
+++ b/apps/mobile/app/(app)/[workspace]/issue/[id]/runs.tsx
@@ -1,7 +1,7 @@
 /**
  * Agent Runs sheet — presented as a formSheet by the parent Stack. Two
  * sections: Active (queued/dispatched/running, created_at desc) and Past
- * (failed → cancelled → completed, completed_at desc within each). Empty
+ * (completed_at desc, status rank as tiebreaker). Empty
  * sections hide entirely.
  *
  * Both entry points (the in-card AgentActivityRow and the Stack-header
@@ -58,9 +58,9 @@ export default function IssueRunsRoute() {
         t.status === "cancelled",
     );
     return filtered.sort((a, b) => {
-      const ord = PAST_STATUS_ORDER[a.status] - PAST_STATUS_ORDER[b.status];
-      if (ord !== 0) return ord;
-      return (b.completed_at ?? "").localeCompare(a.completed_at ?? "");
+      const timeDiff = (b.completed_at ?? "").localeCompare(a.completed_at ?? "");
+      if (timeDiff !== 0) return timeDiff;
+      return PAST_STATUS_ORDER[a.status] - PAST_STATUS_ORDER[b.status];
     });
   }, [allTasks]);
 

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -48,9 +48,9 @@ interface ExecutionLogSectionProps {
   issueId: string;
 }
 
-// Past-runs sort priority: failed first (needs attention), then
-// cancelled (procedural noise), then completed (the boring 'done'
-// case sinks to the bottom). Within each group, newest first.
+// Past-runs sort priority: newest first by timestamp. When two runs
+// share the same timestamp, failed ranks above cancelled, which ranks
+// above completed.
 const PAST_STATUS_RANK: Record<string, number> = {
   failed: 0,
   cancelled: 1,
@@ -96,17 +96,15 @@ export function ExecutionLogSection({ issueId }: ExecutionLogSectionProps) {
         t.status === "failed" ||
         t.status === "cancelled",
     );
-    // Stable sort: failed first, cancelled second, completed last.
-    // Within group: newest completed_at first (fall back to created_at
-    // for malformed rows missing completed_at).
     return past.toSorted((a, b) => {
-      const rankDiff =
-        (PAST_STATUS_RANK[a.status] ?? 99) -
-        (PAST_STATUS_RANK[b.status] ?? 99);
-      if (rankDiff !== 0) return rankDiff;
       const at = a.completed_at ?? a.created_at;
       const bt = b.completed_at ?? b.created_at;
-      return new Date(bt).getTime() - new Date(at).getTime();
+      const timeDiff = new Date(bt).getTime() - new Date(at).getTime();
+      if (timeDiff !== 0) return timeDiff;
+      return (
+        (PAST_STATUS_RANK[a.status] ?? 99) -
+        (PAST_STATUS_RANK[b.status] ?? 99)
+      );
     });
   }, [tasks]);
 


### PR DESCRIPTION
## Summary
- The execution log's past run list now sorts by timestamp (newest first), so runs appear in chronological order.
- Status (failed > cancelled > completed) is kept as a tiebreaker for runs that share the same timestamp.
- Applied consistently to both web and mobile.

## Why
The previous sort put status priority first, so old failed runs floated to the top regardless of age. This was especially disruptive when a backlog of old failed runs polluted the history and buried newer, successful ones — making it hard to understand the actual progression of a task at a glance.

## Risk
- **Low.** Only the sort comparator in two files was changed:
  - `packages/views/issues/components/execution-log-section.tsx`
  - `apps/mobile/app/(app)/[workspace]/issue/[id]/runs.tsx`
- No API, data-model, or persistence changes.
- Rollback: revert the two-file commit (`f998f5a10`).

## Test plan
- [ ] Open an issue with multiple past runs, including at least one old failed run and a newer successful run — confirm the newer run appears above the older failed one.
- [ ] Confirm that two runs with identical timestamps are ordered failed > cancelled > completed.
- [ ] Verify the mobile runs screen shows the same ordering.


## Screenshots (optional)
Before
<img width="254" height="986" alt="image" src="https://github.com/user-attachments/assets/aa89fad4-bb89-4f62-9802-13b44895308e" />
After
<img width="301" height="791" alt="image" src="https://github.com/user-attachments/assets/451644a6-b274-4b14-a4bb-c24eb11e667d" />
