### PR TITLE
fix(runtimes): launch custom runtime command args

### DIFF
--- a/packages/views/runtimes/components/pending-runtime.test.ts
+++ b/packages/views/runtimes/components/pending-runtime.test.ts
@@ -70,6 +70,18 @@ describe("pending custom runtime rows", () => {
     expect(pendingRuntimeCommandName(pending)).toBe("team-codex");
   });
 
+  it("includes fixed args in pending runtime command text", () => {
+    const pending = pendingRuntimeFromProfile({
+      profile: profile({
+        command_name: "agent",
+        fixed_args: ["--model", "composer-2.5"],
+      }),
+      createdAt: Date.parse("2026-01-01T00:00:00Z"),
+    });
+
+    expect(pendingRuntimeCommandName(pending)).toBe("agent --model composer-2.5");
+  });
+
   it("drops the pending row once a real runtime registers for the profile", () => {
     const createdAt = Date.parse("2026-01-01T00:00:00Z");
     const prof = profile();

--- a/packages/views/runtimes/components/pending-runtime.ts
+++ b/packages/views/runtimes/components/pending-runtime.ts
@@ -1,4 +1,5 @@
 import type { AgentRuntime, RuntimeProfile } from "@multica/core/types";
+import { formatRuntimeProfileCommand } from "./runtime-profile-catalog";
 
 export const PENDING_RUNTIME_WARNING_MS = 45_000;
 
@@ -64,7 +65,7 @@ export function pendingRuntimeFromProfile({
   const metadata: PendingRuntimeMetadata = {
     pending_custom_runtime: true,
     runtime_profile_id: profile.id,
-    command_name: profile.command_name,
+    command_name: formatRuntimeProfileCommand(profile),
     pending_since: pendingSince,
   };
 

--- a/packages/views/runtimes/components/runtime-profile-catalog.test.ts
+++ b/packages/views/runtimes/components/runtime-profile-catalog.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { RuntimeProfile } from "@multica/core/types";
-import { buildRuntimeCatalog, PROTOCOL_FAMILIES } from "./runtime-profile-catalog";
+import {
+  buildRuntimeCatalog,
+  formatRuntimeProfileCommand,
+  PROTOCOL_FAMILIES,
+} from "./runtime-profile-catalog";
 
 function profile(
   id: string,
   displayName: string,
   updatedAt: string,
   enabled = true,
+  overrides: Partial<RuntimeProfile> = {},
 ): RuntimeProfile {
   return {
     id,
@@ -21,6 +26,7 @@ function profile(
     enabled,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: updatedAt,
+    ...overrides,
   };
 }
 
@@ -58,5 +64,18 @@ describe("buildRuntimeCatalog", () => {
       "enabled-old",
       "disabled-new",
     ]);
+  });
+});
+
+describe("formatRuntimeProfileCommand", () => {
+  it("renders command_name together with fixed_args for edit/display surfaces", () => {
+    expect(
+      formatRuntimeProfileCommand(
+        profile("prof-args", "Args", "2026-01-02T00:00:00Z", true, {
+          command_name: "agent",
+          fixed_args: ["--model", "composer-2.5", "--label", "two words"],
+        }),
+      ),
+    ).toBe("agent --model composer-2.5 --label 'two words'");
   });
 });

--- a/packages/views/runtimes/components/runtime-profile-catalog.ts
+++ b/packages/views/runtimes/components/runtime-profile-catalog.ts
@@ -63,12 +63,23 @@ export function buildRuntimeCatalog(
   return { customs, builtins };
 }
 
-// NOTE: `fixed_args` is intentionally NOT exposed in the v1 UI. The server
-// still carries the column, but the daemon does not yet splice these args into
-// the agent launch command, so surfacing an input/display here would promise
-// admins a behavior that does not exist. Re-introduce the parse/format helpers
-// and the form field only once the daemon actually passes them to the backend
-// (proven by a test). See TODO(MUL-3284) in server/internal/daemon/daemon.go.
+// NOTE: `fixed_args` is still not exposed as a separate v1 UI field. Admins can
+// type stable launch args in the command field and the server normalizes those
+// tokens into fixed_args; explicit fixed-args editing can be added once the
+// detail/edit UI has a clear affordance for it.
+function quoteRuntimeCommandToken(token: string): string {
+  if (!token) return "''";
+  if (!/[\s'"\\]/.test(token)) return token;
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+export function formatRuntimeProfileCommand(
+  profile: Pick<RuntimeProfile, "command_name" | "fixed_args">,
+): string {
+  return [profile.command_name, ...(profile.fixed_args ?? [])]
+    .map(quoteRuntimeCommandToken)
+    .join(" ");
+}
 
 export interface ProfileFormValues {
   displayName: string;

--- a/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.test.tsx
@@ -120,6 +120,20 @@ describe("RuntimeProfilesDialog", () => {
     expect(screen.getByText("claude")).toBeInTheDocument();
   });
 
+  it("shows fixed args with the profile command", () => {
+    queryState.profiles = [
+      profile({
+        command_name: "agent",
+        fixed_args: ["--model", "composer-2.5"],
+      }),
+    ];
+
+    renderDialog();
+    fireEvent.click(screen.getByRole("option", { name: /Team Codex/i }));
+
+    expect(screen.getByText("agent --model composer-2.5")).toBeInTheDocument();
+  });
+
   it("clears built-in detail when the built-in reference section collapses", () => {
     queryState.profiles = [profile()];
 

--- a/packages/views/runtimes/components/runtime-profiles-dialog.tsx
+++ b/packages/views/runtimes/components/runtime-profiles-dialog.tsx
@@ -42,6 +42,7 @@ import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
 import {
   PROTOCOL_FAMILIES,
   buildRuntimeCatalog,
+  formatRuntimeProfileCommand,
   validateProfileForm,
   type ProfileFormErrorField,
   type ProfileFormValues,
@@ -499,7 +500,9 @@ function DetailPanel({
             <span className="capitalize">{profile.protocol_family}</span>
           </DetailRow>
           <DetailRow label={t(($) => $.profiles.detail.command)}>
-            <span className="font-mono text-xs">{profile.command_name}</span>
+            <span className="font-mono text-xs">
+              {formatRuntimeProfileCommand(profile)}
+            </span>
           </DetailRow>
           <DetailRow label={t(($) => $.profiles.detail.description)}>
             {profile.description ? (
@@ -673,7 +676,7 @@ function ProfileDetailsForm({
 
   const [values, setValues] = useState<ProfileFormValues>({
     displayName: profile?.display_name ?? "",
-    commandName: profile?.command_name ?? "",
+    commandName: profile ? formatRuntimeProfileCommand(profile) : "",
     description: profile?.description ?? "",
   });
   const [errors, setErrors] = useState<ProfileFormErrorField[]>([]);
@@ -703,6 +706,7 @@ function ProfileDetailsForm({
           display_name: values.displayName.trim(),
           protocol_family: family,
           command_name: values.commandName.trim(),
+          fixed_args: [],
           ...(description ? { description } : {}),
         });
         toast.success(t(($) => $.profiles.form.toast_created));
@@ -713,6 +717,7 @@ function ProfileDetailsForm({
           patch: {
             display_name: values.displayName.trim(),
             command_name: values.commandName.trim(),
+            fixed_args: [],
             description: description ? description : null,
           },
         });
@@ -841,11 +846,10 @@ function ProfileDetailsForm({
           />
         </div>
 
-        {/* NOTE: a `fixed_args` input is intentionally omitted in v1 — the
-            daemon does not yet pass these args to the agent launch command, so
-            exposing the field would promise admins a no-op. Re-add only once
-            it's wired end-to-end. See TODO(MUL-3284) in
-            server/internal/daemon/daemon.go. */}
+        {/* NOTE: a separate `fixed_args` input is intentionally omitted in v1.
+            Admins can type stable launch args in the command field; the server
+            normalizes those tokens into fixed_args. Add explicit fixed-args
+            editing once the detail/edit UI has a clear affordance for it. */}
 
         {/* NOTE: a visibility control is intentionally omitted in v1. The
             server forces every profile to 'workspace' because the read paths

--- a/server/cmd/multica/cmd_runtime_profile.go
+++ b/server/cmd/multica/cmd_runtime_profile.go
@@ -91,20 +91,19 @@ func init() {
 
 	// create
 	runtimeProfileCreateCmd.Flags().String("protocol-family", "", "Supported backend the profile routes to (required)")
-	runtimeProfileCreateCmd.Flags().String("command-name", "", "Executable the daemon resolves on PATH (required)")
+	runtimeProfileCreateCmd.Flags().String("command-name", "", "Executable, optionally followed by fixed launch args (required)")
 	runtimeProfileCreateCmd.Flags().String("display-name", "", "Human-readable profile name (required)")
 	runtimeProfileCreateCmd.Flags().String("description", "", "Optional description")
 	runtimeProfileCreateCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// update
 	runtimeProfileUpdateCmd.Flags().String("display-name", "", "New display name")
-	runtimeProfileUpdateCmd.Flags().String("command-name", "", "New command name")
+	runtimeProfileUpdateCmd.Flags().String("command-name", "", "New executable, optionally followed by fixed launch args")
 	runtimeProfileUpdateCmd.Flags().String("description", "", "New description")
-	// NOTE: a --fixed-arg flag is intentionally NOT exposed in v1. The server
-	// carries the fixed_args column, but the daemon does not yet pass these
-	// args to the agent launch command, so a CLI flag would promise admins a
-	// no-op. Re-add once it's wired end-to-end (TODO(MUL-3284), see
-	// server/internal/daemon/daemon.go).
+	// NOTE: a repeated --fixed-arg flag is intentionally not exposed yet.
+	// Admins can include stable launch args in --command-name and the server
+	// normalizes them into fixed_args; a separate flag can be added once the UI
+	// also has explicit fixed-args editing.
 	runtimeProfileUpdateCmd.Flags().Bool("enabled", true, "Enable or disable the profile")
 	runtimeProfileUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 

--- a/server/cmd/multica/cmd_runtime_profile_test.go
+++ b/server/cmd/multica/cmd_runtime_profile_test.go
@@ -155,8 +155,9 @@ func TestRunRuntimeProfileCreate(t *testing.T) {
 	if gotBody["protocol_family"] != "codex" || gotBody["command_name"] != "company-codex" || gotBody["display_name"] != "Company Codex" {
 		t.Errorf("unexpected body: %#v", gotBody)
 	}
-	// fixed_args is intentionally NOT exposed by the CLI in v1 (the daemon does
-	// not yet wire it into the launch command), so it must never be sent.
+	// fixed_args is intentionally not exposed as a separate CLI flag yet. The
+	// server may derive it from command_name, but the CLI should not send a
+	// second explicit field.
 	if _, present := gotBody["fixed_args"]; present {
 		t.Errorf("fixed_args must not be sent by the CLI, got %#v", gotBody["fixed_args"])
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -152,11 +152,14 @@ type Daemon struct {
 	// profileCommandPaths maps a custom runtime profile_id -> the absolute
 	// executable path resolved on PATH for that profile's command_name
 	// (MUL-3284). Populated in registerRuntimesForWorkspace when a profile's
-	// command resolves; read by runTask via customCommandPathForRuntime to
+	// command resolves; read by runTask via customRuntimeLaunchForRuntime to
 	// launch the custom command for a claimed task. Guarded by mu.
 	profileCommandPaths map[string]string
-	reloading    sync.Mutex         // prevents concurrent workspace syncs
-	runtimeSet   *runtimeSetWatcher // multi-subscriber pub/sub for runtime-set changes
+	// profileFixedArgs maps a custom runtime profile_id -> the launch args
+	// every agent bound to that runtime inherits. Guarded by mu.
+	profileFixedArgs map[string][]string
+	reloading        sync.Mutex         // prevents concurrent workspace syncs
+	runtimeSet       *runtimeSetWatcher // multi-subscriber pub/sub for runtime-set changes
 
 	versionsMu    sync.RWMutex      // guards agentVersions
 	agentVersions map[string]string // provider -> detected CLI version (set during registration)
@@ -237,6 +240,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		workspaces:                make(map[string]*workspaceState),
 		runtimeIndex:              make(map[string]Runtime),
 		profileCommandPaths:       make(map[string]string),
+		profileFixedArgs:          make(map[string][]string),
 		runtimeSet:                newRuntimeSetWatcher(),
 		agentVersions:             make(map[string]string),
 		wsHBLastAck:               make(map[string]time.Time),
@@ -848,11 +852,16 @@ func (d *Daemon) findRuntime(id string) *Runtime {
 	return nil
 }
 
-// recordProfileCommandPath remembers the absolute executable path resolved
-// for a custom runtime profile's command_name. Called from
-// registerRuntimesForWorkspace. Lazily initializes the map so test fixtures
-// that build a Daemon literal without seeding every map don't panic.
-func (d *Daemon) recordProfileCommandPath(profileID, path string) {
+type customRuntimeLaunch struct {
+	Path      string
+	FixedArgs []string
+}
+
+// recordProfileLaunch remembers the absolute executable path and inherited
+// fixed args resolved for a custom runtime profile. Called from
+// registerRuntimesForWorkspace. Lazily initializes maps so test fixtures that
+// build a Daemon literal without seeding every map don't panic.
+func (d *Daemon) recordProfileLaunch(profileID, path string, fixedArgs []string) {
 	if profileID == "" || path == "" {
 		return
 	}
@@ -861,7 +870,17 @@ func (d *Daemon) recordProfileCommandPath(profileID, path string) {
 	if d.profileCommandPaths == nil {
 		d.profileCommandPaths = make(map[string]string)
 	}
+	if d.profileFixedArgs == nil {
+		d.profileFixedArgs = make(map[string][]string)
+	}
 	d.profileCommandPaths[profileID] = path
+	d.profileFixedArgs[profileID] = append([]string(nil), fixedArgs...)
+}
+
+// recordProfileCommandPath preserves the older helper used by focused tests
+// and by any future call sites that only need to refresh the executable path.
+func (d *Daemon) recordProfileCommandPath(profileID, path string) {
+	d.recordProfileLaunch(profileID, path, nil)
 }
 
 // customCommandPathForRuntime returns the resolved custom executable path for
@@ -871,20 +890,38 @@ func (d *Daemon) recordProfileCommandPath(profileID, path string) {
 // uses this to override the launch path so a custom runtime can run even when
 // the host has no built-in agent of the same provider installed.
 func (d *Daemon) customCommandPathForRuntime(runtimeID string) (string, bool) {
+	launch, ok := d.customRuntimeLaunchForRuntime(runtimeID)
+	return launch.Path, ok
+}
+
+func (d *Daemon) customRuntimeLaunchForRuntime(runtimeID string) (customRuntimeLaunch, bool) {
 	if runtimeID == "" {
-		return "", false
+		return customRuntimeLaunch{}, false
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	rt, ok := d.runtimeIndex[runtimeID]
 	if !ok || rt.ProfileID == "" {
-		return "", false
+		return customRuntimeLaunch{}, false
 	}
 	path, ok := d.profileCommandPaths[rt.ProfileID]
 	if !ok || path == "" {
-		return "", false
+		return customRuntimeLaunch{}, false
 	}
-	return path, true
+	return customRuntimeLaunch{
+		Path:      path,
+		FixedArgs: append([]string(nil), d.profileFixedArgs[rt.ProfileID]...),
+	}, true
+}
+
+func mergeProfileFixedArgs(profileArgs, agentArgs []string) []string {
+	if len(profileArgs) == 0 {
+		return append([]string(nil), agentArgs...)
+	}
+	merged := make([]string, 0, len(profileArgs)+len(agentArgs))
+	merged = append(merged, profileArgs...)
+	merged = append(merged, agentArgs...)
+	return merged
 }
 
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
@@ -1047,15 +1084,10 @@ func (d *Daemon) appendProfileRuntimes(ctx context.Context, workspaceID string, 
 		if d.cfg.DeviceName != "" {
 			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)
 		}
-		d.recordProfileCommandPath(profile.ID, resolved)
+		d.recordProfileLaunch(profile.ID, resolved, profile.FixedArgs)
 		d.logger.Info("registering custom runtime profile",
 			"workspace_id", workspaceID, "profile_id", profile.ID,
 			"protocol_family", profile.ProtocolFamily, "command_path", resolved)
-		// NOTE: profile.FixedArgs are launch args every agent on this runtime
-		// inherits. Wiring them into the spawned command is intentionally not
-		// done here — it's an optional, best-effort enhancement (see MUL-3284
-		// PR2 task notes). TODO(MUL-3284): plumb FixedArgs into the agent
-		// launch command if/when the agent backend exposes a hook for it.
 		*runtimes = append(*runtimes, map[string]string{
 			"name":       displayName,
 			"type":       profile.ProtocolFamily,
@@ -3127,12 +3159,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Critically, a custom runtime can live on a host that has NO built-in
 	// agent of the same provider installed, so when the runtime is custom we
 	// synthesize an AgentEntry instead of hard-failing on the !ok lookup.
-	if customPath, isCustom := d.customCommandPathForRuntime(task.RuntimeID); isCustom {
-		entry.Path = customPath
+	var customLaunch customRuntimeLaunch
+	if launch, isCustom := d.customRuntimeLaunchForRuntime(task.RuntimeID); isCustom {
+		customLaunch = launch
+		entry.Path = launch.Path
 		ok = true
 		d.logger.Info("task uses custom runtime profile command",
 			"task_id", task.ID, "runtime_id", task.RuntimeID,
-			"provider", provider, "command_path", customPath)
+			"provider", provider, "command_path", launch.Path,
+			"fixed_args", len(launch.FixedArgs))
 	}
 	if !ok {
 		return TaskResult{}, fmt.Errorf("no agent configured for provider %q", provider)
@@ -3442,8 +3477,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	extraArgs := defaultArgsForProvider(d.cfg, provider)
 	var mcpConfig json.RawMessage
 	if task.Agent != nil {
-		customArgs = task.Agent.CustomArgs
+		customArgs = mergeProfileFixedArgs(customLaunch.FixedArgs, task.Agent.CustomArgs)
 		mcpConfig = task.Agent.McpConfig
+	} else {
+		customArgs = mergeProfileFixedArgs(customLaunch.FixedArgs, nil)
 	}
 	// Two-tier model resolution: an explicit agent.model wins,
 	// then the daemon-wide MULTICA_<PROVIDER>_MODEL env var. If

--- a/server/internal/daemon/runtime_profile_test.go
+++ b/server/internal/daemon/runtime_profile_test.go
@@ -161,6 +161,7 @@ func TestRegisterRuntimes_AppendsProfileRuntime(t *testing.T) {
 		DisplayName:    "Company Codex",
 		ProtocolFamily: "codex",
 		CommandName:    "company-codex",
+		FixedArgs:      []string{"--model", "composer-2.5"},
 		Visibility:     "workspace",
 		Enabled:        true,
 	}}
@@ -192,6 +193,9 @@ func TestRegisterRuntimes_AppendsProfileRuntime(t *testing.T) {
 	// The resolved command path must be recorded keyed by profile_id.
 	if got := d.profileCommandPaths["prof-1"]; got != "/opt/bin/company-codex" {
 		t.Errorf("profileCommandPaths[prof-1] = %q, want /opt/bin/company-codex", got)
+	}
+	if got, want := strings.Join(d.profileFixedArgs["prof-1"], "\x00"), "--model\x00composer-2.5"; got != want {
+		t.Errorf("profile fixed args = %#v, want [--model composer-2.5]", d.profileFixedArgs["prof-1"])
 	}
 
 	// The response runtime carries the profile_id back.
@@ -331,6 +335,7 @@ func stubProfilePathExecutable(t *testing.T, executable map[string]bool) {
 	profilePathExecutable = func(path string) bool { return executable[path] }
 	t.Cleanup(func() { profilePathExecutable = orig })
 }
+
 // bookkeeping that runTask relies on to override the launch path.
 func TestCustomCommandPathForRuntime(t *testing.T) {
 	d := freshDaemon("")
@@ -355,5 +360,49 @@ func TestCustomCommandPathForRuntime(t *testing.T) {
 	d.runtimeIndex["rt-unresolved"] = Runtime{ID: "rt-unresolved", Provider: "codex", ProfileID: "prof-missing"}
 	if path, ok := d.customCommandPathForRuntime("rt-unresolved"); ok || path != "" {
 		t.Errorf("unresolved profile: got (%q, %v), want (\"\", false)", path, ok)
+	}
+}
+
+func TestCustomRuntimeLaunchForRuntimeIncludesFixedArgs(t *testing.T) {
+	d := freshDaemon("")
+	d.profileCommandPaths = map[string]string{"prof-1": "/opt/bin/agent"}
+	d.profileFixedArgs = map[string][]string{"prof-1": {"--model", "composer-2.5"}}
+	d.runtimeIndex["rt-custom"] = Runtime{ID: "rt-custom", Provider: "cursor", ProfileID: "prof-1"}
+
+	launch, ok := d.customRuntimeLaunchForRuntime("rt-custom")
+	if !ok {
+		t.Fatal("custom runtime launch not found")
+	}
+	if launch.Path != "/opt/bin/agent" {
+		t.Fatalf("launch path = %q, want /opt/bin/agent", launch.Path)
+	}
+	if got, want := strings.Join(launch.FixedArgs, "\x00"), "--model\x00composer-2.5"; got != want {
+		t.Fatalf("launch fixed args = %#v, want [--model composer-2.5]", launch.FixedArgs)
+	}
+
+	launch.FixedArgs[0] = "--mutated"
+	again, ok := d.customRuntimeLaunchForRuntime("rt-custom")
+	if !ok {
+		t.Fatal("custom runtime launch not found on second lookup")
+	}
+	if again.FixedArgs[0] != "--model" {
+		t.Fatalf("fixed args lookup leaked mutable slice: %#v", again.FixedArgs)
+	}
+}
+
+func TestMergeProfileFixedArgsBeforeAgentCustomArgs(t *testing.T) {
+	got := mergeProfileFixedArgs(
+		[]string{"--model", "composer-2.5"},
+		[]string{"--extra", "value"},
+	)
+	want := []string{"--model", "composer-2.5", "--extra", "value"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("merged args = %#v, want %#v", got, want)
+	}
+
+	got[0] = "--mutated"
+	got = mergeProfileFixedArgs([]string{"--model"}, []string{"sonnet"})
+	if strings.Join(got, "\x00") != "--model\x00sonnet" {
+		t.Fatalf("merge should return a fresh slice, got %#v", got)
 	}
 }

--- a/server/internal/handler/runtime_profile.go
+++ b/server/internal/handler/runtime_profile.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
@@ -97,6 +98,89 @@ func marshalFixedArgs(args []string) ([]byte, error) {
 	return json.Marshal(clean)
 }
 
+func splitRuntimeProfileCommandLine(raw string) (string, []string, error) {
+	input := strings.TrimSpace(raw)
+	if input == "" {
+		return "", nil, errors.New("command_name is required")
+	}
+
+	var tokens []string
+	var b strings.Builder
+	var quote rune
+	escaped := false
+	tokenStarted := false
+
+	flush := func() {
+		tokens = append(tokens, b.String())
+		b.Reset()
+		tokenStarted = false
+	}
+
+	for _, r := range input {
+		if escaped {
+			b.WriteRune(r)
+			tokenStarted = true
+			escaped = false
+			continue
+		}
+		if quote != '\'' && r == '\\' {
+			escaped = true
+			tokenStarted = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				tokenStarted = true
+				continue
+			}
+			b.WriteRune(r)
+			tokenStarted = true
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			tokenStarted = true
+			continue
+		}
+		if unicode.IsSpace(r) {
+			if tokenStarted {
+				flush()
+			}
+			continue
+		}
+		b.WriteRune(r)
+		tokenStarted = true
+	}
+	if escaped {
+		return "", nil, errors.New("command_name has a trailing escape")
+	}
+	if quote != 0 {
+		return "", nil, errors.New("command_name has an unclosed quote")
+	}
+	if tokenStarted {
+		flush()
+	}
+	if len(tokens) == 0 || strings.TrimSpace(tokens[0]) == "" {
+		return "", nil, errors.New("command_name is required")
+	}
+	return tokens[0], tokens[1:], nil
+}
+
+func normalizeRuntimeProfileCommand(commandName string, fixedArgs []string) (string, []string, error) {
+	cmd, inlineArgs, err := splitRuntimeProfileCommandLine(commandName)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(inlineArgs) == 0 {
+		return cmd, fixedArgs, nil
+	}
+	merged := make([]string, 0, len(inlineArgs)+len(fixedArgs))
+	merged = append(merged, inlineArgs...)
+	merged = append(merged, fixedArgs...)
+	return cmd, merged, nil
+}
+
 type createRuntimeProfileRequest struct {
 	DisplayName    string   `json:"display_name"`
 	ProtocolFamily string   `json:"protocol_family"`
@@ -137,11 +221,13 @@ func (h *Handler) CreateRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "unsupported protocol_family: must be one of "+strings.Join(agent.SupportedTypes, ", "))
 		return
 	}
-	if req.CommandName == "" {
-		writeError(w, http.StatusBadRequest, "command_name is required")
+	commandName, fixedArgValues, err := normalizeRuntimeProfileCommand(req.CommandName, req.FixedArgs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	fixedArgs, err := marshalFixedArgs(req.FixedArgs)
+	req.CommandName = commandName
+	fixedArgs, err := marshalFixedArgs(fixedArgValues)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -278,7 +364,20 @@ func (h *Handler) UpdateRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "command_name cannot be empty")
 			return
 		}
-		params.CommandName = strToText(cmd)
+		commandName, inlineArgs, err := splitRuntimeProfileCommandLine(cmd)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		params.CommandName = strToText(commandName)
+		if len(inlineArgs) > 0 {
+			merged := make([]string, 0, len(inlineArgs))
+			merged = append(merged, inlineArgs...)
+			if req.FixedArgs != nil {
+				merged = append(merged, (*req.FixedArgs)...)
+			}
+			req.FixedArgs = &merged
+		}
 	}
 	if req.Description != nil {
 		params.Description = ptrToText(req.Description)

--- a/server/internal/handler/runtime_profile_handler_test.go
+++ b/server/internal/handler/runtime_profile_handler_test.go
@@ -48,6 +48,32 @@ func insertProfileRuntimeFixture(t *testing.T, ctx context.Context, profileID, n
 	return runtimeID
 }
 
+func TestSplitRuntimeProfileCommandLine(t *testing.T) {
+	cmd, args, err := splitRuntimeProfileCommandLine(`agent --model composer-2.5 --flag="quoted value"`)
+	if err != nil {
+		t.Fatalf("split command line: %v", err)
+	}
+	if cmd != "agent" {
+		t.Fatalf("command = %q, want agent", cmd)
+	}
+	want := []string{"--model", "composer-2.5", "--flag=quoted value"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args = %#v, want %#v", args, want)
+		}
+	}
+}
+
+func TestSplitRuntimeProfileCommandLineRejectsUnclosedQuote(t *testing.T) {
+	_, _, err := splitRuntimeProfileCommandLine(`agent --model "composer`)
+	if err == nil {
+		t.Fatal("expected unclosed quote error")
+	}
+}
+
 // TestDeleteRuntimeProfile_ArchivedAgentCascade is the regression guard for the
 // FK-RESTRICT 500: a profile whose only remaining agent is ARCHIVED must still
 // delete cleanly. agent.runtime_id is ON DELETE RESTRICT, so without the
@@ -137,7 +163,6 @@ func TestDeleteRuntimeProfile_ActiveAgentBlocks(t *testing.T) {
 	}
 }
 
-
 // TestCreateRuntimeProfile_ForcesWorkspaceVisibility is the regression guard
 // for the visibility leak: visibility=private is not user-settable in v1
 // because the read paths don't enforce it. A client that POSTs
@@ -181,5 +206,71 @@ func TestCreateRuntimeProfile_ForcesWorkspaceVisibility(t *testing.T) {
 	}
 	if dbVis != "workspace" {
 		t.Fatalf("stored visibility = %q, want workspace", dbVis)
+	}
+}
+
+// TestCreateRuntimeProfile_SplitsInlineCommandArgs covers the field symptom in
+// #4351: users naturally paste the command they run in a terminal, e.g.
+// "agent --model composer-2.5". The server should persist the executable as
+// command_name so the daemon can resolve it on PATH, and persist the remaining
+// tokens as fixed_args so the runtime launches with the same mode.
+func TestCreateRuntimeProfile_SplitsInlineCommandArgs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/runtime-profiles", map[string]any{
+		"display_name":    "Cursor Composer Profile",
+		"protocol_family": "cursor",
+		"command_name":    "agent --model composer-2.5",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.CreateRuntimeProfile(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp RuntimeProfileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM runtime_profile WHERE id = $1`, resp.ID)
+	})
+
+	if resp.CommandName != "agent" {
+		t.Fatalf("response command_name = %q, want agent", resp.CommandName)
+	}
+	wantArgs := []string{"--model", "composer-2.5"}
+	if len(resp.FixedArgs) != len(wantArgs) {
+		t.Fatalf("response fixed_args = %#v, want %#v", resp.FixedArgs, wantArgs)
+	}
+	for i := range wantArgs {
+		if resp.FixedArgs[i] != wantArgs[i] {
+			t.Fatalf("response fixed_args = %#v, want %#v", resp.FixedArgs, wantArgs)
+		}
+	}
+
+	var dbCommand string
+	var dbArgs []byte
+	if err := testPool.QueryRow(ctx, `SELECT command_name, fixed_args FROM runtime_profile WHERE id = $1`, resp.ID).Scan(&dbCommand, &dbArgs); err != nil {
+		t.Fatalf("read stored profile: %v", err)
+	}
+	if dbCommand != "agent" {
+		t.Fatalf("stored command_name = %q, want agent", dbCommand)
+	}
+	var fixedArgs []string
+	if err := json.Unmarshal(dbArgs, &fixedArgs); err != nil {
+		t.Fatalf("decode stored fixed_args: %v", err)
+	}
+	if len(fixedArgs) != len(wantArgs) {
+		t.Fatalf("stored fixed_args = %#v, want %#v", fixedArgs, wantArgs)
+	}
+	for i := range wantArgs {
+		if fixedArgs[i] != wantArgs[i] {
+			t.Fatalf("stored fixed_args = %#v, want %#v", fixedArgs, wantArgs)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4351.

## Summary
- Normalize custom runtime profile command_name into executable plus fixed_args so commands like `agent --model composer-2.5` resolve on PATH.
- Persist and pass profile fixed_args through daemon launches before per-agent custom args.
- Show the full command in runtime profile details, edit form, and pending runtime rows so args can be preserved or removed.

## Verification
- `go test ./internal/daemon -count=1`
- `go test ./internal/handler -run 'TestSplitRuntimeProfileCommandLine|TestCreateRuntimeProfile_SplitsInlineCommandArgs' -count=1`\n- `go test ./cmd/multica -run 'TestRunRuntimeProfileCreate|TestRuntimeProfileCommandsRegistered' -count=1`\n- `pnpm --filter @multica/views exec vitest run runtimes/components/runtime-profile-catalog.test.ts runtimes/components/pending-runtime.test.ts runtimes/components/runtime-profiles-dialog.test.tsx`\n- `pnpm --filter @multica/views typecheck`\n- `git diff --check`