### PR TITLE
MUL-3318: fix GitHub installation account race

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -354,10 +354,41 @@ func (h *Handler) GitHubSetupCallback(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, settingsURL+"&github_error=persist_failed", http.StatusFound)
 		return
 	}
+	inst, err = h.consumePendingGitHubInstallation(r.Context(), inst)
+	if err != nil {
+		slog.Error("github: failed to apply pending installation metadata", "err", err, "installation_id", installationID)
+		http.Redirect(w, r, settingsURL+"&github_error=persist_failed", http.StatusFound)
+		return
+	}
 	h.publish(protocol.EventGitHubInstallationCreated, workspaceID, "system", "", map[string]any{
 		"installation": githubInstallationToBroadcast(inst),
 	})
 	http.Redirect(w, r, settingsURL+"&github_connected=1", http.StatusFound)
+}
+
+func (h *Handler) consumePendingGitHubInstallation(ctx context.Context, inst db.GithubInstallation) (db.GithubInstallation, error) {
+	pending, err := h.Queries.GetPendingGitHubInstallation(ctx, inst.InstallationID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return inst, nil
+		}
+		return inst, err
+	}
+	refreshed, err := h.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:      inst.WorkspaceID,
+		InstallationID:   inst.InstallationID,
+		AccountLogin:     pending.AccountLogin,
+		AccountType:      coalesce(pending.AccountType, "User"),
+		AccountAvatarUrl: pending.AccountAvatarUrl,
+		ConnectedByID:    inst.ConnectedByID,
+	})
+	if err != nil {
+		return inst, err
+	}
+	if err := h.Queries.DeletePendingGitHubInstallation(ctx, inst.InstallationID); err != nil {
+		return inst, err
+	}
+	return refreshed, nil
 }
 
 // fetchInstallationAccount tries to enrich the installation row with the
@@ -632,6 +663,16 @@ type ghInstallationPayload struct {
 	} `json:"installation"`
 }
 
+func githubInstallationAccountFromPayload(p ghInstallationPayload) (login, accountType string, avatar *string, ok bool) {
+	login = strings.TrimSpace(p.Installation.Account.Login)
+	if login == "" {
+		return "", "", nil, false
+	}
+	accountType = coalesce(p.Installation.Account.Type, "User")
+	avatar = strPtrOrNil(p.Installation.Account.AvatarURL)
+	return login, accountType, avatar, true
+}
+
 func (h *Handler) handleInstallationEvent(ctx context.Context, body []byte) {
 	var p ghInstallationPayload
 	if err := json.Unmarshal(body, &p); err != nil {
@@ -648,10 +689,16 @@ func (h *Handler) handleInstallationEvent(ctx context.Context, body []byte) {
 		deleted, err := h.Queries.DeleteGitHubInstallationByInstallationID(ctx, p.Installation.ID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
+				if err := h.Queries.DeletePendingGitHubInstallation(ctx, p.Installation.ID); err != nil {
+					slog.Warn("github: delete pending installation failed", "err", err, "installation_id", p.Installation.ID)
+				}
 				return // already gone — nothing to broadcast
 			}
 			slog.Warn("github: delete installation failed", "err", err, "installation_id", p.Installation.ID)
 			return
+		}
+		if err := h.Queries.DeletePendingGitHubInstallation(ctx, p.Installation.ID); err != nil {
+			slog.Warn("github: delete pending installation failed", "err", err, "installation_id", p.Installation.ID)
 		}
 		// Broadcast the internal row id only — the numeric installation_id is
 		// a management handle that non-admin members are not allowed to see.
@@ -661,26 +708,46 @@ func (h *Handler) handleInstallationEvent(ctx context.Context, body []byte) {
 			"id": uuidToString(deleted.ID),
 		})
 	case "created", "new_permissions_accepted", "unsuspend":
-		// We don't know which workspace this maps to from the webhook
-		// alone — the setup callback handler is what binds installation
-		// to workspace, so we just refresh metadata if we already have
-		// a row.
-		existing, err := h.Queries.GetGitHubInstallationByInstallationID(ctx, p.Installation.ID)
-		if err != nil {
+		login, accountType, avatar, ok := githubInstallationAccountFromPayload(p)
+		if !ok {
+			slog.Warn("github: installation payload missing account login", "installation_id", p.Installation.ID)
 			return
 		}
-		avatar := p.Installation.Account.AvatarURL
+
+		// We don't know which workspace this maps to from the webhook alone.
+		// If the setup callback has not created the workspace binding yet,
+		// keep the account metadata and let the callback consume it after it
+		// creates github_installation.
+		existing, err := h.Queries.GetGitHubInstallationByInstallationID(ctx, p.Installation.ID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				if _, err := h.Queries.UpsertPendingGitHubInstallation(ctx, db.UpsertPendingGitHubInstallationParams{
+					InstallationID:   p.Installation.ID,
+					AccountLogin:     login,
+					AccountType:      accountType,
+					AccountAvatarUrl: ptrToText(avatar),
+				}); err != nil {
+					slog.Warn("github: store pending installation failed", "err", err, "installation_id", p.Installation.ID)
+				}
+				return
+			}
+			slog.Warn("github: lookup installation failed", "err", err, "installation_id", p.Installation.ID)
+			return
+		}
 		inst, err := h.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
 			WorkspaceID:      existing.WorkspaceID,
 			InstallationID:   p.Installation.ID,
-			AccountLogin:     p.Installation.Account.Login,
-			AccountType:      coalesce(p.Installation.Account.Type, "User"),
-			AccountAvatarUrl: ptrToText(strPtrOrNil(avatar)),
+			AccountLogin:     login,
+			AccountType:      accountType,
+			AccountAvatarUrl: ptrToText(avatar),
 			ConnectedByID:    existing.ConnectedByID,
 		})
 		if err != nil {
 			slog.Warn("github: refresh installation failed", "err", err)
 			return
+		}
+		if err := h.Queries.DeletePendingGitHubInstallation(ctx, p.Installation.ID); err != nil {
+			slog.Warn("github: delete pending installation failed", "err", err, "installation_id", p.Installation.ID)
 		}
 		// Broadcast so any open Settings → GitHub tab re-queries the
 		// installations list. Without this, a row created by the setup

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -2051,7 +2051,6 @@ func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
 	}
 }
 
