### PR TITLE
MUL-3255: Mirror Lark issue activity back to source chat

### DIFF
--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -149,6 +151,10 @@ type PatcherQueries interface {
 	GetLarkOutboundCardByTask(ctx context.Context, taskID pgtype.UUID) (db.LarkOutboundCardMessage, error)
 	CreateLarkOutboundCardMessage(ctx context.Context, arg db.CreateLarkOutboundCardMessageParams) (db.LarkOutboundCardMessage, error)
 	UpdateLarkOutboundCardStatus(ctx context.Context, arg db.UpdateLarkOutboundCardStatusParams) error
+	GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error)
+	ClaimLarkIssueCommentMirror(ctx context.Context, arg db.ClaimLarkIssueCommentMirrorParams) (db.LarkIssueCommentMirror, error)
+	MarkLarkIssueCommentMirrorSent(ctx context.Context, commentID pgtype.UUID) error
+	MarkLarkIssueCommentMirrorFailed(ctx context.Context, arg db.MarkLarkIssueCommentMirrorFailedParams) error
 }
 
 // CredentialsResolver decrypts an installation's app_secret for the
@@ -260,6 +266,7 @@ func (p *Patcher) SetTypingIndicatorManager(m *TypingIndicatorManager) {
 func (p *Patcher) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventTaskFailed, p.handleEvent)
 	bus.Subscribe(protocol.EventChatDone, p.handleEvent)
