### PR TITLE
fix(web): preserve CLI callback params across Google OAuth redirect (MUL-3313)

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -125,11 +125,18 @@ function LoginPageContent() {
     router.push(await resolveLoggedInDestination(qc, onboarded, list));
   };
 
-  // Build Google OAuth state: encode platform + next URL so the callback
-  // can redirect to the right place after login.
+  // Build Google OAuth state: encode platform, next URL, and CLI callback
+  // params so the callback can redirect to the right place after login.
+  // CLI callback/state must survive the Google OAuth round-trip so the
+  // post-login callback page can redirect the JWT back to the CLI's local
+  // HTTP listener (critical for headless / WSL2 environments).
   const googleState = [
     platform === "desktop" ? "platform:desktop" : "",
     nextUrl ? `next:${nextUrl}` : "",
+    cliCallbackRaw && validateCliCallback(cliCallbackRaw)
+      ? `cli_callback:${encodeURIComponent(cliCallbackRaw)}`
+      : "",
+    cliState ? `cli_state:${encodeURIComponent(cliState)}` : "",
   ]
     .filter(Boolean)
     .join(",") || undefined;

--- a/apps/web/app/auth/callback/page.test.tsx
+++ b/apps/web/app/auth/callback/page.test.tsx
@@ -197,6 +197,104 @@ describe("CallbackPage", () => {
     });
   });
 
