### PR TITLE
MUL-3417: tolerate OpenClaw config file CLI mismatch

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -486,6 +486,14 @@ func openclawParseActiveConfigPath(out string) (string, bool, error) {
 }
 
 func openclawFallbackActiveConfigPath() (string, bool, error) {
+	if explicitPath := strings.TrimSpace(os.Getenv("OPENCLAW_CONFIG_PATH")); explicitPath != "" {
+		path, err := expandOpenclawPath(explicitPath)
+		if err != nil {
+			return "", false, err
+		}
+		return openclawStatConfigPath(path)
+	}
+
 	candidates, canonicalPath, err := openclawFallbackConfigCandidates()
 	if err != nil {
 		return "", false, err
@@ -521,8 +529,8 @@ var openclawFallbackConfigDirNames = []string{
 }
 
 func openclawFallbackConfigCandidates() ([]string, string, error) {
-	candidates := make([]string, 0, 2+2*len(openclawFallbackConfigFileNames)+len(openclawFallbackConfigDirNames)*len(openclawFallbackConfigFileNames))
-	for _, env := range []string{"OPENCLAW_CONFIG_PATH", "CLAWDBOT_CONFIG_PATH"} {
+	candidates := make([]string, 0, 1+2*len(openclawFallbackConfigFileNames)+len(openclawFallbackConfigDirNames)*len(openclawFallbackConfigFileNames))
+	for _, env := range []string{"CLAWDBOT_CONFIG_PATH"} {
 		if path := strings.TrimSpace(os.Getenv(env)); path != "" {
 			candidates = append(candidates, path)
 		}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -130,9 +130,11 @@ type OpenclawConfigResult struct {
 // resolution to the openclaw CLI itself rather than re-implementing the
 // spec. We:
 //
-//  1. Run `openclaw config file` to find the user's active config path
-//     (handles OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, OPENCLAW_HOME, and
-//     the default location).
+//  1. Run `openclaw config file` to find the user's active config path.
+//     For OpenClaw releases whose `config` command rejects the `file`
+//     subcommand shape, fall back to resolving the documented path env vars:
+//     OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, OPENCLAW_HOME, and the
+//     default location.
 //  2. Run `openclaw config get agents.list --json` to enumerate every
 //     registered agent ID with its resolved fields. The CLI parses JSON5,
 //     follows $include, and substitutes ${VAR} for us.
@@ -435,7 +437,12 @@ func stripUserMcpServers(resolved map[string]any) {
 //
 // The CLI handles the full resolution chain — OPENCLAW_CONFIG_PATH, the
 // state directory (OPENCLAW_STATE_DIR / OPENCLAW_HOME / default), legacy
-// migration, and `~` expansion — so we don't re-implement it here.
+// migration, and `~` expansion — so we prefer it when the installed CLI
+// supports the command.
+//
+// OpenClaw 2026.2.x briefly rejected `openclaw config file` with the generic
+// "too many arguments for 'config'" error. For that command-shape failure only,
+// fall back to the documented path env vars so task prep can still continue.
 //
 // The reported path uses `~` shorthand for the user's home; we expand it
 // so the $include reference we write is unambiguous absolute.
@@ -444,8 +451,15 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 	defer cancel()
 	out, err := openclawExec(ctx, bin, "config", "file")
 	if err != nil {
+		if isOpenclawConfigFileUnsupported(err) {
+			return openclawFallbackActiveConfigPath()
+		}
 		return "", false, err
 	}
+	return openclawParseActiveConfigPath(out)
+}
+
+func openclawParseActiveConfigPath(out string) (string, bool, error) {
 	// OpenClaw may print terminal UI borders (e.g., Doctor warnings) before
 	// the actual path. The path is always the last non-empty line.
 	lines := strings.Split(strings.TrimSpace(out), "\n")
@@ -460,10 +474,49 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 	if path == "" {
 		return "", false, fmt.Errorf("`openclaw config file` returned empty output")
 	}
+	var err error
+	path, err = expandOpenclawPath(path)
+	if err != nil {
+		return "", false, err
+	}
+	return openclawStatConfigPath(path)
+}
+
+func openclawFallbackActiveConfigPath() (string, bool, error) {
+	path := strings.TrimSpace(os.Getenv("OPENCLAW_CONFIG_PATH"))
+	if path == "" {
+		stateDir := strings.TrimSpace(os.Getenv("OPENCLAW_STATE_DIR"))
+		if stateDir == "" {
+			home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
+			var err error
+			if home == "" {
+				home, err = os.UserHomeDir()
+				if err != nil {
+					return "", false, fmt.Errorf("resolve openclaw home: %w", err)
+				}
+			} else {
+				home, err = expandOpenclawPath(home)
+				if err != nil {
+					return "", false, fmt.Errorf("resolve OPENCLAW_HOME: %w", err)
+				}
+			}
+			stateDir = filepath.Join(home, ".openclaw")
+		}
+		path = filepath.Join(stateDir, "openclaw.json")
+	}
+
+	path, err := expandOpenclawPath(path)
+	if err != nil {
+		return "", false, err
+	}
+	return openclawStatConfigPath(path)
+}
+
+func expandOpenclawPath(path string) (string, error) {
 	if path == "~" || strings.HasPrefix(path, "~/") {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
-			return "", false, fmt.Errorf("expand `~` in openclaw config path: %w", herr)
+			return "", fmt.Errorf("expand `~` in openclaw config path: %w", herr)
 		}
 		if path == "~" {
 			path = home
@@ -471,6 +524,17 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
 		}
 	}
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("resolve openclaw config path %q: %w", path, err)
+		}
+		path = abs
+	}
+	return path, nil
+}
+
+func openclawStatConfigPath(path string) (string, bool, error) {
 	if !filepath.IsAbs(path) {
 		return "", false, fmt.Errorf("openclaw reported non-absolute config path %q", path)
 	}
@@ -485,6 +549,13 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 		return "", false, fmt.Errorf("openclaw config path %s is a directory, not a file", path)
 	}
 	return path, true, nil
+}
+
+func isOpenclawConfigFileUnsupported(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "too many arguments for 'config'") ||
+		strings.Contains(msg, "expected 0 arguments but got 1") ||
+		(strings.Contains(msg, "unknown") && strings.Contains(msg, "config") && strings.Contains(msg, "file"))
 }
 
 // openclawResolvedFullConfig fetches the user's fully resolved openclaw

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -452,7 +452,11 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 	out, err := openclawExec(ctx, bin, "config", "file")
 	if err != nil {
 		if isOpenclawConfigFileUnsupported(err) {
-			return openclawFallbackActiveConfigPath()
+			path, exists, ferr := openclawFallbackActiveConfigPath()
+			if ferr != nil {
+				return "", false, fmt.Errorf("fallback after unsupported `openclaw config file` (%v): %w", err, ferr)
+			}
+			return path, exists, nil
 		}
 		return "", false, err
 	}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -132,9 +132,8 @@ type OpenclawConfigResult struct {
 //
 //  1. Run `openclaw config file` to find the user's active config path.
 //     For OpenClaw releases whose `config` command rejects the `file`
-//     subcommand shape, fall back to resolving the documented path env vars:
-//     OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, OPENCLAW_HOME, and the
-//     default location.
+//     subcommand shape, fall back to resolving OpenClaw's active-config
+//     candidates, including legacy Clawdbot/Moltbot/Moldbot locations.
 //  2. Run `openclaw config get agents.list --json` to enumerate every
 //     registered agent ID with its resolved fields. The CLI parses JSON5,
 //     follows $include, and substitutes ${VAR} for us.
@@ -435,14 +434,14 @@ func stripUserMcpServers(resolved map[string]any) {
 // openclawActiveConfigPath runs `openclaw config file` to discover the path
 // the openclaw CLI considers active. Returns (absolutePath, exists, error).
 //
-// The CLI handles the full resolution chain — OPENCLAW_CONFIG_PATH, the
-// state directory (OPENCLAW_STATE_DIR / OPENCLAW_HOME / default), legacy
-// migration, and `~` expansion — so we prefer it when the installed CLI
-// supports the command.
+// The CLI handles the full resolution chain — explicit config path, state
+// directory, OPENCLAW_HOME / default home, legacy locations, migration, and `~`
+// expansion — so we prefer it when the installed CLI supports the command.
 //
 // OpenClaw 2026.2.x briefly rejected `openclaw config file` with the generic
 // "too many arguments for 'config'" error. For that command-shape failure only,
-// fall back to the documented path env vars so task prep can still continue.
+// fall back to the same active-config candidate shape so task prep can still
+// continue without losing upgraded users' legacy config files.
 //
 // The reported path uses `~` shorthand for the user's home; we expand it
 // so the $include reference we write is unambiguous absolute.
@@ -487,33 +486,79 @@ func openclawParseActiveConfigPath(out string) (string, bool, error) {
 }
 
 func openclawFallbackActiveConfigPath() (string, bool, error) {
-	path := strings.TrimSpace(os.Getenv("OPENCLAW_CONFIG_PATH"))
-	if path == "" {
-		stateDir := strings.TrimSpace(os.Getenv("OPENCLAW_STATE_DIR"))
-		if stateDir == "" {
-			home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
-			var err error
-			if home == "" {
-				home, err = os.UserHomeDir()
-				if err != nil {
-					return "", false, fmt.Errorf("resolve openclaw home: %w", err)
-				}
-			} else {
-				home, err = expandOpenclawPath(home)
-				if err != nil {
-					return "", false, fmt.Errorf("resolve OPENCLAW_HOME: %w", err)
-				}
-			}
-			stateDir = filepath.Join(home, ".openclaw")
-		}
-		path = filepath.Join(stateDir, "openclaw.json")
-	}
-
-	path, err := expandOpenclawPath(path)
+	candidates, canonicalPath, err := openclawFallbackConfigCandidates()
 	if err != nil {
 		return "", false, err
 	}
-	return openclawStatConfigPath(path)
+	for _, candidate := range candidates {
+		path, err := expandOpenclawPath(candidate)
+		if err != nil {
+			return "", false, err
+		}
+		exists, err := openclawConfigPathExists(path)
+		if err != nil {
+			return "", false, err
+		}
+		if exists {
+			return path, true, nil
+		}
+	}
+	return openclawStatConfigPath(canonicalPath)
+}
+
+var openclawFallbackConfigFileNames = []string{
+	"openclaw.json",
+	"clawdbot.json",
+	"moltbot.json",
+	"moldbot.json",
+}
+
+var openclawFallbackConfigDirNames = []string{
+	".openclaw",
+	".clawdbot",
+	".moltbot",
+	".moldbot",
+}
+
+func openclawFallbackConfigCandidates() ([]string, string, error) {
+	candidates := make([]string, 0, 2+2*len(openclawFallbackConfigFileNames)+len(openclawFallbackConfigDirNames)*len(openclawFallbackConfigFileNames))
+	for _, env := range []string{"OPENCLAW_CONFIG_PATH", "CLAWDBOT_CONFIG_PATH"} {
+		if path := strings.TrimSpace(os.Getenv(env)); path != "" {
+			candidates = append(candidates, path)
+		}
+	}
+
+	for _, env := range []string{"OPENCLAW_STATE_DIR", "CLAWDBOT_STATE_DIR"} {
+		if dir := strings.TrimSpace(os.Getenv(env)); dir != "" {
+			candidates = appendOpenclawConfigFileCandidates(candidates, dir)
+		}
+	}
+
+	home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
+	var err error
+	if home == "" {
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve openclaw home: %w", err)
+		}
+	} else {
+		home, err = expandOpenclawPath(home)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve OPENCLAW_HOME: %w", err)
+		}
+	}
+
+	for _, dirName := range openclawFallbackConfigDirNames {
+		candidates = appendOpenclawConfigFileCandidates(candidates, filepath.Join(home, dirName))
+	}
+	return candidates, filepath.Join(home, ".openclaw", "openclaw.json"), nil
+}
+
+func appendOpenclawConfigFileCandidates(candidates []string, dir string) []string {
+	for _, name := range openclawFallbackConfigFileNames {
+		candidates = append(candidates, filepath.Join(dir, name))
+	}
+	return candidates
 }
 
 func expandOpenclawPath(path string) (string, error) {
@@ -542,17 +587,25 @@ func openclawStatConfigPath(path string) (string, bool, error) {
 	if !filepath.IsAbs(path) {
 		return "", false, fmt.Errorf("openclaw reported non-absolute config path %q", path)
 	}
+	exists, err := openclawConfigPathExists(path)
+	if err != nil {
+		return "", false, err
+	}
+	return path, exists, nil
+}
+
+func openclawConfigPathExists(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return path, false, nil
+		return false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("stat openclaw config %s: %w", path, err)
+		return false, fmt.Errorf("stat openclaw config %s: %w", path, err)
 	}
 	if info.IsDir() {
-		return "", false, fmt.Errorf("openclaw config path %s is a directory, not a file", path)
+		return false, fmt.Errorf("openclaw config path %s is a directory, not a file", path)
 	}
-	return path, true, nil
+	return true, nil
 }
 
 func isOpenclawConfigFileUnsupported(err error) bool {

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -205,8 +205,8 @@ func TestPrepareOpenclawConfigFailsClosedOnCLIError(t *testing.T) {
 // OpenClaw 2026.2.x builds that rejected `openclaw config file` with
 // "too many arguments for 'config'". That command-shape mismatch should
 // not make every task fail during execenv prep; the daemon can derive the
-// active path from documented OPENCLAW_* path vars and then continue using
-// `config get ... --json` for resolved config data.
+// active path from OpenClaw's documented and legacy config candidates and
+// then continue using `config get ... --json` for resolved config data.
 func TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported(t *testing.T) {
 	envRoot := t.TempDir()
 	workDir := filepath.Join(envRoot, "workdir")
@@ -265,11 +265,26 @@ func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
 				return path
 			},
 		},
+		"legacy_config_path": {
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "custom-clawdbot.json")
+				t.Setenv("CLAWDBOT_CONFIG_PATH", path)
+				return path
+			},
+		},
 		"state_dir": {
 			setup: func(t *testing.T) string {
 				stateDir := t.TempDir()
 				path := filepath.Join(stateDir, "openclaw.json")
 				t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+				return path
+			},
+		},
+		"legacy_state_dir": {
+			setup: func(t *testing.T) string {
+				stateDir := t.TempDir()
+				path := filepath.Join(stateDir, "clawdbot.json")
+				t.Setenv("CLAWDBOT_STATE_DIR", stateDir)
 				return path
 			},
 		},
