### PR TITLE
MUL-3432: fix(daemon): transactional ReportTaskMessages + extract classifyTaskResult (WOR-70)

### DIFF
--- a/server/internal/daemon/classify_task_result_test.go
+++ b/server/internal/daemon/classify_task_result_test.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// TestClassifyTaskResult is the table-driven coverage for the status switch
+// extracted from runTask (F1a). Each case pins the TaskResult disposition for
+// one branch of classifyTaskResult so regressions in the completed / empty-
+// output / poisoned / timeout / idle_watchdog / cancelled / default routing
+// surface as a unit test instead of only end-to-end via d.runner.
+func TestClassifyTaskResult(t *testing.T) {
+	const (
+		provider    = "claude"
+		workDir     = "/wd"
+		envRoot     = "/root"
+		sessionID   = "sess-123"
+		agentTO     = 5 * time.Minute
+		idleWatch   = 30 * time.Minute
+	)
+	env := &execenv.Environment{WorkDir: workDir, RootDir: envRoot}
+	usage := []TaskUsageEntry{{Provider: provider, Model: "claude-3", InputTokens: 10, OutputTokens: 20}}
+	discardLog := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := &Daemon{cfg: Config{AgentTimeout: agentTO, AgentIdleWatchdog: idleWatch}}
+
+	// expectedComment is resolved per-case so derived messages (timeout /
+	// idle_watchdog / unknown-status fallbacks) stay in lockstep with the
+	// production formatters without hardcoding their output verbatim.
+	type expect struct {
+		status        string
+		comment       string
+		failureReason string
+	}
+
+	cases := []struct {
+		name     string
+		provider string
+		result   agent.Result
+		want     expect
+	}{
+		{
+			name:   "completed empty output",
+			result: agent.Result{Status: "completed", Output: "", SessionID: sessionID},
+			want:   expect{status: "completed", comment: ""},
+		},
+		{
+			name:   "completed normal output",
+			result: agent.Result{Status: "completed", Output: "hello world", SessionID: sessionID},
+			want:   expect{status: "completed", comment: "hello world"},
+		},
+		{
+			name:   "completed poisoned iteration limit",
+			result: agent.Result{Status: "completed", Output: "I reached the iteration limit", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: "I reached the iteration limit", failureReason: FailureReasonIterationLimit},
+		},
+		{
+			name:   "completed poisoned agent fallback message",
+			result: agent.Result{Status: "completed", Output: "put your final update inside the content string", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: "put your final update inside the content string", failureReason: FailureReasonAgentFallbackMsg},
+		},
+		{
+			name:   "timeout with explicit error keeps error as comment",
+			result: agent.Result{Status: "timeout", Error: "backend slow", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: "backend slow", failureReason: "timeout"},
+		},
+		{
+			name:   "timeout with empty error synthesises comment from config",
+			result: agent.Result{Status: "timeout", Error: "", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: fmt.Sprintf("%s timed out after %s", provider, agentTO), failureReason: "timeout"},
+		},
+		{
+			// classifyResumeUnsafeTimeout is provider-gated to "codex", so this
+			// case must run under provider=codex (not the shared default).
+			name:     "codex resume-unsafe timeout overrides failure reason",
+			provider: "codex",
+			result:   agent.Result{Status: "timeout", Error: "codex semantic inactivity timeout mid-run", SessionID: sessionID},
+			want:     expect{status: "blocked", comment: "codex semantic inactivity timeout mid-run", failureReason: FailureReasonCodexSemanticInactivity},
+		},
+		{
+			name:   "idle_watchdog with explicit error",
+			result: agent.Result{Status: "idle_watchdog", Error: "frozen child process", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: "frozen child process", failureReason: "idle_watchdog"},
+		},
+		{
+			name:   "idle_watchdog with empty error synthesises comment",
+			result: agent.Result{Status: "idle_watchdog", Error: "", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: idleWatchdogReason(idleWatch), failureReason: "idle_watchdog"},
+		},
+		{
+			name:   "cancelled preserves status string",
+			result: agent.Result{Status: "cancelled", SessionID: sessionID},
+			want:   expect{status: "cancelled", comment: "task cancelled by server"},
+		},
+		{
+			name:   "default failed with classified provider auth error",
+			result: agent.Result{Status: "failed", Error: "API Error: 401 Unauthorized", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: "API Error: 401 Unauthorized", failureReason: "agent_error.provider_auth_or_access"},
+		},
+		{
+			name:   "default failed with poisoned API invalid request",
+			result: agent.Result{Status: "failed", Error: `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}`, SessionID: sessionID},
+			want:   expect{status: "blocked", comment: `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}`, failureReason: FailureReasonAPIInvalidRequest},
+		},
+		{
+			name:   "default failed with empty error synthesises message and falls back to unknown taxonomy",
+			result: agent.Result{Status: "failed", Error: "", SessionID: sessionID},
+			want:   expect{status: "blocked", comment: fmt.Sprintf("%s execution %s", provider, "failed"), failureReason: "agent_error.unknown"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			caseProvider := tc.provider
+			if caseProvider == "" {
+				caseProvider = provider
+			}
+			got := d.classifyTaskResult(tc.result, env, caseProvider, usage, discardLog)
+
+			if got.Status != tc.want.status {
+				t.Errorf("Status = %q, want %q", got.Status, tc.want.status)
+			}
+			if got.Comment != tc.want.comment {
+				t.Errorf("Comment = %q, want %q", got.Comment, tc.want.comment)
+			}
+			if got.FailureReason != tc.want.failureReason {
+				t.Errorf("FailureReason = %q, want %q", got.FailureReason, tc.want.failureReason)
+			}
+			// Identity-forwarded fields must be plumbed through on every branch.
+			if got.SessionID != sessionID {
+				t.Errorf("SessionID = %q, want %q", got.SessionID, sessionID)
+			}
+			if got.WorkDir != workDir {
+				t.Errorf("WorkDir = %q, want %q", got.WorkDir, workDir)
+			}
+			if got.EnvRoot != envRoot {
+				t.Errorf("EnvRoot = %q, want %q", got.EnvRoot, envRoot)
+			}
+			if len(got.Usage) != len(usage) {
+				t.Errorf("len(Usage) = %d, want %d", len(got.Usage), len(usage))
+			}
+		})
+	}
+}
+
+// TestClassifyTaskResultPreservesUsage asserts the usage slice is forwarded by
+// value, not silently dropped, regardless of branch — a regression here would
+// lose per-model token accounting on the server.
+func TestClassifyTaskResultPreservesUsage(t *testing.T) {
+	d := &Daemon{cfg: Config{AgentTimeout: time.Minute, AgentIdleWatchdog: time.Minute}}
+	env := &execenv.Environment{WorkDir: "/wd", RootDir: "/root"}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	usage := []TaskUsageEntry{
+		{Provider: "claude", Model: "m1", InputTokens: 1},
+		{Provider: "claude", Model: "m2", OutputTokens: 2},
+	}
+	got := d.classifyTaskResult(agent.Result{Status: "completed", Output: "done"}, env, "claude", usage, log)
+	if len(got.Usage) != 2 || got.Usage[0].InputTokens != 1 || got.Usage[1].OutputTokens != 2 {
+		t.Errorf("usage not forwarded verbatim: %+v", got.Usage)
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3595,6 +3595,20 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		})
 	}
 
