### PR TITLE
feat(labels)[🛢️]: STR-170 자동 라벨링 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Multica is an AI-native task management platform — like Linear, but with AI ag
 - Supports local (daemon) and cloud agent runtimes
 - Built for 2-10 person AI-native teams
 
+## Custom Implementation Ledger
+
+This checkout may carry workspace-specific behavior that is not part of an official upstream image or release line. Before changing self-hosting, Docker images, or locally customized product behavior, read `CUSTOMIZATIONS.md` and update it in the same PR when the customization changes.
+
 ## Architecture
 
 **Go backend + monorepo frontend (pnpm workspaces + Turborepo) with shared packages.**

--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -1,0 +1,59 @@
+# Customizations
+
+This file is the root-level ledger for behavior that may diverge from an official Multica implementation or image. Read it with `CLAUDE.md` before rebasing, updating official Docker images, or changing self-hosting assets.
+
+## Rules
+
+- Keep custom behavior documented in this file in the same PR that changes it.
+- Prefer small, named settings over hidden behavior so future upgrades can preserve intent.
+- When official images or upstream compose files change, compare this ledger before replacing local files.
+- Keep Docker overrides explicit. If a local compose override, image tag, or Dockerfile patch becomes part of the deployment, list the file path and reapply checklist here.
+
+## Active Customizations
+
+### STR-170 — Auto-label new member-created issues
+
+Status: in progress on branch `agent/builder/STR-170-auto-label-docs`
+
+Purpose: When a workspace admin enables `workspace.settings.auto_label_new_issues`, newly created member-authored issues receive up to two labels. Existing labels are preferred; when the matcher finds a confident category and no matching label exists, the server creates the label and attaches it.
+
+Touched areas:
+
+- `server/internal/service/issue_auto_label.go` — auto-label service, deterministic matcher, label creation/attachment, event payloads.
+- `server/cmd/server/issue_auto_label_listeners.go` — `issue:created` listener for member-authored issues.
+- `server/pkg/db/queries/issue_label.sql` — case-insensitive label lookup by name.
+- `packages/core/workspace/settings.ts` — typed helper for `auto_label_new_issues`.
+- `packages/views/settings/components/workspace-tab.tsx` — Settings → General toggle.
+- `packages/views/locales/*/settings.json` — localized settings copy.
+
+Reapply checklist after upstream updates:
+
+1. Confirm `issue_label` still enforces case-insensitive unique names and `issue_to_label` still has workspace-guarded attachment.
+2. Confirm `IssueService.Create` still emits `protocol.EventIssueCreated` after commit.
+3. Confirm `protocol.EventLabelCreated` and `protocol.EventIssueLabelsChanged` payload shapes still match frontend realtime expectations.
+4. Confirm workspace settings still round-trip as JSON through `UpdateWorkspace`.
+5. Run backend labeler tests and `packages/views` settings tests.
+
+### Self-host Docker image customization
+
+Status: existing supported local-build path
+
+Purpose: Keep local/custom images separate from official GHCR images so an official image update can be pulled without losing local build behavior.
+
+Current files:
+
+- `docker-compose.selfhost.yml` pulls official images by default:
+  - `${MULTICA_BACKEND_IMAGE:-ghcr.io/multica-ai/multica-backend}:${MULTICA_IMAGE_TAG:-latest}`
+  - `${MULTICA_WEB_IMAGE:-ghcr.io/multica-ai/multica-web}:${MULTICA_IMAGE_TAG:-latest}`
+- `docker-compose.selfhost.build.yml` builds local custom images:
+  - `multica-backend:dev` from `Dockerfile`
+  - `multica-web:dev` from `Dockerfile.web`
+- `make selfhost-build` is the intended local/custom image path.
+
+Reapply checklist after official image updates:
+
+1. Pull or inspect upstream changes to `docker-compose.selfhost.yml`, `Dockerfile`, and `Dockerfile.web`.
+2. Keep custom build tags distinct from official tags unless intentionally publishing a release image.
+3. Run `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml config` before starting the stack.
+4. Start with `make selfhost-build` and verify backend `/api/config`, login, and a basic issue create flow.
+5. If deployment needs an additional override file, commit it or document the exact local path and required env vars here.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./workspace/queries": "./workspace/queries.ts",
     "./workspace/mutations": "./workspace/mutations.ts",
     "./workspace/hooks": "./workspace/hooks.ts",
+    "./workspace/settings": "./workspace/settings.ts",
     "./workspace/workspace-url": "./workspace/workspace-url.ts",
     "./workspace/avatar-url": "./workspace/avatar-url.ts",
     "./issues": "./issues/index.ts",

--- a/packages/core/workspace/index.ts
+++ b/packages/core/workspace/index.ts
@@ -1,3 +1,4 @@
 export * from "./queries";
 export * from "./mutations";
 export * from "./hooks";
+export * from "./settings";