@@ -285,6 +300,30 @@ func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
 			setup: func(t *testing.T) string {
 				home := t.TempDir()
 				path := filepath.Join(home, ".openclaw", "openclaw.json")
+				t.Setenv("HOME", home)
+				return path
+			},
+		},
+		"legacy_default_clawdbot": {
+			setup: func(t *testing.T) string {
+				home := t.TempDir()
+				path := filepath.Join(home, ".clawdbot", "clawdbot.json")
+				t.Setenv("HOME", home)
+				return path
+			},
+		},
+		"legacy_default_moltbot": {
+			setup: func(t *testing.T) string {
+				home := t.TempDir()
+				path := filepath.Join(home, ".moltbot", "moltbot.json")
+				t.Setenv("HOME", home)
+				return path
+			},
+		},
+		"legacy_default_moldbot": {
+			setup: func(t *testing.T) string {
+				home := t.TempDir()
+				path := filepath.Join(home, ".moldbot", "moldbot.json")
 				t.Setenv("HOME", home)
 				return path
 			},
@@ -316,6 +355,27 @@ func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
 				t.Errorf("path = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestOpenclawActiveConfigPathFallbackFreshInstallUsesCanonicalPath(t *testing.T) {
+	clearOpenclawPathEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: openclawConfigFileUnsupportedErr()},
+	})
+
+	got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
+	if err != nil {
+		t.Fatalf("openclawActiveConfigPath: %v", err)
+	}
+	want := filepath.Join(home, ".openclaw", "openclaw.json")
+	if got != want {
+		t.Errorf("path = %q, want canonical fresh-install path %q", got, want)
+	}
+	if exists {
+		t.Fatal("exists = true, want false for fresh install")
 	}
 }
 
