### PR TITLE
MUL-3242: fix(daemon): provisioning barrier + GC guard for workdir race

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2224,11 +2224,16 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	)
 
 	// If the task targets a project_resource of type local_directory that
-	// is pinned to this daemon, acquire the path mutex BEFORE StartTask so
-	// the server-side state machine is dispatched → waiting_local_directory
-	// → running rather than backwards-transitioning from running into the
-	// wait state. The release is deferred so a panic or early return
-	// always frees the lock for the next waiter.
+	// is pinned to this daemon, acquire the path mutex before runner.run
+	// so the server-side state machine is dispatched →
+	// waiting_local_directory → running rather than backwards-transitioning
+	// from running into the wait state. The release is deferred so a panic
+	// or early return always frees the lock for the next waiter.
+	//
+	// StartTask itself now lives in runTask (see issue #3999 race A) and
+	// fires only after execenv.Prepare/Reuse has put env.WorkDir on disk,
+	// so consumers that read status==running can resolve the workdir path
+	// without racing the daemon's os.MkdirAll.
 	localRelease, abort := d.acquireLocalDirectoryLockIfNeeded(ctx, task, taskLog)
 	if abort {
 		return
@@ -2237,23 +2242,26 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		defer localRelease()
 	}
 
-	if err := d.client.StartTask(ctx, task.ID); err != nil {
-		taskLog.Error("start task failed", "error", err)
-		startErrMsg := fmt.Sprintf("start task failed: %s", err.Error())
-		// MUL-2946: classify the wrapper error so the failure_reason
-		// column lands in the canonical refined taxonomy rather than
-		// the legacy coarse "agent_error" bucket. A start-task failure
-		// most commonly surfaces as ReasonAgentUnknown (no rule
-		// matches "start task failed: <…>"), but a future provider /
-		// network blip in the wrapper layer would still classify
-		// correctly without us touching this site.
-		if failErr := d.client.FailTask(ctx, task.ID, startErrMsg, "", "", taskfailure.Classify(startErrMsg).String()); failErr != nil {
-			taskLog.Error("fail task after start error", "error", failErr)
-		}
-		return
+	// Hold a process-wide active-root guard for the rest of this task so
+	// the GC loop never sees a window where the env root has neither the
+	// in-process guard nor .gc_meta.json (issue #3999 race B). runTask
+	// installs its own ref-counted mark/unmark internally; without this
+	// outer guard the inner unmark fires when runTask returns, leaving
+	// the directory protected only by the 72h orphan TTL through
+	// reportTaskResult and execenv.WriteGCMeta below. markActiveEnvRoot
+	// is reference-counted, so the duplicate marks runTask installs are
+	// correctly nested within these.
+	predictedEnvRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
+	if predictedEnvRoot != "" {
+		d.markActiveEnvRoot(predictedEnvRoot)
+		defer d.unmarkActiveEnvRoot(predictedEnvRoot)
 	}
-
-	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
+	if task.PriorWorkDir != "" {
+		if priorRoot := filepath.Dir(task.PriorWorkDir); priorRoot != "" && priorRoot != predictedEnvRoot {
+			d.markActiveEnvRoot(priorRoot)
+			defer d.unmarkActiveEnvRoot(priorRoot)
+		}
+	}
 
 	// Create a cancellable context so we can interrupt the running agent
 	// when the server signals the task should stop — either the task reached
@@ -2392,10 +2400,10 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 
 	// While the lock is contended the daemon would otherwise sit blocked on
 	// the path mutex with no signal back from the server — the main
-	// per-task watcher only starts after StartTask. If the user cancels
-	// the issue or it gets reassigned during the wait, we need to notice
-	// promptly so the daemon slot isn't pinned by a phantom waiter. We
-	// spin up the cancellation watcher lazily inside onWait so the
+	// per-task watcher only starts after the lock is acquired. If the user
+	// cancels the issue or it gets reassigned during the wait, we need to
+	// notice promptly so the daemon slot isn't pinned by a phantom waiter.
+	// We spin up the cancellation watcher lazily inside onWait so the
 	// no-contention fast path still costs nothing.
 	waitCtx, waitCancel := context.WithCancel(ctx)
 	defer waitCancel()
@@ -2744,6 +2752,22 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		d.markActiveEnvRoot(env.RootDir)
 		defer d.unmarkActiveEnvRoot(env.RootDir)
 	}
