### PR TITLE
fix(editor): don't wipe in-flight uploads on external content sync

### DIFF
--- a/packages/core/chat/index.ts
+++ b/packages/core/chat/index.ts
@@ -1,4 +1,4 @@
-export { createChatStore, CHAT_MIN_W, CHAT_MIN_H, CHAT_DEFAULT_W, CHAT_DEFAULT_H, DRAFT_NEW_SESSION } from "./store";
+export { createChatStore, CHAT_MIN_W, CHAT_MIN_H, CHAT_DEFAULT_W, CHAT_DEFAULT_H, DRAFT_NEW_SESSION, newSessionDraftKey } from "./store";
 export type { ChatStoreOptions, ChatState, ChatTimelineItem } from "./store";
 export { useRecentContextStore, selectRecentContexts } from "./recent-context-store";
 export type { RecentContextEntry, RecentContextType } from "./recent-context-store";

--- a/packages/core/chat/store.test.ts
+++ b/packages/core/chat/store.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createChatStore, newSessionDraftKey } from "./store";
+import type { StorageAdapter } from "../types";
+
+function memStorage(): StorageAdapter {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => {
+      m.set(k, v);
+    },
+    removeItem: (k) => {
+      m.delete(k);
+    },
+  };
+}
+
+describe("newSessionDraftKey", () => {
+  it("derives a stable per-agent slot for an uncreated chat", () => {
+    expect(newSessionDraftKey("agent-1")).toBe("__new__:agent-1");
+    expect(newSessionDraftKey(null)).toBe("__new__:");
+  });
+});
+
+describe("chat store — migrateInputDraft", () => {
+  let store: ReturnType<typeof createChatStore>;
+
+  beforeEach(() => {
+    store = createChatStore({ storage: memStorage() });
+  });
+
+  it("moves a draft to the new key and clears the source", () => {
+    const from = newSessionDraftKey("agent-1");
+    store.getState().setInputDraft(from, "!file[x.pdf]()");
+
+    store.getState().migrateInputDraft(from, "session-1");
+
+    const drafts = store.getState().inputDrafts;
+    expect(drafts["session-1"]).toBe("!file[x.pdf]()");
+    // Source slot is cleared so it can't resurface in the next new chat.
+    expect(from in drafts).toBe(false);
+  });
+
+  it("is a no-op when the source draft is absent", () => {
+    store.getState().setInputDraft("session-1", "keep me");
+
+    store.getState().migrateInputDraft(newSessionDraftKey("agent-1"), "session-1");
+
+    expect(store.getState().inputDrafts["session-1"]).toBe("keep me");
+  });
+
+  it("is a no-op when from === to", () => {
+    store.getState().setInputDraft("session-1", "keep me");
+
+    store.getState().migrateInputDraft("session-1", "session-1");
+
+    expect(store.getState().inputDrafts["session-1"]).toBe("keep me");
+  });
+});

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -11,6 +11,16 @@ const SESSION_STORAGE_KEY = "multica:chat:activeSessionId";
 const DRAFTS_KEY = "multica:chat:drafts";
 /** Placeholder sessionId for a chat that hasn't been created yet. */
 export const DRAFT_NEW_SESSION = "__new__";
+
+/**
+ * Draft storage key for an as-yet-uncreated chat with the given agent.
+ * Shared by ChatInput (which writes the draft) and ensureSession (which
+ * migrates it onto the real session id the moment the session is created),
+ * so the two never disagree on the slot name.
+ */
+export function newSessionDraftKey(selectedAgentId: string | null): string {
+  return `${DRAFT_NEW_SESSION}:${selectedAgentId ?? ""}`;
+}
 const CHAT_WIDTH_KEY = "multica:chat:width";
 const CHAT_HEIGHT_KEY = "multica:chat:height";
 const CHAT_EXPANDED_KEY = "multica:chat:expanded";
