### PR TITLE
fix(lark): downgrade markdown tables in cards

### DIFF
--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -48,9 +48,11 @@ type APIClient interface {
 	// card (schema 2.0) with a single `tag: "markdown"` body element.
 	// This is the path the chat-reply router takes when the body
 	// contains markdown syntax (fenced code blocks, headings, lists,
-	// tables, etc.) — Lark renders the markdown into formatted text
+	// tables, etc.) — Lark renders most markdown into formatted text
 	// rather than leaving raw `**bold**` / `# heading` characters in
-	// the user's transcript. Returns the card's message_id.
+	// the user's transcript. Table blocks are downgraded before send
+	// because Feishu/Lark caps card table elements. Returns the card's
+	// message_id.
 	SendMarkdownCard(ctx context.Context, p SendMarkdownCardParams) (string, error)
 
 	// SendBindingPromptCard is the dedicated "you need to bind"

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -335,12 +335,14 @@ func (c *httpAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 // SendMarkdownCard posts the agent's reply as an interactive card
 // using Lark's schema-2.0 envelope with a single `tag: "markdown"`
 // body element. Lark's client renders the markdown into formatted
-// text (bold, italics, lists, links, fenced code blocks, tables, …)
+// text (bold, italics, lists, links, fenced code blocks, …)
 // rather than showing raw markdown characters as it does for
-// `msg_type=text`. We deliberately keep `SendTextMessage` as a
-// separate path for plain-prose replies — a card around a one-line
-// "Hello!" adds visual chrome that the user doesn't want; the
-// routing decision (markdown vs text) lives at the Patcher layer.
+// `msg_type=text`. Table blocks are downgraded to fenced text blocks
+// before send because Feishu/Lark rejects cards with too many table
+// elements. We deliberately keep `SendTextMessage` as a separate path
+// for plain-prose replies — a card around a one-line "Hello!" adds
+// visual chrome that the user doesn't want; the routing decision
+// (markdown vs text) lives at the Patcher layer.
 //
 // Why schema 2.0 rather than the legacy schema with a `div` +
 // `lark_md` text element: the legacy `lark_md` tag's markdown
@@ -362,7 +364,7 @@ func (c *httpAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 		"schema": "2.0",
 		"body": map[string]any{
 			"elements": []any{
-				map[string]any{"tag": "markdown", "content": p.Markdown},
+				map[string]any{"tag": "markdown", "content": downgradeMarkdownTablesForLark(p.Markdown)},
 			},
 		},
 	}

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -560,6 +560,53 @@ func TestHTTPClient_SendMarkdownCard_HappyPath(t *testing.T) {
 	}
 }
 
+func TestHTTPClient_SendMarkdownCard_DowngradesMarkdownTables(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok_md", 7200)
+	fake.stubSend(
+		map[string]any{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]string{"message_id": "om_md_1"},
+		},
+		func(r *http.Request, body map[string]string) {
+			var card map[string]any
+			if err := json.Unmarshal([]byte(body["content"]), &card); err != nil {
+				t.Fatalf("content is not valid card JSON: %v", err)
+			}
+			bodyDoc, _ := card["body"].(map[string]any)
+			elements, _ := bodyDoc["elements"].([]any)
+			el, _ := elements[0].(map[string]any)
+			got, _ := el["content"].(string)
+			if !strings.Contains(got, "```text\n| Col A | Col B |\n| --- | --- |\n| 1 | 2 |\n```") {
+				t.Fatalf("markdown table should be downgraded to a text code block, got:\n%s", got)
+			}
+		},
+	)
+
+	c := newTestClient(fake, time.Now)
+	_, err := c.SendMarkdownCard(context.Background(), SendMarkdownCardParams{
+		InstallationID: testCreds(),
+		ChatID:         ChatID("oc_chat_42"),
+		Markdown:       "Before\n\n| Col A | Col B |\n| --- | --- |\n| 1 | 2 |\n\nAfter",
+	})
+	if err != nil {
+		t.Fatalf("send markdown card: %v", err)
+	}
+}
+
+func TestDowngradeMarkdownTablesForLarkLeavesFencedCodeAlone(t *testing.T) {
+	in := "```md\n| already | code |\n| --- | --- |\n```\n\n| A | B |\n| --- | --- |\n| 1 | 2 |"
+	got := downgradeMarkdownTablesForLark(in)
+
+	if strings.Count(got, "```text") != 1 {
+		t.Fatalf("expected exactly one downgraded table block, got:\n%s", got)
+	}
+	if !strings.Contains(got, "```md\n| already | code |\n| --- | --- |\n```") {
+		t.Fatalf("existing fenced code block should stay unchanged, got:\n%s", got)
+	}
+}
+
 // TestHTTPClient_SendTextMessage_EncodesSpecialCharacters guards the
 // inner JSON envelope's escaping. Lark's spec is "content MUST be a
 // JSON-encoded string", which means newlines and quotes have to be
