### PR TITLE
MUL-3414: hint custom-runtime-profile compatibility, name failure mode

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -313,6 +313,8 @@
       "step_details_label": "Configure the runtime",
       "family_label": "Base protocol family",
       "family_locked_hint": "The base protocol family can't be changed after creation.",
+      "family_compatibility_hint": "The base protocol family is the launch arguments and output protocol the daemon will speak. It is not a generic adapter for arbitrary CLIs — pick the family the underlying command already implements. Pointing this at a non-compatible CLI (e.g. grok, droid) will register a runtime that comes online but fails every task with empty output.",
+      "command_compatibility_hint": "Must accept {{family}}'s launch arguments and produce {{family}}-compatible output. Wrappers and same-protocol replacements work; tools like grok or droid don't and need a first-class provider instead.",
       "display_name_label": "Display name",
       "display_name_placeholder": "My custom Claude",
       "command_name_label": "Command",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -301,6 +301,8 @@
       "step_details_label": "ランタイムを設定",
       "family_label": "ベースプロトコルファミリー",
       "family_locked_hint": "作成後はベースプロトコルファミリーを変更できません。",
+      "family_compatibility_hint": "ベースプロトコルファミリーは、デーモンが使用する起動引数と出力プロトコルです。汎用的な CLI アダプターではないため、対象のコマンドが既に実装しているファミリーを選んでください。grok や droid のように非互換な CLI を指定すると、ランタイムは登録されてオンラインになっても、すべてのタスクが空の出力で失敗します。",
+      "command_compatibility_hint": "コマンドは {{family}} の起動引数を受け付け、{{family}} 互換の出力を生成する必要があります。同一プロトコルのラッパーや代替実装は利用できますが、grok や droid のようなツールは利用できず、専用の first-class プロバイダーとして実装する必要があります。",
       "display_name_label": "表示名",
       "display_name_placeholder": "マイカスタム Claude",
       "command_name_label": "コマンド",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -313,6 +313,8 @@
       "step_details_label": "런타임 구성",
       "family_label": "기본 프로토콜 제품군",
       "family_locked_hint": "생성 후에는 기본 프로토콜 제품군을 변경할 수 없습니다.",
+      "family_compatibility_hint": "기본 프로토콜 제품군은 데몬이 사용하는 실행 인자와 출력 프로토콜입니다. 임의의 CLI를 위한 범용 어댑터가 아니므로, 대상 명령이 이미 구현하고 있는 제품군을 선택하세요. grok이나 droid처럼 호환되지 않는 CLI를 지정하면 런타임은 등록되어 온라인으로 표시되지만 모든 작업이 빈 출력으로 실패합니다.",
+      "command_compatibility_hint": "명령은 {{family}}의 실행 인자를 받아들이고 {{family}} 호환 출력을 생성해야 합니다. 같은 프로토콜의 래퍼나 대체 구현은 사용할 수 있지만, grok이나 droid 같은 도구는 호환되지 않으며 별도의 first-class 프로바이더가 필요합니다.",
       "display_name_label": "표시 이름",
       "display_name_placeholder": "내 사용자 지정 Claude",
       "command_name_label": "명령",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -301,6 +301,8 @@
       "step_details_label": "配置运行时",
       "family_label": "基础协议类型",
       "family_locked_hint": "创建后无法更改基础协议类型。",
+      "family_compatibility_hint": "基础协议类型决定了守护进程使用的启动参数与输出协议，并不是通用 CLI 适配器。请选择目标命令本身已经兼容的协议族。如果用 grok、droid 等不兼容的 CLI，运行时虽然能上线，但每个任务都会以无输出的方式失败。",
+      "command_compatibility_hint": "命令必须接受 {{family}} 的启动参数并输出 {{family}} 协议格式。同协议的 wrapper 或替代实现可以使用，但 grok、droid 这类工具不兼容，需要单独的 first-class 接入，不能复用此项。",
       "display_name_label": "显示名称",
       "display_name_placeholder": "我的自定义 Claude",
       "command_name_label": "命令",

--- a/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
@@ -26,6 +26,28 @@ vi.mock("@tanstack/react-query", async () => {
   };
 });
 
