### PR TITLE
fix: link assigned skills to detail pages

### DIFF
--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -2,15 +2,18 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { Agent } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
+import { WorkspaceSlugProvider } from "@multica/core/paths";
+import { NavigationProvider, type NavigationAdapter } from "../../../navigation";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
 
 const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
 
 const mockListSkills = vi.hoisted(() => vi.fn());
+const mockSetAgentSkills = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/hooks", () => ({
   useWorkspaceId: () => "ws-1",
@@ -19,7 +22,7 @@ vi.mock("@multica/core/hooks", () => ({
 vi.mock("@multica/core/api", () => ({
   api: {
     listSkills: (...args: unknown[]) => mockListSkills(...args),
-    setAgentSkills: vi.fn(),
+    setAgentSkills: (...args: unknown[]) => mockSetAgentSkills(...args),
   },
 }));
 
@@ -32,7 +35,7 @@ vi.mock("sonner", () => ({
 
 import { SkillsTab } from "./skills-tab";
 
-const agent: Agent = {
+const baseAgent: Agent = {
   id: "agent-1",
   workspace_id: "ws-1",
   runtime_id: "runtime-1",
@@ -55,7 +58,7 @@ const agent: Agent = {
   archived_by: null,
 };
 
-function renderSkillsTab() {
+function renderSkillsTab(agent: Agent = baseAgent) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -63,20 +66,35 @@ function renderSkillsTab() {
       },
     },
   });
+  const navigation: NavigationAdapter = {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/test/agents/agent-1",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (path) => path,
+  };
 
-  return render(
+  const view = render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <QueryClientProvider client={queryClient}>
-        <SkillsTab agent={agent} />
-      </QueryClientProvider>
+      <WorkspaceSlugProvider slug="test">
+        <NavigationProvider value={navigation}>
+          <QueryClientProvider client={queryClient}>
+            <SkillsTab agent={agent} />
+          </QueryClientProvider>
+        </NavigationProvider>
+      </WorkspaceSlugProvider>
     </I18nProvider>,
   );
+
+  return { ...view, navigation };
 }
 
 describe("SkillsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListSkills.mockResolvedValue([]);
+    mockSetAgentSkills.mockResolvedValue(undefined);
   });
 
   it("does not render the inline Local Runtime Skills section even for local-runtime agents", async () => {
@@ -106,5 +124,46 @@ describe("SkillsTab", () => {
     // already deleted from the mock setup above; this assertion is
     // implicit — the test file would fail to import if the component
     // still referenced runtimeListOptions / runtimeLocalSkillsOptions.)
+  });
+
+  it("navigates to the skill detail page when an assigned skill is clicked", () => {
+    const { navigation } = renderSkillsTab({
+      ...baseAgent,
+      skills: [
+        {
+          id: "skill-1",
+          name: "Review skill",
+          description: "Review pull requests",
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: /Review skill/i }));
+
+    expect(navigation.push).toHaveBeenCalledWith("/test/skills/skill-1");
+  });
+
+  it("does not navigate when removing an assigned skill", async () => {
+    const { navigation } = renderSkillsTab({
+      ...baseAgent,
+      skills: [
+        {
+          id: "skill-1",
+          name: "Review skill",
+          description: "Review pull requests",
+        },
+      ],
+    });
+    const removeButton = screen.getByRole("button", { name: /Remove skill/i });
+
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(mockSetAgentSkills).toHaveBeenCalledWith("agent-1", {
+        skill_ids: [],
+      });
+    });
+    await waitFor(() => expect(removeButton).not.toBeDisabled());
+    expect(navigation.push).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -7,11 +7,13 @@ import { toast } from "sonner";
 import type { Agent } from "@multica/core/types";
 import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { useWorkspacePaths } from "@multica/core/paths";
 import {
   skillListOptions,
   workspaceKeys,
 } from "@multica/core/workspace/queries";
 import { Button } from "@multica/ui/components/ui/button";
+import { AppLink } from "../../../navigation";
 import { SkillAddDialog } from "../skill-add-dialog";
 import { useT } from "../../../i18n";
 
@@ -23,6 +25,7 @@ export function SkillsTab({
   const { t } = useT("agents");
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
+  const paths = useWorkspacePaths();
   // Same query the SkillAddDialog uses (TanStack Query dedupes by key, so
   // this isn't an extra request) — used here only to grey out the "Add
   // skill" button when the workspace has zero skills total. When skills
@@ -92,23 +95,34 @@ export function SkillsTab({
           {agent.skills.map((skill) => (
             <li
               key={skill.id}
-              className="flex items-center gap-2.5 rounded-md border px-3 py-2"
+              className="group/skill-row relative rounded-md transition-colors hover:bg-accent/40 focus-within:bg-accent/40"
             >
-              <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium">{skill.name}</div>
-                {skill.description && (
-                  <div className="truncate text-xs text-muted-foreground">
-                    {skill.description}
-                  </div>
-                )}
-              </div>
+              <AppLink
+                href={paths.skillDetail(skill.id)}
+                className="flex min-w-0 items-center gap-2.5 rounded-md px-2 py-2 pr-8 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span
+                  className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                  aria-hidden="true"
+                >
+                  <FileText className="h-3.5 w-3.5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium">{skill.name}</div>
+                  {skill.description && (
+                    <div className="truncate text-xs text-muted-foreground">
+                      {skill.description}
+                    </div>
+                  )}
+                </div>
+              </AppLink>
               <Button
                 variant="ghost"
                 size="icon-sm"
+                aria-label={t(($) => $.tab_body.skills.remove_aria)}
                 onClick={() => handleRemove(skill.id)}
                 disabled={removing}
-                className="text-muted-foreground hover:text-destructive"
+                className="absolute right-1.5 top-1/2 z-10 -translate-y-1/2 bg-transparent text-muted-foreground/0 opacity-0 transition-opacity hover:bg-transparent hover:text-muted-foreground focus-visible:text-muted-foreground focus-visible:opacity-100 group-hover/skill-row:text-muted-foreground group-hover/skill-row:opacity-100 group-focus-within/skill-row:text-muted-foreground group-focus-within/skill-row:opacity-100"
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -354,6 +354,7 @@
       "add_action": "Add skill",
       "empty_title": "No skills assigned",
       "empty_hint": "Add workspace skills to share team knowledge with this agent.",
+      "remove_aria": "Remove skill",
       "remove_failed_toast": "Failed to remove skill",
       "add_dialog_title": "Add skill",
       "add_dialog_description": "Select a workspace skill to assign to this agent.",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -339,6 +339,7 @@
       "add_action": "スキルを追加",
       "empty_title": "割り当てられたスキルがありません",
       "empty_hint": "ワークスペースのスキルを追加して、チームの知識をこのエージェントと共有しましょう。",
+      "remove_aria": "スキルを削除",
       "remove_failed_toast": "スキルを削除できませんでした",
       "add_dialog_title": "スキルを追加",
       "add_dialog_description": "このエージェントに割り当てるワークスペースのスキルを選択してください。",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -354,6 +354,7 @@
       "add_action": "스킬 추가",
       "empty_title": "할당된 스킬이 없습니다",
       "empty_hint": "워크스페이스 스킬을 추가해 이 에이전트와 팀 지식을 공유하세요.",
+      "remove_aria": "스킬 제거",
       "remove_failed_toast": "스킬을 제거하지 못했습니다",
       "add_dialog_title": "스킬 추가",
       "add_dialog_description": "이 에이전트에 할당할 워크스페이스 스킬을 선택하세요.",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -347,6 +347,7 @@
       "add_action": "添加 skill",
       "empty_title": "尚未分配 skill",
       "empty_hint": "添加工作区 skill，把团队知识共享给这个智能体。",
+      "remove_aria": "移除 skill",
       "remove_failed_toast": "移除 skill 失败",
       "add_dialog_title": "添加 skill",
       "add_dialog_description": "选择一个工作区 skill 分配给该智能体。",


### PR DESCRIPTION
## Summary

Fixes the agent detail Skills tab so assigned skill rows navigate to their workspace skill detail page.

## What changed

- Build assigned-skill links with `useWorkspacePaths().skillDetail(skill.id)`.
- Wrap the clickable skill row body in `AppLink`, while keeping the remove button as a separate non-navigating action.
- Add localized remove-button `aria-label` copy for `en`, `zh-Hans`, `ja`, and `ko`.
- Add regression coverage for skill-row navigation and remove-button non-navigation.

## Root cause

Assigned skills in `SkillsTab` were rendered as plain `<li>` rows, so the row body had no `AppLink` or navigation adapter wiring.

## Validation

- `pnpm --filter @multica/views exec vitest run agents/components/tabs/skills-tab.test.tsx` passed.
- `pnpm --filter @multica/views typecheck` passed.
- `git diff --check` passed.
- `make check` reached E2E after passing TypeScript typecheck, TypeScript unit tests, and Go tests. One Playwright navigation test timed out once while Next dev was still compiling; isolated rerun passed with `ENV_FILE=.env.worktree pnpm exec playwright test e2e/navigation.spec.ts`.
