### PR TITLE
[MUL-3643] fix(execenv): support OpenClaw 2026.6.x agents schema (#3028)

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -516,19 +516,33 @@ func openclawResolvedFullConfig(bin string, timeout time.Duration) (map[string]a
 	return cfg, nil
 }
 
-// openclawResolvedAgentsList fetches the user's resolved agents.list via
-// `openclaw config get agents.list --json`. The CLI returns the post-
-// include, post-env-substitution view of the array, which is exactly the
-// shape we need to rewrite each entry's workspace.
+// openclawResolvedAgentsList fetches the user's resolved per-agent list so
+// each agent's workspace can be pinned to the task workdir.
 //
-// Returns nil (not an error) when agents.list is unset.
+// Two schemas are supported:
+//
+//   - Pre-2026.6: agents live in the config under `agents.list`. We read them
+//     via `openclaw config get agents.list --json`, which returns the post-
+//     include, post-env-substitution array.
+//   - 2026.6.x and later: `agents.list` is no longer a config path — agents
+//     live in a sqlite registry. `config get agents.list` exits non-zero with
+//     "Config path not found: agents.list". We fall back to the
+//     `openclaw agents list --json` *subcommand*, which returns the resolved
+//     registry (each entry carries `id` and `workspace`). Empirically the
+//     wrapper's `agents.list[].workspace` override still beats the registry's
+//     per-agent workspace, so pinning these entries keeps native per-task
+//     skill discovery working under the new schema (see upstream #3028).
+//
+// Returns nil (not an error) when neither source yields any agents.
 func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	out, err := openclawExec(ctx, bin, "config", "get", "agents.list", "--json")
 	if err != nil {
 		if isOpenclawKeyMissing(err) {
-			return nil, nil
+			// New schema: the config path is gone; the agents live in the
+			// sqlite registry. Resolve them via the subcommand instead.
+			return openclawRegistryAgentsList(bin, timeout)
 		}
 		return nil, err
 	}
@@ -539,6 +553,42 @@ func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, error
 	var list []any
 	if err := json.Unmarshal([]byte(trimmed), &list); err != nil {
 		return nil, fmt.Errorf("parse `openclaw config get agents.list --json` output: %w", err)
+	}
+	return list, nil
+}
+
+// openclawRegistryAgentsList resolves agents from the sqlite-backed registry
+// via `openclaw agents list --json` (OpenClaw 2026.6.x+). The subcommand
+// returns an array of objects whose `id` and `workspace` fields are exactly
+// what rewriteAgentsListWorkspaces needs; other fields (identityName, model,
+// agentDir, bindings, isDefault) are carried through verbatim and harmlessly
+// ignored by the wrapper's deep-merge.
+//
+// Returns nil (not an error) when the registry is empty or the subcommand
+// reports no agents — a fresh install with no registered agents is the same
+// "no agents.list to pin" case as the pre-2026.6 unset config path.
+func openclawRegistryAgentsList(bin string, timeout time.Duration) ([]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := openclawExec(ctx, bin, "agents", "list", "--json")
+	if err != nil {
+		// Older OpenClaw builds may lack the subcommand entirely; treat an
+		// unrecognized/missing subcommand the same as "no agents to pin"
+		// rather than failing closed, since the defaults.workspace override
+		// alone still gives correct per-task skill discovery for the common
+		// single-agent case.
+		if isOpenclawKeyMissing(err) || isOpenclawUnknownSubcommand(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+	var list []any
+	if err := json.Unmarshal([]byte(trimmed), &list); err != nil {
+		return nil, fmt.Errorf("parse `openclaw agents list --json` output: %w", err)
 	}
 	return list, nil
 }
@@ -635,9 +685,32 @@ func isOpenclawKeyMissing(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "No value at ") ||
+	// Match case-insensitively: the CLI's "key not found" wording has drifted
+	// across versions and capitalization is not stable. Pre-2026.6 emitted
+	// "Path not found"; OpenClaw 2026.6.x emits "Config path not found:
+	// agents.list" (lowercase "path", "Config" prefix). A case-sensitive
+	// strings.Contains on "Path not found" silently stopped matching the
+	// 2026.6.x string, turning the intended graceful-skip into a fail-closed
+	// error that broke every OpenClaw 2026.6.x runtime (see upstream #3028).
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no value at ") ||
 		strings.Contains(msg, "not set") ||
 		strings.Contains(msg, "missing key") ||
-		strings.Contains(msg, "Path not found")
+		strings.Contains(msg, "path not found")
+}
+
+// isOpenclawUnknownSubcommand returns true when the CLI error indicates the
+// invoked subcommand/option does not exist on this OpenClaw build (e.g. an
+// older release predating `openclaw agents list --json`). Used so the
+// registry fallback degrades to "no agents to pin" rather than failing
+// closed on builds that never had the subcommand.
+func isOpenclawUnknownSubcommand(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unknown command") ||
+		strings.Contains(msg, "unknown option") ||
+		strings.Contains(msg, "does not recognize") ||
+		strings.Contains(msg, "unknown argument")
 }

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -190,8 +190,9 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 	}
 
 	var resolvedList []any
