### PR TITLE
feat(squad): Prometheus counter + delegated_to capture for leader evaluations (refs #4101)

### DIFF
--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -863,12 +863,44 @@ func (h *Handler) RecordSquadLeaderEvaluation(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	details, _ := json.Marshal(map[string]string{
-		"squad_id": uuidToString(squad.ID),
-		"task_id":  util.UUIDToString(taskUUID),
-		"outcome":  req.Outcome,
-		"reason":   req.Reason,
-	})
+	// delegated_to: when outcome=='action', recover which member(s) the leader
+	// just routed the work to by parsing @mentions out of the leader's most
+	// recent comment on this issue. The activity row stores it as a
+	// `delegated_to_<type>` field (member-id or agent-id list) so a future
+	// timeline / metrics view can show "leader routed to X" without re-
+	// scanning the comment thread. We fail open: any lookup or parse failure
+	// silently drops the field — the evaluation row itself must still land.
+	delegatedAgents := []string{}
+	delegatedMembers := []string{}
+	if req.Outcome == "action" {
+		latest, lcErr := h.Queries.GetLatestAgentCommentOnIssue(
+			r.Context(),
+			db.GetLatestAgentCommentOnIssueParams{
+				IssueID:  issue.ID,
+				AuthorID: squad.LeaderID,
+			},
+		)
+		if lcErr == nil {
+			for _, m := range util.ParseMentions(latest.Content) {
+				switch m.Type {
+				case "agent":
+					delegatedAgents = append(delegatedAgents, m.ID)
+				case "member":
+					delegatedMembers = append(delegatedMembers, m.ID)
+				}
+			}
+		}
+	}
+
+	detailsMap := map[string]any{
+		"squad_id":             uuidToString(squad.ID),
+		"task_id":              util.UUIDToString(taskUUID),
+		"outcome":              req.Outcome,
+		"reason":               req.Reason,
+		"delegated_to_agents":  delegatedAgents,
+		"delegated_to_members": delegatedMembers,
+	}
+	details, _ := json.Marshal(detailsMap)
 
 	activity, err := h.Queries.CreateActivity(r.Context(), db.CreateActivityParams{
 		WorkspaceID: issue.WorkspaceID,
@@ -882,6 +914,12 @@ func (h *Handler) RecordSquadLeaderEvaluation(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, "failed to record evaluation")
 		return
 	}
+
+	// Aggregate observability — Prometheus only (operational telemetry on every
+	// leader turn, not product behaviour, so deliberately not paired with a
+	// PostHog Capture). Increment AFTER the activity row landed so a 500 above
+	// does not inflate the counter.
+	h.Metrics.RecordSquadLeaderEvaluation(req.Outcome)
 
 	h.publish(protocol.EventActivityCreated, uuidToString(issue.WorkspaceID), "agent", actorID, map[string]any{
 		"issue_id": uuidToString(issue.ID),

--- a/server/internal/metrics/business_events.go
+++ b/server/internal/metrics/business_events.go
@@ -53,6 +53,7 @@ type businessEventMetrics struct {
 	autopilotRunStarted             *prometheus.CounterVec
 	autopilotRunTerminal            *prometheus.CounterVec
 	autopilotRunSkipped             *prometheus.CounterVec
+	squadLeaderEvaluation           *prometheus.CounterVec
 	webhookDelivery                 *prometheus.CounterVec
 	githubEventReceived             *prometheus.CounterVec
 	githubPRReview                  *prometheus.CounterVec
@@ -158,6 +159,10 @@ func newBusinessEventMetrics() *businessEventMetrics {
 			Name: "multica_autopilot_run_skipped_total",
 			Help: "Total autopilot runs that admission-skipped (concurrency / cooldown / other).",
 		}, metricLabels("multica_autopilot_run_skipped_total")),
+		squadLeaderEvaluation: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "multica_squad_leader_evaluation_total",
+			Help: "Total squad-leader evaluation decisions recorded per trigger, labelled by outcome (action | no_action | failed).",
+		}, metricLabels("multica_squad_leader_evaluation_total")),
 		webhookDelivery: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "multica_webhook_delivery_total",
 			Help: "Total inbound webhook deliveries by provider and outcome.",
@@ -223,6 +228,7 @@ func (e *businessEventMetrics) collectors() []prometheus.Collector {
 		e.autopilotRunStarted,
 		e.autopilotRunTerminal,
 		e.autopilotRunSkipped,
+		e.squadLeaderEvaluation,
 		e.webhookDelivery,
 		e.githubEventReceived,
 		e.githubPRReview,
@@ -358,6 +364,21 @@ func (m *BusinessMetrics) IncForEvent(ev analytics.Event) {
 }
 
 // ---- non-PostHog Record* helpers (typed; no analytics.Event source) -------
+
+// RecordSquadLeaderEvaluation counts a squad-leader evaluation decision
+// recorded per trigger. The outcome label is the same allow-listed value
+// the leader records via `multica squad activity` (action | no_action |
+// failed); unknown values collapse to "other" so cardinality stays bounded.
+// Prometheus-only — there is no paired PostHog event because this fires on
+// every leader turn and is operational observability, not product behaviour.
+func (m *BusinessMetrics) RecordSquadLeaderEvaluation(outcome string) {
+	if m == nil || m.events == nil {
+		return
+	}
+	m.events.squadLeaderEvaluation.WithLabelValues(
+		NormalizeSquadLeaderEvaluationOutcome(outcome),
+	).Inc()
+}
 
 // RecordAutopilotRunSkipped counts an autopilot admission-skip with reason.
 func (m *BusinessMetrics) RecordAutopilotRunSkipped(cadence, reason string) {

--- a/server/internal/metrics/business_test.go
+++ b/server/internal/metrics/business_test.go
@@ -138,6 +138,7 @@ func TestBusinessMetricsRegistryExposesAllFamilies(t *testing.T) {
 
 	// Direct Record* helpers (no PostHog event source).
 	m.RecordAutopilotRunSkipped("manual", "throttled")
+	m.RecordSquadLeaderEvaluation("action")
 	m.RecordWebhookDelivery("github", "dispatched")
 	m.RecordGithubEventReceived("pull_request", "opened")
 	m.RecordGithubPRReview("approved")

--- a/server/internal/metrics/labels.go
+++ b/server/internal/metrics/labels.go
@@ -31,6 +31,7 @@ const (
 	labelAction       = "action"
 	labelResult       = "result"
 	labelOp           = "op"
+	labelOutcome      = "outcome"
 )
 
 var businessMetricLabels = map[string][]string{
@@ -75,6 +76,7 @@ var businessMetricLabels = map[string][]string{
 	"multica_autopilot_run_started_total":              {labelCadence, labelTriggerKind},
 	"multica_autopilot_run_terminal_total":             {labelCadence, labelTriggerKind, labelTerminalStatus},
 	"multica_autopilot_run_skipped_total":              {labelCadence, labelReason},
+	"multica_squad_leader_evaluation_total":            {labelOutcome},
 	"multica_webhook_delivery_total":                   {labelProvider, labelStatus},
 	"multica_github_event_received_total":              {labelEventKind, labelAction},
 	"multica_github_pr_review_total":                   {labelResult},

--- a/server/internal/metrics/labels_pr3.go
+++ b/server/internal/metrics/labels_pr3.go
@@ -90,6 +90,12 @@ var (
 		"unknown":  "unknown",
 	}
 
+	knownSquadLeaderEvaluationOutcomes = map[string]string{
+		"action":    "action",
+		"no_action": "no_action",
+		"failed":    "failed",
+	}
+
 	knownAutopilotSkipReasons = map[string]string{
 		"already_running":   "already_running",
 		"recent_run":        "recent_run",
@@ -318,6 +324,14 @@ func NormalizeAutopilotTrigger(value string) string {
 
 func NormalizeAutopilotSkipReason(value string) string {
 	return normalizeFromAllowList(value, knownAutopilotSkipReasons, "other")
+}
+
+// NormalizeSquadLeaderEvaluationOutcome canonicalises the outcome of a squad
+// leader's per-trigger evaluation (`action` | `no_action` | `failed`). Any
+// other value collapses to `other` so a future outcome value cannot blow up
+// metric cardinality before the allow-list is updated.
+func NormalizeSquadLeaderEvaluationOutcome(value string) string {
+	return normalizeFromAllowList(value, knownSquadLeaderEvaluationOutcomes, "other")
 }
 
 func NormalizeWebhookProvider(value string) string {

--- a/server/internal/metrics/squad_leader_evaluation_test.go
+++ b/server/internal/metrics/squad_leader_evaluation_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestNormalizeSquadLeaderEvaluationOutcome(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"action", "action"},
+		{"no_action", "no_action"},
+		{"failed", "failed"},
+		{"", "other"},
+		{"ACTION", "action"}, // normalizer lower-cases before matching the allow-list
+		{"delegated", "other"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := NormalizeSquadLeaderEvaluationOutcome(c.in); got != c.want {
+				t.Fatalf("NormalizeSquadLeaderEvaluationOutcome(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRecordSquadLeaderEvaluation(t *testing.T) {
+	m := NewBusinessMetrics()
+
+	m.RecordSquadLeaderEvaluation("action")
+	m.RecordSquadLeaderEvaluation("action")
+	m.RecordSquadLeaderEvaluation("no_action")
+	m.RecordSquadLeaderEvaluation("failed")
+	m.RecordSquadLeaderEvaluation("totally-bogus")
+
+	cv := m.events.squadLeaderEvaluation
+	if got := testutil.ToFloat64(cv.WithLabelValues("action")); got != 2 {
+		t.Errorf("counter for outcome=action = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(cv.WithLabelValues("no_action")); got != 1 {
+		t.Errorf("counter for outcome=no_action = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(cv.WithLabelValues("failed")); got != 1 {
+		t.Errorf("counter for outcome=failed = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(cv.WithLabelValues("other")); got != 1 {
+		t.Errorf("counter for outcome=other (bogus collapsed) = %v, want 1", got)
+	}
+}
+
+func TestRecordSquadLeaderEvaluationNilSafe(t *testing.T) {
+	// Mirrors the nil-safety contract of the other Record* helpers — calling
+	// on a nil receiver must not panic so that callers can skip wiring metrics
+	// in tests / minimal CLI builds without guarding every call site.
+	var m *BusinessMetrics
+	m.RecordSquadLeaderEvaluation("action")
+
+	m2 := &BusinessMetrics{}
+	m2.RecordSquadLeaderEvaluation("action")
+}

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -270,6 +270,44 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 	return i, err
 }
 
+const getLatestAgentCommentOnIssue = `-- name: GetLatestAgentCommentOnIssue :one
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
+WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestAgentCommentOnIssueParams struct {
+	IssueID  pgtype.UUID `json:"issue_id"`
+	AuthorID pgtype.UUID `json:"author_id"`
+}
+
+// The most recent agent-authored comment on an issue, used by the squad-leader
+// evaluation recorder to recover the leader's delegation comment (and its
+// @mention list) without forcing the leader to repeat itself in the activity
+// payload. NULL row if the agent has not commented yet — caller treats that
+// as "no delegated_to recorded".
+func (q *Queries) GetLatestAgentCommentOnIssue(ctx context.Context, arg GetLatestAgentCommentOnIssueParams) (Comment, error) {
+	row := q.db.QueryRow(ctx, getLatestAgentCommentOnIssue, arg.IssueID, arg.AuthorID)
+	var i Comment
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+	)
+	return i, err
+}
+
 const getThreadRoot = `-- name: GetThreadRoot :one
 WITH RECURSIVE root_of AS (
     SELECT c.id, c.parent_id

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -1,3 +1,14 @@
+-- name: GetLatestAgentCommentOnIssue :one
+-- The most recent agent-authored comment on an issue, used by the squad-leader
+-- evaluation recorder to recover the leader's delegation comment (and its
+-- @mention list) without forcing the leader to repeat itself in the activity
+-- payload. NULL row if the agent has not commented yet — caller treats that
+-- as "no delegated_to recorded".
+SELECT * FROM comment
+WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
+
 -- name: ListCommentsForIssue :many
 -- All comments for an issue in chronological order, capped at $3 (DB safety
 -- net). Issue p99 is ~30 comments, max ever observed in prod is ~1.1k, so


### PR DESCRIPTION
## What

Two small additions to the existing squad-leader evaluation handler so the data it already collects becomes queryable in aggregate, and so it captures *who* the leader just routed work to — not just that routing happened.

1. **`multica_squad_leader_evaluation_total{outcome}` Prometheus counter.** Incremented from the handler on every successful `/api/issues/{id}/squad-evaluated` call. The outcome label is allow-listed (`action` | `no_action` | `failed`) with `other` fallback so a future outcome value cannot blow up cardinality before the allow-list catches up.
2. **`delegated_to_agents` / `delegated_to_members` in the activity details JSON.** When `outcome=='action'`, the handler now reads the leader's most recent comment on the issue, parses its `@mention`s, and records the routed-to agent/member IDs alongside the existing `outcome` and `reason`.

Refs #4101.

## Why this shape

The handler already writes `activity_log` rows with `action='squad_leader_evaluated'` and `details={squad_id, task_id, outcome, reason}`. That's enough to see one decision; it's not enough to answer two questions an operator running multiple squads will absolutely ask:

- "How often is *this squad's leader* deciding `no_action`?" — needs aggregate, currently requires bespoke SQL on the `details` JSON.
- "When the leader picked `action`, *who did it route to*?" — the answer only lives inside the `@mention` markdown of the leader's most recent comment.

Both gaps are observability shaped, not behaviour shaped. The PR closes them without changing anything semantic: leader still decides via prompt, mention machinery still delivers the actual handoff.

## Why Prometheus-only (no PostHog pair)

This event fires on **every leader turn** — by design, the `squadOperatingProtocol` mandates `multica squad activity` after every trigger. That's the right volume for Grafana / aggregate counters, the wrong volume for PostHog ingestion (and PostHog already carries product-behaviour events at much lower frequency). Followed the same shape as `RecordAutopilotRunSkipped` — typed helper with no `analytics.Event` source — and verified the existing `TestEveryAnalyticsEventHasPrometheusCounter` and `TestNoNakedAnalyticsCaptureInHandlersOrServices` lint tests stay green.

## Scope discipline

- **Recording side only.** No reader / dashboard / UI changes. The counter is exposed through the existing `/metrics` endpoint and the `delegated_to_*` fields show up in the existing `activity_log` row. Surface work is a follow-up now that the data is there.
- **Counter increment is after the row lands.** A 500 from `CreateActivity` does not inflate the counter — symmetric with the activity row.
- **Fail open on comment lookup.** If `GetLatestAgentCommentOnIssue` returns no row or the parse fails, `delegated_to_*` stays empty and the evaluation row itself must still land. The evaluation is the truth; `delegated_to` is best-effort enrichment.
- **Only runs when `outcome='action'`.** `no_action` and `failed` paths skip the extra DB hit + parse — there's nothing to record there.
- **Candidate set explicitly out of scope.** Per the self-correction on #4101, the candidates the leader considered only live inside the model's context; recovering them would mean intercepting model prompts, which is the wrong layer for an observability change.

## sqlc

Added one query in `pkg/db/queries/comment.sql`:

```sql
-- name: GetLatestAgentCommentOnIssue :one
SELECT * FROM comment
WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
ORDER BY created_at DESC, id DESC
LIMIT 1;
```

Regenerated via `sqlc generate`; the only diff is the new binding in `pkg/db/generated/comment.sql.go`.

## Tests

- `internal/metrics/squad_leader_evaluation_test.go`:
  - `TestNormalizeSquadLeaderEvaluationOutcome` — allow-list + `other` fallback, including the lowercase-on-the-way-in behaviour of `normalizeFromAllowList`.
  - `TestRecordSquadLeaderEvaluation` — increments counter per outcome label, including the "bogus value collapses to `other`" guard.
  - `TestRecordSquadLeaderEvaluationNilSafe` — mirrors the nil-receiver contract of the other `Record*` helpers.
- `internal/metrics/business_test.go` — added a call to `RecordSquadLeaderEvaluation` in `TestBusinessMetricsRegistryExposesAllFamilies` so the new family is observable through the standard registry path (this test fails closed if a counter is registered but never exercised).
- `internal/metrics/` full test suite green: `go test ./internal/metrics/ -count=1` — passes including pairing-lint tests, confirming the Prometheus-only shape correctly avoids creating an `analytics.Event` that would demand a PostHog pair.
- Handler-side `RecordSquadLeaderEvaluation` integration test (`internal/handler/squad_no_action_test.go`) does not assert details JSON shape strictly, so the new `delegated_to_*` fields don't break existing assertions; will pass in CI's pgvector environment.

## Local verification

```bash
cd server
go build ./...
go test ./internal/metrics/ ./internal/util/ -count=1 -timeout 120s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