+	bus.Subscribe(protocol.EventCommentCreated, p.handleEvent)
 }
 
 func (p *Patcher) handleEvent(e events.Event) {
@@ -279,6 +286,10 @@ func (p *Patcher) handleEvent(e events.Event) {
 }
 
 func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
+	if e.Type == protocol.EventCommentCreated {
+		return p.mirrorIssueComment(ctx, e)
+	}
+
 	taskID, chatSessionID, ok := taskAndSessionFromEvent(e)
 	if !ok {
 		return nil
@@ -330,6 +341,147 @@ func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
 		return p.fail(ctx, creds, binding, taskID, agentName, e.Payload)
 	}
 	return nil
+}
+
+type issueCommentMirrorPayload struct {
+	ID         string `json:"id"`
+	IssueID    string `json:"issue_id"`
+	AuthorType string `json:"author_type"`
+	AuthorID   string `json:"author_id"`
+	Content    string `json:"content"`
+	Type       string `json:"type"`
+}
+
+type eventCommentCreatedPayload struct {
+	Comment issueCommentMirrorPayload `json:"comment"`
+}
+
+func commentPayloadFromEvent(payload any) (issueCommentMirrorPayload, bool) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return issueCommentMirrorPayload{}, false
+	}
+	var wrapped eventCommentCreatedPayload
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return issueCommentMirrorPayload{}, false
+	}
+	if wrapped.Comment.ID == "" || wrapped.Comment.IssueID == "" {
+		return issueCommentMirrorPayload{}, false
+	}
+	return wrapped.Comment, true
+}
+
+func (p *Patcher) mirrorIssueComment(ctx context.Context, e events.Event) error {
+	comment, ok := commentPayloadFromEvent(e.Payload)
+	if !ok {
+		return nil
+	}
+	if comment.AuthorType != "agent" || strings.TrimSpace(comment.Content) == "" {
+		return nil
+	}
+
+	commentID, err := util.ParseUUID(comment.ID)
+	if err != nil {
+		return nil
+	}
+	issueID, err := util.ParseUUID(comment.IssueID)
+	if err != nil {
+		return nil
+	}
+	authorID, err := util.ParseUUID(comment.AuthorID)
+	if err != nil {
+		return nil
+	}
+
+	issue, err := p.queries.GetIssue(ctx, issueID)
+	if err != nil {
+		return fmt.Errorf("load issue for comment mirror: %w", err)
+	}
+	if !issue.OriginType.Valid || issue.OriginType.String != "lark_chat" || !issue.OriginID.Valid {
+		return nil
+	}
+
+	binding, err := p.queries.GetLarkChatSessionBindingBySession(ctx, issue.OriginID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("lookup lark chat binding for issue comment mirror: %w", err)
+	}
+
+	inst, err := p.queries.GetLarkInstallation(ctx, binding.InstallationID)
+	if err != nil {
+		return fmt.Errorf("load lark installation for issue comment mirror: %w", err)
+	}
+	if InstallationStatus(inst.Status) != InstallationActive {
+		return nil
+	}
+
+	mirror, err := p.queries.ClaimLarkIssueCommentMirror(ctx, db.ClaimLarkIssueCommentMirrorParams{
+		CommentID:      commentID,
+		IssueID:        issue.ID,
+		ChatSessionID:  issue.OriginID,
+		InstallationID: binding.InstallationID,
+		LarkChatID:     binding.LarkChatID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("claim lark issue comment mirror: %w", err)
+	}
+
+	creds, err := p.installationCredentials(inst)
+	if err != nil {
+		_ = p.queries.MarkLarkIssueCommentMirrorFailed(ctx, db.MarkLarkIssueCommentMirrorFailedParams{
+			CommentID: mirror.CommentID,
+			Error:     pgtype.Text{String: err.Error(), Valid: true},
+		})
+		return err
+	}
+
+	authorName := "agent"
+	if agent, agentErr := p.queries.GetAgent(ctx, authorID); agentErr == nil && strings.TrimSpace(agent.Name) != "" {
+		authorName = agent.Name
+	}
+	body := formatMirroredIssueComment(authorName, comment.Content)
+
+	if containsMarkdown(body) {
+		if _, err := p.client.SendMarkdownCard(ctx, SendMarkdownCardParams{
+			InstallationID: creds,
+			ChatID:         ChatID(binding.LarkChatID),
+			Markdown:       body,
+		}); err != nil {
+			_ = p.queries.MarkLarkIssueCommentMirrorFailed(ctx, db.MarkLarkIssueCommentMirrorFailedParams{
+				CommentID: mirror.CommentID,
+				Error:     pgtype.Text{String: err.Error(), Valid: true},
+			})
+			return fmt.Errorf("send mirrored issue comment markdown card: %w", err)
+		}
+	} else if _, err := p.client.SendTextMessage(ctx, SendTextParams{
+		InstallationID: creds,
+		ChatID:         ChatID(binding.LarkChatID),
+		Text:           body,
+	}); err != nil {
+		_ = p.queries.MarkLarkIssueCommentMirrorFailed(ctx, db.MarkLarkIssueCommentMirrorFailedParams{
+			CommentID: mirror.CommentID,
+			Error:     pgtype.Text{String: err.Error(), Valid: true},
+		})
+		return fmt.Errorf("send mirrored issue comment text message: %w", err)
+	}
+
+	if err := p.queries.MarkLarkIssueCommentMirrorSent(ctx, mirror.CommentID); err != nil {
+		return fmt.Errorf("mark lark issue comment mirror sent: %w", err)
+	}
+	return nil
+}
+
+func formatMirroredIssueComment(authorName, content string) string {
+	name := strings.TrimSpace(authorName)
+	if name == "" {
+		name = "agent"
+	}
+	return name + ":\n" + strings.TrimSpace(content)
 }
 
 // sendChatReply turns ChatDonePayload.Content into a Lark message.

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -24,6 +24,12 @@ type fakePatcherQueries struct {
 	installationErr error
 	agent           db.Agent
 	agentErr        error
+	issue           db.Issue
+	issueErr        error
+	mirrorErr       error
+	mirrorClaims    []db.ClaimLarkIssueCommentMirrorParams
+	mirrorSent      []pgtype.UUID
+	mirrorFailed    []db.MarkLarkIssueCommentMirrorFailedParams
 	card            db.LarkOutboundCardMessage
 	cardErr         error
 	created         []db.CreateLarkOutboundCardMessageParams
@@ -59,6 +65,37 @@ func (f *fakePatcherQueries) UpdateLarkOutboundCardStatus(ctx context.Context, a
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.statusUpdates = append(f.statusUpdates, arg)
+	return nil
+}
+func (f *fakePatcherQueries) GetIssue(ctx context.Context, id pgtype.UUID) (db.Issue, error) {
+	return f.issue, f.issueErr
+}
+func (f *fakePatcherQueries) ClaimLarkIssueCommentMirror(ctx context.Context, arg db.ClaimLarkIssueCommentMirrorParams) (db.LarkIssueCommentMirror, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.mirrorErr != nil {
+		return db.LarkIssueCommentMirror{}, f.mirrorErr
+	}
+	f.mirrorClaims = append(f.mirrorClaims, arg)
+	return db.LarkIssueCommentMirror{
+		CommentID:      arg.CommentID,
+		IssueID:        arg.IssueID,
+		ChatSessionID:  arg.ChatSessionID,
+		InstallationID: arg.InstallationID,
+		LarkChatID:     arg.LarkChatID,
+		Status:         "claimed",
+	}, nil
+}
+func (f *fakePatcherQueries) MarkLarkIssueCommentMirrorSent(ctx context.Context, commentID pgtype.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mirrorSent = append(f.mirrorSent, commentID)
+	return nil
+}
+func (f *fakePatcherQueries) MarkLarkIssueCommentMirrorFailed(ctx context.Context, arg db.MarkLarkIssueCommentMirrorFailedParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mirrorFailed = append(f.mirrorFailed, arg)
 	return nil
 }
 
@@ -151,6 +188,11 @@ func newTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeAPIClient
 			Status:             string(InstallationActive),
 			AgentID:            uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
 		},
+		issue: db.Issue{
+			ID:         uuidFromString(t, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+			OriginType: pgtype.Text{String: "lark_chat", Valid: true},
+			OriginID:   uuidFromString(t, "cccccccc-cccc-cccc-cccc-cccccccccccc"),
+		},
 		agent:   db.Agent{Name: "TestAgent"},
 		cardErr: pgx.ErrNoRows,
 	}
@@ -160,6 +202,23 @@ func newTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeAPIClient
 		Now:    time.Now,
 	})
 	return p, q, api
