### PR TITLE
fix(cli): guide remote setup callbacks

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/cli"
@@ -61,6 +62,8 @@ var authLogoutCmd = &cobra.Command{
 // cli_callback URL. Useful when the CLI sits behind a reverse proxy or the
 // auto-detected LAN IP isn't the one the browser can reach.
 const callbackHostFlag = "callback-host"
+
+const callbackHostFlagHelp = "Host/IP the OAuth callback URL points at when the browser can reach this CLI directly. For SSH-only machines, use the printed tunnel hint instead."
 
 func init() {
 	authCmd.AddCommand(authStatusCmd)
@@ -229,7 +232,7 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	serverURL := resolveServerURL(cmd)
 	appURL := resolveAppURL(cmd)
 
-	flagHost, _ := cmd.Flags().GetString(callbackHostFlag)
+	flagHost := callbackHostFlagValue(cmd)
 	callbackHost, bindAddr := resolveCallbackBinding(flagHost, serverURL, appURL, detectOutboundIP)
 
 	// Pin to "tcp4" — a bare "tcp" on macOS can produce an IPv6-only socket
@@ -288,7 +291,7 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	if err := openBrowser(loginURL); err != nil {
 		fmt.Fprintf(os.Stderr, "Could not open browser automatically.\n")
 	}
-	fmt.Fprintf(os.Stderr, "If the browser didn't open, visit:\n  %s\n\nWaiting for authentication...\n", loginURL)
+	fmt.Fprint(os.Stderr, browserLoginInstructions(loginURL, callbackHost, port, runningInSSHSession()))
 
 	// Wait for the JWT from the callback (timeout 5 minutes).
 	var jwtToken string
@@ -348,6 +351,56 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 
 	fmt.Fprintf(os.Stderr, "Authenticated as %s (%s)\nToken saved to config.\n", me.Name, me.Email)
 	return nil
+}
+
+func runningInSSHSession() bool {
+	for _, key := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func callbackHostFlagValue(cmd *cobra.Command) string {
+	for c := cmd; c != nil; c = c.Parent() {
+		if value := nonEmptyFlagValue(c.Flags(), callbackHostFlag); value != "" {
+			return value
+		}
+		if value := nonEmptyFlagValue(c.PersistentFlags(), callbackHostFlag); value != "" {
+			return value
+		}
+		if value := nonEmptyFlagValue(c.InheritedFlags(), callbackHostFlag); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonEmptyFlagValue(flags *pflag.FlagSet, name string) string {
+	if flag := flags.Lookup(name); flag != nil {
+		return strings.TrimSpace(flag.Value.String())
+	}
+	return ""
+}
+
+func callbackHostIsLoopback(host string) bool {
+	h := strings.Trim(strings.TrimSpace(host), "[]")
+	if h == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(h)
+	return ip != nil && ip.IsLoopback()
+}
+
+func browserLoginInstructions(loginURL, callbackHost string, port int, remoteSSH bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "If the browser didn't open, visit:\n  %s\n", loginURL)
+	if remoteSSH && callbackHostIsLoopback(callbackHost) {
+		fmt.Fprintf(&b, "\nRemote SSH session detected. Before opening that URL on your local computer, forward the callback port in another terminal:\n  ssh -L %d:127.0.0.1:%d <user>@<remote-host>\nThen open the URL above in your local browser.\n", port, port)
+	}
+	fmt.Fprintln(&b, "\nWaiting for authentication...")
+	return b.String()
 }
 
 func runAuthLoginToken(cmd *cobra.Command, providedToken string) error {

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -128,6 +128,50 @@ func TestResolveCallbackBinding(t *testing.T) {
 	}
 }
 
+func TestBrowserLoginInstructionsSSHRemoteHint(t *testing.T) {
+	const loginURL = "https://multica.ai/login?cli_callback=http%3A%2F%2Flocalhost%3A43689%2Fcallback"
+
+	got := browserLoginInstructions(loginURL, "localhost", 43689, true)
+	if !strings.Contains(got, "ssh -L 43689:127.0.0.1:43689 <user>@<remote-host>") {
+		t.Fatalf("remote SSH instructions missing tunnel command:\n%s", got)
+	}
+	if !strings.Contains(got, loginURL) {
+		t.Fatalf("instructions missing login URL:\n%s", got)
+	}
+
+	got = browserLoginInstructions(loginURL, "localhost", 43689, false)
+	if strings.Contains(got, "ssh -L") {
+		t.Fatalf("local instructions should not include SSH tunnel command:\n%s", got)
+	}
+
+	got = browserLoginInstructions(loginURL, "192.168.1.25", 43689, true)
+	if strings.Contains(got, "ssh -L") {
+		t.Fatalf("non-loopback callback should not include SSH tunnel command:\n%s", got)
+	}
+}
+
+func TestCallbackHostFlagValueReadsParentSetupFlag(t *testing.T) {
+	var got string
+	setup := &cobra.Command{Use: "setup"}
+	setup.Flags().String(callbackHostFlag, "", "")
+	cloud := &cobra.Command{
+		Use: "cloud",
+		Run: func(cmd *cobra.Command, args []string) {
+			got = callbackHostFlagValue(cmd)
+		},
+	}
+	cloud.Flags().String(callbackHostFlag, "", "")
+	setup.AddCommand(cloud)
+	setup.SetArgs([]string{"--callback-host", "10.0.0.5", "cloud"})
+
+	if err := setup.Execute(); err != nil {
+		t.Fatalf("execute setup cloud: %v", err)
+	}
+	if got != "10.0.0.5" {
+		t.Fatalf("callback host = %q, want parent flag value", got)
+	}
+}
+
 // TestLoginTokenFlagWiring asserts the production loginCmd flag is registered
 // the way #1994 needs it to be: a String flag (not Bool) with a NoOptDefVal
 // so `--token` (no value) keeps its legacy prompt-mode behavior. This is the

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -52,7 +52,7 @@ func init() {
 	// while `--token mul_...` / `--token mcn_...` and the `=value` form
 	// consume the value normally.
 	loginCmd.Flags().Lookup("token").NoOptDefVal = tokenPromptSentinel
-	loginCmd.Flags().String(callbackHostFlag, "", "Host the OAuth callback URL points at (auto-detected from the server's route when empty). Use this for reverse-proxy / FQDN setups where auto-detection picks the wrong interface.")
+	loginCmd.Flags().String(callbackHostFlag, "", callbackHostFlagHelp)
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -26,6 +26,11 @@ If a configuration already exists, you will be prompted before overwriting.
 
 Use 'multica setup self-host' to connect to a self-hosted server instead.
 
+If you run this command over SSH on a remote machine, keep the localhost
+callback and follow the SSH tunnel hint printed during browser login. If your
+browser can reach this CLI directly on a private network address, pass
+--callback-host <host-or-ip>.
+
 Use --profile to create an isolated configuration for a separate environment:
   multica setup self-host --profile staging --server-url https://api-staging.co`,
 	RunE: runSetupCloud,
@@ -35,6 +40,11 @@ var setupCloudCmd = &cobra.Command{
 	Use:   "cloud",
 	Short: "Configure the CLI for Multica Cloud (multica.ai)",
 	Long: `Explicitly configures the CLI to connect to Multica Cloud (multica.ai).
+
+If you run this command over SSH on a remote machine, keep the localhost
+callback and follow the SSH tunnel hint printed during browser login. If your
+browser can reach this CLI directly on a private network address, pass
+--callback-host <host-or-ip>.
 
 This is equivalent to running 'multica setup' without a subcommand.`,
 	RunE: runSetupCloud,
@@ -49,7 +59,7 @@ By default, connects to http://localhost:8080 (backend) and http://localhost:300
 Use --server-url and --app-url to specify a custom server (e.g. an on-premise deployment).
 
 If you run this command from a different machine than the server, also pass
---callback-host <FQDN-or-IP-the-browser-can-reach-back-to-this-machine-on> so
+--callback-host <host-or-ip-the-browser-can-reach-back-to-this-machine-on> so
 the OAuth login flow can return the token to the CLI.
 
 Examples:
@@ -60,11 +70,14 @@ Examples:
 }
 
 func init() {
+	setupCmd.Flags().String(callbackHostFlag, "", callbackHostFlagHelp)
+	setupCloudCmd.Flags().String(callbackHostFlag, "", callbackHostFlagHelp)
+
 	setupSelfHostCmd.Flags().String("server-url", "", "Backend server URL (e.g. https://api.internal.co) (env: MULTICA_SERVER_URL)")
 	setupSelfHostCmd.Flags().String("app-url", "", "Frontend app URL (e.g. https://app.internal.co) (env: MULTICA_APP_URL)")
 	setupSelfHostCmd.Flags().Int("port", 8080, "Backend server port (used when --server-url is not set)")
 	setupSelfHostCmd.Flags().Int("frontend-port", 3000, "Frontend port (used when --app-url is not set)")
-	setupSelfHostCmd.Flags().String(callbackHostFlag, "", "Host the OAuth callback URL points at (auto-detected when empty). Use this for reverse-proxy / FQDN setups.")
+	setupSelfHostCmd.Flags().String(callbackHostFlag, "", callbackHostFlagHelp)
 
 	setupCmd.AddCommand(setupCloudCmd)
 	setupCmd.AddCommand(setupSelfHostCmd)

--- a/server/cmd/multica/cmd_setup_test.go
+++ b/server/cmd/multica/cmd_setup_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -163,6 +165,40 @@ func TestSelfHostAppURLHonorsEnv(t *testing.T) {
 			t.Fatalf("app_url: want flag value, got %q", got)
 		}
 	})
+}
+
+func TestSetupCallbackHostFlagWiring(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "setup", cmd: setupCmd},
+		{name: "setup cloud", cmd: setupCloudCmd},
+		{name: "setup self-host", cmd: setupSelfHostCmd},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cmd.Flag(callbackHostFlag) == nil {
+				t.Fatalf("%s is missing --%s", tc.name, callbackHostFlag)
+			}
+		})
+	}
+}
+
+func TestSetupHelpShowsCallbackHostFlag(t *testing.T) {
+	var out bytes.Buffer
+	setupCmd.SetOut(&out)
+	setupCmd.SetErr(&out)
+	defer setupCmd.SetOut(nil)
+	defer setupCmd.SetErr(nil)
+	if err := setupCmd.Help(); err != nil {
+		t.Fatalf("setup help: %v", err)
+	}
+	if !strings.Contains(out.String(), "--callback-host") {
+		t.Fatalf("setup help should show --%s, got:\n%s", callbackHostFlag, out.String())
+	}
 }
 
 func TestServerHostIsLocal(t *testing.T) {

--- a/server/cmd/multica/help.go
+++ b/server/cmd/multica/help.go
@@ -138,6 +138,11 @@ USAGE
 
 COMMANDS
 {{formatCommandList .Commands}}
+{{- if .HasLocalFlags}}
+
+FLAGS
+{{.LocalFlags.FlagUsages}}
+{{- end}}
 INHERITED FLAGS
   --help   Show help for command
 {{- if .Example}}


### PR DESCRIPTION
## Summary
- expose `--callback-host` on `multica setup` and `multica setup cloud`, reusing the existing login callback override
- print an SSH tunnel hint when browser login runs in an SSH session with a loopback callback
- show local flags in parent-command help so `multica setup --help` documents the callback option

Fixes #4357

## Tests
- `go test ./cmd/multica -run 'TestCallbackHostFlagValueReadsParentSetupFlag|TestSetupHelpShowsCallbackHostFlag|TestSetupCallbackHostFlagWiring|TestBrowserLoginInstructionsSSHRemoteHint'`
- `go run ./cmd/multica setup --help`
- `go run ./cmd/multica setup cloud --help`
- `git diff --check`
- `go test ./...`
