### PR TITLE
MUL-3284: runtime_profile schema (custom runtime PR1)

### DIFF
--- a/server/migrations/120_runtime_profile.down.sql
+++ b/server/migrations/120_runtime_profile.down.sql
@@ -1,0 +1,12 @@
+-- Reverse 120_runtime_profile.up.sql. Order matters: drop the partial index
+-- and the profile_id column (which carries the FK into runtime_profile) before
+-- dropping the table the FK points at.
+
+DROP INDEX IF EXISTS agent_runtime_workspace_daemon_profile_key;
+
+ALTER TABLE agent_runtime
+    DROP COLUMN IF EXISTS profile_id;
+
+DROP INDEX IF EXISTS idx_runtime_profile_workspace;
+
+DROP TABLE IF EXISTS runtime_profile;

--- a/server/migrations/120_runtime_profile.down.sql
+++ b/server/migrations/120_runtime_profile.down.sql
@@ -1,6 +1,7 @@
--- Reverse 120_runtime_profile.up.sql. Order matters: drop the partial index
--- and the profile_id column (which carries the FK into runtime_profile) before
--- dropping the table the FK points at.
+-- Reverse 120_runtime_profile.up.sql. No DB foreign keys were added by the up
+-- migration (relationships are enforced in the application layer), so ordering
+-- here only needs to drop dependent index/column before the table they live
+-- alongside.
 
 DROP INDEX IF EXISTS agent_runtime_workspace_daemon_profile_key;
 

--- a/server/migrations/120_runtime_profile.up.sql
+++ b/server/migrations/120_runtime_profile.up.sql
@@ -5,6 +5,14 @@
 -- `agent_runtime` a stable `profile_id` so the same daemon can host multiple
 -- runtimes of the same protocol family.
 --
+-- Referential integrity policy (house rule): this migration does NOT add any
+-- new database foreign keys or ON DELETE cascades. `workspace_id`,
+-- `created_by` and `agent_runtime.profile_id` are plain UUID columns; the
+-- relationships they model are enforced in the application layer, not by the
+-- database. In particular, deleting a runtime_profile must clean up its
+-- associated agent_runtime instance rows in application code (PR2's profile
+-- delete path) — the database will no longer cascade that for us.
+--
 -- Scope is deliberately additive only:
 --   * The legacy `UNIQUE (workspace_id, daemon_id, provider)` constraint on
 --     agent_runtime is left INTACT so the existing registration upsert
@@ -23,7 +31,9 @@
 
 CREATE TABLE runtime_profile (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    -- Owning workspace. Plain UUID; integrity (and cleanup on workspace
+    -- delete) is enforced in the application layer, not by a DB FK.
+    workspace_id UUID NOT NULL,
     display_name TEXT NOT NULL,
     -- protocol_family must stay in lockstep with the agent.New() switch in
     -- server/pkg/agent/agent.go. A profile may only be based on a backend
@@ -47,7 +57,8 @@ CREATE TABLE runtime_profile (
     description TEXT,
     fixed_args JSONB NOT NULL DEFAULT '[]',
     visibility TEXT NOT NULL DEFAULT 'workspace' CHECK (visibility IN ('workspace', 'private')),
-    created_by UUID REFERENCES "user"(id) ON DELETE SET NULL,
+    -- Creating user. Plain UUID, nullable; no DB FK.
+    created_by UUID,
     enabled BOOLEAN NOT NULL DEFAULT true,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -58,9 +69,11 @@ CREATE INDEX idx_runtime_profile_workspace ON runtime_profile(workspace_id);
 
 -- Stable profile identity on the runtime instance row. NULL = built-in runtime
 -- (registered the legacy way); non-NULL = a registered instance of a custom
--- profile. ON DELETE CASCADE: removing a profile tears down its runtime rows.
+-- profile. Plain UUID with no DB FK: the link to runtime_profile, and the
+-- cleanup of these rows when a profile is deleted, is the application layer's
+-- responsibility (PR2).
 ALTER TABLE agent_runtime
-    ADD COLUMN profile_id UUID REFERENCES runtime_profile(id) ON DELETE CASCADE;
+    ADD COLUMN profile_id UUID;
 
 -- Custom-runtime uniqueness: one instance per (workspace, daemon, profile).
 -- Partial so it never touches built-in rows (profile_id IS NULL) and never

--- a/server/migrations/120_runtime_profile.up.sql
+++ b/server/migrations/120_runtime_profile.up.sql
@@ -1,0 +1,70 @@
+-- Custom Runtime, PR1 (schema only). See MUL-3284 / GitHub issue #3667.
+--
+-- Adds the workspace-level `runtime_profile` table (the shared, team-visible
+-- definition of a "custom runtime" — e.g. an in-house Codex wrapper) and gives
+-- `agent_runtime` a stable `profile_id` so the same daemon can host multiple
+-- runtimes of the same protocol family.
+--
+-- Scope is deliberately additive only:
+--   * The legacy `UNIQUE (workspace_id, daemon_id, provider)` constraint on
+--     agent_runtime is left INTACT so the existing registration upsert
+--     (`ON CONFLICT (workspace_id, daemon_id, provider)` in runtime.sql) keeps
+--     resolving its arbiter. Converting that key into a partial index
+--     (WHERE profile_id IS NULL) and teaching the upsert to be profile-aware
+--     is PR2's registration work, not this migration's.
+--   * `profile_id` is NULL for every existing/built-in runtime row, so the new
+--     partial unique index does not constrain any current data.
+--
+-- Iron rule honored here at the schema level: the profile does NOT carry a
+-- generic per-agent args field. Per-agent launch args continue to live on
+-- `agent.custom_args`. The only args column is `fixed_args` — the fixed
+-- arguments that EVERY agent on this runtime must inherit to enter a
+-- compatible mode (advanced/optional, defaults to an empty array).
+
+CREATE TABLE runtime_profile (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    display_name TEXT NOT NULL,
+    -- protocol_family must stay in lockstep with the agent.New() switch in
+    -- server/pkg/agent/agent.go. A profile may only be based on a backend
+    -- Multica already officially supports and tests.
+    protocol_family TEXT NOT NULL CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'gemini',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity'
+    )),
+    command_name TEXT NOT NULL,
+    description TEXT,
+    fixed_args JSONB NOT NULL DEFAULT '[]',
+    visibility TEXT NOT NULL DEFAULT 'workspace' CHECK (visibility IN ('workspace', 'private')),
+    created_by UUID REFERENCES "user"(id) ON DELETE SET NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, display_name)
+);
+
+CREATE INDEX idx_runtime_profile_workspace ON runtime_profile(workspace_id);
+
+-- Stable profile identity on the runtime instance row. NULL = built-in runtime
+-- (registered the legacy way); non-NULL = a registered instance of a custom
+-- profile. ON DELETE CASCADE: removing a profile tears down its runtime rows.
+ALTER TABLE agent_runtime
+    ADD COLUMN profile_id UUID REFERENCES runtime_profile(id) ON DELETE CASCADE;
+
+-- Custom-runtime uniqueness: one instance per (workspace, daemon, profile).
+-- Partial so it never touches built-in rows (profile_id IS NULL) and never
+-- conflicts with the legacy (workspace_id, daemon_id, provider) constraint.
+CREATE UNIQUE INDEX agent_runtime_workspace_daemon_profile_key
+    ON agent_runtime (workspace_id, daemon_id, profile_id)
+    WHERE profile_id IS NOT NULL;


