### PR TITLE
Add index on "user".created_at (MUL-3246)

### DIFF
--- a/server/migrations/119_user_created_at_index.down.sql
+++ b/server/migrations/119_user_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_created_at;

--- a/server/migrations/119_user_created_at_index.up.sql
+++ b/server/migrations/119_user_created_at_index.up.sql
@@ -1,0 +1,8 @@
+-- Index on "user".created_at to support ordering/filtering users by signup time.
+--
+-- "user" is a reserved word so it stays double-quoted. The migration runner
+-- executes files outside an explicit transaction, so CONCURRENTLY is kept in
+-- its own single-statement migration to avoid Postgres' implicit transaction
+-- block for multi-statement query strings.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_created_at
+    ON "user" (created_at);


### PR DESCRIPTION
## Summary
Adds a database migration (119) that creates an index on the `created_at` column of the `"user"` table.

- `server/migrations/119_user_created_at_index.up.sql` — `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_created_at ON "user" (created_at);`
- `server/migrations/119_user_created_at_index.down.sql` — drops the index.

The `"user"` table is defined in `001_init.up.sql` and had no index on `created_at`. This supports ordering/filtering users by signup time.

## Notes
- Uses `CREATE INDEX CONCURRENTLY` in a single-statement migration, matching the existing index-only migration convention (114/115). The migration runner executes files outside an explicit transaction, so CONCURRENTLY stays isolated.
- No table was altered by hand — the change ships purely as a migration file.

Resolves MUL-3246.
