### PR TITLE
AIC-31: fix codex auto-review pricing alias

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { renderWithI18n } from "../../test/i18n";
 
 // The viewing timezone flows: auth store `user.timezone` → useViewingTimezone()
@@ -10,6 +10,13 @@ import { renderWithI18n } from "../../test/i18n";
 // Capture every queryKey passed to useQuery. queryOptions() inside the
 // dashboard options builders runs for real, so the key is the production key.
 const queryKeys = vi.hoisted(() => [] as unknown[][]);
+const queryState = vi.hoisted(() => ({
+  loading: true,
+  daily: [] as Record<string, unknown>[],
+  byAgent: [] as Record<string, unknown>[],
+  agentRuntime: [] as Record<string, unknown>[],
+  runtimeDaily: [] as Record<string, unknown>[],
+}));
 
 vi.mock("@tanstack/react-query", async () => {
   const actual =
@@ -20,7 +27,20 @@ vi.mock("@tanstack/react-query", async () => {
     ...actual,
     useQuery: (opts: { queryKey: unknown[] }) => {
       queryKeys.push(opts.queryKey);
-      return { data: undefined, isLoading: true };
+      if (queryState.loading) return { data: undefined, isLoading: true };
+      if (opts.queryKey[0] === "dashboard") {
+        switch (opts.queryKey[2]) {
+          case "daily":
+            return { data: queryState.daily, isLoading: false };
+          case "by-agent":
+            return { data: queryState.byAgent, isLoading: false };
+          case "agent-runtime":
+            return { data: queryState.agentRuntime, isLoading: false };
+          case "runtime-daily":
+            return { data: queryState.runtimeDaily, isLoading: false };
+        }
+      }
+      return { data: [], isLoading: false };
     },
   };
 });
@@ -48,14 +68,34 @@ vi.mock("@multica/core/runtimes/custom-pricing-store", () => {
       sel ? sel(state()) : state(),
     { getState: state },
   );
-  return { useCustomPricingStore };
+  return { useCustomPricingStore, getCustomPricing: () => undefined };
 });
+
+vi.mock("../../runtimes/components/charts", () => ({
+  DailyCostChart: () => null,
+  DailyTokensChart: () => null,
+  DailyTimeChart: () => null,
+  DailyTasksChart: () => null,
+  WeeklyCostChart: () => null,
+  WeeklyTokensChart: () => null,
+  WeeklyTimeChart: () => null,
+  WeeklyTasksChart: () => null,
+}));
+
+vi.mock("../../runtimes/components/custom-pricing-dialog", () => ({
+  CustomPricingDialog: () => null,
+}));
 
 import { DashboardPage } from "./dashboard-page";
 
 describe("DashboardPage — viewing timezone drives the query key", () => {
   beforeEach(() => {
     queryKeys.length = 0;
+    queryState.loading = true;
+    queryState.daily = [];
+    queryState.byAgent = [];
+    queryState.agentRuntime = [];
+    queryState.runtimeDaily = [];
     cleanup();
   });
 
@@ -97,4 +137,38 @@ describe("DashboardPage — viewing timezone drives the query key", () => {
       expect(utcKeys[i]).not.toEqual(tokyoKeys[i]);
     }
   });
+
+  it("does not show a pricing gap for codex auto-review usage", () => {
+    queryState.loading = false;
+    queryState.daily = [usageRow("codex-auto-review")];
+
+    renderWithI18n(<DashboardPage />, { locale: "zh-Hans" });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText(/没有维护价格/)).not.toBeInTheDocument();
+  });
+
+  it("still shows the pricing gap banner for truly unmapped models", () => {
+    queryState.loading = false;
+    queryState.daily = [usageRow("unknown-review-model")];
+
+    renderWithI18n(<DashboardPage />, { locale: "zh-Hans" });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "有 1 个模型没有维护价格",
+    );
+    expect(screen.getByText("unknown-review-model")).toBeInTheDocument();
+  });
 });
