### PR TITLE
MUL-3365: keep runtime provider arbiter during profile rollout

### DIFF
--- a/server/internal/migrations/runtime_profile_compat_test.go
+++ b/server/internal/migrations/runtime_profile_compat_test.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeProfileProviderMigrationKeepsLegacyConflictArbiter(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	dir := filepath.Join(filepath.Dir(file), "..", "..", "migrations")
+
+	body, err := os.ReadFile(filepath.Join(dir, "121_agent_runtime_provider_partial_unique.up.sql"))
+	if err != nil {
+		t.Fatalf("read migration 121 up: %v", err)
+	}
+	sql := strings.ToLower(string(body))
+	normalized := strings.Join(strings.Fields(sql), " ")
+
+	if strings.Contains(normalized, "drop constraint agent_runtime_workspace_id_daemon_id_provider_key") {
+		t.Fatalf("migration 121 must not drop the legacy provider unique constraint; old runtime registration SQL still needs it during rolling deploys and rollbacks")
+	}
+	if !strings.Contains(normalized, "create unique index if not exists agent_runtime_workspace_daemon_provider_key") {
+		t.Fatalf("migration 121 should still prepare the built-in runtime partial unique index for profile-aware registration")
+	}
+	if !strings.Contains(normalized, "where profile_id is null") {
+		t.Fatalf("migration 121 provider index must be scoped to built-in runtime rows")
+	}
+}

--- a/server/migrations/121_agent_runtime_provider_partial_unique.down.sql
+++ b/server/migrations/121_agent_runtime_provider_partial_unique.down.sql
@@ -1,15 +1,8 @@
 -- Reverse 121_agent_runtime_provider_partial_unique.up.sql.
 --
