### PR TITLE
MUL-3264: add Codex usage cache backfill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSIO
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o bin/multica ./cmd/multica
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/migrate ./cmd/migrate
 RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/backfill_task_usage_hourly ./cmd/backfill_task_usage_hourly
+RUN cd server && CGO_ENABLED=0 go build -ldflags "-s -w" -o bin/backfill_codex_usage_cache ./cmd/backfill_codex_usage_cache
 
 # --- Runtime stage ---
 FROM alpine:3.21
@@ -32,6 +33,7 @@ COPY --from=builder /src/server/bin/server .
 COPY --from=builder /src/server/bin/multica .
 COPY --from=builder /src/server/bin/migrate .
 COPY --from=builder /src/server/bin/backfill_task_usage_hourly .
+COPY --from=builder /src/server/bin/backfill_codex_usage_cache .
 COPY server/migrations/ ./migrations/
 COPY docker/entrypoint.sh .
 RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh

--- a/docs/codex-usage-cache-backfill.md
+++ b/docs/codex-usage-cache-backfill.md
@@ -1,0 +1,91 @@
+# Codex Usage Cache Backfill
+
+This runbook describes the one-time hosted data repair for Codex usage rows
+created before cached input was normalized at ingestion time.
+
+Do not run this as an automatic database migration. The write step needs an
+operator-selected cutoff, dry-run review, and an explicit execute command.
+
+## When To Run
+
+Run this only after the backend image containing `backfill_codex_usage_cache`
+has been deployed, and only for databases that need historical Codex usage
+correction.
+
+Use the actual hosted deployment time of PR #4083 as `--cutoff`. Do not use the
+PR merge time unless it is also the real production cutover time.
+
+## Execution Model
+
+Run the command from the released backend image as a one-time operator job, such
+as a Kubernetes Job with the normal backend database secret and network access.
+Override the command to execute `./backfill_codex_usage_cache`.
+
+The command defaults to dry-run. It mutates data only when `--execute` is passed.
+
+## Dry Run
+
+First run:
+
+```bash
+./backfill_codex_usage_cache --cutoff <RFC3339_DEPLOY_TIME>
+```
+
+Optionally limit scope while validating:
+
+```bash
+./backfill_codex_usage_cache --cutoff <RFC3339_DEPLOY_TIME> --workspace-id <workspace-uuid>
+```
+
+Review the per-workspace/date output:
+
+- `rows`
+- `input_before`
+- `input_after`
+- `input_tokens_removed`
+- `clamped_rows`
+
+Proceed only if the totals match the expected overcount shape.
+
+## Execute
+
+After dry-run review:
+
+```bash
+./backfill_codex_usage_cache --cutoff <RFC3339_DEPLOY_TIME> --execute
+```
+
+For large datasets, throttle writes:
+
+```bash
+./backfill_codex_usage_cache \
+  --cutoff <RFC3339_DEPLOY_TIME> \
+  --execute \
+  --batch-size 500 \
+  --sleep-between-batches 1s
+```
+
+By default, execution rebuilds affected hourly rollups by calling
+`rollup_task_usage_hourly_window(...)` for the database update window. Leave
+`--rebuild-rollup=true` unless an operator intentionally plans a separate rollup
+rebuild.
+
+## Verification
+
+After execution, run the dry-run command again with the same cutoff and scope.
+Eligible rows should be zero.
+
+Then verify Usage / Runtime dashboard periods that were previously inflated.
+
+## Safety Boundaries
+
+The command updates only rows that match all of these conditions:
+
+- `provider = 'codex'`
+- `cache_read_tokens > 0`
+- `input_tokens > 0`
+- `COALESCE(updated_at, created_at) < --cutoff`
+- optional `--workspace-id` match
+
+Rows without persisted `cache_read_tokens` are intentionally ignored because the
+current database cannot accurately reconstruct cached input for them.

