### PR TITLE
fix(runtimes): align header action button heights to h-8 (MUL-3369)

### DIFF
--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -389,6 +389,7 @@ function PageHeaderBar({
             type="button"
             size="sm"
             variant="outline"
+            className="h-8"
             onClick={onAddRuntime}
           >
             <Plus className="h-3.5 w-3.5" />
@@ -400,6 +401,7 @@ function PageHeaderBar({
             type="button"
             size="sm"
             variant="outline"
+            className="h-8"
             onClick={onOpenCloudRuntime}
           >
             <Cloud className="h-3 w-3" />


### PR DESCRIPTION
## Summary

On the Runtimes page header, the newly added **Add runtime** button rendered 4px shorter than the existing **Add a computer** button, making the action buttons look misaligned.

**Root cause:** every list-page header action button in the app (Skills, Agents, Projects, Autopilots, and "Add a computer") uses `size="sm"` with a `className="h-8 ..."` override, so they all render at the canonical **h-8 (32px)**. The "Add runtime" button (added in PR #4177) used `size="sm"` with no `className`, so it inherited the `sm` default height of **h-7 (28px)**. The sibling **Cloud runtime** button had the same defect.

## Changes

- Added `className="h-8"` to the **Add runtime** and **Cloud runtime** buttons so all three Runtimes-header action buttons resolve to the standard `h-8` height (tailwind-merge dedupes `h-7`→`h-8`, the same mechanism "Add a computer" already uses).

## Verification

- Confirmed against `packages/ui/components/ui/button.tsx`: `size="sm"` = `h-7`, and `h-8` in `className` overrides it via tailwind-merge.
- Cross-checked the canonical pattern across Skills / Agents / Projects / Autopilots headers — all use `h-8`.
- On md+ screens all three buttons now match pixel-for-pixel (same height, padding, gap, rounding, text size, variant).

MUL-3369
