### PR TITLE
fix(daemon): report final task disposition on a detached context (#4336)

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -577,6 +577,31 @@ var skillBundleResolveRetrySchedule = []time.Duration{
 	2 * time.Second,
 }
 
+// terminalCallbackAttemptBudget is the per-attempt wall-clock headroom added on
+// top of the retry sleeps when sizing a detached disposition deadline. Each of
+// the N+1 attempts can spend up to client.Timeout (30s) inside http.Client.Do
+// before failing; budgeting one client-timeout per attempt guarantees the
+// deadline can never truncate the retry schedule even when every attempt runs
+// to its own timeout.
+const terminalCallbackAttemptBudget = 30 * time.Second
+
+// TerminalCallbackBudget returns the minimum wall-clock a Complete/Fail
+// callback needs to run its full retry schedule to completion: the sum of the
+// inter-attempt sleeps plus one per-attempt HTTP budget for each of the N+1
+// attempts, plus a small fixed cushion. It is DERIVED from
+// defaultTerminalRetrySchedule so a caller sizing a detached disposition
+// timeout (daemon.dispositionCtx, issue #4336 / MUL-3443) can never drift out
+// of sync with the MUL-2780 recovery window: shorten the schedule and this
+// shrinks with it; lengthen it and this grows.
+func TerminalCallbackBudget() time.Duration {
+	var sleeps time.Duration
+	for _, d := range defaultTerminalRetrySchedule {
+		sleeps += d
+	}
+	attempts := len(defaultTerminalRetrySchedule) + 1
+	return sleeps + time.Duration(attempts)*terminalCallbackAttemptBudget + 5*time.Second
+}
+
 // retrySleep is the sleep used between retry attempts. Pulled into a package
 // variable so tests can swap in an instant sleep without rewriting the
 // caller's schedule.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2945,9 +2945,15 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		// classifier so the failure_reason column reflects the actual
 		// shape of the failure (provider 5xx, network, process crash,
 		// …) rather than the coarse legacy "agent_error" bucket.
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", taskfailure.Classify(err.Error()).String()); failErr != nil {
+		// #4336: report on a detached, bounded context — if the agent run
+		// errored *because* the daemon is shutting down, `ctx` is already
+		// cancelled and reporting on it would be lost, stranding the task
+		// at `in_progress`.
+		failCtx, failCancel := dispositionCtx(ctx)
+		if failErr := d.client.FailTask(failCtx, task.ID, err.Error(), "", "", taskfailure.Classify(err.Error()).String()); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
 		}
+		failCancel()
 		return
 	}
 
@@ -3113,6 +3119,25 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 	return release, false
 }
 
+// reportDispositionTimeout bounds the detached final-disposition report so a
+// shutdown can't hang on an unreachable server, while still giving the POST
+// enough time to land through a transient blip.
+const reportDispositionTimeout = 15 * time.Second
+
+// dispositionCtx returns a bounded context DETACHED from parentCtx's
+// cancellation (issue #4336). The final task-disposition POST (Complete/Fail)
+// must land even when the daemon is shutting down — at which point the
+// caller's run/loop ctx is already cancelled, so reporting on it aborts with
+// "context canceled", the report is lost, and the cloud strands the task at
+// `in_progress` (which, under a per-agent concurrency cap of 1, permanently
+// wedges that agent's dispatch queue). WithoutCancel preserves request-scoped
+// values (e.g. auth) while ignoring the parent's Done channel; the timeout
+// keeps a shutdown from blocking on an unreachable server. Callers must
+// `defer cancel()`.
+func dispositionCtx(parentCtx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parentCtx), reportDispositionTimeout)
+}
+
 // reportTaskResult writes the final task disposition back to the server.
 //
 // Fail closed: only an explicit "completed" status is reported as success.
@@ -3123,7 +3148,21 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 // the agent may have built a real session before getting stuck, and we want
 // the next chat turn to resume there rather than start over and "forget"
 // the conversation.
