### PR TITLE
feat(daemon): MULTICA_DRY_RUN rehearsal mode for agent task execution (refs #4100)

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -102,6 +102,12 @@ type Config struct {
 	ClaudeArgs                     []string
 	CodexArgs                      []string
 	CodebuddyArgs                  []string
+	// DryRun, when true, makes the daemon short-circuit every agent CLI
+	// invocation and instead return a synthetic "what would have happened"
+	// result. Enabled via MULTICA_DRY_RUN=true; intended as a rehearsal mode
+	// before turning on a new autopilot or before redeploying after a
+	// runaway-cost incident. See issue #4100.
+	DryRun bool
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -419,6 +425,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// Keep env after task: env > default (false)
 	keepEnv := os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "true" || os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "1"
 
+	// Dry-run mode: env > default (false). Mirrors the KEEP_ENV pattern —
+	// truthy values activate the rehearsal path in executeAndDrain. See
+	// Config.DryRun and issue #4100.
+	dryRun := os.Getenv("MULTICA_DRY_RUN") == "true" || os.Getenv("MULTICA_DRY_RUN") == "1"
+
 	// GC config: env > defaults
 	gcEnabled := true
 	if v := os.Getenv("MULTICA_GC_ENABLED"); v == "false" || v == "0" {
@@ -481,6 +492,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		Agents:                         agents,
 		WorkspacesRoot:                 workspacesRoot,
 		KeepEnvAfterTask:               keepEnv,
+		DryRun:                         dryRun,
 		GCEnabled:                      gcEnabled,
 		GCInterval:                     gcInterval,
 		GCTTL:                          gcTTL,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2988,6 +2988,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		CustomArgs:                customArgs,
 		McpConfig:                 mcpConfig,
 		ThinkingLevel:             thinkingLevel,
+		DryRun:                    d.cfg.DryRun,
 	}
 	// Some providers do not reliably load the per-task runtime config files we
 	// write into the task workdir:
@@ -3026,7 +3027,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"timeout", execOpts.Timeout,
 	)
 
-	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
+	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, provider, taskLog, task.ID)
 	if err != nil {
 		return TaskResult{}, err
 	}
@@ -3038,7 +3039,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		firstUsage := result.Usage
 		taskLog.Warn("session resume failed, retrying with fresh session", "error", result.Error)
 		execOpts.ResumeSessionID = ""
-		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
+		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, prompt, execOpts, provider, taskLog, task.ID)
 		if retryErr != nil {
 			taskLog.Error("fresh session also failed to start", "error", retryErr)
 		} else {
@@ -3231,7 +3232,25 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the
 // server), and waits for the final result.
-func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID string) (agent.Result, int32, error) {
+func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, provider string, taskLog *slog.Logger, taskID string) (agent.Result, int32, error) {
+	// Dry-run short-circuit (issue #4100). When the daemon is launched with
+	// MULTICA_DRY_RUN=true, every task that reaches this point is treated as
+	// a rehearsal: the prompt has been fully rendered (skills, runtime brief,
+	// custom_args resolution all ran upstream), but we deliberately skip the
+	// provider call and synthesise a "what would have happened" Result. This
+	// is the smallest viable shape — daemon-wide, not per-task — to let
+	// operators rehearse autopilots and prompt templates before paying for
+	// a real run. Per-task / API-level dry-run is left to a follow-up PR.
+	if opts.DryRun {
+		taskLog.Info("dry-run: skipping backend execute",
+			"provider", provider,
+			"prompt_bytes", len(prompt),
+			"system_prompt_bytes", len(opts.SystemPrompt),
+			"max_turns", opts.MaxTurns,
+		)
+		return agent.BuildDryRunResult(prompt, opts, provider), 0, nil
+	}
+
 	// Wrap the caller's ctx so the idle watchdog (below) can interrupt both
 	// the agent subprocess (via the ctx passed to backend.Execute) AND the
 	// drain loop with a single cancel. Without this layer the backend would

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -982,7 +982,7 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 
 	// First attempt: resume fails (no SessionID in result).
 	opts := agent.ExecOptions{ResumeSessionID: "stale-id"}
-	result, _, err := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+	result, _, err := d.executeAndDrain(ctx, fb, "prompt", opts, "test", taskLog, "task-1")
 	if err != nil {
 		t.Fatalf("first call error: %v", err)
 	}
@@ -994,7 +994,7 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 	if result.Status == "failed" && result.SessionID == "" {
 		firstUsage := result.Usage
 		opts.ResumeSessionID = ""
-		retryResult, _, retryErr := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+		retryResult, _, retryErr := d.executeAndDrain(ctx, fb, "prompt", opts, "test", taskLog, "task-1")
 		if retryErr != nil {
 			t.Fatalf("retry error: %v", retryErr)
 		}
@@ -1030,7 +1030,7 @@ func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 	}
 
 	opts := agent.ExecOptions{ResumeSessionID: "some-id"}
-	result, _, err := d.executeAndDrain(context.Background(), fb, "p", opts, slog.Default(), "t")
+	result, _, err := d.executeAndDrain(context.Background(), fb, "p", opts, "test", slog.Default(), "t")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1100,7 +1100,7 @@ func TestExecuteAndDrain_CodexInactivityReportsToolResultTranscript(t *testing.T
 	result, tools, err := d.executeAndDrain(context.Background(), backend, "prompt", agent.ExecOptions{
 		Timeout:                   5 * time.Second,
 		SemanticInactivityTimeout: 100 * time.Millisecond,
-	}, slog.Default(), "task-stale")
+	}, "test", slog.Default(), "task-stale")
 	if err != nil {
 		t.Fatalf("executeAndDrain: %v", err)
 	}
