### PR TITLE
fix(runtimes): re-enable Delete affordance for owners on self-healing runtimes (MUL-3352)

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -85,7 +85,6 @@
     "all_runtimes": "All runtimes",
     "read_only": "Read-only",
     "delete_button": "Delete runtime",
-    "delete_disabled_tooltip": "This runtime is managed by a running local daemon and will re-register itself within seconds. Stop the daemon process to remove it permanently.",
     "last_seen": "last seen {{when}}",
     "fact_owner": "Owner",
     "fact_device": "Device",
@@ -111,6 +110,7 @@
     "visibility_toast_updated": "Visibility set to {{visibility}}",
     "visibility_toast_failed": "Failed to update visibility",
     "delete_dialog": {
+      "self_heal_notice": "This runtime is managed by a running local daemon. Deleting it will succeed, but the daemon will re-register a fresh runtime within seconds — stop the daemon process first to remove it permanently.",
       "light": {
         "title": "Delete Runtime?",
         "description": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone.",
@@ -131,7 +131,6 @@
         "confirm_one": "Archive {{count}} agent and delete runtime",
         "confirm_other": "Archive {{count}} agents and delete runtime",
         "submitting": "Archiving and deleting...",
-        "self_healing_blocked_toast": "This runtime is managed by a running local daemon and will re-register itself.",
         "delete_failed_toast": "Failed to delete runtime",
         "table": {
           "header_agent": "Agent",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -81,7 +81,6 @@
     "all_runtimes": "すべてのランタイム",
     "read_only": "読み取り専用",
     "delete_button": "ランタイムを削除",
-    "delete_disabled_tooltip": "このランタイムは実行中のローカルデーモンが管理しており、数秒以内に自分で再登録します。完全に削除するには、デーモンプロセスを停止してください。",
     "last_seen": "最終確認 {{when}}",
     "fact_owner": "所有者",
     "fact_device": "デバイス",
@@ -106,6 +105,7 @@
     "visibility_toast_updated": "公開範囲を {{visibility}} に設定しました",
     "visibility_toast_failed": "公開範囲を更新できませんでした",
     "delete_dialog": {
+      "self_heal_notice": "このランタイムは実行中のローカルデーモンに管理されています。削除自体は成功しますが、デーモンプロセスを停止しない限り、数秒以内に新しいランタイムとして再登録されます。完全に削除するには先にデーモンを停止してください。",
       "light": {
         "title": "ランタイムを削除しますか?",
         "description": "「{{name}}」を削除してもよろしいですか? この操作は元に戻せません。",
@@ -123,7 +123,6 @@
         "cancel": "キャンセル",
         "confirm_other": "エージェント {{count}} 個をアーカイブしてランタイムを削除",
         "submitting": "アーカイブして削除中...",
-        "self_healing_blocked_toast": "このランタイムは実行中のローカルデーモンが管理しており、自分で再登録します。",
         "delete_failed_toast": "ランタイムを削除できませんでした",
         "table": {
           "header_agent": "エージェント",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -85,7 +85,6 @@
     "all_runtimes": "모든 런타임",
     "read_only": "읽기 전용",
     "delete_button": "런타임 삭제",
-    "delete_disabled_tooltip": "이 런타임은 실행 중인 로컬 데몬이 관리하며 몇 초 안에 다시 등록됩니다. 영구 제거하려면 데몬 프로세스를 중지하세요.",
     "last_seen": "마지막 확인 {{when}}",
     "fact_owner": "소유자",
     "fact_device": "기기",
@@ -111,6 +110,7 @@
     "visibility_toast_updated": "공개 범위를 {{visibility}}(으)로 설정했습니다",
     "visibility_toast_failed": "공개 범위를 업데이트하지 못했습니다",
     "delete_dialog": {
+      "self_heal_notice": "이 런타임은 실행 중인 로컬 데몬이 관리합니다. 삭제는 성공하지만, 데몬 프로세스를 멈추지 않으면 몇 초 안에 새 런타임이 다시 등록됩니다. 완전히 제거하려면 먼저 데몬을 중지하세요.",
       "light": {
         "title": "런타임을 삭제할까요?",
         "description": "\"{{name}}\"을(를) 삭제할까요? 이 작업은 되돌릴 수 없습니다.",
@@ -131,7 +131,6 @@
         "confirm_one": "에이전트 {{count}}개 보관 및 런타임 삭제",
         "confirm_other": "에이전트 {{count}}개 보관 및 런타임 삭제",
         "submitting": "보관하고 삭제하는 중...",
-        "self_healing_blocked_toast": "이 런타임은 실행 중인 로컬 데몬이 관리하며 다시 등록됩니다.",
         "delete_failed_toast": "런타임을 삭제하지 못했습니다",
         "table": {
           "header_agent": "에이전트",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -81,7 +81,6 @@
     "all_runtimes": "全部运行时",
     "read_only": "只读",
     "delete_button": "删除运行时",
-    "delete_disabled_tooltip": "该运行时由正在运行的本地守护进程托管，删除后会在数秒内自动重新注册。需停止守护进程才能彻底移除。",
     "last_seen": "最后活跃 {{when}}",
     "fact_owner": "所有者",
     "fact_device": "设备",
@@ -106,6 +105,7 @@
     "visibility_toast_updated": "可见性已设为「{{visibility}}」",
     "visibility_toast_failed": "更新可见性失败",
     "delete_dialog": {
+      "self_heal_notice": "该运行时由正在运行的本地守护进程托管。删除会成功，但守护进程会在数秒内重新注册一个新的运行时——若想彻底移除，请先停止守护进程。",
       "light": {
         "title": "删除运行时？",
         "description": "确定要删除「{{name}}」吗？此操作无法撤销。",
@@ -123,7 +123,6 @@
         "cancel": "取消",
         "confirm_other": "归档 {{count}} 个智能体并删除运行时",
         "submitting": "正在归档并删除...",
-        "self_healing_blocked_toast": "该运行时由正在运行的本地守护进程托管，删除后会自动重新注册。",
         "delete_failed_toast": "删除运行时失败",
         "table": {
           "header_agent": "智能体",

--- a/packages/views/runtimes/components/delete-runtime-dialog.test.tsx
+++ b/packages/views/runtimes/components/delete-runtime-dialog.test.tsx
@@ -318,4 +318,76 @@ describe("DeleteRuntimeDialog", () => {
       screen.getByText(/active agent set changed/i),
     ).toBeInTheDocument();
   });
+
+  // MUL-3352: the dialog used to refuse self-healing runtimes outright,
+  // both at the affordance and at confirm. The new contract is owner-led:
+  // the affordance is always live, the dialog raises a warning banner so
+  // the user understands the daemon will re-register a new row unless
+  // they stop the daemon, and confirm proceeds normally.
+  it("renders the self-heal banner in light mode for an online local runtime", () => {
+    renderDialog({
+      runtime: makeRuntime({ runtime_mode: "local", status: "online" }),
+      cachedAgents: [],
+    });
+    expect(
+      screen.getByText(/managed by a running local daemon/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the self-heal banner in cascade mode for an online local runtime with bound agents", () => {
+    renderDialog({
+      runtime: makeRuntime({ runtime_mode: "local", status: "online" }),
+      cachedAgents: [makeAgent("a-1", { name: "Alpha" })],
+    });
+    // Both the destructive cascade banner AND the self-heal banner render —
+    // self-heal sits above the destructive one so the user sees the
+    // daemon-will-respawn warning before scanning the agent table.
+    expect(
+      screen.getByText(/managed by a running local daemon/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Archive 1 agent and delete this Runtime/),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render the self-heal banner for offline local or cloud runtimes", () => {
+    // Offline local: no live daemon, so the warning would be misleading.
+    const { unmount } = renderDialog({
+      runtime: makeRuntime({ runtime_mode: "local", status: "offline" }),
+      cachedAgents: [],
+    });
+    expect(
+      screen.queryByText(/managed by a running local daemon/i),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    // Cloud: managed by Fleet, not a self-restarting local daemon.
+    renderDialog({
+      runtime: makeRuntime({ runtime_mode: "cloud", status: "online" }),
+      cachedAgents: [],
+    });
+    expect(
+      screen.queryByText(/managed by a running local daemon/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("allows confirm to proceed on a self-healing runtime instead of toasting an error", async () => {
+    // The old defensive `handleConfirm` returned early with a toast for
+    // self-healing runtimes; this regression pin makes sure the click
+    // actually lands on the delete API now.
+    apiDeleteRuntime.mockResolvedValueOnce({ status: "ok" });
+
+    const onDeleted = vi.fn();
+    renderDialog({
+      runtime: makeRuntime({ runtime_mode: "local", status: "online" }),
+      cachedAgents: [],
+      onDeleted,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete runtime" }));
+    await waitFor(() =>
+      expect(apiDeleteRuntime).toHaveBeenCalledWith("rt-1"),
+    );
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
 });

--- a/packages/views/runtimes/components/delete-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/delete-runtime-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Globe, Lock } from "lucide-react";
+import { AlertTriangle, Globe, Info, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
 import { ApiError } from "@multica/core/api";
@@ -48,10 +48,11 @@ import { isSelfHealingRuntime } from "../utils";
 //      server snapshot and force the user to re-confirm the checkbox.
 //
 // Self-healing local runtimes (online local daemons that re-register
-// themselves seconds after deletion — see isSelfHealingRuntime) are
-// gated at the affordance level by the row-menu and Diagnostics card,
-// so this dialog never opens for them. We re-check at confirm time as
-// defence in depth in case the runtime flips while the dialog is open.
+// themselves seconds after deletion — see isSelfHealingRuntime) are NOT
+// blocked at this layer (MUL-3352). The trigger affordances let the
+// owner click through, and this dialog raises a self_heal warning banner
+// so the user knows the daemon will re-register a fresh runtime row
+// unless they stop the daemon process first. Confirm proceeds.
 export interface DeleteRuntimeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -116,16 +117,6 @@ export function DeleteRuntimeDialog({
   const cascadeMutation = useArchiveAgentsAndDeleteRuntime(wsId);
 
   const handleConfirm = async () => {
-    // Defensive re-check of the self-healing rule — the affordance is
-    // gated upstream, but a local daemon that came online while the
-    // dialog was open should still block the action.
-    if (isSelfHealingRuntime(runtime)) {
-      toast.error(
-        t(($) => $.detail.delete_dialog.cascade.self_healing_blocked_toast),
-      );
-      return;
-    }
-
     setSubmitting(true);
     setPlanChangedNotice(null);
 
@@ -236,6 +227,29 @@ export function DeleteRuntimeDialog({
 }
 
 // ---------------------------------------------------------------------------
+// Self-heal notice — informational banner shown when the runtime is a live
+// local daemon that re-registers itself within seconds of a server-side
+// delete. Replaces the old "block the affordance and toast on attempt"
+// dance (MUL-3352): the owner now sees the warning *before* confirming
+// rather than discovering it only after they've been told they cannot
+// proceed.
+// ---------------------------------------------------------------------------
+
+function SelfHealNotice({ runtime }: { runtime: AgentRuntime }) {
+  const { t } = useT("runtimes");
+  if (!isSelfHealingRuntime(runtime)) return null;
+  return (
+    <div
+      role="status"
+      className="mt-3 flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-xs"
+    >
+      <Info className="mt-0.5 size-3.5 shrink-0 text-warning" />
+      <span>{t(($) => $.detail.delete_dialog.self_heal_notice)}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Light mode — no active agents, classic "are you sure" prompt. Title and
 // description match the legacy AlertDialog so existing screenshots / muscle
 // memory still apply.
@@ -264,6 +278,7 @@ function LightBody({
             name: runtime.name,
           })}
         </p>
+        <SelfHealNotice runtime={runtime} />
       </div>
       <div className="border-t bg-muted/25 px-5 py-3">
         <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
@@ -338,6 +353,8 @@ function CascadeBody({
             name: runtime.name,
           })}
         </p>
+
+        <SelfHealNotice runtime={runtime} />
 
         {/* Destructive banner — keep the user's eye on the irreversible
             half before they scan the agent table. */}

--- a/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
@@ -165,4 +165,35 @@ describe("RuntimeDetail visibility section", () => {
     // The editor's "Private" choice button must not render in read-only mode.
     expect(screen.queryByText("Private")).not.toBeInTheDocument();
   });
+
+  // MUL-3352: an owner viewing an online local (self-healing) runtime
+  // used to see a disabled Delete button with only a hover tooltip
+  // explaining why. The new contract: the button is always clickable
+  // for owner/admin; the dialog now carries the self-heal warning.
+  it("renders an enabled Delete runtime button for an owner on a self-healing local runtime", () => {
+    renderDetail(
+      makeRuntime({
+        owner_id: "user-me",
+        runtime_mode: "local",
+        status: "online",
+      }),
+    );
+    const btn = screen.getByRole("button", {
+      name: /Delete runtime/i,
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("hides the Delete runtime button entirely for callers who cannot edit", () => {
+    renderDetail(
+      makeRuntime({
+        owner_id: "someone-else",
+        runtime_mode: "local",
+        status: "online",
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Delete runtime/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -31,7 +31,7 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { BreadcrumbHeader } from "../../layout/breadcrumb-header";
 import { AppLink, useNavigation } from "../../navigation";
 import { availabilityConfig, workloadConfig } from "../../agents/presence";
-import { formatLastSeen, isSelfHealingRuntime } from "../utils";
+import { formatLastSeen } from "../utils";
 import { HealthBadge } from "./shared";
 import { ProviderLogo } from "./provider-logo";
 import { UpdateSection } from "./update-section";
@@ -450,7 +450,6 @@ function DiagnosticsCard({
 }) {
   const { t } = useT("runtimes");
   const isLocal = runtime.runtime_mode === "local";
-  const selfHealing = isSelfHealingRuntime(runtime);
   // canDelete here doubles as the "can edit runtime" predicate — it already
   // means "workspace owner/admin OR runtime owner", which is the same gate
   // the server enforces for the visibility PATCH.
@@ -484,42 +483,22 @@ function DiagnosticsCard({
           </div>
         )}
         {canDelete && (
+          // The button stays clickable even when the runtime is a live
+          // local daemon (self-healing). The owner explicitly asked for
+          // it (MUL-3352) — disabling here left them looking at a button
+          // they had every permission to click but couldn't. The dialog
+          // raises a self-heal banner so the user sees the trade-off
+          // before confirming.
           <div className="border-t pt-3">
-            {selfHealing ? (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    // Wrapping span keeps the trigger hoverable — a disabled
-                    // <button> swallows pointer events, so the tooltip would
-                    // never open if it were the trigger itself.
-                    <span className="block w-full">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled
-                        className="h-8 w-full justify-start gap-2 text-destructive"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                        {t(($) => $.detail.delete_button)}
-                      </Button>
-                    </span>
-                  }
-                />
-                <TooltipContent>
-                  {t(($) => $.detail.delete_disabled_tooltip)}
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 w-full justify-start gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                onClick={onDelete}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                {t(($) => $.detail.delete_button)}
-              </Button>
-            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-full justify-start gap-2 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={onDelete}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {t(($) => $.detail.delete_button)}
+            </Button>
           </div>
         )}
       </div>

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -49,7 +49,6 @@ import { DeleteRuntimeDialog } from "./delete-runtime-dialog";
 import {
   computeCostInWindow,
   formatLastSeen,
-  isSelfHealingRuntime,
   pctChange,
 } from "../utils";
 import { splitRuntimeName } from "./runtime-machines";
@@ -82,10 +81,10 @@ const COLUMN_WIDTHS = {
 // gaps).
 const FIXED_TRACKS_WIDTH = 164 + 8 * 12;
 
-// The kebab track is conditional like the owner column: on a healthy
-// local machine EVERY row's only action (delete) is hidden by the
-// self-healing rule, and an unconditionally reserved 28px action track
-// would hang a permanent dead zone off the last column.
+// The kebab track is conditional like the owner column: on a list where
+// no row carries a delete-permission, EVERY row's only action is hidden,
+// and an unconditionally reserved 28px action track would hang a
+// permanent dead zone off the last column.
 function columnTrackVars(
   showOwner: boolean,
   showActions: boolean,
@@ -401,12 +400,14 @@ export function RuntimeRowMenu({
   const { t } = useT("runtimes");
   const [deleteOpen, setDeleteOpen] = useState(false);
   // Delete is currently the only row action; if the row can't run it, drop
-  // the kebab entirely so the column doesn't render an empty popover. The
-  // self-healing case (local + online) is the runtime-detail parity fix —
-  // see isSelfHealingRuntime for the rationale.
-  const selfHealing = isSelfHealingRuntime(runtime);
+  // the kebab entirely so the column doesn't render an empty popover. We
+  // used to also hide it for self-healing runtimes (live local daemon
+  // re-registers within seconds), but MUL-3352 surfaced that owners read
+  // a missing kebab as "I lost my permission" rather than "the daemon
+  // would undo this". The dialog now carries the self-heal warning and
+  // the user gets to decide.
 
-  if (!canDelete || selfHealing) {
+  if (!canDelete) {
     return <span aria-hidden />;
   }
 
@@ -521,9 +522,7 @@ export function RuntimeList({
 
   // Mirrors RuntimeRowMenu's render guard: the kebab track only earns its
   // width when at least one row will actually show the menu.
-  const showActions = rows.some(
-    (row) => row.canDelete && !isSelfHealingRuntime(row.runtime),
-  );
+  const showActions = rows.some((row) => row.canDelete);
 
   return (
     <div className="overflow-x-auto overflow-y-hidden @container">

--- a/packages/views/runtimes/components/runtime-row-menu.test.tsx
+++ b/packages/views/runtimes/components/runtime-row-menu.test.tsx
@@ -129,13 +129,14 @@ function renderActionsCell(row: RuntimeRow) {
 describe("runtime list row menu", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("hides the kebab menu for an online local runtime (self-healing)", () => {
-    // Deleting an online local runtime is a no-op (daemon re-registers in
-    // seconds), so the row menu drops the only action — Delete — entirely.
+  it("renders the kebab menu for an online local runtime (self-healing is no longer hidden)", () => {
+    // MUL-3352: hiding the kebab on a self-healing row left owners reading
+    // it as a missing permission. The action stays available; the dialog
+    // surfaces the self-heal warning instead.
     renderActionsCell(
       makeRow(makeRuntime({ runtime_mode: "local", status: "online" })),
     );
-    expect(screen.queryByLabelText("Row actions")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Row actions")).toBeInTheDocument();
   });
 
   it("renders the kebab menu for an offline local runtime", () => {


### PR DESCRIPTION
## Summary

Closes MUL-3352.

The runtime detail page disabled the **Delete runtime** button — and the runtime-list kebab dropped its only action — whenever the runtime was an online local daemon. The original rationale was reasonable: a live daemon re-registers itself within seconds of a server-side delete, so the click "doesn't stick". But the side effect was that the **runtime Owner** ended up staring at an action they had every permission for, with no obvious reason it was off — exactly the screenshot the issue reporter posted.

This PR rebalances the UX: the affordance stays live for owner / admin, and the dialog raises a self-heal warning before the user confirms.

## Changes

- `runtime-detail.tsx` — drop the disabled-with-tooltip branch on the Diagnostics Delete button. `canDelete` (workspace owner/admin OR runtime owner) now fully governs whether the button is rendered, and it's always clickable when present.
- `runtime-list.tsx` — the row kebab stops hiding itself for self-healing runtimes. `showActions` follows.
- `delete-runtime-dialog.tsx` — remove the defensive self-healing early-return in `handleConfirm` (it returned a toast on the click the user just confirmed). Add a new `SelfHealNotice` banner rendered in both `LightBody` and `CascadeBody` when `isSelfHealingRuntime` is true. The user sees the trade-off **before** pressing the destructive button instead of after.
- locales (`en` / `zh-Hans` / `ja` / `ko`) — drop `detail.delete_disabled_tooltip` and `cascade.self_healing_blocked_toast`; introduce one new `detail.delete_dialog.self_heal_notice` key that powers the banner.
- tests
  - `runtime-row-menu.test.tsx` — flip the assertion for an online local row (kebab is now visible).
  - `delete-runtime-dialog.test.tsx` — banner present in light + cascade for local + online; banner absent for offline-local and cloud; confirm proceeds (calls `apiDeleteRuntime`) instead of toasting.
  - `runtime-detail-visibility.test.tsx` — pin the enabled-Delete case for the runtime owner on a self-healing runtime, and that the button is hidden entirely for callers without delete permission.

## Verification

- `pnpm --filter @multica/views typecheck` — clean.
- `pnpm exec vitest run runtimes/components/runtime-row-menu.test.tsx runtimes/components/delete-runtime-dialog.test.tsx runtimes/components/runtime-detail-visibility.test.tsx runtimes/utils.test.ts` — **73 / 73 passed** across the 4 affected suites (5 + 7 + 8 + 53).
- `pnpm --filter @multica/views lint` — **0 errors**, 17 pre-existing warnings in unrelated files (no warning in any file touched here).

## Notes

- `isSelfHealingRuntime` itself is unchanged; it remains the predicate the new banner uses to decide whether to show.
- Server-side behaviour is unchanged. After a successful delete, the daemon's heartbeat detects `RuntimeGone` and re-registers a fresh runtime row — the banner now states this explicitly so the user can stop the daemon process beforehand if they want a permanent removal.
