### PR TITLE
fix(handler): reject newline characters in label names

### DIFF
--- a/server/internal/handler/label.go
+++ b/server/internal/handler/label.go
@@ -90,9 +90,14 @@ func validateLabelName(raw string) (string, error) {
 	if len(name) > maxLabelNameLen {
 		return "", errors.New("name must be 32 characters or fewer")
 	}
-	// TODO(labels): consider restricting to a charset that excludes newlines,
-	// tabs, and control characters. Emoji are left allowed — users can pick
-	// `🐛 bug` if they want. Tracked as a follow-up so we don't gate this PR.
+	// Newlines corrupt single-line rendering (label chips, dropdowns) and open
+	// a log/CSV injection vector, so reject them outright. Tabs and other
+	// control characters are still a follow-up; emoji are allowed — users can
+	// pick `🐛 bug` if they want. TrimSpace already strips leading/trailing
+	// newlines, so this only fires on a newline embedded in the stored value.
+	if strings.ContainsAny(name, "\n\r") {
+		return "", errors.New("name must not contain newline characters")
+	}
 	return name, nil
 }
 

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -373,6 +373,48 @@ func TestLabelNameTooLong(t *testing.T) {
 	})
 }
 
+// TestLabelNameRejectsNewlines — names containing a newline ("\n" or "\r") must
+// return 400, while a normal name is accepted. Each bad case embeds the newline
+// away from the edges so TrimSpace can't strip it.
+func TestLabelNameRejectsNewlines(t *testing.T) {
+	badNames := []string{
+		"bug\nP0",
+		"bug\rP0",
+		"line1\nline2",
+		"bug\r\nP0",
+	}
+	for _, name := range badNames {
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/labels", map[string]any{
+			"name":  name,
+			"color": "#3b82f6",
+		})
+		testHandler.CreateLabel(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("CreateLabel name %q: expected 400, got %d: %s", name, w.Code, w.Body.String())
+		}
+	}
+
+	// A normal name is accepted.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/labels", map[string]any{
+		"name":  "newline-ok",
+		"color": "#3b82f6",
+	})
+	testHandler.CreateLabel(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateLabel normal name: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created LabelResponse
+	json.NewDecoder(w.Body).Decode(&created)
+	t.Cleanup(func() {
+		w := httptest.NewRecorder()
+		req := newRequest("DELETE", "/api/labels/"+created.ID, nil)
+		req = withURLParam(req, "id", created.ID)
+		testHandler.DeleteLabel(w, req)
+	})
+}
+
 // TestColorCaseNormalization — input `#ABCDEF` must be stored as `#abcdef`
 // so the case-insensitive uniqueness and downstream CSS rendering are
 // consistent. Also accepts a bare `ABCDEF` (no leading #).


### PR DESCRIPTION
Resolves the `TODO(labels)` at `server/internal/handler/label.go:93`.

Label names containing a newline (`\n` / `\r`) are now rejected with a 400. This prevents single-line rendering corruption (label chips, dropdowns) and a log/CSV injection vector. Tabs and other control characters remain a follow-up; emoji stay allowed (TrimSpace already strips leading/trailing newlines, so this only fires on a newline embedded in the stored value).

- `server/internal/handler/label.go`: `validateLabelName` rejects `\n`/`\r` via `strings.ContainsAny`.
- `server/internal/handler/label_test.go`: adds `TestLabelNameRejectsNewlines` (4 bad cases → 400, normal name → 201, with cleanup).
- `go test ./internal/handler/` passes.
