### PR TITLE
MUL-3223: add comment trigger preview analytics

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -103,7 +103,7 @@ Every event is assigned to one dashboard category:
 
 | Category | Events |
 |---|---|
-| `core_loop` | `workspace_created`, `agent_created`, `issue_created`, `chat_message_sent`, `issue_executed`, `autopilot_created`, `squad_created` |
+| `core_loop` | `workspace_created`, `agent_created`, `issue_created`, `chat_message_sent`, `issue_executed`, `autopilot_created`, `squad_created`, `comment_trigger_preview_shown`, `comment_trigger_preview_suppressed`, `comment_trigger_preview_restored`, `comment_trigger_preview_sent` |
 | `onboarding_support` | `onboarding_started`, `onboarding_questionnaire_submitted`, `onboarding_completed`, `onboarding_runtime_path_selected`, `onboarding_runtime_detected` |
 | `acquisition` | `signup`, `download_intent_expressed`, `download_page_viewed`, `download_initiated`, `cloud_waitlist_joined`, `contact_sales_submitted` |
 | `ops_feedback` | `feedback_opened`, `feedback_submitted` |
@@ -645,6 +645,48 @@ sent from a pre-workspace surface.
     keyboard shortcut or error-toast CTA will pass their own value)
   - `workspace_id`: string (UUID) when the modal opens inside a
     workspace. Omitted on pre-workspace surfaces.
+
+- `comment_trigger_preview_shown` — fired from the shared issue root
+  comment composer and reply composer when the agent trigger preview
+  chip changes from not rendered to rendered. Empty previews do not
+  emit an event. Properties:
+  - `composer`: `comment` / `reply`.
+  - `agent_count`: total visible preview agents.
+  - `active_count`: visible preview agents that will still trigger.
+  - `suppressed_count`: visible preview agents the user has disabled.
+  - `sources`: sorted, de-duplicated snapshot of all visible preview
+    agent sources.
+
+- `comment_trigger_preview_suppressed` and
+  `comment_trigger_preview_restored` — fired when the user toggles one
+  visible preview agent off or back on. Properties:
+  - `composer`: `comment` / `reply`.
+  - `agent_count`: total visible preview agents.
+  - `active_count`: visible preview agents that will still trigger
+    after the toggle.
+  - `suppressed_count`: visible preview agents disabled after the
+    toggle.
+  - `source`: source for the single agent that was toggled.
+
+- `comment_trigger_preview_sent` — fired from the create-comment
+  mutation success path, only when the submit-time preview had at least
+  one visible agent. Properties:
+  - `composer`: `comment` / `reply`.
+  - `agent_count`: total visible preview agents at submit time.
+  - `active_count`: submit-time preview agents that still trigger.
+  - `suppressed_count`: submit-time preview agents disabled by the
+    user.
+  - `sources`: sorted, de-duplicated snapshot of all submit-time
+    preview agent sources.
+
+  For comment trigger preview events, `source` is the singular source
+  for the agent affected by a suppress/restore action. `sources` is a
+  snapshot collection for shown/sent events. Both fields use the same
+  strict whitelist: `issue_assignee`, `mention_agent`,
+  `mention_squad_leader`, or `unknown`. New backend source strings must
+  normalize to `unknown`; they must not pass through to PostHog. These
+  events must not include `issue_id`, `workspace_id`, `agent_id`, agent
+  names, agent `reason`, comment content, or raw mention text.
 
 - Attribution is NOT a separate event; UTM + referrer origin are written
   to the `multica_signup_source` cookie on the first anonymous pageview