+  it("redirects to CLI callback with token when state contains valid cli_callback", async () => {
+    const { api: mockedApi } = await import("@multica/core/api");
+    const mockGoogleLogin = mockedApi.googleLogin as ReturnType<typeof vi.fn>;
+
+    const hrefSetter = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, set href(value: string) { hrefSetter(value); } },
+    });
+
+    try {
+      mockSearchParams.set(
+        "state",
+        "cli_callback:http://127.0.0.1:46233/callback,cli_state:abc123",
+      );
+      mockGoogleLogin.mockResolvedValue({ token: "cli-jwt-token" });
+
+      render(<CallbackPage />);
+
+      await waitFor(() => {
+        expect(mockGoogleLogin).toHaveBeenCalledWith(
+          "test-code",
+          expect.stringContaining("/auth/callback"),
+        );
+      });
+
+      await waitFor(() => {
+        expect(hrefSetter).toHaveBeenCalledWith(
+          "http://127.0.0.1:46233/callback?token=cli-jwt-token&state=abc123",
+        );
+      });
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it("falls through to normal web flow when state contains invalid cli_callback", async () => {
+    mockSearchParams.set("state", "cli_callback:https://evil.com/callback");
+    mockLoginWithGoogle.mockResolvedValue(makeUser());
+    mockListWorkspaces.mockResolvedValue([]);
+    mockListMyInvitations.mockResolvedValue([]);
+
+    render(<CallbackPage />);
+
+    await waitFor(() => {
+      // Normal web flow: loginWithGoogle is called (not googleLogin)
+      expect(mockLoginWithGoogle).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(paths.onboarding());
+    });
+  });
+
+  it("redirects to CLI callback even when state also contains platform:desktop", async () => {
+    // cli_callback takes precedence over platform:desktop — the CLI flow
+    // is a specific user intent that should not be derailed by desktop flag.
+    const { api: mockedApi } = await import("@multica/core/api");
+    const mockGoogleLogin = mockedApi.googleLogin as ReturnType<typeof vi.fn>;
+
+    const hrefSetter = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, set href(value: string) { hrefSetter(value); } },
+    });
+
+    try {
+      mockSearchParams.set(
+        "state",
+        "platform:desktop,cli_callback:http://localhost:12345/callback,cli_state:mystate",
+      );
+      mockGoogleLogin.mockResolvedValue({ token: "mixed-jwt" });
+
+      render(<CallbackPage />);
+
+      await waitFor(() => {
+        expect(mockGoogleLogin).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(hrefSetter).toHaveBeenCalledWith(
+          "http://localhost:12345/callback?token=mixed-jwt&state=mystate",
+        );
+      });
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it("onboarded users with missing source land in the workspace; the source-backfill modal is mounted there", async () => {
     // Source attribution backfill is now an in-workspace modal — see
     // `<SourceBackfillModal />` mounted inside `DashboardLayout`. The

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -7,6 +7,7 @@ import { sanitizeNextUrl, useAuthStore } from "@multica/core/auth";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import { paths, resolvePostAuthDestination } from "@multica/core/paths";
 import { api } from "@multica/core/api";
+import { validateCliCallback } from "@multica/views/auth";
 import {
   Card,
   CardHeader,
@@ -46,9 +47,40 @@ function CallbackContent() {
     // so an attacker-controlled `state=next:https://evil` cannot redirect here.
     const nextUrl = sanitizeNextUrl(nextPart ? nextPart.slice(5) : null);
 
+    // CLI callback params — carried across the Google OAuth round-trip so
+    // headless/WSL2 `multica login` can receive the JWT after browser-based
+    // Google auth completes.
+    const cliCallbackPart = stateParts.find((p) => p.startsWith("cli_callback:"));
+    const cliStatePart = stateParts.find((p) => p.startsWith("cli_state:"));
+    const cliCallbackRaw = cliCallbackPart
+      ? decodeURIComponent(cliCallbackPart.slice("cli_callback:".length))
+      : null;
+    const cliState = cliStatePart
+      ? decodeURIComponent(cliStatePart.slice("cli_state:".length))
+      : "";
+
     const redirectUri = `${window.location.origin}/auth/callback`;
 
-    if (isDesktop) {
+    // Validate the CLI callback URL before redirecting — the state parameter
+    // passes through Google OAuth and must be treated as attacker-controlled.
+    const cliCallback =
+      cliCallbackRaw && validateCliCallback(cliCallbackRaw)
+        ? cliCallbackRaw
+        : null;
+
+    if (cliCallback) {
+      // CLI login flow: exchange the Google code for a JWT, then redirect the
+      // token back to the CLI's local HTTP listener (e.g. WSL2 host).
+      api
+        .googleLogin(code, redirectUri)
+        .then(({ token }) => {
+          const separator = cliCallback.includes("?") ? "&" : "?";
+          window.location.href = `${cliCallback}${separator}token=${encodeURIComponent(token)}&state=${encodeURIComponent(cliState)}`;
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : "Login failed");
+        });
+    } else if (isDesktop) {
       // Desktop flow: exchange code for token, then redirect via deep link
       api
         .googleLogin(code, redirectUri)

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -7,7 +7,7 @@ import { sanitizeNextUrl, useAuthStore } from "@multica/core/auth";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import { paths, resolvePostAuthDestination } from "@multica/core/paths";
 import { api } from "@multica/core/api";
-import { validateCliCallback } from "@multica/views/auth";
+import { validateCliCallback, redirectToCliCallback } from "@multica/views/auth";
 import {
   Card,
   CardHeader,
@@ -74,8 +74,7 @@ function CallbackContent() {
       api
         .googleLogin(code, redirectUri)
         .then(({ token }) => {
-          const separator = cliCallback.includes("?") ? "&" : "?";
-          window.location.href = `${cliCallback}${separator}token=${encodeURIComponent(token)}&state=${encodeURIComponent(cliState)}`;
+          redirectToCliCallback(cliCallback, token, cliState);
         })
         .catch((err) => {
           setError(err instanceof Error ? err.message : "Login failed");

--- a/packages/views/auth/index.ts
+++ b/packages/views/auth/index.ts
@@ -1,2 +1,2 @@
-export { LoginPage, validateCliCallback } from "./login-page";
+export { LoginPage, validateCliCallback, redirectToCliCallback } from "./login-page";
 export { useLogout } from "./use-logout";

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -67,7 +67,7 @@ interface LoginPageProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function redirectToCliCallback(url: string, token: string, state: string) {
+export function redirectToCliCallback(url: string, token: string, state: string) {
   const separator = url.includes("?") ? "&" : "?";
   window.location.href = `${url}${separator}token=${encodeURIComponent(token)}&state=${encodeURIComponent(state)}`;
 }


### PR DESCRIPTION
## Problem

When `multica login` runs in a headless/WSL2 environment, the CLI generates a login URL with `cli_callback` and `cli_state` query parameters. The user opens this URL in a browser on another machine, signs in with Google, but the CLI never receives the callback token — it times out after 5 minutes.

Root cause: `cli_callback` and `cli_state` were not encoded into the Google OAuth `state` parameter, so they were lost across the Google OAuth redirect. The callback page had no code path to handle CLI callback redirects after Google OAuth.

## Fix

- **Login page** (`apps/web/app/(auth)/login/page.tsx`): Encode `cli_callback` and `cli_state` into the Google OAuth state parameter (alongside existing `platform` and `next` values). The state format is comma-separated `key:value` pairs.

- **Callback page** (`apps/web/app/auth/callback/page.tsx`): Parse `cli_callback`/`cli_state` from the returned state, validate the callback URL (only allows localhost and RFC 1918 addresses), and redirect the JWT token to the CLI local HTTP listener after successful Google login.

## Why this approach

- The Google OAuth `state` parameter is designed exactly for this — preserving application state across the OAuth redirect cycle.
- The email-based login path already works correctly with CLI callbacks; this makes Google OAuth consistent.
- CLI callback takes precedence over `platform:desktop` in the state, since it represents explicit user intent.

Closes #3049