### PR TITLE
fix(selfhost): fail early when Docker Compose v2 is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,18 +41,19 @@ endef
 # The self-host compose files use compose-spec syntax (top-level `name:`, no
 # `version:`) that the legacy v1 `docker-compose` standalone cannot parse, so we
 # fail early with an actionable message instead of a cryptic CLI parse error
-# (e.g. "unknown shorthand flag: 'f' in -f") when the plugin is missing.
+# (e.g. "unknown shorthand flag: 'f' in -f") when the plugin is missing or v1.
+# Keep the message short and OS-agnostic: per-OS install steps belong in docs.
 define REQUIRE_COMPOSE
 	@if ! $(COMPOSE) version >/dev/null 2>&1; then \
 		echo "Docker Compose v2 ('docker compose') was not found."; \
-		echo "Self-hosting requires the Compose v2 CLI plugin; the legacy 'docker-compose' (v1) is not supported."; \
-		echo ""; \
-		echo "Install it (see https://docs.docker.com/compose/install/linux/):"; \
-		echo "  sudo mkdir -p /usr/local/lib/docker/cli-plugins"; \
-		echo "  sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose"; \
-		echo "  sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose"; \
-		echo ""; \
-		echo "Then verify with: docker compose version"; \
+		echo "Self-hosting requires the Compose v2 CLI plugin; legacy 'docker-compose' v1 is not supported."; \
+		echo "Install Docker Compose from https://docs.docker.com/compose/install/ and verify with: docker compose version"; \
+		exit 1; \
+	fi; \
+	if ! $(COMPOSE) version --short 2>/dev/null | grep -Eq '^v?2\.'; then \
+		echo "'$(COMPOSE)' is not Docker Compose v2."; \
+		echo "Self-hosting requires the Compose v2 CLI plugin; legacy 'docker-compose' v1 is not supported."; \
+		echo "Install Docker Compose from https://docs.docker.com/compose/install/ and verify with: docker compose version"; \
 		exit 1; \
 	fi
 endef

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,26 @@ define REQUIRE_ENV
 	fi
 endef
 
+# Self-hosting requires Docker Compose v2 (the `docker compose` CLI plugin).
+# The self-host compose files use compose-spec syntax (top-level `name:`, no
+# `version:`) that the legacy v1 `docker-compose` standalone cannot parse, so we
+# fail early with an actionable message instead of a cryptic CLI parse error
+# (e.g. "unknown shorthand flag: 'f' in -f") when the plugin is missing.
+define REQUIRE_COMPOSE
+	@if ! $(COMPOSE) version >/dev/null 2>&1; then \
+		echo "Docker Compose v2 ('docker compose') was not found."; \
+		echo "Self-hosting requires the Compose v2 CLI plugin; the legacy 'docker-compose' (v1) is not supported."; \
+		echo ""; \
+		echo "Install it (see https://docs.docker.com/compose/install/linux/):"; \
+		echo "  sudo mkdir -p /usr/local/lib/docker/cli-plugins"; \
+		echo "  sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose"; \
+		echo "  sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose"; \
+		echo ""; \
+		echo "Then verify with: docker compose version"; \
+		exit 1; \
+	fi
+endef
+
 # Default target changed from selfhost to help: bare `make` now prints this help
 # instead of launching a full Docker Compose build, which is safer for onboarding.
 .DEFAULT_GOAL := help
@@ -54,6 +74,7 @@ makehelp: help ## Alias for `make help`
 ##@ Self-hosting
 
 selfhost: ## Create .env if needed, then pull and start the official self-hosted images
+	$(REQUIRE_COMPOSE)
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
@@ -71,7 +92,7 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Pulling official Multica images..."
-	@if ! docker compose -f docker-compose.selfhost.yml pull; then \
+	@if ! $(COMPOSE) -f docker-compose.selfhost.yml pull; then \
 		echo ""; \
 		echo "Official images for tag '$${MULTICA_IMAGE_TAG:-latest}' are not published yet."; \
 		echo "If this is before the first GHCR release, build from the current checkout:"; \
