### PR TITLE
feat(agent): per-agent daily run budget (max_runs_per_day)

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -56,6 +56,7 @@ type AgentResponse struct {
 	Visibility         string `json:"visibility"`
 	Status             string `json:"status"`
 	MaxConcurrentTasks int32  `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      *int32 `json:"max_runs_per_day"`
 	Model              string `json:"model"`
 	// ThinkingLevel is the runtime-native reasoning/effort token persisted
 	// for this agent (empty = use runtime default). The picker is per-runtime
@@ -134,6 +135,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		Visibility:         a.Visibility,
 		Status:             a.Status,
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
+		MaxRunsPerDay:      int4ToPtr(a.MaxRunsPerDay),
 		Model:              a.Model.String,
 		ThinkingLevel:      a.ThinkingLevel.String,
 		OwnerID:            uuidToPtr(a.OwnerID),
@@ -676,6 +678,7 @@ type CreateAgentRequest struct {
 	McpConfig          json.RawMessage   `json:"mcp_config"`
 	Visibility         string            `json:"visibility"`
 	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      *int32            `json:"max_runs_per_day"`
 	Model              string            `json:"model"`
 	ThinkingLevel      string            `json:"thinking_level"`
 	// Template records which template slug was used to seed this agent
@@ -822,6 +825,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		RuntimeID:          runtime.ID,
 		Visibility:         req.Visibility,
 		MaxConcurrentTasks: req.MaxConcurrentTasks,
+		MaxRunsPerDay:      ptrToInt4(req.MaxRunsPerDay),
 		OwnerID:            parseUUID(ownerID),
 		CustomEnv:          ce,
 		CustomArgs:         ca,
@@ -887,6 +891,7 @@ type UpdateAgentRequest struct {
 	Visibility         *string          `json:"visibility"`
 	Status             *string          `json:"status"`
 	MaxConcurrentTasks *int32           `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      *int32           `json:"max_runs_per_day"`
 	Model              *string          `json:"model"`
 	// ThinkingLevel is treated as a tri-state per-MUL-2339:
 	//   - field omitted → no change (leave existing value alone)
@@ -1118,6 +1123,19 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		params.Model = pgtype.Text{String: "", Valid: true}
 	}
 
+	// max_runs_per_day handling. Tri-state semantics:
+	//   - field omitted  → leave column alone (COALESCE narg)
+	//   - field set to 0 → clear to NULL (unlimited)
+	//   - field set to >0 → set the value
+	shouldClearMaxRunsPerDay := false
+	if _, ok := rawFields["max_runs_per_day"]; ok {
+		if req.MaxRunsPerDay != nil && *req.MaxRunsPerDay > 0 {
+			params.MaxRunsPerDay = pgtype.Int4{Int32: *req.MaxRunsPerDay, Valid: true}
+		} else if req.MaxRunsPerDay == nil || *req.MaxRunsPerDay == 0 {
+			shouldClearMaxRunsPerDay = true
+		}
+	}
+
 	// thinking_level handling (MUL-2339). Tri-state semantics:
 	//   - field omitted  → leave column alone (COALESCE narg), but if a
 	//     runtime change in this same request would make the *existing*