-func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result TaskResult, taskLog *slog.Logger) {
+//
+// The final disposition POST runs on a context DETACHED from the caller's
+// run/loop context (issue #4336). On daemon shutdown / restart (including the
+// auto-update self-restart) the parent ctx is already cancelled by the time we
+// get here, so reporting on it aborts with "context canceled" — the report is
+// LOST and the cloud keeps the task `in_progress` forever. With a per-agent
+// concurrency cap of 1 that orphaned task permanently holds the agent's only
+// slot, so every later task to it sits `queued` and never starts. Detaching
+// (WithoutCancel, preserving request-scoped values like auth) under a bounded
+// timeout lets the disposition land even mid-shutdown, so the task reaches a
+// terminal state and the slot is freed.
+func (d *Daemon) reportTaskResult(parentCtx context.Context, taskID string, result TaskResult, taskLog *slog.Logger) {
+	ctx, cancel := dispositionCtx(parentCtx)
+	defer cancel()
+
 	switch result.Status {
 	case "completed":
 		taskLog.Info("task completed", "status", result.Status)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3119,23 +3119,29 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 	return release, false
 }
 
-// reportDispositionTimeout bounds the detached final-disposition report so a
-// shutdown can't hang on an unreachable server, while still giving the POST
-// enough time to land through a transient blip.
-const reportDispositionTimeout = 15 * time.Second
-
 // dispositionCtx returns a bounded context DETACHED from parentCtx's
 // cancellation (issue #4336). The final task-disposition POST (Complete/Fail)
 // must land even when the daemon is shutting down — at which point the
 // caller's run/loop ctx is already cancelled, so reporting on it aborts with
 // "context canceled", the report is lost, and the cloud strands the task at
 // `in_progress` (which, under a per-agent concurrency cap of 1, permanently
-// wedges that agent's dispatch queue). WithoutCancel preserves request-scoped
-// values (e.g. auth) while ignoring the parent's Done channel; the timeout
-// keeps a shutdown from blocking on an unreachable server. Callers must
-// `defer cancel()`.
+// wedges that agent's dispatch queue).
+//
+// The detach is UNCONDITIONAL rather than scoped to an already-cancelled
+// parent: a shutdown can land mid-report (after this check but during the
+// retry loop), and only an unconditional WithoutCancel closes that race. The
+// deadline is sized to the client's full terminal-callback retry budget
+// (TerminalCallbackBudget) so detaching never costs the healthy path its
+// MUL-2780 retries — the original fixed 15s cap silently truncated the 124s
+// window to ~3 of 5 backoffs (MUL-3443). Shutdown still can't hang because the
+// shutdown coordinator independently caps its wait on in-flight tasks at 30s.
+// WithoutCancel preserves request-scoped values (e.g. auth) while ignoring the
+// parent's Done channel. Callers must `defer cancel()`.
+//
+// The deadline is read LIVE from TerminalCallbackBudget() (not cached) so it
+// tracks defaultTerminalRetrySchedule exactly — the two provably cannot drift.
 func dispositionCtx(parentCtx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(parentCtx), reportDispositionTimeout)
+	return context.WithTimeout(context.WithoutCancel(parentCtx), TerminalCallbackBudget())
 }
 
 // reportTaskResult writes the final task disposition back to the server.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2022,6 +2022,48 @@ func TestReportTaskResult_NonCompletedHitsFailEndpoint(t *testing.T) {
 	}
 }
 
