### PR TITLE
[codex] fix self-host docs URL fallback

### DIFF
--- a/apps/web/config/runtime-urls.test.ts
+++ b/apps/web/config/runtime-urls.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveRemoteApiUrl } from "./runtime-urls";
+import { resolveDocsUrl, resolveRemoteApiUrl } from "./runtime-urls";
+
+describe("resolveDocsUrl", () => {
+  it("prefers DOCS_URL when explicitly configured", () => {
+    expect(
+      resolveDocsUrl({
+        DOCS_URL: "https://docs.example.com",
+        NODE_ENV: "production",
+      }),
+    ).toBe("https://docs.example.com");
+  });
+
+  it("uses the public docs site for production builds", () => {
+    expect(resolveDocsUrl({ NODE_ENV: "production" })).toBe(
+      "https://multica.ai",
+    );
+  });
+
+  it("keeps the local docs dev server default outside production", () => {
+    expect(resolveDocsUrl({ NODE_ENV: "development" })).toBe(
+      "http://localhost:4000",
+    );
+    expect(resolveDocsUrl({})).toBe("http://localhost:4000");
+  });
+});
 
 describe("resolveRemoteApiUrl", () => {
   it("prefers REMOTE_API_URL when explicitly configured", () => {

--- a/apps/web/config/runtime-urls.ts
+++ b/apps/web/config/runtime-urls.ts
@@ -1,5 +1,14 @@
 type RuntimeEnv = Record<string, string | undefined>;
 
+export function resolveDocsUrl(env: RuntimeEnv): string {
+  const explicitDocs = env.DOCS_URL?.trim();
+  if (explicitDocs) return explicitDocs;
+
+  if (env.NODE_ENV === "production") return "https://multica.ai";
+
+  return "http://localhost:4000";
+}
+
 export function resolveRemoteApiUrl(env: RuntimeEnv): string {
   const explicitRemote = env.REMOTE_API_URL?.trim();
   if (explicitRemote) return explicitRemote;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,14 +1,14 @@
 import type { NextConfig } from "next";
 import { config } from "dotenv";
 import { resolve } from "path";
-import { resolveRemoteApiUrl } from "./config/runtime-urls";
+import { resolveDocsUrl, resolveRemoteApiUrl } from "./config/runtime-urls";
 import { createMDX } from "fumadocs-mdx/next";
 
 // Load root .env so REMOTE_API_URL is available to next.config.ts
 config({ path: resolve(__dirname, "../../.env") });
 
 const remoteApiUrl = resolveRemoteApiUrl(process.env);
-const docsUrl = process.env.DOCS_URL || "http://localhost:4000";
+const docsUrl = resolveDocsUrl(process.env);
 
 // Parse hostnames from CORS_ALLOWED_ORIGINS so that Next.js dev server
 // allows cross-origin HMR / webpack requests (e.g. from Tailscale IPs).


### PR DESCRIPTION
## What changed

- Added `resolveDocsUrl` so web builds can choose the docs rewrite target from one place.
- Kept `DOCS_URL` as the explicit override.
- Changed production defaults to proxy `/docs` to `https://multica.ai` instead of `http://localhost:4000`.
- Kept non-production defaults pointed at the local docs dev server on port 4000.

## Why

The self-host Docker Compose stack starts Postgres, backend, and frontend, but not the docs app. In a production standalone web container, the previous fallback made `/docs` proxy to `localhost:4000` inside the frontend container, which returns `500 Internal Server Error` when no docs server is running.

## Validation

- `pnpm --filter @multica/web test -- runtime-urls`
- `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build frontend`
- `curl -i http://localhost:3000/docs` returned `200 OK`
- `curl -i http://localhost:3000/docs/zh` returned `200 OK`
- `curl -i http://localhost:8080/health` returned `200 OK`