+
+function usageRow(model: string): Record<string, unknown> {
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    model,
+    input_tokens: 1_000,
+    output_tokens: 250,
+    cache_read_tokens: 100,
+    cache_write_tokens: 50,
+    task_count: 1,
+  };
+}

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { BarChart3, FolderKanban } from "lucide-react";
+import { AlertCircle, BarChart3, FolderKanban } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { Button } from "@multica/ui/components/ui/button";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import {
   Select,
@@ -21,6 +22,7 @@ import {
   dashboardRunTimeDailyOptions,
 } from "@multica/core/dashboard";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
+import type { DashboardUsageDaily } from "@multica/core/types";
 import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import { PageHeader } from "../../layout/page-header";
 import { KpiCard } from "../../runtimes/components/shared";
@@ -39,9 +41,11 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import {
   addDaysIso,
   aggregateByWeek,
+  collectUnmappedModels,
   formatTokens,
   todayIso,
 } from "../../runtimes/utils";
+import { CustomPricingDialog } from "../../runtimes/components/custom-pricing-dialog";
 import { useT } from "../../i18n";
 import {
   aggregateAgentTokens,
@@ -94,7 +98,7 @@ const ALL_PROJECTS = "__all__";
 // Stable references — `data ?? []` would create a new empty array on
 // every render while the query is loading, which breaks useMemo's
 // reference-equality dep check and trips the exhaustive-deps lint rule.
-const EMPTY_DAILY: import("@multica/core/types").DashboardUsageDaily[] = [];
+const EMPTY_DAILY: DashboardUsageDaily[] = [];
 const EMPTY_BY_AGENT: import("@multica/core/types").DashboardUsageByAgent[] = [];
 const EMPTY_RUNTIME: import("@multica/core/types").DashboardAgentRunTime[] = [];
 const EMPTY_RUNTIME_DAILY: import("@multica/core/types").DashboardRunTimeDaily[] = [];
@@ -353,6 +357,8 @@ export function DashboardPage() {
             <DashboardEmpty />
           ) : (
             <>
+              <DashboardUnmappedPricingNotice usage={dailyUsageInWindow} />
+
               {/* KPI row — same 3-divide-x card grid the runtime usage
                   section uses, expanded to four tiles. */}
               <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
@@ -419,6 +425,47 @@ export function DashboardPage() {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function DashboardUnmappedPricingNotice({
+  usage,
+}: {
+  usage: DashboardUsageDaily[];
+}) {
+  const { t } = useT("runtimes");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const unmapped = collectUnmappedModels(usage);
+  if (unmapped.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-3 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs"
+    >
+      <AlertCircle className="h-4 w-4 shrink-0 text-warning" />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="text-foreground">
+          {t(($) => $.usage.unmapped_notice, { count: unmapped.length })}
+        </p>
+        <p className="truncate font-mono text-[11px] text-muted-foreground">
+          {unmapped.join(", ")}
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setDialogOpen(true)}
+      >
+        {t(($) => $.usage.custom_pricing.open_button)}
+      </Button>
+      <CustomPricingDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        unmappedModels={unmapped}
+      />
     </div>
   );
 }

--- a/packages/views/dashboard/utils.test.ts
+++ b/packages/views/dashboard/utils.test.ts
@@ -122,6 +122,30 @@ describe("computeDailyTotals", () => {
     expect(totals.cost).toBe(9); // 3M × $3/M
     expect(totals.taskCount).toBe(5);
   });
+
+  it("includes Codex auto-review aliases in usage dashboard cost totals", () => {
+    const totals = computeDailyTotals([
+      {
+        date: "2026-06-16",
+        model: "codex-auto-review",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_tokens: 1_000_000,
+        cache_write_tokens: 0,
+        task_count: 1,
+      },
+      {
+        date: "2026-06-16",
+        model: "openai:codex-auto-review",
+        input_tokens: 1_000_000,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        task_count: 1,
+      },
+    ]);
+    expect(totals.cost).toBeCloseTo(0.75 + 4.5 + 0.075 + 0.75, 5);
+  });
 });
 
 describe("mergeAgentDashboardRows", () => {

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -241,6 +241,19 @@ describe("estimateCost", () => {
     ).toBeCloseTo(0.75 + 4.5 + 0.075, 5);
   });
 
+  it("prices provider-prefixed and whitespace-padded Codex auto-review aliases", () => {
+    expect(isModelPriced("openai/codex-auto-review")).toBe(true);
+    expect(isModelPriced("openai:codex-auto-review")).toBe(true);
+    expect(isModelPriced(" CODEX-AUTO-REVIEW ")).toBe(true);
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "openai:codex-auto-review",
+        input_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(0.75, 5);
+  });
+
   it("flags catalog SKUs without a published price (gpt-5.5-mini) as unmapped", () => {
     // `gpt-5.5-mini` is in the Codex catalog but OpenAI hasn't published a
     // public rate. We refuse to absorb it into `gpt-5.5` — the diagnostic
@@ -451,6 +464,9 @@ describe("collectUnmappedModels", () => {
     const rows = [
       { ...zeroUsage, model: "claude-sonnet-4-6" },
       { ...zeroUsage, model: "gpt-5-codex" },
+      { ...zeroUsage, model: "codex-auto-review" },
+      { ...zeroUsage, model: "openai/codex-auto-review" },
+      { ...zeroUsage, model: "openai:codex-auto-review" },
       { ...zeroUsage, model: "fictional-model-x" },
     ];
     expect(collectUnmappedModels(rows)).toEqual(["fictional-model-x"]);

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -224,6 +224,23 @@ describe("estimateCost", () => {
     ).toBeCloseTo(1.75 + 14, 5);
   });
 
+  it("prices Codex auto-review's internal alias at the GPT-5.4 mini tier", () => {
+    // Codex OTel usage can report the auto-review subagent as
+    // `codex-auto-review`, which is an internal routing label rather than a
+    // public price-card SKU. Keep it as an explicit alias so the dashboard
+    // includes those tokens without adding a broad Codex fallback.
+    expect(isModelPriced("codex-auto-review")).toBe(true);
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "codex-auto-review",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_read_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(0.75 + 4.5 + 0.075, 5);
+  });
+
   it("flags catalog SKUs without a published price (gpt-5.5-mini) as unmapped", () => {
     // `gpt-5.5-mini` is in the Codex catalog but OpenAI hasn't published a
     // public rate. We refuse to absorb it into `gpt-5.5` — the diagnostic

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -248,6 +248,13 @@ const MODEL_PRICING: Record<
   "cursor":             { input: 3,    output: 15,   cacheRead: 0.5,    cacheWrite: 0 },
 };
 
+const MODEL_ALIASES: Record<string, string> = {
+  // Codex emits this internal label for the auto-review subagent / guardian
+  // path. It is not a public model SKU, so map it to OpenAI's published
+  // GPT-5.4 mini tier for coding / computer-use / subagent work.
+  "codex-auto-review": "gpt-5.4-mini",
+};
+
 // Resolve a model string to its pricing tier. Exact match, with four
 // tolerances applied in order:
 //
@@ -297,6 +304,10 @@ function canonicalCandidates(model: string): string[] {
     seen.add(s);
     out.push(s);
   };
+  const pushAlias = (s: string) => {
+    const alias = MODEL_ALIASES[s];
+    if (alias) push(alias);
+  };
   const stripDate = (s: string) =>
     s.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
   const stripProvider = (s: string) => {
@@ -325,6 +336,9 @@ function canonicalCandidates(model: string): string[] {
   push(stripDate(noProvider));
   push(stripDate(dashed));
   push(stripDate(noTag));
+  for (const candidate of [...out]) {
+    pushAlias(candidate);
+  }
   return out;
 }
 

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -311,8 +311,13 @@ function canonicalCandidates(model: string): string[] {
   const stripDate = (s: string) =>
     s.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
   const stripProvider = (s: string) => {
-    const i = s.indexOf("/");
-    return i > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, i)) ? s.slice(i + 1) : s;
+    for (const sep of ["/", ":"]) {
+      const i = s.indexOf(sep);
+      if (i > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, i))) {
+        return s.slice(i + 1);
+      }
+    }
+    return s;
   };
   // Only Anthropic IDs are dot↔dash equivalent. OpenAI separators are
   // semantic, so we leave `gpt-5.4` etc. alone.
@@ -324,18 +329,30 @@ function canonicalCandidates(model: string): string[] {
   const stripContextTag = (s: string) => s.replace(/\[[^\]]+\]$/, "");
 
   const raw = model;
+  const normalized = raw.trim().toLowerCase();
   const noProvider = stripProvider(raw);
+  const normalizedNoProvider = stripProvider(normalized);
   const dashed = canonAnthropic(noProvider);
+  const normalizedDashed = canonAnthropic(normalizedNoProvider);
   const noTag = stripContextTag(dashed);
+  const normalizedNoTag = stripContextTag(normalizedDashed);
 
   push(raw);
+  push(normalized);
   push(noProvider);
+  push(normalizedNoProvider);
   push(dashed);
+  push(normalizedDashed);
   push(noTag);
+  push(normalizedNoTag);
   push(stripDate(raw));
+  push(stripDate(normalized));
   push(stripDate(noProvider));
+  push(stripDate(normalizedNoProvider));
   push(stripDate(dashed));
+  push(stripDate(normalizedDashed));
   push(stripDate(noTag));
+  push(stripDate(normalizedNoTag));
   for (const candidate of [...out]) {
     pushAlias(candidate);
   }

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -45,7 +45,7 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]5$|^gpt-5-5$`), "openai:gpt-5.5"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4($|-2026-03-05|-xhigh)`), "openai:gpt-5.4"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4-mini($|[^a-z0-9])`), "openai:gpt-5.4-mini"},
-	{regexp.MustCompile(`^codex-auto-review$`), "openai:gpt-5.4-mini"},
+	{regexp.MustCompile(`(^|/|:)codex-auto-review$`), "openai:gpt-5.4-mini"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]3-codex$`), "openai:gpt-5.3-codex"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]2-codex$`), "openai:gpt-5.2-codex"},
 	{regexp.MustCompile(`claude-fable-5`), "anthropic:claude-fable-5"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -45,6 +45,7 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]5$|^gpt-5-5$`), "openai:gpt-5.5"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4($|-2026-03-05|-xhigh)`), "openai:gpt-5.4"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4-mini($|[^a-z0-9])`), "openai:gpt-5.4-mini"},
