### PR TITLE
MUL-3366: remove pending check suite DB cascade

### DIFF
--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -200,6 +200,15 @@ VALUES ($1, $2, 'owner')
 `, wsID, testUserID); err != nil {
 		t.Fatalf("create owner member: %v", err)
 	}
+	if _, err := testPool.Exec(ctx, `
+INSERT INTO github_pending_check_suite (
+	workspace_id, installation_id, repo_owner, repo_name, pr_number,
+	suite_id, head_sha, app_id, status, suite_updated_at
+)
+VALUES ($1, 123456789, 'multica-ai', 'multica', 3366, 987654321, 'abc123', 15368, 'completed', now())
+`, wsID); err != nil {
+		t.Fatalf("create pending check suite: %v", err)
+	}
 
 	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
@@ -216,6 +225,14 @@ VALUES ($1, $2, 'owner')
 	}
 	if exists {
 		t.Fatal("workspace still exists after owner DELETE")
+	}
+
+	var pendingCount int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM github_pending_check_suite WHERE workspace_id = $1`, wsID).Scan(&pendingCount); err != nil {
+		t.Fatalf("verify pending check suites: %v", err)
+	}
+	if pendingCount != 0 {
+		t.Fatalf("pending check suites were not cleaned up for deleted workspace: %d", pendingCount)
 	}
 }
 

--- a/server/migrations/096_pending_check_suite.up.sql
+++ b/server/migrations/096_pending_check_suite.up.sql
@@ -9,7 +9,7 @@
 -- repeated deliveries of the same suite while the PR is still missing are
 -- idempotent — the newer payload simply overwrites the older.
 CREATE TABLE github_pending_check_suite (
-    workspace_id     UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    workspace_id     UUID NOT NULL,
     installation_id  BIGINT NOT NULL,
     repo_owner       TEXT NOT NULL,
     repo_name        TEXT NOT NULL,

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -52,6 +52,9 @@ func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams
 }
 
 const deleteWorkspace = `-- name: DeleteWorkspace :exec
+WITH deleted_pending_check_suites AS (
+    DELETE FROM github_pending_check_suite WHERE workspace_id = $1
+)
 DELETE FROM workspace WHERE id = $1
 `
 

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -39,4 +39,7 @@ WHERE id = $1
 RETURNING issue_counter;
 
 -- name: DeleteWorkspace :exec
+WITH deleted_pending_check_suites AS (
+    DELETE FROM github_pending_check_suite WHERE workspace_id = $1
+)
 DELETE FROM workspace WHERE id = $1;


### PR DESCRIPTION
Summary:
- Removed the database-level workspace FK/cascade from github_pending_check_suite.
- Made DeleteWorkspace explicitly delete pending check suite rows before deleting the workspace.
- Added handler coverage that verifies workspace deletion removes pending check suite rows.

Verification:
- go test ./internal/handler -run TestDeleteWorkspace_OwnerSucceeds -count=1
- make check-worktree

Closes MUL-3366
