### PR TITLE
perf(mobile): FlashList for the inbox & search lists (MUL-3401)

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/_layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Inbox tab stack. Wrapping the inbox screen in a native Stack (instead of
+ * mounting it directly under the JS `<Tabs>`) is what unlocks the iOS
+ * large-title nav bar: `headerLargeTitle` is a UINavigationController
+ * feature exposed only by react-native-screens' native stack — the
+ * react-navigation bottom-tabs header (JS) can't render it.
+ *
+ * The list opts into the "large title collapses to inline on scroll"
+ * behaviour via `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function InboxStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "Inbox" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
@@ -1,10 +1,6 @@
 import { useMemo } from "react";
-import {
-  ActionSheetIOS,
-  Alert,
-  FlatList,
-  View,
-} from "react-native";
+import { ActionSheetIOS, Alert, View } from "react-native";
+import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "@tanstack/react-query";
 import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -142,14 +138,14 @@ export default function Inbox() {
       ) : !data || data.length === 0 ? (
         <InboxEmpty iconColor={THEME[colorScheme].mutedForeground} />
       ) : (
-        <FlatList
+        <FlashList
           data={data}
           keyExtractor={(item) => item.id}
           contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-16" />
           )}
-          contentContainerClassName="pb-6"
+          contentContainerStyle={{ paddingBottom: 24 }}
           renderItem={({ item }) => (
             <SwipeableInboxRow
               item={item}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox/index.tsx
@@ -6,13 +6,12 @@ import {
   View,
 } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { InboxItem } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Header } from "@/components/ui/header";
 import { IconButton } from "@/components/ui/icon-button";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { SwipeableInboxRow } from "@/components/inbox/swipeable-inbox-row";
@@ -114,18 +113,19 @@ export default function Inbox() {
 
   return (
     <View className="flex-1 bg-background">
-      <Header
-        title="Inbox"
-        right={
-          <>
-            <IconButton
-              name="ellipsis-horizontal"
-              onPress={onPressMenu}
-              accessibilityLabel="Inbox actions"
-            />
-            <HeaderActions />
-          </>
-        }
+      <Stack.Screen
+        options={{
+          headerRight: () => (
+            <View className="flex-row items-center gap-1">
+              <IconButton
+                name="ellipsis-horizontal"
+                onPress={onPressMenu}
+                accessibilityLabel="Inbox actions"
+              />
+              <HeaderActions />
+            </View>
+          ),
+        }}
       />
       {isLoading ? (
         <InboxLoading />
@@ -145,6 +145,7 @@ export default function Inbox() {
         <FlatList
           data={data}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-16" />
           )}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/_layout.tsx
@@ -1,0 +1,23 @@
+/**
+ * My Issues tab stack. See inbox/_layout.tsx — wrapping the screen in a
+ * native Stack is what unlocks the iOS large-title nav bar (a
+ * react-native-screens / UINavigationController feature the JS `<Tabs>`
+ * header can't provide). The scope toolbar stays pinned below the bar; the
+ * SectionList drives the large-title → inline collapse via
+ * `contentInsetAdjustmentBehavior="automatic"`.
+ */
+import { Stack } from "expo-router";
+
+export default function MyIssuesStackLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: true,
+        headerLargeTitleShadowVisible: false,
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="index" options={{ title: "My Issues" }} />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues/index.tsx
@@ -17,12 +17,11 @@
 import { useMemo } from "react";
 import { Pressable, SectionList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
-import { Header } from "@/components/ui/header";
 import { HeaderActions } from "@/components/ui/app-header-actions";
 import { StatusIcon } from "@/components/ui/status-icon";
 import { IssueRow } from "@/components/issue/issue-row";
@@ -124,9 +123,12 @@ export default function MyIssues() {
   const showEmptyState =
     !isLoading && !error && filtered.length === 0;
 
-  return (
-    <View className="flex-1 bg-background">
-      <Header title="My Issues" right={<HeaderActions />} />
+  // The scope toolbar + filter chips ride as the SectionList header so the
+  // list sits flush under the nav bar — that's what lets the iOS large title
+  // expand and collapse on scroll. Pinning the toolbar above the list would
+  // pin the title in its collapsed (inline) state.
+  const listHeader = (
+    <>
       <ScopeToolbar
         scopes={SCOPES}
         scope={scope}
@@ -146,30 +148,49 @@ export default function MyIssues() {
           }
         />
       ) : null}
+    </>
+  );
+
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen
+        options={{ headerRight: () => <HeaderActions /> }}
+      />
       {isLoading ? (
-        <IssuesLoading />
+        <>
+          {listHeader}
+          <IssuesLoading />
+        </>
       ) : error ? (
-        <View className="px-4 gap-3 pt-4">
-          <Text className="text-sm text-destructive">
-            Failed to load issues:{" "}
-            {error instanceof Error ? error.message : "unknown error"}
-          </Text>
-          <Button variant="outline" onPress={() => refetch()}>
-            <Text>Retry</Text>
-          </Button>
-        </View>
+        <>
+          {listHeader}
+          <View className="px-4 gap-3 pt-4">
+            <Text className="text-sm text-destructive">
+              Failed to load issues:{" "}
+              {error instanceof Error ? error.message : "unknown error"}
+            </Text>
+            <Button variant="outline" onPress={() => refetch()}>
+              <Text>Retry</Text>
+            </Button>
+          </View>
+        </>
       ) : showEmptyState ? (
-        <EmptyState
-          message={
-            hasActiveFilters
-              ? "No issues match the current filters."
-              : emptyMessageForScope(scope)
-          }
-        />
+        <>
+          {listHeader}
+          <EmptyState
+            message={
+              hasActiveFilters
+                ? "No issues match the current filters."
+                : emptyMessageForScope(scope)
+            }
+          />
+        </>
       ) : (
         <SectionList
           sections={sections}
           keyExtractor={(item) => item.id}
+          contentInsetAdjustmentBehavior="automatic"
+          ListHeaderComponent={listHeader}
           stickySectionHeadersEnabled={false}
           ItemSeparatorComponent={() => (
             <View className="h-px bg-border ml-4" />

--- a/apps/mobile/app/(app)/[workspace]/search.tsx
+++ b/apps/mobile/app/(app)/[workspace]/search.tsx
@@ -14,14 +14,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
-  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
   TextInput,
   View,
-  type ListRenderItem,
 } from "react-native";
+import { FlashList, type ListRenderItem } from "@shopify/flash-list";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useQueries } from "@tanstack/react-query";
 import { router } from "expo-router";
@@ -463,10 +462,11 @@ export default function SearchModal() {
         </View>
 
         {/* Body */}
-        <FlatList
+        <FlashList
           data={data}
           renderItem={renderItem}
           keyExtractor={(item) => item.key}
+          getItemType={(item) => item.kind}
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
           ListEmptyComponent={


### PR DESCRIPTION
## What does this PR do?

Migrates the two main flat scrollable lists — **inbox** and **search** — from `FlatList` to **`@shopify/flash-list` v2** for cell recycling on long lists. FlashList is already a dependency and already powers the chat message list and issue timeline; this extends it to the inbox and global search.

Drop-in: same `data` / `renderItem` / `keyExtractor`. Two specifics:
- `contentContainerClassName` → `contentContainerStyle` (FlashList doesn't honour NativeWind `gap-*` on the content container).
- The search list is heterogeneous (header / issue / project / recent rows), so it gets `getItemType={(item) => item.kind}` to recycle cells by type.

Leaves the **SectionList**-based *My Issues* / *More → Issues* alone — FlashList v2 has no direct SectionList equivalent.

> ⚠️ **Stacked on #4269** (native large-title headers) — inbox is the native-stack folder introduced there. Please **merge #4269 first**; until then the diff includes that branch's commits. Review the **last commit** here.

## Type of Change
- [x] Performance (non-breaking)

## Changes Made
- `(tabs)/inbox/index.tsx`, `search.tsx` — `FlatList` → `FlashList`; `contentContainerStyle`; `getItemType` on search.

## How to Test
1. Open **Search**, type a query — heterogeneous header/issue/project rows render and recycle correctly (screenshot).
2. Inbox scrolls smoothly on long lists; the large-title still collapses (`contentInsetAdjustmentBehavior` preserved).

> Note: this is a scroll-*performance* change — it looks identical in a still. The screenshot proves correct rendering of the heterogeneous search list under FlashList; the win is recycling, best seen live.

## Checklist
- [x] Screenshot of the migrated list rendering correctly
- [x] `pnpm typecheck` passes; verified search rendering in the iOS Simulator

## AI Disclosure
**AI tool used:** Claude Code. Migrated two `FlatList`s to the already-adopted FlashList v2; verified the heterogeneous search list renders correctly in the Simulator.

## Screenshots
Search results rendering under FlashList (heterogeneous rows recycle by `kind`):
![FlashList search](https://raw.githubusercontent.com/voska/multica/pr-assets/flashlist/search-render.png)
