### PR TITLE
fix(server): compute scheduled autopilot next run from claimed planned_at

### DIFF
--- a/server/cmd/server/autopilot_scheduler.go
+++ b/server/cmd/server/autopilot_scheduler.go
@@ -117,12 +117,29 @@ func advanceNextRun(ctx context.Context, queries *db.Queries, t db.ClaimDueSched
 		tz = t.Timezone.String
 	}
 
-	next, err := service.ComputeNextRun(t.CronExpression.String, tz)
+	if !t.PlannedAt.Valid {
+		slog.Warn("autopilot scheduler: planned_at is NULL, cannot compute next run",
+			"trigger_id", util.UUIDToString(t.ID),
+		)
+		return
+	}
+
+	next, err := service.ComputeNextRunFrom(t.CronExpression.String, tz, t.PlannedAt.Time)
 	if err != nil {
 		slog.Warn("autopilot scheduler: failed to compute next run",
 			"trigger_id", util.UUIDToString(t.ID),
 			"cron", t.CronExpression.String,
+			"planned_at", t.PlannedAt.Time,
 			"error", err,
+		)
+		return
+	}
+
+	if !next.After(t.PlannedAt.Time) {
+		slog.Warn("autopilot scheduler: computed next_run_at is not after planned_at",
+			"trigger_id", util.UUIDToString(t.ID),
+			"planned_at", t.PlannedAt.Time,
+			"next_run_at", next,
 		)
 		return
 	}

--- a/server/cmd/server/autopilot_scheduler_test.go
+++ b/server/cmd/server/autopilot_scheduler_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestAdvanceNextRun(t *testing.T) {
+	if testPool == nil {
+		t.Skip("integration DB not available")
+	}
+
+	ctx := context.Background()
+	queries := db.New(testPool)
+	plannedAt := time.Date(2020, time.January, 1, 23, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name            string
+		mutateClaim     func(*db.ClaimDueScheduleTriggersRow)
+		expectNextValid bool
+		expectNext      time.Time
+	}{
+		{
+			name:            "uses claimed planned_at as reference",
+			mutateClaim:     nil,
+			expectNextValid: true,
+			expectNext:      time.Date(2020, time.January, 2, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "planned_at invalid leaves next_run_at NULL",
+			mutateClaim: func(c *db.ClaimDueScheduleTriggersRow) {
+				c.PlannedAt.Valid = false
+			},
+			expectNextValid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID := pickFixtureAgent(t)
+			ap := seedAutopilot(t, queries, "Scheduler planned_at regression "+tc.name, "member", parseUUID(testUserID), agentID)
+
+			trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+				AutopilotID:    ap.ID,
+				Kind:           "schedule",
+				Enabled:        true,
+				CronExpression: pgtype.Text{String: "0 23 * * *", Valid: true},
+				Timezone:       pgtype.Text{String: "UTC", Valid: true},
+				NextRunAt:      pgtype.Timestamptz{Time: plannedAt, Valid: true},
+			})
+			if err != nil {
+				t.Fatalf("CreateAutopilotTrigger: %v", err)
+			}
+
+			claims, err := queries.ClaimDueScheduleTriggers(ctx)
+			if err != nil {
+				t.Fatalf("ClaimDueScheduleTriggers: %v", err)
+			}
+
+			var claimed db.ClaimDueScheduleTriggersRow
+			found := false
+			for _, c := range claims {
+				if c.ID == trigger.ID {
+					claimed = c
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected trigger %v to be claimed; got %d claimed rows", trigger.ID, len(claims))
+			}
+			if !claimed.PlannedAt.Valid {
+				t.Fatal("expected planned_at to be valid on claimed row")
+			}
+			if !claimed.PlannedAt.Time.Equal(plannedAt) {
+				t.Fatalf("expected planned_at %v, got %v", plannedAt, claimed.PlannedAt.Time)
+			}
+
+			if tc.mutateClaim != nil {
+				tc.mutateClaim(&claimed)
+			}
+
+			advanceNextRun(ctx, queries, claimed)
+
+			updated, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+			if err != nil {
+				t.Fatalf("GetAutopilotTrigger: %v", err)
+			}
+
+			if tc.expectNextValid {
+				if !updated.NextRunAt.Valid {
+					t.Fatal("expected next_run_at to be set after advanceNextRun")
+				}
+				if !updated.NextRunAt.Time.Equal(tc.expectNext) {
+					t.Fatalf("expected next_run_at %v, got %v", tc.expectNext, updated.NextRunAt.Time)
+				}
+				return
+			}
+
+			if updated.NextRunAt.Valid {
+				t.Fatalf("expected next_run_at to remain NULL, got %v", updated.NextRunAt.Time)
+			}
+		})
+	}
+}

--- a/server/internal/service/cron.go
+++ b/server/internal/service/cron.go
@@ -10,18 +10,26 @@ import (
 // cronParser accepts standard 5-field cron expressions.
 var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
-// ComputeNextRun parses a cron expression and returns the next fire time
-// in the given timezone.
+// ComputeNextRun parses a cron expression and returns the next fire time in the given
+// timezone, using the current time as reference.
 func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
+	return ComputeNextRunFrom(cronExpr, timezone, time.Now())
+}
+
+// ComputeNextRunFrom parses a cron expression and returns the next fire time in the
+// given timezone, using fromTime as reference.
+func ComputeNextRunFrom(cronExpr, timezone string, fromTime time.Time) (time.Time, error) {
 	sched, err := cronParser.Parse(cronExpr)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse cron: %w", err)
 	}
+
 	loc, err := time.LoadLocation(timezone)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
 	}
