### PR TITLE
MUL-3355: feat(helm): support external PostgreSQL via postgres.external.enabled

### DIFF
--- a/deploy/helm/multica/templates/backend.yaml
+++ b/deploy/helm/multica/templates/backend.yaml
@@ -68,9 +68,11 @@ spec:
                 name: {{ .Release.Name }}-config
             - secretRef:
                 name: {{ .Values.existingSecret }}
+          {{- if not .Values.postgres.external.enabled }}
           env:
             - name: DATABASE_URL
               value: {{ include "multica.databaseUrl" . | quote }}
+          {{- end }}
           {{- if .Values.backend.uploads.persistence.enabled }}
           volumeMounts:
             - name: uploads

--- a/deploy/helm/multica/templates/configmap.yaml
+++ b/deploy/helm/multica/templates/configmap.yaml
@@ -25,6 +25,8 @@ data:
   CLOUDFRONT_KEY_PAIR_ID: {{ .Values.backend.config.cloudfrontKeyPairId | quote }}
   LOCAL_UPLOAD_BASE_URL: {{ .Values.backend.config.localUploadBaseUrl | quote }}
 
-  # --- PostgreSQL (also consumed by the backend to build DATABASE_URL) ---
+  {{- if not .Values.postgres.external.enabled }}
+  # --- PostgreSQL (consumed by the backend to build DATABASE_URL) ---
   POSTGRES_DB: {{ .Values.postgres.database | quote }}
   POSTGRES_USER: {{ .Values.postgres.user | quote }}
+  {{- end }}

--- a/deploy/helm/multica/templates/postgres.yaml
+++ b/deploy/helm/multica/templates/postgres.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.postgres.external.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -97,3 +98,5 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
+
+{{- end }}

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -21,9 +21,20 @@ images:
 # -----------------------------------------------------------------------------
 # Pre-created Secret with sensitive values. Create it before `helm install`:
 #
+# Built-in postgres (default):
 #   kubectl -n <namespace> create secret generic multica-secrets \
 #     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
 #     --from-literal=POSTGRES_PASSWORD="$(openssl rand -hex 16)" \
+#     --from-literal=RESEND_API_KEY="" \
+#     --from-literal=GOOGLE_CLIENT_SECRET="" \
+#     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+#     --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
+#
+# External postgres (postgres.external.enabled=true):
+#   Replace POSTGRES_PASSWORD with DATABASE_URL pointing at your external cluster.
+#   kubectl -n <namespace> create secret generic multica-secrets \
+#     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
+#     --from-literal=DATABASE_URL="postgres://user:pass@host:5432/multica?sslmode=require" \
 #     --from-literal=RESEND_API_KEY="" \
 #     --from-literal=GOOGLE_CLIENT_SECRET="" \
 #     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
@@ -38,6 +49,12 @@ existingSecret: multica-secrets
 # PostgreSQL (pgvector)
 # -----------------------------------------------------------------------------
 postgres:
+  # Set external.enabled=true to skip the built-in postgres Deployment/PVC and
+  # supply DATABASE_URL directly via the existingSecret instead. When true,
+  # the postgres Deployment, PVC, and Service are not created.
+  # Add DATABASE_URL to your existingSecret pointing at the external cluster.
+  external:
+    enabled: false
   database: multica
   user: multica
   persistence:


### PR DESCRIPTION
Closes #4237

## Summary

- Add `postgres.external.enabled` toggle (default `false`) — when `true`, the chart skips creating the built-in Postgres Deployment, PVC, and Service entirely
- Omit the hard-coded `DATABASE_URL` env var from the backend pod in external mode; the URL is supplied via `existingSecret` and picked up through the existing `envFrom.secretRef` mechanism, zero extra wiring needed
- Guard `POSTGRES_DB` / `POSTGRES_USER` in the ConfigMap so they are not emitted when unused
- Update the `existingSecret` creation example in `values.yaml` to show both built-in and external-postgres variants, so users know to add `DATABASE_URL` instead of `POSTGRES_PASSWORD` when switching modes

## Test plan

- [ ] `helm template` with default values renders postgres Deployment + PVC + Service and injects `DATABASE_URL` env — unchanged behavior
- [ ] `helm template` with `postgres.external.enabled: true` renders no postgres resources and no `DATABASE_URL` env; `POSTGRES_DB`/`POSTGRES_USER` absent from ConfigMap
- [ ] Deploy against a real external PostgreSQL (e.g. CNPG) with `DATABASE_URL` in secret — backend starts and migrations run successfully