--- a/packages/core/analytics/comment-trigger-preview.test.ts
+++ b/packages/core/analytics/comment-trigger-preview.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCommentTriggerPreviewSnapshotPayload,
+  buildCommentTriggerPreviewTogglePayload,
+  normalizeCommentTriggerPreviewSource,
+} from "./comment-trigger-preview";
+
+const FORBIDDEN_KEYS = [
+  "reason",
+  "agent_id",
+  "agent_name",
+  "name",
+  "issue_id",
+  "workspace_id",
+] as const;
+
+describe("comment trigger preview analytics", () => {
+  it("normalizes sources through a strict whitelist", () => {
+    expect(normalizeCommentTriggerPreviewSource("issue_assignee")).toBe("issue_assignee");
+    expect(normalizeCommentTriggerPreviewSource("mention_agent")).toBe("mention_agent");
+    expect(normalizeCommentTriggerPreviewSource("mention_squad_leader")).toBe("mention_squad_leader");
+    expect(normalizeCommentTriggerPreviewSource("backend_added_new_source")).toBe("unknown");
+    expect(normalizeCommentTriggerPreviewSource("")).toBe("unknown");
+    expect(normalizeCommentTriggerPreviewSource(null)).toBe("unknown");
+    expect(normalizeCommentTriggerPreviewSource(undefined)).toBe("unknown");
+  });
+
+  it("builds a fail-closed snapshot payload from primitive fields only", () => {
+    const payload = buildCommentTriggerPreviewSnapshotPayload({
+      composer: "comment",
+      agentCount: 3,
+      activeCount: 2,
+      suppressedCount: 1,
+      sources: [
+        "mention_agent",
+        "backend_added_new_source",
+        "issue_assignee",
+        "mention_agent",
+      ],
+    });
+
+    expect(Object.keys(payload).sort()).toEqual([
+      "active_count",
+      "agent_count",
+      "composer",
+      "sources",
+      "suppressed_count",
+    ]);
+    expect(payload).toEqual({
+      composer: "comment",
+      agent_count: 3,
+      active_count: 2,
+      suppressed_count: 1,
+      sources: ["issue_assignee", "mention_agent", "unknown"],
+    });
+    for (const key of FORBIDDEN_KEYS) {
+      expect(payload).not.toHaveProperty(key);
+    }
+    expect(payload.sources).not.toContain("backend_added_new_source");
+  });
+
+  it("builds a fail-closed toggle payload with one normalized source", () => {
+    const payload = buildCommentTriggerPreviewTogglePayload({
+      composer: "reply",
+      agentCount: 2,
+      activeCount: 1,
+      suppressedCount: 1,
+      source: "backend_added_new_source",
+    });
+
+    expect(Object.keys(payload).sort()).toEqual([
+      "active_count",
+      "agent_count",
+      "composer",
+      "source",
+      "suppressed_count",
+    ]);
+    expect(payload).toEqual({
+      composer: "reply",
+      agent_count: 2,
+      active_count: 1,
+      suppressed_count: 1,
+      source: "unknown",
+    });
+    for (const key of FORBIDDEN_KEYS) {
+      expect(payload).not.toHaveProperty(key);
+    }
+  });
+});

--- a/packages/core/analytics/comment-trigger-preview.ts
+++ b/packages/core/analytics/comment-trigger-preview.ts
@@ -1,0 +1,119 @@
+import { captureEvent } from "./index";
+
+export type CommentTriggerPreviewComposer = "comment" | "reply";
+
+export type CommentTriggerPreviewSource =
+  | "issue_assignee"
+  | "mention_agent"
+  | "mention_squad_leader"
+  | "unknown";
+
+export interface CommentTriggerPreviewSnapshotPayload {
+  composer: CommentTriggerPreviewComposer;
+  agent_count: number;
+  active_count: number;
+  suppressed_count: number;
+  sources: CommentTriggerPreviewSource[];
+}
+
+export interface CommentTriggerPreviewTogglePayload {
+  composer: CommentTriggerPreviewComposer;
+  agent_count: number;
+  active_count: number;
+  suppressed_count: number;
+  source: CommentTriggerPreviewSource;
+}
+
+export type CommentTriggerPreviewAnalyticsContext = CommentTriggerPreviewSnapshotPayload;
+
+export function normalizeCommentTriggerPreviewSource(
+  source: string | null | undefined,
+): CommentTriggerPreviewSource {
+  switch (source) {
+    case "issue_assignee":
+    case "mention_agent":
+    case "mention_squad_leader":
+      return source;
+    default:
+      return "unknown";
+  }
+}
+
+export function buildCommentTriggerPreviewSnapshotPayload({
+  composer,
+  agentCount,
+  activeCount,
+  suppressedCount,
+  sources,
+}: {
+  composer: CommentTriggerPreviewComposer;
+  agentCount: number;
+  activeCount: number;
+  suppressedCount: number;
+  sources: readonly string[];
+}): CommentTriggerPreviewSnapshotPayload {
+  return {
+    composer,
+    agent_count: normalizeCount(agentCount),
+    active_count: normalizeCount(activeCount),
+    suppressed_count: normalizeCount(suppressedCount),
+    sources: Array.from(
+      new Set(sources.map((source) => normalizeCommentTriggerPreviewSource(source))),
+    ).sort(),
+  };
+}
+
+export function buildCommentTriggerPreviewTogglePayload({
+  composer,
+  agentCount,
+  activeCount,
+  suppressedCount,
+  source,
+}: {
+  composer: CommentTriggerPreviewComposer;
+  agentCount: number;
+  activeCount: number;
+  suppressedCount: number;
+  source: string | null | undefined;
+}): CommentTriggerPreviewTogglePayload {
+  return {
+    composer,
+    agent_count: normalizeCount(agentCount),
+    active_count: normalizeCount(activeCount),
+    suppressed_count: normalizeCount(suppressedCount),
+    source: normalizeCommentTriggerPreviewSource(source),
+  };
+}
+
+export function captureCommentTriggerPreviewShown(
+  payload: CommentTriggerPreviewSnapshotPayload,
+): void {
+  if (payload.agent_count < 1) return;
+  captureEvent("comment_trigger_preview_shown", { ...payload });
+}
+
+export function captureCommentTriggerPreviewSuppressed(
+  payload: CommentTriggerPreviewTogglePayload,
+): void {
+  if (payload.agent_count < 1) return;
+  captureEvent("comment_trigger_preview_suppressed", { ...payload });
+}
+
+export function captureCommentTriggerPreviewRestored(
+  payload: CommentTriggerPreviewTogglePayload,
+): void {
+  if (payload.agent_count < 1) return;
+  captureEvent("comment_trigger_preview_restored", { ...payload });
+}
+
+export function captureCommentTriggerPreviewSent(
+  payload: CommentTriggerPreviewAnalyticsContext,
+): void {
+  if (payload.agent_count < 1) return;
+  captureEvent("comment_trigger_preview_sent", { ...payload });
+}
+
+function normalizeCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}

