### PR TITLE
feat(mobile): native iOS large-title headers for Inbox & My Issues

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Inbox tab stack. Wrapping the inbox screen in a native Stack (instead of
+ * mounting it directly under the JS `<Tabs>`) is what unlocks the iOS
+ * large-title nav bar: `headerLargeTitle` is a UINavigationController
+ * feature exposed only by react-native-screens' native stack — the
+ * react-navigation bottom-tabs header (JS) can't render it.
+ *
+ * The list opts into the "large title collapses to inline on scroll"
+ * behaviour via `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function InboxStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Inbox" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
@@ -6,13 +6,12 @@ import {
   View,
 } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { InboxItem } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Header } from "@/components/ui/header";
 import { IconButton } from "@/components/ui/icon-button";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { SwipeableInboxRow } from "@/components/inbox/swipeable-inbox-row";
@@ -114,18 +113,19 @@ export default function Inbox() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header
-        title="Inbox"
-        right={
-          <>
-            <IconButton
-              name="ellipsis-horizontal"
-              onPress={onPressMenu}
-              accessibilityLabel="Inbox actions"
-            />
-            <HeaderActions />
-          </>
-        }
+      <Stack.Screen
+        options={{
+          headerRight: () => (
+            <View className="flex-row items-center gap-1">
+              <IconButton
+                name="ellipsis-horizontal"
+                onPress={onPressMenu}
+                accessibilityLabel="Inbox actions"
+              />
+              <HeaderActions />
+            </View>
+          ),
+        }}
       />
       {isLoading ? (
         <InboxLoading />
@@ -145,6 +145,7 @@ export default function Inbox() {
         <FlatList
           data={data}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-16" />
           )}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
@@ -1,0 +1,23 @@
+/**
+ * My Issues tab stack. See inbox/_layout.tsx — wrapping the screen in a
+ * native Stack is what unlocks the iOS large-title nav bar (a
+ * react-native-screens / UINavigationController feature the JS `<Tabs>`
+ * header can't provide). The scope toolbar stays pinned below the bar; the
+ * SectionList drives the large-title → inline collapse via
+ * `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function MyIssuesStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "My Issues" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
@@ -17,12 +17,11 @@
 import { useMemo } from "react";
 import { Pressable, SectionList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
-import { Header } from "@/components/ui/header";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { IssueRow } from "@/components/issue/issue-row";
@@ -124,9 +123,12 @@ export default function MyIssues() {
   const showEmptyState =
     !isLoading && !error && filtered.length === 0;
 
-  return (
-    <View className="flex-1 bg-background">
-      <Header title="My Issues" right={<HeaderActions />} />
+  // The scope toolbar + filter chips ride as the SectionList header so the
+  // list sits flush under the nav bar — that's what lets the iOS large title
+  // expand and collapse on scroll. Pinning the toolbar above the list would
+  // pin the title in its collapsed (inline) state.
+  const listHeader = (
+    <>
       <ScopeToolbar
         scopes={SCOPES}
         scope={scope}
@@ -146,30 +148,49 @@ export default function MyIssues() {
           }
         />
       ) : null}
+    </>
+  );
+
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen
+        options={{ headerRight: () => <HeaderActions /> }}
+      />
       {isLoading ? (
-        <IssuesLoading />
+        <>
+          {listHeader}
+          <IssuesLoading />
+        </>
       ) : error ? (
-        <View className="px-4 gap-3 pt-4">
-          <Text className="text-sm text-destructive">
-            Failed to load issues:{" "}
-            {error instanceof Error ? error.message : "unknown error"}
-          </Text>
-          <Button variant="outline" onPress={() => refetch()}>
-            <Text>Retry</Text>
-          </Button>
-        </View>
+        <>
+          {listHeader}
+          <View className="px-4 gap-3 pt-4">
+            <Text className="text-sm text-destructive">
+              Failed to load issues:{" "}
+              {error instanceof Error ? error.message : "unknown error"}
+            </Text>
+            <Button variant="outline" onPress={() => refetch()}>
+              <Text>Retry</Text>
+            </Button>
+          </View>
+        </>
       ) : showEmptyState ? (
-        <EmptyState
-          message={
-            hasActiveFilters
-              ? "No issues match the current filters."
-              : emptyMessageForScope(scope)
-          }
-        />
+        <>
+          {listHeader}
+          <EmptyState
+            message={
+              hasActiveFilters
+                ? "No issues match the current filters."
+                : emptyMessageForScope(scope)
+            }
+          />
+        </>
       ) : (
         <SectionList
           sections={sections}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
+          ListHeaderComponent={listHeader}
           stickySectionHeadersEnabled={false}
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-4" />


### PR DESCRIPTION
## What does this PR do?

Gives the **Inbox** and **My Issues** tab roots the native iOS **large-title navigation bar** (the title that sits big at rest and collapses to an inline title on scroll — Mail/Settings/Files style), replacing the custom flat JS header.

`headerLargeTitle` is a `UINavigationController` feature exposed only by `react-native-screens`' native stack — the `react-navigation` bottom-tabs header (JS) can't render it. So each of these two tab roots becomes a nested native Stack.

## Related Issue

N/A — native-feel polish; no tracking issue.

Closes #

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)

## Changes Made

- `app/(app)/[workspace]/(tabs)/inbox.tsx` → `inbox/_layout.tsx` (native `Stack` with `headerLargeTitle`) + `inbox/index.tsx`
- `app/(app)/[workspace]/(tabs)/my-issues.tsx` → folder split; the scope toolbar now rides as the `SectionList` `ListHeaderComponent` so the list sits flush under the bar and the title collapses on scroll
- Dropped the custom flat `<Header>`; its action buttons moved into the native `headerRight`
- Lists opt in via `contentInsetAdjustmentBehavior="automatic"`

## How to Test

1. Open **Inbox** or **My Issues** on iOS.
2. The screen title renders as a large iOS title and collapses to an inline title as you scroll.
3. Header actions (search / +) sit in the native nav bar.

## Checklist

- [x] If this change affects the UI, I have included before/after screenshots
- [x] `pnpm typecheck` passes; verified manually in the iOS Simulator
- [ ] No automated test — this is native nav-bar rendering, not unit-testable logic

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Researched 2025–2026 React Native native-feel best practices, then converted each list tab root to a nested native Stack to unlock `headerLargeTitle`. Verified before/after in the iOS Simulator (driven via `idb`).

## Screenshots

**My Issues** — before (flat header) / after (large title)
![My Issues before/after](https://raw.githubusercontent.com/voska/multica/pr-assets/fix1-large-title-headers/my-issues-LABELED.png)

**Inbox** — before / after
![Inbox before/after](https://raw.githubusercontent.com/voska/multica/pr-assets/fix1-large-title-headers/inbox-LABELED.png)
