### PR TITLE
feat(daemon): scope runtime registration to an optional workspace allowlist

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -174,6 +174,7 @@ Daemon behavior is configured via flags or environment variables:
 | Daemon ID | `--daemon-id` | `MULTICA_DAEMON_ID` | hostname |
 | Device name | `--device-name` | `MULTICA_DAEMON_DEVICE_NAME` | hostname |
 | Runtime name | `--runtime-name` | `MULTICA_AGENT_RUNTIME_NAME` | `Local Agent` |
+| Workspace allowlist | `--workspace-allowlist` | `MULTICA_DAEMON_WORKSPACE_ALLOWLIST` | empty (all workspaces) |
 | Workspaces root | — | `MULTICA_WORKSPACES_ROOT` | `~/multica_workspaces` |
 | GC enabled | — | `MULTICA_GC_ENABLED` | `true` (set `false`/`0` to disable) |
 | GC scan interval | — | `MULTICA_GC_INTERVAL` | `1h` |
@@ -181,6 +182,23 @@ Daemon behavior is configured via flags or environment variables:
 | GC orphan TTL (no `.gc_meta.json`) | — | `MULTICA_GC_ORPHAN_TTL` | `72h` |
 | GC artifact TTL (open issues) | — | `MULTICA_GC_ARTIFACT_TTL` | `12h` (set `0` to disable) |
 | GC artifact patterns | — | `MULTICA_GC_ARTIFACT_PATTERNS` | `node_modules,.next,.turbo` |
+
+#### Workspace allowlist
+
+By default the daemon registers a runtime in **every** workspace your login token can reach. On a shared self-hosted instance you may want a given machine to be visible only to specific workspaces — for example, a company build server that should appear in `eskyfun` but not `funtimes`. Pass `--workspace-allowlist` (or set `MULTICA_DAEMON_WORKSPACE_ALLOWLIST`) to restrict it:
+
+```bash
+# Only register in the eskyfun and funtimes workspaces
+multica daemon start --workspace-allowlist eskyfun,funtimes
+
+# Repeatable form works too
+multica daemon start --workspace-allowlist eskyfun --workspace-allowlist funtimes
+
+# Env var equivalent
+MULTICA_DAEMON_WORKSPACE_ALLOWLIST=eskyfun,funtimes multica daemon start
+```
+
+Each entry matches a workspace **slug** (the identifier in its URL, e.g. `eskyfun`) or its **ID**, case-insensitively. When the allowlist is empty (the default), every accessible workspace is registered. Workspaces outside the allowlist are never registered; if a machine previously registered in one, the daemon stops heartbeating it and the server marks that runtime offline shortly after.
 
 #### Workspace garbage collection
 

--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -62,6 +62,28 @@ Key points:
 **Cloud runtimes are coming**, currently in a waitlist phase. Once available, you'll be able to execute agent tasks directly on Multica Cloud without running a local daemon. Sign up with your email on the [download page](https://multica.ai/download) to get notified.
 </Callout>
 
+## Scoping a daemon to specific workspaces
+
+By default a daemon registers a runtime in **every** workspace your login token can reach. On a shared self-hosted instance — multiple teams or orgs on one Multica server — you may want a specific machine to be visible only to certain workspaces. A company build server, for example, might belong in `eskyfun` but not in `funtimes`.
+
+Pass `--workspace-allowlist` (or set `MULTICA_DAEMON_WORKSPACE_ALLOWLIST`) when starting the daemon:
+
+```bash
+# Slug or ID, comma-separated…
+multica daemon start --workspace-allowlist eskyfun,funtimes
+
+# …or repeated, or via env var
+MULTICA_DAEMON_WORKSPACE_ALLOWLIST=eskyfun multica daemon start
+```
+
+- Each entry matches a workspace **slug** (the identifier in its URL) or its **ID**, case-insensitively.
+- An empty allowlist (the default) keeps today's behavior: every accessible workspace is registered.
+- Workspaces outside the allowlist are never registered. If a machine previously registered in one, the daemon stops heartbeating that runtime and the server marks it offline within seconds (and auto-deletes it later, per the thresholds below).
+
+<Callout type="info">
+This filters which workspaces a **daemon** registers in. It does not change what your account can access in the web UI — for that, manage workspace membership instead.
+</Callout>
+
 ## When a runtime is marked offline
 
 Multica uses heartbeats to decide whether a runtime is online. Three key numbers:

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -179,6 +179,7 @@ The daemon runs on the user's local machine, and its config is read from local e
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | Heartbeat interval |
 | `MULTICA_DAEMON_POLL_INTERVAL` | `3s` | Task polling interval |
 | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` | Max concurrent tasks |
+| `MULTICA_DAEMON_WORKSPACE_ALLOWLIST` | empty | Comma-separated workspace slugs or IDs the daemon may register runtimes in. Empty = all accessible workspaces. See [Daemon and runtimes](/daemon-runtimes#scoping-a-daemon-to-specific-workspaces) |
 | `MULTICA_<PROVIDER>_PATH` | matches the CLI name | Path to each AI coding tool's executable (for example `MULTICA_CLAUDE_PATH`) |
 | `MULTICA_<PROVIDER>_MODEL` | empty | Default model for each AI coding tool |
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -88,6 +88,7 @@ func init() {
 	f.Int("max-concurrent-tasks", 0, "Max tasks running in parallel (env: MULTICA_DAEMON_MAX_CONCURRENT_TASKS)")
 	f.Bool("no-auto-update", false, "Disable periodic CLI self-update (env: MULTICA_DAEMON_AUTO_UPDATE=false)")
 	f.Duration("auto-update-interval", 0, "How often to poll GitHub for a newer release (env: MULTICA_DAEMON_AUTO_UPDATE_INTERVAL)")
+	f.StringSlice("workspace-allowlist", nil, "Only register runtimes in these workspaces (slug or ID; comma-separated or repeatable). Empty = all accessible workspaces (env: MULTICA_DAEMON_WORKSPACE_ALLOWLIST)")
 
 	daemonLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	daemonLogsCmd.Flags().IntP("lines", "n", 50, "Number of lines to show")
@@ -107,6 +108,7 @@ func init() {
 	rf.Int("max-concurrent-tasks", 0, "Max tasks running in parallel (env: MULTICA_DAEMON_MAX_CONCURRENT_TASKS)")
 	rf.Bool("no-auto-update", false, "Disable periodic CLI self-update (env: MULTICA_DAEMON_AUTO_UPDATE=false)")
 	rf.Duration("auto-update-interval", 0, "How often to poll GitHub for a newer release (env: MULTICA_DAEMON_AUTO_UPDATE_INTERVAL)")
+	rf.StringSlice("workspace-allowlist", nil, "Only register runtimes in these workspaces (slug or ID; comma-separated or repeatable). Empty = all accessible workspaces (env: MULTICA_DAEMON_WORKSPACE_ALLOWLIST)")
 
 	df := daemonDiskUsageCmd.Flags()
 	df.Bool("by-workspace", false, "Aggregate output by workspace instead of by task")
@@ -320,6 +322,9 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if d, _ := cmd.Flags().GetDuration("auto-update-interval"); d > 0 {
 		args = append(args, "--auto-update-interval", d.String())
 	}
+	if v, _ := cmd.Flags().GetStringSlice("workspace-allowlist"); len(v) > 0 {
+		args = append(args, "--workspace-allowlist", strings.Join(v, ","))
+	}
 
 	// Forward global persistent flags.
 	if v, _ := cmd.Flags().GetString("server-url"); v != "" {
@@ -343,13 +348,15 @@ func runDaemonForeground(cmd *cobra.Command) error {
 			serverURL = c.ServerURL
 		}
 	}
+	allowlist, _ := cmd.Flags().GetStringSlice("workspace-allowlist")
 	overrides := daemon.Overrides{
-		ServerURL:   serverURL,
-		DaemonID:    flagString(cmd, "daemon-id"),
-		DeviceName:  flagString(cmd, "device-name"),
-		RuntimeName: flagString(cmd, "runtime-name"),
-		Profile:     profile,
-		HealthPort:  healthPortForProfile(profile),
+		ServerURL:          serverURL,
+		DaemonID:           flagString(cmd, "daemon-id"),
+		DeviceName:         flagString(cmd, "device-name"),
+		RuntimeName:        flagString(cmd, "runtime-name"),
+		Profile:            profile,
+		HealthPort:         healthPortForProfile(profile),
+		WorkspaceAllowlist: allowlist,
 	}
 	if d, _ := cmd.Flags().GetDuration("poll-interval"); d > 0 {
 		overrides.PollInterval = d

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -325,6 +325,10 @@ func (c *Client) ReportLocalSkillImportResult(ctx context.Context, runtimeID, re
 type WorkspaceInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	// Slug is the human-readable workspace identifier used in URLs (e.g.
+	// "eskyfun"). Surfaced so the daemon's --workspace-allowlist can match on
+	// it; the server already includes it in the /api/workspaces response.
+	Slug string `json:"slug"`
 }
 
 // RenewTokenResponse mirrors handler.RenewPATResponse — kept loose (string +

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	Profile                        string                // profile name (empty = default)
 	Agents                         map[string]AgentEntry // keyed by provider: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, antigravity
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
+	WorkspaceAllowlist             []string              // when non-empty, only register runtimes in workspaces whose slug or ID matches (case-insensitive); empty = all accessible workspaces
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
 	MaxConcurrentTasks             int                   // max tasks running in parallel (default: 20)
@@ -115,10 +116,14 @@ type Config struct {
 // Overrides allows CLI flags to override environment variables and defaults.
 // Zero values are ignored and the env/default value is used instead.
 type Overrides struct {
-	ServerURL         string
-	WorkspacesRoot    string
-	PollInterval      time.Duration
-	HeartbeatInterval time.Duration
+	ServerURL      string
+	WorkspacesRoot string
+	// WorkspaceAllowlist, when non-empty, restricts the daemon to workspaces
+	// whose slug or ID matches one of these entries. Empty = use env/default
+	// (no restriction).
+	WorkspaceAllowlist []string
+	PollInterval       time.Duration
+	HeartbeatInterval  time.Duration
 	// AgentTimeout is a pointer so an explicit `--agent-timeout 0` (no cap) is
 	// distinguishable from "flag not passed". nil = use env/default.
 	AgentTimeout                   *time.Duration
@@ -433,6 +438,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
+	// Workspace allowlist: override > env > default (empty = no restriction).
+	// A non-empty CLI override fully replaces the env value, mirroring the
+	// string-override precedence used for WorkspacesRoot above.
+	workspaceAllowlist := listFromEnv("MULTICA_DAEMON_WORKSPACE_ALLOWLIST")
+	if len(overrides.WorkspaceAllowlist) > 0 {
+		workspaceAllowlist = overrides.WorkspaceAllowlist
+	}
+
 	// Health port: override > default
 	healthPort := DefaultHealthPort
 	if overrides.HealthPort > 0 {
@@ -503,6 +516,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		Profile:                        profile,
 		Agents:                         agents,
 		WorkspacesRoot:                 workspacesRoot,
+		WorkspaceAllowlist:             workspaceAllowlist,
 		KeepEnvAfterTask:               keepEnv,
 		GCEnabled:                      gcEnabled,
 		GCInterval:                     gcInterval,
@@ -627,6 +641,29 @@ func patternsFromEnv(name string, defaults []string) []string {
 			continue
 		}
 		out = append(out, p)
+	}
+	return out
+}
+
+// listFromEnv reads a comma-separated list from env, trimming whitespace and
+// dropping empty entries. Unlike patternsFromEnv it keeps entries containing
+// path separators — the workspace allowlist matches slugs and UUIDs, neither of
+// which is path-shaped, and silently dropping such an entry would be a footgun.
+// Returns nil when the env var is unset or yields no usable entries.
+func listFromEnv(name string) []string {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -857,3 +857,48 @@ func agentKeys(m map[string]AgentEntry) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+// TestLoadConfig_WorkspaceAllowlist covers the --workspace-allowlist resolution
+// (issue #3223): the env var parses a trimmed comma-separated list, a non-empty
+// CLI override fully replaces it, and an unset env yields no restriction.
+func TestLoadConfig_WorkspaceAllowlist(t *testing.T) {
+	t.Run("from env, trimmed", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_DAEMON_WORKSPACE_ALLOWLIST", " eskyfun , funtimes ,")
+		cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if want := []string{"eskyfun", "funtimes"}; !reflect.DeepEqual(cfg.WorkspaceAllowlist, want) {
+			t.Fatalf("WorkspaceAllowlist = %v, want %v", cfg.WorkspaceAllowlist, want)
+		}
+	})
+
+	t.Run("override wins over env", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_DAEMON_WORKSPACE_ALLOWLIST", "eskyfun")
+		cfg, err := LoadConfig(Overrides{
+			ServerURL:          "http://localhost:8080",
+			WorkspacesRoot:     t.TempDir(),
+			WorkspaceAllowlist: []string{"only-this"},
+		})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if want := []string{"only-this"}; !reflect.DeepEqual(cfg.WorkspaceAllowlist, want) {
+			t.Fatalf("WorkspaceAllowlist = %v, want %v", cfg.WorkspaceAllowlist, want)
+		}
+	})
+
+	t.Run("unset env yields no restriction", func(t *testing.T) {
+		stageFakeAgent(t)
+		t.Setenv("MULTICA_DAEMON_WORKSPACE_ALLOWLIST", "")
+		cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if len(cfg.WorkspaceAllowlist) != 0 {
+			t.Fatalf("WorkspaceAllowlist = %v, want empty", cfg.WorkspaceAllowlist)
+		}
+	})
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1605,6 +1605,41 @@ func (d *Daemon) tryRenewToken(ctx context.Context) {
 	}
 }
 
+// workspaceAllowed reports whether ws passes the allowlist. An empty/nil
+// allowlist allows everything, preserving the pre-allowlist behavior of
+// registering in every accessible workspace. Matching is case-insensitive
+// against the workspace slug or ID.
+func workspaceAllowed(allowlist []string, ws WorkspaceInfo) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	slug := strings.ToLower(strings.TrimSpace(ws.Slug))
+	id := strings.ToLower(strings.TrimSpace(ws.ID))
+	for _, entry := range allowlist {
+		e := strings.ToLower(strings.TrimSpace(entry))
+		if e == "" {
+			continue
+		}
+		if e == slug || e == id {
+			return true
+		}
+	}
+	return false
+}
+
+// filterAllowedWorkspaces partitions workspaces into those the allowlist keeps
+// and those it excludes, preserving input order. An empty allowlist keeps all.
+func filterAllowedWorkspaces(allowlist []string, in []WorkspaceInfo) (kept, excluded []WorkspaceInfo) {
+	for _, ws := range in {
+		if workspaceAllowed(allowlist, ws) {
+			kept = append(kept, ws)
+		} else {
+			excluded = append(excluded, ws)
+		}
+	}
+	return kept, excluded
+}
+
 // workspaceSyncLoop periodically fetches the user's workspaces from the API
 // and registers runtimes for any new ones.
 func (d *Daemon) workspaceSyncLoop(ctx context.Context) {
@@ -1638,6 +1673,23 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) error {
 		return fmt.Errorf("list workspaces: %w", err)
 	}
 	d.logger.Debug("workspace sync: fetched workspaces", "count", len(workspaces))
+
+	// Apply the optional workspace allowlist. Excluded workspaces are dropped
+	// here so they are never registered; any that were already tracked (e.g. a
+	// previous run before the allowlist was set) fall out of apiIDs below and
+	// are pruned by the "user no longer belongs to" cleanup further down — their
+	// stale server-side runtimes then expire via missed heartbeats.
+	if len(d.cfg.WorkspaceAllowlist) > 0 {
+		kept, excluded := filterAllowedWorkspaces(d.cfg.WorkspaceAllowlist, workspaces)
+		if len(excluded) > 0 {
+			ids := make([]string, len(excluded))
+			for i, ws := range excluded {
+				ids[i] = ws.ID
+			}
+			d.logger.Debug("workspace sync: excluded by allowlist", "count", len(excluded), "workspace_ids", ids)
+		}
+		workspaces = kept
+	}
 
 	apiIDs := make(map[string]string, len(workspaces)) // id -> name
 	for _, ws := range workspaces {

--- a/server/internal/daemon/workspace_allowlist_test.go
+++ b/server/internal/daemon/workspace_allowlist_test.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// workspaceAllowed / filterAllowedWorkspaces back the --workspace-allowlist
+// feature (issue #3223): an operator can scope a machine's daemon to a subset of
+// the workspaces its token can reach. An empty allowlist must preserve the
+// historical "register in every workspace" behavior, and matching is
+// case-insensitive against the workspace slug or ID.
+func TestWorkspaceAllowed(t *testing.T) {
+	t.Parallel()
+
+	ws := WorkspaceInfo{ID: "11111111-1111-1111-1111-111111111111", Name: "Eskyfun", Slug: "eskyfun"}
+
+	cases := []struct {
+		name      string
+		allowlist []string
+		ws        WorkspaceInfo
+		want      bool
+	}{
+		{"empty allowlist allows all", nil, ws, true},
+		{"slug match", []string{"eskyfun"}, ws, true},
+		{"slug match is case-insensitive", []string{"EskyFun"}, ws, true},
+		{"slug match ignores surrounding whitespace", []string{"  eskyfun "}, ws, true},
+		{"id match", []string{"11111111-1111-1111-1111-111111111111"}, ws, true},
+		{"id match is case-insensitive", []string{"11111111-1111-1111-1111-111111111111"}, WorkspaceInfo{ID: "ABC-DEF", Slug: "x"}, false},
+		{"no match", []string{"funtimes"}, ws, false},
+		{"one of several matches", []string{"funtimes", "eskyfun"}, ws, true},
+		{"blank entries are ignored", []string{"", "   "}, ws, false},
+		{"name is not a match target", []string{"Eskyfun"}, WorkspaceInfo{ID: "id", Name: "Eskyfun", Slug: "slug"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workspaceAllowed(tc.allowlist, tc.ws); got != tc.want {
+				t.Fatalf("workspaceAllowed(%v, %+v) = %v, want %v", tc.allowlist, tc.ws, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterAllowedWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	in := []WorkspaceInfo{
+		{ID: "id-a", Slug: "eskyfun"},
+		{ID: "id-b", Slug: "funtimes"},
+		{ID: "id-c", Slug: "other"},
+	}
+
+	kept, excluded := filterAllowedWorkspaces([]string{"eskyfun", "id-c"}, in)
+	if len(kept) != 2 || kept[0].Slug != "eskyfun" || kept[1].Slug != "other" {
+		t.Fatalf("kept = %+v, want eskyfun + other (input order preserved)", kept)
+	}
+	if len(excluded) != 1 || excluded[0].Slug != "funtimes" {
+		t.Fatalf("excluded = %+v, want funtimes", excluded)
+	}
+
+	// Empty allowlist keeps everything and excludes nothing.
+	kept, excluded = filterAllowedWorkspaces(nil, in)
+	if len(kept) != len(in) || len(excluded) != 0 {
+		t.Fatalf("empty allowlist: kept=%d excluded=%d, want kept=%d excluded=0", len(kept), len(excluded), len(in))
+	}
+}
+
+// syncWorkspacesFromAPI must not register runtimes in workspaces excluded by the
+// allowlist, and must prune any excluded workspace that was already tracked (the
+// case the issue calls out: deleting a runtime via the API otherwise comes back
+// on the next sync). The allowed workspace is left untouched.
+func TestSyncWorkspacesFromAPI_FiltersByAllowlist(t *testing.T) {
+	t.Parallel()
+
+	const (
+		allowID = "ws-allow"
+		denyID  = "ws-deny"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/workspaces":
+			json.NewEncoder(w).Encode([]WorkspaceInfo{
+				{ID: allowID, Name: "Eskyfun", Slug: "eskyfun"},
+				{ID: denyID, Name: "Funtimes", Slug: "funtimes"},
+			})
+		case "/api/daemon/workspaces/" + allowID + "/repos":
+			json.NewEncoder(w).Encode(WorkspaceReposResponse{
+				WorkspaceID:  allowID,
+				Repos:        []RepoData{},
+				ReposVersion: "v1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{
+		client:       NewClient(srv.URL),
+		logger:       slog.Default(),
+		workspaces:   make(map[string]*workspaceState),
+		runtimeIndex: make(map[string]Runtime),
+		runtimeSet:   newRuntimeSetWatcher(),
+		cfg:          Config{WorkspaceAllowlist: []string{"eskyfun"}},
+	}
+	// Both workspaces start tracked with a live runtime — simulating a daemon
+	// that registered everywhere before the allowlist was configured. A live
+	// runtime ID keeps workspaceNeedsRuntimeRecovery from forcing a re-register.
+	d.workspaces[allowID] = newWorkspaceState(allowID, []string{"rt-allow"}, "v1", nil, nil)
+	d.workspaces[denyID] = newWorkspaceState(denyID, []string{"rt-deny"}, "v1", nil, nil)
+	d.runtimeIndex["rt-allow"] = Runtime{ID: "rt-allow"}
+	d.runtimeIndex["rt-deny"] = Runtime{ID: "rt-deny"}
+
+	if err := d.syncWorkspacesFromAPI(context.Background()); err != nil {
+		t.Fatalf("syncWorkspacesFromAPI: %v", err)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.workspaces[denyID]; ok {
+		t.Fatalf("disallowed workspace %q should have been pruned", denyID)
+	}
+	if _, ok := d.runtimeIndex["rt-deny"]; ok {
+		t.Fatalf("runtime for disallowed workspace should have been removed from the index")
+	}
+	if _, ok := d.workspaces[allowID]; !ok {
+		t.Fatalf("allowed workspace %q should still be tracked", allowID)
+	}
+	if _, ok := d.runtimeIndex["rt-allow"]; !ok {
+		t.Fatalf("runtime for allowed workspace should remain in the index")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

The daemon auto-registers a runtime in **every** workspace the logged-in user's token can reach. There is no way to scope a machine to a subset of workspaces, and deleting a runtime via the API is undone on the next 30s sync tick.

This adds an opt-in allowlist so a machine can be limited to specific workspaces — e.g. a company build server visible in `eskyfun` but not `funtimes` on a shared self-hosted instance.

- New `--workspace-allowlist` flag on `multica daemon start` / `restart` (comma-separated or repeatable).
- New `MULTICA_DAEMON_WORKSPACE_ALLOWLIST` env var.
- Each entry matches a workspace **slug or ID**, case-insensitively. Empty allowlist = unchanged behavior (all accessible workspaces).

This is **Option B** from the issue. Approach: apply the filter in `syncWorkspacesFromAPI` — the single choke point every registration flow passes through (initial sync + 30s loop) — rather than scattering checks. Excluded workspaces are never registered; any registered before the allowlist was configured fall out of `apiIDs` and are pruned by the existing "user no longer belongs to" cleanup, after which their stale server-side runtimes expire via missed heartbeats.

## Related Issue

Closes #3223

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `server/internal/daemon/client.go` — add `Slug` to `WorkspaceInfo` (the `/api/workspaces` response already includes it).
- `server/internal/daemon/config.go` — `WorkspaceAllowlist` on `Config` and `Overrides`; parse `MULTICA_DAEMON_WORKSPACE_ALLOWLIST` with override > env > default precedence; `listFromEnv` helper.
- `server/internal/daemon/daemon.go` — `workspaceAllowed` / `filterAllowedWorkspaces` helpers; apply the filter in `syncWorkspacesFromAPI`.
- `server/cmd/multica/cmd_daemon.go` — `--workspace-allowlist` flag on `start`/`restart`, background-arg forwarding, and override wiring.
- Tests: `server/internal/daemon/workspace_allowlist_test.go` (matcher unit tests + a `syncWorkspacesFromAPI` integration test proving excluded workspaces are pruned) and a `LoadConfig` precedence test in `config_test.go`.
- Docs: `CLI_AND_DAEMON.md`, `apps/docs/content/docs/daemon-runtimes.mdx`, `apps/docs/content/docs/environment-variables.mdx`.

## How to Test

1. `cd server && go build ./...`
2. `go test -race ./internal/daemon/...`
3. Manual: `multica daemon start --foreground --workspace-allowlist <your-slug>` registers only in that workspace; `MULTICA_DAEMON_WORKSPACE_ALLOWLIST=<slug>` behaves identically; no flag/env leaves behavior unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — daemon/CLI only)
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs (N/A — no new runtime/tab)
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx (N/A — English docs only; translations left for the i18n pass)
- [x] I have considered and documented any risks above

### Notes for reviewers
- No builtin-skill `SKILL.md` / `references/*-source-map.md` update: none document daemon-start flags (the repo rule targets behavior documented by built-in skills).
- gofmt: only touched-lines formatted. Pre-existing gofmt drift on `main` in unrelated regions of `daemon.go` / `client.go` was deliberately left untouched.

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.8)

**Prompt / approach:** Asked to implement issue #3223 Option B per the contributing guide. The agent read the issue + CONTRIBUTING, mapped the workspace-registration flow to find the single choke point (`syncWorkspacesFromAPI`), confirmed the match target (slug-or-ID) before coding, then mirrored the existing `MULTICA_DAEMON_*` config/flag/env patterns. Tests model the existing `coauthor_enabled_test.go` harness; verified with `go build`, `go vet`, and `go test -race`.