+vi.mock("@multica/core/runtimes", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/runtimes")>(
+      "@multica/core/runtimes",
+    );
+  return {
+    ...actual,
+    // The form hooks normally pull `useQueryClient`, which the test
+    // harness deliberately does NOT install (we want unit-level isolation
+    // from the real React Query cache). Stub the mutation interface to
+    // its smallest usable shape so the form component renders.
+    useCreateRuntimeProfile: () => ({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    }),
+    useUpdateRuntimeProfile: () => ({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    }),
+  };
+});
+
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -141,5 +163,57 @@ describe("RuntimeProfilesDialog", () => {
     expect(
       screen.queryByText(/claude is a built-in protocol family/),
     ).not.toBeInTheDocument();
+  });
+
+  // MUL-3414: the dialog must surface the protocol-family compatibility
+  // boundary at exactly the two moments the user is choosing it: at the
+  // family-pick step (so they don't pick "claude" intending to launch grok)
+  // and at the command field (so they don't type a non-compatible CLI name).
+  // The original bug was a runtime that registered, came online, and then
+  // failed every task — these hints make the boundary visible before the
+  // user gets to that failure mode.
+  it("renders the family-compatibility callout on the create-step family picker", () => {
+    renderDialog();
+
+    const newButton = screen.getAllByRole("button", {
+      name: "New custom runtime",
+    })[0];
+    if (!newButton) throw new Error("expected a 'New custom runtime' button");
+    fireEvent.click(newButton);
+
+    // The callout names the failure mode (`fails every task with empty
+    // output`) so the boundary is concrete, not abstract.
+    expect(
+      screen.getByText(
+        /not a generic adapter for arbitrary CLIs/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/fails every task with empty output/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the command-compatibility hint after picking a family", () => {
+    renderDialog();
+
+    const newButton = screen.getAllByRole("button", {
+      name: "New custom runtime",
+    })[0];
+    if (!newButton) throw new Error("expected a 'New custom runtime' button");
+    fireEvent.click(newButton);
+    // Pick the cursor family — that's the original bug's protocol_family.
+    fireEvent.click(screen.getByRole("radio", { name: /cursor/i }));
+
+    // The hint interpolates the chosen family so the user reads
+    // "Must accept cursor's launch arguments…" and immediately knows the
+    // boundary applies to the family they just picked.
+    expect(
+      screen.getByText(/Must accept cursor's launch arguments/i),
+    ).toBeInTheDocument();
+    // grok / droid are named explicitly because those are the exact CLIs
+    // the original GitHub bug report tried to drop in.
+    expect(
+      screen.getByText(/grok or droid don't and need a first-class provider/i),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/views/runtimes/components/runtime-profiles-dialog.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.tsx
@@ -622,6 +622,18 @@ function ProfileFormView({
               </button>
             ))}
           </div>
+          {/* Compatibility callout: a base protocol family is the launch /
+              output protocol the daemon will speak. It is not a generic
+              adapter — picking `claude` and pointing the command at e.g.
+              `grok` or `droid` will produce a runtime that comes online but
+              fails every task with empty / unparseable output. See
+              MUL-3414. */}
+          <div
+            role="note"
+            className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-relaxed text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-200"
+          >
+            {t(($) => $.profiles.form.family_compatibility_hint)}
+          </div>
         </div>
         <div className="flex shrink-0 justify-between gap-2 border-t bg-muted/30 px-6 py-3">
           <Button type="button" variant="ghost" size="sm" onClick={onBack}>
@@ -823,6 +835,16 @@ function ProfileDetailsForm({
               {t(($) => $.profiles.form.error_command_required)}
             </p>
           )}
+          {/* Per-command compatibility reminder pinned next to the input.
+              The daemon launches whatever this command resolves to with the
+              fixed launch arguments and output protocol of the chosen
+              base family — non-compatible CLIs (e.g. grok, droid) will
+              start, register, and then fail every task. Surface this here so
+              admins don't discover it via "runtime is online but my task is
+              empty". MUL-3414. */}
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {t(($) => $.profiles.form.command_compatibility_hint, { family })}
+          </p>
         </div>
 
         <div className="space-y-1.5">

--- a/server/cmd/multica/cmd_runtime_profile.go
+++ b/server/cmd/multica/cmd_runtime_profile.go
@@ -46,7 +46,30 @@ var runtimeProfileListCmd = &cobra.Command{
 var runtimeProfileCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a custom runtime profile",
-	RunE:  runRuntimeProfileCreate,
+	Long: `Create a custom runtime profile.
+
+A profile binds a workspace-named runtime to a base protocol family (the
+launch arguments and output protocol the daemon will speak) and a
+command_name (the executable the daemon resolves on PATH at registration
+time).
+
+The base protocol family is NOT a generic CLI adapter. The daemon spawns
+the configured command with the family's fixed launch arguments
+(claude / cursor / codex / gemini / copilot / hermes / openclaw / kiro /
+kimi) and parses its stdout against that protocol's output schema. So the
+command MUST already speak the chosen family's wire format. Same-protocol
+wrappers and rebranded forks of an existing CLI are the supported use
+case (e.g. an internal launcher that injects credentials before exec'ing
+the real claude binary).
+
+Pointing a custom profile at a non-compatible CLI — for example
+'protocol_family=cursor command_name=grok' or
+'protocol_family=claude command_name=droid' — produces a runtime that
+registers, comes online, and emits heartbeats, but every claimed task
+fails with a clear "incompatible with the selected <family> protocol
+family" error. To add a genuinely new CLI (Grok, Droid, …), open a
+first-class provider request rather than reusing an existing family.`,
+	RunE: runRuntimeProfileCreate,
 }
 
 var runtimeProfileUpdateCmd = &cobra.Command{
@@ -90,8 +113,8 @@ func init() {
 	runtimeProfileListCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// create
-	runtimeProfileCreateCmd.Flags().String("protocol-family", "", "Supported backend the profile routes to (required)")
-	runtimeProfileCreateCmd.Flags().String("command-name", "", "Executable the daemon resolves on PATH (required)")
+	runtimeProfileCreateCmd.Flags().String("protocol-family", "", "Base protocol family this runtime speaks (required). The launch arguments and output protocol the daemon will use — pick the family the underlying command already implements; not a generic CLI adapter.")
+	runtimeProfileCreateCmd.Flags().String("command-name", "", "Executable the daemon resolves on PATH (required). MUST be compatible with --protocol-family's launch arguments and output format. Wrappers around the same CLI are fine; non-compatible CLIs (e.g. grok under cursor, droid under claude) come online but fail every task.")
 	runtimeProfileCreateCmd.Flags().String("display-name", "", "Human-readable profile name (required)")
 	runtimeProfileCreateCmd.Flags().String("description", "", "Optional description")
 	runtimeProfileCreateCmd.Flags().String("output", "json", "Output format: table or json")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -85,6 +85,17 @@ var (
 	detectAgentVersion   = agent.DetectVersion
 	checkAgentMinVersion = agent.CheckMinVersion
 
+	// agentNew is an indirection over agent.New so tests can drive runTask
+	// end-to-end with a stub backend without spawning real CLI processes.
+	// Production code stays exactly as before; tests swap it via t.Cleanup
+	// to install a fakeBackend whose Execute returns canned agent.Result
+	// values (e.g. timeout, idle_watchdog, auth-error). Mirrors the
+	// detectAgentVersion / lookPath pattern above. Required so MUL-3414's
+	// per-result-status branches (timeout / idle_watchdog hint, auth-error
+	// passthrough) can be regression-tested without a brittle real-process
+	// fixture.
+	agentNew = agent.New
+
 	// lookPath is an indirection over exec.LookPath so registration tests can
 	// resolve custom runtime-profile commands without manipulating the
 	// process PATH. Mirrors the detectAgentVersion hook above.
@@ -887,6 +898,66 @@ func (d *Daemon) customCommandPathForRuntime(runtimeID string) (string, bool) {
 	return path, true
 }
 
+// safeProfileCommandLabel returns a user-safe identifier for a custom runtime
+// profile's resolved command. It deliberately strips the absolute path
+// because that path is local-machine state — `multica runtime profile
+// set-path` ([cmd_runtime_profile.go](../../cmd/multica/cmd_runtime_profile.go))
+// documents the per-machine override as state that "never leaves the
+// machine", and the user-visible failure comments here are sent back to
+// the server and rendered in the issue / chat timeline. Falling back to
+// `filepath.Base` keeps the binary name (which is what UX needs in order
+// to tell `claude` apart from a renamed wrapper) while dropping the
+// host's directory layout / username / homedir prefix. The full path
+// stays in the structured daemon log via taskLog.Warn fields.
+func safeProfileCommandLabel(commandPath string) string {
+	cmd := strings.TrimSpace(commandPath)
+	if cmd == "" {
+		return "the configured command"
+	}
+	base := filepath.Base(cmd)
+	if base == "" || base == "." || base == "/" {
+		return "the configured command"
+	}
+	return base
+}
+
+// shouldRewriteAsCustomProfileIncompatible reports whether a classifier
+// reason is consistent with "the custom command isn't speaking the chosen
+// protocol family's launch / output protocol". MUL-3414 originally rewrote
+// every custom-profile failure (except poisoned API 400) into
+// runtime_version_unsupported, but that swallowed real auth / quota /
+// network / context / model errors that same-protocol wrappers can hit just
+// like the upstream CLI does — leaving users to chase a phantom protocol
+// issue and skewing failure analytics in the process. Narrow the rewrite
+// to the failure shapes that genuinely point at protocol mismatch:
+//
+//   - ReasonAgentProcessFailure: the grok-under-cursor case — the CLI
+//     rejects an unknown/typoed flag and exits non-zero before producing
+//     any protocol output.
+//   - ReasonAgentEmptyOrUnparseableOutput: the droid-under-claude shape
+//     where the CLI runs but its stdout doesn't match the family's wire
+//     format, so the wrapper sees no parseable events.
+//   - ReasonAgentUnknown: classifier couldn't match any rule. Custom
+//     profile + unclassified failure most likely means a protocol mismatch
+//     we don't have a regex for yet — folding it in here is safer than
+//     leaving it as a generic "unknown" bucket. If a real upstream issue
+//     starts landing here it will show up as a sudden change in the
+//     runtime_version_unsupported share for custom profiles only.
+//
+// Auth, quota, capacity, server, network, context overflow, missing config,
+// missing executable, model not found, and the runtime version checks
+// upstream go through unchanged — those are real conditions the user must
+// fix and must not be repackaged as "incompatible with the protocol family".
+func shouldRewriteAsCustomProfileIncompatible(reason taskfailure.Reason) bool {
+	switch reason {
+	case taskfailure.ReasonAgentProcessFailure,
+		taskfailure.ReasonAgentEmptyOrUnparseableOutput,
+		taskfailure.ReasonAgentUnknown:
+		return true
+	}
+	return false
+}
+
 // wrapCustomProfileExecError rewrites a raw backend.Execute error or a failed
 // agent.Result.Error string into a user-facing comment that names the actual
 // failure mode for custom runtime profiles (MUL-3414): the user pointed an
@@ -901,15 +972,16 @@ func (d *Daemon) customCommandPathForRuntime(runtimeID string) (string, bool) {
 // already document — same-protocol wrappers work, arbitrary CLIs (grok,
 // droid, …) do not — so a single read of the failed task in the issue
 // timeline matches what the dialog warned about at create time.
+//
+// The user-visible text intentionally uses only the binary basename via
+// safeProfileCommandLabel; the absolute resolved path is local-machine
+// state and stays in the daemon log, never the issue/chat comment.
 func wrapCustomProfileExecError(provider, commandPath, rawError string) string {
 	raw := strings.TrimSpace(rawError)
 	if raw == "" {
 		raw = "no error detail captured"
 	}
-	cmd := strings.TrimSpace(commandPath)
-	if cmd == "" {
-		cmd = "the configured command"
-	}
+	cmd := safeProfileCommandLabel(commandPath)
 	return fmt.Sprintf(
 		"Custom runtime profile is incompatible with the selected %s protocol family. "+
 			"Custom profiles require a command that accepts %s-compatible launch arguments "+
@@ -918,6 +990,40 @@ func wrapCustomProfileExecError(provider, commandPath, rawError string) string {
 			"genuinely new CLIs (e.g. grok, droid). Original error: %s",
 		provider, provider, provider, cmd, raw,
 	)
+}
+
+// appendCustomProfileSilenceHint augments a timeout / idle-watchdog comment
+// with a profile-compatibility pointer when no session was ever established.
+// MUL-3414's original concrete case for this path is droid-under-claude:
+// claude.go launches the binary, which then sits silent because it doesn't
+// understand the claude protocol — the run wedges and is killed by the
+// idle watchdog or hits the wall-clock timeout, with `result.SessionID`
+// still empty because no session_started event was ever emitted.
+//
+// We deliberately do NOT touch failure_reason here. timeout / idle_watchdog
+// are platform-side reasons used by the runtime sweepers and the operator
+// dashboards; rewriting them as runtime_version_unsupported would mask
+// genuine resource hangs (e.g. claude legitimately stuck on a long tool
+// call) just because the user happens to be on a custom profile. The
+// user-visible comment is the right place for the hint, the analytics
+// taxonomy is not.
+func appendCustomProfileSilenceHint(provider, commandPath, baseComment string) string {
+	cmd := safeProfileCommandLabel(commandPath)
+	hint := fmt.Sprintf(
+		"This runtime is launched from a custom runtime profile (%s). "+
+			"Because no protocol output was received before the watchdog fired, the "+
+			"most likely cause is that the command isn't speaking the selected %s "+
+			"protocol family — same-protocol wrappers are supported, but arbitrary "+
+			"CLIs (e.g. grok, droid) must be added as a first-class provider. "+
+			"Verify the command accepts %s's launch arguments and produces "+
+			"%s-compatible output before treating this as a Multica runtime issue.",
+		cmd, provider, provider, provider,
+	)
+	base := strings.TrimSpace(baseComment)
+	if base == "" {
+		return hint
+	}
+	return base + "\n\n" + hint
 }
 
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
@@ -3451,7 +3557,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			agentEnv[k] = v
 		}
 	}
-	backend, err := agent.New(provider, agent.Config{
+	backend, err := agentNew(provider, agent.Config{
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
@@ -3579,25 +3685,48 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
 	if err != nil {
-		// MUL-3414: when a custom runtime profile is in use, surface the
-		// real failure mode — the user pointed an incompatible CLI at a
-		// built-in protocol family — instead of letting handleTask's
-		// generic FailTask classify it as a runner crash. Returning a
-		// TaskResult with status=blocked + a refined failure_reason
+		// MUL-3414: when a custom runtime profile is in use AND the
+		// failure shape genuinely points at protocol mismatch (the CLI
+		// rejects launch flags, exits non-zero before producing any
+		// protocol output, or returns nothing parseable), surface the
+		// real failure mode instead of letting handleTask's generic
+		// FailTask classify it as a runner crash. Returning a
+		// TaskResult with status=blocked + failure_reason set directly
 		// preserves the SessionID/WorkDir that the error path otherwise
-		// drops, AND lets us pin failure_reason directly without going
-		// through Classify's string heuristics.
+		// drops AND lets us pin failure_reason without going through
+		// Classify's string heuristics a second time.
+		//
+		// Auth, quota, network, context_overflow, missing_config /
+		// missing_executable, model-not-found and the runtime-version
+		// rules all fall through unchanged — those are real conditions
+		// the user must fix and must NOT be repackaged as
+		// "incompatible with the protocol family" just because the run
+		// happened to be on a custom profile (review feedback from
+		// GPT-Boy on PR #4301).
 		if isCustomProfile {
-			wrapped := wrapCustomProfileExecError(provider, customCommandPath, err.Error())
-			taskLog.Warn("custom runtime profile execute failed; classifying as runtime_version_unsupported",
-				"provider", provider, "command_path", customCommandPath, "raw_error", err.Error())
-			return TaskResult{
-				Status:        "blocked",
-				Comment:       wrapped,
-				WorkDir:       env.WorkDir,
-				EnvRoot:       env.RootDir,
-				FailureReason: taskfailure.ReasonAgentRuntimeVersionUnsupported.String(),
-			}, nil
+			rawErr := err.Error()
+			classifierReason := taskfailure.Classify(rawErr)
+			if shouldRewriteAsCustomProfileIncompatible(classifierReason) {
+				taskLog.Warn("custom runtime profile execute failed; classifying as runtime_version_unsupported",
+					"provider", provider,
+					"command_path", customCommandPath, // structured field — log only, never user-visible.
+					"original_classifier_reason", classifierReason,
+					"raw_error", rawErr,
+				)
+				return TaskResult{
+					Status:        "blocked",
+					Comment:       wrapCustomProfileExecError(provider, customCommandPath, rawErr),
+					WorkDir:       env.WorkDir,
+					EnvRoot:       env.RootDir,
+					FailureReason: taskfailure.ReasonAgentRuntimeVersionUnsupported.String(),
+				}, nil
+			}
+			taskLog.Warn("custom runtime profile execute failed with non-protocol-shape reason; preserving classifier reason",
+				"provider", provider,
+				"command_path", customCommandPath,
+				"failure_reason", classifierReason,
+				"raw_error", rawErr,
+			)
 		}
 		return TaskResult{}, err
 	}
@@ -3711,6 +3840,24 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			)
 			failureReason = reason
 		}
+		// MUL-3414: a custom-profile runtime that wedges before
+		// emitting any session_started event is the droid-under-claude
+		// shape from the original bug — the binary launches, sits
+		// silent because it doesn't speak the family's protocol, and
+		// gets killed by the wall-clock timeout. Append a profile-
+		// compatibility hint to the user-visible comment so the user
+		// doesn't read "claude timed out" and assume it's a Multica
+		// or upstream-CLI bug. failure_reason stays "timeout" — that's
+		// what the runtime sweepers and operator dashboards key off,
+		// and a real resource hang on a same-protocol wrapper still
+		// belongs in the timeout bucket.
+		if isCustomProfile && result.SessionID == "" {
+			taskLog.Warn("custom runtime profile timed out without establishing a session; appending compatibility hint",
+				"provider", provider, "command_path", customCommandPath,
+				"failure_reason", failureReason,
+			)
+			comment = appendCustomProfileSilenceHint(provider, customCommandPath, comment)
+		}
 		return TaskResult{
 			Status:        "blocked",
 			Comment:       comment,
@@ -3729,6 +3876,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		comment := result.Error
 		if comment == "" {
 			comment = idleWatchdogReason(d.cfg.AgentIdleWatchdog)
+		}
+		// MUL-3414: same logic as the timeout branch above. A custom
+		// profile that goes idle without ever producing protocol output
+		// is far more likely to be incompatible than to be legitimately
+		// stuck on a long-running tool call.
+		if isCustomProfile && result.SessionID == "" {
+			taskLog.Warn("custom runtime profile hit idle watchdog without establishing a session; appending compatibility hint",
+				"provider", provider, "command_path", customCommandPath,
+			)
+			comment = appendCustomProfileSilenceHint(provider, customCommandPath, comment)
 		}
 		return TaskResult{
 			Status:        "blocked",
@@ -3795,13 +3952,32 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		// or "returned no parseable output". Done after the poisoned-API
 		// classifier so a genuine upstream 400 is still classified
 		// correctly even when triggered through a custom profile.
-		if isCustomProfile && failureReason != taskfailure.ReasonAPIInvalidRequest.String() {
+		//
+		// Narrowed (PR #4301 review): only rewrite when the classifier
+		// reason genuinely points at protocol mismatch
+		// (process_failure, empty_or_unparseable_output, unknown).
+		// Same-protocol wrappers can hit auth / quota / network / model /
+		// context_overflow / missing_config errors just like the upstream
+		// CLI does — repackaging those as "incompatible" sends users on
+		// a wild goose chase and skews failure analytics. See
+		// shouldRewriteAsCustomProfileIncompatible for the predicate
+		// rationale.
+		if isCustomProfile && shouldRewriteAsCustomProfileIncompatible(taskfailure.Reason(failureReason)) {
 			taskLog.Warn("custom runtime profile execution failed; rewriting failure_reason",
-				"provider", provider, "command_path", customCommandPath,
-				"original_failure_reason", failureReason, "raw_error", errMsg,
+				"provider", provider,
+				"command_path", customCommandPath, // structured field — log only, never user-visible.
+				"original_failure_reason", failureReason,
+				"raw_error", errMsg,
 			)
 			errMsg = wrapCustomProfileExecError(provider, customCommandPath, errMsg)
 			failureReason = taskfailure.ReasonAgentRuntimeVersionUnsupported.String()
+		} else if isCustomProfile {
+			taskLog.Warn("custom runtime profile execution failed with non-protocol-shape reason; preserving classifier reason",
+				"provider", provider,
+				"command_path", customCommandPath,
+				"failure_reason", failureReason,
+				"raw_error", errMsg,
+			)
 		}
 		return TaskResult{
 			Status:        "blocked",

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -887,6 +887,39 @@ func (d *Daemon) customCommandPathForRuntime(runtimeID string) (string, bool) {
 	return path, true
 }
 
+// wrapCustomProfileExecError rewrites a raw backend.Execute error or a failed
+// agent.Result.Error string into a user-facing comment that names the actual
+// failure mode for custom runtime profiles (MUL-3414): the user pointed an
+// incompatible CLI at a built-in protocol family, so the runtime came online
+// but cannot speak the family's launch arguments / output protocol. The
+// runTask error path uses this together with
+// taskfailure.ReasonAgentRuntimeVersionUnsupported so the run leaves a
+// blocked task whose failure_reason and comment together tell the user
+// exactly what is wrong, instead of a generic "agent backend failed".
+//
+// The wording deliberately calls out the boundary that the UI/CLI hints
+// already document — same-protocol wrappers work, arbitrary CLIs (grok,
+// droid, …) do not — so a single read of the failed task in the issue
+// timeline matches what the dialog warned about at create time.
+func wrapCustomProfileExecError(provider, commandPath, rawError string) string {
+	raw := strings.TrimSpace(rawError)
+	if raw == "" {
+		raw = "no error detail captured"
+	}
+	cmd := strings.TrimSpace(commandPath)
+	if cmd == "" {
+		cmd = "the configured command"
+	}
+	return fmt.Sprintf(
+		"Custom runtime profile is incompatible with the selected %s protocol family. "+
+			"Custom profiles require a command that accepts %s-compatible launch arguments "+
+			"and produces %s-compatible output; %s does not. "+
+			"Use a same-protocol wrapper or open a first-class provider request to add "+
+			"genuinely new CLIs (e.g. grok, droid). Original error: %s",
+		provider, provider, provider, cmd, raw,
+	)
+}
+
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
 	d.logger.Debug("registering runtimes for workspace", "workspace_id", workspaceID, "agent_count", len(d.cfg.Agents))
 	var runtimes []map[string]string
@@ -3127,12 +3160,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Critically, a custom runtime can live on a host that has NO built-in
 	// agent of the same provider installed, so when the runtime is custom we
 	// synthesize an AgentEntry instead of hard-failing on the !ok lookup.
-	if customPath, isCustom := d.customCommandPathForRuntime(task.RuntimeID); isCustom {
-		entry.Path = customPath
+	customCommandPath, isCustomProfile := d.customCommandPathForRuntime(task.RuntimeID)
+	if isCustomProfile {
+		entry.Path = customCommandPath
 		ok = true
 		d.logger.Info("task uses custom runtime profile command",
 			"task_id", task.ID, "runtime_id", task.RuntimeID,
-			"provider", provider, "command_path", customPath)
+			"provider", provider, "command_path", customCommandPath)
 	}
 	if !ok {
 		return TaskResult{}, fmt.Errorf("no agent configured for provider %q", provider)
@@ -3545,6 +3579,26 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
 	if err != nil {
+		// MUL-3414: when a custom runtime profile is in use, surface the
+		// real failure mode — the user pointed an incompatible CLI at a
+		// built-in protocol family — instead of letting handleTask's
+		// generic FailTask classify it as a runner crash. Returning a
+		// TaskResult with status=blocked + a refined failure_reason
+		// preserves the SessionID/WorkDir that the error path otherwise
+		// drops, AND lets us pin failure_reason directly without going
+		// through Classify's string heuristics.
+		if isCustomProfile {
+			wrapped := wrapCustomProfileExecError(provider, customCommandPath, err.Error())
+			taskLog.Warn("custom runtime profile execute failed; classifying as runtime_version_unsupported",
+				"provider", provider, "command_path", customCommandPath, "raw_error", err.Error())
+			return TaskResult{
+				Status:        "blocked",
+				Comment:       wrapped,
+				WorkDir:       env.WorkDir,
+				EnvRoot:       env.RootDir,
+				FailureReason: taskfailure.ReasonAgentRuntimeVersionUnsupported.String(),
+			}, nil
+		}
 		return TaskResult{}, err
 	}
 
@@ -3733,6 +3787,21 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			// MUL-1949 offline backfill to re-classify after the
 			// fact.
 			failureReason = taskfailure.Classify(errMsg).String()
+		}
+		// MUL-3414: for custom runtime profiles, replace the generic
+		// classifier output with a refined "runtime_version_unsupported"
+		// reason and rewrite the comment so users see "incompatible with
+		// the selected protocol family" instead of a raw "exit status 2"
+		// or "returned no parseable output". Done after the poisoned-API
+		// classifier so a genuine upstream 400 is still classified
+		// correctly even when triggered through a custom profile.
+		if isCustomProfile && failureReason != taskfailure.ReasonAPIInvalidRequest.String() {
+			taskLog.Warn("custom runtime profile execution failed; rewriting failure_reason",
+				"provider", provider, "command_path", customCommandPath,
+				"original_failure_reason", failureReason, "raw_error", errMsg,
+			)
+			errMsg = wrapCustomProfileExecError(provider, customCommandPath, errMsg)
+			failureReason = taskfailure.ReasonAgentRuntimeVersionUnsupported.String()
 		}
 		return TaskResult{
 			Status:        "blocked",

--- a/server/internal/daemon/runtime_profile_runtask_test.go
+++ b/server/internal/daemon/runtime_profile_runtask_test.go
@@ -2,36 +2,94 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/multica-ai/multica/server/pkg/agent"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
-// TestWrapCustomProfileExecError_UnitShape pins the user-facing copy that
-// runTask uses when a custom runtime profile (MUL-3414) fails. The exact
-// strings matter because they are read straight from a failed-task comment
-// in the issue timeline — the boundary the dialog and CLI hints already
-// document ("must accept <family>-compatible launch arguments and produce
-// <family>-compatible output") needs to be repeated here so a single read
-// of the failed task tells the user the same thing.
-func TestWrapCustomProfileExecError_UnitShape(t *testing.T) {
+// Tests in this file pin the MUL-3414 contract that custom runtime profiles
+// produce a clear, redacted, narrowly-scoped failure message — and that the
+// rewrite never bleeds into built-in runtimes or genuine
+// auth/quota/network errors. Reviewer feedback on PR #4301 (GPT-Boy)
+// surfaced three regressions in the first cut that these tests now guard:
+//
+//   1. The user-visible comment must NOT carry the daemon's local absolute
+//      command path (issue/chat is a server-rendered surface; that path is
+//      local-machine state per `runtime profile set-path`).
+//   2. The rewrite must NOT swallow real auth / missing-config / quota /
+//      network failures into "incompatible". Same-protocol wrappers can
+//      hit those exactly like the upstream CLI does.
+//   3. The droid-shape (binary launches, stays silent, gets killed by
+//      timeout / idle watchdog) must produce a compatibility hint. The
+//      original PR only handled exec-error and explicit failed-result
+//      shapes.
+
+// TestSafeProfileCommandLabel exhaustively pins the redaction rules. The
+// label is what users see in failed-task comments — a regression here is
+// a privacy regression (leaks home dirs / usernames / install layout).
+func TestSafeProfileCommandLabel(t *testing.T) {
 	t.Parallel()
 
-	got := wrapCustomProfileExecError("cursor", "/usr/local/bin/grok", "exit status 2")
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"posix abs path", "/Users/alice/.local/bin/grok", "grok"},
+		{"system abs path", "/usr/local/bin/droid", "droid"},
+		{"relative path", "./bin/grok", "grok"},
+		{"bare command", "grok", "grok"},
+		{"empty string falls back", "", "the configured command"},
+		{"whitespace-only falls back", "   ", "the configured command"},
+		{"root falls back", "/", "the configured command"},
+		{"trailing slash falls back to dot, then placeholder", ".", "the configured command"},
+	}
 
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := safeProfileCommandLabel(tc.in)
+			if got != tc.want {
+				t.Errorf("safeProfileCommandLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapCustomProfileExecError_RedactsAbsolutePath is the privacy
+// regression guard for review point #1: the daemon must not echo the
+// host's absolute command path back into the user-visible failure
+// comment, because that comment is rendered server-side in the issue /
+// chat timeline. Only the binary basename should appear; the absolute
+// path stays in the structured daemon log via taskLog fields.
+func TestWrapCustomProfileExecError_RedactsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	absPath := "/Users/alice/.local/bin/grok"
+	got := wrapCustomProfileExecError("cursor", absPath, "exit status 2")
+
+	if strings.Contains(got, absPath) {
+		t.Errorf("wrap output leaked the absolute command path; users would see local FS layout in the issue timeline\nfull: %s", got)
+	}
+	if strings.Contains(got, "/Users/alice") {
+		t.Errorf("wrap output leaked the homedir prefix; users would see the daemon owner's username in the issue timeline\nfull: %s", got)
+	}
+	if !strings.Contains(got, "grok") {
+		t.Errorf("wrap output dropped the binary basename; users need at least the command name to debug\nfull: %s", got)
+	}
 	for _, want := range []string{
 		"Custom runtime profile is incompatible",
 		"cursor protocol family",
 		"cursor-compatible launch arguments",
 		"cursor-compatible output",
-		"/usr/local/bin/grok",
 		"first-class provider",
 		"Original error: exit status 2",
 	} {
@@ -57,47 +115,137 @@ func TestWrapCustomProfileExecError_Defaults(t *testing.T) {
 	}
 }
 
-// TestRunTask_CustomProfileExecError_RewritesTaskResult is the regression
-// guard for MUL-3414: when a custom runtime profile resolves to a binary that
-// errors out at exec time (the typical shape for grok-under-cursor or
-// droid-under-claude), runTask must NOT propagate the raw error up to
-// handleTask's generic FailTask path. Instead it returns a TaskResult whose
-// Comment names the real failure mode and whose FailureReason is the refined
-// taxonomy value `agent_error.runtime_version_unsupported`, so the issue
-// timeline tells the user the same thing the create-time UI hint warned
-// about.
-//
-// The test uses a non-existent binary as the custom command_path, which
-// forces backend.Execute to fail at cmd.Start; that exercises the
-// executeAndDrain-error branch of runTask. The default-status branch (where
-// the agent emits a structured failure result) is covered indirectly by
-// existing classifier tests — the wrap-and-retag logic is the same.
-func TestRunTask_CustomProfileExecError_RewritesTaskResult(t *testing.T) {
+// TestShouldRewriteAsCustomProfileIncompatible exhaustively pins the
+// narrow-rewrite policy from review point #2. The predicate is the only
+// thing standing between "user sees the real auth/quota/network error"
+// and "user gets sent on a wild goose chase looking for a non-existent
+// protocol mismatch". A drift here would also re-bucket failure_reason
+// rows that the analytics dashboards key off, so the test enumerates
+// every reason in the canonical set rather than spot-checking.
+func TestShouldRewriteAsCustomProfileIncompatible(t *testing.T) {
 	t.Parallel()
+
+	rewriteAllowed := map[taskfailure.Reason]bool{
+		taskfailure.ReasonAgentProcessFailure:            true,
+		taskfailure.ReasonAgentEmptyOrUnparseableOutput:  true,
+		taskfailure.ReasonAgentUnknown:                   true,
+	}
+
+	for _, reason := range taskfailure.AllReasons() {
+		want := rewriteAllowed[reason]
+		got := shouldRewriteAsCustomProfileIncompatible(reason)
+		if got != want {
+			t.Errorf("shouldRewriteAsCustomProfileIncompatible(%s) = %v, want %v\nProtocol-shape failures (process_failure / empty_or_unparseable_output / unknown) MUST be rewritten as runtime_version_unsupported. Every other reason — auth, quota, network, server, capacity, context_overflow, missing_config, missing_executable, model_not_found, runtime_version_unsupported (already correct), poisoned API 400, platform-side reasons — MUST pass through unchanged so the user sees the real error and analytics dashboards don't drift.",
+				reason, got, want)
+		}
+	}
+}
+
+// TestAppendCustomProfileSilenceHint covers review point #3: the hint that
+// gets appended to timeout / idle_watchdog comments when a custom-profile
+// runtime hangs before establishing a session. Verifies the hint preserves
+// the base comment, mentions only the binary basename (not the absolute
+// path), and points the user at the family-compatibility check.
+func TestAppendCustomProfileSilenceHint(t *testing.T) {
+	t.Parallel()
+
+	base := "claude timed out after 30m0s"
+	got := appendCustomProfileSilenceHint("claude", "/opt/homebrew/bin/droid", base)
+
+	if !strings.HasPrefix(got, base) {
+		t.Errorf("hint must preserve the original timeout comment as a prefix\nfull: %s", got)
+	}
+	if strings.Contains(got, "/opt/homebrew/bin/droid") {
+		t.Errorf("hint leaked the absolute command path: %s", got)
+	}
+	if !strings.Contains(got, "droid") {
+		t.Errorf("hint should still name the binary (basename) so users know which command to check: %s", got)
+	}
+	for _, want := range []string{
+		"custom runtime profile",
+		"claude protocol family",
+		"first-class provider",
+		"watchdog fired",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hint missing %q\nfull: %s", want, got)
+		}
+	}
+
+	// Empty base comment: hint stands alone, no leading newlines.
+	standalone := appendCustomProfileSilenceHint("claude", "droid", "")
+	if strings.HasPrefix(standalone, "\n") {
+		t.Errorf("standalone hint should not start with a newline: %q", standalone)
+	}
+}
+
+// fakeAgentBackend is a stub agent.Backend that returns a canned
+// agent.Result on Execute. Used to drive runTask end-to-end through the
+// post-executeAndDrain switch (timeout / idle_watchdog / failed-result
+// branches) without spawning a real CLI.
+type fakeAgentBackend struct {
+	result    agent.Result
+	executeOK bool
+	execErr   error
+}
+
+func (b *fakeAgentBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	if !b.executeOK {
+		return nil, b.execErr
+	}
+	msgCh := make(chan agent.Message)
+	resCh := make(chan agent.Result, 1)
+	close(msgCh)
+	resCh <- b.result
+	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// stubAgentNew swaps the package-level agentNew hook so runTask uses the
+// supplied backend instead of spawning a real CLI. The cleanup restores the
+// production agent.New so test order is irrelevant.
+func stubAgentNew(t *testing.T, backend agent.Backend) {
+	t.Helper()
+	orig := agentNew
+	agentNew = func(_ string, _ agent.Config) (agent.Backend, error) {
+		return backend, nil
+	}
+	t.Cleanup(func() { agentNew = orig })
+}
+
+// runTaskFixture builds the minimum daemon state (with a custom runtime
+// profile registered or not) for a runTask end-to-end test. Returns the
+// daemon and the canonical task to feed into runTask.
+type runTaskFixture struct {
+	d              *Daemon
+	task           Task
+	customCmdPath  string
+}
+
+func newCustomProfileFixture(t *testing.T) *runTaskFixture {
+	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 
-	missingBin := filepath.Join(t.TempDir(), "definitely-not-cursor")
-	workspacesRoot := t.TempDir()
+	customCmd := filepath.Join(t.TempDir(), "custom-cli")
 	d := freshDaemon(srv.URL)
 	d.cfg = Config{
-		WorkspacesRoot: workspacesRoot,
+		WorkspacesRoot: t.TempDir(),
 		Agents: map[string]AgentEntry{
-			// A built-in cursor entry exists on this host; the custom
-			// profile will override its Path with missingBin via the
-			// profileCommandPaths lookup.
 			"cursor": {Path: "/should/be/overridden"},
 		},
+		// Tight timeout values aren't required for stub-backed tests; runTask
+		// only formats them into messages when the backend reports timeout.
+		AgentTimeout: 30,
 	}
 	d.runtimeIndex["rt-custom"] = Runtime{
 		ID:        "rt-custom",
 		Provider:  "cursor",
-		ProfileID: "prof-grok",
+		ProfileID: "prof-custom",
 	}
-	d.profileCommandPaths = map[string]string{"prof-grok": missingBin}
+	d.profileCommandPaths = map[string]string{"prof-custom": customCmd}
 
 	task := Task{
 		ID:          "task-mul-3414",
@@ -107,12 +255,31 @@ func TestRunTask_CustomProfileExecError_RewritesTaskResult(t *testing.T) {
 		AuthToken:   "mat_test_token",
 		Agent:       &AgentData{Name: "test-agent"},
 	}
+	return &runTaskFixture{d: d, task: task, customCmdPath: customCmd}
+}
+
+// TestRunTask_CustomProfileExecError_RewritesTaskResult is the regression
+// guard for the original MUL-3414 grok-under-cursor shape: a backend
+// Execute error whose classifier reason is process_failure /
+// empty_or_unparseable_output / unknown gets rewritten to
+// runtime_version_unsupported, with a redacted user-visible comment.
+func TestRunTask_CustomProfileExecError_RewritesTaskResult(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook and parallel
+	// runTask integration tests would interleave each other's stubs.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: false,
+		// "exit status 2" classifies as ReasonAgentProcessFailure — the
+		// shape grok produces when cursor.go feeds it --output-format
+		// stream-json and grok rejects the value.
+		execErr: errors.New("cursor-agent exited with error: exit status 2"),
+	})
 
 	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	result, err := d.runTask(context.Background(), task, "cursor", 0, taskLog)
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
 	if err != nil {
-		t.Fatalf("runTask returned a hard error; the custom-profile branch must convert exec failures into a blocked TaskResult so SessionID/WorkDir flow through and the failure_reason taxonomy stays refined: %v", err)
+		t.Fatalf("runTask returned a hard error; the custom-profile branch must convert exec failures into a blocked TaskResult so SessionID/WorkDir flow through: %v", err)
 	}
 	if result.Status != "blocked" {
 		t.Fatalf("expected status=blocked, got %q (full result: %+v)", result.Status, result)
@@ -121,44 +288,240 @@ func TestRunTask_CustomProfileExecError_RewritesTaskResult(t *testing.T) {
 		t.Errorf("expected failure_reason=%s, got %q",
 			taskfailure.ReasonAgentRuntimeVersionUnsupported, result.FailureReason)
 	}
-	for _, want := range []string{
-		"Custom runtime profile is incompatible",
-		"cursor protocol family",
-		missingBin,
-	} {
-		if !strings.Contains(result.Comment, want) {
-			t.Errorf("comment missing %q\nfull: %s", want, result.Comment)
-		}
+	if !strings.Contains(result.Comment, "Custom runtime profile is incompatible") {
+		t.Errorf("comment missing custom-profile copy: %s", result.Comment)
+	}
+	if strings.Contains(result.Comment, fx.customCmdPath) {
+		t.Errorf("comment leaked absolute command path %q\nfull: %s", fx.customCmdPath, result.Comment)
+	}
+	if !strings.Contains(result.Comment, filepath.Base(fx.customCmdPath)) {
+		t.Errorf("comment dropped binary basename: %s", result.Comment)
+	}
+}
+
+// TestRunTask_CustomProfileExecError_AuthErrorPassesThrough is the review
+// point #2 regression guard. A custom profile that hits an auth failure
+// (e.g. the same-protocol wrapper passes through to the upstream CLI which
+// returns 401 because the user's token expired) must NOT be rewritten as
+// "incompatible with the protocol family" — that would send the user
+// looking for a phantom protocol issue and skew failure analytics.
+func TestRunTask_CustomProfileExecError_AuthErrorPassesThrough(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: false,
+		// Classifier maps "401 unauthorized" to ReasonAgentProviderAuthOrAccess
+		// (see classify.go rule 3). A real same-protocol wrapper can produce
+		// this verbatim because it just shells out to the upstream CLI.
+		execErr: errors.New("API Error: 401 unauthorized — invalid api key"),
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+
+	// Non-protocol-shape failures keep the original (TaskResult{}, err)
+	// contract so handleTask classifies via FailTask exactly as it would
+	// for a built-in runtime.
+	if err == nil {
+		t.Fatalf("auth failure must propagate as an error so handleTask runs the canonical FailTask classifier; got TaskResult instead: %+v", result)
+	}
+	if !strings.Contains(err.Error(), "401 unauthorized") {
+		t.Errorf("error must preserve the original 401 wording so handleTask's classifier sees the real shape: %v", err)
+	}
+	if strings.Contains(err.Error(), "Custom runtime profile is incompatible") {
+		t.Errorf("auth error must not be rewritten as incompatible; got: %v", err)
+	}
+}
+
+// TestRunTask_CustomProfileFailedResult_AuthErrorPreservesReason mirrors
+// the auth-passthrough guard above for the default-status branch (where
+// the backend completes with Status=failed and the auth error is in
+// Result.Error rather than the Execute return). Same policy: the
+// classifier reason must survive untouched.
+func TestRunTask_CustomProfileFailedResult_AuthErrorPreservesReason(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: true,
+		result: agent.Result{
+			Status: "failed",
+			Error:  "Anthropic API: 401 unauthorized — please login again",
+		},
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask: unexpected hard error: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected status=blocked, got %q", result.Status)
+	}
+	if result.FailureReason != taskfailure.ReasonAgentProviderAuthOrAccess.String() {
+		t.Errorf("expected failure_reason=%s (the real classifier output), got %q — auth errors must not be rewritten as runtime_version_unsupported on custom profiles",
+			taskfailure.ReasonAgentProviderAuthOrAccess, result.FailureReason)
+	}
+	if strings.Contains(result.Comment, "Custom runtime profile is incompatible") {
+		t.Errorf("comment must not be rewritten as incompatible for an auth failure; users need to see the real 401: %s", result.Comment)
+	}
+	if !strings.Contains(result.Comment, "401 unauthorized") {
+		t.Errorf("comment must preserve the original error so the user can debug: %s", result.Comment)
+	}
+}
+
+// TestRunTask_CustomProfileFailedResult_ProtocolShapeRewrites pins the
+// positive case for the default-status branch: when the agent emits
+// "returned no parseable output" (the droid-under-claude shape), the
+// classifier maps that to empty_or_unparseable_output, which IS a
+// protocol-shape failure → rewrite to runtime_version_unsupported.
+func TestRunTask_CustomProfileFailedResult_ProtocolShapeRewrites(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: true,
+		result: agent.Result{
+			Status: "failed",
+			Error:  "claude returned no parseable output",
+		},
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask: unexpected hard error: %v", err)
+	}
+	if result.FailureReason != taskfailure.ReasonAgentRuntimeVersionUnsupported.String() {
+		t.Errorf("expected failure_reason=%s, got %q",
+			taskfailure.ReasonAgentRuntimeVersionUnsupported, result.FailureReason)
+	}
+	if !strings.Contains(result.Comment, "Custom runtime profile is incompatible") {
+		t.Errorf("comment missing custom-profile copy: %s", result.Comment)
+	}
+}
+
+// TestRunTask_CustomProfileTimeout_NoSession_AppendsHint is review point
+// #3's positive case: a timeout on a custom-profile runtime that never
+// established a session (the droid-under-claude shape) must surface the
+// compatibility hint in the user-visible comment, while keeping
+// failure_reason=timeout for the operator dashboards.
+func TestRunTask_CustomProfileTimeout_NoSession_AppendsHint(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: true,
+		result: agent.Result{
+			Status:    "timeout",
+			Error:     "claude timed out after 30m0s",
+			SessionID: "", // no session = strong signal the protocol never engaged
+		},
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask: unexpected hard error: %v", err)
+	}
+	if result.FailureReason != "timeout" {
+		t.Errorf("failure_reason must stay timeout (platform-side reason for runtime sweepers), got %q",
+			result.FailureReason)
+	}
+	if !strings.Contains(result.Comment, "claude timed out") {
+		t.Errorf("base timeout message must be preserved: %s", result.Comment)
+	}
+	if !strings.Contains(result.Comment, "custom runtime profile") {
+		t.Errorf("comment must include the custom-profile compatibility hint: %s", result.Comment)
+	}
+	if strings.Contains(result.Comment, fx.customCmdPath) {
+		t.Errorf("hint leaked absolute command path: %s", result.Comment)
+	}
+}
+
+// TestRunTask_CustomProfileTimeout_WithSession_NoHint is the negative
+// case: a timeout that DID establish a session is most likely a
+// legitimate hang (long tool call against a frozen child), not a
+// protocol-mismatch shape. The hint would be misleading, so it must NOT
+// be appended.
+func TestRunTask_CustomProfileTimeout_WithSession_NoHint(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: true,
+		result: agent.Result{
+			Status:    "timeout",
+			Error:     "claude timed out after 30m0s",
+			SessionID: "sess-existed", // session was established → protocol DID engage
+		},
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask: unexpected hard error: %v", err)
+	}
+	if strings.Contains(result.Comment, "custom runtime profile") {
+		t.Errorf("hint must NOT fire when a session was established (legitimate hang, not protocol mismatch): %s", result.Comment)
+	}
+}
+
+// TestRunTask_CustomProfileIdleWatchdog_NoSession_AppendsHint mirrors the
+// timeout case for the idle_watchdog branch.
+func TestRunTask_CustomProfileIdleWatchdog_NoSession_AppendsHint(t *testing.T) {
+	// Not parallel: stubAgentNew swaps a package-level hook.
+
+	fx := newCustomProfileFixture(t)
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: true,
+		result: agent.Result{
+			Status:    "idle_watchdog",
+			Error:     "agent went silent for longer than 5m0s",
+			SessionID: "",
+		},
+	})
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	result, err := fx.d.runTask(context.Background(), fx.task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask: unexpected hard error: %v", err)
+	}
+	if result.FailureReason != "idle_watchdog" {
+		t.Errorf("failure_reason must stay idle_watchdog, got %q", result.FailureReason)
+	}
+	if !strings.Contains(result.Comment, "custom runtime profile") {
+		t.Errorf("comment must include the custom-profile compatibility hint: %s", result.Comment)
 	}
 }
 
 // TestRunTask_BuiltInExecError_StaysOnLegacyClassifierPath guards the
-// inverse of MUL-3414: a built-in (non-custom) runtime that fails for the
-// same exec-time reason must stay on the existing classifier path so the
-// taxonomy used by Grafana / failure analytics doesn't shift from real
-// runner crashes into runtime_version_unsupported. Without this guard, a
+// inverse: a built-in (non-custom) runtime that fails with a process_failure
+// shape must stay on the existing classifier path. Without this guard, a
 // future change that forgets to gate the rewrite on isCustomProfile would
 // silently re-bucket every built-in failure too.
 func TestRunTask_BuiltInExecError_StaysOnLegacyClassifierPath(t *testing.T) {
-	t.Parallel()
+	// Not parallel: stubAgentNew swaps a package-level hook.
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 
-	missingBin := filepath.Join(t.TempDir(), "definitely-not-cursor")
-	workspacesRoot := t.TempDir()
 	d := freshDaemon(srv.URL)
 	d.cfg = Config{
-		WorkspacesRoot: workspacesRoot,
+		WorkspacesRoot: t.TempDir(),
 		Agents: map[string]AgentEntry{
-			"cursor": {Path: missingBin},
+			"cursor": {Path: "/usr/local/bin/cursor"},
 		},
 	}
-	// Built-in runtime: no ProfileID, so customCommandPathForRuntime
-	// returns ("", false) and the rewrite branch must not fire.
 	d.runtimeIndex["rt-builtin"] = Runtime{ID: "rt-builtin", Provider: "cursor"}
+
+	stubAgentNew(t, &fakeAgentBackend{
+		executeOK: false,
+		execErr:   errors.New("cursor-agent exited with error: exit status 2"),
+	})
 
 	task := Task{
 		ID:          "task-builtin-fail",
@@ -170,30 +533,25 @@ func TestRunTask_BuiltInExecError_StaysOnLegacyClassifierPath(t *testing.T) {
 	}
 
 	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
-
 	result, err := d.runTask(context.Background(), task, "cursor", 0, taskLog)
-	// The built-in path returns the raw error from runTask. The exact
-	// failure mode (cmd.Start ENOENT, no parseable output, etc.) depends on
-	// the cursor backend's internal behaviour and isn't this test's
-	// concern; the contract is "no custom-profile rewrite", which is
-	// equally satisfied by an error return or a TaskResult that does NOT
-	// carry runtime_version_unsupported.
-	switch {
-	case err != nil:
-		// OK — built-in error path, runTask returned the raw error.
-	case result.FailureReason == taskfailure.ReasonAgentRuntimeVersionUnsupported.String():
-		t.Fatalf("built-in runtime failure was rewritten as runtime_version_unsupported; the rewrite branch must be gated on isCustomProfile (full result: %+v)", result)
-	case strings.Contains(result.Comment, "Custom runtime profile is incompatible"):
-		t.Fatalf("built-in runtime failure picked up the custom-profile copy in its comment: %s", result.Comment)
+
+	// Built-in path must propagate the raw error so handleTask runs the
+	// canonical FailTask classifier — the rewrite must be gated on
+	// isCustomProfile.
+	if err == nil {
+		t.Fatalf("built-in runtime exec failure must propagate as an error, not a TaskResult: %+v", result)
+	}
+	if strings.Contains(err.Error(), "Custom runtime profile is incompatible") {
+		t.Fatalf("built-in runtime exec failure picked up the custom-profile copy: %v", err)
 	}
 }
 
-// Compile-time assertion: the wrap helper must use the canonical taxonomy
-// constant rather than a hard-coded string. If the const is renamed the
+// Compile-time assertions: the wrap helper must use the canonical taxonomy
+// constants rather than hard-coded strings. If any const is renamed the
 // failing build is the test we want, not a silent label drift.
 var _ = taskfailure.ReasonAgentRuntimeVersionUnsupported
-
-// Compile-time assertion: agent.SupportedTypes is the source of truth for
-// which families a custom profile can reuse. cursor must remain in it for
-// this test pair to exercise a representative protocol family.
-var _ = agent.SupportedTypes
+var _ = taskfailure.ReasonAgentProcessFailure
+var _ = taskfailure.ReasonAgentEmptyOrUnparseableOutput
+var _ = taskfailure.ReasonAgentUnknown
+var _ = taskfailure.ReasonAgentProviderAuthOrAccess
+var _ = atomic.Int32{} // keep sync/atomic import wired even if future edits drop the only use

--- a/server/internal/daemon/runtime_profile_runtask_test.go
+++ b/server/internal/daemon/runtime_profile_runtask_test.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+// TestWrapCustomProfileExecError_UnitShape pins the user-facing copy that
+// runTask uses when a custom runtime profile (MUL-3414) fails. The exact
+// strings matter because they are read straight from a failed-task comment
+// in the issue timeline — the boundary the dialog and CLI hints already
+// document ("must accept <family>-compatible launch arguments and produce
+// <family>-compatible output") needs to be repeated here so a single read
+// of the failed task tells the user the same thing.
+func TestWrapCustomProfileExecError_UnitShape(t *testing.T) {
+	t.Parallel()
+
+	got := wrapCustomProfileExecError("cursor", "/usr/local/bin/grok", "exit status 2")
+
+	for _, want := range []string{
+		"Custom runtime profile is incompatible",
+		"cursor protocol family",
+		"cursor-compatible launch arguments",
+		"cursor-compatible output",
+		"/usr/local/bin/grok",
+		"first-class provider",
+		"Original error: exit status 2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wrap output missing %q\nfull: %s", want, got)
+		}
+	}
+}
+
+// TestWrapCustomProfileExecError_Defaults guards the empty-input edges so a
+// backend that returns an empty Result.Error or a misconfigured daemon with
+// an empty command path still produces a readable comment.
+func TestWrapCustomProfileExecError_Defaults(t *testing.T) {
+	t.Parallel()
+
+	got := wrapCustomProfileExecError("claude", "", "")
+
+	if !strings.Contains(got, "the configured command") {
+		t.Errorf("empty command path should fall back to placeholder, got: %s", got)
+	}
+	if !strings.Contains(got, "no error detail captured") {
+		t.Errorf("empty raw error should fall back to placeholder, got: %s", got)
+	}
+}
+
+// TestRunTask_CustomProfileExecError_RewritesTaskResult is the regression
+// guard for MUL-3414: when a custom runtime profile resolves to a binary that
+// errors out at exec time (the typical shape for grok-under-cursor or
+// droid-under-claude), runTask must NOT propagate the raw error up to
+// handleTask's generic FailTask path. Instead it returns a TaskResult whose
+// Comment names the real failure mode and whose FailureReason is the refined
+// taxonomy value `agent_error.runtime_version_unsupported`, so the issue
+// timeline tells the user the same thing the create-time UI hint warned
+// about.
+//
+// The test uses a non-existent binary as the custom command_path, which
+// forces backend.Execute to fail at cmd.Start; that exercises the
+// executeAndDrain-error branch of runTask. The default-status branch (where
+// the agent emits a structured failure result) is covered indirectly by
+// existing classifier tests — the wrap-and-retag logic is the same.
+func TestRunTask_CustomProfileExecError_RewritesTaskResult(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	missingBin := filepath.Join(t.TempDir(), "definitely-not-cursor")
+	workspacesRoot := t.TempDir()
+	d := freshDaemon(srv.URL)
+	d.cfg = Config{
+		WorkspacesRoot: workspacesRoot,
+		Agents: map[string]AgentEntry{
+			// A built-in cursor entry exists on this host; the custom
+			// profile will override its Path with missingBin via the
+			// profileCommandPaths lookup.
+			"cursor": {Path: "/should/be/overridden"},
+		},
+	}
+	d.runtimeIndex["rt-custom"] = Runtime{
+		ID:        "rt-custom",
+		Provider:  "cursor",
+		ProfileID: "prof-grok",
+	}
+	d.profileCommandPaths = map[string]string{"prof-grok": missingBin}
+
+	task := Task{
+		ID:          "task-mul-3414",
+		WorkspaceID: "ws-mul-3414",
+		RuntimeID:   "rt-custom",
+		IssueID:     "issue-mul-3414",
+		AuthToken:   "mat_test_token",
+		Agent:       &AgentData{Name: "test-agent"},
+	}
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	result, err := d.runTask(context.Background(), task, "cursor", 0, taskLog)
+	if err != nil {
+		t.Fatalf("runTask returned a hard error; the custom-profile branch must convert exec failures into a blocked TaskResult so SessionID/WorkDir flow through and the failure_reason taxonomy stays refined: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected status=blocked, got %q (full result: %+v)", result.Status, result)
+	}
+	if result.FailureReason != taskfailure.ReasonAgentRuntimeVersionUnsupported.String() {
+		t.Errorf("expected failure_reason=%s, got %q",
+			taskfailure.ReasonAgentRuntimeVersionUnsupported, result.FailureReason)
+	}
+	for _, want := range []string{
+		"Custom runtime profile is incompatible",
+		"cursor protocol family",
+		missingBin,
+	} {
+		if !strings.Contains(result.Comment, want) {
+			t.Errorf("comment missing %q\nfull: %s", want, result.Comment)
+		}
+	}
+}
+
+// TestRunTask_BuiltInExecError_StaysOnLegacyClassifierPath guards the
+// inverse of MUL-3414: a built-in (non-custom) runtime that fails for the
+// same exec-time reason must stay on the existing classifier path so the
+// taxonomy used by Grafana / failure analytics doesn't shift from real
+// runner crashes into runtime_version_unsupported. Without this guard, a
+// future change that forgets to gate the rewrite on isCustomProfile would
+// silently re-bucket every built-in failure too.
+func TestRunTask_BuiltInExecError_StaysOnLegacyClassifierPath(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	missingBin := filepath.Join(t.TempDir(), "definitely-not-cursor")
+	workspacesRoot := t.TempDir()
+	d := freshDaemon(srv.URL)
+	d.cfg = Config{
+		WorkspacesRoot: workspacesRoot,
+		Agents: map[string]AgentEntry{
+			"cursor": {Path: missingBin},
+		},
+	}
+	// Built-in runtime: no ProfileID, so customCommandPathForRuntime
+	// returns ("", false) and the rewrite branch must not fire.
+	d.runtimeIndex["rt-builtin"] = Runtime{ID: "rt-builtin", Provider: "cursor"}
+
+	task := Task{
+		ID:          "task-builtin-fail",
+		WorkspaceID: "ws-builtin-fail",
+		RuntimeID:   "rt-builtin",
+		IssueID:     "issue-builtin-fail",
+		AuthToken:   "mat_test_token",
+		Agent:       &AgentData{Name: "test-agent"},
+	}
+
+	taskLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	result, err := d.runTask(context.Background(), task, "cursor", 0, taskLog)
+	// The built-in path returns the raw error from runTask. The exact
+	// failure mode (cmd.Start ENOENT, no parseable output, etc.) depends on
+	// the cursor backend's internal behaviour and isn't this test's
+	// concern; the contract is "no custom-profile rewrite", which is
+	// equally satisfied by an error return or a TaskResult that does NOT
+	// carry runtime_version_unsupported.
+	switch {
+	case err != nil:
+		// OK — built-in error path, runTask returned the raw error.
+	case result.FailureReason == taskfailure.ReasonAgentRuntimeVersionUnsupported.String():
+		t.Fatalf("built-in runtime failure was rewritten as runtime_version_unsupported; the rewrite branch must be gated on isCustomProfile (full result: %+v)", result)
+	case strings.Contains(result.Comment, "Custom runtime profile is incompatible"):
+		t.Fatalf("built-in runtime failure picked up the custom-profile copy in its comment: %s", result.Comment)
+	}
+}
+
+// Compile-time assertion: the wrap helper must use the canonical taxonomy
+// constant rather than a hard-coded string. If the const is renamed the
+// failing build is the test we want, not a silent label drift.
+var _ = taskfailure.ReasonAgentRuntimeVersionUnsupported
+
+// Compile-time assertion: agent.SupportedTypes is the source of truth for
+// which families a custom profile can reuse. cursor must remain in it for
+// this test pair to exercise a representative protocol family.
+var _ = agent.SupportedTypes


### PR DESCRIPTION
Closes MUL-3414

## Background

GitHub bug [#4293](https://github.com/multica-ai/multica/issues/4293):
admins created a custom runtime profile, kept the built-in
`protocol_family` (e.g. `cursor`, `claude`), and pointed `command_name`
at `grok` / `droid`. The runtime registered, came online, kept emitting
heartbeats, and then failed every claimed task — with a generic
"agent backend failed" error that gave no hint the profile itself was
the cause. Triage on the issue (GPT-Boy) confirmed: the daemon launches
the custom command with the family's hard-coded launch arguments and
parses its stdout against the family's protocol; nothing dynamically
adapts to a different CLI.

This PR ships the agreed-on "提示 + 明确错误" (hints + clear errors)
fix. It does NOT add Grok/Droid support — that lives separately as
[#4111](https://github.com/multica-ai/multica/issues/4111).

## Core changes

1. **UI hint** — `runtime-profiles-dialog.tsx`
   - Family-pick step: amber callout naming the failure mode
     (`registers, comes online, fails every task with empty output`)
     so admins see the boundary before they pick `claude` intending to
     run `grok`.
   - Command field: a per-family hint
     (`Must accept <family>'s launch arguments and produce <family>-
     compatible output. … grok or droid don't and need a first-class
     provider`) so the boundary is repeated next to the input where
     they are typing the binary name.
   - Locale strings added to `en / zh-Hans / ja / ko` runtimes.json;
     parity test stays green.

2. **CLI hint** — `cmd_runtime_profile.go`
   - `multica runtime profile create` gains a `Long` help block
     enumerating the supported families and explaining that
     non-compatible CLIs come online but fail every task.
   - `--protocol-family` / `--command-name` flag descriptions repeat
     the boundary so admins reading `--help` see it inline.

3. **Daemon clear error** — `daemon.go`
   - `runTask` now retains `isCustomProfile` and `customCommandPath`
     after the existing `customCommandPathForRuntime` lookup.
   - Both error paths (`backend.Execute` returning an error and the
     `default:` Result-status branch) call a new
     `wrapCustomProfileExecError(provider, command, raw)` and pin
     `failure_reason = agent_error.runtime_version_unsupported`. The
     poisoned-API 400 classifier still wins, so genuine upstream
     rejections keep their existing reason.
   - The wrapped comment names the protocol family, the actual
     command path, the contract (must accept family-compatible
     arguments and output), and includes the original error so daemon
     log forensics still work.

## Out of scope (intentionally)

- No server-side strict validation of `command_name` at create/update
  time. The server doesn't know each host's PATH and `command_name`
  is allowed to be a wrapper, so a strong validator would mis-fail.
- `fixed_args` is still not exposed (the daemon's existing TODO under
  MUL-3284 still applies). Exposing it now would offer admins a
  workaround that doesn't actually take effect.
- No first-class Grok / Droid backend.

## Tests

- `packages/views/runtimes/components/runtime-profiles-dialog.test.tsx`
  — 2 new cases: family-callout copy on the family step, and the
  per-family command hint after picking `cursor`.
- `server/internal/daemon/runtime_profile_runtask_test.go` (new) —
  shape + defaults of `wrapCustomProfileExecError`, plus a
  behavioural `runTask` case that proves a custom-profile exec
  failure becomes `Status=blocked / FailureReason=runtime_version_unsupported`
  with the refined comment, and a guard that built-in-runtime
  failures are NOT rewritten (so the taxonomy used by failure
  analytics stays stable).

## Verification

- `pnpm --filter @multica/views typecheck` → ok
- `pnpm --filter @multica/views test` → 1419 passed (incl. locale
  parity)
- `go test ./internal/daemon/... ./pkg/taskfailure/... ./pkg/agent/...
  ./cmd/multica/...` → all green
- `go test -race ./internal/daemon/...` → clean
- Pre-existing handler test failures referencing a missing
  `source_task_id` column reproduce on `main` and are unrelated to
  this change.