@@ -84,6 +94,14 @@ export interface ChatState {
   /** sessionId accepts a real session UUID or DRAFT_NEW_SESSION. */
   setInputDraft: (sessionId: string, draft: string) => void;
   clearInputDraft: (sessionId: string) => void;
+  /**
+   * Move a draft from one key to another, deleting the source. Used when a
+   * chat session is lazily created: the `__new__:agent` draft is migrated
+   * onto the real sessionId so it isn't stranded under the abandoned key
+   * (which would resurface as a stale draft the next time a new chat opens
+   * for that agent).
+   */
+  migrateInputDraft: (from: string, to: string) => void;
   /** Persist raw size and auto-exit expanded mode. */
   setChatSize: (width: number, height: number) => void;
   setExpanded: (expanded: boolean) => void;
@@ -156,6 +174,19 @@ export function createChatStore(options: ChatStoreOptions) {
       logger.info("clearInputDraft", { sessionId });
       const next = { ...current };
       delete next[sessionId];
+      writeDrafts(storage, wsKey(DRAFTS_KEY), next);
+      set({ inputDrafts: next });
+    },
+    migrateInputDraft: (from, to) => {
+      if (from === to) return;
+      const current = get().inputDrafts;
+      if (!(from in current)) {
+        logger.debug("migrateInputDraft skipped (no source draft)", { from, to });
+        return;
+      }
+      logger.info("migrateInputDraft", { from, to });
+      const next = { ...current, [to]: current[from]! };
+      delete next[from];
       writeDrafts(storage, wsKey(DRAFTS_KEY), next);
       set({ inputDrafts: next });
     },

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -121,6 +121,7 @@ vi.mock("@multica/core/chat", () => {
   };
   return {
     DRAFT_NEW_SESSION: "__draft_new__",
+    newSessionDraftKey: (agentId: string | null) => `__draft_new__:${agentId ?? ""}`,
     useChatStore: Object.assign(
       (selector?: (s: typeof state) => unknown) =>
         selector ? selector(state) : state,

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
-import { useChatStore, DRAFT_NEW_SESSION } from "@multica/core/chat";
+import { useChatStore, newSessionDraftKey } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
 import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
@@ -85,8 +85,7 @@ export function ChatInput({
   // user would see the image flash on then disappear. Keeping editor
   // identity stable across the lazy-create event is what makes
   // first-upload-creates-session work the same as second-upload.
-  const draftKey =
-    activeSessionId ?? `${DRAFT_NEW_SESSION}:${selectedAgentId ?? ""}`;
+  const draftKey = activeSessionId ?? newSessionDraftKey(selectedAgentId);
   // Select a primitive — empty-string fallback keeps referential stability.
   const inputDraft = useChatStore((s) => s.inputDrafts[draftKey] ?? "");
   const setInputDraft = useChatStore((s) => s.setInputDraft);

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -44,7 +44,7 @@ import {
   useMarkChatSessionRead,
   useUpdateChatSession,
 } from "@multica/core/chat/mutations";
-import { useChatStore } from "@multica/core/chat";
+import { useChatStore, newSessionDraftKey } from "@multica/core/chat";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import { ChatResizeHandles } from "./chat-resize-handles";
@@ -186,6 +186,7 @@ export function ChatWindow() {
   const setOpen = useChatStore((s) => s.setOpen);
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const setSelectedAgentId = useChatStore((s) => s.setSelectedAgentId);
+  const migrateInputDraft = useChatStore((s) => s.migrateInputDraft);
   const user = useAuthStore((s) => s.user);
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: members = [] } = useQuery(memberListOptions(wsId));
@@ -370,8 +371,19 @@ export function ChatWindow() {
 
   const handleUploadFile = useCallback(
     async (file: File) => {
+      // An upload in a brand-new chat lazily creates the session, flipping the
+      // draft key from `__new__:agent` to the session id mid-upload. The
+      // in-progress (empty-href) file-card markdown the editor already wrote
+      // into the `__new__:agent` draft would otherwise be stranded there and
+      // resurface as a stale `!file[name]()` the next time a new chat opens for
+      // this agent. Migrate that draft onto the session id so it travels with
+      // the session and the `__new__:agent` slot is cleared.
+      const wasNewSession = !activeSessionId;
       const sessionId = await ensureSession("");
       if (!sessionId) return null;
+      if (wasNewSession) {
+        migrateInputDraft(newSessionDraftKey(selectedAgentId), sessionId);
+      }
       // Prime the messages cache as empty before flipping activeSessionId so
       // ChatMessageList mounts directly (no Skeleton frame). Skip the write
       // when an entry already exists — a concurrent handleSend may have
@@ -384,7 +396,15 @@ export function ChatWindow() {
       setActiveSession(sessionId);
       return uploadWithToast(file, { chatSessionId: sessionId });
     },
-    [ensureSession, uploadWithToast, qc, setActiveSession],
+    [
+      activeSessionId,
+      ensureSession,
+      migrateInputDraft,
+      selectedAgentId,
+      uploadWithToast,
+      qc,
+      setActiveSession,
+    ],
   );
 
   const cancelChatTask = useCallback(

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -10,6 +10,9 @@ const editorState = vi.hoisted(() => ({
   isFocused: false,
   isDestroyed: false,
   markdown: "",
+  // Nodes the mocked doc reports via `descendants`. The content-sync effect
+  // walks these to detect in-flight uploads; default empty = nothing uploading.
+  uploadingNodes: [] as Array<{ attrs: { uploading?: boolean } }>,
 }));
 
 // Records the attachments[] prop the provider received on its most recent
@@ -83,7 +86,14 @@ vi.mock("@tiptap/react", () => ({
         },
         getMarkdown: () => editorState.markdown,
         state: {
-          doc: { content: { size: 0 } },
+          doc: {
+            content: { size: 0 },
+            descendants: (cb: (node: { attrs: { uploading?: boolean } }) => boolean | void) => {
+              for (const node of editorState.uploadingNodes) {
+                if (cb(node) === false) break;
+              }
+            },
+          },
           selection: { empty: true, from: 0, to: 0 },
         },
       };
@@ -109,6 +119,7 @@ describe("ContentEditor", () => {
     editorState.isFocused = false;
     editorState.isDestroyed = false;
     editorState.markdown = "";
+    editorState.uploadingNodes = [];
     editorRef.current = null;
     onCreateFired.value = false;
     latestEditorOptions.current = undefined;
@@ -153,6 +164,25 @@ describe("ContentEditor", () => {
       "new content from server",
       expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
     );
+  });
+
+  it("does not sync while a file upload is in flight (in-flight upload node must survive external defaultValue changes)", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    // A file is uploading: the doc holds a node with attrs.uploading. An
+    // external defaultValue change (e.g. chat lazy-creating a session mid-upload
+    // flips the draft key → defaultValue) must NOT setContent over it, or the
+    // uploading node is wiped and the upload's finalize can't find it.
+    editorState.uploadingNodes = [{ attrs: { uploading: true } }];
+    rerender(<ContentEditor defaultValue="" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+
+    // Once the upload settles (no uploading node), a later external change syncs.
+    editorState.uploadingNodes = [];
+    rerender(<ContentEditor defaultValue="new content from server" />);
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
   });
 
   it("does not sync when editor is focused and has unsaved local edits", () => {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -384,6 +384,21 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     useEffect(() => {
       if (!editor || editor.isDestroyed) return;
 
+      // Guard 0: never clobber an in-flight upload. An external `defaultValue`
+      // change can arrive mid-upload — e.g. chat lazy-creates a session on the
+      // first file upload, which flips `activeSessionId` → the draft key →
+      // `defaultValue`. If we `setContent` over a document that still holds an
+      // `uploading` image/fileCard node, that node is wiped and the upload's
+      // finalize can no longer find it (the file vanishes, leaving an empty
+      // `!file[name]()`). Like the dirty guards below, an uploading node is
+      // local state that an external sync must not overwrite.
+      let hasUploadingNode = false;
+      editor.state.doc.descendants((node) => {
+        if (node.attrs.uploading) hasUploadingNode = true;
+        return !hasUploadingNode;
+      });
+      if (hasUploadingNode) return;
+
       const current = stripBlobUrls(editor.getMarkdown()).trimEnd();
       // "Dirty" = user has local edits not yet flushed through the debounced
       // `onUpdate`. `lastEmittedRef` is advanced only after a debounce fire,


### PR DESCRIPTION
## Problem

Switching agent in chat and then uploading a file (the first upload in the new chat) made the file **vanish** — leaving an empty `!file[name]()` in the draft. Waiting longer before uploading did **not** help; only a second upload (or uploading into a chat that already has a session) worked.

This is a distinct bug from #4192 (MUL-3312), which gated uploads on `activeAgent` — that closed the *no-agent* window, not this one.

## Root cause (confirmed by instrumented logs)

Not a remount — the editor instance stayed alive (`editorIsDestroyed: false`). The node was deleted from the document by the content-sync effect:

1. After switching agent the chat has **no session** (`activeSessionId = null`).
2. The first upload inserts an `uploading` fileCard, then its handler **lazily creates a session** and calls `setActiveSession(null → uuid)` — mid-upload.
3. That flip changes ChatInput's `draftKey` (`__new__:agent` → sessionId). The new key has an empty draft, so `defaultValue` becomes `""`.
4. `ContentEditor`'s "sync external `defaultValue`" effect runs `setContent("")`, **wiping the document including the still-uploading node**.
5. The upload finishes but `finalizeFileCard` can't find the node → the real href is never written → empty `!file[name]()`.

`editorKey` already deliberately excludes `activeSessionId` to avoid a *remount* on this same flip — but the flip still leaked through `draftKey → defaultValue → setContent`.

## Fix

Add a guard at the top of the content-sync effect: if the editor holds any `uploading` node, bail out and don't `setContent`. An in-flight upload is local state an external sync must not overwrite — same principle as the existing dirty/focused guards.

Pure frontend. Only affects the first upload in a new chat (later uploads hit an existing session, so no draft-key flip).

## Test plan

- [ ] New chat → switch agent → upload a file immediately: file stays and finalizes with a real link.
- [ ] Existing chat upload still works.
- [ ] WS-driven description sync into the issue editor still updates content when no upload is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)