### PR TITLE
MUL-3320: feat(lark): add proxy support for WebSocket connections

### DIFF
--- a/server/internal/integrations/lark/ws_connector.go
+++ b/server/internal/integrations/lark/ws_connector.go
@@ -559,7 +559,9 @@ func (g *GorillaDialer) DialContext(ctx context.Context, urlStr string, requestH
 	}
 	// Shallow copy so we don't mutate the shared dialer's Proxy field.
 	dd := *d
-	dd.Proxy = g.Proxy
+	if g.Proxy != nil {
+		dd.Proxy = g.Proxy
+	}
 	if dd.Proxy == nil {
 		dd.Proxy = http.ProxyFromEnvironment
 	}

--- a/server/internal/integrations/lark/ws_connector.go
+++ b/server/internal/integrations/lark/ws_connector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -533,6 +534,14 @@ func (f FrameDecoderFunc) Decode(payload []byte, inst db.LarkInstallation) (Inbo
 // GorillaDialer is the production WSDialer.
 type GorillaDialer struct {
 	Dialer *websocket.Dialer
+
+	// Proxy is the proxy function for WebSocket connections. When nil
+	// (the zero value), the dialer defaults to http.ProxyFromEnvironment
+	// so standard HTTPS_PROXY / HTTP_PROXY / NO_PROXY environment
+	// variables are respected. Set Proxy to a non-nil func to override
+	// (e.g. for custom proxy auth or a fixed proxy URL). To disable proxy
+	// entirely, pass a func that returns (nil, nil).
+	Proxy func(*http.Request) (*url.URL, error)
 }
 
 func NewGorillaDialer() *GorillaDialer {
@@ -548,7 +557,13 @@ func (g *GorillaDialer) DialContext(ctx context.Context, urlStr string, requestH
 	if d == nil {
 		d = websocket.DefaultDialer
 	}
-	c, resp, err := d.DialContext(ctx, urlStr, requestHeader)
+	// Shallow copy so we don't mutate the shared dialer's Proxy field.
+	dd := *d
+	dd.Proxy = g.Proxy
+	if dd.Proxy == nil {
+		dd.Proxy = http.ProxyFromEnvironment
+	}
+	c, resp, err := dd.DialContext(ctx, urlStr, requestHeader)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/server/internal/integrations/lark/ws_connector_test.go
+++ b/server/internal/integrations/lark/ws_connector_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"sync/atomic"

--- a/server/internal/integrations/lark/ws_connector_test.go
+++ b/server/internal/integrations/lark/ws_connector_test.go
@@ -651,6 +651,53 @@ func TestWSConnectorReassemblesChunkedDataFrame(t *testing.T) {
 	}
 }
 
+func TestGorillaDialerProxyDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Default: nil proxy means ProxyFromEnvironment is used.
+	d := NewGorillaDialer()
+	if d.Proxy != nil {
+		t.Error("expected nil Proxy on new dialer")
+	}
+
+	// Setting Proxy to a custom func is preserved.
+	custom := func(r *http.Request) (*url.URL, error) { return nil, nil }
+	d.Proxy = custom
+	if d.Proxy == nil {
+		t.Fatal("Proxy field should accept custom func")
+	}
+
+	// DialContext with a non-existent endpoint exercises the proxy path
+	// without panicking. The connection will fail, but the dialer must
+	// not crash regardless of whether Proxy is nil or custom.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _, err := d.DialContext(ctx, "ws://127.0.0.1:1", nil)
+	if err == nil {
+		t.Error("expected dial to fail against closed port")
+	}
+}
+
+func TestGorillaDialerProxyForwardsError(t *testing.T) {
+	t.Parallel()
+
+	d := NewGorillaDialer()
+	proxyErr := errors.New("proxy refused")
+	d.Proxy = func(r *http.Request) (*url.URL, error) {
+		return nil, proxyErr
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	// gorilla/websocket calls Proxy during CONNECT for wss:// URLs;
+	// for ws:// the Proxy is not invoked (plain TCP, no CONNECT tunnel).
+	// This test verifies the dialer does not panic when Proxy returns
+	// an error — the connection will simply fail fast.
+	_, _, err := d.DialContext(ctx, "ws://127.0.0.1:1", nil)
+	if err == nil {
+		t.Error("expected dial to fail")
+	}
+}
+
 func TestWSConnectorCredentialsErrorIsReturned(t *testing.T) {
 	t.Parallel()
 	credsErr := errors.New("decrypt failed")

--- a/server/internal/integrations/lark/ws_connector_test.go
+++ b/server/internal/integrations/lark/ws_connector_test.go
@@ -652,30 +652,50 @@ func TestWSConnectorReassemblesChunkedDataFrame(t *testing.T) {
 	}
 }
 
-func TestGorillaDialerProxyDefaults(t *testing.T) {
+func TestGorillaDialerPreservesConfiguredDialerProxy(t *testing.T) {
 	t.Parallel()
 
-	// Default: nil proxy means ProxyFromEnvironment is used.
-	d := NewGorillaDialer()
-	if d.Proxy != nil {
-		t.Error("expected nil Proxy on new dialer")
+	proxyErr := errors.New("configured proxy refused")
+	d := &GorillaDialer{
+		Dialer: &websocket.Dialer{
+			Proxy: func(*http.Request) (*url.URL, error) {
+				return nil, proxyErr
+			},
+		},
 	}
 
-	// Setting Proxy to a custom func is preserved.
-	custom := func(r *http.Request) (*url.URL, error) { return nil, nil }
-	d.Proxy = custom
-	if d.Proxy == nil {
-		t.Fatal("Proxy field should accept custom func")
-	}
-
-	// DialContext with a non-existent endpoint exercises the proxy path
-	// without panicking. The connection will fail, but the dialer must
-	// not crash regardless of whether Proxy is nil or custom.
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, _, err := d.DialContext(ctx, "ws://127.0.0.1:1", nil)
-	if err == nil {
-		t.Error("expected dial to fail against closed port")
+	if !errors.Is(err, proxyErr) {
+		t.Fatalf("DialContext error = %v, want %v", err, proxyErr)
+	}
+}
+
+func TestGorillaDialerProxyOverridesConfiguredDialerProxy(t *testing.T) {
+	t.Parallel()
+
+	configuredProxyErr := errors.New("configured proxy refused")
+	overrideProxyErr := errors.New("override proxy refused")
+	d := &GorillaDialer{
+		Dialer: &websocket.Dialer{
+			Proxy: func(*http.Request) (*url.URL, error) {
+				return nil, configuredProxyErr
+			},
+		},
+		Proxy: func(*http.Request) (*url.URL, error) {
+			return nil, overrideProxyErr
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _, err := d.DialContext(ctx, "ws://127.0.0.1:1", nil)
+	if !errors.Is(err, overrideProxyErr) {
+		t.Fatalf("DialContext error = %v, want %v", err, overrideProxyErr)
+	}
+	if errors.Is(err, configuredProxyErr) {
+		t.Fatalf("DialContext used configured proxy error %v instead of override", configuredProxyErr)
 	}
 }
 
@@ -687,15 +707,12 @@ func TestGorillaDialerProxyForwardsError(t *testing.T) {
 	d.Proxy = func(r *http.Request) (*url.URL, error) {
 		return nil, proxyErr
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	// gorilla/websocket calls Proxy during CONNECT for wss:// URLs;
-	// for ws:// the Proxy is not invoked (plain TCP, no CONNECT tunnel).
-	// This test verifies the dialer does not panic when Proxy returns
-	// an error — the connection will simply fail fast.
 	_, _, err := d.DialContext(ctx, "ws://127.0.0.1:1", nil)
-	if err == nil {
-		t.Error("expected dial to fail")
+	if !errors.Is(err, proxyErr) {
+		t.Fatalf("DialContext error = %v, want %v", err, proxyErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add proxy support for Lark WebSocket connections via the `GorillaDialer`.

When no explicit proxy is configured, the dialer defaults to `http.ProxyFromEnvironment`, so standard `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` environment variables are automatically respected. Users can also set `GorillaDialer.Proxy` to a custom function for explicit proxy URLs or proxy auth.

## Changes

1. **Add `Proxy` field to `GorillaDialer`** — `func(*http.Request) (*url.URL, error)`. When nil (the zero value), defaults to `http.ProxyFromEnvironment`.
2. **Apply proxy via shallow copy** — `DialContext` copies the dialer before setting `Proxy` so the shared dialer struct is never mutated.
3. **Unit tests** — verify nil proxy defaults, custom proxy func is preserved, and dialer does not panic when proxy returns an error.

Closes #4032

## How to Test

```
# Unit tests
go test ./server/internal/integrations/lark/ -run TestGorillaDialerProxy -v

# Integration: set HTTPS_PROXY and verify Lark WS connects through proxy
HTTPS_PROXY=http://proxy:8080 multica server
```

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy
- [ ] If this PR touches Chinese product copy, I checked conventions
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Claude backend)

**Prompt / approach:**
The agent analyzed `ws_connector.go` and found that `GorillaDialer` creates a `*websocket.Dialer` without setting the `Proxy` field. Since `gorilla/websocket` natively supports `Dialer.Proxy`, the fix adds a `Proxy` field to `GorillaDialer` and defaults to `http.ProxyFromEnvironment` so standard proxy env vars are respected automatically.