### PR TITLE
Fix renderer freeze on long highlighted timelines

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -313,12 +313,30 @@ vi.mock("@multica/core/issues/stores", () => ({
 // other components doesn't throw; deep-link tests assert the highlight ring
 // instead, which is mechanism-independent and observable without layout.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
+const mockVirtuosoProps = vi.hoisted(() => ({
+  calls: [] as Array<{
+    dataLength: number;
+    initialTopMostItemIndex: unknown;
+  }>,
+}));
 
 vi.mock("react-virtuoso", () => ({
   Virtuoso: forwardRef(function MockVirtuoso(
-    { data, itemContent }: { data: unknown[]; itemContent: (i: number, item: unknown) => unknown },
+    {
+      data,
+      itemContent,
+      initialTopMostItemIndex,
+    }: {
+      data: unknown[];
+      itemContent: (i: number, item: unknown) => unknown;
+      initialTopMostItemIndex?: unknown;
+    },
     ref: any,
   ) {
+    mockVirtuosoProps.calls.push({
+      dataLength: data.length,
+      initialTopMostItemIndex,
+    });
     useImperativeHandle(ref, () => ({
       // Real Virtuoso ref methods are not exercised by tests in this file
       // since the deep-link cold-path drives the container's scrollTop on the
@@ -514,6 +532,7 @@ describe("IssueDetail (shared)", () => {
     // Reset project mock — individual tests override per case. Default fixture
     // has project_id: null so getProject is not invoked.
     mockApiObj.getProject.mockReset();
+    mockVirtuosoProps.calls = [];
   });
 
   it("shows loading skeleton while data is loading", () => {
@@ -1093,6 +1112,31 @@ describe("IssueDetail (shared)", () => {
         expect(
           document.getElementById("comment-reply-1")?.className,
         ).toContain("bg-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]");
+      });
+    });
+
+    it("keeps long highlighted timelines virtualized instead of mounting every comment", async () => {
+      const longTimeline: TimelineEntry[] = Array.from({ length: 120 }, (_, i) => ({
+        type: "comment",
+        id: `comment-${i}`,
+        actor_type: i % 2 === 0 ? "member" : "agent",
+        actor_id: i % 2 === 0 ? "user-1" : "agent-1",
+        content: `Long timeline comment ${i}`,
+        parent_id: null,
+        created_at: `2026-01-18T00:${String(i % 60).padStart(2, "0")}:00Z`,
+        updated_at: `2026-01-18T00:${String(i % 60).padStart(2, "0")}:00Z`,
+        comment_type: "comment",
+      }));
+      mockApiObj.listTimeline.mockResolvedValue(longTimeline);
+
+      renderIssueDetailWithHighlight("comment-99");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("virtuoso-mock")).toBeInTheDocument();
+      });
+      expect(mockVirtuosoProps.calls.at(-1)).toEqual({
+        dataLength: 120,
+        initialTopMostItemIndex: { index: 99, align: "center" },
       });
     });
   });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -393,6 +393,13 @@ function TimelineSkeleton() {
 // activities" line that expands in place.
 const LAST_ACTIVITY_BLOCK_VISIBLE_LIMIT = 8;
 
+// Highlighted inbox/comment deep-links need a real DOM node before the landing
+// effect can center and flash the target. Rendering a short timeline flat keeps
+// that precise landing behavior, but doing it for long agent threads remounts
+// every CommentCard and reruns Markdown/code highlighting on tab restore. Above
+// this limit we keep Virtuoso active and ask it to start near the target row.
+const HIGHLIGHT_FLAT_RENDER_ITEM_LIMIT = 80;
+
 // Collapsible wrapper for an activity block. Older blocks default to a single
 // "N activities" summary line so the timeline isn't dominated by status /
 // priority / assignee churn; the trailing block stays expanded because it
@@ -1011,6 +1018,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     return items.findIndex((it) => it.id === rootId);
   }, [items, highlightCommentId, replyToRoot]);
 
+  const shouldRenderFlatHighlightTimeline =
+    !!highlightCommentId && items.length <= HIGHLIGHT_FLAT_RENDER_ITEM_LIMIT;
+  const highlightInitialTopMostItemIndex =
+    highlightCommentId && !shouldRenderFlatHighlightTimeline && targetIdx >= 0
+      ? ({ index: targetIdx, align: "center" } as const)
+      : undefined;
+
   const {
     reactions: issueReactions,
     toggleReaction: handleToggleIssueReaction,
@@ -1083,10 +1097,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const loading = issueLoading;
 
   // Deep-link landing. Semantically equivalent to navigating to
-  // `#comment-${id}`: find the element with that id, scrollIntoView it.
-  // When `highlightCommentId` is set the timeline below renders flat (no
-  // virtualization), so every comment id is in the DOM by the time this
-  // effect runs after commit.
+  // `#comment-${id}`: find the element with that id, center it inside the
+  // timeline scroll container, then briefly highlight it. Short highlighted
+  // timelines render flat so every comment id exists on first commit. Long
+  // highlighted timelines stay virtualized; `initialTopMostItemIndex` asks
+  // Virtuoso to mount the target neighborhood before this effect runs.
   //
   // For a reply inside a folded resolved thread, the reply is not in items
   // (only the resolved-bar root is). Auto-expand the thread first; the
@@ -2062,22 +2077,20 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               <TimelineSkeleton />
             ) : (
               // Two render modes:
-              //   - `highlightCommentId` set (came from inbox deep-link) →
-              //     render flat. Every comment mounts, every height is real,
-              //     the target id is in the DOM the instant the useEffect
-              //     above runs `scrollIntoView`. No virtualization estimate
-              //     errors, no spacer reflow drift. Pays cold-mount cost
-              //     proportional to items.length (markdown + lowlight per
-              //     comment), which is acceptable in the deep-link case —
-              //     the user has explicit intent to land on a specific item.
-              //   - otherwise → Virtuoso. Browsing mode, virtualization
-              //     wins on first-paint perf for long timelines.
+              //   - short `highlightCommentId` timelines (inbox/comment
+              //     deep-links) render flat. Every comment mounts, every
+              //     height is real, and the target id is in the DOM for an
+              //     exact landing without estimate drift.
+              //   - long highlighted timelines and normal browsing timelines
+              //     use Virtuoso. Inbox tabs can be restored repeatedly, so a
+              //     long deep-link must not pay O(N) Markdown + lowlight mount
+              //     cost every time the desktop tab becomes active again.
               //
-              // The split is deliberate: virtualization and "land precisely
-              // on a target" have fundamentally opposed contracts (estimated
-              // heights vs real heights). Trying to satisfy both in one
-              // path is what produced the bug history this PR closes.
-              !highlightCommentId ? (
+              // The split is deliberate: exact target landing and virtualized
+              // estimated heights still trade precision for performance, but
+              // the tradeoff is bounded so long agent threads keep the desktop
+              // renderer responsive.
+              !shouldRenderFlatHighlightTimeline ? (
                 !scrollContainerEl ? (
                   // Skeleton while the callback ref populates so the gap
                   // between IssueDetail mount and Virtuoso mount doesn't
@@ -2089,6 +2102,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       key={`${wsId}:${id}`}
                       customScrollParent={scrollContainerEl}
                       data={items}
+                      initialTopMostItemIndex={highlightInitialTopMostItemIndex}
                       increaseViewportBy={{ top: 800, bottom: 800 }}
                       computeItemKey={(_i, item) => `${item.kind}:${item.id}`}
                       skipAnimationFrameInResizeObserver


### PR DESCRIPTION
## Summary
- keep long highlighted issue timelines virtualized instead of flat-rendering every CommentCard
- start long highlighted timelines near the target comment with Virtuoso's initial index
- add regression coverage for a 120-comment highlighted timeline

## Root cause
Inbox/comment deep-links pass `highlightCommentId` into IssueDetail. The previous render split disabled Virtuoso whenever that prop was present, so switching back to a persisted Inbox tab could cold-mount every timeline row and rerun Markdown/code highlighting synchronously. Large agent comments made the Electron renderer unresponsive.

## Tests
- `corepack pnpm -C packages/views test issues/components/issue-detail.test.tsx`
- `corepack pnpm -C packages/views typecheck`
- `corepack pnpm -C packages/views lint` (passes with existing unrelated warnings)
- `git diff --check`