+
+	// Issue #3999 race A: now that env.WorkDir is on disk, transition the
+	// server-side state machine dispatched (or waiting_local_directory) →
+	// running. Calling StartTask before Prepare/Reuse let any consumer
+	// that read status==running and resolved
+	// /multica_workspaces/{ws}/{short-id}/workdir hit FileNotFoundError in
+	// the microsecond window before os.MkdirAll ran.
+	//
+	// On error we return early so handleTask's existing FailTask +
+	// taskfailure.Classify path records the failure with the same
+	// "start task failed: <…>" string and the same failure_reason
+	// taxonomy as before — see MUL-2946 for the classifier contract.
+	if err := d.client.StartTask(ctx, task.ID); err != nil {
+		return TaskResult{}, fmt.Errorf("start task failed: %w", err)
+	}
+	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
 	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, taskLog)
 

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -1,0 +1,244 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// TestHandleTask_DoesNotCallStartTaskItself is the regression guard for
+// issue #3999 race A. handleTask must not call /tasks/{id}/start before
+// runner.run — the runner is now responsible for calling StartTask only
+// after execenv.Prepare/Reuse has put env.WorkDir on disk, so consumers
+// that read status==running can resolve the workdir path without racing
+// the daemon's os.MkdirAll.
+//
+// Before the fix: handleTask called StartTask before invoking the runner,
+// flipping the server-side state to "running" while the per-task workdir
+// still didn't exist on disk. Hermes/OpenClaw agents that resolved
+// /multica_workspaces/{ws}/{short-id}/workdir from the running signal
+// would then hit FileNotFoundError.
+func TestHandleTask_DoesNotCallStartTaskItself(t *testing.T) {
+	t.Parallel()
+
+	var (
+		startCalls   atomic.Int64
+		runnerCalled atomic.Bool
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/start"):
+			startCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{
+		client:             NewClient(srv.URL),
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:         make(map[string]*workspaceState),
+		runtimeIndex:       map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "claude"}},
+		activeEnvRoots:     make(map[string]int),
+		cancelPollInterval: time.Hour, // disable poll-cancel path; we only care about the entry-side ordering
+	}
+
+	// Fake runner that does NOT call StartTask — production runTask does
+	// the call itself, after Prepare/Reuse confirms env.WorkDir on disk.
+	d.runner = taskRunnerFunc(func(_ context.Context, _ Task, _ string, _ int, _ *slog.Logger) (TaskResult, error) {
+		runnerCalled.Store(true)
+		return TaskResult{Status: "completed"}, nil
+	})
+
+	task := Task{
+		ID:          "task-no-start",
+		WorkspaceID: "ws-no-start",
+		RuntimeID:   "rt-1",
+		IssueID:     "issue-no-start",
+		Agent:       &AgentData{Name: "test-agent"},
+	}
+
+	d.handleTask(context.Background(), task, 0)
+
+	if !runnerCalled.Load() {
+		t.Fatal("fake runner was never invoked — handleTask aborted before runner.run, can't assert ordering")
+	}
+	if got := startCalls.Load(); got != 0 {
+		t.Fatalf("handleTask called /start %d time(s); StartTask must be runTask's responsibility now (issue #3999 race A)", got)
+	}
+}
+
+// TestRunTask_StartTaskCalledAfterWorkdirOnDisk is the behavioral regression
+// guard for issue #3999 race A. Calls runTask directly with a missing agent
+// binary so the run aborts at exec time — but only AFTER reaching the
+// post-Prepare StartTask call. The fake server records whether the per-task
+// workdir already exists on disk at the moment /start is hit; before the
+// fix it did not.
+func TestRunTask_StartTaskCalledAfterWorkdirOnDisk(t *testing.T) {
+	t.Parallel()
+
+	workspacesRoot := t.TempDir()
+	workspaceID := "ws-runtask"
+	taskID := "task-runtask-after-mkdir"
+	expectedEnvRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+	expectedWorkDir := filepath.Join(expectedEnvRoot, "workdir")
+
+	var (
+		startCalled    atomic.Bool
+		workdirOnDisk  atomic.Bool
+		envRootOnDisk  atomic.Bool
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/start") {
+			startCalled.Store(true)
+			if info, err := os.Stat(expectedWorkDir); err == nil && info.IsDir() {
+				workdirOnDisk.Store(true)
+			}
+			if info, err := os.Stat(expectedEnvRoot); err == nil && info.IsDir() {
+				envRootOnDisk.Store(true)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Provider entry intentionally points at a non-existent binary: runTask
+	// reaches Prepare → StartTask → ReportProgress before agent.Backend.Run
+	// fails at exec time. We don't care about the eventual error; the
+	// regression guard is the order of /start vs. os.MkdirAll(envRoot).
+	missingBin := filepath.Join(t.TempDir(), "definitely-not-claude")
+	d := &Daemon{
+		client:         NewClient(srv.URL),
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:     make(map[string]*workspaceState),
+		runtimeIndex:   map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "claude"}},
+		activeEnvRoots: make(map[string]int),
+		cfg: Config{
+			WorkspacesRoot: workspacesRoot,
+			Agents: map[string]AgentEntry{
+				"claude": {Path: missingBin, Model: ""},
+			},
+		},
+	}
+
+	task := Task{
+		ID:          taskID,
+		WorkspaceID: workspaceID,
+		RuntimeID:   "rt-1",
+		IssueID:     "issue-runtask",
+		Agent:       &AgentData{Name: "test-agent"},
+	}
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// The Run() failure is expected; we only assert the pre-Run ordering.
+	_, _ = d.runTask(context.Background(), task, "claude", 0, taskLog)
+
+	if !startCalled.Load() {
+		t.Fatal("runTask did not call /start — Fix A's StartTask placement is missing")
+	}
+	if !envRootOnDisk.Load() {
+		t.Fatal("envRoot did not exist on disk when /start was called — Prepare must run before StartTask (issue #3999 race A)")
+	}
+	if !workdirOnDisk.Load() {
+		t.Fatal("envRoot/workdir did not exist on disk when /start was called — os.MkdirAll must complete before StartTask (issue #3999 race A)")
+	}
+}
+
+// TestHandleTask_KeepsEnvRootActiveAcrossCompletion is the regression guard
+// for issue #3999 race B. After runner.run returns, the in-process active
+// guard installed inside runTask (defer unmarkActiveEnvRoot at the
+// goroutine's exit) has already fired by the time handleTask calls
+// reportTaskResult and execenv.WriteGCMeta. Without an outer guard at the
+// handleTask level, the GC loop sees a window where the directory has
+// neither isActiveEnvRoot nor a .gc_meta.json file — falling through to
+// orphanByMTime, gated only by the 72h GCOrphanTTL.
+//
+// This test fakes the inner guard's lifecycle (mark + deferred unmark),
+// then asserts that at the moment /complete is hit (i.e. between runner.run
+// returning and WriteGCMeta running), isActiveEnvRoot(envRoot) is still
+// true thanks to the outer guard handleTask installs.
+func TestHandleTask_KeepsEnvRootActiveAcrossCompletion(t *testing.T) {
+	t.Parallel()
+
+	workspacesRoot := t.TempDir()
+	workspaceID := "ws-active-during-complete"
+	taskID := "task-active-during-complete"
+	expectedEnvRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+
+	var (
+		completeCalled atomic.Bool
+		activeAtComplete atomic.Bool
+	)
+
+	d := &Daemon{
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workspaces:         make(map[string]*workspaceState),
+		runtimeIndex:       map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "claude"}},
+		activeEnvRoots:     make(map[string]int),
+		cancelPollInterval: time.Hour,
+		cfg:                Config{WorkspacesRoot: workspacesRoot},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/complete") {
+			completeCalled.Store(true)
+			// This is the exact window race B exposed: the inner deferred
+			// unmark has already fired (see fake runner below); only the
+			// outer guard installed by handleTask keeps the env root in the
+			// active set at this moment.
+			if d.isActiveEnvRoot(expectedEnvRoot) {
+				activeAtComplete.Store(true)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	d.client = NewClient(srv.URL)
+
+	// Fake runner mimics the real runTask's mark/defer-unmark pair. Without
+	// the outer guard added in handleTask, the deferred unmark would bring
+	// isActiveEnvRoot back to false before reportTaskResult fires.
+	d.runner = taskRunnerFunc(func(_ context.Context, tk Task, _ string, _ int, _ *slog.Logger) (TaskResult, error) {
+		predicted := execenv.PredictRootDir(d.cfg.WorkspacesRoot, tk.WorkspaceID, tk.ID)
+		d.markActiveEnvRoot(predicted)
+		defer d.unmarkActiveEnvRoot(predicted)
+		return TaskResult{
+			Status:  "completed",
+			EnvRoot: predicted,
+		}, nil
+	})
+
+	task := Task{
+		ID:          taskID,
+		WorkspaceID: workspaceID,
+		RuntimeID:   "rt-1",
+		IssueID:     "issue-active-during-complete",
+		Agent:       &AgentData{Name: "test-agent"},
+	}
+
+	d.handleTask(context.Background(), task, 0)
+
+	if !completeCalled.Load() {
+		t.Fatal("/complete was never hit — handleTask did not reach reportTaskResult")
+	}
+	if !activeAtComplete.Load() {
+		t.Fatal("env root was NOT in the active set at /complete time — issue #3999 race B regression: GC could reclaim the directory between runner.run returning and WriteGCMeta landing on disk")
+	}
+	// And the outer guard must have been released by the time handleTask
+	// returned, otherwise we'd be leaking active marks across tasks.
+	if d.isActiveEnvRoot(expectedEnvRoot) {
+		t.Fatal("env root remained active after handleTask returned — outer guard's deferred unmark did not fire")
+	}
+}


