### PR TITLE
Add Android production build support

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -48,6 +48,7 @@ Everything below is for app developers — you can ignore the rest if you only w
 | `pnpm android:mobile:device` | Full rebuild + install on **USB Android device**, Debug | local |
 | `pnpm android:mobile:device:staging` | Full rebuild + install on **USB Android device**, Debug | staging |
 | `pnpm android:mobile:device:prod` | Full rebuild + install on **USB Android device**, Debug | production |
+| `pnpm android:mobile:prod:release` | Build standalone **Android Release APK** | production |
 
 `dev:*` runs Metro only — assumes the matching variant is already installed. `ios:mobile*` does a full native rebuild + install.
 
@@ -79,6 +80,21 @@ pnpm android:mobile:staging
 
 The first Android run performs an Expo prebuild and creates the native Gradle
 project if `apps/mobile/android/` is missing.
+
+To build a standalone production APK that connects to `multica.ai`, run:
+
+```bash
+pnpm android:mobile:prod:release
+```
+
+The APK is written to:
+
+```text
+apps/mobile/android/app/build/outputs/apk/release/multica-production-release.apk
+```
+
+This is a local sideload build signed with the generated debug keystore, not a
+Play Store upload artifact.
 
 ## First-time setup
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,6 +1,6 @@
-# Multica Mobile (iOS)
+# Multica Mobile (iOS + Android)
 
-Expo + React Native iOS client for Multica. Independent from web/desktop — shares only types from `@multica/core/`. See [`CLAUDE.md`](./CLAUDE.md) for the locked tech-stack baseline and import rules.
+Expo + React Native mobile client for Multica. Independent from web/desktop — shares only types from `@multica/core/`. See [`CLAUDE.md`](./CLAUDE.md) for the locked tech-stack baseline and import rules.
 
 ## Just want to use it on your phone? (no development)
 
@@ -42,10 +42,43 @@ Everything below is for app developers — you can ignore the rest if you only w
 | `pnpm ios:mobile:device:staging:release` | Full rebuild + install on **USB iPhone**, Release (standalone) | staging |
 | `pnpm ios:mobile:device:prod` | Full rebuild + install on **USB iPhone**, Debug | production |
 | `pnpm ios:mobile:device:prod:release` | Full rebuild + install on **USB iPhone**, Release (standalone) | production |
+| `pnpm android:mobile` | Full rebuild + install on **Android emulator / device**, Debug | local |
+| `pnpm android:mobile:staging` | Full rebuild + install on **Android emulator / device**, Debug | staging |
+| `pnpm android:mobile:prod` | Full rebuild + install on **Android emulator / device**, Debug | production |
+| `pnpm android:mobile:device` | Full rebuild + install on **USB Android device**, Debug | local |
+| `pnpm android:mobile:device:staging` | Full rebuild + install on **USB Android device**, Debug | staging |
+| `pnpm android:mobile:device:prod` | Full rebuild + install on **USB Android device**, Debug | production |
 
 `dev:*` runs Metro only — assumes the matching variant is already installed. `ios:mobile*` does a full native rebuild + install.
 
