### PR TITLE
refactor(scheduler): add PlansForScope hook for non-cadence jobs (1/3 MUL-3551)

### DIFF
--- a/server/internal/scheduler/db_ops.go
+++ b/server/internal/scheduler/db_ops.go
@@ -314,11 +314,16 @@ func encodeResult(in map[string]any) (string, error) {
 	return string(b), nil
 }
 
-// latestPlanInfo returns the latest known plan_time for (job, scope)
+// LatestPlanInfo returns the latest known plan_time for (job, scope)
 // plus the fields the catch-up planner needs to decide whether the row
 // is still claimable at the same plan_time (FAILED-with-retry) or
 // finished and the next plan_time should advance past it.
-type latestPlanInfo struct {
+//
+// Exported so a JobSpec.PlansForScope hook can inspect the same view
+// the built-in Cadence planner uses — in particular Found / PlanTime
+// to know where to resume plan enumeration, and RetryEligible to keep
+// the cursor on a FAILED-with-retry plan_time.
+type LatestPlanInfo struct {
 	Found       bool
 	PlanTime    time.Time
 	Status      string
@@ -336,7 +341,7 @@ type latestPlanInfo struct {
 // passed; the every_plan planner uses this to keep the cursor on the
 // retry-eligible bucket so tryClaim's retry-from-FAILED branch can
 // fire.
-func (i latestPlanInfo) RetryEligible(now time.Time) bool {
+func (i LatestPlanInfo) RetryEligible(now time.Time) bool {
 	if !i.Found {
 		return false
 	}
@@ -359,8 +364,8 @@ func latestPlan(
 	pool *pgxpool.Pool,
 	jobName string,
 	scope Scope,
-) (latestPlanInfo, error) {
-	var info latestPlanInfo
+) (LatestPlanInfo, error) {
+	var info LatestPlanInfo
 	var nextRetry pgtype.Timestamptz
 	err := pool.QueryRow(ctx, `
 		SELECT plan_time, status, attempt, max_attempts, next_retry_at

--- a/server/internal/scheduler/manager.go
+++ b/server/internal/scheduler/manager.go
@@ -195,6 +195,27 @@ func (m *Manager) plansForTick(
 	scope Scope,
 	now time.Time,
 ) ([]time.Time, error) {
+	// Hook-driven jobs (e.g. Autopilot schedule triggers, which derive
+	// plan_times from per-trigger cron expressions instead of a
+	// uniform Cadence grid) bypass the Cadence planner entirely. We
+	// still read the latest stored plan so the hook can decide whether
+	// to resume from there, and still apply MaxPlansPerTick as a
+	// safety cap on whatever the hook returns.
+	if job.PlansForScope != nil {
+		info, err := latestPlan(ctx, m.pool, job.Name, scope)
+		if err != nil {
+			return nil, err
+		}
+		plans, err := job.PlansForScope(ctx, scope, now, info)
+		if err != nil {
+			return nil, fmt.Errorf("scheduler: plans hook for %q: %w", job.Name, err)
+		}
+		if job.MaxPlansPerTick > 0 && len(plans) > job.MaxPlansPerTick {
+			plans = plans[:job.MaxPlansPerTick]
+		}
+		return plans, nil
+	}
+
 	eligible := now.Add(-job.ScheduleDelay)
 	latest := FloorPlan(eligible, job.Cadence)
 	if latest.After(eligible) {

--- a/server/internal/scheduler/plans_for_scope_test.go
+++ b/server/internal/scheduler/plans_for_scope_test.go
@@ -1,0 +1,251 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestJobSpecValidatePlansForScopeRelaxesCadence covers the relaxed
+// JobSpec.validate() rule: when PlansForScope is set, Cadence is
+// optional because the hook owns plan_time selection (used by the
+// Autopilot schedule job, where each trigger's cron expression is
+// arbitrary and does not fit a single Cadence grid).
+func TestJobSpecValidatePlansForScopeRelaxesCadence(t *testing.T) {
+	base := JobSpec{
+		Name:              "hook_validate",
+		RunTimeout:        time.Minute,
+		StaleTimeout:      2 * time.Minute,
+		HeartbeatInterval: 30 * time.Second,
+		MaxAttempts:       1,
+		Scopes:            StaticScopes(ScopeGlobal),
+		Handler: func(ctx context.Context, in HandlerInput) (HandlerResult, error) {
+			return HandlerResult{}, nil
+		},
+	}
+
+	t.Run("cadence still required without hook", func(t *testing.T) {
+		j := base
+		err := j.validate()
+		if err == nil {
+			t.Fatalf("expected validate error when both Cadence and PlansForScope are unset")
+		}
+		if !strings.Contains(err.Error(), "cadence must be > 0") {
+			t.Fatalf("expected cadence error, got %v", err)
+		}
+	})
+
+	t.Run("cadence optional when hook is set", func(t *testing.T) {
+		j := base
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		if err := j.validate(); err != nil {
+			t.Fatalf("expected validate to pass with PlansForScope and no Cadence; got %v", err)
+		}
+	})
+
+	t.Run("every_plan max_plans_per_tick still required without hook", func(t *testing.T) {
+		j := base
+		j.Cadence = 5 * time.Minute
+		j.CatchUpMode = CatchUpEveryPlan
+		err := j.validate()
+		if err == nil || !strings.Contains(err.Error(), "max_plans_per_tick") {
+			t.Fatalf("expected max_plans_per_tick error for every_plan without hook, got %v", err)
+		}
+	})
+
+	t.Run("every_plan max_plans_per_tick optional with hook", func(t *testing.T) {
+		j := base
+		j.CatchUpMode = CatchUpEveryPlan // legal but ignored when hook is set
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		if err := j.validate(); err != nil {
+			t.Fatalf("hook-driven jobs may leave max_plans_per_tick=0; got %v", err)
+		}
+	})
+
+	t.Run("other invariants still fire", func(t *testing.T) {
+		// RunTimeout > 0 must still be enforced even when the hook is set.
+		j := base
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		j.RunTimeout = 0
+		err := j.validate()
+		if err == nil || !strings.Contains(err.Error(), "run_timeout") {
+			t.Fatalf("expected run_timeout invariant to still fire with hook, got %v", err)
+		}
+	})
+}
+
+// TestManagerPlansForScopeHookDrivesPlans verifies end-to-end that a
+// JobSpec.PlansForScope hook fully replaces the Cadence planner:
+//
+//   - The hook is invoked with a fresh LatestPlanInfo{Found:false} on
+//     first tick, then with the prior plan on the second tick.
+//   - Every plan_time the hook returns is claimed and finalised
+//     SUCCESS by the manager — proof the hook is wired through the
+//     same tryClaim/runClaimed lease path as Cadence-driven jobs.
+//   - MaxPlansPerTick caps an over-eager hook without erroring.
+//   - Cadence=0 is legal when PlansForScope is set.
+//
+// Lives in the integration tier (requires DATABASE_URL) because it
+// exercises the manager's actual SQL primitives, not a stub.
+func TestManagerPlansForScopeHookDrivesPlans(t *testing.T) {
+	pool := integrationPool(t)
+	job := newTestJobSpec(uniqueJobName(t, "hook_planner"))
+	t.Cleanup(func() { cleanupExecutions(t, pool, job.Name) })
+
+	ctx := context.Background()
+	now, err := dbNow(ctx, pool)
+	if err != nil {
+		t.Fatalf("dbNow: %v", err)
+	}
+
+	// Hook-driven job: arbitrary plan_times, no Cadence.
+	job.Cadence = 0
+	job.CatchUpMode = CatchUpLatestOnly // ignored when hook is set, but exercise the path
+	job.MaxPlansPerTick = 2             // safety cap; we'll return 3 from the hook below
+
+	// Plan_times the hook will offer in tick 1. Deliberately NOT on a
+	// uniform Cadence grid so the Cadence planner would never produce
+	// them — proving the hook bypasses FloorPlan entirely.
+	t0 := now.Add(-3 * time.Minute).Truncate(time.Second)
+	t1 := now.Add(-2*time.Minute - 17*time.Second).Truncate(time.Second)
+	t2 := now.Add(-1 * time.Minute).Truncate(time.Second)
+	t3 := now.Add(-15 * time.Second).Truncate(time.Second) // beyond MaxPlansPerTick; should be dropped
+
+	var hookCalls atomic.Int32
+	var lastSeenFound atomic.Bool
+	var lastSeenPlan atomic.Pointer[time.Time]
+
+	job.PlansForScope = func(ctx context.Context, scope Scope, ts time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+		hookCalls.Add(1)
+		lastSeenFound.Store(latest.Found)
+		if latest.Found {
+			pt := latest.PlanTime
+			lastSeenPlan.Store(&pt)
+		} else {
+			lastSeenPlan.Store(nil)
+		}
+		// Realistic hook contract: return only plan_times strictly
+		// after the most recent stored one. This is exactly what the
+		// Autopilot scheduler will do — compute cron occurrences in
+		// (latest.PlanTime, now]. We always *could* return everything
+		// and rely on tryClaim's conflict-no-op for idempotency, but
+		// returning fewer plans is cheaper and exercises the
+		// LatestPlanInfo plumbing.
+		all := []time.Time{t0, t1, t2, t3}
+		var out []time.Time
+		for _, p := range all {
+			if !latest.Found || p.After(latest.PlanTime) {
+				out = append(out, p)
+			}
+		}
+		return out, nil
+	}
+
+	mgr := NewManager(pool, Options{RunnerID: "hook-planner-runner"})
+	if err := mgr.Register(*job); err != nil {
+		t.Fatalf("register hook-driven job: %v", err)
+	}
+
+	// Tick 1: no prior plan, hook returns all 4 plans, MaxPlansPerTick
+	// truncates to {t0, t1}.
+	if err := mgr.runOnce(ctx); err != nil {
+		t.Fatalf("runOnce tick 1: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called on tick 1")
+	}
+	if lastSeenFound.Load() {
+		t.Fatalf("first tick should see LatestPlanInfo{Found:false}")
+	}
+
+	rows := dumpJobRows(t, pool, job.Name)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 plans claimed (MaxPlansPerTick=2), got %d: %+v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Status != "SUCCESS" {
+			t.Fatalf("hook-claimed plan should finish SUCCESS, got %q at %s", r.Status, r.PlanTime)
+		}
+	}
+	wantPlans := []time.Time{t0.UTC(), t1.UTC()}
+	for i, r := range rows {
+		if !r.PlanTime.Equal(wantPlans[i]) {
+			t.Fatalf("plan[%d] = %s; want %s (MaxPlansPerTick should preserve hook order)",
+				i, r.PlanTime.Format(time.RFC3339Nano), wantPlans[i].Format(time.RFC3339Nano))
+		}
+	}
+
+	// Tick 2: latest stored plan is t1. The hook now returns only the
+	// plans strictly after t1 — i.e. {t2, t3}. MaxPlansPerTick=2 lets
+	// both through this tick. The hook must see Found=true with the
+	// latest plan_time (t1, picked by latestPlan ORDER BY plan_time
+	// DESC).
+	hookCalls.Store(0)
+	if err := mgr.runOnce(ctx); err != nil {
+		t.Fatalf("runOnce tick 2: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called on tick 2")
+	}
+	if !lastSeenFound.Load() {
+		t.Fatalf("second tick should see LatestPlanInfo{Found:true}")
+	}
+	if got := lastSeenPlan.Load(); got == nil || !got.Equal(t1.UTC()) {
+		var gotStr string
+		if got != nil {
+			gotStr = got.Format(time.RFC3339Nano)
+		}
+		t.Fatalf("second tick's LatestPlanInfo.PlanTime should be the most recent stored plan; want %s got %s",
+			t1.UTC().Format(time.RFC3339Nano), gotStr)
+	}
+
+	rows = dumpJobRows(t, pool, job.Name)
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 plans after tick 2 (tick 1 left {t0,t1}, tick 2 adds {t2,t3}), got %d: %+v",
+			len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Status != "SUCCESS" {
+			t.Fatalf("all plans should be SUCCESS after tick 2, got %q at %s", r.Status, r.PlanTime)
+		}
+	}
+}
+
+// TestManagerPlansForScopeHookEmptyIsNoOp covers the "nothing due"
+// path: an empty plan slice must not error, must not block subsequent
+// scopes, and must not produce any sys_cron_executions row.
+func TestManagerPlansForScopeHookEmptyIsNoOp(t *testing.T) {
+	pool := integrationPool(t)
+	job := newTestJobSpec(uniqueJobName(t, "hook_empty"))
+	t.Cleanup(func() { cleanupExecutions(t, pool, job.Name) })
+
+	job.Cadence = 0
+	var hookCalls atomic.Int32
+	job.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+		hookCalls.Add(1)
+		return nil, nil
+	}
+
+	mgr := NewManager(pool, Options{RunnerID: "hook-empty-runner"})
+	if err := mgr.Register(*job); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := mgr.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called for the registered job")
+	}
+	rows := dumpJobRows(t, pool, job.Name)
+	if len(rows) != 0 {
+		t.Fatalf("empty hook output must not create rows; got %d", len(rows))
+	}
+}

--- a/server/internal/scheduler/spec.go
+++ b/server/internal/scheduler/spec.go
@@ -160,6 +160,33 @@ type JobSpec struct {
 	// use the helper StaticScopes(ScopeGlobal).
 	Scopes ScopeProvider
 
+	// PlansForScope, if non-nil, REPLACES the Cadence-based planner for
+	// this job. The hook receives the most recent stored plan for the
+	// (job, scope) pair and the current DB-derived `now`; it returns
+	// the list of plan_times (canonical UTC) to attempt this tick.
+	// Returning an empty slice means "nothing due this tick".
+	//
+	// When PlansForScope is set, Cadence / CatchUpMode / CatchUpWindow
+	// have no effect on planning — the hook is in full control of
+	// which plan_times exist. The remaining timing fields (RunTimeout,
+	// StaleTimeout, HeartbeatInterval, MaxAttempts, RetryBackoff,
+	// AllowStaleReentry) still govern lease and retry behaviour, and
+	// MaxPlansPerTick still acts as a safety cap on the slice returned
+	// by the hook (the manager truncates anything beyond it).
+	//
+	// Designed for jobs whose plan_times do not form a uniform Cadence
+	// grid — e.g. Autopilot schedule triggers driven by arbitrary cron
+	// expressions, where each trigger is its own scope and the
+	// occurrence times are computed per-trigger from cron + timezone.
+	//
+	// The hook is invoked once per (job, scope) per tick. Plan_times
+	// returned by the hook are passed unchanged to tryClaim, so the
+	// hook is responsible for returning canonical UTC timestamps. A
+	// plan_time that is already finalised is safe to return: tryClaim
+	// treats it as a conflict and the row is not re-run.
+	PlansForScope func(ctx context.Context, scope Scope, now time.Time,
+		latest LatestPlanInfo) ([]time.Time, error)
+
 	// Handler is the per-execution business logic.
 	Handler Handler
 }
@@ -179,8 +206,8 @@ func (j *JobSpec) validate() error {
 	if strings.TrimSpace(j.Name) == "" {
 		return fmt.Errorf("scheduler: job name is required")
 	}
-	if j.Cadence <= 0 {
-		return fmt.Errorf("scheduler: job %q: cadence must be > 0", j.Name)
+	if j.PlansForScope == nil && j.Cadence <= 0 {
+		return fmt.Errorf("scheduler: job %q: cadence must be > 0 (or set PlansForScope)", j.Name)
 	}
 	if j.RunTimeout <= 0 {
 		return fmt.Errorf("scheduler: job %q: run_timeout must be > 0", j.Name)
@@ -201,7 +228,7 @@ func (j *JobSpec) validate() error {
 	if j.Handler == nil {
 		return fmt.Errorf("scheduler: job %q: handler is required", j.Name)
 	}
-	if j.CatchUpMode == CatchUpEveryPlan && j.MaxPlansPerTick <= 0 {
+	if j.PlansForScope == nil && j.CatchUpMode == CatchUpEveryPlan && j.MaxPlansPerTick <= 0 {
 		return fmt.Errorf("scheduler: job %q: max_plans_per_tick must be > 0 for every_plan catch-up", j.Name)
 	}
 	return nil


### PR DESCRIPTION
## Summary

PR 1 of 3 for the scheduled-Autopilot refactor on MUL-3551.

Adds an optional `JobSpec.PlansForScope` hook to `server/internal/scheduler`. The hook lets a job own its plan_time selection for jobs whose plan_times do not fit a single Cadence grid — most notably the upcoming `autopilot_schedule_dispatch` job where every trigger has its own cron expression.

This PR has **no behaviour change** on its own. It is the smallest, lowest-risk foundation in the stack.

## What changed

- `JobSpec.PlansForScope` is a new optional hook: `func(ctx, scope, now, latest LatestPlanInfo) ([]time.Time, error)`.
- `Manager.plansForTick` delegates to the hook when set, bypassing `FloorPlan(db_now, Cadence)` entirely. `latestPlan` is still loaded so the hook can resume from the most recent stored occurrence; `MaxPlansPerTick` still caps the slice as a safety net.
- The previously private `latestPlanInfo` is exported as `LatestPlanInfo` so hook implementations outside this package can read it. The `RetryEligible` helper is preserved.
- `JobSpec.validate` relaxes two rules when the hook is set:
  - `Cadence > 0` becomes optional (the hook owns plan selection)
  - `MaxPlansPerTick > 0` for `CatchUpEveryPlan` only fires on Cadence-driven jobs
- All other invariants (`RunTimeout > 0`, `StaleTimeout > RunTimeout`, etc.) still fire regardless of the hook.

Existing `rollup_task_usage_hourly` is untouched — its JobSpec leaves `PlansForScope` nil.

## How tested

`go test ./internal/scheduler/...` against local Postgres:

- `TestJobSpecValidatePlansForScopeRelaxesCadence` — pure unit, covers each `validate()` branch (cadence required without hook / optional with hook / max_plans_per_tick required without hook / optional with hook / other invariants still fire).
- `TestManagerPlansForScopeHookDrivesPlans` — DB-backed, registers a hook job with `Cadence=0`, runs two ticks, asserts:
  - First tick sees `LatestPlanInfo{Found:false}` and `MaxPlansPerTick=2` truncates the hook's output to the first two plans, which are claimed + finalised SUCCESS by the manager (proves the hook output flows through the same `tryClaim` / `runClaimed` lease path).
  - Second tick sees `LatestPlanInfo{Found:true, PlanTime:<latest>}` and the hook's "newer than latest" pattern produces exactly the two remaining plans, all SUCCESS.
- `TestManagerPlansForScopeHookEmptyIsNoOp` — empty hook output is a valid no-op (no rows created, no error).
- The existing test suite still passes (`TestStaleStealTerminalUpdateIgnored`, `TestConcurrentClaimsSingleWinner`, `TestManagerEveryPlanRetriesFailedSamePlanTime`, `TestManagerTickClosesAbandonedRunning`, `TestManagerHandlerPanicWritesFailed`, `TestFloorPlanUTC`).

`go build ./...` and `go vet ./...` clean on the server module.

## Next in the stack

- PR 2: `autopilot_run.planned_at` column + `DispatchAutopilotForPlan` (dispatch-layer idempotency on the existing scheduler path).
- PR 3: register `autopilot_schedule_dispatch` JobSpec using this hook + delete the legacy `cmd/server/autopilot_scheduler.go` goroutine.

Each PR is independently deployable and rollback-able.

Refs MUL-3551 / [MUL-3551](mention://issue/f24a87de-369b-4bdf-bdde-fa68134a1a57)
