### PR TITLE
fix(issues): refine Stage field icon and dropdown font

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -14,7 +14,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleCheck,
-  Hash,
+  Milestone,
   MoreHorizontal,
   PanelRight,
   Pin,
@@ -1531,7 +1531,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                         <PriorityIcon priority="medium" inheritColor className="text-muted-foreground" />
                       )}
                       {k === "stage" && (
-                        <Hash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        <Milestone className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       )}
                       {k === "start_date" && (
                         <CalendarClock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/packages/views/issues/components/pickers/stage-picker.tsx
+++ b/packages/views/issues/components/pickers/stage-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Hash } from "lucide-react";
+import { Milestone } from "lucide-react";
 import type { UpdateIssueRequest } from "@multica/core/types";
 import { PropertyPicker, PickerItem } from "./property-picker";
 import { useT } from "../../../i18n";
@@ -65,7 +65,7 @@ export function StagePicker({
       trigger={
         customTrigger ?? (
           <>
-            <Hash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Milestone className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate">
               {stage == null
                 ? t(($) => $.stage.none)
@@ -82,7 +82,7 @@ export function StagePicker({
           setOpen(false);
         }}
       >
-        <span className="truncate text-muted-foreground">{t(($) => $.stage.none)}</span>
+        <span className="truncate text-xs text-muted-foreground">{t(($) => $.stage.none)}</span>
       </PickerItem>
       {options.map((s) => (
         <PickerItem
@@ -93,8 +93,8 @@ export function StagePicker({
             setOpen(false);
           }}
         >
-          <span className="inline-flex items-center gap-1.5">
-            <Hash className="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span className="inline-flex items-center gap-1.5 text-xs">
+            <Milestone className="h-3 w-3 shrink-0 text-muted-foreground" />
             {t(($) => $.stage.value, { n: s })}
           </span>
         </PickerItem>


### PR DESCRIPTION
## Summary

Two small UI fixes for the newly-added **Stage** property on the issue detail page:

1. **Icon** — replaced the `#` (`Hash`) icon with `Milestone` (lucide-react), which reads better as a "stage / phase" marker. Swapped in all three places it appears: the picker trigger, the dropdown option rows, and the "Add property" menu entry. `Hash` is no longer imported in either file.
2. **Dropdown font** — shrank the Stage dropdown option text to `text-xs`. Scoped to the Stage picker only (the "None" row + each "Stage N" row); the shared `PickerItem` keeps `text-sm`, so priority/status/assignee/label dropdowns are unchanged.

## Files

- `packages/views/issues/components/pickers/stage-picker.tsx`
- `packages/views/issues/components/issue-detail.tsx`

## Verification

- `pnpm --filter @multica/views typecheck` — clean
- `pnpm --filter @multica/views exec vitest run .../stage-picker.test.tsx` — 5/5 pass

No tests asserted on the icon or font size, so no test changes were needed. Purely visual; no logic touched.