+	{regexp.MustCompile(`^codex-auto-review$`), "openai:gpt-5.4-mini"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]3-codex$`), "openai:gpt-5.3-codex"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]2-codex$`), "openai:gpt-5.2-codex"},
 	{regexp.MustCompile(`claude-fable-5`), "anthropic:claude-fable-5"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -17,7 +17,7 @@ type ModelPrice struct {
 var modelPrices = map[string]ModelPrice{
 	"openai:gpt-5.5":              {Provider: "openai", Model: "gpt-5.5", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 0.50, OutputPerM: 30.00},
 	"openai:gpt-5.4":              {Provider: "openai", Model: "gpt-5.4", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15.00},
-	"openai:gpt-5.4-mini":         {Provider: "openai", Model: "gpt-5.4-mini", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.50},
+	"openai:gpt-5.4-mini":         {Provider: "openai", Model: "gpt-5.4-mini", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.75, OutputPerM: 4.50},
 	"openai:gpt-5.3-codex":        {Provider: "openai", Model: "gpt-5.3-codex", InputPerM: 1.75, CacheReadPerM: 0.175, CacheWritePerM: 0.175, OutputPerM: 14.00},
 	"openai:gpt-5.2-codex":        {Provider: "openai", Model: "gpt-5.2-codex", InputPerM: 1.75, CacheReadPerM: 0.175, CacheWritePerM: 0.175, OutputPerM: 14.00},
 	"anthropic:claude-fable-5":    {Provider: "anthropic", Model: "claude-fable-5", InputPerM: 10.00, CacheReadPerM: 1.00, CacheWritePerM: 12.50, OutputPerM: 50.00},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -31,3 +31,21 @@ func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
 		}
 	}
 }
