### PR TITLE
WAN-96: clarify self-host websocket build docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,8 @@ MULTICA_LARK_CALLBACK_BASE_URL=
 # Frontend
 # Leave empty — auto-derived from page origin in browser, set by Makefile for local dev.
 # NEXT_PUBLIC_API_URL also feeds the Next.js SSR proxy when explicitly set.
+# For self-host Docker, NEXT_PUBLIC_* values only affect source-built web images;
+# changing them in runtime env for a prebuilt image does not rewrite the browser bundle.
 NEXT_PUBLIC_API_URL=
 NEXT_PUBLIC_WS_URL=
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -36,11 +36,14 @@ COPY packages/ packages/
 # Re-link after source overlay (fixes any symlinks overwritten by COPY)
 RUN pnpm install --frozen-lockfile --offline
 
-# Set build-time env: tells Next.js rewrites to proxy API calls to the backend service
+# Set build-time env. These values are baked into the Next.js standalone output:
+# runtime environment on a prebuilt image does not change client-side NEXT_PUBLIC_*.
 ARG REMOTE_API_URL=http://backend:8080
+ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_WS_URL
 ARG NEXT_PUBLIC_APP_VERSION=dev
 ENV REMOTE_API_URL=$REMOTE_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
 ENV STANDALONE=true

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -263,12 +263,20 @@ For the frontend:
 
 ```bash
 pnpm install
-pnpm build
+
+# Build-time values: set these before `pnpm build`.
+REMOTE_API_URL=http://localhost:8080 pnpm build
 
 # Start the frontend (production mode)
 cd apps/web
-REMOTE_API_URL=http://localhost:8080 pnpm start
+pnpm start
 ```
+
+`REMOTE_API_URL`, `NEXT_PUBLIC_API_URL`, and `NEXT_PUBLIC_WS_URL` are build-time
+inputs for the production web bundle. Setting them only on `pnpm start` or in the
+runtime environment of an already-built web image does not change the bundled
+API base URL, Next rewrite destinations, or browser WebSocket URL. Rebuild the
+frontend whenever those values change.
 
 ## Reverse Proxy
 
@@ -380,6 +388,11 @@ NEXT_PUBLIC_API_URL=https://api.example.com
 NEXT_PUBLIC_WS_URL=wss://api.example.com/ws
 ```
 
+For prebuilt web images, these `NEXT_PUBLIC_*` values are already bundled. Runtime
+environment overrides affect the container process only; they do not rewrite the
+client bundle. Use the source-build override and rebuild when the browser must
+call a different API or WebSocket origin.
+
 ## LAN / Non-localhost Access
 
 By default, Multica works on `localhost`. If you access it from another machine on the LAN (e.g. `http://192.168.1.100:3000`), you need to tell the backend to accept that origin:
@@ -398,7 +411,7 @@ docker compose -f docker-compose.selfhost.yml up -d
 
 ### WebSocket for LAN / Non-localhost Access
 
