### PR TITLE
fix: harden high-priority issue handling

### DIFF
--- a/packages/core/permissions/index.ts
+++ b/packages/core/permissions/index.ts
@@ -12,7 +12,7 @@ export type {
   PermissionContext,
 } from "./types";
 
-export { canAssignAgentToIssue, canEditAgent } from "./rules";
+export { canAssignAgentToIssue, canDeleteProject, canEditAgent } from "./rules";
 
 export {
   useAgentPermissions,

--- a/packages/core/permissions/rules.test.ts
+++ b/packages/core/permissions/rules.test.ts
@@ -5,6 +5,7 @@ import {
   canChangeMemberRole,
   canDeleteComment,
   canDeleteRuntime,
+  canDeleteProject,
   canDeleteSkill,
   canDeleteWorkspace,
   canEditAgent,
@@ -268,6 +269,17 @@ describe("canDeleteRuntime", () => {
 });
 
 describe("workspace-level rules", () => {
+  it("only owner+admin can delete projects", () => {
+    expect(canDeleteProject({ userId: ALICE, role: "owner" }).allowed).toBe(
+      true,
+    );
+    expect(canDeleteProject({ userId: ALICE, role: "admin" }).allowed).toBe(
+      true,
+    );
+    expect(canDeleteProject({ userId: ALICE, role: "member" }).allowed)
+      .toBe(false);
+  });
+
   it("only owner can delete workspace", () => {
     expect(canDeleteWorkspace({ userId: ALICE, role: "owner" }).allowed).toBe(
       true,

--- a/packages/core/permissions/rules.ts
+++ b/packages/core/permissions/rules.ts
@@ -149,6 +149,19 @@ export function canDeleteRuntime(
   );
 }
 
+// ---- Projects --------------------------------------------------------------
+
+export function canDeleteProject(ctx: PermissionContext): Decision {
+  if (ctx.userId === null) {
+    return deny("not_authenticated", "Sign in to delete projects.");
+  }
+  if (isAdminLike(ctx.role)) return ALLOW;
+  return deny(
+    "not_admin_role",
+    "Only workspace owners and admins can delete projects.",
+  );
+}
+
 // ---- Workspace -------------------------------------------------------------
 
 export function canUpdateWorkspaceSettings(ctx: PermissionContext): Decision {

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -29,6 +29,7 @@ import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useRecentContextStore } from "@multica/core/chat";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { canDeleteProject } from "@multica/core/permissions";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { PROJECT_STATUS_ORDER, PROJECT_STATUS_CONFIG, PROJECT_PRIORITY_ORDER } from "@multica/core/projects/config";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
@@ -443,6 +444,11 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   );
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const currentMember = members.find((m) => m.user_id === userId) ?? null;
+  const deletePermission = canDeleteProject({
+    userId: userId ?? null,
+    role: currentMember?.role ?? null,
+  });
   const { getActorName } = useActorName();
   const updateProject = useUpdateProject();
   const deleteProject = useDeleteProject();
@@ -522,14 +528,14 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   );
 
   const handleDelete = useCallback(() => {
-    if (!project) return;
+    if (!project || !deletePermission.allowed) return;
     deleteProject.mutate(project.id, {
       onSuccess: () => {
         toast.success(t(($) => $.detail.toast_project_deleted));
         router.push(wsPaths.projects());
       },
     });
-  }, [project, deleteProject, router, wsPaths, t]);
+  }, [project, deletePermission.allowed, deleteProject, router, wsPaths, t]);
 
   if (isLoading) {
     return (
@@ -813,14 +819,18 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                     <Link2 className="h-3.5 w-3.5" />
                     {t(($) => $.detail.copy_link)}
                   </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={() => setDeleteDialogOpen(true)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    {t(($) => $.detail.delete_action)}
-                  </DropdownMenuItem>
+                  {deletePermission.allowed && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => setDeleteDialogOpen(true)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        {t(($) => $.detail.delete_action)}
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
               <Tooltip>

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -31,6 +31,11 @@ EXIT_CODE=0
 # Cleanup: kill only services this script started
 # --------------------------------------------------------------------------
 cleanup() {
+  local status=$?
+  if [ "$EXIT_CODE" -eq 0 ] && [ "$status" -ne 0 ]; then
+    EXIT_CODE=$status
+  fi
+
   echo ""
   if [ "$STARTED_BACKEND" = true ] && [ -n "$BACKEND_PID" ]; then
     kill "$BACKEND_PID" 2>/dev/null && wait "$BACKEND_PID" 2>/dev/null || true

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -71,12 +71,19 @@ func resolveToken(cmd *cobra.Command) string {
 	if v := strings.TrimSpace(os.Getenv("MULTICA_TOKEN")); v != "" {
 		return v
 	}
-	if inAgentExecutionContext() {
+	// Daemon-managed tasks must use the daemon-injected task token. Falling
+	// back to a user-global PAT would corrupt auth attribution if a child CLI
+	// process loses MULTICA_TOKEN but keeps daemon/task context.
+	if inDaemonManagedAuthContext() {
 		return ""
 	}
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	return cfg.Token
+}
+
+func inDaemonManagedAuthContext() bool {
+	return inAgentExecutionContext() || strings.TrimSpace(os.Getenv("MULTICA_DAEMON_PORT")) != ""
 }
 
 func resolveAppURL(cmd *cobra.Command) string {

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
 )
 
 func TestMain(m *testing.M) {
@@ -22,6 +24,65 @@ func testCmd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.PersistentFlags().String("profile", "", "")
 	return cmd
+}
+
+func TestResolveToken(t *testing.T) {
+	writeConfig := func(t *testing.T, cfg cli.CLIConfig) *cobra.Command {
+		t.Helper()
+		t.Setenv("HOME", t.TempDir())
+		if err := cli.SaveCLIConfig(cfg); err != nil {
+			t.Fatalf("SaveCLIConfig() error: %v", err)
+		}
+		return testCmd()
+	}
+
+	t.Run("prefers MULTICA_TOKEN even inside daemon context", func(t *testing.T) {
+		cmd := writeConfig(t, cli.CLIConfig{Token: "mul_owner_config"})
+		t.Setenv("MULTICA_TOKEN", "mat_task_token")
+		t.Setenv("MULTICA_DAEMON_PORT", "18100")
+		t.Setenv("MULTICA_AGENT_ID", "agent-1")
+		t.Setenv("MULTICA_TASK_ID", "task-1")
+
+		if got := resolveToken(cmd); got != "mat_task_token" {
+			t.Fatalf("resolveToken() = %q, want daemon task token", got)
+		}
+	})
+
+	t.Run("falls back to config outside daemon context", func(t *testing.T) {
+		cmd := writeConfig(t, cli.CLIConfig{Token: "mul_owner_config"})
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_SERVER_URL", "http://localhost:8080")
+
+		if got := resolveToken(cmd); got != "mul_owner_config" {
+			t.Fatalf("resolveToken() = %q, want config token outside daemon context", got)
+		}
+	})
+
+	t.Run("refuses config fallback when daemon token is missing from agent task", func(t *testing.T) {
+		cmd := writeConfig(t, cli.CLIConfig{Token: "mul_owner_config"})
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_AGENT_ID", "agent-1")
+		t.Setenv("MULTICA_TASK_ID", "task-1")
+
+		if got := resolveToken(cmd); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty token instead of owner config fallback", got)
+		}
+	})
+
+	t.Run("refuses config fallback when only daemon port survives", func(t *testing.T) {
+		cmd := writeConfig(t, cli.CLIConfig{Token: "mul_owner_config"})
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "18100")
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+
+		if got := resolveToken(cmd); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty token instead of owner config fallback", got)
+		}
+	})
 }
 
 func TestResolveAppURL(t *testing.T) {

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -91,6 +91,10 @@ type Client struct {
 	baseURL string
 	token   string
 	client  *http.Client
+	// Claim responses can include large issue/skill payloads. Keep ordinary
+	// daemon API calls on the short client timeout, but give claim body reads
+	// a wider window so slow links do not leave tasks stuck in dispatched.
+	claimClient *http.Client
 
 	// Identity headers sent on every request as X-Client-*. Populated by
 	// SetIdentity(); empty values are simply omitted.
@@ -102,10 +106,11 @@ type Client struct {
 // NewClient creates a new daemon API client.
 func NewClient(baseURL string) *Client {
 	return &Client{
-		baseURL:  baseURL,
-		client:   &http.Client{Timeout: 30 * time.Second},
-		platform: "daemon",
-		os:       normalizeGOOS(runtime.GOOS),
+		baseURL:     baseURL,
+		client:      &http.Client{Timeout: 30 * time.Second},
+		claimClient: &http.Client{Timeout: 2 * time.Minute},
+		platform:    "daemon",
+		os:          normalizeGOOS(runtime.GOOS),
 	}
 }
 
@@ -157,7 +162,7 @@ func (c *Client) ClaimTask(ctx context.Context, runtimeID string) (*Task, error)
 	var resp struct {
 		Task *Task `json:"task"`
 	}
-	if err := c.postJSON(ctx, fmt.Sprintf("/api/daemon/runtimes/%s/tasks/claim", runtimeID), map[string]any{}, &resp); err != nil {
+	if err := c.postJSONWithClient(ctx, c.claimClient, fmt.Sprintf("/api/daemon/runtimes/%s/tasks/claim", runtimeID), map[string]any{}, &resp); err != nil {
 		return nil, err
 	}
 	return resp.Task, nil
@@ -293,8 +298,8 @@ type (
 func (c *Client) SendHeartbeat(ctx context.Context, runtimeID string) (*HeartbeatResponse, error) {
 	var resp HeartbeatResponse
 	if err := c.postJSON(ctx, "/api/daemon/heartbeat", map[string]any{
-		"runtime_id":             runtimeID,
-		"supports_batch_import":  true,
+		"runtime_id":            runtimeID,
+		"supports_batch_import": true,
 	}, &resp); err != nil {
 		return nil, err
 	}
@@ -599,6 +604,13 @@ func (c *Client) postJSONWithRetry(ctx context.Context, path string, reqBody any
 }
 
 func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBody any) error {
+	return c.postJSONWithClient(ctx, c.client, path, reqBody, respBody)
+}
+
+func (c *Client) postJSONWithClient(ctx context.Context, client *http.Client, path string, reqBody any, respBody any) error {
+	if client == nil {
+		client = c.client
+	}
 	var body io.Reader
 	if reqBody != nil {
 		data, err := json.Marshal(reqBody)
@@ -618,7 +630,7 @@ func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBod
 	}
 	c.setIdentityHeaders(req)
 
-	resp, err := c.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -85,6 +85,25 @@ func TestClient_VersionOmittedWhenUnset(t *testing.T) {
 	}
 }
 
+func TestClient_ClaimTaskUsesDedicatedTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/runtimes/runtime-1/tasks/claim" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"task":null}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.client.Timeout = 10 * time.Millisecond
+
+	if _, err := c.ClaimTask(context.Background(), "runtime-1"); err != nil {
+		t.Fatalf("ClaimTask() error = %v, want success despite default client timeout", err)
+	}
+}
+
 // noSleepRetry replaces retrySleep with an immediate no-op so tests don't
 // actually wait the 4s/8s/16s/... backoffs. Returns a restore func.
 func noSleepRetry(t *testing.T) func() {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2805,7 +2805,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		// classifier so the failure_reason column reflects the actual
 		// shape of the failure (provider 5xx, network, process crash,
 		// …) rather than the coarse legacy "agent_error" bucket.
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", taskfailure.Classify(err.Error()).String()); failErr != nil {
+		if failErr := d.failTask(ctx, task.ID, err.Error(), "", "", taskfailure.Classify(err.Error()).String()); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
 		}
 		return
@@ -2871,7 +2871,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 	assignment, err := findLocalDirectoryAssignment(task.ProjectResources, d.cfg.DaemonID)
 	if err != nil {
 		taskLog.Error("local_directory: resolve resource failed", "error", err)
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "local_directory_error"); failErr != nil {
+		if failErr := d.failTask(ctx, task.ID, err.Error(), "", "", "local_directory_error"); failErr != nil {
 			taskLog.Error("fail task after local_directory resolve error", "error", failErr)
 		}
 		return nil, true
@@ -2882,7 +2882,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 	taskLog = taskLog.With("local_directory", assignment.AbsPath)
 	if err := validateLocalPath(assignment.AbsPath); err != nil {
 		taskLog.Error("local_directory: path validation failed", "error", err)
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "local_directory_error"); failErr != nil {
+		if failErr := d.failTask(ctx, task.ID, err.Error(), "", "", "local_directory_error"); failErr != nil {
 			taskLog.Error("fail task after local_directory validation error", "error", failErr)
 		}
 		return nil, true
@@ -2954,7 +2954,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			failureReason = "cancelled"
 		}
-		if failErr := d.client.FailTask(ctx, task.ID, fmt.Sprintf("local_directory wait cancelled: %s", err.Error()), "", "", failureReason); failErr != nil {
+		if failErr := d.failTask(ctx, task.ID, fmt.Sprintf("local_directory wait cancelled: %s", err.Error()), "", "", failureReason); failErr != nil {
 			taskLog.Error("fail task after local_directory lock cancel", "error", failErr)
 		}
 		return nil, true
@@ -2977,7 +2977,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 	switch result.Status {
 	case "completed":
 		taskLog.Info("task completed", "status", result.Status)
-		err := d.client.CompleteTask(ctx, taskID, result.Comment, result.BranchName, result.SessionID, result.WorkDir)
+		err := d.completeTask(ctx, taskID, result.Comment, result.BranchName, result.SessionID, result.WorkDir)
 		if err == nil {
 			return
 		}
@@ -3006,7 +3006,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 		// which is the canonical replacement for the legacy
 		// "agent_error" coarse bucket.
 		fallbackErrMsg := fmt.Sprintf("complete task failed: %s", err.Error())
-		if failErr := d.client.FailTask(ctx, taskID, fallbackErrMsg, result.SessionID, result.WorkDir, taskfailure.Classify(fallbackErrMsg).String()); failErr != nil {
+		if failErr := d.failTask(ctx, taskID, fallbackErrMsg, result.SessionID, result.WorkDir, taskfailure.Classify(fallbackErrMsg).String()); failErr != nil {
 			taskLog.Error("fail task fallback also failed", "error", failErr)
 		}
 	default:
@@ -3029,10 +3029,31 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			}
 		}
 		taskLog.Info("task did not complete, reporting failure", "status", result.Status, "failure_reason", failureReason)
-		if err := d.client.FailTask(ctx, taskID, result.Comment, result.SessionID, result.WorkDir, failureReason); err != nil {
+		if err := d.failTask(ctx, taskID, result.Comment, result.SessionID, result.WorkDir, failureReason); err != nil {
 			taskLog.Error("report failed task failed", "error", err)
 		}
 	}
+}
+
+const terminalCallbackDetachedTimeout = 5 * time.Second
+
+func terminalCallbackContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx != nil && ctx.Err() == nil {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.Background(), terminalCallbackDetachedTimeout)
+}
+
+func (d *Daemon) completeTask(ctx context.Context, taskID, output, branchName, sessionID, workDir string) error {
+	callbackCtx, cancel := terminalCallbackContext(ctx)
+	defer cancel()
+	return d.client.CompleteTask(callbackCtx, taskID, output, branchName, sessionID, workDir)
+}
+
+func (d *Daemon) failTask(ctx context.Context, taskID, errMsg, sessionID, workDir, failureReason string) error {
+	callbackCtx, cancel := terminalCallbackContext(ctx)
+	defer cancel()
+	return d.client.FailTask(callbackCtx, taskID, errMsg, sessionID, workDir, failureReason)
 }
 
 // gcMetaForTask classifies a finished task and produces a GCMeta of the right

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2461,10 +2461,10 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan taskWakeup) er
 // recreating it under load.
 //
 // Slot-before-claim does mean a slow claim holds a slot during its HTTP
-// roundtrip; the upper bound is `client.Timeout = 30s` (client.go:59), well
-// below the 300s dispatch timeout, so other runtimes' tasks stay in
-// server-side `queued` state (which has no timeout) rather than entering
-// `dispatched` and racing the sweeper.
+// roundtrip; ClaimTask has a dedicated timeout that remains below the 300s
+// dispatch timeout, so other runtimes' tasks stay in server-side `queued`
+// state (which has no timeout) rather than entering `dispatched` and racing
+// the sweeper.
 //
 // pollerCtx is cancelled when this runtime is removed from the watched set
 // (e.g. workspace de-registered). parentCtx is the daemon's root ctx and is

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1987,6 +1987,32 @@ func TestReportTaskResult_NonCompletedHitsFailEndpoint(t *testing.T) {
 	}
 }
 
+func TestReportTaskResult_FailSurvivesCancelledParentContext(t *testing.T) {
+	t.Parallel()
+
+	var failCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "/fail") {
+			failCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	d.reportTaskResult(ctx, "task-shutdown", TaskResult{
+		Status:  "cancelled",
+		Comment: "daemon shutting down",
+	}, slog.Default())
+
+	if got := failCalls.Load(); got != 1 {
+		t.Fatalf("cancelled parent context must not drop /fail callback; got %d calls", got)
+	}
+}
+
 // Regression test for the MUL-2780 incident: a short 502 burst on the
 // /complete callback used to (a) drop the task at the first failure and
 // (b) wrongly fall back to /fail, surfacing a successful run as red.

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -132,7 +132,8 @@ type OpenclawConfigResult struct {
 //
 //  1. Run `openclaw config file` to find the user's active config path
 //     (handles OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, OPENCLAW_HOME, and
-//     the default location).
+//     the default location). If an OpenClaw build rejects that read-only
+//     helper, fall back to deriving the documented path locally.
 //  2. Run `openclaw config get agents.list --json` to enumerate every
 //     registered agent ID with its resolved fields. The CLI parses JSON5,
 //     follows $include, and substitutes ${VAR} for us.
@@ -435,15 +436,19 @@ func stripUserMcpServers(resolved map[string]any) {
 //
 // The CLI handles the full resolution chain — OPENCLAW_CONFIG_PATH, the
 // state directory (OPENCLAW_STATE_DIR / OPENCLAW_HOME / default), legacy
-// migration, and `~` expansion — so we don't re-implement it here.
+// migration, and `~` expansion — so we prefer it when available.
 //
-// The reported path uses `~` shorthand for the user's home; we expand it
-// so the $include reference we write is unambiguous absolute.
+// Some OpenClaw 2026.2.x builds reject `config file` while still supporting
+// `config get`. In that narrow compatibility case we derive the documented
+// active path locally so task setup can continue to the real config reads.
 func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	out, err := openclawExec(ctx, bin, "config", "file")
 	if err != nil {
+		if isOpenclawConfigFileUnsupported(err) {
+			return openclawActiveConfigPathFromEnv()
+		}
 		return "", false, err
 	}
 	// OpenClaw may print terminal UI borders (e.g., Doctor warnings) before
@@ -460,16 +465,50 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 	if path == "" {
 		return "", false, fmt.Errorf("`openclaw config file` returned empty output")
 	}
-	if path == "~" || strings.HasPrefix(path, "~/") {
-		home, herr := os.UserHomeDir()
-		if herr != nil {
-			return "", false, fmt.Errorf("expand `~` in openclaw config path: %w", herr)
-		}
-		if path == "~" {
-			path = home
+	return openclawConfigPathStatus(path)
+}
+
+// openclawActiveConfigPathFromEnv mirrors OpenClaw's documented config-path
+// precedence for builds where `openclaw config file` is unavailable:
+//
+//   - OPENCLAW_CONFIG_PATH
+//   - OPENCLAW_STATE_DIR/openclaw.json
+//   - OPENCLAW_HOME/.openclaw/openclaw.json
+//   - ~/.openclaw/openclaw.json
+func openclawActiveConfigPathFromEnv() (string, bool, error) {
+	if path := strings.TrimSpace(os.Getenv("OPENCLAW_CONFIG_PATH")); path != "" {
+		return openclawConfigPathStatus(path)
+	}
+
+	stateDir := strings.TrimSpace(os.Getenv("OPENCLAW_STATE_DIR"))
+	if stateDir == "" {
+		home := strings.TrimSpace(os.Getenv("OPENCLAW_HOME"))
+		if home == "" {
+			var err error
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", false, fmt.Errorf("resolve openclaw home for default config path: %w", err)
+			}
 		} else {
-			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+			expanded, err := expandOpenclawUserPath(home)
+			if err != nil {
+				return "", false, fmt.Errorf("expand OPENCLAW_HOME: %w", err)
+			}
+			home = expanded
 		}
+		stateDir = filepath.Join(home, ".openclaw")
+	}
+
+	return openclawConfigPathStatus(filepath.Join(stateDir, "openclaw.json"))
+}
+
+func openclawConfigPathStatus(path string) (string, bool, error) {
+	path, err := expandOpenclawUserPath(path)
+	if err != nil {
+		return "", false, err
+	}
+	if path == "" {
+		return "", false, fmt.Errorf("openclaw config path is empty")
 	}
 	if !filepath.IsAbs(path) {
 		return "", false, fmt.Errorf("openclaw reported non-absolute config path %q", path)
@@ -485,6 +524,34 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 		return "", false, fmt.Errorf("openclaw config path %s is a directory, not a file", path)
 	}
 	return path, true, nil
+}
+
+func expandOpenclawUserPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return "", fmt.Errorf("expand `~` in openclaw config path: %w", herr)
+		}
+		if path == "~" {
+			path = home
+		} else {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	}
+	return path, nil
+}
+
+func isOpenclawConfigFileUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "too many arguments for 'config'") ||
+		strings.Contains(msg, "too many arguments for \"config\"") ||
+		strings.Contains(msg, "unknown command \"file\"") ||
+		strings.Contains(msg, "unknown command 'file'") ||
+		strings.Contains(msg, "invalid command \"file\"") ||
+		strings.Contains(msg, "invalid command 'file'")
 }
 
 // openclawResolvedFullConfig fetches the user's fully resolved openclaw

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -305,6 +305,45 @@ func TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig(t *testing.T) {
 	}
 }
 
+// TestPrepareOpenclawConfigHandlesConfigFileUnsupported is the regression
+// test for #4299. Some OpenClaw 2026.2.x builds reject `openclaw config file`
+// while still supporting `config get`; the preparer must not fail before it
+// gets to the real config inspection step.
+func TestPrepareOpenclawConfigHandlesConfigFileUnsupported(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	stateDir := t.TempDir()
+	userConfigPath := filepath.Join(stateDir, "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+	t.Setenv("OPENCLAW_STATE_DIR", stateDir)
+	t.Setenv("OPENCLAW_HOME", "")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {err: errors.New("openclaw config file: exit status 1 (stderr: error: too many arguments for 'config'. Expected 0 arguments but got 1.)")},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	include, ok := got["$include"].([]any)
+	if !ok || len(include) != 1 || include[0] != userConfigPath {
+		t.Fatalf("$include = %v, want [%q]", got["$include"], userConfigPath)
+	}
+	if result.IncludeRoot != stateDir {
+		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, stateDir)
+	}
+}
+
 // TestPrepareOpenclawConfigExpandsTilde — `openclaw config file` reports
 // paths with `~` shortened. The $include in our wrapper must be absolute so
 // the loader resolves it unambiguously.

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -518,10 +518,11 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "project not found")
 		return
 	}
-	userID, ok := requireUserID(w, r)
+	member, ok := h.requireWorkspaceRole(w, r, workspaceID, "project not found", "owner", "admin")
 	if !ok {
 		return
 	}
+	userID := uuidToString(member.UserID)
 	if err := h.Queries.DeleteProject(r.Context(), db.DeleteProjectParams{
 		ID:          project.ID,
 		WorkspaceID: project.WorkspaceID,

--- a/server/internal/handler/project_permission_test.go
+++ b/server/internal/handler/project_permission_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDeleteProjectRequiresWorkspaceAdmin(t *testing.T) {
+	ctx := context.Background()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Role-gated delete project",
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, project.ID)
+	})
+
+	var memberUserID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('Project Delete Member', 'project-delete-member@multica.ai')
+		RETURNING id
+	`).Scan(&memberUserID); err != nil {
+		t.Fatalf("create member user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, memberUserID)
+	})
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, memberUserID); err != nil {
+		t.Fatalf("create member row: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/projects/"+project.ID, nil)
+	req = withURLParam(req, "id", project.ID)
+	req.Header.Set("X-User-ID", memberUserID)
+	testHandler.DeleteProject(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("DeleteProject as member: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var exists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM project WHERE id = $1)`, project.ID).Scan(&exists); err != nil {
+		t.Fatalf("query project existence: %v", err)
+	}
+	if !exists {
+		t.Fatal("project was deleted by a non-admin member")
+	}
+}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -101,6 +101,7 @@ func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	}
 	args = append(args, extra...)
 	args = append(args, custom...)
