### PR TITLE
MUL-3446: keep chat output in chat

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -782,7 +782,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- Print exactly one final line: `Created <identifier-or-id>: <title>` after a successful `multica issue create`. Use the created issue's `identifier` from JSON output when available; otherwise use its `id`. Do not assume any workspace issue prefix such as `MUL-`; workspaces can use custom prefixes.\n")
 		b.WriteString("- On CLI failure, exit with the CLI error as the only output. The platform translates that into a `quick_create_failed` inbox item carrying the original prompt for the user.\n")
 	case ctx.ChatSessionID != "":
-		b.WriteString("This is a chat task. Your final assistant response is delivered directly to the chat window, so do not call `multica issue comment add` unless the user explicitly asks you to write a comment to a specific issue.\n")
+		b.WriteString("This is a chat session. Your reply is delivered directly to the chat window the user is reading.\n")
 	default:
 		if ctx.IsSquadLeader {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`** — unless your outcome is `no_action`. When you evaluate a trigger and decide no action is needed, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment that announces no_action, acknowledges another agent, or says you are exiting silently — such comments are noise. For all other outcomes (`action`, `failed`), a comment is still mandatory.\n\n")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -781,6 +781,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- Do NOT call `multica issue comment add` — the issue you just created has no conversation context for this run.\n")
 		b.WriteString("- Print exactly one final line: `Created <identifier-or-id>: <title>` after a successful `multica issue create`. Use the created issue's `identifier` from JSON output when available; otherwise use its `id`. Do not assume any workspace issue prefix such as `MUL-`; workspaces can use custom prefixes.\n")
 		b.WriteString("- On CLI failure, exit with the CLI error as the only output. The platform translates that into a `quick_create_failed` inbox item carrying the original prompt for the user.\n")
+	case ctx.ChatSessionID != "":
+		b.WriteString("This is a chat task. Your final assistant response is delivered directly to the chat window, so do not call `multica issue comment add` unless the user explicitly asks you to write a comment to a specific issue.\n")
 	default:
 		if ctx.IsSquadLeader {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`** — unless your outcome is `no_action`. When you evaluate a trigger and decide no action is needed, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment that announces no_action, acknowledges another agent, or says you are exiting silently — such comments are noise. For all other outcomes (`action`, `failed`), a comment is still mandatory.\n\n")

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -343,9 +343,8 @@ func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
 	out := buildMetaSkillContent("claude", TaskContextForEnv{ChatSessionID: "chat-1"})
 
 	for _, want := range []string{
-		"This is a chat task",
-		"delivered directly to the chat window",
-		"unless the user explicitly asks you to write a comment to a specific issue",
+		"This is a chat session",
+		"Your reply is delivered directly to the chat window the user is reading",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("chat brief missing chat output guidance %q\n---\n%s", want, out)
@@ -355,6 +354,8 @@ func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
 	for _, banned := range []string{
 		"Final results MUST be delivered via `multica issue comment add`",
 		"The user does NOT see your terminal output",
+		"do not call `multica issue comment add`",
+		"unless the user explicitly asks",
 	} {
 		if strings.Contains(out, banned) {
 			t.Errorf("chat brief must not inherit issue-comment output warning %q\n---\n%s", banned, out)

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -337,6 +337,31 @@ func TestInstructionPrecedenceOnlyAppliesToAssignmentWorkflow(t *testing.T) {
 	}
 }
 
+func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
+	t.Parallel()
+
+	out := buildMetaSkillContent("claude", TaskContextForEnv{ChatSessionID: "chat-1"})
+
+	for _, want := range []string{
+		"This is a chat task",
+		"delivered directly to the chat window",
+		"unless the user explicitly asks you to write a comment to a specific issue",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("chat brief missing chat output guidance %q\n---\n%s", want, out)
+		}
+	}
+
+	for _, banned := range []string{
+		"Final results MUST be delivered via `multica issue comment add`",
+		"The user does NOT see your terminal output",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("chat brief must not inherit issue-comment output warning %q\n---\n%s", banned, out)
+		}
+	}
+}
+
 // The sub-issue creation rule must reach top-level parents that have no
 // `parent_issue_id` of their own — that is where the `todo` vs `backlog`
 // decision matters most. The section must not gate on this issue being


### PR DESCRIPTION
Closes MUL-3446

## Summary
- add a chat-specific Output branch so chat responses stay in the chat window by default
- keep issue comments allowed only when the user explicitly asks to write to a specific issue
- add a regression test that chat briefs do not inherit the issue-comment MUST warning

## Test
- go test ./internal/daemon/execenv