@@ -379,6 +439,8 @@ func clearOpenclawPathEnv(t *testing.T) {
 	t.Setenv("OPENCLAW_CONFIG_PATH", "")
 	t.Setenv("OPENCLAW_STATE_DIR", "")
 	t.Setenv("OPENCLAW_HOME", "")
+	t.Setenv("CLAWDBOT_CONFIG_PATH", "")
+	t.Setenv("CLAWDBOT_STATE_DIR", "")
 }
 
 func openclawConfigFileUnsupportedErr() error {

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -201,6 +201,59 @@ func TestPrepareOpenclawConfigFailsClosedOnCLIError(t *testing.T) {
 	}
 }
 
+// TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported covers
+// OpenClaw 2026.2.x builds that rejected `openclaw config file` with
+// "too many arguments for 'config'". That command-shape mismatch should
+// not make every task fail during execenv prep; the daemon can derive the
+// active path from documented OPENCLAW_* path vars and then continue using
+// `config get ... --json` for resolved config data.
+func TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	userConfigDir := t.TempDir()
+	userConfigPath := filepath.Join(userConfigDir, "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+	t.Setenv("OPENCLAW_CONFIG_PATH", userConfigPath)
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: errors.New("openclaw config file: exit status 1 (stderr: error: too many arguments for 'config'. Expected 0 arguments but got 1.)")},
+		"config get agents.list --json": {stdout: `[
+			{ "id": "coder", "model": "openai/gpt-5" }
+		]`},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+
+	got := mustReadJSON(t, result.ConfigPath)
+	include, ok := got["$include"].([]any)
+	if !ok || len(include) != 1 || include[0] != userConfigPath {
+		t.Errorf("$include = %v, want fallback OPENCLAW_CONFIG_PATH %q", got["$include"], userConfigPath)
+	}
+	if result.IncludeRoot != userConfigDir {
+		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, userConfigDir)
+	}
+	agents := got["agents"].(map[string]any)
+	list := agents["list"].([]any)
+	if len(list) != 1 || list[0].(map[string]any)["workspace"] != workDir {
+		t.Errorf("agents.list workspace rewrite after fallback = %v, want workDir %q", list, workDir)
+	}
+	if len(stub.calls) != 2 {
+		t.Fatalf("openclaw calls = %d, want 2: %+v", len(stub.calls), stub.calls)
+	}
+	if strings.Join(stub.calls[1].args, " ") != "config get agents.list --json" {
+		t.Errorf("second openclaw call = %q, want config get agents.list --json", strings.Join(stub.calls[1].args, " "))
+	}
+}
+
 // TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList — the second
 // fail-closed surface. When `openclaw config get agents.list --json`
 // returns junk we can't parse, we fail rather than guess.

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -379,6 +379,35 @@ func TestOpenclawActiveConfigPathFallbackFreshInstallUsesCanonicalPath(t *testin
 	}
 }
 
