### PR TITLE
fix(issue): skip child-done notification when parent is in backlog

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -26,6 +26,11 @@ import (
 //   - issue.ParentIssueID must be set
 //   - parent must not be "done" or "cancelled" — the parent is already
 //     closed and a notification has no follow-up to drive
+//   - parent must not be "backlog" — a parent parked in backlog is being
+//     deliberately held for later; waking its assignee (which can then
+//     promote sibling backlog sub-issues into todo) is exactly the
+//     unwanted auto-activation reported in #4320 / MUL-3497. A parked
+//     parent stays inert until the user explicitly moves it out of backlog.
 //   - parent assignee must not be a member (human). Humans read their
 //     issues manually; an automated system comment is pure noise for them
 //     and there is nothing to "trigger" on a human assignee. Skipping the
@@ -64,6 +69,14 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 		return
 	}
 	if parent.Status == "done" || parent.Status == "cancelled" {
+		return
+	}
+	// A parent parked in backlog is deliberately held for later. Posting the
+	// system comment would wake its assignee, and the woken agent can then
+	// promote sibling backlog sub-issues into todo — the surprise auto-
+	// activation reported in #4320 / MUL-3497. Skip the whole notification so
+	// a backlog parent stays inert until the user explicitly promotes it.
+	if parent.Status == "backlog" {
 		return
 	}
 	// Human-assigned parents read their own timeline; an automated system

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -212,6 +212,22 @@ func TestChildDoneSkippedWhenParentCancelled(t *testing.T) {
 	}
 }
 
+// TestChildDoneSkippedWhenParentBacklog — a parent deliberately parked in
+// `backlog` must not be woken when a child completes. Waking it would
+// re-activate the parent assignee, which can then promote sibling backlog
+// sub-issues into todo — the surprise auto-activation reported in #4320 /
+// MUL-3497. No system comment, no trigger, until the user explicitly moves
+// the parent out of backlog.
+func TestChildDoneSkippedWhenParentBacklog(t *testing.T) {
+	fx := newChildDoneFixture(t, "backlog")
+
+	updateChildStatus(t, fx.child.ID, "done")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+		t.Errorf("parent at 'backlog' should not receive notification, got %d comments", got)
+	}
+}
+
 // TestChildDoneSkippedWhenNoParent — an issue with no parent_issue_id must
 // not produce any system comment on anything.
 func TestChildDoneSkippedWhenNoParent(t *testing.T) {


### PR DESCRIPTION
## Problem

Reported in Discussion #4320 (MUL-3497): tasks deliberately parked in **Backlog** were auto-activated into **To Do**, and a "Multica" actor appeared to be prompting users' agents.

Root cause: when a sub-issue transitions to `done`, `notifyParentOfChildDone` posts a system comment ("Multica" is the display name for `author_type='system'`) on the parent and explicitly wakes the parent's assignee agent. The woken agent then promotes sibling `backlog` sub-issues into `todo` — which in turn fires their assignees. If the **parent itself** is sitting in `backlog`, the user is deliberately holding it for later, so waking it (and the promotion chain that follows) is exactly the surprise being reported.

## Change

Add a `backlog` guard to `notifyParentOfChildDone`, alongside the existing `done` / `cancelled` guards. When the parent is in `backlog`, the whole notification is skipped — no system comment, no mention, no agent/squad trigger — until the user explicitly moves the parent out of backlog.

This keeps the documented serial sub-task workflow intact for **active** parents (todo / in_progress / in_review / blocked); only parked parents are now left inert, matching the "Backlog = parking lot, user-triggered only" semantics the product already applies to the create/assign path (`shouldEnqueueAgentTask`).

## Test

- `TestChildDoneSkippedWhenParentBacklog` — parent at `backlog`, child → done, asserts zero system comments on the parent.
- Full `TestChildDone*` suite passes (no regression to the active-parent, member, squad, and self-loop-guard cases).

## Scope note

This is the targeted fix requested for the backlog-parent case. The broader options discussed on MUL-3497 (a per-issue/workspace opt-out toggle, or making `backlog` immune to agent-driven promotion in `UpdateIssue`) are intentionally out of scope here.

MUL-3497
