### PR TITLE
NEX-470: keep chat send available while running

### DIFF
--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -14,6 +14,7 @@ interface SubmitButtonProps {
   disabled?: boolean;
   loading?: boolean;
   running?: boolean;
+  allowSubmitWhileRunning?: boolean;
   onStop?: () => void;
   /**
    * Tooltip shown over the send button when idle. Pass a string or a node
@@ -31,37 +32,47 @@ function SubmitButton({
   disabled,
   loading,
   running,
+  allowSubmitWhileRunning,
   onStop,
   tooltip,
   stopTooltip,
 }: SubmitButtonProps) {
+  const submitButton = (
+    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
+      {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
+    </Button>
+  );
+  const submit = tooltip ? (
+    <Tooltip>
+      <TooltipTrigger render={submitButton} />
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
+  ) : submitButton;
+
   if (running) {
     const stopButton = (
       <Button size="icon-sm" onClick={onStop}>
         <Square className="fill-current" />
       </Button>
     );
-    if (!stopTooltip) return stopButton;
-    return (
+    const stop = stopTooltip ? (
       <Tooltip>
         <TooltipTrigger render={stopButton} />
         <TooltipContent side="top">{stopTooltip}</TooltipContent>
       </Tooltip>
-    );
+    ) : stopButton;
+    if (allowSubmitWhileRunning) {
+      return (
+        <>
+          {stop}
+          {submit}
+        </>
+      );
+    }
+    return stop;
   }
 
-  const submitButton = (
-    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
-      {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
-    </Button>
-  );
-  if (!tooltip) return submitButton;
-  return (
-    <Tooltip>
-      <TooltipTrigger render={submitButton} />
-      <TooltipContent side="top">{tooltip}</TooltipContent>
-    </Tooltip>
-  );
+  return submit;
 }
 
 export { SubmitButton, type SubmitButtonProps };

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -333,6 +333,25 @@ describe("ChatInput attachment wiring", () => {
 });
 
 describe("ChatInput async send", () => {
+  it("allows sending another message while a task is already running", async () => {
+    const onSend = vi.fn();
+    const onStop = vi.fn();
+    renderInput({ isRunning: true, onSend, onStop });
+
+    fireEvent.change(screen.getByTestId("editor"), { target: { value: "queue next" } });
+
+    let sendButton: HTMLElement;
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      sendButton = buttons[buttons.length - 1]!;
+      expect(sendButton).not.toBeDisabled();
+    });
+    fireEvent.click(sendButton!);
+
+    expect(onSend).toHaveBeenCalledWith("queue next", undefined);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
   it("restores a cancelled empty run draft into the editor", async () => {
     const onRestoreDraftConsumed = vi.fn();
     renderInput({

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -169,10 +169,9 @@ export function ChatInput({
 
   const handleSend = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
-    if (!content || isRunning || isSubmitting || disabled || noAgent) {
+    if (!content || isSubmitting || disabled || noAgent) {
       logger.debug("input.send skipped", {
         emptyContent: !content,
-        isRunning,
         isSubmitting,
         disabled,
         noAgent,
@@ -309,6 +308,7 @@ export function ChatInput({
             onClick={handleSend}
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             running={isRunning}
+            allowSubmitWhileRunning
             onStop={onStop}
             tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
             stopTooltip={t(($) => $.input.stop_tooltip)}


### PR DESCRIPTION
## Summary
- Keep chat send available while a task is already running by rendering stop + send actions together.
- Remove the `isRunning` guard from `ChatInput` send handling so follow-up messages can queue.
- Add a regression test for sending another message while `isRunning=true`.

## Verification
- `pnpm --filter @multica/views exec vitest run chat/components/chat-input.test.tsx --reporter=verbose`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/ui typecheck`
- `curl -I -L https://multica.nexai.co.kr/nexai/usage` returned HTTP 200
- Live bundle check found `allowSubmitWhileRunning`, `send-button`, and `chat-input` in the deployed dashboard layout chunk.

## Notes
- Authenticated browser validation for `dashboard.nexai.co.kr/multica` is still required for final issue closure because unauthenticated access redirects to Google sign-in.
