### PR TITLE
feat: support --recurse-submodules in repo checkout

### DIFF
--- a/server/cmd/multica/cmd_repo.go
+++ b/server/cmd/multica/cmd_repo.go
@@ -26,9 +26,11 @@ var repoCheckoutCmd = &cobra.Command{
 }
 
 var repoCheckoutRef string
+var repoCheckoutSubmodules bool
 
 func init() {
 	repoCheckoutCmd.Flags().StringVar(&repoCheckoutRef, "ref", "", "branch, tag, or commit to check out instead of the remote default branch")
+	repoCheckoutCmd.Flags().BoolVar(&repoCheckoutSubmodules, "recurse-submodules", false, "initialize and update submodules after checkout")
 	repoCmd.AddCommand(repoCheckoutCmd)
 }
 
@@ -50,13 +52,14 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get working directory: %w", err)
 	}
 
-	reqBody := map[string]string{
-		"url":          repoURL,
-		"workspace_id": workspaceID,
-		"workdir":      workDir,
-		"ref":          repoCheckoutRef,
-		"agent_name":   agentName,
-		"task_id":      taskID,
+	reqBody := map[string]any{
+		"url":               repoURL,
+		"workspace_id":      workspaceID,
+		"workdir":           workDir,
+		"ref":               repoCheckoutRef,
+		"agent_name":        agentName,
+		"task_id":           taskID,
+		"recurse_submodules": repoCheckoutSubmodules,
 	}
 
 	data, err := json.Marshal(reqBody)
@@ -82,8 +85,9 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 	}
 
 	var result struct {
-		Path       string `json:"path"`
-		BranchName string `json:"branch_name"`
+		Path            string   `json:"path"`
+		BranchName      string   `json:"branch_name"`
+		SubmoduleErrors []string `json:"submodule_errors"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		return fmt.Errorf("parse response: %w", err)
@@ -91,6 +95,9 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stdout, "%s\n", result.Path)
 	fmt.Fprintf(os.Stderr, "Checked out %s → %s (branch: %s)\n", repoURL, result.Path, result.BranchName)
+	for _, e := range result.SubmoduleErrors {
+		fmt.Fprintf(os.Stderr, "Warning: submodule init failed: %s\n", e)
+	}
 
 	return nil
 }

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -53,12 +53,13 @@ func (d *Daemon) listenHealth() (net.Listener, error) {
 
 // repoCheckoutRequest is the body of a POST /repo/checkout request.
 type repoCheckoutRequest struct {
-	URL         string `json:"url"`
-	WorkspaceID string `json:"workspace_id"`
-	WorkDir     string `json:"workdir"`
-	Ref         string `json:"ref,omitempty"`
-	AgentName   string `json:"agent_name"`
-	TaskID      string `json:"task_id"`
+	URL               string `json:"url"`
+	WorkspaceID       string `json:"workspace_id"`
+	WorkDir           string `json:"workdir"`
+	Ref               string `json:"ref,omitempty"`
+	AgentName         string `json:"agent_name"`
+	TaskID            string `json:"task_id"`
+	RecurseSubmodules bool   `json:"recurse_submodules,omitempty"`
 }
 
 // healthHandler returns the /health HTTP handler. Extracted from serveHealth
@@ -186,6 +187,7 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 			AgentName:           req.AgentName,
 			TaskID:              req.TaskID,
 			CoAuthoredByEnabled: d.workspaceCoAuthoredByEnabled(req.WorkspaceID),
+			Submodules:          req.RecurseSubmodules,
 		})
 		if err != nil {
 			d.logger.Error("repo checkout failed", "url", req.URL, "error", err)

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -3,6 +3,7 @@
 package repocache
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
 )
 
 // gitEnv returns an environment for git subprocesses that contact remotes.
@@ -45,9 +45,11 @@ func gitEnv() []string {
 	idx := strconv.Itoa(existing)
 	return append(base,
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_CONFIG_COUNT="+strconv.Itoa(existing+1),
+		"GIT_CONFIG_COUNT="+strconv.Itoa(existing+2),
 		"GIT_CONFIG_KEY_"+idx+"=safe.directory",
 		"GIT_CONFIG_VALUE_"+idx+"=*",
+		"GIT_CONFIG_KEY_"+strconv.Itoa(existing+1)+"=protocol.file.allow",
+		"GIT_CONFIG_VALUE_"+strconv.Itoa(existing+1)+"=always",
 	)
 }
 
@@ -302,6 +304,26 @@ func gitFetch(barePath string) error {
 	return nil
 }
 
+// initSubmodules runs `git submodule update --init --recursive` in the
+// given worktree directory. The worktree must already be checked out.
+// Returns an error if the git command fails; callers decide whether
+// to treat this as fatal.
+func initSubmodules(worktreePath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "submodule", "update", "--init", "--recursive")
+	cmd.Env = gitEnv()
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("git submodule update timed out after 5m: %w", err)
+		}
+		return fmt.Errorf("git submodule update: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // runGitFetch is the raw `git fetch origin` wrapper. Callers should go through
 // gitFetch, which migrates legacy caches first.
 func runGitFetch(barePath string) error {
@@ -382,12 +404,14 @@ type WorktreeParams struct {
 	AgentName           string // for branch naming
 	TaskID              string // for branch naming uniqueness
 	CoAuthoredByEnabled bool   // install prepare-commit-msg hook for Co-authored-by trailer
+	Submodules          bool   // run git submodule update --init --recursive after checkout
 }
 
 // WorktreeResult describes a successfully created worktree.
 type WorktreeResult struct {
-	Path       string `json:"path"`        // absolute path to the worktree
-	BranchName string `json:"branch_name"` // git branch created for this worktree
+	Path            string   `json:"path"`                        // absolute path to the worktree
+	BranchName      string   `json:"branch_name"`                 // git branch created for this worktree
+	SubmoduleErrors []string `json:"submodule_errors,omitempty"`  // errors from submodule init (non-fatal)
 }
 
 // CreateWorktree looks up the bare cache for a repo, fetches latest, and creates
@@ -477,6 +501,18 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			}
 		}
 
+		result := &WorktreeResult{
+			Path:       worktreePath,
+			BranchName: actualBranch,
+		}
+
+		if params.Submodules {
+			if err := initSubmodules(worktreePath); err != nil {
+				c.logger.Warn("repo checkout: submodule init failed (non-fatal)", "url", params.RepoURL, "error", err)
+				result.SubmoduleErrors = append(result.SubmoduleErrors, err.Error())
+			}
+		}
+
 		c.logger.Info("repo checkout: existing worktree updated",
 			"url", params.RepoURL,
 			"path", worktreePath,
@@ -484,10 +520,7 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			"base", baseRef,
 		)
 
-		return &WorktreeResult{
-			Path:       worktreePath,
-			BranchName: actualBranch,
-		}, nil
+		return result, nil
 	}
 
 	// Create a new worktree. createWorktree may rename the branch to avoid
@@ -515,6 +548,18 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		}
 	}
 
+	result := &WorktreeResult{
+		Path:       worktreePath,
+		BranchName: actualBranch,
+	}
+
+	if params.Submodules {
+		if err := initSubmodules(worktreePath); err != nil {
+			c.logger.Warn("repo checkout: submodule init failed (non-fatal)", "url", params.RepoURL, "error", err)
+			result.SubmoduleErrors = append(result.SubmoduleErrors, err.Error())
+		}
+	}
+
 	c.logger.Info("repo checkout: worktree created",
 		"url", params.RepoURL,
 		"path", worktreePath,
@@ -522,10 +567,7 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		"base", baseRef,
 	)
 
-	return &WorktreeResult{
-		Path:       worktreePath,
-		BranchName: actualBranch,
-	}, nil
+	return result, nil
 }
 
 func resolveBaseRef(barePath, requestedRef string) (string, error) {

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -60,6 +60,12 @@ func TestGitEnv(t *testing.T) {
 	if !envHas(env, "GIT_CONFIG_VALUE_0=*") {
 		t.Error("gitEnv() must include GIT_CONFIG_VALUE_0=*")
 	}
+	if !envHas(env, "GIT_CONFIG_KEY_1=protocol.file.allow") {
+		t.Error("gitEnv() must include GIT_CONFIG_KEY_1=protocol.file.allow")
+	}
+	if !envHas(env, "GIT_CONFIG_VALUE_1=always") {
+		t.Error("gitEnv() must include GIT_CONFIG_VALUE_1=always")
+	}
 }
 
 func TestGitEnvPreservesExistingConfig(t *testing.T) {
@@ -83,14 +89,20 @@ func TestGitEnvPreservesExistingConfig(t *testing.T) {
 	}
 
 	// safe.directory must be appended at index 2 (next available).
-	if !envHas("GIT_CONFIG_COUNT=3") {
-		t.Error("expected GIT_CONFIG_COUNT=3")
+	if !envHas("GIT_CONFIG_COUNT=4") {
+		t.Error("expected GIT_CONFIG_COUNT=4")
 	}
 	if !envHas("GIT_CONFIG_KEY_2=safe.directory") {
 		t.Error("expected GIT_CONFIG_KEY_2=safe.directory")
 	}
 	if !envHas("GIT_CONFIG_VALUE_2=*") {
 		t.Error("expected GIT_CONFIG_VALUE_2=*")
+	}
+	if !envHas("GIT_CONFIG_KEY_3=protocol.file.allow") {
+		t.Error("expected GIT_CONFIG_KEY_3=protocol.file.allow")
+	}
+	if !envHas("GIT_CONFIG_VALUE_3=always") {
+		t.Error("expected GIT_CONFIG_VALUE_3=always")
 	}
 
 	// Original entries must still be present.
@@ -233,6 +245,33 @@ func createTestRepoAt(t *testing.T, dir string) string {
 		}
 	}
 	return dir
+}
+
+// createTestRepoWithSubmodule creates a repo that has a .gitmodules pointing
+// to a local submodule repo. Returns the parent repo path.
+func createTestRepoWithSubmodule(t *testing.T) string {
+	t.Helper()
+
+	subRepo := createTestRepo(t)
+	parentRepo := createTestRepo(t)
+
+	// Use gitEnv() so that protocol.file.allow=always is set, which is
+	// required for newer git versions to clone from local file paths.
+	for _, args := range [][]string{
+		{"-C", parentRepo, "submodule", "add", subRepo, "mysubmodule"},
+		{"-C", parentRepo, "commit", "-am", "add submodule"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(gitEnv(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), out, err)
+		}
+	}
+
+	return parentRepo
 }
 
 func TestSyncAndLookup(t *testing.T) {
@@ -1453,5 +1492,125 @@ func TestGetRemoteDefaultBranchAmbiguousOriginReturnsEmpty(t *testing.T) {
 	got := getRemoteDefaultBranch(barePath)
 	if got != "" {
 		t.Fatalf("getRemoteDefaultBranch = %q, want \"\" (ambiguous origin/* must not guess)", got)
+	}
+}
+
+func TestCreateWorktreeWithSubmodules(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepoWithSubmodule(t)
+	cacheRoot := t.TempDir()
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     workDir,
+		AgentName:   "test-agent",
+		TaskID:      "submodule-test",
+		Submodules:  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	if len(result.SubmoduleErrors) > 0 {
+		t.Fatalf("expected no submodule errors, got: %v", result.SubmoduleErrors)
+	}
+
+	submoduleGit := filepath.Join(result.Path, "mysubmodule", ".git")
+	if _, err := os.Stat(submoduleGit); os.IsNotExist(err) {
+		t.Fatalf("submodule .git not found at %s", submoduleGit)
+	}
+}
+
+func TestCreateWorktreeSubmodulesDisabledByDefault(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepoWithSubmodule(t)
+	cacheRoot := t.TempDir()
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     workDir,
+		AgentName:   "test-agent",
+		TaskID:      "no-submodule-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	submoduleDir := filepath.Join(result.Path, "mysubmodule")
+	entries, err := os.ReadDir(submoduleDir)
+	if err != nil {
+		t.Fatalf("read submodule dir failed: %v", err)
+	}
+	if len(entries) > 0 {
+		t.Errorf("expected empty submodule dir when Submodules=false, got %d entries", len(entries))
+	}
+}
+
+func TestInitSubmodulesFailure(t *testing.T) {
+	t.Parallel()
+
+	// Create a proper submodule setup, then delete the submodule source
+	// so that git submodule update fails when trying to fetch.
+	subRepo := createTestRepo(t)
+	parentRepo := createTestRepo(t)
+
+	// Properly register the submodule (creates gitlink entry in the index).
+	for _, args := range [][]string{
+		{"-C", parentRepo, "submodule", "add", subRepo, "badsub"},
+		{"-C", parentRepo, "commit", "-am", "add submodule"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(gitEnv(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), out, err)
+		}
+	}
+
+	// Delete the submodule source so the URL in .gitmodules becomes unreachable.
+	if err := os.RemoveAll(subRepo); err != nil {
+		t.Fatalf("remove submodule source: %v", err)
+	}
+
+	cacheRoot := t.TempDir()
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: parentRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     parentRepo,
+		WorkDir:     workDir,
+		AgentName:   "test-agent",
+		TaskID:      "submodule-fail-test",
+		Submodules:  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree should succeed even if submodules fail: %v", err)
+	}
+
+	if len(result.SubmoduleErrors) == 0 {
+		t.Fatal("expected submodule errors for unreachable URL")
+	}
+	if !strings.Contains(result.SubmoduleErrors[0], "git submodule update") {
+		t.Errorf("expected error to mention 'git submodule update', got: %s", result.SubmoduleErrors[0])
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Add `--recurse-submodules` flag to `multica repo checkout` so agents can initialize git submodules after worktree creation. Currently the parent repo is checked out but submodule working trees are left uninitialized, forcing agents to manually run `git submodule update --init --recursive`.

## Related Issue

Closes #3686

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/repocache/cache.go` — Add `initSubmodules()` function with 5-min timeout, add `Submodules` field to `WorktreeParams`, add `SubmoduleErrors` to `WorktreeResult`, call `initSubmodules` in both `CreateWorktree` code paths when enabled. Add `protocol.file.allow=always` to `gitEnv()` for git 2.38+ compatibility.
- `server/internal/daemon/repocache/cache_test.go` — Add `createTestRepoWithSubmodule` helper, `TestCreateWorktreeWithSubmodules`, `TestCreateWorktreeSubmodulesDisabledByDefault`, `TestInitSubmodulesFailure`.
- `server/internal/daemon/health.go` — Add `RecurseSubmodules` field to `repoCheckoutRequest`, pass to `WorktreeParams.Submodules`.
- `server/cmd/multica/cmd_repo.go` — Add `--recurse-submodules` CLI flag, change request body to `map[string]any`, handle `SubmoduleErrors` in response with stderr warnings.

## How to Test

1. `cd server && go test ./internal/daemon/repocache/ -count=1 -v -run "TestCreateWorktreeWithSubmodules|TestCreateWorktreeSubmodulesDisabledByDefault|TestInitSubmodulesFailure"`
2. `cd server && go run ./cmd/multica/ repo checkout --help` — verify `--recurse-submodules` flag appears
3. `cd server && go test ./...` — full test suite passes

## Checklist

- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** opencode (mimo-v2.5-pro)

**Prompt / approach:**
Used brainstorming skill to refine requirements from issue #3686 into a design spec, then writing-plans skill to create an implementation plan, then subagent-driven-development skill to execute the plan task-by-task with spec compliance and code quality reviews after each task.

## Screenshots (optional)

N/A — CLI-only change, no UI.