### PR TITLE
refactor(codex): make permission approval auto-grant observable (MUL-3451)

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1467,7 +1467,7 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/permissions/requestApproval":
-		c.respond(id, codexPermissionsApprovalResponse(raw["params"]))
+		c.respond(id, codexPermissionsApprovalResponse(raw["params"], c.cfg.Logger))
 	case "mcpServer/elicitation/request":
 		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
@@ -1478,20 +1478,39 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 	}
 }
 
-func codexPermissionsApprovalResponse(params json.RawMessage) map[string]any {
+// codexPermissionsApprovalResponse builds the auto-grant reply for a Codex
+// item/permissions/requestApproval server request. In daemon mode there is no
+// human to approve, so we echo back the requested network / fileSystem profile
+// and scope it to the current turn, mirroring the other auto-accept branches in
+// handleServerRequest.
+//
+// The grant is intentionally limited to the network / fileSystem keys we
+// understand. A parse failure and any dropped key are logged so that a future
+// app-server protocol that adds a new permission shape is visible in daemon
+// logs instead of being silently narrowed away.
+func codexPermissionsApprovalResponse(params json.RawMessage, logger *slog.Logger) map[string]any {
 	var payload struct {
 		Permissions map[string]any `json:"permissions"`
 	}
-	_ = json.Unmarshal(params, &payload)
+	if err := json.Unmarshal(params, &payload); err != nil && logger != nil {
+		logger.Warn("codex: failed to parse permission approval request; granting empty turn-scoped profile", "error", err)
+	}
 
 	granted := map[string]any{}
-	if payload.Permissions != nil {
-		if network, ok := payload.Permissions["network"]; ok && network != nil {
-			granted["network"] = network
+	var dropped []string
+	for key, value := range payload.Permissions {
+		switch key {
+		case "network", "fileSystem":
+			if value != nil {
+				granted[key] = value
+			}
+		default:
+			dropped = append(dropped, key)
 		}
-		if fileSystem, ok := payload.Permissions["fileSystem"]; ok && fileSystem != nil {
-			granted["fileSystem"] = fileSystem
-		}
+	}
+	if len(dropped) > 0 && logger != nil {
+		sort.Strings(dropped)
+		logger.Warn("codex: dropping unrecognized permission keys from approval request; add explicit handling if the app-server protocol expanded", "keys", dropped)
 	}
 
 	return map[string]any{

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -246,6 +247,55 @@ func TestCodexHandleServerRequestPermissionsApproval(t *testing.T) {
 	}
 	if got := fileSystem["read"].([]any)[0]; got != "/tmp/repo" {
 		t.Fatalf("expected fileSystem.read to round-trip, got %v", got)
+	}
+}
+
+func TestCodexPermissionsApprovalResponseDropsUnknownKeysAndLogs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	resp := codexPermissionsApprovalResponse(
+		json.RawMessage(`{"permissions":{"network":{"enabled":true},"gpu":{"enabled":true}}}`),
+		logger,
+	)
+
+	if resp["scope"] != "turn" {
+		t.Fatalf("expected scope=turn, got %v", resp["scope"])
+	}
+	perms, ok := resp["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected permissions object, got %v", resp["permissions"])
+	}
+	if _, ok := perms["network"]; !ok {
+		t.Fatalf("expected network permission to be granted, got %v", perms)
+	}
+	if _, ok := perms["gpu"]; ok {
+		t.Fatalf("expected unrecognized key gpu to be dropped, got %v", perms)
+	}
+	if !strings.Contains(buf.String(), "gpu") {
+		t.Fatalf("expected dropped key to be logged, got %q", buf.String())
+	}
+}
+
+func TestCodexPermissionsApprovalResponseMalformedParamsLogs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	resp := codexPermissionsApprovalResponse(json.RawMessage(`{"permissions":"not-an-object"}`), logger)
+
+	if resp["scope"] != "turn" {
+		t.Fatalf("expected scope=turn, got %v", resp["scope"])
+	}
+	perms, ok := resp["permissions"].(map[string]any)
+	if !ok || len(perms) != 0 {
+		t.Fatalf("expected empty permissions on malformed params, got %v", resp["permissions"])
+	}
+	if !strings.Contains(buf.String(), "failed to parse") {
+		t.Fatalf("expected parse failure to be logged, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4346, which made the daemon auto-grant Codex `item/permissions/requestApproval` requests (fixing the #4341 stall/timeout). This addresses the review nits on that PR by making the auto-grant path observable, without changing the granted response.

`codexPermissionsApprovalResponse` echoes back the requested `network` / `fileSystem` profile scoped to the current turn. Previously two things happened silently:

- A malformed `params` payload was dropped (`_ = json.Unmarshal(...)`), leaving an empty grant with no trace.
- Any permission key outside `network` / `fileSystem` was ignored, so a future app-server protocol that adds a new permission shape would be narrowed away invisibly.

Both cases are now logged at WARN. The drop is rewritten as a single key loop so an unrecognized key is detected explicitly rather than being whatever falls outside the two hard-coded `if`s.

## What is intentionally not changed

- The granted response shape (`{permissions: {network, fileSystem}, scope: "turn"}`) is unchanged — same wire behavior, same auto-accept semantics.
- The `setTurnError` first-write-wins behavior (the third review nit) is left as-is on purpose: when an unsupported request and a later turn failure both occur, the unsupported request is the more likely root cause, so capturing it first is the desired diagnostic.

## Verification

- `gofmt -l` clean, `go vet ./pkg/agent` clean
- `go test ./pkg/agent -count=1` — full package green
- New unit tests: `TestCodexPermissionsApprovalResponseDropsUnknownKeysAndLogs`, `TestCodexPermissionsApprovalResponseMalformedParamsLogs`

Refs #4346, #4341 · MUL-3451
