### PR TITLE
feat(cli): add --thinking-level to agent create and update

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -162,6 +162,7 @@ func init() {
 	agentCreateCmd.Flags().String("runtime-id", "", "Runtime ID (required)")
 	agentCreateCmd.Flags().String("runtime-config", "", "Runtime config as JSON string")
 	agentCreateCmd.Flags().String("model", "", "Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o). Prefer this over passing --model in --custom-args.")
+	agentCreateCmd.Flags().String("thinking-level", "", "Reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex: none|minimal|low|medium|high|xhigh). The set is runtime/model-specific and validated server-side — an unknown value is rejected. Empty = runtime default.")
 	agentCreateCmd.Flags().String("custom-args", "", "Custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to set an empty map.")
 	agentCreateCmd.Flags().Bool("custom-env-stdin", false, "Read the --custom-env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
@@ -180,6 +181,7 @@ func init() {
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
+	agentUpdateCmd.Flags().String("thinking-level", "", "New reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex: none|minimal|low|medium|high|xhigh). The set is runtime/model-specific and validated server-side. Pass an empty string to clear and fall back to the runtime default.")
 	agentUpdateCmd.Flags().String("custom-args", "", "New custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	// custom_env is intentionally NOT part of `agent update`. Use
 	// `multica agent env set <id>` — that path is owner/admin-only,
@@ -469,6 +471,14 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
 	}
+	// thinking_level mirrors model: a thin pass-through to the top-level agent
+	// field the server already accepts and validates (IsKnownThinkingValue).
+	// The CLI deliberately does not enumerate valid levels — they are
+	// runtime/model-specific and the server owns the catalog (MUL-2339).
+	if cmd.Flags().Changed("thinking-level") {
+		v, _ := cmd.Flags().GetString("thinking-level")
+		body["thinking_level"] = v
+	}
 	if cmd.Flags().Changed("visibility") {
 		v, _ := cmd.Flags().GetString("visibility")
 		body["visibility"] = v
@@ -538,6 +548,13 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
 	}
+	// thinking_level is a tri-state on the server (omitted = no change, "" =
+	// clear to runtime default, value = set). Sending the key only when the
+	// flag was provided produces exactly that, the same way --model behaves.
+	if cmd.Flags().Changed("thinking-level") {
+		v, _ := cmd.Flags().GetString("thinking-level")
+		body["thinking_level"] = v
+	}
 	if cmd.Flags().Changed("visibility") {
 		v, _ := cmd.Flags().GetString("visibility")
 		body["visibility"] = v
@@ -557,7 +574,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --thinking-level, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -1284,3 +1284,201 @@ func TestAgentGetTableIncludesAvatarURL(t *testing.T) {
 		t.Fatalf("table output missing avatar_url value: %s", string(out))
 	}
 }
+
+// TestAgentCreateSendsThinkingLevel verifies `agent create --thinking-level`
+// puts the value on the top-level `thinking_level` key of the POST body —
+// the same field the web inspector and HTTP API already accept. The value is
+// passed through verbatim; provider-level validation is the server's job
+// (IsKnownThinkingValue), exactly as `--model` defers model validation.
+func TestAgentCreateSendsThinkingLevel(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent", "thinking_level": "high"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("instructions", "", "")
+	cmd.Flags().String("thinking-level", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	_ = cmd.Flags().Set("name", "TestAgent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+	_ = cmd.Flags().Set("thinking-level", "high")
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/agents" {
+		t.Fatalf("path = %q, want /api/agents", gotPath)
+	}
+	if gotBody["thinking_level"] != "high" {
+		t.Fatalf("thinking_level body = %v, want high", gotBody["thinking_level"])
+	}
+}
+
+// TestAgentCreateOmitsThinkingLevelWhenUnset guards the Changed-gated send:
+// an unset --thinking-level must not appear in the body at all, so the server
+// applies its default instead of receiving an explicit empty string.
+func TestAgentCreateOmitsThinkingLevelWhenUnset(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("thinking-level", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	_ = cmd.Flags().Set("name", "TestAgent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	if _, ok := gotBody["thinking_level"]; ok {
+		t.Fatalf("unset --thinking-level must be omitted from the body; got %v", gotBody)
+	}
+}
+
+// TestAgentUpdateSendsThinkingLevel covers both update modes that mirror
+// --model: setting an explicit level, and passing an empty string to clear
+// back to the runtime default. In both cases the key must be present in the
+// PUT body — the server reads it as a tri-state pointer (omitted = no change,
+// "" = clear, value = set), so the CLI's only job is to send the key when the
+// flag was provided.
+func TestAgentUpdateSendsThinkingLevel(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"set explicit level", "xhigh"},
+		{"empty string clears", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				json.NewEncoder(w).Encode(map[string]any{"id": "agent-123", "name": "TestAgent", "thinking_level": tc.value})
+			}))
+			defer srv.Close()
+
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "test-token")
+			t.Setenv("MULTICA_AGENT_ID", "")
+			t.Setenv("MULTICA_TASK_ID", "")
+
+			cmd := &cobra.Command{Use: "update"}
+			cmd.Flags().String("thinking-level", "", "")
+			cmd.Flags().String("output", "json", "")
+			cmd.Flags().String("profile", "", "")
+			if err := cmd.Flags().Set("thinking-level", tc.value); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+				t.Fatalf("runAgentUpdate: %v", err)
+			}
+			if gotMethod != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", gotMethod)
+			}
+			if gotPath != "/api/agents/agent-123" {
+				t.Fatalf("path = %q, want /api/agents/agent-123", gotPath)
+			}
+			v, ok := gotBody["thinking_level"]
+			if !ok {
+				t.Fatalf("body missing thinking_level key; got %v", gotBody)
+			}
+			if v != tc.value {
+				t.Fatalf("thinking_level body = %v, want %q", v, tc.value)
+			}
+		})
+	}
+}
+
+// TestAgentCreateAndUpdateExposeThinkingLevelFlag guarantees the flag stays
+// wired on both write surfaces. The read side (`agent get`) already exposes
+// thinking_level; this is the matching write surface (#4170).
+func TestAgentCreateAndUpdateExposeThinkingLevelFlag(t *testing.T) {
+	if agentCreateCmd.Flag("thinking-level") == nil {
+		t.Error("agent create must expose --thinking-level")
+	}
+	if agentUpdateCmd.Flag("thinking-level") == nil {
+		t.Error("agent update must expose --thinking-level")
+	}
+}
+
+// TestAgentCreateThinkingLevelServerRejectionSurfaces proves the CLI does not
+// own thinking-level validation: a runtime whose provider has no thinking
+// concept (or an unknown literal) is rejected server-side with a 400, and that
+// message must reach the user rather than being swallowed. This is why the CLI
+// can stay a thin pass-through — the server already owns the (provider, model)
+// catalog (server/pkg/agent/thinking.go).
+func TestAgentCreateThinkingLevelServerRejectionSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{"error":"thinking_level \"max\" is not a recognised value for runtime \"gemini\""}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("thinking-level", "", "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	_ = cmd.Flags().Set("name", "TestAgent")
+	_ = cmd.Flags().Set("runtime-id", "runtime-gemini")
+	_ = cmd.Flags().Set("thinking-level", "max")
+
+	err := runAgentCreate(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when server rejects thinking_level, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a recognised value for runtime") {
+		t.Fatalf("server thinking_level rejection should surface to the user; got: %v", err)
+	}
+}

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -58,8 +58,8 @@ multica agent create --name <name> --runtime-id <runtime-id> \
 `runAgentCreate` builds a JSON body and posts it to `/api/agents`. It only
 adds a key when its flag was provided — `description`/`instructions` on a
 non-empty value, the rest (`runtime-config`, `custom-args`, `model`,
-`visibility`, …) on the flag being `Changed` — so omitted flags fall through
-to server defaults rather than sending empty strings.
+`thinking-level`, `visibility`, …) on the flag being `Changed` — so omitted
+flags fall through to server defaults rather than sending empty strings.
 
 The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 `instructions`, `runtime_id`, `runtime_config`, `custom_env`, `custom_args`,
