### PR TITLE
fix(markdown): STR-158 highlight review status badges

### DIFF
--- a/packages/ui/markdown/Markdown.tsx
+++ b/packages/ui/markdown/Markdown.tsx
@@ -13,6 +13,7 @@ import { CodeBlock, InlineCode } from './CodeBlock'
 import { isAllowedFileCardHref, preprocessFileCards } from './file-cards'
 import { preprocessLinks } from './linkify'
 import { preprocessMentionShortcodes } from './mentions'
+import { rehypeReviewStatusBadges } from './status-badges'
 import 'katex/dist/katex.min.css'
 import './markdown.css'
 
@@ -450,7 +451,7 @@ export function Markdown({
           remarkBreaks,
           [remarkGfm, { singleTilde: false }],
         ]}
-        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeReviewStatusBadges, rehypeKatex]}
         urlTransform={urlTransform}
         components={components}
       >

--- a/packages/ui/markdown/index.ts
+++ b/packages/ui/markdown/index.ts
@@ -1,6 +1,7 @@
 export { Markdown, MemoizedMarkdown, type MarkdownProps, type RenderMode } from './Markdown'
 export { CodeBlock, InlineCode, type CodeBlockProps } from './CodeBlock'
 export { StreamingMarkdown, type StreamingMarkdownProps } from './StreamingMarkdown'
+export { rehypeReviewStatusBadges } from './status-badges'
 export { preprocessLinks, detectLinks, hasLinks } from './linkify'
 export { preprocessMentionShortcodes } from './mentions'
 export {

--- a/packages/ui/markdown/markdown.css
+++ b/packages/ui/markdown/markdown.css
@@ -7,3 +7,33 @@
 .markdown-content .katex-display > .katex {
   white-space: nowrap;
 }
+
+.markdown-content .review-status-badge {
+  display: inline-flex;
+  min-height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  margin-inline: 0.125rem;
+  padding: 0 0.45rem;
+  border: 1px solid currentColor;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+  white-space: nowrap;
+}
+
+.markdown-content .review-status-badge-pass {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 13%, transparent);
+  border-color: color-mix(in srgb, var(--success) 38%, transparent);
+}
+
+.markdown-content .review-status-badge-fail {
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 12%, transparent);
+  border-color: color-mix(in srgb, var(--destructive) 40%, transparent);
+}

--- a/packages/ui/markdown/status-badges.ts
+++ b/packages/ui/markdown/status-badges.ts
@@ -1,0 +1,91 @@
+type ReviewStatus = "PASS" | "FAIL"
+
+type HastNode = {
+  type?: string
+  tagName?: string
+  value?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+const REVIEW_STATUS_RE = /\[(PASS|FAIL)\]|\b(PASS|FAIL)\b/g
+const STATUS_BADGE_SKIP_TAGS = new Set([
+  "a",
+  "code",
+  "kbd",
+  "pre",
+  "samp",
+  "script",
+  "style",
+])
+
+export function rehypeReviewStatusBadges() {
+  return function transformReviewStatusTree(tree: HastNode): void {
+    transformReviewStatusBadges(tree)
+  }
+}
+
+function transformReviewStatusBadges(node: HastNode): void {
+  if (node.type === "element" && STATUS_BADGE_SKIP_TAGS.has(node.tagName ?? "")) {
+    return
+  }
+
+  if (!Array.isArray(node.children)) return
+
+  const nextChildren: HastNode[] = []
+
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      const split = splitReviewStatusText(child.value)
+      nextChildren.push(...(split ?? [child]))
+      continue
+    }
+
+    transformReviewStatusBadges(child)
+    nextChildren.push(child)
+  }
+
+  node.children = nextChildren
+}
+
+function splitReviewStatusText(value: string): HastNode[] | null {
+  REVIEW_STATUS_RE.lastIndex = 0
+
+  const nodes: HastNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = REVIEW_STATUS_RE.exec(value)) !== null) {
+    const status = (match[1] ?? match[2]) as ReviewStatus | undefined
+    if (!status) continue
+
+    if (match.index > lastIndex) {
+      nodes.push({ type: "text", value: value.slice(lastIndex, match.index) })
+    }
+
+    nodes.push(createReviewStatusBadge(status))
+    lastIndex = match.index + match[0].length
+  }
+
+  if (nodes.length === 0) return null
+
+  if (lastIndex < value.length) {
+    nodes.push({ type: "text", value: value.slice(lastIndex) })
+  }
+
+  return nodes
+}
+
+function createReviewStatusBadge(status: ReviewStatus): HastNode {
+  return {
+    type: "element",
+    tagName: "span",
+    properties: {
+      className: [
+        "review-status-badge",
+        `review-status-badge-${status.toLowerCase()}`,
+      ],
+    },
+    children: [{ type: "text", value: status }],
+  }
+}