@@ -1155,7 +1155,7 @@ func TestExecuteAndDrain_ContextCancelled_ReportsCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	result, _, err := d.executeAndDrain(ctx, blockingBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t")
+	result, _, err := d.executeAndDrain(ctx, blockingBackend{}, "p", agent.ExecOptions{}, "test", slog.Default(), "t")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1194,7 +1194,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresOnInactivity(t *testing.T) {
 	t.Cleanup(cancel)
 
 	start := time.Now()
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, "test", slog.Default(), "t-idle")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1224,7 +1224,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresWhenNoMessageEverArrives(t *testing.T
 	// emitOne=false models a backend that hangs before sending any message.
 	// lastActivityAt is initialised at executeAndDrain entry, so the same
 	// window applies even with zero traffic.
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: false}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-zero")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: false}, "p", agent.ExecOptions{}, "test", slog.Default(), "t-idle-zero")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1245,7 +1245,7 @@ func TestExecuteAndDrain_IdleWatchdog_DisabledWhenZero(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(80*time.Millisecond, cancel)
 
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-off")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, "test", slog.Default(), "t-idle-off")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1271,7 +1271,7 @@ func TestExecuteAndDrain_IdleWatchdog_HappyPathDoesNotFire(t *testing.T) {
 		},
 	}
 
-	result, _, err := d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{}, slog.Default(), "t-idle-happy")
+	result, _, err := d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{}, "test", slog.Default(), "t-idle-happy")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1342,6 +1342,7 @@ func TestExecuteAndDrain_IdleWatchdog_DoesNotFireDuringInFlightToolCall(t *testi
 		longToolCallBackend{toolSilence: 200 * time.Millisecond},
 		"p",
 		agent.ExecOptions{},
+		"test",
 		slog.Default(),
 		"t-long-tool",
 	)
