### PR TITLE
feat(issues): add previous/next navigation buttons in the issue detail

### DIFF
--- a/e2e/issue-sibling-nav.spec.ts
+++ b/e2e/issue-sibling-nav.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page } from "@playwright/test";
+import { loginAsDefault, createTestApi } from "./helpers";
+import type { TestApiClient } from "./fixtures";
+
+/**
+ * E2E: previous/next navigation from inside the issue detail.
+ *
+ * The board/list views publish the column the user is looking at; the detail
+ * reads it back so you can step between sibling issues without backing out to
+ * the board. Here we open a column, walk to the bottom (Next greys out), then
+ * walk back to the top (Previous greys out), proving both the stepping and the
+ * end-of-column disabled states.
+ */
+test.describe("Issue detail previous/next navigation", () => {
+  let api: TestApiClient;
+  let wsSlug: string;
+
+  test.beforeEach(async ({ page }) => {
+    api = await createTestApi();
+    wsSlug = await loginAsDefault(page);
+  });
+
+  test.afterEach(async () => {
+    await api?.cleanup();
+  });
+
+  async function clickAndAwaitNavigation(page: Page, button: ReturnType<Page["getByRole"]>) {
+    const before = page.url();
+    await button.click();
+    await page.waitForFunction((url) => location.href !== url, before);
+  }
+
+  test("steps through a column and greys out at the ends", async ({ page }) => {
+    // Three issues in the same column so it has a clear top, middle and bottom.
+    const stamp = Date.now();
+    const titles = [
+      `Sibling nav A ${stamp}`,
+      `Sibling nav B ${stamp}`,
+      `Sibling nav C ${stamp}`,
+    ];
+    for (const title of titles) {
+      await api.createIssue(title, { status: "todo" });
+    }
+    await page.reload();
+
+    // Open one of our issues from the board.
+    const card = page
+      .locator('a[href*="/issues/"]')
+      .filter({ hasText: titles[1] });
+    await expect(card).toBeVisible({ timeout: 10000 });
+    await card.click();
+    await page.waitForURL(/\/issues\/[\w-]+/);
+
+    const prev = page.getByRole("button", { name: "Previous issue" });
+    const next = page.getByRole("button", { name: "Next issue" });
+
+    // Coming from the board, the column context exists, so both show.
+    await expect(prev).toBeVisible();
+    await expect(next).toBeVisible();
+
+    // Walk to the bottom of the column. Each step must land on a new issue and
+    // never revisit one, so navigation is strictly forward.
+    const visited = new Set<string>([page.url()]);
+    for (let i = 0; i < 50 && !(await next.isDisabled()); i++) {
+      await clickAndAwaitNavigation(page, next);
+      await expect(next).toBeVisible();
+      expect(visited.has(page.url())).toBe(false);
+      visited.add(page.url());
+    }
+    // At the last card there is nowhere further down.
+    await expect(next).toBeDisabled();
+    await expect(prev).toBeEnabled();
+
+    // Walk back up to the top the same way.
+    for (let i = 0; i < 50 && !(await prev.isDisabled()); i++) {
+      await clickAndAwaitNavigation(page, prev);
+      await expect(prev).toBeVisible();
+    }
+    // At the first card there is nowhere further up.
+    await expect(prev).toBeDisabled();
+    await expect(next).toBeEnabled();
+  });
+
+  test("hides the buttons when there is no column context (deep link)", async ({ page }) => {
+    // An issue opened cold — never having visited a list this session — has no
+    // siblings to offer, so the controls stay hidden rather than dangling.
+    const issue = await api.createIssue(`Deep link ${Date.now()}`, { status: "todo" });
+    // `page.goto` is a full document load, so the in-memory navigation store
+    // starts empty here regardless of the board `loginAsDefault` left mounted —
+    // no realtime publish from issue creation can leak into this assertion.
+    await page.goto(`/${wsSlug}/issues/${issue.id}`);
+    await page.waitForURL(/\/issues\/[\w-]+/);
+
+    // The detail has loaded (its sidebar is present)...
+    await expect(page.locator("text=Properties")).toBeVisible({ timeout: 10000 });
+    // ...but with no list context, neither navigation button renders.
+    await expect(page.getByRole("button", { name: "Previous issue" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Next issue" })).toHaveCount(0);
+  });
+});

--- a/packages/core/issues/stores/issue-navigation-store.test.ts
+++ b/packages/core/issues/stores/issue-navigation-store.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  useIssueNavigationStore,
+  getIssueSiblings,
+} from "./issue-navigation-store";
+
+const COLUMNS = {
+  "status:todo": ["a", "b", "c"],
+  "status:in_progress": ["d", "e"],
+  "status:done": [],
+};
+
+describe("getIssueSiblings", () => {
+  it("returns both neighbours for an issue in the middle of a column", () => {
+    expect(getIssueSiblings(COLUMNS, "b")).toEqual({
+      hasContext: true,
+      prevId: "a",
+      nextId: "c",
+    });
+  });
+
+  it("has no previous at the top of a column", () => {
+    expect(getIssueSiblings(COLUMNS, "a")).toEqual({
+      hasContext: true,
+      prevId: null,
+      nextId: "b",
+    });
+  });
+
+  it("has no next at the bottom of a column", () => {
+    expect(getIssueSiblings(COLUMNS, "c")).toEqual({
+      hasContext: true,
+      prevId: "b",
+      nextId: null,
+    });
+  });
+
+  it("has context but no neighbours for a single-issue column", () => {
+    // The disabled-at-both-ends case the toolbar relies on: the buttons render
+    // (hasContext) but both are greyed out.
+    expect(getIssueSiblings({ "status:todo": ["only"] }, "only")).toEqual({
+      hasContext: true,
+      prevId: null,
+      nextId: null,
+    });
+  });
+
+  it("navigates within the issue's own column, never across columns", () => {
+    // "d" is the first card of the in_progress column — its previous is null,
+    // not "c" (the last todo card).
+    expect(getIssueSiblings(COLUMNS, "d")).toEqual({
+      hasContext: true,
+      prevId: null,
+      nextId: "e",
+    });
+  });
+
+  it("reports no context when the issue isn't in any published column", () => {
+    expect(getIssueSiblings(COLUMNS, "missing")).toEqual({
+      hasContext: false,
+      prevId: null,
+      nextId: null,
+    });
+  });
+
+  it("reports no context against an empty snapshot (deep link, never visited a list)", () => {
+    expect(getIssueSiblings({}, "a")).toEqual({
+      hasContext: false,
+      prevId: null,
+      nextId: null,
+    });
+  });
+
+  it("reports no context when nothing was published for the workspace", () => {
+    expect(getIssueSiblings(undefined, "a")).toEqual({
+      hasContext: false,
+      prevId: null,
+      nextId: null,
+    });
+  });
+});
+
+describe("useIssueNavigationStore", () => {
+  beforeEach(() => {
+    useIssueNavigationStore.setState({ byWorkspace: {} });
+  });
+
+  it("publishes and clears columns per workspace", () => {
+    useIssueNavigationStore.getState().setColumns("ws-1", COLUMNS);
+    expect(useIssueNavigationStore.getState().byWorkspace["ws-1"]).toBe(COLUMNS);
+
+    useIssueNavigationStore.getState().clear("ws-1");
+    expect(useIssueNavigationStore.getState().byWorkspace["ws-1"]).toBeUndefined();
+  });
+
+  it("keeps each workspace's columns independent", () => {
+    const a = { "status:todo": ["a"] };
+    const b = { "status:todo": ["b"] };
+    useIssueNavigationStore.getState().setColumns("ws-a", a);
+    useIssueNavigationStore.getState().setColumns("ws-b", b);
+
+    // Clearing one workspace (e.g. its swimlane mounting) leaves the other's
+    // open-detail context intact — the desktop multi-tab case.
+    useIssueNavigationStore.getState().clear("ws-b");
+    expect(useIssueNavigationStore.getState().byWorkspace["ws-a"]).toBe(a);
+    expect(useIssueNavigationStore.getState().byWorkspace["ws-b"]).toBeUndefined();
+  });
+
+  it("keeps the state reference stable when clearing an absent workspace", () => {
+    const before = useIssueNavigationStore.getState().byWorkspace;
+    useIssueNavigationStore.getState().clear("ws-never-set");
+    expect(useIssueNavigationStore.getState().byWorkspace).toBe(before);
+  });
+});

--- a/packages/core/issues/stores/issue-navigation-store.ts
+++ b/packages/core/issues/stores/issue-navigation-store.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { create } from "zustand";
+
+/**
+ * Ephemeral record of the list the user is currently navigating, used to power
+ * previous/next navigation from inside the issue detail view.
+ *
+ * The detail page is a standalone route that only knows its own issue id — it
+ * has no idea which board column or list row the user clicked to get there. So
+ * the board and list views publish their displayed columns here as they render,
+ * and the detail reads them back to offer "previous / next issue in this
+ * column" without making the user back out to the list first.
+ *
+ * Keyed by workspace id so an open detail in one workspace isn't disturbed by a
+ * list rendering in another — desktop keeps background tabs mounted, and each
+ * tab is scoped to its own workspace. Within a single workspace it is
+ * last-writer-wins: whichever board/list rendered most recently is the surface
+ * the user is looking at, which is the one we want previous/next to follow.
+ *
+ * Each entry maps a column id (a status or assignee group) to the issue ids in
+ * that column, ordered exactly as shown. It is deliberately NOT persisted: it
+ * mirrors the last list you looked at this session, and a snapshot restored
+ * across reloads would point at issues you can no longer see. Views with no
+ * meaningful column ordering (swimlane, gantt) clear their workspace's entry so
+ * the detail never offers navigation that wouldn't match what the user sees.
+ */
+interface IssueNavigationState {
+  byWorkspace: Record<string, Record<string, string[]>>;
+  setColumns: (wsId: string, columns: Record<string, string[]>) => void;
+  clear: (wsId: string) => void;
+}
+
+export const useIssueNavigationStore = create<IssueNavigationState>()((set) => ({
+  byWorkspace: {},
+  setColumns: (wsId, columns) =>
+    set((state) => ({
+      byWorkspace: { ...state.byWorkspace, [wsId]: columns },
+    })),
+  clear: (wsId) =>
+    set((state) => {
+      // Keep the reference stable when there's nothing to clear so subscribers
+      // (the open detail) don't re-render needlessly.
+      if (!state.byWorkspace[wsId]) return state;
+      const next = { ...state.byWorkspace };
+      delete next[wsId];
+      return { byWorkspace: next };
+    }),
+}));
+
+export interface IssueSiblings {
+  /** True when the issue was found in the last-viewed list, so previous/next
+   *  navigation is meaningful. The detail hides the buttons when this is false
+   *  (e.g. the user deep-linked straight to the issue). */
+  hasContext: boolean;
+  /** Issue above the current one in its column, or null at the top. */
+  prevId: string | null;
+  /** Issue below the current one in its column, or null at the bottom. */
+  nextId: string | null;
+}
+
+const NO_SIBLINGS: IssueSiblings = { hasContext: false, prevId: null, nextId: null };
+
+/**
+ * Locate `issueId` within the published columns and return its immediate
+ * neighbours. Pure — the React glue lives in `@multica/views`. The first column
+ * that contains the issue wins; an issue never legitimately sits in two columns
+ * of the same list, so order of iteration doesn't matter. A missing snapshot
+ * (`undefined`, e.g. nothing published for this workspace yet) yields no
+ * context.
+ */
+export function getIssueSiblings(
+  columns: Record<string, string[]> | undefined,
+  issueId: string,
+): IssueSiblings {
+  if (!columns) return NO_SIBLINGS;
+  for (const ids of Object.values(columns)) {
+    const index = ids.indexOf(issueId);
+    if (index === -1) continue;
+    return {
+      hasContext: true,
+      prevId: index > 0 ? ids[index - 1]! : null,
+      nextId: index < ids.length - 1 ? ids[index + 1]! : null,
+    };
+  }
+  return NO_SIBLINGS;
+}

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -24,8 +24,10 @@ import type { AssigneeGroupedIssuesFilter, IssueSortParam, MyIssuesFilter } from
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { useWorkspaceId } from "@multica/core/hooks";
 import { BoardColumn, BOARD_CARD_WIDTH, type BoardColumnGroup } from "./board-column";
 import { BoardCardContent } from "./board-card";
+import { useRegisterIssueNavigation } from "../hooks";
 import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import type { ChildProgress } from "./list-row";
@@ -151,6 +153,7 @@ export function BoardView({
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
 }) {
   const { t } = useT("issues");
+  const wsId = useWorkspaceId();
   const grouping = useViewStore((s) => s.grouping);
   const sortBy = useViewStore((s) => s.sortBy);
   const sortFieldKey = sortBy === "created_at" ? "created" : sortBy;
@@ -222,6 +225,15 @@ export function BoardView({
     () => makeKanbanCollision(groupIds),
     [groupIds],
   );
+
+  // Publish the resting column order for the issue detail's previous/next
+  // navigation. Derived from props rather than the local `columns` state below
+  // so an in-progress drag never leaks a transient ordering into navigation.
+  const navColumns = useMemo(
+    () => buildColumns(groupedIssues, groups, grouping),
+    [groupedIssues, groups, grouping],
+  );
+  useRegisterIssueNavigation(wsId, navColumns);
 
   // --- Drag state ---
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);

--- a/packages/views/issues/components/gantt-view.tsx
+++ b/packages/views/issues/components/gantt-view.tsx
@@ -23,6 +23,7 @@ import { StatusIcon } from "./status-icon";
 import { PriorityIcon } from "./priority-icon";
 import { IssueActionsContextMenu } from "../actions";
 import { sortIssues } from "../utils/sort";
+import { useClearIssueNavigation } from "../hooks";
 import { useT } from "../../i18n";
 
 // ---------------------------------------------------------------------------
@@ -442,6 +443,11 @@ function ScheduledRow({
 
 export function GanttView({ issues }: { issues: Issue[] }) {
   const { t } = useT("issues");
+  // A timeline has no column to step through, so clear this workspace's
+  // published columns rather than let the detail offer navigation unrelated to
+  // this view.
+  const wsId = useWorkspaceId();
+  useClearIssueNavigation(wsId);
   const zoom = useViewStore((s) => s.ganttZoom);
   const showCompleted = useViewStore((s) => s.ganttShowCompleted);
   const sortBy = useViewStore((s) => s.sortBy);

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
   CircleCheck,
   Milestone,
   MoreHorizontal,
@@ -98,6 +99,7 @@ import {
   rightSidebarPanelMotionProps,
   useAnimatedRightSidebarState,
 } from "../../layout/animated-right-sidebar";
+import { useIssueSiblings } from "../hooks/use-issue-navigation";
 
 function SubscriberPopoverContent({
   members,
@@ -717,6 +719,19 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const canModerateComments =
     currentUserRole === "owner" || currentUserRole === "admin";
   const { data: allIssues = [] } = useQuery(issueListOptions(wsId));
+
+  // Previous / next navigation within the column the user came from. The board
+  // and list views publish their displayed columns to an ephemeral store; we
+  // read back the current issue's neighbours. `hasContext` is false on a deep
+  // link (no list visited this session), in which case the buttons are hidden.
+  const siblings = useIssueSiblings(wsId, id);
+  // `paths` is rebuilt on every render (useWorkspacePaths), so memoizing this
+  // would buy nothing; a plain handler reads clearer. Only ever invoked from an
+  // inline onClick, so the fresh identity each render costs nothing.
+  const goToSibling = (siblingId: string | null) => {
+    if (siblingId) router.push(paths.issueDetail(siblingId));
+  };
+
   const { getActorName } = useActorName();
   const { uploadWithToast } = useFileUpload(api);
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -1818,6 +1833,44 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 it never overlaps the title (which truncates to make room).
                 It self-hides when no agent is active. */}
             <IssueAgentHeaderChip issueId={id} />
+            {siblings.hasContext && (
+              <>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="text-muted-foreground"
+                        disabled={!siblings.prevId}
+                        aria-label={t(($) => $.detail.prev_issue_tooltip)}
+                        onClick={() => goToSibling(siblings.prevId)}
+                      >
+                        <ChevronUp />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent side="bottom">{t(($) => $.detail.prev_issue_tooltip)}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="text-muted-foreground"
+                        disabled={!siblings.nextId}
+                        aria-label={t(($) => $.detail.next_issue_tooltip)}
+                        onClick={() => goToSibling(siblings.nextId)}
+                      >
+                        <ChevronDown />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent side="bottom">{t(($) => $.detail.next_issue_tooltip)}</TooltipContent>
+                </Tooltip>
+              </>
+            )}
             {onDone && issue.status !== "done" && issue.status !== "cancelled" && (
               <Tooltip>
                 <TooltipTrigger

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -25,6 +25,8 @@ import { StatusHeading } from "./status-heading";
 import { ListRow, DraggableListRow, type ChildProgress } from "./list-row";
 import { useDragSettle } from "./use-drag-settle";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
+import { useRegisterIssueNavigation } from "../hooks";
+import { useWorkspaceId } from "@multica/core/hooks";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
@@ -84,6 +86,7 @@ export function ListView({
   );
   const sortBy = useViewStore((s) => s.sortBy);
   const { t } = useT("issues");
+  const wsId = useWorkspaceId();
 
   const sortFieldKey = sortBy === "created_at" ? "created" : sortBy;
   const sortLabel = sortBy !== "position"
@@ -116,6 +119,15 @@ export function ListView({
     () => new Map(groups.map((g) => [g.id, g])),
     [groups],
   );
+
+  // Publish the resting column order for the issue detail's previous/next
+  // navigation. Derived from props rather than the drag-mutated `columns`
+  // state below so an in-progress drag never leaks into navigation.
+  const navColumns = useMemo(
+    () => buildColumns(issues, groups, "status"),
+    [issues, groups],
+  );
+  useRegisterIssueNavigation(wsId, navColumns);
 
   // --- Drag state ---
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -54,6 +54,7 @@ import { AppLink } from "../../navigation";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
 import type { ChildProgress } from "./list-row";
+import { useClearIssueNavigation } from "../hooks";
 import { useT } from "../../i18n";
 import type { IssueActivityState } from "../surface/activity";
 import type { IssueCreateDefaults } from "../surface/types";
@@ -496,6 +497,10 @@ export function SwimLaneView({
   const swimlaneOrder = swimlaneOrders[swimlaneGrouping];
 
   const wsId = useWorkspaceId();
+  // The 2D lane×status grid has no single "column" the detail can step through,
+  // so clear this workspace's published columns rather than offer navigation
+  // that wouldn't match what the user sees here.
+  useClearIssueNavigation(wsId);
 
   const { data: snapshot = [] } = useQuery({
     ...agentTaskSnapshotOptions(wsId),

--- a/packages/views/issues/hooks/index.ts
+++ b/packages/views/issues/hooks/index.ts
@@ -4,3 +4,8 @@ export { useIssueSubscribers } from "./use-issue-subscribers";
 export { useIssueDetailScrollRestore } from "./use-issue-detail-scroll-restore";
 export { useInPageFind } from "./use-in-page-find";
 export { useResolveIssueIdentifier } from "./use-resolve-issue-identifier";
+export {
+  useRegisterIssueNavigation,
+  useClearIssueNavigation,
+  useIssueSiblings,
+} from "./use-issue-navigation";

--- a/packages/views/issues/hooks/use-issue-navigation.test.tsx
+++ b/packages/views/issues/hooks/use-issue-navigation.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useIssueNavigationStore } from "@multica/core/issues/stores/issue-navigation-store";
+import {
+  useRegisterIssueNavigation,
+  useClearIssueNavigation,
+  useIssueSiblings,
+} from "./use-issue-navigation";
+
+const WS = "ws-1";
+
+beforeEach(() => {
+  useIssueNavigationStore.setState({ byWorkspace: {} });
+});
+
+describe("issue navigation hooks", () => {
+  it("publishes columns so the detail can read a sibling pair back", () => {
+    renderHook(() => useRegisterIssueNavigation(WS, { "status:todo": ["a", "b", "c"] }));
+    const { result } = renderHook(() => useIssueSiblings(WS, "b"));
+    expect(result.current).toEqual({ hasContext: true, prevId: "a", nextId: "c" });
+  });
+
+  it("keeps the published snapshot after the list view unmounts", () => {
+    // The core guarantee: navigating into an issue unmounts the board/list, but
+    // the detail still needs the columns the user just left. A future "clear on
+    // unmount" refactor would silently break previous/next — this pins it.
+    const list = renderHook(() => useRegisterIssueNavigation(WS, { "status:todo": ["a", "b"] }));
+    list.unmount();
+    const { result } = renderHook(() => useIssueSiblings(WS, "a"));
+    expect(result.current).toEqual({ hasContext: true, prevId: null, nextId: "b" });
+  });
+
+  it("clears published columns so navigation is hidden", () => {
+    useIssueNavigationStore.getState().setColumns(WS, { "status:todo": ["a", "b"] });
+    renderHook(() => useClearIssueNavigation(WS));
+    const { result } = renderHook(() => useIssueSiblings(WS, "a"));
+    expect(result.current.hasContext).toBe(false);
+  });
+
+  it("only reads the current workspace's columns", () => {
+    renderHook(() => useRegisterIssueNavigation("other-ws", { c: ["a", "b"] }));
+    const { result } = renderHook(() => useIssueSiblings(WS, "a"));
+    expect(result.current.hasContext).toBe(false);
+  });
+
+  it("lets the most recent list win when columns are republished", () => {
+    const { rerender } = renderHook(
+      ({ cols }) => useRegisterIssueNavigation(WS, cols),
+      { initialProps: { cols: { c1: ["a", "b"] } as Record<string, string[]> } },
+    );
+    rerender({ cols: { c1: ["x", "y", "z"] } });
+    const { result } = renderHook(() => useIssueSiblings(WS, "y"));
+    expect(result.current).toEqual({ hasContext: true, prevId: "x", nextId: "z" });
+  });
+});

--- a/packages/views/issues/hooks/use-issue-navigation.ts
+++ b/packages/views/issues/hooks/use-issue-navigation.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import {
+  useIssueNavigationStore,
+  getIssueSiblings,
+  type IssueSiblings,
+} from "@multica/core/issues/stores/issue-navigation-store";
+
+/**
+ * Publish the columns a list view is currently showing so the issue detail can
+ * offer previous/next navigation within a column. Called by the board and list
+ * views with the active workspace id and their displayed column map.
+ *
+ * Within a workspace the most recent caller wins, which is always the surface
+ * the user is looking at. This relies on at most one board/list being mounted
+ * per workspace at a time — true today since every view is a mutually exclusive
+ * `viewMode` branch and the reuse sites (my-issues, projects, actor panels)
+ * live on separate routes. A future split/peek layout co-mounting two lists in
+ * one workspace would make this last-writer-wins across them.
+ *
+ * The snapshot intentionally outlives the list view: navigating into an issue
+ * unmounts the list, but the detail still needs the columns the user just left.
+ */
+export function useRegisterIssueNavigation(
+  wsId: string,
+  columns: Record<string, string[]>,
+): void {
+  const setColumns = useIssueNavigationStore((s) => s.setColumns);
+  useEffect(() => {
+    setColumns(wsId, columns);
+  }, [wsId, columns, setColumns]);
+}
+
+/**
+ * Clear this workspace's published columns on mount. Views without a meaningful
+ * column ordering (swimlane, gantt) call this so the detail won't offer
+ * navigation that wouldn't match what the user was looking at when they opened
+ * the issue.
+ */
+export function useClearIssueNavigation(wsId: string): void {
+  const clear = useIssueNavigationStore((s) => s.clear);
+  useEffect(() => {
+    clear(wsId);
+  }, [wsId, clear]);
+}
+
+/**
+ * Resolve the previous/next issue for the detail view from the last list
+ * published for this workspace. Selecting the stable per-workspace columns
+ * reference (not a freshly built object) keeps this from re-rendering on every
+ * store write, including writes scoped to other workspaces.
+ */
+export function useIssueSiblings(wsId: string, issueId: string): IssueSiblings {
+  const columns = useIssueNavigationStore((s) => s.byWorkspace[wsId]);
+  return useMemo(() => getIssueSiblings(columns, issueId), [columns, issueId]);
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -236,6 +236,8 @@
       "next": "Next match",
       "close": "Close find"
     },
+    "prev_issue_tooltip": "Previous issue",
+    "next_issue_tooltip": "Next issue",
     "update_failed": "Failed to update issue",
     "link_copied": "Link copied",
     "link_copy_failed": "Failed to copy link",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -233,6 +233,8 @@
       "next": "次の一致",
       "close": "検索を閉じる"
     },
+    "prev_issue_tooltip": "前のイシュー",
+    "next_issue_tooltip": "次のイシュー",
     "update_failed": "イシューを更新できませんでした",
     "link_copied": "リンクをコピーしました",
     "link_copy_failed": "リンクをコピーできませんでした",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -233,6 +233,8 @@
       "next": "다음 일치",
       "close": "찾기 닫기"
     },
+    "prev_issue_tooltip": "이전 이슈",
+    "next_issue_tooltip": "다음 이슈",
     "update_failed": "이슈를 업데이트하지 못했습니다",
     "link_copied": "링크를 복사했습니다",
     "link_copy_failed": "링크를 복사하지 못했습니다",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -233,6 +233,8 @@
       "next": "下一个",
       "close": "关闭查找"
     },
+    "prev_issue_tooltip": "上一个 issue",
+    "next_issue_tooltip": "下一个 issue",
     "update_failed": "更新 issue 失败",
     "link_copied": "已复制链接",
     "link_copy_failed": "复制链接失败",


### PR DESCRIPTION
## Summary

- add up (previous) / down (next) buttons to the issue detail header that step to the adjacent issue in the same column, without backing out to the board or list first
- grey the buttons out at the top and bottom of the column; hide them entirely when there is no list context (for example a deep link straight to an issue)
- publish each board/list view's displayed column ordering (the existing `buildColumns` map) into a new ephemeral, workspace-keyed Zustand store (`packages/core/issues/stores/issue-navigation-store.ts`); the detail reads back the current issue's neighbours via `useIssueSiblings`
- clear the store from swimlane and gantt, which have no single column to step through, so the detail never offers navigation that would not match what the user was looking at
- add `prev_issue_tooltip` / `next_issue_tooltip` across `en` / `ja` / `ko` / `zh-Hans` (zh-Hans keeps lowercase English `issue` per the mixed-rule)

## Why this shape

The detail is a standalone route that only knows its own issue id, fully decoupled from the list the user came from, so the list publishes its column ordering and the detail reads it back. The store is deliberately not persisted (it mirrors the last list you looked at this session) and is keyed by workspace so an open detail in one workspace is not clobbered by a list rendering in another, which matters on desktop where background tabs stay mounted. Neighbours are resolved inside the issue's own column, so "next" never crosses a column boundary, which is what drives the greyed-out states at the ends. If a sibling was deleted while the detail was open, the existing "issue not found" state handles it.

## Scope and follow-ups

Wires the two views where a "column" is unambiguous: board and list. They are reused across `/issues`, `/my-issues`, `/projects` and the actor panels, so the feature lights up broadly. Swimlane and gantt are intentionally out of scope here (they only clear, they never publish) to keep the change focused and reviewable. Follow-ups: publish a column ordering from swimlane and gantt so they get navigation too, and add keyboard shortcuts for parity with Linear.

## Changes

- `packages/core/issues/stores/issue-navigation-store.ts` (+test): the workspace-keyed store and the pure `getIssueSiblings` resolver
- `packages/views/issues/hooks/use-issue-navigation.ts` (+test): `useRegisterIssueNavigation` / `useClearIssueNavigation` / `useIssueSiblings`
- `packages/views/issues/components/{board,list}-view.tsx`: publish the displayed columns
- `packages/views/issues/components/{swimlane,gantt}-view.tsx`: clear the workspace's columns on mount
- `packages/views/issues/components/issue-detail.tsx`: the up/down buttons in the header
- `packages/views/locales/{en,ja,ko,zh-Hans}/issues.json`: tooltip strings
- `e2e/issue-sibling-nav.spec.ts`: end-to-end coverage

## Verification

- `pnpm --filter @multica/core --filter @multica/views typecheck`
- `pnpm --filter @multica/core --filter @multica/views lint`
- `pnpm --filter @multica/core --filter @multica/views test` (core + views suites green; i18n parity passes with the new keys)
- `pnpm exec playwright test e2e/issue-sibling-nav.spec.ts` (against a live stack: steps a column to both ends asserting the greyed states, plus the deep-link case)

Manually verified in the running app: opened a board issue, stepped to the top and bottom of the column (buttons greying out at each end), and confirmed a deep-linked issue shows no buttons.

## Screenshots

Up (previous) / down (next) buttons in the issue detail header, stepping through a column.

**Middle of a column (both active)**

<img width="1680" height="88" alt="toolbar-middle" src="https://github.com/user-attachments/assets/f7d8c8a8-42eb-49f1-9b91-ee9cd7024947" />

**Top of the column (previous greyed out)**

<img width="1680" height="88" alt="toolbar-top" src="https://github.com/user-attachments/assets/2b35be91-8935-49f9-a367-5d340a58aa28" />

**Bottom of the column (next greyed out)**

<img width="1680" height="88" alt="toolbar-bottom" src="https://github.com/user-attachments/assets/daaabe3e-22ac-499a-b08f-450b41e17b9d" />

### Open for more screenshots
<details>
<summary>Full detail view, for context</summary>

**Middle of a column**

<img width="1440" height="900" alt="02-detail-middle" src="https://github.com/user-attachments/assets/6f160943-fc03-4fad-b892-95f659ba53a8" />

**Top of the column (previous greyed out)**

<img width="1440" height="900" alt="04-detail-top" src="https://github.com/user-attachments/assets/21ab91ae-2e0e-4b20-858d-b53fe3a0d37c" />

</details>

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.8)

**Prompt / approach:** Asked it to add next/previous issue navigation to the web detail view. It explored the issue views to find that the detail is decoupled from the list, chose the "list publishes its column ordering, detail reads it back" approach, implemented it, wrote the unit/hook/e2e tests, ran a multi-model review pass, then stood up a local stack and drove it with Playwright to verify the three states. The workspace keying of the store came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
