### PR TITLE
MUL-3548: fix(cli): add daemon signal check to resolveToken() to prevent silent PAT fallback in agent child processes

### DIFF
--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -119,6 +119,7 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 		t.Setenv("MULTICA_AGENT_ID", "")
 		t.Setenv("MULTICA_TASK_ID", "")
 		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
 
 		if got := resolveToken(testCmd()); got != "mul_profile_token" {
 			t.Fatalf("resolveToken() = %q, want profile token", got)
@@ -142,6 +143,28 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 
 		if got := resolveToken(testCmd()); got != "mat_task_token" {
 			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN", got)
+		}
+	})
+
+	t.Run("daemon port set without agent context avoids config fallback", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "19514")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty (daemon port set, fail closed)", got)
+		}
+	})
+
+	t.Run("daemon port set with explicit task token uses task token", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "mat_task_token")
+		t.Setenv("MULTICA_DAEMON_PORT", "19514")
+
+		if got := resolveToken(testCmd()); got != "mat_task_token" {
+			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN (task token wins over daemon signal)", got)
 		}
 	})
 }

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -167,6 +167,37 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN (task token wins over daemon signal)", got)
 		}
 	})
+
+	// MULTICA_SERVER_URL is a user-facing env var that may be set in a
+	// normal shell. It is NOT a daemon identity signal — only
+	// MULTICA_DAEMON_PORT is. The config fallback must still work when
+	// SERVER_URL is set but no daemon signal is present.
+	t.Run("MULTICA_SERVER_URL alone does not block config fallback", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "https://api.multica.ai")
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token (SERVER_URL is not a daemon identity signal)", got)
+		}
+	})
+
+	// Normal CLI usage: no daemon signals whatsoever. The user-global
+	// config token must be reachable. This is the most basic path and
+	// must not be broken by any daemon-signal guard expansion.
+	t.Run("no daemon signals, normal CLI reads config token", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "")
+
+		if got := resolveToken(testCmd()); got != "mul_profile_token" {
+			t.Fatalf("resolveToken() = %q, want profile token (normal CLI flow)", got)
+		}
+	})
 }
 
 func TestNewAPIClient_AgentContextRequiresTaskToken(t *testing.T) {

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -77,6 +77,15 @@ func resolveToken(cmd *cobra.Command) string {
 	if inAgentExecutionContext() {
 		return ""
 	}
+	// A daemon-managed agent process may lose MULTICA_AGENT_ID /
+	// MULTICA_TASK_ID in child subprocesses (the runtime may not forward
+	// them), but MULTICA_DAEMON_PORT persists. When we detect the daemon
+	// signal we fail closed — never silently fall back to the user-global
+	// config token, because that fallback is how agent operations land as
+	// the wrong actor.
+	if os.Getenv("MULTICA_DAEMON_PORT") != "" {
+		return ""
+	}
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	return cfg.Token


### PR DESCRIPTION
## Summary

When a daemon-managed agent process spawns child subprocesses, the runtime may not forward `MULTICA_AGENT_ID` / `MULTICA_TASK_ID`, causing `inAgentExecutionContext()` to return `false`. Without this fix, `resolveToken()` would then silently fall back to the user-global CLI config token, which is how agent operations land as the wrong actor (e.g. comments attributed to the runtime owner rather than the agent).

## Fix

Insert a `MULTICA_DAEMON_PORT` check between the agent-context guard and the config fallback in `resolveToken()`. `MULTICA_DAEMON_PORT` is always set by the daemon when it spawns agent tasks and is less likely to be stripped by runtime child-process isolation. When detected, we **fail closed** (return empty) instead of reaching the user-global config.

## Trade-off (fail-closed)

A process that is genuinely not in a daemon-managed context but somehow has `MULTICA_DAEMON_PORT` set will also refuse to use the config token. In practice, `MULTICA_DAEMON_PORT` is only set in the agent env block injected by the daemon's task runner, so the signal is specific enough to be reliable.

## Changes

- **`server/cmd/multica/cmd_auth.go`**: Added `MULTICA_DAEMON_PORT` env check in `resolveToken()` (+8 lines)
- **`server/cmd/multica/cmd_agent_test.go`**: Added two test cases to `TestResolveToken_AgentContextSkipsConfig` covering daemon signal behavior (+22 lines), and explicitly unset `MULTICA_DAEMON_PORT` in the existing "outside agent context" test case

## References

- Upstream issue: #4204
- Root cause analysis: agent child processes lose `MULTICA_AGENT_ID` / `MULTICA_TASK_ID` env vars, causing silent fallback to the user-global CLI token
- Design decision: use `MULTICA_DAEMON_PORT` as a fail-closed guard — this env var is reliably set by the daemon task runner and unlikely to be stripped by child-process isolation