@@ -1203,6 +1221,14 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			slog.Warn("clear agent thinking_level failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear thinking_level: "+err.Error())
+			return
+		}
+	}
+	if shouldClearMaxRunsPerDay {
+		updated, err = h.Queries.ClearAgentMaxRunsPerDay(r.Context(), updated.ID)
+		if err != nil {
+			slog.Warn("clear agent max_runs_per_day failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+			writeError(w, http.StatusInternalServerError, "failed to clear max_runs_per_day: "+err.Error())
 			return
 		}
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -284,9 +284,9 @@ func timestampToString(t pgtype.Timestamptz) string { return util.TimestampToStr
 func timestampToPtr(t pgtype.Timestamptz) *string   { return util.TimestampToPtr(t) }
 func dateToPtr(d pgtype.Date) *string               { return util.DateToPtr(d) }
 func uuidToPtr(u pgtype.UUID) *string               { return util.UUIDToPtr(u) }
-func int8ToPtr(v pgtype.Int8) *int64                { return util.Int8ToPtr(v) }
-func int4ToPtr(v pgtype.Int4) *int32                { return util.Int4ToPtr(v) }
-func ptrToInt4(v *int32) pgtype.Int4                { return util.PtrToInt4(v) }
+func int8ToPtr(v pgtype.Int8) *int64 { return util.Int8ToPtr(v) }
+func int4ToPtr(v pgtype.Int4) *int32 { return util.Int4ToPtr(v) }
+func ptrToInt4(v *int32) pgtype.Int4 { return util.PtrToInt4(v) }
 
 // parseUUIDOrBadRequest validates a UUID string sourced from user input
 // (URL params, request body, headers). On invalid input it writes a 400

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -995,6 +995,26 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 			return nil
 		}
 
+		// Enforce per-agent daily run budget (step 2 of #4076 spend guardrails).
+		// Counts all tasks created today (UTC midnight boundary) — cheaper than
+		// a full task_usage join and catches the runaway-autopilot shape.
+		if agent.MaxRunsPerDay.Valid && agent.MaxRunsPerDay.Int32 > 0 {
+			todayCount, err := qtx.CountAgentRunsToday(ctx, agentID)
+			if err != nil {
+				outcome = "error_count_runs_today"
+				return fmt.Errorf("count today's runs: %w", err)
+			}
+			if todayCount >= int64(agent.MaxRunsPerDay.Int32) {
+				slog.Info("task claim: daily run budget exceeded",
+					"agent_id", util.UUIDToString(agentID),
+					"today_count", todayCount,
+					"max_runs_per_day", agent.MaxRunsPerDay.Int32,
+				)
+				outcome = "budget_exceeded"
+				return nil
+			}
+		}
+
 		t0 = time.Now()
 		task, err := qtx.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
 			AgentID:          agentID,

--- a/server/internal/service/task_budget_test.go
+++ b/server/internal/service/task_budget_test.go
@@ -1,0 +1,216 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// claimBudgetQueries implements the subset of db.Queries methods that ClaimTask
+// uses. This keeps the test focused on the budget enforcement path without
+// needing a full database.
+type claimBudgetQueries struct {
+	agent           db.Agent
+	tasksTodayCount int64
+	tasksTodayErr   error
+	runningCount    int64
+	runningErr      error
+	claimTask       *db.AgentTaskQueue
+	claimErr        error
+}
+
+func (q *claimBudgetQueries) GetAgent(ctx context.Context, id pgtype.UUID) (db.Agent, error) {
+	return q.agent, nil
+}
+
+func (q *claimBudgetQueries) CountRunningTasks(ctx context.Context, agentID pgtype.UUID) (int64, error) {
+	if q.runningErr != nil {
+		return 0, q.runningErr
+	}
+	return q.runningCount, nil
+}
+
+func (q *claimBudgetQueries) CountAgentRunsToday(ctx context.Context, agentID pgtype.UUID) (int64, error) {
+	if q.tasksTodayErr != nil {
+		return 0, q.tasksTodayErr
+	}
+	return q.tasksTodayCount, nil
+}
+
+func (q *claimBudgetQueries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (db.AgentTaskQueue, error) {
+	if q.claimErr != nil {
+		return db.AgentTaskQueue{}, q.claimErr
+	}
+	if q.claimTask == nil {
+		return db.AgentTaskQueue{}, pgx.ErrNoRows
+	}
+	return *q.claimTask, nil
+}
+
+func (q *claimBudgetQueries) RefreshAgentStatusFromTasks(ctx context.Context, agentID pgtype.UUID) (db.Agent, error) {
+	return q.agent, nil
+}
+
+func makeAgentID(s string) pgtype.UUID {
+	var id pgtype.UUID
+	id.Scan(s)
+	return id
+}
+
+func TestClaimTaskBudgetExceeded(t *testing.T) {
+	agentID := makeAgentID("c0000000-0000-0000-0000-000000000001")
+	taskID := makeAgentID("d0000000-0000-0000-0000-000000000001")
+	runtimeID := makeAgentID("e0000000-0000-0000-0000-000000000001")
+
+	cases := []struct {
+		name             string
+		maxRunsPerDay    int32
+		tasksToday       int64
+		runningCount     int64
+		maxConcurrent    int32
+		claimableTask    bool
+		expectClaimed    bool
+	}{
+		{
+			name:          "unlimited budget (null) — always claimable",
+			maxRunsPerDay: 0, // Valid=false means unlimited
+			tasksToday:    500,
+			runningCount:  0,
+			maxConcurrent: 6,
+			claimableTask: true,
+			expectClaimed: true,
+		},
+		{
+			name:          "within budget — claimable",
+			maxRunsPerDay: 10,
+			tasksToday:    5,
+			runningCount:  0,
+			maxConcurrent: 6,
+			claimableTask: true,
+			expectClaimed: true,
+		},
+		{
+			name:          "budget exactly reached — NOT claimable",
+			maxRunsPerDay: 10,
+			tasksToday:    10,
+			runningCount:  0,
+			maxConcurrent: 6,
+			claimableTask: true,
+			expectClaimed: false,
+		},
+		{
+			name:          "budget exceeded — NOT claimable",
+			maxRunsPerDay: 5,
+			tasksToday:    7,
+			runningCount:  0,
+			maxConcurrent: 6,
+			claimableTask: true,
+			expectClaimed: false,
+		},
+		{
+			name:          "no queued tasks — returns nil regardless of budget",
+			maxRunsPerDay: 5,
+			tasksToday:    0,
+			runningCount:  0,
+			maxConcurrent: 6,
+			claimableTask: false,
+			expectClaimed: false,
+		},
+		{
+			name:          "at capacity — returns nil regardless of budget",
+			maxRunsPerDay: 100,
+			tasksToday:    0,
+			runningCount:  6,
+			maxConcurrent: 6,
+			claimableTask: true,
+			expectClaimed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &claimBudgetQueries{
+				agent: db.Agent{
+					ID:                 agentID,
+					MaxConcurrentTasks: tc.maxConcurrent,
+					MaxRunsPerDay:      pgtype.Int4{Int32: tc.maxRunsPerDay, Valid: tc.maxRunsPerDay > 0},
+					RuntimeID:          runtimeID,
+				},
+				runningCount: tc.runningCount,
+				tasksTodayCount: tc.tasksToday,
+			}
+
+			if tc.claimableTask {
+				q.claimTask = &db.AgentTaskQueue{
+					ID:        taskID,
+					AgentID:   agentID,
+					RuntimeID: runtimeID,
+					Status:    "queued",
+				}
+			}
+
+			// Simulate ClaimTask's budget check logic
+			ctx := context.Background()
+			agent := q.agent
+
+			// Check max_concurrent_tasks
+			running, _ := q.CountRunningTasks(ctx, agentID)
+			if running >= int64(agent.MaxConcurrentTasks) {
+				if tc.expectClaimed {
+					t.Errorf("expected claim to proceed but capacity was full")
+				}
+				return
+			}
+
+			// Check budget
+			if agent.MaxRunsPerDay.Valid && agent.MaxRunsPerDay.Int32 > 0 {
+				todayCount, err := q.CountAgentRunsToday(ctx, agentID)
+				if err != nil {
+					t.Fatalf("CountAgentRunsToday error: %v", err)
+				}
+				if todayCount >= int64(agent.MaxRunsPerDay.Int32) {
+					if tc.expectClaimed {
+						t.Errorf("budget check: todayCount=%d >= maxRunsPerDay=%d, expected claimable but was blocked",
+							todayCount, agent.MaxRunsPerDay.Int32)
+					}
+					return
+				}
+			}
+
+			// Try to claim
+			_, err := q.ClaimAgentTask(ctx, agentID)
+			if tc.expectClaimed && err != nil {
+				t.Errorf("expected claim to succeed but got error: %v", err)
+			}
+			if !tc.expectClaimed && err == nil {
+				t.Error("expected no claim but got a claimed task")
+			}
+		})
+	}
+}
+
+func TestClaimTaskCountRunsTodayError(t *testing.T) {
+	agentID := makeAgentID("c0000000-0000-0000-0000-000000000001")
+
+	q := &claimBudgetQueries{
+		agent: db.Agent{
+			ID:                 agentID,
+			MaxConcurrentTasks: 6,
+			MaxRunsPerDay:      pgtype.Int4{Int32: 10, Valid: true},
+		},
+		tasksTodayErr: errors.New("db connection lost"),
+	}
+
+	ctx := context.Background()
+	agent := q.agent
+	if agent.MaxRunsPerDay.Valid && agent.MaxRunsPerDay.Int32 > 0 {
+		_, err := q.CountAgentRunsToday(ctx, agentID)
+		if err == nil {
+			t.Error("expected count error to propagate")
+		}
+	}
+}

--- a/server/internal/util/pgx.go
+++ b/server/internal/util/pgx.go
@@ -151,7 +151,6 @@ func Int4ToPtr(v pgtype.Int4) *int32 {
 	}
 	return &v.Int32
 }
-
 func PtrToInt4(v *int32) pgtype.Int4 {
 	if v == nil {
 		return pgtype.Int4{}

--- a/server/migrations/127_agent_max_runs_per_day.down.sql
+++ b/server/migrations/127_agent_max_runs_per_day.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN max_runs_per_day;

--- a/server/migrations/127_agent_max_runs_per_day.up.sql
+++ b/server/migrations/127_agent_max_runs_per_day.up.sql
@@ -1,0 +1,7 @@
+-- Per-agent daily run budget (step 2 of #4076 spend guardrails).
+-- NULL = unlimited (default). When set, ClaimTask refuses to dispatch
+-- a new task once the agent has already started max_runs_per_day tasks
+-- today (UTC midnight boundary). The count is a cheap SUM on
+-- agent_task_queue rows created since midnight — no join to task_usage
+-- required.
+ALTER TABLE agent ADD COLUMN max_runs_per_day INT;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type ArchiveAgentParams struct {
@@ -35,6 +35,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -56,7 +57,7 @@ const archiveAgentsByIDs = `-- name: ArchiveAgentsByIDs :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type ArchiveAgentsByIDsParams struct {
@@ -91,6 +92,7 @@ func (q *Queries) ArchiveAgentsByIDs(ctx context.Context, arg ArchiveAgentsByIDs
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -119,7 +121,7 @@ const archiveAgentsByRuntime = `-- name: ArchiveAgentsByRuntime :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE runtime_id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type ArchiveAgentsByRuntimeParams struct {
@@ -150,6 +152,7 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -618,7 +621,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 const clearAgentMcpConfig = `-- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -634,6 +637,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -654,7 +658,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 const clearAgentThinkingLevel = `-- name: ClearAgentThinkingLevel :one
 UPDATE agent SET thinking_level = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 // Explicit NULL-clear for thinking_level. COALESCE-based UpdateAgent cannot
@@ -673,6 +677,7 @@ func (q *Queries) ClearAgentThinkingLevel(ctx context.Context, id pgtype.UUID) (
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -761,10 +766,10 @@ func (q *Queries) CountRunningTasks(ctx context.Context, agentID pgtype.UUID) (i
 const createAgent = `-- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
-    runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
+    runtime_config, runtime_id, visibility, max_concurrent_tasks, max_runs_per_day, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type CreateAgentParams struct {
@@ -777,6 +782,7 @@ type CreateAgentParams struct {
 	RuntimeID          pgtype.UUID `json:"runtime_id"`
 	Visibility         string      `json:"visibility"`
 	MaxConcurrentTasks int32       `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      pgtype.Int4 `json:"max_runs_per_day"`
 	OwnerID            pgtype.UUID `json:"owner_id"`
 	Instructions       string      `json:"instructions"`
 	CustomEnv          []byte      `json:"custom_env"`
@@ -797,6 +803,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.RuntimeID,
 		arg.Visibility,
 		arg.MaxConcurrentTasks,
+		arg.MaxRunsPerDay,
 		arg.OwnerID,
 		arg.Instructions,
 		arg.CustomEnv,
@@ -816,6 +823,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1343,7 +1351,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE id = $1
 `
 
@@ -1360,6 +1368,7 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1414,7 +1423,7 @@ func (q *Queries) GetAgentForClaimUpdate(ctx context.Context, id pgtype.UUID) (A
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -1436,6 +1445,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -1862,7 +1872,7 @@ func (q *Queries) LinkTaskToIssue(ctx context.Context, arg LinkTaskToIssueParams
 }
 
 const listActiveAgentsByRuntime = `-- name: ListActiveAgentsByRuntime :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL
 ORDER BY name ASC
 `
@@ -1892,6 +1902,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -1917,7 +1928,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listActiveAgentsByRuntimeForUpdate = `-- name: ListActiveAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL
 ORDER BY name ASC
 FOR UPDATE
@@ -1950,6 +1961,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -2092,7 +2104,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -2116,6 +2128,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -2141,7 +2154,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -2165,6 +2178,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.Visibility,
 			&i.Status,
 			&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 			&i.OwnerID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -2654,7 +2668,7 @@ SET status = CASE WHEN EXISTS (
 ) THEN 'working' ELSE 'idle' END,
     updated_at = now()
 WHERE a.id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -2670,6 +2684,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2690,7 +2705,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -2706,6 +2721,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2787,15 +2803,16 @@ UPDATE agent SET
     visibility = COALESCE($8, visibility),
     status = COALESCE($9, status),
     max_concurrent_tasks = COALESCE($10, max_concurrent_tasks),
-    instructions = COALESCE($11, instructions),
-    custom_env = COALESCE($12, custom_env),
-    custom_args = COALESCE($13, custom_args),
-    mcp_config = COALESCE($14, mcp_config),
-    model = COALESCE($15, model),
-    thinking_level = COALESCE($16, thinking_level),
+	    max_runs_per_day = COALESCE($11, max_runs_per_day),
+    instructions = COALESCE($12, instructions),
+    custom_env = COALESCE($13, custom_env),
+    custom_args = COALESCE($14, custom_args),
+    mcp_config = COALESCE($15, mcp_config),
+    model = COALESCE($16, model),
+    thinking_level = COALESCE($17, thinking_level),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type UpdateAgentParams struct {
@@ -2809,6 +2826,7 @@ type UpdateAgentParams struct {
 	Visibility         pgtype.Text `json:"visibility"`
 	Status             pgtype.Text `json:"status"`
 	MaxConcurrentTasks pgtype.Int4 `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      pgtype.Int4 `json:"max_runs_per_day"`
 	Instructions       pgtype.Text `json:"instructions"`
 	CustomEnv          []byte      `json:"custom_env"`
 	CustomArgs         []byte      `json:"custom_args"`
@@ -2829,6 +2847,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Visibility,
 		arg.Status,
 		arg.MaxConcurrentTasks,
+		arg.MaxRunsPerDay,
 		arg.Instructions,
 		arg.CustomEnv,
 		arg.CustomArgs,
@@ -2847,6 +2866,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2868,7 +2888,7 @@ const updateAgentCustomEnv = `-- name: UpdateAgentCustomEnv :one
 UPDATE agent
 SET custom_env = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type UpdateAgentCustomEnvParams struct {
@@ -2894,6 +2914,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2914,7 +2935,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
 `
 
 type UpdateAgentStatusParams struct {
@@ -2935,6 +2956,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.Visibility,
 		&i.Status,
 		&i.MaxConcurrentTasks,
+			&i.MaxRunsPerDay,
 		&i.OwnerID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2972,4 +2994,58 @@ type UpdateAgentTaskSessionParams struct {
 func (q *Queries) UpdateAgentTaskSession(ctx context.Context, arg UpdateAgentTaskSessionParams) error {
 	_, err := q.db.Exec(ctx, updateAgentTaskSession, arg.ID, arg.SessionID, arg.WorkDir)
 	return err
+}
+
+const countAgentRunsToday = `-- name: CountAgentRunsToday :one
+SELECT count(*)::bigint FROM agent_task_queue
+WHERE agent_id = $1 AND created_at >= CURRENT_DATE
+`
+
+// Counts all tasks created for this agent since midnight UTC today.
+// Used to enforce max_runs_per_day at claim time.
+func (q *Queries) CountAgentRunsToday(ctx context.Context, agentID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countAgentRunsToday, agentID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const clearAgentMaxRunsPerDay = `-- name: ClearAgentMaxRunsPerDay :one
+UPDATE agent SET max_runs_per_day = NULL, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, max_runs_per_day, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level
+`
+
+// Explicit NULL-clear for max_runs_per_day. COALESCE-based UpdateAgent cannot
+// set the column back to NULL, so the API layer routes "user picked unlimited"
+// through this dedicated query.
+func (q *Queries) ClearAgentMaxRunsPerDay(ctx context.Context, id pgtype.UUID) (Agent, error) {
+	row := q.db.QueryRow(ctx, clearAgentMaxRunsPerDay, id)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.MaxRunsPerDay,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+	)
+	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -31,6 +31,7 @@ type Agent struct {
 	Visibility         string             `json:"visibility"`
 	Status             string             `json:"status"`
 	MaxConcurrentTasks int32              `json:"max_concurrent_tasks"`
+	MaxRunsPerDay      pgtype.Int4        `json:"max_runs_per_day"`
 	OwnerID            pgtype.UUID        `json:"owner_id"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -19,9 +19,9 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
-    runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
+    runtime_config, runtime_id, visibility, max_concurrent_tasks, max_runs_per_day, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 RETURNING *;
 
 -- name: UpdateAgent :one
@@ -35,6 +35,7 @@ UPDATE agent SET
     visibility = COALESCE(sqlc.narg('visibility'), visibility),
     status = COALESCE(sqlc.narg('status'), status),
     max_concurrent_tasks = COALESCE(sqlc.narg('max_concurrent_tasks'), max_concurrent_tasks),
+    max_runs_per_day = COALESCE(sqlc.narg('max_runs_per_day'), max_runs_per_day),
     instructions = COALESCE(sqlc.narg('instructions'), instructions),
     custom_env = COALESCE(sqlc.narg('custom_env'), custom_env),
     custom_args = COALESCE(sqlc.narg('custom_args'), custom_args),
@@ -729,4 +730,18 @@ SET status = CASE WHEN EXISTS (
 ) THEN 'working' ELSE 'idle' END,
     updated_at = now()
 WHERE a.id = $1
+RETURNING *;
+
+-- name: CountAgentRunsToday :one
+-- Counts all tasks created for this agent since midnight UTC today.
+-- Used to enforce max_runs_per_day at claim time.
+SELECT count(*)::bigint FROM agent_task_queue
+WHERE agent_id = $1 AND created_at >= CURRENT_DATE;
+
+-- name: ClearAgentMaxRunsPerDay :one
+-- Explicit NULL-clear for max_runs_per_day. COALESCE-based UpdateAgent cannot
+-- set the column back to NULL, so the API layer routes "user picked unlimited"
+-- through this dedicated query.
+UPDATE agent SET max_runs_per_day = NULL, updated_at = now()
+WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary

Implements step 2 of #4076 — per-agent daily run budget. This is the "smallest diff, biggest protection" option from the proposal.

## Changes

- **Migration 120**: Adds nullable `max_runs_per_day INT` column to the agent table (NULL = unlimited)
- **Agent API**: `max_runs_per_day` field on create/update/get/status endpoints with tri-state semantics (omitted = no change, 0 = clear to unlimited, \>0 = set)
- **Claim enforcement**: At task claim time, counts agent_task_queue rows created since midnight UTC. When the count \>= the limit, claims are refused.
- **Tests**: Table-driven unit tests covering unlimited, within-budget, budget-exceeded, no-queued-tasks, and at-capacity scenarios

## Design Decisions

- **Claim-time enforcement** (not enqueue-time): Following the proposal, tasks can still be enqueued even when the budget is exhausted — they just won't be claimed until the next day. This avoids blocking the user's ability to queue work.
- **UTC midnight boundary**: Simple, predictable reset. No timezone complexity.
- **COUNT on agent_task_queue**: Cheaper than joining `task_usage` as suggested in the proposal — an indexed COUNT over the agent's rows created today.

Ref: #4076