-HTTP requests (issues, comments, uploads) work on LAN out of the box — Next.js rewrites proxy `/api`, `/auth`, and `/uploads` to the backend. **WebSockets do not**: Next.js rewrites only forward HTTP requests, not the `Upgrade` handshake a WebSocket needs. If you open the app on `http://<lan-ip>:3000`, real-time features (chat streaming, live issue updates, notifications) will fail to connect until you do one of the following:
+HTTP requests (issues, comments, uploads) work on LAN out of the box when the browser talks to the frontend origin — Next.js rewrites proxy `/api`, `/auth`, and `/uploads` to the backend. **WebSockets do not use that HTTP rewrite path**: the frontend derives `ws(s)://<page-host>/ws` when `NEXT_PUBLIC_WS_URL` is empty, so the browser needs either a reverse proxy that forwards `/ws` upgrades on that same origin or a rebuild with an explicit backend WebSocket URL. If you open the app on `http://<lan-ip>:3000`, real-time features (chat streaming, live issue updates, notifications) will fail to connect until you do one of the following:
 
 1. **Put a reverse proxy in front of the stack (recommended).** Nginx or Caddy terminates the WebSocket upgrade and forwards it to the backend on port 8080. See the [Reverse Proxy](#reverse-proxy) section above — the Nginx example already includes a `location /ws { ... }` block with the correct `Upgrade` / `Connection` headers. Once a proxy is in place the browser connects directly through it, so no frontend rebuild is needed.
 
@@ -412,11 +425,43 @@ HTTP requests (issues, comments, uploads) work on LAN out of the box — Next.js
    docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
    ```
 
-   `NEXT_PUBLIC_WS_URL` is a build-time variable (see `Dockerfile.web`), so setting it only in `environment:` on the pre-built image has no effect — you must use the `selfhost.build.yml` override that rebuilds the image.
+   `NEXT_PUBLIC_WS_URL` is a build-time variable (see `Dockerfile.web`), so setting it only in `environment:` on the prebuilt image has no effect — you must use the `selfhost.build.yml` override that rebuilds the image.
 
 **Also required: allowlist the browser origin.** The two options above fix the WebSocket *upgrade proxying*, but a second, independent setting gates the connection: the backend validates the WebSocket `Origin` header against an allowlist that defaults to `localhost` only. When you open Multica from any other origin — a LAN IP **or a public domain behind a reverse proxy** — set `CORS_ALLOWED_ORIGINS` (or `FRONTEND_ORIGIN`) on the backend to that exact origin and restart, exactly as shown under [LAN / Non-localhost Access](#lan--non-localhost-access) above. Otherwise the upgrade is refused with `403`: the backend logs `websocket: request origin not allowed by Upgrader.CheckOrigin` and the browser console loops `disconnected, reconnecting in 3s`, while HTTP requests (and manual page refreshes) keep working because they are same-origin to the page. The single value covers both HTTP CORS and the WebSocket origin check.
 
 > **Note:** If you need to hard-code a different public API / WebSocket endpoint into the web image for any other reason, use the same source-build override: `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build`.
+
+### Web/API Smoke Matrix
+
+Use this matrix before declaring a self-host network shape ready. It keeps four
+checks separate because a deployment can pass HTTP API reachability while still
+failing login cookies, WebSocket upgrades, or backend origin validation.
+
+| Mode | HTTP API smoke | Login cookie smoke | WebSocket smoke | Backend origin allowlist |
+|---|---|---|---|---|
+| Localhost (`http://localhost:3000` + backend `:8080`) | `curl -i http://localhost:3000/api/config` should return `200` from the frontend rewrite; `curl -i http://localhost:8080/readyz` should return ready | Sign in from `http://localhost:3000`; cookies are plain HTTP because `FRONTEND_ORIGIN` is empty or `http://localhost:3000` | Browser DevTools → WS should connect to `ws://localhost:3000/ws`; if it fails in standalone mode, put a local proxy in front or rebuild with `NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws` | Defaults include localhost origins; no extra allowlist needed for localhost |
+| LAN IP (`http://<lan-ip>:3000`, optional backend `:8080`) | `curl -i http://<lan-ip>:3000/api/config` and, if baking direct WS, `curl -i http://<lan-ip>:8080/readyz` | Set `FRONTEND_ORIGIN=http://<lan-ip>:3000`; leave `COOKIE_DOMAIN` empty for IP hosts; sign in from another LAN machine | Recommended: reverse proxy `/ws` on the frontend origin. Without proxy, rebuild with `NEXT_PUBLIC_WS_URL=ws://<lan-ip>:8080/ws` and make backend port reachable | Set `CORS_ALLOWED_ORIGINS=http://<lan-ip>:3000` or matching `FRONTEND_ORIGIN` before testing WS |
+| Single-domain reverse proxy (`https://multica.example.com`) | `curl -i https://multica.example.com/api/config` and `curl -i https://multica.example.com/readyz` if the proxy exposes readiness | Set `FRONTEND_ORIGIN=https://multica.example.com`; sign in and confirm `Secure` cookies are stored | DevTools → WS should connect to `wss://multica.example.com/ws`; proxy must route `/ws` before the frontend catch-all and forward `Upgrade` | Set `CORS_ALLOWED_ORIGINS=https://multica.example.com` or matching `FRONTEND_ORIGIN` |
+| Separate-domain reverse proxy (`https://app.example.com` + `https://api.example.com`) | `curl -i https://api.example.com/readyz`; rebuild source web image with `NEXT_PUBLIC_API_URL=https://api.example.com` if the browser should call the API host directly | Use HTTPS. Set `FRONTEND_ORIGIN=https://app.example.com`; if setting `COOKIE_DOMAIN`, use a real shared parent domain, never an IP literal | Rebuild with `NEXT_PUBLIC_WS_URL=wss://api.example.com/ws`; proxy on `api.example.com` must forward `/ws` `Upgrade` | Set `CORS_ALLOWED_ORIGINS=https://app.example.com` or matching `FRONTEND_ORIGIN`; this covers both HTTP CORS and WebSocket `Origin` |
+
+For a protocol-level WebSocket probe, use headers that actually request an
+upgrade, for example:
+
+```bash
+curl -i \
+  -H 'Connection: Upgrade' \
+  -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  -H 'Origin: https://multica.example.com' \
+  https://multica.example.com/ws
+```
+
+Expected results: `101 Switching Protocols` means the proxy/backend accepted the
+upgrade; `403` with backend logs mentioning origin rejection means fix
+`FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS`; `404`, `426`, or a plain HTML/Next
+response means `/ws` is still reaching the frontend or a proxy path that does
+not forward WebSocket upgrades.
 
 ## Health Check
 

--- a/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
@@ -374,12 +374,20 @@ For the frontend:
 
 ```bash
 pnpm install
-pnpm build
+
+# Build-time values: set these before `pnpm build`.
+REMOTE_API_URL=http://localhost:8080 pnpm build
 
 # Start the frontend (production mode)
 cd apps/web
-REMOTE_API_URL=http://localhost:8080 pnpm start
+pnpm start
 ```
+
+`REMOTE_API_URL`, `NEXT_PUBLIC_API_URL`, and `NEXT_PUBLIC_WS_URL` are build-time
+inputs for the production web bundle. Setting them only on `pnpm start` or in the
+runtime environment of an already-built web image does not change the bundled
+API base URL, Next rewrite destinations, or browser WebSocket URL. Rebuild the
+frontend whenever those values change.
 
 ## Reverse Proxy
 
@@ -488,6 +496,11 @@ REMOTE_API_URL=https://api.example.com
 NEXT_PUBLIC_API_URL=https://api.example.com
 NEXT_PUBLIC_WS_URL=wss://api.example.com/ws
 ```
+
+For prebuilt web images, these `NEXT_PUBLIC_*` values are already bundled. Runtime
+environment overrides affect the container process only; they do not rewrite the
+client bundle. Use the source-build override and rebuild when the browser must
+call a different API or WebSocket origin.
 
 ## Health Check
 

--- a/apps/docs/content/docs/self-host-quickstart.ja.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.ja.mdx
@@ -192,6 +192,10 @@ multica.example.com {
 
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) も堅実な選択肢です — ホストにポートを一切公開せずに TLS と公開ホスト名を提供してくれます。Nginx で同等に構成する方法（`app.` / `api.` を別々のホスト名に分離、WebSocket 用の `proxy_set_header Upgrade`）も同じくらいうまく動作します。重要な要件は、TLS の終端と `/ws` での `Upgrade` ヘッダーの転送です。
 
+<Callout type="warning">
+ブラウザが使う WebSocket URL は web イメージのビルド時に bundle に焼き込まれます。prebuilt イメージでは、コンテナ実行時の環境変数で `NEXT_PUBLIC_WS_URL` や `NEXT_PUBLIC_API_URL` を変えてもブラウザの挙動は変わりません。デフォルトの同一オリジン `/ws` はリバースプロキシで転送するか、`docker-compose.selfhost.build.yml` で再ビルドしてください。高度なガイドには localhost / LAN / 単一ドメイン / 分離ドメインの smoke matrix があります。
+</Callout>
+
 ## 6. エージェントの作成 + 最初のタスクの割り当て
 
 Cloud と同じ流れです — [Cloud クイックスタート → ステップ5-6](/cloud-quickstart#5-create-an-agent)を参照してください。
@@ -268,7 +272,7 @@ multica setup self-host \
 
 - **バックエンドが起動しない**: `docker compose -f docker-compose.selfhost.yml logs backend` でコンテナのログを確認してください。たいていは `.env` の不正な `DATABASE_URL` または `JWT_SECRET` が原因です
 - **認証コードが届かない**: メールバックエンドが構成されていない場合（Resend も SMTP もない）→ `docker compose logs backend` で `[DEV] Verification code` を探してください
-- **WebSocket が接続できない**: 公開デプロイでは、`FRONTEND_ORIGIN` を実際のフロントエンドのドメインに必ず設定する必要があります。[トラブルシューティング → WebSocket が接続できない](/troubleshooting#websocket-wont-connect)を参照してください
+- **WebSocket が接続できない**: リバースプロキシまたはビルド時の `NEXT_PUBLIC_WS_URL` と、バックエンドの `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS` の両方を確認してください。[トラブルシューティング → WebSocket が接続できない](/troubleshooting#websocket-wont-connect)を参照してください
 - **使用量 / ランタイムのダッシュボードがゼロのまま**: `rollup_task_usage_hourly()` がスケジューリングされていません — 上記の [ステップ7](#7-usage-rollup-no-operator-action-required)と[トラブルシューティング → 使用量ダッシュボードがゼロと表示される](/troubleshooting#usage-dashboard-stays-at-zero)を参照してください
 - **`migrate up` が `refusing to drop legacy daily rollups` で失敗する**: `v0.3.4 → v0.3.5+` のアップグレード経路ガードです。MUL-2957 以降、migrate コマンドは migration 103 を適用する前に自動でバックフィルを実行します — [ステップ7](#7-usage-rollup-no-operator-action-required)を参照してください
 

--- a/apps/docs/content/docs/self-host-quickstart.ko.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.ko.mdx
@@ -192,6 +192,10 @@ multica.example.com {
 
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)도 견고한 선택지입니다 — 호스트에 어떤 포트도 노출하지 않고도 TLS와 공개 호스트네임을 제공합니다. Nginx로 동등하게 구성하는 방법(`app.` / `api.`을 별도 호스트네임으로 분리, WebSocket용 `proxy_set_header Upgrade`)도 똑같이 잘 동작합니다. 핵심 요구 사항은 TLS 종료와 `/ws`에서의 `Upgrade` 헤더 전달입니다.
 
+<Callout type="warning">
+브라우저가 사용하는 WebSocket URL은 web 이미지 빌드 시 bundle에 포함됩니다. prebuilt 이미지를 사용할 때 컨테이너 런타임 env에서 `NEXT_PUBLIC_WS_URL` 또는 `NEXT_PUBLIC_API_URL`을 바꿔도 브라우저 동작은 바뀌지 않습니다. 기본 동일 origin `/ws` 경로는 리버스 프록시로 전달하거나 `docker-compose.selfhost.build.yml`로 다시 빌드하세요. 고급 가이드에는 localhost / LAN / 단일 도메인 / 분리 도메인 smoke matrix가 있습니다.
+</Callout>
+
 ## 6. 에이전트 생성 + 첫 작업 할당
 
 Cloud와 동일한 흐름입니다 — [Cloud 빠른 시작 → 5-6단계](/cloud-quickstart#5-create-an-agent)를 참고하세요.
@@ -268,7 +272,7 @@ multica setup self-host \
 
 - **백엔드가 시작되지 않음**: `docker compose -f docker-compose.selfhost.yml logs backend`로 컨테이너 로그를 확인하세요. 보통 `.env`의 잘못된 `DATABASE_URL` 또는 `JWT_SECRET`이 원인입니다
 - **인증 코드를 받지 못함**: 이메일 백엔드가 구성되지 않은 경우(Resend도 SMTP도 없음) → `docker compose logs backend`에서 `[DEV] Verification code`를 찾으세요
-- **WebSocket이 연결되지 않음**: 공개 배포에서는 반드시 `FRONTEND_ORIGIN`을 실제 프런트엔드 도메인으로 설정해야 합니다. [문제 해결 → WebSocket이 연결되지 않음](/troubleshooting#websocket-wont-connect)을 참고하세요
+- **WebSocket이 연결되지 않음**: 리버스 프록시 또는 빌드 시 `NEXT_PUBLIC_WS_URL`, 그리고 백엔드 `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS`를 모두 확인하세요. [문제 해결 → WebSocket이 연결되지 않음](/troubleshooting#websocket-wont-connect)을 참고하세요
 - **사용량 / 런타임 대시보드가 0에 머무름**: `rollup_task_usage_hourly()`가 스케줄링되지 않고 있습니다 — 위의 [7단계](#7-usage-rollup-no-operator-action-required)와 [문제 해결 → 사용량 대시보드가 0으로 표시됨](/troubleshooting#usage-dashboard-stays-at-zero)을 참고하세요
 - **`migrate up`이 `refusing to drop legacy daily rollups`로 실패함**: `v0.3.4 → v0.3.5+` 업그레이드 경로 가드입니다. MUL-2957부터 migrate 명령이 migration 103을 적용하기 전에 백필을 자동으로 실행합니다 — [7단계](#7-usage-rollup-no-operator-action-required)를 참고하세요
 

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -193,6 +193,10 @@ After bringing the proxy up, set `FRONTEND_ORIGIN=https://multica.example.com` i
 
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) is another solid option — it gives you TLS and a public hostname without exposing any port on the host at all. An Nginx equivalent (separate `app.` / `api.` hostnames, `proxy_set_header Upgrade` for WebSockets) works just as well; the key requirements are TLS termination and forwarding the `Upgrade` header on `/ws`.
 
