### PR TITLE
fix: drop migration FKs/cascades + verify all migrations in readiness check (MUL-3404)

### DIFF
--- a/server/cmd/server/health.go
+++ b/server/cmd/server/health.go
@@ -14,7 +14,12 @@ import (
 	"github.com/multica-ai/multica/server/internal/migrations"
 )
 
-const readinessQuery = `SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)`
+// readinessQuery counts how many of the binary's required migration versions
+// are recorded as applied. We compare the count to the number of required
+// versions rather than checking a single "latest" row, so a missing
+// out-of-order migration (numbered below an already-applied later one) is
+// detected instead of being masked by the later version's presence.
+const readinessQuery = `SELECT COUNT(*) FROM schema_migrations WHERE version = ANY($1)`
 
 const readinessCacheTTL = 3 * time.Second
 
@@ -24,12 +29,12 @@ type readinessDB interface {
 }
 
 type serverHealth struct {
-	db              readinessDB
-	latestMigration string
-	initErr         error
-	cacheTTL        time.Duration
-	refreshMu       sync.Mutex
-	cache           atomic.Pointer[cachedReadiness]
+	db                 readinessDB
+	requiredMigrations []string
+	initErr            error
+	cacheTTL           time.Duration
+	refreshMu          sync.Mutex
+	cache              atomic.Pointer[cachedReadiness]
 }
 
 type cachedReadiness struct {
@@ -53,12 +58,12 @@ type readinessChecks struct {
 }
 
 func newServerHealth(pool *pgxpool.Pool) *serverHealth {
-	latestMigration, err := migrations.LatestVersion()
+	requiredMigrations, err := migrations.AllVersions()
 	return &serverHealth{
-		db:              pool,
-		latestMigration: latestMigration,
-		initErr:         err,
-		cacheTTL:        readinessCacheTTL,
+		db:                 pool,
+		requiredMigrations: requiredMigrations,
+		initErr:            err,
+		cacheTTL:           readinessCacheTTL,
 	}
 }
 
@@ -132,20 +137,23 @@ func (h *serverHealth) computeReadiness(parent context.Context) (readinessRespon
 		return resp, http.StatusServiceUnavailable
 	}
 
-	if h.initErr != nil || h.latestMigration == "" {
+	if h.initErr != nil || len(h.requiredMigrations) == 0 {
 		resp.Status = "not_ready"
 		resp.Checks.Migrations = "error"
 		return resp, http.StatusServiceUnavailable
 	}
 
-	var applied bool
-	if err := h.db.QueryRow(ctx, readinessQuery, h.latestMigration).Scan(&applied); err != nil {
+	var appliedCount int
+	if err := h.db.QueryRow(ctx, readinessQuery, h.requiredMigrations).Scan(&appliedCount); err != nil {
 		resp.Status = "not_ready"
 		resp.Checks.Migrations = "error"
 		return resp, http.StatusServiceUnavailable
 	}
 
-	if !applied {
+	// version is the schema_migrations PK, so each required version matches at
+	// most one row; a count below the required total means at least one
+	// migration this binary needs has not been applied.
+	if appliedCount < len(h.requiredMigrations) {
 		resp.Status = "not_ready"
 		resp.Checks.Migrations = "out_of_date"
 		return resp, http.StatusServiceUnavailable

--- a/server/cmd/server/health_test.go
+++ b/server/cmd/server/health_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 type stubReadinessDB struct {
-	pingErr    error
-	queryErr   error
-	applied    bool
-	pingCalls  atomic.Int32
-	queryCalls atomic.Int32
+	pingErr      error
+	queryErr     error
+	appliedCount int
+	pingCalls    atomic.Int32
+	queryCalls   atomic.Int32
 }
 
 func (s *stubReadinessDB) Ping(context.Context) error {
@@ -28,27 +28,27 @@ func (s *stubReadinessDB) Ping(context.Context) error {
 
 func (s *stubReadinessDB) QueryRow(context.Context, string, ...any) pgx.Row {
 	s.queryCalls.Add(1)
-	return stubRow{applied: s.applied, err: s.queryErr}
+	return stubRow{appliedCount: s.appliedCount, err: s.queryErr}
 }
 
 type stubRow struct {
-	applied bool
-	err     error
+	appliedCount int
+	err          error
 }
 
 func (r stubRow) Scan(dest ...any) error {
 	if r.err != nil {
 		return r.err
 	}
-	*(dest[0].(*bool)) = r.applied
+	*(dest[0].(*int)) = r.appliedCount
 	return nil
 }
 
 func TestServerHealthReadyHandlerDBPingFailure(t *testing.T) {
 	db := &stubReadinessDB{pingErr: errors.New("db unavailable")}
 	h := &serverHealth{
-		db:              db,
-		latestMigration: "056_example",
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
 	}
 
 	rec := httptest.NewRecorder()
@@ -76,10 +76,10 @@ func TestServerHealthReadyHandlerDBPingFailure(t *testing.T) {
 }
 
 func TestServerHealthReadyHandlerMigrationOutOfDate(t *testing.T) {
-	db := &stubReadinessDB{applied: false}
+	db := &stubReadinessDB{appliedCount: 0}
 	h := &serverHealth{
-		db:              db,
-		latestMigration: "056_example",
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
 	}
 
 	rec := httptest.NewRecorder()
@@ -106,12 +106,42 @@ func TestServerHealthReadyHandlerMigrationOutOfDate(t *testing.T) {
 	}
 }
 
-func TestServerHealthReadinessCachesResult(t *testing.T) {
-	db := &stubReadinessDB{applied: true}
+func TestServerHealthReadyHandlerMigrationPartiallyApplied(t *testing.T) {
+	// Three migrations required but only two recorded — the out-of-order case
+	// the old "is the latest version applied?" check used to mask. Readiness
+	// must report not_ready, not ok.
+	db := &stubReadinessDB{appliedCount: 2}
 	h := &serverHealth{
-		db:              db,
-		latestMigration: "056_example",
-		cacheTTL:        time.Minute,
+		db:                 db,
+		requiredMigrations: []string{"120_a", "120_b", "121_c"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	h.readyHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var resp readinessResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "not_ready" {
+		t.Fatalf("status = %q, want %q", resp.Status, "not_ready")
+	}
+	if resp.Checks.Migrations != "out_of_date" {
+		t.Fatalf("migrations check = %q, want %q", resp.Checks.Migrations, "out_of_date")
+	}
+}
+
+func TestServerHealthReadinessCachesResult(t *testing.T) {
+	db := &stubReadinessDB{appliedCount: 1}
+	h := &serverHealth{
+		db:                 db,
+		requiredMigrations: []string{"056_example"},
+		cacheTTL:           time.Minute,
 	}
 
 	resp1, status1 := h.readiness(context.Background())

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -812,7 +812,27 @@ func (h *Handler) DeleteAutopilot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteAutopilot(r.Context(), idUUID); err != nil {
+	// autopilot_subscriber carries no DB-level foreign key/cascade (repo rule:
+	// referential cleanup lives in the application layer), so delete the
+	// subscriber template alongside the autopilot in one transaction. Without
+	// this, deleting an autopilot would orphan its subscriber rows.
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	if err := qtx.DeleteAutopilotSubscribersForAutopilot(r.Context(), idUUID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+		return
+	}
+	if err := qtx.DeleteAutopilot(r.Context(), idUUID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
 		return
 	}

--- a/server/internal/handler/autopilot_subscriber_test.go
+++ b/server/internal/handler/autopilot_subscriber_test.go
@@ -596,3 +596,74 @@ func TestAutopilotDispatchSkipsInboxWhenNoSubscribers(t *testing.T) {
 		t.Fatalf("issue_subscribed inbox rows = %d, want 0 (no subscribers)", inboxCount)
 	}
 }
+
+// TestDeleteAutopilotRemovesSubscribers guards the app-layer cleanup that
+// replaced the dropped autopilot_subscriber → autopilot ON DELETE CASCADE:
+// deleting an autopilot must also delete its subscriber template rows in the
+// same transaction, leaving no orphans behind.
+func TestDeleteAutopilotRemovesSubscribers(t *testing.T) {
+	ctx := context.Background()
+	var autopilotID string
+	defer func() {
+		if autopilotID != "" {
+			testPool.Exec(ctx, `DELETE FROM autopilot_subscriber WHERE autopilot_id = $1`, autopilotID)
+			testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+		}
+	}()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("load test agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
+		"title":          "Delete-with-subscribers autopilot",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+		"subscribers": []map[string]any{
+			{"user_type": "member", "user_id": testUserID},
+		},
+	})
+	testHandler.CreateAutopilot(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created AutopilotResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+	autopilotID = created.ID
+
+	var before int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_subscriber WHERE autopilot_id = $1`, autopilotID).Scan(&before); err != nil {
+		t.Fatalf("count subscribers before delete: %v", err)
+	}
+	if before != 1 {
+		t.Fatalf("subscriber rows before delete = %d, want 1", before)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/autopilots/"+autopilotID+"?workspace_id="+testWorkspaceID, nil)
+	req = withURLParam(req, "id", autopilotID)
+	testHandler.DeleteAutopilot(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteAutopilot: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var after int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_subscriber WHERE autopilot_id = $1`, autopilotID).Scan(&after); err != nil {
+		t.Fatalf("count subscribers after delete: %v", err)
+	}
+	if after != 0 {
+		t.Fatalf("subscriber rows after delete = %d, want 0 (app-layer cleanup)", after)
+	}
+
+	var autopilotRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot WHERE id = $1`, autopilotID).Scan(&autopilotRows); err != nil {
+		t.Fatalf("count autopilot after delete: %v", err)
+	}
+	if autopilotRows != 0 {
+		t.Fatalf("autopilot rows after delete = %d, want 0", autopilotRows)
+	}
+}

--- a/server/internal/migrations/migrations.go
+++ b/server/internal/migrations/migrations.go
@@ -69,16 +69,24 @@ func Files(direction string) ([]string, error) {
 	return files, nil
 }
 
-// LatestVersion returns the latest "up" migration version found on disk.
-func LatestVersion() (string, error) {
+// AllVersions returns every "up" migration version found on disk, in apply
+// order. The readiness check verifies that all of them are recorded in
+// schema_migrations — checking only the lexically-last version would miss an
+// out-of-order migration (one numbered below an already-applied later one),
+// letting a server report ready while running against a schema that lacks it.
+func AllVersions() ([]string, error) {
 	files, err := Files("up")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(files) == 0 {
-		return "", fmt.Errorf("no up migrations found")
+		return nil, fmt.Errorf("no up migrations found")
 	}
-	return ExtractVersion(files[len(files)-1]), nil
+	versions := make([]string, len(files))
+	for i, f := range files {
+		versions[i] = ExtractVersion(f)
+	}
+	return versions, nil
 }
 
 // ExtractVersion strips the .up.sql / .down.sql suffix from a migration file.

--- a/server/migrations/120_autopilot_subscriber.down.sql
+++ b/server/migrations/120_autopilot_subscriber.down.sql
@@ -1,7 +1,10 @@
 -- Rows still carrying reason='autopilot' would violate the restored CHECK
--- constraint, so drop them first. Operators wanting an audit trail should
--- backfill reason='manual' before rolling this back.
-DELETE FROM issue_subscriber WHERE reason = 'autopilot';
+-- constraint. Relabel them to 'manual' (a value the restored CHECK still
+-- allows) instead of deleting them, so rolling back narrows the reason taxonomy
+-- without silently dropping who is subscribed. The reason column is not part of
+-- issue_subscriber's PK (issue_id, user_type, user_id), so this UPDATE can never
+-- collide with an existing row for the same subscriber.
+UPDATE issue_subscriber SET reason = 'manual' WHERE reason = 'autopilot';
 
 ALTER TABLE issue_subscriber DROP CONSTRAINT issue_subscriber_reason_check;
 ALTER TABLE issue_subscriber ADD CONSTRAINT issue_subscriber_reason_check

--- a/server/migrations/120_autopilot_subscriber.up.sql
+++ b/server/migrations/120_autopilot_subscriber.up.sql
@@ -1,9 +1,12 @@
 -- Template list of workspace members auto-subscribed to every issue spawned
 -- by the autopilot. Members-only for now (broaden the CHECK to expand).
--- No FK on user_id — workspace membership is enforced at the API boundary
--- (isWorkspaceEntity in the handler), matching issue_subscriber.
+-- No foreign keys or cascades — autopilot existence and workspace membership
+-- are both enforced in the application layer (the autopilot delete handler
+-- removes these rows in the same transaction; membership is checked at the API
+-- boundary via isWorkspaceEntity), per the repo rule. Mirrors issue_subscriber's
+-- app-level user_id handling.
 CREATE TABLE autopilot_subscriber (
-    autopilot_id UUID NOT NULL REFERENCES autopilot(id) ON DELETE CASCADE,
+    autopilot_id UUID NOT NULL,
     user_type    TEXT NOT NULL CHECK (user_type IN ('member')),
     user_id      UUID NOT NULL,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/server/migrations/120_comment_source_task_id.up.sql
+++ b/server/migrations/120_comment_source_task_id.up.sql
@@ -1,2 +1,8 @@
+-- Trace pointer to the agent_task_queue row that produced this comment, used by
+-- the "retry failed agent comment" affordance. No FK on source_task_id: the
+-- referenced task can be GC'd independently of the comment it produced, and the
+-- relationship is resolved in the application layer (a missing task simply means
+-- the source is no longer retryable). Matches the repo rule that foreign keys
+-- and cascades are handled by the app, not the database.
 ALTER TABLE comment
-  ADD COLUMN source_task_id UUID REFERENCES agent_task_queue(id) ON DELETE SET NULL;
+  ADD COLUMN source_task_id UUID;


### PR DESCRIPTION
## Summary

Fixes the two BLOCK findings from the Preflight pre-deploy review (MUL-3404 thread). Both concern migrations that landed on `main` after `v0.3.24` and are **not yet released**, so they are corrected in place.

### BLOCK #1 — DB foreign keys / cascades + destructive down-migration

The repo resolves referential integrity in the application layer (no DB foreign keys or cascades). Two new migrations violated that:

- `120_autopilot_subscriber.up.sql`: `autopilot_id ... REFERENCES autopilot(id) ON DELETE CASCADE` → plain `UUID NOT NULL`. The cascade is replaced by **explicit app-layer cleanup**: `DeleteAutopilot` now deletes the subscriber template and the autopilot in one transaction (the `DeleteAutopilotSubscribersForAutopilot` query already existed for the PATCH full-replace path). Without this, deleting an autopilot would orphan its subscriber rows — so this is a real behavior fix, not just a schema cosmetic.
- `120_comment_source_task_id.up.sql`: `source_task_id UUID REFERENCES agent_task_queue(id) ON DELETE SET NULL` → plain `UUID`. `source_task_id` is an output-only trace pointer for the "retry failed agent comment" affordance; nothing hard-deletes `agent_task_queue`, so `ON DELETE SET NULL` never fired. Removal is behavior-neutral.
- `120_autopilot_subscriber.down.sql`: stopped silently dropping subscriptions on rollback — `DELETE FROM issue_subscriber WHERE reason='autopilot'` → `UPDATE ... SET reason='manual'` (a value the restored CHECK allows; `reason` is not in the PK so no collision). The subscription survives; only the label narrows.

### BLOCK #2 — out-of-order migration invisible to the readiness check

The migrate tool is **set-based** (`schema_migrations.version` is the PK, each file checked individually), so `migrate up` *does* apply an out-of-order migration (one numbered below an already-applied later one). The real gap was `/readyz`: it only verified the **lexically-last** migration existed, so a DB missing an out-of-order migration could still report ready while 500ing on the code that needs the absent schema (the symptom Preflight reproduced: `column "source_task_id" does not exist`).

- `migrations.LatestVersion` → `AllVersions`.
- `health.go` now counts how many required versions are applied (`SELECT COUNT(*) FROM schema_migrations WHERE version = ANY($1)`) and reports `out_of_date` if any is missing — order-independent.

Chose the readiness fix over renumbering the migrations: renumbering an already-applied migration would make the set-based tool try to re-run it (CREATE TABLE → "already exists"); the readiness fix addresses the root cause and is safe regardless of apply order.

## Verification (ran against a local Postgres)

- `migrate up` applies the corrected `120_*` migrations cleanly; schema confirmed to have **no** FK on `autopilot_subscriber.autopilot_id` or `comment.source_task_id`.
- `go test ./internal/handler` (incl. new `TestDeleteAutopilotRemovesSubscribers`) ✅
- `go test ./cmd/server` — the package Preflight reported failing — now ✅, incl. new `TestServerHealthReadyHandlerMigrationPartiallyApplied` (partial-applied set → `out_of_date`).
- `go test ./cmd/migrate` ✅; `go build ./...`, `go vet`, `gofmt` clean on touched files.
- `sqlc generate` produces no diff (FK removal doesn't change column types/nullability).

Relates to MUL-3404.
