### PR TITLE
Prevent daemon task CLI fallback to user tokens

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon"
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
 var agentCmd = &cobra.Command{
@@ -249,7 +250,7 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 	if serverURL == "" {
 		return nil, fmt.Errorf("server URL not set: use --server-url flag, MULTICA_SERVER_URL env, or 'multica config set server_url <url>'")
 	}
-	if inAgentExecutionContext() && !strings.HasPrefix(token, "mat_") {
+	if inDaemonManagedExecutionContext() && !strings.HasPrefix(token, "mat_") {
 		return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token")
 	}
 
@@ -287,15 +288,47 @@ func normalizeAPIBaseURL(raw string) string {
 	return raw
 }
 
-// inAgentExecutionContext reports whether the CLI is being invoked from
-// inside a daemon-managed agent task (daemon sets MULTICA_AGENT_ID and
-// MULTICA_TASK_ID in the agent env). In that context the workspace must be
-// provided explicitly by the daemon — falling back to user-global
-// ~/.multica/config.json would let the agent act on whatever workspace the
-// user last configured, which is how cross-workspace contamination happens
-// when multiple workspaces share a host.
+// inAgentExecutionContext reports whether the CLI has explicit task identity
+// markers from a daemon-managed agent task.
 func inAgentExecutionContext() bool {
 	return os.Getenv("MULTICA_AGENT_ID") != "" || os.Getenv("MULTICA_TASK_ID") != ""
+}
+
+// inDaemonManagedExecutionContext reports whether the CLI is being invoked
+// from inside a daemon-managed agent task. MULTICA_DAEMON_PORT is included as
+// a defense-in-depth marker for subprocesses that lose MULTICA_AGENT_ID or
+// MULTICA_TASK_ID but still run under the daemon environment. In this context
+// workspace and token must come from daemon-provided env; falling back to
+// user-global ~/.multica/config.json can make agent writes land as a member.
+func inDaemonManagedExecutionContext() bool {
+	return inAgentExecutionContext() || os.Getenv("MULTICA_DAEMON_PORT") != "" || hasDaemonTaskContextMarker()
+}
+
+func hasDaemonTaskContextMarker() bool {
+	dir, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+	for {
+		markerPath := filepath.Join(dir, execenv.TaskContextMarkerRelPath)
+		data, err := os.ReadFile(markerPath)
+		if err == nil {
+			var marker struct {
+				ManagedBy string `json:"managed_by"`
+			}
+			if json.Unmarshal(data, &marker) == nil && marker.ManagedBy == execenv.TaskContextMarkerManagedBy {
+				return true
+			}
+		} else if !os.IsNotExist(err) {
+			return true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
 }
 
 func resolveWorkspaceID(cmd *cobra.Command) string {
@@ -305,7 +338,7 @@ func resolveWorkspaceID(cmd *cobra.Command) string {
 	}
 	// Inside an agent task the daemon is the only authority on workspace
 	// identity. Never read the user-global CLI config here.
-	if inAgentExecutionContext() {
+	if inDaemonManagedExecutionContext() {
 		return ""
 	}
 	profile := resolveProfile(cmd)
@@ -319,7 +352,7 @@ func resolveWorkspaceID(cmd *cobra.Command) string {
 func requireWorkspaceID(cmd *cobra.Command) (string, error) {
 	id := resolveWorkspaceID(cmd)
 	if id == "" {
-		if inAgentExecutionContext() {
+		if inDaemonManagedExecutionContext() {
 			return "", fmt.Errorf("workspace_id is required: MULTICA_WORKSPACE_ID must be set by the daemon in agent execution context (no fallback to user config)")
 		}
 		return "", fmt.Errorf("workspace_id is required: use --workspace-id flag, set MULTICA_WORKSPACE_ID env, or run 'multica config set workspace_id <id>'")

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -251,6 +251,16 @@ func newAPIClient(cmd *cobra.Command) (*cli.APIClient, error) {
 		return nil, fmt.Errorf("server URL not set: use --server-url flag, MULTICA_SERVER_URL env, or 'multica config set server_url <url>'")
 	}
 	if inDaemonManagedExecutionContext() && !strings.HasPrefix(token, "mat_") {
+		// When the ONLY daemon signal is a workdir marker (no MULTICA_AGENT_ID /
+		// MULTICA_TASK_ID / MULTICA_DAEMON_PORT), the likeliest cause outside a
+		// real task is a leftover marker from a crashed daemon task in a
+		// local_directory. Name the exact file so a normal user can recover
+		// instead of hitting an opaque "requires mat_ token" error.
+		if !inAgentExecutionContext() && os.Getenv("MULTICA_DAEMON_PORT") == "" {
+			if markerPath := daemonTaskContextMarkerPath(); markerPath != "" {
+				return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token; detected a daemon task marker at %s — if you are not running inside an agent task this is likely a leftover, remove it and retry", markerPath)
+			}
+		}
 		return nil, fmt.Errorf("agent execution context requires MULTICA_TOKEN to be a task-scoped mat_ token")
 	}
 
@@ -305,9 +315,16 @@ func inDaemonManagedExecutionContext() bool {
 }
 
 func hasDaemonTaskContextMarker() bool {
+	return daemonTaskContextMarkerPath() != ""
+}
+
+// daemonTaskContextMarkerPath walks up from the current working directory and
+// returns the path of the first readable daemon-task marker whose managed_by
+// matches, or "" when none is found.
+func daemonTaskContextMarkerPath() string {
 	dir, err := os.Getwd()
 	if err != nil {
-		return false
+		return ""
 	}
 	for {
 		markerPath := filepath.Join(dir, execenv.TaskContextMarkerRelPath)
@@ -324,13 +341,13 @@ func hasDaemonTaskContextMarker() bool {
 				ManagedBy string `json:"managed_by"`
 			}
 			if json.Unmarshal(data, &marker) == nil && marker.ManagedBy == execenv.TaskContextMarkerManagedBy {
-				return true
+				return markerPath
 			}
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return false
+			return ""
 		}
 		dir = parent
 	}

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -311,16 +311,21 @@ func hasDaemonTaskContextMarker() bool {
 	}
 	for {
 		markerPath := filepath.Join(dir, execenv.TaskContextMarkerRelPath)
-		data, err := os.ReadFile(markerPath)
-		if err == nil {
+		// Only a marker we can read AND whose managed_by matches counts as a
+		// daemon-task signal. Any other outcome — missing file, unreadable
+		// path, or a foreign file at this name — is treated as "no signal
+		// here", so we keep walking up. We must not fail closed on an
+		// unrelated read error (e.g. an unsearchable ancestor directory on a
+		// normal user's machine), which would refuse their PAT for no reason;
+		// the daemon writes this marker world-readable in the agent's own
+		// workdir, so a legitimate agent can always read it.
+		if data, err := os.ReadFile(markerPath); err == nil {
 			var marker struct {
 				ManagedBy string `json:"managed_by"`
 			}
 			if json.Unmarshal(data, &marker) == nil && marker.ManagedBy == execenv.TaskContextMarkerManagedBy {
 				return true
 			}
-		} else if !os.IsNotExist(err) {
-			return true
 		}
 
 		parent := filepath.Dir(dir)

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
 // freshAgentEnvSetCmd returns a standalone cobra.Command with the three
@@ -30,6 +31,36 @@ func freshAgentEnvSetCmd() *cobra.Command {
 	c.Flags().Bool("custom-env-stdin", false, "")
 	c.Flags().String("custom-env-file", "", "")
 	return c
+}
+
+func chdirWithDaemonTaskMarker(t *testing.T) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	markerPath := filepath.Join(workDir, execenv.TaskContextMarkerRelPath)
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		t.Fatalf("create marker dir: %v", err)
+	}
+	data := []byte(`{"managed_by":"` + execenv.TaskContextMarkerManagedBy + `"}`)
+	if err := os.WriteFile(markerPath, data, 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	nested := filepath.Join(workDir, "repo", "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested cwd: %v", err)
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(nested); err != nil {
+		t.Fatalf("chdir nested: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
 }
 
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
@@ -53,6 +84,7 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("outside agent context falls back to config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_WORKSPACE_ID", "")
 
 		got := resolveWorkspaceID(testCmd())
@@ -64,6 +96,7 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("agent context with explicit env uses env", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_WORKSPACE_ID", "env-ws")
 
 		got := resolveWorkspaceID(testCmd())
@@ -75,6 +108,7 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("agent context without env returns empty, never config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_WORKSPACE_ID", "")
 
 		got := resolveWorkspaceID(testCmd())
@@ -86,6 +120,30 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("task marker alone also counts as agent context", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_WORKSPACE_ID", "")
+
+		if got := resolveWorkspaceID(testCmd()); got != "" {
+			t.Fatalf("resolveWorkspaceID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("daemon port marker also skips config", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "27182")
+		t.Setenv("MULTICA_WORKSPACE_ID", "")
+
+		if got := resolveWorkspaceID(testCmd()); got != "" {
+			t.Fatalf("resolveWorkspaceID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("workdir marker also skips config when env is stripped", func(t *testing.T) {
+		chdirWithDaemonTaskMarker(t)
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_WORKSPACE_ID", "")
 
 		if got := resolveWorkspaceID(testCmd()); got != "" {
@@ -96,6 +154,7 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("requireWorkspaceID surfaces agent-context error", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_WORKSPACE_ID", "")
 
 		_, err := requireWorkspaceID(testCmd())
@@ -118,6 +177,19 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("outside agent context falls back to config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_TOKEN", "")
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token", got)
+		}
+	})
+
+	t.Run("explicit server URL alone still allows normal config token fallback", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
 		t.Setenv("MULTICA_TOKEN", "")
 		t.Setenv("MULTICA_DAEMON_PORT", "")
 
@@ -129,6 +201,7 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 	t.Run("agent context without env never reads config", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_TOKEN", "")
 
 		if got := resolveToken(testCmd()); got != "" {
@@ -136,9 +209,35 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("daemon port marker without env never reads config", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "27182")
+		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+		t.Setenv("MULTICA_TOKEN", "")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty in daemon-managed context without MULTICA_TOKEN", got)
+		}
+	})
+
+	t.Run("workdir marker without env never reads config", func(t *testing.T) {
+		chdirWithDaemonTaskMarker(t)
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+		t.Setenv("MULTICA_TOKEN", "")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty in daemon-managed context without MULTICA_TOKEN", got)
+		}
+	})
+
 	t.Run("agent context uses explicit task token env", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 		t.Setenv("MULTICA_TOKEN", "mat_task_token")
 
 		if got := resolveToken(testCmd()); got != "mat_task_token" {
@@ -241,6 +340,50 @@ func TestNewAPIClient_AgentContextRequiresTaskToken(t *testing.T) {
 			t.Fatalf("client token = %q, want task token", client.Token)
 		}
 	})
+}
+
+func TestNewAPIClient_DaemonPortRequiresTaskToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "27182")
+	t.Setenv("MULTICA_TOKEN", "")
+
+	if err := cli.SaveCLIConfig(cli.CLIConfig{Token: "mul_profile_token", WorkspaceID: "config-file-ws"}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	_, err := newAPIClient(testCmd())
+	if err == nil {
+		t.Fatal("newAPIClient(): expected error without task token")
+	}
+	if !strings.Contains(err.Error(), "mat_ token") {
+		t.Fatalf("newAPIClient() error = %q, want mat_ token guidance", err.Error())
+	}
+}
+
+func TestNewAPIClient_WorkdirMarkerRequiresTaskToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	t.Setenv("MULTICA_TOKEN", "")
+	chdirWithDaemonTaskMarker(t)
+
+	if err := cli.SaveCLIConfig(cli.CLIConfig{Token: "mul_profile_token", WorkspaceID: "config-file-ws"}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	_, err := newAPIClient(testCmd())
+	if err == nil {
+		t.Fatal("newAPIClient(): expected error without task token")
+	}
+	if !strings.Contains(err.Error(), "mat_ token") {
+		t.Fatalf("newAPIClient() error = %q, want mat_ token guidance", err.Error())
+	}
 }
 
 // TestParseCustomEnv covers the --custom-env flag parser used by

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -63,6 +63,27 @@ func chdirWithDaemonTaskMarker(t *testing.T) {
 	})
 }
 
+// TestNewAPIClient_LeftoverMarkerActionableError verifies that a stale
+// daemon-task marker with no daemon env (the local_directory crash-leftover
+// case) fails closed with an actionable message that names the marker file,
+// rather than an opaque "requires mat_ token" error.
+func TestNewAPIClient_LeftoverMarkerActionableError(t *testing.T) {
+	chdirWithDaemonTaskMarker(t)
+	t.Setenv("MULTICA_AGENT_ID", "")
+	t.Setenv("MULTICA_TASK_ID", "")
+	t.Setenv("MULTICA_DAEMON_PORT", "")
+	t.Setenv("MULTICA_TOKEN", "")
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+
+	if _, err := newAPIClient(testCmd()); err == nil {
+		t.Fatal("newAPIClient(): expected error for leftover daemon-task marker, got nil")
+	} else if !strings.Contains(err.Error(), execenv.TaskContextMarkerRelPath) {
+		t.Fatalf("error should name the marker path; got %q", err.Error())
+	} else if !strings.Contains(err.Error(), "leftover") {
+		t.Fatalf("error should hint it may be a leftover; got %q", err.Error())
+	}
+}
+
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
 // the cross-workspace contamination bug (#1235). Inside a daemon-spawned
 // agent task (MULTICA_AGENT_ID / MULTICA_TASK_ID set), the CLI must NOT

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -234,6 +234,44 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 
+	// A non-regular file at the marker path (here a directory) makes
+	// os.ReadFile fail with a non-IsNotExist error. That must NOT be read as a
+	// daemon-task signal: a normal user whose ancestor tree happens to contain
+	// such a path (or any unreadable one) must still reach their config token,
+	// rather than be locked out by a fail-closed guard on an unrelated error.
+	t.Run("unreadable marker path does not fail closed", func(t *testing.T) {
+		workDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workDir, execenv.TaskContextMarkerRelPath), 0o755); err != nil {
+			t.Fatalf("create marker-as-dir: %v", err)
+		}
+		nested := filepath.Join(workDir, "repo")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("create nested cwd: %v", err)
+		}
+		prev, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("get cwd: %v", err)
+		}
+		if err := os.Chdir(nested); err != nil {
+			t.Fatalf("chdir nested: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chdir(prev); err != nil {
+				t.Fatalf("restore cwd: %v", err)
+			}
+		})
+
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "")
+		t.Setenv("MULTICA_TOKEN", "")
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token (unreadable marker path must not fail closed)", got)
+		}
+	})
+
 	t.Run("agent context uses explicit task token env", func(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "agent-123")
 		t.Setenv("MULTICA_TASK_ID", "task-456")

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -74,7 +74,7 @@ func resolveToken(cmd *cobra.Command) string {
 	if v := strings.TrimSpace(os.Getenv("MULTICA_TOKEN")); v != "" {
 		return v
 	}
-	if inAgentExecutionContext() {
+	if inDaemonManagedExecutionContext() {
 		return ""
 	}
 	// A daemon-managed agent process may lose MULTICA_AGENT_ID /

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -74,16 +74,11 @@ func resolveToken(cmd *cobra.Command) string {
 	if v := strings.TrimSpace(os.Getenv("MULTICA_TOKEN")); v != "" {
 		return v
 	}
+	// Inside a daemon-managed task, never fall back to the user-global config
+	// token: that silent fallback is how agent writes land as the wrong actor.
+	// inDaemonManagedExecutionContext already covers the MULTICA_DAEMON_PORT
+	// signal for subprocesses that lost MULTICA_AGENT_ID / MULTICA_TASK_ID.
 	if inDaemonManagedExecutionContext() {
-		return ""
-	}
-	// A daemon-managed agent process may lose MULTICA_AGENT_ID /
-	// MULTICA_TASK_ID in child subprocesses (the runtime may not forward
-	// them), but MULTICA_DAEMON_PORT persists. When we detect the daemon
-	// signal we fail closed — never silently fall back to the user-global
-	// config token, because that fallback is how agent operations land as
-	// the wrong actor.
-	if os.Getenv("MULTICA_DAEMON_PORT") != "" {
 		return ""
 	}
 	profile := resolveProfile(cmd)

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -10,9 +10,16 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Unsetenv("MULTICA_AGENT_ID")
-	os.Unsetenv("MULTICA_TASK_ID")
-	os.Unsetenv("MULTICA_TOKEN")
+	for _, key := range []string{
+		"MULTICA_AGENT_ID",
+		"MULTICA_TASK_ID",
+		"MULTICA_TOKEN",
+		"MULTICA_DAEMON_PORT",
+		"MULTICA_WORKSPACE_ID",
+		"MULTICA_SERVER_URL",
+	} {
+		os.Unsetenv(key)
+	}
 	os.Exit(m.Run())
 }
 

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -11,6 +12,21 @@ import (
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	"gopkg.in/yaml.v3"
 )
+
+// TaskContextMarkerRelPath is a non-secret marker the daemon writes under the
+// task workdir. The CLI uses it as a fallback daemon-task signal when a child
+// sandbox strips all MULTICA_* env vars before invoking `multica`.
+const TaskContextMarkerRelPath = ".multica/daemon_task_context.json"
+
+// TaskContextMarkerManagedBy is the marker discriminator the CLI checks before
+// treating TaskContextMarkerRelPath as daemon-owned.
+const TaskContextMarkerManagedBy = "multica-daemon-task"
+
+type taskContextMarkerFile struct {
+	ManagedBy string `json:"managed_by"`
+	AgentID   string `json:"agent_id,omitempty"`
+	IssueID   string `json:"issue_id,omitempty"`
+}
 
 // writeContextFiles renders and writes .agent_context/issue_context.md and
 // skills into the appropriate provider-native location.
@@ -35,6 +51,10 @@ import (
 // cloud-mode tasks whose envRoot is wiped wholesale by the GC loop — may
 // pass nil to skip the bookkeeping entirely.
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
+	if err := writeTaskContextMarker(workDir, ctx, manifest); err != nil {
+		return err
+	}
+
 	contextDir := filepath.Join(workDir, ".agent_context")
 	if err := recordMkdirAll(contextDir, 0o755, manifest); err != nil {
 		return fmt.Errorf("create .agent_context dir: %w", err)
@@ -78,6 +98,47 @@ func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest
 		return fmt.Errorf("write project resources: %w", err)
 	}
 
+	return nil
+}
+
+func writeTaskContextMarker(workDir string, ctx TaskContextForEnv, manifest *sidecarManifest) error {
+	dir := filepath.Dir(filepath.Join(workDir, TaskContextMarkerRelPath))
+	if err := recordMkdirAll(dir, 0o755, manifest); err != nil {
+		return fmt.Errorf("create .multica dir: %w", err)
+	}
+	// The sidecar manifest removes this marker on normal local_directory
+	// cleanup. If a crash leaves it behind, the CLI intentionally treats it
+	// as daemon context and fails closed instead of using a user PAT.
+	payload := taskContextMarkerFile{
+		ManagedBy: TaskContextMarkerManagedBy,
+		AgentID:   ctx.AgentID,
+		IssueID:   ctx.IssueID,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal task context marker: %w", err)
+	}
+	if err := recordWriteFile(filepath.Join(workDir, TaskContextMarkerRelPath), data, 0o644, manifest); err != nil {
+		if errors.Is(err, errPathPreExists) {
+			path := filepath.Join(workDir, TaskContextMarkerRelPath)
+			existing, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return fmt.Errorf("read existing task context marker: %w", readErr)
+			}
+			var marker taskContextMarkerFile
+			if json.Unmarshal(existing, &marker) != nil || marker.ManagedBy != TaskContextMarkerManagedBy {
+				return fmt.Errorf("write task context marker: %w", err)
+			}
+			if writeErr := os.WriteFile(path, data, 0o644); writeErr != nil {
+				return fmt.Errorf("refresh task context marker: %w", writeErr)
+			}
+			if manifest != nil {
+				manifest.Files = append(manifest.Files, path)
+			}
+			return nil
+		}
+		return fmt.Errorf("write task context marker: %w", err)
+	}
 	return nil
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -134,6 +134,24 @@ func TestPrepareDirectoryMode(t *testing.T) {
 		}
 	}
 
+	markerContent, err := os.ReadFile(filepath.Join(env.WorkDir, TaskContextMarkerRelPath))
+	if err != nil {
+		t.Fatalf("failed to read task context marker: %v", err)
+	}
+	var marker struct {
+		ManagedBy string `json:"managed_by"`
+		IssueID   string `json:"issue_id"`
+	}
+	if err := json.Unmarshal(markerContent, &marker); err != nil {
+		t.Fatalf("task context marker unmarshal: %v\n%s", err, string(markerContent))
+	}
+	if marker.ManagedBy != TaskContextMarkerManagedBy {
+		t.Fatalf("marker managed_by = %q, want %q", marker.ManagedBy, TaskContextMarkerManagedBy)
+	}
+	if marker.IssueID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Fatalf("marker issue_id = %q, want issue id", marker.IssueID)
+	}
+
 	// Verify skill files.
 	skillContent, err := os.ReadFile(filepath.Join(env.WorkDir, ".agent_context", "skills", "code-review", "SKILL.md"))
 	if err != nil {
@@ -320,7 +338,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	}
 	for _, e := range entries {
 		name := e.Name()
-		if name != ".agent_context" && name != "CLAUDE.md" && name != ".claude" {
+		if name != ".agent_context" && name != ".multica" && name != "CLAUDE.md" && name != ".claude" {
 			t.Errorf("unexpected entry in workdir: %s", name)
 		}
 	}
@@ -1461,7 +1479,7 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	}
 	for _, e := range entries {
 		name := e.Name()
-		if name != ".agent_context" && name != "AGENTS.md" {
+		if name != ".agent_context" && name != ".multica" && name != "AGENTS.md" {
 			t.Errorf("unexpected entry in workdir: %s", name)
 		}
 	}


### PR DESCRIPTION
Fixes #4204

## Summary
- treat `MULTICA_DAEMON_PORT` as a daemon-managed execution marker in CLI auth/workspace resolution
- refuse config-file token/workspace fallback when that marker is present and `MULTICA_TOKEN` / `MULTICA_WORKSPACE_ID` are missing
- keep normal user CLI behavior where `MULTICA_SERVER_URL` alone can still pair with the saved config token

## Review against issue
- A daemon task subprocess that keeps `MULTICA_DAEMON_PORT` but loses `MULTICA_TOKEN`, `MULTICA_AGENT_ID`, and `MULTICA_TASK_ID` now fails closed instead of silently using a `mul_` PAT.
- `newAPIClient` applies the existing task-scoped `mat_` requirement to the daemon marker path as well.
- The change intentionally does not treat `MULTICA_SERVER_URL` alone as daemon context because users commonly set it for normal CLI sessions.

## Verification
- `go test ./cmd/multica -run 'TestResolve(Token|WorkspaceID)|TestNewAPIClient'`\n- `go test ./cmd/multica`\n- `git diff --check`