### PR TITLE
fix(codex): handle app-server permission requests

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -753,7 +753,11 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			switch {
 			case aborted:
 				finalStatus = "aborted"
-				finalError = "turn was aborted"
+				if errMsg := c.getTurnError(); errMsg != "" {
+					finalError = errMsg
+				} else {
+					finalError = "turn was aborted"
+				}
 			default:
 				if errMsg := c.getTurnError(); errMsg != "" {
 					finalStatus = "failed"
@@ -1462,11 +1466,37 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
+	case "item/permissions/requestApproval":
+		c.respond(id, codexPermissionsApprovalResponse(raw["params"]))
 	case "mcpServer/elicitation/request":
 		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
+		msg := fmt.Sprintf("unsupported codex app-server request: %s", method)
 		c.cfg.Logger.Warn("codex: unhandled server request", "method", method, "id", id)
-		c.respondError(id, -32601, fmt.Sprintf("unhandled server request: %s", method))
+		c.setTurnError(msg)
+		c.respondError(id, -32601, msg)
+	}
+}
+
+func codexPermissionsApprovalResponse(params json.RawMessage) map[string]any {
+	var payload struct {
+		Permissions map[string]any `json:"permissions"`
+	}
+	_ = json.Unmarshal(params, &payload)
+
+	granted := map[string]any{}
+	if payload.Permissions != nil {
+		if network, ok := payload.Permissions["network"]; ok && network != nil {
+			granted["network"] = network
+		}
+		if fileSystem, ok := payload.Permissions["fileSystem"]; ok && fileSystem != nil {
+			granted["fileSystem"] = fileSystem
+		}
+	}
+
+	return map[string]any{
+		"permissions": granted,
+		"scope":       "turn",
 	}
 }
 

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -203,6 +203,52 @@ func TestCodexHandleServerRequestMCPElicitation(t *testing.T) {
 	}
 }
 
+func TestCodexHandleServerRequestPermissionsApproval(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":14,"method":"item/permissions/requestApproval","params":{"permissions":{"network":{"enabled":true},"fileSystem":{"read":["/tmp/repo"],"write":["/tmp/repo"]}}}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(14) {
+		t.Fatalf("expected id=14, got %v", resp["id"])
+	}
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got response: %v", resp)
+	}
+	if result["scope"] != "turn" {
+		t.Fatalf("expected scope=turn, got %v", result["scope"])
+	}
+	permissions, ok := result["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected permissions object, got %v", result["permissions"])
+	}
+	network, ok := permissions["network"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected network permissions object, got %v", permissions["network"])
+	}
+	if network["enabled"] != true {
+		t.Fatalf("expected network.enabled=true, got %v", network["enabled"])
+	}
+	fileSystem, ok := permissions["fileSystem"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fileSystem permissions object, got %v", permissions["fileSystem"])
+	}
+	if got := fileSystem["read"].([]any)[0]; got != "/tmp/repo" {
+		t.Fatalf("expected fileSystem.read to round-trip, got %v", got)
+	}
+}
+
 func TestCodexHandleServerRequestUnknownReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -231,6 +277,9 @@ func TestCodexHandleServerRequestUnknownReturnsError(t *testing.T) {
 	}
 	if errObj["code"] != float64(-32601) {
 		t.Fatalf("expected error code -32601, got %v", errObj["code"])
+	}
+	if got := c.getTurnError(); !strings.Contains(got, "some/unknown/method") {
+		t.Fatalf("expected turn error to include unsupported request method, got %q", got)
 	}
 }
 
@@ -1473,6 +1522,37 @@ func TestCodexExecuteFailsWhenProcessExitsDuringActiveTurn(t *testing.T) {
 	}
 	if strings.Contains(result.Error, "timeout") {
 		t.Fatalf("process exit should fail fast instead of timeout, got %q", result.Error)
+	}
+}
+
+func TestCodexExecuteSurfacesUnsupportedServerRequestOnInterruptedTurn(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-request"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-request","turn":{"id":"turn-request"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":99,"method":"item/tool/call","params":{"threadId":"thr-request","turnId":"turn-request","callId":"call-1","namespace":null,"tool":"custom","arguments":{}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-request","turn":{"id":"turn-request","status":"interrupted"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 5 * time.Second,
+	})
+	if result.Status != "aborted" {
+		t.Fatalf("expected aborted, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "unsupported codex app-server request: item/tool/call") {
+		t.Fatalf("expected unsupported request error, got %q", result.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Auto-approve Codex `item/permissions/requestApproval` server requests in daemon mode by granting the requested network/filesystem permission profile for the current turn.
- Preserve unsupported Codex app-server request details when a turn later completes as `interrupted`, instead of surfacing only `turn was aborted`.
- Add unit and fake app-server coverage for the permission request path and interrupted-turn diagnostics.

Refs #4341

## Verification

- `go test ./pkg/agent -count=1`
- `go test ./internal/daemon -run 'Codex|executeAndDrain' -count=1`\n- `git diff --check`