+// Regression test for issue #4336: the final disposition report must land
+// even when the caller's run/loop context is ALREADY cancelled (daemon
+// shutdown / restart / auto-update). Before the fix, reportTaskResult posted
+// on the cancelled parent ctx, FailTask aborted with "context canceled", the
+// report was lost, and the cloud stranded the task at `in_progress` — which,
+// under a per-agent concurrency cap of 1, permanently wedged the agent's
+// dispatch queue. dispositionCtx detaches from the parent's cancellation
+// (WithoutCancel) so the POST still reaches the server.
+func TestReportTaskResult_FailReportSurvivesCancelledParentCtx(t *testing.T) {
+	t.Parallel()
+
+	rec := &reportTaskResultRecorder{}
+	srv := httptest.NewServer(rec.handler(t))
+	t.Cleanup(srv.Close)
+
+	// Simulate the shutdown path: the context the run loop hands to
+	// reportTaskResult is already cancelled.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	d.reportTaskResult(cancelledCtx, "task-shutdown", TaskResult{
+		Status:        "blocked",
+		Comment:       "force-stopped by idle watchdog",
+		FailureReason: "idle_watchdog",
+		SessionID:     "ses-shutdown",
+		WorkDir:       "/tmp/shutdown",
+	}, slog.Default())
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if rec.path != "/api/daemon/tasks/task-shutdown/fail" {
+		t.Fatalf("expected /fail endpoint to be hit despite cancelled parent ctx, got %q (report was lost — task would strand at in_progress)", rec.path)
+	}
+	if rec.payload["failure_reason"] != "idle_watchdog" {
+		t.Errorf("failure_reason: got %v, want idle_watchdog", rec.payload["failure_reason"])
+	}
+	if rec.payload["session_id"] != "ses-shutdown" {
+		t.Errorf("session_id: got %v, want ses-shutdown", rec.payload["session_id"])
+	}
+}
+
 // Regression test for the MUL-2780 incident: a short 502 burst on the
 // /complete callback used to (a) drop the task at the first failure and
 // (b) wrongly fall back to /fail, surfacing a successful run as red.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2064,6 +2064,105 @@ func TestReportTaskResult_FailReportSurvivesCancelledParentCtx(t *testing.T) {
 	}
 }
 
+// TestTerminalCallbackBudget_CoversFullSchedule pins the derivation invariant
+// behind MUL-3443: the detached disposition deadline must be at least as long
+// as the terminal retry schedule it is supposed to protect. A regression that
+// shrinks the budget below the schedule sum (the original fixed 15s cap did
+// exactly this — 15s < 124s) would truncate the MUL-2780 recovery window and
+// is caught here without waiting on wall-clock.
+func TestTerminalCallbackBudget_CoversFullSchedule(t *testing.T) {
+	var sleeps time.Duration
+	for _, d := range defaultTerminalRetrySchedule {
+		sleeps += d
+	}
+	budget := TerminalCallbackBudget()
+	if budget < sleeps {
+		t.Fatalf("disposition budget %s is shorter than the retry sleep sum %s — the deadline would truncate the retry schedule (MUL-3443 regression)", budget, sleeps)
+	}
+	// The budget must also outrun the deadline that dispositionCtx actually
+	// installs, so the two are wired to the same source.
+	ctx, cancel := dispositionCtx(context.Background())
+	defer cancel()
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("dispositionCtx must set a deadline")
+	}
+	if remaining := time.Until(dl); remaining < sleeps {
+		t.Fatalf("dispositionCtx deadline leaves only %s, less than the %s retry schedule needs", remaining, sleeps)
+	}
+}
+
+// TestReportTaskResult_DispositionSpansFullScheduleUnderSustained502 is the
+// WALL-CLOCK regression for MUL-3443. Unlike the other disposition tests it
+// does NOT swap in noSleepRetry — it runs the real retrySleep against a real
+// (scaled-down) retry schedule so the interaction between the dispositionCtx
+// deadline and the backoff sleeps is actually exercised. That is precisely the
+// interaction the fixed 15s cap broke and that the no-sleep tests are blind to:
+// with zeroed sleeps a too-short deadline never bites, so the truncation is
+// invisible.
+//
+// Under sustained 502s the disposition POST must run its FULL schedule
+// (len(schedule)+1 attempts) and the call must span at least the sum of the
+// backoff sleeps — proving the detached deadline did not cut the retry loop
+// short.
+func TestReportTaskResult_DispositionSpansFullScheduleUnderSustained502(t *testing.T) {
+	t.Parallel()
+
+	// Real, scaled-down schedule so this stays a sub-second wall-clock test
+	// while still using real time.Sleep via the default retrySleep.
+	prevSchedule := defaultTerminalRetrySchedule
+	defaultTerminalRetrySchedule = []time.Duration{
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		60 * time.Millisecond,
+	}
+	t.Cleanup(func() { defaultTerminalRetrySchedule = prevSchedule })
+
+	var scheduleSum time.Duration
+	for _, d := range defaultTerminalRetrySchedule {
+		scheduleSum += d
+	}
+	wantAttempts := int32(len(defaultTerminalRetrySchedule) + 1)
+
+	var completeCalls, failCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/complete"):
+			completeCalls.Add(1)
+			w.WriteHeader(http.StatusBadGateway) // sustained transient error
+		case strings.HasSuffix(req.URL.Path, "/fail"):
+			failCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	start := time.Now()
+	d.reportTaskResult(context.Background(), "task-502-storm", TaskResult{
+		Status:  "completed",
+		Comment: "ok",
+	}, slog.Default())
+	elapsed := time.Since(start)
+
+	if got := completeCalls.Load(); got != wantAttempts {
+		t.Fatalf("expected %d /complete attempts across the full schedule, got %d — the disposition deadline truncated the retry loop (MUL-3443)", wantAttempts, got)
+	}
+	// The full schedule's sleeps must actually have elapsed; a deadline that
+	// cut the loop short would return well before scheduleSum.
+	if elapsed < scheduleSum {
+		t.Fatalf("disposition returned after %s, less than the %s schedule sum — retries were truncated", elapsed, scheduleSum)
+	}
+	// A sustained transient failure must NOT be downgraded to /fail (that would
+	// surface a real success as red — the MUL-2780 rule this budget protects).
+	if got := failCalls.Load(); got != 0 {
+		t.Fatalf("sustained 502 on /complete must not fall back to /fail, got %d", got)
+	}
+}
+
 // Regression test for the MUL-2780 incident: a short 502 burst on the
 // /complete callback used to (a) drop the task at the first failure and
 // (b) wrongly fall back to /fail, surfacing a successful run as red.


