### PR TITLE
MUL-3232: suggest profiles for empty daemon disk usage

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -735,9 +736,11 @@ func runDaemonDiskUsage(cmd *cobra.Command, _ []string) error {
 
 	if byWorkspace {
 		printDiskUsageWorkspaceTable(os.Stdout, report)
+		printDiskUsageEmptyHint(os.Stdout, report, profile, rootOverride)
 		return nil
 	}
 	printDiskUsageTaskTable(os.Stdout, report)
+	printDiskUsageEmptyHint(os.Stdout, report, profile, rootOverride)
 	return nil
 }
 
@@ -812,6 +815,153 @@ func printDiskUsageWorkspaceTable(w io.Writer, report daemon.DiskUsageReport) {
 	fmt.Fprintf(w, "\nTotal: %s across %d workspace(s); %s reclaimable as artifacts (%.1f%%).\n",
 		formatBytes(report.TotalSizeBytes), report.TotalWorkspaceCount,
 		formatBytes(report.TotalArtifactSizeBytes), report.TotalArtifactRatio*100)
+}
+
+func printDiskUsageEmptyHint(w io.Writer, report daemon.DiskUsageReport, profile, rootOverride string) {
+	if report.TotalTaskCount != 0 || rootOverride != "" {
+		return
+	}
+	suggestions := diskUsageProfileSuggestions(profile, report.WorkspacesRoot)
+	if len(suggestions) == 0 {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Other workspace roots contain task directories:")
+	for _, s := range suggestions {
+		fmt.Fprintf(w, "  %s  # %s (%d task%s)\n",
+			s.Command, s.Root, s.TaskCount, pluralS(s.TaskCount))
+	}
+}
+
+type diskUsageProfileSuggestion struct {
+	Profile   string
+	Command   string
+	Root      string
+	TaskCount int
+}
+
+func diskUsageProfileSuggestions(currentProfile, currentRoot string) []diskUsageProfileSuggestion {
+	out := make([]diskUsageProfileSuggestion, 0)
+	if currentProfile != "" {
+		if root, err := daemon.ResolveWorkspacesRoot("", ""); err == nil && !samePath(root, currentRoot) {
+			if taskCount := countDiskUsageTaskDirs(root); taskCount > 0 {
+				out = append(out, diskUsageProfileSuggestion{
+					Profile:   "",
+					Command:   "multica daemon disk-usage",
+					Root:      root,
+					TaskCount: taskCount,
+				})
+			}
+		}
+	}
+
+	profilesRoot, err := profilesRootDir()
+	if err != nil {
+		return out
+	}
+	entries, err := os.ReadDir(profilesRoot)
+	if err != nil {
+		return out
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		profile := entry.Name()
+		if profile == currentProfile {
+			continue
+		}
+		root, err := daemon.ResolveWorkspacesRoot(profile, "")
+		if err != nil || samePath(root, currentRoot) {
+			continue
+		}
+		taskCount := countDiskUsageTaskDirs(root)
+		if taskCount == 0 {
+			continue
+		}
+		out = append(out, diskUsageProfileSuggestion{
+			Profile:   profile,
+			Command:   "multica --profile " + shellQuoteArg(profile) + " daemon disk-usage",
+			Root:      root,
+			TaskCount: taskCount,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TaskCount == out[j].TaskCount {
+			return out[i].Profile < out[j].Profile
+		}
+		return out[i].TaskCount > out[j].TaskCount
+	})
+	const maxSuggestions = 5
+	if len(out) > maxSuggestions {
+		out = out[:maxSuggestions]
+	}
+	return out
+}
+
+func shellQuoteArg(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '-' || r == '_' || r == '.' || r == '/' ||
+			r >= '0' && r <= '9' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= 'a' && r <= 'z')
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func countDiskUsageTaskDirs(root string) int {
+	wsEntries, err := os.ReadDir(root)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, wsEntry := range wsEntries {
+		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" {
+			continue
+		}
+		taskEntries, err := os.ReadDir(filepath.Join(root, wsEntry.Name()))
+		if err != nil {
+			continue
+		}
+		for _, taskEntry := range taskEntries {
+			if taskEntry.IsDir() {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func profilesRootDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".multica", "profiles"), nil
+}
+
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	aa, errA := filepath.Abs(a)
+	bb, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	return aa == bb
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // formatRatio renders a 0..1 fraction as a percentage to one decimal. A

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/multica-ai/multica/server/internal/daemon"
 )
 
 // TestDaemonAlive locks in the liveness predicate the lifecycle commands rely
@@ -127,6 +131,86 @@ func TestPrintDaemonStatusAlignsValuesWithProfileLabel(t *testing.T) {
 	}
 }
 
+func TestPrintDiskUsageEmptyHintSuggestsProfilesWithTasks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+
+	mkdirProfile(t, home, "empty")
+	mkdirProfile(t, home, "one-task")
+	mkdirProfile(t, home, "space profile")
+	mkdirProfile(t, home, "two-tasks")
+
+	writeDiskUsageTaskFile(t, home, "one-task", "ws1", "task1", "workdir/main.go")
+	writeDiskUsageTaskFile(t, home, "space profile", "ws3", "task1", "workdir/main.go")
+	writeDiskUsageTaskFile(t, home, "two-tasks", "ws2", "task1", "workdir/main.go")
+	writeDiskUsageTaskFile(t, home, "two-tasks", "ws2", "task2", "workdir/main.go")
+
+	var out bytes.Buffer
+	printDiskUsageEmptyHint(&out, daemon.DiskUsageReport{
+		WorkspacesRoot: filepath.Join(home, "multica_workspaces"),
+	}, "", "")
+
+	got := out.String()
+	if !strings.Contains(got, "Other workspace roots contain task directories:") {
+		t.Fatalf("hint output = %q, want profile suggestion header", got)
+	}
+	if !strings.Contains(got, "multica --profile two-tasks daemon disk-usage") {
+		t.Fatalf("hint output = %q, want two-tasks profile command", got)
+	}
+	if !strings.Contains(got, "multica --profile one-task daemon disk-usage") {
+		t.Fatalf("hint output = %q, want one-task profile command", got)
+	}
+	if !strings.Contains(got, "multica --profile 'space profile' daemon disk-usage") {
+		t.Fatalf("hint output = %q, want shell-quoted profile command", got)
+	}
+	if strings.Contains(got, "empty") {
+		t.Fatalf("hint output = %q, want empty profile omitted", got)
+	}
+	if strings.Index(got, "two-tasks") > strings.Index(got, "one-task") {
+		t.Fatalf("hint output = %q, want larger profile first", got)
+	}
+}
+
+func TestPrintDiskUsageEmptyHintSuggestsDefaultFromNamedProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+
+	writeDefaultDiskUsageTaskFile(t, home, "ws0", "task0", "workdir/main.go")
+
+	var out bytes.Buffer
+	printDiskUsageEmptyHint(&out, daemon.DiskUsageReport{
+		WorkspacesRoot: filepath.Join(home, "multica_workspaces_named"),
+	}, "named", "")
+
+	got := out.String()
+	if !strings.Contains(got, "multica daemon disk-usage") {
+		t.Fatalf("hint output = %q, want default profile command", got)
+	}
+	if strings.Contains(got, "--profile") {
+		t.Fatalf("hint output = %q, want default profile command without --profile", got)
+	}
+}
+
+func TestPrintDiskUsageEmptyHintSkipsExplicitRootOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+
+	mkdirProfile(t, home, "has-task")
+	writeDiskUsageTaskFile(t, home, "has-task", "ws1", "task1", "workdir/main.go")
+
+	var out bytes.Buffer
+	printDiskUsageEmptyHint(&out, daemon.DiskUsageReport{
+		WorkspacesRoot: filepath.Join(home, "custom-root"),
+	}, "", filepath.Join(home, "custom-root"))
+
+	if got := out.String(); got != "" {
+		t.Fatalf("hint output = %q, want no hint for explicit root override", got)
+	}
+}
+
 func valueColumn(t *testing.T, line string) int {
 	t.Helper()
 	colon := strings.Index(line, ":")
@@ -140,4 +224,33 @@ func valueColumn(t *testing.T, line string) int {
 	}
 	t.Fatalf("line missing value: %q", line)
 	return 0
+}
+
+func mkdirProfile(t *testing.T, home, profile string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(home, ".multica", "profiles", profile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeDiskUsageTaskFile(t *testing.T, home, profile, workspaceID, taskID, rel string) {
+	t.Helper()
+	path := filepath.Join(home, "multica_workspaces_"+profile, workspaceID, taskID, rel)
+	writeDiskUsageFile(t, path)
+}
+
+func writeDefaultDiskUsageTaskFile(t *testing.T, home, workspaceID, taskID, rel string) {
+	t.Helper()
+	path := filepath.Join(home, "multica_workspaces", workspaceID, taskID, rel)
+	writeDiskUsageFile(t, path)
+}
+
+func writeDiskUsageFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Summary:
- Add a hint when `multica daemon disk-usage` finds no task dirs in the selected profile root but other configured profile roots contain tasks.
- Keep JSON output unchanged and skip hints for explicit `--workspaces-root` overrides.
- Count task directories cheaply for suggestions instead of doing full size scans.

Verification:
- `go test ./cmd/multica`
- `go test ./internal/daemon -run TestScanDiskUsage`
- `go run ./cmd/multica daemon disk-usage --top 1`