### PR TITLE
MUL-3496: fix(skills): authenticate raw.githubusercontent.com downloads for private repo imports

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -1698,11 +1698,21 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 
 // --- Shared helpers ---
 
+// rawGitHubContentHost serves raw GitHub file content. fetchRawFile attaches the
+// GITHUB_TOKEN only for this host: the same function downloads files from
+// non-GitHub skill sources (clawhub.ai, skills.sh), and an unconditional auth
+// header would leak the token to those third-party hosts.
+const rawGitHubContentHost = "raw.githubusercontent.com"
+
 // fetchRawFile downloads a URL and returns the body bytes. Returns an error
 // if the response exceeds maxImportFileSize so we never silently truncate a
 // half-downloaded skill file into the workspace.
 func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
-	resp, err := httpClient.Get(fileURL)
+	req, err := newRawFileRequest(fileURL)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1718,6 +1728,22 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: file exceeds %d byte limit", errImportCapExceeded, maxImportFileSize)
 	}
 	return body, nil
+}
+
+// newRawFileRequest builds the GET request for a raw skill file, attaching the
+// GitHub auth header only when the URL targets GitHub's raw content host. The
+// host gate lives here, separate from the round-trip, so it can be unit tested
+// without a live network call — GITHUB_TOKEN must never reach a non-GitHub
+// skill host.
+func newRawFileRequest(fileURL string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, fileURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(req.URL.Hostname(), rawGitHubContentHost) {
+		addGitHubAuthHeader(req)
+	}
+	return req, nil
 }
 
 // escapeRefPath percent-encodes each segment of a git ref individually so

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -833,6 +833,60 @@ func TestFetchFromGitHub_BlobURLImportsSpecificSkill(t *testing.T) {
 	}
 }
 
+// --- Raw file auth header host gating ---
+
+// The GitHub token must reach raw.githubusercontent.com (so private-repo
+// SKILL.md / file downloads authenticate) but must never be sent to the
+// non-GitHub hosts (clawhub.ai, skills.sh) that share fetchRawFile.
+func TestNewRawFileRequest_AttachesGitHubTokenOnlyForRawGitHubHost(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "secret-token")
+
+	cases := []struct {
+		name     string
+		url      string
+		wantAuth string
+	}{
+		{
+			name:     "raw github host authenticates",
+			url:      "https://raw.githubusercontent.com/acme/private/main/skills/foo/SKILL.md",
+			wantAuth: "Bearer secret-token",
+		},
+		{
+			name:     "clawhub host never receives the token",
+			url:      "https://clawhub.ai/api/skills/foo/file?path=SKILL.md",
+			wantAuth: "",
+		},
+		{
+			name:     "skills.sh host never receives the token",
+			url:      "https://skills.sh/acme/foo/SKILL.md",
+			wantAuth: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := newRawFileRequest(tc.url)
+			if err != nil {
+				t.Fatalf("newRawFileRequest(%q): %v", tc.url, err)
+			}
+			if got := req.Header.Get("Authorization"); got != tc.wantAuth {
+				t.Fatalf("Authorization = %q, want %q", got, tc.wantAuth)
+			}
+		})
+	}
+}
+
+func TestNewRawFileRequest_NoAuthHeaderWhenTokenUnset(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+
+	req, err := newRawFileRequest("https://raw.githubusercontent.com/acme/private/main/SKILL.md")
+	if err != nil {
+		t.Fatalf("newRawFileRequest: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty when GITHUB_TOKEN is unset", got)
+	}
+}
+
 // --- Bundle / file size cap tests ---
 
 func TestFetchRawFile_ReturnsErrorOnOversizedFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Importing a skill from a **private / internal GitHub repo** failed even with `GITHUB_TOKEN` set, surfacing in the CLI as a generic `502 server error`.

Root cause: skill import constructs `raw.githubusercontent.com` URLs by hand and downloads them through `fetchRawFile`, which issued a plain unauthenticated `httpClient.Get`. PR #2215 added GitHub auth (`doGitHubAPIGet` / `addGitHubAuthHeader`) but only wired it into the `api.github.com` path — the raw content download path was missed. So for a private repo the directory listing (API) succeeded and the actual file download (raw) returned `404`, which `ImportSkill` maps to `http.StatusBadGateway` (502).

Fixes #4385.

## Changes

- `fetchRawFile` now attaches the existing `GITHUB_TOKEN` bearer header — **but only when the URL host is `raw.githubusercontent.com`**. `fetchRawFile` is shared with `clawhub.ai` / `skills.sh` downloads, so an unconditional header would leak the token to third-party hosts. The host gate is extracted into a small `newRawFileRequest` helper so it can be unit-tested without a live round-trip.
- Added `TestNewRawFileRequest_*` covering both the positive case (raw GitHub host gets `Bearer <token>`) and the security property (clawhub.ai / skills.sh never receive the token, and no header when `GITHUB_TOKEN` is unset).

No CLI flags, API fields, or documented import behavior changed — this only makes the existing `GITHUB_TOKEN` convention cover the raw-download path it was always meant to. (`multica-skill-importing` source map intentionally tolerates line drift, so no doc update.)

## Out of scope / possible follow-up

The 403/404 → generic `502` mapping is unchanged here. A follow-up could translate private-content 403/404 into a clearer, actionable error (token lacks scope / repo not accessible / `SKILL.md` path not found) instead of a 502.

## Testing

- `go build ./internal/handler/` — clean
- `go vet ./internal/handler/` — clean
- `gofmt -l` — clean
- `go test ./internal/handler/ -run 'RawFile|FetchFrom|Skill|Import|GitHub' -count=1` — pass
- New tests pass: `go test ./internal/handler/ -run TestNewRawFileRequest -v`

MUL-3496