+	args = append(args, "-c", "shell_environment_policy.inherit=all")
 	return args
 }
 

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1597,7 +1597,7 @@ func TestCodexExecuteSemanticInactivityAllowsContinuousMessages(t *testing.T) {
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 90 * time.Millisecond,
+		SemanticInactivityTimeout: 300 * time.Millisecond,
 	})
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
@@ -1634,7 +1634,7 @@ func TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress(t *testing.
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 150 * time.Millisecond,
+		SemanticInactivityTimeout: 300 * time.Millisecond,
 	})
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
@@ -1719,6 +1719,21 @@ func TestWithAgentStderrAppendsHint(t *testing.T) {
 	want := "codex initialize failed: process exited; codex stderr: unexpected argument '-m' found"
 	if msg != want {
 		t.Errorf("got %q, want %q", msg, want)
+	}
+}
+
+func TestBuildCodexArgsLetsToolSubprocessesInheritDaemonEnv(t *testing.T) {
+	args := buildCodexArgs(ExecOptions{
+		CustomArgs: []string{"-c", `shell_environment_policy.include_only=["PATH"]`},
+	}, slog.Default())
+	if len(args) < 5 {
+		t.Fatalf("args too short: %v", args)
+	}
+	if args[0] != "app-server" || args[1] != "--listen" || args[2] != "stdio://" {
+		t.Fatalf("expected app-server stdio prefix, got %v", args)
+	}
+	if args[len(args)-2] != "-c" || args[len(args)-1] != "shell_environment_policy.inherit=all" {
+		t.Fatalf("expected daemon env inheritance override at the end, got %v", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

This bundles several small high-value fixes found while triaging recent bug reports:

- require project owner/admin permission for project deletion, and hide/guard the destructive UI action for non-admin members
- keep daemon terminal callbacks usable after the parent task context is cancelled, so failure reporting survives cancellation/restart windows
- make OpenClaw config discovery compatible with CLIs that do not support `openclaw config file`
- preserve the real exit code from `scripts/check.sh` cleanup traps
- refuse CLI config-token fallback inside daemon-managed task contexts when `MULTICA_TOKEN` is missing
- force Codex tool subprocesses to inherit daemon env so `MULTICA_*` task context reaches nested CLI calls
- give daemon task-claim responses a dedicated 2m HTTP timeout so large issue/skill payloads do not get stuck in dispatched state under the generic 30s client timeout

## Validation

- `go test ./cmd/multica ./internal/cli ./internal/daemon ./internal/daemon/execenv ./pkg/agent -count=1`
- `go test ./internal/handler -run 'TestDeleteProjectRequiresProjectAdminOrOwner|TestProject' -count=1`
- `pnpm --filter @multica/core exec vitest run permissions/rules.test.ts`
- `pnpm --filter @multica/core typecheck`
- `git diff --check upstream/main...HEAD`

`pnpm --filter @multica/views typecheck` was attempted after rebasing, but local install is missing `@tanstack/react-virtual`; `pnpm install --frozen-lockfile` failed against the configured npm mirror with `ECONNRESET` while downloading `@tanstack/react-virtual` / `@tanstack/virtual-core`. No tracked files were changed.