### PR TITLE
feat(squad): surface member skills in leader briefing roster

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -25,6 +26,8 @@ Your responsibilities, in order:
 
 1. **Read the issue** (title, description, latest comments, acceptance
    criteria) and decide which squad member is best suited to do the work.
+   Match the task to each member's listed **skills** and role in the Squad
+   Roster below — prefer the member whose skills cover the work.
 2. **Delegate by @mention.** Post a single comment on this issue that
    @mentions the chosen member(s) and tells them what to do.
    - **Be terse.** Every Multica agent already has full context of the
@@ -178,7 +181,9 @@ func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember) strin
 		if ag.ArchivedAt.Valid {
 			return ""
 		}
-		return formatRosterRow(ag.Name, "agent", role, formatMention(ag.Name, "agent", id))
+		// Agents carry skills; surfacing them lets the leader delegate by
+		// capability instead of guessing from the free-text role label.
+		return formatRosterRow(ag.Name, "agent", role, agentSkillsRosterSegment(ctx, q, m.MemberID), formatMention(ag.Name, "agent", id))
 	case "member":
 		user, err := q.GetUser(ctx, m.MemberID)
 		if err != nil {
@@ -186,14 +191,38 @@ func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember) strin
 		}
 		// Mention syntax for humans uses the user_id (matches the rest of
 		// the product — see util.MentionRe and frontend mention payloads).
+		// Humans have no Multica skills, so no skills segment is rendered.
 		userID := util.UUIDToString(m.MemberID)
-		return formatRosterRow(user.Name, "member (human)", role, formatMention(user.Name, "member", userID))
+		return formatRosterRow(user.Name, "member (human)", role, "", formatMention(user.Name, "member", userID))
 	default:
 		return ""
 	}
 }
 
-func formatRosterRow(name, kind, role, mention string) string {
+// agentSkillsRosterSegment returns the roster segment describing an agent
+// member's assigned skills. "skills: a, b" when the agent has skills (the
+// names are pre-sorted by ListAgentSkillSummaries), "no skills assigned" when
+// it has none so the leader knows the capability is genuinely absent, and ""
+// only when the lookup fails — a transient DB error degrades to the prior
+// name+role row rather than asserting a misleading "no skills". Builtin
+// multica-* skills are added at runtime (not in agent_skill) and are
+// deliberately omitted; the leader cares about the configured capabilities.
+func agentSkillsRosterSegment(ctx context.Context, q *db.Queries, agentID pgtype.UUID) string {
+	skills, err := q.ListAgentSkillSummaries(ctx, agentID)
+	if err != nil {
+		return ""
+	}
+	if len(skills) == 0 {
+		return "no skills assigned"
+	}
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		names = append(names, s.Name)
+	}
+	return "skills: " + strings.Join(names, ", ")
+}
+
+func formatRosterRow(name, kind, role, skills, mention string) string {
 	var sb strings.Builder
 	sb.WriteString("- ")
 	sb.WriteString(name)
@@ -203,6 +232,10 @@ func formatRosterRow(name, kind, role, mention string) string {
 		sb.WriteString(`, role: "`)
 		sb.WriteString(role)
 		sb.WriteString(`"`)
+	}
+	if skills != "" {
+		sb.WriteString(" — ")
+		sb.WriteString(skills)
 	}
 	sb.WriteString(" — `")
 	sb.WriteString(mention)

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -150,6 +150,64 @@ func TestBuildSquadLeaderBriefing_FullSquad(t *testing.T) {
 	}
 }
 
