### PR TITLE
MUL-3467: batch load squad roster skills

### DIFF
--- a/server/internal/auth/pat_cache_test.go
+++ b/server/internal/auth/pat_cache_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient mirrors the helper in the handler package: connect to
-// REDIS_TEST_URL, flush, and skip when unset so `go test ./...` works on a
-// stock laptop without a Redis instance running.
+const redisTestDB = 11
+
+// newRedisTestClient connects to REDIS_TEST_URL, uses this package's logical
+// test DB, flushes, and skips when unset so `go test ./...` works on a stock
+// laptop without a Redis instance running.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -22,6 +24,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDB
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {
@@ -45,7 +48,7 @@ func TestPATCache_NilSafe(t *testing.T) {
 		t.Fatalf("nil cache must miss; got (%q, %v)", v, ok)
 	}
 	c.Set(ctx, "any-hash", "user-1", AuthCacheTTL) // no panic
-	c.Invalidate(ctx, "any-hash")                 // no panic
+	c.Invalidate(ctx, "any-hash")                  // no panic
 }
 
 func TestNewPATCache_NilRedisReturnsNil(t *testing.T) {

--- a/server/internal/handler/runtime_local_skills_redis_store_test.go
+++ b/server/internal/handler/runtime_local_skills_redis_store_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+const redisTestDB = 14
+
 // newRedisTestClient connects to the Redis instance indicated by REDIS_TEST_URL
-// and flushes it so each test starts from a clean slate. The helper skips the
-// calling test if the env var is unset — matches the DATABASE_URL gating in
-// the rest of the suite so `go test ./...` still works on a stock laptop
-// without a running Redis.
+// and flushes this package's logical test DB so each test starts from a clean
+// slate. The helper skips the calling test if the env var is unset — matches
+// the DATABASE_URL gating in the rest of the suite so `go test ./...` still
+// works on a stock laptop without a running Redis.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -26,6 +28,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDB
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {

--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -142,6 +142,8 @@ func buildSquadRoster(ctx context.Context, q *db.Queries, squad db.Squad) string
 		members = nil
 	}
 
+	skillNamesByAgentID, skillsLoaded := loadSquadMemberSkillNames(ctx, q, members, util.UUIDToString(squad.LeaderID))
+
 	rows := make([]string, 0, len(members))
 	for _, m := range members {
 		// Skip the leader if they happen to also be in the member list —
@@ -149,7 +151,7 @@ func buildSquadRoster(ctx context.Context, q *db.Queries, squad db.Squad) string
 		if m.MemberType == "agent" && util.UUIDToString(m.MemberID) == util.UUIDToString(squad.LeaderID) {
 			continue
 		}
-		row := renderMemberRow(ctx, q, m)
+		row := renderMemberRow(ctx, q, m, skillNamesByAgentID, skillsLoaded)
 		if row != "" {
 			rows = append(rows, row)
 		}
@@ -167,9 +169,41 @@ func buildSquadRoster(ctx context.Context, q *db.Queries, squad db.Squad) string
 	return sb.String()
 }
 
+func loadSquadMemberSkillNames(ctx context.Context, q *db.Queries, members []db.SquadMember, leaderID string) (map[string][]string, bool) {
+	agentIDs := make([]pgtype.UUID, 0)
+	seen := make(map[string]struct{}, len(members))
+	for _, m := range members {
+		if m.MemberType != "agent" {
+			continue
+		}
+		id := util.UUIDToString(m.MemberID)
+		if id == leaderID {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		agentIDs = append(agentIDs, m.MemberID)
+	}
+	if len(agentIDs) == 0 {
+		return map[string][]string{}, true
+	}
+	rows, err := q.ListAgentSkillNamesByAgentIDs(ctx, agentIDs)
+	if err != nil {
+		return nil, false
+	}
+	byAgentID := make(map[string][]string, len(agentIDs))
+	for _, row := range rows {
+		id := util.UUIDToString(row.AgentID)
+		byAgentID[id] = append(byAgentID[id], row.Name)
+	}
+	return byAgentID, true
+}
+
 // renderMemberRow renders a single roster row, returning "" if the member
 // can't be resolved or should be skipped (e.g. archived agent).
-func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember) string {
+func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember, skillNamesByAgentID map[string][]string, skillsLoaded bool) string {
 	id := util.UUIDToString(m.MemberID)
 	role := strings.TrimSpace(m.Role)
 	switch m.MemberType {
@@ -183,7 +217,7 @@ func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember) strin
 		}
 		// Agents carry skills; surfacing them lets the leader delegate by
 		// capability instead of guessing from the free-text role label.
-		return formatRosterRow(ag.Name, "agent", role, agentSkillsRosterSegment(ctx, q, m.MemberID), formatMention(ag.Name, "agent", id))
+		return formatRosterRow(ag.Name, "agent", role, agentSkillsRosterSegment(skillNamesByAgentID, skillsLoaded, id), formatMention(ag.Name, "agent", id))
 	case "member":
 		user, err := q.GetUser(ctx, m.MemberID)
 		if err != nil {
@@ -201,23 +235,17 @@ func renderMemberRow(ctx context.Context, q *db.Queries, m db.SquadMember) strin
 
 // agentSkillsRosterSegment returns the roster segment describing an agent
 // member's assigned skills. "skills: a, b" when the agent has skills (the
-// names are pre-sorted by ListAgentSkillSummaries), "no skills assigned" when
-// it has none so the leader knows the capability is genuinely absent, and ""
-// only when the lookup fails — a transient DB error degrades to the prior
-// name+role row rather than asserting a misleading "no skills". Builtin
-// multica-* skills are added at runtime (not in agent_skill) and are
-// deliberately omitted; the leader cares about the configured capabilities.
-func agentSkillsRosterSegment(ctx context.Context, q *db.Queries, agentID pgtype.UUID) string {
-	skills, err := q.ListAgentSkillSummaries(ctx, agentID)
-	if err != nil {
+// names are pre-sorted by ListAgentSkillNamesByAgentIDs), "no skills assigned"
+// when it has none so the leader knows the capability is genuinely absent, and
+// "" only when the lookup fails — a transient DB error degrades to the prior
+// name+role row rather than asserting a misleading "no skills".
+func agentSkillsRosterSegment(skillNamesByAgentID map[string][]string, skillsLoaded bool, agentID string) string {
+	if !skillsLoaded {
 		return ""
 	}
-	if len(skills) == 0 {
+	names := skillNamesByAgentID[agentID]
+	if len(names) == 0 {
 		return "no skills assigned"
-	}
-	names := make([]string, 0, len(skills))
-	for _, s := range skills {
-		names = append(names, s.Name)
 	}
 	return "skills: " + strings.Join(names, ", ")
 }

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -150,8 +150,7 @@ func TestBuildSquadLeaderBriefing_FullSquad(t *testing.T) {
 	}
 }
 
-// assignSkillToAgent creates a workspace skill and attaches it to the agent,
-// registering cleanup for the skill row (agent_skill cascades on skill delete).
+// assignSkillToAgent creates a workspace skill and attaches it to the agent.
 func assignSkillToAgent(t *testing.T, agentID, skillName string) {
 	t.Helper()
 	ctx := context.Background()
@@ -163,7 +162,14 @@ func assignSkillToAgent(t *testing.T, agentID, skillName string) {
 	`, testWorkspaceID, skillName, testUserID).Scan(&skillID); err != nil {
 		t.Fatalf("create skill %s: %v", skillName, err)
 	}
-	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM skill WHERE id = $1`, skillID) })
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(ctx, `DELETE FROM agent_skill WHERE agent_id = $1 AND skill_id = $2`, agentID, skillID); err != nil {
+			t.Errorf("cleanup agent skill %s/%s: %v", agentID, skillName, err)
+		}
+		if _, err := testPool.Exec(ctx, `DELETE FROM skill WHERE id = $1`, skillID); err != nil {
+			t.Errorf("cleanup skill %s: %v", skillName, err)
+		}
+	})
 	if _, err := testPool.Exec(ctx,
 		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
 		agentID, skillID,
@@ -183,7 +189,7 @@ func TestBuildSquadLeaderBriefing_MemberSkillsInRoster(t *testing.T) {
 
 	skilled := createHandlerTestAgent(t, "Skilled Bot", []byte("[]"))
 	addAgentMember(t, squad.ID, skilled, "backend")
-	// ListAgentSkillSummaries orders by name ASC → "polars" before "stat…".
+	// ListAgentSkillNamesByAgentIDs orders by name ASC → "polars" before "stat…".
 	assignSkillToAgent(t, skilled, "polars")
 	assignSkillToAgent(t, skilled, "statistical-analysis")
 

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient connects to REDIS_TEST_URL, flushes, and skips when
-// unset — same gating pattern the rest of the suite uses for Redis-backed
-// tests, so `go test ./...` works on a stock laptop without a Redis.
+const redisTestDB = 13
+
+// newRedisTestClient connects to REDIS_TEST_URL, uses this package's logical
+// test DB, flushes, and skips when unset — same gating pattern the rest of the
+// suite uses for Redis-backed tests, so `go test ./...` works on a stock laptop
+// without a Redis.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -26,6 +29,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDB
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {
@@ -298,7 +302,6 @@ func TestAuth_PATCacheHit(t *testing.T) {
 		t.Fatalf("expected cached X-User-ID, got %q", gotUserID)
 	}
 }
-
 
 // TestAuth_MCN_NoVerifierConfigured pins the same fail-closed branch
 // as the daemon side: with no MULTICA_CLOUD_FLEET_URL configured, an

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -94,7 +94,8 @@ Contracts:
 - `instructions` section appears only when non-empty (squad_briefing.go:110-112);
 - archived agent members are skipped from roster (squad_briefing.go:178-179);
 - agent member roster rows list assigned workspace skills via
-  `agentSkillsRosterSegment` (ListAgentSkillSummaries) — "skills: a, b" or
+  `loadSquadMemberSkillNames` (ListAgentSkillNamesByAgentIDs) and
+  `agentSkillsRosterSegment` — "skills: a, b" or
   "no skills assigned"; builtin multica-* skills are excluded and human
   members carry no skills segment (squad_briefing.go renderMemberRow);
 - no traced behavior injects `instructions` into every squad member.

--- a/server/internal/service/empty_claim_cache_test.go
+++ b/server/internal/service/empty_claim_cache_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// newRedisTestClient mirrors the helper in internal/auth: connect to
-// REDIS_TEST_URL, flush, and skip when unset so `go test ./...` works
-// on a stock laptop without a Redis instance running.
+const redisTestDB = 12
+
+// newRedisTestClient connects to REDIS_TEST_URL, uses this package's logical
+// test DB, flushes, and skips when unset so `go test ./...` works on a stock
+// laptop without a Redis instance running.
 func newRedisTestClient(t *testing.T) *redis.Client {
 	t.Helper()
 	url := os.Getenv("REDIS_TEST_URL")
@@ -22,6 +24,7 @@ func newRedisTestClient(t *testing.T) *redis.Client {
 	if err != nil {
 		t.Fatalf("parse REDIS_TEST_URL: %v", err)
 	}
+	opts.DB = redisTestDB
 	rdb := redis.NewClient(opts)
 	ctx := context.Background()
 	if err := rdb.Ping(ctx).Err(); err != nil {

--- a/server/pkg/db/generated/skill.sql.go
+++ b/server/pkg/db/generated/skill.sql.go
@@ -198,6 +198,39 @@ func (q *Queries) GetSkillInWorkspace(ctx context.Context, arg GetSkillInWorkspa
 	return i, err
 }
 
+const listAgentSkillNamesByAgentIDs = `-- name: ListAgentSkillNamesByAgentIDs :many
+SELECT ask.agent_id, s.name
+FROM agent_skill ask
+JOIN skill s ON s.id = ask.skill_id
+WHERE ask.agent_id = ANY($1::uuid[])
+ORDER BY ask.agent_id, s.name ASC
+`
+
+type ListAgentSkillNamesByAgentIDsRow struct {
+	AgentID pgtype.UUID `json:"agent_id"`
+	Name    string      `json:"name"`
+}
+
+func (q *Queries) ListAgentSkillNamesByAgentIDs(ctx context.Context, agentIds []pgtype.UUID) ([]ListAgentSkillNamesByAgentIDsRow, error) {
+	rows, err := q.db.Query(ctx, listAgentSkillNamesByAgentIDs, agentIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAgentSkillNamesByAgentIDsRow{}
+	for rows.Next() {
+		var i ListAgentSkillNamesByAgentIDsRow
+		if err := rows.Scan(&i.AgentID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentSkillSummaries = `-- name: ListAgentSkillSummaries :many
 SELECT s.id, s.workspace_id, s.name, s.description, s.config, s.created_by, s.created_at, s.updated_at
 FROM skill s

--- a/server/pkg/db/queries/skill.sql
+++ b/server/pkg/db/queries/skill.sql
@@ -92,6 +92,13 @@ JOIN agent_skill ask ON ask.skill_id = s.id
 WHERE ask.agent_id = $1
 ORDER BY s.name ASC;
 
+-- name: ListAgentSkillNamesByAgentIDs :many
+SELECT ask.agent_id, s.name
+FROM agent_skill ask
+JOIN skill s ON s.id = ask.skill_id
+WHERE ask.agent_id = ANY(sqlc.arg('agent_ids')::uuid[])
+ORDER BY ask.agent_id, s.name ASC;
+
 -- name: AddAgentSkill :exec
 INSERT INTO agent_skill (agent_id, skill_id)
 VALUES ($1, $2)


### PR DESCRIPTION
## Summary

- Batch-load squad member skill names when building the leader briefing roster.
- Keep the existing fallback behavior: if the skill lookup fails, roster rows degrade to the prior name/type/role/mention shape.
- Clean up the squad briefing test helper so `agent_skill` rows are deleted explicitly before deleting the test skill.

## Testing

- `go test ./internal/handler`

MUL-3467