--- a/packages/core/workspace/settings.test.ts
+++ b/packages/core/workspace/settings.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_LABEL_NEW_ISSUES_SETTING,
+  isAutoLabelNewIssuesEnabled,
+  withAutoLabelNewIssuesSetting,
+} from "./settings";
+
+describe("workspace settings", () => {
+  it("reads auto-label new issues only when explicitly enabled", () => {
+    expect(isAutoLabelNewIssuesEnabled(undefined)).toBe(false);
+    expect(isAutoLabelNewIssuesEnabled({ [AUTO_LABEL_NEW_ISSUES_SETTING]: false })).toBe(false);
+    expect(isAutoLabelNewIssuesEnabled({ [AUTO_LABEL_NEW_ISSUES_SETTING]: "true" })).toBe(false);
+    expect(isAutoLabelNewIssuesEnabled({ [AUTO_LABEL_NEW_ISSUES_SETTING]: true })).toBe(true);
+  });
+
+  it("merges auto-label setting without dropping existing workspace settings", () => {
+    expect(withAutoLabelNewIssuesSetting({ github_enabled: true }, true)).toEqual({
+      github_enabled: true,
+      [AUTO_LABEL_NEW_ISSUES_SETTING]: true,
+    });
+  });
+});

--- a/packages/core/workspace/settings.ts
+++ b/packages/core/workspace/settings.ts
@@ -1,0 +1,17 @@
+export const AUTO_LABEL_NEW_ISSUES_SETTING = "auto_label_new_issues";
+
+export function isAutoLabelNewIssuesEnabled(
+  settings: Record<string, unknown> | null | undefined,
+): boolean {
+  return settings?.[AUTO_LABEL_NEW_ISSUES_SETTING] === true;
+}
+
+export function withAutoLabelNewIssuesSetting(
+  settings: Record<string, unknown> | null | undefined,
+  enabled: boolean,
+): Record<string, unknown> {
+  return {
+    ...(settings ?? {}),
+    [AUTO_LABEL_NEW_ISSUES_SETTING]: enabled,
+  };
+}

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -145,6 +145,8 @@
     "issue_prefix_hint": "Used in issue numbers like {{example}}.",
     "prefix_confirm_title": "Change issue prefix?",
     "prefix_confirm_description": "All issues will be renumbered from {{oldPrefix}}-N to {{newPrefix}}-N. External references — pull request titles, branch names, links in docs and chat — that use {{oldPrefix}}-N will stop resolving.",
+    "auto_label_title": "Auto-label new issues",
+    "auto_label_description": "When a member creates an issue, Multica suggests up to two labels and creates a matching label when none exists.",
     "save": "Save",
     "saving": "Saving...",
     "manage_hint": "Only admins and owners can update workspace settings.",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -141,6 +141,8 @@
     "issue_prefix_hint": "{{example}} のようなイシュー番号に使用されます。",
     "prefix_confirm_title": "イシュー接頭辞を変更しますか？",
     "prefix_confirm_description": "すべてのイシュー番号が {{oldPrefix}}-N から {{newPrefix}}-N に振り直されます。Pull request のタイトル、ブランチ名、ドキュメントやチャットのリンクなど、{{oldPrefix}}-N を使用している外部参照は解決されなくなります。",
+    "auto_label_title": "新しいイシューを自動ラベル付け",
+    "auto_label_description": "メンバーがイシューを作成すると、Multica が最大 2 件のラベルを提案し、適切なラベルがなければ作成します。",
     "save": "保存",
     "saving": "保存中...",
     "manage_hint": "ワークスペース設定を更新できるのは admin と owner のみです。",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -145,6 +145,8 @@
     "issue_prefix_hint": "{{example}} 같은 이슈 번호에 사용됩니다.",
     "prefix_confirm_title": "이슈 접두사를 변경할까요?",
     "prefix_confirm_description": "모든 이슈 번호가 {{oldPrefix}}-N에서 {{newPrefix}}-N으로 다시 매겨집니다. Pull request 제목, 브랜치 이름, 문서와 채팅의 링크처럼 {{oldPrefix}}-N을 사용하는 외부 참조는 더 이상 연결되지 않습니다.",
+    "auto_label_title": "새 이슈 자동 라벨링",
+    "auto_label_description": "멤버가 이슈를 만들면 Multica가 최대 2개의 라벨을 추천하고, 맞는 라벨이 없으면 새로 만듭니다.",
     "save": "저장",
     "saving": "저장하는 중...",
     "manage_hint": "관리자와 소유자만 워크스페이스 설정을 업데이트할 수 있습니다.",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -145,6 +145,8 @@
     "issue_prefix_hint": "用于 issue 编号，例如 {{example}}。",
     "prefix_confirm_title": "确认修改 issue 前缀？",
     "prefix_confirm_description": "所有 issue 将从 {{oldPrefix}}-N 重命名为 {{newPrefix}}-N。任何使用旧编号的外部引用——PR 标题、分支名、文档与聊天中的链接——都会失效。",
+    "auto_label_title": "自动标记新 issue",
+    "auto_label_description": "成员创建 issue 时，Multica 会推荐最多 2 个标签；没有合适标签时会自动创建。",
     "save": "保存",
     "saving": "保存中...",
     "manage_hint": "只有管理员和所有者可以修改工作区设置。",