@@ -1383,7 +1384,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresOnStuckInFlightTool(t *testing.T) {
 	t.Cleanup(cancel)
 
 	start := time.Now()
-	result, _, err := d.executeAndDrain(ctx, stuckInFlightToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-stuck-tool")
+	result, _, err := d.executeAndDrain(ctx, stuckInFlightToolBackend{}, "p", agent.ExecOptions{}, "test", slog.Default(), "t-stuck-tool")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1419,7 +1420,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresAfterToolResultIfBackendStaysSilent(t
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	result, _, err := d.executeAndDrain(ctx, tailIdleAfterToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-tail-idle")
+	result, _, err := d.executeAndDrain(ctx, tailIdleAfterToolBackend{}, "p", agent.ExecOptions{}, "test", slog.Default(), "t-tail-idle")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1710,6 +1711,53 @@ func TestEnsureRepoReadyConcurrentMissRefreshesOnce(t *testing.T) {
 	// must serialize them so the server is only called once.
 	if got := refreshCalls.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 refresh call, got %d", got)
+	}
+}
+
+// recordingBackend fails the test if Execute is called; used to assert that
+// the dry-run short-circuit never reaches the provider.
+type recordingBackend struct {
+	t *testing.T
+}
+
+func (r recordingBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	r.t.Fatal("dry-run path must not invoke backend.Execute")
+	return nil, nil
+}
+
+func TestExecuteAndDrain_DryRunShortCircuits(t *testing.T) {
+	d := newTestDaemon(t)
+	prompt := "hello multica"
+	opts := agent.ExecOptions{
+		SystemPrompt: "be terse",
+		MaxTurns:     10,
+		DryRun:       true,
+	}
+
+	result, tools, err := d.executeAndDrain(
+		context.Background(),
+		recordingBackend{t: t},
+		prompt,
+		opts,
+		"claude",
+		slog.Default(),
+		"task-dry",
+	)
+	if err != nil {
+		t.Fatalf("dry-run executeAndDrain: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Errorf("dry-run status = %q, want completed", result.Status)
+	}
+	if tools != 0 {
+		t.Errorf("dry-run must report 0 tool calls, got %d", tools)
+	}
+	usage, ok := result.Usage["_dry_run"]
+	if !ok || usage.InputTokens == 0 {
+		t.Errorf("dry-run usage missing _dry_run entry: %+v", result.Usage)
+	}
+	if usage.OutputTokens != 0 {
+		t.Errorf("dry-run must not record output tokens, got %d", usage.OutputTokens)
 	}
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -46,6 +46,52 @@ type ExecOptions struct {
 	// field rather than fail (so MUL-2339 can grow runtime support
 	// incrementally without breaking unrelated agents).
 	ThinkingLevel string
+	// DryRun, when true, signals that the execution should NOT invoke the
+	// underlying agent CLI. The daemon short-circuits the call in
+	// executeAndDrain and produces a synthetic Result describing what would
+	// have been sent (rendered prompt size, coarse input-token estimate),
+	// without spending any provider tokens. Useful as a rehearsal before
+	// turning on a new autopilot or before redeploying after a runaway-cost
+	// incident — see issue #4100.
+	DryRun bool
+}
+
+// EstimateInputTokens returns a coarse estimate of the input token count for
+// a rendered prompt + system prompt. Used by dry-run paths; intentionally a
+// rule-of-thumb (~4 bytes/token) rather than a real tokenizer call, because
+// the whole point of dry-run is to avoid any provider round-trip.
+func EstimateInputTokens(prompt, systemPrompt string) int64 {
+	const bytesPerToken = 4
+	total := len(prompt) + len(systemPrompt)
+	if total == 0 {
+		return 0
+	}
+	return int64(total+bytesPerToken-1) / int64(bytesPerToken)
+}
+
+// BuildDryRunResult constructs the synthetic Result returned for a dry-run
+// execution. Status is "completed" so the daemon's existing happy-path
+// post-processing applies; Output carries a human-readable summary, and
+// Usage records the estimate under a special "_dry_run" model key so it
+// shows up clearly in task_usage downstream without polluting real model
+// rollups.
+func BuildDryRunResult(prompt string, opts ExecOptions, provider string) Result {
+	est := EstimateInputTokens(prompt, opts.SystemPrompt)
+	header := LaunchHeader(provider)
+	if header == "" {
+		header = provider
+	}
+	return Result{
+		Status: "completed",
+		Output: fmt.Sprintf(
+			"[dry-run] %s\nrendered prompt: %d bytes (system: %d bytes)\nestimated input tokens: %d\nmax_turns: %d (0 = backend default)\nno provider call was made.",
+			header, len(prompt), len(opts.SystemPrompt), est, opts.MaxTurns,
+		),
+		DurationMs: 0,
+		Usage: map[string]TokenUsage{
+			"_dry_run": {InputTokens: est},
+		},
+	}
 }
 
 // runContext derives the execution context for an agent subprocess from the

--- a/server/pkg/agent/dryrun_test.go
+++ b/server/pkg/agent/dryrun_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateInputTokens(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		system string
+		want   int64
+	}{
+		{name: "empty", prompt: "", system: "", want: 0},
+		{name: "exact multiple", prompt: "abcd", system: "", want: 1},
+		{name: "rounds up", prompt: "abcde", system: "", want: 2},
+		{name: "includes system prompt", prompt: "abcd", system: "efgh", want: 2},
+		{name: "rule of thumb 4 bytes per token", prompt: strings.Repeat("x", 400), system: "", want: 100},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EstimateInputTokens(tt.prompt, tt.system); got != tt.want {
+				t.Fatalf("EstimateInputTokens(%q, %q) = %d, want %d", tt.prompt, tt.system, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildDryRunResult(t *testing.T) {
+	res := BuildDryRunResult(
+		"hello world hello world",
+		ExecOptions{SystemPrompt: "be helpful", MaxTurns: 25},
+		"claude",
+	)
+	if res.Status != "completed" {
+		t.Errorf("status = %q, want %q", res.Status, "completed")
+	}
+	if !strings.Contains(res.Output, "[dry-run]") {
+		t.Errorf("Output missing dry-run marker: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "claude (stream-json)") {
+		t.Errorf("Output missing claude launch header: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "max_turns: 25") {
+		t.Errorf("Output missing max_turns: %q", res.Output)
+	}
+	usage, ok := res.Usage["_dry_run"]
+	if !ok {
+		t.Fatalf("Usage missing _dry_run key: %+v", res.Usage)
+	}
+	// 23 prompt + 10 system = 33 bytes, /4 round-up = 9
+	if usage.InputTokens != 9 {
+		t.Errorf("dry-run input tokens = %d, want 9", usage.InputTokens)
+	}
+	if usage.OutputTokens != 0 {
+		t.Errorf("dry-run must not record output tokens, got %d", usage.OutputTokens)
+	}
+}
+
+func TestBuildDryRunResultUnknownProviderFallsBack(t *testing.T) {
+	res := BuildDryRunResult("hi", ExecOptions{}, "made-up-provider")
+	if !strings.Contains(res.Output, "made-up-provider") {
+		t.Fatalf("Output should include unknown provider name verbatim: %q", res.Output)
+	}
+}


### PR DESCRIPTION
## What

A single daemon-wide environment switch — `MULTICA_DRY_RUN=true` — that turns the agent task path into a **rehearsal**: every task that reaches `executeAndDrain` short-circuits before `backend.Execute`, and the daemon synthesises a "what would have happened" `Result` describing the rendered prompt size, a coarse input-token estimate, and the configured `--max-turns` ceiling. No provider call is made; no provider tokens are spent.

Refs #4100.

## Why this shape

The issue argues for an eventual per-task / API-level dry-run, but the design discussion in #4100 will take time and the operational gap is **today**:

1. Operator finishes wiring a new autopilot.
2. They want to know "what will happen the first time this fires" without paying for a real run.
3. Today: the only way to find out is to fire it for real.
4. After this PR: launch a side-by-side daemon (or temporarily restart the production one) with `MULTICA_DRY_RUN=true`, let the trigger fire once, inspect the autopilot run's result, then flip the flag off.

That's the smallest viable shape that turns a real budget risk into a non-issue. Per-task and API-driven dry-run can land later without changing the contract this PR establishes.

## Why daemon-wide, not per-task

Looked at putting the short-circuit at each backend's `Execute` entry — but there are 13 backends and the daemon's `executeAndDrain` is already the single point that wraps them. Short-circuiting there means:

- One opt-in site, not 13.
- The decision is uniform — claude/codex/gemini/etc. all behave identically in dry-run.
- The wrapping ctx, watchdog, drain machinery, and result-processing paths around the short-circuit are unchanged, so the rest of the daemon code is bit-for-bit identical between dry-run and real runs.

## What it doesn't change

- **No schema.** `task_usage` is keyed by model, so the synthetic estimate lives under a `"_dry_run"` model key. Downstream rollups can choose to filter or surface it without changing structure.
- **No protocol.** `task.result.output` carries the dry-run summary as plain text — no new fields, no new message types. Existing UIs render it as a normal completed task with a clearly-labelled output.
- **No new dependencies.** Token estimate is a rule-of-thumb `(len(prompt)+len(system))/4` — exact tokenisation would defeat the purpose (it requires a real model call).

## What the output actually looks like

```
[dry-run] claude (stream-json)
rendered prompt: 2347 bytes (system: 412 bytes)
estimated input tokens: 690
max_turns: 30 (0 = backend default)
no provider call was made.
```

Combined with `MULTICA_CLAUDE_ARGS="--max-turns 30"` (from #1467), this is enough for an operator to estimate worst-case spend before going live.

## Tests

- `pkg/agent/dryrun_test.go`:
  - `EstimateInputTokens` boundary cases (empty, exact multiple of 4, rounding up, includes system prompt, rule-of-thumb).
  - `BuildDryRunResult` structure assertions (status, output content, usage key, no output tokens).
  - Unknown-provider fallback (`LaunchHeader` returns empty → provider name verbatim).
- `internal/daemon/daemon_test.go`:
  - `TestExecuteAndDrain_DryRunShortCircuits` uses a `recordingBackend` whose `Execute` fails the test if called. This asserts the actual safety property we care about: the dry-run path **never** reaches the provider. Also covers `tools == 0` and the `_dry_run` usage row presence.
- Full existing daemon test suite still green (`go test ./internal/daemon/`); the only mechanical change there is the new `provider` parameter on `executeAndDrain` (passed as `"test"` in existing tests).

## Out of scope (follow-ups if maintainers want them)

- `multica autopilot trigger <id> --dry-run` CLI flag — needs an API-level field, design covered in #4100.
- `multica autopilot forecast <id> --window 7d` — uses dry-run × cron expansion to project N-day spend. Builds on this PR.
- Surfacing the dry-run badge in the UI separately from a normal completed task.

## Local verification

```bash
cd server
go build ./...
go test ./pkg/agent/ ./internal/daemon/ -count=1 -timeout 120s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