+	return d.classifyTaskResult(result, env, provider, usageEntries, taskLog), nil
+}
+
+// classifyTaskResult maps an agent run result to the TaskResult that runTask
+// forwards to handleTask. Equivalent extraction of runTask's former status
+// switch (the only side effects are the taskLog Warn calls), pulled out so
+// each branch is unit-testable instead of reachable only via d.runner.
+func (d *Daemon) classifyTaskResult(
+	result agent.Result,
+	env *execenv.Environment,
+	provider string,
+	usageEntries []TaskUsageEntry,
+	taskLog *slog.Logger,
+) TaskResult {
 	switch result.Status {
 	case "completed":
 		if result.Output == "" {
@@ -3610,7 +3624,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 				WorkDir:   env.WorkDir,
 				EnvRoot:   env.RootDir,
 				Usage:     usageEntries,
-			}, nil
+			}
 		}
 		// Detect "poisoned" terminal output: the agent didn't reach a real
 		// conclusion but emitted a known fallback marker (iteration limit,
@@ -3631,7 +3645,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 				EnvRoot:       env.RootDir,
 				Usage:         usageEntries,
 				FailureReason: reason,
-			}, nil
+			}
 		}
 		return TaskResult{
 			Status:    "completed",
@@ -3640,7 +3654,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			WorkDir:   env.WorkDir,
 			EnvRoot:   env.RootDir,
 			Usage:     usageEntries,
-		}, nil
+		}
 	case "timeout":
 		// Surface session_id/work_dir so the chat resume pointer is kept
 		// in sync even when the agent times out after building a session.
