### PR TITLE
fix(desktop): avoid duplicate sidebar tabs

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -626,7 +626,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />
@@ -690,7 +690,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />
@@ -714,7 +714,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />

--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -90,6 +90,30 @@ describe("AppLink", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it("activateTabOnClick delegates normal clicks to openInNewTab in the foreground", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const adapter = makeAdapter({ push, openInNewTab });
+
+    renderLink(adapter, { href: "/issues", activateTabOnClick: true });
+    fireEvent.click(screen.getByText("go"));
+
+    expect(openInNewTab).toHaveBeenCalledWith("/issues", undefined, {
+      activate: true,
+    });
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("activateTabOnClick falls back to push when the adapter has no tab API", () => {
+    const push = vi.fn();
+    const adapter = makeAdapter({ push });
+
+    renderLink(adapter, { href: "/issues", activateTabOnClick: true });
+    fireEvent.click(screen.getByText("go"));
+
+    expect(push).toHaveBeenCalledWith("/issues");
+  });
+
   it("a caller-supplied onClick passed via spread cannot silently override the navigation handler", () => {
     const push = vi.fn();
     const adapter = makeAdapter({ push });

--- a/packages/views/navigation/app-link.tsx
+++ b/packages/views/navigation/app-link.tsx
@@ -5,11 +5,13 @@ import { useNavigation } from "./context";
 
 interface AppLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
+  /** Desktop tab shells can opt into open-or-activate semantics for primary clicks. */
+  activateTabOnClick?: boolean;
 }
 
 export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
   function AppLink(
-    { href, children, onClick, onMouseEnter, onFocus, ...props },
+    { href, children, onClick, onMouseEnter, onFocus, activateTabOnClick, ...props },
     ref,
   ) {
     const { push, openInNewTab, prefetch } = useNavigation();
@@ -27,6 +29,10 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
       // (close popover, clear selection, blur the trigger) lands in the
       // same tick rather than getting deferred behind the transition.
       onClick?.(e);
+      if (activateTabOnClick && openInNewTab) {
+        openInNewTab(href, undefined, { activate: true });
+        return;
+      }
       push(href);
     };
 


### PR DESCRIPTION
## Summary
- add an opt-in AppLink mode that lets desktop tab shells open or activate an existing tab on primary clicks
- use that mode for sidebar navigation links so clicking an active destination does not also trigger default anchor navigation
- cover the foreground tab activation path and web fallback path with AppLink tests

Fixes #4284

## Tests
- pnpm --filter @multica/views exec vitest run navigation/app-link.test.tsx
- pnpm --filter @multica/views typecheck
- git diff --check