+	var agentsFromRegistry bool
 	if exists {
-		resolvedList, err = openclawResolvedAgentsList(bin, timeout)
+		resolvedList, agentsFromRegistry, err = openclawResolvedAgentsList(bin, timeout)
 		if err != nil {
 			return OpenclawConfigResult{}, fmt.Errorf("read openclaw agents.list: %w", err)
 		}
@@ -248,7 +249,7 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 		}
 	}
 
-	cfg := buildPerTaskOpenclawConfig(activePath, exists, snapshotPath, resolvedList, workDir, managedMcp, hasManagedMcp, opts.Gateway)
+	cfg := buildPerTaskOpenclawConfig(activePath, exists, snapshotPath, resolvedList, agentsFromRegistry, workDir, managedMcp, hasManagedMcp, opts.Gateway)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -304,12 +305,22 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 // snapshot $include has already dropped the user's `mcp` block, the
 // resulting view of `mcp.servers` is exactly the managed set — including
 // `{}` for "admin saved no servers" (mirrors `hasManagedCodexMcpConfig`).
-func buildPerTaskOpenclawConfig(activePath string, exists bool, snapshotPath string, resolvedList []any, workDir string, managedMcp map[string]any, hasManagedMcp bool, gateway OpenclawGatewayPin) map[string]any {
+func buildPerTaskOpenclawConfig(activePath string, exists bool, snapshotPath string, resolvedList []any, agentsFromRegistry bool, workDir string, managedMcp map[string]any, hasManagedMcp bool, gateway OpenclawGatewayPin) map[string]any {
 	agents := map[string]any{
 		"defaults": map[string]any{"workspace": workDir},
 	}
-	if rewritten := rewriteAgentsListWorkspaces(resolvedList, workDir); rewritten != nil {
-		agents["list"] = rewritten
+	// Only write per-agent overrides back to the wrapper when they came from
+	// the config-schema `agents.list` path (pre-2026.6). A registry-sourced
+	// list (OpenClaw 2026.6.x+) is NOT valid `agents.list[]` config — the
+	// schema validator rejects it ("agents.list.0: Invalid input") and fails
+	// closed before the agent runs. 2026.6.x has no in-config path for per-
+	// agent workspace pinning, so `agents.defaults.workspace` (set above) is
+	// the only knob, and it is sufficient: OpenClaw applies it to the agent it
+	// selects from the registry (see upstream #3028, write-side half).
+	if !agentsFromRegistry {
+		if rewritten := rewriteAgentsListWorkspaces(resolvedList, workDir); rewritten != nil {
+			agents["list"] = rewritten
+		}
 	}
 	cfg := map[string]any{
 		"agents": agents,
@@ -516,25 +527,24 @@ func openclawResolvedFullConfig(bin string, timeout time.Duration) (map[string]a
 	return cfg, nil
 }
 
-// openclawResolvedAgentsList fetches the user's resolved per-agent list so
-// each agent's workspace can be pinned to the task workdir.
+// openclawResolvedAgentsList fetches the user's resolved per-agent list and
+// reports which schema produced it. The schema matters downstream: a config-
+// sourced list is itself valid `agents.list[]` config and may be written back
+// into the wrapper to pin per-agent workspaces, whereas a registry-sourced
+// list MUST NOT be written back — see openclawRegistryAgentsList.
 //
 // Two schemas are supported:
 //
 //   - Pre-2026.6: agents live in the config under `agents.list`. We read them
 //     via `openclaw config get agents.list --json`, which returns the post-
-//     include, post-env-substitution array.
+//     include, post-env-substitution array. fromRegistry=false.
 //   - 2026.6.x and later: `agents.list` is no longer a config path — agents
 //     live in a sqlite registry. `config get agents.list` exits non-zero with
 //     "Config path not found: agents.list". We fall back to the
-//     `openclaw agents list --json` *subcommand*, which returns the resolved
-//     registry (each entry carries `id` and `workspace`). Empirically the
-//     wrapper's `agents.list[].workspace` override still beats the registry's
-//     per-agent workspace, so pinning these entries keeps native per-task
-//     skill discovery working under the new schema (see upstream #3028).
+//     `openclaw agents list --json` *subcommand*. fromRegistry=true.
 //
-// Returns nil (not an error) when neither source yields any agents.
-func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, error) {
+// Returns (nil, false, nil) when neither source yields any agents.
+func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	out, err := openclawExec(ctx, bin, "config", "get", "agents.list", "--json")
@@ -542,31 +552,40 @@ func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, error
 		if isOpenclawKeyMissing(err) {
 			// New schema: the config path is gone; the agents live in the
 			// sqlite registry. Resolve them via the subcommand instead.
-			return openclawRegistryAgentsList(bin, timeout)
+			list, rerr := openclawRegistryAgentsList(bin, timeout)
+			return list, true, rerr
 		}
-		return nil, err
+		return nil, false, err
 	}
 	trimmed := strings.TrimSpace(out)
 	if trimmed == "" || trimmed == "null" {
-		return nil, nil
+		return nil, false, nil
 	}
 	var list []any
 	if err := json.Unmarshal([]byte(trimmed), &list); err != nil {
-		return nil, fmt.Errorf("parse `openclaw config get agents.list --json` output: %w", err)
+		return nil, false, fmt.Errorf("parse `openclaw config get agents.list --json` output: %w", err)
 	}
-	return list, nil
+	return list, false, nil
 }
 
 // openclawRegistryAgentsList resolves agents from the sqlite-backed registry
-// via `openclaw agents list --json` (OpenClaw 2026.6.x+). The subcommand
-// returns an array of objects whose `id` and `workspace` fields are exactly
-// what rewriteAgentsListWorkspaces needs; other fields (identityName, model,
-// agentDir, bindings, isDefault) are carried through verbatim and harmlessly
-// ignored by the wrapper's deep-merge.
+// via `openclaw agents list --json` (OpenClaw 2026.6.x+).
+//
+// **The result is for read-side use only — it must never be written back into
+// the wrapper as `agents.list`.** The registry entries carry CLI-only fields
+// (identityName, identitySource, agentDir, bindings, isDefault) that are NOT
+// part of the 2026.6.x config schema's `agents.list[]` shape; OpenClaw's
+// validator rejects them ("agents.list.0: Invalid input") and fails closed
+// before the agent runs. Worse, `agents.list` is no longer a valid config
+// path at all in 2026.6.x — there is no in-config way to pin a per-agent
+// workspace. The per-task workspace is instead pinned via
+// `agents.defaults.workspace` alone, which the wrapper always sets and which
+// OpenClaw applies to the agent it selects from the registry (verified on
+// 2026.6.8). Callers gate the write-back on fromRegistry from
+// openclawResolvedAgentsList.
 //
 // Returns nil (not an error) when the registry is empty or the subcommand
-// reports no agents — a fresh install with no registered agents is the same
-// "no agents.list to pin" case as the pre-2026.6 unset config path.
+// reports no agents.
 func openclawRegistryAgentsList(bin string, timeout time.Duration) ([]any, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -249,6 +249,11 @@ func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
 	stub := installOpenclawStub(t, map[string]openclawResponse{
 		"config file":                   {stdout: userConfigPath},
 		"config get agents.list --json": {err: errors.New("openclaw: No value at agents.list")},
+		// Pre-2026.6 single-agent installs with no per-agent overrides resolve
+		// to an empty registry once the config-path probe reports missing.
+		// (2026.6.x registry-population is covered by
+		// TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry.)
+		"agents list --json": {stdout: "null"},
 	})
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
@@ -1176,5 +1181,126 @@ func TestBuildPerTaskOpenclawConfigPartialGatewayOmitsZeroFields(t *testing.T) {
 	}
 	if _, present := gw["tls"]; present {
 		t.Errorf("tls field must be omitted when false, got %v", gw["tls"])
+	}
+}
+
+// TestIsOpenclawKeyMissing covers the "key not found" wordings the CLI has
+// emitted across versions. The 2026.6.x string ("Config path not found:
+// agents.list", lowercase "path") is the regression from upstream #3028:
+// the matcher used to compare case-sensitively against "Path not found" and
+// silently stopped recognizing this, turning the intended graceful-skip
+// into a fail-closed error that broke every OpenClaw 2026.6.x runtime.
+func TestIsOpenclawKeyMissing(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"pre-2026.6 No value at", errors.New("openclaw: No value at agents.list"), true},
+		{"pre-2026.6 Path not found", errors.New("openclaw config get agents.list --json: Path not found"), true},
+		{"not set", errors.New("agents.list is not set"), true},
+		{"missing key", errors.New("missing key: agents.list"), true},
+		{
+			"2026.6.x Config path not found (verbatim #3028)",
+			errors.New("openclaw config get agents.list --json: exit status 1 (stderr: Config path not found: agents.list. Run openclaw config validate to inspect config shape.)"),
+			true,
+		},
+		{"real failure stays an error", errors.New("openclaw: failed to read config: permission denied"), false},
+		{"malformed json is not a missing key", errors.New("parse output: invalid character 'x'"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOpenclawKeyMissing(tc.err); got != tc.want {
+				t.Errorf("isOpenclawKeyMissing(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry — OpenClaw 2026.6.x
+// removed the `agents.list` config path; `config get agents.list` exits
+// non-zero with "Config path not found" and the agents live in a sqlite
+// registry reachable via the `openclaw agents list --json` subcommand. The
+// preparer must (a) treat the config-path error as "missing, fall back" and
+// (b) source the per-agent workspace from the registry subcommand so each
+// agent's workspace is still pinned to the task workdir (not just defaults).
+func TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	userConfigPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	registry := `[{"id":"main","identityName":"Beau","workspace":"/Users/cob/.openclaw/workspace","model":"anthropic/claude-sonnet-4-6","isDefault":true}]`
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: userConfigPath},
+		// New-schema error, verbatim #3028 string.
+		"config get agents.list --json": {err: errors.New("openclaw config get agents.list --json: exit status 1 (stderr: Config path not found: agents.list. Run openclaw config validate to inspect config shape.)")},
+		// Registry subcommand returns the real agents.
+		"agents list --json": {stdout: registry},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	agents := got["agents"].(map[string]any)
+	if agents["defaults"].(map[string]any)["workspace"] != workDir {
+		t.Errorf("defaults.workspace not pinned to workDir")
+	}
+	list, present := agents["list"].([]any)
+	if !present {
+		t.Fatalf("agents.list missing — registry fallback did not emit per-agent overrides, got %v", agents)
+	}
+	if len(list) != 1 {
+		t.Fatalf("agents.list len = %d, want 1", len(list))
+	}
+	entry := list[0].(map[string]any)
+	if entry["id"] != "main" {
+		t.Errorf("agents.list[0].id = %v, want main", entry["id"])
+	}
+	if entry["workspace"] != workDir {
+		t.Errorf("agents.list[0].workspace = %v, want %s (per-task pin)", entry["workspace"], workDir)
+	}
+}
+
+// TestPrepareOpenclawConfigNewSchemaEmptyRegistry — new-schema config-path
+// error plus an empty registry (`[]`) is the 2026.6.x equivalent of "no
+// agents.list": emit defaults.workspace only, omit agents.list, no error.
+func TestPrepareOpenclawConfigNewSchemaEmptyRegistry(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	userConfigPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: userConfigPath},
+		"config get agents.list --json": {err: errors.New("Config path not found: agents.list")},
+		"agents list --json":            {stdout: "[]"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	agents := got["agents"].(map[string]any)
+	if _, present := agents["list"]; present {
+		t.Errorf("agents.list should be omitted for empty registry, got %v", agents["list"])
+	}
+	if agents["defaults"].(map[string]any)["workspace"] != workDir {
+		t.Errorf("defaults.workspace not set")
 	}
 }

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1115,7 +1115,7 @@ func TestBuildPerTaskOpenclawConfigOmitsGatewayWhenZero(t *testing.T) {
 	t.Parallel()
 
 	cfg := buildPerTaskOpenclawConfig(
-		"", false, "", nil, "/workdir", nil, false,
+		"", false, "", nil, false, "/workdir", nil, false,
 		OpenclawGatewayPin{},
 	)
 	if _, present := cfg["gateway"]; present {
@@ -1133,7 +1133,7 @@ func TestBuildPerTaskOpenclawConfigWritesGatewayBlock(t *testing.T) {
 		TLS:   true,
 	}
 	cfg := buildPerTaskOpenclawConfig(
-		"", false, "", nil, "/workdir", nil, false,
+		"", false, "", nil, false, "/workdir", nil, false,
 		pin,
 	)
 
@@ -1172,7 +1172,7 @@ func TestBuildPerTaskOpenclawConfigPartialGatewayOmitsZeroFields(t *testing.T) {
 	// fields must not land in the wrapper as empty strings/zeros — that
 	// would override the user's value with junk.
 	cfg := buildPerTaskOpenclawConfig(
-		"", false, "", nil, "/workdir", nil, false,
+		"", false, "", nil, false, "/workdir", nil, false,
 		OpenclawGatewayPin{Host: "gw.internal", Port: 18789},
 	)
 	gw := cfg["gateway"].(map[string]any)
@@ -1219,14 +1219,20 @@ func TestIsOpenclawKeyMissing(t *testing.T) {
 	}
 }
 
-// TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry — OpenClaw 2026.6.x
+// TestPrepareOpenclawConfigNewSchemaOmitsAgentsList — OpenClaw 2026.6.x
 // removed the `agents.list` config path; `config get agents.list` exits
 // non-zero with "Config path not found" and the agents live in a sqlite
-// registry reachable via the `openclaw agents list --json` subcommand. The
-// preparer must (a) treat the config-path error as "missing, fall back" and
-// (b) source the per-agent workspace from the registry subcommand so each
-// agent's workspace is still pinned to the task workdir (not just defaults).
-func TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry(t *testing.T) {
+// registry reachable via the `openclaw agents list --json` subcommand.
+//
+// The preparer must (a) treat the config-path error as "missing, fall back"
+// (read-side, #3028 first half) and (b) NOT write the registry-sourced agents
+// back into the wrapper as `agents.list` (write-side, #3028 second half).
+// `agents.list` is not a valid 2026.6.x config path — its schema validator
+// rejects the registry shape ("agents.list.0: Invalid input") and fails
+// closed before the agent runs. Per-task workspace pinning for the new schema
+// rides on `agents.defaults.workspace` alone, which OpenClaw applies to the
+// agent it selects from the registry.
+func TestPrepareOpenclawConfigNewSchemaOmitsAgentsList(t *testing.T) {
 	envRoot := t.TempDir()
 	workDir := filepath.Join(envRoot, "workdir")
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
@@ -1237,7 +1243,10 @@ func TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry(t *testing.T) {
 		t.Fatalf("write user cfg: %v", err)
 	}
 
-	registry := `[{"id":"main","identityName":"Beau","workspace":"/Users/cob/.openclaw/workspace","model":"anthropic/claude-sonnet-4-6","isDefault":true}]`
+	// Real registry shape from `openclaw agents list --json` on 2026.6.8 —
+	// carries CLI-only fields (identityName, agentDir, bindings, isDefault)
+	// that the config schema rejects if written back as agents.list[].
+	registry := `[{"id":"main","identityName":"Beau","identitySource":"identity","workspace":"/Users/cob/.openclaw/workspace","agentDir":"/Users/cob/.openclaw/agents/main/agent","model":"anthropic/claude-sonnet-4-6","bindings":0,"isDefault":true}]`
 	stub := installOpenclawStub(t, map[string]openclawResponse{
 		"config file": {stdout: userConfigPath},
 		// New-schema error, verbatim #3028 string.
@@ -1255,19 +1264,8 @@ func TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry(t *testing.T) {
 	if agents["defaults"].(map[string]any)["workspace"] != workDir {
 		t.Errorf("defaults.workspace not pinned to workDir")
 	}
-	list, present := agents["list"].([]any)
-	if !present {
-		t.Fatalf("agents.list missing — registry fallback did not emit per-agent overrides, got %v", agents)
-	}
-	if len(list) != 1 {
-		t.Fatalf("agents.list len = %d, want 1", len(list))
-	}
-	entry := list[0].(map[string]any)
-	if entry["id"] != "main" {
-		t.Errorf("agents.list[0].id = %v, want main", entry["id"])
-	}
-	if entry["workspace"] != workDir {
-		t.Errorf("agents.list[0].workspace = %v, want %s (per-task pin)", entry["workspace"], workDir)
+	if _, present := agents["list"]; present {
+		t.Fatalf("agents.list must be omitted for a registry-sourced (2026.6.x) host — OpenClaw rejects it; got %v", agents["list"])
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

OpenClaw 2026.6.x runtimes fail at execution-environment prep with:

```
prepare execution environment: execenv: prepare openclaw config: read openclaw agents.list:
openclaw config get agents.list --json: exit status 1
(stderr: Config path not found: agents.list. Run openclaw config validate to inspect config shape.)
```

Two layers, both in `server/internal/daemon/execenv/openclaw_config.go`:

1. **Schema drift.** OpenClaw 2026.6.x removed the `agents.list` *config path*. The config now holds only `agents.defaults`; the agents themselves live in a sqlite registry reached via the `openclaw agents list --json` *subcommand*. `openclaw config validate` reports the config as valid — the key simply no longer exists.
2. **The existing guard missed the new error string.** `openclawResolvedAgentsList()` already intends to tolerate a missing `agents.list` via `isOpenclawKeyMissing(err) -> return nil, nil`. But the matcher compared against `"Path not found"` (capital P) with case-sensitive `strings.Contains`. OpenClaw 2026.6.x emits `Config path not found: agents.list` (lowercase `path`, `Config` prefix), so the guard never fired, the error propagated, prep failed closed, and the task never started.

This broke **every** OpenClaw 2026.6.x runtime, not a single deployment.

### Why this approach (skip-only was not safe)

The minimal fix is just making `isOpenclawKeyMissing` case-insensitive, which restores the intended graceful-skip. But skip-only drops per-agent workspace pinning: the wrapper would set only `agents.defaults.workspace`, and OpenClaw's resolution order is `agents.list[id].workspace -> agents.defaults.workspace -> ~/.openclaw/workspace`. An agent created with `openclaw agents add --workspace ...` carries a registry-level workspace that would then silently re-route the native skill scanner back to the shared workspace — defeating the per-task skill discovery this whole flow exists for.

So `openclawResolvedAgentsList` now **falls back to the registry subcommand** (`openclaw agents list --json`) when the config path is gone, and pins each agent's workspace exactly as the pre-2026.6 path did. Verified empirically against a real OpenClaw 2026.6.8 install that the wrapper's `agents.list[].workspace` override beats the registry's per-agent workspace, so per-task skill discovery keeps working under the new schema.

## Related Issue

Closes #3028

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/daemon/execenv/openclaw_config.go`
  - `isOpenclawKeyMissing`: case-insensitive match (`strings.ToLower` + lowercased needles), so it recognizes both pre-2026.6 `Path not found` and 2026.6.x `Config path not found`.
  - `openclawResolvedAgentsList`: on a missing config path, fall back to the new `openclawRegistryAgentsList` instead of returning empty.
  - New `openclawRegistryAgentsList`: resolves agents via `openclaw agents list --json`; returns `nil` (not error) on empty/`null` registry; degrades to `nil` on builds that predate the subcommand (new `isOpenclawUnknownSubcommand` guard) rather than failing closed.
- `server/internal/daemon/execenv/openclaw_config_test.go`
  - New `TestIsOpenclawKeyMissing` table test, including the **verbatim #3028 string** and negative cases (real failures / malformed JSON stay errors).
  - New `TestPrepareOpenclawConfigNewSchemaFallsBackToRegistry`: new-schema error -> registry subcommand -> `agents.list[].workspace` pinned to the task workdir.
  - New `TestPrepareOpenclawConfigNewSchemaEmptyRegistry`: empty registry -> defaults-only, `agents.list` omitted, no error.
  - Updated `TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty` for the new fallback flow.

## How to Test

Reproduce the bug shape and verify the fix with a real OpenClaw 2026.6.x install:

1. On a 2026.6.x host, `openclaw config get agents.list --json` exits 1 with `Config path not found: agents.list ...`, while `openclaw agents list --json` returns the registry array (each entry has `id` + `workspace`). Confirmed on OpenClaw 2026.6.8 (844f405).
2. `cd server && go test ./internal/daemon/execenv/...` — all green, including the three new/updated tests above.
3. `cd server && go vet ./internal/daemon/execenv/ && gofmt -l internal/daemon/execenv/openclaw_config.go internal/daemon/execenv/openclaw_config_test.go` — clean.
4. `make build` (or `GOOS=darwin GOARCH=arm64 go build ./cmd/multica`) — builds clean.
5. Empirical wrapper check on a live 2026.6.8 host: a wrapper config with `$include` of the user config plus `agents.list:[{id, workspace:<taskdir>}]` makes `openclaw agents list --json` report `<taskdir>` as the agent's workspace, confirming the override path works under the new schema.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (daemon Go code, no UI)
- [ ] I have updated relevant documentation to reflect my changes — N/A (no new runtime/tool/UI tab)
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy and docs — N/A
- [ ] If this PR touches Chinese product copy — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Reed Ops, JockiBox SWE fleet)

**Prompt / approach:** Investigated the execenv prep failure from the live OpenClaw 2026.6.8 error string, read the daemon source to find the two-layer root cause (case-sensitive guard + dead config path), then validated the new schema behavior empirically against a real OpenClaw 2026.6.8 install (`config get agents.list` error string, `agents list --json` registry shape, and that a wrapper `agents.list[].workspace` override still beats the registry workspace) before choosing schema-adapt over skip-only. Tests mirror the verbatim CLI error and registry output observed on the live host.

---

### Update — write-side half folded in (commit `d08f026d3`)

The read-side fix above made execenv prep pass and the agent reach `started`, but a coupled write-side bug in the same file still killed the task: `buildPerTaskOpenclawConfig` wrote the resolved agents back into the wrapper as an `agents.list[]` array. In 2026.6.x `agents.list` is no longer a valid config path, and the registry entries carry CLI-only fields (`identityName`, `agentDir`, `bindings`, `isDefault`, `identitySource`). OpenClaw's schema validator rejects them:

```
OpenClaw config is invalid
Problem: - agents.list.0: Invalid input
```

→ OpenClaw exits before the agent runs → empty stdout → `agent_error.empty_or_unparseable_output`. Confirmed on a live OpenClaw 2026.6.8 host (a minimal `{id,workspace}` entry validates, but the real registry shape fails with `agents.list.0: Invalid input`).

**Fix:** version-aware emission. `openclawResolvedAgentsList` now also reports whether the list was config-sourced (pre-2026.6, valid `agents.list[]` — safe to write back) or registry-sourced (2026.6.x — must NOT be written back). `buildPerTaskOpenclawConfig` only emits `agents.list` for the config-sourced case. For the new schema, per-task workspace pinning rides on `agents.defaults.workspace` alone, which OpenClaw applies to the agent it selects from the registry (verified: a defaults-only wrapper both validates and pins the resolved workspace on 2026.6.8). Older pre-sqlite OpenClaw hosts still get the array form.

**Tests:** the new-schema test now asserts the generated 2026.6.x wrapper contains **no** `agents.list` key (using the real registry shape including the rejected fields); the pre-2026.6 delegate test still asserts `agents.list` **is** emitted (version-aware regression guard).