-Bundle id and display name switch on `APP_ENV` (see `app.config.ts`), so Dev / Staging / Production variants can coexist on the same device or simulator.
+Bundle id / Android package name and display name switch on `APP_ENV` (see `app.config.ts`), so Dev / Staging / Production variants can coexist on the same device or simulator.
+
+## Try it on Android
+
+The Android path uses the same Expo app as iOS. Install Android Studio or the
+Android SDK command-line tools, make sure an emulator is running or a USB device
+is visible in `adb devices`, then run:
+
+```bash
+pnpm android:mobile:staging
+```
+
+For local backend testing, create `apps/mobile/.env.development.local` from the
+template and point `EXPO_PUBLIC_API_URL` at your Mac's LAN IP. Then run:
+
+```bash
+pnpm android:mobile
+```
+
+If your shell defaults to an older Java, run Android commands with a modern JDK:
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+pnpm android:mobile:staging
+```
+
+The first Android run performs an Expo prebuild and creates the native Gradle
+project if `apps/mobile/android/` is missing.
 
 ## First-time setup
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -47,6 +47,17 @@ export default ({ config }: ConfigContext): ExpoConfig => {
           ? "ai.multica.mobile.staging"
           : (process.env.EXPO_BUNDLE_IDENTIFIER_DEV ?? "ai.multica.mobile.dev"),
     },
+    android: {
+      package: isProd
+        ? (process.env.EXPO_ANDROID_PACKAGE_PROD ?? "ai.multica.mobile")
+        : isStaging
+          ? "ai.multica.mobile.staging"
+          : (process.env.EXPO_ANDROID_PACKAGE_DEV ?? "ai.multica.mobile.dev"),
+      adaptiveIcon: {
+        foregroundImage: "./assets/icon.png",
+        backgroundColor: "#ffffff",
+      },
+    },
     plugins: [
       "expo-router",
       "expo-secure-store",

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -121,8 +121,10 @@ import type { ZodType } from "zod";
 import { getCurrentSlug } from "./workspace-store";
 import { parseWithFallback } from "@/lib/parse-response";
 import { createRequestId } from "@/lib/request-id";
+import { Platform } from "react-native";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
+const CLIENT_OS = Platform.OS;
 
 if (!API_URL) {
   throw new Error(
@@ -200,7 +202,7 @@ class ApiClient {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "X-Client-Platform": "mobile",
-      "X-Client-OS": "ios",
+      "X-Client-OS": CLIENT_OS,
       "X-Client-Version": "0.1.0",
       "X-Request-ID": rid,
       ...((init.headers as Record<string, string>) ?? {}),
@@ -1195,7 +1197,7 @@ class ApiClient {
     const headers: Record<string, string> = {
       // No Content-Type — let fetch set the multipart boundary.
       "X-Client-Platform": "mobile",
-      "X-Client-OS": "ios",
+      "X-Client-OS": CLIENT_OS,
       "X-Client-Version": "0.1.0",
       "X-Request-ID": rid,
     };

--- a/apps/mobile/data/realtime/ws-client.ts
+++ b/apps/mobile/data/realtime/ws-client.ts
@@ -27,6 +27,7 @@ import type {
   WSEventType,
   WSMessage,
 } from "@multica/core/types";
+import { Platform } from "react-native";
 
 /** Generic handler used internally by the dispatcher map. Each `on<E>()`
  *  call narrows this to `(payload: WSEventPayload<E>, actorId?) => void`
@@ -62,6 +63,7 @@ export interface WSClientOptions {
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_CAP_MS = 30_000;
 const RECONNECT_MAX_EXPONENT = 6; // 1s → 64s ceiling, capped at 30s
+const CLIENT_OS = Platform.OS;
 
 /**
  * Lifecycle state — drives whether onclose schedules a reconnect:
@@ -188,7 +190,7 @@ export class WSClient {
     const url = new URL(this.opts.url);
     url.searchParams.set("workspace_slug", this.opts.workspaceSlug);
     url.searchParams.set("client_platform", "mobile");
-    url.searchParams.set("client_os", "ios");
+    url.searchParams.set("client_os", CLIENT_OS);
     if (this.opts.clientVersion) {
       url.searchParams.set("client_version", this.opts.clientVersion);
     }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "android:device": "expo run:android --device",
     "android:device:staging": "dotenv -e .env.staging -- cross-env APP_ENV=staging expo run:android --device",
     "android:device:prod": "dotenv -e .env.production -- cross-env APP_ENV=production expo run:android --device",
+    "android:prod:release": "dotenv -e .env.production -- cross-env APP_ENV=production bash scripts/build-android-production-apk.sh",
     "lint": "expo lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,12 @@
     "ios:device:staging:release": "dotenv -e .env.staging -- cross-env APP_ENV=staging expo run:ios --device --configuration Release",
     "ios:device:prod": "dotenv -e .env.production -- cross-env APP_ENV=production expo run:ios --device",
     "ios:device:prod:release": "dotenv -e .env.production -- cross-env APP_ENV=production expo run:ios --device --configuration Release",
+    "android": "expo run:android",
+    "android:staging": "dotenv -e .env.staging -- cross-env APP_ENV=staging expo run:android",
+    "android:prod": "dotenv -e .env.production -- cross-env APP_ENV=production expo run:android",
+    "android:device": "expo run:android --device",
+    "android:device:staging": "dotenv -e .env.staging -- cross-env APP_ENV=staging expo run:android --device",
+    "android:device:prod": "dotenv -e .env.production -- cross-env APP_ENV=production expo run:android --device",
     "lint": "expo lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/apps/mobile/scripts/build-android-production-apk.sh
+++ b/apps/mobile/scripts/build-android-production-apk.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MOBILE_DIR/../.." && pwd)"
+ANDROID_DIR="$MOBILE_DIR/android"
+TARGET_PACKAGE="${EXPO_ANDROID_PACKAGE_PROD:-ai.multica.mobile}"
+APK_NAME="${APK_NAME:-multica-production-release.apk}"
+LOCAL_MAVEN_DIR="$ANDROID_DIR/.local-maven"
+INIT_SCRIPT="$ANDROID_DIR/.local-release-init.gradle"
+
+export APP_ENV="${APP_ENV:-production}"
+export NODE_ENV="${NODE_ENV:-production}"
+export EXPO_PUBLIC_API_URL="${EXPO_PUBLIC_API_URL:-https://api.multica.ai}"
+export EXPO_PUBLIC_WEB_URL="${EXPO_PUBLIC_WEB_URL:-https://multica.ai}"
+export EXPO_ANDROID_PACKAGE_PROD="$TARGET_PACKAGE"
+
+if [[ -z "${JAVA_HOME:-}" ]]; then
+  if [[ -d "/Library/Java/JavaVirtualMachines/jdk-18.0.1.1.jdk/Contents/Home" ]]; then
+    export JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk-18.0.1.1.jdk/Contents/Home"
+  elif [[ -d "/Applications/Android Studio.app/Contents/jbr/Contents/Home" ]]; then
+    export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+  elif [[ -x /usr/libexec/java_home ]]; then
+    export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+  fi
+fi
+
+mkdir -p "$LOCAL_MAVEN_DIR/com/github/gregcockroft/AndroidMath/v1.1.0"
+
+download_if_missing() {
+  local url="$1"
+  local destination="$2"
+
+  if [[ ! -s "$destination" ]]; then
+    curl --fail --location --silent --show-error "$url" --output "$destination"
+  fi
+}
+
+download_if_missing \
+  "https://www.jitpack.io/com/github/gregcockroft/AndroidMath/v1.1.0/AndroidMath-v1.1.0.pom" \
+  "$LOCAL_MAVEN_DIR/com/github/gregcockroft/AndroidMath/v1.1.0/AndroidMath-v1.1.0.pom"
+
+download_if_missing \
+  "https://www.jitpack.io/com/github/gregcockroft/AndroidMath/v1.1.0/AndroidMath-v1.1.0.aar" \
+  "$LOCAL_MAVEN_DIR/com/github/gregcockroft/AndroidMath/v1.1.0/AndroidMath-v1.1.0.aar"
+
+cd "$MOBILE_DIR"
+pnpm exec expo prebuild --platform android --no-install
+
+# Clear the app build directory so Gradle's createBundleReleaseJsAndAssets
+# task can never reuse a stale JS bundle from a previous variant (staging
+# vs production). Without this, Gradle sees the task as UP-TO-DATE when
+# only EXPO_PUBLIC_* env vars changed and silently bundles the wrong API URL.
+rm -rf "$ANDROID_DIR/app/build"
+
+cat > "$INIT_SCRIPT" <<'GRADLE'
+allprojects {
+  buildscript {
+    repositories {
+      maven { url new File(rootDir, ".local-maven").toURI() }
+      google()
+      mavenCentral()
+    }
+  }
+  repositories {
+    maven { url new File(rootDir, ".local-maven").toURI() }
+    google()
+    mavenCentral()
+  }
+}
+
+gradle.projectsEvaluated {
+  def appProject = gradle.rootProject.findProject(":app")
+  if (appProject == null) {
+    return
+  }
+
+  def targetPackage = System.getenv("EXPO_ANDROID_PACKAGE_PROD") ?: "ai.multica.mobile"
+  def fixReactNativeEntryPoint = {
+    def entryPoint = new File(appProject.buildDir, "generated/autolinking/src/main/java/com/facebook/react/ReactNativeApplicationEntryPoint.java")
+    if (entryPoint.exists()) {
+      def text = entryPoint.getText("UTF-8")
+      def fixed = text
+        .replace("ai.multica.mobile.dev.BuildConfig", "${targetPackage}.BuildConfig")
+        .replace("ai.multica.mobile.staging.BuildConfig", "${targetPackage}.BuildConfig")
+      if (fixed != text) {
+        entryPoint.setText(fixed, "UTF-8")
+      }
+    }
+  }
+
+  appProject.tasks.matching { it.name == "generateReactNativeEntryPoint" }.configureEach {
+    it.doLast {
+      fixReactNativeEntryPoint()
+    }
+  }
+
+  appProject.tasks.matching { it.name == "compileReleaseJavaWithJavac" }.configureEach {
+    it.doFirst {
+      fixReactNativeEntryPoint()
+    }
+  }
+}
+GRADLE
+
+export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$ANDROID_DIR/.gradle-release}"
+
+"$ANDROID_DIR/gradlew" \
+  --no-daemon \
+  --max-workers="${GRADLE_MAX_WORKERS:-2}" \
+  --init-script "$INIT_SCRIPT" \
+  -p "$ANDROID_DIR" \
+  :app:assembleRelease \
+  -Pandroid.compileSdkVersion=36 \
+  -Pandroid.targetSdkVersion=36 \
+  -x lintVitalAnalyzeRelease \
+  -x lintVitalRelease
+
+APK_PATH="$ANDROID_DIR/app/build/outputs/apk/release/app-release.apk"
+FINAL_APK_PATH="$ANDROID_DIR/app/build/outputs/apk/release/$APK_NAME"
+cp "$APK_PATH" "$FINAL_APK_PATH"
+
+printf 'Production APK: %s\n' "$FINAL_APK_PATH"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "ios:mobile:device:staging:release": "pnpm -C apps/mobile ios:device:staging:release",
     "ios:mobile:device:prod": "pnpm -C apps/mobile ios:device:prod",
     "ios:mobile:device:prod:release": "pnpm -C apps/mobile ios:device:prod:release",
+    "android:mobile": "pnpm -C apps/mobile android",
+    "android:mobile:staging": "pnpm -C apps/mobile android:staging",
+    "android:mobile:prod": "pnpm -C apps/mobile android:prod",
+    "android:mobile:device": "pnpm -C apps/mobile android:device",
+    "android:mobile:device:staging": "pnpm -C apps/mobile android:device:staging",
+    "android:mobile:device:prod": "pnpm -C apps/mobile android:device:prod",
     "build": "turbo build --filter=!@multica/mobile",
     "typecheck": "turbo typecheck --filter=!@multica/mobile",
     "test": "turbo test --filter=!@multica/mobile",
@@ -37,6 +43,9 @@
       "@types/react": "catalog:",
       "@types/react-dom": "catalog:",
       "@xmldom/xmldom": "^0.8.13"
+    },
+    "patchedDependencies": {
+      "@react-native/gradle-plugin@0.83.6": "patches/@react-native__gradle-plugin@0.83.6.patch"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "android:mobile:device": "pnpm -C apps/mobile android:device",
     "android:mobile:device:staging": "pnpm -C apps/mobile android:device:staging",
     "android:mobile:device:prod": "pnpm -C apps/mobile android:device:prod",
+    "android:mobile:prod:release": "pnpm -C apps/mobile android:prod:release",
     "build": "turbo build --filter=!@multica/mobile",
     "typecheck": "turbo typecheck --filter=!@multica/mobile",
     "test": "turbo test --filter=!@multica/mobile",

--- a/patches/@react-native__gradle-plugin@0.83.6.patch
+++ b/patches/@react-native__gradle-plugin@0.83.6.patch
@@ -1,0 +1,13 @@
+diff --git a/settings.gradle.kts b/settings.gradle.kts
+index b3c46a3bf5eb21c0bb1c9435b5582aecbc57d57a..14f1e9c2063ef10ca3f2ecbb2336b8a4aacfcc9c 100644
+--- a/settings.gradle.kts
++++ b/settings.gradle.kts
+@@ -13,7 +13,7 @@ pluginManagement {
+   }
+ }
+ 
+-plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0") }
++plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0") }
+ 
+ include(
+     ":react-native-gradle-plugin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,11 @@ overrides:
   '@types/react-dom': ^19.2.0
   '@xmldom/xmldom': ^0.8.13
 
+patchedDependencies:
+  '@react-native/gradle-plugin@0.83.6':
+    hash: c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784
+    path: patches/@react-native__gradle-plugin@0.83.6.patch
+
 importers:
 
   .:
@@ -13578,7 +13583,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/gradle-plugin@0.83.6': {}
+  '@react-native/gradle-plugin@0.83.6(patch_hash=c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784)': {}
 
   '@react-native/js-polyfills@0.83.6': {}
 
@@ -20592,7 +20597,7 @@ snapshots:
       '@react-native/assets-registry': 0.83.6
       '@react-native/codegen': 0.83.6(@babel/core@7.29.0)
       '@react-native/community-cli-plugin': 0.83.6
-      '@react-native/gradle-plugin': 0.83.6
+      '@react-native/gradle-plugin': 0.83.6(patch_hash=c1b594a16e682d621b6a960926f8ce13fc92edfb397884cfe7fcb0518996a784)
       '@react-native/js-polyfills': 0.83.6
       '@react-native/normalize-colors': 0.83.6
       '@react-native/virtualized-lists': 0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## Summary

- add Android mobile app configuration for dev, staging, and production package IDs
- add production API/Web URL handling for the mobile API and websocket clients
- add a reproducible production release APK build script and npm entrypoints
- document Android mobile build commands

## Notes

- APK artifacts are intentionally not committed.
- The release build script clears the generated Android app build directory before bundling so production env vars cannot reuse a stale staging JS bundle.

## Verification

- Previously built a production release APK locally after adding the release script.
- Latest re-run was blocked by Maven dependency download connection resets while resolving Kotlin/Android Gradle dependencies; no code compile error was reached in that attempt.