### PR TITLE
feat(mobile): swipe-to-complete + long-press status menu on issue rows

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Header } from "@/components/ui/header";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { StatusIcon } from "@/components/ui/status-icon";
-import { IssueRow } from "@/components/issue/issue-row";
+import { SwipeableIssueRow } from "@/components/issue/swipeable-issue-row";
 import { IssuesLoading } from "@/components/issue/issues-loading";
 import {
   buildMyIssuesFilter,
@@ -183,7 +183,7 @@ export default function MyIssues() {
           )}
           contentContainerClassName="pb-6"
           renderItem={({ item }) => (
-            <IssueRow
+            <SwipeableIssueRow
               issue={item}
               onPress={() => {
                 if (wsSlug) router.push(`/${wsSlug}/issue/${item.id}`);

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
@@ -16,6 +16,7 @@
  */
 import { useMemo } from "react";
 import { Pressable, SectionList, View } from "react-native";
+import SegmentedControl from "@react-native-segmented-control/segmented-control";
 import { useQuery } from "@tanstack/react-query";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -260,29 +261,25 @@ function ScopeToolbar<S extends string>({
   onOpenFilter: () => void;
   hasActiveFilters: boolean;
 }) {
+  const { colorScheme } = useColorScheme();
+  const selectedIndex = Math.max(
+    0,
+    scopes.findIndex((s) => s.value === scope),
+  );
   return (
-    <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
-      <View className="flex-row items-center gap-1 flex-shrink min-w-0">
-        {scopes.map((s) => {
-          const active = scope === s.value;
-          return (
-            <Button
-              key={s.value}
-              variant="outline"
-              size="sm"
-              onPress={() => onChange(s.value)}
-              className={active ? "bg-accent" : ""}
-              accessibilityState={{ selected: active }}
-            >
-              <Text
-                numberOfLines={1}
-                className={active ? "text-accent-foreground" : "text-muted-foreground"}
-              >
-                {s.label}
-              </Text>
-            </Button>
-          );
-        })}
+    <View className="flex-row items-center gap-2 px-4 pt-2 pb-2">
+      <View className="flex-1 min-w-0">
+        {/* Native iOS UISegmentedControl: authentic sliding selection +
+            system selection haptic, instead of the custom pill row. */}
+        <SegmentedControl
+          values={scopes.map((s) => s.label)}
+          selectedIndex={selectedIndex}
+          appearance={colorScheme}
+          onChange={(e) => {
+            const next = scopes[e.nativeEvent.selectedSegmentIndex];
+            if (next) onChange(next.value);
+          }}
+        />
       </View>
       <FilterButton
         onPress={onOpenFilter}

--- a/apps/mobile/components/issue/issue-context-menu.tsx
+++ b/apps/mobile/components/issue/issue-context-menu.tsx
@@ -1,0 +1,48 @@
+/**
+ * Status actions for the native iOS menu (UIMenu via @react-native-menu/menu)
+ * shown when an issue row is long-pressed — see SwipeableIssueRow. Cancelled is
+ * destructive (red).
+ *
+ * Swipe handles the one quick, safe action (Done). This menu is the deliberate
+ * path to *any* status. Options are identical for human- and agent-assigned
+ * issues — the affordance never forks by assignee type.
+ *
+ * Each action carries an SF Symbol (`image`). NOTE: @react-native-menu/menu
+ * does not currently render action images on the New Architecture (Fabric) —
+ * the menu is text-only for now. The symbols are kept so icons appear once the
+ * library closes that gap; the icon-capable alternative
+ * (react-native-ios-context-menu) does not yet compile against RN 0.83.
+ *
+ * NOTE (agent side effect): advancing an agent-assigned issue into an active
+ * state (e.g. backlog → todo) kicks the agent off to start working — real
+ * compute. The exact trigger rule lives in the backend; a future refinement is
+ * to confirm that consequence. Left out for now pending the precise rule.
+ */
+import type { MenuAction } from "@react-native-menu/menu";
+import type { Issue, IssueStatus } from "@multica/core/types";
+import { STATUS_LABEL } from "@/lib/issue-status";
+
+// Workflow order. SF Symbols echo the status semantics.
+const STATUS_MENU: { status: IssueStatus; symbol: string }[] = [
+  { status: "backlog", symbol: "tray" },
+  { status: "todo", symbol: "circle" },
+  { status: "in_progress", symbol: "circle.lefthalf.filled" },
+  { status: "in_review", symbol: "eye" },
+  { status: "blocked", symbol: "exclamationmark.octagon" },
+  { status: "done", symbol: "checkmark.circle.fill" },
+  { status: "cancelled", symbol: "xmark.circle" },
+];
+
+/** Every status except the issue's current one (selecting it would no-op). */
+export function statusMenuActions(issue: Issue): MenuAction[] {
+  return STATUS_MENU.filter(({ status }) => status !== issue.status).map(
+    ({ status, symbol }) => ({
+      id: status,
+      title: STATUS_LABEL[status],
+      image: symbol,
+      ...(status === "cancelled"
+        ? { attributes: { destructive: true } }
+        : {}),
+    }),
+  );
+}

--- a/apps/mobile/components/issue/swipeable-issue-row.tsx
+++ b/apps/mobile/components/issue/swipeable-issue-row.tsx
@@ -24,11 +24,13 @@ import Animated, {
 import ReanimatedSwipeable, {
   type SwipeableMethods,
 } from "react-native-gesture-handler/ReanimatedSwipeable";
+import { MenuView } from "@react-native-menu/menu";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
-import type { Issue } from "@multica/core/types";
+import type { Issue, IssueStatus } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { IssueRow } from "@/components/issue/issue-row";
+import { statusMenuActions } from "@/components/issue/issue-context-menu";
 import { useUpdateIssue } from "@/data/mutations/issues";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
@@ -62,7 +64,17 @@ export function SwipeableIssueRow({ issue, onPress, showStatus }: Props) {
         <CompleteAction isDone={isDone} onPress={fire} drag={drag} />
       )}
     >
-      <IssueRow issue={issue} onPress={onPress} showStatus={showStatus} />
+      {/* Long-press → native iOS UIMenu of statuses. */}
+      <MenuView
+        title={issue.identifier}
+        shouldOpenOnLongPress
+        actions={statusMenuActions(issue)}
+        onPressAction={({ nativeEvent }) =>
+          update.mutate({ status: nativeEvent.event as IssueStatus })
+        }
+      >
+        <IssueRow issue={issue} onPress={onPress} showStatus={showStatus} />
+      </MenuView>
     </ReanimatedSwipeable>
   );
 }

--- a/apps/mobile/components/issue/swipeable-issue-row.tsx
+++ b/apps/mobile/components/issue/swipeable-issue-row.tsx
@@ -1,0 +1,125 @@
+/**
+ * Trailing-swipe-to-complete wrapper for issue rows — the canonical task-app
+ * gesture (Reminders / Things / Todoist). Mirrors components/inbox/
+ * swipeable-inbox-row.tsx: same ReanimatedSwipeable, same reveal-only (no
+ * auto-fire) behaviour, same one-shot medium haptic when the drag crosses the
+ * action width.
+ *
+ * The action is status-aware: an open issue reveals a green "Done"; an
+ * already-done issue reveals a neutral "Reopen" (→ todo). The status mutation
+ * is optimistic (useUpdateIssue), and on settle the My Issues / list queries
+ * invalidate, so the row animates to its new status section.
+ *
+ * Reveal-only on purpose: a full-swipe auto-complete is too easy to trigger by
+ * accident on a fast vertical scroll. The user taps the revealed action — Mail
+ * / Linear do the same.
+ */
+import { useRef } from "react";
+import { Pressable, View } from "react-native";
+import Animated, {
+  type SharedValue,
+  useAnimatedReaction,
+  runOnJS,
+} from "react-native-reanimated";
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from "react-native-gesture-handler/ReanimatedSwipeable";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import type { Issue } from "@multica/core/types";
+import { Text } from "@/components/ui/text";
+import { IssueRow } from "@/components/issue/issue-row";
+import { useUpdateIssue } from "@/data/mutations/issues";
+import { useColorScheme } from "@/lib/use-color-scheme";
+import { THEME } from "@/lib/theme";
+
+const ACTION_WIDTH = 88;
+
+interface Props {
+  issue: Issue;
+  onPress: () => void;
+  showStatus?: boolean;
+}
+
+export function SwipeableIssueRow({ issue, onPress, showStatus }: Props) {
+  const ref = useRef<SwipeableMethods>(null);
+  const update = useUpdateIssue(issue.id);
+  const isDone = issue.status === "done";
+
+  const fire = () => {
+    // Close before mutating so the swipe spring doesn't fight the row's move
+    // to a different status section on the next invalidated render.
+    ref.current?.close();
+    update.mutate({ status: isDone ? "todo" : "done" });
+  };
+
+  return (
+    <ReanimatedSwipeable
+      ref={ref}
+      friction={2}
+      rightThreshold={ACTION_WIDTH}
+      renderRightActions={(_progress, drag) => (
+        <CompleteAction isDone={isDone} onPress={fire} drag={drag} />
+      )}
+    >
+      <IssueRow issue={issue} onPress={onPress} showStatus={showStatus} />
+    </ReanimatedSwipeable>
+  );
+}
+
+function CompleteAction({
+  isDone,
+  onPress,
+  drag,
+}: {
+  isDone: boolean;
+  onPress: () => void;
+  drag: SharedValue<number>;
+}) {
+  const { colorScheme } = useColorScheme();
+
+  // One-shot haptic when the drag crosses the action width threshold. Runs on
+  // the UI thread; runOnJS bridges to the JS-only Haptics call.
+  useAnimatedReaction(
+    () => drag.value <= -ACTION_WIDTH,
+    (crossed, prev) => {
+      if (crossed && !prev) {
+        runOnJS(Haptics.impactAsync)(Haptics.ImpactFeedbackStyle.Medium);
+      }
+    },
+    [],
+  );
+
+  return (
+    <Animated.View
+      style={{
+        width: ACTION_WIDTH,
+        backgroundColor: isDone
+          ? THEME[colorScheme].muted
+          : THEME[colorScheme].success,
+      }}
+    >
+      <Pressable
+        onPress={onPress}
+        accessibilityLabel={isDone ? "Reopen issue" : "Mark issue done"}
+        className="flex-1 items-center justify-center"
+      >
+        <View className="items-center gap-0.5">
+          <Ionicons
+            name={isDone ? "arrow-undo-outline" : "checkmark-circle-outline"}
+            size={20}
+            color={isDone ? THEME[colorScheme].mutedForeground : "white"}
+          />
+          <Text
+            className="text-xs"
+            style={{
+              color: isDone ? THEME[colorScheme].mutedForeground : "white",
+            }}
+          >
+            {isDone ? "Reopen" : "Done"}
+          </Text>
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,7 @@
     "@multica/core": "workspace:*",
     "@react-native-community/datetimepicker": "8.6.0",
     "@react-native-community/netinfo": "11.5.2",
+    "@react-native-menu/menu": "^2.0.0",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@react-navigation/elements": "^2.9.17",
     "@react-navigation/native": "^7.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
       '@react-native-community/netinfo':
         specifier: 11.5.2
         version: 11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@react-native-menu/menu':
+        specifier: ^2.0.0
+        version: 2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@react-native-segmented-control/segmented-control':
         specifier: 2.5.7
         version: 2.5.7(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -419,7 +422,7 @@ importers:
         version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+        version: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
@@ -733,7 +736,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -3368,6 +3371,12 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '>=0.59'
+
+  '@react-native-menu/menu@2.0.0':
+    resolution: {integrity: sha512-hb8Mirw6aKPGONhgo52IiNpwHtISVrgCT3rMdFX1qS7eOFNzOcQh8d2UDnaH5zVpxN+QuvWtaaiRMGFpIjzdtA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@react-native-segmented-control/segmented-control@2.5.7':
     resolution: {integrity: sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==}
@@ -10358,6 +10367,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -11865,7 +11875,7 @@ snapshots:
       ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12120,7 +12130,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -13474,6 +13484,11 @@ snapshots:
       expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   '@react-native-community/netinfo@11.5.2(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+
+  '@react-native-menu/menu@2.0.0(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
@@ -17097,7 +17112,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.14(fb4q2ydjsib3h2ixce2lptexem):
+  expo-router@55.0.14(28857138dad78e037ca803b5df54c4f8):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## What does this PR do?

Adds the canonical task-app row interactions to **My Issues** rows:

- **Swipe-to-complete** — trailing-swipe a row to reveal a green **Done** action (Reminders / Things / Todoist pattern); already-done issues reveal a neutral **Reopen**. Mirrors the existing `SwipeableInboxRow` exactly (reveal-only, no auto-fire, one-shot medium haptic on threshold cross).
- **Long-press → native status menu** — long-press opens a native iOS `UIMenu` (`@react-native-menu/menu`) listing every status except the current one (Cancelled destructive); selecting one runs the optimistic status mutation.

So the row gets the full vocabulary: **swipe = quick Done · long-press = any status · tap = open.** Status changes use the same options for human- and agent-assigned issues (the affordance never forks by assignee type).

> ⚠️ **Stacked on #4270** (native segmented control). Please **merge #4270 first**; until then this PR's diff includes that branch's commit. Review the **last two commits** here.

## Related Issue

N/A — native-feel feature; no tracking issue.

Closes #

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `components/issue/swipeable-issue-row.tsx` (new) — wraps the shared `IssueRow` in `ReanimatedSwipeable` + native `MenuView`
- `components/issue/issue-context-menu.tsx` (new) — builds the status `MenuAction[]`
- `app/(app)/[workspace]/(tabs)/my-issues.tsx` — render `SwipeableIssueRow` in the list

## How to Test

1. Open **My Issues** on iOS.
2. Trailing-swipe a row → tap the revealed **Done** → the issue moves to the Done section.
3. Long-press a row → pick a status from the native menu → it updates optimistically.

## Checklist

- [x] If this change affects the UI, I have included before/after screenshots
- [x] `pnpm typecheck` passes; verified manually in the iOS Simulator
- [ ] No automated test — gesture/native-menu interactions

## Known limitation

`@react-native-menu/menu` does not render action **icons** on the New Architecture (Fabric) with RN 0.83 yet; the menu is text-only for now (SF Symbols are configured so icons appear once the lib closes that gap). The icon-capable `react-native-ios-context-menu` does not compile against RN 0.83.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Mirrored the proven inbox swipe wrapper for issues; added a native long-press menu for full status control. Verified the revealed swipe action + native menu in the iOS Simulator (gestures can't be driven via `idb`, so the states were captured by briefly triggering them programmatically).

## Screenshots

Swipe-to-complete — revealed **Done** action:
![Swipe to complete](https://raw.githubusercontent.com/voska/multica/pr-assets/fix5-swipe-complete/swipe-to-complete-revealed.png)

Long-press — native status menu:
![Long-press status menu](https://raw.githubusercontent.com/voska/multica/pr-assets/fix6-longpress-status/native-menu-NO-icons.png)
