### PR TITLE
Fix scheduled autopilot double-fire under clock skew

### DIFF
--- a/server/cmd/server/autopilot_scheduler.go
+++ b/server/cmd/server/autopilot_scheduler.go
@@ -117,13 +117,19 @@ func advanceNextRun(ctx context.Context, queries *db.Queries, t db.ClaimDueSched
 		)
 		return
 	}
+	if !t.ClaimedAt.Valid {
+		slog.Warn("autopilot scheduler: claimed trigger missing claim time",
+			"trigger_id", util.UUIDToString(t.ID),
+		)
+		return
+	}
 
 	tz := service.DefaultAutopilotTriggerTimezone
 	if t.Timezone.Valid && t.Timezone.String != "" {
 		tz = t.Timezone.String
 	}
 
-	next, err := service.ComputeNextRunAfter(t.CronExpression.String, tz, t.ScheduledFireAt.Time)
+	next, err := service.ComputeNextRunAfter(t.CronExpression.String, tz, t.ClaimedAt.Time)
 	if err != nil {
 		slog.Warn("autopilot scheduler: failed to compute next run",
 			"trigger_id", util.UUIDToString(t.ID),

--- a/server/cmd/server/autopilot_scheduler.go
+++ b/server/cmd/server/autopilot_scheduler.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -89,20 +91,54 @@ func tickScheduledAutopilots(ctx context.Context, queries *db.Queries, svc *serv
 				"autopilot_id", util.UUIDToString(t.AutopilotID),
 				"error", err,
 			)
+			restoreClaimedTrigger(ctx, queries, t)
 			continue
 		}
 
 		// Dispatch the claimed schedule occurrence.
-		if _, err := svc.DispatchScheduledAutopilot(ctx, autopilot, t.ID, t.ScheduledFireAt); err != nil {
+		run, err := svc.DispatchScheduledAutopilot(ctx, autopilot, t.ID, t.ScheduledFireAt)
+		if err != nil {
 			slog.Warn("autopilot scheduler: dispatch failed",
 				"autopilot_id", util.UUIDToString(autopilot.ID),
 				"trigger_id", util.UUIDToString(t.ID),
 				"error", err,
 			)
+			if !shouldAdvanceAfterScheduleDispatch(run, err) {
+				restoreClaimedTrigger(ctx, queries, t)
+				continue
+			}
 		}
 
 		// Advance next_run_at for this trigger.
 		advanceNextRun(ctx, queries, t)
+	}
+}
+
+func shouldAdvanceAfterScheduleDispatch(run *db.AutopilotRun, err error) bool {
+	if err == nil || run != nil {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == "23505" &&
+		pgErr.ConstraintName == "idx_autopilot_run_schedule_occurrence"
+}
+
+func restoreClaimedTrigger(ctx context.Context, queries *db.Queries, t db.ClaimDueScheduleTriggersRow) {
+	if !t.ScheduledFireAt.Valid {
+		slog.Warn("autopilot scheduler: cannot restore claimed trigger without scheduled fire time",
+			"trigger_id", util.UUIDToString(t.ID),
+		)
+		return
+	}
+	if err := queries.RestoreClaimedTriggerNextRun(ctx, db.RestoreClaimedTriggerNextRunParams{
+		ID:        t.ID,
+		NextRunAt: t.ScheduledFireAt,
+	}); err != nil {
+		slog.Warn("autopilot scheduler: failed to restore claimed trigger",
+			"trigger_id", util.UUIDToString(t.ID),
+			"error", err,
+		)
 	}
 }
 

--- a/server/cmd/server/autopilot_scheduler.go
+++ b/server/cmd/server/autopilot_scheduler.go
@@ -92,8 +92,8 @@ func tickScheduledAutopilots(ctx context.Context, queries *db.Queries, svc *serv
 			continue
 		}
 
-		// Dispatch the autopilot run.
-		if _, err := svc.DispatchAutopilot(ctx, autopilot, t.ID, "schedule", nil); err != nil {
+		// Dispatch the claimed schedule occurrence.
+		if _, err := svc.DispatchScheduledAutopilot(ctx, autopilot, t.ID, t.ScheduledFireAt); err != nil {
 			slog.Warn("autopilot scheduler: dispatch failed",
 				"autopilot_id", util.UUIDToString(autopilot.ID),
 				"trigger_id", util.UUIDToString(t.ID),
@@ -111,13 +111,19 @@ func advanceNextRun(ctx context.Context, queries *db.Queries, t db.ClaimDueSched
 	if !t.CronExpression.Valid || t.CronExpression.String == "" {
 		return
 	}
+	if !t.ScheduledFireAt.Valid {
+		slog.Warn("autopilot scheduler: claimed trigger missing scheduled fire time",
+			"trigger_id", util.UUIDToString(t.ID),
+		)
+		return
+	}
 
 	tz := service.DefaultAutopilotTriggerTimezone
 	if t.Timezone.Valid && t.Timezone.String != "" {
 		tz = t.Timezone.String
 	}
 
-	next, err := service.ComputeNextRun(t.CronExpression.String, tz)
+	next, err := service.ComputeNextRunAfter(t.CronExpression.String, tz, t.ScheduledFireAt.Time)
 	if err != nil {
 		slog.Warn("autopilot scheduler: failed to compute next run",
 			"trigger_id", util.UUIDToString(t.ID),

--- a/server/cmd/server/autopilot_scheduler_test.go
+++ b/server/cmd/server/autopilot_scheduler_test.go
@@ -197,6 +197,58 @@ func TestScheduledAutopilotDispatchIsIdempotentPerOccurrence(t *testing.T) {
 	}
 }
 
+func TestScheduledAutopilotSkipIsIdempotentPerOccurrence(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	offlineAgentID := createOfflineSchedulerAgent(t, "scheduled-skip-idempotency")
+	ap := seedAutopilot(t, queries, "Scheduled skip occurrence idempotency", "member", parseUUID(testUserID), offlineAgentID)
+	fireAt := time.Date(2099, 1, 2, 10, 0, 0, 0, time.UTC)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "0 10 * * *")
+	scheduledFireAt := pgtype.Timestamptz{Time: fireAt, Valid: true}
+
+	run, err := autopilotSvc.DispatchScheduledAutopilot(ctx, ap, trigger.ID, scheduledFireAt)
+	if err != nil {
+		t.Fatalf("first DispatchScheduledAutopilot: %v", err)
+	}
+	if run.Status != "skipped" {
+		t.Fatalf("expected skipped run, got %q", run.Status)
+	}
+	if !run.FailureReason.Valid || !strings.Contains(run.FailureReason.String, "offline") {
+		t.Fatalf("expected offline skip reason, got %+v", run.FailureReason)
+	}
+	if !run.ScheduledFireAt.Valid || !run.ScheduledFireAt.Time.Equal(fireAt) {
+		t.Fatalf("expected run scheduled_fire_at %s, got %+v", fireAt, run.ScheduledFireAt)
+	}
+	if run.TaskID.Valid {
+		t.Fatalf("expected skipped run not to enqueue a task, got %v", run.TaskID)
+	}
+
+	if _, err := autopilotSvc.DispatchScheduledAutopilot(ctx, ap, trigger.ID, scheduledFireAt); err == nil {
+		t.Fatal("expected duplicate skipped scheduled occurrence to fail")
+	} else if !shouldAdvanceAfterScheduleDispatch(nil, err) {
+		t.Fatalf("expected scheduler to advance after duplicate skipped occurrence, got %v", err)
+	}
+
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM autopilot_run
+		WHERE trigger_id = $1
+		  AND source = 'schedule'
+		  AND status = 'skipped'
+		  AND scheduled_fire_at = $2
+	`, trigger.ID, fireAt).Scan(&count); err != nil {
+		t.Fatalf("count skipped scheduled runs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one skipped run for the scheduled occurrence, got %d", count)
+	}
+}
+
 func createScheduleTrigger(t *testing.T, queries *db.Queries, autopilotID pgtype.UUID, nextRunAt time.Time, cronExpr string) db.AutopilotTrigger {
 	t.Helper()
 	trigger, err := queries.CreateAutopilotTrigger(context.Background(), db.CreateAutopilotTriggerParams{
@@ -211,4 +263,41 @@ func createScheduleTrigger(t *testing.T, queries *db.Queries, autopilotID pgtype
 		t.Fatalf("CreateAutopilotTrigger: %v", err)
 	}
 	return trigger
+}
+
+func createOfflineSchedulerAgent(t *testing.T, name string) pgtype.UUID {
+	t.Helper()
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%s-%d", name, time.Now().UnixNano())
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'local', $3, 'offline', '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), suffix+" runtime", suffix+"_runtime").Scan(&runtimeID); err != nil {
+		t.Fatalf("create offline runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'local', '{}'::jsonb, $3, 'workspace', 1, $4)
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), suffix+" agent", runtimeID, parseUUID(testUserID)).Scan(&agentID); err != nil {
+		t.Fatalf("create offline agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	return parseUUID(agentID)
 }

--- a/server/cmd/server/autopilot_scheduler_test.go
+++ b/server/cmd/server/autopilot_scheduler_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -93,6 +96,58 @@ func TestAdvanceNextRunCollapsesMissedOccurrencesAtClaimTime(t *testing.T) {
 	want := claimTime.Add(5 * time.Minute)
 	if !updated.NextRunAt.Valid || !updated.NextRunAt.Time.Equal(want) {
 		t.Fatalf("expected next_run_at %s, got %+v", want, updated.NextRunAt)
+	}
+}
+
+func TestRestoreClaimedTriggerNextRunRequeuesOccurrence(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	ap := seedAutopilot(t, queries, "Scheduler restore claimed occurrence", "member", parseUUID(testUserID), pickFixtureAgent(t))
+	fireAt := time.Date(2020, 1, 2, 10, 0, 0, 0, time.UTC)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "0 10 * * *")
+
+	claimed, err := queries.ClaimDueScheduleTriggers(ctx)
+	if err != nil {
+		t.Fatalf("ClaimDueScheduleTriggers: %v", err)
+	}
+	var got *db.ClaimDueScheduleTriggersRow
+	for i := range claimed {
+		if claimed[i].ID == trigger.ID {
+			got = &claimed[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("claimed triggers did not include test trigger %v", trigger.ID)
+	}
+
+	restoreClaimedTrigger(ctx, queries, *got)
+
+	updated, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTrigger: %v", err)
+	}
+	if !updated.NextRunAt.Valid || !updated.NextRunAt.Time.Equal(fireAt) {
+		t.Fatalf("expected restored next_run_at %s, got %+v", fireAt, updated.NextRunAt)
+	}
+}
+
+func TestShouldAdvanceAfterScheduleDispatch(t *testing.T) {
+	if !shouldAdvanceAfterScheduleDispatch(nil, nil) {
+		t.Fatal("expected successful dispatch to advance")
+	}
+	if !shouldAdvanceAfterScheduleDispatch(&db.AutopilotRun{}, errors.New("recorded failure")) {
+		t.Fatal("expected dispatch with a recorded run to advance")
+	}
+	duplicate := fmt.Errorf("create run: %w", &pgconn.PgError{
+		Code:           "23505",
+		ConstraintName: "idx_autopilot_run_schedule_occurrence",
+	})
+	if !shouldAdvanceAfterScheduleDispatch(nil, duplicate) {
+		t.Fatal("expected duplicate scheduled occurrence to advance")
+	}
+	if shouldAdvanceAfterScheduleDispatch(nil, errors.New("temporary database error")) {
+		t.Fatal("expected unrecorded transient failure to restore instead of advance")
 	}
 }
 

--- a/server/cmd/server/autopilot_scheduler_test.go
+++ b/server/cmd/server/autopilot_scheduler_test.go
@@ -37,12 +37,15 @@ func TestClaimDueScheduleTriggersReturnsScheduledFireAt(t *testing.T) {
 	if !got.ScheduledFireAt.Valid || !got.ScheduledFireAt.Time.Equal(fireAt) {
 		t.Fatalf("expected scheduled_fire_at %s, got %+v", fireAt, got.ScheduledFireAt)
 	}
+	if !got.ClaimedAt.Valid {
+		t.Fatal("expected claimed_at to be set")
+	}
 	if got.NextRunAt.Valid {
 		t.Fatalf("expected claimed trigger next_run_at to be cleared, got %s", got.NextRunAt.Time)
 	}
 }
 
-func TestAdvanceNextRunUsesClaimedScheduledFireAt(t *testing.T) {
+func TestAdvanceNextRunUsesClaimTime(t *testing.T) {
 	ctx := context.Background()
 	queries := db.New(testPool)
 	ap := seedAutopilot(t, queries, "Scheduler advance from occurrence", "member", parseUUID(testUserID), pickFixtureAgent(t))
@@ -54,6 +57,7 @@ func TestAdvanceNextRunUsesClaimedScheduledFireAt(t *testing.T) {
 		CronExpression:  pgtype.Text{String: "0 10 * * *", Valid: true},
 		Timezone:        pgtype.Text{String: "UTC", Valid: true},
 		ScheduledFireAt: pgtype.Timestamptz{Time: fireAt, Valid: true},
+		ClaimedAt:       pgtype.Timestamptz{Time: fireAt, Valid: true},
 	})
 
 	updated, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
@@ -61,6 +65,32 @@ func TestAdvanceNextRunUsesClaimedScheduledFireAt(t *testing.T) {
 		t.Fatalf("GetAutopilotTrigger: %v", err)
 	}
 	want := time.Date(2099, 1, 3, 10, 0, 0, 0, time.UTC)
+	if !updated.NextRunAt.Valid || !updated.NextRunAt.Time.Equal(want) {
+		t.Fatalf("expected next_run_at %s, got %+v", want, updated.NextRunAt)
+	}
+}
+
+func TestAdvanceNextRunCollapsesMissedOccurrencesAtClaimTime(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	ap := seedAutopilot(t, queries, "Scheduler advance skips missed occurrences", "member", parseUUID(testUserID), pickFixtureAgent(t))
+	fireAt := time.Date(2020, 1, 2, 10, 0, 0, 0, time.UTC)
+	claimTime := fireAt.Add(2 * time.Hour)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "*/5 * * * *")
+
+	advanceNextRun(ctx, queries, db.ClaimDueScheduleTriggersRow{
+		ID:              trigger.ID,
+		CronExpression:  pgtype.Text{String: "*/5 * * * *", Valid: true},
+		Timezone:        pgtype.Text{String: "UTC", Valid: true},
+		ScheduledFireAt: pgtype.Timestamptz{Time: fireAt, Valid: true},
+		ClaimedAt:       pgtype.Timestamptz{Time: claimTime, Valid: true},
+	})
+
+	updated, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTrigger: %v", err)
+	}
+	want := claimTime.Add(5 * time.Minute)
 	if !updated.NextRunAt.Valid || !updated.NextRunAt.Time.Equal(want) {
 		t.Fatalf("expected next_run_at %s, got %+v", want, updated.NextRunAt)
 	}

--- a/server/cmd/server/autopilot_scheduler_test.go
+++ b/server/cmd/server/autopilot_scheduler_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestClaimDueScheduleTriggersReturnsScheduledFireAt(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	ap := seedAutopilot(t, queries, "Scheduler claim scheduled fire time", "member", parseUUID(testUserID), pickFixtureAgent(t))
+	fireAt := time.Date(2020, 1, 2, 10, 0, 0, 0, time.UTC)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "0 10 * * *")
+
+	claimed, err := queries.ClaimDueScheduleTriggers(ctx)
+	if err != nil {
+		t.Fatalf("ClaimDueScheduleTriggers: %v", err)
+	}
+
+	var got *db.ClaimDueScheduleTriggersRow
+	for i := range claimed {
+		if claimed[i].ID == trigger.ID {
+			got = &claimed[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("claimed triggers did not include test trigger %v", trigger.ID)
+	}
+	if !got.ScheduledFireAt.Valid || !got.ScheduledFireAt.Time.Equal(fireAt) {
+		t.Fatalf("expected scheduled_fire_at %s, got %+v", fireAt, got.ScheduledFireAt)
+	}
+	if got.NextRunAt.Valid {
+		t.Fatalf("expected claimed trigger next_run_at to be cleared, got %s", got.NextRunAt.Time)
+	}
+}
+
+func TestAdvanceNextRunUsesClaimedScheduledFireAt(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	ap := seedAutopilot(t, queries, "Scheduler advance from occurrence", "member", parseUUID(testUserID), pickFixtureAgent(t))
+	fireAt := time.Date(2099, 1, 2, 10, 0, 0, 0, time.UTC)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "0 10 * * *")
+
+	advanceNextRun(ctx, queries, db.ClaimDueScheduleTriggersRow{
+		ID:              trigger.ID,
+		CronExpression:  pgtype.Text{String: "0 10 * * *", Valid: true},
+		Timezone:        pgtype.Text{String: "UTC", Valid: true},
+		ScheduledFireAt: pgtype.Timestamptz{Time: fireAt, Valid: true},
+	})
+
+	updated, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+	if err != nil {
+		t.Fatalf("GetAutopilotTrigger: %v", err)
+	}
+	want := time.Date(2099, 1, 3, 10, 0, 0, 0, time.UTC)
+	if !updated.NextRunAt.Valid || !updated.NextRunAt.Time.Equal(want) {
+		t.Fatalf("expected next_run_at %s, got %+v", want, updated.NextRunAt)
+	}
+}
+
+func TestScheduledAutopilotDispatchIsIdempotentPerOccurrence(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	ap := seedAutopilot(t, queries, "Scheduled dispatch occurrence idempotency", "member", parseUUID(testUserID), pickFixtureAgent(t))
+	fireAt := time.Date(2099, 1, 2, 10, 0, 0, 0, time.UTC)
+	trigger := createScheduleTrigger(t, queries, ap.ID, fireAt, "0 10 * * *")
+	scheduledFireAt := pgtype.Timestamptz{Time: fireAt, Valid: true}
+
+	run, err := autopilotSvc.DispatchScheduledAutopilot(ctx, ap, trigger.ID, scheduledFireAt)
+	if err != nil {
+		t.Fatalf("first DispatchScheduledAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if run.TaskID.Valid {
+			_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, run.TaskID)
+		}
+	})
+	if !run.ScheduledFireAt.Valid || !run.ScheduledFireAt.Time.Equal(fireAt) {
+		t.Fatalf("expected run scheduled_fire_at %s, got %+v", fireAt, run.ScheduledFireAt)
+	}
+
+	if _, err := autopilotSvc.DispatchScheduledAutopilot(ctx, ap, trigger.ID, scheduledFireAt); err == nil {
+		t.Fatal("expected duplicate scheduled occurrence to fail")
+	} else if !strings.Contains(err.Error(), "create run") {
+		t.Fatalf("expected duplicate to fail while creating run, got %v", err)
+	}
+
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM autopilot_run
+		WHERE trigger_id = $1
+		  AND source = 'schedule'
+		  AND scheduled_fire_at = $2
+	`, trigger.ID, fireAt).Scan(&count); err != nil {
+		t.Fatalf("count scheduled runs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one run for the scheduled occurrence, got %d", count)
+	}
+}
+
+func createScheduleTrigger(t *testing.T, queries *db.Queries, autopilotID pgtype.UUID, nextRunAt time.Time, cronExpr string) db.AutopilotTrigger {
+	t.Helper()
+	trigger, err := queries.CreateAutopilotTrigger(context.Background(), db.CreateAutopilotTriggerParams{
+		AutopilotID:    autopilotID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: cronExpr, Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+		NextRunAt:      pgtype.Timestamptz{Time: nextRunAt, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+	return trigger
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -39,6 +39,10 @@ type AutopilotService struct {
 // when computing next run times.
 const DefaultAutopilotTriggerTimezone = "UTC"
 
+type dispatchAutopilotOptions struct {
+	ScheduledFireAt pgtype.Timestamptz
+}
+
 func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *TaskService) *AutopilotService {
 	return &AutopilotService{Queries: q, TxStarter: tx, Bus: bus, TaskSvc: taskSvc}
 }
@@ -63,8 +67,31 @@ func (s *AutopilotService) DispatchAutopilot(
 	source string,
 	payload []byte,
 ) (*db.AutopilotRun, error) {
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, dispatchAutopilotOptions{})
+}
+
+// DispatchScheduledAutopilot dispatches one claimed schedule occurrence.
+func (s *AutopilotService) DispatchScheduledAutopilot(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	scheduledFireAt pgtype.Timestamptz,
+) (*db.AutopilotRun, error) {
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, "schedule", nil, dispatchAutopilotOptions{
+		ScheduledFireAt: scheduledFireAt,
+	})
+}
+
+func (s *AutopilotService) dispatchAutopilot(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	opts dispatchAutopilotOptions,
+) (*db.AutopilotRun, error) {
 	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
-		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason)
+		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason, opts)
 	}
 
 	// Determine initial status based on execution mode.
@@ -74,12 +101,13 @@ func (s *AutopilotService) DispatchAutopilot(
 	}
 
 	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
-		AutopilotID:    autopilot.ID,
-		TriggerID:      triggerID,
-		Source:         source,
-		Status:         initialStatus,
-		TriggerPayload: payload,
-		SquadID:        autopilotSquadAttribution(autopilot),
+		AutopilotID:     autopilot.ID,
+		TriggerID:       triggerID,
+		Source:          source,
+		Status:          initialStatus,
+		TriggerPayload:  payload,
+		SquadID:         autopilotSquadAttribution(autopilot),
+		ScheduledFireAt: opts.ScheduledFireAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create run: %w", err)
@@ -859,14 +887,16 @@ func (s *AutopilotService) recordSkippedRun(
 	source string,
 	payload []byte,
 	reason string,
+	opts dispatchAutopilotOptions,
 ) (*db.AutopilotRun, error) {
 	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
-		AutopilotID:    autopilot.ID,
-		TriggerID:      triggerID,
-		Source:         source,
-		Status:         "skipped",
-		TriggerPayload: payload,
-		SquadID:        autopilotSquadAttribution(autopilot),
+		AutopilotID:     autopilot.ID,
+		TriggerID:       triggerID,
+		Source:          source,
+		Status:          "skipped",
+		TriggerPayload:  payload,
+		SquadID:         autopilotSquadAttribution(autopilot),
+		ScheduledFireAt: opts.ScheduledFireAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create skipped run: %w", err)

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -6,5 +6,5 @@
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
-- `server/cmd/server/autopilot_scheduler.go` claims due schedule triggers, passes the claimed `scheduled_fire_at` into `DispatchScheduledAutopilot`, and advances from that occurrence instead of the app server clock.
+- `server/cmd/server/autopilot_scheduler.go` claims due schedule triggers, passes the claimed `scheduled_fire_at` into `DispatchScheduledAutopilot`, and advances from DB `claimed_at` so missed occurrences collapse.
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -6,4 +6,5 @@
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
+- `server/cmd/server/autopilot_scheduler.go` claims due schedule triggers, passes the claimed `scheduled_fire_at` into `DispatchScheduledAutopilot`, and advances from that occurrence instead of the app server clock.
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.

--- a/server/internal/service/cron.go
+++ b/server/internal/service/cron.go
@@ -13,6 +13,12 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 // ComputeNextRun parses a cron expression and returns the next fire time
 // in the given timezone.
 func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
+	return ComputeNextRunAfter(cronExpr, timezone, time.Now())
+}
+
+// ComputeNextRunAfter parses a cron expression and returns the next fire time
+// after the provided base instant in the given timezone.
+func ComputeNextRunAfter(cronExpr, timezone string, base time.Time) (time.Time, error) {
 	sched, err := cronParser.Parse(cronExpr)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse cron: %w", err)
@@ -21,7 +27,7 @@ func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
 	}
-	return sched.Next(time.Now().In(loc)), nil
+	return sched.Next(base.In(loc)), nil
 }
 
 // ValidateTimezone returns an error if the timezone string is not recognized.

--- a/server/internal/service/cron_test.go
+++ b/server/internal/service/cron_test.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeNextRunAfterUsesProvidedBase(t *testing.T) {
+	base := time.Date(2099, 1, 2, 10, 0, 0, 0, time.UTC)
+
+	next, err := ComputeNextRunAfter("0 10 * * *", "UTC", base)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAfter: %v", err)
+	}
+
+	want := time.Date(2099, 1, 3, 10, 0, 0, 0, time.UTC)
+	if !next.Equal(want) {
+		t.Fatalf("expected next run %s, got %s", want, next)
+	}
+}

--- a/server/migrations/123_autopilot_schedule_occurrence_idempotency.down.sql
+++ b/server/migrations/123_autopilot_schedule_occurrence_idempotency.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_autopilot_run_schedule_occurrence;
+
+ALTER TABLE autopilot_run
+    DROP COLUMN IF EXISTS scheduled_fire_at;

--- a/server/migrations/123_autopilot_schedule_occurrence_idempotency.up.sql
+++ b/server/migrations/123_autopilot_schedule_occurrence_idempotency.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE autopilot_run
+    ADD COLUMN IF NOT EXISTS scheduled_fire_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_autopilot_run_schedule_occurrence
+    ON autopilot_run (trigger_id, source, scheduled_fire_at)
+    WHERE source = 'schedule'
+      AND trigger_id IS NOT NULL
+      AND scheduled_fire_at IS NOT NULL;

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -52,6 +52,7 @@ WITH due AS (
     SELECT
         t.id,
         t.next_run_at AS scheduled_fire_at,
+        now()::timestamptz AS claimed_at,
         a.workspace_id AS autopilot_workspace_id
     FROM autopilot_trigger t
     JOIN autopilot a ON t.autopilot_id = a.id
@@ -67,7 +68,7 @@ UPDATE autopilot_trigger t
 SET next_run_at = NULL
 FROM due
 WHERE t.id = due.id
-RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, due.scheduled_fire_at, due.autopilot_workspace_id
+RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, due.scheduled_fire_at, due.claimed_at, due.autopilot_workspace_id
 `
 
 type ClaimDueScheduleTriggersRow struct {
@@ -87,6 +88,7 @@ type ClaimDueScheduleTriggersRow struct {
 	SigningSecret        pgtype.Text        `json:"signing_secret"`
 	EventFilters         []byte             `json:"event_filters"`
 	ScheduledFireAt      pgtype.Timestamptz `json:"scheduled_fire_at"`
+	ClaimedAt            pgtype.Timestamptz `json:"claimed_at"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -121,6 +123,7 @@ func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueSched
 			&i.SigningSecret,
 			&i.EventFilters,
 			&i.ScheduledFireAt,
+			&i.ClaimedAt,
 			&i.AutopilotWorkspaceID,
 		); err != nil {
 			return nil, err

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -914,6 +914,25 @@ func (q *Queries) RecoverLostTriggers(ctx context.Context) ([]RecoverLostTrigger
 	return items, nil
 }
 
+const restoreClaimedTriggerNextRun = `-- name: RestoreClaimedTriggerNextRun :exec
+UPDATE autopilot_trigger
+SET next_run_at = $2,
+    updated_at = now()
+WHERE id = $1
+  AND kind = 'schedule'
+  AND next_run_at IS NULL
+`
+
+type RestoreClaimedTriggerNextRunParams struct {
+	ID        pgtype.UUID        `json:"id"`
+	NextRunAt pgtype.Timestamptz `json:"next_run_at"`
+}
+
+func (q *Queries) RestoreClaimedTriggerNextRun(ctx context.Context, arg RestoreClaimedTriggerNextRunParams) error {
+	_, err := q.db.Exec(ctx, restoreClaimedTriggerNextRun, arg.ID, arg.NextRunAt)
+	return err
+}
+
 const rotateAutopilotTriggerWebhookToken = `-- name: RotateAutopilotTriggerWebhookToken :one
 UPDATE autopilot_trigger
 SET webhook_token = $2,

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -48,16 +48,26 @@ func (q *Queries) AdvanceTriggerNextRun(ctx context.Context, arg AdvanceTriggerN
 
 const claimDueScheduleTriggers = `-- name: ClaimDueScheduleTriggers :many
 
+WITH due AS (
+    SELECT
+        t.id,
+        t.next_run_at AS scheduled_fire_at,
+        a.workspace_id AS autopilot_workspace_id
+    FROM autopilot_trigger t
+    JOIN autopilot a ON t.autopilot_id = a.id
+    WHERE t.kind = 'schedule'
+      AND t.enabled = true
+      AND t.next_run_at IS NOT NULL
+      AND t.next_run_at <= now()
+      AND a.status = 'active'
+    ORDER BY t.next_run_at ASC, t.id ASC
+    FOR UPDATE OF t SKIP LOCKED
+)
 UPDATE autopilot_trigger t
 SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
-  AND a.status = 'active'
-RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
+FROM due
+WHERE t.id = due.id
+RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, due.scheduled_fire_at, due.autopilot_workspace_id
 `
 
 type ClaimDueScheduleTriggersRow struct {
@@ -76,6 +86,7 @@ type ClaimDueScheduleTriggersRow struct {
 	Provider             string             `json:"provider"`
 	SigningSecret        pgtype.Text        `json:"signing_secret"`
 	EventFilters         []byte             `json:"event_filters"`
+	ScheduledFireAt      pgtype.Timestamptz `json:"scheduled_fire_at"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -109,6 +120,7 @@ func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueSched
 			&i.Provider,
 			&i.SigningSecret,
 			&i.EventFilters,
+			&i.ScheduledFireAt,
 			&i.AutopilotWorkspaceID,
 		); err != nil {
 			return nil, err
@@ -185,20 +197,21 @@ func (q *Queries) CreateAutopilot(ctx context.Context, arg CreateAutopilotParams
 const createAutopilotRun = `-- name: CreateAutopilotRun :one
 
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, scheduled_fire_at
 ) VALUES (
     $1, $4, $2, $3, $5,
-    $6
-) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+    $6, $7
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type CreateAutopilotRunParams struct {
-	AutopilotID    pgtype.UUID `json:"autopilot_id"`
-	Source         string      `json:"source"`
-	Status         string      `json:"status"`
-	TriggerID      pgtype.UUID `json:"trigger_id"`
-	TriggerPayload []byte      `json:"trigger_payload"`
-	SquadID        pgtype.UUID `json:"squad_id"`
+	AutopilotID     pgtype.UUID        `json:"autopilot_id"`
+	Source          string             `json:"source"`
+	Status          string             `json:"status"`
+	TriggerID       pgtype.UUID        `json:"trigger_id"`
+	TriggerPayload  []byte             `json:"trigger_payload"`
+	SquadID         pgtype.UUID        `json:"squad_id"`
+	ScheduledFireAt pgtype.Timestamptz `json:"scheduled_fire_at"`
 }
 
 // =====================
@@ -216,6 +229,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		arg.TriggerID,
 		arg.TriggerPayload,
 		arg.SquadID,
+		arg.ScheduledFireAt,
 	)
 	var i AutopilotRun
 	err := row.Scan(
@@ -233,6 +247,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -460,7 +475,7 @@ func (q *Queries) GetAutopilotInWorkspace(ctx context.Context, arg GetAutopilotI
 }
 
 const getAutopilotRun = `-- name: GetAutopilotRun :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at FROM autopilot_run
 WHERE id = $1
 `
 
@@ -482,13 +497,14 @@ func (q *Queries) GetAutopilotRun(ctx context.Context, id pgtype.UUID) (Autopilo
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
 
 const getAutopilotRunByIssue = `-- name: GetAutopilotRunByIssue :one
 
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at FROM autopilot_run
 WHERE issue_id = $1 AND status IN ('issue_created', 'running')
 LIMIT 1
 `
@@ -514,6 +530,7 @@ func (q *Queries) GetAutopilotRunByIssue(ctx context.Context, issueID pgtype.UUI
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -603,7 +620,7 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 }
 
 const listAutopilotRuns = `-- name: ListAutopilotRuns :many
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at FROM autopilot_run
 WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -639,6 +656,7 @@ func (q *Queries) ListAutopilotRuns(ctx context.Context, arg ListAutopilotRunsPa
 			&i.Result,
 			&i.CreatedAt,
 			&i.SquadID,
+			&i.ScheduledFireAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1222,7 +1240,7 @@ const updateAutopilotRunCompleted = `-- name: UpdateAutopilotRunCompleted :one
 UPDATE autopilot_run
 SET status = 'completed', completed_at = now(), result = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunCompletedParams struct {
@@ -1248,6 +1266,7 @@ func (q *Queries) UpdateAutopilotRunCompleted(ctx context.Context, arg UpdateAut
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -1256,7 +1275,7 @@ const updateAutopilotRunFailed = `-- name: UpdateAutopilotRunFailed :one
 UPDATE autopilot_run
 SET status = 'failed', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunFailedParams struct {
@@ -1282,6 +1301,7 @@ func (q *Queries) UpdateAutopilotRunFailed(ctx context.Context, arg UpdateAutopi
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -1290,7 +1310,7 @@ const updateAutopilotRunIssueCreated = `-- name: UpdateAutopilotRunIssueCreated 
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunIssueCreatedParams struct {
@@ -1316,6 +1336,7 @@ func (q *Queries) UpdateAutopilotRunIssueCreated(ctx context.Context, arg Update
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -1324,7 +1345,7 @@ const updateAutopilotRunRunning = `-- name: UpdateAutopilotRunRunning :one
 UPDATE autopilot_run
 SET status = 'running', task_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunRunningParams struct {
@@ -1350,6 +1371,7 @@ func (q *Queries) UpdateAutopilotRunRunning(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -1358,7 +1380,7 @@ const updateAutopilotRunSkipped = `-- name: UpdateAutopilotRunSkipped :one
 UPDATE autopilot_run
 SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunSkippedParams struct {
@@ -1390,6 +1412,7 @@ func (q *Queries) UpdateAutopilotRunSkipped(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }
@@ -1401,7 +1424,7 @@ SET status = 'skipped',
     failure_reason = $2,
     result = $3
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, scheduled_fire_at
 `
 
 type UpdateAutopilotRunSkippedWithResultParams struct {
@@ -1428,6 +1451,7 @@ func (q *Queries) UpdateAutopilotRunSkippedWithResult(ctx context.Context, arg U
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.ScheduledFireAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -136,20 +136,21 @@ type Autopilot struct {
 }
 
 type AutopilotRun struct {
-	ID             pgtype.UUID        `json:"id"`
-	AutopilotID    pgtype.UUID        `json:"autopilot_id"`
-	TriggerID      pgtype.UUID        `json:"trigger_id"`
-	Source         string             `json:"source"`
-	Status         string             `json:"status"`
-	IssueID        pgtype.UUID        `json:"issue_id"`
-	TaskID         pgtype.UUID        `json:"task_id"`
-	TriggeredAt    pgtype.Timestamptz `json:"triggered_at"`
-	CompletedAt    pgtype.Timestamptz `json:"completed_at"`
-	FailureReason  pgtype.Text        `json:"failure_reason"`
-	TriggerPayload []byte             `json:"trigger_payload"`
-	Result         []byte             `json:"result"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	SquadID        pgtype.UUID        `json:"squad_id"`
+	ID              pgtype.UUID        `json:"id"`
+	AutopilotID     pgtype.UUID        `json:"autopilot_id"`
+	TriggerID       pgtype.UUID        `json:"trigger_id"`
+	Source          string             `json:"source"`
+	Status          string             `json:"status"`
+	IssueID         pgtype.UUID        `json:"issue_id"`
+	TaskID          pgtype.UUID        `json:"task_id"`
+	TriggeredAt     pgtype.Timestamptz `json:"triggered_at"`
+	CompletedAt     pgtype.Timestamptz `json:"completed_at"`
+	FailureReason   pgtype.Text        `json:"failure_reason"`
+	TriggerPayload  []byte             `json:"trigger_payload"`
+	Result          []byte             `json:"result"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	SquadID         pgtype.UUID        `json:"squad_id"`
+	ScheduledFireAt pgtype.Timestamptz `json:"scheduled_fire_at"`
 }
 
 type AutopilotSubscriber struct {

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -119,6 +119,14 @@ SET next_run_at = sqlc.narg('next_run_at'),
     updated_at = now()
 WHERE id = $1;
 
+-- name: RestoreClaimedTriggerNextRun :exec
+UPDATE autopilot_trigger
+SET next_run_at = sqlc.narg('next_run_at'),
+    updated_at = now()
+WHERE id = $1
+  AND kind = 'schedule'
+  AND next_run_at IS NULL;
+
 -- name: GetWebhookTriggerByToken :one
 -- Look up a webhook trigger by its public bearer token. Joined to autopilot
 -- so the webhook handler can derive the workspace from the trigger's parent

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -259,6 +259,7 @@ WITH due AS (
     SELECT
         t.id,
         t.next_run_at AS scheduled_fire_at,
+        now()::timestamptz AS claimed_at,
         a.workspace_id AS autopilot_workspace_id
     FROM autopilot_trigger t
     JOIN autopilot a ON t.autopilot_id = a.id
@@ -274,7 +275,7 @@ UPDATE autopilot_trigger t
 SET next_run_at = NULL
 FROM due
 WHERE t.id = due.id
-RETURNING t.*, due.scheduled_fire_at, due.autopilot_workspace_id;
+RETURNING t.*, due.scheduled_fire_at, due.claimed_at, due.autopilot_workspace_id;
 
 -- =====================
 -- Task Queue (run_only mode)

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -187,10 +187,10 @@ RETURNING *;
 -- agent_id on agent_task_queue still records who actually ran the work
 -- (the squad leader); squad_id lets reports group by squad without a join.
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, scheduled_fire_at
 ) VALUES (
     $1, sqlc.narg('trigger_id'), $2, $3, sqlc.narg('trigger_payload'),
-    sqlc.narg('squad_id')
+    sqlc.narg('squad_id'), sqlc.narg('scheduled_fire_at')
 ) RETURNING *;
 
 -- name: GetAutopilotRun :one
@@ -255,16 +255,26 @@ RETURNING *;
 -- name: ClaimDueScheduleTriggers :many
 -- Atomically claim all due schedule triggers to prevent concurrent execution.
 -- Joins the autopilot table to ensure only active autopilots are fired.
+WITH due AS (
+    SELECT
+        t.id,
+        t.next_run_at AS scheduled_fire_at,
+        a.workspace_id AS autopilot_workspace_id
+    FROM autopilot_trigger t
+    JOIN autopilot a ON t.autopilot_id = a.id
+    WHERE t.kind = 'schedule'
+      AND t.enabled = true
+      AND t.next_run_at IS NOT NULL
+      AND t.next_run_at <= now()
+      AND a.status = 'active'
+    ORDER BY t.next_run_at ASC, t.id ASC
+    FOR UPDATE OF t SKIP LOCKED
+)
 UPDATE autopilot_trigger t
 SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
-  AND t.next_run_at IS NOT NULL
-  AND t.next_run_at <= now()
-  AND a.status = 'active'
-RETURNING t.*, a.workspace_id AS autopilot_workspace_id;
+FROM due
+WHERE t.id = due.id
+RETURNING t.*, due.scheduled_fire_at, due.autopilot_workspace_id;
 
 -- =====================
 -- Task Queue (run_only mode)
@@ -373,4 +383,3 @@ ON CONFLICT (autopilot_id, user_type, user_id) DO NOTHING;
 -- Paired with a re-insert loop to implement full-replace PATCH semantics.
 DELETE FROM autopilot_subscriber
 WHERE autopilot_id = $1;
-


### PR DESCRIPTION
## Summary

Closes #4384.

Scheduled autopilot claims used the database clock (`now()`), but advancing the next run used the app server clock (`time.Now()`). When a server node clock lagged behind the DB around the fire time, `cron.Next(time.Now())` could compute the same already-claimed occurrence again, causing another due trigger and duplicate autopilot work.

This PR:
- captures the claimed schedule occurrence as `scheduled_fire_at` before clearing `next_run_at`
- captures the same SQL statement's DB claim time as `claimed_at`
- dispatches scheduled autopilots with `scheduled_fire_at` as the occurrence idempotency key
- advances the cron schedule from `claimed_at`, preserving the previous "collapse missed occurrences" behavior after downtime while avoiding app-server clock skew
- restores a claimed trigger to its original `scheduled_fire_at` when dispatch fails before any run is recorded, so transient DB/load failures retry instead of silently dropping the occurrence
- stores `scheduled_fire_at` on `autopilot_run` and adds a partial unique index for schedule occurrence idempotency

## Coverage

- Scheduler claim path now returns both the original planned fire time and DB claim time.
- Scheduler advance path uses DB claim time, so stale triggers after downtime jump to the next future occurrence instead of replaying every missed interval.
- Scheduled dispatch records the planned occurrence on normal and skipped runs.
- DB uniqueness prevents duplicate runs for the same `(trigger_id, source, scheduled_fire_at)` schedule occurrence.
- Dispatch/load failures with no recorded run restore the claimed occurrence for retry; failures with a recorded run, and duplicate occurrence conflicts, still advance.

## Tests

- `make sqlc`
- `make migrate-up`
- `set -a; . ./.env.worktree; set +a; cd server; go test ./internal/service -run TestComputeNextRunAfterUsesProvidedBase -count=1`
- `set -a; . ./.env.worktree; set +a; cd server; go test ./cmd/server -run 'Test(RestoreClaimedTriggerNextRunRequeuesOccurrence|ShouldAdvanceAfterScheduleDispatch|ClaimDueScheduleTriggersReturnsScheduledFireAt|AdvanceNextRunUsesClaimTime|AdvanceNextRunCollapsesMissedOccurrencesAtClaimTime|ScheduledAutopilotDispatchIsIdempotentPerOccurrence)$' -count=1`
- `set -a; . ./.env.worktree; set +a; cd server; go test ./cmd/server -count=1`
- `set -a; . ./.env.worktree; set +a; cd server; go test ./internal/handler ./internal/service ./cmd/server -count=1`
- Earlier on this PR branch: `set -a; . ./.env.worktree; set +a; cd server; go test ./... -count=1`
- `git diff --check`