-
 // generateTestRSAKeyPEM mints an RSA-2048 key, returns its PKCS#1 PEM
 // encoding (the format GitHub hands operators when they create the App)
 // and the parsed *rsa.PrivateKey for verification.
@@ -2387,5 +2386,117 @@ func TestWebhook_InstallationCreatedRefreshesUnknownLogin(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Errorf("expected github_installation:created broadcast after webhook refresh, got none in 2s")
+	}
+}
+
+// TestSetupCallback_ConsumesPendingInstallationCreated covers the inverse
+// race to TestWebhook_InstallationCreatedRefreshesUnknownLogin: GitHub can
+// deliver installation.created before the setup callback has created the local
+// workspace binding. The webhook cannot broadcast yet, but it must not be lost;
+// the callback consumes the pending account metadata even if its direct GitHub
+// API lookup falls back to the "unknown" placeholder.
+func TestSetupCallback_ConsumesPendingInstallationCreated(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "pending-installation-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+	t.Setenv("GITHUB_APP_ID", "")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", "")
+	t.Setenv("FRONTEND_ORIGIN", "https://app.example.test")
+
+	const installationID int64 = 81818181
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+		testPool.Exec(ctx, `DELETE FROM github_pending_installation WHERE installation_id = $1`, installationID)
+	})
+
+	// Force fetchInstallationAccount to take its degraded path. This pins that
+	// the final real account name comes from the earlier webhook, not the
+	// setup callback's synchronous GitHub API lookup.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "auth required", http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	oldBase := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = oldBase })
+
+	body, _ := json.Marshal(map[string]any{
+		"action": "created",
+		"installation": map[string]any{
+			"id": installationID,
+			"account": map[string]any{
+				"login":      "pending-octocat",
+				"type":       "Organization",
+				"avatar_url": "https://example.com/pending.png",
+			},
+		},
+	})
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	rec := httptest.NewRecorder()
+	hookReq := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(body))
+	hookReq.Header.Set("X-GitHub-Event", "installation")
+	hookReq.Header.Set("X-Hub-Signature-256", sig)
+	testHandler.HandleGitHubWebhook(rec, hookReq)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook: expected 202, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var pendingLogin string
+	if err := testPool.QueryRow(ctx,
+		`SELECT account_login FROM github_pending_installation WHERE installation_id = $1`,
+		installationID,
+	).Scan(&pendingLogin); err != nil {
+		t.Fatalf("pending installation row not stored: %v", err)
+	}
+	if pendingLogin != "pending-octocat" {
+		t.Fatalf("pending account_login = %q, want pending-octocat", pendingLogin)
+	}
+
+	state, err := signState(testWorkspaceID)
+	if err != nil {
+		t.Fatalf("signState: %v", err)
+	}
+	setupReq := httptest.NewRequest("GET",
+		fmt.Sprintf("/api/github/setup?installation_id=%d&state=%s", installationID, state),
+		nil,
+	)
+	setupRec := httptest.NewRecorder()
+	testHandler.GitHubSetupCallback(setupRec, setupReq)
+	if setupRec.Code != http.StatusFound {
+		t.Fatalf("setup callback: expected 302, got %d (%s)", setupRec.Code, setupRec.Body.String())
+	}
+	if loc := setupRec.Header().Get("Location"); !strings.Contains(loc, "github_connected=1") {
+		t.Fatalf("setup callback redirect = %q, want github_connected=1", loc)
+	}
+
+	got, err := testHandler.Queries.GetGitHubInstallationByInstallationID(ctx, installationID)
+	if err != nil {
+		t.Fatalf("get installation: %v", err)
+	}
+	if got.AccountLogin != "pending-octocat" {
+		t.Errorf("account_login = %q, want pending-octocat (callback left the unknown placeholder)", got.AccountLogin)
+	}
+	if got.AccountType != "Organization" {
+		t.Errorf("account_type = %q, want Organization", got.AccountType)
+	}
+	if got.AccountAvatarUrl.String != "https://example.com/pending.png" || !got.AccountAvatarUrl.Valid {
+		t.Errorf("account_avatar_url = %+v, want pending avatar", got.AccountAvatarUrl)
+	}
+
+	var pendingCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM github_pending_installation WHERE installation_id = $1`,
+		installationID,
+	).Scan(&pendingCount); err != nil {
+		t.Fatalf("count pending installation: %v", err)
+	}
+	if pendingCount != 0 {
+		t.Fatalf("pending installation row should be consumed, got count %d", pendingCount)
 	}
 }

--- a/server/migrations/120_github_pending_installation.down.sql
+++ b/server/migrations/120_github_pending_installation.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS github_pending_installation;

--- a/server/migrations/120_github_pending_installation.up.sql
+++ b/server/migrations/120_github_pending_installation.up.sql
@@ -1,0 +1,13 @@
+-- Temporarily stores installation webhook account metadata when GitHub sends
+-- installation.created before the setup callback has bound installation_id to
+-- a workspace. No foreign keys: the workspace binding is resolved later by the
+-- setup callback.
+CREATE TABLE github_pending_installation (
+    installation_id BIGINT PRIMARY KEY,
+    account_login   TEXT NOT NULL CHECK (account_login <> ''),
+    account_type    TEXT NOT NULL DEFAULT 'User'
+        CHECK (account_type IN ('User', 'Organization')),
+    account_avatar_url TEXT,
+    received_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/server/pkg/db/generated/github.sql.go
+++ b/server/pkg/db/generated/github.sql.go
@@ -91,6 +91,15 @@ func (q *Queries) DeleteGitHubInstallationByInstallationID(ctx context.Context, 
 	return i, err
 }
 
+const deletePendingGitHubInstallation = `-- name: DeletePendingGitHubInstallation :exec
+DELETE FROM github_pending_installation WHERE installation_id = $1
+`
+
+func (q *Queries) DeletePendingGitHubInstallation(ctx context.Context, installationID int64) error {
+	_, err := q.db.Exec(ctx, deletePendingGitHubInstallation, installationID)
+	return err
+}
+
 const getGitHubInstallationByID = `-- name: GetGitHubInstallationByID :one
 SELECT id, workspace_id, installation_id, account_login, account_type, account_avatar_url, connected_by_id, created_at, updated_at FROM github_installation
 WHERE id = $1