@@ -92,6 +92,16 @@ happens in the CLI, not the create handler.
 literal returns 400, but a value that is valid for the provider yet
 unsupported for the chosen model is NOT rejected here — that gap surfaces as a
 daemon-side task error at execution time.
+
+Set it from the CLI with `--thinking-level` on `agent create` and `agent
+update`, mirroring `--model`: the flag is a thin pass-through to the top-level
+`thinking_level` field, and on update an empty string (`--thinking-level ""`)
+clears it back to the runtime default. The CLI deliberately does not enumerate
+the valid levels — they are runtime/model-specific (Claude
+`low|medium|high|xhigh|max`, Codex `none|minimal|low|medium|high|xhigh`, and
+others), so it forwards whatever you pass and lets the server's provider
+catalog accept or reject it. A runtime whose provider has no thinking concept
+rejects any non-empty value with a 400.
 
 ### model vs custom_args
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -19,19 +19,20 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | Contract | Line | Behavior | Safe check |
 |---|---|---|---|
 | Create flags: `name`, `description`, `instructions`, `runtime-id` | 159–162 | Registered create flags; `name`/`runtime-id` enforced in `runAgentCreate` | `multica agent create --help` |
-| `runtime-config`, `model`, `custom-args` flags | 163–165 | `model` help: "Prefer this over passing --model in --custom-args"; `custom-args` help names codex/openclaw rejecting `--model` (CLI help only, not server-enforced) | `multica agent create --help` |
-| Secret-safe env input: `custom-env`, `custom-env-stdin`, `custom-env-file` | 166–168 | `--custom-env` warns about shell history / `ps`; stdin and file modes keep secrets off the command line; mutually exclusive | `multica agent create --help` |
-| Secret-safe MCP input: `mcp-config`, `mcp-config-stdin`, `mcp-config-file` (create) | 169–171 | Same three-channel pattern as `custom-env`; `--mcp-config` warns about shell history / `ps`; value must be a JSON object or `null` | `multica agent create --help` |
-| MCP flags on `agent update` | 192–194 | Same three channels on update; `--mcp-config null` clears. Unlike `custom_env`, `mcp_config` IS settable via update | `multica agent update --help` |
-| `runAgentCreate` builds body + `POST /api/agents` | 414 | Only sets a body key when the flag `Changed`; posts to `/api/agents` (line 482) | read 414–489 |
-| Body assembly: description/instructions/runtime-config/custom-args/custom-env/mcp-config/model | 437–478 | `resolveCustomEnv` (455) and `resolveMcpConfig` (460) gate their secret channels; omitted flags are not sent | read 437–478 |
-| `runAgentUpdate` sends `mcp_config` | 550 | `resolveMcpConfig` adds `mcp_config` to the `PUT /api/agents/{id}` body (564); `custom_env` is intentionally not a flag here | read 495–565 |
-| `parseMcpConfig` / `resolveMcpConfig` helpers | 1066, 1094 | Validator (object-or-`null`, content-free errors) + three-channel resolver, mirroring `parseCustomEnv`/`resolveCustomEnv` | read 1066–1150 |
-| `agent skills set` = replace-all | 772 | `PUT /api/agents/{id}/skills` (790); `--skill-ids ''` clears all (779) | `multica agent skills set --help` |
-| `agent skills add` = additive | 797 | `POST /api/agents/{id}/skills/add` (818); requires ≥1 id (804, 808) | `multica agent skills add --help` |
-| `agent skills list` | 740 | reads bindings, no side effect | `multica agent skills list --help` |
-| `agent env get` | 874 | `GET /api/agents/{id}/env` | `multica agent env get --help` |
-| `agent env set` | 909 | `PUT /api/agents/{id}/env` with full `custom_env` map (923, 929) | `multica agent env set --help` |
+| `runtime-config`, `model`, `thinking-level`, `custom-args` flags | 163–166 | `model` help: "Prefer this over passing --model in --custom-args"; `thinking-level` is a thin pass-through (server validates the provider enum, empty = runtime default); `custom-args` help names codex/openclaw rejecting `--model` (CLI help only, not server-enforced) | `multica agent create --help` |
+| Secret-safe env input: `custom-env`, `custom-env-stdin`, `custom-env-file` | 167–169 | `--custom-env` warns about shell history / `ps`; stdin and file modes keep secrets off the command line; mutually exclusive | `multica agent create --help` |
+| Secret-safe MCP input: `mcp-config`, `mcp-config-stdin`, `mcp-config-file` (create) | 170–172 | Same three-channel pattern as `custom-env`; `--mcp-config` warns about shell history / `ps`; value must be a JSON object or `null` | `multica agent create --help` |
+| MCP flags on `agent update` | 194–196 | Same three channels on update; `--mcp-config null` clears. Unlike `custom_env`, `mcp_config` IS settable via update | `multica agent update --help` |
+| `thinking-level` flag on `agent update` | 184 | New reasoning/effort level; thin pass-through; `--thinking-level ""` clears to runtime default (mirrors `--model`) | `multica agent update --help` |
+| `runAgentCreate` builds body + `POST /api/agents` | 419 | Only sets a body key when the flag `Changed`; posts to `/api/agents` (line 495) | read 419–496 |
+| Body assembly: description/instructions/runtime-config/custom-args/custom-env/mcp-config/model/thinking-level | 438–488 | `resolveCustomEnv` (460) and `resolveMcpConfig` (465) gate their secret channels; `model` (470) and `thinking_level` (478) are `Changed`-gated pass-throughs; omitted flags are not sent | read 438–488 |
+| `runAgentUpdate` sends `thinking_level` / `mcp_config` | 508 | `thinking_level` added when `--thinking-level` is `Changed` (556); `resolveMcpConfig` adds `mcp_config` (570); `PUT /api/agents/{id}` at 584; `custom_env` is intentionally not a flag here | read 508–585 |
+| `parseMcpConfig` / `resolveMcpConfig` helpers | 1086, 1114 | Validator (object-or-`null`, content-free errors) + three-channel resolver, mirroring `parseCustomEnv`/`resolveCustomEnv` | read 1086–1170 |
+| `agent skills set` = replace-all | 792 | `PUT /api/agents/{id}/skills` (810); `--skill-ids ''` clears all (798–799) | `multica agent skills set --help` |
+| `agent skills add` = additive | 817 | `POST /api/agents/{id}/skills/add` (838); requires ≥1 id (823–828) | `multica agent skills add --help` |
+| `agent skills list` | 760 | reads bindings, no side effect | `multica agent skills list --help` |
+| `agent env get` | 894 | `GET /api/agents/{id}/env` | `multica agent env get --help` |
+| `agent env set` | 929 | `PUT /api/agents/{id}/env` with full `custom_env` map (935, 949) | `multica agent env set --help` |
 
 Note: the CLI no longer exposes `--from-template`. The agent-template backend
 still exists (registry `server/internal/agenttmpl/`, handler `agent_template.go`,


### PR DESCRIPTION
## What does this PR do?

Adds a `--thinking-level` flag to `multica agent create` and `multica agent update`.

Agents already carry a top-level `thinking_level` field — it's returned by `agent get --output json`, set by the web inspector, and accepted/validated by `PUT /api/agents/{id}` — but the CLI had no flag to write it. Anyone managing agents from the CLI (scripts, version-controlled agent definitions, bulk model migrations) could set `--model` but not the thinking depth, and had to drop to raw HTTP for that one field.

The flag mirrors `--model` exactly: a thin pass-through to the top-level `thinking_level` field. The write endpoint and validation already existed, so this is just wiring a flag onto an endpoint that already accepts it.

**Why no client-side level list?** The set of valid levels is runtime/model-specific and the project deliberately does not flatten the per-provider vocabularies onto a shared enum (`server/pkg/agent/thinking.go`, MUL-2339). The server already owns the catalog: `agent.IsKnownThinkingValue` returns a `400` for an unknown literal *or* a runtime whose provider has no thinking concept, and the CLI surfaces that message verbatim. Keeping the CLI a pass-through is consistent with how `--model` defers model validation to the server.

## Related Issue

Closes #4170

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `server/cmd/multica/cmd_agent.go`: register `--thinking-level` on `agentCreateCmd` and `agentUpdateCmd`; `Changed`-gate it into the request body (so an unset flag is omitted and the server applies its default); add it to the `agent update` no-fields error message.
- `server/cmd/multica/cmd_agent_test.go`: tests for create/update sending the field, unset-omission, empty-string-clears, a guard that both commands expose the flag, and that a server-side rejection (runtime without a thinking concept) surfaces to the user.
- `server/internal/service/builtin_skills/multica-creating-agents/`: document the new CLI write surface in `SKILL.md` and re-derive the shifted `cmd_agent.go` line numbers in the source map.

## How to Test

1. `cd server && go test ./cmd/multica/ -run Thinking` (and `./internal/service/ -run CreatingAgentsSkill` for the builtin-skill conformance).
2. `multica agent update <agent-id> --thinking-level high` → persists; verify with `multica agent get <agent-id> --output json`.
3. `multica agent update <agent-id> --thinking-level ""` → clears back to the runtime default.
4. `multica agent create --name x --runtime-id <runtime-without-thinking> --thinking-level high` → the server's `400` ("thinking_level … is not a recognised value for runtime …") is printed by the CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A (CLI-only)
- [x] I have updated relevant documentation to reflect my changes (builtin `multica-creating-agents` skill + source map)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs — N/A (no new runtime/tool/tab)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Asked to solve #4170 end to end. The agent read the issue, traced the existing `thinking_level` stack (HTTP request structs, `IsKnownThinkingValue` provider-enum gate on create, the tri-state pointer + `ClearAgentThinkingLevel` clear path on update, and the dynamic per-`(provider, model)` discovery in `server/pkg/agent/thinking.go`), confirmed the gap was purely the missing CLI flag, then mirrored the established `--model` pattern. TDD: failing tests first, then the wiring. The "don't enumerate levels in the CLI" decision came from the MUL-2339 comment that the provider vocabularies must round-trip exactly through each runtime's own values.