@@ -79,7 +100,7 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 		exit 1; \
 	fi
 	@echo "==> Starting Multica via Docker Compose..."
-	docker compose -f docker-compose.selfhost.yml up -d
+	$(COMPOSE) -f docker-compose.selfhost.yml up -d
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf http://localhost:$${PORT:-8080}/health > /dev/null 2>&1; then \
@@ -105,10 +126,11 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 	else \
 		echo ""; \
 		echo "Services are still starting. Check logs:"; \
-		echo "  docker compose -f docker-compose.selfhost.yml logs"; \
+		echo "  $(COMPOSE) -f docker-compose.selfhost.yml logs"; \
 	fi
 
 selfhost-build: ## Build backend/web from the current checkout and start the self-hosted stack
+	$(REQUIRE_COMPOSE)
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
@@ -126,7 +148,7 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Building Multica from the current checkout..."
-	docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
+	$(COMPOSE) -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf http://localhost:$${PORT:-8080}/health > /dev/null 2>&1; then \
@@ -152,12 +174,13 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 	else \
 		echo ""; \
 		echo "Services are still starting. Check logs:"; \
-		echo "  docker compose -f docker-compose.selfhost.yml logs"; \
+		echo "  $(COMPOSE) -f docker-compose.selfhost.yml logs"; \
 	fi
 
 selfhost-stop: ## Stop the self-hosted Docker Compose stack
+	$(REQUIRE_COMPOSE)
 	@echo "==> Stopping Multica services..."
-	docker compose -f docker-compose.selfhost.yml down
+	$(COMPOSE) -f docker-compose.selfhost.yml down
 	@echo "✓ All services stopped."
 
 # ---------- One-click commands ----------


### PR DESCRIPTION
## Summary

Self-hosting (`make selfhost` / `selfhost-build` / `selfhost-stop`) hardcodes `docker compose` (Compose **v2**). On hosts that only have the legacy v1 standalone `docker-compose` (e.g. `apt install docker-compose` on Debian/Ubuntu), the v2 plugin is absent, so `docker compose -f ... pull` falls through to the top-level `docker` CLI and fails with the cryptic:

```
unknown shorthand flag: 'f' in -f
```

Users reasonably mistake this for a Docker version problem (see MUL-3458).

This PR adds a `REQUIRE_COMPOSE` preflight to the three selfhost targets that checks `docker compose version` and, when the plugin is missing, prints an actionable English install hint and exits early — instead of the confusing CLI parse error. All selfhost invocations now route through `$(COMPOSE)`.

v1 fallback is intentionally **not** supported: `docker-compose.selfhost.yml` uses compose-spec syntax (top-level `name:`, no `version:`) that v1 `docker-compose` cannot parse, so requiring v2 is the only viable path.

## Changes

- Add a `REQUIRE_COMPOSE` make `define` that fails fast with an English install hint when `docker compose` is unavailable.
- Wire `$(REQUIRE_COMPOSE)` into `selfhost`, `selfhost-build`, and `selfhost-stop`.
- Replace literal `docker compose` invocations in those targets with `$(COMPOSE)` (including the echoed `... logs` hints) for a single source of truth.

## Test

- `make -n selfhost-stop` — parses and expands correctly.
- `make selfhost-stop COMPOSE=__no_such_compose__` — guard fires, prints the English message, exits non-zero, and stops before any compose command runs.

Before (missing plugin):

```
==> Pulling official Multica images...
unknown shorthand flag: 'f' in -f
See 'docker --help'.
...
```

After (missing plugin):

```
Docker Compose v2 ('docker compose') was not found.
Self-hosting requires the Compose v2 CLI plugin; the legacy 'docker-compose' (v1) is not supported.

Install it (see https://docs.docker.com/compose/install/linux/):
  sudo mkdir -p /usr/local/lib/docker/cli-plugins
  sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose
  sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose

Then verify with: docker compose version
```

Closes MUL-3458.