@@ -209,6 +218,24 @@ func (q *Queries) GetIssuePullRequestCloseAggregate(ctx context.Context, issueID
 	row := q.db.QueryRow(ctx, getIssuePullRequestCloseAggregate, issueID)
 	var i GetIssuePullRequestCloseAggregateRow
 	err := row.Scan(&i.OpenCount, &i.MergedWithCloseIntentCount)
+	return i, err
+}
+
+const getPendingGitHubInstallation = `-- name: GetPendingGitHubInstallation :one
+SELECT installation_id, account_login, account_type, account_avatar_url, received_at, updated_at FROM github_pending_installation WHERE installation_id = $1
+`
+
+func (q *Queries) GetPendingGitHubInstallation(ctx context.Context, installationID int64) (GithubPendingInstallation, error) {
+	row := q.db.QueryRow(ctx, getPendingGitHubInstallation, installationID)
+	var i GithubPendingInstallation
+	err := row.Scan(
+		&i.InstallationID,
+		&i.AccountLogin,
+		&i.AccountType,
+		&i.AccountAvatarUrl,
+		&i.ReceivedAt,
+		&i.UpdatedAt,
+	)
 	return i, err
 }
 
@@ -595,6 +622,46 @@ func (q *Queries) UpsertGitHubPullRequest(ctx context.Context, arg UpsertGitHubP
 		&i.Additions,
 		&i.Deletions,
 		&i.ChangedFiles,
+	)
+	return i, err
+}
+
+const upsertPendingGitHubInstallation = `-- name: UpsertPendingGitHubInstallation :one
+INSERT INTO github_pending_installation (
+    installation_id, account_login, account_type, account_avatar_url
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT (installation_id) DO UPDATE SET
+    account_login = EXCLUDED.account_login,
+    account_type = EXCLUDED.account_type,
+    account_avatar_url = EXCLUDED.account_avatar_url,
+    updated_at = now()
+RETURNING installation_id, account_login, account_type, account_avatar_url, received_at, updated_at
+`
+
+type UpsertPendingGitHubInstallationParams struct {
+	InstallationID   int64       `json:"installation_id"`
+	AccountLogin     string      `json:"account_login"`
+	AccountType      string      `json:"account_type"`
+	AccountAvatarUrl pgtype.Text `json:"account_avatar_url"`
+}
+
+func (q *Queries) UpsertPendingGitHubInstallation(ctx context.Context, arg UpsertPendingGitHubInstallationParams) (GithubPendingInstallation, error) {
+	row := q.db.QueryRow(ctx, upsertPendingGitHubInstallation,
+		arg.InstallationID,
+		arg.AccountLogin,
+		arg.AccountType,
+		arg.AccountAvatarUrl,
+	)
+	var i GithubPendingInstallation
+	err := row.Scan(
+		&i.InstallationID,
+		&i.AccountLogin,
+		&i.AccountType,
+		&i.AccountAvatarUrl,
+		&i.ReceivedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -279,6 +279,15 @@ type GithubInstallation struct {
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 }
 
+type GithubPendingInstallation struct {
+	InstallationID   int64              `json:"installation_id"`
+	AccountLogin     string             `json:"account_login"`
+	AccountType      string             `json:"account_type"`
+	AccountAvatarUrl pgtype.Text        `json:"account_avatar_url"`
+	ReceivedAt       pgtype.Timestamptz `json:"received_at"`
+	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+}
+
 type GithubPullRequest struct {
 	ID              pgtype.UUID        `json:"id"`
 	WorkspaceID     pgtype.UUID        `json:"workspace_id"`

--- a/server/pkg/db/queries/github.sql
+++ b/server/pkg/db/queries/github.sql
@@ -37,6 +37,26 @@ DELETE FROM github_installation WHERE id = $1 AND workspace_id = $2;
 DELETE FROM github_installation WHERE installation_id = $1
 RETURNING id, workspace_id;
 
+-- name: UpsertPendingGitHubInstallation :one
+INSERT INTO github_pending_installation (
+    installation_id, account_login, account_type, account_avatar_url
+) VALUES (
+    $1, $2, $3, sqlc.narg('account_avatar_url')
+)
+ON CONFLICT (installation_id) DO UPDATE SET
+    account_login = EXCLUDED.account_login,
+    account_type = EXCLUDED.account_type,
+    account_avatar_url = EXCLUDED.account_avatar_url,
+    updated_at = now()
+RETURNING *;
+
+-- name: DeletePendingGitHubInstallation :exec
+DELETE FROM github_pending_installation WHERE installation_id = $1;
+
+-- name: GetPendingGitHubInstallation :one
+SELECT * FROM github_pending_installation WHERE installation_id = $1
+;
+
 -- =====================
 -- GitHub Pull Request
 -- =====================


### PR DESCRIPTION
## Summary

Fixes the GitHub App installation race where `installation.created` can arrive before the setup callback has created the local workspace binding. In that ordering, the webhook previously returned early and the later callback could still persist `account_login = "unknown"`, leaving Settings stuck until a manual webhook redelivery.

This PR:
- Adds a durable `github_pending_installation` table keyed by `installation_id` with no foreign keys.
- Stores account metadata from early installation webhooks when no local installation row exists yet.
- Has the setup callback consume pending metadata before broadcasting `github_installation:created`.
- Keeps the existing late-webhook refresh path and clears stale pending rows on refresh/delete.

Fixes #4186
Closes MUL-3318

## Testing

- `go test ./internal/handler -run 'TestSetupCallback_ConsumesPendingInstallationCreated|TestWebhook_InstallationCreatedRefreshesUnknownLogin|TestFetchInstallationAccount|TestSignGitHubAppJWT' -count=1`
- `go test ./internal/handler -count=1`
- `go vet ./...`