+<Callout type="warning">
+The browser WebSocket URL is bundled into the web image at build time. With the prebuilt image, changing `NEXT_PUBLIC_WS_URL` or `NEXT_PUBLIC_API_URL` in container runtime env does not change browser behavior. Use a reverse proxy for the default same-origin `/ws` path, or rebuild with `docker-compose.selfhost.build.yml`. The advanced guide includes a localhost / LAN / single-domain / separate-domain smoke matrix.
+</Callout>
+
 ## 6. Create an agent + assign your first task
 
 Same flow as Cloud — see [Cloud quickstart → Steps 5-6](/cloud-quickstart#5-create-an-agent).
@@ -267,7 +271,7 @@ The full reference — three login modes, the `backend` ExternalName workaround 
 
 - **Backend won't start**: check container logs with `docker compose -f docker-compose.selfhost.yml logs backend`; usually it's a bad `DATABASE_URL` or `JWT_SECRET` in `.env`
 - **Verification code not received**: no email backend is configured (neither Resend nor SMTP) → look for `[DEV] Verification code` in `docker compose logs backend`
-- **WebSocket won't connect**: for public deployments you must set `FRONTEND_ORIGIN` to your real frontend domain; see [Troubleshooting → WebSocket won't connect](/troubleshooting#websocket-wont-connect)
+- **WebSocket won't connect**: check both the reverse proxy or build-time `NEXT_PUBLIC_WS_URL` and the backend `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS`; see [Troubleshooting → WebSocket won't connect](/troubleshooting#websocket-wont-connect)
 - **Usage / Runtime dashboard stays at zero**: `rollup_task_usage_hourly()` isn't being scheduled — see [Step 7](#7-usage-rollup-no-operator-action-required) above and [Troubleshooting → Usage dashboard shows zero](/troubleshooting#usage-dashboard-stays-at-zero)
 - **`migrate up` fails with `refusing to drop legacy daily rollups`**: upgrade-path guard from `v0.3.4 → v0.3.5+`. As of MUL-2957 the migrate command runs the backfill automatically before applying migration 103 — see [Step 7](#7-usage-rollup-no-operator-action-required)
 

--- a/apps/docs/content/docs/self-host-quickstart.zh.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.zh.mdx
@@ -192,6 +192,10 @@ multica.example.com {
 
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) 也是不错的选择——它直接给一个公开域名 + TLS，host 上不用对外暴露任何端口。Nginx 也能做（分 `app.` / `api.` 两个域名 + `proxy_set_header Upgrade` 转 WebSocket），关键就是终结 TLS、并在 `/ws` 上转发 `Upgrade` 头。
 
+<Callout type="warning">
+浏览器使用的 WebSocket URL 是在 web 镜像构建时打进 bundle 的。使用预构建镜像时，在容器运行期改 `NEXT_PUBLIC_WS_URL` 或 `NEXT_PUBLIC_API_URL` 不会改变浏览器行为。默认同源 `/ws` 请用反向代理转发，或者通过 `docker-compose.selfhost.build.yml` 重新构建。高级指南里有 localhost / LAN / 单域名 / 分域名 smoke 矩阵。
+</Callout>
+
 ## 6. 创建智能体 + 分配第一个任务
 
 流程和 Cloud 一样——见 [Cloud 快速上手 → 5-6 步](/cloud-quickstart#5-创建智能体)。
@@ -268,7 +272,7 @@ multica setup self-host \
 
 - **后端起不来**：看容器日志 `docker compose -f docker-compose.selfhost.yml logs backend`；常见是 `.env` 里 `DATABASE_URL` 或 `JWT_SECRET` 有问题
 - **验证码收不到**：没配任何邮件后端（Resend 和 SMTP 都没设） → 从 `docker compose logs backend` 里找 `[DEV] Verification code`
-- **WebSocket 连不上**：公网部署必须设 `FRONTEND_ORIGIN` 成你真实的前端域名；见 [故障排查 → WebSocket 连不上](/troubleshooting#websocket-连不上)
+- **WebSocket 连不上**：同时检查反向代理或构建期 `NEXT_PUBLIC_WS_URL`，以及后端 `FRONTEND_ORIGIN` / `CORS_ALLOWED_ORIGINS`；见 [故障排查 → WebSocket 连不上](/troubleshooting#websocket-连不上)
 - **Usage / Runtime 看板一直是 0**：没人调度 `rollup_task_usage_hourly()` —— 见上面的 [第 7 步](#7-usage-rollup-no-operator-action-required) 和 [故障排查 → Usage 看板一直是 0](/troubleshooting#usage-看板一直是-0)
 - **`migrate up` 报 `refusing to drop legacy daily rollups`**：`v0.3.4 → v0.3.5+` 升级路径的 fail-closed guard。从 MUL-2957 起 migrate 命令在应用 migration 103 之前会自动跑 backfill —— 见 [第 7 步](#7-usage-rollup-no-operator-action-required)
 

--- a/apps/docs/content/docs/troubleshooting.ja.mdx
+++ b/apps/docs/content/docs/troubleshooting.ja.mdx
@@ -70,19 +70,33 @@ multica issue show <issue-id>             # inspect task history
 1. **Origin チェックの失敗** — フロントエンドのドメインがサーバーの CORS 許可リストにありません。デフォルトの許可リストには `localhost:3000/5173/5174` のみが含まれ、公開インターネットでセルフホストするには `FRONTEND_ORIGIN` が必要です
 2. **プロトコルの不一致** — `https://` のフロントエンドには `wss://` が必要で、HTTP は `ws://` を使います
 3. **リバースプロキシが WebSocket アップグレードを有効にしていない** — Nginx / Envoy / HAProxy はデフォルトでは `Upgrade` ヘッダーを転送しません
-4. **JWT クッキーの期限切れまたは欠落** — 30 日の有効期限後にログインし直していない
+4. **bundle に焼き込まれた WebSocket URL が誤っている** — `NEXT_PUBLIC_WS_URL` は web イメージのビルド時の値です。prebuilt イメージの実行時 env を変えてもブラウザ URL は変わりません
+5. **JWT クッキーの期限切れまたは欠落** — 30 日の有効期限後にログインし直していない
 
 **診断方法**:
 
 - ブラウザの DevTools → Network → 「WS」でフィルタリングし、接続状態とステータスコードを確認してください
 - サーバーログで `"rejected origin"` / `"websocket"` を grep してください — origin の問題であれば明示的に表示されます
-- `curl -i http://<server-host>:8080/ws` は（`Upgrade` ヘッダー付きで）`101 Switching Protocols` を返すはずです
+- 完全な upgrade header 付きで経路を確認してください。例:
+
+  ```bash
+  curl -i \
+    -H 'Connection: Upgrade' \
+    -H 'Upgrade: websocket' \
+    -H 'Sec-WebSocket-Version: 13' \
+    -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+    -H 'Origin: https://multica.yourdomain.com' \
+    https://multica.yourdomain.com/ws
+  ```
+
+  `101 Switching Protocols` は upgrade 経路が動作していることを示します。`403` は通常バックエンドが `Origin` を拒否しています。HTML/404/426 は通常 `/ws` がフロントエンド、または WebSocket upgrade 非対応のプロキシ経路に到達しています。
 
 **解決方法**:
 
 - Origin エラー → サーバーの `.env` に `FRONTEND_ORIGIN=https://multica.yourdomain.com` を設定（またはカンマ区切りの `CORS_ALLOWED_ORIGINS`）し、サーバーを再起動してください
 - プロトコルの不一致 → `FRONTEND_ORIGIN` のプロトコルがフロントエンドと一致しているか確認してください
 - リバースプロキシ → Nginx に `proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection "upgrade";` を追加してください
+- bundle の URL エラー → デフォルトの同一オリジン `/ws` にはリバースプロキシを使うか、`NEXT_PUBLIC_WS_URL=wss://.../ws` で web イメージをソースから再ビルドしてください。prebuilt イメージの実行時 env だけでは不十分です
 - クッキーの期限切れ → ページを再読み込みしてログインし直してください
 
 ## メールが届かない

--- a/apps/docs/content/docs/troubleshooting.ko.mdx
+++ b/apps/docs/content/docs/troubleshooting.ko.mdx
@@ -70,19 +70,33 @@ multica issue show <issue-id>             # inspect task history
 1. **Origin 검사 실패** — 여러분의 프런트엔드 도메인이 서버의 CORS 허용 목록에 없습니다. 기본 허용 목록에는 `localhost:3000/5173/5174`만 포함되며, 공개 인터넷에서 자체 호스팅하려면 `FRONTEND_ORIGIN`이 필요합니다
 2. **프로토콜 불일치** — `https://` 프런트엔드에는 `wss://`가 필요하고, HTTP는 `ws://`를 사용합니다
 3. **리버스 프록시가 WebSocket 업그레이드를 활성화하지 않음** — Nginx / Envoy / HAProxy는 기본적으로 `Upgrade` 헤더를 전달하지 않습니다
-4. **JWT 쿠키 만료 또는 누락** — 30일 만료 후 다시 로그인하지 않음
+4. **번들에 포함된 WebSocket URL이 잘못됨** — `NEXT_PUBLIC_WS_URL`은 web 이미지 빌드 시 값입니다. prebuilt 이미지의 런타임 env를 바꿔도 브라우저 URL은 바뀌지 않습니다
+5. **JWT 쿠키 만료 또는 누락** — 30일 만료 후 다시 로그인하지 않음
 
 **진단 방법**:
 
 - 브라우저 DevTools → Network → "WS"로 필터링하여 연결 상태와 상태 코드를 확인하세요
 - 서버 로그에서 `"rejected origin"` / `"websocket"`을 grep하세요 — origin 문제라면 명시적으로 표기됩니다
-- `curl -i http://<server-host>:8080/ws`는 `101 Switching Protocols`를 반환해야 합니다(`Upgrade` 헤더 포함)
+- 전체 upgrade header로 경로를 확인하세요. 예:
+
+  ```bash
+  curl -i \
+    -H 'Connection: Upgrade' \
+    -H 'Upgrade: websocket' \
+    -H 'Sec-WebSocket-Version: 13' \
+    -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+    -H 'Origin: https://multica.yourdomain.com' \
+    https://multica.yourdomain.com/ws
+  ```
+
+  `101 Switching Protocols`는 upgrade 경로가 동작한다는 뜻입니다. `403`은 보통 백엔드가 `Origin`을 거부한 것입니다. HTML/404/426은 보통 `/ws`가 프런트엔드 또는 WebSocket upgrade를 전달하지 않는 프록시 경로에 도달했다는 뜻입니다.
 
 **해결 방법**:
 
 - Origin 오류 → 서버의 `.env`에 `FRONTEND_ORIGIN=https://multica.yourdomain.com`을 설정(또는 쉼표로 구분한 `CORS_ALLOWED_ORIGINS`)하고 서버를 재시작하세요
 - 프로토콜 불일치 → `FRONTEND_ORIGIN`의 프로토콜이 프런트엔드와 일치하는지 확인하세요
 - 리버스 프록시 → Nginx에 `proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection "upgrade";`를 추가하세요
+- 번들 URL 오류 → 기본 동일 origin `/ws`에는 리버스 프록시를 사용하거나 `NEXT_PUBLIC_WS_URL=wss://.../ws`로 web 이미지를 소스에서 다시 빌드하세요. prebuilt 이미지의 런타임 env만으로는 충분하지 않습니다
 - 쿠키 만료 → 페이지를 새로고침하고 다시 로그인하세요
 
 ## 이메일이 수신되지 않음

--- a/apps/docs/content/docs/troubleshooting.mdx
+++ b/apps/docs/content/docs/troubleshooting.mdx
@@ -70,19 +70,33 @@ On the server side (self-host), grep for `"no_tasks"` / `"no_capacity"` to see t
 1. **Origin check failure** — your frontend domain isn't in the server's CORS allowlist. The default allowlist only includes `localhost:3000/5173/5174`; self-hosting on the public internet requires `FRONTEND_ORIGIN`
 2. **Protocol mismatch** — frontend on `https://` needs `wss://`; HTTP uses `ws://`
 3. **Reverse proxy doesn't enable WebSocket upgrade** — Nginx / Envoy / HAProxy don't forward the `Upgrade` header by default
-4. **JWT cookie expired or missing** — no re-sign-in after the 30-day expiry
+4. **Wrong bundled WebSocket URL** — `NEXT_PUBLIC_WS_URL` is baked into the web image at build time; changing runtime env on a prebuilt image does not change the browser URL
+5. **JWT cookie expired or missing** — no re-sign-in after the 30-day expiry
 
 **How to diagnose**:
 
 - Browser DevTools → Network → filter by "WS" and check connection state and status code
 - Grep server logs for `"rejected origin"` / `"websocket"` — an origin issue spells itself out
-- `curl -i http://<server-host>:8080/ws` should return `101 Switching Protocols` (with the `Upgrade` header)
+- Probe the upgrade path with headers, for example:
+
+  ```bash
+  curl -i \
+    -H 'Connection: Upgrade' \
+    -H 'Upgrade: websocket' \
+    -H 'Sec-WebSocket-Version: 13' \
+    -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+    -H 'Origin: https://multica.yourdomain.com' \
+    https://multica.yourdomain.com/ws
+  ```
+
+  `101 Switching Protocols` means the upgrade path works; `403` usually means the backend rejected `Origin`; HTML/404/426 usually means `/ws` reached the frontend or a proxy path without WebSocket upgrade support.
 
 **How to fix**:
 
 - Wrong origin → set `FRONTEND_ORIGIN=https://multica.yourdomain.com` in the server's `.env` (or comma-separated `CORS_ALLOWED_ORIGINS`) and restart the server
 - Protocol mismatch → make sure `FRONTEND_ORIGIN`'s protocol matches the frontend's
 - Reverse proxy → in Nginx, add `proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection "upgrade";`
+- Wrong bundled URL → use a same-origin reverse proxy for `/ws`, or rebuild the web image from source with `NEXT_PUBLIC_WS_URL=wss://.../ws`; runtime env on the prebuilt image is not enough
 - Cookie expired → refresh the page and sign in again
 
 ## Emails not received

--- a/apps/docs/content/docs/troubleshooting.zh.mdx
+++ b/apps/docs/content/docs/troubleshooting.zh.mdx
@@ -70,19 +70,33 @@ multica issue show <issue-id>             # 看 task 历史
 1. **Origin 校验失败** —— 你的前端域名不在 server 的 CORS 白名单里。默认白名单只包含 `localhost:3000/5173/5174`，self-host 到公网必须配 `FRONTEND_ORIGIN`
 2. **协议不匹配** —— 前端用 `https://` 需要 `wss://`，HTTP 用 `ws://`
 3. **反向代理没开 WebSocket upgrade** —— Nginx / Envoy / HAProxy 默认不转发 `Upgrade` header
-4. **JWT cookie 过期或丢失** —— 30 天过期后没重登
+4. **打包进去的 WebSocket URL 不对** —— `NEXT_PUBLIC_WS_URL` 是 web 镜像构建期值；在预构建镜像运行期改 env 不会改变浏览器 URL
+5. **JWT cookie 过期或丢失** —— 30 天过期后没重登
 
 **怎么查**：
 
 - 浏览器 DevTools → Network → 筛选 "WS"，看连接状态和状态码
 - Server 日志里 grep `"rejected origin"` / `"websocket"` —— 如果是 origin 问题会明确写出来
-- `curl -i http://<server-host>:8080/ws` 应该返回 `101 Switching Protocols`（需要带 `Upgrade` header）
+- 用完整 upgrade header 探测路径，例如：
+
+  ```bash
+  curl -i \
+    -H 'Connection: Upgrade' \
+    -H 'Upgrade: websocket' \
+    -H 'Sec-WebSocket-Version: 13' \
+    -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+    -H 'Origin: https://multica.yourdomain.com' \
+    https://multica.yourdomain.com/ws
+  ```
+
+  `101 Switching Protocols` 表示 upgrade 路径正常；`403` 通常是后端拒绝 `Origin`；HTML/404/426 通常表示 `/ws` 打到了前端或没有 WebSocket upgrade 的代理路径。
 
 **怎么修**：
 
 - Origin 错 → 在 server 的 `.env` 设 `FRONTEND_ORIGIN=https://multica.yourdomain.com`（或逗号分隔的 `CORS_ALLOWED_ORIGINS`），重启 server
 - 协议不匹配 → 确保 `FRONTEND_ORIGIN` 的协议和前端一致
 - 反向代理 → 在 Nginx 加 `proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection "upgrade";`
+- 打包 URL 错 → 默认同源 `/ws` 请用反向代理，或者用 `NEXT_PUBLIC_WS_URL=wss://.../ws` 从源码重新构建 web 镜像；只改预构建镜像运行期 env 不够
 - Cookie 过期 → 刷新页面重新登录
 
 ## 邮件没收到

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -28,9 +28,10 @@ function hasLegacyToken(): boolean {
   }
 }
 
-// Derive WebSocket URL from the page origin so self-hosted / LAN deployments
-// work without explicit NEXT_PUBLIC_WS_URL.  The Next.js rewrite rule
-// (/ws → backend) handles proxying.
+// Derive the default browser WebSocket URL from the page origin. This works
+// when a reverse proxy forwards /ws upgrades to the backend on the same host.
+// Plain Next.js rewrites are for HTTP routes and should not be treated as the
+// WebSocket upgrade path for LAN / self-host deployments.
 function deriveWsUrl(): string | undefined {
   if (process.env.NEXT_PUBLIC_WS_URL) return process.env.NEXT_PUBLIC_WS_URL;
   if (typeof window === "undefined") return undefined;

--- a/docker-compose.selfhost.build.yml
+++ b/docker-compose.selfhost.build.yml
@@ -19,5 +19,6 @@ services:
       dockerfile: Dockerfile.web
       args:
         REMOTE_API_URL: http://backend:8080
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-}
         NEXT_PUBLIC_APP_VERSION: dev

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -46,6 +46,18 @@ require_config "$config" 'FRONTEND_ORIGIN: http://localhost:3100'
 require_config "$config" 'GOOGLE_REDIRECT_URI: http://localhost:3100/auth/callback'
 require_config "$config" 'MULTICA_APP_URL: http://localhost:3100'
 
+build_config="$(
+  env NEXT_PUBLIC_API_URL=https://api.example.com NEXT_PUBLIC_WS_URL=wss://api.example.com/ws \
+    docker compose \
+      --env-file "$tmp_env" \
+      -f docker-compose.selfhost.yml \
+      -f docker-compose.selfhost.build.yml \
+      config
+)"
+
+require_config "$build_config" 'NEXT_PUBLIC_API_URL: https://api.example.com'
+require_config "$build_config" 'NEXT_PUBLIC_WS_URL: wss://api.example.com/ws'
+
 for script in scripts/dev.sh scripts/check.sh; do
   if ! grep -Fq '. scripts/local-env.sh' "$script"; then
     echo "$script must source scripts/local-env.sh for shared local env derivation."


### PR DESCRIPTION
Closes WAN-96

## Summary
- Clarify that frontend API and WebSocket public env values are bundled at web build time for source-built images.
- Align self-host docs and web comments around default same-origin WebSocket derivation and reverse proxy upgrade handling.
- Add smoke guidance for localhost, LAN IP, single-domain reverse proxy, and separate-domain reverse proxy modes.

## Validation
- bash -n scripts/selfhost-config.test.sh
- bash scripts/selfhost-config.test.sh
- docker compose config for prebuilt and source-build self-host paths
- pnpm --filter @multica/web test -- apps/web/config/runtime-urls.test.ts
- pnpm --filter @multica/web exec tsc --noEmit --pretty false
- pnpm --filter @multica/docs exec tsc --noEmit --pretty false
- git diff --check

## Notes
- No production, cluster, secret, image tag, or release config changes.
- This PR publishes the already verified WAN-96 commit from the fork path after direct upstream push was denied.