### PR TITLE
feat(mobile): app-icon lockup + email autofill on auth screens

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -6,7 +6,7 @@ import * as Haptics from "expo-haptics";
 import { Text } from "@/components/ui/text";
 import { TextField } from "@/components/ui/text-field";
 import { Button } from "@/components/ui/button";
-import { MulticaLogo } from "@/components/brand/multica-logo";
+import { BrandMark } from "@/components/brand/brand-mark";
 import { useAuthStore } from "@/data/auth-store";
 import { mapAuthError } from "@/lib/auth-error";
 
@@ -39,14 +39,14 @@ export default function Login() {
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <View className="flex-1 justify-center px-6 gap-6">
-          <View className="items-center gap-3">
-            <MulticaLogo size={32} />
-            <View className="gap-1 items-center">
-              <Text className="text-2xl font-semibold text-foreground">
+        <View className="flex-1 justify-center px-6 gap-8">
+          <View className="items-center gap-5">
+            <BrandMark size={72} />
+            <View className="gap-2 items-center">
+              <Text className="text-3xl font-bold text-foreground">
                 Sign in to Multica
               </Text>
-              <Text className="text-sm text-muted-foreground text-center">
+              <Text className="text-base text-muted-foreground text-center">
                 Enter your email and we&apos;ll send you a verification code.
               </Text>
             </View>
@@ -56,8 +56,10 @@ export default function Login() {
             <TextField
               autoCapitalize="none"
               autoComplete="email"
+              autoCorrect={false}
               autoFocus
               keyboardType="email-address"
+              textContentType="emailAddress"
               placeholder="you@example.com"
               value={email}
               onChangeText={setEmail}

--- a/apps/mobile/app/(auth)/verify.tsx
+++ b/apps/mobile/app/(auth)/verify.tsx
@@ -6,7 +6,7 @@ import * as Haptics from "expo-haptics";
 import { Text } from "@/components/ui/text";
 import { OtpInput, type OtpInputRef } from "@/components/ui/otp-input";
 import { Button } from "@/components/ui/button";
-import { MulticaLogo } from "@/components/brand/multica-logo";
+import { BrandMark } from "@/components/brand/brand-mark";
 import { useAuthStore } from "@/data/auth-store";
 import { mapAuthError } from "@/lib/auth-error";
 
@@ -74,14 +74,14 @@ export default function Verify() {
         className="flex-1"
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <View className="flex-1 justify-center px-6 gap-6">
-          <View className="items-center gap-3">
-            <MulticaLogo size={32} />
-            <View className="gap-1 items-center">
-              <Text className="text-2xl font-semibold text-foreground">
+        <View className="flex-1 justify-center px-6 gap-8">
+          <View className="items-center gap-5">
+            <BrandMark size={72} />
+            <View className="gap-2 items-center">
+              <Text className="text-3xl font-bold text-foreground">
                 Enter verification code
               </Text>
-              <Text className="text-sm text-muted-foreground text-center">
+              <Text className="text-base text-muted-foreground text-center">
                 We sent a 6-digit code to {email}
               </Text>
             </View>

--- a/apps/mobile/components/brand/brand-mark.tsx
+++ b/apps/mobile/components/brand/brand-mark.tsx
@@ -1,0 +1,51 @@
+/**
+ * App-icon lockup for first-impression surfaces (auth screens).
+ *
+ * Renders the actual Multica app icon (assets/icon.png — the same asset wired
+ * as `icon` in app.config.ts), not a recreation, so the login is anchored to
+ * the exact mark users see on their home screen. The source icon is an opaque
+ * white square with the squircle inset; we clip to a rounded frame and scale
+ * the image up slightly to crop that white margin, so it reads correctly on
+ * both light and dark backgrounds.
+ */
+import { View } from "react-native";
+import { Image } from "expo-image";
+
+const ICON = require("../../assets/icon.png");
+
+export function BrandMark({ size = 72 }: { size?: number }) {
+  // Crop the icon's white margin so its squircle fills our rounded frame.
+  const inner = size * 1.16;
+  const offset = -(inner - size) / 2;
+  return (
+    <View
+      style={{
+        shadowColor: "#000",
+        shadowOpacity: 0.18,
+        shadowRadius: 14,
+        shadowOffset: { width: 0, height: 6 },
+      }}
+    >
+      <View
+        style={{
+          width: size,
+          height: size,
+          // iOS continuous-corner ratio (~0.2237 of the side) for the squircle.
+          borderRadius: size * 0.2237,
+          overflow: "hidden",
+        }}
+      >
+        <Image
+          source={ICON}
+          style={{
+            width: inner,
+            height: inner,
+            marginLeft: offset,
+            marginTop: offset,
+          }}
+          contentFit="cover"
+        />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Polishes the **login / verify** first-impression surfaces with the *real* product mark and a genuine iOS autofill fix — no invented assets.

- **App-icon lockup.** The screens led with a bare 32pt sigil. They now render the **actual Multica app icon** (`assets/icon.png`, the same asset wired as `icon` in `app.config.ts`) in a clipped squircle — not a recreation. The source icon is an opaque white square with the squircle inset, so it's clipped + scaled to crop the white margin and read correctly on light *and* dark.
- **Stronger type** — title to 3xl bold, subtitle to base, with a touch more vertical rhythm.
- **iOS email autofill** on the login field: `textContentType="emailAddress"` (saved-email / Hide My Email) + `autoCorrect={false}`. (The verify screen's one-time-code autofill was already handled by `input-otp-native`.)

## Type of Change
- [x] UI polish (non-breaking)

## Changes Made
- `components/brand/brand-mark.tsx` (new) — renders the real app icon in a squircle frame.
- `app/(auth)/login.tsx`, `app/(auth)/verify.tsx` — use `BrandMark`, bump type; login gets the email autofill props.

## How to Test
1. Sign out → the login screen leads with the app icon + bold title.
2. The email field offers iOS saved-email / Hide-My-Email autofill above the keyboard.
3. Request a code → verify screen carries the same mark; the OTP field accepts one-time-code autofill.

## Checklist
- [x] Before/after screenshot included
- [x] `pnpm typecheck` passes; verified in the iOS Simulator

## AI Disclosure
**AI tool used:** Claude Code. Used the existing app-icon asset (no recreated graphics) and wired the iOS email-autofill content type; verified in the Simulator.

## Screenshots
Before (bare sigil) / after (real app icon + autofill):
![Auth before/after](https://raw.githubusercontent.com/voska/multica/pr-assets/auth-first-impression/before-after.png)