-	return sched.Next(time.Now().In(loc)), nil
+
+	return sched.Next(fromTime.In(loc)), nil
 }
 
 // ValidateTimezone returns an error if the timezone string is not recognized.

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -48,16 +48,31 @@ func (q *Queries) AdvanceTriggerNextRun(ctx context.Context, arg AdvanceTriggerN
 
 const claimDueScheduleTriggers = `-- name: ClaimDueScheduleTriggers :many
 
-UPDATE autopilot_trigger t
-SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
-  AND a.status = 'active'
-RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
+WITH due AS (
+  SELECT
+    t.id,
+    t.next_run_at AS planned_at
+  FROM autopilot_trigger t
+  JOIN autopilot a ON a.id = t.autopilot_id
+  WHERE t.kind = 'schedule'
+    AND t.enabled = true
+    AND t.next_run_at IS NOT NULL
+    AND t.next_run_at <= now()
+    AND a.status = 'active'
+  FOR UPDATE SKIP LOCKED
+),
+claimed AS (
+  UPDATE autopilot_trigger t
+  SET next_run_at = NULL
+  FROM due
+  WHERE t.id = due.id
+  RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, due.planned_at
+)
+SELECT
+  claimed.id, claimed.autopilot_id, claimed.kind, claimed.enabled, claimed.cron_expression, claimed.timezone, claimed.next_run_at, claimed.webhook_token, claimed.label, claimed.last_fired_at, claimed.created_at, claimed.updated_at, claimed.provider, claimed.signing_secret, claimed.event_filters, claimed.planned_at,
+  a.workspace_id AS autopilot_workspace_id
+FROM claimed
+JOIN autopilot a ON a.id = claimed.autopilot_id
 `
 
 type ClaimDueScheduleTriggersRow struct {
@@ -76,6 +91,7 @@ type ClaimDueScheduleTriggersRow struct {
 	Provider             string             `json:"provider"`
 	SigningSecret        pgtype.Text        `json:"signing_secret"`
 	EventFilters         []byte             `json:"event_filters"`
+	PlannedAt            pgtype.Timestamptz `json:"planned_at"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -83,7 +99,7 @@ type ClaimDueScheduleTriggersRow struct {
 // Scheduler Queries
 // =====================
 // Atomically claim all due schedule triggers to prevent concurrent execution.
-// Joins the autopilot table to ensure only active autopilots are fired.
+// Returns planned_at (the original next_run_at) so scheduler can advance from DB-based claimed time.
 func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueScheduleTriggersRow, error) {
 	rows, err := q.db.Query(ctx, claimDueScheduleTriggers)
 	if err != nil {
@@ -109,6 +125,7 @@ func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueSched
 			&i.Provider,
 			&i.SigningSecret,
 			&i.EventFilters,
+			&i.PlannedAt,
 			&i.AutopilotWorkspaceID,
 		); err != nil {
 			return nil, err

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -254,17 +254,32 @@ RETURNING *;
 
 -- name: ClaimDueScheduleTriggers :many
 -- Atomically claim all due schedule triggers to prevent concurrent execution.
--- Joins the autopilot table to ensure only active autopilots are fired.
-UPDATE autopilot_trigger t
-SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
-  AND a.status = 'active'
-RETURNING t.*, a.workspace_id AS autopilot_workspace_id;
+-- Returns planned_at (the original next_run_at) so scheduler can advance from DB-based claimed time.
+WITH due AS (
+  SELECT
+    t.id,
+    t.next_run_at AS planned_at
+  FROM autopilot_trigger t
+  JOIN autopilot a ON a.id = t.autopilot_id
+  WHERE t.kind = 'schedule'
+    AND t.enabled = true
+    AND t.next_run_at IS NOT NULL
+    AND t.next_run_at <= now()
+    AND a.status = 'active'
+  FOR UPDATE SKIP LOCKED
+),
+claimed AS (
+  UPDATE autopilot_trigger t
+  SET next_run_at = NULL
+  FROM due
+  WHERE t.id = due.id
+  RETURNING t.*, due.planned_at
+)
+SELECT
+  claimed.*,
+  a.workspace_id AS autopilot_workspace_id
+FROM claimed
+JOIN autopilot a ON a.id = claimed.autopilot_id;
 
 -- =====================
 -- Task Queue (run_only mode)


### PR DESCRIPTION
## What does this PR do?
Fixes a scheduler race/clock-skew bug where the same scheduled autopilot occurrence could be re-scheduled and fired again in multi-node deployments.

This PR addresses the scheduler clock-skew path only; duplicate-run idempotency is intentionally left for a follow-up PR

Root cause:

- Due triggers were claimed using DB time.
- Next run was recomputed from node-local time.
- If node time lagged behind DB time, the scheduler could compute the same occurrence again.

This PR fixes that by computing next_run_at from the claimed planned occurrence time returned by the claim query, not from local wall clock time.

## Related Issue

Refs #4384

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made
- Updated due-trigger claim query to return `planned_at` (original `next_run_at` at claim time).
- Regenerated sqlc artifacts for updated query shape.
- Added reference-time cron helper `ComputeNextRunFrom` and kept `ComputeNextRun` as wrapper.
- Updated scheduler advancement logic to compute from claimed `planned_at` instead of local `now`.
    - Defensive check for `planned_at` validity.
    - Monotonicity guard ensuring `next_run_at` is strictly after `planned_at`.
- Added table-driven regression test for `planned_at`-based advancement and invalid `planned_at` path.

## How to Test
1. Regenerate sqlc:
   `make sqlc`
2. Run focused scheduler regression test:
   `go test ./cmd/server -run TestAdvanceNextRun`
3. Run affected package tests:
   `go test ./internal/service ./cmd/server`

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge