### PR TITLE
feat: add opt-in react-grab dev element inspector (web + desktop)

### DIFF
--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -13,4 +13,18 @@ import "@fontsource/geist-mono/400.css";
 import "@fontsource/geist-mono/700.css";
 import "./globals.css";
 
+// react-grab: dev-only element inspector. Hold ⌘C (Mac) / Ctrl+C and click any
+// element to copy its source path + line + component stack for pasting to an AI.
+// Opt-in per developer: only loads when VITE_REACT_GRAB is set in a local,
+// gitignored apps/desktop/.env.development.local — it never activates for anyone
+// else, and the whole branch is tree-shaken out of production builds. The web app
+// wires the same tool via next/script in apps/web/app/layout.tsx.
+// See https://www.react-grab.com/
+if (import.meta.env.DEV && import.meta.env.VITE_REACT_GRAB) {
+  const grab = document.createElement("script");
+  grab.src = "//unpkg.com/react-grab/dist/index.global.js";
+  grab.crossOrigin = "anonymous";
+  document.head.appendChild(grab);
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import Script from "next/script";
 import { Inter, Geist_Mono, Source_Serif_4 } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@multica/ui/components/ui/sonner";
@@ -116,6 +117,21 @@ export default async function RootLayout({
       className={cn("antialiased font-sans h-full", inter.variable, geistMono.variable, sourceSerif.variable)}
     >
       <body className="h-full overflow-hidden">
+        {/*
+          react-grab: dev-only element inspector. Hold ⌘C (Mac) / Ctrl+C and click
+          any element to copy its source path + line + component stack for pasting
+          to an AI. Opt-in per developer: only loads when REACT_GRAB is set in a
+          local, gitignored apps/web/.env.local — it never activates for anyone
+          else. Both guards are read server-side, so the <Script> is omitted from
+          the HTML entirely unless you opted in. See https://www.react-grab.com/
+        */}
+        {process.env.NODE_ENV === "development" && process.env.REACT_GRAB && (
+          <Script
+            src="//unpkg.com/react-grab/dist/index.global.js"
+            crossOrigin="anonymous"
+            strategy="beforeInteractive"
+          />
+        )}
         <ThemeProvider>
           <WebProviders locale={locale} resources={resources}>
             {children}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -120,12 +120,15 @@ export default async function RootLayout({
         {/*
           react-grab: dev-only element inspector. Hold ⌘C (Mac) / Ctrl+C and click
           any element to copy its source path + line + component stack for pasting
-          to an AI. Opt-in per developer: only loads when REACT_GRAB is set in a
-          local, gitignored apps/web/.env.local — it never activates for anyone
+          to an AI. Opt-in per developer: only loads when VITE_REACT_GRAB is set in
+          a local, gitignored apps/web/.env.local — it never activates for anyone
           else. Both guards are read server-side, so the <Script> is omitted from
-          the HTML entirely unless you opted in. See https://www.react-grab.com/
+          the HTML entirely unless you opted in. The VITE_ prefix is shared with the
+          desktop renderer (apps/desktop/src/renderer/src/main.tsx), where Vite only
+          exposes VITE_-prefixed vars to client code, so one var name covers both
+          apps. See https://www.react-grab.com/
         */}
-        {process.env.NODE_ENV === "development" && process.env.REACT_GRAB && (
+        {process.env.NODE_ENV === "development" && process.env.VITE_REACT_GRAB && (
           <Script
             src="//unpkg.com/react-grab/dist/index.global.js"
             crossOrigin="anonymous"


### PR DESCRIPTION
## What

Adds [react-grab](https://www.react-grab.com/) — a dev-time element inspector. Hold **⌘C** (Mac) / **Ctrl+C** and click any element to copy its source file path + line + component stack to the clipboard, for pasting to an AI. Wired into **both** the web app and the Electron desktop renderer.

## Opt-in via one var: `VITE_REACT_GRAB`

A single variable name controls both apps. It only activates when set in a **gitignored** local env file; for everyone else the script never loads, and in production the branch is tree-shaken out entirely.

| App | Enable locally |
| --- | --- |
| Web (`apps/web/app/layout.tsx`) | `echo 'VITE_REACT_GRAB=1' >> apps/web/.env.local` |
| Desktop (`apps/desktop/src/renderer/src/main.tsx`) | `echo 'VITE_REACT_GRAB=1' >> apps/desktop/.env.development.local` |

Restart the dev server after editing the env file. (The two apps are separate dev servers with separate env files — same var name, set wherever you're running.)

## Why the `VITE_` prefix

The desktop renderer is bundled by Vite, which only injects `VITE_`-prefixed env vars into client code — so a shared name must carry that prefix. The web guard reads `process.env` server-side in the root layout, where the name is unconstrained, so it reads the same `VITE_REACT_GRAB` happily.

## Notes

- **No npm dependency added** — loaded from unpkg per react-grab's official setup; no babel/SWC plugin needed (it walks React's dev-mode fiber `_debugSource` at runtime).
- Web uses `next/script` with `beforeInteractive`; desktop injects a `<script>` in the renderer entry (no CSP/sandbox blocks it — `webSecurity` is off).
- Did not run typecheck/lint locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)