+// assignSkillToAgent creates a workspace skill and attaches it to the agent,
+// registering cleanup for the skill row (agent_skill cascades on skill delete).
+func assignSkillToAgent(t *testing.T, agentID, skillName string) {
+	t.Helper()
+	ctx := context.Background()
+	var skillID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO skill (workspace_id, name, description, content, created_by)
+		VALUES ($1, $2, '', '', $3)
+		RETURNING id
+	`, testWorkspaceID, skillName, testUserID).Scan(&skillID); err != nil {
+		t.Fatalf("create skill %s: %v", skillName, err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM skill WHERE id = $1`, skillID) })
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+		agentID, skillID,
+	); err != nil {
+		t.Fatalf("assign skill %s to agent: %v", skillName, err)
+	}
+}
+
+// TestBuildSquadLeaderBriefing_MemberSkillsInRoster locks in the delegation
+// fix: an agent member's assigned skills appear in the leader roster so the
+// leader can route by capability. Agents with no skills get an explicit
+// marker; human members never carry a skills segment.
+func TestBuildSquadLeaderBriefing_MemberSkillsInRoster(t *testing.T) {
+	ctx := context.Background()
+	leaderID, _ := seededLeaderAgent(t)
+	squad := seedSquadForBriefing(t, leaderID, "Skilled Squad", "")
+
+	skilled := createHandlerTestAgent(t, "Skilled Bot", []byte("[]"))
+	addAgentMember(t, squad.ID, skilled, "backend")
+	// ListAgentSkillSummaries orders by name ASC → "polars" before "stat…".
+	assignSkillToAgent(t, skilled, "polars")
+	assignSkillToAgent(t, skilled, "statistical-analysis")
+
+	plain := createHandlerTestAgent(t, "Plain Bot", []byte("[]"))
+	addAgentMember(t, squad.ID, plain, "")
+
+	memberRowID, userID, userName := seededHumanMember(t)
+	_ = memberRowID
+	addHumanMember(t, squad.ID, userID, "reviewer")
+
+	out := buildSquadLeaderBriefing(ctx, testHandler.Queries, squad)
+
+	if !strings.Contains(out, "skills: polars, statistical-analysis") {
+		t.Errorf("expected skilled member skills in roster, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Plain Bot — agent — no skills assigned") {
+		t.Errorf("expected no-skills marker for skill-less agent, got:\n%s", out)
+	}
+	if strings.Contains(out, userName+" — member (human), role: \"reviewer\" — skills:") ||
+		strings.Contains(out, userName+" — member (human), role: \"reviewer\" — no skills") {
+		t.Errorf("human member must not render a skills segment, got:\n%s", out)
+	}
+}
+
 func TestBuildSquadLeaderBriefing_OnlyLeader(t *testing.T) {
 	ctx := context.Background()
 	leaderID, _ := seededLeaderAgent(t)
@@ -226,34 +284,34 @@ func TestBuildSquadLeaderBriefing_MentionsRoundTrip(t *testing.T) {
 // claimAndDecodeAgent runs ClaimTaskByRuntime for the given runtime and
 // returns the agent block of the response. Fails the test on non-200.
 func claimAndDecodeAgent(t *testing.T, runtimeID string) *TaskAgentData {
-t.Helper()
-w := httptest.NewRecorder()
-req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-squad-briefing")
-req = withURLParam(req, "runtimeId", runtimeID)
-testHandler.ClaimTaskByRuntime(w, req)
-if w.Code != http.StatusOK {
-t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
-}
-var resp struct {
-Task *struct {
-Agent *TaskAgentData `json:"agent"`
-} `json:"task"`
-}
-if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-t.Fatalf("decode: %v", err)
-}
-if resp.Task == nil || resp.Task.Agent == nil {
-t.Fatalf("expected task.agent in response, got: %s", w.Body.String())
-}
-return resp.Task.Agent
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-squad-briefing")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Task *struct {
+			Agent *TaskAgentData `json:"agent"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task == nil || resp.Task.Agent == nil {
+		t.Fatalf("expected task.agent in response, got: %s", w.Body.String())
+	}
+	return resp.Task.Agent
 }
 
 // queueSquadIssueTaskFor creates an issue assigned to the squad and a queued
 // task for the given (agentID, runtimeID). Returns the issue + task IDs.
 func queueSquadIssueTaskFor(t *testing.T, squadID, agentID, runtimeID string, issueNumber int) (issueID, taskID string) {
-t.Helper()
-ctx := context.Background()
-if err := testPool.QueryRow(ctx, `
+	t.Helper()
+	ctx := context.Background()
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO issue (
 workspace_id, title, status, priority, creator_id, creator_type,
 assignee_type, assignee_id, number, position
@@ -261,101 +319,101 @@ assignee_type, assignee_id, number, position
 'squad', $3, $4, 0)
 RETURNING id
 `, testWorkspaceID, testUserID, squadID, issueNumber).Scan(&issueID); err != nil {
-t.Fatalf("create squad-assigned issue: %v", err)
-}
-t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+		t.Fatalf("create squad-assigned issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
 
-if err := testPool.QueryRow(ctx, `
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
 VALUES ($1, $2, $3, 'queued', 0)
 RETURNING id
 `, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
-t.Fatalf("queue task: %v", err)
-}
-t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
-return
+		t.Fatalf("queue task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	return
 }
 
 // TestClaimTask_LeaderGetsBriefing — when the squad leader claims a task on
 // a squad-assigned issue, the response's agent.instructions must include
 // the Operating Protocol + Roster + user instructions.
 func TestClaimTask_LeaderGetsBriefing(t *testing.T) {
-if testHandler == nil {
-t.Skip("database not available")
-}
-ctx := context.Background()
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
 
-var leaderID, runtimeID string
-if err := testPool.QueryRow(ctx,
-`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
-testWorkspaceID,
-).Scan(&leaderID, &runtimeID); err != nil {
-t.Fatalf("get leader agent: %v", err)
-}
+	var leaderID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&leaderID, &runtimeID); err != nil {
+		t.Fatalf("get leader agent: %v", err)
+	}
 
-squad := seedSquadForBriefing(t, leaderID, "Briefing Claim Squad", "Be terse.")
+	squad := seedSquadForBriefing(t, leaderID, "Briefing Claim Squad", "Be terse.")
 
-helper := createHandlerTestAgent(t, "Briefing Helper", []byte("[]"))
-addAgentMember(t, squad.ID, helper, "implementer")
+	helper := createHandlerTestAgent(t, "Briefing Helper", []byte("[]"))
+	addAgentMember(t, squad.ID, helper, "implementer")
 
-queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), leaderID, runtimeID, 95001)
+	queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), leaderID, runtimeID, 95001)
 
