### PR TITLE
feat(views): hierarchical sub-issue display in list view

### DIFF
--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { ListTodo } from "lucide-react";
 import type { UpdateIssueRequest } from "@multica/core/types";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIssueViewStore, useClearFiltersOnWorkspaceChange, type IssueDateFilter } from "@multica/core/issues/stores/view-store";
 import { dateOnlyToLocalDate } from "@multica/core/issues/date";
 import { useIssuesScopeStore } from "@multica/core/issues/stores/issues-scope-store";
@@ -13,7 +13,7 @@ import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-contex
 import { filterIssues } from "../utils/filter";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
+import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, childrenByParentsOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -27,6 +27,7 @@ import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
 
 const EMPTY_CHILD_PROGRESS = new Map<string, ChildProgress>();
+const EMPTY_CHILDREN = new Map<string, Issue[]>();
 
 function issueDateFilterToApiParams(filter: IssueDateFilter | null) {
   if (!filter) return {};
@@ -191,6 +192,23 @@ export function IssuesPage() {
   // regardless of client-side pagination or filtering of done issues.
   const { data: childProgressMap = EMPTY_CHILD_PROGRESS } = useQuery(childIssueProgressOptions(wsId));
 
+  // Collect parent IDs from visible issues that have children.
+  const visibleParentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        ids.add(issue.id);
+      }
+    }
+    return [...ids].sort();
+  }, [issues, childProgressMap]);
+
+  // Fetch children for the visible parent issues.
+  const queryClient = useQueryClient();
+  const { data: childrenMap = EMPTY_CHILDREN } = useQuery(
+    childrenByParentsOptions(wsId, visibleParentIds, queryClient),
+  );
+
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
       return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
@@ -284,7 +302,7 @@ export function IssuesPage() {
                 sort={queryParams}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} sort={queryParams} onMoveIssue={handleMoveIssue} />
+              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} childrenMap={childrenMap} sort={queryParams} onMoveIssue={handleMoveIssue} />
             )}
           </div>
         )}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { ListTodo } from "lucide-react";