+
+func TestPriceForModelAliasCodexAutoReview(t *testing.T) {
+	got, ok := PriceForModelAlias("codex-auto-review")
+	if !ok {
+		t.Fatal("PriceForModelAlias(codex-auto-review) did not resolve")
+	}
+	want := ModelPrice{
+		Provider:       "openai",
+		Model:          "gpt-5.4-mini",
+		InputPerM:      0.75,
+		CacheReadPerM:  0.075,
+		CacheWritePerM: 0.075,
+		OutputPerM:     4.5,
+	}
+	if got != want {
+		t.Fatalf("PriceForModelAlias(codex-auto-review) = %+v, want %+v", got, want)
+	}
+}

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -33,10 +33,6 @@ func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
 }
 
 func TestPriceForModelAliasCodexAutoReview(t *testing.T) {
-	got, ok := PriceForModelAlias("codex-auto-review")
-	if !ok {
-		t.Fatal("PriceForModelAlias(codex-auto-review) did not resolve")
-	}
 	want := ModelPrice{
 		Provider:       "openai",
 		Model:          "gpt-5.4-mini",
@@ -45,7 +41,18 @@ func TestPriceForModelAliasCodexAutoReview(t *testing.T) {
 		CacheWritePerM: 0.075,
 		OutputPerM:     4.5,
 	}
-	if got != want {
-		t.Fatalf("PriceForModelAlias(codex-auto-review) = %+v, want %+v", got, want)
+	for _, model := range []string{
+		"codex-auto-review",
+		"openai/codex-auto-review",
+		"openai:codex-auto-review",
+		" CODEX-AUTO-REVIEW ",
+	} {
+		got, ok := PriceForModelAlias(model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", model)
+		}
+		if got != want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", model, got, want)
+		}
 	}
 }

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -38,7 +38,7 @@ func TestPriceForModelAliasCodexAutoReview(t *testing.T) {
 		Model:          "gpt-5.4-mini",
 		InputPerM:      0.75,
 		CacheReadPerM:  0.075,
-		CacheWritePerM: 0.075,
+		CacheWritePerM: 0.75,
 		OutputPerM:     4.5,
 	}
 	for _, model := range []string{


### PR DESCRIPTION
## Summary
- map Codex's internal `codex-auto-review` usage label to the maintained GPT-5.4 mini pricing tier in dashboard/runtime cost math
- harden frontend model normalization to trim/lowercase names and handle provider-prefixed aliases such as `openai/codex-auto-review` and `openai:codex-auto-review`
- add the same provider-prefixed alias coverage to backend LLM metrics pricing
- wire the workspace Usage page to the same unmapped-pricing notice path, so the actual `/usage` page no longer reports `codex-auto-review` as missing pricing after refresh
- align backend GPT-5.4 mini cache-write pricing with the frontend/OpenAI semantics: cache writes are priced at the input rate, while cache reads use the discounted cached-input rate
- cover runtime unmapped detection, usage-dashboard totals, workspace Usage page banner behavior, and Go metrics pricing with focused tests

## Root Cause
`codex-auto-review` is emitted by Codex for the auto-review/subagent path, but it is not a public OpenAI price-card SKU. The maintained rate tables only handled public model IDs.

The first follow-up hardened alias normalization in the PR worktree, but the user was refreshing their running local self-host instance at `~/.multica/server`, served from Docker images `multica-web:dev` / `multica-backend:dev`. Those containers were built before the PR worktree changes, so the visible `localhost:3000` page still loaded the old bundle and continued to report `codex-auto-review` as unpriced.

For pricing, I rechecked current public information on 2026-06-16:
- OpenAI API pricing lists `gpt-5.4-mini` at input $0.75 / 1M, cached input $0.075 / 1M, output $4.50 / 1M.
- OpenAI Codex pricing docs list GPT-5.4 mini among Codex models.
- An OpenAI Codex issue documents `model="codex-auto-review"` appearing in OTel token usage and not being an official public pricing SKU.

## Local Self-Host Fix Applied
On the actual running local checkout `~/.multica/server`:
- added `codex-auto-review -> gpt-5.4-mini` frontend alias with trim/lowercase and `openai/` / `openai:` support
- added dashboard component regression coverage so `codex-auto-review` rows do not show the unmapped-pricing banner
- added backend metrics alias coverage for the same model forms
- rebuilt and restarted the running local Docker services:
  - `multica-web:dev` / `multica-frontend-1`
  - `multica-backend:dev` / `multica-backend-1`
- confirmed the new `localhost:3000/aict/usage` HTML loads the new usage chunk and the built JS bundle contains the `codex-auto-review` alias

## Validation
PR worktree:
- `go test ./internal/metrics`
- `../../node_modules/.bin/vitest run dashboard/components/dashboard-page.test.tsx dashboard/utils.test.ts runtimes/utils.test.ts` (76 tests)
- `../../node_modules/.bin/tsc --noEmit` from `packages/views`
- `../../node_modules/.bin/eslint dashboard/components/dashboard-page.tsx dashboard/components/dashboard-page.test.tsx dashboard/utils.ts dashboard/utils.test.ts runtimes/utils.ts runtimes/utils.test.ts` (0 errors; 4 existing unused-disable warnings in `runtimes/utils.test.ts`)
- `git diff --check`

Local self-host checkout (`~/.multica/server`):
- `go test ./internal/metrics`
- `../../node_modules/.bin/vitest run runtimes/utils.test.ts dashboard/components/dashboard-page.test.tsx dashboard/utils.test.ts` (75 tests)
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/eslint runtimes/utils.ts runtimes/utils.test.ts dashboard/components/dashboard-page.tsx dashboard/components/dashboard-page.test.tsx dashboard/utils.ts dashboard/utils.test.ts` (0 errors; 4 existing unused-disable warnings in `runtimes/utils.test.ts`)
- `git diff --check`
- `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build backend frontend`
- `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build backend` after the cache-write rate correction

Closes AIC-31
