### PR TITLE
fix(daemon): prevent large claim response timeouts

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -92,6 +92,11 @@ type Client struct {
 	token   string
 	client  *http.Client
 
+	// Claim responses can include agent instructions, skills, repos, and task
+	// context. Keep their body-read budget separate from the normal daemon API
+	// calls so large issue payloads do not time out at the generic 30s cap.
+	claimClient *http.Client
+
 	// Identity headers sent on every request as X-Client-*. Populated by
 	// SetIdentity(); empty values are simply omitted.
 	platform string
@@ -99,13 +104,19 @@ type Client struct {
 	os       string
 }
 
+const (
+	defaultHTTPTimeout      = 30 * time.Second
+	defaultClaimTaskTimeout = 75 * time.Second
+)
+
 // NewClient creates a new daemon API client.
 func NewClient(baseURL string) *Client {
 	return &Client{
-		baseURL:  baseURL,
-		client:   &http.Client{Timeout: 30 * time.Second},
-		platform: "daemon",
-		os:       normalizeGOOS(runtime.GOOS),
+		baseURL:     baseURL,
+		client:      &http.Client{Timeout: defaultHTTPTimeout},
+		claimClient: &http.Client{Timeout: defaultClaimTaskTimeout},
+		platform:    "daemon",
+		os:          normalizeGOOS(runtime.GOOS),
 	}
 }
 
@@ -157,7 +168,7 @@ func (c *Client) ClaimTask(ctx context.Context, runtimeID string) (*Task, error)
 	var resp struct {
 		Task *Task `json:"task"`
 	}
-	if err := c.postJSON(ctx, fmt.Sprintf("/api/daemon/runtimes/%s/tasks/claim", runtimeID), map[string]any{}, &resp); err != nil {
+	if err := c.postJSONWithClient(ctx, c.claimHTTPClient(), fmt.Sprintf("/api/daemon/runtimes/%s/tasks/claim", runtimeID), map[string]any{}, &resp); err != nil {
 		return nil, err
 	}
 	return resp.Task, nil
@@ -293,8 +304,8 @@ type (
 func (c *Client) SendHeartbeat(ctx context.Context, runtimeID string) (*HeartbeatResponse, error) {
 	var resp HeartbeatResponse
 	if err := c.postJSON(ctx, "/api/daemon/heartbeat", map[string]any{
-		"runtime_id":             runtimeID,
-		"supports_batch_import":  true,
+		"runtime_id":            runtimeID,
+		"supports_batch_import": true,
 	}, &resp); err != nil {
 		return nil, err
 	}
@@ -599,6 +610,17 @@ func (c *Client) postJSONWithRetry(ctx context.Context, path string, reqBody any
 }
 
 func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBody any) error {
+	return c.postJSONWithClient(ctx, c.client, path, reqBody, respBody)
+}
+
+func (c *Client) claimHTTPClient() *http.Client {
+	if c.claimClient != nil {
+		return c.claimClient
+	}
+	return c.client
+}
+
+func (c *Client) postJSONWithClient(ctx context.Context, httpClient *http.Client, path string, reqBody any, respBody any) error {
 	var body io.Reader
 	if reqBody != nil {
 		data, err := json.Marshal(reqBody)
@@ -618,7 +640,7 @@ func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBod
 	}
 	c.setIdentityHeaders(req)
 
-	resp, err := c.client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -85,6 +85,36 @@ func TestClient_VersionOmittedWhenUnset(t *testing.T) {
 	}
 }
 
+func TestClaimTaskUsesDedicatedTimeoutForLargeResponses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/runtimes/runtime-1/tasks/claim" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"task":`))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(120 * time.Millisecond)
+		_, _ = w.Write([]byte(`null}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.client.Timeout = 30 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	task, err := c.ClaimTask(ctx, "runtime-1")
+	if err != nil {
+		t.Fatalf("ClaimTask should not use the generic client timeout: %v", err)
+	}
+	if task != nil {
+		t.Fatalf("task = %#v, want nil", task)
+	}
+}
+
 // noSleepRetry replaces retrySleep with an immediate no-op so tests don't
 // actually wait the 4s/8s/16s/... backoffs. Returns a restore func.
 func noSleepRetry(t *testing.T) func() {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -155,8 +155,8 @@ type Daemon struct {
 	// command resolves; read by runTask via customCommandPathForRuntime to
 	// launch the custom command for a claimed task. Guarded by mu.
 	profileCommandPaths map[string]string
-	reloading    sync.Mutex         // prevents concurrent workspace syncs
-	runtimeSet   *runtimeSetWatcher // multi-subscriber pub/sub for runtime-set changes
+	reloading           sync.Mutex         // prevents concurrent workspace syncs
+	runtimeSet          *runtimeSetWatcher // multi-subscriber pub/sub for runtime-set changes
 
 	versionsMu    sync.RWMutex      // guards agentVersions
 	agentVersions map[string]string // provider -> detected CLI version (set during registration)
@@ -2352,9 +2352,9 @@ func (d *Daemon) triggerRestart() {
 // pollLoop supervises one runtimePoller goroutine per registered runtime,
 // fans wake-up signals out to all of them, and waits for in-flight tasks to
 // drain on shutdown. Per-runtime workers replace the previous round-robin
-// loop so that a slow ClaimTask call (HTTP 30s timeout) for one runtime no
-// longer delays claims on every other runtime — that was the cross-workspace
-// stall mode reported in MUL-1744.
+// loop so that a slow ClaimTask call for one runtime no longer delays claims
+// on every other runtime — that was the cross-workspace stall mode reported in
+// MUL-1744.
 func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan taskWakeup) error {
 	sem := newTaskSlotSemaphore(d.cfg.MaxConcurrentTasks)
 	var taskWG sync.WaitGroup   // tracks in-flight handleTask goroutines
@@ -2461,9 +2461,9 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan taskWakeup) er
 // recreating it under load.
 //
 // Slot-before-claim does mean a slow claim holds a slot during its HTTP
-// roundtrip; the upper bound is `client.Timeout = 30s` (client.go:59), well
-// below the 300s dispatch timeout, so other runtimes' tasks stay in
-// server-side `queued` state (which has no timeout) rather than entering
+// roundtrip; the upper bound is the daemon client's dedicated claim timeout,
+// still below the server-side dispatch timeout, so other runtimes' tasks stay
+// in server-side `queued` state (which has no timeout) rather than entering
 // `dispatched` and racing the sweeper.
 //
 // pollerCtx is cancelled when this runtime is removed from the watched set

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1194,7 +1194,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 
 	if task == nil {
 		slog.Debug("no task to claim", "runtime_id", runtimeID)
-		writeJSON(w, http.StatusOK, map[string]any{"task": nil})
+		writeMaybeCompressedJSON(w, r, http.StatusOK, map[string]any{"task": nil})
 		outcome = "no_task"
 		return
 	}
@@ -1800,7 +1800,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	resp.AuthToken = tokenStr
 
 	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID)
-	writeJSON(w, http.StatusOK, map[string]any{"task": resp})
+	writeMaybeCompressedJSON(w, r, http.StatusOK, map[string]any{"task": resp})
 }
 
 // trailingUserMessages returns the run of user messages after the last

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -199,7 +199,7 @@ func TestClaimTaskByRuntime_ReclaimsStaleDispatchedTask(t *testing.T) {
 	ctx := context.Background()
 	runtimeID := createClaimReclaimRuntime(t, ctx, "Stale dispatch reclaim runtime")
 	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Stale dispatch reclaim agent")
-	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "120 seconds", false)
+	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "180 seconds", false)
 
 	task, body := claimTaskByRuntimeForTest(t, runtimeID)
 	if task == nil {
@@ -230,7 +230,7 @@ func TestClaimTaskByRuntime_DoesNotReclaimFreshDispatchedTask(t *testing.T) {
 	ctx := context.Background()
 	runtimeID := createClaimReclaimRuntime(t, ctx, "Fresh dispatch reclaim runtime")
 	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Fresh dispatch reclaim agent")
-	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "75 seconds", false)
+	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "100 seconds", false)
 
 	task, body := claimTaskByRuntimeForTest(t, runtimeID)
 	if task != nil {
@@ -239,7 +239,7 @@ func TestClaimTaskByRuntime_DoesNotReclaimFreshDispatchedTask(t *testing.T) {
 
 	var stillFresh bool
 	if err := testPool.QueryRow(ctx, `
-		SELECT dispatched_at < now() - interval '70 seconds'
+		SELECT dispatched_at < now() - interval '95 seconds'
 		FROM agent_task_queue
 		WHERE id = $1
 	`, taskID).Scan(&stillFresh); err != nil {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -228,6 +230,30 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)
+}
+
+func writeMaybeCompressedJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
+	if !requestAcceptsGzip(r) {
+		writeJSON(w, status, v)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Add("Vary", "Accept-Encoding")
+	w.WriteHeader(status)
+	gz := gzip.NewWriter(w)
+	defer gz.Close()
+	json.NewEncoder(gz).Encode(v)
+}
+
+func requestAcceptsGzip(r *http.Request) bool {
+	for _, part := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		coding := strings.TrimSpace(strings.SplitN(part, ";", 2)[0])
+		if strings.EqualFold(coding, "gzip") {
+			return true
+		}
+	}
+	return false
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/server/internal/handler/json_compression_test.go
+++ b/server/internal/handler/json_compression_test.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteMaybeCompressedJSONHonorsGzip(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/runtimes/rt/tasks/claim", nil)
+	req.Header.Set("Accept-Encoding", "br, gzip")
+	w := httptest.NewRecorder()
+
+	writeMaybeCompressedJSON(w, req, http.StatusOK, map[string]string{
+		"payload": strings.Repeat("claim-response-", 128),
+	})
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := resp.Header.Get("Vary"); !strings.Contains(got, "Accept-Encoding") {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("new gzip reader: %v", err)
+	}
+	defer gz.Close()
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("read gzip body: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode compressed json: %v", err)
+	}
+	if got["payload"] != strings.Repeat("claim-response-", 128) {
+		t.Fatalf("payload did not round-trip")
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -81,10 +81,11 @@ func truncateForSummary(s string, maxRunes int) string {
 
 const (
 	taskAnalyticsContextCacheMax = 4096
-	// claimResponseRecoveryWindow must exceed daemon client.Timeout for
-	// /tasks/claim (30s) plus /tasks/{id}/start (30s) plus scheduling slack, so
-	// an in-flight StartTask cannot be reclaimed and double-dispatched.
-	claimResponseRecoveryWindow = 90 * time.Second
+	// claimResponseRecoveryWindow must exceed the daemon's dedicated
+	// /tasks/claim timeout (75s) plus /tasks/{id}/start (30s) plus scheduling
+	// slack, so an in-flight large claim response cannot be reclaimed and
+	// double-dispatched before the daemon has a chance to StartTask.
+	claimResponseRecoveryWindow = 120 * time.Second
 )
 
 // buildCommentTriggerSummary fetches the comment content and truncates


### PR DESCRIPTION
Fixes #4072.
Related to #4246.

## Summary
- Give daemon task claims a dedicated 75s HTTP timeout instead of sharing the generic 30s daemon API client timeout.
- Compress successful `/tasks/claim` JSON responses when the daemon advertises gzip support, reducing large skill/instruction payload transfer size.
- Extend the stale-dispatched claim recovery window to 120s so large in-flight claim responses are not reclaimed and double-dispatched before `StartTask`.

## Verification
- `go test ./internal/daemon -count=1`
- `go test ./internal/handler -count=1`
- `go test ./internal/service -count=1`
- `git diff --check`