### PR TITLE
fix(auth): autofocus OTP input on verification step

### DIFF
--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -11,6 +11,11 @@ if (typeof globalThis.ResizeObserver === "undefined") {
   } as unknown as typeof ResizeObserver;
 }
 
+// jsdom doesn't implement elementFromPoint; input-otp uses it internally.
+if (typeof document.elementFromPoint !== "function") {
+  document.elementFromPoint = () => null;
+}
+
 // jsdom 29 / Node.js 22+ may not provide a proper Web Storage API.
 // Create a proper localStorage mock if methods are missing.
 if (

--- a/packages/views/auth/login-page.test.tsx
+++ b/packages/views/auth/login-page.test.tsx
@@ -198,6 +198,23 @@ describe("LoginPage", () => {
     expect(screen.getByText(/test@example.com/)).toBeInTheDocument();
   });
 
+  it("autofocuses the OTP input when the code step opens", async () => {
+    mockSendCode.mockResolvedValueOnce(undefined);
+    renderWithI18n(<LoginPage onSuccess={onSuccess} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    });
+
+    // The OTP field should be focused on mount so the user can type the code
+    // without clicking it first — important when repeatedly switching accounts.
+    expect(getOTPInput()).toHaveFocus();
+  });
+
   it("shows error when sendCode fails", async () => {
     mockSendCode.mockRejectedValueOnce(new Error("Rate limited"));
     renderWithI18n(<LoginPage onSuccess={onSuccess} />);

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -349,6 +349,7 @@ export function LoginPage({
           </CardHeader>
           <CardContent className="flex flex-col items-center gap-4">
             <InputOTP
+              autoFocus
               maxLength={6}
               value={code}
               onChange={(value) => {


### PR DESCRIPTION
## What does this PR do?

The login email-verification step renders the OTP input without focus. On every login you have to click the field before you can type the code — small friction that's especially noticeable when switching between accounts repeatedly.

Thinking path: Multica is built for fast, repeated logins (account/workspace switching is a core flow), so the verification step is hit often. The email step's `<Input>` on the same page already autofocuses, and the mobile OTP component (`apps/mobile/app/(auth)/verify.tsx`) already passes `autoFocus` — the web verification step was the only login input missing it. Adding `autoFocus` makes the cursor land in the field as soon as the step mounts, consistent with the patterns already in the codebase.

## Related Issue

No existing issue — happy to open one if you'd prefer it tracked separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/views/auth/login-page.tsx`: add `autoFocus` to the `InputOTP` on the verification (`code`) step.

## How to Test

1. Go to `/login`, enter an email, submit.
2. On the "Check your email" step, the cursor is now in the OTP field on arrival.
3. Type the code without clicking first.

Before: field is unfocused, a click is required. After: the field is focused on mount.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`packages/views` `login-page.test.tsx` 33/33, `@multica/views` typecheck clean)
- [x] I have added or updated tests where applicable — added a `packages/views` test asserting the OTP input is focused on mount of the verification step (fails if the `autoFocus` prop is removed)
- [ ] If this change affects the UI, I have included before/after screenshots — it's a focus-state change (cursor in field on mount); hard to convey in a static image, happy to add a short GIF if useful
- [x] I have considered and documented any risks above — none beyond focus moving to the OTP field on mount
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (Opus)

**Prompt / approach:** I reported the UX annoyance — the OTP field isn't focused when the verification step opens, so I have to click it every time I switch accounts. Claude located the `InputOTP` in `packages/views/auth/login-page.tsx`, confirmed that the email step on the same page and the mobile OTP component already autofocus, added the matching `autoFocus` prop, and ran the existing unit test + package typecheck before committing.
