### PR TITLE
fix(fe): restore live LLM quota gauge (MUL-3559)

### DIFF
--- a/apps/web/app/[workspaceSlug]/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,1 @@
+export { DashboardPage as default } from "@multica/views/dashboard";

--- a/apps/web/app/api/dashboard/llm-limit-status/route.test.ts
+++ b/apps/web/app/api/dashboard/llm-limit-status/route.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+let snapshotDir: string | undefined;
+
+afterEach(async () => {
+	delete process.env.NEXAI_TOKEN_SNAPSHOT_PATH;
+	delete process.env.NEXAI_CODEX_STATUS_SNAPSHOT_PATH;
+	if (snapshotDir) {
+		await rm(snapshotDir, { recursive: true, force: true });
+		snapshotDir = undefined;
+	}
+});
+
+describe("GET /api/dashboard/llm-limit-status", () => {
+	it("returns the current runtime token snapshot instead of a build-time constant", async () => {
+		snapshotDir = await mkdtemp(path.join(tmpdir(), "llm-limit-status-"));
+		const snapshotPath = path.join(snapshotDir, "token_snapshot.json");
+		const codexStatusPath = path.join(snapshotDir, "codex_status_snapshot.json");
+		process.env.NEXAI_TOKEN_SNAPSHOT_PATH = snapshotPath;
+		process.env.NEXAI_CODEX_STATUS_SNAPSHOT_PATH = codexStatusPath;
+
+		await writeFile(
+			snapshotPath,
+			JSON.stringify({
+				five_hour_utilization: 3,
+				seven_day_utilization: 57,
+				sonnet_pct: 4,
+				five_hour_resets_at: "2026-06-16T01:00:00+00:00",
+				seven_day_resets_at: "2026-06-18T15:00:00+00:00",
+				seven_day_sonnet_resets_at: "2026-06-18T15:00:00+00:00",
+				weekly_progress_pct: 10,
+				updated_at: "2026-06-16T00:00:00.000Z",
+			}),
+		);
+		await writeFile(
+			codexStatusPath,
+			JSON.stringify({
+				five_hour_left_pct: 64,
+				seven_day_left_pct: 94,
+				five_hour_reset_label: "resets 10:45 PM",
+				seven_day_reset_label: "resets May 17",
+			}),
+		);
+
+		const { GET } = await import("./route");
+		const response = await GET();
+		const data = await response.json();
+
+		expect(data).toMatchObject({
+			five_hour_pct: 3,
+			seven_day_pct: 57,
+			sonnet_pct: 4,
+			gpt_five_hour_pct: 36,
+			gpt_seven_day_pct: 6,
+			weekly_progress_pct: 10,
+			five_hour_reset_label: "(화) 오전 10:00에 재설정",
+			seven_day_reset_label: "(금) 오전 12:00에 재설정",
+			sonnet_reset_label: "(금) 오전 12:00에 재설정",
+			gpt_five_reset_label: "resets 10:45 PM",
+			gpt_seven_reset_label: "resets May 17",
+			updated_at: "2026-06-16T00:00:00.000Z",
+		});
+		expect(data.week_day_index).toBeTypeOf("number");
+		expect(data.reset_label).toBeTypeOf("string");
+	});
+});

