### PR TITLE
feat(autopilot): enforce minimum interval between schedule trigger fires

### DIFF
--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -737,6 +737,10 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		if req.Timezone != nil && *req.Timezone != "" {
 			tz = *req.Timezone
 		}
+		if err := service.ValidateCronMinInterval(*req.CronExpression, tz); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		t, err := computeNextRun(*req.CronExpression, tz)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -1017,6 +1021,16 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		tz = *req.Timezone
 	}
 	if prev.Kind == "schedule" && cronExpr != "" {
+		// Only re-validate the interval floor when the expression (or its
+		// timezone) actually changed — an unrelated field update on a trigger
+		// that predates a tightened AUTOPILOT_MIN_TRIGGER_INTERVAL must not
+		// start failing.
+		if req.CronExpression != nil || req.Timezone != nil {
+			if err := service.ValidateCronMinInterval(cronExpr, tz); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
 		t, err := computeNextRun(cronExpr, tz)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -49,6 +49,8 @@ multica autopilot trigger-rotate-url <autopilot-id> <trigger-id> --yes --output 
 
 Use `trigger` only when the user explicitly asks for a manual run. Use `trigger-rotate-url` only when rotating a webhook URL; the old URL stops being valid.
 
+Schedule triggers enforce a minimum interval between consecutive fires (default 5 minutes; operators tune it via the server-side `AUTOPILOT_MIN_TRIGGER_INTERVAL` env var, `0` disables). Creating or updating a trigger whose cron expression fires more often than the floor returns a 400 — pick a sparser cadence instead of retrying.
+
 Webhook trigger output can include a URL/token. Do not paste webhook tokens or signing material into comments, logs, docs, or PRs. Redact secrets.
 
 ## Debugging

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -6,4 +6,5 @@
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
+- `server/internal/service/cron.go` has `ValidateCronMinInterval`, enforced by the trigger create/update handlers in `server/internal/handler/autopilot.go`; the floor comes from `AUTOPILOT_MIN_TRIGGER_INTERVAL` (default 5m, `0` disables).
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.

--- a/server/internal/service/cron.go
+++ b/server/internal/service/cron.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -22,6 +23,77 @@ func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
 	}
 	return sched.Next(time.Now().In(loc)), nil
+}
+
+// DefaultMinTriggerInterval is the floor enforced between consecutive
+// schedule-trigger fires unless overridden via AUTOPILOT_MIN_TRIGGER_INTERVAL.
+// A runaway high-frequency autopilot is the single biggest token-burn risk
+// (each fire dispatches an agent run), so the default is deliberately
+// conservative.
+const DefaultMinTriggerInterval = 5 * time.Minute
+
+// minTriggerIntervalSamples is how many consecutive fire times are inspected
+// when validating a cron expression against the interval floor. Eight samples
+// catch both uniform high-frequency patterns (* * * * *) and bursty lists
+// (0,1,2 * * * *) without noticeably slowing down trigger creation.
+const minTriggerIntervalSamples = 8
+
+// MinTriggerInterval returns the enforced floor between consecutive schedule
+// fires. AUTOPILOT_MIN_TRIGGER_INTERVAL accepts a Go duration string
+// (e.g. "1m", "30s"); an explicit zero or negative value disables the check.
+// Unparseable values fall back to the default rather than silently disabling
+// the guard.
+func MinTriggerInterval() time.Duration {
+	raw := os.Getenv("AUTOPILOT_MIN_TRIGGER_INTERVAL")
+	if raw == "" {
+		return DefaultMinTriggerInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return DefaultMinTriggerInterval
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// ValidateCronMinInterval rejects cron expressions whose consecutive fire
+// times are closer together than the configured floor. The expression is
+// assumed to be already parseable (callers validate via ComputeNextRun);
+// parse errors are still returned for safety.
+func ValidateCronMinInterval(cronExpr, timezone string) error {
+	return validateCronMinInterval(cronExpr, timezone, MinTriggerInterval())
+}
+
+func validateCronMinInterval(cronExpr, timezone string, floor time.Duration) error {
+	if floor <= 0 {
+		return nil
+	}
+	sched, err := cronParser.Parse(cronExpr)
+	if err != nil {
+		return fmt.Errorf("parse cron: %w", err)
+	}
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return fmt.Errorf("invalid timezone %q: %w", timezone, err)
+	}
+	prev := sched.Next(time.Now().In(loc))
+	for i := 0; i < minTriggerIntervalSamples; i++ {
+		next := sched.Next(prev)
+		if next.IsZero() {
+			// The expression stops firing within the sampled window.
+			return nil
+		}
+		if gap := next.Sub(prev); gap < floor {
+			return fmt.Errorf(
+				"cron expression %q fires runs %s apart; the minimum allowed interval between runs is %s (operators can tune AUTOPILOT_MIN_TRIGGER_INTERVAL)",
+				cronExpr, gap, floor,
+			)
+		}
+		prev = next
+	}
+	return nil
 }
 
 // ValidateTimezone returns an error if the timezone string is not recognized.

--- a/server/internal/service/cron_test.go
+++ b/server/internal/service/cron_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateCronMinInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		floor   time.Duration
+		wantErr bool
+	}{
+		{name: "every minute rejected at default floor", expr: "* * * * *", floor: 5 * time.Minute, wantErr: true},
+		{name: "every two minutes rejected at default floor", expr: "*/2 * * * *", floor: 5 * time.Minute, wantErr: true},
+		{name: "every five minutes accepted at default floor", expr: "*/5 * * * *", floor: 5 * time.Minute, wantErr: false},
+		{name: "hourly accepted", expr: "0 * * * *", floor: 5 * time.Minute, wantErr: false},
+		{name: "daily accepted", expr: "0 9 * * *", floor: 5 * time.Minute, wantErr: false},
+		{name: "bursty minute list rejected", expr: "0,1,2 9 * * *", floor: 5 * time.Minute, wantErr: true},
+		{name: "zero floor disables check", expr: "* * * * *", floor: 0, wantErr: false},
+		{name: "invalid expression returns error", expr: "not a cron", floor: 5 * time.Minute, wantErr: true},
+		{name: "stricter floor rejects hourly", expr: "0 * * * *", floor: 2 * time.Hour, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCronMinInterval(tt.expr, "UTC", tt.floor)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateCronMinInterval(%q, UTC, %s) error = %v, wantErr %v", tt.expr, tt.floor, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCronMinIntervalInvalidTimezone(t *testing.T) {
+	err := validateCronMinInterval("0 * * * *", "Not/AZone", 5*time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "invalid timezone") {
+		t.Fatalf("expected invalid timezone error, got %v", err)
+	}
+}
+
+func TestMinTriggerIntervalEnvOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "unset uses default", env: "", want: DefaultMinTriggerInterval},
+		{name: "custom duration", env: "1m", want: time.Minute},
+		{name: "explicit zero disables", env: "0", want: 0},
+		{name: "negative disables", env: "-5m", want: 0},
+		{name: "garbage falls back to default", env: "soon", want: DefaultMinTriggerInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AUTOPILOT_MIN_TRIGGER_INTERVAL", tt.env)
+			if got := MinTriggerInterval(); got != tt.want {
+				t.Fatalf("MinTriggerInterval() with env %q = %s, want %s", tt.env, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Server-side validation that rejects schedule triggers whose cron expression fires more often than a configurable floor (default **5 minutes**, tunable via `AUTOPILOT_MIN_TRIGGER_INTERVAL`, `0` disables).

## Why

A schedule trigger is the highest-leverage token-burn surface in the product: every fire dispatches a full agent run, and nothing in the chain (scheduler → DispatchAutopilot → task queue) imposes any frequency limit today. `* * * * *` is accepted as-is and produces 1,440 agent runs/day from a single trigger.

Two existing characteristics make this worse than a normal footgun:

- Usage data lands via `taskusagebackfill` + hourly rollup, so the operator can't see the burn while it's happening.
- The autopilot failure monitor only auto-pauses on **failures** (≥50 runs, ≥90% fail, 7d lookback, 24h scan) — a *successfully* runaway autopilot never trips it.

I burned a real token budget this way on a self-hosted deployment before noticing. #1467 added `custom_args` / `MULTICA_CLAUDE_ARGS` to cap per-run cost; this PR caps run *frequency*, the other half of the equation.

## How

- `service/cron.go`: `ValidateCronMinInterval` samples the next 8 fire times and rejects if any consecutive gap is below the floor. Catches both uniform patterns (`*/2 * * * *`) and bursty lists (`0,1,2 9 * * *`).
- `handler/autopilot.go`: enforced on trigger create, and on update **only when `cron_expression` or `timezone` actually changed** — unrelated field updates on triggers that predate a tightened floor keep working.
- Env override follows the existing `AUTOPILOT_FAIL_MONITOR_*` pattern; unparseable values fall back to the default rather than silently disabling the guard.
- Built-in skill `multica-autopilots` SKILL.md + source map updated per the source-traced-contract rule in CLAUDE.md.

## Testing

- `go test ./internal/service/ -run 'Cron|MinTriggerInterval'` — 15 cases covering rejection/acceptance at the floor, bursty lists, zero/negative/garbage env values, invalid timezone.
- `go build ./...`, `go vet`, `gofmt` clean; `./internal/handler` test suite compiles and passes.

## Not in scope (follow-up if you want them)

- Frontend validation mirroring the floor in `trigger-config.tsx` (server-side remains the boundary).
- Workspace-level spend caps / real-time burn visibility — filing separately as a feature issue since it's a design discussion rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
