### PR TITLE
AI-111 add Partner Workspace sample data contract

### DIFF
--- a/docs/partner-workspace/fixtures/partner-records.sample.json
+++ b/docs/partner-workspace/fixtures/partner-records.sample.json
@@ -1,0 +1,330 @@
+{
+  "schema_version": "partner-workspace.sample.v1",
+  "source_policy": {
+    "raw_source_material_in_repo": false,
+    "allowed_material": ["redacted", "normalized", "source_references"]
+  },
+  "partners": [
+    {
+      "id": "partner-wingstop-ai20",
+      "display_name": "Wingstop",
+      "partner_type": "brand",
+      "origin_issue_refs": [
+        {
+          "source_type": "multica_issue",
+          "source_ref": "multica:issue:AI-20"
+        }
+      ],
+      "current_stage": {
+        "id": "stage-wingstop-meeting-coordination",
+        "label": "meeting_scheduled",
+        "summary": "Historical AI-20 record reached international development meeting coordination after background review and schedule negotiation.",
+        "evidence_refs": ["ev-ai20-wingstop-thread", "ev-ai20-wingstop-schedule-comment"]
+      },
+      "contacts": [
+        {
+          "id": "contact-wingstop-business-development",
+          "display_name": "Redacted Wingstop business development contact",
+          "role": "Business Development Manager - International",
+          "organization": "Wingstop",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai20-wingstop-timeline-comment"]
+        },
+        {
+          "id": "contact-wingstop-global-development",
+          "display_name": "Redacted Wingstop global development coordinator",
+          "role": "Team Coordinator Global Development",
+          "organization": "Wingstop",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai20-wingstop-schedule-comment"]
+        }
+      ],
+      "inputs": [
+        {
+          "id": "input-wingstop-email-thread",
+          "input_type": "email",
+          "source": {
+            "source_type": "gmail",
+            "source_ref": "gmail:thread:19e6708f96565a63",
+            "source_label": "Wingstop outreach thread",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-10T07:04:09Z",
+          "title": "Wingstop schedule coordination thread",
+          "normalized_summary": "Thread contains initial outreach, company background exchange, review acknowledgement, and proposed meeting times.",
+          "redaction_level": "metadata_only",
+          "evidence_refs": ["ev-ai20-wingstop-thread", "ev-ai20-wingstop-message-19eb04"]
+        },
+        {
+          "id": "input-wingstop-manual-summary",
+          "input_type": "manual_note",
+          "source": {
+            "source_type": "multica_comment",
+            "source_ref": "multica:comment:925fc391-78fc-4fc9-beff-aa23e6267cdd",
+            "source_label": "Wingstop timeline summary",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-01T12:29:00Z",
+          "title": "Operator-reviewed Wingstop timeline",
+          "normalized_summary": "Manual summary lists the known email sequence and recommends a short acknowledgement rather than repeated background material.",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai20-wingstop-timeline-comment"]
+        },
+        {
+          "id": "input-wingstop-chat-constraint",
+          "input_type": "chat_record",
+          "source": {
+            "source_type": "multica_comment",
+            "source_ref": "multica:comment:2e9b22c4-92db-4f09-ae2f-82e1d5f01df8",
+            "source_label": "User scheduling constraint",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-10T07:36:52Z",
+          "title": "User prefers Beijing work-hour meetings",
+          "normalized_summary": "User asked to avoid late Beijing meetings and to wait while VooV and Zoom real-time translation are tested.",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai20-wingstop-user-constraint"]
+        }
+      ],
+      "evidence": [
+        {
+          "id": "ev-ai20-wingstop-thread",
+          "source_ref": "gmail:thread:19e6708f96565a63",
+          "evidence_type": "thread_id",
+          "supports": ["claim-wingstop-has-active-outreach-thread", "stage-wingstop-meeting-coordination"],
+          "confidence": "source"
+        },
+        {
+          "id": "ev-ai20-wingstop-message-19eb04",
+          "source_ref": "gmail:message:19eb04b435f7fb20",
+          "evidence_type": "message_id",
+          "supports": ["claim-wingstop-proposed-times"],
+          "confidence": "source"
+        },
+        {
+          "id": "ev-ai20-wingstop-timeline-comment",
+          "source_ref": "multica:comment:925fc391-78fc-4fc9-beff-aa23e6267cdd",
+          "evidence_type": "comment_id",
+          "supports": ["claim-wingstop-background-reviewed"],
+          "confidence": "derived"
+        },
+        {
+          "id": "ev-ai20-wingstop-schedule-comment",
+          "source_ref": "multica:comment:1acd5357-4136-45ab-a744-b12af6d35b81",
+          "evidence_type": "comment_id",
+          "supports": ["action-wingstop-propose-work-hour-options"],
+          "confidence": "derived"
+        },
+        {
+          "id": "ev-ai20-wingstop-user-constraint",
+          "source_ref": "multica:comment:2e9b22c4-92db-4f09-ae2f-82e1d5f01df8",
+          "evidence_type": "comment_id",
+          "supports": ["claim-user-prefers-work-hour-meetings", "action-wingstop-propose-work-hour-options"],
+          "confidence": "source"
+        }
+      ],
+      "actions": [
+        {
+          "id": "action-wingstop-propose-work-hour-options",
+          "action_type": "schedule_meeting",
+          "status": "executed",
+          "title": "Send Beijing work-hour meeting options after human approval",
+          "rationale": "User preferred avoiding late Beijing calls and wanted VooV/Zoom testing before sending a final meeting link.",
+          "requires_human_confirmation": true,
+          "evidence_refs": ["ev-ai20-wingstop-schedule-comment", "ev-ai20-wingstop-user-constraint"]
+        }
+      ],
+      "claims": [
+        {
+          "id": "claim-wingstop-has-active-outreach-thread",
+          "statement": "Wingstop was an active AI-20 outreach partner with a tracked Gmail thread.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai20-wingstop-thread"]
+        },
+        {
+          "id": "claim-wingstop-background-reviewed",
+          "statement": "The AI-20 thread included a company-background review before schedule coordination.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai20-wingstop-timeline-comment"]
+        },
+        {
+          "id": "claim-wingstop-proposed-times",
+          "statement": "A Wingstop coordination message proposed specific meeting time options.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai20-wingstop-message-19eb04"]
+        },
+        {
+          "id": "claim-user-prefers-work-hour-meetings",
+          "statement": "The user preferred meeting options inside Beijing working hours instead of late-day calls.",
+          "claim_type": "user_preference",
+          "evidence_refs": ["ev-ai20-wingstop-user-constraint"]
+        }
+      ]
+    },
+    {
+      "id": "partner-playa-bowls-ai103",
+      "display_name": "Playa Bowls",
+      "partner_type": "brand",
+      "origin_issue_refs": [
+        {
+          "source_type": "multica_issue",
+          "source_ref": "multica:issue:AI-103"
+        }
+      ],
+      "current_stage": {
+        "id": "stage-playa-meeting-scheduled",
+        "label": "meeting_scheduled",
+        "summary": "Active AI-103 record has a confirmed meeting window and pending meeting-tool coordination.",
+        "evidence_refs": ["ev-ai103-description", "ev-ai103-playa-thread"]
+      },
+      "contacts": [
+        {
+          "id": "contact-playa-growth",
+          "display_name": "Redacted Playa Bowls growth contact",
+          "role": "Chief Growth Officer",
+          "organization": "Playa Bowls",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai103-description"]
+        }
+      ],
+      "inputs": [
+        {
+          "id": "input-playa-email-thread",
+          "input_type": "email",
+          "source": {
+            "source_type": "gmail",
+            "source_ref": "gmail:thread:19e6cbe11a4f708f",
+            "source_label": "Playa Bowls active thread",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-10T07:57:45Z",
+          "title": "Playa Bowls meeting coordination and opportunity discussion",
+          "normalized_summary": "Thread captures China opportunity discussion, potential regional development structure, and meeting coordination.",
+          "redaction_level": "metadata_only",
+          "evidence_refs": ["ev-ai103-playa-thread"]
+        },
+        {
+          "id": "input-playa-meeting-note-placeholder",
+          "input_type": "meeting_note",
+          "source": {
+            "source_type": "manual_entry",
+            "source_ref": "manual:future-meeting-note:playa-bowls",
+            "source_label": "Placeholder for post-call notes",
+            "raw_available_outside_repo": false
+          },
+          "observed_at": "2026-06-19T00:00:00Z",
+          "title": "Post-call note slot",
+          "normalized_summary": "Fixture reserves a non-email input for future meeting notes so the schema is not email-only.",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-schema-non-email-requirement"]
+        },
+        {
+          "id": "input-playa-positioning-attachment",
+          "input_type": "attachment",
+          "source": {
+            "source_type": "multica_attachment",
+            "source_ref": "multica:attachment:019eb0ca-20e2-7758-83fe-b226a83982d6",
+            "source_label": "Unified positioning document",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-10T09:08:17Z",
+          "title": "Unified request and positioning attachment",
+          "normalized_summary": "Attachment is referenced as source material for outbound positioning; raw attachment is not committed.",
+          "redaction_level": "metadata_only",
+          "evidence_refs": ["ev-ai103-positioning-attachment"]
+        },
+        {
+          "id": "input-playa-operating-note",
+          "input_type": "manual_note",
+          "source": {
+            "source_type": "multica_issue",
+            "source_ref": "multica:issue:AI-103",
+            "source_label": "AI-103 issue description",
+            "raw_available_outside_repo": true
+          },
+          "observed_at": "2026-06-10T07:57:45Z",
+          "title": "Active operating state for Playa Bowls",
+          "normalized_summary": "Issue description records meeting time, contact role, key topics, and waiting state.",
+          "redaction_level": "redacted",
+          "evidence_refs": ["ev-ai103-description"]
+        }
+      ],
+      "evidence": [
+        {
+          "id": "ev-ai103-description",
+          "source_ref": "multica:issue:AI-103",
+          "evidence_type": "issue_id",
+          "supports": ["stage-playa-meeting-scheduled", "claim-playa-meeting-confirmed", "claim-playa-discussion-topics"],
+          "confidence": "derived"
+        },
+        {
+          "id": "ev-ai103-playa-thread",
+          "source_ref": "gmail:thread:19e6cbe11a4f708f",
+          "evidence_type": "thread_id",
+          "supports": ["claim-playa-has-active-thread", "stage-playa-meeting-scheduled"],
+          "confidence": "source"
+        },
+        {
+          "id": "ev-ai103-positioning-attachment",
+          "source_ref": "multica:attachment:019eb0ca-20e2-7758-83fe-b226a83982d6",
+          "evidence_type": "attachment_id",
+          "supports": ["claim-positioning-attachment-exists"],
+          "confidence": "source"
+        },
+        {
+          "id": "ev-schema-non-email-requirement",
+          "source_ref": "multica:issue:AI-111",
+          "evidence_type": "issue_id",
+          "supports": ["input-playa-meeting-note-placeholder"],
+          "confidence": "source"
+        }
+      ],
+      "actions": [
+        {
+          "id": "action-playa-prepare-meeting",
+          "action_type": "prepare_meeting",
+          "status": "suggested",
+          "title": "Prepare China opportunity and supply-chain discussion notes",
+          "rationale": "AI-103 records topics around regional development, proprietary products, import versus localization, and pilot-first collaboration.",
+          "requires_human_confirmation": false,
+          "evidence_refs": ["ev-ai103-description", "ev-ai103-playa-thread"]
+        },
+        {
+          "id": "action-playa-send-meeting-link",
+          "action_type": "schedule_meeting",
+          "status": "needs_human_confirmation",
+          "title": "Send selected meeting-tool link after tool choice is confirmed",
+          "rationale": "Sending a calendar or meeting link is an external action and must remain human-confirmed.",
+          "requires_human_confirmation": true,
+          "evidence_refs": ["ev-ai103-description"]
+        }
+      ],
+      "claims": [
+        {
+          "id": "claim-playa-has-active-thread",
+          "statement": "Playa Bowls has an active Gmail thread tracked under AI-103.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai103-playa-thread"]
+        },
+        {
+          "id": "claim-playa-meeting-confirmed",
+          "statement": "The AI-103 operating record contains a confirmed Playa Bowls meeting window and a pending meeting-tool step.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai103-description"]
+        },
+        {
+          "id": "claim-playa-discussion-topics",
+          "statement": "The active record identifies pilot-first cooperation, China opportunity, proprietary product supply, and localization as meeting topics.",
+          "claim_type": "recommendation",
+          "evidence_refs": ["ev-ai103-description"]
+        },
+        {
+          "id": "claim-positioning-attachment-exists",
+          "statement": "AI-103 includes an attachment for unified positioning material, referenced by attachment ID only.",
+          "claim_type": "workflow_state",
+          "evidence_refs": ["ev-ai103-positioning-attachment"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/partner-workspace/sample-data-contract.md
+++ b/docs/partner-workspace/sample-data-contract.md
@@ -1,0 +1,197 @@
+# Partner Workspace Sample Data Contract
+
+Status: Draft for Milestone 1.
+
+This contract defines the redacted, normalized sample data shape for Partner Workspace V1. It is based on the AI-20 historical outreach issue and the AI-103 active outreach and meeting-prep issue. Raw source material stays outside the repository.
+
+## Source Inventory
+
+### AI-20
+
+AI-20 is the historical index for the original international brand outreach workflow.
+
+Representative source material:
+
+| Source ref | Type | Representative content | Repo treatment |
+| --- | --- | --- | --- |
+| `multica:issue:AI-20` | manual_note | Original user request, workflow decisions, old metadata, and closure decision moving active work to AI-103. | Use as source reference only. |
+| `multica:comment:925fc391-78fc-4fc9-beff-aa23e6267cdd` | manual_note | Wingstop email timeline summary and recommendation. | Normalize into partner history; do not copy raw thread. |
+| `gmail:thread:19e6708f96565a63` | email_thread | Wingstop outreach, background responses, review acknowledgement, meeting coordination. | Store only message IDs, summaries, and derived claims. |
+| `multica:comment:920aca7f-e0c6-4738-bff4-fa943c8ab45f` | manual_note | Historical brand follow-up list and suggested new brands. | Normalize into partner/action candidates. |
+| `multica:comment:14809da4-c222-489f-a8a5-d3a2988962d4` | manual_note | AI-20 closure and migration to AI-103. | Use for issue lineage. |
+
+### AI-103
+
+AI-103 is the active operating issue for brand outreach patrol, reply handling, meeting scheduling, meeting-prep, NDA/platform work, and follow-up.
+
+Representative source material:
+
+| Source ref | Type | Representative content | Repo treatment |
+| --- | --- | --- | --- |
+| `multica:issue:AI-103` | manual_note | Current operating rules, active partner states, contacts, Gmail IDs, meeting times, waiting_on metadata. | Normalize into partner records and workflow rules. |
+| `gmail:thread:19e6cbe11a4f708f` | email_thread | Playa Bowls contact history and meeting coordination. | Store redacted partner state and message IDs only. |
+| `multica:comment:8a4968c0-2c06-4e97-be19-a9617a64b694` | email_summary | Patrol found The Halal Guys and GDK inbound updates; includes connector failure case. | Normalize as inputs and evidence without raw body. |
+| `multica:comment:a5f7b26e-ccba-4b6e-b435-0fdf10be4f92` | manual_note | GDK reschedule recommendation derived from user screenshots and constraints. | Normalize as chat/manual-note-derived action. |
+| `multica:comment:bb642dc1-dbd9-42d0-901e-f49f8eca3af9` | manual_note | Product direction: Partner Workspace is generic, not email-only. | Use as contract evidence. |
+| `multica:attachment:019eb0ca-20e2-7758-83fe-b226a83982d6` | attachment | Unified positioning document attached to AI-103. | Reference attachment ID only; raw file is not committed here. |
+
+## Repository Boundary
+
+Allowed in repo:
+
+- Normalized partner records.
+- Redacted contact roles and public brand names.
+- Source references such as Multica issue IDs, comment IDs, attachment IDs, and Gmail message/thread IDs.
+- Derived summaries, stages, actions, and validation fixtures.
+
+Not allowed in repo:
+
+- Raw email bodies.
+- Full screenshots or OCR dumps.
+- Personal phone numbers, private emails, signatures, calendar links, meeting links, legal documents, or NDA text.
+- Unredacted attachments from Multica, Gmail, WeChat, or local files.
+- Claims without source references.
+
+## Core Schema
+
+The fixture root is an object with `schema_version`, `source_policy`, and `partners`.
+
+```ts
+type SampleDataset = {
+  schema_version: "partner-workspace.sample.v1";
+  source_policy: {
+    raw_source_material_in_repo: false;
+    allowed_material: Array<"redacted" | "normalized" | "source_references">;
+  };
+  partners: PartnerRecord[];
+};
+```
+
+### Partner
+
+```ts
+type PartnerRecord = {
+  id: string;
+  display_name: string;
+  partner_type: "brand" | "vendor" | "landlord" | "supplier" | "agency" | "other";
+  origin_issue_refs: SourceRef[];
+  current_stage: Stage;
+  contacts: Contact[];
+  inputs: Input[];
+  evidence: Evidence[];
+  actions: Action[];
+  claims: Claim[];
+};
+```
+
+### Input
+
+`Input` is any inbound or operator-created material that can change partner understanding. The model must support more than email.
+
+```ts
+type Input = {
+  id: string;
+  input_type: "email" | "meeting_note" | "chat_record" | "attachment" | "manual_note";
+  source: InputSource;
+  observed_at: string;
+  title: string;
+  normalized_summary: string;
+  redaction_level: "none_public" | "redacted" | "metadata_only";
+  evidence_refs: string[];
+};
+```
+
+### Input Source
+
+```ts
+type InputSource = {
+  source_type: "gmail" | "multica_issue" | "multica_comment" | "multica_attachment" | "manual_entry" | "meeting_tool" | "chat_tool";
+  source_ref: string;
+  source_label?: string;
+  raw_available_outside_repo: boolean;
+};
+```
+
+### Evidence
+
+Evidence is the bridge between a normalized claim/action and the source material. Every sample-derived claim must cite one or more evidence IDs.
+
+```ts
+type Evidence = {
+  id: string;
+  source_ref: string;
+  evidence_type: "thread_id" | "message_id" | "issue_id" | "comment_id" | "attachment_id" | "operator_note" | "meeting_note";
+  supports: string[];
+  confidence: "source" | "derived" | "inferred";
+};
+```
+
+### Stage
+
+```ts
+type Stage = {
+  id: string;
+  label: "research" | "outreach_sent" | "awaiting_reply" | "qualification" | "meeting_scheduled" | "meeting_done" | "legal_or_nda" | "waiting_partner" | "closed";
+  summary: string;
+  evidence_refs: string[];
+};
+```
+
+### Action
+
+```ts
+type Action = {
+  id: string;
+  action_type: "draft_reply" | "send_email" | "mark_read" | "schedule_meeting" | "prepare_meeting" | "request_materials" | "review_nda" | "follow_up" | "research" | "no_action";
+  status: "suggested" | "needs_human_confirmation" | "approved" | "executed" | "waiting_partner" | "blocked" | "closed";
+  title: string;
+  rationale: string;
+  requires_human_confirmation: boolean;
+  due_at?: string;
+  evidence_refs: string[];
+};
+```
+
+### Claim
+
+```ts
+type Claim = {
+  id: string;
+  statement: string;
+  claim_type: "partner_fact" | "contact_fact" | "workflow_state" | "user_preference" | "risk" | "recommendation";
+  evidence_refs: string[];
+};
+```
+
+## Normalized Fixture Draft
+
+The companion fixture file is:
+
+- `docs/partner-workspace/fixtures/partner-records.sample.json`
+
+It contains:
+
+- One AI-20-derived partner record: Wingstop historical outreach and meeting coordination.
+- One AI-103-derived partner record: Playa Bowls active meeting state.
+- A small non-email input coverage set using meeting note, chat record, attachment, and manual note input examples.
+
+## Validation Standard
+
+A sample dataset is valid only when all checks pass:
+
+1. It includes at least one `PartnerRecord` derived from AI-20 and at least one from AI-103.
+2. Every `Claim.evidence_refs`, `Stage.evidence_refs`, `Action.evidence_refs`, and `Input.evidence_refs` entry points to an existing evidence object.
+3. Every sample-derived claim has at least one source reference. Uncited claims are invalid even when they look obvious.
+4. The dataset includes all five input types: `email`, `meeting_note`, `chat_record`, `attachment`, and `manual_note`.
+5. The dataset is not email-only: at least two non-email input types must be attached to a partner record that also has an email input.
+6. No raw email body, raw screenshot OCR, private meeting link, private calendar link, phone number, private address, or unredacted legal material appears in committed fixtures.
+7. Any action with external side effects has `requires_human_confirmation: true`. This includes `send_email`, `mark_read`, `schedule_meeting`, `review_nda`, and commitment-bearing follow-up.
+8. Any source that points to raw material has `raw_available_outside_repo: true` and stores only a source reference in the repo.
+9. If evidence confidence is `inferred`, the claim or action text must visibly state that it is inferred or recommended, not a fact.
+10. Partner model names stay generic. Fixtures may mention real public brand names, but schema fields must not encode a brand-only or email-only workflow.
+
+## Notes for Implementation
+
+- Treat source references as opaque IDs; do not fetch raw material at runtime unless the user grants access through the proper connector/CLI.
+- UI should display evidence chips next to generated summaries, stages, and actions.
+- Draft generation is allowed in V1, but execution is not automatic. Human confirmation remains part of the data contract.


### PR DESCRIPTION
## Summary

- Added `docs/partner-workspace/sample-data-contract.md` for AI-111 Milestone 1.
- Added a redacted normalized fixture draft at `docs/partner-workspace/fixtures/partner-records.sample.json`.
- Defined Partner, Input, Input Source, Evidence, Stage, Action, and Claim structures with source-reference requirements.
- Captured AI-20 and AI-103 representative source inventories without committing raw emails, screenshots, private contact details, or attachments.

## Validation

- `jq empty docs/partner-workspace/fixtures/partner-records.sample.json`
- Custom Node invariant check passed: 2 partner records, AI-20 and AI-103 coverage, all five input types, evidence references resolve, and side-effect actions require human confirmation.
- `git diff --cached --check`
- Private-material scan found only policy text and one generic rationale mention of calendar/meeting links.