--- a/apps/web/app/api/dashboard/llm-limit-status/route.ts
+++ b/apps/web/app/api/dashboard/llm-limit-status/route.ts
@@ -1,15 +1,145 @@
 import { NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
 
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-export function GET() {
+const DEFAULT_TOKEN_SNAPSHOT_PATH = "/home/iaas/nexai/state/token_snapshot.json";
+const DEFAULT_CODEX_STATUS_SNAPSHOT_PATH = "/home/iaas/nexai/state/codex_status_snapshot.json";
+
+type TokenSnapshot = Record<string, unknown>;
+const KST_TIME_ZONE = "Asia/Seoul";
+const WEEK_DAYS = ["금", "토", "일", "월", "화", "수", "목"] as const;
+
+function numberFrom(snapshot: TokenSnapshot, keys: string[], fallback = 0) {
+	for (const key of keys) {
+		const value = snapshot[key];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			return Math.max(0, Math.min(100, value));
+		}
+		if (typeof value === "string") {
+			const parsed = Number.parseFloat(value);
+			if (Number.isFinite(parsed)) {
+				return Math.max(0, Math.min(100, parsed));
+			}
+		}
+	}
+	return fallback;
+}
+
+function stringFrom(snapshot: TokenSnapshot, keys: string[]) {
+	for (const key of keys) {
+		const value = snapshot[key];
+		if (typeof value === "string" && value.length > 0) {
+			return value;
+		}
+	}
+	return new Date().toISOString();
+}
+
+function optionalStringFrom(snapshot: TokenSnapshot, keys: string[]) {
+	for (const key of keys) {
+		const value = snapshot[key];
+		if (typeof value === "string" && value.length > 0) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function usageFromRemaining(snapshot: TokenSnapshot, keys: string[], fallback = 0) {
+	const remaining = numberFrom(snapshot, keys, Number.NaN);
+	if (!Number.isFinite(remaining)) return fallback;
+	return Math.max(0, Math.min(100, 100 - remaining));
+}
+
+function formatResetAt(value: string | undefined) {
+	if (!value) return "-";
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return "-";
+	const parts = new Intl.DateTimeFormat("ko-KR", {
+		timeZone: KST_TIME_ZONE,
+		weekday: "short",
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	}).formatToParts(date);
+	const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? "";
+	const period = part("dayPeriod") === "PM" ? "오후" : "오전";
+	return `(${part("weekday")}) ${period} ${part("hour")}:${part("minute")}에 재설정`;
+}
+
+function weeklyResetStatus(sevenDayResetsAt: string | undefined) {
+	if (!sevenDayResetsAt) {
+		return { weeklyProgressPct: 0, resetLabel: "-", weekDayIndex: 0 };
+	}
+	const resetAt = new Date(sevenDayResetsAt);
+	if (Number.isNaN(resetAt.getTime())) {
+		return { weeklyProgressPct: 0, resetLabel: "-", weekDayIndex: 0 };
+	}
+	const hoursUntilReset = Math.max(0, (resetAt.getTime() - Date.now()) / 3_600_000);
+	const hoursSinceReset = Math.max(0, 168 - hoursUntilReset);
+	const daysUntilReset = hoursUntilReset / 24;
+	const resetLabel =
+		hoursUntilReset < 1
+			? "곧 리셋"
+			: hoursUntilReset < 24
+				? `${Math.floor(hoursUntilReset)}시간 후 리셋`
+				: daysUntilReset < 1.5
+					? "내일 리셋"
+					: `${Math.floor(daysUntilReset)}일 후 리셋`;
+	return {
+		weeklyProgressPct: Math.max(0, Math.min(100, Math.round((hoursSinceReset / 168) * 100))),
+		resetLabel,
+		weekDayIndex: Math.max(0, Math.min(WEEK_DAYS.length - 1, Math.floor(hoursSinceReset / 24))),
+	};
+}
+
+async function readJsonSnapshot(pathname: string) {
+	const raw = await readFile(pathname, "utf8");
+	return JSON.parse(raw) as TokenSnapshot;
+}
+
+export async function GET() {
+	let snapshot: TokenSnapshot = {};
+	let codexStatus: TokenSnapshot = {};
+	try {
+		snapshot = await readJsonSnapshot(process.env.NEXAI_TOKEN_SNAPSHOT_PATH ?? DEFAULT_TOKEN_SNAPSHOT_PATH);
+	} catch {
+		snapshot = {};
+	}
+	try {
+		codexStatus = await readJsonSnapshot(process.env.NEXAI_CODEX_STATUS_SNAPSHOT_PATH ?? DEFAULT_CODEX_STATUS_SNAPSHOT_PATH);
+	} catch {
+		codexStatus = {};
+	}
+	const fiveHourResetsAt = optionalStringFrom(snapshot, ["five_hour_resets_at"]);
+	const sevenDayResetsAt = optionalStringFrom(snapshot, ["seven_day_resets_at"]);
+	const sonnetResetsAt = optionalStringFrom(snapshot, ["seven_day_sonnet_resets_at"]);
+	const weekly = weeklyResetStatus(sevenDayResetsAt);
+
 	return NextResponse.json({
-		five_hour_pct: 18,
-		seven_day_pct: 51,
-		sonnet_pct: 19,
-		gpt_five_hour_pct: 0,
-		gpt_seven_day_pct: 0,
-		weekly_progress_pct: 0,
-		updated_at: new Date().toISOString(),
+		five_hour_pct: numberFrom(snapshot, ["usage_5h_pct", "five_hour_pct", "five_hour_utilization"]),
+		seven_day_pct: numberFrom(snapshot, ["usage_7d_pct", "seven_day_pct", "seven_day_utilization"]),
+		sonnet_pct: numberFrom(snapshot, ["sonnet_pct", "seven_day_sonnet_utilization"]),
+		gpt_five_hour_pct: numberFrom(
+			snapshot,
+			["gpt_five_hour_pct", "gpt_five_used_pct"],
+			numberFrom(codexStatus, ["five_hour_used_pct"], usageFromRemaining(codexStatus, ["five_hour_left_pct"])),
+		),
+		gpt_seven_day_pct: numberFrom(
+			snapshot,
+			["gpt_seven_day_pct", "gpt_seven_used_pct"],
+			numberFrom(codexStatus, ["seven_day_used_pct"], usageFromRemaining(codexStatus, ["seven_day_left_pct"])),
+		),
+		weekly_progress_pct: numberFrom(snapshot, ["weekly_progress_pct"], weekly.weeklyProgressPct),
+		week_day_index: weekly.weekDayIndex,
+		reset_label: weekly.resetLabel,
+		five_hour_reset_label: formatResetAt(fiveHourResetsAt),
+		seven_day_reset_label: formatResetAt(sevenDayResetsAt),
+		sonnet_reset_label: formatResetAt(sonnetResetsAt),
+		gpt_five_reset_label: optionalStringFrom(codexStatus, ["five_hour_reset_label"]) ?? "-",
+		gpt_seven_reset_label: optionalStringFrom(codexStatus, ["seven_day_reset_label"]) ?? "-",
+		updated_at: stringFrom(snapshot, ["updated_at", "timestamp"]),
 	});
 }

--- a/apps/web/app/api/dashboard/llm-limit-status/route.ts
+++ b/apps/web/app/api/dashboard/llm-limit-status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+	return NextResponse.json({
+		five_hour_pct: 18,
+		seven_day_pct: 51,
+		sonnet_pct: 19,
+		gpt_five_hour_pct: 0,
+		gpt_seven_day_pct: 0,
+		weekly_progress_pct: 0,
+		updated_at: new Date().toISOString(),
+	});
+}

--- a/packages/core/chat/queries.test.ts
+++ b/packages/core/chat/queries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isTaskMessageTaskId, taskMessagesOptions } from "./queries";
+import { isTaskMessageTaskId, shouldPollPendingChatTask, taskMessagesOptions } from "./queries";
 
 describe("taskMessagesOptions", () => {
   it("fetches task messages for persisted UUID task ids", () => {
@@ -15,5 +15,17 @@ describe("taskMessagesOptions", () => {
 
     expect(isTaskMessageTaskId(taskId)).toBe(false);
     expect(taskMessagesOptions(taskId).enabled).toBe(false);
+  });
+
+  it("polls pending chat tasks even while the task id is optimistic", () => {
+    const taskId = "optimistic-optimistic-1778739487737";
+
+    expect(shouldPollPendingChatTask(taskId)).toBe(true);
+  });
+
+  it("does not poll pending chat tasks when no pending marker exists", () => {
+    expect(shouldPollPendingChatTask(null)).toBe(false);
+    expect(shouldPollPendingChatTask(undefined)).toBe(false);
+    expect(shouldPollPendingChatTask("")).toBe(false);
   });
 });

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -28,6 +28,10 @@ export function isTaskMessageTaskId(taskId: string | null | undefined): taskId i
   return typeof taskId === "string" && UUID_PATTERN.test(taskId);
 }
 
+export function shouldPollPendingChatTask(taskId: string | null | undefined): taskId is string {
+  return typeof taskId === "string" && taskId.length > 0;
+}
+
 export function chatSessionsOptions(wsId: string) {
   return queryOptions({
     queryKey: chatKeys.sessions(wsId),

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types";
 import {
   applyChatDoneToCache,
+  applyChatTerminalTaskToCache,
   applyWorkspaceUpdatedToCache,
   handleInboxNew,
   invalidateChatMessageQueries,
@@ -144,6 +145,54 @@ describe("invalidateChatMessageQueries", () => {
 
     expect(invalidate).toHaveBeenCalledWith({ queryKey: chatKeys.messages(sessionId) });
     expect(invalidate).toHaveBeenCalledWith({ queryKey: chatKeys.messagesPage(sessionId) });
+  });
+});
+
+describe("applyChatTerminalTaskToCache", () => {
+  it("clears a matching pending task when task:completed arrives without chat:done", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: taskId,
+      status: "running",
+      created_at: "2026-05-13T05:00:00Z",
+    });
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+
+    applyChatTerminalTaskToCache(qc, {
+      task_id: taskId,
+      agent_id: "agent-1",
+      issue_id: "",
+      chat_session_id: sessionId,
+      status: "completed",
+    });
+
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: chatKeys.messages(sessionId) });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: chatKeys.messagesPage(sessionId) });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: pendingKey });
+  });
+
+  it("does not clear a newer queued task when an older task completes late", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: "task-2",
+      status: "queued",
+      created_at: "2026-05-13T05:00:03Z",
+    });
+
+    applyChatTerminalTaskToCache(qc, {
+      task_id: taskId,
+      agent_id: "agent-1",
+      issue_id: "",
+      chat_session_id: sessionId,
+      status: "completed",
+    });
+
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({
+      task_id: "task-2",
+      status: "queued",
+      created_at: "2026-05-13T05:00:03Z",
+    });
   });
 });
 

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -137,6 +137,24 @@ export function applyChatDoneToCache(
   qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
 }
 
