### PR TITLE
feat(squad): add squad-level concurrency limits with task queuing

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1033,7 +1033,7 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 	// back to queued so another agent in the squad can claim it later.
 	if claimed.IssueID.Valid {
 		if released, releaseReason := s.maybeReleaseSquadTask(ctx, *claimed); released {
-			slog.Debug("task claim: squad at capacity, task released back to queued",
+			slog.Info("task claim: squad at capacity, task released back to queued",
 				"task_id", util.UUIDToString(claimed.ID),
 				"agent_id", util.UUIDToString(agentID),
 				"reason", releaseReason,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1026,6 +1026,23 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 	}
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(claimed.ID), "agent_id", util.UUIDToString(agentID))
+
+	// Squad concurrency check: if the claimed task belongs to a squad-assigned
+	// issue and the squad has a max_concurrent_tasks cap, verify the squad has
+	// capacity before proceeding. If the squad is at capacity, release the task
+	// back to queued so another agent in the squad can claim it later.
+	if claimed.IssueID.Valid {
+		if released, releaseReason := s.maybeReleaseSquadTask(ctx, *claimed); released {
+			slog.Debug("task claim: squad at capacity, task released back to queued",
+				"task_id", util.UUIDToString(claimed.ID),
+				"agent_id", util.UUIDToString(agentID),
+				"reason", releaseReason,
+			)
+			outcome = "squad_at_capacity"
+			return nil, nil
+		}
+	}
+
 	s.captureTaskDispatched(ctx, *claimed)
 
 	// Refresh agent status from active tasks. This avoids a stale unconditional
@@ -1043,6 +1060,48 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 
 	outcome = "claimed"
 	return claimed, nil
+}
+
+// maybeReleaseSquadTask checks whether the squad this task belongs to is at
+// capacity. If the squad has max_concurrent_tasks > 0 and the current running
+// count meets or exceeds it, the task is released back to queued and the
+// function returns (true, reason). Otherwise returns (false, "").
+func (s *TaskService) maybeReleaseSquadTask(ctx context.Context, task db.AgentTaskQueue) (bool, string) {
+	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
+	if err != nil {
+		// Issue not found or load error — let the claim proceed.
+		return false, ""
+	}
+	if issue.AssigneeType.String != "squad" || !issue.AssigneeID.Valid {
+		// Not a squad-assigned issue — no squad limit applies.
+		return false, ""
+	}
+	squad, err := s.Queries.GetSquad(ctx, issue.AssigneeID)
+	if err != nil {
+		// Squad not found — let the claim proceed.
+		return false, ""
+	}
+	if squad.MaxConcurrentTasks <= 0 {
+		// 0 means no limit (matching agent.max_concurrent_tasks semantics).
+		return false, ""
+	}
+	running, err := s.Queries.CountRunningSquadTasks(ctx, issue.AssigneeID)
+	if err != nil {
+		return false, ""
+	}
+	if running >= int64(squad.MaxConcurrentTasks) {
+		// Squad at capacity: release the task back to queued.
+		n, relErr := s.Queries.ReleaseTaskToQueued(ctx, task.ID)
+		if relErr != nil {
+			return false, ""
+		}
+		if n == 0 {
+			// Another goroutine already touched this task — don't block.
+			return false, ""
+		}
+		return true, "squad_max_concurrent"
+	}
+	return false, ""
 }
 
 // ClaimTaskForRuntime claims the next runnable task for a runtime while

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1062,10 +1062,11 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 	return claimed, nil
 }
 
-// maybeReleaseSquadTask checks whether the squad this task belongs to is at
+// maybeReleaseSquadTask checks whether the squad this task belongs to is over
 // capacity. If the squad has max_concurrent_tasks > 0 and the current running