-import type { UpdateIssueRequest } from "@multica/core/types";
+import type { Issue, UpdateIssueRequest } from "@multica/core/types";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIssueViewStore, useClearFiltersOnWorkspaceChange, type IssueDateFilter } from "@multica/core/issues/stores/view-store";

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { ChevronRight, CornerDownRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
@@ -38,6 +39,12 @@ function ListRowContent({
   containerStyle,
   containerProps,
   checkboxProps,
+  indent = 0,
+  isParent = false,
+  isExpanded = false,
+  childCount = 0,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -46,6 +53,12 @@ function ListRowContent({
   containerStyle?: React.CSSProperties;
   containerProps?: Record<string, unknown>;
   checkboxProps?: Pick<React.HTMLAttributes<HTMLDivElement>, "onClick" | "onMouseDown" | "onPointerDown">;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -72,10 +85,37 @@ function ListRowContent({
         ref={containerRef}
         style={containerStyle}
         {...containerProps}
-        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
+        className={`group/row flex h-9 items-center gap-2 pr-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
+        role="row"
       >
+        {/* Indent spacer for child rows */}
+        {indent > 0 && (
+          <div style={{ width: indent * 24 }} className="shrink-0" />
+        )}
+        {/* Expand / collapse toggle for parent rows (replaces priority icon slot) */}
+        {isParent ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onToggleChildren?.();
+            }}
+            className="flex shrink-0 items-center justify-center w-4 h-4 rounded-sm hover:bg-muted cursor-pointer transition-transform"
+            style={{ transform: isExpanded ? "rotate(90deg)" : undefined }}
+            aria-label={isExpanded ? "Collapse sub-issues" : "Expand sub-issues"}
+          >
+            <ChevronRight className="size-3.5 text-muted-foreground" />
+          </button>
+        ) : indent > 0 ? (
+          /* Branch indicator for child rows */
+          <div className="flex shrink-0 items-center justify-center w-4 h-4">
+            <CornerDownRight className="size-3.5 text-muted-foreground/50" />
+          </div>
+        ) : null}
+        {/* Priority icon + checkbox */}
         <div
           className="relative flex shrink-0 items-center justify-center w-4 h-4"
           {...checkboxProps}
@@ -104,6 +144,16 @@ function ListRowContent({
 
           <span className="flex min-w-0 flex-1 items-center gap-1.5">
             <span className="truncate">{issue.title}</span>
+            {isParent && childCount > 0 && (
+              <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                ({childCount})
+              </span>
+            )}
+            {parentIdentifier && (
+              <span className="shrink-0 text-[11px] text-muted-foreground/70 truncate max-w-[120px]">
+                &larr; {parentIdentifier}
+              </span>
+            )}
             {showChildProgress && (
               <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
                 <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
@@ -158,11 +208,34 @@ function ListRowContent({
 export const ListRow = memo(function ListRow({
   issue,
   childProgress,
+  indent,
+  isParent,
+  isExpanded,
+  childCount,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
-  return <ListRowContent issue={issue} childProgress={childProgress} />;
+  return (
+    <ListRowContent
+      issue={issue}
+      childProgress={childProgress}
+      indent={indent}
+      isParent={isParent}
+      isExpanded={isExpanded}
+      childCount={childCount}
+      onToggleChildren={onToggleChildren}
+      parentIdentifier={parentIdentifier}
+    />
+  );
 });
 
 const animateLayoutChanges: AnimateLayoutChanges = (args) => {
@@ -179,10 +252,22 @@ export const DraggableListRow = memo(function DraggableListRow({
   issue,
   childProgress,
   disableSorting,
+  indent,
+  isParent,
+  isExpanded,
+  childCount,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   disableSorting?: boolean;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
   const {
     attributes,
@@ -212,6 +297,12 @@ export const DraggableListRow = memo(function DraggableListRow({
       containerStyle={style}
       containerProps={{ ...attributes, ...listeners }}
       checkboxProps={{ onClick: stopDrag, onMouseDown: stopDrag, onPointerDown: stopDrag }}
+      indent={indent}
+      isParent={isParent}
+      isExpanded={isExpanded}
+      childCount={childCount}
+      onToggleChildren={onToggleChildren}
+      parentIdentifier={parentIdentifier}
     />
   );
 });

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -33,8 +33,22 @@ function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
 }
 
+const STATUS_CN: Record<string, string> = {
+  todo: "待办",
+  in_progress: "进行中",
+  in_review: "审核中",
+  done: "已完成",
+  backlog: "待规划",
+  cancelled: "已取消",
+  blocked: "阻塞中",
+};
+
 function getStatusColor(status: string): string {
   return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
+}
+
+function formatStatusLabel(status: string): string {
+  return STATUS_CN[status] ?? status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function ListRowContent({
@@ -203,7 +217,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{parentInfo.status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}]
+                  [{formatStatusLabel(parentInfo.status)}]
                 </span>
               </button>
             )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -22,6 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import { useT } from "../../i18n";
 import type { ParentInfo, CrossStatusChild } from "../utils/hierarchy";
 
 export interface ChildProgress {
@@ -33,22 +34,8 @@ function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
 }
 
-const STATUS_CN: Record<string, string> = {
-  todo: "待办",
-  in_progress: "进行中",
-  in_review: "审核中",
-  done: "已完成",
-  backlog: "待规划",
-  cancelled: "已取消",
-  blocked: "阻塞中",
-};
-
 function getStatusColor(status: string): string {
   return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
-}
-
-function formatStatusLabel(status: string): string {
-  return STATUS_CN[status] ?? status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function ListRowContent({
@@ -88,6 +75,7 @@ function ListRowContent({
   onHoverParent?: (parentStatus: string | null) => void;
   onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
+  const { t } = useT("issues");
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
   const p = useWorkspacePaths();
@@ -217,7 +205,7 @@ function ListRowContent({
                 ({childCount})
               </span>
             )}
-            {isParent && crossStatusChildCount > 0 && (
+            {crossStatusChildCount > 0 && (
               <div className="relative shrink-0" ref={crossDropdownRef}>
                 <button
                   type="button"
@@ -228,8 +216,7 @@ function ListRowContent({
                   }}
                   className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
                 >
-                  {/* eslint-disable-next-line i18next/no-literal-string */}
-                  ↓ {crossStatusChildCount} 跨状态
+                  ↓ {crossStatusChildCount} {t(($) => $.list.cross_status)}
                 </button>
                 {crossDropdownOpen && crossStatusChildren.length > 0 && (
                   <div className="absolute top-full left-0 z-50 mt-1 bg-popover border border-border rounded-md shadow-md p-1 min-w-[200px] max-h-[240px] overflow-y-auto">
@@ -251,7 +238,7 @@ function ListRowContent({
                           {child.identifier}
                         </span>
                         <span className={`shrink-0 ${getStatusColor(child.status)}`}>
-                          [{formatStatusLabel(child.status)}]
+                          [{t(($) => $.status[child.status])}]
                         </span>
                       </button>
                     ))}
@@ -272,7 +259,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{formatStatusLabel(parentInfo.status)}]
+                  [{t(($) => $.status[parentInfo.status])}]
                 </span>
               </button>
             )}
@@ -354,6 +341,10 @@ export const ListRow = memo(function ListRow({
   onHoverParent?: (parentStatus: string | null) => void;
   onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
+  const handleToggle = useCallback(() => {
+    onToggleChildren?.();
+  }, [onToggleChildren]);
+
   return (
     <ListRowContent
       issue={issue}
@@ -364,7 +355,7 @@ export const ListRow = memo(function ListRow({
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
       crossStatusChildren={crossStatusChildren}
-      onToggleChildren={onToggleChildren}
+      onToggleChildren={handleToggle}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
       onScrollToParent={onScrollToParent}
@@ -430,6 +421,10 @@ export const DraggableListRow = memo(function DraggableListRow({
     transition,
   };
 
+  const handleToggle = useCallback(() => {
+    onToggleChildren?.();
+  }, [onToggleChildren]);
+
   return (
     <ListRowContent
       issue={issue}
@@ -445,7 +440,7 @@ export const DraggableListRow = memo(function DraggableListRow({
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
       crossStatusChildren={crossStatusChildren}
-      onToggleChildren={onToggleChildren}
+      onToggleChildren={handleToggle}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
       onScrollToParent={onScrollToParent}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -228,6 +228,7 @@ function ListRowContent({
                   }}
                   className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
                 >
+                  {/* eslint-disable-next-line i18next/no-literal-string */}
                   ↓ {crossStatusChildCount} 跨状态
                 </button>
                 {crossDropdownOpen && crossStatusChildren.length > 0 && (

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, type Ref } from "react";
+import { memo, useCallback, type Ref } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -8,6 +8,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { ChevronRight, CornerDownRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
+import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { formatDateOnly } from "@multica/core/issues/date";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -21,6 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import type { ParentInfo } from "../utils/hierarchy";
 
 export interface ChildProgress {
   done: number;
@@ -29,6 +31,10 @@ export interface ChildProgress {
 
 function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
+}
+
+function getStatusColor(status: string): string {
+  return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
 }
 
 function ListRowContent({
@@ -43,8 +49,11 @@ function ListRowContent({
   isParent = false,
   isExpanded = false,
   childCount = 0,
+  crossStatusChildCount = 0,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -57,8 +66,11 @@ function ListRowContent({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -79,12 +91,36 @@ function ListRowContent({
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showLabels = storeProperties.labels && labels.length > 0;
 
+  const handleChipClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!parentInfo) return;
+
+      if (e.metaKey || e.ctrlKey) {
+        window.open(p.issueDetail(parentInfo.parentId), "_blank");
+      } else {
+        onScrollToParent?.(parentInfo.parentId, parentInfo.status);
+      }
+    },
+    [parentInfo, p, onScrollToParent],
+  );
+
+  const handleChipMouseEnter = useCallback(() => {
+    if (parentInfo) onHoverParent?.(parentInfo.status);
+  }, [parentInfo, onHoverParent]);
+
+  const handleChipMouseLeave = useCallback(() => {
+    onHoverParent?.(null);
+  }, [onHoverParent]);
+
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
         ref={containerRef}
         style={containerStyle}
         {...containerProps}
+        data-issue-id={issue.id}
         className={`group/row flex h-9 items-center gap-2 pr-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
@@ -149,10 +185,27 @@ function ListRowContent({
                 ({childCount})
               </span>
             )}
-            {parentIdentifier && (
-              <span className="shrink-0 text-[11px] text-muted-foreground/70 truncate max-w-[120px]">
-                &larr; {parentIdentifier}
+            {isParent && crossStatusChildCount > 0 && (
+              <span className="shrink-0 text-[11px] text-muted-foreground/50 tabular-nums">
+                ↓ {crossStatusChildCount} cross-status
               </span>
+            )}
+            {parentInfo && (
+              <button
+                type="button"
+                onClick={handleChipClick}
+                onMouseEnter={handleChipMouseEnter}
+                onMouseLeave={handleChipMouseLeave}
+                className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-muted/60 hover:bg-muted cursor-pointer transition-colors max-w-[200px]"
+                title={`← ${parentInfo.identifier} — Click to scroll, Cmd+Click to open`}
+              >
+                <span className="text-[11px] text-muted-foreground/70 truncate">
+                  ← {parentInfo.identifier}
+                </span>
+                <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
+                  [{parentInfo.status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}]
+                </span>
+              </button>
             )}
             {showChildProgress && (
               <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
@@ -212,8 +265,11 @@ export const ListRow = memo(function ListRow({
   isParent,
   isExpanded,
   childCount,
+  crossStatusChildCount,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -221,8 +277,11 @@ export const ListRow = memo(function ListRow({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   return (
     <ListRowContent
@@ -232,8 +291,11 @@ export const ListRow = memo(function ListRow({
       isParent={isParent}
       isExpanded={isExpanded}
       childCount={childCount}
+      crossStatusChildCount={crossStatusChildCount}
       onToggleChildren={onToggleChildren}
-      parentIdentifier={parentIdentifier}
+      parentInfo={parentInfo}
+      onHoverParent={onHoverParent}
+      onScrollToParent={onScrollToParent}
     />
   );
 });
@@ -256,8 +318,11 @@ export const DraggableListRow = memo(function DraggableListRow({
   isParent,
   isExpanded,
   childCount,
+  crossStatusChildCount,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -266,8 +331,11 @@ export const DraggableListRow = memo(function DraggableListRow({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   const {
     attributes,
@@ -301,8 +369,11 @@ export const DraggableListRow = memo(function DraggableListRow({
       isParent={isParent}
       isExpanded={isExpanded}
       childCount={childCount}
+      crossStatusChildCount={crossStatusChildCount}
       onToggleChildren={onToggleChildren}
-      parentIdentifier={parentIdentifier}
+      parentInfo={parentInfo}
+      onHoverParent={onHoverParent}
+      onScrollToParent={onScrollToParent}
     />
   );
 });

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -238,7 +238,7 @@ function ListRowContent({
                           {child.identifier}
                         </span>
                         <span className={`shrink-0 ${getStatusColor(child.status)}`}>
-                          [{t(($) => $.status[child.status])}]
+                          [{t(($) => $.status[child.status as keyof typeof $.status])}]
                         </span>
                       </button>
                     ))}
@@ -259,7 +259,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{t(($) => $.status[parentInfo.status])}]
+                  [{t(($) => $.status[parentInfo.status as keyof typeof $.status])}]
                 </span>
               </button>
             )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, type Ref } from "react";
+import { memo, useCallback, useState, useEffect, useRef, type Ref } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -22,7 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
-import type { ParentInfo } from "../utils/hierarchy";
+import type { ParentInfo, CrossStatusChild } from "../utils/hierarchy";
 
 export interface ChildProgress {
   done: number;
@@ -64,6 +64,7 @@ function ListRowContent({
   isExpanded = false,
   childCount = 0,
   crossStatusChildCount = 0,
+  crossStatusChildren = [],
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -81,6 +82,7 @@ function ListRowContent({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -97,6 +99,22 @@ function ListRowContent({
   });
   const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
   const labels = issue.labels ?? [];
+
+  // Dropdown state for cross-status badge.
+  const [crossDropdownOpen, setCrossDropdownOpen] = useState(false);
+  const crossDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click.
+  useEffect(() => {
+    if (!crossDropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (crossDropdownRef.current && !crossDropdownRef.current.contains(e.target as Node)) {
+        setCrossDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [crossDropdownOpen]);
 
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
@@ -200,9 +218,45 @@ function ListRowContent({
               </span>
             )}
             {isParent && crossStatusChildCount > 0 && (
-              <span className="shrink-0 text-[11px] text-muted-foreground/50 tabular-nums">
-                ↓ {crossStatusChildCount} cross-status
-              </span>
+              <div className="relative shrink-0" ref={crossDropdownRef}>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setCrossDropdownOpen((v) => !v);
+                  }}
+                  className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
+                >
+                  ↓ {crossStatusChildCount} 跨状态
+                </button>
+                {crossDropdownOpen && crossStatusChildren.length > 0 && (
+                  <div className="absolute top-full left-0 z-50 mt-1 bg-popover border border-border rounded-md shadow-md p-1 min-w-[200px] max-h-[240px] overflow-y-auto">
+                    {crossStatusChildren.map((child) => (
+                      <button
+                        key={child.id}
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          setCrossDropdownOpen(false);
+                          onScrollToParent?.(child.id, child.status);
+                        }}
+                        onMouseEnter={() => onHoverParent?.(child.status)}
+                        onMouseLeave={() => onHoverParent?.(null)}
+                        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] rounded-sm hover:bg-accent cursor-pointer transition-colors"
+                      >
+                        <span className="text-muted-foreground/70 truncate flex-1">
+                          {child.identifier}
+                        </span>
+                        <span className={`shrink-0 ${getStatusColor(child.status)}`}>
+                          [{formatStatusLabel(child.status)}]
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
             {parentInfo && (
               <button
@@ -280,6 +334,7 @@ export const ListRow = memo(function ListRow({
   isExpanded,
   childCount,
   crossStatusChildCount,
+  crossStatusChildren,
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -292,6 +347,7 @@ export const ListRow = memo(function ListRow({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -306,6 +362,7 @@ export const ListRow = memo(function ListRow({
       isExpanded={isExpanded}
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
+      crossStatusChildren={crossStatusChildren}
       onToggleChildren={onToggleChildren}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
@@ -333,6 +390,7 @@ export const DraggableListRow = memo(function DraggableListRow({
   isExpanded,
   childCount,
   crossStatusChildCount,
+  crossStatusChildren,
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -346,6 +404,7 @@ export const DraggableListRow = memo(function DraggableListRow({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -384,6 +443,7 @@ export const DraggableListRow = memo(function DraggableListRow({
       isExpanded={isExpanded}
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
+      crossStatusChildren={crossStatusChildren}
       onToggleChildren={onToggleChildren}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -38,8 +38,10 @@ import {
   getMoveUpdates,
 } from "../utils/drag-utils";
 import type { BoardColumnGroup } from "./board-column";
+import { buildHierarchy, type RenderItem } from "../utils/hierarchy";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+const EMPTY_CHILDREN_MAP = new Map<string, Issue[]>();
 const EMPTY_IDS: string[] = [];
 
 function buildListGroups(visibleStatuses: IssueStatus[]): BoardColumnGroup[] {
@@ -55,6 +57,7 @@ export function ListView({
   issues,
   visibleStatuses,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  childrenMap = EMPTY_CHILDREN_MAP,
   myIssuesScope,
   myIssuesFilter,
   projectId,
@@ -64,6 +67,7 @@ export function ListView({
   issues: Issue[];
   visibleStatuses: IssueStatus[];
   childProgressMap?: Map<string, ChildProgress>;
+  childrenMap?: Map<string, Issue[]>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
   projectId?: string;
@@ -83,6 +87,21 @@ export function ListView({
   const sortLabel = sortBy !== "position"
     ? t(($) => $.board.ordered_by, { field: t(($) => $.display[`sort_${sortFieldKey}` as keyof typeof $.display]) })
     : null;
+
+  // Track which parent issues have their children expanded in the list view.
+  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
+
+  const toggleExpandParent = useCallback((parentId: string) => {
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentId)) {
+        next.delete(parentId);
+      } else {
+        next.add(parentId);
+      }
+      return next;
+    });
+  }, []);
 
   const expandedStatuses = useMemo(
     () =>
@@ -306,6 +325,9 @@ export function ListView({
             issueIds={columns[statusGroupId(status)] ?? EMPTY_IDS}
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
+            childrenMap={childrenMap}
+            expandedParents={expandedParents}
+            onToggleExpand={toggleExpandParent}
             myIssuesOpts={myIssuesOpts}
             projectId={projectId}
             dragEnabled={dragEnabled}
@@ -355,6 +377,9 @@ function StatusAccordionItem({
   issueIds,
   issueMap,
   childProgressMap,
+  childrenMap,
+  expandedParents,
+  onToggleExpand,
   myIssuesOpts,
   projectId,
   dragEnabled,
@@ -366,6 +391,9 @@ function StatusAccordionItem({
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap: Map<string, ChildProgress>;
+  childrenMap: Map<string, Issue[]>;
+  expandedParents: ReadonlySet<string>;
+  onToggleExpand: (parentId: string) => void;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
   dragEnabled: boolean;
@@ -389,6 +417,34 @@ function StatusAccordionItem({
       return issue ? [issue] : [];
     }),
     [issueIds, issueMap],
+  );
+
+  // Build the set of issue IDs in this status group (for hierarchy resolution).
+  const statusIssueIds = useMemo(
+    () => new Set(issueIds),
+    [issueIds],
+  );
+
+  // Build a parent-id → identifier map for resolving cross-status parent references.
+  const parentIdentifierMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        map.set(issue.id, issue.identifier);
+      }
+    }
+    return map;
+  }, [issues, childProgressMap]);
+
+  // Build hierarchical render items for this status group.
+  const renderItems = useMemo(
+    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap),
+    [issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap],
+  );
+
+  const allRenderIds = useMemo(
+    () => renderItems.map((r) => r.issue.id),
+    [renderItems],
   );
 
   const selectedCount = issueIds.filter((id) => selectedIds.has(id)).length;
@@ -455,15 +511,21 @@ function StatusAccordionItem({
         </div>
       </Accordion.Header>
       <Accordion.Panel>
-        {issues.length > 0 ? (
+        {renderItems.length > 0 ? (
           dragEnabled ? (
-            <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
-              {issues.map((issue) => (
+            <SortableContext items={allRenderIds} strategy={verticalListSortingStrategy}>
+              {renderItems.map((item) => (
                 <DraggableListRow
-                  key={issue.id}
-                  issue={issue}
-                  childProgress={childProgressMap.get(issue.id)}
-                  disableSorting={disableSorting}
+                  key={item.issue.id}
+                  issue={item.issue}
+                  childProgress={childProgressMap.get(item.issue.id)}
+                  disableSorting={disableSorting || item.indent > 0}
+                  indent={item.indent}
+                  isParent={item.isParent}
+                  isExpanded={expandedParents.has(item.issue.id)}
+                  childCount={item.childCount}
+                  onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
+                  parentIdentifier={item.parentIdentifier}
                 />
               ))}
               {hasMore && (
@@ -472,8 +534,18 @@ function StatusAccordionItem({
             </SortableContext>
           ) : (
             <>
-              {issues.map((issue) => (
-                <ListRow key={issue.id} issue={issue} childProgress={childProgressMap.get(issue.id)} />
+              {renderItems.map((item) => (
+                <ListRow
+                  key={item.issue.id}
+                  issue={item.issue}
+                  childProgress={childProgressMap.get(item.issue.id)}
+                  indent={item.indent}
+                  isParent={item.isParent}
+                  isExpanded={expandedParents.has(item.issue.id)}
+                  childCount={item.childCount}
+                  onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
+                  parentIdentifier={item.parentIdentifier}
+                />
               ))}
               {hasMore && (
                 <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -127,20 +127,21 @@ export function ListView({
             el.scrollIntoView({ behavior: "auto", block: "center" });
             // Flash highlight: outline ring + background using rgba()
             // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
-            el.style.transition = "background-color 500ms ease-out, outline-color 500ms ease-out";
+            el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
             el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
             el.style.outline = "4px solid #a78bfa";
-            // Let the highlight render for at least one frame, then clear.
+            // Hold the highlight visible for 800ms, then clear to trigger the
+            // 800ms CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
               el.style.outline = "";
-            }, 100);
-            // Clean up inline properties after the transition completes.
+            }, 800);
+            // Clean up inline properties after hold + transition complete.
             setTimeout(() => {
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
               el.style.removeProperty("outline");
-            }, 700);
+            }, 1700);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,22 +125,22 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: inset ring + deeper background via inline style
-            // (classList is purged by Tailwind JIT so we avoid it entirely).
-            el.style.transition = "background-color 500ms ease-out, box-shadow 500ms ease-out";
-            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 30%, transparent)";
-            el.style.boxShadow = "inset 0 0 0 2px var(--color-brand, #a78bfa)";
-            // Force reflow so the browser registers the initial state, then clear
-            // to trigger the transition back to normal.
-            void el.offsetHeight;
-            el.style.backgroundColor = "";
-            el.style.boxShadow = "";
+            // Flash highlight: outline ring + background using rgba()
+            // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
+            el.style.transition = "background-color 500ms ease-out, outline-color 500ms ease-out";
+            el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
+            el.style.outline = "4px solid #a78bfa";
+            // Let the highlight render for at least one frame, then clear.
+            setTimeout(() => {
+              el.style.backgroundColor = "";
+              el.style.outline = "";
+            }, 100);
             // Clean up inline properties after the transition completes.
             setTimeout(() => {
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
-              el.style.removeProperty("box-shadow");
-            }, 600);
+              el.style.removeProperty("outline");
+            }, 700);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,17 +125,21 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight via inline style (classList would be purged by Tailwind JIT).
-            // The row already has transition-colors in its className, so backgroundColor
-            // changes animate smoothly.
-            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 20%, transparent)";
-            // Force style recalculation so the browser picks up the background change
-            // before clearing it, which triggers the transition.
+            // Flash highlight: inset ring + deeper background via inline style
+            // (classList is purged by Tailwind JIT so we avoid it entirely).
+            el.style.transition = "background-color 500ms ease-out, box-shadow 500ms ease-out";
+            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 30%, transparent)";
+            el.style.boxShadow = "inset 0 0 0 2px var(--color-brand, #a78bfa)";
+            // Force reflow so the browser registers the initial state, then clear
+            // to trigger the transition back to normal.
             void el.offsetHeight;
             el.style.backgroundColor = "";
-            // Clean up the inline style property after the transition completes.
+            el.style.boxShadow = "";
+            // Clean up inline properties after the transition completes.
             setTimeout(() => {
+              el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
+              el.style.removeProperty("box-shadow");
             }, 600);
           }
         });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,6 +125,14 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`);
           if (el) {
             el.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Flash highlight the target row: brief bg-brand/20 → transparent.
+            el.classList.add("bg-brand/20", "transition-colors", "duration-500");
+            setTimeout(() => {
+              el.classList.remove("bg-brand/20");
+              setTimeout(() => {
+                el.classList.remove("transition-colors", "duration-500");
+              }, 500);
+            }, 100);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -122,17 +122,21 @@ export function ListView({
       // Wait two frames for the accordion expansion to render, then scroll.
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          const el = document.querySelector(`[data-issue-id="${parentId}"]`);
+          const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
-            el.scrollIntoView({ behavior: "smooth", block: "center" });
-            // Flash highlight the target row: brief bg-brand/20 → transparent.
-            el.classList.add("bg-brand/20", "transition-colors", "duration-500");
+            el.scrollIntoView({ behavior: "auto", block: "center" });
+            // Flash highlight via inline style (classList would be purged by Tailwind JIT).
+            // The row already has transition-colors in its className, so backgroundColor
+            // changes animate smoothly.
+            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 20%, transparent)";
+            // Force style recalculation so the browser picks up the background change
+            // before clearing it, which triggers the transition.
+            void el.offsetHeight;
+            el.style.backgroundColor = "";
+            // Clean up the inline style property after the transition completes.
             setTimeout(() => {
-              el.classList.remove("bg-brand/20");
-              setTimeout(() => {
-                el.classList.remove("transition-colors", "duration-500");
-              }, 500);
-            }, 100);
+              el.style.removeProperty("background-color");
+            }, 600);
           }
         });
       });
@@ -585,6 +589,7 @@ function StatusAccordionItem({
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
                   crossStatusChildCount={item.crossStatusChildCount}
+                  crossStatusChildren={item.crossStatusChildren}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
                   parentInfo={item.parentInfo}
                   onHoverParent={onHoverParent}
@@ -607,6 +612,7 @@ function StatusAccordionItem({
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
                   crossStatusChildCount={item.crossStatusChildCount}
+                  crossStatusChildren={item.crossStatusChildren}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
                   parentInfo={item.parentInfo}
                   onHoverParent={onHoverParent}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -165,7 +165,10 @@ export function ListView({
     ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
     : undefined;
 
-  const dragEnabled = !!onMoveIssue;
+  // Disable DnD when any parent is expanded: the flat column order
+  // diverges from the hierarchical render order, so drop-position math
+  // would be inaccurate. Re-collapse all parents to re-enable.
+  const dragEnabled = !!onMoveIssue && expandedParents.size === 0;
 
   const groups = useMemo(
     () => buildListGroups(visibleStatuses),

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,23 +125,27 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: outline ring + background using rgba()
-            // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
+            // Flash highlight: outline ring + background using rgba().
             el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
             el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
             el.style.outline = "4px solid #a78bfa";
-            // Hold the highlight visible for 800ms, then clear to trigger the
-            // 800ms CSS transition fade-out.
+            // Hold the highlight for 150ms (safe margin for 30fps low-end devices),
+            // then clear to trigger the CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
-              el.style.outline = "";
-            }, 800);
-            // Clean up inline properties after hold + transition complete.
-            setTimeout(() => {
+              // Only clear outlineColor so the outline fades via transition instead
+              // of hard-cutting (clearing outline-style would remove it instantly).
+              el.style.outlineColor = "rgba(167, 139, 250, 0)";
+            }, 150);
+            // Clean up inline properties exactly when the transition ends.
+            const onEnd = () => {
+              el.removeEventListener("transitionend", onEnd);
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
               el.style.removeProperty("outline");
-            }, 1700);
+              el.style.removeProperty("outline-color");
+            };
+            el.addEventListener("transitionend", onEnd);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -38,7 +38,7 @@ import {
   getMoveUpdates,
 } from "../utils/drag-utils";
 import type { BoardColumnGroup } from "./board-column";
-import { buildHierarchy, type RenderItem } from "../utils/hierarchy";
+import { buildHierarchy, type ParentInfo } from "../utils/hierarchy";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 const EMPTY_CHILDREN_MAP = new Map<string, Issue[]>();
@@ -103,6 +103,35 @@ export function ListView({
     });
   }, []);
 
+  // Track which parent status column is hovered via a cross-status chip.
+  const [hoveredParentStatus, setHoveredParentStatus] = useState<string | null>(null);
+
+  const handleHoverParent = useCallback((parentStatus: string | null) => {
+    setHoveredParentStatus(parentStatus);
+  }, []);
+
+  // Scroll to a parent issue — expand the target column first if collapsed,
+  // then scroll the row into view.
+  const handleScrollToParent = useCallback(
+    (parentId: string, parentStatus: string) => {
+      const statusKey = parentStatus as IssueStatus;
+      // Expand the target column if it's collapsed.
+      if (listCollapsedStatuses.includes(statusKey)) {
+        toggleListCollapsed(statusKey);
+      }
+      // Wait two frames for the accordion expansion to render, then scroll.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const el = document.querySelector(`[data-issue-id="${parentId}"]`);
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+          }
+        });
+      });
+    },
+    [listCollapsedStatuses, toggleListCollapsed],
+  );
+
   const expandedStatuses = useMemo(
     () =>
       visibleStatuses.filter(
@@ -166,6 +195,22 @@ export function ListView({
   if (!isDraggingRef.current && !isSettlingRef.current) {
     issueMapRef.current = issueMap;
   }
+
+  // Build a global parent-info map: parentId → { identifier, status }
+  // for all issues that have child progress (i.e., are known parents).
+  const parentInfoMap = useMemo(() => {
+    const map = new Map<string, ParentInfo>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        map.set(issue.id, {
+          identifier: issue.identifier,
+          status: issue.status,
+          parentId: issue.id,
+        });
+      }
+    }
+    return map;
+  }, [issues, childProgressMap]);
 
   const collisionDetection = useMemo(
     () => makeKanbanCollision(groupIds),
@@ -328,6 +373,10 @@ export function ListView({
             childrenMap={childrenMap}
             expandedParents={expandedParents}
             onToggleExpand={toggleExpandParent}
+            parentInfoMap={parentInfoMap}
+            highlightedStatus={hoveredParentStatus}
+            onHoverParent={handleHoverParent}
+            onScrollToParent={handleScrollToParent}
             myIssuesOpts={myIssuesOpts}
             projectId={projectId}
             dragEnabled={dragEnabled}
@@ -380,6 +429,10 @@ function StatusAccordionItem({
   childrenMap,
   expandedParents,
   onToggleExpand,
+  parentInfoMap,
+  highlightedStatus,
+  onHoverParent,
+  onScrollToParent,
   myIssuesOpts,
   projectId,
   dragEnabled,
@@ -394,6 +447,10 @@ function StatusAccordionItem({
   childrenMap: Map<string, Issue[]>;
   expandedParents: ReadonlySet<string>;
   onToggleExpand: (parentId: string) => void;
+  parentInfoMap: Map<string, ParentInfo>;
+  highlightedStatus: string | null;
+  onHoverParent: (parentStatus: string | null) => void;
+  onScrollToParent: (parentId: string, parentStatus: string) => void;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
   dragEnabled: boolean;
@@ -425,21 +482,10 @@ function StatusAccordionItem({
     [issueIds],
   );
 
-  // Build a parent-id → identifier map for resolving cross-status parent references.
-  const parentIdentifierMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const issue of issues) {
-      if (childProgressMap.has(issue.id)) {
-        map.set(issue.id, issue.identifier);
-      }
-    }
-    return map;
-  }, [issues, childProgressMap]);
-
   // Build hierarchical render items for this status group.
   const renderItems = useMemo(
-    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap),
-    [issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap],
+    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap),
+    [issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap],
   );
 
   const allRenderIds = useMemo(
@@ -458,12 +504,18 @@ function StatusAccordionItem({
 
   const disableSorting = !!sortLabel;
 
+  const isHighlighted = highlightedStatus === status;
+
   return (
     <Accordion.Item value={status} ref={dragEnabled ? setDroppableRef : undefined}>
       <Accordion.Header
         className={`group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent ${
           isOver && !isExpanded
             ? "ring-2 ring-brand/25 bg-accent/15"
+            : ""
+        } ${
+          isHighlighted
+            ? "ring-1 ring-brand/20 bg-accent/10"
             : ""
         }`}
       >
@@ -524,8 +576,11 @@ function StatusAccordionItem({
                   isParent={item.isParent}
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
+                  crossStatusChildCount={item.crossStatusChildCount}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
-                  parentIdentifier={item.parentIdentifier}
+                  parentInfo={item.parentInfo}
+                  onHoverParent={onHoverParent}
+                  onScrollToParent={onScrollToParent}
                 />
               ))}
               {hasMore && (
@@ -543,8 +598,11 @@ function StatusAccordionItem({
                   isParent={item.isParent}
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
+                  crossStatusChildCount={item.crossStatusChildCount}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
-                  parentIdentifier={item.parentIdentifier}
+                  parentInfo={item.parentInfo}
+                  onHoverParent={onHoverParent}
+                  onScrollToParent={onScrollToParent}
                 />
               ))}
               {hasMore && (

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,17 +125,17 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: outline ring + background using rgba().
+            // Flash highlight: outline ring + background using brand token.
             el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
-            el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
-            el.style.outline = "4px solid #a78bfa";
+            el.style.backgroundColor = "color-mix(in srgb, var(--brand) 30%, transparent)";
+            el.style.outline = "4px solid var(--brand)";
             // Hold the highlight for 150ms (safe margin for 30fps low-end devices),
             // then clear to trigger the CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
               // Only clear outlineColor so the outline fades via transition instead
               // of hard-cutting (clearing outline-style would remove it instantly).
-              el.style.outlineColor = "rgba(167, 139, 250, 0)";
+              el.style.outlineColor = "color-mix(in srgb, var(--brand) 0%, transparent)";
             }, 150);
             // Clean up inline properties exactly when the transition ends.
             const onEnd = () => {

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Issue } from "@multica/core/types";
 import { buildHierarchy, type ParentInfo } from "./hierarchy";
 
-function makeIssue(overrides: Partial<Issue> = {}): Issue {
+function makeIssue(overrides: Partial<Issue> & { stage?: number | null } = {}): Issue {
   return {
     id: "i-1",
     workspace_id: "ws-1",
@@ -22,10 +22,11 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     start_date: null,
     due_date: null,
     metadata: {},
+    stage: null,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  };
+  } as Issue;
 }
 
 function makeParentInfo(parentId: string, identifier: string, status: string): ParentInfo {

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -50,16 +50,16 @@ describe("buildHierarchy", () => {
     // Children are not expanded inline (parent not expanded), so the fallback
     // appends them as orphaned items.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].childCount).toBe(2);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.childCount).toBe(2);
+    expect(result[0]!.indent).toBe(0);
 
     // Children appended as orphaned (parent not in expandedParents).
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].orphaned).toBe(true);
-    expect(result[2].issue.id).toBe("c2");
-    expect(result[2].orphaned).toBe(true);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.orphaned).toBe(true);
+    expect(result[2]!.issue.id).toBe("c2");
+    expect(result[2]!.orphaned).toBe(true);
   });
 
   it("expands children when parent is in expandedParents set", () => {
@@ -76,14 +76,14 @@ describe("buildHierarchy", () => {
 
     // Parent + 2 children rendered.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
     // Children are rendered at indent=1 when parent is expanded.
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
-    expect(result[1].isParent).toBe(false);
-    expect(result[2].issue.id).toBe("c2");
-    expect(result[2].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
+    expect(result[1]!.isParent).toBe(false);
+    expect(result[2]!.issue.id).toBe("c2");
+    expect(result[2]!.indent).toBe(1);
   });
 
   // ── Scenario 2: all-cross-status parent ──
@@ -103,12 +103,12 @@ describe("buildHierarchy", () => {
     // Parent should NOT be marked as isParent (no same-status children),
     // but should have crossStatusChildCount > 0.
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].childCount).toBe(0);
-    expect(result[0].crossStatusChildCount).toBe(1);
-    expect(result[0].crossStatusChildren).toHaveLength(1);
-    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-2");
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.childCount).toBe(0);
+    expect(result[0]!.crossStatusChildCount).toBe(1);
+    expect(result[0]!.crossStatusChildren).toHaveLength(1);
+    expect(result[0]!.crossStatusChildren[0]!.identifier).toBe("OXY-2");
   });
 
   // ── Scenario 3: mixed (some same-status + some cross-status) ──
@@ -126,17 +126,17 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
 
     expect(result).toHaveLength(2); // parent + same-status child
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].childCount).toBe(1);
-    expect(result[0].crossStatusChildCount).toBe(1);
-    expect(result[0].crossStatusChildren).toHaveLength(1);
-    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-3");
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.childCount).toBe(1);
+    expect(result[0]!.crossStatusChildCount).toBe(1);
+    expect(result[0]!.crossStatusChildren).toHaveLength(1);
+    expect(result[0]!.crossStatusChildren[0]!.identifier).toBe("OXY-3");
 
     // Cross-status child rows appear in the crossStatusChildren list only.
     // The same-status child is rendered inline.
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
   });
 
   // ── Scenario 4: multi-level recursion ──
@@ -156,17 +156,17 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.indent).toBe(0);
 
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].isParent).toBe(true); // has a grandchild
-    expect(result[1].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.isParent).toBe(true); // has a grandchild
+    expect(result[1]!.indent).toBe(1);
 
-    expect(result[2].issue.id).toBe("g1");
-    expect(result[2].isParent).toBe(false);
-    expect(result[2].indent).toBe(2);
+    expect(result[2]!.issue.id).toBe("g1");
+    expect(result[2]!.isParent).toBe(false);
+    expect(result[2]!.indent).toBe(2);
   });
 
   it("does not expand grandchild when child is not expanded", () => {
@@ -187,12 +187,12 @@ describe("buildHierarchy", () => {
     // Parent expanded → shows child inline. Child NOT expanded → grandchild
     // is appended as orphaned by the fallback.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
     // Grandchild is orphaned since child is not expanded.
-    expect(result[2].issue.id).toBe("g1");
-    expect(result[2].orphaned).toBe(true);
+    expect(result[2]!.issue.id).toBe("g1");
+    expect(result[2]!.orphaned).toBe(true);
   });
 
   // ── Scenario 5: cross-status child renders as top-level with parentInfo ──
@@ -213,12 +213,12 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
 
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("c1");
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].indent).toBe(0);
-    expect(result[0].parentInfo).toBeDefined();
-    expect(result[0].parentInfo!.identifier).toBe("OXY-1");
-    expect(result[0].parentInfo!.status).toBe("done");
+    expect(result[0]!.issue.id).toBe("c1");
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.indent).toBe(0);
+    expect(result[0]!.parentInfo).toBeDefined();
+    expect(result[0]!.parentInfo!.identifier).toBe("OXY-1");
+    expect(result[0]!.parentInfo!.status).toBe("done");
   });
 
   // ── Scenario 6: orphan fallback ──
@@ -241,9 +241,9 @@ describe("buildHierarchy", () => {
 
     // Should be rendered as top-level with orphaned flag.
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("o1");
-    expect(result[0].orphaned).toBe(true);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("o1");
+    expect(result[0]!.orphaned).toBe(true);
+    expect(result[0]!.indent).toBe(0);
   });
 
   // ── Scenario 7: no children at all ──
@@ -259,10 +259,10 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(2);
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].childCount).toBe(0);
-    expect(result[0].crossStatusChildCount).toBe(0);
-    expect(result[1].isParent).toBe(false);
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.childCount).toBe(0);
+    expect(result[0]!.crossStatusChildCount).toBe(0);
+    expect(result[1]!.isParent).toBe(false);
   });
 
   // ── Scenario 8: multiple top-level parents ──
@@ -283,11 +283,11 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(4);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
-    expect(result[2].issue.id).toBe("p2");
-    expect(result[3].issue.id).toBe("c2");
-    expect(result[3].indent).toBe(1);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
+    expect(result[2]!.issue.id).toBe("p2");
+    expect(result[3]!.issue.id).toBe("c2");
+    expect(result[3]!.indent).toBe(1);
   });
 });

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from "vitest";
+import type { Issue } from "@multica/core/types";
+import { buildHierarchy, type ParentInfo } from "./hierarchy";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "i-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Test",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "u-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeParentInfo(parentId: string, identifier: string, status: string): ParentInfo {
+  return { parentId, identifier, status };
+}
+
+describe("buildHierarchy", () => {
+  // ── Scenario 1: same-status nesting ──
+  it("nests children under their parent when parent and children share the same status", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-3", status: "todo", parent_issue_id: "p1" });
+
+    const issues = [parent, child1, child2];
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1, child2]]]);
+    const statusIssueIds = new Set(["p1", "c1", "c2"]);
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent is top-level with isParent=true, childCount=2.
+    // Children are not expanded inline (parent not expanded), so the fallback
+    // appends them as orphaned items.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].childCount).toBe(2);
+    expect(result[0].indent).toBe(0);
+
+    // Children appended as orphaned (parent not in expandedParents).
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].orphaned).toBe(true);
+    expect(result[2].issue.id).toBe("c2");
+    expect(result[2].orphaned).toBe(true);
+  });
+
+  it("expands children when parent is in expandedParents set", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-3", status: "todo", parent_issue_id: "p1" });
+
+    const issues = [parent, child1, child2];
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1, child2]]]);
+    const statusIssueIds = new Set(["p1", "c1", "c2"]);
+    const expandedParents = new Set(["p1"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent + 2 children rendered.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    // Children are rendered at indent=1 when parent is expanded.
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    expect(result[1].isParent).toBe(false);
+    expect(result[2].issue.id).toBe("c2");
+    expect(result[2].indent).toBe(1);
+  });
+
+  // ── Scenario 2: all-cross-status parent ──
+  it("shows crossStatusChildCount and crossStatusChildren when parent has only cross-status children", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "done" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+
+    // Parent is in "done" status group; child is in "todo" — different group.
+    const issues = [parent]; // only parent in this group
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1]]]);
+    const statusIssueIds = new Set(["p1"]); // child1 is NOT in this status group
+    const expandedParents = new Set<string>();
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "done")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    // Parent should NOT be marked as isParent (no same-status children),
+    // but should have crossStatusChildCount > 0.
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].childCount).toBe(0);
+    expect(result[0].crossStatusChildCount).toBe(1);
+    expect(result[0].crossStatusChildren).toHaveLength(1);
+    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-2");
+  });
+
+  // ── Scenario 3: mixed (some same-status + some cross-status) ──
+  it("handles mixed children: some same-status, some cross-status", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const sameChild = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const crossChild = makeIssue({ id: "c2", identifier: "OXY-3", status: "done", parent_issue_id: "p1" });
+
+    const issues = [parent, sameChild];
+    const childrenMap = new Map<string, Issue[]>([["p1", [sameChild, crossChild]]]);
+    const statusIssueIds = new Set(["p1", "c1"]); // c2 is cross-status
+    const expandedParents = new Set(["p1"]);
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "todo")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    expect(result).toHaveLength(2); // parent + same-status child
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].childCount).toBe(1);
+    expect(result[0].crossStatusChildCount).toBe(1);
+    expect(result[0].crossStatusChildren).toHaveLength(1);
+    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-3");
+
+    // Cross-status child rows appear in the crossStatusChildren list only.
+    // The same-status child is rendered inline.
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+  });
+
+  // ── Scenario 4: multi-level recursion ──
+  it("supports multi-level nesting: parent → child → grandchild", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const grandchild = makeIssue({ id: "g1", identifier: "OXY-3", status: "todo", parent_issue_id: "c1" });
+
+    const issues = [parent, child, grandchild];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child]],
+      ["c1", [grandchild]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "g1"]);
+    const expandedParents = new Set(["p1", "c1"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].indent).toBe(0);
+
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].isParent).toBe(true); // has a grandchild
+    expect(result[1].indent).toBe(1);
+
+    expect(result[2].issue.id).toBe("g1");
+    expect(result[2].isParent).toBe(false);
+    expect(result[2].indent).toBe(2);
+  });
+
+  it("does not expand grandchild when child is not expanded", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const grandchild = makeIssue({ id: "g1", identifier: "OXY-3", status: "todo", parent_issue_id: "c1" });
+
+    const issues = [parent, child, grandchild];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child]],
+      ["c1", [grandchild]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "g1"]);
+    const expandedParents = new Set(["p1"]); // only parent expanded, not child
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent expanded → shows child inline. Child NOT expanded → grandchild
+    // is appended as orphaned by the fallback.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    // Grandchild is orphaned since child is not expanded.
+    expect(result[2].issue.id).toBe("g1");
+    expect(result[2].orphaned).toBe(true);
+  });
+
+  // ── Scenario 5: cross-status child renders as top-level with parentInfo ──
+  it("renders cross-status child at top level with parentInfo chip", () => {
+    const crossChild = makeIssue({
+      id: "c1",
+      identifier: "OXY-2",
+      status: "todo",
+      parent_issue_id: "p1",
+    });
+
+    const issues = [crossChild]; // only the child in this group, parent is in another
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["c1"]); // parent p1 NOT in this group
+    const expandedParents = new Set<string>();
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "done")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("c1");
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].indent).toBe(0);
+    expect(result[0].parentInfo).toBeDefined();
+    expect(result[0].parentInfo!.identifier).toBe("OXY-1");
+    expect(result[0].parentInfo!.status).toBe("done");
+  });
+
+  // ── Scenario 6: orphan fallback ──
+  it("marks orphaned issues that have a parent in the same status but parent is not in the list", () => {
+    // Child whose parent is in the same status group but the parent issue
+    // is not in the provided issues array (e.g. filtered out).
+    const orphan = makeIssue({
+      id: "o1",
+      identifier: "OXY-5",
+      status: "todo",
+      parent_issue_id: "p-missing",
+    });
+
+    const issues = [orphan];
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["o1", "p-missing"]); // parent would be in same status if present
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Should be rendered as top-level with orphaned flag.
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("o1");
+    expect(result[0].orphaned).toBe(true);
+    expect(result[0].indent).toBe(0);
+  });
+
+  // ── Scenario 7: no children at all ──
+  it("handles issues with no children gracefully", () => {
+    const issue1 = makeIssue({ id: "a1", identifier: "OXY-10", status: "todo" });
+    const issue2 = makeIssue({ id: "a2", identifier: "OXY-11", status: "todo" });
+
+    const issues = [issue1, issue2];
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["a1", "a2"]);
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].childCount).toBe(0);
+    expect(result[0].crossStatusChildCount).toBe(0);
+    expect(result[1].isParent).toBe(false);
+  });
+
+  // ── Scenario 8: multiple top-level parents ──
+  it("handles multiple top-level parent issues independently", () => {
+    const parent1 = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const parent2 = makeIssue({ id: "p2", identifier: "OXY-3", status: "todo" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-4", status: "todo", parent_issue_id: "p2" });
+
+    const issues = [parent1, child1, parent2, child2];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child1]],
+      ["p2", [child2]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "p2", "c2"]);
+    const expandedParents = new Set(["p1", "p2"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(4);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    expect(result[2].issue.id).toBe("p2");
+    expect(result[3].issue.id).toBe("c2");
+    expect(result[3].indent).toBe(1);
+  });
+});

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -65,7 +65,7 @@ function renderSubtree(
 
   // Build the list of cross-status children for the dropdown.
   const crossStatusChildren: CrossStatusChild[] = [];
-  if (isParent && crossStatusCount > 0) {
+  if (crossStatusCount > 0) {
     for (const child of allChildren) {
       if (!statusIssueIds.has(child.id)) {
         crossStatusChildren.push({
@@ -91,7 +91,7 @@ function renderSubtree(
       indent,
       isParent,
       childCount: isParent ? sameStatusCount : 0,
-      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      crossStatusChildCount: crossStatusCount,
       crossStatusChildren,
       parentInfo,
     },

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -1,6 +1,16 @@
 import type { Issue } from "@multica/core/types";
 
 /**
+ * Info about a cross-status parent, used to render a clickable chip
+ * on child rows whose parent lives in a different status column.
+ */
+export interface ParentInfo {
+  identifier: string;
+  status: string;
+  parentId: string;
+}
+
+/**
  * A single item in the render tree for a status group.
  * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
  */
@@ -12,8 +22,10 @@ export interface RenderItem {
   isParent: boolean;
   /** Number of children nested under this parent in the same status group. */
   childCount: number;
-  /** When a child's parent is NOT in the same status group, show the parent's identifier. */
-  parentIdentifier?: string;
+  /** Number of children in other status groups (for cross-status badge on parent row). */
+  crossStatusChildCount: number;
+  /** When a child's parent is NOT in the same status group, info about that parent. */
+  parentInfo?: ParentInfo;
   /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
   orphaned?: boolean;
 }
@@ -24,20 +36,20 @@ export interface RenderItem {
  * - Children whose parent IS in the same status group are nested right after
  *   the parent, with indent=1.
  * - Children whose parent is in a different status group render at top level
- *   with a subtle `parentIdentifier` label.
+ *   with a clickable `parentInfo` chip.
  *
  * @param issues - a single status-group's issues (already filtered by status).
  * @param childrenMap - parent_issue_id → its direct children (all statuses).
  * @param statusIssueIds - the set of all issue ids that belong to this status group.
  * @param expandedParents - the set of parent issue ids whose children are expanded.
- * @param parentIdentifierMap - parent issue id → its identifier string (e.g., "MUL-123").
+ * @param parentInfoMap - parent issue id → { identifier, status } for all known parents.
  */
 export function buildHierarchy(
   issues: Issue[],
   childrenMap: Map<string, readonly Issue[]>,
   statusIssueIds: Set<string>,
   expandedParents: ReadonlySet<string>,
-  parentIdentifierMap?: Map<string, string>,
+  parentInfoMap?: Map<string, ParentInfo>,
 ): RenderItem[] {
   const result: RenderItem[] = [];
 
@@ -79,18 +91,24 @@ export function buildHierarchy(
     const isParent = !!nestedChildren && nestedChildren.length > 0;
     const expanded = expandedParents.has(issue.id);
 
-    // Resolve parent identifier for children whose parent is in another status group.
-    let parentIdentifier: string | undefined;
+    // Compute cross-status child count for parent rows.
+    const allChildren = childrenMap.get(issue.id) ?? [];
+    const sameStatusCount = nestedChildren?.length ?? 0;
+    const crossStatusCount = allChildren.length - sameStatusCount;
+
+    // Resolve parent info for children whose parent is in another status group.
+    let parentInfo: ParentInfo | undefined;
     if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
-      parentIdentifier = parentIdentifierMap?.get(issue.parent_issue_id);
+      parentInfo = parentInfoMap?.get(issue.parent_issue_id);
     }
 
     result.push({
       issue,
       indent: 0,
       isParent,
-      childCount: isParent ? nestedChildren!.length : 0,
-      parentIdentifier,
+      childCount: isParent ? sameStatusCount : 0,
+      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      parentInfo,
     });
 
     if (isParent && expanded) {
@@ -100,6 +118,7 @@ export function buildHierarchy(
           indent: 1,
           isParent: false,
           childCount: 0,
+          crossStatusChildCount: 0,
         });
       }
     }
@@ -114,6 +133,7 @@ export function buildHierarchy(
         indent: 0,
         isParent: false,
         childCount: 0,
+        crossStatusChildCount: 0,
         orphaned: !!issue.parent_issue_id,
       });
     }

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -1,0 +1,123 @@
+import type { Issue } from "@multica/core/types";
+
+/**
+ * A single item in the render tree for a status group.
+ * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
+ */
+export interface RenderItem {
+  issue: Issue;
+  /** 0 = top-level, 1 = first-level child, etc. */
+  indent: number;
+  /** True when this issue has visible children nested under it (in the same status). */
+  isParent: boolean;
+  /** Number of children nested under this parent in the same status group. */
+  childCount: number;
+  /** When a child's parent is NOT in the same status group, show the parent's identifier. */
+  parentIdentifier?: string;
+  /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
+  orphaned?: boolean;
+}
+
+/**
+ * Organise a status-group's flat issue list into a hierarchical order:
+ * - Top-level issues first (no parent, or parent in a different status).
+ * - Children whose parent IS in the same status group are nested right after
+ *   the parent, with indent=1.
+ * - Children whose parent is in a different status group render at top level
+ *   with a subtle `parentIdentifier` label.
+ *
+ * @param issues - a single status-group's issues (already filtered by status).
+ * @param childrenMap - parent_issue_id → its direct children (all statuses).
+ * @param statusIssueIds - the set of all issue ids that belong to this status group.
+ * @param expandedParents - the set of parent issue ids whose children are expanded.
+ * @param parentIdentifierMap - parent issue id → its identifier string (e.g., "MUL-123").
+ */
+export function buildHierarchy(
+  issues: Issue[],
+  childrenMap: Map<string, readonly Issue[]>,
+  statusIssueIds: Set<string>,
+  expandedParents: ReadonlySet<string>,
+  parentIdentifierMap?: Map<string, string>,
+): RenderItem[] {
+  const result: RenderItem[] = [];
+
+  // Build a lookup for which parents have children in this status.
+  const childrenInStatus = new Map<string, Issue[]>();
+  for (const issue of issues) {
+    if (!issue.parent_issue_id) continue;
+    const children = childrenMap.get(issue.parent_issue_id);
+    if (!children) continue;
+
+    // Only count children that are in the same status group.
+    const sameStatusChildren = children.filter((c) => statusIssueIds.has(c.id));
+    if (sameStatusChildren.length === 0) continue;
+
+    const bucket = childrenInStatus.get(issue.parent_issue_id);
+    if (bucket) {
+      bucket.push(issue);
+    } else {
+      childrenInStatus.set(issue.parent_issue_id, [issue]);
+    }
+  }
+
+  // Separate top-level vs. child issues.
+  const topLevel: Issue[] = [];
+  const childIds = new Set<string>();
+
+  for (const issue of issues) {
+    if (!issue.parent_issue_id || !statusIssueIds.has(issue.parent_issue_id)) {
+      // No parent, or parent not in this status group.
+      topLevel.push(issue);
+    } else {
+      // Parent is in this status group — this issue will be nested.
+      childIds.add(issue.id);
+    }
+  }
+
+  for (const issue of topLevel) {
+    const nestedChildren = childrenInStatus.get(issue.id);
+    const isParent = !!nestedChildren && nestedChildren.length > 0;
+    const expanded = expandedParents.has(issue.id);
+
+    // Resolve parent identifier for children whose parent is in another status group.
+    let parentIdentifier: string | undefined;
+    if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
+      parentIdentifier = parentIdentifierMap?.get(issue.parent_issue_id);
+    }
+
+    result.push({
+      issue,
+      indent: 0,
+      isParent,
+      childCount: isParent ? nestedChildren!.length : 0,
+      parentIdentifier,
+    });
+
+    if (isParent && expanded) {
+      for (const child of nestedChildren!) {
+        result.push({
+          issue: child,
+          indent: 1,
+          isParent: false,
+          childCount: 0,
+        });
+      }
+    }
+  }
+
+  // Append any children whose parent wasn't in the top-level (shouldn't happen,
+  // but guards against edge cases where parent was filtered or not loaded).
+  for (const issue of issues) {
+    if (!result.some((r) => r.issue.id === issue.id)) {
+      result.push({
+        issue,
+        indent: 0,
+        isParent: false,
+        childCount: 0,
+        orphaned: !!issue.parent_issue_id,
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -11,6 +11,16 @@ export interface ParentInfo {
 }
 
 /**
+ * Lightweight reference to a cross-status child, used in the
+ * expandable dropdown on the parent row.
+ */
+export interface CrossStatusChild {
+  identifier: string;
+  status: string;
+  id: string;
+}
+
+/**
  * A single item in the render tree for a status group.
  * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
  */
@@ -24,6 +34,8 @@ export interface RenderItem {
   childCount: number;
   /** Number of children in other status groups (for cross-status badge on parent row). */
   crossStatusChildCount: number;
+  /** Cross-status children for the expandable dropdown on the parent row. */
+  crossStatusChildren: CrossStatusChild[];
   /** When a child's parent is NOT in the same status group, info about that parent. */
   parentInfo?: ParentInfo;
   /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
@@ -51,6 +63,20 @@ function renderSubtree(
   const sameStatusCount = nestedChildren?.length ?? 0;
   const crossStatusCount = allChildren.length - sameStatusCount;
 
+  // Build the list of cross-status children for the dropdown.
+  const crossStatusChildren: CrossStatusChild[] = [];
+  if (isParent && crossStatusCount > 0) {
+    for (const child of allChildren) {
+      if (!statusIssueIds.has(child.id)) {
+        crossStatusChildren.push({
+          identifier: child.identifier,
+          status: child.status,
+          id: child.id,
+        });
+      }
+    }
+  }
+
   // Resolve parent info for top-level items whose parent is cross-status.
   // Children rendered via recursion always have their parent in the same status,
   // so parentInfo is only needed for top-level cross-status orphans.
@@ -66,6 +92,7 @@ function renderSubtree(
       isParent,
       childCount: isParent ? sameStatusCount : 0,
       crossStatusChildCount: isParent ? crossStatusCount : 0,
+      crossStatusChildren,
       parentInfo,
     },
   ];
@@ -166,6 +193,7 @@ export function buildHierarchy(
         isParent: false,
         childCount: 0,
         crossStatusChildCount: 0,
+        crossStatusChildren: [],
         orphaned: !!issue.parent_issue_id,
       });
     }

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -31,10 +31,69 @@ export interface RenderItem {
 }
 
 /**
+ * Recursively render a single issue and, if it is an expanded parent,
+ * all of its same-status descendants.
+ */
+function renderSubtree(
+  issue: Issue,
+  indent: number,
+  childrenInStatus: Map<string, Issue[]>,
+  childrenMap: Map<string, readonly Issue[]>,
+  expandedParents: ReadonlySet<string>,
+  statusIssueIds: Set<string>,
+  parentInfoMap?: Map<string, ParentInfo>,
+): RenderItem[] {
+  const nestedChildren = childrenInStatus.get(issue.id);
+  const isParent = !!nestedChildren && nestedChildren.length > 0;
+  const expanded = expandedParents.has(issue.id);
+
+  const allChildren = childrenMap.get(issue.id) ?? [];
+  const sameStatusCount = nestedChildren?.length ?? 0;
+  const crossStatusCount = allChildren.length - sameStatusCount;
+
+  // Resolve parent info for top-level items whose parent is cross-status.
+  // Children rendered via recursion always have their parent in the same status,
+  // so parentInfo is only needed for top-level cross-status orphans.
+  let parentInfo: ParentInfo | undefined;
+  if (indent === 0 && issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
+    parentInfo = parentInfoMap?.get(issue.parent_issue_id);
+  }
+
+  const result: RenderItem[] = [
+    {
+      issue,
+      indent,
+      isParent,
+      childCount: isParent ? sameStatusCount : 0,
+      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      parentInfo,
+    },
+  ];
+
+  if (isParent && expanded) {
+    for (const child of nestedChildren!) {
+      result.push(
+        ...renderSubtree(
+          child,
+          indent + 1,
+          childrenInStatus,
+          childrenMap,
+          expandedParents,
+          statusIssueIds,
+          parentInfoMap,
+        ),
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
  * Organise a status-group's flat issue list into a hierarchical order:
  * - Top-level issues first (no parent, or parent in a different status).
  * - Children whose parent IS in the same status group are nested right after
- *   the parent, with indent=1.
+ *   the parent with increasing indent, recursively for any depth.
  * - Children whose parent is in a different status group render at top level
  *   with a clickable `parentInfo` chip.
  *
@@ -74,57 +133,30 @@ export function buildHierarchy(
 
   // Separate top-level vs. child issues.
   const topLevel: Issue[] = [];
-  const childIds = new Set<string>();
 
   for (const issue of issues) {
     if (!issue.parent_issue_id || !statusIssueIds.has(issue.parent_issue_id)) {
       // No parent, or parent not in this status group.
       topLevel.push(issue);
-    } else {
-      // Parent is in this status group — this issue will be nested.
-      childIds.add(issue.id);
     }
   }
 
+  // Recursively render each top-level issue and its descendants.
   for (const issue of topLevel) {
-    const nestedChildren = childrenInStatus.get(issue.id);
-    const isParent = !!nestedChildren && nestedChildren.length > 0;
-    const expanded = expandedParents.has(issue.id);
-
-    // Compute cross-status child count for parent rows.
-    const allChildren = childrenMap.get(issue.id) ?? [];
-    const sameStatusCount = nestedChildren?.length ?? 0;
-    const crossStatusCount = allChildren.length - sameStatusCount;
-
-    // Resolve parent info for children whose parent is in another status group.
-    let parentInfo: ParentInfo | undefined;
-    if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
-      parentInfo = parentInfoMap?.get(issue.parent_issue_id);
-    }
-
-    result.push({
-      issue,
-      indent: 0,
-      isParent,
-      childCount: isParent ? sameStatusCount : 0,
-      crossStatusChildCount: isParent ? crossStatusCount : 0,
-      parentInfo,
-    });
-
-    if (isParent && expanded) {
-      for (const child of nestedChildren!) {
-        result.push({
-          issue: child,
-          indent: 1,
-          isParent: false,
-          childCount: 0,
-          crossStatusChildCount: 0,
-        });
-      }
-    }
+    result.push(
+      ...renderSubtree(
+        issue,
+        0,
+        childrenInStatus,
+        childrenMap,
+        expandedParents,
+        statusIssueIds,
+        parentInfoMap,
+      ),
+    );
   }
 
-  // Append any children whose parent wasn't in the top-level (shouldn't happen,
+  // Append any issues that weren't rendered (shouldn't happen in normal use,
   // but guards against edge cases where parent was filtered or not loaded).
   for (const issue of issues) {
     if (!result.some((r) => r.issue.id === issue.id)) {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -134,7 +134,8 @@
   },
   "list": {
     "empty_status": "No issues",
-    "add_issue_tooltip": "Add issue"
+    "add_issue_tooltip": "Add issue",
+    "cross_status": "cross-status"
   },
   "swimlane": {
     "no_parent": "No parent",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -132,7 +132,8 @@
   },
   "list": {
     "empty_status": "イシューなし",
-    "add_issue_tooltip": "イシューを追加"
+    "add_issue_tooltip": "イシューを追加",
+    "cross_status": "クロスステータス"
   },
   "swimlane": {
     "no_parent": "親イシューなし",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -134,7 +134,8 @@
   },
   "list": {
     "empty_status": "이슈 없음",
-    "add_issue_tooltip": "이슈 추가"
+    "add_issue_tooltip": "이슈 추가",
+    "cross_status": "교차 상태"
   },
   "swimlane": {
     "no_parent": "상위 이슈 없음",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -132,7 +132,8 @@
   },
   "list": {
     "empty_status": "无 issue",
-    "add_issue_tooltip": "新建 issue"
+    "add_issue_tooltip": "新建 issue",
+    "cross_status": "跨状态"
   },
   "swimlane": {
     "no_parent": "无父级",


### PR DESCRIPTION
## Summary

Add hierarchical sub-issue display to the issue list view. Sub-issues now render with visual nesting, expand/collapse toggles, and indentation.

## What changed

### New: hierarchy.ts utility
Builds a render tree from the flat issue list + children map. Within each status group, children whose parent is in the same status nest under the parent (indent=1). Cross-status children render at top level with a parent reference label.

### Updated: list-row.tsx
New props: indent, isParent, isExpanded, childCount, onToggleChildren, parentIdentifier. Expand/collapse chevron toggle on parent rows, indent indicator on child rows, child count badge, and cross-status parent references.

### Updated: list-view.tsx
Accepts childrenMap prop, manages expandedParents state, uses buildHierarchy to transform flat issues per status group into hierarchical render items.

### Updated: issues-page.tsx
Fetches children for visible parent issues via childrenByParentsOptions, passes childrenMap to ListView.

Closes #4180