### PR TITLE
MUL-3438: fix(projects): require admin for project deletion

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -445,6 +445,11 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     enabled: !!userId,
   });
   const isPinned = pinnedItems.some((p) => p.item_type === "project" && p.item_id === projectId);
+  const isWorkspaceAdmin = useMemo(() => {
+    if (!userId) return false;
+    const me = members.find((m) => m.user_id === userId);
+    return me?.role === "owner" || me?.role === "admin";
+  }, [members, userId]);
   const createPin = useCreatePin();
   const deletePinMut = useDeletePin();
   const descEditorRef = useRef<ContentEditorRef>(null);
@@ -781,14 +786,18 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                     <Link2 className="h-3.5 w-3.5" />
                     {t(($) => $.detail.copy_link)}
                   </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={() => setDeleteDialogOpen(true)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    {t(($) => $.detail.delete_action)}
-                  </DropdownMenuItem>
+                  {isWorkspaceAdmin && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => setDeleteDialogOpen(true)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        {t(($) => $.detail.delete_action)}
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
               <Tooltip>
@@ -857,22 +866,24 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       </ResizablePanelGroup>
 
       {/* Delete confirmation */}
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t(($) => $.delete_dialog.title)}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t(($) => $.delete_dialog.description)}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t(($) => $.delete_dialog.cancel)}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-white hover:bg-destructive/90">
-              {t(($) => $.delete_dialog.confirm)}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {isWorkspaceAdmin && (
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t(($) => $.delete_dialog.title)}</AlertDialogTitle>
+              <AlertDialogDescription>
+                {t(($) => $.delete_dialog.description)}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t(($) => $.delete_dialog.cancel)}</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete} className="bg-destructive text-white hover:bg-destructive/90">
+                {t(($) => $.delete_dialog.confirm)}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </>
   );
 }

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -518,10 +518,11 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "project not found")
 		return
 	}
-	userID, ok := requireUserID(w, r)
+	requester, ok := h.requireWorkspaceRole(w, r, uuidToString(project.WorkspaceID), "project not found", "owner", "admin")
 	if !ok {
 		return
 	}
+	userID := uuidToString(requester.UserID)
 	if err := h.Queries.DeleteProject(r.Context(), db.DeleteProjectParams{
 		ID:          project.ID,
 		WorkspaceID: project.WorkspaceID,

--- a/server/internal/handler/project_validation_test.go
+++ b/server/internal/handler/project_validation_test.go
@@ -142,6 +142,9 @@ func createProjectPermissionTestMember(t *testing.T, role string) string {
 
 	ctx := context.Background()
 	email := "project-delete-" + role + "@multica.test"
+	// The schema uses no foreign keys or cascades, so a leftover member from a
+	// prior run won't disappear when its user is deleted. Drop the member first.
+	_, _ = testPool.Exec(ctx, `DELETE FROM member WHERE user_id IN (SELECT id FROM "user" WHERE email = $1)`, email)
 	_, _ = testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
 
 	var userID string
@@ -153,6 +156,9 @@ RETURNING id
 		t.Fatalf("create %s user: %v", role, err)
 	}
 	t.Cleanup(func() {
+		// No cascade in the schema: remove the member row before its user so the
+		// shared test workspace isn't left with an orphaned member record.
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM member WHERE user_id = $1`, userID)
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
 	})
 

--- a/server/internal/handler/project_validation_test.go
+++ b/server/internal/handler/project_validation_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -90,4 +91,98 @@ func TestUpdateProjectInvalidStatusReturns400(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid update status, got %d: %s", w.Code, w.Body.String())
 	}
+}
+
+func TestDeleteProjectRequiresAdminOrOwner(t *testing.T) {
+	memberUserID := createProjectPermissionTestMember(t, "member")
+	project := createProjectPermissionTestProject(t, "delete permission denied project")
+
+	w := httptest.NewRecorder()
+	req := newRequestAs(memberUserID, "DELETE", "/api/projects/"+project.ID, nil)
+	req = withURLParam(req, "id", project.ID)
+	testHandler.DeleteProject(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for plain member project delete, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var exists bool
+	if err := testPool.QueryRow(context.Background(), `SELECT EXISTS (SELECT 1 FROM project WHERE id = $1)`, project.ID).Scan(&exists); err != nil {
+		t.Fatalf("verify project exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("project was deleted despite plain member request")
+	}
+}
+
+func TestDeleteProjectAllowsAdmin(t *testing.T) {
+	adminUserID := createProjectPermissionTestMember(t, "admin")
+	project := createProjectPermissionTestProject(t, "delete permission admin project")
+
+	w := httptest.NewRecorder()
+	req := newRequestAs(adminUserID, "DELETE", "/api/projects/"+project.ID, nil)
+	req = withURLParam(req, "id", project.ID)
+	testHandler.DeleteProject(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for admin project delete, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var exists bool
+	if err := testPool.QueryRow(context.Background(), `SELECT EXISTS (SELECT 1 FROM project WHERE id = $1)`, project.ID).Scan(&exists); err != nil {
+		t.Fatalf("verify project deleted: %v", err)
+	}
+	if exists {
+		t.Fatal("project still exists after admin delete")
+	}
+}
+
+func createProjectPermissionTestMember(t *testing.T, role string) string {
+	t.Helper()
+
+	ctx := context.Background()
+	email := "project-delete-" + role + "@multica.test"
+	_, _ = testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
+
+	var userID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO "user" (name, email)
+VALUES ($1, $2)
+RETURNING id
+`, "Project Delete "+role, email).Scan(&userID); err != nil {
+		t.Fatalf("create %s user: %v", role, err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+INSERT INTO member (workspace_id, user_id, role)
+VALUES ($1, $2, $3)
+`, testWorkspaceID, userID, role); err != nil {
+		t.Fatalf("create %s member: %v", role, err)
+	}
+
+	return userID
+}
+
+func createProjectPermissionTestProject(t *testing.T, title string) ProjectResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": title,
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, project.ID)
+	})
+	return project
 }


### PR DESCRIPTION
## Summary
- require the deleting user to be a workspace owner or admin before deleting a project
- authorize against the project row workspace, not only caller supplied request context
- hide the project detail delete action for non-admin workspace members
- add regression coverage for plain members being denied and admins being allowed

Fixes #4220

## Tests
- go test ./internal/handler -run 'TestDeleteProjectRequiresAdminOrOwner|TestDeleteProjectAllowsAdmin|TestCreateProjectValidStatusReturns201|TestUpdateProjectInvalidStatusReturns400'
- pnpm --filter @multica/views typecheck
- git diff --check

## Notes
- I also tried a broader project-pattern handler test run. It fails in this local worktree because the shared test database schema is missing unrelated newer schema objects: profile_id and autopilot_subscriber. The targeted project-delete tests above pass.