### PR TITLE
fix: lower cloud runtime free server limit

### DIFF
--- a/server/internal/handler/cloud_runtime.go
+++ b/server/internal/handler/cloud_runtime.go
@@ -9,18 +9,28 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/multica-ai/multica/server/internal/cloudruntime"
 	"github.com/multica-ai/multica/server/internal/logger"
 )
 
-const maxCloudRuntimeRequestBodySize = 1 << 20
+const (
+	maxCloudRuntimeRequestBodySize = 1 << 20
+
+	// Fleet owns the billing decision; multica-api stamps the product
+	// allowance onto create-node requests so the cloud side has one
+	// threshold to enforce. More than one server is billable.
+	cloudRuntimeFreeServerLimit       = 1
+	cloudRuntimeFreeServerLimitHeader = "X-Multica-Free-Server-Limit"
+)
 
 type cloudRuntimeProxyOptions struct {
 	withUserID bool
 	withQuery  bool
 	withBody   bool
+	headers    http.Header
 }
 
 func (h *Handler) GetCloudRuntimeService(w http.ResponseWriter, r *http.Request) {
@@ -55,6 +65,9 @@ func (h *Handler) CreateCloudRuntimeNode(w http.ResponseWriter, r *http.Request)
 	h.proxyCloudRuntime(w, r, http.MethodPost, "/api/v1/nodes", cloudRuntimeProxyOptions{
 		withUserID: true,
 		withBody:   true,
+		headers: http.Header{
+			cloudRuntimeFreeServerLimitHeader: []string{strconv.Itoa(cloudRuntimeFreeServerLimit)},
+		},
 	})
 }
 
@@ -136,6 +149,7 @@ func (h *Handler) proxyCloudRuntime(w http.ResponseWriter, r *http.Request, meth
 		Body:      body,
 		UserID:    userID,
 		RequestID: cloudRuntimeRequestID(r),
+		Headers:   opts.headers,
 	})
 	if err != nil {
 		writeCloudRuntimeError(w, r, err)

--- a/server/internal/handler/cloud_runtime_test.go
+++ b/server/internal/handler/cloud_runtime_test.go
@@ -80,6 +80,9 @@ func TestCreateCloudRuntimeNodeForwardsBody(t *testing.T) {
 	if proxy.req.RequestID != "api-request-id" {
 		t.Fatalf("proxied request id = %q", proxy.req.RequestID)
 	}
+	if got := proxy.req.Headers.Get(cloudRuntimeFreeServerLimitHeader); got != "1" {
+		t.Fatalf("free server limit header = %q", got)
+	}
 	if got := w.Header().Get("X-Request-ID"); got != "fleet-request-id" {
 		t.Fatalf("response request id = %q", got)
 	}


### PR DESCRIPTION
## Summary
- set the Cloud Runtime free server threshold forwarded to Fleet to 1
- keep the threshold centralized in the cloud runtime proxy layer
- cover create-node forwarding with a regression assertion

## Tests
- GOPATH=/tmp/go GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go/pkg/mod go test ./internal/handler -run 'TestCreateCloudRuntimeNodeForwardsBody|TestCloudRuntime'

Note: I did not find an existing hard-coded threshold of 2 in this repository. The current multica repo proxies Cloud Runtime creation to Fleet, so this PR stamps the new threshold on create-node requests for Fleet billing enforcement.