### PR TITLE
fix(scripts): fix version comparison to prevent unnecessary CLI upgrades (MUL-3335)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -262,8 +262,8 @@ upgrade_cli_brew() {
 install_cli() {
   if command_exists multica; then
     local current_ver
-    # `multica version` outputs "multica v0.1.13 (commit: abc1234)" — extract just the version
-    current_ver=$(multica version 2>/dev/null | awk '{print $2}' || echo "unknown")
+    # `multica version` outputs "multica 0.3.23 (commit: f46b929eb, built: 2026-06-16T10:11:56Z)" — extract just the version
+    current_ver=$(multica version 2>/dev/null | awk 'NR==1{print $2}' || echo "unknown")
 
     local latest_ver
     latest_ver=$(get_latest_version)
@@ -285,7 +285,7 @@ install_cli() {
     fi
 
     local new_ver
-    new_ver=$(multica version 2>/dev/null | awk '{print $2}' || echo "unknown")
+    new_ver=$(multica version 2>/dev/null | awk 'NR==1{print $2}' || echo "unknown")
     ok "Multica CLI upgraded ($current_ver → $new_ver)"
     return 0
   fi


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `install.sh` always triggers a CLI upgrade even when the installed version already matches the latest release. The root cause is that `multica version` now outputs two lines, and the version extraction with `awk '{print $2}'` captures both lines, making the comparison always fail.

## Related Issue

Closes #4226

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `scripts/install.sh`: Changed `awk '{print $2}'` to `awk 'NR==1{print $2}'` to only extract the version from the first line of `multica version` output (2 occurrences in `install_cli()`)
- Updated the inline comment to reflect the current `multica version` output format

## How to Test

1. Install multica CLI v0.3.23 (current latest)
2. Run `curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash`
3. Before fix: always triggers "upgrading..." even when already on latest
4. After fix: correctly reports "Multica CLI is up to date"

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**
Used Claude Code to identify that `multica version` output changed from single-line to multi-line format, causing the awk-based version extraction to break. Claude Code also identified that `install.ps1` was not affected (already uses `Select-Object -First 1`).