--- a/packages/core/analytics/index.ts
+++ b/packages/core/analytics/index.ts
@@ -78,6 +78,21 @@ export {
   type FeedbackOpenedSource,
 } from "./feedback";
 
+export {
+  buildCommentTriggerPreviewSnapshotPayload,
+  buildCommentTriggerPreviewTogglePayload,
+  captureCommentTriggerPreviewRestored,
+  captureCommentTriggerPreviewSent,
+  captureCommentTriggerPreviewShown,
+  captureCommentTriggerPreviewSuppressed,
+  normalizeCommentTriggerPreviewSource,
+  type CommentTriggerPreviewAnalyticsContext,
+  type CommentTriggerPreviewComposer,
+  type CommentTriggerPreviewSnapshotPayload,
+  type CommentTriggerPreviewSource,
+  type CommentTriggerPreviewTogglePayload,
+} from "./comment-trigger-preview";
+
 export interface AnalyticsConfig {
   key: string;
   host: string;

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -7,13 +7,20 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { setApiInstance } from "../api";
+import type { CommentTriggerPreviewAnalyticsContext } from "../analytics";
 import type { ApiClient } from "../api/client";
-import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus, useResolveComment } from "./mutations";
+import {
+  useCreateComment,
+  useLoadMoreByAssigneeGroup,
+  useLoadMoreByStatus,
+  useResolveComment,
+} from "./mutations";
 import {
   issueKeys,
   type IssueSortParam,
 } from "./queries";
 import type {
+  Comment,
   GroupedIssuesResponse,
   Issue,
   ListIssuesCache,
@@ -22,6 +29,16 @@ import type {
   ListIssuesResponse,
   TimelineEntry,
 } from "../types";
+
+const captureCommentTriggerPreviewSent = vi.hoisted(() => vi.fn());
+
+vi.mock("../analytics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../analytics")>();
+  return {
+    ...actual,
+    captureCommentTriggerPreviewSent,
+  };
+});
 
 vi.mock("../hooks", () => ({
   useWorkspaceId: () => "ws-1",
@@ -61,6 +78,119 @@ function createWrapper(qc: QueryClient) {
     return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
   };
 }
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: "comment-1",
+    issue_id: "issue-1",
+    author_type: "member",
+    author_id: "user-1",
+    content: "hello",
+    type: "comment",
+    parent_id: null,
+    reactions: [],
+    attachments: [],
+    created_at: "2026-06-11T00:00:00Z",
+    updated_at: "2026-06-11T00:00:00Z",
+    resolved_at: null,
+    resolved_by_type: null,
+    resolved_by_id: null,
+    ...overrides,
+  };
+}
+
+describe("useCreateComment", () => {
+  let qc: QueryClient;
+  let createComment: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    createComment = vi.fn().mockResolvedValue(makeComment());
+    captureCommentTriggerPreviewSent.mockReset();
+    setApiInstance({ createComment } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("does not capture sent analytics when no trigger preview context is provided", async () => {
+    const { result } = renderHook(() => useCreateComment("issue-1"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ content: "hello" });
+    });
+
+    expect(captureCommentTriggerPreviewSent).not.toHaveBeenCalled();
+  });
+
+  it("does not capture sent analytics when the submit-time agent count is zero", async () => {
+    const { result } = renderHook(() => useCreateComment("issue-1"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        content: "hello",
+        triggerPreviewAnalytics: {
+          composer: "comment",
+          agent_count: 0,
+          active_count: 0,
+          suppressed_count: 0,
+          sources: [],
+        },
+      });
+    });
+
+    expect(captureCommentTriggerPreviewSent).not.toHaveBeenCalled();
+  });
+
+  it("captures sent analytics from mutation success using submit-time counts", async () => {
+    const triggerPreviewAnalytics: CommentTriggerPreviewAnalyticsContext = {
+      composer: "reply",
+      agent_count: 2,
+      active_count: 1,
+      suppressed_count: 1,
+      sources: ["issue_assignee", "mention_agent"],
+    };
+    const { result } = renderHook(() => useCreateComment("issue-1"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        content: "hello",
+        triggerPreviewAnalytics,
+      });
+    });
+
+    expect(captureCommentTriggerPreviewSent).toHaveBeenCalledTimes(1);
+    expect(captureCommentTriggerPreviewSent).toHaveBeenCalledWith(triggerPreviewAnalytics);
+  });
+
+  it("does not capture sent analytics when comment creation fails", async () => {
+    createComment.mockRejectedValueOnce(new Error("create failed"));
+    const { result } = renderHook(() => useCreateComment("issue-1"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await expect(result.current.mutateAsync({
+      content: "hello",
+      triggerPreviewAnalytics: {
+        composer: "comment",
+        agent_count: 1,
+        active_count: 1,
+        suppressed_count: 0,
+        sources: ["issue_assignee"],
+      },
+    })).rejects.toThrow("create failed");
+
+    expect(captureCommentTriggerPreviewSent).not.toHaveBeenCalled();
+  });
+});
 
 describe("useLoadMoreByStatus", () => {
   let qc: QueryClient;

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -2,6 +2,10 @@ import { useState, useCallback } from "react";
 import { useMutation, useQueryClient, type QueryKey } from "@tanstack/react-query";
 import { api } from "../api";
 import {
+  captureCommentTriggerPreviewSent,
+  type CommentTriggerPreviewAnalyticsContext,
+} from "../analytics";
+import {
   issueKeys,
   ISSUE_PAGE_SIZE,
   type AssigneeGroupedIssuesFilter,
@@ -605,8 +609,9 @@ export function useCreateComment(issueId: string) {
       parentId?: string;
       attachmentIds?: string[];
       suppressAgentIds?: string[];
+      triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext;
     }) => api.createComment(issueId, content, type, parentId, attachmentIds, suppressAgentIds),
-    onSuccess: (comment) => {
+    onSuccess: (comment, { triggerPreviewAnalytics }) => {
       const entry: TimelineEntry = {
         type: "comment",
         id: comment.id,
@@ -632,6 +637,9 @@ export function useCreateComment(issueId: string) {
       // task now dedupes follow-up triggers), so cached previews for this
       // issue are stale the moment the create lands.
       qc.invalidateQueries({ queryKey: issueKeys.commentTriggerPreview(issueId) });
+      if (triggerPreviewAnalytics && triggerPreviewAnalytics.agent_count >= 1) {
+        captureCommentTriggerPreviewSent(triggerPreviewAnalytics);
+      }
     },
     // No onSettled invalidate. The `comment:created` WS broadcast keeps
     // the timeline cache fresh after a successful create, and reconnect

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -37,6 +37,7 @@ import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { ReplyInput } from "./reply-input";
 import type { TimelineEntry, Attachment } from "@multica/core/types";
+import type { CommentTriggerPreviewAnalyticsContext } from "@multica/core/analytics";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { useCommentCollapseStore, useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
@@ -102,7 +103,13 @@ interface CommentCardProps {
    * `CommentRow` has to rerun the rule per row.
    */
   canModerate?: boolean;
-  onReply: (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<void>;
+  onReply: (
+    parentId: string,
+    content: string,
+    attachmentIds?: string[],
+    suppressAgentIds?: string[],
+    triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+  ) => Promise<void>;
   onEdit: (commentId: string, content: string, attachmentIds: string[]) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
@@ -928,7 +935,13 @@ function CommentCardImpl({
                   avatarType="member"
                   avatarId={currentUserId ?? ""}
                   draftKey={`reply:${issueId}:${entry.id}`}
-                  onSubmit={(content, attachmentIds, suppressAgentIds) => onReply(entry.id, content, attachmentIds, suppressAgentIds)}
+                  onSubmit={(content, attachmentIds, suppressAgentIds, triggerPreviewAnalytics) => onReply(
+                    entry.id,
+                    content,
+                    attachmentIds,
+                    suppressAgentIds,
+                    triggerPreviewAnalytics,
+                  )}
                 />
               </div>
             </>

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import type { CommentTriggerPreviewAnalyticsContext } from "@multica/core/analytics";
 import { renderWithI18n } from "../../test/i18n";
 import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
@@ -97,7 +98,12 @@ function renderReplyInput({
   onSubmit = vi.fn().mockResolvedValue(undefined),
   size = "sm",
 }: {
-  onSubmit?: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<void>;
+  onSubmit?: (
+    content: string,
+    attachmentIds?: string[],
+    suppressAgentIds?: string[],
+    triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+  ) => Promise<void>;
   size?: "sm" | "default";
 } = {}) {
   const view = renderWithProviders(
@@ -168,7 +174,7 @@ describe("comment composers", () => {
     fireEvent.click(getSubmitButton(container));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith("hello from composer", undefined, undefined);
+      expect(onSubmit).toHaveBeenCalledWith("hello from composer", undefined, undefined, undefined);
     });
   });
 
@@ -181,7 +187,7 @@ describe("comment composers", () => {
     fireEvent.click(getSubmitButton(container));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith("thread reply", undefined, undefined);
+      expect(onSubmit).toHaveBeenCalledWith("thread reply", undefined, undefined, undefined);
     });
   });
 });

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -7,16 +7,23 @@ import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
+import type { CommentTriggerPreviewAnalyticsContext } from "@multica/core/analytics";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
 import { useCommentTriggerPreview } from "../hooks/use-comment-trigger-preview";
+import { useCommentTriggerPreviewAnalytics } from "../hooks/use-comment-trigger-preview-analytics";
 
 interface CommentInputProps {
   issueId: string;
-  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<void>;
+  onSubmit: (
+    content: string,
+    attachmentIds?: string[],
+    suppressAgentIds?: string[],
+    triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+  ) => Promise<void>;
 }
 
 function CommentInput({ issueId, onSubmit }: CommentInputProps) {
@@ -33,6 +40,14 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const [submitting, setSubmitting] = useState(false);
   const [suppressedAgentIds, setSuppressedAgentIds] = useState<Set<string>>(() => new Set());
   const triggerPreview = useCommentTriggerPreview({ issueId, content });
+  const {
+    captureToggle: captureTriggerPreviewToggle,
+    buildSentContext: buildTriggerPreviewSentContext,
+  } = useCommentTriggerPreviewAnalytics({
+    composer: "comment",
+    agents: triggerPreview.agents,
+    suppressedAgentIds,
+  });
   // Attachments uploaded in this composer session. Drives both:
   //  - submit-time `attachment_ids` payload (filtered to URLs still in markdown)
   //  - the editor's AttachmentDownloadProvider, so file-card Eye buttons can
@@ -80,13 +95,12 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   }, [triggerPreview.agents]);
 
   const toggleSuppressedAgent = useCallback((agentId: string) => {
-    setSuppressedAgentIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(agentId)) next.delete(agentId);
-      else next.add(agentId);
-      return next;
-    });
-  }, []);
+    const next = new Set(suppressedAgentIds);
+    if (next.has(agentId)) next.delete(agentId);
+    else next.add(agentId);
+    setSuppressedAgentIds(next);
+    captureTriggerPreviewToggle(agentId, next);
+  }, [captureTriggerPreviewToggle, suppressedAgentIds]);
 
   const handleSubmit = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
