### PR TITLE
[codex] hide issue numbers in sidebar pins

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -172,7 +172,8 @@ describe("PinRow", () => {
   it("renders loaded details", async () => {
     detail.current = { isPending: false, isError: false, data: { identifier: "MUL-123", title: "Keep this pin", status: "todo" }, error: null };
     render(<AppSidebar />);
-    expect(await screen.findByText("MUL-123 Keep this pin")).toBeInTheDocument();
+    expect(await screen.findByText("Keep this pin")).toBeInTheDocument();
+    expect(screen.queryByText("MUL-123 Keep this pin")).not.toBeInTheDocument();
   });
 
   it("does not also highlight the parent workspace nav for an active pin", async () => {
@@ -186,7 +187,7 @@ describe("PinRow", () => {
 
     const { container } = render(<AppSidebar />);
 
-    expect((await screen.findByText("MUL-123 Keep this pin")).closest("button")).toHaveAttribute(
+    expect((await screen.findByText("Keep this pin")).closest("button")).toHaveAttribute(
       "data-active",
       "true",
     );

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -286,7 +286,7 @@ function PinRow({
     if (issueQuery.isPending) return <PinSkeleton />;
     if (issueQuery.isError || !issueQuery.data) return null;
     const issue = issueQuery.data;
-    const label = issue.identifier ? `${issue.identifier} ${issue.title}` : issue.title;
+    const label = issue.title;
     const iconNode = (
       /* Override parent [&_svg]:size-4 — pinned items need smaller icons to match sm size */
       <StatusIcon status={issue.status} className="!size-3.5 shrink-0" />


### PR DESCRIPTION
## Summary

Hide the issue identifier prefix for issue pins in the app sidebar, so pinned issues render as the issue title only.

## Why

Sidebar pins are a compact navigation surface. The issue detail route still uses the issue id, and the status icon remains visible, but the visible label no longer needs to repeat the issue number before the title.

## Changes

- Updated the sidebar pin label for issue pins to use `issue.title` directly.
- Updated the sidebar tests to assert that `MUL-123 Keep this pin` is no longer rendered while the title still appears and active pin highlighting still works.

## Validation

- `pnpm --filter @multica/views exec vitest run layout/app-sidebar.test.tsx` passed.
- `make check-worktree` was attempted. TypeScript typecheck and all TS unit tests passed; the run then failed in the unrelated Go metrics test `server/internal/metrics TestBusinessSamplerStatementTimeoutCutsHungQuery`, where the local Postgres setup returned a client timeout instead of the expected SQLSTATE 57014 statement timeout.