-agent := claimAndDecodeAgent(t, runtimeID)
-for _, want := range []string{
-"## Squad Operating Protocol",
-"## Squad Roster",
-"Leader (you):",
-"## Squad Instructions (Briefing Claim Squad)",
-"Be terse.",
-"`[@Briefing Helper](mention://agent/" + helper + ")`",
-} {
-if !strings.Contains(agent.Instructions, want) {
-t.Errorf("expected agent.instructions to contain %q\n--- instructions ---\n%s", want, agent.Instructions)
-}
-}
+	agent := claimAndDecodeAgent(t, runtimeID)
+	for _, want := range []string{
+		"## Squad Operating Protocol",
+		"## Squad Roster",
+		"Leader (you):",
+		"## Squad Instructions (Briefing Claim Squad)",
+		"Be terse.",
+		"`[@Briefing Helper](mention://agent/" + helper + ")`",
+	} {
+		if !strings.Contains(agent.Instructions, want) {
+			t.Errorf("expected agent.instructions to contain %q\n--- instructions ---\n%s", want, agent.Instructions)
+		}
+	}
 }
 
 // TestClaimTask_NonLeaderGetsNoBriefing — when a non-leader squad member
 // claims a task on a squad-assigned issue, NO briefing is injected.
 func TestClaimTask_NonLeaderGetsNoBriefing(t *testing.T) {
-if testHandler == nil {
-t.Skip("database not available")
-}
-ctx := context.Background()
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
 
-var leaderID string
-if err := testPool.QueryRow(ctx,
-`SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
-testWorkspaceID,
-).Scan(&leaderID); err != nil {
-t.Fatalf("get leader agent: %v", err)
-}
+	var leaderID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&leaderID); err != nil {
+		t.Fatalf("get leader agent: %v", err)
+	}
 
-squad := seedSquadForBriefing(t, leaderID, "Non-Leader Squad", "Squad guidance.")
+	squad := seedSquadForBriefing(t, leaderID, "Non-Leader Squad", "Squad guidance.")
 
-// Create a second agent (NOT the leader) with its own runtime so the
-// claim path picks its task without ambiguity.
-helperID := createHandlerTestAgent(t, "Non Leader Helper", []byte("[]"))
-addAgentMember(t, squad.ID, helperID, "")
-var helperRuntime string
-if err := testPool.QueryRow(ctx,
-`SELECT runtime_id FROM agent WHERE id = $1`, helperID,
-).Scan(&helperRuntime); err != nil {
-t.Fatalf("get helper runtime: %v", err)
-}
+	// Create a second agent (NOT the leader) with its own runtime so the
+	// claim path picks its task without ambiguity.
+	helperID := createHandlerTestAgent(t, "Non Leader Helper", []byte("[]"))
+	addAgentMember(t, squad.ID, helperID, "")
+	var helperRuntime string
+	if err := testPool.QueryRow(ctx,
+		`SELECT runtime_id FROM agent WHERE id = $1`, helperID,
+	).Scan(&helperRuntime); err != nil {
+		t.Fatalf("get helper runtime: %v", err)
+	}
 
-queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), helperID, helperRuntime, 95002)
+	queueSquadIssueTaskFor(t, util.UUIDToString(squad.ID), helperID, helperRuntime, 95002)
 
-agent := claimAndDecodeAgent(t, helperRuntime)
-for _, mustNot := range []string{
-"Squad Operating Protocol",
-"Squad Roster",
-"Squad Instructions (Non-Leader Squad)",
-} {
-if strings.Contains(agent.Instructions, mustNot) {
-t.Errorf("non-leader claim should NOT contain %q\n--- instructions ---\n%s", mustNot, agent.Instructions)
-}
-}
+	agent := claimAndDecodeAgent(t, helperRuntime)
+	for _, mustNot := range []string{
+		"Squad Operating Protocol",
+		"Squad Roster",
+		"Squad Instructions (Non-Leader Squad)",
+	} {
+		if strings.Contains(agent.Instructions, mustNot) {
+			t.Errorf("non-leader claim should NOT contain %q\n--- instructions ---\n%s", mustNot, agent.Instructions)
+		}
+	}
 }
 
 // Avoid "imported and not used: pgtype" if helpers above are the only users.

--- a/server/internal/service/builtin_skills/multica-squads/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-squads/SKILL.md
@@ -138,7 +138,12 @@ agent instructions. The briefing includes:
 - Squad Instructions, only when `instructions` is non-empty.
 
 Roster entries include member name, member type, mention markdown, and non-empty
-role. Archived agent members are skipped from the briefing roster.
+role. For agent members the roster also lists their assigned skills
+(`skills: a, b`, or `no skills assigned` when the agent has none) so the leader
+can delegate by capability instead of guessing from the role label; human
+members carry no skills segment. Builtin `multica-*` skills are not listed —
+only the workspace skills explicitly attached to the agent. Archived agent
+members are skipped from the briefing roster.
 
 ## Issue assignment behavior
 

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -81,7 +81,7 @@ Contracts:
 Source:
 
 ```text
-server/internal/handler/squad_briefing.go         # buildSquadLeaderBriefing ~104, buildSquadRoster ~121, renderMemberRow ~169
+server/internal/handler/squad_briefing.go         # buildSquadLeaderBriefing ~104, buildSquadRoster ~121, renderMemberRow ~169, agentSkillsRosterSegment, formatRosterRow
 server/internal/handler/daemon.go                  # briefing injection ~1187, ~1530
 ```
 
@@ -93,6 +93,10 @@ Contracts:
   (squad_briefing.go:104-117);
 - `instructions` section appears only when non-empty (squad_briefing.go:110-112);
 - archived agent members are skipped from roster (squad_briefing.go:178-179);
+- agent member roster rows list assigned workspace skills via
+  `agentSkillsRosterSegment` (ListAgentSkillSummaries) — "skills: a, b" or
+  "no skills assigned"; builtin multica-* skills are excluded and human
+  members carry no skills segment (squad_briefing.go renderMemberRow);
 - no traced behavior injects `instructions` into every squad member.
 
 ## Issue Assignment


### PR DESCRIPTION
## What

When an issue is assigned to a squad, only the **leader** agent is triggered; it coordinates by `@mention`-delegating to members. The leader briefing's **Squad Roster** listed each member's name, type, role and mention link — but **not the member's assigned skills**. So the leader had to infer each member's capability from the free-text `role` label alone when deciding who to delegate to.

This surfaces each agent member's assigned skills directly in the roster row:

    - Web Researcher — agent, role: "member" — skills: parallel-web, perplexity-search, research-lookup, x-research — `[@Web Researcher](mention://agent/…)`

## How

- `renderMemberRow` loads each agent member's skills via `ListAgentSkillSummaries`; `formatRosterRow` renders a `skills: a, b` segment (or `no skills assigned` when the agent has none).
- Builtin `multica-*` skills are excluded (they aren't in `agent_skill`); human members carry no skills segment; a skill-lookup error degrades to the prior name+role row rather than asserting a misleading "no skills".
- Operating-protocol step 1 now tells the leader to match the task to each member's listed skills.
- Live-read at briefing-build time, so it reflects per-agent skill changes on the next trigger. No schema change, no new field.

## Tests / docs

- Adds `TestBuildSquadLeaderBriefing_MemberSkillsInRoster`.
- Updates the `multica-squads` builtin skill and its `references/squad-source-map.md` per the source-traced-skill convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
