### PR TITLE
fix(notifications): skip squad assignees in subscriber + inbox listeners

### DIFF
--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -558,8 +558,11 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		// Track who already got notified to avoid duplicates
 		skip := map[string]bool{e.ActorID: true}
 
-		// Direct notification to assignee
-		if issue.AssigneeType != nil && issue.AssigneeID != nil {
+		// Direct notification to assignee. Skip squad assignees —
+		// inbox_item.recipient_type is CHECK-constrained to
+		// ('member','agent'), and the squad leader is dispatched via
+		// its task instead (EnqueueTaskForSquadLeader).
+		if issue.AssigneeType != nil && issue.AssigneeID != nil && *issue.AssigneeType != "squad" {
 			skip[*issue.AssigneeID] = true
 			notifyDirect(ctx, queries, bus,
 				*issue.AssigneeType, *issue.AssigneeID,
@@ -613,8 +616,9 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 			}
 			assigneeDetails, _ := json.Marshal(detailsMap)
 
-			// Direct: notify new assignee about assignment
-			if issue.AssigneeType != nil && issue.AssigneeID != nil {
+			// Direct: notify new assignee about assignment. Skip squad
+			// assignees (see issue:created listener for rationale).
+			if issue.AssigneeType != nil && issue.AssigneeID != nil && *issue.AssigneeType != "squad" {
 				notifyDirect(ctx, queries, bus,
 					*issue.AssigneeType, *issue.AssigneeID,
 					e.WorkspaceID, e, issue.ID, issue.Status,

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -487,6 +487,101 @@ func TestSubscriberSystemCommentDoesNotSubscribe(t *testing.T) {
 	}
 }
 
+// TestNotification_SquadAssigneeSkipsInbox is the squad-assignee analog of
+// TestNotification_SystemCommentSkipsInboxAndMentions: when an issue is created
+// or reassigned with assignee_type='squad', the notification listener must
+// NOT call notifyDirect with recipient_type='squad' — inbox_item.recipient_type
+// is CHECK-constrained to ('member','agent') (SQLSTATE 23514), and the squad
+// leader is dispatched via EnqueueTaskForSquadLeader instead. The fix mirrors
+// the author_type='system' gate from MUL-2538.
+//
+// Covers both the issue:created and issue:updated (assignee_changed) paths.
+// Same caveat as the system-comment test: the behavioral assertion holds
+// either way (the insert fails), but the test pins the invariant and will
+// fail loudly if anyone widens inbox_item.recipient_type to include 'squad'
+// without revisiting this listener.
+func TestNotification_SquadAssigneeSkipsInbox(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	squadID := createTestSquad(t, testWorkspaceID, testUserID, "Notification Squad")
+	t.Cleanup(func() { cleanupTestSquad(t, squadID) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	var inboxEvents []events.Event
+	bus.Subscribe(protocol.EventInboxNew, func(e events.Event) {
+		inboxEvents = append(inboxEvents, e)
+	})
+
+	// --- issue:created with squad assignee ---
+	createdType := "squad"
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:           issueID,
+				WorkspaceID:  testWorkspaceID,
+				Title:        "squad-assigned at creation",
+				Status:       "todo",
+				Priority:     "medium",
+				CreatorType:  "member",
+				CreatorID:    testUserID,
+				AssigneeType: &createdType,
+				AssigneeID:   &squadID,
+			},
+		},
+	})
+
+	// --- issue:updated reassigning to the squad ---
+	updatedType := "squad"
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:           issueID,
+				WorkspaceID:  testWorkspaceID,
+				Title:        "squad-assigned at creation",
+				Status:       "todo",
+				Priority:     "medium",
+				CreatorType:  "member",
+				CreatorID:    testUserID,
+				AssigneeType: &updatedType,
+				AssigneeID:   &squadID,
+			},
+			"assignee_changed": true,
+		},
+	})
+
+	// No inbox item should exist for the squad (recipient_type='squad' would
+	// be rejected anyway, but the listener must short-circuit before the
+	// insert — the assertion pins the invariant).
+	squadItems, err := queries.ListInboxItems(context.Background(), db.ListInboxItemsParams{
+		WorkspaceID:   util.MustParseUUID(testWorkspaceID),
+		RecipientType: "squad",
+		RecipientID:   util.MustParseUUID(squadID),
+	})
+	if err != nil {
+		t.Fatalf("ListInboxItems for squad: %v", err)
+	}
+	if len(squadItems) != 0 {
+		t.Fatalf("expected 0 inbox items for squad assignee, got %d", len(squadItems))
+	}
+	if len(inboxEvents) != 0 {
+		t.Fatalf("expected 0 inbox:new events for squad-assigned issue, got %d", len(inboxEvents))
+	}
+}
+
 // TestNotification_AssigneeChanged verifies the full assignee change flow:
 // - New assignee gets "issue_assigned" (Direct)
 // - Old assignee gets "unassigned" (Direct)

