### PR TITLE
fix(issues): reflect real common value in batch toolbar pickers (MUL-3510)

### DIFF
--- a/packages/core/issues/batch.test.ts
+++ b/packages/core/issues/batch.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import type { Issue } from "../types";
+import { commonIssueFields } from "./batch";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Issue 1",
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 1,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("commonIssueFields", () => {
+  it("returns all-null for an empty selection (nothing to reflect)", () => {
+    expect(commonIssueFields([])).toEqual({
+      status: null,
+      priority: null,
+      assignee: null,
+    });
+  });
+
+  it("reflects a single issue's own fields", () => {
+    const common = commonIssueFields([
+      makeIssue({ status: "in_progress", priority: "high", assignee_type: "member", assignee_id: "u-1" }),
+    ]);
+    expect(common.status).toBe("in_progress");
+    expect(common.priority).toBe("high");
+    expect(common.assignee).toEqual({ type: "member", id: "u-1" });
+  });
+
+  it("returns the shared status when every issue agrees, not a hardcoded default", () => {
+    // Regression for MUL-3510: the batch picker used to assert "todo"
+    // regardless of the selection.
+    const common = commonIssueFields([
+      makeIssue({ id: "a", status: "in_review" }),
+      makeIssue({ id: "b", status: "in_review" }),
+    ]);
+    expect(common.status).toBe("in_review");
+  });
+
+  it("returns null status when the selection spans different statuses (mixed)", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", status: "todo" }),
+      makeIssue({ id: "b", status: "done" }),
+    ]);
+    expect(common.status).toBeNull();
+  });
+
+  it("derives each field independently — shared status, mixed priority", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", status: "blocked", priority: "urgent" }),
+      makeIssue({ id: "b", status: "blocked", priority: "low" }),
+    ]);
+    expect(common.status).toBe("blocked");
+    expect(common.priority).toBeNull();
+  });
+
+  it("treats an all-unassigned selection as a real shared value, not mixed", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", assignee_type: null, assignee_id: null }),
+      makeIssue({ id: "b", assignee_type: null, assignee_id: null }),
+    ]);
+    expect(common.assignee).toEqual({ type: null, id: null });
+  });
+
+  it("returns the shared assignee when every issue points at the same actor", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", assignee_type: "agent", assignee_id: "agent-1" }),
+      makeIssue({ id: "b", assignee_type: "agent", assignee_id: "agent-1" }),
+    ]);
+    expect(common.assignee).toEqual({ type: "agent", id: "agent-1" });
+  });
+
+  it("returns null assignee when actors differ", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", assignee_type: "member", assignee_id: "u-1" }),
+      makeIssue({ id: "b", assignee_type: "member", assignee_id: "u-2" }),
+    ]);
+    expect(common.assignee).toBeNull();
+  });
+
+  it("returns null assignee when some are assigned and some are unassigned", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", assignee_type: "member", assignee_id: "u-1" }),
+      makeIssue({ id: "b", assignee_type: null, assignee_id: null }),
+    ]);
+    expect(common.assignee).toBeNull();
+  });
+
+  it("distinguishes assignees of the same id but different type", () => {
+    const common = commonIssueFields([
+      makeIssue({ id: "a", assignee_type: "member", assignee_id: "x" }),
+      makeIssue({ id: "b", assignee_type: "agent", assignee_id: "x" }),
+    ]);
+    expect(common.assignee).toBeNull();
+  });
+});

