### PR TITLE
feat(mobile): sort assignees by frequency

### DIFF
--- a/apps/mobile/components/issue/pickers/assignee-picker-body.tsx
+++ b/apps/mobile/components/issue/pickers/assignee-picker-body.tsx
@@ -4,7 +4,7 @@
  * status-picker-body.tsx for the split rationale.
  *
  * Mirrors web `packages/views/issues/components/pickers/assignee-picker.tsx`
- * (mobile skips frequency-sort; alphabetical instead).
+ * frequency sorting while keeping mobile's selected-row pin.
  *
  * Header + search bar are owned by the iOS native nav header registered in
  * `app/(app)/[workspace]/_layout.tsx` (assignee Stack.Screen sets
@@ -28,6 +28,7 @@ import { ActorAvatar } from "@/components/ui/actor-avatar";
 import { memberListOptions } from "@/data/queries/members";
 import { agentListOptions } from "@/data/queries/agents";
 import { squadListOptions } from "@/data/queries/squads";
+import { assigneeFrequencyOptions } from "@/data/queries/assignee-frequency";
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { useScrollToTopOnChange } from "@/lib/use-scroll-to-top-on-change";
 import { THEME } from "@/lib/theme";
@@ -66,6 +67,7 @@ export function AssigneePickerBody({ value, query, onChange }: Props) {
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: squads = [] } = useQuery(squadListOptions(wsId));
+  const { data: frequency = [] } = useQuery(assigneeFrequencyOptions(wsId));
   const listRef = useScrollToTopOnChange(query);
   const { colorScheme } = useColorScheme();
   // Tint color for the checkmark accessory. Project uses a monochrome
@@ -78,18 +80,29 @@ export function AssigneePickerBody({ value, query, onChange }: Props) {
   const rows = useMemo<Row[]>(() => {
     const q = query.trim().toLowerCase();
     const matchName = (name: string) => !q || name.toLowerCase().includes(q);
+    const freqMap = new Map<string, number>();
+    for (const entry of frequency) {
+      freqMap.set(
+        `${entry.assignee_type}:${entry.assignee_id}`,
+        entry.frequency,
+      );
+    }
+    const getFreq = (type: string, id: string) =>
+      freqMap.get(`${type}:${id}`) ?? 0;
 
     const memberRows: Row[] = [...members]
       .filter((m) => matchName(m.name))
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort(
+        (a, b) => getFreq("member", b.user_id) - getFreq("member", a.user_id),
+      )
       .map((m) => ({ kind: "member" as const, member: m }));
     const agentRows: Row[] = [...agents]
       .filter((a) => matchName(a.name))
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => getFreq("agent", b.id) - getFreq("agent", a.id))
       .map((a) => ({ kind: "agent" as const, agent: a }));
     const squadRows: Row[] = [...squads]
       .filter((s) => !s.archived_at && matchName(s.name))
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => getFreq("squad", b.id) - getFreq("squad", a.id))
       .map((s) => ({ kind: "squad" as const, squad: s }));
 
     if (q) return [...memberRows, ...agentRows, ...squadRows];
@@ -108,7 +121,7 @@ export function AssigneePickerBody({ value, query, onChange }: Props) {
       ...agentRows.filter((r) => !isRowSelected(value, r)),
       ...squadRows.filter((r) => !isRowSelected(value, r)),
     ];
-  }, [members, agents, squads, query, value]);
+  }, [members, agents, squads, frequency, query, value]);
 
   const isSelected = (row: Row) => isRowSelected(value, row);
 

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -57,6 +57,7 @@ import type {
   User,
   Workspace,
 } from "@multica/core/types";
+import type { AssigneeFrequencyEntry } from "@multica/core/types/activity";
 import {
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_ENTRIES,
@@ -68,6 +69,7 @@ import {
   ActiveTasksResponseSchema,
   AgentListSchema,
   AgentTaskListSchema,
+  AssigneeFrequencyListSchema,
   AttachmentListSchema,
   AttachmentSchema,
   ChatMessageListSchema,
@@ -78,6 +80,7 @@ import {
   EMPTY_ACTIVE_TASKS_RESPONSE,
   EMPTY_AGENT_LIST,
   EMPTY_AGENT_TASK_LIST,
+  EMPTY_ASSIGNEE_FREQUENCY_LIST,
   EMPTY_ATTACHMENT_LIST,
   EMPTY_CHAT_MESSAGE_LIST,
   EMPTY_CHAT_PENDING_TASK,
@@ -538,6 +541,20 @@ class ApiClient {
     return parseWithFallback(raw, SquadListSchema, EMPTY_SQUAD_LIST, {
       endpoint: "listSquads",
     });
+  }
+
+  async getAssigneeFrequency(
+    opts?: { signal?: AbortSignal },
+  ): Promise<AssigneeFrequencyEntry[]> {
+    const raw = await this.fetch<unknown>("/api/assignee-frequency", {
+      signal: opts?.signal,
+    });
+    return parseWithFallback(
+      raw,
+      AssigneeFrequencyListSchema,
+      EMPTY_ASSIGNEE_FREQUENCY_LIST,
+      { endpoint: "getAssigneeFrequency" },
+    );
   }
 
   // --- Issues ---

--- a/apps/mobile/data/queries/assignee-frequency.ts
+++ b/apps/mobile/data/queries/assignee-frequency.ts
@@ -1,0 +1,9 @@
+import { queryOptions } from "@tanstack/react-query";
+import { api } from "@/data/api";
+
+export const assigneeFrequencyOptions = (wsId: string | null) =>
+  queryOptions({
+    queryKey: ["workspaces", wsId, "assignee-frequency"] as const,
+    queryFn: ({ signal }) => api.getAssigneeFrequency({ signal }),
+    enabled: !!wsId,
+  });

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -10,6 +10,7 @@
  * (root CLAUDE.md "API Response Compatibility") for these endpoints.
  */
 import { z } from "zod";
+import type { AssigneeFrequencyEntry } from "@multica/core/types/activity";
 import type {
   Agent,
   AgentTask,
@@ -620,6 +621,18 @@ export const RuntimeSchema: z.ZodType<RuntimeDevice> = z.object({
 
 export const RuntimeListSchema = z.array(RuntimeSchema).default([]);
 export const EMPTY_RUNTIME_LIST: RuntimeDevice[] = [];
+
+export const AssigneeFrequencyEntrySchema: z.ZodType<AssigneeFrequencyEntry> =
+  z.object({
+    assignee_type: z.string().default(""),
+    assignee_id: z.string().default(""),
+    frequency: z.number().default(0),
+  }).loose();
+
+export const AssigneeFrequencyListSchema = z
+  .array(AssigneeFrequencyEntrySchema)
+  .default([]);
+export const EMPTY_ASSIGNEE_FREQUENCY_LIST: AssigneeFrequencyEntry[] = [];
 
 // Squad schema — fields mobile actually consumes for the @mention suggestion
 // bar (id, name, archived_at filter) plus identity/timestamp fields that are


### PR DESCRIPTION
## Summary
- add mobile assignee-frequency API parsing with Zod fallback
- add mobile TanStack query options using the web-compatible key shape
- sort assignee picker members, agents, and squads by assignment frequency after filtering while keeping the selected-row pin

## Verification
- pnpm -C apps/mobile typecheck
- pnpm -C apps/mobile lint (passes with existing warnings outside touched files)