--- a/packages/views/settings/components/workspace-tab.test.tsx
+++ b/packages/views/settings/components/workspace-tab.test.tsx
@@ -16,6 +16,7 @@ const workspaceRef = vi.hoisted(() => ({
     description: "",
     context: "",
     issue_prefix: "TES",
+    settings: {} as Record<string, unknown>,
     repos: [] as { url: string }[],
   },
 }));
@@ -110,13 +111,14 @@ describe("WorkspaceTab — issue prefix editing", () => {
       description: "",
       context: "",
       issue_prefix: "TES",
+      settings: { github_enabled: true },
       repos: [],
     };
     membersRef.current = [{ user_id: "user-1", role: "owner" }];
     mockUpdateWorkspace.mockImplementation(
       async (
         _id: string,
-        payload: { issue_prefix?: string; name?: string },
+        payload: { issue_prefix?: string; name?: string; settings?: Record<string, unknown> },
       ) => ({
         ...workspaceRef.current,
         ...payload,
@@ -151,11 +153,15 @@ describe("WorkspaceTab — issue prefix editing", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledTimes(1);
     });
-    // No issue_prefix in the payload when unchanged — avoids no-op churn
-    // and keeps the request shape identical to pre-feature behavior.
+    // No issue_prefix or settings in the payload when unchanged — avoids no-op
+    // churn and avoids overwriting concurrent settings from stale cache.
     expect(mockUpdateWorkspace).toHaveBeenCalledWith(
       "workspace-1",
       expect.not.objectContaining({ issue_prefix: expect.anything() }),
+    );
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.not.objectContaining({ settings: expect.anything() }),
     );
     expect(screen.queryByText(/Change issue prefix/i)).toBeNull();
     // Non-prefix saves must NOT invalidate the issue cache — would
@@ -233,5 +239,30 @@ describe("WorkspaceTab — issue prefix editing", () => {
     membersRef.current = [{ user_id: "user-1", role: "member" }];
     render(<WorkspaceTab />, { wrapper: I18nWrapper });
     expect(screen.getByPlaceholderText("TES")).toBeDisabled();
+  });
+
+  it("saves the auto-label setting without dropping existing settings", async () => {
+    const user = userEvent.setup();
+    workspaceRef.current.settings = {
+      github_enabled: true,
+      auto_label_new_issues: false,
+    };
+    render(<WorkspaceTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("switch", { name: "Auto-label new issues" }));
+    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith(
+      "workspace-1",
+      expect.objectContaining({
+        settings: {
+          github_enabled: true,
+          auto_label_new_issues: true,
+        },
+      }),
+    );
   });
 });

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Camera, Loader2, Save, LogOut } from "lucide-react";
+import { Camera, Loader2, Save, LogOut, Tags } from "lucide-react";
 import { Input } from "@multica/ui/components/ui/input";
 import { Textarea } from "@multica/ui/components/ui/textarea";
 import { Label } from "@multica/ui/components/ui/label";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
+import { Switch } from "@multica/ui/components/ui/switch";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -27,6 +28,10 @@ import {
   workspaceKeys,
   workspaceListOptions,
 } from "@multica/core/workspace/queries";
+import {
+  isAutoLabelNewIssuesEnabled,
+  withAutoLabelNewIssuesSetting,
+} from "@multica/core/workspace/settings";
 import { issueKeys } from "@multica/core/issues/queries";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -102,6 +107,9 @@ export function WorkspaceTab() {
   const [description, setDescription] = useState(workspace?.description ?? "");
   const [context, setContext] = useState(workspace?.context ?? "");
   const [issuePrefix, setIssuePrefix] = useState(workspace?.issue_prefix ?? "");
+  const [autoLabelNewIssues, setAutoLabelNewIssues] = useState(
+    isAutoLabelNewIssuesEnabled(workspace?.settings),
+  );
   const [saving, setSaving] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
@@ -132,6 +140,7 @@ export function WorkspaceTab() {
     setDescription(workspace?.description ?? "");
     setContext(workspace?.context ?? "");
     setIssuePrefix(workspace?.issue_prefix ?? "");
+    setAutoLabelNewIssues(isAutoLabelNewIssuesEnabled(workspace?.settings));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on id only; see comment above
   }, [workspace?.id]);
 
@@ -145,6 +154,8 @@ export function WorkspaceTab() {
   const prefixChanged =
     !!workspace && normalizedPrefix !== workspace.issue_prefix;
   const prefixInvalid = normalizedPrefix.length === 0;
+  const autoLabelChanged =
+    !!workspace && isAutoLabelNewIssuesEnabled(workspace.settings) !== autoLabelNewIssues;
 
   const performSave = async (includePrefix: boolean) => {
     if (!workspace) return;
@@ -154,6 +165,9 @@ export function WorkspaceTab() {
         name,
         description,
         context,
+        ...(autoLabelChanged
+          ? { settings: withAutoLabelNewIssuesSetting(workspace.settings, autoLabelNewIssues) }
+          : {}),
         ...(includePrefix ? { issue_prefix: normalizedPrefix } : {}),
       });
       qc.setQueryData(workspaceKeys.list(), (old: Workspace[] | undefined) =>
@@ -358,6 +372,29 @@ export function WorkspaceTab() {
                   example: `${normalizedPrefix || workspace.issue_prefix}-123`,
                 })}
               </p>