@@ -107,6 +121,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
         content,
         activeIds.length > 0 ? activeIds : undefined,
         suppressAgentIds.length > 0 ? suppressAgentIds : undefined,
+        buildTriggerPreviewSentContext(),
       );
       editorRef.current?.clearContent();
       setContent("");

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -8,12 +8,14 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
+import type { CommentTriggerPreviewAnalyticsContext } from "@multica/core/analytics";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { useCommentDraftStore, type CommentDraftKey } from "@multica/core/issues/stores";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
 import { useCommentTriggerPreview } from "../hooks/use-comment-trigger-preview";
+import { useCommentTriggerPreviewAnalytics } from "../hooks/use-comment-trigger-preview-analytics";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +27,12 @@ interface ReplyInputProps {
   placeholder?: string;
   avatarType: string;
   avatarId: string;
-  onSubmit: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<void>;
+  onSubmit: (
+    content: string,
+    attachmentIds?: string[],
+    suppressAgentIds?: string[],
+    triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+  ) => Promise<void>;
   size?: "sm" | "default";
   /** When set, hydrates/persists the in-progress reply via the draft store.
    *  Required for replies inside virtualized timeline threads, where the
@@ -62,6 +69,14 @@ function ReplyInput({
   const [submitting, setSubmitting] = useState(false);
   const [suppressedAgentIds, setSuppressedAgentIds] = useState<Set<string>>(() => new Set());
   const triggerPreview = useCommentTriggerPreview({ issueId, parentId, content });
+  const {
+    captureToggle: captureTriggerPreviewToggle,
+    buildSentContext: buildTriggerPreviewSentContext,
+  } = useCommentTriggerPreviewAnalytics({
+    composer: "reply",
+    agents: triggerPreview.agents,
+    suppressedAgentIds,
+  });
   // Attachments uploaded in this composer session — see CommentInput for the
   // rationale (drives both submit-time attachment_ids and editor previews).
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
@@ -103,13 +118,12 @@ function ReplyInput({
   }, [triggerPreview.agents]);
 
   const toggleSuppressedAgent = useCallback((agentId: string) => {
-    setSuppressedAgentIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(agentId)) next.delete(agentId);
-      else next.add(agentId);
-      return next;
-    });
-  }, []);
+    const next = new Set(suppressedAgentIds);
+    if (next.has(agentId)) next.delete(agentId);
+    else next.add(agentId);
+    setSuppressedAgentIds(next);
+    captureTriggerPreviewToggle(agentId, next);
+  }, [captureTriggerPreviewToggle, suppressedAgentIds]);
 
   const handleSubmit = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
@@ -129,6 +143,7 @@ function ReplyInput({
         content,
         activeIds.length > 0 ? activeIds : undefined,
         suppressAgentIds.length > 0 ? suppressAgentIds : undefined,
+        buildTriggerPreviewSentContext(),
       );
       editorRef.current?.clearContent();
       setContent("");

--- a/packages/views/issues/hooks/use-comment-trigger-preview-analytics.test.ts
+++ b/packages/views/issues/hooks/use-comment-trigger-preview-analytics.test.ts
@@ -1,0 +1,146 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CommentTriggerPreviewAgent } from "@multica/core/types";
+
+import { useCommentTriggerPreviewAnalytics } from "./use-comment-trigger-preview-analytics";
+
+const captureCommentTriggerPreviewShown = vi.hoisted(() => vi.fn());
+const captureCommentTriggerPreviewSuppressed = vi.hoisted(() => vi.fn());
+const captureCommentTriggerPreviewRestored = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/analytics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/analytics")>();
+  return {
+    ...actual,
+    captureCommentTriggerPreviewShown,
+    captureCommentTriggerPreviewSuppressed,
+    captureCommentTriggerPreviewRestored,
+  };
+});
+
+const walt: CommentTriggerPreviewAgent = {
+  id: "agent-1",
+  name: "Walt",
+  source: "issue_assignee",
+  reason: "private reason",
+};
+
+const kim: CommentTriggerPreviewAgent = {
+  id: "agent-2",
+  name: "Kim",
+  source: "mention_agent",
+  reason: "private reason",
+};
+
+const futureSource: CommentTriggerPreviewAgent = {
+  id: "agent-3",
+  name: "Future",
+  source: "backend_added_new_source",
+  reason: "private reason",
+};
+
+afterEach(() => {
+  captureCommentTriggerPreviewShown.mockReset();
+  captureCommentTriggerPreviewSuppressed.mockReset();
+  captureCommentTriggerPreviewRestored.mockReset();
+});
+
+describe("useCommentTriggerPreviewAnalytics", () => {
+  it("captures shown only when the preview chip becomes visible", () => {
+    const { rerender } = renderHook(
+      ({ agents }) => useCommentTriggerPreviewAnalytics({
+        composer: "comment",
+        agents,
+        suppressedAgentIds: new Set<string>(),
+      }),
+      { initialProps: { agents: [] as CommentTriggerPreviewAgent[] } },
+    );
+
+    expect(captureCommentTriggerPreviewShown).not.toHaveBeenCalled();
+
+    rerender({ agents: [walt] });
+    expect(captureCommentTriggerPreviewShown).toHaveBeenCalledTimes(1);
+    expect(captureCommentTriggerPreviewShown).toHaveBeenCalledWith({
+      composer: "comment",
+      agent_count: 1,
+      active_count: 1,
+      suppressed_count: 0,
+      sources: ["issue_assignee"],
+    });
+
+    rerender({ agents: [walt, kim] });
+    expect(captureCommentTriggerPreviewShown).toHaveBeenCalledTimes(1);
+
+    rerender({ agents: [] });
+    rerender({ agents: [futureSource] });
+    expect(captureCommentTriggerPreviewShown).toHaveBeenCalledTimes(2);
+    expect(captureCommentTriggerPreviewShown).toHaveBeenLastCalledWith({
+      composer: "comment",
+      agent_count: 1,
+      active_count: 1,
+      suppressed_count: 0,
+      sources: ["unknown"],
+    });
+  });
+
+  it("captures suppress and restore with operation-after counts", () => {
+    const { result } = renderHook(
+      () => useCommentTriggerPreviewAnalytics({
+        composer: "reply",
+        agents: [walt, kim],
+        suppressedAgentIds: new Set<string>(),
+      }),
+    );
+
+    result.current.captureToggle("agent-2", new Set(["agent-2"]));
+
+    expect(captureCommentTriggerPreviewSuppressed).toHaveBeenCalledWith({
+      composer: "reply",
+      agent_count: 2,
+      active_count: 1,
+      suppressed_count: 1,
+      source: "mention_agent",
+    });
+
+    result.current.captureToggle("agent-2", new Set());
+
+    expect(captureCommentTriggerPreviewRestored).toHaveBeenCalledWith({
+      composer: "reply",
+      agent_count: 2,
+      active_count: 2,
+      suppressed_count: 0,
+      source: "mention_agent",
+    });
+  });
+
+  it("builds sent context only when the submit-time preview has agents", () => {
+    const { result, rerender } = renderHook(
+      ({ agents, suppressedAgentIds }) => useCommentTriggerPreviewAnalytics({
+        composer: "reply",
+        agents,
+        suppressedAgentIds,
+      }),
+      {
+        initialProps: {
+          agents: [] as CommentTriggerPreviewAgent[],
+          suppressedAgentIds: new Set<string>(),
+        },
+      },
+    );
+
+    expect(result.current.buildSentContext()).toBeUndefined();
+
+    rerender({
+      agents: [walt, kim, futureSource],
+      suppressedAgentIds: new Set(["agent-1"]),
+    });
+
+    expect(result.current.buildSentContext()).toEqual({
+      composer: "reply",
+      agent_count: 3,
+      active_count: 2,
+      suppressed_count: 1,
+      sources: ["issue_assignee", "mention_agent", "unknown"],
+    });
+  });
+});

--- a/packages/views/issues/hooks/use-comment-trigger-preview-analytics.ts
+++ b/packages/views/issues/hooks/use-comment-trigger-preview-analytics.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  buildCommentTriggerPreviewSnapshotPayload,
+  buildCommentTriggerPreviewTogglePayload,
+  captureCommentTriggerPreviewRestored,
+  captureCommentTriggerPreviewShown,
+  captureCommentTriggerPreviewSuppressed,
+  type CommentTriggerPreviewAnalyticsContext,
+  type CommentTriggerPreviewComposer,
+} from "@multica/core/analytics";
+import type { CommentTriggerPreviewAgent } from "@multica/core/types";
+
+export function useCommentTriggerPreviewAnalytics({
+  composer,
+  agents,
+  suppressedAgentIds,
+}: {
+  composer: CommentTriggerPreviewComposer;
+  agents: CommentTriggerPreviewAgent[];
+  suppressedAgentIds: Set<string>;
+}) {
+  const wasVisibleRef = useRef(false);
+  const snapshot = useMemo(
+    () => buildSnapshotPayload(composer, agents, suppressedAgentIds),
+    [agents, composer, suppressedAgentIds],
+  );
+
+  useEffect(() => {
+    const visible = agents.length > 0;
+    if (visible && !wasVisibleRef.current) {
+      captureCommentTriggerPreviewShown(snapshot);
+    }
+    wasVisibleRef.current = visible;
+  }, [agents.length, snapshot]);
+
+  const captureToggle = useCallback((
+    agentId: string,
+    nextSuppressedAgentIds: Set<string>,
+  ) => {
+    const agent = agents.find((candidate) => candidate.id === agentId);
+    if (!agent || agents.length === 0) return;
+
+    const suppressedCount = countSuppressedAgents(agents, nextSuppressedAgentIds);
+    const payload = buildCommentTriggerPreviewTogglePayload({
+      composer,
+      agentCount: agents.length,
+      activeCount: agents.length - suppressedCount,
+      suppressedCount,
+      source: agent.source,
+    });
+
+    if (nextSuppressedAgentIds.has(agentId)) {
+      captureCommentTriggerPreviewSuppressed(payload);
+    } else {
+      captureCommentTriggerPreviewRestored(payload);
+    }
+  }, [agents, composer]);
+
+  const buildSentContext = useCallback((): CommentTriggerPreviewAnalyticsContext | undefined => {
+    if (agents.length < 1) return undefined;
+    return snapshot;
+  }, [agents.length, snapshot]);
+
+  return { captureToggle, buildSentContext };
+}
+
+function buildSnapshotPayload(
+  composer: CommentTriggerPreviewComposer,
+  agents: CommentTriggerPreviewAgent[],
+  suppressedAgentIds: Set<string>,
+): CommentTriggerPreviewAnalyticsContext {
+  const suppressedCount = countSuppressedAgents(agents, suppressedAgentIds);
+  return buildCommentTriggerPreviewSnapshotPayload({
+    composer,
+    agentCount: agents.length,
+    activeCount: agents.length - suppressedCount,
+    suppressedCount,
+    sources: agents.map((agent) => agent.source),
+  });
+}
+
+function countSuppressedAgents(
+  agents: CommentTriggerPreviewAgent[],
+  suppressedAgentIds: Set<string>,
+): number {
+  return agents.reduce(
+    (count, agent) => count + (suppressedAgentIds.has(agent.id) ? 1 : 0),
+    0,
+  );
+}

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -33,6 +33,7 @@ import {
   useToggleCommentReaction,
   type ToggleCommentReactionVars,
 } from "@multica/core/issues/mutations";
+import type { CommentTriggerPreviewAnalyticsContext } from "@multica/core/analytics";
 import { sortTimelineEntriesAsc } from "@multica/core/issues/timeline-sort";
 import { useWSEvent, useWSReconnect } from "@multica/core/realtime";
 import { toast } from "sonner";
@@ -259,10 +260,20 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   // --- Mutation functions ---
 
   const submitComment = useCallback(
-    async (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => {
+    async (
+      content: string,
+      attachmentIds?: string[],
+      suppressAgentIds?: string[],
+      triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+    ) => {
       if (!content.trim() || !userId) return;
       try {
-        await createComment({ content, attachmentIds, suppressAgentIds });
+        await createComment({
+          content,
+          attachmentIds,
+          suppressAgentIds,
+          triggerPreviewAnalytics,
+        });
       } catch (err) {
         toast.error(
           err instanceof Error && err.message
@@ -275,7 +286,13 @@ export function useIssueTimeline(issueId: string, userId?: string) {
   );
 
   const submitReply = useCallback(
-    async (parentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => {
+    async (
+      parentId: string,
+      content: string,
+      attachmentIds?: string[],
+      suppressAgentIds?: string[],
+      triggerPreviewAnalytics?: CommentTriggerPreviewAnalyticsContext,
+    ) => {
       if (!content.trim() || !userId) return;
       try {
         await createComment({
@@ -284,6 +301,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
           parentId,
           attachmentIds,
           suppressAgentIds,
+          triggerPreviewAnalytics,
         });
       } catch (err) {
         toast.error(


### PR DESCRIPTION
## Summary
- Add typed frontend analytics helpers for comment trigger preview events, including strict source normalization to `unknown` for non-whitelisted backend source strings.
- Wire root comment and reply composers to emit preview shown/suppress/restore events and pass submit-time preview analytics context into comment creation.
- Emit `comment_trigger_preview_sent` only from the create-comment mutation success path when submit-time `agent_count >= 1`.
- Document `source` vs `sources`, operation-after counts for suppress/restore, submit-time counts for sent, and the forbidden fields.

## Verification
- `pnpm --filter @multica/core exec vitest run analytics/comment-trigger-preview.test.ts issues/mutations.test.tsx` — 2 files, 15 tests passed.
- `pnpm --filter @multica/views exec vitest run issues/hooks/use-comment-trigger-preview-analytics.test.ts issues/components/comment-composers.test.tsx issues/components/comment-trigger-chips.test.tsx` — 3 files, 15 tests passed.
- `pnpm --filter @multica/core exec vitest run analytics` — 2 files, 14 tests passed.
- `pnpm typecheck` — 6 tasks successful.
- `git diff --check` — passed.

Refs MUL-3223.
