### PR TITLE
fix(editor): insert @mention/slash selection on mouse click (#1039)

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef, type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { workspaceKeys } from "@multica/core/workspace/queries";
@@ -574,5 +574,41 @@ describe("createMentionSuggestion", () => {
 
     const items = result as MentionItem[];
     expect(items.some((i) => i.type === "agent" && i.label === "魏和尚")).toBe(true);
+  });
+
+  it("inserts on mouse selection by cancelling the row's mousedown blur (#1039)", () => {
+    // All MentionRow variants (agent / member / squad / issue / project) share
+    // the same `onMouseDown={preventSuggestionBlur}` guard. Exercise it through
+    // an issue row, which renders without the ActorAvatar -> useQuery dependency
+    // that the agent/member rows require.
+    const command = vi.fn();
+    render(
+      <I18nWrapper>
+        <MentionList
+          items={[
+            { id: "i1", label: "MUL-1", type: "issue", description: "Login bug", status: "todo" },
+          ]}
+          query="login"
+          command={command}
+        />
+      </I18nWrapper>,
+    );
+
+    const row = screen.getByRole("button", { name: /MUL-1/ });
+
+    // The row must cancel `mousedown` so the contenteditable keeps focus and
+    // the Tiptap suggestion range survives until `onClick` runs. Without this,
+    // a mouse click blurs the editor, the range is torn down, and the mention
+    // never inserts (keyboard works because focus never leaves the editor).
+    // fireEvent returns false when a handler called preventDefault().
+    expect(fireEvent.mouseDown(row)).toBe(false);
+
+    // Cancelling mousedown must not swallow the click — mouse selection still
+    // fires the command, matching the keyboard (arrow + Enter) path.
+    fireEvent.click(row);
+    expect(command).toHaveBeenCalledTimes(1);
+    expect(command).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "i1", type: "issue" }),
+    );
   });
 });

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -42,7 +42,11 @@ import {
   sortUserItemsByRecency,
 } from "./mention-recency";
 import { matchesPinyin } from "./pinyin-match";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPickerAcceptKey,