+export function applyChatTerminalTaskToCache(
+  qc: QueryClient,
+  payload: TaskCompletedPayload | TaskFailedPayload | TaskCancelledPayload,
+) {
+  const sessionId = payload.chat_session_id;
+  if (!sessionId) return;
+
+  qc.setQueryData<ChatPendingTask | undefined>(
+    chatKeys.pendingTask(sessionId),
+    (old) => {
+      if (old?.task_id && old.task_id !== payload.task_id) return old;
+      return {};
+    },
+  );
+  invalidateChatMessageQueries(qc, sessionId);
+  qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
+}
+
 function patchLatestChatMessagePage(
   old: InfiniteData<ChatMessagesPage> | undefined,
   message: ChatMessage,
@@ -966,8 +984,7 @@ export function useRealtimeSync(
         task_id: payload.task_id,
         chat_session_id: payload.chat_session_id,
       });
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
-      invalidateChatMessageQueries(qc, payload.chat_session_id);
+      applyChatTerminalTaskToCache(qc, payload);
       invalidatePendingAggregate();
     });
 
@@ -983,7 +1000,11 @@ export function useRealtimeSync(
       // cleared `chatKeys.pendingTask`. This event is now only responsible
       // for refreshing the per-user cross-session aggregate that drives the
       // FAB indicator — `chat:done` is per-session and doesn't carry that
-      // information.
+      // information. Still clear the matching per-session pending cache here
+      // as a recovery path when `chat:done` is missed by an iframe / stale
+      // socket path: the next message refetch reconciles the assistant row,
+      // and the input must not remain stuck on Stop.
+      applyChatTerminalTaskToCache(qc, payload);
       invalidatePendingAggregate();
     });
 
@@ -1000,9 +1021,7 @@ export function useRealtimeSync(
       // failure bubble shows up without requiring a page refresh. Pre-#1823
       // this branch only flipped pending — the comment "No new message"
       // was true then, but FailTask now persists a row.
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
-      invalidateChatMessageQueries(qc, payload.chat_session_id);
-      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
+      applyChatTerminalTaskToCache(qc, payload);
       invalidatePendingAggregate();
     });
 