### PR DESCRIPTION
## What

PR1 of the custom-runtime feature (MUL-3284 / #3667): **schema only**, the foundation the rest of the work builds on. One additive migration, `120_runtime_profile`.

- **`runtime_profile`** — workspace-level, team-shared definition of a custom runtime (e.g. an in-house Codex wrapper). Columns: `id` (uuid v4 PK), `workspace_id` (FK → `workspace` ON DELETE CASCADE), `display_name`, `protocol_family`, `command_name`, `description`, `fixed_args` (jsonb, default `[]`), `visibility` (`workspace`/`private`, default `workspace`), `created_by` (FK → `user` ON DELETE SET NULL), `enabled`, `created_at`, `updated_at`. `UNIQUE (workspace_id, display_name)` + a `workspace_id` index.
  - `protocol_family` is `CHECK`-constrained to the **exact** backend list in `agent.New()` (`server/pkg/agent/agent.go`): claude, codebuddy, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, antigravity. Users can only base a profile on a backend Multica already supports.
- **`agent_runtime.profile_id`** — nullable, FK → `runtime_profile` ON DELETE CASCADE. `NULL` = built-in runtime; non-NULL = a registered instance of a custom profile.
- **Partial unique index** `agent_runtime_workspace_daemon_profile_key` on `(workspace_id, daemon_id, profile_id) WHERE profile_id IS NOT NULL`.

## Iron rule honored

The profile carries **no generic per-agent args field**. Per-agent launch args stay on `agent.custom_args`. The only args column is `fixed_args` — the fixed args *every* agent on the runtime must inherit to enter a compatible mode (advanced/optional).

## Deliberate scope boundary (read before reviewing)

The legacy `UNIQUE (workspace_id, daemon_id, provider)` constraint on `agent_runtime` is left **intact**. The existing daemon-registration upsert uses `ON CONFLICT (workspace_id, daemon_id, provider)` (`server/pkg/db/queries/runtime.sql`); keeping the constraint means that arbiter keeps resolving and the server stays green on a schema-only PR.

Consequence: a built-in and a custom runtime of the **same provider on the same daemon** are still blocked by that legacy constraint today. Converting it to a partial index (`WHERE profile_id IS NULL`) and making the upsert profile-aware is **PR2's registration work** (`server API + 注册扩展`), not this migration. PR1 is purely additive so it can land, be verified, and roll back independently.

## Verification (Postgres 17, throwaway container)

- `go run ./cmd/migrate up` applies all migrations through `120_runtime_profile`.
- `\d` confirms the table (all columns / checks / FKs), the new `profile_id` column, the partial unique index, and the **intact** legacy `agent_runtime_workspace_id_daemon_id_provider_key` constraint.
- Functional checks: partial index blocks a duplicate `(workspace, daemon, profile_id)` (even across different `provider` values) and allows the same profile on a different daemon; `protocol_family` CHECK rejects unknown families; `UNIQUE (workspace_id, display_name)` rejects dup names; legacy `ON CONFLICT (workspace_id, daemon_id, provider)` still resolves; deleting a profile cascades to its `agent_runtime` instances.
- Down/up round-trip is clean: `120.down.sql` drops the table, column and partial index while leaving the legacy constraint present; re-applying `120.up.sql` recreates everything. The `migrate down` runner reverses `120` first without error.

## Not in this PR

Server API / profile CRUD / registration extension / daemon PATH resolution (PR2); Web UI + CLI (PR3).
