### PR TITLE
refactor(runtimes): trim redundant copy in custom runtimes dialog (MUL-3367)

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -275,7 +275,7 @@
   "profiles": {
     "cta": "Add runtime",
     "dialog_title": "Custom runtimes",
-    "dialog_description": "Create and manage custom runtime backends based on supported protocol families.",
+    "dialog_description": "Workspace-specific commands built on the supported protocol families below.",
     "close": "Close",
     "add_new": "New custom runtime",
     "list_title": "Runtime backends",
@@ -286,7 +286,7 @@
     "builtin_section_aria": "Supported built-in protocol families",
     "builtin_reference": "Reference",
     "empty_title": "Create your first custom runtime",
-    "empty_description": "Start from a supported protocol family such as Claude or Codex, then point Multica at the command your daemon should run.",
+    "empty_description": "Pick a base protocol family, then point Multica at the command to run.",
     "badge_builtin": "Built-in",
     "badge_custom": "Custom",
     "badge_disabled": "Disabled",
@@ -302,9 +302,8 @@
       "no_description": "No description",
       "edit": "Edit",
       "delete": "Delete",
-      "default_title": "Manage custom runtimes",
-      "default_description": "Custom runtimes let your agents use a workspace-specific command while keeping the same supported protocol family.",
-      "default_builtin_hint": "Need a base protocol? Expand the supported protocols section on the left."
+      "default_title": "Select a runtime",
+      "default_description": "Pick one from the list to see its details."
     },
     "form": {
       "create_title": "New custom runtime",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -263,7 +263,7 @@
   "profiles": {
     "cta": "ランタイムを追加",
     "dialog_title": "カスタムランタイム",
-    "dialog_description": "サポートされているプロトコルファミリーを基に、エージェント用のカスタムランタイムバックエンドを作成・管理します。",
+    "dialog_description": "下記のサポートされているプロトコルファミリー上に作るワークスペース固有のコマンド。",
     "close": "閉じる",
     "add_new": "新しいカスタムランタイム",
     "list_title": "ランタイムバックエンド",
@@ -274,7 +274,7 @@
     "builtin_section_aria": "サポートされている組み込みプロトコルファミリー",
     "builtin_reference": "参考",
     "empty_title": "最初のカスタムランタイムを作成",
-    "empty_description": "Claude や Codex など、サポートされているプロトコルファミリーを選び、この daemon が実行するコマンドを指定します。",
+    "empty_description": "ベースプロトコルファミリーを選び、Multica が実行するコマンドを指定します。",
     "badge_builtin": "組み込み",
     "badge_custom": "カスタム",
     "badge_disabled": "無効",
@@ -290,9 +290,8 @@
       "no_description": "説明なし",
       "edit": "編集",
       "delete": "削除",
-      "default_title": "カスタムランタイムを管理",
-      "default_description": "カスタムランタイムを使うと、サポートされている基本プロトコルを保ちながら、ワークスペース固有のコマンドをエージェントに使用させられます。",
-      "default_builtin_hint": "基本プロトコルが必要な場合は、左側のサポートプロトコルを展開してください。"
+      "default_title": "ランタイムを選択",
+      "default_description": "リストから 1 つ選んで詳細を表示します。"
     },
     "form": {
       "create_title": "新しいカスタムランタイム",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -275,7 +275,7 @@
   "profiles": {
     "cta": "런타임 추가",
     "dialog_title": "사용자 지정 런타임",
-    "dialog_description": "지원되는 프로토콜 제품군을 기반으로 에이전트가 사용할 사용자 지정 런타임 백엔드를 만들고 관리합니다.",
+    "dialog_description": "아래 지원되는 프로토콜 제품군 위에 만드는 워크스페이스별 명령입니다.",
     "close": "닫기",
     "add_new": "새 사용자 지정 런타임",
     "list_title": "런타임 백엔드",
@@ -286,7 +286,7 @@
     "builtin_section_aria": "지원되는 기본 제공 프로토콜 제품군",
     "builtin_reference": "참고",
     "empty_title": "첫 사용자 지정 런타임 만들기",
-    "empty_description": "Claude나 Codex 같은 지원되는 프로토콜 제품군에서 시작한 다음 이 daemon이 실행할 명령을 지정하세요.",
+    "empty_description": "기본 프로토콜 제품군을 선택한 다음 Multica가 실행할 명령을 지정하세요.",
     "badge_builtin": "기본 제공",
     "badge_custom": "사용자 지정",
     "badge_disabled": "비활성화됨",
@@ -302,9 +302,8 @@
       "no_description": "설명 없음",
       "edit": "편집",
       "delete": "삭제",
-      "default_title": "사용자 지정 런타임 관리",
-      "default_description": "사용자 지정 런타임은 지원되는 기본 프로토콜 제품군을 유지하면서 에이전트가 워크스페이스별 명령을 사용하도록 합니다.",
-      "default_builtin_hint": "기본 프로토콜이 필요하면 왼쪽의 지원 프로토콜 섹션을 펼치세요."
+      "default_title": "런타임 선택",
+      "default_description": "목록에서 항목을 선택해 세부 정보를 확인하세요."
     },
     "form": {
       "create_title": "새 사용자 지정 런타임",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -263,7 +263,7 @@
   "profiles": {
     "cta": "添加运行时",
     "dialog_title": "自定义运行时",
-    "dialog_description": "基于支持的协议族，创建和管理智能体可使用的自定义运行时后端。",
+    "dialog_description": "基于下方支持的协议族构建的工作区专属命令。",
     "close": "关闭",
     "add_new": "新建自定义运行时",
     "list_title": "运行时后端",
@@ -274,7 +274,7 @@
     "builtin_section_aria": "支持的内置协议族",
     "builtin_reference": "参考",
     "empty_title": "创建第一个自定义运行时",
-    "empty_description": "从 Claude、Codex 等支持的协议族开始，然后指定这个 Daemon 应该运行的命令。",
+    "empty_description": "选择一个基础协议族，然后指定 Multica 要运行的命令。",
     "badge_builtin": "内置",
     "badge_custom": "自定义",
     "badge_disabled": "已禁用",
@@ -290,9 +290,8 @@
       "no_description": "无描述",
       "edit": "编辑",
       "delete": "删除",
-      "default_title": "管理自定义运行时",
-      "default_description": "自定义运行时让智能体使用工作区指定的命令，同时保持受支持的基础协议族。",
-      "default_builtin_hint": "需要选择基础协议？可以展开左侧的支持协议参考。"
+      "default_title": "选择一个运行时",
+      "default_description": "从左侧列表中选择一项查看详情。"
     },
     "form": {
       "create_title": "新建自定义运行时",

--- a/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
@@ -82,7 +82,7 @@ describe("RuntimeProfilesDialog", () => {
       screen.getByText("Create your first custom runtime"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/such as Claude or Codex/),
+      screen.getByText(/Pick a base protocol family/),
     ).toBeInTheDocument();
 
     const builtinsToggle = screen.getByRole("button", {
@@ -137,7 +137,7 @@ describe("RuntimeProfilesDialog", () => {
 
     fireEvent.click(builtinsToggle);
 
-    expect(screen.getByText("Manage custom runtimes")).toBeInTheDocument();
+    expect(screen.getByText("Select a runtime")).toBeInTheDocument();
     expect(
       screen.queryByText(/claude is a built-in protocol family/),
     ).not.toBeInTheDocument();

--- a/packages/views/runtimes/components/runtime-profiles-dialog.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.tsx
@@ -440,9 +440,6 @@ function DetailPanel({
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
             {t(($) => $.profiles.detail.default_description)}
           </p>
-          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-            {t(($) => $.profiles.detail.default_builtin_hint)}
-          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Background

[MUL-3367](https://multica/issues/MUL-3367): the Custom runtimes dialog had too much text and repeated the same idea three different places.

The screenshot in the issue showed:
- a header tagline ("Create and manage custom runtime backends based on supported protocol families."),
- a left-column empty-state body ("Start from a supported protocol family such as Claude or Codex, then point Multica at the command your daemon should run."),
- and a right-panel default state ("Manage custom runtimes" + a paragraph + "Need a base protocol? Expand the supported protocols section on the left.")

… all of which were saying the same thing in slightly different words.

## Core changes

- **`dialog_description`** — header tagline reduced to a short sentence that lets the protocol-families list below speak for itself.
- **`empty_description`** — drops the "such as Claude or Codex" example (already enumerated in the visible protocols list directly under it) and the "your daemon should run" filler.
- **`detail.default_title` / `default_description`** — replace the "Manage custom runtimes" + restate-the-header paragraph with a quiet "Select a runtime" placeholder + a one-line hint to pick from the list.
- **`detail.default_builtin_hint`** — removed entirely. The supported-protocols section is right there in the left column with its own toggle, and each built-in row carries a `Reference` badge. Pointing at it from the right panel was noise.

Locales updated in lockstep: `en`, `zh-Hans`, `ja`, `ko`. JSX consumer of the dropped key is removed.

## Testing

- `pnpm --filter @multica/views typecheck` → clean.
- `pnpm --filter @multica/views test` → 1395 tests pass (138 files), including the 3 `runtime-profiles-dialog.test.tsx` cases whose copy assertions were updated to match.
- `pnpm --filter @multica/views lint` → 0 errors (only pre-existing warnings in unrelated files).

No behavior change beyond copy: button affordances, empty-state structure, builtins toggle, create/edit/delete flows are all untouched.
