### PR TITLE
test: isolate Redis-backed package tests

### DIFF
--- a/server/internal/auth/pat_cache_test.go
+++ b/server/internal/auth/pat_cache_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+const redisTestDBAuth = 10
+
 // newRedisTestClient mirrors the helper in the handler package: connect to
-// REDIS_TEST_URL, flush, and skip when unset so `go test ./...` works on a
-// stock laptop without a Redis instance running.
+// a package-dedicated REDIS_TEST_URL DB, flush, and skip when unset so
+// `go test ./...` works on a stock laptop without a Redis instance running.
+// The DB split prevents package-parallel tests from deleting each other's
+// Redis keys via FlushDB.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -22,6 +26,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDBAuth
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {
@@ -45,7 +50,7 @@ func TestPATCache_NilSafe(t *testing.T) {
 		t.Fatalf("nil cache must miss; got (%q, %v)", v, ok)
 	}
 	c.Set(ctx, "any-hash", "user-1", AuthCacheTTL) // no panic
-	c.Invalidate(ctx, "any-hash")                 // no panic
+	c.Invalidate(ctx, "any-hash")                  // no panic
 }
 
 func TestNewPATCache_NilRedisReturnsNil(t *testing.T) {

--- a/server/internal/handler/runtime_local_skills_redis_store_test.go
+++ b/server/internal/handler/runtime_local_skills_redis_store_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient connects to the Redis instance indicated by REDIS_TEST_URL
-// and flushes it so each test starts from a clean slate. The helper skips the
+const redisTestDBHandler = 12
+
+// newRedisTestClient connects to a package-dedicated REDIS_TEST_URL DB and
+// flushes it so each test starts from a clean slate. The helper skips the
 // calling test if the env var is unset — matches the DATABASE_URL gating in
 // the rest of the suite so `go test ./...` still works on a stock laptop
-// without a running Redis.
+// without a running Redis. The DB split prevents package-parallel tests from
+// deleting each other's Redis keys via FlushDB.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -26,6 +29,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDBHandler
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -13,9 +13,13 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient connects to REDIS_TEST_URL, flushes, and skips when
-// unset — same gating pattern the rest of the suite uses for Redis-backed
-// tests, so `go test ./...` works on a stock laptop without a Redis.
+const redisTestDBMiddleware = 11
+
+// newRedisTestClient connects to a package-dedicated REDIS_TEST_URL DB,
+// flushes, and skips when unset — same gating pattern the rest of the suite
+// uses for Redis-backed tests, so `go test ./...` works on a stock laptop
+// without a Redis. The DB split prevents package-parallel tests from deleting
+// each other's Redis keys via FlushDB.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -26,6 +30,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDBMiddleware
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {
@@ -298,7 +303,6 @@ func TestAuth_PATCacheHit(t *testing.T) {
 		t.Fatalf("expected cached X-User-ID, got %q", gotUserID)
 	}
 }
-
 
 // TestAuth_MCN_NoVerifierConfigured pins the same fail-closed branch
 // as the daemon side: with no MULTICA_CLOUD_FLEET_URL configured, an

--- a/server/internal/service/empty_claim_cache_test.go
+++ b/server/internal/service/empty_claim_cache_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient mirrors the helper in internal/auth: connect to
-// REDIS_TEST_URL, flush, and skip when unset so `go test ./...` works
-// on a stock laptop without a Redis instance running.
+const redisTestDBService = 13
+
+// newRedisTestClient mirrors the helper in internal/auth: connect to a
+// package-dedicated REDIS_TEST_URL DB, flush, and skip when unset so
+// `go test ./...` works on a stock laptop without a Redis instance running.
+// The DB split prevents package-parallel tests from deleting each other's
+// Redis keys via FlushDB.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -22,6 +26,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDBService
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {


### PR DESCRIPTION
## Summary

- Assign package-dedicated Redis DBs to Redis-backed Go test helpers before calling `FlushDB`.
- Prevent package-parallel `go test ./...` runs from deleting another package's freshly-set cache keys.
- Covers the Redis cache miss pattern observed in #4302 backend CI (`Set` followed by immediate `Get` miss in auth/cache tests).

Related: #4302

## Verification

- `cd server && go test ./internal/auth ./internal/middleware ./internal/service -count=1`
- `cd server && go test ./internal/handler -run 'MembershipCache|Redis(LocalSkill|Update|Model|Liveness)' -count=1`\n- `git diff --check HEAD~1..HEAD`\n\nNote: local Redis/Postgres services are not running here, so service-backed tests that require those dependencies skip per the existing helpers; this patch targets the CI shared-Redis isolation issue diagnosed from the failed #4302 backend job.