### PR DESCRIPTION
Fixes [#3999](https://github.com/multica-ai/multica/issues/3999).

## Background

The daemon flipped the server-side task state machine to `running` via `client.StartTask` **before** `runTask` ran the `os.MkdirAll` inside `execenv.Prepare` that creates the per-task workdir. Hermes/OpenClaw runtimes (and any other consumer that resolves `/multica_workspaces/{ws}/{short-id}/workdir` from the running signal) could hit `FileNotFoundError` in the microsecond window between the two events.

There is also a smaller defense-in-depth race at completion: `runTask`'s deferred `unmarkActiveEnvRoot` fires when `runTask` returns, but `execenv.WriteGCMeta` runs later in `handleTask`. During that gap the directory has neither the in-process active guard nor `.gc_meta.json`, so the GC loop falls through to `orphanByMTime` (gated only by the 72h `GCOrphanTTL`).

## Core changes

**Race A (primary) — `server/internal/daemon/daemon.go`:**

- Remove the `StartTask` + "Launching <provider>" `ReportProgress` block from `handleTask`.
- Re-issue both calls inside `runTask` immediately after `execenv.Prepare` / `execenv.Reuse` returns a non-nil `env` (i.e. `env.WorkDir` is on disk). Errors surface as a `runTask` error so `handleTask`'s existing `FailTask` + `taskfailure.Classify` path keeps the same `"start task failed: <…>"` string and the same failure_reason taxonomy (MUL-2946).
- The `local_directory` state machine ordering is preserved: `acquireLocalDirectoryLockIfNeeded` still runs first in `handleTask`, so transitions are still `dispatched → waiting_local_directory → running` (`running` just lands one Prepare's worth of milliseconds later).

**Race B (defense-in-depth) — `server/internal/daemon/daemon.go`:**

- In `handleTask`, install a process-wide `markActiveEnvRoot` guard right after the local-directory lock is acquired and defer the unmark. The guard wraps the entire post-lock section: `runner.run` → `reportTaskResult` → `execenv.WriteGCMeta`. `activeEnvRoots` is reference-counted, so `runTask`'s inner mark/unmark nests cleanly inside the outer guard.
- Cover the Reuse path the same way (mark `filepath.Dir(task.PriorWorkDir)` when it differs from the predicted root).

## Verification

```
go build ./...                          # clean
go vet ./internal/daemon/...            # clean
go test ./internal/daemon/... -count=1  # PASS (incl. 3 new tests)
```

## New regression tests

In `server/internal/daemon/workdir_race_test.go`:

- **`TestHandleTask_DoesNotCallStartTaskItself`** — invariant guard: `handleTask` must never directly hit `/tasks/{id}/start`. Fails before Fix A (counts 1 call), passes after.
- **`TestRunTask_StartTaskCalledAfterWorkdirOnDisk`** — behavioral guard: drives `runTask` directly with a missing agent binary so the run fails after StartTask but lets us assert that at the moment `/start` is hit, both `envRoot` and `envRoot/workdir` already exist on disk.
- **`TestHandleTask_KeepsEnvRootActiveAcrossCompletion`** — behavioral guard for race B: a fake runner mimics the inner mark/defer-unmark pair, then the test asserts `isActiveEnvRoot(envRoot)` is true at the moment `/complete` is served (i.e. between `runner.run` returning and `WriteGCMeta` running). It also asserts the outer guard releases by the time `handleTask` returns.

## Test plan

- All existing daemon tests (`go test ./internal/daemon/... -count=1`) continue to pass — including the `TestHandleTask_ReportsUsageBefore*` tests, the local_directory dispatch tests, and the runtime isolation / pollLoop shutdown tests.
- Three new regression tests (above) lock the contract in.

## Risk

Low. The only behaviorally observable change for clients of the task state machine is that `status == running` now strictly implies `envRoot/workdir` is on disk; nothing in the codebase depended on the previous (incorrect) earlier transition. `local_directory` ordering is preserved by construction.
