### PR TITLE
Expose agent thinking level in CLI

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -162,6 +162,7 @@ func init() {
 	agentCreateCmd.Flags().String("runtime-id", "", "Runtime ID (required)")
 	agentCreateCmd.Flags().String("runtime-config", "", "Runtime config as JSON string")
 	agentCreateCmd.Flags().String("model", "", "Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o). Prefer this over passing --model in --custom-args.")
+	agentCreateCmd.Flags().String("thinking-level", "", "Thinking level for providers that support it. Pass an empty string to use the runtime default.")
 	agentCreateCmd.Flags().String("custom-args", "", "Custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to set an empty map.")
 	agentCreateCmd.Flags().Bool("custom-env-stdin", false, "Read the --custom-env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
@@ -180,6 +181,7 @@ func init() {
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
+	agentUpdateCmd.Flags().String("thinking-level", "", "New thinking level. Pass an empty string to clear and fall back to the runtime default.")
 	agentUpdateCmd.Flags().String("custom-args", "", "New custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	// custom_env is intentionally NOT part of `agent update`. Use
 	// `multica agent env set <id>` — that path is owner/admin-only,
@@ -469,6 +471,10 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
 	}
+	if cmd.Flags().Changed("thinking-level") {
+		v, _ := cmd.Flags().GetString("thinking-level")
+		body["thinking_level"] = v
+	}
 	if cmd.Flags().Changed("visibility") {
 		v, _ := cmd.Flags().GetString("visibility")
 		body["visibility"] = v
@@ -538,6 +544,10 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
 	}
+	if cmd.Flags().Changed("thinking-level") {
+		v, _ := cmd.Flags().GetString("thinking-level")
+		body["thinking_level"] = v
+	}
 	if cmd.Flags().Changed("visibility") {
 		v, _ := cmd.Flags().GetString("visibility")
 		body["visibility"] = v
@@ -557,7 +567,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --thinking-level, --custom-args, --mcp-config, --visibility, --status, or --max-concurrent-tasks (env vars now live behind `multica agent env set <id>`)")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -290,6 +290,7 @@ func TestAgentUpdateNoFieldsErrorPointsAtEnvCommand(t *testing.T) {
 	cmd.Flags().String("runtime-id", "", "")
 	cmd.Flags().String("runtime-config", "", "")
 	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("thinking-level", "", "")
 	cmd.Flags().String("custom-args", "", "")
 	cmd.Flags().String("visibility", "", "")
 	cmd.Flags().String("status", "", "")
@@ -304,6 +305,128 @@ func TestAgentUpdateNoFieldsErrorPointsAtEnvCommand(t *testing.T) {
 	msg := err.Error()
 	if !strings.Contains(msg, "multica agent env set") {
 		t.Fatalf("no-fields error must direct users to `multica agent env set`; got: %q", msg)
+	}
+}
+
+func newAgentCreateBodyTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("instructions", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("runtime-config", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("thinking-level", "", "")
+	cmd.Flags().String("custom-args", "", "")
+	cmd.Flags().String("custom-env", "", "")
+	cmd.Flags().Bool("custom-env-stdin", false, "")
+	cmd.Flags().String("custom-env-file", "", "")
+	cmd.Flags().String("mcp-config", "", "")
+	cmd.Flags().Bool("mcp-config-stdin", false, "")
+	cmd.Flags().String("mcp-config-file", "", "")
+	cmd.Flags().String("visibility", "private", "")
+	cmd.Flags().Int32("max-concurrent-tasks", 6, "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	return cmd
+}
+
+func newAgentUpdateBodyTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("instructions", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("runtime-config", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("thinking-level", "", "")
+	cmd.Flags().String("custom-args", "", "")
+	cmd.Flags().String("mcp-config", "", "")
+	cmd.Flags().Bool("mcp-config-stdin", false, "")
+	cmd.Flags().String("mcp-config-file", "", "")
+	cmd.Flags().String("visibility", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().Int32("max-concurrent-tasks", 0, "")
+	cmd.Flags().String("output", "json", "")
+	cmd.Flags().String("profile", "", "")
+	return cmd
+}
+
+func TestAgentCreateSendsThinkingLevel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/agents" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "agent-1", "name": gotBody["name"]})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := newAgentCreateBodyTestCmd()
+	_ = cmd.Flags().Set("name", "Planner")
+	_ = cmd.Flags().Set("runtime-id", "runtime-1")
+	_ = cmd.Flags().Set("model", "claude-sonnet-4-6")
+	_ = cmd.Flags().Set("thinking-level", "max")
+
+	if _, err := captureStdout(t, func() error { return runAgentCreate(cmd, nil) }); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+	if gotBody["thinking_level"] != "max" {
+		t.Fatalf("thinking_level = %#v, want max; body=%#v", gotBody["thinking_level"], gotBody)
+	}
+	if gotBody["runtime_config"] != nil {
+		t.Fatalf("runtime_config should be omitted when only --thinking-level is set; body=%#v", gotBody)
+	}
+}
+
+func TestAgentUpdateSendsThinkingLevelAndAllowsClear(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/agents/agent-1" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		bodies = append(bodies, body)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "agent-1", "name": "Planner"})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	setCmd := newAgentUpdateBodyTestCmd()
+	_ = setCmd.Flags().Set("thinking-level", "medium")
+	if _, err := captureStdout(t, func() error { return runAgentUpdate(setCmd, []string{"agent-1"}) }); err != nil {
+		t.Fatalf("runAgentUpdate set: %v", err)
+	}
+
+	clearCmd := newAgentUpdateBodyTestCmd()
+	_ = clearCmd.Flags().Set("thinking-level", "")
+	if _, err := captureStdout(t, func() error { return runAgentUpdate(clearCmd, []string{"agent-1"}) }); err != nil {
+		t.Fatalf("runAgentUpdate clear: %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(bodies))
+	}
+	if bodies[0]["thinking_level"] != "medium" {
+		t.Fatalf("set body = %#v, want thinking_level medium", bodies[0])
+	}
+	if got, ok := bodies[1]["thinking_level"]; !ok || got != "" {
+		t.Fatalf("clear body = %#v, want explicit empty thinking_level", bodies[1])
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -50,6 +50,7 @@ Minimum create call (`--name` and `--runtime-id` are both required):
 
 ```bash
 multica agent create --name <name> --runtime-id <runtime-id> \
+  --model <model-id> --thinking-level <level> \
   --description "<short catalog summary>" \
   --instructions "<runtime behavior contract>" \
   --output json
@@ -58,8 +59,8 @@ multica agent create --name <name> --runtime-id <runtime-id> \
 `runAgentCreate` builds a JSON body and posts it to `/api/agents`. It only
 adds a key when its flag was provided — `description`/`instructions` on a
 non-empty value, the rest (`runtime-config`, `custom-args`, `model`,
-`visibility`, …) on the flag being `Changed` — so omitted flags fall through
-to server defaults rather than sending empty strings.
+`thinking-level`, `visibility`, …) on the flag being `Changed` — so omitted
+flags fall through to server defaults rather than sending empty strings.
 
 The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 `instructions`, `runtime_id`, `runtime_config`, `custom_env`, `custom_args`,
@@ -74,7 +75,7 @@ The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 | `instructions` | `agent.instructions` | none | daemon → provider at claim time |
 | `runtime_id` | `agent.runtime_id` | required (400) + must resolve to a runtime in this workspace | selects runtime/provider |
 | `model` | `agent.model` (nullable) | none beyond runtime support | daemon reads; empty = runtime default |
-| `thinking_level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400 | daemon; empty = runtime default |
+| `thinking_level` / `--thinking-level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400 | daemon; empty = runtime default |
 | `custom_args` | `agent.custom_args` (JSON array) | JSON shape checked CLI-side; server stores as-is | daemon (extra CLI switches); defaults to `[]` |
 | `runtime_config` | `agent.runtime_config` (JSON) | JSON shape checked CLI-side; server stores as-is | runtime-specific config; defaults to `{}` |
 | `custom_env` | `agent.custom_env` (JSON object) | — | daemon (process env); see Env & secrets |
@@ -88,7 +89,8 @@ Defaults when omitted: `runtime_config` → `{}`, `custom_env` → `{}`,
 are typed `[]string`/`any` and marshaled as-is — the JSON-shape rejection
 happens in the CLI, not the create handler.
 
-`thinking_level` is validated only at the provider level: an unrecognized
+`thinking_level` is set with `--thinking-level` on `agent create` and
+`agent update`. It is validated only at the provider level: an unrecognized
 literal returns 400, but a value that is valid for the provider yet
 unsupported for the chosen model is NOT rejected here — that gap surfaces as a
 daemon-side task error at execution time.

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -19,13 +19,13 @@ go test ./internal/service -run TestBuiltinSkillsConformToTemplate
 | Contract | Line | Behavior | Safe check |
 |---|---|---|---|
 | Create flags: `name`, `description`, `instructions`, `runtime-id` | 159–162 | Registered create flags; `name`/`runtime-id` enforced in `runAgentCreate` | `multica agent create --help` |
-| `runtime-config`, `model`, `custom-args` flags | 163–165 | `model` help: "Prefer this over passing --model in --custom-args"; `custom-args` help names codex/openclaw rejecting `--model` (CLI help only, not server-enforced) | `multica agent create --help` |
+| `runtime-config`, `model`, `thinking-level`, `custom-args` flags | 163–166 | `model` help: "Prefer this over passing --model in --custom-args"; `thinking-level` writes top-level `agent.thinking_level`; `custom-args` help names codex/openclaw rejecting `--model` (CLI help only, not server-enforced) | `multica agent create --help` |
 | Secret-safe env input: `custom-env`, `custom-env-stdin`, `custom-env-file` | 166–168 | `--custom-env` warns about shell history / `ps`; stdin and file modes keep secrets off the command line; mutually exclusive | `multica agent create --help` |
 | Secret-safe MCP input: `mcp-config`, `mcp-config-stdin`, `mcp-config-file` (create) | 169–171 | Same three-channel pattern as `custom-env`; `--mcp-config` warns about shell history / `ps`; value must be a JSON object or `null` | `multica agent create --help` |
 | MCP flags on `agent update` | 192–194 | Same three channels on update; `--mcp-config null` clears. Unlike `custom_env`, `mcp_config` IS settable via update | `multica agent update --help` |
 | `runAgentCreate` builds body + `POST /api/agents` | 414 | Only sets a body key when the flag `Changed`; posts to `/api/agents` (line 482) | read 414–489 |
-| Body assembly: description/instructions/runtime-config/custom-args/custom-env/mcp-config/model | 437–478 | `resolveCustomEnv` (455) and `resolveMcpConfig` (460) gate their secret channels; omitted flags are not sent | read 437–478 |
-| `runAgentUpdate` sends `mcp_config` | 550 | `resolveMcpConfig` adds `mcp_config` to the `PUT /api/agents/{id}` body (564); `custom_env` is intentionally not a flag here | read 495–565 |
+| Body assembly: description/instructions/runtime-config/custom-args/custom-env/mcp-config/model/thinking-level | 437–482 | `resolveCustomEnv` (455) and `resolveMcpConfig` (460) gate their secret channels; omitted flags are not sent | read 437–482 |
+| `runAgentUpdate` sends `thinking_level` and `mcp_config` | 540, 554 | `--thinking-level` adds top-level `thinking_level`; `resolveMcpConfig` adds `mcp_config` to the `PUT /api/agents/{id}` body (568); `custom_env` is intentionally not a flag here | read 495–569 |
 | `parseMcpConfig` / `resolveMcpConfig` helpers | 1066, 1094 | Validator (object-or-`null`, content-free errors) + three-channel resolver, mirroring `parseCustomEnv`/`resolveCustomEnv` | read 1066–1150 |
 | `agent skills set` = replace-all | 772 | `PUT /api/agents/{id}/skills` (790); `--skill-ids ''` clears all (779) | `multica agent skills set --help` |
 | `agent skills add` = additive | 797 | `POST /api/agents/{id}/skills/add` (818); requires ≥1 id (804, 808) | `multica agent skills add --help` |


### PR DESCRIPTION
Fixes #4170

## Summary
- add `--thinking-level` to `multica agent create` and `multica agent update`
- send top-level `thinking_level` only when the flag is explicitly provided, including explicit empty string for clearing
- update the built-in creating-agents skill docs/source map to mention the CLI flag

## Review against issue
- The CLI now exposes the existing API field on both create and update paths.
- Omitted flags still fall through to server defaults.
- Validation stays server/provider-side; this PR does not invent a CLI enum or alter runtime config behavior.

## Verification
- `go test ./cmd/multica`
- `go test ./internal/service -run TestBuiltinSkillsConformToTemplate`
- `git diff --check`