### PR TITLE
feat(cli): STR-208 오토파일럿 구독자 플래그 추가

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -653,14 +653,18 @@ multica autopilot create \
   --title "Nightly bug triage" \
   --description "Scan todo issues and prioritize." \
   --agent "Lambda" \
-  --mode create_issue
+  --mode create_issue \
+  --subscriber "Alice"
 
 multica autopilot update <id> --status paused
 multica autopilot update <id> --description "New prompt"
+multica autopilot update <id> --subscriber "Alice" --subscriber "Bob"
+multica autopilot update <id> --clear-subscribers
 multica autopilot delete <id>
 ```
 
 `--mode` accepts `create_issue` (creates a new issue on each run and assigns it to the agent) or `run_only` (enqueues a direct agent task without creating an issue). `--agent` accepts either a name or UUID.
+`--subscriber` accepts a workspace member name or user ID and may be repeated; on update it replaces the autopilot's subscriber template. Subscribers receive inbox notifications for issues created by a `create_issue` autopilot. Use `--clear-subscribers` to remove all autopilot subscribers.
 
 ### Manual Trigger
 

--- a/packages/core/issues/cache-helpers.test.ts
+++ b/packages/core/issues/cache-helpers.test.ts
@@ -21,6 +21,7 @@ function mk(id: string, status: Issue["status"], position: number): Issue {
     parent_issue_id: null,
     project_id: null,
     position,
+    stage: null,
     start_date: null,
     due_date: null,
     metadata: {},

--- a/packages/views/issues/utils/drag-utils.test.ts
+++ b/packages/views/issues/utils/drag-utils.test.ts
@@ -19,6 +19,7 @@ function mk(id: string, position: number): Issue {
     parent_issue_id: null,
     project_id: null,
     position,
+    stage: null,
     start_date: null,
     due_date: null,
     metadata: {},

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -124,6 +124,7 @@ func init() {
 	autopilotCreateCmd.Flags().String("priority", "none", "Priority for created issues (none, low, medium, high, urgent)")
 	autopilotCreateCmd.Flags().String("project", "", "Project ID (optional)")
 	autopilotCreateCmd.Flags().String("issue-title-template", "", "Template for issue titles (create_issue mode). Only {{date}} (UTC, YYYY-MM-DD) is interpolated; any other {{...}} token is rejected at create-time.")
+	autopilotCreateCmd.Flags().StringArray("subscriber", nil, "Member subscriber to notify for issues this autopilot creates (name or user ID; repeatable)")
 	autopilotCreateCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// update
@@ -135,6 +136,8 @@ func init() {
 	autopilotUpdateCmd.Flags().String("status", "", "New status (active, paused)")
 	autopilotUpdateCmd.Flags().String("mode", "", "New execution mode (create_issue or run_only)")
 	autopilotUpdateCmd.Flags().String("issue-title-template", "", "New issue title template. Only {{date}} (UTC, YYYY-MM-DD) is interpolated; any other {{...}} token is rejected.")
+	autopilotUpdateCmd.Flags().StringArray("subscriber", nil, "Replace subscribers with this member (name or user ID; repeatable)")
+	autopilotUpdateCmd.Flags().Bool("clear-subscribers", false, "Remove all autopilot subscribers")
 	autopilotUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// delete
@@ -313,6 +316,13 @@ func runAutopilotCreate(cmd *cobra.Command, _ []string) error {
 	if v, _ := cmd.Flags().GetString("issue-title-template"); v != "" {
 		body["issue_title_template"] = v
 	}
+	if subscriberRefs, _ := cmd.Flags().GetStringArray("subscriber"); len(subscriberRefs) > 0 {
+		subscribers, err := resolveAutopilotSubscriberInputs(ctx, client, subscriberRefs)
+		if err != nil {
+			return err
+		}
+		body["subscribers"] = subscribers
+	}
 
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/autopilots", body, &result); err != nil {
@@ -388,6 +398,20 @@ func runAutopilotUpdate(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("issue-title-template") {
 		v, _ := cmd.Flags().GetString("issue-title-template")
 		body["issue_title_template"] = v
+	}
+	clearSubscribers, _ := cmd.Flags().GetBool("clear-subscribers")
+	subscriberRefs, _ := cmd.Flags().GetStringArray("subscriber")
+	if clearSubscribers && len(subscriberRefs) > 0 {
+		return fmt.Errorf("--subscriber and --clear-subscribers are mutually exclusive")
+	}
+	if clearSubscribers {
+		body["subscribers"] = []map[string]string{}
+	} else if cmd.Flags().Changed("subscriber") {
+		subscribers, err := resolveAutopilotSubscriberInputs(ctx, client, subscriberRefs)
+		if err != nil {
+			return err
+		}
+		body["subscribers"] = subscribers
 	}
 
 	if len(body) == 0 {
@@ -711,6 +735,33 @@ func runAutopilotTriggerDelete(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Trigger %s deleted.\n", triggerRef.ID)
 	return nil
+}
+
+func resolveAutopilotSubscriberInputs(ctx context.Context, client *cli.APIClient, refs []string) ([]map[string]string, error) {
+	inputs := make([]map[string]string, 0, len(refs))
+	seen := map[string]struct{}{}
+	memberOnly := assigneeKinds{member: true}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref) == "" {
+			return nil, fmt.Errorf("--subscriber cannot be empty")
+		}
+		userType, userID, err := resolveAssignee(ctx, client, ref, memberOnly)
+		if err != nil {
+			return nil, fmt.Errorf("resolve subscriber %q: %w", ref, err)
+		}
+		if userType != "member" {
+			return nil, fmt.Errorf("subscriber %q resolved to %s; autopilot subscribers must be members", ref, userType)
+		}
+		if _, ok := seen[userID]; ok {
+			continue
+		}
+		seen[userID] = struct{}{}
+		inputs = append(inputs, map[string]string{
+			"user_type": "member",
+			"user_id":   userID,
+		})
+	}
+	return inputs, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -22,6 +22,7 @@ func newAutopilotCreateTestCmd() *cobra.Command {
 	cmd.Flags().String("priority", "none", "")
 	cmd.Flags().String("project", "", "")
 	cmd.Flags().String("issue-title-template", "", "")
+	cmd.Flags().StringArray("subscriber", nil, "")
 	cmd.Flags().String("output", "json", "")
 	return cmd
 }
@@ -36,6 +37,8 @@ func newAutopilotUpdateTestCmd() *cobra.Command {
 	cmd.Flags().String("status", "", "")
 	cmd.Flags().String("mode", "", "")
 	cmd.Flags().String("issue-title-template", "", "")
+	cmd.Flags().StringArray("subscriber", nil, "")
+	cmd.Flags().Bool("clear-subscribers", false, "")
 	cmd.Flags().String("output", "json", "")
 	return cmd
 }
@@ -172,6 +175,53 @@ func TestRunAutopilotCreateSendsProjectID(t *testing.T) {
 	}
 }
 
+func TestRunAutopilotCreateSendsSubscribers(t *testing.T) {
+	const (
+		agentID = "11111111-1111-1111-1111-111111111111"
+		userID  = "22222222-2222-2222-2222-222222222222"
+	)
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"user_id": userID, "name": "Alice"},
+			})
+		case "/api/autopilots":
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "autopilot-1",
+				"title":       "Daily planner",
+				"subscribers": body["subscribers"],
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Daily planner")
+	_ = cmd.Flags().Set("agent", agentID)
+	_ = cmd.Flags().Set("mode", "create_issue")
+	_ = cmd.Flags().Set("subscriber", "Alice")
+
+	if err := runAutopilotCreate(cmd, nil); err != nil {
+		t.Fatalf("runAutopilotCreate: %v", err)
+	}
+	assertAutopilotSubscriberBody(t, body, userID)
+}
+
 func TestRunAutopilotUpdateSendsProjectIDChanges(t *testing.T) {
 	const (
 		autopilotID = "33333333-3333-3333-3333-333333333333"
@@ -229,6 +279,129 @@ func TestRunAutopilotUpdateSendsProjectIDChanges(t *testing.T) {
 			t.Fatalf("project_id = %#v, want nil", got)
 		}
 	})
+}
+
+func TestRunAutopilotUpdateSendsSubscriberReplacement(t *testing.T) {
+	const (
+		autopilotID = "33333333-3333-3333-3333-333333333333"
+		userID      = "22222222-2222-2222-2222-222222222222"
+	)
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"user_id": userID, "name": "Alice"},
+			})
+		case "/api/autopilots/" + autopilotID:
+			if r.Method != http.MethodPatch {
+				t.Errorf("method = %s, want PATCH", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          autopilotID,
+				"title":       "Daily planner",
+				"subscribers": body["subscribers"],
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotUpdateTestCmd()
+	_ = cmd.Flags().Set("subscriber", "Alice")
+	if err := runAutopilotUpdate(cmd, []string{autopilotID}); err != nil {
+		t.Fatalf("runAutopilotUpdate: %v", err)
+	}
+	assertAutopilotSubscriberBody(t, body, userID)
+}
+
+func TestRunAutopilotUpdateCanClearSubscribers(t *testing.T) {
+	const autopilotID = "33333333-3333-3333-3333-333333333333"
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":          autopilotID,
+			"title":       "Daily planner",
+			"subscribers": body["subscribers"],
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotUpdateTestCmd()
+	_ = cmd.Flags().Set("clear-subscribers", "true")
+	if err := runAutopilotUpdate(cmd, []string{autopilotID}); err != nil {
+		t.Fatalf("runAutopilotUpdate: %v", err)
+	}
+	subscribers, ok := body["subscribers"].([]any)
+	if !ok {
+		t.Fatalf("subscribers = %#v, want array", body["subscribers"])
+	}
+	if len(subscribers) != 0 {
+		t.Fatalf("subscribers length = %d, want 0", len(subscribers))
+	}
+}
+
+func TestRunAutopilotUpdateRejectsSubscriberAndClear(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotUpdateTestCmd()
+	_ = cmd.Flags().Set("subscriber", "Alice")
+	_ = cmd.Flags().Set("clear-subscribers", "true")
+
+	err := runAutopilotUpdate(cmd, []string{"33333333-3333-3333-3333-333333333333"})
+	if err == nil {
+		t.Fatal("expected mutually exclusive subscriber flags error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive", err)
+	}
+}
+
+func assertAutopilotSubscriberBody(t *testing.T, body map[string]any, userID string) {
+	t.Helper()
+	subscribers, ok := body["subscribers"].([]any)
+	if !ok {
+		t.Fatalf("subscribers = %#v, want array", body["subscribers"])
+	}
+	if len(subscribers) != 1 {
+		t.Fatalf("subscribers length = %d, want 1", len(subscribers))
+	}
+	sub, ok := subscribers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("subscriber = %#v, want object", subscribers[0])
+	}
+	if sub["user_type"] != "member" {
+		t.Fatalf("user_type = %#v, want member", sub["user_type"])
+	}
+	if sub["user_id"] != userID {
+		t.Fatalf("user_id = %#v, want %q", sub["user_id"], userID)
+	}
 }
 
 func TestUUIDRegexp(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds CLI support for autopilot subscriber templates so member subscribers can be set from `multica autopilot create` and replaced or cleared from `multica autopilot update`.

This closes the CLI gap with the existing server/frontend subscriber support and lets automation-created issues notify the intended member through inbox.

## Related Issue

Multica issue: STR-208

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added repeatable `--subscriber` to `multica autopilot create`.
- Added repeatable `--subscriber` and `--clear-subscribers` to `multica autopilot update`.
- Reused member-only assignee resolution so subscriber flags accept member names or user IDs.
- Added CLI tests for create, replace, clear, and mutually exclusive subscriber flags.
- Updated `CLI_AND_DAEMON.md` with subscriber flag examples and semantics.
- Merged latest `main` and added the missing `stage: null` test fixture field required by the current `Issue` type.

## How to Test

1. `cd server && mise x go@1.26.1 -- go test ./cmd/multica`
2. `pnpm --filter @multica/core typecheck`
3. Create or update a `create_issue` autopilot with `--subscriber <member>` and confirm `subscribers` appears in `multica autopilot get <id> --output json`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented from Multica issue STR-208. The local autopilot needed Korean issue output and member inbox notification; while updating it, the existing CLI lacked autopilot subscriber flags even though the server and frontend already supported subscriber templates. I added the missing CLI surface, tests, and docs, then used the built CLI to update the local autopilot.

## Screenshots (optional)

N/A. CLI-only change.
