### PR TITLE
fix(issues): add settle-lock to swimlane drag

### DIFF
--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -612,11 +612,34 @@ describe("SwimLaneView", () => {
       });
     });
 
-    expect(mockOnMoveIssue).toHaveBeenCalledWith("orphan-1", {
-      parent_issue_id: null,
-      status: "in_progress",
-      position: 300,
+    expect(mockOnMoveIssue).toHaveBeenCalledWith(
+      "orphan-1",
+      { parent_issue_id: null, status: "in_progress", position: 300 },
+      expect.any(Function),
+    );
+  });
+
+  it("passes a settle callback that releases the lock without error", () => {
+    const mockOnMoveIssue = vi.fn();
+    renderWithI18n(
+      <SwimLaneView issues={mockIssues} onMoveIssue={mockOnMoveIssue} />,
+    );
+
+    const targetCellId = "swim:parent:none:in_progress";
+    act(() => {
+      lastOnDragOver({ active: { id: "orphan-1" }, over: { id: targetCellId } });
     });
+    act(() => {
+      lastOnDragEnd({ active: { id: "orphan-1" }, over: { id: targetCellId } });
+    });
+
+    // The move carries a settle callback (held from drop until the mutation
+    // settles); invoking it releases the lock and re-syncs from the cache.
+    const onSettled = mockOnMoveIssue.mock.calls[0]?.[2] as
+      | (() => void)
+      | undefined;
+    expect(typeof onSettled).toBe("function");
+    expect(() => act(() => onSettled?.())).not.toThrow();
   });
 
   it("does not call onMoveIssue when drop target equals source cell (no-op)", () => {
@@ -661,6 +684,7 @@ describe("SwimLaneView", () => {
         parent_issue_id: "parent-1",
         status: "todo",
       }),
+      expect.any(Function),
     );
   });
 
@@ -1060,6 +1084,7 @@ describe("SwimLaneView", () => {
     expect(mockOnMoveIssue).toHaveBeenCalledWith(
       "issue-c",
       expect.objectContaining({ project_id: "proj-1", status: "todo" }),
+      expect.any(Function),
     );
   });
 
@@ -1082,6 +1107,7 @@ describe("SwimLaneView", () => {
     expect(mockOnMoveIssue).toHaveBeenCalledWith(
       "issue-a",
       expect.objectContaining({ project_id: null, status: "in_review" }),
+      expect.any(Function),
     );
   });
 
@@ -1164,6 +1190,7 @@ describe("SwimLaneView", () => {
         assignee_id: "user-1",
         status: "in_review",
       }),
+      expect.any(Function),
     );
   });
 
@@ -1190,6 +1217,7 @@ describe("SwimLaneView", () => {
         assignee_id: null,
         status: "done",
       }),
+      expect.any(Function),
     );
   });
 

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -467,7 +467,11 @@ export function SwimLaneView({
   activeFilters?: Omit<IssueFilters, "statusFilters" | "runningIssueIds">;
   visibleStatuses?: IssueStatus[];
   hiddenStatuses?: IssueStatus[];
-  onMoveIssue: (issueId: string, updates: SwimLaneMoveUpdates) => void;
+  onMoveIssue: (
+    issueId: string,
+    updates: SwimLaneMoveUpdates,
+    onSettled?: () => void,
+  ) => void;
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
@@ -782,6 +786,12 @@ export function SwimLaneView({
 
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
   const isDraggingRef = useRef(false);
+  // Settle lock: held from drop until the move mutation settles, so a cache
+  // change that lands mid-flight (e.g. a membership refetch) does not rebuild
+  // localCells out from under the optimistic move. Mirrors board-view /
+  // list-view. settleVersion forces the resync once the lock releases.
+  const isSettlingRef = useRef(false);
+  const [settleVersion, setSettleVersion] = useState(0);
 
   const issueMap = useMemo(() => {
     const map = new Map<string, Issue>();
@@ -790,7 +800,7 @@ export function SwimLaneView({
   }, [mergedIssues]);
 
   const issueMapRef = useRef(issueMap);
-  if (!isDraggingRef.current) {
+  if (!isDraggingRef.current && !isSettlingRef.current) {
     issueMapRef.current = issueMap;
   }
 
@@ -799,10 +809,10 @@ export function SwimLaneView({
   localCellsRef.current = localCells;
 
   useEffect(() => {
-    if (!isDraggingRef.current) {
+    if (!isDraggingRef.current && !isSettlingRef.current) {
       setLocalCells(cells);
     }
-  }, [cells]);
+  }, [cells, settleVersion]);
 
   const recentlyMovedRef = useRef(false);
   useEffect(() => {
@@ -1062,11 +1072,19 @@ export function SwimLaneView({
         return;
       }
 
-      onMoveIssue(activeId, {
-        ...targetLane.moveUpdates,
-        status: finalOverCell.status as IssueStatus,
-        position: newPosition,
-      });
+      isSettlingRef.current = true;
+      onMoveIssue(
+        activeId,
+        {
+          ...targetLane.moveUpdates,
+          status: finalOverCell.status as IssueStatus,
+          position: newPosition,
+        },
+        () => {
+          isSettlingRef.current = false;
+          setSettleVersion((v) => v + 1);
+        },
+      );
     },
     [cells, cellSet, laneByKey, laneGroups, onMoveIssue, swimlaneGrouping, viewStoreApi],
   );


### PR DESCRIPTION
## What & why

Stacked on #4415. The swimlane (lane) view drag had **no settle window**: its resync `useEffect` (and the `issueMap` freeze) guarded only `isDraggingRef`, so a cache change landing after drop but before the move mutation settled could rebuild `localCells` out from under the optimistic move. The board and list views already have this settle-lock; swimlane was the last drag surface missing it.

(Its exposure is already reduced by the cache-layer fixes in #4415 — most mid-flight refetches are gone — but the lock makes swimlane correct on the membership-change refetches that remain, and keeps the three drag surfaces consistent.)

## Changes

- Add `isSettlingRef` + `settleVersion`; gate both the resync `useEffect` and the `issueMap` freeze on them (mirrors board-view / list-view).
- `handleDragEnd` holds the lock from drop and releases it in the move's `onSettled` callback, forcing a single resync from the reconciled cache.
- Widen the `onMoveIssue` prop to accept the optional `onSettled` callback board/list already use; the parent `handleMoveIssue` supplies it.

## Verification

- `@multica/views` 1430 tests pass (incl. updated drag assertions + a new settle-callback test); `tsc --noEmit` + eslint clean.

## Scope

Frontend-only — `packages/views/issues/components/swimlane-view.tsx` (+ its test).

Reviewed approach: Howard required swimlane be its own PR (large 2D component, isolated rollback) — this is that PR.

Multica: MUL-3493