+  preventSuggestionBlur,
+} from "./suggestion-popup";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -397,6 +401,7 @@ function MentionRow({
         className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs transition-colors ${
           selected ? "bg-accent" : "hover:bg-accent/50"
         } ${isClosed ? "opacity-60" : ""}`}
+        onMouseDown={preventSuggestionBlur}
         onClick={onSelect}
       >
         <span className="flex h-7 w-7 shrink-0 items-center justify-center">
@@ -431,6 +436,7 @@ function MentionRow({
         className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs transition-colors ${
           selected ? "bg-accent" : "hover:bg-accent/50"
         }`}
+        onMouseDown={preventSuggestionBlur}
         onClick={onSelect}
       >
         <span className="flex h-7 w-7 shrink-0 items-center justify-center">
@@ -458,6 +464,7 @@ function MentionRow({
       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
         selected ? "bg-accent" : "hover:bg-accent/50"
       }`}
+      onMouseDown={preventSuggestionBlur}
       onClick={onSelect}
     >
       <ActorAvatar

--- a/packages/views/editor/extensions/slash-command-suggestion.test.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.test.tsx
@@ -89,6 +89,7 @@ function items(qc: QueryClient, query = ""): SlashCommandItem[] {
   return config.items!({
     query,
     editor: {} as never,
+    signal: new AbortController().signal,
   }) as SlashCommandItem[];
 }
 

--- a/packages/views/editor/extensions/slash-command-suggestion.test.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createRef, type ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -89,7 +89,6 @@ function items(qc: QueryClient, query = ""): SlashCommandItem[] {
   return config.items!({
     query,
     editor: {} as never,
-    signal: new AbortController().signal,
   }) as SlashCommandItem[];
 }
 
@@ -432,5 +431,29 @@ describe("SlashCommandList built-in command rendering", () => {
     expect(
       getByText("Add a note — won't trigger any agents"),
     ).toBeInTheDocument();
+  });
+
+  it("inserts on mouse selection by cancelling the row's mousedown blur (#1039)", () => {
+    const command = vi.fn();
+    render(
+      <I18nWrapper>
+        <SlashCommandList
+          items={[{ id: "s1", label: "deploy", description: "Ship it" }]}
+          query="dep"
+          command={command}
+        />
+      </I18nWrapper>,
+    );
+
+    const row = screen.getByRole("button", { name: /deploy/ });
+
+    // Same root cause as the @mention popup: the row must cancel `mousedown`
+    // so the editor keeps focus and the suggestion range survives until the
+    // click selects the skill. fireEvent returns false when preventDefault ran.
+    expect(fireEvent.mouseDown(row)).toBe(false);
+
+    fireEvent.click(row);
+    expect(command).toHaveBeenCalledTimes(1);
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({ id: "s1" }));
   });
 });

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -19,7 +19,11 @@ import { isImeComposing } from "@multica/core/utils";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPickerAcceptKey,
+  preventSuggestionBlur,
+} from "./suggestion-popup";
 
 const MAX_ITEMS = 20;
 
@@ -139,6 +143,7 @@ export const SlashCommandList = forwardRef<
             className={`flex w-full flex-col gap-0.5 px-3 py-1.5 text-left text-xs transition-colors ${
               selectedIndex === index ? "bg-accent" : "hover:bg-accent/50"
             }`}
+            onMouseDown={preventSuggestionBlur}
             onClick={() => selectItem(index)}
           >
             <span className="font-medium">/{item.label}</span>

--- a/packages/views/editor/extensions/suggestion-popup.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentType } from "react";
+import type { ComponentType, MouseEvent as ReactMouseEvent } from "react";
 import { autoUpdate, computePosition, flip, offset, shift, size } from "@floating-ui/dom";
 import { ReactRenderer } from "@tiptap/react";
 import { exitSuggestion, type SuggestionKeyDownProps, type SuggestionProps } from "@tiptap/suggestion";
@@ -30,6 +30,21 @@ export function isPickerAcceptKey(event: KeyboardEvent): boolean {
     !event.metaKey &&
     !event.altKey
   );
+}
+
+/**
+ * Keep the editor's selection when a suggestion row is chosen with the mouse.
+ *
+ * A bare click on a popup row fires `mousedown` first, whose default action
+ * moves focus out of the contenteditable. That blur tears down the Tiptap
+ * suggestion range before the row's `onClick` runs, so `command()` executes
+ * against a dead range and nothing is inserted — the candidate "disappears"
+ * on mouse selection while the keyboard path (focus never leaves the editor)
+ * works fine. Wiring this to a row's `onMouseDown` cancels the focus shift;
+ * the click still fires and inserts as expected. See issue #1039.
+ */
+export function preventSuggestionBlur(event: ReactMouseEvent): void {
+  event.preventDefault();
 }
 
 interface SuggestionPopupRenderOptions<


### PR DESCRIPTION
## Summary

Closes #1039.

Selecting a candidate in the **@mention** popup (and the **slash-command** popup) with the **mouse** did nothing -- the agent name was never inserted -- while the **keyboard** path (arrow keys + Enter) worked. A maintainer confirmed in #1039 that this is "an event-handler discrepancy in the mention plugin".

### Root cause

The popup rows are `<button>`s with only an `onClick` handler. On a mouse selection, `mousedown` fires first, and its default action moves focus to the button -- out of the editor's `contenteditable`. That blur tears down the Tiptap suggestion state (the active range) *before* the row's `onClick` runs, so `command()` executes against a dead range and inserts nothing. The keyboard path never moves focus out of the editor, so it always worked.

The existing `suggestion-popup.test.tsx` "row clicks insert" test passes only because jsdom's synthetic `pointerDown`/`click` don't perform the real-browser focus shift, so the blur never happens in tests.

### Fix

Add a shared `preventSuggestionBlur` helper in `suggestion-popup.tsx` and wire it to every suggestion row's `onMouseDown`. Cancelling the `mousedown` default keeps focus in the editor; the `click` still fires and inserts as expected. This is the canonical fix for ProseMirror/Tiptap suggestion dropdowns.

Applied to:
- `mention-suggestion.tsx` -- all three `MentionRow` variants (agent/member/squad, issue, project). This is the #1039 fix.
- `slash-command-suggestion.tsx` -- the slash/skill picker rows, which share the identical popup pattern and the same latent bug.

### Tests

- New regression test in `mention-suggestion.test.tsx` and `slash-command-suggestion.test.tsx`: the row cancels `mousedown` (so the editor keeps focus) and the click still invokes the command. Verified the mention test fails without the fix and passes with it.
- `pnpm --filter @multica/views exec vitest run editor/extensions/` -> 18 files, 149 tests pass.
- `pnpm --filter @multica/views typecheck` -> clean.
- `eslint` on the 5 changed files -> clean.

### Impact / risk

Low and self-contained. `preventDefault()` on `mousedown` does not suppress the subsequent `click`, and the keyboard path is unchanged. Only the editor-suggestion popups are affected.

Generated with Claude Code