### PR TITLE
MUL-3405: constrain issue mention chips in chat

### DIFF
--- a/packages/views/issues/components/issue-chip.test.tsx
+++ b/packages/views/issues/components/issue-chip.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useQuery } from "@tanstack/react-query";
+import { IssueChip } from "./issue-chip";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/issues/queries", () => ({
+  issueListOptions: () => ({ queryKey: ["issues"] }),
+  issueDetailOptions: (_workspaceId: string, issueId: string) => ({
+    queryKey: ["issue", issueId],
+  }),
+}));
+
+vi.mock("./status-icon", () => ({
+  StatusIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="status-icon" className={className} />
+  ),
+}));
+
+const mockUseQuery = vi.mocked(useQuery);
+
+describe("IssueChip", () => {
+  beforeEach(() => {
+    mockUseQuery.mockImplementation((options: { queryKey?: readonly unknown[] }) => {
+      if (options.queryKey?.[0] === "issues") {
+        return {
+          data: [
+            {
+              id: "issue-1",
+              identifier: "MUL-3405",
+              title: "A very long issue title that should stay inside a narrow chat bubble",
+              status: "todo",
+            },
+          ],
+        } as ReturnType<typeof useQuery>;
+      }
+      return { data: undefined } as ReturnType<typeof useQuery>;
+    });
+  });
+
+  it("caps the chip to its parent container and truncates the title", () => {
+    render(<IssueChip issueId="issue-1" />);
+
+    const chip = screen.getByText("MUL-3405").closest(".issue-mention");
+    expect(chip).toHaveClass("min-w-0", "max-w-[min(18rem,100%)]");
+    expect(screen.getByText("A very long issue title that should stay inside a narrow chat bubble"))
+      .toHaveClass("min-w-0", "truncate");
+  });
+
+  it("truncates unresolved fallback labels inside the chip width", () => {
+    render(
+      <IssueChip
+        issueId="missing-issue"
+        fallbackLabel="MUL-999999999999999999999999999999999"
+      />,
+    );
+
+    expect(screen.getByText("MUL-999999999999999999999999999999999"))
+      .toHaveClass("min-w-0", "truncate");
+  });
+});

--- a/packages/views/issues/components/issue-chip.tsx
+++ b/packages/views/issues/components/issue-chip.tsx
@@ -7,7 +7,7 @@ import { StatusIcon } from "./status-icon";
 
 /**
  * Compact, presentation-only representation of an issue —
- * `<StatusIcon> <identifier> <title>`, bordered, truncating to max-w-72.
+ * `<StatusIcon> <identifier> <title>`, bordered, capped at 18rem or parent width.
  *
  * This is the single source of truth for the "issue-mention card" look.
  * It is intentionally **not** a link or button: callers wrap it in whatever

--- a/packages/views/issues/components/issue-chip.tsx
+++ b/packages/views/issues/components/issue-chip.tsx
@@ -28,7 +28,7 @@ export interface IssueChipProps {
 }
 
 const BASE_CLASS =
-  "issue-mention inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs max-w-72";
+  "issue-mention inline-flex min-w-0 max-w-[min(18rem,100%)] items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs";
 
 export function IssueChip({ issueId, fallbackLabel, className }: IssueChipProps) {
   const wsId = useWorkspaceId();
@@ -47,7 +47,7 @@ export function IssueChip({ issueId, fallbackLabel, className }: IssueChipProps)
   if (!issue) {
     return (
       <span className={cls}>
-        <span className="font-medium text-muted-foreground">
+        <span className="min-w-0 truncate font-medium text-muted-foreground">
           {fallbackLabel ?? issueId.slice(0, 8)}
         </span>
       </span>
@@ -60,7 +60,7 @@ export function IssueChip({ issueId, fallbackLabel, className }: IssueChipProps)
       <span className="font-medium text-muted-foreground shrink-0">
         {issue.identifier}
       </span>
-      <span className="text-foreground truncate">{issue.title}</span>
+      <span className="min-w-0 truncate text-foreground">{issue.title}</span>
     </span>
   );
 }

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -18,7 +18,7 @@ interface IssueMentionCardProps {
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
   return (
-    <AppLink href={p.issueDetail(issueId)} className="issue-mention not-prose inline-flex">
+    <AppLink href={p.issueDetail(issueId)} className="issue-mention not-prose inline-flex max-w-full align-middle">
       <IssueChip
         issueId={issueId}
         fallbackLabel={fallbackLabel}


### PR DESCRIPTION
## Summary

- Constrain issue mention chips so they cannot exceed the parent container width in narrow chat bubbles.
- Allow issue titles and unresolved fallback labels to shrink and truncate inside the chip.
- Add coverage for the issue chip width and truncation classes.

Closes MUL-3405

## Verification

- `pnpm --filter @multica/views test -- issues/components/issue-chip.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint`
