### PR TITLE
fix: sort sub-issues by number ASC instead of position

### DIFF
--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -625,7 +625,7 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 const listChildIssues = `-- name: ListChildIssues :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
 WHERE parent_issue_id = $1
-ORDER BY number ASC
+ORDER BY number DESC
 `
 
 func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID) ([]Issue, error) {
@@ -677,7 +677,7 @@ const listChildrenByParents = `-- name: ListChildrenByParents :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id = ANY($2::uuid[])
-ORDER BY parent_issue_id, number ASC
+ORDER BY parent_issue_id, number DESC
 `
 
 type ListChildrenByParentsParams struct {

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -625,7 +625,7 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 const listChildIssues = `-- name: ListChildIssues :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC
+ORDER BY number ASC
 `
 
 func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID) ([]Issue, error) {
@@ -677,7 +677,7 @@ const listChildrenByParents = `-- name: ListChildrenByParents :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id = ANY($2::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC
+ORDER BY parent_issue_id, number ASC
 `
 
 type ListChildrenByParentsParams struct {

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -236,7 +236,7 @@ WHERE i.workspace_id = $1
 -- name: ListChildIssues :many
 SELECT * FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC;
+ORDER BY number ASC;
 
 -- name: ListChildrenByParents :many
 -- Batched variant of ListChildIssues: returns all children for the given
@@ -247,7 +247,7 @@ ORDER BY position ASC, created_at DESC;
 SELECT * FROM issue
 WHERE workspace_id = sqlc.arg('workspace_id')
   AND parent_issue_id = ANY(sqlc.arg('parent_ids')::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC;
+ORDER BY parent_issue_id, number ASC;
 
 -- name: GetIssueByOrigin :one
 -- Finds the issue stamped with a specific (origin_type, origin_id) pair.

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -236,7 +236,7 @@ WHERE i.workspace_id = $1
 -- name: ListChildIssues :many
 SELECT * FROM issue
 WHERE parent_issue_id = $1
-ORDER BY number ASC;
+ORDER BY number DESC;
 
 -- name: ListChildrenByParents :many
 -- Batched variant of ListChildIssues: returns all children for the given
@@ -247,7 +247,7 @@ ORDER BY number ASC;
 SELECT * FROM issue
 WHERE workspace_id = sqlc.arg('workspace_id')
   AND parent_issue_id = ANY(sqlc.arg('parent_ids')::uuid[])
-ORDER BY parent_issue_id, number ASC;
+ORDER BY parent_issue_id, number DESC;
 
 -- name: GetIssueByOrigin :one
 -- Finds the issue stamped with a specific (origin_type, origin_id) pair.


### PR DESCRIPTION
## What does this PR do?

Fixes the sub-issue list display order. Sub-issues rendered in issue detail pages and Swimlane views are currently sorted by `position ASC`, which places newly created sub-issues in an unpredictable order because `position` is computed per-(workspace, status) rather than relative to sibling sub-issues.

This PR changes the `ORDER BY` clause in `ListChildIssues` and `ListChildrenByParents` from `position ASC, created_at DESC` to `number DESC`, so sub-issues display newest-first by their issue number (matching user expectations).

## Related Issue

Closes #4232

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/db/queries/issue.sql:239` — Changed `ListChildIssues` ORDER BY from `position ASC, created_at DESC` to `number DESC`
- `server/pkg/db/queries/issue.sql:250` — Changed `ListChildrenByParents` ORDER BY from `parent_issue_id, position ASC, created_at DESC` to `parent_issue_id, number DESC`
- `server/pkg/db/generated/issue.sql.go` — Regenerated via `sqlc generate` (v1.31.1). Only `issue.sql.go` changed; the diff is identical to the SQL source changes (two ORDER BY lines). All other generated files are unchanged.

## How to Test

1. Create a parent issue
2. Create 6 sub-issues (`POST /api/issues?workspace_id=<id>` with `parent_issue_id`)
3. Create 12 more sub-issues
4. Navigate to the parent issue detail page or `GET /api/issues/<parent_id>/children`
5. Verify sub-issues appear newest-first by `number` (e.g., 18, 17, …, 1) — newest at top

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`server/internal/handler` ✅, `server/cmd/server` ✅)
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

### Risks Considered

- **Main issue list ordering**: Not affected — `ListIssues` and `ListGroupedIssues` use separate SQL queries with their own `ORDER BY position ASC, created_at DESC`, which are unchanged.
- **Kanban drag-reorder**: Not affected — the `position` column is unchanged; sub-issue queries simply stop using it for sorting.
- **NULL safety**: `number` has a `NOT NULL DEFAULT 0` constraint (migration 020), so every row has a valid value.
- **Sub-issues with mixed statuses**: Previously, sub-issues with different statuses had positions computed from different MIN pools, causing interleaved order. The `number`-based sort is deterministic regardless of status.
- **Newest-first semantics**: `number DESC` puts the most recently created sub-issues at the top of the list, matching conventions in similar tools (GitHub issues, Linear, etc.).

## AI Disclosure

**AI tool used:** OpenCode (Claude backend)

**Prompt / approach:**
Root cause was identified by tracing the full code path: `issueposition.NextTopPosition()` computes position across `(workspace_id, status)` scope, not relative to sibling sub-issues. The SQL `ORDER BY position ASC` therefore produces unpredictable ordering. The fix replaces `position ASC` with `number DESC` — a deterministic key that sorts newest-first, matching user expectations. Generated code was produced by running `sqlc generate` (v1.31.1) to ensure correctness.
## What does this PR do?

Fixes the sub-issue list display order. Sub-issues rendered in issue detail pages and Swimlane views are currently sorted by `position ASC`, which places newly created sub-issues in an unpredictable order because `position` is computed per-(workspace, status) rather than relative to sibling sub-issues.

This PR changes the `ORDER BY` clause in `ListChildIssues` and `ListChildrenByParents` from `position ASC, created_at DESC` to `number DESC`, so sub-issues display newest-first by their issue number (matching user expectations).

## Related Issue

Closes #4232

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/db/queries/issue.sql:239` — Changed `ListChildIssues` ORDER BY from `position ASC, created_at DESC` to `number DESC`
- `server/pkg/db/queries/issue.sql:250` — Changed `ListChildrenByParents` ORDER BY from `parent_issue_id, position ASC, created_at DESC` to `parent_issue_id, number DESC`
- `server/pkg/db/generated/issue.sql.go` — Regenerated via `sqlc generate` (v1.31.1). Only `issue.sql.go` changed; the diff is identical to the SQL source changes (two ORDER BY lines). All other generated files are unchanged.

## How to Test

1. Create a parent issue
2. Create 6 sub-issues (`POST /api/issues?workspace_id=<id>` with `parent_issue_id`)
3. Create 12 more sub-issues
4. Navigate to the parent issue detail page or `GET /api/issues/<parent_id>/children`
5. Verify sub-issues appear newest-first by `number` (e.g., 18, 17, …, 1) — newest at top

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`server/internal/handler` ✅, `server/cmd/server` ✅)
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

### Risks Considered

- **Main issue list ordering**: Not affected — `ListIssues` and `ListGroupedIssues` use separate SQL queries with their own `ORDER BY position ASC, created_at DESC`, which are unchanged.
- **Kanban drag-reorder**: Not affected — the `position` column is unchanged; sub-issue queries simply stop using it for sorting.
- **NULL safety**: `number` has a `NOT NULL DEFAULT 0` constraint (migration 020), so every row has a valid value.
- **Sub-issues with mixed statuses**: Previously, sub-issues with different statuses had positions computed from different MIN pools, causing interleaved order. The `number`-based sort is deterministic regardless of status.
- **Newest-first semantics**: `number DESC` puts the most recently created sub-issues at the top of the list, matching conventions in similar tools (GitHub issues, Linear, etc.).

## AI Disclosure

**AI tool used:** OpenCode (Claude backend)

**Prompt / approach:**
Root cause was identified by tracing the full code path: `issueposition.NextTopPosition()` computes position across `(workspace_id, status)` scope, not relative to sibling sub-issues. The SQL `ORDER BY position ASC` therefore produces unpredictable ordering. The fix replaces `position ASC` with `number DESC` — a deterministic key that sorts newest-first, matching user expectations. Generated code was produced by running `sqlc generate` (v1.31.1) to ensure correctness.
## What does this PR do?

Fixes the sub-issue list display order. Sub-issues rendered in issue detail pages and Swimlane views are currently sorted by `position ASC`, which places newly created sub-issues in an unpredictable order because `position` is computed per-(workspace, status) rather than relative to sibling sub-issues.

This PR changes the `ORDER BY` clause in `ListChildIssues` and `ListChildrenByParents` from `position ASC, created_at DESC` to `number DESC`, so sub-issues display newest-first by their issue number (matching user expectations).

## Related Issue

Closes #4232

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/db/queries/issue.sql:239` — Changed `ListChildIssues` ORDER BY from `position ASC, created_at DESC` to `number DESC`
- `server/pkg/db/queries/issue.sql:250` — Changed `ListChildrenByParents` ORDER BY from `parent_issue_id, position ASC, created_at DESC` to `parent_issue_id, number DESC`
- `server/pkg/db/generated/issue.sql.go` — Regenerated via `sqlc generate` (v1.31.1). Only `issue.sql.go` changed; the diff is identical to the SQL source changes (two ORDER BY lines). All other generated files are unchanged.

## How to Test

1. Create a parent issue
2. Create 6 sub-issues (`POST /api/issues?workspace_id=<id>` with `parent_issue_id`)
3. Create 12 more sub-issues
4. Navigate to the parent issue detail page or `GET /api/issues/<parent_id>/children`
5. Verify sub-issues appear newest-first by `number` (e.g., 18, 17, …, 1) — newest at top

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`server/internal/handler` ✅, `server/cmd/server` ✅)
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

### Risks Considered

- **Main issue list ordering**: Not affected — `ListIssues` and `ListGroupedIssues` use separate SQL queries with their own `ORDER BY position ASC, created_at DESC`, which are unchanged.
- **Kanban drag-reorder**: Not affected — the `position` column is unchanged; sub-issue queries simply stop using it for sorting.
- **NULL safety**: `number` has a `NOT NULL DEFAULT 0` constraint (migration 020), so every row has a valid value.
- **Sub-issues with mixed statuses**: Previously, sub-issues with different statuses had positions computed from different MIN pools, causing interleaved order. The `number`-based sort is deterministic regardless of status.
- **Newest-first semantics**: `number DESC` puts the most recently created sub-issues at the top of the list, matching conventions in similar tools (GitHub issues, Linear, etc.).

## AI Disclosure

**AI tool used:** OpenCode (Claude backend)

**Prompt / approach:**
Root cause was identified by tracing the full code path: `issueposition.NextTopPosition()` computes position across `(workspace_id, status)` scope, not relative to sibling sub-issues. The SQL `ORDER BY position ASC` therefore produces unpredictable ordering. The fix replaces `position ASC` with `number DESC` — a deterministic key that sorts newest-first, matching user expectations. Generated code was produced by running `sqlc generate` (v1.31.1) to ensure correctness.


<img width="905" height="315" alt="image" src="https://github.com/user-attachments/assets/3000907c-68ca-4fbf-8e78-63d9639faa2a" />