### PR TITLE
feat(issues): open agent activity chip on hover (MUL-3507)

### DIFF
--- a/packages/views/issues/components/issue-agent-header-chip.test.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.test.tsx
@@ -8,6 +8,9 @@ import { renderWithI18n } from "../../test/i18n";
 const mockState = vi.hoisted(() => ({
   snapshot: [] as unknown[],
   taskMessagesOptions: vi.fn(),
+  // Captures the props the chip passes to PopoverTrigger so a test can assert
+  // the card is wired to open on hover, not only on click.
+  triggerProps: undefined as Record<string, unknown> | undefined,
 }));
 
 vi.mock("@multica/core/hooks", () => ({
@@ -43,10 +46,14 @@ vi.mock("@multica/ui/components/ui/popover", async () => {
     PopoverTrigger: ({
       render,
       children,
+      ...props
     }: {
       render: React.ReactElement;
       children: React.ReactNode;
-    }) => React.cloneElement(render, undefined, children),
+    } & Record<string, unknown>) => {
+      mockState.triggerProps = props;
+      return React.cloneElement(render, undefined, children);
+    },
     PopoverContent: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="agent-popover-content">{children}</div>
     ),
@@ -100,6 +107,7 @@ beforeEach(() => {
   cleanup();
   vi.clearAllMocks();
   mockState.snapshot = [];
+  mockState.triggerProps = undefined;
 });
 
 describe("IssueAgentHeaderChip", () => {
@@ -127,6 +135,20 @@ describe("IssueAgentHeaderChip", () => {
       "task-running",
     );
     expect(mockState.taskMessagesOptions).not.toHaveBeenCalled();
+  });
+
+  it("opens the activity card on hover, not only on click", () => {
+    mockState.snapshot = [makeTask({})];
+
+    renderWithI18n(<IssueAgentHeaderChip issueId="issue-1" />);
+
+    // Base UI gates hover-to-open on `openOnHover` on the trigger. Without it
+    // the chip would be click-only, which is the behavior MUL-3507 replaces.
+    // The trigger stays a real <button>, so click/keyboard access is retained.
+    expect(mockState.triggerProps?.openOnHover).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Walt is working" }),
+    ).toBeInTheDocument();
   });
 
   it("uses the concise multi-agent working label", () => {

--- a/packages/views/issues/components/issue-agent-header-chip.tsx
+++ b/packages/views/issues/components/issue-agent-header-chip.tsx
@@ -32,9 +32,10 @@ import { useT } from "../../i18n";
 //   - queued only        → "{name} is queued" / "N agents queued",
 //                          half-opacity avatars / muted text (no beam)
 //
-// Click opens a compact Popover card with the same active rows as the right
-// panel. Those rows show necessary status/time and task entry actions, but do
-// not render event counts or prefetch task messages for a count.
+// Hovering the chip opens a compact Popover card with the same active rows as
+// the right panel (click / keyboard still toggle it for touch and a11y). Those
+// rows show necessary status/time and task entry actions, but do not render
+// event counts or prefetch task messages for a count.
 
 interface IssueAgentHeaderChipProps {
   issueId: string;
@@ -106,7 +107,18 @@ function ActiveChip({ issueId, running, queued }: ActiveChipProps) {
   return (
     <div className="flex items-center gap-1">
       <Popover>
+        {/* Hover opens the card so the live activity reads as a glanceable
+            status surface, not a click target. In Base UI the hover config
+            lives on the Trigger (a popover can have multiple triggers), not
+            the Root. The trigger stays a real button, so click and keyboard
+            (Enter/Space) still toggle it for touch and a11y. A short open
+            delay avoids flicker when the pointer merely passes over the chip;
+            the close delay keeps it open while the pointer travels across the
+            hover bridge into the interactive rows. */}
         <PopoverTrigger
+          openOnHover
+          delay={150}
+          closeDelay={200}
           render={
             <button
               type="button"


### PR DESCRIPTION
## Problem

The header "agent is working" chip required a **click** to reveal the activity card. Expected behavior (MUL-3507): hovering the chip should open the card, so the live signal reads as a glanceable status surface rather than a click target.

## Change

`packages/views/issues/components/issue-agent-header-chip.tsx`:

- Added `openOnHover delay={150} closeDelay={200}` to the chip's `PopoverTrigger`. In Base UI v1.x the hover config lives on `Popover.Trigger` (a popover can have multiple triggers), **not** `Popover.Root` — verified against the official docs.
- The trigger stays a real `<button>`, so click + keyboard (Enter/Space) still toggle the card for touch and a11y.
- Updated the component doc comment that still said "click opens the card".

`packages/views/issues/components/issue-agent-header-chip.test.tsx`:

- Added a regression test asserting `openOnHover` is wired on the trigger. The existing tests mock the popover and would pass for both a click-only and a hover implementation; this new test fails for a click-only regression.

## Verification

- Prop placement verified against base-ui.com/react/components/popover.
- Not run locally: `pnpm typecheck` / tests — the agent worktree has no installed dependencies. CI should run them.

## Note / follow-up

The card hosts interactive `ActiveTaskRow`s that can open a modal (confirm/transcript, kept alive via `keepMounted`). With hover-open, the popover closes on pointer-leave after `closeDelay` (set to 200ms). The trigger→popup hover bridge covers normal travel, but the "hover the card, then click to open a nested modal" path is worth a quick manual check to confirm the modal isn't dismissed when the pointer leaves the popover.

MUL-3507