+func TestOpenclawActiveConfigPathFallbackOpenclawConfigPathHardOverride(t *testing.T) {
+	clearOpenclawPathEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	explicitPath := filepath.Join(t.TempDir(), "missing-openclaw.json")
+	t.Setenv("OPENCLAW_CONFIG_PATH", explicitPath)
+	legacyPath := filepath.Join(home, ".clawdbot", "clawdbot.json")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy config dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: openclawConfigFileUnsupportedErr()},
+	})
+
+	got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
+	if err != nil {
+		t.Fatalf("openclawActiveConfigPath: %v", err)
+	}
+	if got != explicitPath {
+		t.Errorf("path = %q, want OPENCLAW_CONFIG_PATH hard override %q", got, explicitPath)
+	}
+	if exists {
+		t.Fatal("exists = true, want false when explicit OPENCLAW_CONFIG_PATH is missing")
+	}
+}
+
 func TestOpenclawActiveConfigPathFallbackErrorIncludesOriginalCLIError(t *testing.T) {
 	clearOpenclawPathEnv(t)
 	badPath := filepath.Join(t.TempDir(), "openclaw.json")

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -254,6 +254,137 @@ func TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported(t *testing.T) {
 	}
 }
 
+func TestOpenclawActiveConfigPathFallbackSources(t *testing.T) {
+	cases := map[string]struct {
+		setup func(t *testing.T) string
+	}{
+		"config_path": {
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "custom-openclaw.json")
+				t.Setenv("OPENCLAW_CONFIG_PATH", path)
+				return path
+			},
+		},
+		"state_dir": {
+			setup: func(t *testing.T) string {
+				stateDir := t.TempDir()
+				path := filepath.Join(stateDir, "openclaw.json")
+				t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+				return path
+			},
+		},
+		"openclaw_home": {
+			setup: func(t *testing.T) string {
+				home := t.TempDir()
+				path := filepath.Join(home, ".openclaw", "openclaw.json")
+				t.Setenv("OPENCLAW_HOME", home)
+				return path
+			},
+		},
+		"default_home": {
+			setup: func(t *testing.T) string {
+				home := t.TempDir()
+				path := filepath.Join(home, ".openclaw", "openclaw.json")
+				t.Setenv("HOME", home)
+				return path
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			clearOpenclawPathEnv(t)
+			want := tc.setup(t)
+			if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+				t.Fatalf("mkdir config dir: %v", err)
+			}
+			if err := os.WriteFile(want, []byte(`{}`), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			stub := installOpenclawStub(t, map[string]openclawResponse{
+				"config file": {err: openclawConfigFileUnsupportedErr()},
+			})
+
+			got, exists, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
+			if err != nil {
+				t.Fatalf("openclawActiveConfigPath: %v", err)
+			}
+			if !exists {
+				t.Fatal("exists = false, want true")
+			}
+			if got != want {
+				t.Errorf("path = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestOpenclawActiveConfigPathFallbackErrorIncludesOriginalCLIError(t *testing.T) {
+	clearOpenclawPathEnv(t)
+	badPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.MkdirAll(badPath, 0o755); err != nil {
+		t.Fatalf("mkdir bad config path: %v", err)
+	}
+	t.Setenv("OPENCLAW_CONFIG_PATH", badPath)
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: openclawConfigFileUnsupportedErr()},
+	})
+
+	_, _, err := openclawActiveConfigPath(stub.bin, openclawCLITimeout)
+	if err == nil {
+		t.Fatal("openclawActiveConfigPath succeeded with directory config path; expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "too many arguments for 'config'") {
+		t.Errorf("error %q lost original unsupported CLI stderr", msg)
+	}
+	if !strings.Contains(msg, "is a directory") {
+		t.Errorf("error %q lost fallback failure detail", msg)
+	}
+}
+
+func TestIsOpenclawConfigFileUnsupportedMatchesKnownShapes(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"reported_too_many_arguments": {
+			err:  errors.New("openclaw config file: exit status 1 (stderr: error: too many arguments for 'config')"),
+			want: true,
+		},
+		"reported_expected_zero_args": {
+			err:  errors.New("Expected 0 arguments but got 1."),
+			want: true,
+		},
+		"unknown_config_file": {
+			err:  errors.New("unknown subcommand `file` for `openclaw config`"),
+			want: true,
+		},
+		"real_config_validation_error": {
+			err:  errors.New("openclaw config validation failed: missing gateway.auth.token"),
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isOpenclawConfigFileUnsupported(tc.err); got != tc.want {
+				t.Errorf("isOpenclawConfigFileUnsupported(%q) = %t, want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func clearOpenclawPathEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	t.Setenv("OPENCLAW_HOME", "")
+}
+
+func openclawConfigFileUnsupportedErr() error {
+	return errors.New("openclaw config file: exit status 1 (stderr: error: too many arguments for 'config'. Expected 0 arguments but got 1.)")
+}
+
 // TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList — the second
 // fail-closed surface. When `openclaw config get agents.list --json`
 // returns junk we can't parse, we fail rather than guess.


### PR DESCRIPTION
## Summary

- keep `openclaw config file` as the preferred active-config discovery path when supported
- fall back only for known 2026.2-style command-shape errors from `openclaw config file`
- preserve `OPENCLAW_CONFIG_PATH` as a hard override: if it is set, fallback returns that path even when missing, so later `openclaw config get ...` reads from the same active config location
- otherwise mirror OpenClaw's active-config candidate search, including:
  - legacy `CLAWDBOT_CONFIG_PATH`
  - `OPENCLAW_STATE_DIR` and legacy `CLAWDBOT_STATE_DIR`
  - default `~/.openclaw`, `~/.clawdbot`, `~/.moltbot`, and `~/.moldbot` directories
  - `openclaw.json`, `clawdbot.json`, `moltbot.json`, and `moldbot.json` filenames
- preserve the original `openclaw config file` stderr if the env/path fallback also fails
- add regression coverage for execenv prep fallback, new and legacy fallback path sources, `OPENCLAW_CONFIG_PATH` hard override, known unsupported-command matcher shapes, and fresh-install canonical fallback

Fallback is intentionally limited to these known command-shape signals: `too many arguments for 'config'`, `Expected 0 arguments but got 1`, or an `unknown ... config ... file` form. Other CLI errors still fail closed.

Closes MUL-3417
Fixes #4299

## Testing

- `go test ./internal/daemon/execenv`
- `go test ./internal/daemon/...`
