### PR TITLE
fix(desktop): avoid duplicate sidebar tabs

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
@@ -51,12 +52,25 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
   }: {
     children: React.ReactNode;
     isActive?: boolean;
-    render?: React.ReactElement<{ href?: string }>;
-  }) => (
-    <button type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href}>
-      {children}
-    </button>
-  ),
+    render?: React.ReactElement<{
+      children?: React.ReactNode;
+      href?: string;
+      "data-active"?: string;
+      "data-href"?: string;
+    }>;
+  }) =>
+    React.isValidElement(render) ? (
+      React.cloneElement(
+        render,
+        {
+          "data-active": isActive ? "true" : undefined,
+          "data-href": render.props.href,
+        },
+        children,
+      )
+    ) : (
+      <button type="button" data-active={isActive ? "true" : undefined}>{children}</button>
+    ),
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarRail: () => null,
 }));
@@ -83,7 +97,26 @@ vi.mock("./help-launcher", () => ({ HelpLauncher: () => null }));
 vi.mock("../auth", () => ({ useLogout: () => vi.fn() }));
 vi.mock("../issues/components/status-icon", () => ({ StatusIcon: () => <span /> }));
 vi.mock("../navigation", () => ({
-  AppLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+  AppLink: ({
+    children,
+    href,
+    activateTabOnClick,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    activateTabOnClick?: boolean;
+    "data-active"?: string;
+    "data-href"?: string;
+  }) => (
+    <a
+      href={href}
+      data-activate-tab-on-click={activateTabOnClick ? "true" : undefined}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
   useNavigation: () => ({ pathname: navigation.current.pathname, push: vi.fn() }),
 }));
 vi.mock("../projects/components/project-icon", () => ({ ProjectIcon: () => <span /> }));
@@ -187,10 +220,25 @@ describe("PinRow", () => {
 
     const { container } = render(<AppSidebar />);
 
-    expect((await screen.findByText("Keep this pin")).closest("button")).toHaveAttribute(
+    expect((await screen.findByText("Keep this pin")).closest("a")).toHaveAttribute(
       "data-active",
       "true",
     );
-    expect(container.querySelector('button[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+    expect(container.querySelector('a[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+  });
+
+  it("opens pinned item clicks through desktop tab activation", async () => {
+    detail.current = {
+      isPending: false,
+      isError: false,
+      data: { identifier: "MUL-123", title: "Keep this pin", status: "todo" },
+      error: null,
+    };
+
+    render(<AppSidebar />);
+
+    const pinLink = await screen.findByRole("link", { name: /Keep this pin/ });
+    expect(pinLink).toHaveAttribute("href", "/acme/issues/issue-1");
+    expect(pinLink).toHaveAttribute("data-activate-tab-on-click", "true");
   });
 });

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -200,7 +200,7 @@ function SortablePinItem({
       <SidebarMenuButton
         size="sm"
         isActive={isActive}
-        render={<AppLink href={href} draggable={false} />}
+        render={<AppLink href={href} draggable={false} activateTabOnClick />}
         onClick={(event) => {
           if (wasDragged.current) {
             wasDragged.current = false;
@@ -631,7 +631,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />
@@ -695,7 +695,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />
@@ -719,7 +719,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={<AppLink href={href} activateTabOnClick />}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />

--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -90,6 +90,30 @@ describe("AppLink", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it("activateTabOnClick delegates normal clicks to openInNewTab in the foreground", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const adapter = makeAdapter({ push, openInNewTab });
+
+    renderLink(adapter, { href: "/issues", activateTabOnClick: true });
+    fireEvent.click(screen.getByText("go"));
+
+    expect(openInNewTab).toHaveBeenCalledWith("/issues", undefined, {
+      activate: true,
+    });
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("activateTabOnClick falls back to push when the adapter has no tab API", () => {
+    const push = vi.fn();
+    const adapter = makeAdapter({ push });
+
+    renderLink(adapter, { href: "/issues", activateTabOnClick: true });
+    fireEvent.click(screen.getByText("go"));
+
+    expect(push).toHaveBeenCalledWith("/issues");
+  });
+
   it("a caller-supplied onClick passed via spread cannot silently override the navigation handler", () => {
     const push = vi.fn();
     const adapter = makeAdapter({ push });

--- a/packages/views/navigation/app-link.tsx
+++ b/packages/views/navigation/app-link.tsx
@@ -5,11 +5,13 @@ import { useNavigation } from "./context";
 
 interface AppLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
+  /** Desktop tab shells can opt into open-or-activate semantics for primary clicks. */
+  activateTabOnClick?: boolean;
 }
 
 export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
   function AppLink(
-    { href, children, onClick, onMouseEnter, onFocus, ...props },
+    { href, children, onClick, onMouseEnter, onFocus, activateTabOnClick, ...props },
     ref,
   ) {
     const { push, openInNewTab, prefetch } = useNavigation();
@@ -27,6 +29,10 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
       // (close popover, clear selection, blur the trigger) lands in the
       // same tick rather than getting deferred behind the transition.
       onClick?.(e);
+      if (activateTabOnClick && openInNewTab) {
+        openInNewTab(href, undefined, { activate: true });
+        return;
+      }
       push(href);
     };
 


### PR DESCRIPTION
## Summary

- Route desktop sidebar primary nav links through tab open-or-activate behavior so existing issue/project paths are activated instead of duplicated.
- Apply the same activation path to pinned sidebar issue/project rows via `SortablePinItem`.
- Strengthen sidebar/app-link regression coverage so pinned links render the mocked `SidebarMenuButton.render` element and assert the activation flag.

Refs #4284
Related to #4326

## Verification

- `pnpm --filter @multica/views exec vitest run layout/app-sidebar.test.tsx navigation/app-link.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (exits 0; existing warnings only)
- `git diff --check upstream/main...HEAD`