### PR TITLE
feat: add project issue creation entry

### DIFF
--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -2,6 +2,9 @@
   "page": {
     "title": "Projects",
     "new_project": "New project",
+    "new_issue": "New Issue",
+    "new_issue_disabled": "Create a project before adding issues",
+    "select_issue_project": "Select project",
     "empty": "No projects yet",
     "create_first": "Create your first project",
     "view_compact": "Compact",

--- a/packages/views/locales/ja/projects.json
+++ b/packages/views/locales/ja/projects.json
@@ -2,6 +2,9 @@
   "page": {
     "title": "プロジェクト",
     "new_project": "新規プロジェクト",
+    "new_issue": "新規 Issue",
+    "new_issue_disabled": "Issue を追加する前にプロジェクトを作成してください",
+    "select_issue_project": "プロジェクトを選択",
     "empty": "プロジェクトはまだありません",
     "create_first": "最初のプロジェクトを作成",
     "view_compact": "コンパクト",

--- a/packages/views/locales/ko/projects.json
+++ b/packages/views/locales/ko/projects.json
@@ -2,6 +2,9 @@
   "page": {
     "title": "프로젝트",
     "new_project": "새 프로젝트",
+    "new_issue": "새 Issue",
+    "new_issue_disabled": "이슈를 추가하려면 먼저 프로젝트를 만드세요",
+    "select_issue_project": "프로젝트 선택",
     "empty": "아직 프로젝트가 없습니다",
     "create_first": "첫 프로젝트 만들기",
     "view_compact": "간결하게",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -2,6 +2,9 @@
   "page": {
     "title": "项目",
     "new_project": "新建项目",
+    "new_issue": "新建 Issue",
+    "new_issue_disabled": "请先创建项目再添加 Issue",
+    "select_issue_project": "选择项目",
     "empty": "还没有项目",
     "create_first": "创建第一个项目",
     "view_compact": "紧凑视图",

--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -217,7 +217,10 @@ function renderProjects(adapter = makeAdapter()) {
 }
 
 function projectRow() {
-  const row = screen.getByText(PROJECT.title).closest('[role="row"]');
+  const row = screen
+    .getAllByText(PROJECT.title)
+    .map((el) => el.closest('[role="row"]'))
+    .find(Boolean);
   if (!row) throw new Error("project row not found");
   return row as HTMLElement;
 }
@@ -320,5 +323,28 @@ describe("ProjectsPage compact row navigation", () => {
     expect(push).toHaveBeenNthCalledWith(1, "/test-workspace/projects/project-1");
     expect(push).toHaveBeenNthCalledWith(2, "/test-workspace/projects/project-1");
     expect(push).toHaveBeenNthCalledWith(3, "/test-workspace/projects/project-1");
+  });
+});
+
+describe("ProjectsPage header issue creation", () => {
+  it("opens the create issue modal with the selected project", async () => {
+    const user = userEvent.setup();
+    renderProjects();
+
+    await user.click(screen.getByRole("button", { name: "New Issue" }));
+    await user.click(screen.getByRole("button", { name: "Launch Plan" }));
+
+    expect(mocks.openModal).toHaveBeenCalledWith("create-issue", {
+      project_id: "project-1",
+    });
+  });
+
+  it("disables the new issue entry when there are no projects", () => {
+    mocks.projects = [];
+
+    renderProjects();
+
+    expect(screen.getByRole("button", { name: "New Issue" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Launch Plan" })).not.toBeInTheDocument();
   });
 });

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Rows3,
   Search,
+  SquarePen,
   Trash2,
   X,
 } from "lucide-react";
@@ -764,6 +765,63 @@ function ProjectBatchToolbar({
   );
 }
 
+function NewIssueProjectPicker({ projects }: { projects: Project[] }) {
+  const { t } = useT("projects");
+  const [open, setOpen] = useState(false);
+  const hasProjects = projects.length > 0;
+
+  const openCreateIssue = (projectId: string) => {
+    useModalStore.getState().open("create-issue", { project_id: projectId });
+    setOpen(false);
+  };
+
+  const trigger = (
+    <Button
+      size="sm"
+      variant="outline"
+      className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+      aria-label={t(($) => $.page.new_issue)}
+      disabled={!hasProjects}
+    >
+      <SquarePen className="h-3.5 w-3.5" />
+      <span className="hidden md:inline">{t(($) => $.page.new_issue)}</span>
+    </Button>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <PopoverTrigger render={<TooltipTrigger render={trigger} />} />
+        <TooltipContent side="bottom">
+          {hasProjects
+            ? t(($) => $.page.new_issue)
+            : t(($) => $.page.new_issue_disabled)}
+        </TooltipContent>
+      </Tooltip>
+      {hasProjects && (
+        <PopoverContent align="end" className="w-64 p-1">
+          <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+            {t(($) => $.page.select_issue_project)}
+          </div>
+          <div className="max-h-72 overflow-y-auto">
+            {projects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                onClick={() => openCreateIssue(project.id)}
+              >
+                <ProjectIcon project={project} size="sm" />
+                <span className="truncate">{project.title}</span>
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      )}
+    </Popover>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -923,16 +981,19 @@ export function ProjectsPage() {
             </span>
           )}
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
-          aria-label={t(($) => $.page.new_project)}
-          onClick={openCreateProject}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          <span className="hidden md:inline">{t(($) => $.page.new_project)}</span>
-        </Button>
+        <div className="flex items-center gap-1">
+          <NewIssueProjectPicker projects={projects} />
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+            aria-label={t(($) => $.page.new_project)}
+            onClick={openCreateProject}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">{t(($) => $.page.new_project)}</span>
+          </Button>
+        </div>
       </PageHeader>
 
       {showEmpty ? (


### PR DESCRIPTION
## Summary
- add a New Issue action beside New project on the Projects page header
- require users to choose a project before opening the create issue modal with project_id prefilled
- add project page tests and locale strings

## Verification
- corepack pnpm -C packages/views test projects-page.test.tsx
- NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm -C packages/views typecheck
- corepack pnpm -C packages/views lint (0 errors; existing warnings only)