### PR TITLE
fix: re-sign unresolved attachment media urls

### DIFF
--- a/packages/views/editor/attachment.test.tsx
+++ b/packages/views/editor/attachment.test.tsx
@@ -366,6 +366,36 @@ describe("Attachment — image dispatch", () => {
     expect(getAttachmentMock).toHaveBeenCalledWith(id);
   });
 
+  it("re-signs URL-only inline media when no resolver record is available (MUL-3254)", async () => {
+    // If the markdown parser has only the durable API URL, the attachment id
+    // is still recoverable from the URL itself. Token-mode clients must not
+    // depend on the context resolver having a hydrated record before they can
+    // fetch fresh signed metadata.
+    getBaseUrlMock.mockReturnValue("https://multica-api.copilothub.ai");
+    configStore.setState({ cdnDomain: "cdn.example.test", cdnSigned: true });
+    const id = "11111111-2222-3333-4444-555555555555";
+    const markdownUrl = `https://multica-api.copilothub.ai/api/attachments/${id}/download`;
+    const signed =
+      "https://cdn.example.test/uploads/ws/shot.png?Signature=fresh&Key-Pair-Id=K";
+    getAttachmentMock.mockResolvedValue(makeRecord({ id, download_url: signed }));
+
+    renderWithQuery(
+      <Attachment
+        attachment={{
+          kind: "url",
+          url: markdownUrl,
+          filename: "shot.png",
+          forceKind: "image",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector("img")?.getAttribute("src")).toBe(signed);
+    });
+    expect(getAttachmentMock).toHaveBeenCalledWith(id);
+  });
+
   it("keeps the picked URL when fresh metadata has no signed download_url (MUL-3254)", async () => {
     // Non-CloudFront deployments return the API path again as download_url —
     // swapping to it gains nothing, so the original pick must stay.

--- a/packages/views/editor/attachment.tsx
+++ b/packages/views/editor/attachment.tsx
@@ -324,15 +324,17 @@ function useResignedInlineMediaURL(
   attachmentId: string | undefined,
   pickedUrl: string,
 ): string {
+  const idFromPickedUrl = attachmentIdFromDownloadURL(pickedUrl);
+  const resignAttachmentId = attachmentId ?? idFromPickedUrl;
   const needsResign =
-    !!attachmentId &&
+    !!resignAttachmentId &&
     !!pickedUrl &&
-    attachmentIdFromDownloadURL(pickedUrl) !== undefined &&
+    idFromPickedUrl !== undefined &&
     (api.getBaseUrl?.() ?? "") !== "";
 
   const { data: fresh } = useQuery({
-    queryKey: ["attachment-inline-resign", attachmentId],
-    queryFn: () => api.getAttachment(attachmentId as string),
+    queryKey: ["attachment-inline-resign", resignAttachmentId],
+    queryFn: () => api.getAttachment(resignAttachmentId as string),
     enabled: needsResign,
     staleTime: RESIGN_STALE_MS,
     gcTime: RESIGN_STALE_MS,


### PR DESCRIPTION
## Summary
- derive the attachment id from `/api/attachments/{id}/download` inline media URLs when the resolver has no hydrated attachment record
- use that id to fetch fresh attachment metadata in token-mode clients, preserving #4085's signed-CDN swap for URL-only markdown images
- add a regression test for the unresolved URL-only path

## Testing
- `pnpm --filter @multica/views test -- editor/attachment.test.tsx` (ran all @multica/views tests: 130 files / 1294 tests)
- `pnpm --filter @multica/views typecheck`
- `git diff --check`