--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -30,8 +30,15 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 		// Subscribe the creator
 		addSubscriber(bus, queries, e.WorkspaceID, issue.ID, issue.CreatorType, issue.CreatorID, "creator")
 
-		// Subscribe the assignee if exists and different from creator
+		// Subscribe the assignee if exists and different from creator.
+		// Skip squad assignees — the squad leader is dispatched via
+		// EnqueueTaskForSquadLeader (service/autopilot.go), and
+		// issue_subscriber.user_type is CHECK-constrained to
+		// ('member','agent') so a squad row would only log noise
+		// (cf. the author_type=='system' gate in the comment:created
+		// listener, MUL-2538).
 		if issue.AssigneeType != nil && issue.AssigneeID != nil &&
+			*issue.AssigneeType != "squad" &&
 			!(*issue.AssigneeType == issue.CreatorType && *issue.AssigneeID == issue.CreatorID) {
 			addSubscriber(bus, queries, e.WorkspaceID, issue.ID, *issue.AssigneeType, *issue.AssigneeID, "assignee")
 		}
@@ -55,9 +62,10 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 			return
 		}
 
-		// Subscribe new assignee if assignee changed
+		// Subscribe new assignee if assignee changed. Skip squad assignees
+		// (see issue:created listener above for rationale).
 		if assigneeChanged, _ := payload["assignee_changed"].(bool); assigneeChanged {
-			if issue.AssigneeType != nil && issue.AssigneeID != nil {
+			if issue.AssigneeType != nil && issue.AssigneeID != nil && *issue.AssigneeType != "squad" {
 				addSubscriber(bus, queries, e.WorkspaceID, issue.ID, *issue.AssigneeType, *issue.AssigneeID, "assignee")
 			}
 		}

--- a/server/cmd/server/subscriber_listeners_test.go
+++ b/server/cmd/server/subscriber_listeners_test.go
@@ -60,6 +60,34 @@ func cleanupTestUser(t *testing.T, email string) {
 	testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
 }
 
+// createTestSquad inserts a squad led by a workspace agent and returns its
+// UUID string. Mirrors the INSERT shape used in
+// server/internal/handler/squad_assign_trigger_test.go.
+func createTestSquad(t *testing.T, workspaceID, creatorID, name string) string {
+	t.Helper()
+	ctx := context.Background()
+	var leaderID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1
+	`, workspaceID).Scan(&leaderID); err != nil {
+		t.Fatalf("load fixture agent for squad leader: %v", err)
+	}
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, workspaceID, name, leaderID, creatorID).Scan(&squadID); err != nil {
+		t.Fatalf("createTestSquad: %v", err)
+	}
+	return squadID
+}
+
+func cleanupTestSquad(t *testing.T, squadID string) {
+	t.Helper()
+	testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+}
+
 func isSubscribed(t *testing.T, queries *db.Queries, issueID, userType, userID string) bool {
 	t.Helper()
 	subscribed, err := queries.IsIssueSubscriber(context.Background(), db.IsIssueSubscriberParams{
@@ -414,4 +442,106 @@ func TestParseUUIDConsistency(t *testing.T) {
 		}
 	}()
 	_ = parseUUID("")
+}
+
+// TestSubscriberIssueCreated_SquadAssigneeNotSubscribed guards the fix for
+// the squad-assignee CHECK-constraint noise: when an issue is created with
+// assignee_type='squad', the subscriber listener must NOT call
+// AddIssueSubscriber with user_type='squad' (which the DB rejects with
+// SQLSTATE 23514 — cf. the author_type='system' gate for MUL-2538). The
+// squad leader is dispatched via EnqueueTaskForSquadLeader instead, so a
+// subscriber row is both impossible and redundant.
+//
+// Same caveat as TestSubscriberSystemCommentDoesNotSubscribe: the behavioral
+// assertion (no squad row) holds either way because the insert fails, but
+// the test pins the invariant and will fail loudly if anyone widens the
+// issue_subscriber.user_type CHECK to include 'squad' without also revisiting
+// this listener.
+func TestSubscriberIssueCreated_SquadAssigneeNotSubscribed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+
+	squadID := createTestSquad(t, testWorkspaceID, testUserID, "Subscriber Squad (created)")
+	t.Cleanup(func() { cleanupTestSquad(t, squadID) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+
+	assigneeType := "squad"
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:           issueID,
+				WorkspaceID:  testWorkspaceID,
+				Title:        "squad-assigned at creation",
+				Status:       "todo",
+				Priority:     "medium",
+				CreatorType:  "member",
+				CreatorID:    testUserID,
+				AssigneeType: &assigneeType,
+				AssigneeID:   &squadID,
+			},
+		},
+	})
+
+	// Creator is the only subscriber — the squad assignee must not produce
+	// a second row (nor a failed insert logged at error level).
+	if isSubscribed(t, queries, issueID, "squad", squadID) {
+		t.Fatal("squad assignee must not be subscribed as user_type='squad'")
+	}
+	if count := subscriberCount(t, queries, issueID); count != 1 {
+		t.Fatalf("expected 1 subscriber (creator only) for squad-assigned issue, got %d", count)
+	}
+	if !isSubscribed(t, queries, issueID, "member", testUserID) {
+		t.Fatal("creator must still be subscribed on a squad-assigned issue")
+	}
+}
+
+// TestSubscriberIssueUpdated_SquadAssigneeNotSubscribed is the issue:updated
+// analog: reassigning an issue to a squad must not try to insert a squad
+// subscriber row.
+func TestSubscriberIssueUpdated_SquadAssigneeNotSubscribed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+
+	squadID := createTestSquad(t, testWorkspaceID, testUserID, "Subscriber Squad (updated)")
+	t.Cleanup(func() { cleanupTestSquad(t, squadID) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+
+	assigneeType := "squad"
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:           issueID,
+				WorkspaceID:  testWorkspaceID,
+				Title:        "reassigned to squad",
+				Status:       "todo",
+				Priority:     "medium",
+				CreatorType:  "member",
+				CreatorID:    testUserID,
+				AssigneeType: &assigneeType,
+				AssigneeID:   &squadID,
+			},
+			"assignee_changed": true,
+		},
+	})
+
+	if isSubscribed(t, queries, issueID, "squad", squadID) {
+		t.Fatal("squad assignee must not be subscribed as user_type='squad' after reassignment")
+	}
+	if count := subscriberCount(t, queries, issueID); count != 0 {
+		t.Fatalf("expected 0 subscribers when only a squad assignee change fired, got %d", count)
+	}
 }


### PR DESCRIPTION
## Problem

When an issue is created or reassigned with `assignee_type='squad'`, the subscriber and notification listeners call `AddIssueSubscriber` and `notifyDirect` with `user_type='squad'` / `recipient_type='squad'`. Both `issue_subscriber.user_type` and `inbox_item.recipient_type` are CHECK-constrained to `('member','agent')`, so every squad assignment logs two `SQLSTATE 23514` errors in production:

```
ERR failed to add issue subscriber ... user_type=squad ... reason=assignee
    error="... issue_subscriber_user_type_check (SQLSTATE 23514)"
ERR direct notification creation failed ... type=issue_assigned
    error="... inbox_item_recipient_type_check (SQLSTATE 23514)"
```

The squad leader is already dispatched via `EnqueueTaskForSquadLeader` (`service/autopilot.go`), so a subscriber row and an inbox item are both impossible **and** redundant — the squad has no inbox to read.

## Context

This is the remaining server-side gap between two existing fixes:

- **MUL-2165** taught the CLI resolver to opt out of `squad` resolution for `project.lead_type` and the subscriber handler (`isWorkspaceEntity`), but the **server-side event-bus listeners** were not touched. The `issue:created` / `issue:updated` listeners kept forwarding `*AssigneeType` straight into `AddIssueSubscriber`.
- **MUL-2538** added an `author_type == "system"` early-return in `subscriber_listeners.go` and `notification_listeners.go` for the child-done system comment, with an explicit comment noting *"issue_subscriber.user_type is constrained to (`member`,`agent`); without the gate the listener would log a constraint violation."* The squad-assignee case — the same shape of bug — was left open.

This PR closes that gap using the same boundary-level gate pattern the team has applied both times.

## Changes

- `subscriber_listeners.go`: gate the assignee branch in the `issue:created` and `issue:updated` listeners on `*AssigneeType != "squad"`.
- `notification_listeners.go`: same gate on the two `notifyDirect` call sites that produce `issue_assigned`.
- Tests: `createTestSquad` helper + 3 regression tests (`TestSubscriberIssueCreated_SquadAssigneeNotSubscribed`, `TestSubscriberIssueUpdated_SquadAssigneeNotSubscribed`, `TestNotification_SquadAssigneeSkipsInbox`) mirroring the MUL-2538 system-comment test pair.

## Verification

- `go build ./cmd/server/` and `go vet ./cmd/server/` clean.
- `go test -race -run 'TestSubscriber|TestNotification' ./cmd/server/` — all 30 tests pass (3 new + existing subscriber/notification suite).
- Verified against the **unfixed** production code: the new tests reproduce the exact production error lines (`SQLSTATE 23514` on both tables); with the fix applied, those errors are gone.

## A note on the regression-test shape

The new tests are invariant guards — they pass both with and without the source fix because the DB rejects the bad insert either way (the listener swallows the error and continues). This is the **same tradeoff** the MUL-2538 tests accepted (`TestSubscriberSystemCommentDoesNotSubscribe`, `TestNotification_SystemCommentSkipsInboxAndMentions`). The value of these tests is:

1. They pin the contract (squad assignee produces no subscriber row / no inbox item).
2. They will **fail loudly** if anyone later widens the CHECK constraints to include `squad` without revisiting these listeners — preventing a silent regression where squad rows start getting inserted with the old listener logic.

I kept the style consistent with the existing MUL-2538 tests rather than introducing slog-output capture, which would be inconsistent with the package's testing conventions. Happy to switch to stricter output-capture tests if the team prefers.