### PR TITLE
MUL-3304: align projects compact row navigation

### DIFF
--- a/packages/views/navigation/use-row-link.test.tsx
+++ b/packages/views/navigation/use-row-link.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavigationProvider } from "./context";
+import { useRowLink } from "./use-row-link";
+import type { NavigationAdapter } from "./types";
+
+function makeAdapter(
+  overrides: Partial<NavigationAdapter> = {},
+): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => p,
+    ...overrides,
+  };
+}
+
+function Probe({ href = "/acme/projects/p1" }: { href?: string }) {
+  const rowLink = useRowLink();
+  return (
+    <div role="row" {...rowLink(href)}>
+      row
+    </div>
+  );
+}
+
+function renderProbe(adapter: NavigationAdapter) {
+  return render(
+    <NavigationProvider value={adapter}>
+      <Probe />
+    </NavigationProvider>,
+  );
+}
+
+describe("useRowLink", () => {
+  it("pushes on plain left click", () => {
+    const push = vi.fn();
+    const adapter = makeAdapter({ push });
+
+    renderProbe(adapter);
+    fireEvent.click(screen.getByRole("row"));
+
+    expect(push).toHaveBeenCalledWith("/acme/projects/p1");
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses openInNewTab instead of push for cmd/ctrl click when available", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const adapter = makeAdapter({ push, openInNewTab });
+
+    renderProbe(adapter);
+    fireEvent.click(screen.getByRole("row"), { metaKey: true });
+    fireEvent.click(screen.getByRole("row"), { ctrlKey: true });
+
+    expect(openInNewTab).toHaveBeenCalledTimes(2);
+    expect(openInNewTab).toHaveBeenNthCalledWith(1, "/acme/projects/p1");
+    expect(openInNewTab).toHaveBeenNthCalledWith(2, "/acme/projects/p1");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a single push for cmd/ctrl click without openInNewTab", () => {
+    const push = vi.fn();
+    const adapter = makeAdapter({ push });
+
+    renderProbe(adapter);
+    fireEvent.click(screen.getByRole("row"), { metaKey: true });
+    fireEvent.click(screen.getByRole("row"), { ctrlKey: true });
+
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(push).toHaveBeenNthCalledWith(1, "/acme/projects/p1");
+    expect(push).toHaveBeenNthCalledWith(2, "/acme/projects/p1");
+  });
+
+  it("opens a background tab and prevents default for middle click when available", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const adapter = makeAdapter({ push, openInNewTab });
+
+    renderProbe(adapter);
+    const event = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    screen.getByRole("row").dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openInNewTab).toHaveBeenCalledWith("/acme/projects/p1");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("falls back to one prevented push for middle click without openInNewTab", () => {
+    const push = vi.fn();
+    const adapter = makeAdapter({ push });
+
+    renderProbe(adapter);
+    const event = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    screen.getByRole("row").dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(push).toHaveBeenCalledWith("/acme/projects/p1");
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -1,0 +1,324 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Project } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { NavigationProvider, type NavigationAdapter } from "../../navigation";
+import { ProjectsPage } from "./projects-page";
+
+const mocks = vi.hoisted(() => ({
+  projects: [] as Project[],
+  members: [] as Array<{ user_id: string; name: string; role: string }>,
+  agents: [] as Array<{ id: string; name: string; archived_at: string | null }>,
+  pins: [] as Array<{ item_type: string; item_id: string }>,
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  createPin: vi.fn(),
+  deletePin: vi.fn(),
+  openModal: vi.fn(),
+  projectViewState: {
+    viewMode: "compact",
+    sortField: "name",
+    sortDirection: "asc",
+    hiddenColumns: [] as string[],
+    filters: { statuses: [], priorities: [], leads: [] },
+    setViewMode: vi.fn(),
+    toggleSort: vi.fn(),
+    setSortField: vi.fn(),
+    setSortDirection: vi.fn(),
+    toggleColumn: vi.fn(),
+    toggleFilter: vi.fn(),
+    clearFilters: vi.fn(),
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: { queryKey?: readonly unknown[] }) => {
+    const key = options.queryKey?.[0];
+    if (key === "projects") {
+      return { data: mocks.projects, isLoading: false };
+    }
+    if (key === "members") {
+      return { data: mocks.members, isLoading: false };
+    }
+    if (key === "agents") {
+      return { data: mocks.agents, isLoading: false };
+    }
+    if (key === "pins") {
+      return { data: mocks.pins, isLoading: false };
+    }
+    return { data: [], isLoading: false };
+  },
+}));
+
+vi.mock("@multica/core/projects", () => ({
+  projectListOptions: () => ({ queryKey: ["projects"] }),
+  useUpdateProject: () => ({ mutate: mocks.updateProject }),
+  useDeleteProject: () => ({ mutate: mocks.deleteProject }),
+  useProjectViewStore: (selector: (state: unknown) => unknown) =>
+    selector(mocks.projectViewState),
+}));
+
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({ queryKey: ["pins"] }),
+  useCreatePin: () => ({ mutate: mocks.createPin }),
+  useDeletePin: () => ({ mutate: mocks.deletePin }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    projectDetail: (id: string) => `/test-workspace/projects/${id}`,
+    memberDetail: (id: string) => `/test-workspace/members/${id}`,
+    agentDetail: (id: string) => `/test-workspace/agents/${id}`,
+  }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"] }),
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: () => "Test Lead",
+    getActorInitials: () => "TL",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: {
+    getState: () => ({ open: mocks.openModal }),
+  },
+}));
+
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => (
+    <>{render}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuCheckboxItem: ({
+    children,
+    onCheckedChange,
+  }: {
+    children: React.ReactNode;
+    onCheckedChange?: () => void;
+  }) => (
+    <button type="button" onClick={onCheckedChange}>
+      {children}
+    </button>
+  ),
+  DropdownMenuRadioGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuRadioItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="tooltip">{children}</div>
+  ),
+}));
+
+const PROJECT: Project = {
+  id: "project-1",
+  workspace_id: "workspace-1",
+  title: "Launch Plan",
+  description: null,
+  icon: null,
+  status: "in_progress",
+  priority: "high",
+  lead_type: null,
+  lead_id: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  issue_count: 3,
+  done_count: 1,
+  resource_count: 0,
+};
+
+function makeAdapter(
+  overrides: Partial<NavigationAdapter> = {},
+): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/test-workspace/projects",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => p,
+    ...overrides,
+  };
+}
+
+function renderProjects(adapter = makeAdapter()) {
+  renderWithI18n(
+    <NavigationProvider value={adapter}>
+      <ProjectsPage />
+    </NavigationProvider>,
+  );
+  return adapter;
+}
+
+function projectRow() {
+  const row = screen.getByText(PROJECT.title).closest('[role="row"]');
+  if (!row) throw new Error("project row not found");
+  return row as HTMLElement;
+}
+
+beforeEach(() => {
+  mocks.projects = [PROJECT];
+  mocks.members = [
+    { user_id: "user-1", name: "User One", role: "admin" },
+  ];
+  mocks.agents = [];
+  mocks.pins = [];
+  mocks.updateProject.mockClear();
+  mocks.deleteProject.mockClear();
+  mocks.createPin.mockClear();
+  mocks.deletePin.mockClear();
+  mocks.openModal.mockClear();
+  mocks.projectViewState.viewMode = "compact";
+  mocks.projectViewState.sortField = "name";
+  mocks.projectViewState.sortDirection = "asc";
+  mocks.projectViewState.hiddenColumns = [];
+  mocks.projectViewState.filters = { statuses: [], priorities: [], leads: [] };
+});
+
+describe("ProjectsPage compact row navigation", () => {
+  it("renders the project name as text, not a title link", () => {
+    renderProjects();
+
+    const row = projectRow();
+    expect(within(row).getByText(PROJECT.title).tagName).toBe("SPAN");
+    expect(
+      within(row).queryByRole("link", { name: PROJECT.title }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("navigates from the row surface", async () => {
+    const user = userEvent.setup();
+    const push = vi.fn();
+    renderProjects(makeAdapter({ push }));
+
+    await user.click(projectRow());
+
+    expect(push).toHaveBeenCalledWith("/test-workspace/projects/project-1");
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not navigate when inline controls are clicked", async () => {
+    const user = userEvent.setup();
+    const push = vi.fn();
+    renderProjects(makeAdapter({ push }));
+    const row = projectRow();
+
+    await user.click(within(row).getByRole("button", { pressed: false }));
+    await user.click(within(row).getByRole("button", { name: "Project actions" }));
+    await user.click(within(row).getAllByRole("button", { name: "In Progress" })[0]!);
+    await user.click(within(row).getAllByRole("button", { name: "High" })[0]!);
+    await user.click(within(row).getByRole("button", { name: "—" }));
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("uses the rowLink modifier and middle-click paths when openInNewTab is available", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    renderProjects(makeAdapter({ push, openInNewTab }));
+    const row = projectRow();
+
+    fireEvent.click(row, { metaKey: true });
+    fireEvent.click(row, { ctrlKey: true });
+    const middleClick = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    row.dispatchEvent(middleClick);
+
+    expect(middleClick.defaultPrevented).toBe(true);
+    expect(openInNewTab).toHaveBeenCalledTimes(3);
+    expect(openInNewTab).toHaveBeenNthCalledWith(1, "/test-workspace/projects/project-1");
+    expect(openInNewTab).toHaveBeenNthCalledWith(2, "/test-workspace/projects/project-1");
+    expect(openInNewTab).toHaveBeenNthCalledWith(3, "/test-workspace/projects/project-1");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("has a single rowLink path for modifier and middle clicks without openInNewTab", () => {
+    const push = vi.fn();
+    renderProjects(makeAdapter({ push }));
+    const row = projectRow();
+
+    fireEvent.click(row, { metaKey: true });
+    fireEvent.click(row, { ctrlKey: true });
+    const middleClick = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    row.dispatchEvent(middleClick);
+
+    expect(middleClick.defaultPrevented).toBe(true);
+    expect(push).toHaveBeenCalledTimes(3);
+    expect(push).toHaveBeenNthCalledWith(1, "/test-workspace/projects/project-1");
+    expect(push).toHaveBeenNthCalledWith(2, "/test-workspace/projects/project-1");
+    expect(push).toHaveBeenNthCalledWith(3, "/test-workspace/projects/project-1");
+  });
+});

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import {
   ArrowDown,
   ArrowUp,
@@ -39,7 +39,7 @@ import { useAuthStore } from "@multica/core/auth";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { memberListOptions } from "@multica/core/workspace/queries";
 import { useModalStore } from "@multica/core/modals";
-import { AppLink } from "../../navigation";
+import { AppLink, useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
@@ -130,10 +130,8 @@ function leadFilterValue(p: Project): string | null {
 // ---------------------------------------------------------------------------
 // Table (compact) view — ListGrid. Name + status are the core columns;
 // priority/progress/lead/issues/created collapse below @2xl, with min-width
-// + the wrapper's overflow as the escape valve. Rows are NOT whole-row
-// links: the name is the navigation target and the rest of the row is
-// inline-editable (status/priority/lead pickers), matching the prior
-// behaviour and avoiding navigate-vs-edit conflicts.
+// + the wrapper's overflow as the escape valve. Rows use whole-row mouse
+// navigation; inline controls stop propagation so edit/menu clicks stay local.
 // ---------------------------------------------------------------------------
 
 const COLUMN_WIDTHS: Record<ProjectColumnKey, number> = {
@@ -157,6 +155,8 @@ const FIXED_TRACKS_WIDTH = 384 + 10 * 12;
 const GRID_COLS =
   "grid-cols-[0.75rem_1rem_minmax(120px,1fr)_116px_1.75rem_0.75rem] " +
   "@2xl:grid-cols-[0.75rem_1rem_minmax(200px,1fr)_116px_var(--pjc-priority)_var(--pjc-progress)_var(--pjc-lead)_var(--pjc-issues)_var(--pjc-created)_1.75rem_0.75rem]";
+
+const stopRowNavigation = (e: MouseEvent) => e.stopPropagation();
 
 function columnTrackVars(
   isVisible: (key: ProjectColumnKey) => boolean,
@@ -321,7 +321,11 @@ function CheckboxCell({
       <button
         type="button"
         aria-pressed={checked}
-        onClick={onToggle}
+        onClick={(e) => {
+          stopRowNavigation(e);
+          onToggle();
+        }}
+        onAuxClick={stopRowNavigation}
         className={`-m-1.5 flex items-center p-1.5 ${
           checked ? "" : "opacity-0 transition-opacity group-hover/row:opacity-100"
         }`}
@@ -339,6 +343,8 @@ function ProjectTableRow({
   isColVisible,
   selected,
   onToggleSelect,
+  rowHref,
+  rowLink,
 }: {
   project: Project;
   pinned: boolean;
@@ -346,8 +352,9 @@ function ProjectTableRow({
   isColVisible: (key: ProjectColumnKey) => boolean;
   selected: boolean;
   onToggleSelect: () => void;
+  rowHref: string;
+  rowLink: ReturnType<typeof useRowLink>;
 }) {
-  const wsPaths = useWorkspacePaths();
   const formatRelativeDate = useFormatRelativeDate();
   const updateProject = useUpdateProject();
   const handleUpdate = useCallback(
@@ -356,25 +363,25 @@ function ProjectTableRow({
   );
 
   return (
-    <ListGridRow className={`h-11 ${selected ? "bg-accent/30" : ""}`}>
+    <ListGridRow
+      className={`h-11 cursor-pointer ${selected ? "bg-accent/30" : ""}`}
+      {...rowLink(rowHref)}
+    >
       <CheckboxCell checked={selected} onToggle={onToggleSelect} />
       <ListGridCell className="gap-2">
         <ProjectIcon project={project} size="sm" />
-        <AppLink
-          href={wsPaths.projectDetail(project.id)}
-          className="min-w-0 truncate text-sm font-medium hover:underline"
-        >
+        <span className="min-w-0 truncate text-sm font-medium">
           {project.title}
-        </AppLink>
+        </span>
       </ListGridCell>
 
       {/* status — core column, always visible */}
-      <ListGridCell>
+      <ListGridCell onClick={stopRowNavigation} onAuxClick={stopRowNavigation}>
         <ProjectStatusBadge project={project} handleUpdate={handleUpdate} align="start" />
       </ListGridCell>
 
       {isColVisible("priority") ? (
-        <ListGridCell className="hidden @2xl:flex">
+        <ListGridCell className="hidden @2xl:flex" onClick={stopRowNavigation} onAuxClick={stopRowNavigation}>
           <ProjectPriorityBadge project={project} handleUpdate={handleUpdate} align="start" />
         </ListGridCell>
       ) : (
@@ -390,7 +397,7 @@ function ProjectTableRow({
       )}
 
       {isColVisible("lead") ? (
-        <ListGridCell className="hidden @2xl:flex">
+        <ListGridCell className="hidden @2xl:flex" onClick={stopRowNavigation} onAuxClick={stopRowNavigation}>
           <ProjectLeadPicker
             project={project}
             handleUpdate={handleUpdate}
@@ -433,7 +440,9 @@ function ProjectTableRow({
       )}
 
       <ListGridCell className="justify-end px-0">
-        <ProjectRowActions project={project} pinned={pinned} canDelete={canDelete} />
+        <span onClick={stopRowNavigation} onAuxClick={stopRowNavigation} className="flex items-center">
+          <ProjectRowActions project={project} pinned={pinned} canDelete={canDelete} />
+        </span>
       </ListGridCell>
     </ListGridRow>
   );
@@ -762,6 +771,8 @@ function ProjectBatchToolbar({
 export function ProjectsPage() {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
+  const wsPaths = useWorkspacePaths();
+  const rowLink = useRowLink();
   const currentUser = useAuthStore((s) => s.user);
   const { getActorName } = useActorName();
 
@@ -1205,6 +1216,8 @@ export function ProjectsPage() {
                     isColVisible={isColVisible}
                     selected={selectedIds.has(project.id)}
                     onToggleSelect={() => toggleSelected(project.id)}
+                    rowHref={wsPaths.projectDetail(project.id)}
+                    rowLink={rowLink}
                   />
                 ))}
               </ListGrid>

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -209,8 +209,8 @@ function ProgressRing({ project }: { project: Project }) {
   );
 }
 
-// Interactive cell wrapper: the inline pickers live in a non-navigating row,
-// so they need no stopPropagation, but keep edits from bubbling oddly.
+// Compact rows own whole-row navigation; callers stop propagation around this
+// menu so action clicks do not bubble into the rowLink handler.
 function ProjectRowActions({
   project,
   pinned,


### PR DESCRIPTION
## Summary
- make Projects compact/list rows use `useRowLink` as the only navigation entry
- render the compact project name cell as plain text, matching Skills/Agents
- stop click/auxclick propagation from compact inline controls
- add coverage for row navigation, non-navigation controls, and modifier/middle-click paths

## Verification
- `corepack pnpm --filter @multica/views exec vitest run navigation/use-row-link.test.tsx projects/components/projects-page.test.tsx`
- `corepack pnpm --filter @multica/views typecheck`
- `corepack pnpm --filter @multica/views lint`
- `corepack pnpm --filter @multica/views test`
