### PR TITLE
fix(issue): add timeline summary parameter to reduce payload size

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -837,6 +837,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 
 			// Comments
 			r.Route("/api/comments/{commentId}", func(r chi.Router) {
+				r.Get("/", h.GetComment)
 				r.Put("/", h.UpdateComment)
 				r.Delete("/", h.DeleteComment)
 				r.Post("/resolve", h.ResolveComment)

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -25,8 +25,9 @@ type TimelineEntry struct {
 	Details json.RawMessage `json:"details,omitempty"`
 
 	// Comment-only fields
-	Content        *string              `json:"content,omitempty"`
-	ParentID       *string              `json:"parent_id,omitempty"`
+	Content          *string              `json:"content,omitempty"`
+	ContentTruncated *bool                `json:"content_truncated,omitempty"`
+	ParentID         *string              `json:"parent_id,omitempty"`
 	UpdatedAt      *string              `json:"updated_at,omitempty"`
 	CommentType    *string              `json:"comment_type,omitempty"`
 	Reactions      []ReactionResponse   `json:"reactions,omitempty"`
@@ -103,10 +104,25 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 	wantWrapped := q.Get("limit") != "" || q.Get("before") != "" ||
 		q.Get("after") != "" || q.Get("around") != ""
 
+	summary := false
+	if summaryStr := q.Get("summary"); summaryStr != "" {
+		switch summaryStr {
+		case "true":
+			summary = true
+		case "false":
+		default:
+			writeError(w, http.StatusBadRequest, "invalid summary parameter; expected boolean")
+			return
+		}
+	}
+
 	if wantWrapped {
 		entries := h.mergeTimeline(r, comments, activities, false)
 		if entries == nil {
 			entries = []TimelineEntry{}
+		}
+		if summary {
+			applySummaryToEntries(entries)
 		}
 		resp := timelinePaginatedResponse{Entries: entries}
 		// `around=<id>`: locate the anchor in the DESC slice so the legacy
@@ -127,6 +143,9 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 	entries := h.mergeTimeline(r, comments, activities, true)
 	if entries == nil {
 		entries = []TimelineEntry{}
+	}
+	if summary {
+		applySummaryToEntries(entries)
 	}
 	writeJSON(w, http.StatusOK, entries)
 }
@@ -209,6 +228,20 @@ func activityToEntry(a db.ActivityLog) TimelineEntry {
 		Action:    &action,
 		Details:   a.Details,
 		CreatedAt: timestampToString(a.CreatedAt),
+	}
+}
+
+// applySummaryToEntries clips comment content in-place to summaryContentRunes
+// for the timeline summary projection. Activity entries are left unchanged —
+// only comment-type entries with non-nil Content are clipped.
+func applySummaryToEntries(entries []TimelineEntry) {
+	for i := range entries {
+		if entries[i].Type != "comment" || entries[i].Content == nil {
+			continue
+		}
+		clipped, truncated := summarizeContent(*entries[i].Content)
+		entries[i].Content = &clipped
+		entries[i].ContentTruncated = &truncated
 	}
 }
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1464,6 +1464,36 @@ func (h *Handler) computeMentionedAgentCommentTriggers(ctx context.Context, issu
 	return triggers
 }
 
+// GetComment returns a single comment by id, scoped to the current workspace.
+// It returns the full comment body without summary clipping — callers that want
+// truncated content should use ListComments with summary=true or ListTimeline
+// with summary=true instead.
+func (h *Handler) GetComment(w http.ResponseWriter, r *http.Request) {
+	commentId := chi.URLParam(r, "commentId")
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "comment not found")
+		return
+	}
+	grouped := h.groupReactions(r, []pgtype.UUID{comment.ID})
+	groupedAtt := h.groupAttachments(r, []pgtype.UUID{comment.ID})
+	cid := uuidToString(comment.ID)
+	resp := commentToResponse(comment, grouped[cid], groupedAtt[cid])
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	commentId := chi.URLParam(r, "commentId")
 


### PR DESCRIPTION
## Summary

Backend changes to reduce `/timeline` API response payload by adding a `summary=true` query parameter that clips comment content to 200 runes.

## Changes

### server/internal/handler/activity.go
- Added `ContentTruncated *bool` field to `TimelineEntry` struct — frontend uses this to decide whether to show "expand full text" button
- Added `summary` query param parsing in `ListTimeline` — same pattern as `comment.go:236-246`
- Added `applySummaryToEntries` helper — only clips comment-type entries (activity entries untouched), reuses existing `summarizeContent` from comment.go

### server/internal/handler/comment.go
- Added `GetComment` handler — returns full comment body (no summary clipping) for the frontend "expand full text" button
- Uses `GetCommentInWorkspace` for workspace isolation
- Includes reactions and attachments

### server/cmd/server/router.go
- Added `r.Get("/", h.GetComment)` to `/api/comments/{commentId}` route group

## Backward Compatibility

- No `summary` param → behavior unchanged (full content returned)
- `ContentTruncated` is omitempty — absent from responses when not in summary mode