### PR TITLE
feat(mobile): native iOS nav bar for the Chat tab

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat/_layout.tsx
@@ -1,0 +1,19 @@
+/**
+ * Chat tab stack. Like inbox/ and my-issues/, wrapping the screen in a native
+ * Stack is what gives it a real iOS nav bar (blur material, native title
+ * treatment) instead of the JS `<Header>` bar.
+ *
+ * Unlike those list tabs, Chat is a *conversation* view, so it uses an inline
+ * title — NOT `headerLargeTitle`. The title (session switcher) and the
+ * new-chat / delete actions are set dynamically from the screen via
+ * `<Stack.Screen options>` so they can read the active session + handlers.
+ */
+import { Stack } from "expo-router";
+
+export default function ChatStackLayout() {
+  return (
+    <Stack screenOptions={{ headerShadowVisible: false }}>
+      <Stack.Screen name="index" />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat/index.tsx
@@ -37,8 +37,9 @@ import {
   Platform,
   View,
 } from "react-native";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
+import { useHeaderHeight } from "@react-navigation/elements";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   Agent,
@@ -71,7 +72,6 @@ import { useChatSessionRealtime } from "@/data/realtime/use-chat-session-realtim
 import { canAssignAgent } from "@/lib/can-assign-agent";
 import { useWorkspaceAgentAvailability } from "@/lib/workspace-agent-availability";
 import { useAgentPresence } from "@/lib/use-agent-presence";
-import { Header } from "@/components/ui/header";
 import { ChatTitleButton } from "@/components/chat/chat-title-button";
 import { ChatSessionActions } from "@/components/chat/chat-session-actions";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
@@ -83,6 +83,9 @@ import { useChatSelectStore } from "@/data/chat-select-store";
 
 export default function ChatTab() {
   const qc = useQueryClient();
+  // Native header height — used to offset the keyboard avoider, since the
+  // native nav bar lives outside this screen's view tree.
+  const headerHeight = useHeaderHeight();
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const wsSlug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
   const userId = useAuthStore((s) => s.user?.id);
@@ -364,31 +367,34 @@ export default function ChatTab() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header
-        center={
-          <ChatTitleButton
-            currentSession={activeSession}
-            currentAgent={currentAgent}
-            onPress={() => {
-              if (!wsSlug) return;
-              router.push({
-                pathname: "/[workspace]/chat-sessions",
-                params: { workspace: wsSlug },
-              });
-            }}
-          />
-        }
-        right={
-          <ChatSessionActions
-            showMore={!!activeSession}
-            onMorePress={handleDeleteActive}
-            onNewPress={handleNewChat}
-          />
-        }
+      <Stack.Screen
+        options={{
+          headerTitle: () => (
+            <ChatTitleButton
+              currentSession={activeSession}
+              currentAgent={currentAgent}
+              onPress={() => {
+                if (!wsSlug) return;
+                router.push({
+                  pathname: "/[workspace]/chat-sessions",
+                  params: { workspace: wsSlug },
+                });
+              }}
+            />
+          ),
+          headerRight: () => (
+            <ChatSessionActions
+              showMore={!!activeSession}
+              onMorePress={handleDeleteActive}
+              onNewPress={handleNewChat}
+            />
+          ),
+        }}
       />
       {availability === "none" ? <NoAgentBanner /> : null}
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={headerHeight}
         className="flex-1"
       >
         <ChatMessageList

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Inbox tab stack. Wrapping the inbox screen in a native Stack (instead of
+ * mounting it directly under the JS `<Tabs>`) is what unlocks the iOS
+ * large-title nav bar: `headerLargeTitle` is a UINavigationController
+ * feature exposed only by react-native-screens' native stack — the
+ * react-navigation bottom-tabs header (JS) can't render it.
+ *
+ * The list opts into the "large title collapses to inline on scroll"
+ * behaviour via `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function InboxStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Inbox" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
@@ -6,13 +6,12 @@ import {
   View,
 } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { InboxItem } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Header } from "@/components/ui/header";
 import { IconButton } from "@/components/ui/icon-button";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { SwipeableInboxRow } from "@/components/inbox/swipeable-inbox-row";
@@ -114,18 +113,19 @@ export default function Inbox() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header
-        title="Inbox"
-        right={
-          <>
-            <IconButton
-              name="ellipsis-horizontal"
-              onPress={onPressMenu}
-              accessibilityLabel="Inbox actions"
-            />
-            <HeaderActions />
-          </>
-        }
+      <Stack.Screen
+        options={{
+          headerRight: () => (
+            <View className="flex-row items-center gap-1">
+              <IconButton
+                name="ellipsis-horizontal"
+                onPress={onPressMenu}
+                accessibilityLabel="Inbox actions"
+              />
+              <HeaderActions />
+            </View>
+          ),
+        }}
       />
       {isLoading ? (
         <InboxLoading />
@@ -145,6 +145,7 @@ export default function Inbox() {
         <FlatList
           data={data}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-16" />
           )}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
@@ -1,0 +1,23 @@
+/**
+ * My Issues tab stack. See inbox/_layout.tsx — wrapping the screen in a
+ * native Stack is what unlocks the iOS large-title nav bar (a
+ * react-native-screens / UINavigationController feature the JS `<Tabs>`
+ * header can't provide). The scope toolbar stays pinned below the bar; the
+ * SectionList drives the large-title → inline collapse via
+ * `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function MyIssuesStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "My Issues" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
@@ -17,12 +17,11 @@
 import { useMemo } from "react";
 import { Pressable, SectionList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
-import { Header } from "@/components/ui/header";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { IssueRow } from "@/components/issue/issue-row";
@@ -124,9 +123,12 @@ export default function MyIssues() {
   const showEmptyState =
     !isLoading && !error && filtered.length === 0;
 
-  return (
-    <View className="flex-1 bg-background">
-      <Header title="My Issues" right={<HeaderActions />} />
+  // The scope toolbar + filter chips ride as the SectionList header so the
+  // list sits flush under the nav bar — that's what lets the iOS large title
+  // expand and collapse on scroll. Pinning the toolbar above the list would
+  // pin the title in its collapsed (inline) state.
+  const listHeader = (
+    <>
       <ScopeToolbar
         scopes={SCOPES}
         scope={scope}
@@ -146,30 +148,49 @@ export default function MyIssues() {
           }
         />
       ) : null}
+    </>
+  );
+
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen
+        options={{ headerRight: () => <HeaderActions /> }}
+      />
       {isLoading ? (
-        <IssuesLoading />
+        <>
+          {listHeader}
+          <IssuesLoading />
+        </>
       ) : error ? (
-        <View className="px-4 gap-3 pt-4">
-          <Text className="text-sm text-destructive">
-            Failed to load issues:{" "}
-            {error instanceof Error ? error.message : "unknown error"}
-          </Text>
-          <Button variant="outline" onPress={() => refetch()}>
-            <Text>Retry</Text>
-          </Button>
-        </View>
+        <>
+          {listHeader}
+          <View className="px-4 gap-3 pt-4">
+            <Text className="text-sm text-destructive">
+              Failed to load issues:{" "}
+              {error instanceof Error ? error.message : "unknown error"}
+            </Text>
+            <Button variant="outline" onPress={() => refetch()}>
+              <Text>Retry</Text>
+            </Button>
+          </View>
+        </>
       ) : showEmptyState ? (
-        <EmptyState
-          message={
-            hasActiveFilters
-              ? "No issues match the current filters."
-              : emptyMessageForScope(scope)
-          }
-        />
+        <>
+          {listHeader}
+          <EmptyState
+            message={
+              hasActiveFilters
+                ? "No issues match the current filters."
+                : emptyMessageForScope(scope)
+            }
+          />
+        </>
       ) : (
         <SectionList
           sections={sections}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
+          ListHeaderComponent={listHeader}
           stickySectionHeadersEnabled={false}
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-4" />


### PR DESCRIPTION
## What does this PR do?

Gives the **Chat tab** a real iOS nav bar. Like inbox/ and my-issues/, the screen is wrapped in a native `Stack` so it gets the native nav bar (blur material, native title treatment) instead of the JS `<Header>` bar.

Chat is a *conversation* view, not a list, so it uses an **inline title — NOT `headerLargeTitle`**. The session-switcher title button and the new-chat / delete actions move into the native `headerTitle` / `headerRight`, configured from the screen via `<Stack.Screen options>` so they read live state (active session, current agent, handlers). The keyboard avoider is offset by the native header height (`useHeaderHeight`) since the nav bar now lives outside the screen's view tree.

> ⚠️ **Stacked on #4269** (native large-title headers) — it introduces the native-stack header pattern this builds on. Please **merge #4269 first**; until then this PR's diff includes that branch's commits. Review the **last commit** here.

## Type of Change
- [x] New feature / native-feel improvement (non-breaking)

## Changes Made
- `(tabs)/chat.tsx` → `(tabs)/chat/_layout.tsx` (native Stack) + `(tabs)/chat/index.tsx` (header moved into native slots; keyboard offset).

## How to Test
1. Open the **Chat** tab on iOS — it has a native nav bar; the centered title shows the session switcher (tap → session sheet), the `+` opens a new chat.
2. With an agent present, the composer sits correctly above the keyboard.

## Checklist
- [x] After screenshot included (the JS-header "before" is the current Chat tab)
- [x] `pnpm typecheck` passes; verified rendering in the iOS Simulator
- [ ] Live keyboard-avoidance with an agent present is worth a manual pass

## AI Disclosure
**AI tool used:** Claude Code. Applied the existing native-stack header pattern to the Chat tab; verified the header + content render in the Simulator.

## Screenshots
Native nav bar (session switcher title + new-chat action):
![Chat native header](https://raw.githubusercontent.com/voska/multica/pr-assets/chat-header/after.png)