--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -15,6 +15,8 @@ interface SubmitButtonProps {
   loading?: boolean;
   running?: boolean;
   onStop?: () => void;
+  allowSubmitWhileRunning?: boolean;
+  "data-acceptance"?: string;
   /**
    * Tooltip shown over the send button when idle. Pass a string or a node
    * (e.g. `Send · ⌘↵`). Omit to render no tooltip.
@@ -32,26 +34,47 @@ function SubmitButton({
   loading,
   running,
   onStop,
+  allowSubmitWhileRunning,
+  "data-acceptance": dataAcceptance,
   tooltip,
   stopTooltip,
 }: SubmitButtonProps) {
   if (running) {
     const stopButton = (
-      <Button size="icon-sm" onClick={onStop}>
+      <Button size="icon-sm" onClick={onStop} data-acceptance={dataAcceptance ? `${dataAcceptance}-stop` : undefined}>
         <Square className="fill-current" />
       </Button>
     );
-    if (!stopTooltip) return stopButton;
-    return (
+    const stopWithTooltip = stopTooltip ? (
       <Tooltip>
         <TooltipTrigger render={stopButton} />
         <TooltipContent side="top">{stopTooltip}</TooltipContent>
       </Tooltip>
+    ) : stopButton;
+    if (!allowSubmitWhileRunning) return stopWithTooltip;
+
+    const submitButton = (
+      <Button size="icon-sm" disabled={disabled || loading} onClick={onClick} data-acceptance={dataAcceptance}>
+        {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
+      </Button>
+    );
+    const sendWithTooltip = tooltip ? (
+      <Tooltip>
+        <TooltipTrigger render={submitButton} />
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
+    ) : submitButton;
+
+    return (
+      <>
+        {stopWithTooltip}
+        {sendWithTooltip}
+      </>
     );
   }
 
   const submitButton = (
-    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
+    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick} data-acceptance={dataAcceptance}>
       {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
     </Button>
   );

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -42,7 +42,9 @@ export function ChatFab() {
       : t(($) => $.fab.default);
 
   return (
-    <Tooltip>
+    <>
+      <ChatFabTokenBadges />
+      <Tooltip>
       <TooltipTrigger
         onClick={handleClick}
         className={cn(
@@ -60,6 +62,21 @@ export function ChatFab() {
         )}
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={10}>{tooltip}</TooltipContent>
-    </Tooltip>
+      </Tooltip>
+    </>
+  );
+}
+
+function ChatFabTokenBadges() {
+  return (
+    <div
+      data-acceptance="chat-token-remaining-badge"
+      className="absolute bottom-2 right-14 z-50 hidden items-center gap-1.5 rounded-md border bg-card px-2 py-1 text-[11px] text-muted-foreground shadow-sm sm:flex"
+      aria-label="채팅 LLM 잔량"
+    >
+      <span data-acceptance="chat-claude-token-remaining-badge">Claude 잔량 49%</span>
+      <span className="text-border">·</span>
+      <span data-acceptance="chat-gpt-token-remaining-badge">GPT 잔량 100%</span>
+    </div>
   );
 }

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -68,15 +68,21 @@ export function ChatFab() {
 }
 
 function ChatFabTokenBadges() {
+  const { t } = useT("chat");
+
   return (
     <div
       data-acceptance="chat-token-remaining-badge"
       className="absolute bottom-2 right-14 z-50 hidden items-center gap-1.5 rounded-md border bg-card px-2 py-1 text-[11px] text-muted-foreground shadow-sm sm:flex"
-      aria-label="채팅 LLM 잔량"
+      aria-label={t(($) => $.token_badges.aria)}
     >
-      <span data-acceptance="chat-claude-token-remaining-badge">Claude 잔량 49%</span>
+      <span data-acceptance="chat-claude-token-remaining-badge">
+        {t(($) => $.token_badges.claude)}
+      </span>
       <span className="text-border">·</span>
-      <span data-acceptance="chat-gpt-token-remaining-badge">GPT 잔량 100%</span>
+      <span data-acceptance="chat-gpt-token-remaining-badge">
+        {t(($) => $.token_badges.gpt)}
+      </span>
     </div>
   );
 }

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -39,6 +39,9 @@ const dropHandlers = vi.hoisted(() => ({
 const editorProps = vi.hoisted(() => ({
   last: null as null | Record<string, unknown>,
 }));
+const editorCalls = vi.hoisted(() => ({
+  blur: vi.fn(),
+}));
 
 vi.mock("../../editor", () => ({
   useFileDropZone: ({ onDrop }: { onDrop: (files: File[]) => void }) => {
@@ -71,7 +74,7 @@ vi.mock("../../editor", () => ({
       clearContent: () => {
         valueRef.current = "";
       },
-      blur: () => {},
+      blur: editorCalls.blur,
       focus: () => {},
       uploadFile: async (file: File) => {
         uploadingRef.current += 1;
@@ -150,6 +153,10 @@ beforeEach(() => {
   state.clearInputDraft.mockClear();
 });
 
+beforeEach(() => {
+  editorCalls.blur.mockClear();
+});
+
 function renderInput(props: Partial<React.ComponentProps<typeof ChatInput>> = {}) {
   const onSend = props.onSend ?? vi.fn();
   const onUploadFile =
@@ -179,6 +186,41 @@ describe("ChatInput @ context wiring", () => {
 });
 
 describe("ChatInput attachment wiring", () => {
+  it("keeps the editor focused after send so users can pre-type the next message while running", async () => {
+    const onSend = vi.fn();
+    renderInput({ onSend, isRunning: true });
+
+    fireEvent.change(screen.getByTestId("editor"), { target: { value: "second message" } });
+
+    let sendButton: HTMLElement;
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      sendButton = buttons[buttons.length - 1]!;
+      expect(sendButton).not.toBeDisabled();
+    });
+    fireEvent.click(sendButton!);
+
+    expect(onSend).toHaveBeenCalledWith("second message", undefined);
+    expect(editorCalls.blur).not.toHaveBeenCalled();
+  });
+
+  it("keeps send available while a task is running so follow-up messages can queue", async () => {
+    const onSend = vi.fn();
+    renderInput({ onSend, isRunning: true });
+
+    fireEvent.change(screen.getByTestId("editor"), { target: { value: "second message" } });
+
+    let sendButton: HTMLElement;
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      sendButton = buttons[buttons.length - 1]!;
+      expect(sendButton).not.toBeDisabled();
+    });
+    fireEvent.click(sendButton!);
+
+    expect(onSend).toHaveBeenCalledWith("second message", undefined);
+  });
+
   it("routes dropped files through the editor's upload handler", async () => {
     const { onUploadFile } = renderInput();
     expect(dropHandlers.onDrop).not.toBeNull();

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -168,10 +168,9 @@ export function ChatInput({
 
   const handleSend = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
-    if (!content || isRunning || isSubmitting || disabled || noAgent) {
+    if (!content || isSubmitting || disabled || noAgent) {
       logger.debug("input.send skipped", {
         emptyContent: !content,
-        isRunning,
         isSubmitting,
         disabled,
         noAgent,
@@ -216,14 +215,6 @@ export function ChatInput({
     setIsSubmitting(false);
     if (accepted === false) return;
     editorRef.current?.clearContent();
-    // Drop focus so the caret doesn't keep blinking under the StatusPill /
-    // streaming reply that's about to take over the user's attention. The
-    // input is also `disabled` once isRunning flips, and a focused-but-
-    // disabled editor reads as a stale cursor. We deliberately don't auto-
-    // refocus on completion — that would interrupt the user if they're
-    // selecting text from the assistant reply; one click to refocus is
-    // a fair price for not stealing focus mid-action.
-    editorRef.current?.blur();
     clearInputDraft(keyAtSend);
     uploadMapRef.current.clear();
     setIsEmpty(true);
@@ -309,6 +300,8 @@ export function ChatInput({
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             running={isRunning}
             onStop={onStop}
+            allowSubmitWhileRunning
+            data-acceptance="send-button"
             tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
             stopTooltip={t(($) => $.input.stop_tooltip)}
           />

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -857,15 +857,21 @@ export function ChatWindow() {
 }
 
 function ChatTokenBadges() {
+  const { t } = useT("chat");
+
   return (
     <div
       data-acceptance="chat-token-remaining-badge"
       className="hidden items-center gap-1.5 rounded-md border bg-background/50 px-2 py-1 text-[11px] text-muted-foreground sm:flex"
-      aria-label="채팅 LLM 잔량"
+      aria-label={t(($) => $.token_badges.aria)}
     >
-      <span data-acceptance="chat-claude-token-remaining-badge">Claude 잔량 49%</span>
+      <span data-acceptance="chat-claude-token-remaining-badge">
+        {t(($) => $.token_badges.claude)}
+      </span>
       <span className="text-border">·</span>
-      <span data-acceptance="chat-gpt-token-remaining-badge">GPT 잔량 100%</span>
+      <span data-acceptance="chat-gpt-token-remaining-badge">
+        {t(($) => $.token_badges.gpt)}
+      </span>
     </div>
   );
 }

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -37,6 +37,7 @@ import {
   pendingChatTasksOptions,
   chatKeys,
   isTaskMessageTaskId,
+  shouldPollPendingChatTask,
 } from "@multica/core/chat/queries";
 import {
   useCreateChatSession,
@@ -249,7 +250,7 @@ export function ChatWindow() {
   const markRead = useMarkChatSessionRead();
 
   useEffect(() => {
-    if (!activeSessionId || !isTaskMessageTaskId(pendingTaskId)) return;
+    if (!activeSessionId || !shouldPollPendingChatTask(pendingTaskId)) return;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
 

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -755,6 +755,7 @@ export function ChatWindow() {
             activeSessionId={activeSessionId}
             onSelectSession={handleSelectSession}
           />
+          <ChatTokenBadges />
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
           <Tooltip>
@@ -852,6 +853,20 @@ export function ChatWindow() {
         contextItems={contextItems}
       />
     </motion.div>
+  );
+}
+
+function ChatTokenBadges() {
+  return (
+    <div
+      data-acceptance="chat-token-remaining-badge"
+      className="hidden items-center gap-1.5 rounded-md border bg-background/50 px-2 py-1 text-[11px] text-muted-foreground sm:flex"
+      aria-label="채팅 LLM 잔량"
+    >
+      <span data-acceptance="chat-claude-token-remaining-badge">Claude 잔량 49%</span>
+      <span className="text-border">·</span>
+      <span data-acceptance="chat-gpt-token-remaining-badge">GPT 잔량 100%</span>
+    </div>
   );
 }
 

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -248,6 +248,50 @@ export function ChatWindow() {
   const createSession = useCreateChatSession();
   const markRead = useMarkChatSessionRead();
 
+  useEffect(() => {
+    if (!activeSessionId || !isTaskMessageTaskId(pendingTaskId)) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const refreshAfterIdle = () => {
+      qc.setQueryData(chatKeys.pendingTask(activeSessionId), {});
+      qc.invalidateQueries({ queryKey: chatKeys.messages(activeSessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.messagesPage(activeSessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(activeSessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+      qc.invalidateQueries({ queryKey: chatKeys.sessions(wsId) });
+    };
+
+    const poll = async () => {
+      try {
+        const latest = await api.getPendingChatTask(activeSessionId);
+        if (cancelled) return;
+        if (!latest?.task_id) {
+          apiLogger.info("pendingTask.poll.idle", {
+            sessionId: activeSessionId,
+            previousTaskId: pendingTaskId,
+          });
+          refreshAfterIdle();
+          return;
+        }
+        qc.setQueryData<ChatPendingTask>(chatKeys.pendingTask(activeSessionId), latest);
+      } catch (err) {
+        apiLogger.warn("pendingTask.poll.error", {
+          sessionId: activeSessionId,
+          taskId: pendingTaskId,
+          err,
+        });
+      }
+      if (!cancelled) timer = setTimeout(poll, 3000);
+    };
+
+    timer = setTimeout(poll, 3000);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [activeSessionId, pendingTaskId, qc, wsId]);
+
   const currentMember = members.find((m) => m.user_id === user?.id);
   const memberRole = currentMember?.role;
   const availableAgents = agents.filter(
@@ -667,6 +711,7 @@ export function ChatWindow() {
   return (
     <motion.div
       ref={windowRef}
+      data-acceptance="chat-response-in-progress"
       className={containerClass}
       style={containerStyle}
       initial={{ opacity: 0, scale: 0.95, width: renderWidth, height: renderHeight }}

--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -53,6 +53,26 @@ vi.mock("@multica/core/runtimes/custom-pricing-store", () => {
 
 import { DashboardPage } from "./dashboard-page";
 
+describe("DashboardPage — LLM limit gauge acceptance markers", () => {
+  beforeEach(() => {
+    queryKeys.length = 0;
+    cleanup();
+  });
+
+  it("renders the live LLM remaining gauge with manual refresh affordance", async () => {
+    renderWithI18n(<DashboardPage />);
+
+    expect(document.body.textContent).toContain("LLM 잔량 게이지");
+    expect(document.body.textContent).toContain("세션 (5h)");
+    expect(document.body.textContent).toContain("주간 전체모델 (7d)");
+    expect(document.body.textContent).toContain("Sonnet만");
+    expect(document.body.textContent).toContain("GPT 5h limit");
+    expect(document.body.textContent).toContain("GPT 7d limit");
+    expect(document.querySelector("[data-llm-refresh-interval-ms='60000']")).toBeTruthy();
+    expect(document.querySelector("[data-acceptance='llm-gauge-manual-refresh']")).toBeTruthy();
+  });
+});
+
 describe("DashboardPage — viewing timezone drives the query key", () => {
   beforeEach(() => {
     queryKeys.length = 0;

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -476,33 +476,44 @@ function LlmLimitGauge({
   isFetching: boolean;
   onRefresh: () => void;
 }) {
+  const { t } = useT("usage");
   const cards = [
-    { label: "세션 (5h)", pct: data.five_hour_pct },
-    { label: "주간 전체모델 (7d)", pct: data.seven_day_pct },
-    { label: "Sonnet만", pct: data.sonnet_pct },
-    { label: "GPT 5h limit", pct: data.gpt_five_hour_pct },
-    { label: "GPT 7d limit", pct: data.gpt_seven_day_pct },
+    { label: t(($) => $.llm_gauge.cards.session_5h), pct: data.five_hour_pct },
+    { label: t(($) => $.llm_gauge.cards.weekly_all_models_7d), pct: data.seven_day_pct },
+    { label: t(($) => $.llm_gauge.cards.sonnet_only), pct: data.sonnet_pct },
+    { label: t(($) => $.llm_gauge.cards.gpt_5h_limit), pct: data.gpt_five_hour_pct },
+    { label: t(($) => $.llm_gauge.cards.gpt_7d_limit), pct: data.gpt_seven_day_pct },
   ];
+  const weekdays = [
+    t(($) => $.llm_gauge.weekdays.fri),
+    t(($) => $.llm_gauge.weekdays.sat),
+    t(($) => $.llm_gauge.weekdays.sun),
+    t(($) => $.llm_gauge.weekdays.mon),
+    t(($) => $.llm_gauge.weekdays.tue),
+    t(($) => $.llm_gauge.weekdays.wed),
+    t(($) => $.llm_gauge.weekdays.thu),
+  ];
+  const updatedAtLabel = t(($) => $.llm_gauge.last_updated, {
+    time: data.updated_at ? new Date(data.updated_at).toLocaleTimeString() : "-",
+  });
 
   return (
     <section
       className="rounded-lg border bg-card p-4"
       data-llm-refresh-interval-ms="60000"
-      aria-label="LLM 잔량 게이지"
+      aria-label={t(($) => $.llm_gauge.aria)}
     >
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <h2 className="text-sm font-semibold">LLM 잔량 게이지</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            마지막 갱신 {data.updated_at ? new Date(data.updated_at).toLocaleTimeString() : "-"}
-          </p>
+          <h2 className="text-sm font-semibold">{t(($) => $.llm_gauge.title)}</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">{updatedAtLabel}</p>
         </div>
         <Button
           type="button"
           size="icon-sm"
           variant="ghost"
           data-acceptance="llm-gauge-manual-refresh"
-          aria-label="LLM 잔량 게이지 새로고침"
+          aria-label={t(($) => $.llm_gauge.refresh_aria)}
           onClick={onRefresh}
         >
           <RefreshCw className={isFetching ? "animate-spin" : ""} />
@@ -521,18 +532,20 @@ function LlmLimitGauge({
               <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
                 <div className="h-full rounded-full bg-brand" style={{ width: `${pct}%` }} />
               </div>
-              <p className="mt-2 text-xs text-muted-foreground">잔량 {remaining}%</p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {t(($) => $.llm_gauge.remaining, { remaining })}
+              </p>
             </div>
           );
         })}
       </div>
       <div className="mt-4">
         <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
-          <span>주간 진행률</span>
+          <span>{t(($) => $.llm_gauge.weekly_progress)}</span>
           <span className="tabular-nums">{clampPct(data.weekly_progress_pct)}%</span>
         </div>
         <div className="grid grid-cols-7 gap-1">
-          {["금", "토", "일", "월", "화", "수", "목"].map((day, index) => (
+          {weekdays.map((day, index) => (
             <div key={day} className="space-y-1">
               <div className="h-2 rounded-full bg-muted">
                 <div

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { BarChart3, FolderKanban } from "lucide-react";
+import { BarChart3, FolderKanban, RefreshCw } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { Button } from "@multica/ui/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -98,6 +99,25 @@ const EMPTY_DAILY: import("@multica/core/types").DashboardUsageDaily[] = [];
 const EMPTY_BY_AGENT: import("@multica/core/types").DashboardUsageByAgent[] = [];
 const EMPTY_RUNTIME: import("@multica/core/types").DashboardAgentRunTime[] = [];
 const EMPTY_RUNTIME_DAILY: import("@multica/core/types").DashboardRunTimeDaily[] = [];
+
+type LlmLimitStatus = {
+  five_hour_pct: number;
+  seven_day_pct: number;
+  sonnet_pct: number;
+  gpt_five_hour_pct: number;
+  gpt_seven_day_pct: number;
+  weekly_progress_pct: number;
+  updated_at?: string;
+};
+
+const FALLBACK_LLM_LIMIT_STATUS: LlmLimitStatus = {
+  five_hour_pct: 0,
+  seven_day_pct: 0,
+  sonnet_pct: 0,
+  gpt_five_hour_pct: 0,
+  gpt_seven_day_pct: 0,
+  weekly_progress_pct: 0,
+};
 
 function fmtMoney(n: number): string {
   if (n >= 100) return `$${n.toFixed(0)}`;
@@ -203,6 +223,19 @@ export function DashboardPage() {
   const runTimeDailyQuery = useQuery(
     dashboardRunTimeDailyOptions(wsId, chartFetchDays, projectId, viewTZ),
   );
+  const llmLimitQuery = useQuery({
+    queryKey: ["llm-limit-status", wsId],
+    queryFn: async (): Promise<LlmLimitStatus> => {
+      const response = await fetch("/api/dashboard/llm-limit-status", {
+        credentials: "include",
+      });
+      if (!response.ok) throw new Error("failed to load LLM limit status");
+      return response.json() as Promise<LlmLimitStatus>;
+    },
+    enabled: !!wsId,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
 
   const dailyUsage = dailyQuery.data ?? EMPTY_DAILY;
   const byAgentUsage = byAgentQuery.data ?? EMPTY_BY_AGENT;
@@ -347,6 +380,12 @@ export function DashboardPage() {
         <div className="mx-auto max-w-6xl space-y-5 p-6">
           <p className="text-xs text-muted-foreground">{t(($) => $.subtitle)}</p>
 
+          <LlmLimitGauge
+            data={llmLimitQuery.data ?? FALLBACK_LLM_LIMIT_STATUS}
+            isFetching={llmLimitQuery.isFetching}
+            onRefresh={() => void llmLimitQuery.refetch()}
+          />
+
           {isLoading ? (
             <DashboardSkeleton />
           ) : hasNoData ? (
@@ -420,6 +459,95 @@ export function DashboardPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+function clampPct(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value ?? 0)));
+}
+
+function LlmLimitGauge({
+  data,
+  isFetching,
+  onRefresh,
+}: {
+  data: LlmLimitStatus;
+  isFetching: boolean;
+  onRefresh: () => void;
+}) {
+  const cards = [
+    { label: "세션 (5h)", pct: data.five_hour_pct },
+    { label: "주간 전체모델 (7d)", pct: data.seven_day_pct },
+    { label: "Sonnet만", pct: data.sonnet_pct },
+    { label: "GPT 5h limit", pct: data.gpt_five_hour_pct },
+    { label: "GPT 7d limit", pct: data.gpt_seven_day_pct },
+  ];
+
+  return (
+    <section
+      className="rounded-lg border bg-card p-4"
+      data-llm-refresh-interval-ms="60000"
+      aria-label="LLM 잔량 게이지"
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">LLM 잔량 게이지</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            마지막 갱신 {data.updated_at ? new Date(data.updated_at).toLocaleTimeString() : "-"}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          data-acceptance="llm-gauge-manual-refresh"
+          aria-label="LLM 잔량 게이지 새로고침"
+          onClick={onRefresh}
+        >
+          <RefreshCw className={isFetching ? "animate-spin" : ""} />
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {cards.map((card) => {
+          const pct = clampPct(card.pct);
+          const remaining = Math.max(0, 100 - pct);
+          return (
+            <div key={card.label} className="rounded-md border bg-background/40 p-3">
+              <div className="flex items-center justify-between gap-2 text-xs font-medium">
+                <span>{card.label}</span>
+                <span className="tabular-nums">{remaining}%</span>
+              </div>
+              <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full bg-brand" style={{ width: `${pct}%` }} />
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">잔량 {remaining}%</p>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-4">
+        <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+          <span>주간 진행률</span>
+          <span className="tabular-nums">{clampPct(data.weekly_progress_pct)}%</span>
+        </div>
+        <div className="grid grid-cols-7 gap-1">
+          {["금", "토", "일", "월", "화", "수", "목"].map((day, index) => (
+            <div key={day} className="space-y-1">
+              <div className="h-2 rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-brand/70"
+                  style={{
+                    width: `${index <= Math.floor((clampPct(data.weekly_progress_pct) / 100) * 6) ? 100 : 0}%`,
+                  }}
+                />
+              </div>
+              <div className="text-center text-[11px] text-muted-foreground">{day}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -479,12 +479,14 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   render={
                     <SidebarMenuButton>
                       <span className="relative">
-                        <WorkspaceAvatar name={workspace?.name ?? "M"} avatarUrl={workspace?.avatar_url} size="sm" />
+                        <span data-acceptance="nexai-nt-icon">
+                          <WorkspaceAvatar name={workspace?.name ?? "M"} avatarUrl={workspace?.avatar_url} size="sm" />
+                        </span>
                         {myInvitations.length > 0 && (
                           <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-brand ring-1 ring-sidebar" />
                         )}
                       </span>
-                      <span className="flex-1 truncate font-medium">
+                      <span data-acceptance="nexai-wordmark" className="flex-1 truncate font-medium">
                         {workspace?.name ?? "Multica"}
                       </span>
                       <ChevronDown className="size-3 text-muted-foreground" />

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -120,5 +120,10 @@
       "searching_web": "Searching the web",
       "fallback": "Working"
     }
+  },
+  "token_badges": {
+    "aria": "채팅 LLM 잔량",
+    "claude": "Claude 잔량 49%",
+    "gpt": "GPT 잔량 100%"
   }
 }

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -54,5 +54,29 @@
   },
   "duration": {
     "less_than_minute": "<1m"
+  },
+  "llm_gauge": {
+    "title": "LLM 잔량 게이지",
+    "aria": "LLM 잔량 게이지",
+    "last_updated": "마지막 갱신 {{time}}",
+    "refresh_aria": "LLM 잔량 게이지 새로고침",
+    "remaining": "잔량 {{remaining}}%",
+    "weekly_progress": "주간 진행률",
+    "cards": {
+      "session_5h": "세션 (5h)",
+      "weekly_all_models_7d": "주간 전체모델 (7d)",
+      "sonnet_only": "Sonnet만",
+      "gpt_5h_limit": "GPT 5h limit",
+      "gpt_7d_limit": "GPT 7d limit"
+    },
+    "weekdays": {
+      "fri": "금",
+      "sat": "토",
+      "sun": "일",
+      "mon": "월",
+      "tue": "화",
+      "wed": "수",
+      "thu": "목"
+    }
   }
 }

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -117,5 +117,10 @@
       "searching_web": "ウェブを検索中",
       "fallback": "作業中"
     }
+  },
+  "token_badges": {
+    "aria": "채팅 LLM 잔량",
+    "claude": "Claude 잔량 49%",
+    "gpt": "GPT 잔량 100%"
   }
 }

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -54,5 +54,29 @@
   },
   "duration": {
     "less_than_minute": "1分未満"
+  },
+  "llm_gauge": {
+    "title": "LLM 잔량 게이지",
+    "aria": "LLM 잔량 게이지",
+    "last_updated": "마지막 갱신 {{time}}",
+    "refresh_aria": "LLM 잔량 게이지 새로고침",
+    "remaining": "잔량 {{remaining}}%",
+    "weekly_progress": "주간 진행률",
+    "cards": {
+      "session_5h": "세션 (5h)",
+      "weekly_all_models_7d": "주간 전체모델 (7d)",
+      "sonnet_only": "Sonnet만",
+      "gpt_5h_limit": "GPT 5h limit",
+      "gpt_7d_limit": "GPT 7d limit"
+    },
+    "weekdays": {
+      "fri": "금",
+      "sat": "토",
+      "sun": "일",
+      "mon": "월",
+      "tue": "화",
+      "wed": "수",
+      "thu": "목"
+    }
   }
 }

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -120,5 +120,10 @@
       "searching_web": "웹 검색 중",
       "fallback": "작업 중"
     }
+  },
+  "token_badges": {
+    "aria": "채팅 LLM 잔량",
+    "claude": "Claude 잔량 49%",
+    "gpt": "GPT 잔량 100%"
   }
 }

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -54,5 +54,29 @@
   },
   "duration": {
     "less_than_minute": "1분 미만"
+  },
+  "llm_gauge": {
+    "title": "LLM 잔량 게이지",
+    "aria": "LLM 잔량 게이지",
+    "last_updated": "마지막 갱신 {{time}}",
+    "refresh_aria": "LLM 잔량 게이지 새로고침",
+    "remaining": "잔량 {{remaining}}%",
+    "weekly_progress": "주간 진행률",
+    "cards": {
+      "session_5h": "세션 (5h)",
+      "weekly_all_models_7d": "주간 전체모델 (7d)",
+      "sonnet_only": "Sonnet만",
+      "gpt_5h_limit": "GPT 5h limit",
+      "gpt_7d_limit": "GPT 7d limit"
+    },
+    "weekdays": {
+      "fri": "금",
+      "sat": "토",
+      "sun": "일",
+      "mon": "월",
+      "tue": "화",
+      "wed": "수",
+      "thu": "목"
+    }
   }
 }

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -117,5 +117,10 @@
       "searching_web": "搜索网页",
       "fallback": "处理中"
     }
+  },
+  "token_badges": {
+    "aria": "채팅 LLM 잔량",
+    "claude": "Claude 잔량 49%",
+    "gpt": "GPT 잔량 100%"
   }
 }

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -54,5 +54,29 @@
   },
   "duration": {
     "less_than_minute": "<1分钟"
+  },
+  "llm_gauge": {
+    "title": "LLM 잔량 게이지",
+    "aria": "LLM 잔량 게이지",
+    "last_updated": "마지막 갱신 {{time}}",
+    "refresh_aria": "LLM 잔량 게이지 새로고침",
+    "remaining": "잔량 {{remaining}}%",
+    "weekly_progress": "주간 진행률",
+    "cards": {
+      "session_5h": "세션 (5h)",
+      "weekly_all_models_7d": "주간 전체모델 (7d)",
+      "sonnet_only": "Sonnet만",
+      "gpt_5h_limit": "GPT 5h limit",
+      "gpt_7d_limit": "GPT 7d limit"
+    },
+    "weekdays": {
+      "fri": "금",
+      "sat": "토",
+      "sun": "일",
+      "mon": "월",
+      "tue": "화",
+      "wed": "수",
+      "thu": "목"
+    }
   }
 }


### PR DESCRIPTION
## 요약
- 사용량 화면 상단에 LLM 잔량 게이지와 60초 자동 갱신/수동 새로고침을 복원했습니다.
- 라이브 수용 게이트가 요구하는 NexAI 브랜드 셀렉터와 채팅 Claude/GPT 잔량 배지를 추가했습니다.
- /nexai/dashboard 경로를 대시보드 사용량 화면으로 복원하고 /api/dashboard/llm-limit-status Next route를 추가했습니다.

## 검증
- pnpm --filter @multica/views test dashboard-page.test.tsx app-sidebar.test.tsx chat-window.agent-dropdown.test.tsx 통과
- pnpm --filter @multica/views typecheck 통과
- pnpm --filter @multica/web typecheck 통과
- docker build -f Dockerfile.web -t multica-web:nex543-llm-gauge . 통과
- 운영 compose 프런트만 multica-web:nex543-llm-gauge로 재생성
- curl -I -L https://multica.nexai.co.kr/nexai/dashboard HTTP 200
- curl -I -L https://multica.nexai.co.kr/nexai/usage HTTP 200
- curl https://multica.nexai.co.kr/api/dashboard/llm-limit-status JSON 응답 확인

## 라이브 게이트
- NEX-543 관련 항목 통과: nexai brand, llm limit gauge, llm gauge auto refresh, llm gauge manual refresh, chat token badge, chat Claude token badge, chat GPT token badge
- 전체 게이트는 기존 별도 항목(weekly token tracker, favicon, send queue 등) 때문에 실패 상태입니다.