--- a/packages/views/common/markdown.test.tsx
+++ b/packages/views/common/markdown.test.tsx
@@ -89,4 +89,15 @@ describe("Markdown", () => {
     expect(screen.getByTestId("project-chip")).toHaveTextContent("project-123");
     expect(screen.getByRole("link")).toHaveAttribute("href", "/projects/project-123");
   });
+
+  it("renders standalone review status words as badges", () => {
+    const { container } = render(
+      <Markdown>{"Preview QA: PASS\n\nPR checks: FAIL"}</Markdown>,
+    );
+
+    const badges = Array.from(container.querySelectorAll(".review-status-badge"));
+    expect(badges.map((badge) => badge.textContent)).toEqual(["PASS", "FAIL"]);
+    expect(badges[0]).toHaveClass("review-status-badge-pass");
+    expect(badges[1]).toHaveClass("review-status-badge-fail");
+  });
 });

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -242,6 +242,75 @@ describe("ReadonlyContent issue mention Markdown", () => {
   });
 });
 
+describe("ReadonlyContent review status badges", () => {
+  it("renders bracketed PASS and FAIL review markers as badges", () => {
+    const { container } = render(
+      <ReadonlyContent
+        content={[
+          "## **결론**",
+          "[FAIL] 코드/preview 동작은 확인됐지만, PR이 아직 merge-ready 상태가 아닙니다.",
+          "",
+          "## **Findings**",
+          "[PASS] 수정 필요 finding 없음",
+        ].join("\n")}
+      />,
+    );
+
+    const badges = Array.from(container.querySelectorAll(".review-status-badge"));
+    expect(badges.map((badge) => badge.textContent)).toEqual(["FAIL", "PASS"]);
+    expect(badges[0]).toHaveClass("review-status-badge-fail");
+    expect(badges[1]).toHaveClass("review-status-badge-pass");
+    expect(container.textContent).not.toContain("[FAIL]");
+    expect(container.textContent).not.toContain("[PASS]");
+  });
+
+  it("renders standalone PASS and FAIL summary/table values as badges", () => {
+    const { container } = render(
+      <ReadonlyContent
+        content={[
+          "Preview QA: PASS",
+          "Scope / Unrelated Changes: PASS",
+          "PR checks: FAIL (`Require Assignee`)",
+          "",
+          "| Check | Status |",
+          "| --- | --- |",
+          "| Preview | PASS |",
+          "| Checks | FAIL |",
+        ].join("\n")}
+      />,
+    );
+
+    const badges = Array.from(container.querySelectorAll(".review-status-badge"));
+    expect(badges.map((badge) => badge.textContent)).toEqual([
+      "PASS",
+      "PASS",
+      "FAIL",
+      "PASS",
+      "FAIL",
+    ]);
+  });
+
+  it("does not convert status words inside links or code", () => {
+    const { container, getByRole } = render(
+      <ReadonlyContent
+        content={[
+          "`PASS`",
+          "[PASS](https://example.com)",
+          "",
+          "```",
+          "FAIL",
+          "```",
+        ].join("\n")}
+      />,
+    );
+
+    expect(container.querySelector(".review-status-badge")).toBeNull();
+    expect(getByRole("link")).toHaveTextContent("PASS");
+    expect(container.querySelector("code")?.textContent).toBe("PASS");
+    expect(container.querySelector("pre code")?.textContent?.trim()).toBe("FAIL");
+  });
+});
+
 describe("ReadonlyContent code styling", () => {
   const literalCode = "uv run --extra dev pytest -q";
 

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -37,7 +37,7 @@ import { IssueMentionCard } from "../issues/components/issue-mention-card";
 import { ProjectChip } from "../projects/components/project-chip";
 import { useLinkHover, LinkHoverCard } from "./link-hover-card";
 import { openLink, isMentionHref } from "./utils/link-handler";
-import { isAllowedFileCardHref } from "@multica/ui/markdown";
+import { isAllowedFileCardHref, rehypeReviewStatusBadges } from "@multica/ui/markdown";
 import { preprocessMarkdown } from "./utils/preprocess";
 import { highlightToHtml } from "./utils/highlight-markdown";
 import { MermaidDiagram } from "./mermaid-diagram";
@@ -380,7 +380,7 @@ export const ReadonlyContent = memo(function ReadonlyContent({
             remarkBreaks,
             [remarkGfm, { singleTilde: false }],
           ]}
-          rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
+          rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeReviewStatusBadges, rehypeKatex]}
           urlTransform={urlTransform}
           components={components}
         >

--- a/packages/views/editor/styles/prose.css
+++ b/packages/views/editor/styles/prose.css
@@ -373,6 +373,37 @@
   margin: 0 0.125rem;
 }
 
