### PR TITLE
MUL-3267: fix(markdown): disable single-dollar inline math in web renderer

### DIFF
--- a/packages/ui/markdown/Markdown.tsx
+++ b/packages/ui/markdown/Markdown.tsx
@@ -445,7 +445,11 @@ export function Markdown({
   return (
     <div className={cn('markdown-content break-words', className)}>
       <ReactMarkdown
-        remarkPlugins={[remarkMath, remarkBreaks, [remarkGfm, { singleTilde: false }]]}
+        remarkPlugins={[
+          [remarkMath, { singleDollarTextMath: false }],
+          remarkBreaks,
+          [remarkGfm, { singleTilde: false }],
+        ]}
         rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
         urlTransform={urlTransform}
         components={components}

--- a/packages/views/editor/readonly-content-math.test.tsx
+++ b/packages/views/editor/readonly-content-math.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { Markdown } from "@multica/ui/markdown";
+import { ReadonlyContent } from "./readonly-content";
+
+// Prose with two dollar amounts and `~` (approximately) markers. With
+// remark-math's default single-dollar parsing, everything between the two
+// `$` signs is swallowed into a KaTeX inline-math span and rendered in an
+// italic math font, with `~` treated as a TeX non-breaking space.
+const FINANCE_TEXT =
+  "Revenue ≈ $120/mo gross (~$85 net of fees), 12 active subscriptions";
+
+describe("dollar amounts in markdown", () => {
+  it("Markdown renders $ amounts as plain text, not inline math", () => {
+    const { container } = render(<Markdown>{FINANCE_TEXT}</Markdown>);
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain(
+      "$120/mo gross (~$85 net of fees)",
+    );
+  });
+
+  it("ReadonlyContent renders $ amounts as plain text, not inline math", () => {
+    const { container } = render(<ReadonlyContent content={FINANCE_TEXT} />);
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain(
+      "$120/mo gross (~$85 net of fees)",
+    );
+  });
+
+  it("still renders explicit $$ display math", () => {
+    const { container } = render(<Markdown>{"$$\nE = mc^2\n$$"}</Markdown>);
+    expect(container.querySelector(".katex")).not.toBeNull();
+  });
+});

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -92,7 +92,7 @@ describe("ReadonlyContent math rendering", () => {
     const { container } = render(
       <ReadonlyContent
         content={[
-          "Inline math: $E = mc^2$",
+          "Inline math: $$E = mc^2$$",
           "",
           "$$",
           "\\int_0^1 x^2 \\, dx",

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -375,7 +375,11 @@ export const ReadonlyContent = memo(function ReadonlyContent({
     <AttachmentDownloadProvider attachments={attachments}>
       <div ref={wrapperRef} className={cn("rich-text-editor readonly text-sm", className)}>
         <ReactMarkdown
-          remarkPlugins={[remarkMath, remarkBreaks, [remarkGfm, { singleTilde: false }]]}
+          remarkPlugins={[
+            [remarkMath, { singleDollarTextMath: false }],
+            remarkBreaks,
+            [remarkGfm, { singleTilde: false }],
+          ]}
           rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
           urlTransform={urlTransform}
           components={components}


### PR DESCRIPTION
## Problem

On web, any comment or issue body containing two dollar amounts in one paragraph renders the text between them in an italic KaTeX math font, with `~` characters garbled. Example input:

> Revenue ≈ $120/mo gross (~$85 net of fees), 12 active subscriptions

Everything between `$120` and `$85` is parsed as inline TeX. Agent-generated finance content trips this constantly.

## Root cause

`remark-math` defaults to `singleDollarTextMath: true`, so any `$…$` pair becomes inline math. In TeX, `~` is a non-breaking space, which is why tildes vanish inside the affected span. (`remark-gfm` already has `singleTilde: false`, so strikethrough is not involved.)

## Fix

Pass `singleDollarTextMath: false` to `remark-math` in both web render paths (`packages/ui/markdown/Markdown.tsx`, `packages/views/editor/readonly-content.tsx`) — the same behavior GitHub uses. Explicit `$$…$$` math (inline and display) still renders; the existing math test is updated to that syntax.

## Testing

- New regression test `packages/views/editor/readonly-content-math.test.tsx` covers both `Markdown` and `ReadonlyContent` with dollar-amount prose (no `.katex` spans, text intact) plus a `$$` still-works case.
- `pnpm typecheck` clean; `pnpm --filter @multica/views test` — 1276/1276 passing.

Fixes #3856.
