### PR TITLE
feat(mobile): always-visible workspace switcher in the header + drop switch confirm

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
@@ -72,6 +72,7 @@ import { canAssignAgent } from "@/lib/can-assign-agent";
 import { useWorkspaceAgentAvailability } from "@/lib/workspace-agent-availability";
 import { useAgentPresence } from "@/lib/use-agent-presence";
 import { Header } from "@/components/ui/header";
+import { WorkspaceSwitcherButton } from "@/components/workspace/workspace-switcher-button";
 import { ChatTitleButton } from "@/components/chat/chat-title-button";
 import { ChatSessionActions } from "@/components/chat/chat-session-actions";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
@@ -365,6 +366,7 @@ export default function ChatTab() {
   return (
     <View className="flex-1 bg-background">
       <Header
+        left={<WorkspaceSwitcherButton />}
         center={
           <ChatTitleButton
             currentSession={activeSession}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/ui/header";
 import { IconButton } from "@/components/ui/icon-button";
 import { HeaderActions } from "@/components/ui/app-header-actions";
+import { WorkspaceSwitcherButton } from "@/components/workspace/workspace-switcher-button";
 import { SwipeableInboxRow } from "@/components/inbox/swipeable-inbox-row";
 import { inboxListOptions } from "@/data/queries/inbox";
 import {
@@ -116,6 +117,7 @@ export default function Inbox() {
     <View className="flex-1 bg-background">
       <Header
         title="Inbox"
+        left={<WorkspaceSwitcherButton />}
         right={
           <>
             <IconButton

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
@@ -24,6 +24,7 @@ import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Header } from "@/components/ui/header";
 import { HeaderActions } from "@/components/ui/app-header-actions";
+import { WorkspaceSwitcherButton } from "@/components/workspace/workspace-switcher-button";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { IssueRow } from "@/components/issue/issue-row";
 import { IssuesLoading } from "@/components/issue/issues-loading";
@@ -126,7 +127,11 @@ export default function MyIssues() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header title="My Issues" right={<HeaderActions />} />
+      <Header
+        title="My Issues"
+        left={<WorkspaceSwitcherButton />}
+        right={<HeaderActions />}
+      />
       <ScopeToolbar
         scopes={SCOPES}
         scope={scope}

--- a/apps/mobile/app/(app)/[workspace]/switch-workspace.tsx
+++ b/apps/mobile/app/(app)/[workspace]/switch-workspace.tsx
@@ -1,26 +1,19 @@
 /**
  * Workspace switcher — presented as a formSheet by the parent Stack.
  *
- * Reached from the More popover's WorkspaceCard (collapsed single-row entry).
- * Lists every workspace the user belongs to, current one disabled with a
- * checkmark. Tapping a non-current row triggers an iOS-native `Alert.alert`
- * confirm — only after the user confirms do we dismiss the sheet and
- * `router.replace` to the target slug.
+ * Reached from the header's WorkspaceSwitcherButton (the always-visible
+ * current-workspace avatar) and the More popover's WorkspaceCard. Lists every
+ * workspace the user belongs to, current one disabled with a checkmark.
+ * Tapping a non-current row switches immediately — no confirm gate: this is a
+ * dedicated full-sheet list of clearly-labelled rows, so an accidental tap
+ * isn't a real risk, and a confirm on every switch is friction.
  *
- * Why a confirm step:
- *   The previous flow ("popover → tap row → instant switch") had no friction
- *   against fat-finger taps in the cramped popover, and the user lost their
- *   entire navigation context (tabs, scroll position) with one accidental
- *   tap. iOS Alert is the platform-correct gate (mobile/CLAUDE.md Principle
- *   3 — iOS native > RNR > discuss).
- *
- * Switching itself stays minimal: `router.dismiss()` to close this sheet,
- * then `router.replace(/${slug}/inbox)`. The downstream WorkspaceRouteLayout
+ * Switching stays minimal: `router.dismiss()` to close this sheet, then
+ * `router.replace(/${slug}/inbox)`. The downstream WorkspaceRouteLayout
  * handles `setCurrentWorkspace(slug, uuid)` on mount.
  */
 import {
   ActivityIndicator,
-  Alert,
   Pressable,
   ScrollView,
   View,
@@ -45,20 +38,11 @@ export default function SwitchWorkspaceRoute() {
 
   const onSelect = (ws: Workspace) => {
     if (ws.slug === activeSlug) return;
-    Alert.alert(
-      "Switch workspace",
-      `Switch to "${ws.name}"?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Switch",
-          onPress: () => {
-            router.dismiss();
-            router.replace(`/${ws.slug}/inbox`);
-          },
-        },
-      ],
-    );
+    // Switch immediately — no confirm. This is a dedicated full-sheet list of
+    // clearly-labelled rows (not the old cramped popover), so an accidental
+    // tap isn't a real risk, and a confirm gate on every switch is friction.
+    router.dismiss();
+    router.replace(`/${ws.slug}/inbox`);
   };
 
   return (

--- a/apps/mobile/components/workspace/workspace-switcher-button.tsx
+++ b/apps/mobile/components/workspace/workspace-switcher-button.tsx
@@ -1,0 +1,37 @@
+/**
+ * Persistent current-workspace indicator for the tab-root header's leading
+ * slot — the Slack / Linear / Notion pattern: the active workspace's avatar is
+ * always visible top-left, and tapping it opens the switcher.
+ *
+ * Lives in the header (not just the More tab) so you can always tell which
+ * workspace you're in at a glance, and switch from anywhere.
+ */
+import { Pressable } from "react-native";
+import { router } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { WorkspaceAvatar } from "@/components/workspace/workspace-avatar";
+import { workspaceListOptions } from "@/data/queries/workspaces";
+import { useWorkspaceStore } from "@/data/workspace-store";
+
+export function WorkspaceSwitcherButton() {
+  const slug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
+  const { data } = useQuery(workspaceListOptions());
+  const workspace = data?.find((w) => w.slug === slug);
+
+  if (!workspace || !slug) return null;
+
+  return (
+    <Pressable
+      onPress={() => router.push(`/${slug}/switch-workspace`)}
+      accessibilityLabel={`Current workspace: ${workspace.name}. Tap to switch workspace.`}
+      hitSlop={8}
+      className="px-1 active:opacity-60"
+    >
+      <WorkspaceAvatar
+        name={workspace.name}
+        avatarUrl={workspace.avatar_url}
+        size={28}
+      />
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Two related workspace-switcher improvements:

1. **Always-visible workspace indicator.** The active workspace's avatar now sits in the **leading slot of every tab header** (Inbox / My Issues / Chat), tappable to open the switcher — the Slack / Linear / Notion pattern. You can always tell which workspace you're in, and switch from anywhere (not just the More tab).
2. **Dropped the switch confirmation.** Removed the `Alert.alert("Switch to X?")` gate on workspace switch. Its original fat-finger rationale was the *old cramped popover*; the switcher is now a dedicated full-sheet list of clearly-labelled rows, so the confirm was just friction.

## Related Issue

N/A — UX improvement; no tracking issue.

Closes #

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `components/workspace/workspace-switcher-button.tsx` (new) — the header workspace avatar → opens the switcher
- `(tabs)/inbox.tsx`, `(tabs)/my-issues.tsx`, `(tabs)/chat.tsx` — pass it to the `Header` `left` slot
- `[workspace]/switch-workspace.tsx` — remove the `Alert.alert` confirm; tap switches immediately

> **Note for reviewers:** this overlaps **#4269** (large-title headers). If #4269 merges first, this PR's one-line reconcile is to move the avatar from the flat `<Header left=…>` prop to the native `headerLeft` option. Verified that combination works.

## How to Test

1. Open any tab — the current workspace avatar is in the top-left of the header.
2. Tap it → the switcher sheet opens.
3. Tap a different workspace → it switches immediately (no confirmation dialog).

## Checklist

- [x] If this change affects the UI, I have included before/after screenshots
- [x] `pnpm typecheck` passes; verified manually in the iOS Simulator
- [ ] No automated test — header rendering / navigation

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Researched canonical workspace/org-switcher placement (header leading slot vs bottom bar) and confirmed the header-avatar pattern, then implemented it + removed the now-unnecessary confirm. Verified in the iOS Simulator.

## Screenshots

Before (no workspace indicator) / after (workspace avatar, top-left):
![Workspace before/after](https://raw.githubusercontent.com/voska/multica/pr-assets/fix7-workspace-switcher/CHOOSE-workspace.png)

Switcher opens from the avatar:
![Switcher](https://raw.githubusercontent.com/voska/multica/pr-assets/fix7-workspace-switcher/switcher-opens-from-avatar.png)