@@ -3665,7 +3679,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			EnvRoot:       env.RootDir,
 			FailureReason: failureReason,
 			Usage:         usageEntries,
-		}, nil
+		}
 	case "idle_watchdog":
 		// The idle watchdog force-stopped the run because the backend
 		// went silent (e.g. claude blocked on a tool call against a
@@ -3684,7 +3698,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			EnvRoot:       env.RootDir,
 			FailureReason: "idle_watchdog",
 			Usage:         usageEntries,
-		}, nil
+		}
 	case "cancelled":
 		// Server cancelled the task (e.g. issue reassignment, user cancel).
 		// handleTask's cancelledByPoll branch already discards this result,
@@ -3698,7 +3712,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			WorkDir:   env.WorkDir,
 			EnvRoot:   env.RootDir,
 			Usage:     usageEntries,
-		}, nil
+		}
 	default:
 		errMsg := result.Error
 		if errMsg == "" {
@@ -3742,7 +3756,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			EnvRoot:       env.RootDir,
 			Usage:         usageEntries,
 			FailureReason: failureReason,
-		}, nil
+		}
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2205,6 +2205,19 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Persist the whole batch in one transaction so a mid-batch DB error
+	// rolls back every prior insert instead of leaving a partial transcript
+	// (prefix committed + broadcast, suffix silently lost).
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		slog.Error("failed to begin task message tx", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist task message")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	created := make([]db.TaskMessage, 0, len(req.Messages))
 	for _, msg := range req.Messages {
 		// Redact sensitive information before persisting or broadcasting.
 		msg.Content = redact.Text(msg.Content)
@@ -2215,7 +2228,7 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 		if msg.Input != nil {
 			inputJSON, _ = json.Marshal(msg.Input)
 		}
-		created, createErr := h.Queries.CreateTaskMessage(r.Context(), db.CreateTaskMessageParams{
+		row, createErr := qtx.CreateTaskMessage(r.Context(), db.CreateTaskMessageParams{
 			TaskID:  parseUUID(taskID),
 			Seq:     int32(msg.Seq),
 			Type:    msg.Type,
@@ -2229,10 +2242,20 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to persist task message")
 			return
 		}
+		created = append(created, row)
+	}
 
-		if workspaceID != "" {
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("failed to commit task message batch", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist task message")
+		return
+	}
+
+	// Publish only after commit so no event ever describes an uncommitted row.
+	if workspaceID != "" {
+		for _, row := range created {
 			h.publishTask(protocol.EventTaskMessage, workspaceID, "system", "", taskID,
-				taskMessageToPayload(created, taskID, uuidToString(task.IssueID)))
+				taskMessageToPayload(row, taskID, uuidToString(task.IssueID)))
 		}
 	}
 

--- a/server/internal/handler/daemon_report_messages_test.go
+++ b/server/internal/handler/daemon_report_messages_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+var f4IssueNumber int64
+
+// f4SeedIssue inserts a minimal issue in the test workspace so
+// ReportTaskMessages can resolve a workspace_id and exercise the realtime
+// publish path. A monotonic issue number keeps the (workspace_id, number)
+// unique constraint satisfied across test runs.
+func f4SeedIssue(t *testing.T) string {
+	t.Helper()
+	num := atomic.AddInt64(&f4IssueNumber, 1) + 900000
+	var id string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number)
+		VALUES ($1, 'f4 task-message test', 'todo', 'none', 'member', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, num).Scan(&id); err != nil {
+		t.Fatalf("seed f4 issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, id) })
+	return id
+}
+
+func reportTaskMessagesHTTP(t *testing.T, taskID string, msgs []TaskMessageRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(TaskMessageBatchRequest{Messages: msgs})
+	r := newRequest("POST", "/api/daemon/tasks/"+taskID+"/messages", json.RawMessage(body))
+	r = withURLParam(r, "taskId", taskID)
+	w := httptest.NewRecorder()
+	testHandler.ReportTaskMessages(w, r)
+	return w
+}
+
+func countTaskMessages(t *testing.T, taskID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM task_message WHERE task_id = $1`, taskID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count task_message: %v", err)
+	}
+	return n
+}
+
+// taskMessageEventCapture counts protocol.EventTaskMessage events published
+// during a test, mirroring the comment event capture used by the resolve
+// tests. Bus.Subscribe has no Unsubscribe, so the capture is process-global
+// for the test run; each test tags its task id and filters on it.
+type taskMessageEventCapture struct {
+	mu     sync.Mutex
+	seen   map[string]int
+}
+
+func captureTaskMessageEvents() *taskMessageEventCapture {
+	cap := &taskMessageEventCapture{seen: make(map[string]int)}
+	testHandler.Bus.Subscribe(protocol.EventTaskMessage, func(e events.Event) {
+		cap.mu.Lock()
+		cap.seen[e.TaskID]++
+		cap.mu.Unlock()
+	})
+	return cap
+}
+
+func (c *taskMessageEventCapture) forTask(taskID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.seen[taskID]
+}
+
+// TestReportTaskMessagesHappyPath verifies the transactional batch path
+// persists every message and publishes a realtime event per row only after
+// the commit succeeds.
+func TestReportTaskMessagesHappyPath(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture unavailable (no database)")
+	}
+	agentID := createHandlerTestAgent(t, "f4-msg-happy", nil)
+	issueID := f4SeedIssue(t)
+	taskID := createHandlerTestTaskForAgentOnIssue(t, agentID, issueID)
+
+	cap := captureTaskMessageEvents()
+	w := reportTaskMessagesHTTP(t, taskID, []TaskMessageRequest{
+		{Seq: 1, Type: "text", Content: "first"},
+		{Seq: 2, Type: "text", Content: "second"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if n := countTaskMessages(t, taskID); n != 2 {
+		t.Errorf("persisted rows = %d, want 2", n)
+	}
+	if n := cap.forTask(taskID); n != 2 {
+		t.Errorf("published events = %d, want 2 (publish must follow commit)", n)
+	}
+}
+
+// TestReportTaskMessagesAtomicOnMidBatchFailure is the core F4 regression: a
+// mid-batch DB error must roll back the whole batch instead of leaving a
+// partial transcript, and must not broadcast any event for the rolled-back
+// rows. The second message carries a NUL byte in Tool — Tool bypasses
+// redaction and Postgres rejects 0x00 in text with an invalid-byte-sequence
+// error, which deterministically fails the second INSERT while the first
+// would otherwise succeed.
+func TestReportTaskMessagesAtomicOnMidBatchFailure(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture unavailable (no database)")
+	}
+	agentID := createHandlerTestAgent(t, "f4-msg-atomic", nil)
+	issueID := f4SeedIssue(t)
+	taskID := createHandlerTestTaskForAgentOnIssue(t, agentID, issueID)
+
+	cap := captureTaskMessageEvents()
+	w := reportTaskMessagesHTTP(t, taskID, []TaskMessageRequest{
+		{Seq: 1, Type: "text", Content: "would-be-prefix"},
+		{Seq: 2, Type: "text", Tool: "bad\x00tool", Content: "triggers invalid byte sequence"},
+	})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if n := countTaskMessages(t, taskID); n != 0 {
+		t.Errorf("persisted rows = %d, want 0 (whole batch must roll back)", n)
+	}
+	if n := cap.forTask(taskID); n != 0 {
+		t.Errorf("published events = %d, want 0 (no event for rolled-back rows)", n)
+	}
+}
+
+// TestReportTaskMessagesEmptyBatchIsNoop locks in the early return so the new
+// transaction path is never opened for an empty payload.
+func TestReportTaskMessagesEmptyBatchIsNoop(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture unavailable (no database)")
+	}
+	agentID := createHandlerTestAgent(t, "f4-msg-empty", nil)
+	taskID := createHandlerTestTaskForAgent(t, agentID)
+
+	w := reportTaskMessagesHTTP(t, taskID, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if n := countTaskMessages(t, taskID); n != 0 {
+		t.Errorf("persisted rows = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
## WOR-70 — daemon task-message pipeline: round 1 (F4 + F1a)

First round of the adversarial review on the daemon task claim → run → message-report chain. Scope locked by Codex to two self-contained, zero-behaviour-regression items; the seq/drain correctness work (F2/F3) and the `executeAndDrain` extraction (F1b) are explicitly deferred to a follow-up "message pipeline" round (see **Deferred** below).

### Scope

**F4 — `ReportTaskMessages` transactional consistency** (`server/internal/handler/daemon.go`)
The batch previously inserted each `task_message` in its own implicit transaction and published the realtime event inline, so a mid-batch DB error left the prefix committed + broadcast while the suffix was silently dropped — a partial, non-self-healing transcript. The whole batch is now wrapped in one `TxStarter` transaction (all-or-nothing), and events are published only after `Commit` succeeds. This mirrors the existing `ResolveComment` pattern (`comment.go:1720`: "Published after commit so no event ever describes an uncommitted state"). **Daemon-side retry is intentionally out of scope** (behaviour change, tracked for the follow-up round).

**F1a — extract `classifyTaskResult`** (`server/internal/daemon/daemon.go`)
`runTask`'s terminal status switch (~150 lines: completed / empty-output / poisoned / timeout / idle_watchdog / cancelled / default) was only reachable end-to-end via `d.runner`, so every fix in that cluster had the whole 647-line function as its blast radius. Extracted verbatim into `(d *Daemon) classifyTaskResult(result, env, provider, usageEntries, taskLog) TaskResult` so each branch is unit-testable. Equivalent extraction — the only change is the 7 returns drop `, nil` (the method returns `TaskResult`, not error).

### Boundary respected
Does **not** touch `executeAndDrain`, the drain `seq` counter, or the claim-response gzip rollback area (HEAD is the `#4307` revert point — that unstable region is deliberately avoided). F5 (`parseUUID(taskID)` vs `task.ID`; `mergeUsage` alias) is left as record-only per the round's scope.

### Verification
```
cd server
go vet ./...                       # clean
go build ./...                     # clean
go test -race -count=1 ./internal/daemon/ ./internal/handler/
```
- `daemon -race`: **PASS** (incl. F1a — 14 table-driven branch cases + usage pass-through)
- `handler -race` full suite: **PASS** (incl. F4 — happy-path 2 rows + 2 post-commit events; atomicity: NUL byte in `Tool` bypasses redaction → `SQLSTATE 22021` on 2nd insert → 500, 0 rows, 0 events; empty-batch noop)

### Risk review — Chrys sign-off
Chrys's final risk review **approved both items with no required changes** ("放行 F4 + F1a；未发现必须调整项"). Confirmed independently on a fresh checkout: F4 transaction semantics + commit-before-publish ordering are correct and match 10+ existing in-repo transaction sites; the NUL-byte failure injection is the only clean way to deterministically trigger a mid-batch DB error through the public API given `Queries` is a concrete (non-stub-able) `*db.Queries`; F1a is a line-for-line equivalent extraction with `executeAndDrain`/drain-seq untouched.

### Deferred to the follow-up "message pipeline" round (R1–R6, non-blocking)
| # | Item |
| --- | --- |
| R1 | F3 — retry path resets `seq` to 0; collides with the first attempt's seqs (non-unique index, silent interleaving) |
| R2 | F2 — within a flush window, text/tool seq ordering is inverted (logical-order bug) |
| R3 | F1b — `executeAndDrain` / `buildExecOptions` extraction (large; touches the post-revert unstable area) |
| R4 | daemon-side batch retry on non-200 (F4 made the write all-or-nothing; transient errors now drop the whole batch until retry lands) |
| R5 | post-commit publish is still O(N) synchronous (not a regression) |
| R6 | NUL-byte test injection is test-maintenance-only; revisit if `Tool` ever gets redacted |

Ref: WOR-70