--- a/packages/core/issues/batch.ts
+++ b/packages/core/issues/batch.ts
@@ -1,0 +1,72 @@
+import type {
+  Issue,
+  IssueStatus,
+  IssuePriority,
+  IssueAssigneeType,
+} from "../types";
+
+/**
+ * Shared assignee across a selection. `{ type: null, id: null }` means every
+ * selected issue is unassigned — a real shared value, distinct from a mixed
+ * selection (which {@link commonIssueFields} reports as `assignee: null`).
+ */
+export interface CommonAssignee {
+  type: IssueAssigneeType | null;
+  id: string | null;
+}
+
+/**
+ * The status / priority / assignee shared by every issue in a batch selection.
+ * A field is `null` when the selection is empty or the issues disagree
+ * ("mixed"). Batch property pickers use this to reflect the real common value
+ * and fall back to an empty (no-checkmark) state when the values differ,
+ * instead of asserting a hardcoded default.
+ */
+export interface CommonIssueFields {
+  status: IssueStatus | null;
+  priority: IssuePriority | null;
+  assignee: CommonAssignee | null;
+}
+
+/**
+ * Returns the value shared by every item, or `null` when the list is empty or
+ * the items disagree. Comparison is by primitive equality, so callers pass a
+ * scalar key (collapse composite values to a string before calling).
+ */
+function sharedValue<T>(values: readonly T[]): T | null {
+  if (values.length === 0) return null;
+  const first = values[0]!;
+  return values.every((v) => v === first) ? first : null;
+}
+
+const ASSIGNEE_KEY_SEP = "\u0000";
+
+/**
+ * Collapse a polymorphic assignee (type + id, either nullable) into a single
+ * comparable key so all-unassigned issues compare equal to each other and
+ * distinct from any assigned actor.
+ */
+function assigneeKey(type: IssueAssigneeType | null, id: string | null): string {
+  return `${type ?? ""}${ASSIGNEE_KEY_SEP}${id ?? ""}`;
+}
+
+/**
+ * Derive the common status / priority / assignee of the selected issues.
+ * Pass the already-filtered selection (the issues that are actually selected),
+ * mirroring how the skill list filters its rows by `selectedIds` before
+ * handing them to its batch toolbar.
+ */
+export function commonIssueFields(issues: readonly Issue[]): CommonIssueFields {
+  const status = sharedValue(issues.map((i) => i.status));
+  const priority = sharedValue(issues.map((i) => i.priority));
+
+  const sharedAssigneeKey = sharedValue(
+    issues.map((i) => assigneeKey(i.assignee_type, i.assignee_id)),
+  );
+  const assignee =
+    sharedAssigneeKey !== null && issues.length > 0
+      ? { type: issues[0]!.assignee_type, id: issues[0]!.assignee_id }
+      : null;
+
+  return { status, priority, assignee };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "./workspace/workspace-url": "./workspace/workspace-url.ts",
     "./workspace/avatar-url": "./workspace/avatar-url.ts",
     "./issues": "./issues/index.ts",
+    "./issues/batch": "./issues/batch.ts",
     "./issues/queries": "./issues/queries.ts",
     "./issues/mutations": "./issues/mutations.ts",
     "./issues/timeline-sort": "./issues/timeline-sort.ts",

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -216,7 +216,7 @@ export function ActorIssuesPanel({
             />
           </div>
         )}
-        <BatchActionToolbar />
+        <BatchActionToolbar issues={issues} />
       </div>
     </ViewStoreProvider>
   );