--- Restoring the non-partial constraint requires that no two rows share
--- (workspace_id, daemon_id, provider). Custom-runtime rows (profile_id IS NOT
--- NULL) can violate that if a built-in and a custom runtime of the same
--- provider coexist on one daemon, so a clean downgrade assumes such rows have
--- been removed first (PR2's feature being rolled back). The DROP INDEX is
--- unconditional; the ADD CONSTRAINT will fail loudly if duplicates remain,
--- which is the correct, non-silent behavior for a rollback.
+-- The up migration is additive and deliberately keeps the legacy
+-- agent_runtime_workspace_id_daemon_id_provider_key constraint for rolling
+-- deploy/rollback compatibility. Rolling this migration back only removes the
+-- prepared partial index.
 
 DROP INDEX IF EXISTS agent_runtime_workspace_daemon_provider_key;
-
-ALTER TABLE agent_runtime
-    ADD CONSTRAINT agent_runtime_workspace_id_daemon_id_provider_key
-        UNIQUE (workspace_id, daemon_id, provider);

--- a/server/migrations/121_agent_runtime_provider_partial_unique.up.sql
+++ b/server/migrations/121_agent_runtime_provider_partial_unique.up.sql
@@ -1,28 +1,26 @@
--- Custom Runtime, PR2 (registration extension). See MUL-3284 / GitHub #3667.
+-- Custom Runtime, PR2 compatibility stage. See MUL-3284 / GitHub #3667.
 --
--- PR1 (migration 120) added agent_runtime.profile_id and a partial unique index
--- for custom-runtime instances, but deliberately left the legacy
--- UNIQUE (workspace_id, daemon_id, provider) constraint intact so the existing
--- registration upsert kept working. That non-partial constraint blocks a
--- built-in runtime (profile_id IS NULL) and a custom runtime of the SAME
--- protocol family (provider) from coexisting on one daemon.
+-- Migration 120 added agent_runtime.profile_id and the custom-runtime partial
+-- unique index on (workspace_id, daemon_id, profile_id) WHERE profile_id IS NOT
+-- NULL, while deliberately retaining the legacy UNIQUE (workspace_id, daemon_id,
+-- provider) constraint. Old server builds still use:
 --
--- PR2 makes registration profile-aware, so we now convert that legacy key into
--- a PARTIAL unique index scoped to built-in rows only (profile_id IS NULL).
--- Combined with 120's partial index on (workspace_id, daemon_id, profile_id)
--- WHERE profile_id IS NOT NULL, this lets a single daemon host the built-in
--- codex AND any number of custom codex-based profiles without collision, while
--- still enforcing one built-in runtime per (workspace, daemon, provider).
+--   ON CONFLICT (workspace_id, daemon_id, provider)
 --
--- The matching upserts now spell out the predicate in their ON CONFLICT
--- arbiter (see pkg/db/queries/runtime.sql): built-in registration targets
--- (workspace_id, daemon_id, provider) WHERE profile_id IS NULL; custom
--- registration targets (workspace_id, daemon_id, profile_id) WHERE
--- profile_id IS NOT NULL.
+-- That statement requires a non-partial unique/exclusion arbiter on exactly
+-- those columns at plan time. Dropping the legacy constraint in the same
+-- release as profile-aware registration would break rolling deploys and
+-- rollbacks: any old API pod that registers a daemon runtime after this
+-- migration lands would fail before it can execute the DO UPDATE path.
+--
+-- This migration is therefore intentionally additive. It prepares the built-in
+-- runtime partial unique index used by the new profile-aware upsert, but keeps
+-- the legacy full constraint in place for old binaries. The full constraint
+-- still prevents built-in and custom runtimes of the same provider from
+-- coexisting on one daemon during this compatibility stage; a later, separately
+-- released migration may drop agent_runtime_workspace_id_daemon_id_provider_key
+-- after every running server build has stopped using the old conflict target.
 
-ALTER TABLE agent_runtime
-    DROP CONSTRAINT agent_runtime_workspace_id_daemon_id_provider_key;
-
-CREATE UNIQUE INDEX agent_runtime_workspace_daemon_provider_key
+CREATE UNIQUE INDEX IF NOT EXISTS agent_runtime_workspace_daemon_provider_key
     ON agent_runtime (workspace_id, daemon_id, provider)
     WHERE profile_id IS NULL;

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -964,10 +964,10 @@ type UpsertAgentRuntimeRow struct {
 // (xmax = 0) AS inserted distinguishes a fresh insert (true) from an upsert
 // that updated an existing row (false). Analytics reads this to fire
 // runtime_registered/runtime_ready only on first-time registration.
-// Built-in runtimes carry no profile_id. The arbiter is the partial unique
-// index from migration 121 (WHERE profile_id IS NULL); the predicate must be
-// spelled out so Postgres selects that partial index, not the custom-runtime
-// one on (workspace_id, daemon_id, profile_id).
+// Built-in runtimes carry no profile_id. The predicate matches migration 121's
+// prepared partial unique index; migration 121 also keeps the legacy full
+// UNIQUE (workspace_id, daemon_id, provider) constraint so older server builds
+// can keep registering runtimes during rolling deploys and rollbacks.
 func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntimeParams) (UpsertAgentRuntimeRow, error) {
 	row := q.db.QueryRow(ctx, upsertAgentRuntime,
 		arg.WorkspaceID,

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -45,10 +45,10 @@ INSERT INTO agent_runtime (
     owner_id,
     last_seen_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
--- Built-in runtimes carry no profile_id. The arbiter is the partial unique
--- index from migration 121 (WHERE profile_id IS NULL); the predicate must be
--- spelled out so Postgres selects that partial index, not the custom-runtime
--- one on (workspace_id, daemon_id, profile_id).
+-- Built-in runtimes carry no profile_id. The predicate matches migration 121's
+-- prepared partial unique index; migration 121 also keeps the legacy full
+-- UNIQUE (workspace_id, daemon_id, provider) constraint so older server builds
+-- can keep registering runtimes during rolling deploys and rollbacks.
 ON CONFLICT (workspace_id, daemon_id, provider) WHERE profile_id IS NULL
 DO UPDATE SET
     name = EXCLUDED.name,


### PR DESCRIPTION
## Summary

- Keeps migration 121 additive by retaining the legacy `UNIQUE (workspace_id, daemon_id, provider)` constraint that old runtime registration SQL needs during rolling deploys and rollback.
- Still prepares the built-in-runtime partial unique index for the new profile-aware upsert path.
- Updates comments and adds a regression test that blocks reintroducing the unsafe constraint drop.

Closes MUL-3365

## Notes

This is a compatibility-stage migration. While the legacy full constraint remains, built-in and custom runtimes with the same provider still cannot coexist on one daemon. Dropping `agent_runtime_workspace_id_daemon_id_provider_key` should be a later migration after all running server builds have stopped using the old conflict target.

## Tests

- `go test ./internal/migrations`
- `go test ./pkg/db/...`
- `go test ./pkg/agent`

The focused handler test command was also attempted, but the local database is not migrated to include `agent_runtime.profile_id` / `runtime_profile`, so those tests failed on local schema drift before exercising this patch.