@@ -1109,8 +1156,8 @@ func TestHTTPClient_GetBotInfo_HappyPath(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"bot": map[string]any{
-				"open_id":   "ou_bot_42",
-				"app_name":  "PersonalAgent",
+				"open_id":    "ou_bot_42",
+				"app_name":   "PersonalAgent",
 				"avatar_url": "https://example/avatar.png",
 			},
 		})

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -607,6 +607,15 @@ func TestDowngradeMarkdownTablesForLarkLeavesFencedCodeAlone(t *testing.T) {
 	}
 }
 
+func TestDowngradeMarkdownTablesForLarkHandlesTablesWithoutOuterPipes(t *testing.T) {
+	in := "Before\n\nCol A | Col B\n--- | ---\n1 | 2\n\nAfter"
+	got := downgradeMarkdownTablesForLark(in)
+
+	if !strings.Contains(got, "```text\nCol A | Col B\n--- | ---\n1 | 2\n```") {
+		t.Fatalf("markdown table without outer pipes should be downgraded to a text code block, got:\n%s", got)
+	}
+}
+
 // TestHTTPClient_SendTextMessage_EncodesSpecialCharacters guards the
 // inner JSON envelope's escaping. Lark's spec is "content MUST be a
 // JSON-encoded string", which means newlines and quotes have to be

--- a/server/internal/integrations/lark/markdown_tables.go
+++ b/server/internal/integrations/lark/markdown_tables.go
@@ -1,0 +1,65 @@
+package lark
+
+import "strings"
+
+// downgradeMarkdownTablesForLark keeps markdown replies on the schema-2.0 card
+// path while preventing Lark from materializing GFM tables as card table
+// elements. Feishu/Lark rejects cards with too many table elements, but a
+// fenced text block preserves the tabular content without hitting that quota.
+func downgradeMarkdownTablesForLark(markdown string) string {
+	lines := strings.Split(markdown, "\n")
+	out := make([]string, 0, len(lines))
+	inFence := false
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		if isMarkdownFence(line) {
+			inFence = !inFence
+			out = append(out, line)
+			i++
+			continue
+		}
+		if !inFence && i+1 < len(lines) && isMarkdownTableRow(line) && isMarkdownTableSeparator(lines[i+1]) {
+			start := i
+			i += 2
+			for i < len(lines) && isMarkdownTableRow(lines[i]) {
+				i++
+			}
+			out = append(out, "```text")
+			out = append(out, lines[start:i]...)
+			out = append(out, "```")
+			continue
+		}
+		out = append(out, line)
+		i++
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func isMarkdownFence(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+func isMarkdownTableRow(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "|") && strings.HasSuffix(trimmed, "|") && strings.Count(trimmed, "|") >= 2
+}
+
+func isMarkdownTableSeparator(line string) bool {
+	trimmed := strings.Trim(strings.TrimSpace(line), "|")
+	cells := strings.Split(trimmed, "|")
+	if len(cells) < 2 {
+		return false
+	}
+	for _, cell := range cells {
+		value := strings.TrimSpace(cell)
+		value = strings.TrimPrefix(value, ":")
+		value = strings.TrimSuffix(value, ":")
+		if len(value) < 3 || strings.Trim(value, "-") != "" {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/integrations/lark/markdown_tables.go
+++ b/server/internal/integrations/lark/markdown_tables.go
@@ -44,12 +44,14 @@ func isMarkdownFence(line string) bool {
 
 func isMarkdownTableRow(line string) bool {
 	trimmed := strings.TrimSpace(line)
-	return strings.HasPrefix(trimmed, "|") && strings.HasSuffix(trimmed, "|") && strings.Count(trimmed, "|") >= 2
+	if !strings.Contains(trimmed, "|") {
+		return false
+	}
+	return len(markdownTableCells(trimmed)) >= 2
 }
 
 func isMarkdownTableSeparator(line string) bool {
-	trimmed := strings.Trim(strings.TrimSpace(line), "|")
-	cells := strings.Split(trimmed, "|")
+	cells := markdownTableCells(line)
 	if len(cells) < 2 {
 		return false
 	}
@@ -62,4 +64,12 @@ func isMarkdownTableSeparator(line string) bool {
 		}
 	}
 	return true
+}
+
+func markdownTableCells(line string) []string {
+	trimmed := strings.Trim(strings.TrimSpace(line), "|")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "|")
 }


### PR DESCRIPTION
## Summary
- downgrade GFM table blocks in Lark markdown cards to fenced `text` code blocks before sending
- leave existing fenced code blocks unchanged while preserving the table content as readable text
- update Lark markdown card docs/tests to cover Feishu/Lark table element limits

Fixes #4133

## Tests
- `go test ./internal/integrations/lark -run 'TestHTTPClient_SendMarkdownCard_DowngradesMarkdownTables|TestDowngradeMarkdownTablesForLarkLeavesFencedCodeAlone|TestHTTPClient_SendMarkdownCard_HappyPath'`\n- `go test ./internal/integrations/lark`\n- `git diff --check`\n- `go test ./...`