+            </div>
+            <div className="flex items-start justify-between gap-3 rounded-md border bg-muted/30 p-3">
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  <Tags className="h-4 w-4 text-muted-foreground" />
+                  <Label
+                    htmlFor="auto-label-new-issues"
+                    className="text-sm font-medium"
+                  >
+                    {t(($) => $.workspace.auto_label_title)}
+                  </Label>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t(($) => $.workspace.auto_label_description)}
+                </p>
+              </div>
+              <Switch
+                id="auto-label-new-issues"
+                checked={autoLabelNewIssues}
+                onCheckedChange={setAutoLabelNewIssues}
+                disabled={!canManageWorkspace}
+                aria-label={t(($) => $.workspace.auto_label_title)}
+              />
             </div>
             <div className="flex items-center justify-end gap-2 pt-1">
               <Button

--- a/server/cmd/server/issue_auto_label_listeners.go
+++ b/server/cmd/server/issue_auto_label_listeners.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func registerIssueAutoLabelListeners(bus *events.Bus, svc *service.IssueAutoLabelService) {
+	if bus == nil || svc == nil {
+		return
+	}
+	bus.Subscribe(protocol.EventIssueCreated, func(e events.Event) {
+		if e.ActorType != "member" {
+			return
+		}
+		issueID := issueIDFromCreatedPayload(e.Payload)
+		if issueID == "" {
+			return
+		}
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := svc.AutoLabelCreatedIssue(ctx, issueID); err != nil {
+				slog.Warn("issue auto-label: failed",
+					"workspace_id", e.WorkspaceID,
+					"issue_id", issueID,
+					"error", err,
+				)
+			}
+		}()
+	})
+}
+
+func issueIDFromCreatedPayload(payload any) string {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return ""
+	}
+	if issueID, ok := m["issue_id"].(string); ok {
+		return issueID
+	}
+	issue, ok := extractIssueFields(m["issue"])
+	if !ok {
+		return ""
+	}
+	return issue.ID
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -257,6 +257,7 @@ func main() {
 	registerSubscriberListeners(bus, queries)
 	registerActivityListeners(bus, queries)
 	registerNotificationListeners(bus, queries)
+	registerIssueAutoLabelListeners(bus, service.NewIssueAutoLabelService(queries, bus, nil))
 
 	metricsConfig := obsmetrics.ConfigFromEnv()
 	var metricsServer *http.Server

--- a/server/internal/service/issue_auto_label.go
+++ b/server/internal/service/issue_auto_label.go
@@ -1,0 +1,364 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	WorkspaceSettingAutoLabelNewIssues = "auto_label_new_issues"
+	maxAutoLabelsPerIssue              = 2
+	minAutoLabelConfidence             = 0.65
+)
+
+// IssueLabelRecommendation is a recommender output that the service can
+// resolve to an existing label or create as a new workspace label.
+type IssueLabelRecommendation struct {
+	Name       string
+	Confidence float64
+}
+
+// IssueLabelRecommender keeps the auto-labeling policy swappable without
+// coupling issue creation to a specific model or heuristic.
+type IssueLabelRecommender interface {
+	RecommendIssueLabels(ctx context.Context, issue db.Issue, existing []db.IssueLabel) ([]IssueLabelRecommendation, error)
+}
+
+// IssueAutoLabelService applies labels to newly created member-authored issues.
+type IssueAutoLabelService struct {
+	Queries     *db.Queries
+	Bus         *events.Bus
+	Recommender IssueLabelRecommender
+}
+
+func NewIssueAutoLabelService(q *db.Queries, bus *events.Bus, recommender IssueLabelRecommender) *IssueAutoLabelService {
+	if recommender == nil {
+		recommender = NewKeywordIssueLabelRecommender()
+	}
+	return &IssueAutoLabelService{
+		Queries:     q,
+		Bus:         bus,
+		Recommender: recommender,
+	}
+}
+
+func AutoLabelNewIssuesEnabled(settings []byte) bool {
+	if len(settings) == 0 {
+		return false
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(settings, &parsed); err != nil {
+		return false
+	}
+	return parsed[WorkspaceSettingAutoLabelNewIssues] == true
+}
+
+func (s *IssueAutoLabelService) AutoLabelCreatedIssue(ctx context.Context, issueID string) error {
+	if s == nil || s.Queries == nil || s.Recommender == nil {
+		return nil
+	}
+	issueUUID, err := util.ParseUUID(issueID)
+	if err != nil {
+		return err
+	}
+	issue, err := s.Queries.GetIssue(ctx, issueUUID)
+	if err != nil {
+		return err
+	}
+	if issue.CreatorType != "member" {
+		return nil
+	}
+	workspace, err := s.Queries.GetWorkspace(ctx, issue.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	if !AutoLabelNewIssuesEnabled(workspace.Settings) {
+		return nil
+	}
+	current, err := s.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return err
+	}
+	if len(current) > 0 {
+		return nil
+	}
+	existing, err := s.Queries.ListLabels(ctx, issue.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	recommendations, err := s.Recommender.RecommendIssueLabels(ctx, issue, existing)
+	if err != nil {
+		return err
+	}
+
+	attached := 0
+	for _, rec := range recommendations {
+		if attached >= maxAutoLabelsPerIssue {
+			break
+		}
+		if rec.Confidence < minAutoLabelConfidence {
+			continue
+		}
+		label, created, err := s.ensureLabel(ctx, issue.WorkspaceID, rec.Name, existing)
+		if err != nil {
+			slog.Warn("issue auto-label: failed to ensure label",
+				"issue_id", util.UUIDToString(issue.ID),
+				"label", rec.Name,
+				"error", err,
+			)
+			continue
+		}
+		if created {
+			existing = append(existing, label)
+			s.publishLabelCreated(issue.WorkspaceID, label)
+		}
+		if err := s.Queries.AttachLabelToIssue(ctx, db.AttachLabelToIssueParams{
+			IssueID:     issue.ID,
+			LabelID:     label.ID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			slog.Warn("issue auto-label: failed to attach label",
+				"issue_id", util.UUIDToString(issue.ID),
+				"label_id", util.UUIDToString(label.ID),
+				"error", err,
+			)
+			continue
+		}
+		attached++
+	}
+	if attached == 0 {
+		return nil
+	}
+
+	labels, err := s.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return err
+	}
+	s.publishIssueLabelsChanged(issue.WorkspaceID, issue.ID, labels)
+	return nil
+}
+
+func (s *IssueAutoLabelService) ensureLabel(ctx context.Context, workspaceID pgtype.UUID, rawName string, existing []db.IssueLabel) (db.IssueLabel, bool, error) {
+	name, err := normalizeAutoLabelName(rawName)
+	if err != nil {
+		return db.IssueLabel{}, false, err
+	}
+	normalized := strings.ToLower(name)
+	for _, label := range existing {
+		if strings.ToLower(label.Name) == normalized {
+			return label, false, nil
+		}
+	}
+	label, err := s.Queries.CreateLabel(ctx, db.CreateLabelParams{
+		WorkspaceID: workspaceID,
+		Name:        name,
+		Color:       colorForAutoLabel(name),
+	})
+	if err == nil {
+		return label, true, nil
+	}
+	if !isAutoLabelUniqueViolation(err) {
+		return db.IssueLabel{}, false, err
+	}
+	label, err = s.Queries.GetLabelByName(ctx, db.GetLabelByNameParams{
+		WorkspaceID: workspaceID,
+		Name:        name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.IssueLabel{}, false, err
+		}
+		return db.IssueLabel{}, false, err
+	}
+	return label, false, nil
+}
+
+func normalizeAutoLabelName(raw string) (string, error) {
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return "", errors.New("label name is required")
+	}
+	if len(name) > 32 {
+		return "", errors.New("label name must be 32 characters or fewer")
+	}
+	return name, nil
+}
+
+func isAutoLabelUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+func (s *IssueAutoLabelService) publishLabelCreated(workspaceID pgtype.UUID, label db.IssueLabel) {
+	if s.Bus == nil {
+		return
+	}
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventLabelCreated,
+		WorkspaceID: util.UUIDToString(workspaceID),
+		ActorType:   "system",
+		Payload: map[string]any{
+			"label": labelEventPayload(label),
+		},
+	})
+}
+
+func (s *IssueAutoLabelService) publishIssueLabelsChanged(workspaceID, issueID pgtype.UUID, labels []db.IssueLabel) {
+	if s.Bus == nil {
+		return
+	}
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventIssueLabelsChanged,
+		WorkspaceID: util.UUIDToString(workspaceID),
+		ActorType:   "system",
+		Payload: map[string]any{
+			"issue_id": util.UUIDToString(issueID),
+			"labels":   labelListEventPayload(labels),
+		},
+	})
+}
+
+func labelListEventPayload(labels []db.IssueLabel) []map[string]any {
+	out := make([]map[string]any, len(labels))
+	for i, label := range labels {
+		out[i] = labelEventPayload(label)
+	}
+	return out
+}
+
+func labelEventPayload(label db.IssueLabel) map[string]any {
+	return map[string]any{
+		"id":           util.UUIDToString(label.ID),
+		"workspace_id": util.UUIDToString(label.WorkspaceID),
+		"name":         label.Name,
+		"color":        label.Color,
+		"created_at":   util.TimestampToString(label.CreatedAt),
+		"updated_at":   util.TimestampToString(label.UpdatedAt),
+	}
+}
+
+type keywordLabelCategory struct {
+	Name     string
+	Keywords []string
+}
+
+type KeywordIssueLabelRecommender struct {
+	categories []keywordLabelCategory
+}
+
+func NewKeywordIssueLabelRecommender() *KeywordIssueLabelRecommender {
+	return &KeywordIssueLabelRecommender{categories: defaultKeywordLabelCategories()}
+}
+
+func (r *KeywordIssueLabelRecommender) RecommendIssueLabels(_ context.Context, issue db.Issue, _ []db.IssueLabel) ([]IssueLabelRecommendation, error) {
+	if r == nil {
+		r = NewKeywordIssueLabelRecommender()
+	}
+	title := strings.ToLower(issue.Title)
+	description := ""
+	if issue.Description.Valid {
+		description = strings.ToLower(issue.Description.String)
+	}
+
+	type scoredRecommendation struct {
+		IssueLabelRecommendation
+		score int
+	}
+	scored := make([]scoredRecommendation, 0, len(r.categories))
+	for _, category := range r.categories {
+		score := 0
+		for _, keyword := range category.Keywords {
+			needle := strings.ToLower(keyword)
+			score += strings.Count(title, needle) * 2
+			score += strings.Count(description, needle)
+		}
+		if score == 0 {
+			continue
+		}
+		confidence := math.Min(0.95, 0.55+(float64(score)*0.15))
+		scored = append(scored, scoredRecommendation{
+			IssueLabelRecommendation: IssueLabelRecommendation{
+				Name:       category.Name,
+				Confidence: confidence,
+			},
+			score: score,
+		})
+	}
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].score == scored[j].score {
+			return scored[i].Name < scored[j].Name
+		}
+		return scored[i].score > scored[j].score
+	})
+	out := make([]IssueLabelRecommendation, 0, maxAutoLabelsPerIssue)
+	for _, rec := range scored {
+		out = append(out, rec.IssueLabelRecommendation)
+		if len(out) >= maxAutoLabelsPerIssue {
+			break
+		}
+	}
+	return out, nil
+}
+
+func defaultKeywordLabelCategories() []keywordLabelCategory {
+	return []keywordLabelCategory{
+		{Name: "bug", Keywords: []string{"bug", "error", "crash", "fail", "failed", "failure", "broken", "regression", "fix", "오류", "버그", "실패", "에러", "고장", "报错", "错误"}},
+		{Name: "feature", Keywords: []string{"feature", "add", "create", "support", "implement", "new", "기능", "추가", "구현", "만들", "新建", "新增", "支持"}},
+		{Name: "docs", Keywords: []string{"docs", "documentation", "readme", "guide", "document", "문서", "기록", "정리", "가이드", "文档", "指南"}},
+		{Name: "ui", Keywords: []string{"ui", "ux", "design", "layout", "button", "modal", "screen", "화면", "디자인", "버튼", "界面", "设计"}},
+		{Name: "backend", Keywords: []string{"api", "server", "database", "db", "migration", "backend", "sql", "서버", "백엔드", "데이터베이스", "后端", "数据库"}},
+		{Name: "frontend", Keywords: []string{"frontend", "react", "component", "view", "web", "프론트", "컴포넌트", "前端", "组件"}},
+		{Name: "devops", Keywords: []string{"docker", "image", "deploy", "ci", "workflow", "release", "infra", "compose", "도커", "배포", "이미지", "部署", "镜像"}},
+		{Name: "automation", Keywords: []string{"auto", "automatic", "automation", "autopilot", "label", "labels", "자동", "자동화", "라벨", "自动", "标签"}},
+	}
+}
+
+func colorForAutoLabel(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "bug":
+		return "#ef4444"
+	case "feature":
+		return "#3b82f6"
+	case "docs":
+		return "#6366f1"
+	case "ui":
+		return "#ec4899"
+	case "backend":
+		return "#0f766e"
+	case "frontend":
+		return "#8b5cf6"
+	case "devops":
+		return "#f59e0b"
+	case "automation":
+		return "#06b6d4"
+	default:
+		palette := []string{"#ef4444", "#f97316", "#eab308", "#22c55e", "#06b6d4", "#3b82f6", "#8b5cf6", "#ec4899"}
+		hash := 0
+		for _, r := range strings.ToLower(name) {
+			hash = int(r) + ((hash << 5) - hash)
+		}
+		if hash < 0 {
+			hash = -hash
+		}
+		return palette[hash%len(palette)]
+	}
+}