+/* Review report status badges - generated from standalone PASS / FAIL tokens. */
+.rich-text-editor .review-status-badge {
+  display: inline-flex;
+  min-height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  margin-inline: 0.125rem;
+  padding: 0 0.45rem;
+  border: 1px solid currentColor;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+  white-space: nowrap;
+}
+
+.rich-text-editor .review-status-badge-pass {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 13%, transparent);
+  border-color: color-mix(in srgb, var(--success) 38%, transparent);
+}
+
+.rich-text-editor .review-status-badge-fail {
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 12%, transparent);
+  border-color: color-mix(in srgb, var(--destructive) 40%, transparent);
+}
+
 /* Strong / emphasis */
 .rich-text-editor strong {
   font-weight: 600;


### PR DESCRIPTION
## Summary

- Render standalone `PASS` / `FAIL` and bracketed `[PASS]` / `[FAIL]` review markers as semantic status badges in Markdown output.
- Apply the transform to both the shared Markdown renderer and readonly issue comment content.
- Add focused coverage for bracketed markers, summary/table statuses, and skipped code/link content.

## Preview QA

Preview URL: pending. Vercel has not created a usable preview deployment for this fork PR yet because an IndexLabs team member must authorize the deployment.

Once the preview is available, verify these cases from STR-158 instead of only checking one happy path:

| Case | What to verify | Expected result |
| --- | --- | --- |
| Review conclusion marker | `## **결론**` followed by `[FAIL] 코드/preview 동작은...` | `FAIL` renders as a destructive status badge and the surrounding Korean text remains readable. |
| Top-level summary lines | `Preview QA: PASS`, `Scope / Unrelated Changes: PASS`, `PR checks: FAIL (...)` | Each standalone `PASS` / `FAIL` renders as the matching badge inline without changing the label text. |
| Findings section | `## **Findings**` followed by `[PASS] 수정 필요 finding 없음` | `PASS` renders as a success badge. |
| Scope section | `## **Scope / Unrelated Changes**` followed by `[PASS] unrelated 변경 없음` | `PASS` renders as a success badge. |
| Preview QA section | `## **Preview QA**` followed by `[PASS] 로그인 및 핵심 화면 진입 성공` | `PASS` renders as a success badge in section body text. |
| Verification table | Markdown table cells containing `PASS` and `FAIL` | Status cells render badges while the table layout stays stable. |
| Code/link exclusions | Inline code, fenced code blocks, and links containing `PASS` / `FAIL` | Status words remain plain text in code and links; no badge is injected there. |
| Shared Markdown renderer | The same sample in a non-editor Markdown surface | Badges render consistently outside readonly issue/comment content. |

<details>
<summary>Preview screenshots</summary>

No preview screenshots are attached yet because the preview deployment is blocked by Vercel authorization for the fork PR.

When the preview URL becomes available, attach screenshots here for:

- Review conclusion + summary status badges.
- Findings / Scope / Preview QA section badges.
- Verification table badges.
- Code/link exclusion sample if a preview test fixture exposes it.

</details>

## Validation

- `pnpm --filter @multica/views exec vitest run editor/readonly-content.test.tsx common/markdown.test.tsx`
- `pnpm --filter @multica/ui typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/ui lint`
- `pnpm --filter @multica/views lint`
- `make check`
- GitHub CI: frontend, backend, installer (ubuntu), installer (macos) all passed.
