### PR TITLE
fix(cli): prevent silent token fallback to config PAT in daemon-managed subprocesses

### DIFF
--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -119,6 +119,7 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
 		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 
 		if got := resolveToken(testCmd()); got != "mul_profile_token" {
 			t.Fatalf("resolveToken() = %q, want profile token", got)
@@ -142,6 +143,64 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 
 		if got := resolveToken(testCmd()); got != "mat_task_token" {
 			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN", got)
+		}
+	})
+}
+
+// TestResolveToken_DaemonConfigBlocksFallback is a regression test for #4204.
+// When a subprocess loses MULTICA_AGENT_ID / MULTICA_TASK_ID but still has
+// MULTICA_DAEMON_PORT (set by the daemon), the CLI must NOT silently fall
+// back to the config-file mul_ PAT — that would cause agent comments to be
+// misattributed to the workspace owner.
+func TestResolveToken_DaemonConfigBlocksFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := cli.SaveCLIConfig(cli.CLIConfig{Token: "mul_profile_token"}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Neither agent context marker is set (simulates subprocess that lost them).
+	baseEnv := func() {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "")
+	}
+
+	t.Run("daemon port set blocks config fallback", func(t *testing.T) {
+		baseEnv()
+		t.Setenv("MULTICA_DAEMON_PORT", "9876")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty (daemon port set, must not fall back to config PAT)", got)
+		}
+	})
+
+	t.Run("server url alone does not block config fallback", func(t *testing.T) {
+		baseEnv()
+		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token (server url alone is not a daemon signal; users may set it)", got)
+		}
+	})
+
+	t.Run("neither set still falls back to config", func(t *testing.T) {
+		baseEnv()
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token (no daemon env set, config fallback is expected)", got)
+		}
+	})
+
+	t.Run("MULTICA_TOKEN takes priority over daemon guard", func(t *testing.T) {
+		baseEnv()
+		t.Setenv("MULTICA_DAEMON_PORT", "9876")
+		t.Setenv("MULTICA_TOKEN", "mat_task_token")
+
+		if got := resolveToken(testCmd()); got != "mat_task_token" {
+			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN value (should always win)", got)
 		}
 	})
 }

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -74,6 +74,19 @@ func resolveToken(cmd *cobra.Command) string {
 	if inAgentExecutionContext() {
 		return ""
 	}
+	// If the daemon injected its port but the subprocess lost
+	// MULTICA_AGENT_ID / MULTICA_TASK_ID, the CLI is still running
+	// inside a daemon-managed task. Falling back to a config-file
+	// mul_ PAT would cause silent identity misattribution — agent
+	// comments would appear under the workspace owner's name.
+	// Return "" to force a clear error instead (#4204).
+	//
+	// MULTICA_DAEMON_PORT is the specific signal: only the daemon sets
+	// it, and users never would. MULTICA_SERVER_URL is NOT used as a
+	// signal here because users may set it in their shell profile.
+	if os.Getenv("MULTICA_DAEMON_PORT") != "" {
+		return ""
+	}
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	return cfg.Token


### PR DESCRIPTION
## Summary

Fixes #4204.

When a daemon-spawned subprocess loses `MULTICA_AGENT_ID` and `MULTICA_TASK_ID` env vars but retains `MULTICA_DAEMON_PORT`, `resolveToken()` previously fell through to the config-file `mul_` PAT. This caused agent comments to be silently misattributed to the workspace owner.

## Root Cause

The CLI's token resolution has this fallback chain:

1. `MULTICA_TOKEN` env var → use task-scoped `mat_` token (correct)
2. `inAgentExecutionContext()` → if true, return `""` (correct)
3. `~/.multica/config.json` → fall back to user's `mul_` PAT (BUG)

Step 3 is reached when ALL THREE env vars (`MULTICA_TOKEN`, `MULTICA_AGENT_ID`, `MULTICA_TASK_ID`) are missing from a subprocess. `inAgentExecutionContext()` returns false because it checks `MULTICA_AGENT_ID` and `MULTICA_TASK_ID`, so the CLI falls through to the config file and authenticates as the workspace owner.

## Fix

Add a guard between steps 2 and 3: if `MULTICA_DAEMON_PORT` is set, we're still inside a daemon-managed task even though the agent-context markers were lost. Return `""` to force a clear error.

`MULTICA_DAEMON_PORT` is the correct signal because:
- The daemon always sets it when spawning tasks
- Users never set it in their shell profiles (unlike `MULTICA_SERVER_URL`)

## Changes

- `server/cmd/multica/cmd_auth.go`: Add `MULTICA_DAEMON_PORT` guard in `resolveToken()`
- `server/cmd/multica/cmd_agent_test.go`: Add `TestResolveToken_DaemonConfigBlocksFallback` with 4 subtests covering the new guard, plus fix a pre-existing test to clean `MULTICA_DAEMON_PORT`

## Testing

```
go test ./cmd/multica/ -run "TestResolveToken" -v
# All tests pass (12 subtests across 2 test functions)
```