### PR DESCRIPTION
## Summary

Fixes #4336.

On daemon shutdown/restart — including the **auto-update self-restart** — the caller's run/loop context is already cancelled by the time `reportTaskResult` runs. The final `Complete`/`Fail` POST therefore aborts with `context canceled`, the report is **lost**, and the server keeps the task at `in_progress`. Under a per-agent concurrency cap of 1, that orphaned task permanently holds the agent's only slot, so every later task assigned to it sits `queued` and never starts — a silent, agent-wide dispatch freeze that only clears when an operator forces a state transition on the stuck issue.

Observed in the journal:

```
ERR report failed task failed task=f6d4f790 error="context canceled"
ERR report failed task failed task=cb83a56e error="context canceled"
```
(each preceded by the auto-update `upgrade completed, restarting` line).

## Fix

Add `dispositionCtx(parentCtx)` — a context **detached** from the parent's cancellation via `context.WithoutCancel` (preserving request-scoped values such as auth) under a bounded 15s timeout. The terminal disposition reports now run on it:

- `reportTaskResult` — the `Complete`/`Fail` (incl. the permanent-rejection fallback) calls.
- `runTask`'s bare-error `FailTask` path (the run can error *because* the daemon is shutting down).

So the disposition lands even mid-shutdown, the task reaches a terminal state, and the agent's slot is freed. The timeout keeps a shutdown from blocking on an unreachable server.

This addresses fix option (1) from the issue (report on a fresh/detached context). The complementary startup-reconciliation (option 2) is left for a follow-up — this change alone closes the common path where the report is *generated* but dropped.

## Test

`TestReportTaskResult_FailReportSurvivesCancelledParentCtx` passes a pre-cancelled parent context and asserts the `/fail` endpoint is still hit with the right payload. Verified it **fails without the fix** (FailTask aborts `context canceled`, `/fail` never hit) and **passes with it**. Full `internal/daemon` suite green; `gofmt` clean; diff scoped to the two files (+83/-2).

## Notes

- `context.WithoutCancel` requires Go 1.21+; the module is on `go 1.26.1`.
- Behavior unchanged on the normal (non-shutdown) path — the detached context simply also carries through when the parent is alive.