+}
+
+func commentCreatedEvent(t *testing.T, commentID, issueID, authorID pgtype.UUID, authorType, content string) events.Event {
+	t.Helper()
+	return events.Event{
+		Type: protocol.EventCommentCreated,
+		Payload: map[string]any{
+			"comment": map[string]any{
+				"id":          uuidString(commentID),
+				"issue_id":    uuidString(issueID),
+				"author_type": authorType,
+				"author_id":   uuidString(authorID),
+				"content":     content,
+				"type":        "comment",
+			},
+		},
+	}
 }
 
 // TestPatcherSendsPlainTextOnChatDone pins the new behaviour Bohan asked
@@ -270,6 +329,96 @@ func TestPatcherRoutesPlainReplyToText(t *testing.T) {
 	}
 	if len(api.mdCardSent) != 0 {
 		t.Errorf("plain prose must NOT wrap in a markdown card; got %d card sends", len(api.mdCardSent))
+	}
+}
+
+func TestPatcherMirrorsLarkOriginatedIssueAgentComment(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	commentID := uuidFromString(t, "dddddddd-dddd-dddd-dddd-dddddddddddd")
+	issueID := uuidFromString(t, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	agentID := uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+	p.handleEvent(events.Event{
+		Type: protocol.EventCommentCreated,
+		Payload: map[string]any{
+			"comment": map[string]any{
+				"id":          uuidString(commentID),
+				"issue_id":    uuidString(issueID),
+				"author_type": "agent",
+				"author_id":   uuidString(agentID),
+				"content":     "Done from the specialist agent.",
+				"type":        "comment",
+			},
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 1 {
+		t.Fatalf("expected one mirrored issue comment; got %d", len(api.textSent))
+	}
+	got := api.textSent[0]
+	if got.ChatID != ChatID(q.binding.LarkChatID) {
+		t.Errorf("chat_id mismatch: got %q want %q", got.ChatID, q.binding.LarkChatID)
+	}
+	if got.Text != "TestAgent:\nDone from the specialist agent." {
+		t.Errorf("mirrored text mismatch: got %q", got.Text)
+	}
+	if len(q.mirrorSent) != 1 || q.mirrorSent[0] != commentID {
+		t.Fatalf("expected comment mirror marked sent once; got %#v", q.mirrorSent)
+	}
+}
+
+func TestPatcherDoesNotMirrorNonLarkIssueComment(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	q.issue.OriginType = pgtype.Text{}
+	commentID := uuidFromString(t, "dddddddd-dddd-dddd-dddd-dddddddddddd")
+	agentID := uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+	p.handleEvent(commentCreatedEvent(t, commentID, q.issue.ID, agentID, "agent", "Should stay on the issue only."))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 0 || len(api.mdCardSent) != 0 {
+		t.Fatalf("non-Lark issue comments must not mirror; got text=%d markdown=%d", len(api.textSent), len(api.mdCardSent))
+	}
+	if len(q.mirrorClaims) != 0 {
+		t.Fatalf("non-Lark issue comment must not claim mirror row; got %d claims", len(q.mirrorClaims))
+	}
+}
+
+func TestPatcherDoesNotResendDuplicateMirroredComment(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	q.mirrorErr = pgx.ErrNoRows
+	commentID := uuidFromString(t, "dddddddd-dddd-dddd-dddd-dddddddddddd")
+	agentID := uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+	p.handleEvent(commentCreatedEvent(t, commentID, q.issue.ID, agentID, "agent", "Already mirrored."))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 0 || len(api.mdCardSent) != 0 {
+		t.Fatalf("duplicate mirror claim must not resend; got text=%d markdown=%d", len(api.textSent), len(api.mdCardSent))
+	}
+}
+
+func TestPatcherMirrorsMarkdownIssueCommentAsMarkdownCard(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	commentID := uuidFromString(t, "dddddddd-dddd-dddd-dddd-dddddddddddd")
+	agentID := uuidFromString(t, "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+	p.handleEvent(commentCreatedEvent(t, commentID, q.issue.ID, agentID, "agent", "# Result\n\n- Completed"))
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 1 {
+		t.Fatalf("expected one mirrored markdown card; got %d", len(api.mdCardSent))
+	}
+	if api.mdCardSent[0].Markdown != "TestAgent:\n# Result\n\n- Completed" {
+		t.Errorf("markdown mismatch: got %q", api.mdCardSent[0].Markdown)
+	}
+	if len(api.textSent) != 0 {
+		t.Fatalf("markdown comment must not send text; got %d", len(api.textSent))
 	}
 }
 

--- a/server/migrations/119_lark_issue_comment_mirror.down.sql
+++ b/server/migrations/119_lark_issue_comment_mirror.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS lark_issue_comment_mirror;

--- a/server/migrations/119_lark_issue_comment_mirror.up.sql
+++ b/server/migrations/119_lark_issue_comment_mirror.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS lark_issue_comment_mirror (
+    comment_id UUID PRIMARY KEY REFERENCES comment(id) ON DELETE CASCADE,
+    issue_id UUID NOT NULL REFERENCES issue(id) ON DELETE CASCADE,
+    chat_session_id UUID NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
+    installation_id UUID NOT NULL REFERENCES lark_installation(id) ON DELETE CASCADE,
+    lark_chat_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'claimed' CHECK (status IN ('claimed', 'sent', 'failed')),
+    error TEXT,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    sent_at TIMESTAMPTZ,
+    failed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lark_issue_comment_mirror_issue_id
+    ON lark_issue_comment_mirror(issue_id);
+
+CREATE INDEX IF NOT EXISTS idx_lark_issue_comment_mirror_chat_session_id
+    ON lark_issue_comment_mirror(chat_session_id);
+
+CREATE INDEX IF NOT EXISTS idx_lark_issue_comment_mirror_installation_status
+    ON lark_issue_comment_mirror(installation_id, status);

--- a/server/pkg/db/generated/lark.sql.go
+++ b/server/pkg/db/generated/lark.sql.go
@@ -149,6 +149,53 @@ func (q *Queries) ClaimLarkInboundDedup(ctx context.Context, arg ClaimLarkInboun
 	return i, err
 }
 
+const claimLarkIssueCommentMirror = `-- name: ClaimLarkIssueCommentMirror :one
+
+INSERT INTO lark_issue_comment_mirror (
+    comment_id, issue_id, chat_session_id, installation_id, lark_chat_id, status
+) VALUES (
+    $1, $2, $3, $4, $5, 'claimed'
+)
+ON CONFLICT (comment_id) DO NOTHING
+RETURNING comment_id, issue_id, chat_session_id, installation_id, lark_chat_id, status, error, claimed_at, sent_at, failed_at, updated_at
+`
+
+type ClaimLarkIssueCommentMirrorParams struct {
+	CommentID      pgtype.UUID `json:"comment_id"`
+	IssueID        pgtype.UUID `json:"issue_id"`
+	ChatSessionID  pgtype.UUID `json:"chat_session_id"`
+	InstallationID pgtype.UUID `json:"installation_id"`
+	LarkChatID     string      `json:"lark_chat_id"`
+}
+
+// =====================
+// lark_issue_comment_mirror
+// =====================
+func (q *Queries) ClaimLarkIssueCommentMirror(ctx context.Context, arg ClaimLarkIssueCommentMirrorParams) (LarkIssueCommentMirror, error) {
+	row := q.db.QueryRow(ctx, claimLarkIssueCommentMirror,
+		arg.CommentID,
+		arg.IssueID,
+		arg.ChatSessionID,
+		arg.InstallationID,
+		arg.LarkChatID,
+	)
+	var i LarkIssueCommentMirror
+	err := row.Scan(
+		&i.CommentID,
+		&i.IssueID,
+		&i.ChatSessionID,
+		&i.InstallationID,
+		&i.LarkChatID,
+		&i.Status,
+		&i.Error,
+		&i.ClaimedAt,
+		&i.SentAt,
+		&i.FailedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const consumeLarkBindingToken = `-- name: ConsumeLarkBindingToken :one
 UPDATE lark_binding_token
 SET consumed_at = now()
@@ -893,6 +940,39 @@ func (q *Queries) MarkLarkInboundDedupProcessed(ctx context.Context, arg MarkLar
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const markLarkIssueCommentMirrorFailed = `-- name: MarkLarkIssueCommentMirrorFailed :exec
+UPDATE lark_issue_comment_mirror
+SET status = 'failed',
+    error = $2,
+    failed_at = now(),
+    updated_at = now()
+WHERE comment_id = $1
+`
+
+type MarkLarkIssueCommentMirrorFailedParams struct {
+	CommentID pgtype.UUID `json:"comment_id"`
+	Error     pgtype.Text `json:"error"`
+}
+
+func (q *Queries) MarkLarkIssueCommentMirrorFailed(ctx context.Context, arg MarkLarkIssueCommentMirrorFailedParams) error {
+	_, err := q.db.Exec(ctx, markLarkIssueCommentMirrorFailed, arg.CommentID, arg.Error)
+	return err
+}
+
+const markLarkIssueCommentMirrorSent = `-- name: MarkLarkIssueCommentMirrorSent :exec
+UPDATE lark_issue_comment_mirror
+SET status = 'sent',
+    error = NULL,
+    sent_at = now(),
+    updated_at = now()
+WHERE comment_id = $1
+`
+
+func (q *Queries) MarkLarkIssueCommentMirrorSent(ctx context.Context, commentID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, markLarkIssueCommentMirrorSent, commentID)
+	return err
 }
 
 const purgeExpiredLarkBindingTokens = `-- name: PurgeExpiredLarkBindingTokens :exec

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -465,6 +465,20 @@ type LarkInstallation struct {
 	Region             string             `json:"region"`
 }
 
+type LarkIssueCommentMirror struct {
+	CommentID      pgtype.UUID        `json:"comment_id"`
+	IssueID        pgtype.UUID        `json:"issue_id"`
+	ChatSessionID  pgtype.UUID        `json:"chat_session_id"`
+	InstallationID pgtype.UUID        `json:"installation_id"`
+	LarkChatID     string             `json:"lark_chat_id"`
+	Status         string             `json:"status"`
+	Error          pgtype.Text        `json:"error"`
+	ClaimedAt      pgtype.Timestamptz `json:"claimed_at"`
+	SentAt         pgtype.Timestamptz `json:"sent_at"`
+	FailedAt       pgtype.Timestamptz `json:"failed_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
 type LarkOutboundCardMessage struct {
 	ID                pgtype.UUID        `json:"id"`
 	ChatSessionID     pgtype.UUID        `json:"chat_session_id"`

--- a/server/pkg/db/queries/lark.sql
+++ b/server/pkg/db/queries/lark.sql
@@ -405,3 +405,32 @@ RETURNING *;
 -- handles dedup can sweep these too.
 DELETE FROM lark_binding_token
 WHERE expires_at < $1;
+
+-- =====================
+-- lark_issue_comment_mirror
+-- =====================
+
+-- name: ClaimLarkIssueCommentMirror :one
+INSERT INTO lark_issue_comment_mirror (
+    comment_id, issue_id, chat_session_id, installation_id, lark_chat_id, status
+) VALUES (
+    $1, $2, $3, $4, $5, 'claimed'
+)
+ON CONFLICT (comment_id) DO NOTHING
+RETURNING *;
+
+-- name: MarkLarkIssueCommentMirrorSent :exec
+UPDATE lark_issue_comment_mirror
+SET status = 'sent',
+    error = NULL,
+    sent_at = now(),
+    updated_at = now()
+WHERE comment_id = $1;
+
+-- name: MarkLarkIssueCommentMirrorFailed :exec
+UPDATE lark_issue_comment_mirror
+SET status = 'failed',
+    error = $2,
+    failed_at = now(),
+    updated_at = now()
+WHERE comment_id = $1;


### PR DESCRIPTION
## Summary
- Subscribe the Lark outbound patcher to `comment:created` events and mirror agent-authored comments from Lark-originated issues back to the original chat.
- Add durable idempotency for mirrored issue comments so duplicate events or retries do not send duplicate Lark messages.
- Cover the simulated Lark issue activity flow, non-Lark exclusions, duplicate suppression, and Markdown routing with tests.

Closes #4055

## Test Plan
- [x] `go test ./internal/integrations/lark -run "TestPatcherMirrorsLarkOriginatedIssueAgentComment|TestPatcherDoesNotMirrorNonLarkIssueComment|TestPatcherDoesNotResendDuplicateMirroredComment|TestPatcherMirrorsMarkdownIssueCommentAsMarkdownCard" -count=1 -v`
- [x] `go test ./internal/integrations/lark -count=1`
- [x] `go test ./internal/service -count=1`
- [x] `go test ./internal/taskusagebackfill -count=1`

## Notes
- Full `go test ./... -count=1` currently reaches unrelated existing failures in `server/internal/handler` heartbeat tests because the local Docker Postgres clock is behind the host clock by roughly 0.6-0.9 seconds; the Lark integration package passes independently.
- No live Lark bot binding was used for this PR because the local database has no `lark_installation` or `lark_chat_session_binding` rows for the existing test bot.