-// count meets or exceeds it, the task is released back to queued and the
-// function returns (true, reason). Otherwise returns (false, "").
+// count (which includes the just-claimed task) strictly exceeds the cap, the
+// task is released back to queued and the function returns (true, reason).
+// Otherwise returns (false, "").
 func (s *TaskService) maybeReleaseSquadTask(ctx context.Context, task db.AgentTaskQueue) (bool, string) {
 	issue, err := s.Queries.GetIssue(ctx, task.IssueID)
 	if err != nil {
@@ -1089,7 +1090,7 @@ func (s *TaskService) maybeReleaseSquadTask(ctx context.Context, task db.AgentTa
 	if err != nil {
 		return false, ""
 	}
-	if running >= int64(squad.MaxConcurrentTasks) {
+	if running > int64(squad.MaxConcurrentTasks) {
 		// Squad at capacity: release the task back to queued.
 		n, relErr := s.Queries.ReleaseTaskToQueued(ctx, task.ID)
 		if relErr != nil {

--- a/server/internal/service/task_squad_concurrency_test.go
+++ b/server/internal/service/task_squad_concurrency_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -16,11 +17,10 @@ import (
 // (the first word after the sqlc name comment). Exec always succeeds unless
 // releaseErr is set.
 type squadTestDBTX struct {
-	// QueryRow responses, keyed by sqlc query tag.
-	issue      *db.Issue
-	issueErr   error
-	squad      *db.Squad
-	squadErr   error
+	issue        *db.Issue
+	issueErr     error
+	squad        *db.Squad
+	squadErr     error
 	runningCount int64
 	runningErr   error
 	releaseRows  int64
@@ -39,16 +39,17 @@ func (m *squadTestDBTX) Query(_ context.Context, _ string, _ ...interface{}) (pg
 }
 
 func (m *squadTestDBTX) QueryRow(_ context.Context, sql string, args ...interface{}) pgx.Row {
-	// GetIssue: SELECT * FROM issue WHERE id = $1
-	if m.issue != nil || m.issueErr != nil {
+	// Route by sqlc query name comment embedded in the SQL string.
+	// Each generated query starts with "-- name: QueryName :kind".
+	switch {
+	case strings.Contains(sql, "-- name: GetIssue"):
 		return &issueRow{issue: m.issue, err: m.issueErr}
-	}
-	// GetSquad: SELECT * FROM squad WHERE id = $1
-	if m.squad != nil || m.squadErr != nil {
+	case strings.Contains(sql, "-- name: GetSquad"):
 		return &squadRow{squad: m.squad, err: m.squadErr}
+	default:
+		// CountRunningSquadTasks, CountTodayAgentTasks, etc.
+		return &countRow{count: m.runningCount, err: m.runningErr}
 	}
-	// CountRunningSquadTasks / CountTodayAgentTasks
-	return &countRow{count: m.runningCount, err: m.runningErr}
 }
 
 // issueRow implements pgx.Row for GetIssue.
@@ -61,16 +62,26 @@ func (r *issueRow) Scan(dest ...any) error {
 	if r.err != nil {
 		return r.err
 	}
+	if r.issue == nil {
+		return pgx.ErrNoRows
+	}
+	var uuidIdx int
 	for _, d := range dest {
 		switch v := d.(type) {
 		case *pgtype.UUID:
-			*v = r.issue.ID
-		case *string:
-			*v = r.issue.AssigneeType
-		case *pgtype.Text:
-			if v == &r.issue.AssigneeType {
-				// already handled above as string
+			// GetIssue column order: ID(0), WorkspaceID(1), AssigneeID(7),
+			// CreatorID(9), ParentIssueID(11), ProjectID(19), OriginID(22).
+			// maybeReleaseSquadTask only reads AssigneeID (pos 7).
+			if uuidIdx == 7 {
+				*v = r.issue.AssigneeID
+			} else {
+				*v = r.issue.ID
 			}
+			uuidIdx++
+		case *string:
+			*v = ""
+		case *pgtype.Text:
+			*v = r.issue.AssigneeType
 		}
 	}
 	return nil
@@ -85,6 +96,9 @@ type squadRow struct {
 func (r *squadRow) Scan(dest ...any) error {
 	if r.err != nil {
 		return r.err
+	}
+	if r.squad == nil {
+		return pgx.ErrNoRows
 	}
 	for _, d := range dest {
 		switch v := d.(type) {
@@ -126,17 +140,17 @@ func TestMaybeReleaseSquadTask(t *testing.T) {
 
 	noLimitSquad := &db.Squad{ID: squadID, MaxConcurrentTasks: 0}
 	capOneSquad := &db.Squad{ID: squadID, MaxConcurrentTasks: 1}
-	squadIssue := &db.Issue{ID: issueID, AssigneeType: "squad"}
-	agentIssue := &db.Issue{ID: issueID, AssigneeType: "agent"}
+	squadIssue := &db.Issue{ID: issueID, AssigneeType: pgtype.Text{String: "squad", Valid: true}, AssigneeID: squadID}
+	agentIssue := &db.Issue{ID: issueID, AssigneeType: pgtype.Text{String: "agent", Valid: true}}
 
 	task := db.AgentTaskQueue{ID: taskID, IssueID: issueID}
 	taskNoIssue := db.AgentTaskQueue{ID: taskID, IssueID: pgtype.UUID{}}
 
 	tests := []struct {
-		name    string
-		mock    squadTestDBTX
-		task    db.AgentTaskQueue
-		want    bool
+		name       string
+		mock       squadTestDBTX
+		task       db.AgentTaskQueue
+		want       bool
 		wantReason string
 	}{
 		{
@@ -158,11 +172,21 @@ func TestMaybeReleaseSquadTask(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "under limit (1 running, max=1) → true released",
+			name: "at capacity (1 running, max=1) → false (running count includes just-claimed task)",
 			mock: squadTestDBTX{
 				issue:        squadIssue,
 				squad:        capOneSquad,
 				runningCount: 1,
+			},
+			task: task,
+			want: false,
+		},
+		{
+			name: "over capacity (2 running, max=1) → true released",
+			mock: squadTestDBTX{
+				issue:        squadIssue,
+				squad:        capOneSquad,
+				runningCount: 2,
 				releaseRows:  1,
 			},
 			task:       task,
@@ -185,17 +209,17 @@ func TestMaybeReleaseSquadTask(t *testing.T) {
 				issue:        squadIssue,
 				squad:        capOneSquad,
 				runningCount: 2,
-				releaseRows:  0, // another goroutine already touched the task
+				releaseRows:  0,
 			},
-			task:       task,
-			want:       false,
+			task: task,
+			want: false,
 		},
 		{
 			name: "release DB error → false (fail open)",
 			mock: squadTestDBTX{
 				issue:        squadIssue,
 				squad:        capOneSquad,
-				runningCount: 1,
+				runningCount: 2,
 				releaseErr:   pgx.ErrNoRows,
 			},
 			task: task,
@@ -207,7 +231,7 @@ func TestMaybeReleaseSquadTask(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			mock := tc.mock // copy
+			mock := tc.mock
 			q := db.New(&mock)
 			svc := &TaskService{Queries: q}
 

--- a/server/internal/service/task_squad_concurrency_test.go
+++ b/server/internal/service/task_squad_concurrency_test.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// squadTestDBTX routes QueryRow and Exec calls for maybeReleaseSquadTask tests.
+// Each QueryRow call is identified by a query tag embedded in the SQL string
+// (the first word after the sqlc name comment). Exec always succeeds unless
+// releaseErr is set.
+type squadTestDBTX struct {
+	// QueryRow responses, keyed by sqlc query tag.
+	issue      *db.Issue
+	issueErr   error
+	squad      *db.Squad
+	squadErr   error
+	runningCount int64
+	runningErr   error
+	releaseRows  int64
+	releaseErr   error
+}
+
+func (m *squadTestDBTX) Exec(_ context.Context, sql string, _ ...interface{}) (pgconn.CommandTag, error) {
+	if m.releaseErr != nil {
+		return pgconn.NewCommandTag(""), m.releaseErr
+	}
+	return pgconn.NewCommandTag("UPDATE " + strconv.FormatInt(m.releaseRows, 10)), nil
+}
+
+func (m *squadTestDBTX) Query(_ context.Context, _ string, _ ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (m *squadTestDBTX) QueryRow(_ context.Context, sql string, args ...interface{}) pgx.Row {
+	// GetIssue: SELECT * FROM issue WHERE id = $1
+	if m.issue != nil || m.issueErr != nil {
+		return &issueRow{issue: m.issue, err: m.issueErr}
+	}
+	// GetSquad: SELECT * FROM squad WHERE id = $1
+	if m.squad != nil || m.squadErr != nil {
+		return &squadRow{squad: m.squad, err: m.squadErr}
+	}
+	// CountRunningSquadTasks / CountTodayAgentTasks
+	return &countRow{count: m.runningCount, err: m.runningErr}
+}
+
+// issueRow implements pgx.Row for GetIssue.
+type issueRow struct {
+	issue *db.Issue
+	err   error
+}
+
+func (r *issueRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for _, d := range dest {
+		switch v := d.(type) {
+		case *pgtype.UUID:
+			*v = r.issue.ID
+		case *string:
+			*v = r.issue.AssigneeType
+		case *pgtype.Text:
+			if v == &r.issue.AssigneeType {
+				// already handled above as string
+			}
+		}
+	}
+	return nil
+}
+
+// squadRow implements pgx.Row for GetSquad.
+type squadRow struct {
+	squad *db.Squad
+	err   error
+}
+
+func (r *squadRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for _, d := range dest {
+		switch v := d.(type) {
+		case *pgtype.UUID:
+			*v = r.squad.ID
+		case *string:
+			*v = r.squad.Name
+		case *int32:
+			*v = r.squad.MaxConcurrentTasks
+		}
+	}
+	return nil
+}
+
+// countRow implements pgx.Row for count queries (returns int64).
+type countRow struct {
+	count int64
+	err   error
+}
+
+func (r *countRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for _, d := range dest {
+		if v, ok := d.(*int64); ok {
+			*v = r.count
+		}
+	}
+	return nil
+}
+
+func TestMaybeReleaseSquadTask(t *testing.T) {
+	t.Parallel()
+
+	squadID := testUUID(1)
+	issueID := testUUID(2)
+	taskID := testUUID(3)
+
+	noLimitSquad := &db.Squad{ID: squadID, MaxConcurrentTasks: 0}
+	capOneSquad := &db.Squad{ID: squadID, MaxConcurrentTasks: 1}
+	squadIssue := &db.Issue{ID: issueID, AssigneeType: "squad"}
+	agentIssue := &db.Issue{ID: issueID, AssigneeType: "agent"}
+
+	task := db.AgentTaskQueue{ID: taskID, IssueID: issueID}
+	taskNoIssue := db.AgentTaskQueue{ID: taskID, IssueID: pgtype.UUID{}}
+
+	tests := []struct {
+		name    string
+		mock    squadTestDBTX
+		task    db.AgentTaskQueue
+		want    bool
+		wantReason string
+	}{
+		{
+			name: "no issue id → false",
+			mock: squadTestDBTX{},
+			task: taskNoIssue,
+			want: false,
+		},
+		{
+			name: "non-squad issue → false",
+			mock: squadTestDBTX{issue: agentIssue},
+			task: task,
+			want: false,
+		},
+		{
+			name: "max_concurrent_tasks = 0 → false",
+			mock: squadTestDBTX{issue: squadIssue, squad: noLimitSquad},
+			task: task,
+			want: false,
+		},
+		{
+			name: "under limit (1 running, max=1) → true released",
+			mock: squadTestDBTX{
+				issue:        squadIssue,
+				squad:        capOneSquad,
+				runningCount: 1,
+				releaseRows:  1,
+			},
+			task:       task,
+			want:       true,
+			wantReason: "squad_max_concurrent",
+		},
+		{
+			name: "under limit (0 running, max=1) → false",
+			mock: squadTestDBTX{
+				issue:        squadIssue,
+				squad:        capOneSquad,
+				runningCount: 0,
+			},
+			task: task,
+			want: false,
+		},
+		{
+			name: "release returns 0 rows → false (race with another goroutine)",
+			mock: squadTestDBTX{
+				issue:        squadIssue,
+				squad:        capOneSquad,
+				runningCount: 2,
+				releaseRows:  0, // another goroutine already touched the task
+			},
+			task:       task,
+			want:       false,
+		},
+		{
+			name: "release DB error → false (fail open)",
+			mock: squadTestDBTX{
+				issue:        squadIssue,
+				squad:        capOneSquad,
+				runningCount: 1,
+				releaseErr:   pgx.ErrNoRows,
+			},
+			task: task,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := tc.mock // copy
+			q := db.New(&mock)
+			svc := &TaskService{Queries: q}
+
+			released, reason := svc.maybeReleaseSquadTask(context.Background(), tc.task)
+			if released != tc.want {
+				t.Errorf("released = %v, want %v", released, tc.want)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/server/migrations/120_squad_max_concurrent_tasks.down.sql
+++ b/server/migrations/120_squad_max_concurrent_tasks.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE squad DROP COLUMN max_concurrent_tasks;

--- a/server/migrations/120_squad_max_concurrent_tasks.up.sql
+++ b/server/migrations/120_squad_max_concurrent_tasks.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE squad ADD COLUMN max_concurrent_tasks INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN squad.max_concurrent_tasks IS 'Maximum concurrent tasks for this squad. 0 means no limit (same semantics as agent.max_concurrent_tasks).';

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2975,10 +2975,10 @@ func (q *Queries) UpdateAgentTaskSession(ctx context.Context, arg UpdateAgentTas
 }
 
 
-const releaseTaskToQueued = \`-- name: ReleaseTaskToQueued :execrows
+const releaseTaskToQueued = `-- name: ReleaseTaskToQueued :execrows
 UPDATE agent_task_queue SET status = 'queued', dispatched_at = NULL
 WHERE id = $1 AND status = 'dispatched'
-\`
+`
 
 func (q *Queries) ReleaseTaskToQueued(ctx context.Context, id pgtype.UUID) (int64, error) {
 	tag, err := q.db.Exec(ctx, releaseTaskToQueued, id)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2687,6 +2687,21 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 	return i, err
 }
 
+const releaseTaskToQueued = `-- name: ReleaseTaskToQueued :execrows
+UPDATE agent_task_queue SET status = 'queued', dispatched_at = NULL
+WHERE id = $1 AND status = 'dispatched'
+`
+
+// Return a dispatched task back to the queued pool. Used when a
+// post-claim capacity check (e.g. squad concurrency) rejects the task.
+func (q *Queries) ReleaseTaskToQueued(ctx context.Context, id pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, releaseTaskToQueued, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
@@ -2972,15 +2987,4 @@ type UpdateAgentTaskSessionParams struct {
 func (q *Queries) UpdateAgentTaskSession(ctx context.Context, arg UpdateAgentTaskSessionParams) error {
 	_, err := q.db.Exec(ctx, updateAgentTaskSession, arg.ID, arg.SessionID, arg.WorkDir)
 	return err
-}
-
-
-const releaseTaskToQueued = `-- name: ReleaseTaskToQueued :execrows
-UPDATE agent_task_queue SET status = 'queued', dispatched_at = NULL
-WHERE id = $1 AND status = 'dispatched'
-`
-
-func (q *Queries) ReleaseTaskToQueued(ctx context.Context, id pgtype.UUID) (int64, error) {
-	tag, err := q.db.Exec(ctx, releaseTaskToQueued, id)
-	return tag.RowsAffected(), err
 }

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2973,3 +2973,14 @@ func (q *Queries) UpdateAgentTaskSession(ctx context.Context, arg UpdateAgentTas
 	_, err := q.db.Exec(ctx, updateAgentTaskSession, arg.ID, arg.SessionID, arg.WorkDir)
 	return err
 }
+
+
+const releaseTaskToQueued = \`-- name: ReleaseTaskToQueued :execrows
+UPDATE agent_task_queue SET status = 'queued', dispatched_at = NULL
+WHERE id = $1 AND status = 'dispatched'
+\`
+
+func (q *Queries) ReleaseTaskToQueued(ctx context.Context, id pgtype.UUID) (int64, error) {
+	tag, err := q.db.Exec(ctx, releaseTaskToQueued, id)
+	return tag.RowsAffected(), err
+}

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -719,8 +719,9 @@ type Squad struct {
 	ArchivedAt   pgtype.Timestamptz `json:"archived_at"`
 	ArchivedBy   pgtype.UUID        `json:"archived_by"`
 	AvatarUrl    pgtype.Text        `json:"avatar_url"`
-	Instructions        string             `json:"instructions"`
-	MaxConcurrentTasks  int32              `json:"max_concurrent_tasks"`
+	Instructions string             `json:"instructions"`
+	// Maximum concurrent tasks for this squad. 0 means no limit (same semantics as agent.max_concurrent_tasks).
+	MaxConcurrentTasks int32 `json:"max_concurrent_tasks"`
 }
 
 type SquadMember struct {

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -719,7 +719,8 @@ type Squad struct {
 	ArchivedAt   pgtype.Timestamptz `json:"archived_at"`
 	ArchivedBy   pgtype.UUID        `json:"archived_by"`
 	AvatarUrl    pgtype.Text        `json:"avatar_url"`
-	Instructions string             `json:"instructions"`
+	Instructions        string             `json:"instructions"`
+	MaxConcurrentTasks  int32              `json:"max_concurrent_tasks"`
 }
 
 type SquadMember struct {

--- a/server/pkg/db/generated/squad.sql.go
+++ b/server/pkg/db/generated/squad.sql.go
@@ -703,13 +703,13 @@ func (q *Queries) UpdateSquadMemberRole(ctx context.Context, arg UpdateSquadMemb
 }
 
 
-const countRunningSquadTasks = \`-- name: CountRunningSquadTasks :one
+const countRunningSquadTasks = `-- name: CountRunningSquadTasks :one
 SELECT count(*) FROM agent_task_queue atq
 JOIN issue i ON i.id = atq.issue_id
 WHERE i.assignee_type = 'squad'
   AND i.assignee_id = $1
   AND atq.status IN ('dispatched', 'running', 'waiting_local_directory')
-\`
+`
 
 func (q *Queries) CountRunningSquadTasks(ctx context.Context, squadID pgtype.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, countRunningSquadTasks, squadID)

--- a/server/pkg/db/generated/squad.sql.go
+++ b/server/pkg/db/generated/squad.sql.go
@@ -46,7 +46,7 @@ func (q *Queries) AddSquadMember(ctx context.Context, arg AddSquadMemberParams) 
 const archiveSquad = `-- name: ArchiveSquad :one
 UPDATE squad SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions
+RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks
 `
 
 type ArchiveSquadParams struct {
@@ -70,8 +70,27 @@ func (q *Queries) ArchiveSquad(ctx context.Context, arg ArchiveSquadParams) (Squ
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
+}
+
+const countRunningSquadTasks = `-- name: CountRunningSquadTasks :one
+SELECT count(*) FROM agent_task_queue atq
+JOIN issue i ON i.id = atq.issue_id
+WHERE i.assignee_type = 'squad'
+  AND i.assignee_id = $1
+  AND atq.status IN ('dispatched', 'running', 'waiting_local_directory')
+`
+
+// Count tasks currently consuming a squad's concurrency capacity.
+// Only counts tasks for issues assigned to this squad; tasks for
+// non-squad issues or chat tasks are excluded.
+func (q *Queries) CountRunningSquadTasks(ctx context.Context, assigneeID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countRunningSquadTasks, assigneeID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const countSquadMembers = `-- name: CountSquadMembers :one
@@ -88,7 +107,7 @@ func (q *Queries) CountSquadMembers(ctx context.Context, squadID pgtype.UUID) (i
 const createSquad = `-- name: CreateSquad :one
 INSERT INTO squad (workspace_id, name, description, leader_id, creator_id, avatar_url)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions
+RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks
 `
 
 type CreateSquadParams struct {
@@ -123,12 +142,13 @@ func (q *Queries) CreateSquad(ctx context.Context, arg CreateSquadParams) (Squad
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
 }
 
 const getSquad = `-- name: GetSquad :one
-SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad WHERE id = $1
+SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks FROM squad WHERE id = $1
 `
 
 func (q *Queries) GetSquad(ctx context.Context, id pgtype.UUID) (Squad, error) {
@@ -147,12 +167,13 @@ func (q *Queries) GetSquad(ctx context.Context, id pgtype.UUID) (Squad, error) {
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
 }
 
 const getSquadByAssignee = `-- name: GetSquadByAssignee :one
-SELECT s.id, s.workspace_id, s.name, s.description, s.leader_id, s.creator_id, s.created_at, s.updated_at, s.archived_at, s.archived_by, s.avatar_url, s.instructions FROM squad s WHERE s.id = $1 AND s.workspace_id = $2
+SELECT s.id, s.workspace_id, s.name, s.description, s.leader_id, s.creator_id, s.created_at, s.updated_at, s.archived_at, s.archived_by, s.avatar_url, s.instructions, s.max_concurrent_tasks FROM squad s WHERE s.id = $1 AND s.workspace_id = $2
 `
 
 type GetSquadByAssigneeParams struct {
@@ -177,12 +198,13 @@ func (q *Queries) GetSquadByAssignee(ctx context.Context, arg GetSquadByAssignee
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
 }
 
 const getSquadInWorkspace = `-- name: GetSquadInWorkspace :one
-SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad WHERE id = $1 AND workspace_id = $2
+SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks FROM squad WHERE id = $1 AND workspace_id = $2
 `
 
 type GetSquadInWorkspaceParams struct {
@@ -206,6 +228,7 @@ func (q *Queries) GetSquadInWorkspace(ctx context.Context, arg GetSquadInWorkspa
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
 }
@@ -231,7 +254,7 @@ func (q *Queries) IsSquadMember(ctx context.Context, arg IsSquadMemberParams) (b
 }
 
 const listAllSquads = `-- name: ListAllSquads :many
-SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad WHERE workspace_id = $1 ORDER BY created_at ASC
+SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks FROM squad WHERE workspace_id = $1 ORDER BY created_at ASC
 `
 
 func (q *Queries) ListAllSquads(ctx context.Context, workspaceID pgtype.UUID) ([]Squad, error) {
@@ -256,6 +279,7 @@ func (q *Queries) ListAllSquads(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.ArchivedBy,
 			&i.AvatarUrl,
 			&i.Instructions,
+			&i.MaxConcurrentTasks,
 		); err != nil {
 			return nil, err
 		}
@@ -480,7 +504,7 @@ func (q *Queries) ListSquadMembers(ctx context.Context, squadID pgtype.UUID) ([]
 }
 
 const listSquads = `-- name: ListSquads :many
-SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad WHERE workspace_id = $1 AND archived_at IS NULL ORDER BY created_at ASC
+SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks FROM squad WHERE workspace_id = $1 AND archived_at IS NULL ORDER BY created_at ASC
 `
 
 func (q *Queries) ListSquads(ctx context.Context, workspaceID pgtype.UUID) ([]Squad, error) {
@@ -505,6 +529,7 @@ func (q *Queries) ListSquads(ctx context.Context, workspaceID pgtype.UUID) ([]Sq
 			&i.ArchivedBy,
 			&i.AvatarUrl,
 			&i.Instructions,
+			&i.MaxConcurrentTasks,
 		); err != nil {
 			return nil, err
 		}
@@ -517,7 +542,7 @@ func (q *Queries) ListSquads(ctx context.Context, workspaceID pgtype.UUID) ([]Sq
 }
 
 const listSquadsByMember = `-- name: ListSquadsByMember :many
-SELECT s.id, s.workspace_id, s.name, s.description, s.leader_id, s.creator_id, s.created_at, s.updated_at, s.archived_at, s.archived_by, s.avatar_url, s.instructions FROM squad s
+SELECT s.id, s.workspace_id, s.name, s.description, s.leader_id, s.creator_id, s.created_at, s.updated_at, s.archived_at, s.archived_by, s.avatar_url, s.instructions, s.max_concurrent_tasks FROM squad s
 JOIN squad_member sm ON sm.squad_id = s.id
 WHERE s.workspace_id = $1 AND sm.member_type = $2 AND sm.member_id = $3
 ORDER BY s.created_at ASC
@@ -552,6 +577,7 @@ func (q *Queries) ListSquadsByMember(ctx context.Context, arg ListSquadsByMember
 			&i.ArchivedBy,
 			&i.AvatarUrl,
 			&i.Instructions,
+			&i.MaxConcurrentTasks,
 		); err != nil {
 			return nil, err
 		}
@@ -631,7 +657,7 @@ UPDATE squad SET
     instructions = COALESCE($6, instructions),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions
+RETURNING id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions, max_concurrent_tasks
 `
 
 type UpdateSquadParams struct {
@@ -666,6 +692,7 @@ func (q *Queries) UpdateSquad(ctx context.Context, arg UpdateSquadParams) (Squad
 		&i.ArchivedBy,
 		&i.AvatarUrl,
 		&i.Instructions,
+		&i.MaxConcurrentTasks,
 	)
 	return i, err
 }
@@ -700,20 +727,4 @@ func (q *Queries) UpdateSquadMemberRole(ctx context.Context, arg UpdateSquadMemb
 		&i.CreatedAt,
 	)
 	return i, err
-}
-
-
-const countRunningSquadTasks = `-- name: CountRunningSquadTasks :one
-SELECT count(*) FROM agent_task_queue atq
-JOIN issue i ON i.id = atq.issue_id
-WHERE i.assignee_type = 'squad'
-  AND i.assignee_id = $1
-  AND atq.status IN ('dispatched', 'running', 'waiting_local_directory')
-`
-
-func (q *Queries) CountRunningSquadTasks(ctx context.Context, squadID pgtype.UUID) (int64, error) {
-	row := q.db.QueryRow(ctx, countRunningSquadTasks, squadID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
 }

--- a/server/pkg/db/generated/squad.sql.go
+++ b/server/pkg/db/generated/squad.sql.go
@@ -701,3 +701,19 @@ func (q *Queries) UpdateSquadMemberRole(ctx context.Context, arg UpdateSquadMemb
 	)
 	return i, err
 }
+
+
+const countRunningSquadTasks = \`-- name: CountRunningSquadTasks :one
+SELECT count(*) FROM agent_task_queue atq
+JOIN issue i ON i.id = atq.issue_id
+WHERE i.assignee_type = 'squad'
+  AND i.assignee_id = $1
+  AND atq.status IN ('dispatched', 'running', 'waiting_local_directory')
+\`
+
+func (q *Queries) CountRunningSquadTasks(ctx context.Context, squadID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countRunningSquadTasks, squadID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -730,3 +730,9 @@ SET status = CASE WHEN EXISTS (
     updated_at = now()
 WHERE a.id = $1
 RETURNING *;
+
+-- name: ReleaseTaskToQueued :execrows
+-- Return a dispatched task back to the queued pool. Used when a
+-- post-claim capacity check (e.g. squad concurrency) rejects the task.
+UPDATE agent_task_queue SET status = 'queued', dispatched_at = NULL
+WHERE id = $1 AND status = 'dispatched';

--- a/server/pkg/db/queries/squad.sql
+++ b/server/pkg/db/queries/squad.sql
@@ -149,3 +149,13 @@ LEFT JOIN issue i
        ON i.id = atq.issue_id
 WHERE sm.squad_id = $1
 ORDER BY sm.created_at ASC, atq.dispatched_at DESC NULLS LAST;
+
+-- name: CountRunningSquadTasks :one
+-- Count tasks currently consuming a squad's concurrency capacity.
+-- Only counts tasks for issues assigned to this squad; tasks for
+-- non-squad issues or chat tasks are excluded.
+SELECT count(*) FROM agent_task_queue atq
+JOIN issue i ON i.id = atq.issue_id
+WHERE i.assignee_type = 'squad'
+  AND i.assignee_id = $1
+  AND atq.status IN ('dispatched', 'running', 'waiting_local_directory');


### PR DESCRIPTION
## Summary

Add `max_concurrent_tasks` to the squad table so workspace owners can limit how many squad tasks run in parallel. When a squad reaches its concurrency cap, newly claimed tasks are released back to the queued pool and retried on the next poll cycle — the same semantics as per-agent `max_concurrent_tasks`.

This addresses the use case where multiple squad agents running in parallel on a local GPU cause OOM or "context size exceeded" errors. Setting `max_concurrent_tasks = 1` serializes squad execution.

## Changes

1. **Migration 120**: add `max_concurrent_tasks INTEGER NOT NULL DEFAULT 0` to the `squad` table (0 = no limit).
2. **`CountRunningSquadTasks` query**: counts tasks in `dispatched`/`running`/`waiting_local_directory` for issues assigned to a given squad.
3. **`ReleaseTaskToQueued` query**: resets a just-claimed task back to `queued` when a post-claim capacity check rejects it.
4. **`maybeReleaseSquadTask` in `ClaimTask()`**: after `ClaimAgentTask` succeeds, checks the issue's squad capacity and releases the task if the squad is at its limit. Tasks for non-squad issues and chat tasks are unaffected.

Closes #4051

## Design decisions

- **Post-claim check**: the capacity check runs AFTER `ClaimAgentTask` atomically claims the task. If the squad is at capacity, `ReleaseTaskToQueued` puts it back. This avoids a race between capacity-check and claim, and the task is naturally retried on the next poll cycle.
- **0 = unlimited**: matching `agent.max_concurrent_tasks` semantics — existing squads stay unlimited until configured.
- **No migration for existing squads needed**: the DEFAULT 0 ensures existing behavior is preserved.
- **Dead code in `ReleaseTaskToQueued` result check**: returns early if `n == 0` (another goroutine already touched the task) to avoid blocking.

## How to Test

```
# Unit: run all task service tests
go test ./server/internal/service/ -count=1

# Verify migration
make migrate-up && make migrate-down
```

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy
- [ ] If this PR touches Chinese product copy, I checked conventions
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

**Prompt / approach:**
The agent explored the full Squad task dispatch chain (issue assignment → leader enqueue → leader briefing → @mention delegation → member claim), identified that no squad-level concurrency mechanism exists, and implemented a post-claim capacity check mirroring the existing per-agent `max_concurrent_tasks` pattern. The approach adds `max_concurrent_tasks` to the squad schema, a running-count query joining `agent_task_queue` on `issue` by squad assignment, and a release-back-to-queued fallback in the claim hot path.