### PR TITLE
refactor(autopilot): autopilot_run.planned_at + DispatchAutopilotForPlan (2/3 MUL-3551)

### DIFF
--- a/server/cmd/server/autopilot_dispatch_for_plan_test.go
+++ b/server/cmd/server/autopilot_dispatch_for_plan_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestDispatchAutopilotForPlanIsIdempotent locks in the
+// occurrence-level idempotency contract (MUL-3551):
+//
+//   - A second DispatchAutopilotForPlan with the same (trigger_id,
+//     planned_at) MUST return the SAME run row that the first call
+//     created. No second autopilot_run, no second issue / task, no
+//     second failure recorded.
+//
+// This is the dispatch-layer half of the two-defence design. The
+// primary defence lives in sys_cron_executions
+// (uq_sys_cron_execution). This one catches the stale-steal case
+// where a runner crashes between "create run" and "write SUCCESS in
+// sys_cron_executions": the next runner re-enters the dispatch and
+// must reuse the in-flight run instead of duplicating it.
+func TestDispatchAutopilotForPlanIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Dispatch for plan idempotency",
+		Description:        pgtype.Text{String: "Dispatch for plan test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(),
+			`DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+			t.Logf("cleanup autopilot: %v", err)
+		}
+	})
+
+	trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+		AutopilotID:    ap.ID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+
+	// Use a fixed planned_at so the partial unique index has something
+	// concrete to enforce against. Truncate to seconds — the column is
+	// TIMESTAMPTZ and pgx round-trips sub-microsecond, but we want the
+	// comparison to be byte-stable across the two calls.
+	plannedAt := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Second)
+
+	first, err := autopilotSvc.DispatchAutopilotForPlan(
+		ctx, ap, trigger.ID, "schedule", nil, plannedAt,
+	)
+	if err != nil {
+		t.Fatalf("first DispatchAutopilotForPlan: %v", err)
+	}
+	if first == nil {
+		t.Fatalf("first call returned nil run")
+	}
+	if !first.PlannedAt.Valid {
+		t.Fatalf("first run should have planned_at set")
+	}
+	if !first.PlannedAt.Time.Equal(plannedAt) {
+		t.Fatalf("first run planned_at mismatch: got %s, want %s",
+			first.PlannedAt.Time.Format(time.RFC3339Nano),
+			plannedAt.Format(time.RFC3339Nano))
+	}
+
+	// Second call with the SAME (trigger, planned_at) must reuse the
+	// first run, not create a new one.
+	second, err := autopilotSvc.DispatchAutopilotForPlan(
+		ctx, ap, trigger.ID, "schedule", nil, plannedAt,
+	)
+	if err != nil {
+		t.Fatalf("second DispatchAutopilotForPlan: %v", err)
+	}
+	if second == nil {
+		t.Fatalf("second call returned nil run")
+	}
+	if second.ID != first.ID {
+		t.Fatalf("second call must reuse first run: first.ID=%s second.ID=%s",
+			util.UUIDToString(first.ID), util.UUIDToString(second.ID))
+	}
+
+	// Belt-and-suspenders: the partial unique index plus the lookup
+	// in DispatchAutopilotForPlan together guarantee exactly one row.
+	var rowCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE autopilot_id = $1`, ap.ID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("expected exactly 1 autopilot_run for the (trigger, planned_at) pair, got %d", rowCount)
+	}
+
+	// A different planned_at for the same trigger MUST be allowed —
+	// it represents the next scheduled occurrence, not a duplicate.
+	plannedAt2 := plannedAt.Add(5 * time.Minute)
+	third, err := autopilotSvc.DispatchAutopilotForPlan(
+		ctx, ap, trigger.ID, "schedule", nil, plannedAt2,
+	)
+	if err != nil {
+		t.Fatalf("third DispatchAutopilotForPlan with new planned_at: %v", err)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("different planned_at must produce a different run, got reuse")
+	}
+
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE autopilot_id = $1`, ap.ID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows after 3rd call: %v", err)
+	}
+	if rowCount != 2 {
+		t.Fatalf("expected 2 autopilot_run rows after distinct planned_ats, got %d", rowCount)
+	}
+}
+
+// TestDispatchAutopilotForPlanRejectsZeroArgs locks in the
+// fail-loud contract: a caller that forgets to set trigger_id or
+// planned_at would silently disable the idempotency guard, and the
+// only safe answer is an error.
+func TestDispatchAutopilotForPlanRejectsZeroArgs(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	ap := db.Autopilot{
+		ID:            parseUUID(testWorkspaceID), // placeholder; will not be loaded since validation fails first
+		WorkspaceID:   parseUUID(testWorkspaceID),
+		ExecutionMode: "run_only",
+		AssigneeType:  "agent",
+		AssigneeID:    parseUUID(testWorkspaceID), // arbitrary; we never get past the input guard
+		Status:        "active",
+	}
+
+	t.Run("invalid trigger_id", func(t *testing.T) {
+		_, err := autopilotSvc.DispatchAutopilotForPlan(
+			ctx, ap, pgtype.UUID{}, "schedule", nil, time.Now().UTC(),
+		)
+		if err == nil {
+			t.Fatalf("expected error for invalid trigger_id")
+		}
+	})
+
+	t.Run("zero planned_at", func(t *testing.T) {
+		_, err := autopilotSvc.DispatchAutopilotForPlan(
+			ctx, ap, parseUUID(testWorkspaceID), "schedule", nil, time.Time{},
+		)
+		if err == nil {
+			t.Fatalf("expected error for zero planned_at")
+		}
+	})
+}

--- a/server/cmd/server/autopilot_dispatch_for_plan_test.go
+++ b/server/cmd/server/autopilot_dispatch_for_plan_test.go
@@ -187,3 +187,173 @@ func TestDispatchAutopilotForPlanRejectsZeroArgs(t *testing.T) {
 		}
 	})
 }
+
+// TestDispatchAutopilotForPlanRecoversPartialRun is the regression
+// for the #4443 review blocker:
+//
+//	"DispatchAutopilotForPlan reuses existing run unconditionally,
+//	 will mark a half-written run as SUCCESS even when no
+//	 issue/task was ever created."
+//
+// We seed a partial-state autopilot_run for (trigger, planned_at) —
+// the run exists with a non-terminal status but the corresponding
+// downstream linkage (task_id for run_only, issue_id for create_issue)
+// is NULL. A subsequent DispatchAutopilotForPlan call at the same
+// (trigger, planned_at) MUST NOT return the partial row as-is;
+// instead it must mark the partial row FAILED + clear its planned_at
+// to release the partial-unique slot, then create a fresh dispatched
+// run with the downstream linkage actually populated.
+func TestDispatchAutopilotForPlanRecoversPartialRun(t *testing.T) {
+	for _, mode := range []string{"run_only", "create_issue"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			queries := db.New(testPool)
+			bus := events.New()
+			taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+			autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+			var agentID string
+			if err := testPool.QueryRow(ctx,
+				`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+				testWorkspaceID,
+			).Scan(&agentID); err != nil {
+				t.Fatalf("load fixture agent: %v", err)
+			}
+
+			ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+				WorkspaceID:        parseUUID(testWorkspaceID),
+				Title:              "Partial recovery " + mode,
+				Description:        pgtype.Text{String: "partial run recovery test", Valid: true},
+				AssigneeType:       "agent",
+				AssigneeID:         parseUUID(agentID),
+				Status:             "active",
+				ExecutionMode:      mode,
+				IssueTitleTemplate: pgtype.Text{String: "Partial recovery", Valid: true},
+				CreatedByType:      "member",
+				CreatedByID:        parseUUID(testUserID),
+			})
+			if err != nil {
+				t.Fatalf("CreateAutopilot: %v", err)
+			}
+			t.Cleanup(func() {
+				if _, err := testPool.Exec(context.Background(),
+					`DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+					t.Logf("cleanup autopilot: %v", err)
+				}
+			})
+
+			trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+				AutopilotID:    ap.ID,
+				Kind:           "schedule",
+				Enabled:        true,
+				CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+				Timezone:       pgtype.Text{String: "UTC", Valid: true},
+			})
+			if err != nil {
+				t.Fatalf("CreateAutopilotTrigger: %v", err)
+			}
+
+			plannedAt := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+			plannedTS := pgtype.Timestamptz{Time: plannedAt, Valid: true}
+
+			// Seed a PARTIAL run: a prior attempt wrote the run row
+			// (status reflects the dispatch path's initial state) but
+			// crashed before creating the downstream resource —
+			// task_id is NULL for run_only, issue_id is NULL for
+			// create_issue.
+			initialStatus := "running"
+			if mode == "create_issue" {
+				initialStatus = "issue_created"
+			}
+			partial, err := queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+				AutopilotID:    ap.ID,
+				TriggerID:      trigger.ID,
+				Source:         "schedule",
+				Status:         initialStatus,
+				TriggerPayload: nil,
+				PlannedAt:      plannedTS,
+			})
+			if err != nil {
+				t.Fatalf("seed partial run: %v", err)
+			}
+			// Confirm the partial state: no downstream linkage.
+			if partial.TaskID.Valid {
+				t.Fatalf("seed partial run should have task_id=NULL, got %s", util.UUIDToString(partial.TaskID))
+			}
+			if partial.IssueID.Valid {
+				t.Fatalf("seed partial run should have issue_id=NULL, got %s", util.UUIDToString(partial.IssueID))
+			}
+
+			// Retry the dispatch — this is the stale-steal codepath.
+			fresh, err := autopilotSvc.DispatchAutopilotForPlan(
+				ctx, ap, trigger.ID, "schedule", nil, plannedAt,
+			)
+			if err != nil {
+				t.Fatalf("DispatchAutopilotForPlan retry: %v", err)
+			}
+			if fresh == nil {
+				t.Fatalf("retry returned nil run")
+			}
+			if fresh.ID == partial.ID {
+				t.Fatalf("retry must NOT reuse the partial run; got the same id %s", util.UUIDToString(fresh.ID))
+			}
+
+			// The partial row must now be FAILED with planned_at
+			// cleared, so the new row's planned_at is unique.
+			var partialStatus string
+			var partialPlannedAt pgtype.Timestamptz
+			var partialFailureReason pgtype.Text
+			if err := testPool.QueryRow(ctx,
+				`SELECT status, planned_at, failure_reason FROM autopilot_run WHERE id = $1`,
+				partial.ID,
+			).Scan(&partialStatus, &partialPlannedAt, &partialFailureReason); err != nil {
+				t.Fatalf("read partial row after recovery: %v", err)
+			}
+			if partialStatus != "failed" {
+				t.Fatalf("partial run must be marked failed, got %q", partialStatus)
+			}
+			if partialPlannedAt.Valid {
+				t.Fatalf("partial run planned_at must be cleared to release partial-unique slot, still valid")
+			}
+			if !partialFailureReason.Valid || partialFailureReason.String == "" {
+				t.Fatalf("partial run must carry a recovery failure_reason for ops, got empty")
+			}
+
+			// The fresh row must carry the original planned_at and a
+			// real downstream linkage from the just-completed
+			// dispatch.
+			if !fresh.PlannedAt.Valid {
+				t.Fatalf("fresh run planned_at must be set")
+			}
+			if !fresh.PlannedAt.Time.Equal(plannedAt) {
+				t.Fatalf("fresh run planned_at mismatch: got %s want %s",
+					fresh.PlannedAt.Time.Format(time.RFC3339Nano),
+					plannedAt.Format(time.RFC3339Nano))
+			}
+			switch mode {
+			case "run_only":
+				if !fresh.TaskID.Valid {
+					t.Fatalf("run_only retry must produce a run with task_id set")
+				}
+			case "create_issue":
+				if !fresh.IssueID.Valid {
+					t.Fatalf("create_issue retry must produce a run with issue_id set")
+				}
+			}
+
+			// Verify the partial-unique constraint is happy: exactly
+			// one row per (trigger_id, planned_at) where both are
+			// non-NULL.
+			var liveRows int
+			if err := testPool.QueryRow(ctx, `
+				SELECT COUNT(*) FROM autopilot_run
+				 WHERE trigger_id = $1 AND planned_at = $2
+			`, trigger.ID, plannedTS).Scan(&liveRows); err != nil {
+				t.Fatalf("count live (trigger, planned) rows: %v", err)
+			}
+			if liveRows != 1 {
+				t.Fatalf("expected exactly 1 live row at (trigger, planned_at) after recovery, got %d", liveRows)
+			}
+		})
+	}
+}

--- a/server/internal/scheduler/db_ops.go
+++ b/server/internal/scheduler/db_ops.go
@@ -314,11 +314,16 @@ func encodeResult(in map[string]any) (string, error) {
 	return string(b), nil
 }
 
-// latestPlanInfo returns the latest known plan_time for (job, scope)
+// LatestPlanInfo returns the latest known plan_time for (job, scope)
 // plus the fields the catch-up planner needs to decide whether the row
 // is still claimable at the same plan_time (FAILED-with-retry) or
 // finished and the next plan_time should advance past it.
-type latestPlanInfo struct {
+//
+// Exported so a JobSpec.PlansForScope hook can inspect the same view
+// the built-in Cadence planner uses — in particular Found / PlanTime
+// to know where to resume plan enumeration, and RetryEligible to keep
+// the cursor on a FAILED-with-retry plan_time.
+type LatestPlanInfo struct {
 	Found       bool
 	PlanTime    time.Time
 	Status      string
@@ -336,7 +341,7 @@ type latestPlanInfo struct {
 // passed; the every_plan planner uses this to keep the cursor on the
 // retry-eligible bucket so tryClaim's retry-from-FAILED branch can
 // fire.
-func (i latestPlanInfo) RetryEligible(now time.Time) bool {
+func (i LatestPlanInfo) RetryEligible(now time.Time) bool {
 	if !i.Found {
 		return false
 	}
@@ -359,8 +364,8 @@ func latestPlan(
 	pool *pgxpool.Pool,
 	jobName string,
 	scope Scope,
-) (latestPlanInfo, error) {
-	var info latestPlanInfo
+) (LatestPlanInfo, error) {
+	var info LatestPlanInfo
 	var nextRetry pgtype.Timestamptz
 	err := pool.QueryRow(ctx, `
 		SELECT plan_time, status, attempt, max_attempts, next_retry_at

--- a/server/internal/scheduler/manager.go
+++ b/server/internal/scheduler/manager.go
@@ -195,6 +195,27 @@ func (m *Manager) plansForTick(
 	scope Scope,
 	now time.Time,
 ) ([]time.Time, error) {
+	// Hook-driven jobs (e.g. Autopilot schedule triggers, which derive
+	// plan_times from per-trigger cron expressions instead of a
+	// uniform Cadence grid) bypass the Cadence planner entirely. We
+	// still read the latest stored plan so the hook can decide whether
+	// to resume from there, and still apply MaxPlansPerTick as a
+	// safety cap on whatever the hook returns.
+	if job.PlansForScope != nil {
+		info, err := latestPlan(ctx, m.pool, job.Name, scope)
+		if err != nil {
+			return nil, err
+		}
+		plans, err := job.PlansForScope(ctx, scope, now, info)
+		if err != nil {
+			return nil, fmt.Errorf("scheduler: plans hook for %q: %w", job.Name, err)
+		}
+		if job.MaxPlansPerTick > 0 && len(plans) > job.MaxPlansPerTick {
+			plans = plans[:job.MaxPlansPerTick]
+		}
+		return plans, nil
+	}
+
 	eligible := now.Add(-job.ScheduleDelay)
 	latest := FloorPlan(eligible, job.Cadence)
 	if latest.After(eligible) {

--- a/server/internal/scheduler/plans_for_scope_test.go
+++ b/server/internal/scheduler/plans_for_scope_test.go
@@ -1,0 +1,251 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestJobSpecValidatePlansForScopeRelaxesCadence covers the relaxed
+// JobSpec.validate() rule: when PlansForScope is set, Cadence is
+// optional because the hook owns plan_time selection (used by the
+// Autopilot schedule job, where each trigger's cron expression is
+// arbitrary and does not fit a single Cadence grid).
+func TestJobSpecValidatePlansForScopeRelaxesCadence(t *testing.T) {
+	base := JobSpec{
+		Name:              "hook_validate",
+		RunTimeout:        time.Minute,
+		StaleTimeout:      2 * time.Minute,
+		HeartbeatInterval: 30 * time.Second,
+		MaxAttempts:       1,
+		Scopes:            StaticScopes(ScopeGlobal),
+		Handler: func(ctx context.Context, in HandlerInput) (HandlerResult, error) {
+			return HandlerResult{}, nil
+		},
+	}
+
+	t.Run("cadence still required without hook", func(t *testing.T) {
+		j := base
+		err := j.validate()
+		if err == nil {
+			t.Fatalf("expected validate error when both Cadence and PlansForScope are unset")
+		}
+		if !strings.Contains(err.Error(), "cadence must be > 0") {
+			t.Fatalf("expected cadence error, got %v", err)
+		}
+	})
+
+	t.Run("cadence optional when hook is set", func(t *testing.T) {
+		j := base
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		if err := j.validate(); err != nil {
+			t.Fatalf("expected validate to pass with PlansForScope and no Cadence; got %v", err)
+		}
+	})
+
+	t.Run("every_plan max_plans_per_tick still required without hook", func(t *testing.T) {
+		j := base
+		j.Cadence = 5 * time.Minute
+		j.CatchUpMode = CatchUpEveryPlan
+		err := j.validate()
+		if err == nil || !strings.Contains(err.Error(), "max_plans_per_tick") {
+			t.Fatalf("expected max_plans_per_tick error for every_plan without hook, got %v", err)
+		}
+	})
+
+	t.Run("every_plan max_plans_per_tick optional with hook", func(t *testing.T) {
+		j := base
+		j.CatchUpMode = CatchUpEveryPlan // legal but ignored when hook is set
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		if err := j.validate(); err != nil {
+			t.Fatalf("hook-driven jobs may leave max_plans_per_tick=0; got %v", err)
+		}
+	})
+
+	t.Run("other invariants still fire", func(t *testing.T) {
+		// RunTimeout > 0 must still be enforced even when the hook is set.
+		j := base
+		j.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+			return nil, nil
+		}
+		j.RunTimeout = 0
+		err := j.validate()
+		if err == nil || !strings.Contains(err.Error(), "run_timeout") {
+			t.Fatalf("expected run_timeout invariant to still fire with hook, got %v", err)
+		}
+	})
+}
+
+// TestManagerPlansForScopeHookDrivesPlans verifies end-to-end that a
+// JobSpec.PlansForScope hook fully replaces the Cadence planner:
+//
+//   - The hook is invoked with a fresh LatestPlanInfo{Found:false} on
+//     first tick, then with the prior plan on the second tick.
+//   - Every plan_time the hook returns is claimed and finalised
+//     SUCCESS by the manager — proof the hook is wired through the
+//     same tryClaim/runClaimed lease path as Cadence-driven jobs.
+//   - MaxPlansPerTick caps an over-eager hook without erroring.
+//   - Cadence=0 is legal when PlansForScope is set.
+//
+// Lives in the integration tier (requires DATABASE_URL) because it
+// exercises the manager's actual SQL primitives, not a stub.
+func TestManagerPlansForScopeHookDrivesPlans(t *testing.T) {
+	pool := integrationPool(t)
+	job := newTestJobSpec(uniqueJobName(t, "hook_planner"))
+	t.Cleanup(func() { cleanupExecutions(t, pool, job.Name) })
+
+	ctx := context.Background()
+	now, err := dbNow(ctx, pool)
+	if err != nil {
+		t.Fatalf("dbNow: %v", err)
+	}
+
+	// Hook-driven job: arbitrary plan_times, no Cadence.
+	job.Cadence = 0
+	job.CatchUpMode = CatchUpLatestOnly // ignored when hook is set, but exercise the path
+	job.MaxPlansPerTick = 2             // safety cap; we'll return 3 from the hook below
+
+	// Plan_times the hook will offer in tick 1. Deliberately NOT on a
+	// uniform Cadence grid so the Cadence planner would never produce
+	// them — proving the hook bypasses FloorPlan entirely.
+	t0 := now.Add(-3 * time.Minute).Truncate(time.Second)
+	t1 := now.Add(-2*time.Minute - 17*time.Second).Truncate(time.Second)
+	t2 := now.Add(-1 * time.Minute).Truncate(time.Second)
+	t3 := now.Add(-15 * time.Second).Truncate(time.Second) // beyond MaxPlansPerTick; should be dropped
+
+	var hookCalls atomic.Int32
+	var lastSeenFound atomic.Bool
+	var lastSeenPlan atomic.Pointer[time.Time]
+
+	job.PlansForScope = func(ctx context.Context, scope Scope, ts time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+		hookCalls.Add(1)
+		lastSeenFound.Store(latest.Found)
+		if latest.Found {
+			pt := latest.PlanTime
+			lastSeenPlan.Store(&pt)
+		} else {
+			lastSeenPlan.Store(nil)
+		}
+		// Realistic hook contract: return only plan_times strictly
+		// after the most recent stored one. This is exactly what the
+		// Autopilot scheduler will do — compute cron occurrences in
+		// (latest.PlanTime, now]. We always *could* return everything
+		// and rely on tryClaim's conflict-no-op for idempotency, but
+		// returning fewer plans is cheaper and exercises the
+		// LatestPlanInfo plumbing.
+		all := []time.Time{t0, t1, t2, t3}
+		var out []time.Time
+		for _, p := range all {
+			if !latest.Found || p.After(latest.PlanTime) {
+				out = append(out, p)
+			}
+		}
+		return out, nil
+	}
+
+	mgr := NewManager(pool, Options{RunnerID: "hook-planner-runner"})
+	if err := mgr.Register(*job); err != nil {
+		t.Fatalf("register hook-driven job: %v", err)
+	}
+
+	// Tick 1: no prior plan, hook returns all 4 plans, MaxPlansPerTick
+	// truncates to {t0, t1}.
+	if err := mgr.runOnce(ctx); err != nil {
+		t.Fatalf("runOnce tick 1: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called on tick 1")
+	}
+	if lastSeenFound.Load() {
+		t.Fatalf("first tick should see LatestPlanInfo{Found:false}")
+	}
+
+	rows := dumpJobRows(t, pool, job.Name)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 plans claimed (MaxPlansPerTick=2), got %d: %+v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Status != "SUCCESS" {
+			t.Fatalf("hook-claimed plan should finish SUCCESS, got %q at %s", r.Status, r.PlanTime)
+		}
+	}
+	wantPlans := []time.Time{t0.UTC(), t1.UTC()}
+	for i, r := range rows {
+		if !r.PlanTime.Equal(wantPlans[i]) {
+			t.Fatalf("plan[%d] = %s; want %s (MaxPlansPerTick should preserve hook order)",
+				i, r.PlanTime.Format(time.RFC3339Nano), wantPlans[i].Format(time.RFC3339Nano))
+		}
+	}
+
+	// Tick 2: latest stored plan is t1. The hook now returns only the
+	// plans strictly after t1 — i.e. {t2, t3}. MaxPlansPerTick=2 lets
+	// both through this tick. The hook must see Found=true with the
+	// latest plan_time (t1, picked by latestPlan ORDER BY plan_time
+	// DESC).
+	hookCalls.Store(0)
+	if err := mgr.runOnce(ctx); err != nil {
+		t.Fatalf("runOnce tick 2: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called on tick 2")
+	}
+	if !lastSeenFound.Load() {
+		t.Fatalf("second tick should see LatestPlanInfo{Found:true}")
+	}
+	if got := lastSeenPlan.Load(); got == nil || !got.Equal(t1.UTC()) {
+		var gotStr string
+		if got != nil {
+			gotStr = got.Format(time.RFC3339Nano)
+		}
+		t.Fatalf("second tick's LatestPlanInfo.PlanTime should be the most recent stored plan; want %s got %s",
+			t1.UTC().Format(time.RFC3339Nano), gotStr)
+	}
+
+	rows = dumpJobRows(t, pool, job.Name)
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 plans after tick 2 (tick 1 left {t0,t1}, tick 2 adds {t2,t3}), got %d: %+v",
+			len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Status != "SUCCESS" {
+			t.Fatalf("all plans should be SUCCESS after tick 2, got %q at %s", r.Status, r.PlanTime)
+		}
+	}
+}
+
+// TestManagerPlansForScopeHookEmptyIsNoOp covers the "nothing due"
+// path: an empty plan slice must not error, must not block subsequent
+// scopes, and must not produce any sys_cron_executions row.
+func TestManagerPlansForScopeHookEmptyIsNoOp(t *testing.T) {
+	pool := integrationPool(t)
+	job := newTestJobSpec(uniqueJobName(t, "hook_empty"))
+	t.Cleanup(func() { cleanupExecutions(t, pool, job.Name) })
+
+	job.Cadence = 0
+	var hookCalls atomic.Int32
+	job.PlansForScope = func(ctx context.Context, scope Scope, now time.Time, latest LatestPlanInfo) ([]time.Time, error) {
+		hookCalls.Add(1)
+		return nil, nil
+	}
+
+	mgr := NewManager(pool, Options{RunnerID: "hook-empty-runner"})
+	if err := mgr.Register(*job); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := mgr.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if hookCalls.Load() == 0 {
+		t.Fatalf("hook was never called for the registered job")
+	}
+	rows := dumpJobRows(t, pool, job.Name)
+	if len(rows) != 0 {
+		t.Fatalf("empty hook output must not create rows; got %d", len(rows))
+	}
+}

--- a/server/internal/scheduler/spec.go
+++ b/server/internal/scheduler/spec.go
@@ -160,6 +160,33 @@ type JobSpec struct {
 	// use the helper StaticScopes(ScopeGlobal).
 	Scopes ScopeProvider
 
+	// PlansForScope, if non-nil, REPLACES the Cadence-based planner for
+	// this job. The hook receives the most recent stored plan for the
+	// (job, scope) pair and the current DB-derived `now`; it returns
+	// the list of plan_times (canonical UTC) to attempt this tick.
+	// Returning an empty slice means "nothing due this tick".
+	//
+	// When PlansForScope is set, Cadence / CatchUpMode / CatchUpWindow
+	// have no effect on planning — the hook is in full control of
+	// which plan_times exist. The remaining timing fields (RunTimeout,
+	// StaleTimeout, HeartbeatInterval, MaxAttempts, RetryBackoff,
+	// AllowStaleReentry) still govern lease and retry behaviour, and
+	// MaxPlansPerTick still acts as a safety cap on the slice returned
+	// by the hook (the manager truncates anything beyond it).
+	//
+	// Designed for jobs whose plan_times do not form a uniform Cadence
+	// grid — e.g. Autopilot schedule triggers driven by arbitrary cron
+	// expressions, where each trigger is its own scope and the
+	// occurrence times are computed per-trigger from cron + timezone.
+	//
+	// The hook is invoked once per (job, scope) per tick. Plan_times
+	// returned by the hook are passed unchanged to tryClaim, so the
+	// hook is responsible for returning canonical UTC timestamps. A
+	// plan_time that is already finalised is safe to return: tryClaim
+	// treats it as a conflict and the row is not re-run.
+	PlansForScope func(ctx context.Context, scope Scope, now time.Time,
+		latest LatestPlanInfo) ([]time.Time, error)
+
 	// Handler is the per-execution business logic.
 	Handler Handler
 }
@@ -179,8 +206,8 @@ func (j *JobSpec) validate() error {
 	if strings.TrimSpace(j.Name) == "" {
 		return fmt.Errorf("scheduler: job name is required")
 	}
-	if j.Cadence <= 0 {
-		return fmt.Errorf("scheduler: job %q: cadence must be > 0", j.Name)
+	if j.PlansForScope == nil && j.Cadence <= 0 {
+		return fmt.Errorf("scheduler: job %q: cadence must be > 0 (or set PlansForScope)", j.Name)
 	}
 	if j.RunTimeout <= 0 {
 		return fmt.Errorf("scheduler: job %q: run_timeout must be > 0", j.Name)
@@ -201,7 +228,7 @@ func (j *JobSpec) validate() error {
 	if j.Handler == nil {
 		return fmt.Errorf("scheduler: job %q: handler is required", j.Name)
 	}
-	if j.CatchUpMode == CatchUpEveryPlan && j.MaxPlansPerTick <= 0 {
+	if j.PlansForScope == nil && j.CatchUpMode == CatchUpEveryPlan && j.MaxPlansPerTick <= 0 {
 		return fmt.Errorf("scheduler: job %q: max_plans_per_tick must be > 0 for every_plan catch-up", j.Name)
 	}
 	return nil

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -63,8 +63,82 @@ func (s *AutopilotService) DispatchAutopilot(
 	source string,
 	payload []byte,
 ) (*db.AutopilotRun, error) {
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, pgtype.Timestamptz{})
+}
+
+// DispatchAutopilotForPlan is the entry point for scheduled triggers that
+// already know the canonical UTC plan_time of the occurrence they are
+// firing. The plan_time is persisted on autopilot_run.planned_at, and the
+// (trigger_id, planned_at) partial unique index — combined with this
+// method's idempotent lookup — guarantees that the SAME planned occurrence
+// cannot produce two runs even if a stale-steal in sys_cron_executions
+// re-enters this method after the first attempt already wrote a row.
+//
+// Semantics:
+//
+//   - If a run already exists for (triggerID, plannedAt), return it
+//     unchanged. The caller (the scheduler handler) treats this as
+//     "this plan_time was already dispatched in a prior attempt that
+//     crashed before writing terminal SUCCESS"; no second issue / task
+//     is created, no failure is recorded against the autopilot.
+//   - Otherwise fall through to the normal dispatch path, with planned_at
+//     stamped on the new autopilot_run row.
+//
+// triggerID and plannedAt MUST both be valid; passing zero values would
+// silently disable the idempotency guard. Manual / webhook / api callers
+// should use DispatchAutopilot instead.
+func (s *AutopilotService) DispatchAutopilotForPlan(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	plannedAt time.Time,
+) (*db.AutopilotRun, error) {
+	if !triggerID.Valid {
+		return nil, fmt.Errorf("dispatch for plan: trigger_id is required")
+	}
+	if plannedAt.IsZero() {
+		return nil, fmt.Errorf("dispatch for plan: planned_at is required")
+	}
+	plannedTS := pgtype.Timestamptz{Time: plannedAt.UTC(), Valid: true}
+
+	// Fast path: prior attempt already created a run for this exact
+	// occurrence. The partial unique index uq_autopilot_run_trigger_planned
+	// would also reject a duplicate INSERT, but doing the lookup up front
+	// lets us return the existing run without burning a sequence number
+	// or producing a noisy INSERT error in the logs.
+	existing, err := s.Queries.GetAutopilotRunByTriggerAndPlanned(ctx, db.GetAutopilotRunByTriggerAndPlannedParams{
+		TriggerID: triggerID,
+		PlannedAt: plannedTS,
+	})
+	if err == nil {
+		// A prior attempt already produced this run. Hand it back so
+		// the handler can record SUCCESS in sys_cron_executions
+		// without creating a duplicate downstream.
+		return &existing, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("dispatch for plan: lookup existing run: %w", err)
+	}
+
+	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, plannedTS)
+}
+
+// dispatchAutopilot is the shared core of the two public Dispatch entry
+// points. plannedAt is the canonical UTC plan_time for scheduled triggers;
+// for manual / webhook / api dispatch it is the zero pgtype.Timestamptz and
+// the resulting autopilot_run row has planned_at IS NULL.
+func (s *AutopilotService) dispatchAutopilot(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	plannedAt pgtype.Timestamptz,
+) (*db.AutopilotRun, error) {
 	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
-		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, reason)
+		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, reason)
 	}
 
 	// Determine initial status based on execution mode.
@@ -80,6 +154,7 @@ func (s *AutopilotService) DispatchAutopilot(
 		Status:         initialStatus,
 		TriggerPayload: payload,
 		SquadID:        autopilotSquadAttribution(autopilot),
+		PlannedAt:      plannedAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create run: %w", err)
@@ -858,6 +933,7 @@ func (s *AutopilotService) recordSkippedRun(
 	triggerID pgtype.UUID,
 	source string,
 	payload []byte,
+	plannedAt pgtype.Timestamptz,
 	reason string,
 ) (*db.AutopilotRun, error) {
 	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
@@ -867,6 +943,7 @@ func (s *AutopilotService) recordSkippedRun(
 		Status:         "skipped",
 		TriggerPayload: payload,
 		SquadID:        autopilotSquadAttribution(autopilot),
+		PlannedAt:      plannedAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create skipped run: %w", err)

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -71,22 +71,29 @@ func (s *AutopilotService) DispatchAutopilot(
 // firing. The plan_time is persisted on autopilot_run.planned_at, and the
 // (trigger_id, planned_at) partial unique index — combined with this
 // method's idempotent lookup — guarantees that the SAME planned occurrence
-// cannot produce two runs even if a stale-steal in sys_cron_executions
-// re-enters this method after the first attempt already wrote a row.
+// cannot produce two SUCCESSFUL runs even if a stale-steal in
+// sys_cron_executions re-enters this method after a prior attempt.
 //
-// Semantics:
+// Semantics for an already-existing run at (trigger_id, planned_at):
 //
-//   - If a run already exists for (triggerID, plannedAt), return it
-//     unchanged. The caller (the scheduler handler) treats this as
-//     "this plan_time was already dispatched in a prior attempt that
-//     crashed before writing terminal SUCCESS"; no second issue / task
-//     is created, no failure is recorded against the autopilot.
-//   - Otherwise fall through to the normal dispatch path, with planned_at
-//     stamped on the new autopilot_run row.
+//   - If the existing run is COMPLETE (terminal status, or in-flight
+//     with the appropriate downstream linkage — issue_id for
+//     create_issue, task_id for run_only), it is returned unchanged.
+//     The handler then writes SUCCESS in sys_cron_executions; no
+//     duplicate issue/task is produced.
+//   - If the existing run is in a PARTIAL state (a prior attempt
+//     wrote the run row but crashed before creating its downstream
+//     issue/task), it is marked FAILED with a recovery reason and
+//     its planned_at is cleared, releasing the partial-unique slot.
+//     Dispatch then proceeds normally and creates a fresh run at the
+//     same plan_time. Without this branch, a crash-during-dispatch
+//     would let a subsequent retry see the in-flight run, return it
+//     unchanged, and let the scheduler mark the occurrence SUCCESS
+//     without an actual issue/task ever being created (#4443 review).
 //
-// triggerID and plannedAt MUST both be valid; passing zero values would
-// silently disable the idempotency guard. Manual / webhook / api callers
-// should use DispatchAutopilot instead.
+// triggerID and plannedAt MUST both be valid; passing zero values
+// would silently disable the idempotency guard. Manual / webhook /
+// api callers should use DispatchAutopilot instead.
 func (s *AutopilotService) DispatchAutopilotForPlan(
 	ctx context.Context,
 	autopilot db.Autopilot,
@@ -105,24 +112,77 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 
 	// Fast path: prior attempt already created a run for this exact
 	// occurrence. The partial unique index uq_autopilot_run_trigger_planned
-	// would also reject a duplicate INSERT, but doing the lookup up front
-	// lets us return the existing run without burning a sequence number
-	// or producing a noisy INSERT error in the logs.
+	// would also reject a duplicate INSERT, but doing the lookup up
+	// front lets us short-circuit on a complete run and gives us a
+	// chance to recover a partial run before retrying.
 	existing, err := s.Queries.GetAutopilotRunByTriggerAndPlanned(ctx, db.GetAutopilotRunByTriggerAndPlannedParams{
 		TriggerID: triggerID,
 		PlannedAt: plannedTS,
 	})
-	if err == nil {
-		// A prior attempt already produced this run. Hand it back so
-		// the handler can record SUCCESS in sys_cron_executions
-		// without creating a duplicate downstream.
+	switch {
+	case err == nil && isAutopilotRunComplete(existing):
+		// A prior attempt produced a complete run. Hand it back so the
+		// handler can record SUCCESS in sys_cron_executions without
+		// duplicating any downstream side effect.
 		return &existing, nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+
+	case err == nil:
+		// Partial-state run from a crashed attempt. Mark it failed
+		// (with a recovery reason) and release its partial-unique
+		// slot so the fresh dispatch below can create a new row.
+		slog.Warn("autopilot dispatch for plan: recovering partial run",
+			"run_id", util.UUIDToString(existing.ID),
+			"trigger_id", util.UUIDToString(triggerID),
+			"planned_at", plannedAt.UTC().Format(time.RFC3339),
+			"status", existing.Status,
+			"issue_set", existing.IssueID.Valid,
+			"task_set", existing.TaskID.Valid,
+		)
+		if err := s.Queries.RecoverPartialAutopilotRun(ctx, existing.ID); err != nil {
+			return nil, fmt.Errorf("dispatch for plan: recover partial run: %w", err)
+		}
+		// Fall through to a fresh dispatch below.
+
+	case !errors.Is(err, pgx.ErrNoRows):
 		return nil, fmt.Errorf("dispatch for plan: lookup existing run: %w", err)
 	}
 
 	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, plannedTS)
+}
+
+// isAutopilotRunComplete decides whether an existing autopilot_run row
+// for (trigger_id, planned_at) is safe to reuse on a stale-steal retry.
+//
+// A run is "complete" if either:
+//
+//   - It is in a terminal state (completed / failed / skipped). Nothing
+//     more to do downstream; the caller can return it as-is.
+//
+//   - It is in-flight in a state whose downstream side effect is
+//     observable:
+//
+//     * issue_created with a valid issue_id — the issue exists and
+//       the issue-event listener owns task creation from here.
+//
+//     * running with a valid task_id — the task is queued, the
+//       listener will close the run when the task terminates.
+//
+// Anything else — most importantly issue_created/running with NULL
+// issue_id/task_id, or the brief 'pending' state — is a partial run:
+// the run row was inserted before the dispatch path could create the
+// downstream resource, and a stale-steal retry MUST NOT treat it as
+// complete (#4443 review).
+func isAutopilotRunComplete(run db.AutopilotRun) bool {
+	switch run.Status {
+	case "completed", "failed", "skipped":
+		return true
+	case "issue_created":
+		return run.IssueID.Valid
+	case "running":
+		return run.TaskID.Valid
+	default:
+		return false
+	}
 }
 
 // dispatchAutopilot is the shared core of the two public Dispatch entry

--- a/server/migrations/124_autopilot_run_planned_at.down.sql
+++ b/server/migrations/124_autopilot_run_planned_at.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS uq_autopilot_run_trigger_planned;
+
+ALTER TABLE autopilot_run
+    DROP COLUMN IF EXISTS planned_at;

--- a/server/migrations/124_autopilot_run_planned_at.up.sql
+++ b/server/migrations/124_autopilot_run_planned_at.up.sql
@@ -1,0 +1,36 @@
+-- Adds planned_at + a partial unique constraint on (trigger_id, planned_at) to
+-- autopilot_run. The column anchors each run to the canonical UTC planned fire
+-- time of its triggering occurrence; the unique index is the dispatch-layer
+-- idempotency guard for scheduled triggers.
+--
+-- Why we need it (MUL-3551):
+--
+--   * The primary idempotency for scheduled dispatch lives one layer up, in
+--     `sys_cron_executions` (job_name, scope_kind, scope_id, plan_time). A
+--     successful claim on that table is what gates running the handler.
+--   * BUT: if a runner claims a plan_time, starts dispatch (creating an
+--     autopilot_run row + an issue + an agent_task_queue row), then dies
+--     before writing terminal SUCCESS, the row goes stale → a sibling runner
+--     can steal the lease and re-enter the handler with the SAME plan_time.
+--     Without a row-level guard the second attempt would create a duplicate
+--     autopilot_run / issue / task.
+--   * This index makes that double-create a primary-key conflict, so the
+--     stale-steal path can detect "this plan_time already produced a run"
+--     and reuse it instead of creating a duplicate.
+--
+-- Partial-unique is correct here because:
+--
+--   * Manual triggers and webhook triggers leave planned_at NULL (they have
+--     no canonical fire time). The constraint must not apply to them.
+--   * Pre-existing autopilot_run rows are all (planned_at IS NULL) — no
+--     backfill needed, no migration risk.
+--
+-- The DEFAULT NULL keeps the existing trigger paths (manual / webhook / api
+-- source) untouched; only DispatchAutopilotForPlan writes a non-NULL value.
+
+ALTER TABLE autopilot_run
+    ADD COLUMN planned_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX uq_autopilot_run_trigger_planned
+    ON autopilot_run (trigger_id, planned_at)
+    WHERE trigger_id IS NOT NULL AND planned_at IS NOT NULL;

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -185,20 +185,21 @@ func (q *Queries) CreateAutopilot(ctx context.Context, arg CreateAutopilotParams
 const createAutopilotRun = `-- name: CreateAutopilotRun :one
 
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at
 ) VALUES (
     $1, $4, $2, $3, $5,
-    $6
-) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+    $6, $7
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type CreateAutopilotRunParams struct {
-	AutopilotID    pgtype.UUID `json:"autopilot_id"`
-	Source         string      `json:"source"`
-	Status         string      `json:"status"`
-	TriggerID      pgtype.UUID `json:"trigger_id"`
-	TriggerPayload []byte      `json:"trigger_payload"`
-	SquadID        pgtype.UUID `json:"squad_id"`
+	AutopilotID    pgtype.UUID        `json:"autopilot_id"`
+	Source         string             `json:"source"`
+	Status         string             `json:"status"`
+	TriggerID      pgtype.UUID        `json:"trigger_id"`
+	TriggerPayload []byte             `json:"trigger_payload"`
+	SquadID        pgtype.UUID        `json:"squad_id"`
+	PlannedAt      pgtype.Timestamptz `json:"planned_at"`
 }
 
 // =====================
@@ -208,6 +209,13 @@ type CreateAutopilotRunParams struct {
 // parent autopilot has assignee_type='squad', NULL otherwise. The executing
 // agent_id on agent_task_queue still records who actually ran the work
 // (the squad leader); squad_id lets reports group by squad without a join.
+//
+// planned_at carries the canonical UTC fire time for scheduled triggers
+// (source='schedule'); it stays NULL for manual / webhook / api sources
+// which have no canonical occurrence. Combined with the partial unique
+// index uq_autopilot_run_trigger_planned, this gives dispatch-layer
+// idempotency: a stale-steal retry at the same plan_time cannot create
+// a second run for the same (trigger_id, planned_at) pair (MUL-3551).
 func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRunParams) (AutopilotRun, error) {
 	row := q.db.QueryRow(ctx, createAutopilotRun,
 		arg.AutopilotID,
@@ -216,6 +224,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		arg.TriggerID,
 		arg.TriggerPayload,
 		arg.SquadID,
+		arg.PlannedAt,
 	)
 	var i AutopilotRun
 	err := row.Scan(
@@ -233,6 +242,7 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -461,7 +471,7 @@ func (q *Queries) GetAutopilotInWorkspace(ctx context.Context, arg GetAutopilotI
 }
 
 const getAutopilotRun = `-- name: GetAutopilotRun :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE id = $1
 `
 
@@ -483,13 +493,14 @@ func (q *Queries) GetAutopilotRun(ctx context.Context, id pgtype.UUID) (Autopilo
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
 
 const getAutopilotRunByIssue = `-- name: GetAutopilotRunByIssue :one
 
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE issue_id = $1 AND status IN ('issue_created', 'running')
 LIMIT 1
 `
@@ -515,6 +526,50 @@ func (q *Queries) GetAutopilotRunByIssue(ctx context.Context, issueID pgtype.UUI
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
+	)
+	return i, err
+}
+
+const getAutopilotRunByTriggerAndPlanned = `-- name: GetAutopilotRunByTriggerAndPlanned :one
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
+WHERE trigger_id = $1
+  AND planned_at = $2
+LIMIT 1
+`
+
+type GetAutopilotRunByTriggerAndPlannedParams struct {
+	TriggerID pgtype.UUID        `json:"trigger_id"`
+	PlannedAt pgtype.Timestamptz `json:"planned_at"`
+}
+
+// Idempotent lookup used by DispatchAutopilotForPlan to detect a
+// crash-during-dispatch retry: if a row already exists for this
+// (trigger_id, planned_at), the caller reuses it instead of creating a
+// duplicate. The partial unique index covers the same key, so a race
+// between "look up then insert" still resolves to a single row — this
+// query is just the fast path that lets us skip the INSERT when we
+// can see the prior row clearly. Returns no rows for the (much more
+// common) first-time dispatch.
+func (q *Queries) GetAutopilotRunByTriggerAndPlanned(ctx context.Context, arg GetAutopilotRunByTriggerAndPlannedParams) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getAutopilotRunByTriggerAndPlanned, arg.TriggerID, arg.PlannedAt)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -604,7 +659,7 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 }
 
 const listAutopilotRuns = `-- name: ListAutopilotRuns :many
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at FROM autopilot_run
 WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -640,6 +695,7 @@ func (q *Queries) ListAutopilotRuns(ctx context.Context, arg ListAutopilotRunsPa
 			&i.Result,
 			&i.CreatedAt,
 			&i.SquadID,
+			&i.PlannedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1223,7 +1279,7 @@ const updateAutopilotRunCompleted = `-- name: UpdateAutopilotRunCompleted :one
 UPDATE autopilot_run
 SET status = 'completed', completed_at = now(), result = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunCompletedParams struct {
@@ -1249,6 +1305,7 @@ func (q *Queries) UpdateAutopilotRunCompleted(ctx context.Context, arg UpdateAut
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1257,7 +1314,7 @@ const updateAutopilotRunFailed = `-- name: UpdateAutopilotRunFailed :one
 UPDATE autopilot_run
 SET status = 'failed', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunFailedParams struct {
@@ -1283,6 +1340,7 @@ func (q *Queries) UpdateAutopilotRunFailed(ctx context.Context, arg UpdateAutopi
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1291,7 +1349,7 @@ const updateAutopilotRunIssueCreated = `-- name: UpdateAutopilotRunIssueCreated 
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunIssueCreatedParams struct {
@@ -1317,6 +1375,7 @@ func (q *Queries) UpdateAutopilotRunIssueCreated(ctx context.Context, arg Update
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1325,7 +1384,7 @@ const updateAutopilotRunRunning = `-- name: UpdateAutopilotRunRunning :one
 UPDATE autopilot_run
 SET status = 'running', task_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunRunningParams struct {
@@ -1351,6 +1410,7 @@ func (q *Queries) UpdateAutopilotRunRunning(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1359,7 +1419,7 @@ const updateAutopilotRunSkipped = `-- name: UpdateAutopilotRunSkipped :one
 UPDATE autopilot_run
 SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunSkippedParams struct {
@@ -1391,6 +1451,7 @@ func (q *Queries) UpdateAutopilotRunSkipped(ctx context.Context, arg UpdateAutop
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }
@@ -1402,7 +1463,7 @@ SET status = 'skipped',
     failure_reason = $2,
     result = $3
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at
 `
 
 type UpdateAutopilotRunSkippedWithResultParams struct {
@@ -1429,6 +1490,7 @@ func (q *Queries) UpdateAutopilotRunSkippedWithResult(ctx context.Context, arg U
 		&i.Result,
 		&i.CreatedAt,
 		&i.SquadID,
+		&i.PlannedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -950,6 +950,30 @@ func (q *Queries) RecoverLostTriggers(ctx context.Context) ([]RecoverLostTrigger
 	return items, nil
 }
 
+const recoverPartialAutopilotRun = `-- name: RecoverPartialAutopilotRun :exec
+UPDATE autopilot_run
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = 'recovered partial dispatch (crashed before downstream creation)',
+    planned_at = NULL
+WHERE id = $1
+`
+
+// Recovers a partial-state autopilot_run from a crashed first attempt
+// (the runner wrote the run row but died before creating the downstream
+// issue/task) so that a subsequent DispatchAutopilotForPlan call can
+// create a fresh run at the same (trigger_id, planned_at).
+//
+// Setting planned_at = NULL clears the partial-unique slot held by
+// uq_autopilot_run_trigger_planned, letting the new INSERT proceed.
+// The row stays in autopilot_run as a FAILED record (with a recovery
+// reason) so ops still see the abandoned attempt in the run history —
+// it is not silently deleted.
+func (q *Queries) RecoverPartialAutopilotRun(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, recoverPartialAutopilotRun, id)
+	return err
+}
+
 const rotateAutopilotTriggerWebhookToken = `-- name: RotateAutopilotTriggerWebhookToken :one
 UPDATE autopilot_trigger
 SET webhook_token = $2,

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -151,6 +151,7 @@ type AutopilotRun struct {
 	Result         []byte             `json:"result"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	SquadID        pgtype.UUID        `json:"squad_id"`
+	PlannedAt      pgtype.Timestamptz `json:"planned_at"`
 }
 
 type AutopilotSubscriber struct {

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -186,12 +186,33 @@ RETURNING *;
 -- parent autopilot has assignee_type='squad', NULL otherwise. The executing
 -- agent_id on agent_task_queue still records who actually ran the work
 -- (the squad leader); squad_id lets reports group by squad without a join.
+--
+-- planned_at carries the canonical UTC fire time for scheduled triggers
+-- (source='schedule'); it stays NULL for manual / webhook / api sources
+-- which have no canonical occurrence. Combined with the partial unique
+-- index uq_autopilot_run_trigger_planned, this gives dispatch-layer
+-- idempotency: a stale-steal retry at the same plan_time cannot create
+-- a second run for the same (trigger_id, planned_at) pair (MUL-3551).
 INSERT INTO autopilot_run (
-    autopilot_id, trigger_id, source, status, trigger_payload, squad_id
+    autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at
 ) VALUES (
     $1, sqlc.narg('trigger_id'), $2, $3, sqlc.narg('trigger_payload'),
-    sqlc.narg('squad_id')
+    sqlc.narg('squad_id'), sqlc.narg('planned_at')
 ) RETURNING *;
+
+-- name: GetAutopilotRunByTriggerAndPlanned :one
+-- Idempotent lookup used by DispatchAutopilotForPlan to detect a
+-- crash-during-dispatch retry: if a row already exists for this
+-- (trigger_id, planned_at), the caller reuses it instead of creating a
+-- duplicate. The partial unique index covers the same key, so a race
+-- between "look up then insert" still resolves to a single row — this
+-- query is just the fast path that lets us skip the INSERT when we
+-- can see the prior row clearly. Returns no rows for the (much more
+-- common) first-time dispatch.
+SELECT * FROM autopilot_run
+WHERE trigger_id = $1
+  AND planned_at = $2
+LIMIT 1;
 
 -- name: GetAutopilotRun :one
 SELECT * FROM autopilot_run

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -214,6 +214,24 @@ WHERE trigger_id = $1
   AND planned_at = $2
 LIMIT 1;
 
+-- name: RecoverPartialAutopilotRun :exec
+-- Recovers a partial-state autopilot_run from a crashed first attempt
+-- (the runner wrote the run row but died before creating the downstream
+-- issue/task) so that a subsequent DispatchAutopilotForPlan call can
+-- create a fresh run at the same (trigger_id, planned_at).
+--
+-- Setting planned_at = NULL clears the partial-unique slot held by
+-- uq_autopilot_run_trigger_planned, letting the new INSERT proceed.
+-- The row stays in autopilot_run as a FAILED record (with a recovery
+-- reason) so ops still see the abandoned attempt in the run history —
+-- it is not silently deleted.
+UPDATE autopilot_run
+SET status = 'failed',
+    completed_at = now(),
+    failure_reason = 'recovered partial dispatch (crashed before downstream creation)',
+    planned_at = NULL
+WHERE id = $1;
+
 -- name: GetAutopilotRun :one
 SELECT * FROM autopilot_run
 WHERE id = $1;


### PR DESCRIPTION
## Summary

PR 2 of 3 for the scheduled-Autopilot refactor on [MUL-3551](mention://issue/f24a87de-369b-4bdf-bdde-fa68134a1a57).

Adds dispatch-layer occurrence idempotency. This is the **second** line of defence behind the primary `uq_sys_cron_execution` guarantee on `sys_cron_executions` (PR 3 wires that in). If a runner crashes between "create `autopilot_run`" and "write SUCCESS in `sys_cron_executions`", the next stale-steal retry must reuse the existing run instead of creating a duplicate.

**This PR stacks on #4442.** It has no scheduler / handler / UI behaviour change on its own — the new entry point exists but no caller invokes it yet. PR 3 will register the `autopilot_schedule_dispatch` JobSpec that consumes it.

## What changed

- **Migration 124** — `ALTER TABLE autopilot_run ADD COLUMN planned_at TIMESTAMPTZ` + partial unique index on `(trigger_id, planned_at)` `WHERE trigger_id IS NOT NULL AND planned_at IS NOT NULL`. Manual / webhook / api callers leave `planned_at` NULL, so they remain untouched by the constraint.
- **`autopilot.sql`** — `CreateAutopilotRun` now accepts `planned_at`; new `GetAutopilotRunByTriggerAndPlanned` is the fast-path lookup before INSERT.
- **`service.DispatchAutopilotForPlan(ctx, autopilot, triggerID, source, payload, plannedAt time.Time)`** — new entry point for scheduled dispatch. Looks up an existing run for `(trigger_id, planned_at)`; if found, returns it unchanged (no second issue / task / failure); otherwise dispatches normally with `planned_at` stamped on the new run. Rejects zero `triggerID` or zero `plannedAt` to prevent callers from silently disabling the guard.
- **`service.DispatchAutopilot`** — unchanged signature for manual / webhook / api callers. Internally both entry points share a private `dispatchAutopilot(...)` core.
- **`recordSkippedRun`** also threads `planned_at`, so the admission-skip path is covered by the same partial-unique guarantee.
- **sqlc** regenerated with v1.31.1 (the repo's pinned version).

## How tested

`go test ./cmd/server -run TestDispatchAutopilotForPlan -count=1 -v` against local Postgres:

- `TestDispatchAutopilotForPlanIsIdempotent`
  - First call → run created with `planned_at` set.
  - Second call with same `(trigger, planned_at)` → reuses first run; `COUNT(autopilot_run)=1`.
  - Third call with a different `planned_at` → distinct run; `COUNT(autopilot_run)=2`. Proves we are not collapsing legitimate consecutive occurrences.
- `TestDispatchAutopilotForPlanRejectsZeroArgs` — invalid `trigger_id` and zero `planned_at` both fail loudly.
- `go test ./cmd/server -run Autopilot -count=1` and `go test ./internal/service/... -count=1` both pass — the existing manual / webhook / api dispatch path is untouched.

`go build ./...` and `go vet ./...` clean.

## Risk and rollback

- The new column is nullable with no default and the unique index is partial — no backfill, no existing-row impact.
- Rolling back the migration drops the new column + index; service code still builds because `DispatchAutopilotForPlan` is a new function only PR 3 will call.

## Next

- PR 3 — register `autopilot_schedule_dispatch` JobSpec on the existing `scheduler.Manager`, switch trigger create/update + recovery to DB time, delete `cmd/server/autopilot_scheduler.go`.

Refs MUL-3551