--- a/packages/views/issues/components/batch-action-toolbar.test.tsx
+++ b/packages/views/issues/components/batch-action-toolbar.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Issue } from "@multica/core/types";
+import { BatchActionToolbar } from "./batch-action-toolbar";
+
+// Mutable selection state shared with the store mock below. The real toolbar
+// derives the pickers' current value from the issues it can resolve out of
+// this selection, so each test sets `selection.selectedIds` before rendering.
+const selection = vi.hoisted(() => ({
+  selectedIds: new Set<string>(),
+  clear: () => {},
+}));
+
+vi.mock("@multica/core/issues/stores/selection-store", () => ({
+  useIssueSelectionStore: (selector: (s: typeof selection) => unknown) =>
+    selector(selection),
+}));
+
+vi.mock("@multica/core/issues/mutations", () => ({
+  useBatchUpdateIssues: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useBatchDeleteIssues: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "label" }),
+}));
+
+// Render each picker as a probe that surfaces the value the toolbar passed in,
+// so the test asserts the wiring (real `commonIssueFields` runs underneath).
+vi.mock("./pickers", () => ({
+  StatusPicker: ({ status }: { status: string | null }) => (
+    <div data-testid="status-picker" data-status={status ?? "__none__"} />
+  ),
+  PriorityPicker: ({ priority }: { priority: string | null }) => (
+    <div data-testid="priority-picker" data-priority={priority ?? "__none__"} />
+  ),
+  AssigneePicker: ({
+    assigneeType,
+    assigneeId,
+    mixed,
+  }: {
+    assigneeType: string | null;
+    assigneeId: string | null;
+    mixed?: boolean;
+  }) => (
+    <div
+      data-testid="assignee-picker"
+      data-assignee-type={assigneeType ?? "__null__"}
+      data-assignee-id={assigneeId ?? "__null__"}
+      data-mixed={String(Boolean(mixed))}
+    />
+  ),
+}));
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Issue 1",
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 1,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  selection.selectedIds = new Set();
+});
+
+describe("BatchActionToolbar picker wiring", () => {
+  it("reflects the shared status / priority / assignee of the selected issues", () => {
+    const issues = [
+      makeIssue({ id: "a", status: "in_progress", priority: "high", assignee_type: "member", assignee_id: "u-1" }),
+      makeIssue({ id: "b", status: "in_progress", priority: "high", assignee_type: "member", assignee_id: "u-1" }),
+    ];
+    selection.selectedIds = new Set(["a", "b"]);
+
+    render(<BatchActionToolbar issues={issues} />);
+
+    expect(screen.getByTestId("status-picker")).toHaveAttribute("data-status", "in_progress");
+    expect(screen.getByTestId("priority-picker")).toHaveAttribute("data-priority", "high");
+    const assignee = screen.getByTestId("assignee-picker");
+    expect(assignee).toHaveAttribute("data-assignee-type", "member");
+    expect(assignee).toHaveAttribute("data-assignee-id", "u-1");
+    expect(assignee).toHaveAttribute("data-mixed", "false");
+  });
+
+  it("falls back to an empty (no-checkmark) state when the selection is mixed", () => {
+    const issues = [
+      makeIssue({ id: "a", status: "todo", priority: "none", assignee_type: "member", assignee_id: "u-1" }),
+      makeIssue({ id: "b", status: "done", priority: "urgent", assignee_type: "agent", assignee_id: "ag-1" }),
+    ];
+    selection.selectedIds = new Set(["a", "b"]);
+
+    render(<BatchActionToolbar issues={issues} />);
+
+    expect(screen.getByTestId("status-picker")).toHaveAttribute("data-status", "__none__");
+    expect(screen.getByTestId("priority-picker")).toHaveAttribute("data-priority", "__none__");
+    expect(screen.getByTestId("assignee-picker")).toHaveAttribute("data-mixed", "true");
+  });
+
+  it("treats an all-unassigned selection as unassigned, not mixed", () => {
+    const issues = [
+      makeIssue({ id: "a", assignee_type: null, assignee_id: null }),
+      makeIssue({ id: "b", assignee_type: null, assignee_id: null }),
+    ];
+    selection.selectedIds = new Set(["a", "b"]);
+
+    render(<BatchActionToolbar issues={issues} />);
+
+    const assignee = screen.getByTestId("assignee-picker");
+    expect(assignee).toHaveAttribute("data-mixed", "false");
+    expect(assignee).toHaveAttribute("data-assignee-type", "__null__");
+    expect(assignee).toHaveAttribute("data-assignee-id", "__null__");
+  });
+
+  it("renders nothing when nothing is selected", () => {
+    render(<BatchActionToolbar issues={[makeIssue({ id: "a" })]} />);
+    expect(screen.queryByTestId("status-picker")).toBeNull();
+  });
+});

