### PR TITLE
fix(desktop): restore correct filename in save dialog for attachment downloads

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -219,6 +219,16 @@ function createWindow(): void {
     window.webContents.send("locale:system-changed", current);
   });
 
+  // Without this handler, Electron derives the save-dialog filename from the
+  // URL path (e.g. "/api/attachments/<id>/download" → "download.txt") and
+  // ignores the Content-Disposition header sent by the server. Forwarding
+  // getFilename() restores the correct name from Content-Disposition.
+  window.webContents.session.on("will-download", (_event, item) => {
+    item.setSaveDialogOptions({
+      defaultPath: join(app.getPath("downloads"), item.getFilename()),
+    });
+  });
+
   window.webContents.setWindowOpenHandler((details) => {
     openExternalSafely(details.url);
     return { action: "deny" };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,22 @@ import {
   clearFreezeBreadcrumb,
 } from "./freeze-breadcrumb";
 
+// Guards against registering the will-download handler more than once on the
+// same session. window.webContents.session is shared, and createWindow() can
+// be called again on macOS (app "activate" after all windows are closed).
+const downloadDialogSessions = new WeakSet<Electron.Session>();
+
+function installDownloadSaveDialogHandler(window: BrowserWindow): void {
+  const { session } = window.webContents;
+  if (downloadDialogSessions.has(session)) return;
+  downloadDialogSessions.add(session);
+  session.on("will-download", (_event, item) => {
+    item.setSaveDialogOptions({
+      defaultPath: join(app.getPath("downloads"), item.getFilename()),
+    });
+  });
+}
+
 // Bundled icon used for dock/taskbar branding. macOS/Windows production
 // builds let the OS pick up the icon from the .app bundle / .exe resources,
 // but Linux production needs an explicit BrowserWindow `icon` — AppImage
@@ -219,15 +235,7 @@ function createWindow(): void {
     window.webContents.send("locale:system-changed", current);
   });
 
-  // Without this handler, Electron derives the save-dialog filename from the
-  // URL path (e.g. "/api/attachments/<id>/download" → "download.txt") and
-  // ignores the Content-Disposition header sent by the server. Forwarding
-  // getFilename() restores the correct name from Content-Disposition.
-  window.webContents.session.on("will-download", (_event, item) => {
-    item.setSaveDialogOptions({
-      defaultPath: join(app.getPath("downloads"), item.getFilename()),
-    });
-  });
+  installDownloadSaveDialogHandler(window);
 
   window.webContents.setWindowOpenHandler((details) => {
     openExternalSafely(details.url);


### PR DESCRIPTION
## Problem

Closes #4153

When downloading an attachment from the desktop app, the native save dialog always shows `download.txt` as the filename — regardless of the actual file type or name.

**Root cause:** `win.webContents.downloadURL()` is called without a `will-download` session handler. Without this handler, Electron derives the suggested filename from the URL path (`/api/attachments/<id>/download` → `download.txt`) and ignores the `Content-Disposition` header sent by the server.

This does not affect the browser (web) version, which handles `Content-Disposition` natively and works correctly.

## Fix

Add a `will-download` event listener on `window.webContents.session` that reads the correct filename via `item.getFilename()` (which parses `Content-Disposition`) and passes it to `setSaveDialogOptions`. The user still gets the native save dialog — just with the correct default filename and extension.

## Testing

- Self-hosted deployment, LocalStorage storage mode, desktop app `0.3.24`
- Before: save dialog shows `download.txt` for all attachment types
- After: save dialog shows the correct filename (e.g. `IKS Logo Red.png`, `IKS RGB.ai`)