### PR TITLE
MUL-3306: validate issue status and priority

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -238,6 +238,27 @@ var validIssueStatuses = []string{
 	"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled",
 }
 
+var validIssuePriorities = []string{
+	"urgent", "high", "medium", "low", "none",
+}
+
+func validateIssueStatus(status string) error {
+	return validateIssueEnum("status", status, validIssueStatuses)
+}
+
+func validateIssuePriority(priority string) error {
+	return validateIssueEnum("priority", priority, validIssuePriorities)
+}
+
+func validateIssueEnum(field, value string, allowed []string) error {
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid %s %q; valid values: %s", field, value, strings.Join(allowed, ", "))
+}
+
 func init() {
 	issueCmd.AddCommand(issueListCmd)
 	issueCmd.AddCommand(issueGetCmd)
@@ -659,6 +680,18 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	if title == "" {
 		return fmt.Errorf("--title is required")
 	}
+	statusFlag, _ := cmd.Flags().GetString("status")
+	if statusFlag != "" {
+		if err := validateIssueStatus(statusFlag); err != nil {
+			return err
+		}
+	}
+	priorityFlag, _ := cmd.Flags().GetString("priority")
+	if priorityFlag != "" {
+		if err := validateIssuePriority(priorityFlag); err != nil {
+			return err
+		}
+	}
 
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -682,11 +715,11 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	if hasDesc {
 		body["description"] = desc
 	}
-	if v, _ := cmd.Flags().GetString("status"); v != "" {
-		body["status"] = v
+	if statusFlag != "" {
+		body["status"] = statusFlag
 	}
-	if v, _ := cmd.Flags().GetString("priority"); v != "" {
-		body["priority"] = v
+	if priorityFlag != "" {
+		body["priority"] = priorityFlag
 	}
 	if v, _ := cmd.Flags().GetString("parent"); v != "" {
 		parent, err := resolveIssueRef(ctx, client, v)
@@ -828,6 +861,21 @@ func activeDuplicateIssueCreateMessage(err error) (string, bool) {
 }
 
 func runIssueUpdate(cmd *cobra.Command, args []string) error {
+	statusChanged := cmd.Flags().Changed("status")
+	statusFlag, _ := cmd.Flags().GetString("status")
+	if statusChanged {
+		if err := validateIssueStatus(statusFlag); err != nil {
+			return err
+		}
+	}
+	priorityChanged := cmd.Flags().Changed("priority")
+	priorityFlag, _ := cmd.Flags().GetString("priority")
+	if priorityChanged {
+		if err := validateIssuePriority(priorityFlag); err != nil {
+			return err
+		}
+	}
+
 	client, err := newAPIClient(cmd)
 	if err != nil {
 		return err
@@ -853,13 +901,11 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 		}
 		body["description"] = desc
 	}
-	if cmd.Flags().Changed("status") {
-		v, _ := cmd.Flags().GetString("status")
-		body["status"] = v
+	if statusChanged {
+		body["status"] = statusFlag
 	}
-	if cmd.Flags().Changed("priority") {
-		v, _ := cmd.Flags().GetString("priority")
-		body["priority"] = v
+	if priorityChanged {
+		body["priority"] = priorityFlag
 	}
 	if cmd.Flags().Changed("project") {
 		v, _ := cmd.Flags().GetString("project")
@@ -994,15 +1040,8 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	id := args[0]
 	status := args[1]
 
-	valid := false
-	for _, s := range validIssueStatuses {
-		if s == status {
-			valid = true
-			break
-		}
-	}
-	if !valid {
-		return fmt.Errorf("invalid status %q; valid values: %s", status, strings.Join(validIssueStatuses, ", "))
+	if err := validateIssueStatus(status); err != nil {
+		return err
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2107,3 +2107,100 @@ func TestValidIssueStatuses(t *testing.T) {
 		t.Errorf("validIssueStatuses has %d entries, expected %d", len(validIssueStatuses), len(expected))
 	}
 }
+
+func TestValidateIssueStatus(t *testing.T) {
+	for _, s := range validIssueStatuses {
+		if err := validateIssueStatus(s); err != nil {
+			t.Errorf("status %q should be valid, got: %v", s, err)
+		}
+	}
+	err := validateIssueStatus("active")
+	if err == nil {
+		t.Fatal("status \"active\" should be rejected")
+	}
+	if !strings.Contains(err.Error(), "backlog") {
+		t.Errorf("error should list valid statuses, got: %v", err)
+	}
+}
+
+func TestValidateIssuePriority(t *testing.T) {
+	expected := map[string]bool{
+		"urgent": true,
+		"high":   true,
+		"medium": true,
+		"low":    true,
+		"none":   true,
+	}
+	for _, p := range validIssuePriorities {
+		if !expected[p] {
+			t.Errorf("unexpected priority in validIssuePriorities: %q", p)
+		}
+		if err := validateIssuePriority(p); err != nil {
+			t.Errorf("priority %q should be valid, got: %v", p, err)
+		}
+	}
+	if len(validIssuePriorities) != len(expected) {
+		t.Errorf("validIssuePriorities has %d entries, expected %d", len(validIssuePriorities), len(expected))
+	}
+	err := validateIssuePriority("P1")
+	if err == nil {
+		t.Fatal("priority \"P1\" should be rejected")
+	}
+	if !strings.Contains(err.Error(), "urgent") {
+		t.Errorf("error should list valid priorities, got: %v", err)
+	}
+}
+
+func TestRunIssueCreateRejectsInvalidStatusBeforeRequest(t *testing.T) {
+	cmd := newIssueCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Invalid status")
+	_ = cmd.Flags().Set("status", "active")
+	err := runIssueCreate(cmd, nil)
+	if err == nil {
+		t.Fatal("runIssueCreate should reject invalid status")
+	}
+	if !strings.Contains(err.Error(), "valid values") {
+		t.Fatalf("expected valid values error, got: %v", err)
+	}
+}
+
+func TestRunIssueCreateRejectsInvalidPriorityBeforeRequest(t *testing.T) {
+	cmd := newIssueCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Invalid priority")
+	_ = cmd.Flags().Set("priority", "P1")
+	err := runIssueCreate(cmd, nil)
+	if err == nil {
+		t.Fatal("runIssueCreate should reject invalid priority")
+	}
+	if !strings.Contains(err.Error(), "valid values") {
+		t.Fatalf("expected valid values error, got: %v", err)
+	}
+}
+
+func TestRunIssueUpdateRejectsInvalidStatusBeforeRequest(t *testing.T) {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("priority", "", "")
+	_ = cmd.Flags().Set("status", "active")
+	err := runIssueUpdate(cmd, []string{"MUL-1"})
+	if err == nil {
+		t.Fatal("runIssueUpdate should reject invalid status")
+	}
+	if !strings.Contains(err.Error(), "valid values") {
+		t.Fatalf("expected valid values error, got: %v", err)
+	}
+}
+
+func TestRunIssueUpdateRejectsInvalidPriorityBeforeRequest(t *testing.T) {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("priority", "", "")
+	_ = cmd.Flags().Set("priority", "P1")
+	err := runIssueUpdate(cmd, []string{"MUL-1"})
+	if err == nil {
+		t.Fatal("runIssueUpdate should reject invalid priority")
+	}
+	if !strings.Contains(err.Error(), "valid values") {
+		t.Fatalf("expected valid values error, got: %v", err)
+	}
+}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -61,6 +61,23 @@ type IssueResponse struct {
 	Labels *[]LabelResponse `json:"labels,omitempty"`
 }
 
+// validIssueStatuses / validIssuePriorities mirror the CHECK constraints on
+// the issue table. Write handlers pre-validate these so callers get a clean
+// 400 with the allowed values instead of a database CHECK violation bubbling
+// up as a 500.
+var validIssueStatuses = []string{"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"}
+var validIssuePriorities = []string{"urgent", "high", "medium", "low", "none"}
+
+func validateIssueEnum(w http.ResponseWriter, field, value string, allowed []string) bool {
+	for _, a := range allowed {
+		if value == a {
+			return true
+		}
+	}
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid %s %q; valid values: %s", field, value, strings.Join(allowed, ", ")))
+	return false
+}
+
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 	identifier := issuePrefix + "-" + strconv.Itoa(int(i.Number))
 	return IssueResponse{
@@ -2007,6 +2024,12 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	if priority == "" {
 		priority = "none"
 	}
+	if !validateIssueEnum(w, "status", status, validIssueStatuses) {
+		return
+	}
+	if !validateIssueEnum(w, "priority", priority, validIssuePriorities) {
+		return
+	}
 
 	var assigneeType pgtype.Text
 	var assigneeID pgtype.UUID
@@ -2252,9 +2275,15 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		params.Description = pgtype.Text{String: *req.Description, Valid: true}
 	}
 	if req.Status != nil {
+		if !validateIssueEnum(w, "status", *req.Status, validIssueStatuses) {
+			return
+		}
 		params.Status = pgtype.Text{String: *req.Status, Valid: true}
 	}
 	if req.Priority != nil {
+		if !validateIssueEnum(w, "priority", *req.Priority, validIssuePriorities) {
+			return
+		}
 		params.Priority = pgtype.Text{String: *req.Priority, Valid: true}
 	}
 	if req.Position != nil {
@@ -2745,6 +2774,16 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	if !hasMutation {
 		writeJSON(w, http.StatusOK, map[string]any{"updated": 0})
 		return
+	}
+	if req.Updates.Status != nil {
+		if !validateIssueEnum(w, "status", *req.Updates.Status, validIssueStatuses) {
+			return
+		}
+	}
+	if req.Updates.Priority != nil {
+		if !validateIssueEnum(w, "priority", *req.Updates.Priority, validIssuePriorities) {
+			return
+		}
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)

--- a/server/internal/handler/issue_validation_test.go
+++ b/server/internal/handler/issue_validation_test.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateIssueInvalidStatusReturns400(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "invalid status issue",
+		"status": "active",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "backlog") {
+		t.Errorf("expected error to list valid statuses, got: %s", body)
+	}
+}
+
+func TestCreateIssueInvalidPriorityReturns400(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":    "invalid priority issue",
+		"priority": "P1",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "urgent") {
+		t.Errorf("expected error to list valid priorities, got: %s", body)
+	}
+}
+
+func TestUpdateIssueInvalidStatusReturns400(t *testing.T) {
+	issueID := createTestIssue(t, "update invalid status issue", "todo", "none")
+	t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "active"})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateIssueInvalidPriorityReturns400(t *testing.T) {
+	issueID := createTestIssue(t, "update invalid priority issue", "todo", "none")
+	t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"priority": "P1"})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchUpdateIssuesInvalidStatusReturns400(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{"not-needed"},
+		"updates": map[string]any{
+			"status": "active",
+		},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid status, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchUpdateIssuesInvalidPriorityReturns400(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{"not-needed"},
+		"updates": map[string]any{
+			"priority": "P1",
+		},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds server-side validation for issue `status` and `priority` on create, update, and batch update so invalid enum values return 400 with the allowed values instead of bubbling DB CHECK violations as 500s.
- Adds CLI-side validation for `multica issue create/update --status/--priority` and reuses the same status validator for `multica issue status`.
- Adds regression coverage for invalid issue status/priority on API handlers and CLI commands.

Closes #4148
Relates to MUL-3306

## Testing

- `go test ./internal/handler -run 'IssueInvalid|BatchUpdateIssuesInvalid|CreateIssueInvalid|UpdateIssueInvalid'`
- `go test ./cmd/multica -run 'ValidateIssue|RunIssue(Create|Update)RejectsInvalid|ValidIssueStatuses'`
- `go test ./internal/handler`
- `go test ./cmd/multica`
