### PR TITLE
AOL-546: keep autopilot list order stable

### DIFF
--- a/packages/core/autopilots/stores/view-store.test.ts
+++ b/packages/core/autopilots/stores/view-store.test.ts
@@ -1,0 +1,12 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { useAutopilotsViewStore } from "./view-store";
+
+describe("useAutopilotsViewStore", () => {
+  it("defaults to newest-created order", () => {
+    const initialState = useAutopilotsViewStore.getInitialState();
+
+    expect(initialState.sortField).toBe("created");
+    expect(initialState.sortDirection).toBe("desc");
+  });
+});

--- a/packages/core/autopilots/stores/view-store.ts
+++ b/packages/core/autopilots/stores/view-store.ts
@@ -92,8 +92,8 @@ export interface AutopilotsViewState {
 
 const DEFAULTS = {
   scope: "all" as AutopilotScope,
-  sortField: "lastRun" as AutopilotSortField,
-  sortDirection: AUTOPILOT_SORT_DEFAULT_DIRECTION.lastRun,
+  sortField: "created" as AutopilotSortField,
+  sortDirection: AUTOPILOT_SORT_DEFAULT_DIRECTION.created,
   hiddenColumns: AUTOPILOT_DEFAULT_HIDDEN_COLUMNS,
   filters: EMPTY_AUTOPILOT_FILTERS,
 };

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -718,7 +718,11 @@ export function AutopilotsPage() {
       // lastRun: never-ran rows sort as oldest.
       const av = a.last_run_at ? Date.parse(a.last_run_at) : 0;
       const bv = b.last_run_at ? Date.parse(b.last_run_at) : 0;
-      return (av - bv) * dir || a.title.localeCompare(b.title);
+      return (
+        (av - bv) * dir ||
+        Date.parse(b.created_at) - Date.parse(a.created_at) ||
+        a.title.localeCompare(b.title)
+      );
     });
     return filtered;
   }, [scopeRows, filters, sortField, sortDirection]);


### PR DESCRIPTION
Closes AOL-546

## Summary
- default the autopilots list to newest-created order, matching the list API
- keep last-run sorting stable by falling back to created time before title
- add a store test covering the default sort

## Verification
- pnpm --filter @multica/core test -- autopilots/stores/view-store.test.ts
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck