### PR TITLE
feat: route project description to agents

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2673,6 +2673,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		Repos:                            convertReposForEnv(task.Repos),
 		ProjectID:                        task.ProjectID,
 		ProjectTitle:                     task.ProjectTitle,
+		ProjectDescription:               task.ProjectDescription,
 		ProjectResources:                 convertProjectResourcesForEnv(task.ProjectResources),
 		ChatSessionID:                    task.ChatSessionID,
 		AutopilotRunID:                   task.AutopilotRunID,

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -75,6 +75,7 @@ type TaskContextForEnv struct {
 	Repos                   []RepoContextForEnv     // workspace repos available for checkout
 	ProjectID               string                  // issue's project, when present
 	ProjectTitle            string                  // human-readable project title
+	ProjectDescription      string                  // project.description used as agent-facing project context
 	ProjectResources        []ProjectResourceForEnv // resources attached to the project
 	ChatSessionID           string                  // non-empty for chat tasks
 	AutopilotRunID          string                  // non-empty for autopilot run_only tasks

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -149,9 +149,10 @@ func TestPrepareWithProjectResources(t *testing.T) {
 	workspacesRoot := t.TempDir()
 
 	taskCtx := TaskContextForEnv{
-		IssueID:      "11111111-2222-3333-4444-555555555555",
-		ProjectID:    "22222222-3333-4444-5555-666666666666",
-		ProjectTitle: "Agent UX 2026",
+		IssueID:            "11111111-2222-3333-4444-555555555555",
+		ProjectID:          "22222222-3333-4444-5555-666666666666",
+		ProjectTitle:       "Agent UX 2026",
+		ProjectDescription: "Use the project description as agent context.",
 		ProjectResources: []ProjectResourceForEnv{
 			{
 				ID:           "33333333-4444-5555-6666-777777777777",
@@ -213,6 +214,8 @@ func TestPrepareWithProjectResources(t *testing.T) {
 	for _, want := range []string{
 		"## Project Context",
 		"Agent UX 2026",
+		"Project description:",
+		"Use the project description as agent context.",
 		"GitHub repo",
 		"https://github.com/multica-ai/multica",
 		"default branch: `main`",

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -554,13 +554,21 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed, and can pass `--ref` for review/QA on a non-default branch or commit.\n\n")
 	}
 
-	// Inject project-scoped context (resources attached to the issue's project).
-	// The full structured payload is also available at .multica/project/resources.json
-	// so skills can consume it programmatically.
-	if ctx.ProjectID != "" || len(ctx.ProjectResources) > 0 {
+	// Inject project-scoped context. The project description is the unified
+	// human-facing and agent-facing project context; resources are pointers
+	// attached to the same project. The full structured resource payload is
+	// also available at .multica/project/resources.json so skills can consume
+	// it programmatically.
+	projectDescription := strings.TrimRight(ctx.ProjectDescription, " \t\r\n")
+	if ctx.ProjectID != "" || projectDescription != "" || len(ctx.ProjectResources) > 0 {
 		b.WriteString("## Project Context\n\n")
 		if ctx.ProjectTitle != "" {
 			fmt.Fprintf(&b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
+		}
+		if projectDescription != "" {
+			b.WriteString("Project description:\n\n")
+			b.WriteString(projectDescription)
+			b.WriteString("\n\n")
 		}
 		if len(ctx.ProjectResources) > 0 {
 			b.WriteString("Project resources (also written to `.multica/project/resources.json`):\n\n")

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -30,9 +30,24 @@ func BuildPrompt(task Task, provider string) string {
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
+	writeProjectDescriptionPrompt(&b, task)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	fmt.Fprintf(&b, "For comment history, follow the rule in your runtime workflow file (assignment-triggered tasks treat the read as mandatory). `multica issue comment list %s --output json` returns all comments for the issue (server caps at 2000). On long-running issues use `--recent 20 --output json` to read the 20 most recently active threads, then page older threads via the stderr `Next thread cursor: ...` line and the matching `--before` / `--before-id` until you have enough history. `--since <RFC3339>` is still available for incremental polling and may combine with `--recent`.\n", task.IssueID)
 	return b.String()
+}
+
+func writeProjectDescriptionPrompt(b *strings.Builder, task Task) {
+	description := strings.TrimRight(task.ProjectDescription, " \t\r\n")
+	if description == "" {
+		return
+	}
+	if task.ProjectTitle != "" {
+		fmt.Fprintf(b, "Project context from %q:\n\n", task.ProjectTitle)
+	} else {
+		b.WriteString("Project context:\n\n")
+	}
+	b.WriteString(description)
+	b.WriteString("\n\n")
 }
 
 // buildQuickCreatePrompt constructs a prompt for quick-create tasks. The
@@ -105,6 +120,10 @@ func buildQuickCreatePrompt(task Task) string {
 	} else {
 		b.WriteString("- **project**: omit. The platform will route the issue to the workspace default.\n")
 	}
+	if strings.TrimRight(task.ProjectDescription, " \t\r\n") != "" {
+		b.WriteString("\n")
+		writeProjectDescriptionPrompt(&b, task)
+	}
 	// parent — pinned by the modal when the user opened it from "Add sub
 	// issue" on an existing issue. Pass the UUID (never the identifier) so
 	// the create lands the sub-issue under the right parent even when the
@@ -140,6 +159,7 @@ func buildCommentPrompt(task Task, provider string) string {
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
+	writeProjectDescriptionPrompt(&b, task)
 	if task.TriggerCommentContent != "" {
 		authorLabel := "A user"
 		if task.TriggerAuthorType == "agent" {

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -154,6 +154,48 @@ func TestBuildQuickCreatePromptProjectPinning(t *testing.T) {
 	}
 }
 
+func TestBuildPromptsIncludeProjectDescriptionContext(t *testing.T) {
+	task := Task{
+		IssueID:            "issue-123",
+		ProjectTitle:       "Web App",
+		ProjectDescription: "Prefer the React app conventions.\nKeep API changes minimal.",
+	}
+	for name, out := range map[string]string{
+		"assignment": BuildPrompt(task, "claude"),
+		"comment": BuildPrompt(Task{
+			IssueID:               task.IssueID,
+			ProjectTitle:          task.ProjectTitle,
+			ProjectDescription:    task.ProjectDescription,
+			TriggerCommentID:      "comment-123",
+			TriggerCommentContent: "please continue",
+		}, "claude"),
+		"quick-create": buildQuickCreatePrompt(Task{
+			QuickCreatePrompt:  "fix the nav",
+			ProjectID:          "11111111-2222-3333-4444-555555555555",
+			ProjectTitle:       task.ProjectTitle,
+			ProjectDescription: task.ProjectDescription,
+		}),
+	} {
+		if !strings.Contains(out, "Project context from \"Web App\"") {
+			t.Errorf("%s prompt missing project context heading:\n%s", name, out)
+		}
+		if !strings.Contains(out, task.ProjectDescription) {
+			t.Errorf("%s prompt missing project description:\n%s", name, out)
+		}
+	}
+}
+
+func TestBuildPromptSkipsBlankProjectDescriptionContext(t *testing.T) {
+	out := BuildPrompt(Task{
+		IssueID:            "issue-123",
+		ProjectTitle:       "Web App",
+		ProjectDescription: " \n\t",
+	}, "claude")
+	if strings.Contains(out, "Project context") {
+		t.Errorf("blank project description should not render project context prompt, got:\n%s", out)
+	}
+}
+
 // TestBuildQuickCreatePromptParentPinning verifies that when the user
 // opened quick-create from "Add sub issue" on an existing issue, the prompt
 // instructs the agent to pass `--parent <uuid>` so the new issue is filed

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -49,6 +49,7 @@ type Task struct {
 	Repos                    []RepoData            `json:"repos,omitempty"`
 	ProjectID                string                `json:"project_id,omitempty"`                  // issue's project, when present
 	ProjectTitle             string                `json:"project_title,omitempty"`               // human-readable project title for context injection
+	ProjectDescription       string                `json:"project_description,omitempty"`         // project.description used as agent-facing project context
 	ProjectResources         []ProjectResourceData `json:"project_resources,omitempty"`           // project-scoped resources to expose to the agent
 	PriorSessionID           string                `json:"prior_session_id,omitempty"`            // Claude session ID from a previous task on this issue
 	PriorWorkDir             string                `json:"prior_work_dir,omitempty"`              // work_dir from a previous task on this issue

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -233,28 +233,29 @@ type AgentTaskResponse struct {
 	// as `## Workspace Context` so every agent running in this workspace —
 	// regardless of issue / chat / autopilot / quick-create — sees the same
 	// shared context. Empty when the workspace owner hasn't set it.
-	WorkspaceContext string                `json:"workspace_context,omitempty"`
-	ThreadName       string                `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
-	Status           string                `json:"status"`
-	Priority         int32                 `json:"priority"`
-	DispatchedAt     *string               `json:"dispatched_at"`
-	StartedAt        *string               `json:"started_at"`
-	CompletedAt      *string               `json:"completed_at"`
-	Result           any                   `json:"result"`
-	Error            *string               `json:"error"`
-	FailureReason    string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt          int32                 `json:"attempt"`
-	MaxAttempts      int32                 `json:"max_attempts"`
-	ParentTaskID     *string               `json:"parent_task_id,omitempty"`
-	Agent            *TaskAgentData        `json:"agent,omitempty"`
-	Repos            []RepoData            `json:"repos,omitempty"`
-	ProjectID        string                `json:"project_id,omitempty"`        // issue's project, when present
-	ProjectTitle     string                `json:"project_title,omitempty"`     // for surfacing in agent context
-	ProjectResources []ProjectResourceData `json:"project_resources,omitempty"` // resources attached to the project
-	CreatedAt        string                `json:"created_at"`
-	PriorSessionID   string                `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
-	PriorWorkDir     string                `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
-	WorkDir          string                `json:"work_dir,omitempty"`         // local working directory pinned for this task; populated once the daemon reports it
+	WorkspaceContext   string                `json:"workspace_context,omitempty"`
+	ThreadName         string                `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
+	Status             string                `json:"status"`
+	Priority           int32                 `json:"priority"`
+	DispatchedAt       *string               `json:"dispatched_at"`
+	StartedAt          *string               `json:"started_at"`
+	CompletedAt        *string               `json:"completed_at"`
+	Result             any                   `json:"result"`
+	Error              *string               `json:"error"`
+	FailureReason      string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt            int32                 `json:"attempt"`
+	MaxAttempts        int32                 `json:"max_attempts"`
+	ParentTaskID       *string               `json:"parent_task_id,omitempty"`
+	Agent              *TaskAgentData        `json:"agent,omitempty"`
+	Repos              []RepoData            `json:"repos,omitempty"`
+	ProjectID          string                `json:"project_id,omitempty"`          // issue's project, when present
+	ProjectTitle       string                `json:"project_title,omitempty"`       // for surfacing in agent context
+	ProjectDescription string                `json:"project_description,omitempty"` // project.description used as agent-facing project context
+	ProjectResources   []ProjectResourceData `json:"project_resources,omitempty"`   // resources attached to the project
+	CreatedAt          string                `json:"created_at"`
+	PriorSessionID     string                `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
+	PriorWorkDir       string                `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
+	WorkDir            string                `json:"work_dir,omitempty"`         // local working directory pinned for this task; populated once the daemon reports it
 	// RelativeWorkDir is a privacy-safe display form of WorkDir intended for
 	// the UI. For standard tasks it strips the daemon's workspaces root so
 	// the user sees `<wsUUID>/<taskShort>/workdir`; for local_directory

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1232,6 +1232,9 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				resp.ProjectID = uuidToString(issue.ProjectID)
 				if proj, err := h.Queries.GetProject(r.Context(), issue.ProjectID); err == nil {
 					resp.ProjectTitle = proj.Title
+					if proj.Description.Valid {
+						resp.ProjectDescription = proj.Description.String
+					}
 				}
 				if rows := h.listProjectResourcesForProject(r.Context(), issue.ProjectID); len(rows) > 0 {
 					out := make([]ProjectResourceData, 0, len(rows))
@@ -1507,6 +1510,9 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 					resp.ProjectID = qc.ProjectID
 					if proj, err := h.Queries.GetProject(r.Context(), projectUUID); err == nil {
 						resp.ProjectTitle = proj.Title
+						if proj.Description.Valid {
+							resp.ProjectDescription = proj.Description.String
+						}
 					}
 					if rows := h.listProjectResourcesForProject(r.Context(), projectUUID); len(rows) > 0 {
 						out := make([]ProjectResourceData, 0, len(rows))

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1777,9 +1777,10 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 	// Project + project_resource(github_repo) with a URL that is NOT in the
 	// workspace's repos list.
 	var projectID string
+	const projectDescription = "Agents should treat this project description as project context."
 	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, "Claim project repo override").Scan(&projectID); err != nil {
+		INSERT INTO project (workspace_id, title, description) VALUES ($1, $2, $3) RETURNING id
+	`, testWorkspaceID, "Claim project repo override", projectDescription).Scan(&projectID); err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
@@ -1834,9 +1835,10 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 
 	var resp struct {
 		Task *struct {
-			Repos            []RepoData            `json:"repos"`
-			ProjectID        string                `json:"project_id"`
-			ProjectResources []ProjectResourceData `json:"project_resources"`
+			Repos              []RepoData            `json:"repos"`
+			ProjectID          string                `json:"project_id"`
+			ProjectDescription string                `json:"project_description"`
+			ProjectResources   []ProjectResourceData `json:"project_resources"`
 		} `json:"task"`
 	}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
@@ -1847,6 +1849,9 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 	}
 	if resp.Task.ProjectID != projectID {
 		t.Errorf("project_id = %q, want %q", resp.Task.ProjectID, projectID)
+	}
+	if resp.Task.ProjectDescription != projectDescription {
+		t.Errorf("project_description = %q, want %q", resp.Task.ProjectDescription, projectDescription)
 	}
 	if len(resp.Task.Repos) != 1 || resp.Task.Repos[0].URL != projectRepoURL {
 		t.Fatalf("expected resp.Repos to contain only the project repo URL, got %+v", resp.Task.Repos)
@@ -2440,6 +2445,9 @@ type claimRuntimeGuardTask struct {
 	PriorWorkDir             string   `json:"prior_work_dir"`
 	ChatMessage              string   `json:"chat_message"`
 	ThreadName               string   `json:"thread_name"`
+	ProjectID                string   `json:"project_id"`
+	ProjectTitle             string   `json:"project_title"`
+	ProjectDescription       string   `json:"project_description"`
 	QuickCreateAttachmentIDs []string `json:"quick_create_attachment_ids"`
 }
 
@@ -3089,11 +3097,23 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 
 	quickPrompt := "create a follow-up issue for Codex session titles"
 	attachmentID := "019ec09d-6222-722b-bdfa-427b105d80be"
+	projectDescription := "Use this description as the quick-create project context."
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title, description)
+		VALUES ($1, 'Quick-create Project', $2)
+		RETURNING id
+	`, testWorkspaceID, projectDescription).Scan(&projectID); err != nil {
+		t.Fatalf("setup: create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
 	quickContext, _ := json.Marshal(map[string]any{
 		"type":           "quick_create",
 		"prompt":         quickPrompt,
 		"requester_id":   testUserID,
 		"workspace_id":   testWorkspaceID,
+		"project_id":     projectID,
 		"attachment_ids": []string{attachmentID},
 	})
 
@@ -3107,6 +3127,15 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
 	if task.ThreadName != quickPrompt {
 		t.Fatalf("quick-create task thread_name = %q, want prompt", task.ThreadName)
+	}
+	if task.ProjectID != projectID {
+		t.Fatalf("quick-create task project_id = %q, want %q", task.ProjectID, projectID)
+	}
+	if task.ProjectTitle != "Quick-create Project" {
+		t.Fatalf("quick-create task project_title = %q, want Quick-create Project", task.ProjectTitle)
+	}
+	if task.ProjectDescription != projectDescription {
+		t.Fatalf("quick-create task project_description = %q, want %q", task.ProjectDescription, projectDescription)
 	}
 	if len(task.QuickCreateAttachmentIDs) != 1 || task.QuickCreateAttachmentIDs[0] != attachmentID {
 		t.Fatalf("quick-create attachment ids = %#v, want [%q]", task.QuickCreateAttachmentIDs, attachmentID)


### PR DESCRIPTION
## What does this PR do?

Routes the existing project description into the agent-facing project context path.

This is a smaller follow-up to #4052. Instead of adding a separate `project.context` field, this treats `project.description` as the single source of truth: readable by humans in the product and available to agents during project-scoped runs.

## Related Issue

Related to #3103.
Follow-up to #4052.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `project_description` to daemon task responses and daemon task context.
- Populated `project_description` from `project.description` for issue-bound tasks.
- Populated `project_description` from `project.description` for quick-create tasks when a project is selected.
- Rendered the project description in the runtime `## Project Context` brief.
- Injected the project description into assignment, comment-triggered, and quick-create per-turn prompts so resumed sessions do not rely only on runtime config files.
- Added tests for claim payloads, runtime brief rendering, and prompt injection.

## How to Test

Manual verification:

1. Create or update a project with a non-empty description.
2. Create an issue in that project and run an agent on it, or start a quick-create agent run with that project selected.
3. Verify the claimed task includes `project_description` and the generated runtime brief contains `## Project Context` with the project description.
4. For assignment, comment-triggered, or quick-create runs, verify the per-turn prompt includes the same project description so resumed sessions receive it too.

Automated checks:

1. `cd server && go test ./internal/daemon -run 'TestBuildPromptsIncludeProjectDescriptionContext|TestBuildPromptSkipsBlankProjectDescriptionContext|TestBuildQuickCreatePromptProjectPinning'`
2. `cd server && go test ./internal/daemon/execenv -run TestPrepareWithProjectResources`
3. `cd server && go test ./internal/handler -run 'TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos|TestClaimTask_QuickCreatePopulatesThreadName'`
4. `cd server && go test ./internal/daemon ./internal/daemon/execenv ./internal/handler`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**

I used Codex to inspect the closed #4052 feedback, identify the accepted product direction, and implement the narrower follow-up: reuse `project.description` instead of introducing a separate project context field. I traced the data through daemon claim response, daemon task context, runtime brief rendering, and per-turn prompt generation, then added focused tests for each path.

## Screenshots (optional)

N/A. This change does not affect the UI.