--- a/packages/views/issues/components/batch-action-toolbar.tsx
+++ b/packages/views/issues/components/batch-action-toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { X, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
@@ -14,16 +14,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
-import type { UpdateIssueRequest } from "@multica/core/types";
+import type { Issue, UpdateIssueRequest } from "@multica/core/types";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { commonIssueFields } from "@multica/core/issues/batch";
 import { useBatchUpdateIssues, useBatchDeleteIssues } from "@multica/core/issues/mutations";
 import { StatusPicker, PriorityPicker, AssigneePicker } from "./pickers";
 import { useT } from "../../i18n";
 import { cn } from "@multica/ui/lib/utils";
 
 export function BatchActionToolbar({
+  issues,
   placement = "fixed-bottom",
 }: {
+  /**
+   * The universe of selectable issues at this call site (the same list the
+   * rows are rendered from). The toolbar filters it by the global selection to
+   * reflect the real common status / priority / assignee of the selected
+   * issues, mirroring how the skill list filters its rows by `selectedIds`.
+   */
+  issues: Issue[];
   /**
    * "fixed-bottom" — floats at the bottom of the viewport (default; used by
    * full-screen issue lists).
@@ -36,6 +45,14 @@ export function BatchActionToolbar({
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const clear = useIssueSelectionStore((s) => s.clear);
   const count = selectedIds.size;
+
+  // Reflect the real shared value of the selected issues in each picker; fall
+  // back to an empty (no-checkmark) state when the selection is mixed, instead
+  // of asserting a hardcoded default.
+  const common = useMemo(
+    () => commonIssueFields(issues.filter((i) => selectedIds.has(i.id))),
+    [issues, selectedIds],
+  );
 
   const [statusOpen, setStatusOpen] = useState(false);
   const [priorityOpen, setPriorityOpen] = useState(false);
@@ -101,7 +118,7 @@ export function BatchActionToolbar({
 
         {/* Status */}
         <StatusPicker
-          status="todo"
+          status={common.status}
           onUpdate={handleBatchUpdate}
           open={statusOpen}
           onOpenChange={setStatusOpen}
@@ -112,7 +129,7 @@ export function BatchActionToolbar({
 
         {/* Priority */}
         <PriorityPicker
-          priority="none"
+          priority={common.priority}
           onUpdate={handleBatchUpdate}
           open={priorityOpen}
           onOpenChange={setPriorityOpen}
@@ -123,8 +140,9 @@ export function BatchActionToolbar({
 
         {/* Assignee */}
         <AssigneePicker
-          assigneeType={null}
-          assigneeId={null}
+          assigneeType={common.assignee?.type ?? null}
+          assigneeId={common.assignee?.id ?? null}
+          mixed={common.assignee === null}
           onUpdate={handleBatchUpdate}
           open={assigneeOpen}
           onOpenChange={setAssigneeOpen}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2004,7 +2004,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
                 {/* Inline batch toolbar — appears next to the rows when
                     selections exist, instead of as a far-away fixed bar. */}
-                <BatchActionToolbar placement="inline" />
+                <BatchActionToolbar issues={childIssues} placement="inline" />
 
                 {/* List */}
                 {!subIssuesCollapsed && (

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -288,7 +288,7 @@ export function IssuesPage() {
             )}
           </div>
         )}
-        {viewMode === "list" && <BatchActionToolbar />}
+        {viewMode === "list" && <BatchActionToolbar issues={issues} />}
       </ViewStoreProvider>
     </div>
   );

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -40,6 +40,7 @@ export function canAssignAgent(
 export function AssigneePicker({
   assigneeType,
   assigneeId,
+  mixed = false,
   onUpdate,
   trigger: customTrigger,
   triggerRender,
@@ -49,6 +50,13 @@ export function AssigneePicker({
 }: {
   assigneeType: IssueAssigneeType | null;
   assigneeId: string | null;
+  /**
+   * `true` when a batch selection spans different assignees ("mixed"): no row
+   * is checked, including the unassigned row. Distinct from `assigneeType` /
+   * `assigneeId` both being `null`, which means every selected issue is
+   * genuinely unassigned and the unassigned row should be checked.
+   */
+  mixed?: boolean;
   onUpdate: (updates: Partial<UpdateIssueRequest>) => void;
   trigger?: React.ReactNode;
   triggerRender?: React.ReactElement;
@@ -129,7 +137,7 @@ export function AssigneePicker({
       {/* Unassigned option — hidden when search is active */}
       {!query && (
         <PickerItem
-          selected={!assigneeType && !assigneeId}
+          selected={!mixed && !assigneeType && !assigneeId}
           onClick={() => {
             onUpdate({ assignee_type: null, assignee_id: null });
             setOpen(false);

--- a/packages/views/issues/components/pickers/priority-picker.tsx
+++ b/packages/views/issues/components/pickers/priority-picker.tsx
@@ -17,7 +17,13 @@ export function PriorityPicker({
   align,
   defaultOpen = false,
 }: {
-  priority: IssuePriority;
+  /**
+   * The currently-selected priority, used to check the matching row. `null`
+   * means "no single current value" (e.g. a batch selection spanning several
+   * priorities) — no row is checked. Single-issue callers always pass a
+   * concrete priority.
+   */
+  priority: IssuePriority | null;
   onUpdate: (updates: Partial<UpdateIssueRequest>) => void;
   trigger?: React.ReactNode;
   triggerRender?: React.ReactElement;
@@ -41,12 +47,13 @@ export function PriorityPicker({
       align={align}
       triggerRender={triggerRender}
       trigger={
-        customTrigger ?? (
+        customTrigger ??
+        (priority != null ? (
           <>
             <PriorityIcon priority={priority} className="shrink-0" />
             <span className="truncate">{t(($) => $.priority[priority])}</span>
           </>
-        )
+        ) : null)
       }
     >
       {PRIORITY_ORDER.map((p) => {

--- a/packages/views/issues/components/pickers/status-picker.tsx
+++ b/packages/views/issues/components/pickers/status-picker.tsx
@@ -16,7 +16,13 @@ export function StatusPicker({
   onOpenChange: controlledOnOpenChange,
   align,
 }: {
-  status: IssueStatus;
+  /**
+   * The currently-selected status, used to check the matching row. `null`
+   * means "no single current value" (e.g. a batch selection spanning several
+   * statuses) — no row is checked. Single-issue callers always pass a concrete
+   * status.
+   */
+  status: IssueStatus | null;
   onUpdate: (updates: Partial<UpdateIssueRequest>) => void;
   trigger?: React.ReactNode;
   triggerRender?: React.ReactElement;
@@ -37,12 +43,13 @@ export function StatusPicker({
       align={align}
       triggerRender={triggerRender}
       trigger={
-        customTrigger ?? (
+        customTrigger ??
+        (status != null ? (
           <>
             <StatusIcon status={status} className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{t(($) => $.status[status])}</span>
           </>
-        )
+        ) : null)
       }
     >
       {ALL_STATUSES.map((s) => {

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -302,7 +302,7 @@ export function MyIssuesPage() {
             )}
           </div>
         )}
-        {viewMode === "list" && <BatchActionToolbar />}
+        {viewMode === "list" && <BatchActionToolbar issues={issues} />}
       </ViewStoreProvider>
     </div>
   );

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -405,7 +405,7 @@ function ProjectIssuesSurface({
         sort={sort}
         ganttIssues={ganttIssues}
       />
-      <BatchActionToolbar />
+      <BatchActionToolbar issues={projectIssues} />
     </>
   );
 }


### PR DESCRIPTION
## What & why

Fixes MUL-3510. In the Kanban **List** mode, selecting issues and opening the bulk **Status** picker always showed `todo` as the checked/current value, regardless of the selected issues' real statuses. The batch write itself was fine — only the picker's displayed current value was wrong.

Root cause: `batch-action-toolbar.tsx` hardcoded the pickers' current value (`status="todo"`, `priority="none"`, assignee `null/null`). `StatusPicker` checks the row where `s === status`, so `todo` was always checked. The same defect applied to **priority** and **assignee**, and the toolbar is reused in 5 places (issues list, my-issues, project detail, actor issues panel, sub-issues), all inheriting it.

The selection store holds only IDs, so the toolbar never saw the issue objects — it could only assert a constant. The skill list avoids this by filtering its rows by `selectedIds` and passing the full data down; this PR applies the same approach to issues.

## Changes

- New pure helper `commonIssueFields(issues)` in `@multica/core/issues/batch` returning the **shared** status / priority / assignee of a selection, or `null` (mixed/empty). All-unassigned stays a real shared value (`{type:null,id:null}`), distinct from mixed.
- `BatchActionToolbar` takes an `issues` prop (the selectable universe), filters it by the global selection, and feeds the derived common values into the pickers. Each of the 5 call sites passes its issue array.
- Pickers accept a nullable current value (no row checked when `null`). `AssigneePicker` gains a `mixed` flag so an all-unassigned selection still checks "No assignee" while a mixed one checks nothing.
- No UI copy or interaction changes.

## Behavior

| Selection | Picker shows |
| --- | --- |
| All issues share a status/priority/assignee | that value checked (real reflection) |
| Mixed | nothing checked (it's a "set to" action) |
| All unassigned | "No assignee" checked |

## Verification

- `pnpm test` — core **599 passed**, views **1433 passed** (incl. new `batch.test.ts` and `batch-action-toolbar.test.tsx`)
- `pnpm typecheck` — clean (core + views)
- `eslint` — clean on changed files

## Risk

Low. Picker prop widening is backward compatible (single-issue callers always pass a concrete value). The batch update path (which issues get written) is unchanged — only the displayed current value is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