--- a/server/cmd/backfill_codex_usage_cache/integration_test.go
+++ b/server/cmd/backfill_codex_usage_cache/integration_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/multica-ai/multica/server/internal/migrations"
+)
+
+func TestExecuteBackfillUpdatesOnlyEligibleCodexRowsAndRebuildsRollup(t *testing.T) {
+	adminURL := os.Getenv("DATABASE_URL")
+	if adminURL == "" {
+		adminURL = "postgres://multica:multica@localhost:5432/multica?sslmode=disable"
+	}
+
+	ctx := context.Background()
+	if !testDatabaseReachable(ctx, adminURL) {
+		t.Skip("integration test requires Postgres at DATABASE_URL")
+	}
+
+	tmpDB := fmt.Sprintf("multica_codex_usage_backfill_%d", time.Now().UnixNano())
+	if err := testCreateDatabase(ctx, adminURL, tmpDB); err != nil {
+		t.Fatalf("create temp database %s: %v", tmpDB, err)
+	}
+	t.Cleanup(func() {
+		if err := testDropDatabase(context.Background(), adminURL, tmpDB); err != nil {
+			t.Logf("drop temp database %s: %v", tmpDB, err)
+		}
+	})
+
+	pool, err := pgxpool.New(ctx, testReplaceDatabase(adminURL, tmpDB))
+	if err != nil {
+		t.Fatalf("connect to temp database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := testApplyMigrationsUpTo(ctx, pool, "102_task_usage_hourly_pipeline"); err != nil {
+		t.Fatalf("apply migrations to 102: %v", err)
+	}
+
+	cutoff := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	createdAt := cutoff.Add(-48 * time.Hour)
+	oldUpdatedAt := cutoff.Add(-24 * time.Hour)
+	newUpdatedAt := cutoff.Add(24 * time.Hour)
+
+	workspaceID, _, _, targetTaskID := seedBackfillTaskUsageFixture(t, ctx, pool, "target")
+	_, _, _, otherWorkspaceTaskID := seedBackfillTaskUsageFixture(t, ctx, pool, "other")
+
+	targetID := seedTaskUsageRow(t, ctx, pool, targetTaskID, "codex", "gpt-5-codex", 1000, 50, 300, createdAt, oldUpdatedAt)
+	postCutoffID := seedTaskUsageRow(t, ctx, pool, targetTaskID, "codex", "gpt-5-codex-new", 900, 50, 200, createdAt, newUpdatedAt)
+	nonCodexID := seedTaskUsageRow(t, ctx, pool, targetTaskID, "claude", "claude-test", 800, 50, 200, createdAt, oldUpdatedAt)
+	zeroCacheID := seedTaskUsageRow(t, ctx, pool, targetTaskID, "codex", "gpt-5-codex-no-cache", 700, 50, 0, createdAt, oldUpdatedAt)
+	otherWorkspaceID := seedTaskUsageRow(t, ctx, pool, otherWorkspaceTaskID, "codex", "gpt-5-codex-other-workspace", 600, 50, 100, createdAt, oldUpdatedAt)
+
+	cfg := config{
+		cutoff:      cutoff,
+		workspaceID: workspaceID,
+		batchSize:   10,
+	}
+
+	summary, total, err := loadDryRunSummary(ctx, pool, cfg)
+	if err != nil {
+		t.Fatalf("load dry-run summary: %v", err)
+	}
+	if len(summary) != 1 {
+		t.Fatalf("summary rows = %d, want 1: %#v", len(summary), summary)
+	}
+	if total.Rows != 1 || total.InputBefore != 1000 || total.InputAfter != 700 || total.Overcount != 300 {
+		t.Fatalf("unexpected dry-run total: %+v", total)
+	}
+	assertTaskUsageInput(t, ctx, pool, targetID, 1000)
+
+	updateStartedAt, err := databaseClock(ctx, pool)
+	if err != nil {
+		t.Fatalf("read update start clock: %v", err)
+	}
+	updatedRows, removedTokens, err := executeBackfill(ctx, pool, cfg)
+	if err != nil {
+		t.Fatalf("execute backfill: %v", err)
+	}
+	if updatedRows != 1 || removedTokens != 300 {
+		t.Fatalf("updatedRows=%d removedTokens=%d, want 1/300", updatedRows, removedTokens)
+	}
+	updateFinishedAt, err := databaseClock(ctx, pool)
+	if err != nil {
+		t.Fatalf("read update finish clock: %v", err)
+	}
+	rollupFrom, rollupTo := rollupWindow(updateStartedAt, updateFinishedAt)
+	var rollupRows int64
+	if err := pool.QueryRow(ctx,
+		`SELECT rollup_task_usage_hourly_window($1::timestamptz, $2::timestamptz)`,
+		rollupFrom, rollupTo,
+	).Scan(&rollupRows); err != nil {
+		t.Fatalf("rebuild hourly rollup: %v", err)
+	}
+	if rollupRows == 0 {
+		t.Fatalf("expected hourly rollup rows to be touched")
+	}
+
+	assertTaskUsageInput(t, ctx, pool, targetID, 700)
+	assertTaskUsageInput(t, ctx, pool, postCutoffID, 900)
+	assertTaskUsageInput(t, ctx, pool, nonCodexID, 800)
+	assertTaskUsageInput(t, ctx, pool, zeroCacheID, 700)
+	assertTaskUsageInput(t, ctx, pool, otherWorkspaceID, 600)
+
+	var targetUpdatedAt time.Time
+	if err := pool.QueryRow(ctx, `SELECT updated_at FROM task_usage WHERE id = $1`, targetID).Scan(&targetUpdatedAt); err != nil {
+		t.Fatalf("read target updated_at: %v", err)
+	}
+	if !targetUpdatedAt.After(cutoff) {
+		t.Fatalf("target updated_at = %s, want after cutoff %s", targetUpdatedAt, cutoff)
+	}
+
+	updatedRows, removedTokens, err = executeBackfill(ctx, pool, cfg)
+	if err != nil {
+		t.Fatalf("execute backfill second time: %v", err)
+	}
+	if updatedRows != 0 || removedTokens != 0 {
+		t.Fatalf("second execution updatedRows=%d removedTokens=%d, want 0/0", updatedRows, removedTokens)
+	}
+
+	var hourlyInput, hourlyCache int64
+	if err := pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(input_tokens), 0)::bigint,
+		       COALESCE(SUM(cache_read_tokens), 0)::bigint
+		  FROM task_usage_hourly
+		 WHERE workspace_id = $1
+		   AND provider = 'codex'
+		   AND model = 'gpt-5-codex'
+	`, workspaceID).Scan(&hourlyInput, &hourlyCache); err != nil {
+		t.Fatalf("read hourly rollup: %v", err)
+	}
+	if hourlyInput != 700 || hourlyCache != 300 {
+		t.Fatalf("hourly rollup input/cache = %d/%d, want 700/300", hourlyInput, hourlyCache)
+	}
+}
+
+func seedTaskUsageRow(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	taskID, provider, model string,
+	input, output, cacheRead int64,
+	createdAt, updatedAt time.Time,
+) string {
+	t.Helper()
+
+	var id string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO task_usage (
+			task_id, provider, model,
+			input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, 0, $7, $8)
+		RETURNING id
+	`, taskID, provider, model, input, output, cacheRead, createdAt, updatedAt).Scan(&id); err != nil {
+		t.Fatalf("seed task_usage row %s/%s: %v", provider, model, err)
+	}
+	return id
+}
+
+func assertTaskUsageInput(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id string, want int64) {
+	t.Helper()
+	var got int64
+	if err := pool.QueryRow(ctx, `SELECT input_tokens FROM task_usage WHERE id = $1`, id).Scan(&got); err != nil {
+		t.Fatalf("read task_usage %s: %v", id, err)
+	}
+	if got != want {
+		t.Fatalf("task_usage %s input_tokens = %d, want %d", id, got, want)
+	}
+}
+
+func seedBackfillTaskUsageFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool, suffix string) (string, string, string, string) {
+	t.Helper()
+
+	var wsID, runtimeID, agentID, taskID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "codex backfill "+suffix, "codex-backfill-"+suffix).Scan(&wsID); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', 'codex', 'online',
+		        '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id
+	`, wsID, "codex backfill runtime "+suffix).Scan(&runtimeID); err != nil {
+		t.Fatalf("seed runtime: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1)
+		RETURNING id
+	`, wsID, "codex backfill agent "+suffix, runtimeID).Scan(&agentID); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, payload
+		)
+		VALUES ($1, $2, 'queued', '{}'::jsonb)
+		RETURNING id
+	`, agentID, runtimeID).Scan(&taskID); err != nil {
+		altErr := pool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, runtime_id)
+			VALUES ($1, $2)
+			RETURNING id
+		`, agentID, runtimeID).Scan(&taskID)
+		if altErr != nil {
+			t.Fatalf("seed agent_task_queue: %v / %v", err, altErr)
+		}
+	}
+	return wsID, runtimeID, agentID, taskID
+}
+
+func testResolveMigrationsDir() (string, error) {
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller(0) failed")
+	}
+	dir := filepath.Join(filepath.Dir(here), "..", "..", "migrations")
+	dir = filepath.Clean(dir)
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("migrations dir not at %s", dir)
+	}
+	return dir, nil
+}
+
+func testDatabaseReachable(ctx context.Context, url string) bool {
+	pool, err := pgxpool.New(ctx, url)
+	if err != nil {
+		return false
+	}
+	defer pool.Close()
+	return pool.Ping(ctx) == nil
+}
+
+func testCreateDatabase(ctx context.Context, adminURL, name string) error {
+	conn, err := pgx.Connect(ctx, adminURL)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(ctx)
+	if _, err := conn.Exec(ctx, fmt.Sprintf(`CREATE DATABASE %q`, name)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func testDropDatabase(ctx context.Context, adminURL, name string) error {
+	conn, err := pgx.Connect(ctx, adminURL)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(ctx)
+	if _, err := conn.Exec(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS %q WITH (FORCE)`, name)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func testReplaceDatabase(url, name string) string {
+	idx := strings.LastIndex(url, "/")
+	if idx < 0 {
+		return url
+	}
+	rest := url[idx+1:]
+	q := strings.Index(rest, "?")
+	if q < 0 {
+		return url[:idx+1] + name
+	}
+	return url[:idx+1] + name + rest[q:]
+}
+
+func testApplyMigrationsUpTo(ctx context.Context, pool *pgxpool.Pool, lastVersion string) error {
+	dir, err := testResolveMigrationsDir()
+	if err != nil {
+		return err
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*.up.sql"))
+	if err != nil {
+		return err
+	}
+	sort.Strings(files)
+
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		)
+	`); err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		v := migrations.ExtractVersion(f)
+		sql, err := os.ReadFile(f)
+		if err != nil {
+			return err
+		}
+		if _, err := pool.Exec(ctx, string(sql)); err != nil {
+			return fmt.Errorf("apply %s: %w", v, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING`,
+			v); err != nil {
+			return err
+		}
+		if v == lastVersion {
+			return nil
+		}
+	}
+	return fmt.Errorf("migration %q not found", lastVersion)
+}

--- a/server/cmd/backfill_codex_usage_cache/main.go
+++ b/server/cmd/backfill_codex_usage_cache/main.go
@@ -1,0 +1,329 @@
+// Backfill_codex_usage_cache corrects historical Codex task_usage rows
+// written before Codex cached input was normalized at ingestion time.
+//
+// This is a hosted-data repair tool, not a general migration:
+//   - dry-run is the default; pass --execute to mutate data
+//   - only provider='codex' rows with persisted cache_read_tokens are touched
+//   - --cutoff must be the actual hosted deployment time of the ingestion fix
+//   - rows updated after the cutoff are left alone to avoid double-subtracting
+//   - the hourly rollup is rebuilt explicitly from the updated_at window
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/logger"
+)
+
+const rollupAdvisoryLockID = 4246
+
+type config struct {
+	cutoff              time.Time
+	cutoffRaw           string
+	workspaceID         string
+	batchSize           int
+	sleepBetweenBatches time.Duration
+	execute             bool
+	rebuildRollup       bool
+}
+
+type summaryRow struct {
+	WorkspaceID   string
+	DateUTC       string
+	Rows          int64
+	InputBefore   int64
+	InputAfter    int64
+	Overcount     int64
+	ClampedRows   int64
+	MinCreatedUTC time.Time
+	MaxCreatedUTC time.Time
+}
+
+type totals struct {
+	Rows        int64
+	InputBefore int64
+	InputAfter  int64
+	Overcount   int64
+	ClampedRows int64
+}
+
+func main() {
+	logger.Init()
+	if err := run(); err != nil {
+		slog.Error("codex usage cache backfill failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg := config{}
+	flag.StringVar(&cfg.cutoffRaw, "cutoff", "", "required RFC3339 hosted deployment time of the Codex usage normalization fix")
+	flag.StringVar(&cfg.workspaceID, "workspace-id", "", "optional workspace UUID to limit the backfill")
+	flag.IntVar(&cfg.batchSize, "batch-size", 1000, "number of task_usage rows to update per batch when --execute is set")
+	flag.DurationVar(&cfg.sleepBetweenBatches, "sleep-between-batches", 0, "pause between update batches to throttle write pressure")
+	flag.BoolVar(&cfg.execute, "execute", false, "mutate task_usage rows; without this flag the command only prints a dry-run summary")
+	flag.BoolVar(&cfg.rebuildRollup, "rebuild-rollup", true, "after --execute, call rollup_task_usage_hourly_window for the update window")
+	flag.Parse()
+
+	now := time.Now().UTC()
+	if err := cfg.parseAndValidate(now); err != nil {
+		return err
+	}
+
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgres://multica:multica@localhost:5432/multica?sslmode=disable"
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("ping database: %w", err)
+	}
+
+	rows, total, err := loadDryRunSummary(ctx, pool, cfg)
+	if err != nil {
+		return err
+	}
+	logSummary(cfg, rows, total)
+	if total.Rows == 0 {
+		slog.Info("no eligible Codex task_usage rows found")
+		return nil
+	}
+	if !cfg.execute {
+		slog.Info("dry-run complete; review the summary, then re-run with --execute to apply the backfill")
+		return nil
+	}
+
+	lockConn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire advisory-lock connection: %w", err)
+	}
+	defer lockConn.Release()
+	if _, err := lockConn.Exec(ctx, `SELECT pg_advisory_lock($1)`, rollupAdvisoryLockID); err != nil {
+		return fmt.Errorf("acquire advisory lock %d: %w", rollupAdvisoryLockID, err)
+	}
+	defer func() {
+		_, _ = lockConn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, rollupAdvisoryLockID)
+	}()
+
+	updateStartedAt, err := databaseClock(ctx, pool)
+	if err != nil {
+		return err
+	}
+
+	updatedRows, removedTokens, err := executeBackfill(ctx, pool, cfg)
+	if err != nil {
+		return err
+	}
+	slog.Info("task_usage rows updated", "rows", updatedRows, "input_tokens_removed", removedTokens)
+	if updatedRows == 0 || !cfg.rebuildRollup {
+		return nil
+	}
+
+	updateFinishedAt, err := databaseClock(ctx, pool)
+	if err != nil {
+		return err
+	}
+	rollupFrom, rollupTo := rollupWindow(updateStartedAt, updateFinishedAt)
+	var rollupRows int64
+	if err := pool.QueryRow(ctx,
+		`SELECT rollup_task_usage_hourly_window($1::timestamptz, $2::timestamptz)`,
+		rollupFrom, rollupTo,
+	).Scan(&rollupRows); err != nil {
+		return fmt.Errorf("rebuild hourly rollup for update window %s..%s: %w",
+			rollupFrom.Format(time.RFC3339), rollupTo.Format(time.RFC3339), err)
+	}
+	slog.Info("hourly rollup rebuilt",
+		"from", rollupFrom.Format(time.RFC3339),
+		"to", rollupTo.Format(time.RFC3339),
+		"rows_touched", rollupRows)
+	return nil
+}
+
+func (cfg *config) parseAndValidate(now time.Time) error {
+	if cfg.cutoffRaw == "" {
+		return fmt.Errorf("--cutoff is required; use the hosted deployment time of the Codex usage normalization fix")
+	}
+	cutoff, err := time.Parse(time.RFC3339, cfg.cutoffRaw)
+	if err != nil {
+		return fmt.Errorf("parse --cutoff as RFC3339: %w", err)
+	}
+	cutoff = cutoff.UTC()
+	if !cutoff.Before(now) {
+		return fmt.Errorf("--cutoff must be before now; refusing a future cutoff because it could double-subtract already-normalized rows")
+	}
+	if cfg.batchSize <= 0 {
+		return fmt.Errorf("--batch-size must be positive")
+	}
+	cfg.cutoff = cutoff
+	return nil
+}
+
+func loadDryRunSummary(ctx context.Context, pool *pgxpool.Pool, cfg config) ([]summaryRow, totals, error) {
+	const query = `
+SELECT
+    a.workspace_id::text AS workspace_id,
+    (tu.created_at AT TIME ZONE 'UTC')::date::text AS date_utc,
+    COUNT(*)::bigint AS rows,
+    COALESCE(SUM(tu.input_tokens), 0)::bigint AS input_before,
+    COALESCE(SUM(GREATEST(tu.input_tokens - tu.cache_read_tokens, 0)), 0)::bigint AS input_after,
+    COALESCE(SUM(tu.input_tokens - GREATEST(tu.input_tokens - tu.cache_read_tokens, 0)), 0)::bigint AS overcount,
+    COUNT(*) FILTER (WHERE tu.input_tokens < tu.cache_read_tokens)::bigint AS clamped_rows,
+    MIN(tu.created_at) AS min_created_at,
+    MAX(tu.created_at) AS max_created_at
+FROM task_usage tu
+JOIN agent_task_queue atq ON atq.id = tu.task_id
+JOIN agent a ON a.id = atq.agent_id
+WHERE tu.provider = 'codex'
+  AND tu.cache_read_tokens > 0
+  AND tu.input_tokens > 0
+  AND COALESCE(tu.updated_at, tu.created_at) < $1
+  AND (NULLIF($2, '')::uuid IS NULL OR a.workspace_id = NULLIF($2, '')::uuid)
+GROUP BY a.workspace_id, (tu.created_at AT TIME ZONE 'UTC')::date
+ORDER BY a.workspace_id, date_utc`
+	rows, err := pool.Query(ctx, query, cfg.cutoff, cfg.workspaceID)
+	if err != nil {
+		return nil, totals{}, fmt.Errorf("load dry-run summary: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []summaryRow
+	var total totals
+	for rows.Next() {
+		var row summaryRow
+		if err := rows.Scan(
+			&row.WorkspaceID,
+			&row.DateUTC,
+			&row.Rows,
+			&row.InputBefore,
+			&row.InputAfter,
+			&row.Overcount,
+			&row.ClampedRows,
+			&row.MinCreatedUTC,
+			&row.MaxCreatedUTC,
+		); err != nil {
+			return nil, totals{}, fmt.Errorf("scan dry-run summary: %w", err)
+		}
+		summaries = append(summaries, row)
+		total.Rows += row.Rows
+		total.InputBefore += row.InputBefore
+		total.InputAfter += row.InputAfter
+		total.Overcount += row.Overcount
+		total.ClampedRows += row.ClampedRows
+	}
+	if err := rows.Err(); err != nil {
+		return nil, totals{}, fmt.Errorf("iterate dry-run summary: %w", err)
+	}
+	return summaries, total, nil
+}
+
+func logSummary(cfg config, rows []summaryRow, total totals) {
+	slog.Info("Codex usage cache backfill candidate total",
+		"execute", cfg.execute,
+		"cutoff", cfg.cutoff.Format(time.RFC3339),
+		"workspace_id", cfg.workspaceID,
+		"rows", total.Rows,
+		"input_before", total.InputBefore,
+		"input_after", total.InputAfter,
+		"input_tokens_removed", total.Overcount,
+		"clamped_rows", total.ClampedRows)
+	for _, row := range rows {
+		slog.Info("candidate summary",
+			"workspace_id", row.WorkspaceID,
+			"date_utc", row.DateUTC,
+			"rows", row.Rows,
+			"input_before", row.InputBefore,
+			"input_after", row.InputAfter,
+			"input_tokens_removed", row.Overcount,
+			"clamped_rows", row.ClampedRows,
+			"min_created_at", row.MinCreatedUTC.UTC().Format(time.RFC3339),
+			"max_created_at", row.MaxCreatedUTC.UTC().Format(time.RFC3339))
+	}
+}
+
+func executeBackfill(ctx context.Context, pool *pgxpool.Pool, cfg config) (int64, int64, error) {
+	const query = `
+WITH candidates AS (
+    SELECT
+        tu.id,
+        (tu.input_tokens - GREATEST(tu.input_tokens - tu.cache_read_tokens, 0))::bigint AS removed_tokens
+      FROM task_usage tu
+      JOIN agent_task_queue atq ON atq.id = tu.task_id
+      JOIN agent a ON a.id = atq.agent_id
+     WHERE tu.provider = 'codex'
+       AND tu.cache_read_tokens > 0
+       AND tu.input_tokens > 0
+       AND COALESCE(tu.updated_at, tu.created_at) < $1
+       AND (NULLIF($2, '')::uuid IS NULL OR a.workspace_id = NULLIF($2, '')::uuid)
+     ORDER BY COALESCE(tu.updated_at, tu.created_at), tu.id
+     LIMIT $3
+     FOR UPDATE OF tu SKIP LOCKED
+),
+updated AS (
+    UPDATE task_usage tu
+       SET input_tokens = GREATEST(tu.input_tokens - tu.cache_read_tokens, 0),
+           updated_at = now()
+      FROM candidates c
+     WHERE tu.id = c.id
+     RETURNING c.removed_tokens
+)
+SELECT COUNT(*)::bigint, COALESCE(SUM(removed_tokens), 0)::bigint FROM updated`
+
+	var totalRows, totalRemoved int64
+	for {
+		var rows, removed int64
+		if err := pool.QueryRow(ctx, query, cfg.cutoff, cfg.workspaceID, cfg.batchSize).Scan(&rows, &removed); err != nil {
+			return totalRows, totalRemoved, fmt.Errorf("update Codex task_usage batch: %w", err)
+		}
+		if rows == 0 {
+			break
+		}
+		totalRows += rows
+		totalRemoved += removed
+		slog.Info("updated Codex task_usage batch", "rows", rows, "input_tokens_removed", removed, "total_rows", totalRows)
+		if cfg.sleepBetweenBatches > 0 {
+			select {
+			case <-time.After(cfg.sleepBetweenBatches):
+			case <-ctx.Done():
+				return totalRows, totalRemoved, ctx.Err()
+			}
+		}
+	}
+	return totalRows, totalRemoved, nil
+}
+
+func databaseClock(ctx context.Context, pool *pgxpool.Pool) (time.Time, error) {
+	var ts time.Time
+	if err := pool.QueryRow(ctx, `SELECT clock_timestamp()`).Scan(&ts); err != nil {
+		return time.Time{}, fmt.Errorf("read database clock: %w", err)
+	}
+	return ts.UTC(), nil
+}
+
+func rollupWindow(startedAt, finishedAt time.Time) (time.Time, time.Time) {
+	return startedAt.UTC().Add(-time.Second), finishedAt.UTC().Add(time.Second)
+}
+
+func correctedInputTokens(inputTokens, cacheReadTokens int64) int64 {
+	corrected := inputTokens - cacheReadTokens
+	if corrected < 0 {
+		return 0
+	}
+	return corrected
+}

--- a/server/cmd/backfill_codex_usage_cache/main_test.go
+++ b/server/cmd/backfill_codex_usage_cache/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCorrectedInputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input int64
+		cache int64
+		want  int64
+	}{
+		{name: "subtracts cached input", input: 1000, cache: 300, want: 700},
+		{name: "zero cache leaves input unchanged", input: 1000, cache: 0, want: 1000},
+		{name: "clamps negative values", input: 100, cache: 300, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := correctedInputTokens(tt.input, tt.cache); got != tt.want {
+				t.Fatalf("correctedInputTokens(%d, %d) = %d, want %d", tt.input, tt.cache, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigParseAndValidate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 18, 3, 30, 0, 0, time.UTC)
+	t.Run("requires cutoff", func(t *testing.T) {
+		t.Parallel()
+		cfg := config{batchSize: 100}
+		if err := cfg.parseAndValidate(now); err == nil || !strings.Contains(err.Error(), "--cutoff is required") {
+			t.Fatalf("expected missing cutoff error, got %v", err)
+		}
+	})
+	t.Run("rejects future cutoff", func(t *testing.T) {
+		t.Parallel()
+		cfg := config{cutoffRaw: now.Add(time.Minute).Format(time.RFC3339), batchSize: 100}
+		if err := cfg.parseAndValidate(now); err == nil || !strings.Contains(err.Error(), "before now") {
+			t.Fatalf("expected future cutoff error, got %v", err)
+		}
+	})
+	t.Run("rejects invalid batch size", func(t *testing.T) {
+		t.Parallel()
+		cfg := config{cutoffRaw: now.Add(-time.Minute).Format(time.RFC3339), batchSize: 0}
+		if err := cfg.parseAndValidate(now); err == nil || !strings.Contains(err.Error(), "batch-size") {
+			t.Fatalf("expected batch-size error, got %v", err)
+		}
+	})
+	t.Run("normalizes cutoff to UTC", func(t *testing.T) {
+		t.Parallel()
+		cfg := config{cutoffRaw: "2026-06-18T10:00:00+08:00", batchSize: 100}
+		if err := cfg.parseAndValidate(now); err != nil {
+			t.Fatalf("parseAndValidate: %v", err)
+		}
+		want := time.Date(2026, 6, 18, 2, 0, 0, 0, time.UTC)
+		if !cfg.cutoff.Equal(want) {
+			t.Fatalf("cutoff = %s, want %s", cfg.cutoff, want)
+		}
+	})
+}
+
+func TestRollupWindowPadsDatabaseClockRange(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 6, 18, 3, 0, 0, 0, time.UTC)
+	finished := started.Add(30 * time.Second)
+	from, to := rollupWindow(started, finished)
+	if want := started.Add(-time.Second); !from.Equal(want) {
+		t.Fatalf("from = %s, want %s", from, want)
+	}
+	if want := finished.Add(time.Second); !to.Equal(want) {
+		t.Fatalf("to = %s, want %s", to, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `server/cmd/backfill_codex_usage_cache`, a one-time operator command for correcting historical Codex `task_usage` rows written before cached input was normalized.
- Defaults to dry-run and requires `--execute` to mutate data.
- Limits candidates to `provider = 'codex'`, `cache_read_tokens > 0`, `input_tokens > 0`, and `COALESCE(updated_at, created_at) < --cutoff`.
- Updates raw `task_usage.input_tokens` with `greatest(input_tokens - cache_read_tokens, 0)`, bumps `updated_at`, and explicitly rebuilds hourly rollups for the DB update window.
- Builds and copies the command into the backend Docker image for one-time operator-job execution.
- Adds `docs/codex-usage-cache-backfill.md` with the dry-run, execute, throttling, and verification runbook.

## Operator Notes

Do not run this as an automatic DB migration. The write step needs an operator-selected cutoff, dry-run review, and explicit execution.

After deploying the backend image that contains `backfill_codex_usage_cache`, run it as a one-time operator job with production backend DB credentials/network access.

Dry-run first using the actual hosted deployment time for #4083:

```bash
./backfill_codex_usage_cache --cutoff <RFC3339_DEPLOY_TIME>
```

After reviewing the per-workspace/date summary, execute:

```bash
./backfill_codex_usage_cache --cutoff <RFC3339_DEPLOY_TIME> --execute
```

Rows without persisted `cache_read_tokens` are intentionally ignored because the current DB cannot accurately reconstruct cached input for them.

## Testing

- `go test -count=1 ./cmd/backfill_codex_usage_cache`
- `go test -count=1 ./cmd/backfill_task_usage_hourly ./cmd/backfill_codex_usage_cache ./internal/taskusagebackfill`
