### PR TITLE
MUL-3264: normalize Codex cached input usage

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1675,11 +1675,23 @@ func (c *codexClient) extractUsageFromMap(data map[string]any) {
 	c.usageMu.Lock()
 	defer c.usageMu.Unlock()
 
-	// Try various key conventions.
-	c.usage.InputTokens += codexInt64(usageMap, "input_tokens", "input", "prompt_tokens")
+	// Codex reports cached input as a prompt-token detail: cached_input_tokens
+	// are included in input_tokens. Persist mutually-exclusive buckets so
+	// dashboard cost math does not charge cached input twice.
+	inputTokens := codexInt64(usageMap, "input_tokens", "input", "prompt_tokens")
+	cacheReadTokens := codexInt64(usageMap, "cached_input_tokens", "cache_read_tokens", "cache_read_input_tokens")
+	c.usage.InputTokens += codexUncachedInputTokens(inputTokens, cacheReadTokens)
 	c.usage.OutputTokens += codexInt64(usageMap, "output_tokens", "output", "completion_tokens")
-	c.usage.CacheReadTokens += codexInt64(usageMap, "cache_read_tokens", "cache_read_input_tokens")
+	c.usage.CacheReadTokens += cacheReadTokens
 	c.usage.CacheWriteTokens += codexInt64(usageMap, "cache_write_tokens", "cache_creation_input_tokens")
+}
+
+func codexUncachedInputTokens(inputTokens, cachedInputTokens int64) int64 {
+	uncached := inputTokens - cachedInputTokens
+	if uncached < 0 {
+		return 0
+	}
+	return uncached
 }
 
 // codexInt64 returns the first non-zero int64 value from the map for the given keys.
@@ -1839,7 +1851,7 @@ func parseCodexSessionFile(path string) *codexSessionUsage {
 					cachedTokens = usage.CacheReadInputTokens
 				}
 				result.usage = TokenUsage{
-					InputTokens:     usage.InputTokens,
+					InputTokens:     codexUncachedInputTokens(usage.InputTokens, cachedTokens),
 					OutputTokens:    usage.OutputTokens + usage.ReasoningOutputTokens,
 					CacheReadTokens: cachedTokens,
 				}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -381,6 +381,28 @@ func TestCodexRawTurnCompleted(t *testing.T) {
 	}
 }
 
+func TestCodexRawTurnCompletedSubtractsCachedInput(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.onTurnDone = func(aborted bool) {}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-usage","status":"completed","usage":{"input_tokens":1000,"cached_input_tokens":300,"output_tokens":50}}}}`)
+
+	c.usageMu.Lock()
+	defer c.usageMu.Unlock()
+	if c.usage.InputTokens != 700 {
+		t.Fatalf("input tokens = %d, want uncached 700", c.usage.InputTokens)
+	}
+	if c.usage.CacheReadTokens != 300 {
+		t.Fatalf("cache read tokens = %d, want 300", c.usage.CacheReadTokens)
+	}
+	if c.usage.OutputTokens != 50 {
+		t.Fatalf("output tokens = %d, want 50", c.usage.OutputTokens)
+	}
+}
+
 func TestCodexRawTurnCompletedDeduplication(t *testing.T) {
 	t.Parallel()
 
@@ -545,6 +567,37 @@ func TestCodexSetTurnErrorFirstWins(t *testing.T) {
 
 	if got := c.getTurnError(); got != "first" {
 		t.Fatalf("expected first-wins semantics, got %q", got)
+	}
+}
+
+func TestParseCodexSessionFileSubtractsCachedInput(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	content := strings.Join([]string{
+		`{"timestamp":"2026-06-12T17:29:27.587Z","type":"turn_context","payload":{"model":"gpt-5.5"}}`,
+		`{"timestamp":"2026-06-12T17:35:37.479Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":300,"output_tokens":40,"reasoning_output_tokens":10,"total_tokens":1040},"model":"gpt-5.5"}}}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got := parseCodexSessionFile(path)
+	if got == nil {
+		t.Fatal("expected usage")
+	}
+	if got.model != "gpt-5.5" {
+		t.Fatalf("model = %q, want gpt-5.5", got.model)
+	}
+	if got.usage.InputTokens != 700 {
+		t.Fatalf("input tokens = %d, want uncached 700", got.usage.InputTokens)
+	}
+	if got.usage.CacheReadTokens != 300 {
+		t.Fatalf("cache read tokens = %d, want 300", got.usage.CacheReadTokens)
+	}
+	if got.usage.OutputTokens != 50 {
+		t.Fatalf("output tokens = %d, want 50", got.usage.OutputTokens)
 	}
 }
 


### PR DESCRIPTION
Summary
- Normalize Codex cached input at ingestion so cached_input_tokens are not counted again as full-price input tokens.
- Apply the same normalization to raw turn usage and session JSONL token_count fallback parsing.
- Add regression coverage for both Codex usage paths.

Testing
- go test ./pkg/agent

Fixes MUL-3264
Fixes #4078