### PR TITLE
MUL-3332: prioritize custom runtime profiles

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -281,7 +281,7 @@
     "builtin_section_aria": "Supported built-in protocol families",
     "builtin_reference": "Reference",
     "empty_title": "Create your first custom runtime",
-    "empty_description": "Start from a supported protocol family, then point Multica at the command your daemon should run.",
+    "empty_description": "Start from a supported protocol family such as Claude or Codex, then point Multica at the command your daemon should run.",
     "badge_builtin": "Built-in",
     "badge_custom": "Custom",
     "badge_disabled": "Disabled",
@@ -297,7 +297,6 @@
       "no_description": "No description",
       "edit": "Edit",
       "delete": "Delete",
-      "select_hint": "Select a runtime to see its details.",
       "default_title": "Manage custom runtimes",
       "default_description": "Custom runtimes let your agents use a workspace-specific command while keeping the same supported protocol family.",
       "default_builtin_hint": "Need a base protocol? Expand the supported protocols section on the left."

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -271,15 +271,22 @@
   "profiles": {
     "cta": "Add runtime",
     "dialog_title": "Custom runtimes",
-    "dialog_description": "Define custom runtime backends for your agents. Built-in families are shown for reference.",
+    "dialog_description": "Create and manage custom runtime backends based on supported protocol families.",
     "add_new": "New custom runtime",
-    "list_title": "Runtimes",
-    "empty_custom": "No custom runtimes yet. Built-in families are listed above.",
+    "list_title": "Runtime backends",
+    "custom_section_title": "Custom runtimes ({{count}})",
+    "custom_section_aria": "Custom runtimes",
+    "builtin_section_title": "Supported base protocols ({{count}})",
+    "builtin_section_hint": "Built-in families are read-only reference options.",
+    "builtin_section_aria": "Supported built-in protocol families",
+    "builtin_reference": "Reference",
+    "empty_title": "Create your first custom runtime",
+    "empty_description": "Start from a supported protocol family, then point Multica at the command your daemon should run.",
     "badge_builtin": "Built-in",
     "badge_custom": "Custom",
     "badge_disabled": "Disabled",
     "builtin_detail": {
-      "title": "Built-in runtime",
+      "title": "Built-in protocol family",
       "description": "{{family}} is a built-in protocol family. It can't be edited or removed.",
       "read_only": "Read-only"
     },
@@ -290,7 +297,10 @@
       "no_description": "No description",
       "edit": "Edit",
       "delete": "Delete",
-      "select_hint": "Select a runtime to see its details."
+      "select_hint": "Select a runtime to see its details.",
+      "default_title": "Manage custom runtimes",
+      "default_description": "Custom runtimes let your agents use a workspace-specific command while keeping the same supported protocol family.",
+      "default_builtin_hint": "Need a base protocol? Expand the supported protocols section on the left."
     },
     "form": {
       "create_title": "New custom runtime",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -259,15 +259,22 @@
   "profiles": {
     "cta": "ランタイムを追加",
     "dialog_title": "カスタムランタイム",
-    "dialog_description": "エージェント用のカスタムランタイムバックエンドを定義します。組み込みファミリーは参考として表示されます。",
+    "dialog_description": "サポートされているプロトコルファミリーを基に、エージェント用のカスタムランタイムバックエンドを作成・管理します。",
     "add_new": "新しいカスタムランタイム",
-    "list_title": "ランタイム",
-    "empty_custom": "カスタムランタイムはまだありません。組み込みファミリーは上に表示されています。",
+    "list_title": "ランタイムバックエンド",
+    "custom_section_title": "カスタムランタイム（{{count}}）",
+    "custom_section_aria": "カスタムランタイム",
+    "builtin_section_title": "サポートされている基本プロトコル（{{count}}）",
+    "builtin_section_hint": "組み込みファミリーは読み取り専用の参考情報です。",
+    "builtin_section_aria": "サポートされている組み込みプロトコルファミリー",
+    "builtin_reference": "参考",
+    "empty_title": "最初のカスタムランタイムを作成",
+    "empty_description": "サポートされているプロトコルファミリーを選び、この daemon が実行するコマンドを指定します。",
     "badge_builtin": "組み込み",
     "badge_custom": "カスタム",
     "badge_disabled": "無効",
     "builtin_detail": {
-      "title": "組み込みランタイム",
+      "title": "組み込みプロトコルファミリー",
       "description": "{{family}} は組み込みのプロトコルファミリーです。編集や削除はできません。",
       "read_only": "読み取り専用"
     },
@@ -278,7 +285,10 @@
       "no_description": "説明なし",
       "edit": "編集",
       "delete": "削除",
-      "select_hint": "ランタイムを選択すると詳細が表示されます。"
+      "select_hint": "ランタイムを選択すると詳細が表示されます。",
+      "default_title": "カスタムランタイムを管理",
+      "default_description": "カスタムランタイムを使うと、サポートされている基本プロトコルを保ちながら、ワークスペース固有のコマンドをエージェントに使用させられます。",
+      "default_builtin_hint": "基本プロトコルが必要な場合は、左側のサポートプロトコルを展開してください。"
     },
     "form": {
       "create_title": "新しいカスタムランタイム",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -269,7 +269,7 @@
     "builtin_section_aria": "サポートされている組み込みプロトコルファミリー",
     "builtin_reference": "参考",
     "empty_title": "最初のカスタムランタイムを作成",
-    "empty_description": "サポートされているプロトコルファミリーを選び、この daemon が実行するコマンドを指定します。",
+    "empty_description": "Claude や Codex など、サポートされているプロトコルファミリーを選び、この daemon が実行するコマンドを指定します。",
     "badge_builtin": "組み込み",
     "badge_custom": "カスタム",
     "badge_disabled": "無効",
@@ -285,7 +285,6 @@
       "no_description": "説明なし",
       "edit": "編集",
       "delete": "削除",
-      "select_hint": "ランタイムを選択すると詳細が表示されます。",
       "default_title": "カスタムランタイムを管理",
       "default_description": "カスタムランタイムを使うと、サポートされている基本プロトコルを保ちながら、ワークスペース固有のコマンドをエージェントに使用させられます。",
       "default_builtin_hint": "基本プロトコルが必要な場合は、左側のサポートプロトコルを展開してください。"

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -271,15 +271,22 @@
   "profiles": {
     "cta": "런타임 추가",
     "dialog_title": "사용자 지정 런타임",
-    "dialog_description": "에이전트를 위한 사용자 지정 런타임 백엔드를 정의합니다. 기본 제공 제품군은 참고용으로 표시됩니다.",
+    "dialog_description": "지원되는 프로토콜 제품군을 기반으로 에이전트가 사용할 사용자 지정 런타임 백엔드를 만들고 관리합니다.",
     "add_new": "새 사용자 지정 런타임",
-    "list_title": "런타임",
-    "empty_custom": "아직 사용자 지정 런타임이 없습니다. 기본 제공 제품군은 위에 표시됩니다.",
+    "list_title": "런타임 백엔드",
+    "custom_section_title": "사용자 지정 런타임({{count}})",
+    "custom_section_aria": "사용자 지정 런타임",
+    "builtin_section_title": "지원되는 기본 프로토콜({{count}})",
+    "builtin_section_hint": "기본 제공 제품군은 읽기 전용 참고 항목입니다.",
+    "builtin_section_aria": "지원되는 기본 제공 프로토콜 제품군",
+    "builtin_reference": "참고",
+    "empty_title": "첫 사용자 지정 런타임 만들기",
+    "empty_description": "지원되는 프로토콜 제품군에서 시작한 다음 이 daemon이 실행할 명령을 지정하세요.",
     "badge_builtin": "기본 제공",
     "badge_custom": "사용자 지정",
     "badge_disabled": "비활성화됨",
     "builtin_detail": {
-      "title": "기본 제공 런타임",
+      "title": "기본 제공 프로토콜 제품군",
       "description": "{{family}}은(는) 기본 제공 프로토콜 제품군입니다. 편집하거나 삭제할 수 없습니다.",
       "read_only": "읽기 전용"
     },
@@ -290,7 +297,10 @@
       "no_description": "설명 없음",
       "edit": "편집",
       "delete": "삭제",
-      "select_hint": "런타임을 선택하면 세부 정보가 표시됩니다."
+      "select_hint": "런타임을 선택하면 세부 정보가 표시됩니다.",
+      "default_title": "사용자 지정 런타임 관리",
+      "default_description": "사용자 지정 런타임은 지원되는 기본 프로토콜 제품군을 유지하면서 에이전트가 워크스페이스별 명령을 사용하도록 합니다.",
+      "default_builtin_hint": "기본 프로토콜이 필요하면 왼쪽의 지원 프로토콜 섹션을 펼치세요."
     },
     "form": {
       "create_title": "새 사용자 지정 런타임",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -281,7 +281,7 @@
     "builtin_section_aria": "지원되는 기본 제공 프로토콜 제품군",
     "builtin_reference": "참고",
     "empty_title": "첫 사용자 지정 런타임 만들기",
-    "empty_description": "지원되는 프로토콜 제품군에서 시작한 다음 이 daemon이 실행할 명령을 지정하세요.",
+    "empty_description": "Claude나 Codex 같은 지원되는 프로토콜 제품군에서 시작한 다음 이 daemon이 실행할 명령을 지정하세요.",
     "badge_builtin": "기본 제공",
     "badge_custom": "사용자 지정",
     "badge_disabled": "비활성화됨",
@@ -297,7 +297,6 @@
       "no_description": "설명 없음",
       "edit": "편집",
       "delete": "삭제",
-      "select_hint": "런타임을 선택하면 세부 정보가 표시됩니다.",
       "default_title": "사용자 지정 런타임 관리",
       "default_description": "사용자 지정 런타임은 지원되는 기본 프로토콜 제품군을 유지하면서 에이전트가 워크스페이스별 명령을 사용하도록 합니다.",
       "default_builtin_hint": "기본 프로토콜이 필요하면 왼쪽의 지원 프로토콜 섹션을 펼치세요."

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -259,15 +259,22 @@
   "profiles": {
     "cta": "添加运行时",
     "dialog_title": "自定义运行时",
-    "dialog_description": "为你的智能体定义自定义运行时后端。内置类型仅供参考。",
+    "dialog_description": "基于支持的协议族，创建和管理智能体可使用的自定义运行时后端。",
     "add_new": "新建自定义运行时",
-    "list_title": "运行时",
-    "empty_custom": "暂无自定义运行时。内置类型已列在上方。",
+    "list_title": "运行时后端",
+    "custom_section_title": "自定义运行时（{{count}}）",
+    "custom_section_aria": "自定义运行时",
+    "builtin_section_title": "支持的基础协议（{{count}}）",
+    "builtin_section_hint": "内置协议族为只读参考。",
+    "builtin_section_aria": "支持的内置协议族",
+    "builtin_reference": "参考",
+    "empty_title": "创建第一个自定义运行时",
+    "empty_description": "从支持的协议族开始，然后指定这个 Daemon 应该运行的命令。",
     "badge_builtin": "内置",
     "badge_custom": "自定义",
     "badge_disabled": "已禁用",
     "builtin_detail": {
-      "title": "内置运行时",
+      "title": "内置协议族",
       "description": "{{family}} 是内置协议类型，无法编辑或删除。",
       "read_only": "只读"
     },
@@ -278,7 +285,10 @@
       "no_description": "无描述",
       "edit": "编辑",
       "delete": "删除",
-      "select_hint": "选择一个运行时以查看详情。"
+      "select_hint": "选择一个运行时以查看详情。",
+      "default_title": "管理自定义运行时",
+      "default_description": "自定义运行时让智能体使用工作区指定的命令，同时保持受支持的基础协议族。",
+      "default_builtin_hint": "需要选择基础协议？可以展开左侧的支持协议参考。"
     },
     "form": {
       "create_title": "新建自定义运行时",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -269,7 +269,7 @@
     "builtin_section_aria": "支持的内置协议族",
     "builtin_reference": "参考",
     "empty_title": "创建第一个自定义运行时",
-    "empty_description": "从支持的协议族开始，然后指定这个 Daemon 应该运行的命令。",
+    "empty_description": "从 Claude、Codex 等支持的协议族开始，然后指定这个 Daemon 应该运行的命令。",
     "badge_builtin": "内置",
     "badge_custom": "自定义",
     "badge_disabled": "已禁用",
@@ -285,7 +285,6 @@
       "no_description": "无描述",
       "edit": "编辑",
       "delete": "删除",
-      "select_hint": "选择一个运行时以查看详情。",
       "default_title": "管理自定义运行时",
       "default_description": "自定义运行时让智能体使用工作区指定的命令，同时保持受支持的基础协议族。",
       "default_builtin_hint": "需要选择基础协议？可以展开左侧的支持协议参考。"

--- a/packages/views/runtimes/components/runtime-profile-catalog.test.ts
+++ b/packages/views/runtimes/components/runtime-profile-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeProfile } from "@multica/core/types";
+import { buildRuntimeCatalog, PROTOCOL_FAMILIES } from "./runtime-profile-catalog";
+
+function profile(
+  id: string,
+  displayName: string,
+  updatedAt: string,
+  enabled = true,
+): RuntimeProfile {
+  return {
+    id,
+    workspace_id: "ws-1",
+    display_name: displayName,
+    protocol_family: "codex",
+    command_name: "codex",
+    description: null,
+    fixed_args: [],
+    visibility: "workspace",
+    created_by: "user-1",
+    enabled,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: updatedAt,
+  };
+}
+
+describe("buildRuntimeCatalog", () => {
+  it("keeps custom profiles separate from built-in protocol families", () => {
+    const catalog = buildRuntimeCatalog([
+      profile("prof-1", "Team Codex", "2026-01-02T00:00:00Z"),
+    ]);
+
+    expect(catalog.customs).toHaveLength(1);
+    expect(catalog.customs[0]).toMatchObject({
+      kind: "custom",
+      id: "prof-1",
+      protocolFamily: "codex",
+    });
+    expect(catalog.builtins).toHaveLength(PROTOCOL_FAMILIES.length);
+    expect(catalog.builtins[0]).toMatchObject({
+      kind: "builtin",
+      id: `builtin:${PROTOCOL_FAMILIES[0]}`,
+      protocolFamily: PROTOCOL_FAMILIES[0],
+    });
+  });
+
+  it("sorts custom profiles by enabled state, recency, then display name", () => {
+    const catalog = buildRuntimeCatalog([
+      profile("disabled-new", "Disabled New", "2026-01-04T00:00:00Z", false),
+      profile("enabled-old", "Alpha", "2026-01-01T00:00:00Z"),
+      profile("enabled-new-a", "Zulu", "2026-01-03T00:00:00Z"),
+      profile("enabled-new-b", "Bravo", "2026-01-03T00:00:00Z"),
+    ]);
+
+    expect(catalog.customs.map((entry) => entry.id)).toEqual([
+      "enabled-new-b",
+      "enabled-new-a",
+      "enabled-old",
+      "disabled-new",
+    ]);
+  });
+});

--- a/packages/views/runtimes/components/runtime-profile-catalog.ts
+++ b/packages/views/runtimes/components/runtime-profile-catalog.ts
@@ -5,9 +5,8 @@ import {
 } from "@multica/core/types";
 
 // A single row in the runtimes catalog the management dialog renders: the
-// built-in protocol families ship as read-only reference rows, the custom
-// profiles as editable rows. They render mixed in one list, each tagged with
-// its kind so the row can stamp the right badge (built-in vs custom).
+// built-in protocol families ship as read-only reference rows, while custom
+// profiles are the user's editable assets.
 export type RuntimeCatalogEntry =
   | {
       kind: "builtin";
@@ -22,19 +21,22 @@ export type RuntimeCatalogEntry =
       profile: RuntimeProfile;
     };
 
+export interface RuntimeCatalogSections {
+  customs: RuntimeCatalogEntry[];
+  builtins: RuntimeCatalogEntry[];
+}
+
 // Re-export the whitelist as a typed array so callers (the family picker,
 // the catalog builder) share the single source of truth.
 export const PROTOCOL_FAMILIES: readonly RuntimeProtocolFamily[] =
   RUNTIME_PROFILE_PROTOCOL_FAMILIES;
 
-// buildRuntimeCatalog produces the mixed, flat list: every built-in family
-// first (in whitelist order), then the custom profiles (alphabetical by
-// display name, case-insensitive). No grouping / headers — the row badge is
-// the only built-in-vs-custom signal, matching the locked progressive-
-// disclosure design.
+// buildRuntimeCatalog keeps user-owned custom profiles separate from built-in
+// protocol families. The dialog renders customs as the primary management
+// surface and built-ins as a collapsed reference section.
 export function buildRuntimeCatalog(
   profiles: RuntimeProfile[],
-): RuntimeCatalogEntry[] {
+): RuntimeCatalogSections {
   const builtins: RuntimeCatalogEntry[] = PROTOCOL_FAMILIES.map((family) => ({
     kind: "builtin" as const,
     id: `builtin:${family}`,
@@ -42,11 +44,15 @@ export function buildRuntimeCatalog(
   }));
 
   const customs: RuntimeCatalogEntry[] = [...profiles]
-    .sort((a, b) =>
-      a.display_name.localeCompare(b.display_name, undefined, {
+    .sort((a, b) => {
+      if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+      const aTime = Date.parse(a.updated_at) || 0;
+      const bTime = Date.parse(b.updated_at) || 0;
+      if (aTime !== bTime) return bTime - aTime;
+      return a.display_name.localeCompare(b.display_name, undefined, {
         sensitivity: "base",
-      }),
-    )
+      });
+    })
     .map((profile) => ({
       kind: "custom" as const,
       id: profile.id,
@@ -54,7 +60,7 @@ export function buildRuntimeCatalog(
       profile,
     }));
 
-  return [...builtins, ...customs];
+  return { customs, builtins };
 }
 
 // NOTE: `fixed_args` is intentionally NOT exposed in the v1 UI. The server

--- a/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { RuntimeProfile } from "@multica/core/types";
+import enCommon from "../../locales/en/common.json";
+import enRuntimes from "../../locales/en/runtimes.json";
+
+const queryState = vi.hoisted(() => ({
+  profiles: [] as RuntimeProfile[],
+  isLoading: false,
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({
+      data: queryState.profiles,
+      isLoading: queryState.isLoading,
+    })),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("./delete-runtime-profile-dialog", () => ({
+  DeleteRuntimeProfileDialog: () => null,
+}));
+
+vi.mock("./provider-logo", () => ({
+  ProviderLogo: () => null,
+}));
+
+import { RuntimeProfilesDialog } from "./runtime-profiles-dialog";
+
+const TEST_RESOURCES = { en: { common: enCommon, runtimes: enRuntimes } };
+
+function profile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
+  return {
+    id: "prof-1",
+    workspace_id: "ws-1",
+    display_name: "Team Codex",
+    protocol_family: "codex",
+    command_name: "codex",
+    description: null,
+    fixed_args: [],
+    visibility: "workspace",
+    created_by: "user-1",
+    enabled: true,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderDialog() {
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <RuntimeProfilesDialog wsId="ws-1" onClose={vi.fn()} />
+    </I18nProvider>,
+  );
+}
+
+describe("RuntimeProfilesDialog", () => {
+  beforeEach(() => {
+    queryState.profiles = [];
+    queryState.isLoading = false;
+    vi.clearAllMocks();
+  });
+
+  it("shows the custom empty state and keeps built-in protocols collapsed", () => {
+    renderDialog();
+
+    expect(
+      screen.getByText("Create your first custom runtime"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/such as Claude or Codex/),
+    ).toBeInTheDocument();
+
+    const builtinsToggle = screen.getByRole("button", {
+      name: /Supported base protocols/,
+    });
+    expect(builtinsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("claude")).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "New custom runtime" }),
+    ).toHaveLength(2);
+  });
+
+  it("renders custom profiles before the collapsed built-in reference section", () => {
+    queryState.profiles = [profile()];
+
+    renderDialog();
+
+    const customTitle = screen.getByText("Custom runtimes (1)");
+    const customRow = screen.getByText("Team Codex");
+    const builtinsToggle = screen.getByRole("button", {
+      name: /Supported base protocols/,
+    });
+
+    expect(customRow).toBeInTheDocument();
+    expect(builtinsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      customTitle.compareDocumentPosition(builtinsToggle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.queryByText("claude")).not.toBeInTheDocument();
+
+    fireEvent.click(builtinsToggle);
+
+    expect(builtinsToggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("claude")).toBeInTheDocument();
+  });
+
+  it("clears built-in detail when the built-in reference section collapses", () => {
+    queryState.profiles = [profile()];
+
+    renderDialog();
+
+    const builtinsToggle = screen.getByRole("button", {
+      name: /Supported base protocols/,
+    });
+    fireEvent.click(builtinsToggle);
+    fireEvent.click(screen.getByRole("option", { name: /claude/i }));
+
+    expect(
+      screen.getByText(/claude is a built-in protocol family/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(builtinsToggle);
+
+    expect(screen.getByText("Manage custom runtimes")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/claude is a built-in protocol family/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/runtimes/components/runtime-profiles-dialog.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.tsx
@@ -3,6 +3,7 @@
 import { useId, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import {
+  ChevronDown,
   ChevronLeft,
   Loader2,
   Pencil,
@@ -43,6 +44,7 @@ import {
   type ProfileFormErrorField,
   type ProfileFormValues,
   type RuntimeCatalogEntry,
+  type RuntimeCatalogSections,
 } from "./runtime-profile-catalog";
 import { useT } from "../../i18n";
 
@@ -73,17 +75,36 @@ export function RuntimeProfilesDialog({
     useState<RuntimeProtocolFamily>(PROTOCOL_FAMILIES[0] ?? "claude");
 
   const catalog = useMemo(() => buildRuntimeCatalog(profiles), [profiles]);
+  const entries = useMemo(
+    () => [...catalog.customs, ...catalog.builtins],
+    [catalog],
+  );
   const selectedEntry =
-    catalog.find((entry) => entry.id === selectedId) ?? null;
+    entries.find((entry) => entry.id === selectedId) ?? null;
+  const openCreateForm = () =>
+    setState({ surface: "form", mode: "create", step: "family" });
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="flex max-h-[88vh] flex-col gap-0 p-0 sm:max-w-3xl">
         <DialogHeader className="border-b px-6 py-5">
-          <DialogTitle className="flex items-center gap-2 text-base">
-            <Server className="h-4 w-4 text-muted-foreground" />
-            {t(($) => $.profiles.dialog_title)}
-          </DialogTitle>
+          <div className="flex items-start justify-between gap-3">
+            <DialogTitle className="flex min-w-0 items-center gap-2 text-base">
+              <Server className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">{t(($) => $.profiles.dialog_title)}</span>
+            </DialogTitle>
+            {state.surface === "browse" && (
+              <Button
+                type="button"
+                size="sm"
+                className="h-8 shrink-0 px-2.5"
+                onClick={openCreateForm}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                {t(($) => $.profiles.add_new)}
+              </Button>
+            )}
+          </div>
           <DialogDescription className="text-xs">
             {t(($) => $.profiles.dialog_description)}
           </DialogDescription>
@@ -118,17 +139,16 @@ export function RuntimeProfilesDialog({
         ) : (
           <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
             <CatalogList
-              entries={catalog}
+              catalog={catalog}
               loading={isLoading}
               selectedId={selectedId}
               onSelect={setSelectedId}
-              onAddNew={() =>
-                setState({ surface: "form", mode: "create", step: "family" })
-              }
+              onAddNew={openCreateForm}
             />
             <DetailPanel
               entry={selectedEntry}
               wsId={wsId}
+              onAddNew={openCreateForm}
               onEdit={(profile) =>
                 setState({ surface: "form", mode: "edit", profile })
               }
@@ -142,58 +162,148 @@ export function RuntimeProfilesDialog({
 }
 
 // ---------------------------------------------------------------------------
-// Master list — built-in families + custom profiles, mixed, each badged.
+// Master list — custom profiles first, built-in families as collapsed reference.
 // ---------------------------------------------------------------------------
 
 function CatalogList({
-  entries,
+  catalog,
   loading,
   selectedId,
   onSelect,
   onAddNew,
 }: {
-  entries: RuntimeCatalogEntry[];
+  catalog: RuntimeCatalogSections;
   loading: boolean;
   selectedId: string | null;
   onSelect: (id: string) => void;
   onAddNew: () => void;
 }) {
   const { t } = useT("runtimes");
-  const hasCustom = entries.some((entry) => entry.kind === "custom");
+  const [builtinsOpen, setBuiltinsOpen] = useState(false);
+  const hasCustom = catalog.customs.length > 0;
 
   return (
     <div className="flex min-h-0 flex-col border-b md:border-b-0 md:border-r">
-      <div className="flex shrink-0 items-center justify-between border-b bg-background px-4 py-2.5">
+      <div className="flex shrink-0 items-center justify-between border-b bg-background px-4 py-3">
         <h3 className="text-sm font-medium">
           {t(($) => $.profiles.list_title)}
         </h3>
-        <Button type="button" size="sm" className="h-7 px-2" onClick={onAddNew}>
-          <Plus className="h-3.5 w-3.5" />
-          {t(($) => $.profiles.add_new)}
-        </Button>
       </div>
       {loading ? (
         <div className="flex h-40 items-center justify-center">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
       ) : (
-        <ul className="min-h-0 flex-1 overflow-y-auto py-1" role="listbox" aria-label={t(($) => $.profiles.list_title)}>
-          {entries.map((entry) => (
-            <li key={entry.id}>
-              <CatalogRow
-                entry={entry}
-                active={entry.id === selectedId}
-                onClick={() => onSelect(entry.id)}
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+          <section aria-labelledby="runtime-profile-custom-section">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h4
+                id="runtime-profile-custom-section"
+                className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+              >
+                {t(($) => $.profiles.custom_section_title, {
+                  count: catalog.customs.length,
+                })}
+              </h4>
+            </div>
+            {hasCustom ? (
+              <ul
+                className="space-y-1"
+                role="listbox"
+                aria-label={t(($) => $.profiles.custom_section_aria)}
+              >
+                {catalog.customs.map((entry) => (
+                  <li key={entry.id}>
+                    <CatalogRow
+                      entry={entry}
+                      active={entry.id === selectedId}
+                      onClick={() => onSelect(entry.id)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyCustomState onAddNew={onAddNew} />
+            )}
+          </section>
+
+          <section aria-labelledby="runtime-profile-builtin-section">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-expanded={builtinsOpen}
+              aria-controls="runtime-profile-builtin-list"
+              onClick={() => setBuiltinsOpen((open) => !open)}
+            >
+              <span className="min-w-0">
+                <span
+                  id="runtime-profile-builtin-section"
+                  className="block text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                >
+                  {t(($) => $.profiles.builtin_section_title, {
+                    count: catalog.builtins.length,
+                  })}
+                </span>
+                <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                  {t(($) => $.profiles.builtin_section_hint)}
+                </span>
+              </span>
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                  builtinsOpen && "rotate-180",
+                )}
               />
-            </li>
-          ))}
-          {!hasCustom && (
-            <li className="px-4 py-3 text-xs text-muted-foreground">
-              {t(($) => $.profiles.empty_custom)}
-            </li>
-          )}
-        </ul>
+            </button>
+            {builtinsOpen && (
+              <ul
+                id="runtime-profile-builtin-list"
+                className="mt-2 space-y-1"
+                role="listbox"
+                aria-label={t(($) => $.profiles.builtin_section_aria)}
+              >
+                {catalog.builtins.map((entry) => (
+                  <li key={entry.id}>
+                    <CatalogRow
+                      entry={entry}
+                      active={entry.id === selectedId}
+                      onClick={() => onSelect(entry.id)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
       )}
+    </div>
+  );
+}
+
+function EmptyCustomState({ onAddNew }: { onAddNew: () => void }) {
+  const { t } = useT("runtimes");
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+          <Server className="h-4 w-4 text-muted-foreground" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h5 className="text-sm font-medium">{t(($) => $.profiles.empty_title)}</h5>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {t(($) => $.profiles.empty_description)}
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            className="mt-3 h-8 px-2.5"
+            onClick={onAddNew}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t(($) => $.profiles.add_new)}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -211,6 +321,7 @@ function CatalogRow({
   const label =
     entry.kind === "custom" ? entry.profile.display_name : entry.protocolFamily;
   const disabled = entry.kind === "custom" && !entry.profile.enabled;
+  const isBuiltin = entry.kind === "builtin";
   return (
     <button
       type="button"
@@ -218,12 +329,17 @@ function CatalogRow({
       aria-selected={active}
       onClick={onClick}
       className={cn(
-        "flex w-full min-w-0 items-center gap-2.5 px-4 py-2 text-left transition-colors",
-        active ? "bg-accent" : "hover:bg-accent/50",
+        "flex w-full min-w-0 items-center gap-2.5 rounded-md px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        active && "bg-accent",
+        !active && !isBuiltin && "hover:bg-accent/50",
+        isBuiltin && !active && "text-muted-foreground hover:bg-muted/40",
       )}
     >
       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border bg-background">
-        <ProviderLogo provider={entry.protocolFamily} className="h-4 w-4" />
+        <ProviderLogo
+          provider={entry.protocolFamily}
+          className={cn("h-4 w-4", isBuiltin && "opacity-75")}
+        />
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
@@ -247,26 +363,12 @@ function CatalogRow({
           </span>
         )}
       </span>
-      <KindBadge kind={entry.kind} />
-    </button>
-  );
-}
-
-function KindBadge({ kind }: { kind: "builtin" | "custom" }) {
-  const { t } = useT("runtimes");
-  return (
-    <span
-      className={cn(
-        "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
-        kind === "custom"
-          ? "bg-info/10 text-info"
-          : "bg-muted text-muted-foreground",
+      {isBuiltin && (
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {t(($) => $.profiles.builtin_reference)}
+        </span>
       )}
-    >
-      {kind === "custom"
-        ? t(($) => $.profiles.badge_custom)
-        : t(($) => $.profiles.badge_builtin)}
-    </span>
+    </button>
   );
 }
 
@@ -278,11 +380,13 @@ function KindBadge({ kind }: { kind: "builtin" | "custom" }) {
 function DetailPanel({
   entry,
   wsId,
+  onAddNew,
   onEdit,
   onDeleted,
 }: {
   entry: RuntimeCatalogEntry | null;
   wsId: string;
+  onAddNew: () => void;
   onEdit: (profile: RuntimeProfile) => void;
   onDeleted: () => void;
 }) {
@@ -291,10 +395,25 @@ function DetailPanel({
 
   if (!entry) {
     return (
-      <div className="flex min-h-[12rem] flex-1 items-center justify-center p-6 text-center">
-        <p className="text-sm text-muted-foreground">
-          {t(($) => $.profiles.detail.select_hint)}
-        </p>
+      <div className="flex min-h-[12rem] flex-1 items-center justify-center p-6">
+        <div className="max-w-sm text-center">
+          <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-md border bg-background">
+            <Server className="h-5 w-5 text-muted-foreground" />
+          </span>
+          <h3 className="mt-4 text-base font-semibold">
+            {t(($) => $.profiles.detail.default_title)}
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            {t(($) => $.profiles.detail.default_description)}
+          </p>
+          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+            {t(($) => $.profiles.detail.default_builtin_hint)}
+          </p>
+          <Button type="button" size="sm" className="mt-4" onClick={onAddNew}>
+            <Plus className="h-3.5 w-3.5" />
+            {t(($) => $.profiles.add_new)}
+          </Button>
+        </div>
       </div>
     );
   }

--- a/packages/views/runtimes/components/runtime-profiles-dialog.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.tsx
@@ -49,7 +49,7 @@ import {
 import { useT } from "../../i18n";
 
 // The dialog runs in two surfaces that swap inside one Popup:
-//   - "browse": master list (built-in + custom, badged) + adaptive detail
+//   - "browse": custom-first master list + adaptive detail
 //   - "form":   create (2-step) or edit (single step, family locked)
 type DialogState =
   | { surface: "browse" }
@@ -148,7 +148,6 @@ export function RuntimeProfilesDialog({
             <DetailPanel
               entry={selectedEntry}
               wsId={wsId}
-              onAddNew={openCreateForm}
               onEdit={(profile) =>
                 setState({ surface: "form", mode: "edit", profile })
               }
@@ -175,12 +174,15 @@ function CatalogList({
   catalog: RuntimeCatalogSections;
   loading: boolean;
   selectedId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (id: string | null) => void;
   onAddNew: () => void;
 }) {
   const { t } = useT("runtimes");
   const [builtinsOpen, setBuiltinsOpen] = useState(false);
   const hasCustom = catalog.customs.length > 0;
+  const selectedIsBuiltin = catalog.builtins.some(
+    (entry) => entry.id === selectedId,
+  );
 
   return (
     <div className="flex min-h-0 flex-col border-b md:border-b-0 md:border-r">
@@ -233,7 +235,15 @@ function CatalogList({
               className="flex w-full items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-expanded={builtinsOpen}
               aria-controls="runtime-profile-builtin-list"
-              onClick={() => setBuiltinsOpen((open) => !open)}
+              onClick={() =>
+                setBuiltinsOpen((open) => {
+                  const nextOpen = !open;
+                  if (!nextOpen && selectedIsBuiltin) {
+                    onSelect(null);
+                  }
+                  return nextOpen;
+                })
+              }
             >
               <span className="min-w-0">
                 <span
@@ -380,13 +390,11 @@ function CatalogRow({
 function DetailPanel({
   entry,
   wsId,
-  onAddNew,
   onEdit,
   onDeleted,
 }: {
   entry: RuntimeCatalogEntry | null;
   wsId: string;
-  onAddNew: () => void;
   onEdit: (profile: RuntimeProfile) => void;
   onDeleted: () => void;
 }) {
@@ -409,10 +417,6 @@ function DetailPanel({
           <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
             {t(($) => $.profiles.detail.default_builtin_hint)}
           </p>
-          <Button type="button" size="sm" className="mt-4" onClick={onAddNew}>
-            <Plus className="h-3.5 w-3.5" />
-            {t(($) => $.profiles.add_new)}
-          </Button>
         </div>
       </div>
     );


### PR DESCRIPTION
Follow-up for MUL-3332.

## Summary
- Make custom runtime profiles the primary content in the dialog.
- Move built-in protocol families into a collapsed read-only reference section.
- Add empty-state and header CTAs for creating a custom runtime.
- Sort custom profiles by enabled state, updated time, then display name.
- Update runtime profile copy across supported locales.

## Verification
- `pnpm --filter @multica/views test -- runtime-profile-catalog locales/parity`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint`