--- a/server/internal/service/issue_auto_label_test.go
+++ b/server/internal/service/issue_auto_label_test.go
@@ -1,0 +1,219 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func autoLabelTestQueries(t *testing.T) (*pgxpool.Pool, *db.Queries) {
+	t.Helper()
+	ctx := context.Background()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgres://multica:multica@localhost:5432/multica?sslmode=disable"
+	}
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		t.Skipf("database unavailable: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("database unreachable: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool, db.New(pool)
+}
+
+func createAutoLabelFixture(t *testing.T, pool *pgxpool.Pool, settings string) (workspaceID string, userID string) {
+	t.Helper()
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	email := fmt.Sprintf("auto-label-%d@multica.ai", suffix)
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('Auto Label Test User', $1)
+		RETURNING id
+	`, email).Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, settings, issue_prefix)
+		VALUES ('Auto Label Tests', $1, $2::jsonb, 'ALT')
+		RETURNING id
+	`, fmt.Sprintf("auto-label-%d", suffix), settings).Scan(&workspaceID); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'owner')
+	`, workspaceID, userID); err != nil {
+		t.Fatalf("insert member: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, workspaceID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+	return workspaceID, userID
+}
+
+func createAutoLabelIssue(t *testing.T, pool *pgxpool.Pool, workspaceID, creatorType, creatorID, title, description string) string {
+	t.Helper()
+	var issueID string
+	if err := pool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, title, description, status, priority, creator_type, creator_id, position, number)
+		VALUES ($1, $2, $3, 'todo', 'medium', $4, $5, 0,
+		        (SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1))
+		RETURNING id
+	`, workspaceID, title, description, creatorType, creatorID).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	return issueID
+}
+
+func TestIssueAutoLabelServiceAttachesExistingLabel(t *testing.T) {
+	pool, queries := autoLabelTestQueries(t)
+	workspaceID, userID := createAutoLabelFixture(t, pool, `{"auto_label_new_issues":true}`)
+	label, err := queries.CreateLabel(context.Background(), db.CreateLabelParams{
+		WorkspaceID: util.MustParseUUID(workspaceID),
+		Name:        "Bug",
+		Color:       "#ef4444",
+	})
+	if err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	issueID := createAutoLabelIssue(t, pool, workspaceID, "member", userID, "Fix crash on login", "The login screen fails after submit.")
+
+	svc := NewIssueAutoLabelService(queries, events.New(), nil)
+	if err := svc.AutoLabelCreatedIssue(context.Background(), issueID); err != nil {
+		t.Fatalf("AutoLabelCreatedIssue: %v", err)
+	}
+
+	labels, err := queries.ListLabelsByIssue(context.Background(), db.ListLabelsByIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	if err != nil {
+		t.Fatalf("ListLabelsByIssue: %v", err)
+	}
+	if len(labels) != 1 || labels[0].ID != label.ID {
+		t.Fatalf("expected existing Bug label to be attached, got %+v", labels)
+	}
+	all, err := queries.ListLabels(context.Background(), util.MustParseUUID(workspaceID))
+	if err != nil {
+		t.Fatalf("ListLabels: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected no duplicate labels, got %d", len(all))
+	}
+}
+
+func TestIssueAutoLabelServiceCreatesMissingLabel(t *testing.T) {
+	pool, queries := autoLabelTestQueries(t)
+	workspaceID, userID := createAutoLabelFixture(t, pool, `{"auto_label_new_issues":true}`)
+	issueID := createAutoLabelIssue(t, pool, workspaceID, "member", userID, "Docker image deploy failure", "The compose workflow cannot deploy the backend image.")
+
+	svc := NewIssueAutoLabelService(queries, events.New(), nil)
+	if err := svc.AutoLabelCreatedIssue(context.Background(), issueID); err != nil {
+		t.Fatalf("AutoLabelCreatedIssue: %v", err)
+	}
+
+	labels, err := queries.ListLabelsByIssue(context.Background(), db.ListLabelsByIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	if err != nil {
+		t.Fatalf("ListLabelsByIssue: %v", err)
+	}
+	if len(labels) != 2 || labels[0].Name != "bug" || labels[1].Name != "devops" {
+		t.Fatalf("expected bug and devops labels, got %+v", labels)
+	}
+}
+
+func TestIssueAutoLabelServiceSkipsWhenSettingOff(t *testing.T) {
+	pool, queries := autoLabelTestQueries(t)
+	workspaceID, userID := createAutoLabelFixture(t, pool, `{}`)
+	issueID := createAutoLabelIssue(t, pool, workspaceID, "member", userID, "Fix crash on login", "The login screen fails after submit.")
+
+	svc := NewIssueAutoLabelService(queries, events.New(), nil)
+	if err := svc.AutoLabelCreatedIssue(context.Background(), issueID); err != nil {
+		t.Fatalf("AutoLabelCreatedIssue: %v", err)
+	}
+
+	labels, err := queries.ListLabelsByIssue(context.Background(), db.ListLabelsByIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	if err != nil {
+		t.Fatalf("ListLabelsByIssue: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("expected no labels when setting is off, got %+v", labels)
+	}
+}
+
+func TestIssueAutoLabelServiceSkipsAlreadyLabeledIssue(t *testing.T) {
+	pool, queries := autoLabelTestQueries(t)
+	workspaceID, userID := createAutoLabelFixture(t, pool, `{"auto_label_new_issues":true}`)
+	issueID := createAutoLabelIssue(t, pool, workspaceID, "member", userID, "Fix crash on login", "The login screen fails after submit.")
+	label, err := queries.CreateLabel(context.Background(), db.CreateLabelParams{
+		WorkspaceID: util.MustParseUUID(workspaceID),
+		Name:        "manual",
+		Color:       "#64748b",
+	})
+	if err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	if err := queries.AttachLabelToIssue(context.Background(), db.AttachLabelToIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		LabelID:     label.ID,
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	}); err != nil {
+		t.Fatalf("AttachLabelToIssue: %v", err)
+	}
+
+	svc := NewIssueAutoLabelService(queries, events.New(), nil)
+	if err := svc.AutoLabelCreatedIssue(context.Background(), issueID); err != nil {
+		t.Fatalf("AutoLabelCreatedIssue: %v", err)
+	}
+
+	labels, err := queries.ListLabelsByIssue(context.Background(), db.ListLabelsByIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	if err != nil {
+		t.Fatalf("ListLabelsByIssue: %v", err)
+	}
+	if len(labels) != 1 || labels[0].Name != "manual" {
+		t.Fatalf("expected only manual label, got %+v", labels)
+	}
+}
+
+func TestIssueAutoLabelServiceSkipsAgentCreatedIssue(t *testing.T) {
+	pool, queries := autoLabelTestQueries(t)
+	workspaceID, userID := createAutoLabelFixture(t, pool, `{"auto_label_new_issues":true}`)
+	issueID := createAutoLabelIssue(t, pool, workspaceID, "agent", userID, "Fix crash on login", "The login screen fails after submit.")
+
+	svc := NewIssueAutoLabelService(queries, events.New(), nil)
+	if err := svc.AutoLabelCreatedIssue(context.Background(), issueID); err != nil {
+		t.Fatalf("AutoLabelCreatedIssue: %v", err)
+	}
+
+	labels, err := queries.ListLabelsByIssue(context.Background(), db.ListLabelsByIssueParams{
+		IssueID:     util.MustParseUUID(issueID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	if err != nil {
+		t.Fatalf("ListLabelsByIssue: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Fatalf("expected no labels for agent-created issue, got %+v", labels)
+	}
+}

--- a/server/pkg/db/generated/issue_label.sql.go
+++ b/server/pkg/db/generated/issue_label.sql.go
@@ -135,6 +135,31 @@ func (q *Queries) GetLabel(ctx context.Context, arg GetLabelParams) (IssueLabel,
 	return i, err
 }
 
+const getLabelByName = `-- name: GetLabelByName :one
+SELECT id, workspace_id, name, color, created_at, updated_at FROM issue_label
+WHERE workspace_id = $1 AND LOWER(name) = LOWER($2)
+LIMIT 1
+`
+
+type GetLabelByNameParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Name        string      `json:"name"`
+}
+
+func (q *Queries) GetLabelByName(ctx context.Context, arg GetLabelByNameParams) (IssueLabel, error) {
+	row := q.db.QueryRow(ctx, getLabelByName, arg.WorkspaceID, arg.Name)
+	var i IssueLabel
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Color,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listLabels = `-- name: ListLabels :many
 SELECT id, workspace_id, name, color, created_at, updated_at FROM issue_label
 WHERE workspace_id = $1

--- a/server/pkg/db/queries/issue_label.sql
+++ b/server/pkg/db/queries/issue_label.sql
@@ -7,6 +7,11 @@ ORDER BY LOWER(name) ASC;
 SELECT * FROM issue_label
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetLabelByName :one
+SELECT * FROM issue_label
+WHERE workspace_id = $1 AND LOWER(name) = LOWER($2)
+LIMIT 1;
+
 -- name: CreateLabel :one
 INSERT INTO issue_label (workspace_id, name, color)
 VALUES ($1, $2, $3)


### PR DESCRIPTION
## 변경 사항

- 워크스페이스 설정 `auto_label_new_issues`가 켜진 경우 member가 새 issue를 만들면 백엔드가 최대 2개 라벨을 자동으로 붙입니다.
- 기존 라벨을 우선 사용하고, 없으면 deterministic matcher가 canonical 라벨을 생성한 뒤 `label:created` / `issue_labels:changed` 이벤트를 발행합니다.
- Settings → General에 자동 라벨링 토글을 추가하고, 기존 workspace settings를 덮어쓰지 않도록 변경된 경우에만 merge 저장합니다.
- `CUSTOMIZATIONS.md`를 추가하고 `CLAUDE.md`에서 참조하도록 해, 공식 구현체/이미지와 다른 커스텀 사항 및 Docker local-build 경로를 루트 컨텍스트로 기록했습니다.

## 스키마 변경

- 마이그레이션은 없습니다.
- sqlc query만 추가했습니다: `GetLabelByName`으로 workspace 안에서 라벨 이름을 case-insensitive 조회합니다.
- 이 환경에는 `sqlc` 바이너리가 없어 `make sqlc`는 실행하지 못했고, 생성 파일은 query와 동일한 형태로 수동 반영했습니다.

## 테스트

- `pnpm --filter @multica/core exec vitest run workspace/settings.test.ts`
- `pnpm --filter @multica/views exec vitest run settings/components/workspace-tab.test.tsx`
- `pnpm typecheck`
- `pnpm test`

## 미실행 / 환경 제약

- `make test ENV_FILE=.env.worktree`는 PostgreSQL/worktree DB 준비 후 `go: command not found`로 중단되었습니다.
- `make sqlc`는 `sqlc: command not found`로 중단되었습니다.

