### PR TITLE
MUL-3360 feat(daemon): retry rate-limited tasks with exponential backoff

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1568,7 +1568,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	// blocking the FailTask handler: the backoff can be minutes long and
 	// we don't want to hold the HTTP handler goroutine open.
 	if reason == string(taskfailure.ReasonAgentProviderCapacityOrRateLimit) {
-		backoff := rateLimitBackoff(parent.Attempt)
+		backoff := rateLimitBackoff(parent.Attempt + 1)
 		slog.Info("task rate-limited, scheduling retry with backoff",
 			"task_id", util.UUIDToString(parent.ID),
 			"attempt", parent.Attempt,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1581,11 +1581,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		go func() {
 			timer := time.NewTimer(backoff)
 			defer timer.Stop()
-			select {
-			case <-bgCtx.Done():
-				return
-			case <-timer.C:
-			}
+			<-timer.C
 			child, err := qs.CreateRetryTask(bgCtx, parent.ID)
 			if err != nil {
 				slog.Warn("rate-limit retry failed",

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"sync"
@@ -1449,13 +1450,13 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// Auto-retry eligible failures (orphan, timeout, runtime_offline,
 	// runtime_recovery). The helper itself enforces attempt < max_attempts
 	// and only triggers for issue/chat tasks.
-	retried, _ := s.MaybeRetryFailedTask(ctx, task)
+	retried, retryScheduled, _ := s.MaybeRetryFailedTask(ctx, task)
 
-	// Skip the per-failure system comment when we'll immediately retry —
-	// the new task will surface its own status to the user, and we don't
-	// want to spam the issue with "task timed out" messages on every
-	// daemon hiccup.
-	if errMsg != "" && task.IssueID.Valid && retried == nil {
+	// Skip the per-failure system comment when a retry was scheduled
+	// (synchronously or deferred) — the new task will surface its own
+	// status to the user, and we don't want to spam the issue with
+	// "task timed out" messages on every daemon hiccup.
+	if errMsg != "" && task.IssueID.Valid && retried == nil && !retryScheduled {
 		s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(errMsg), "system", task.TriggerCommentID, task.ID)
 	}
 
@@ -1464,7 +1465,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// conversation history shows what happened. Skip when auto-retry is
 	// pending (the new attempt will write its own outcome) — same guard as
 	// the issue path above.
-	if task.ChatSessionID.Valid && retried == nil {
+	if task.ChatSessionID.Valid && retried == nil && !retryScheduled {
 		if _, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
 			ChatSessionID: task.ChatSessionID,
 			Role:          "assistant",
@@ -1488,7 +1489,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// requester so they can either retry or fall back to the advanced form
 	// without losing their original prompt. Skipped when an auto-retry is
 	// pending — the new attempt will write its own outcome.
-	if retried == nil {
+	if retried == nil && !retryScheduled {
 		if qc, ok := s.parseQuickCreateContext(task); ok {
 			s.notifyQuickCreateFailed(ctx, task, qc, errMsg)
 		}
@@ -1507,11 +1508,11 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
 var retryableReasons = map[string]bool{
-	"runtime_offline":                            true,
-	"runtime_recovery":                           true,
-	"timeout":                                    true,
-	"codex_semantic_inactivity":                  true,
 	"agent_error.provider_capacity_or_rate_limit": true,
+	"codex_semantic_inactivity":                   true,
+	"runtime_offline":                             true,
+	"runtime_recovery":                            true,
+	"timeout":                                     true,
 }
 
 func resumeUnsafeFailureReason(reason string) bool {
@@ -1531,20 +1532,22 @@ func resumeUnsafeFailureReason(reason string) bool {
 // max_attempts budget. The child task inherits agent/runtime/issue/chat
 // links and, for resume-safe failures, the parent's session_id/work_dir so
 // the agent can resume the conversation when the backend supports it. Returns
-// the new task, or nil when no retry was created.
+// the new task (nil when no retry was created), whether a retry was scheduled
+// (true for both synchronous and deferred/goroutine-based retries), and an
+// error.
 //
 // Autopilot tasks are NOT auto-retried here; the autopilot scheduler owns
 // its own re-run cadence and we don't want to double-fire it.
-func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentTaskQueue) (*db.AgentTaskQueue, error) {
+func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentTaskQueue) (*db.AgentTaskQueue, bool, error) {
 	if parent.Status != "failed" {
-		return nil, nil
+		return nil, false, nil
 	}
 	reason := ""
 	if parent.FailureReason.Valid {
 		reason = parent.FailureReason.String
 	}
 	if !retryableReasons[reason] {
-		return nil, nil
+		return nil, false, nil
 	}
 	if parent.Attempt >= parent.MaxAttempts {
 		slog.Info("task auto-retry skipped: budget exhausted",
@@ -1552,14 +1555,14 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 			"attempt", parent.Attempt,
 			"max_attempts", parent.MaxAttempts,
 		)
-		return nil, nil
+		return nil, false, nil
 	}
 	if parent.AutopilotRunID.Valid {
 		// Autopilot has its own retry semantics; do not double-trigger.
-		return nil, nil
+		return nil, false, nil
 	}
 	if !parent.IssueID.Valid && !parent.ChatSessionID.Valid {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	// Rate-limit failures get exponential backoff before the retry is
@@ -1598,7 +1601,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 			broadcast(bgCtx, protocol.EventTaskQueued, child)
 			notify(bgCtx, child)
 		}()
-		return nil, nil
+		return nil, true, nil
 	}
 
 	child, err := s.Queries.CreateRetryTask(ctx, parent.ID)
@@ -1608,7 +1611,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 			"reason", reason,
 			"error", err,
 		)
-		return nil, err
+		return nil, false, err
 	}
 	slog.Info("task auto-retry enqueued",
 		"parent_task_id", util.UUIDToString(parent.ID),
@@ -1622,20 +1625,24 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	// see EnqueueTaskForIssue for ordering rationale.
 	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, child)
 	s.NotifyTaskEnqueued(ctx, child)
-	return &child, nil
+	return &child, true, nil
 }
 
 // rateLimitBackoff returns the delay before a rate-limited retry can be
-// enqueued. Exponential: 60s → 180s → 540s → capped at 30 min.
+// enqueued. Exponential with ±20% jitter: 60s → 180s → 540s → 1620s →
+// capped at 30 min (1800s). Jitter spreads out retries so tasks that
+// shared the same attempt count don't all re-collide with the throttle.
 func rateLimitBackoff(attempt int32) time.Duration {
 	const (
 		base    = 60
-		capSecs = 1800
+		capSecs = 1800.0
 	)
-	secs := base
+	secs := float64(base)
 	for i := int32(1); i < attempt && secs < capSecs; i++ {
 		secs *= 3
 	}
+	// ±20% jitter so simultaneous rate-limited tasks spread out, then cap.
+	secs *= 0.8 + rand.Float64()*0.4
 	if secs > capSecs {
 		secs = capSecs
 	}
@@ -1786,7 +1793,7 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 	for _, t := range tasks {
 		// Auto-retry first so the issue stays in_progress rather than
 		// flapping todo → in_progress within a tick.
-		if child, _ := s.MaybeRetryFailedTask(ctx, t); child != nil {
+		if child, retryScheduled, _ := s.MaybeRetryFailedTask(ctx, t); child != nil || retryScheduled {
 			retried++
 			if t.IssueID.Valid {
 				retriedIssues[util.UUIDToString(t.IssueID)] = true

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1507,10 +1507,11 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
 var retryableReasons = map[string]bool{
-	"runtime_offline":           true,
-	"runtime_recovery":          true,
-	"timeout":                   true,
-	"codex_semantic_inactivity": true,
+	"runtime_offline":                            true,
+	"runtime_recovery":                           true,
+	"timeout":                                    true,
+	"codex_semantic_inactivity":                  true,
+	"agent_error.provider_capacity_or_rate_limit": true,
 }
 
 func resumeUnsafeFailureReason(reason string) bool {
@@ -1561,6 +1562,49 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		return nil, nil
 	}
 
+	// Rate-limit failures get exponential backoff before the retry is
+	// enqueued so the daemon doesn't immediately claim the child and hit
+	// the same upstream throttle. We spawn a goroutine rather than
+	// blocking the FailTask handler: the backoff can be minutes long and
+	// we don't want to hold the HTTP handler goroutine open.
+	if reason == string(taskfailure.ReasonAgentProviderCapacityOrRateLimit) {
+		backoff := rateLimitBackoff(parent.Attempt)
+		slog.Info("task rate-limited, scheduling retry with backoff",
+			"task_id", util.UUIDToString(parent.ID),
+			"attempt", parent.Attempt,
+			"backoff", backoff,
+		)
+		bgCtx := context.WithoutCancel(ctx)
+		qs := s.Queries
+		broadcast := s.broadcastTaskEvent
+		notify := s.NotifyTaskEnqueued
+		go func() {
+			timer := time.NewTimer(backoff)
+			defer timer.Stop()
+			select {
+			case <-bgCtx.Done():
+				return
+			case <-timer.C:
+			}
+			child, err := qs.CreateRetryTask(bgCtx, parent.ID)
+			if err != nil {
+				slog.Warn("rate-limit retry failed",
+					"parent_task_id", util.UUIDToString(parent.ID),
+					"error", err,
+				)
+				return
+			}
+			slog.Info("rate-limit retry enqueued",
+				"parent_task_id", util.UUIDToString(parent.ID),
+				"child_task_id", util.UUIDToString(child.ID),
+				"attempt", child.Attempt,
+			)
+			broadcast(bgCtx, protocol.EventTaskQueued, child)
+			notify(bgCtx, child)
+		}()
+		return nil, nil
+	}
+
 	child, err := s.Queries.CreateRetryTask(ctx, parent.ID)
 	if err != nil {
 		slog.Warn("task auto-retry failed",
@@ -1583,6 +1627,23 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, child)
 	s.NotifyTaskEnqueued(ctx, child)
 	return &child, nil
+}
+
+// rateLimitBackoff returns the delay before a rate-limited retry can be
+// enqueued. Exponential: 60s → 180s → 540s → capped at 30 min.
+func rateLimitBackoff(attempt int32) time.Duration {
+	const (
+		base    = 60
+		capSecs = 1800
+	)
+	secs := base
+	for i := int32(1); i < attempt && secs < capSecs; i++ {
+		secs *= 3
+	}
+	if secs > capSecs {
+		secs = capSecs
+	}
+	return time.Duration(secs) * time.Second
 }
 
 // RerunIssue creates a fresh queued task for an agent on the issue. Used by

--- a/server/internal/service/task_backoff_test.go
+++ b/server/internal/service/task_backoff_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimitBackoff(t *testing.T) {
+	cases := []struct {
+		attempt int32
+		want    time.Duration
+	}{
+		// First retry (attempt 1): 60s
+		{attempt: 1, want: 60 * time.Second},
+		// Second retry: 180s
+		{attempt: 2, want: 180 * time.Second},
+		// Third retry: 540s
+		{attempt: 3, want: 540 * time.Second},
+		// Fourth retry: 1620s (below cap)
+		{attempt: 4, want: 1620 * time.Second},
+		// Fifth retry and beyond: capped at 1800s
+		{attempt: 5, want: 1800 * time.Second},
+		{attempt: 10, want: 1800 * time.Second},
+		// Zero/negative attempt: treated as attempt 1
+		{attempt: 0, want: 60 * time.Second},
+		{attempt: -1, want: 60 * time.Second},
+	}
+
+	for _, tc := range cases {
+		got := rateLimitBackoff(tc.attempt)
+		if got != tc.want {
+			t.Errorf("rateLimitBackoff(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+}

--- a/server/internal/service/task_backoff_test.go
+++ b/server/internal/service/task_backoff_test.go
@@ -8,28 +8,30 @@ import (
 func TestRateLimitBackoff(t *testing.T) {
 	cases := []struct {
 		attempt int32
-		want    time.Duration
+		min     time.Duration
+		max     time.Duration
 	}{
-		// First retry (attempt 1): 60s
-		{attempt: 1, want: 60 * time.Second},
-		// Second retry: 180s
-		{attempt: 2, want: 180 * time.Second},
-		// Third retry: 540s
-		{attempt: 3, want: 540 * time.Second},
-		// Fourth retry: 1620s (below cap)
-		{attempt: 4, want: 1620 * time.Second},
-		// Fifth retry and beyond: capped at 1800s
-		{attempt: 5, want: 1800 * time.Second},
-		{attempt: 10, want: 1800 * time.Second},
+		// First retry (attempt 1): 60s ±20% → [48s, 72s]
+		{attempt: 1, min: 48 * time.Second, max: 72 * time.Second},
+		// Second retry: 180s ±20% → [144s, 216s]
+		{attempt: 2, min: 144 * time.Second, max: 216 * time.Second},
+		// Third retry: 540s ±20% → [432s, 648s]
+		{attempt: 3, min: 432 * time.Second, max: 648 * time.Second},
+		// Fourth retry: 1620s ±20% → [1296s, 1944s] (clamped at 1800s by cap)
+		{attempt: 4, min: 1296 * time.Second, max: 1800 * time.Second},
+		// Fifth retry: pre-jitter is 4860s, capped at 1800s after jitter
+		{attempt: 5, min: 1800 * time.Second, max: 1800 * time.Second},
+		{attempt: 10, min: 1800 * time.Second, max: 1800 * time.Second},
 		// Zero/negative attempt: treated as attempt 1
-		{attempt: 0, want: 60 * time.Second},
-		{attempt: -1, want: 60 * time.Second},
+		{attempt: 0, min: 48 * time.Second, max: 72 * time.Second},
+		{attempt: -1, min: 48 * time.Second, max: 72 * time.Second},
 	}
 
 	for _, tc := range cases {
 		got := rateLimitBackoff(tc.attempt)
-		if got != tc.want {
-			t.Errorf("rateLimitBackoff(%d) = %v, want %v", tc.attempt, got, tc.want)
+		if got < tc.min || got > tc.max {
+			t.Errorf("rateLimitBackoff(%d) = %v, want [%v, %v]",
+				tc.attempt, got, tc.min, tc.max)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

When the agent subprocess returns an upstream 429 rate-limit error, the daemon classifies it correctly via `taskfailure.Classify` as `agent_error.provider_capacity_or_rate_limit`, but `MaybeRetryFailedTask` skipped it because the reason was not in `retryableReasons`. The task failed permanently even though the failure is transient.

## Changes

1. **Add `agent_error.provider_capacity_or_rate_limit` to `retryableReasons`** so `MaybeRetryFailedTask` is allowed to spawn a retry child task.

2. **Apply exponential backoff before the retry is enqueued**: `60s → 180s → 540s → capped at 30 min`. For rate-limit retries, we spawn a goroutine that sleeps for the backoff period before calling `CreateRetryTask`, so the `FailTask` HTTP handler is not blocked. Existing retry reasons (`runtime_offline`, `timeout`, etc.) continue to retry immediately with no delay.

3. **`rateLimitBackoff` helper + unit test** in `task_backoff_test.go`.

## Design decisions

- The rate-limited conversation is **not poisoned** — `session_id` is preserved on retry so the agent resumes where it left off.
- Backoff is goroutine-based rather than a new `next_attempt_at` DB column. A column-based approach is cleaner long-term (survives daemon restarts, visible in dashboards) but requires a migration + sqlc regeneration. This PR establishes the retry semantics first; the column can be a follow-up.
- The existing `taskfailure.Classify` already correctly maps 429 errors to `agent_error.provider_capacity_or_rate_limit` — no new classifier needed in `poisoned.go`.

## How to Test

1. Run the backoff unit tests:
   ```
   go test ./server/internal/service/ -run TestRateLimitBackoff -v
   ```
2. Verify backoff progression: attempt 0→60s, 1→180s, 2→540s, 3→1800s, 4→1800s, 5→1800s, 10→1800s (capped at 30 min).
3. Verify invalid inputs: attempt -1 returns 60s (base duration, no negative exponent).
4. Run full service test suite:
   ```
   go test ./server/internal/service/ -count=1
   ```

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Claude backend)

**Prompt / approach:**
The agent analyzed the code path in `daemon.go` and `poisoned.go`, identified that `agent_error.provider_capacity_or_rate_limit` was missing from `retryableReasons`, and implemented exponential backoff (60s base, 3x multiplier, 30min cap) via a goroutine-based approach. Unit tests cover the full attempt range including edge cases (attempt 0, negative attempt, capped max).

Closes #3681