### PR TITLE
style(runtimes): unify header action buttons to match Add a computer (MUL-3368)

### DIFF
--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -383,16 +383,24 @@ function PageHeaderBar({
           </span>
         )}
       </div>
+      {/* Quiet chrome buttons (outline, icon-only below md) — primary is
+          reserved for the empty state's CTA. All three share the same
+          dimensions, padding, and responsive icon-only behavior so the
+          header reads as a single, consistent action group. */}
       <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
         {canManageProfiles && (
           <Button
             type="button"
             size="sm"
             variant="outline"
+            className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+            aria-label={t(($) => $.profiles.cta)}
             onClick={onAddRuntime}
           >
             <Plus className="h-3.5 w-3.5" />
-            {t(($) => $.profiles.cta)}
+            <span className="hidden md:inline">
+              {t(($) => $.profiles.cta)}
+            </span>
           </Button>
         )}
         {cloudRuntimeEnabled && (
@@ -400,14 +408,16 @@ function PageHeaderBar({
             type="button"
             size="sm"
             variant="outline"
+            className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+            aria-label={t(($) => $.cloud_runtime.action)}
             onClick={onOpenCloudRuntime}
           >
-            <Cloud className="h-3 w-3" />
-            {t(($) => $.cloud_runtime.action)}
+            <Cloud className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">
+              {t(($) => $.cloud_runtime.action)}
+            </span>
           </Button>
         )}
-        {/* Quiet chrome button (outline, icon-only below md) — primary is
-            reserved for the empty state's CTA. */}
         <Button
           type="button"
           size="sm"


### PR DESCRIPTION
## Background

[MUL-3368](https://multica.dev/issue/MUL-3368) — the runtimes page header has three outline action buttons that previously rendered with subtly inconsistent dimensions, padding, icon sizes, and responsive behavior:

| Button | Old style |
|---|---|
| **Add runtime** | default `size="sm"` (h-7), label always visible, no `aria-label` |
| **Cloud Runtime** | default `size="sm"` (h-7), label always visible, no `aria-label`, Cloud icon `h-3 w-3` (smaller than others) |
| **Add a computer** | `h-8 w-8 ... md:w-auto md:px-2.5` (icon-only below md, expands on md+), with `aria-label`, label wrapped in `hidden md:inline`, Plus icon `h-3.5 w-3.5` |

The user reported that they read as three different styles crammed into one header. Below md they also wrap onto a second line for users with both Cloud Runtime enabled and admin role.

## Core change

Align "Add runtime" and "Cloud Runtime" to the "Add a computer" pattern so all three buttons share:

- the same `h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5` className → identical height (h-8), identical horizontal padding, identical icon-only-on-mobile / icon+label-on-md+ behavior,
- the same icon size (`h-3.5 w-3.5`) — Cloud was `h-3 w-3`,
- an `aria-label` on every button (so the icon-only state below md remains screen-reader accessible),
- the label wrapped in `<span className="hidden md:inline">` so all three collapse together below md.

No behavior or wiring is changed — `onAddRuntime`, `onOpenCloudRuntime`, `onConnectRemote` and their gating (`canManageProfiles`, `cloudRuntimeEnabled`) are untouched. This is a pure visual / a11y consistency pass on the header bar.

## Test focus

- ✅ `pnpm turbo typecheck --filter=@multica/views` — 3/3 packages pass.
- ✅ `pnpm turbo lint test --filter=@multica/views` — 138 test files / 1395 tests pass.
- Manual visual check (recommended for reviewers): on the Runtimes page, confirm with the workspace SaaS build (`cloudRuntimeEnabled=true`) and an owner/admin account that all three buttons share the same height, padding, and icon size; resize below md to confirm all three collapse to icon-only together.
