### PR TITLE
MUL-3560: gate runtime brief sections per task kind (PR 0.6)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -4003,16 +4003,23 @@ func TestInjectRuntimeConfigAssignmentTriggerMentionsRecent(t *testing.T) {
 // when the task carries a real issue id (comment-triggered or
 // assignment-triggered). Chat / quick-create / run-only autopilot don't
 // have an issue, so injecting the section there would just guarantee a
-// failed CLI call on every entry. The discovery line in Available
-// Commands → Core is global and must appear everywhere so that the agent
-// can still reach the commands if a future workflow path needs them.
+// failed CLI call on every entry.
+//
+// The Available Commands → Core discovery lines are emitted for every
+// kind EXCEPT quick-create: quick-create gets a minimal `issue create`-
+// only Available Commands variant (introduced in MUL-3560 PR 0.6)
+// because its hard guardrails forbid `issue get` / `issue status` /
+// `issue comment add` / metadata commands anyway. Listing them in
+// Available Commands would tempt the model to bend the guardrail. The
+// other four kinds (comment / assignment / autopilot / chat) keep the
+// full Core list so an agent that needs metadata discovery has it.
 func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 	t.Parallel()
 
-	// Discovery lines in Available Commands → Core must appear in EVERY
-	// runtime config, regardless of trigger type. These are the single
-	// discovery point for the CLI when an agent decides to read or write
-	// metadata outside the numbered workflow.
+	// Discovery lines in Available Commands → Core must appear in every
+	// runtime config EXCEPT quick-create. These are the single discovery
+	// point for the CLI when an agent decides to read or write metadata
+	// outside the numbered workflow.
 	coreDiscoveryLines := []string{
 		"multica issue metadata list <issue-id>",
 		"multica issue metadata set <issue-id> --key <k> --value <v> [--type string|number|bool]",
@@ -4165,10 +4172,23 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			}
 			s := string(data)
 
-			// Global Core discovery lines apply everywhere.
-			for _, want := range coreDiscoveryLines {
-				if !strings.Contains(s, want) {
-					t.Errorf("Available Commands → Core missing %q\n---\n%s", want, s)
+			// Global Core discovery lines apply everywhere EXCEPT
+			// quick-create, which uses the minimal Available
+			// Commands variant introduced in MUL-3560 PR 0.6. For
+			// quick-create we assert the inverse — the lines must
+			// be absent — so a future regression that re-adds the
+			// full Core list to quick-create fails this test.
+			if tc.ctx.QuickCreatePrompt != "" {
+				for _, banned := range coreDiscoveryLines {
+					if strings.Contains(s, banned) {
+						t.Errorf("quick_create Available Commands should NOT advertise %q (minimal variant)\n---\n%s", banned, s)
+					}
+				}
+			} else {
+				for _, want := range coreDiscoveryLines {
+					if !strings.Contains(s, want) {
+						t.Errorf("Available Commands → Core missing %q\n---\n%s", want, s)
+					}
 				}
 			}
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -366,14 +366,34 @@ func CleanupRuntimeConfig(workDir, provider string) error {
 // As of MUL-3560 PR 0.5 the builder is a thin kind-aware dispatcher: each
 // section of the brief lives in its own `writeXxx` helper (see
 // runtime_config_sections.go), and the assembly order is driven by the
-// taskKind classification (see runtime_config_kind.go). This PR is a
-// pure refactor — output is byte-for-byte identical to the pre-refactor
-// monolithic builder for every existing test fixture. The follow-up PR
-// (0.6) will start gating sections per the Section × Kind matrix from
-// Eve's MUL-3560 design comment (e.g. drop Mentions / Comment Formatting /
-// Issue Metadata out of quick-create), with negative assertions added
-// alongside each removal so each kind's brief contract becomes
-// machine-checked.
+// taskKind classification (see runtime_config_kind.go).
+//
+// PR 0.6 layers per-kind section gating on top of that dispatcher: every
+// section that a given kind has no use for is now elided at the call site
+// instead of rendered and ignored. The current matrix is:
+//
+//	Section               | comment | assign | autopilot | quick_create | chat
+//	----------------------+---------+--------+-----------+--------------+------
+//	Available Commands    |   full  |  full  |   full    |   minimal    | full
+//	Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
+//	Repositories          |    △    |   △    |     △     |      —       |  △
+//	Project Context       |    △    |   △    |     —     |      —       |  —
+//	Issue Metadata        |    ✓    |   ✓    |     —     |      —       |  —
+//	Instruction Precedence|    —    |   ✓    |     —     |      —       |  —
+//	Sub-issue Creation    |    ✓    |   ✓    |     —     |      —       |  —
+//	Skills                |    ✓    |   ✓    |     ✓     |      —       |  ✓
+//	Mentions              |    ✓    |   ✓    |     —     |      —       |  —
+//	Attachments           |    ✓    |   ✓    |     —     |      —       |  —
+//
+// (✓ always; — never; △ data-driven inside the helper.) Always-on rows —
+// Header, Background Task Safety, Agent Identity, Requesting User, Task
+// Initiator, Workspace Context, Workflow, Always Use CLI, Output — are
+// shared by every kind and emitted unconditionally (or gated by their own
+// data preconditions).
+//
+// The matrix above is the source of truth for any later content-gating
+// change; updating either side without the other is the regression
+// TestBuildMetaSkillContentKindMatrix catches.
 func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	var b strings.Builder
 	kind := classifyTask(ctx)
@@ -394,19 +414,48 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	writeTaskInitiator(&b, ctx)
 	writeWorkspaceContext(&b, ctx)
 
-	// === Available Commands + Comment Formatting ===
+	// === Available Commands ===
 	//
-	// In the pre-refactor builder both sections are unconditional. PR 0.5
-	// preserves that — the follow-up PR will replace Available Commands
-	// with a per-kind subset (quick-create gets only `issue create`,
-	// autopilot gets a read-only subset, etc.) and drop Comment Formatting
-	// for kinds that never post comments.
-	writeAvailableCommands(&b)
-	writeCommentFormatting(&b)
+	// Most kinds get the full Core CLI list. Quick-create collapses to a
+	// minimal "just `issue create`" form because its hard guardrails
+	// forbid get / status / comment add anyway — there is no value in
+	// rendering 4k chars of commands the agent must not call. Autopilot
+	// keeps the full list because run-only autopilot tasks are open-
+	// ended and may need any command via their instructions.
+	switch kind {
+	case kindQuickCreate:
+		writeAvailableCommandsQuickCreate(&b)
+	default:
+		writeAvailableCommands(&b)
+	}
+
+	// === Comment Formatting ===
+	//
+	// Only kinds that actually post issue comments need the
+	// `--content-file` shell-safety drill. Chat replies go through the
+	// chat pipeline, not `comment add`; quick-create runs exactly one
+	// `issue create` then exits; autopilot run-only does not comment by
+	// default (per its workflow guardrails).
+	if kind == kindCommentTriggered || kind == kindAssignmentTriggered {
+		writeCommentFormatting(&b)
+	}
 
 	// === Conditional context sections ===
-	writeRepositories(&b, ctx)
-	writeProjectContext(&b, ctx)
+	//
+	// Repositories: cut from quick-create only — that kind's hard
+	// guardrails forbid checkout. All other kinds keep the existing
+	// data-driven `if len(ctx.Repos) > 0` guard inside the helper.
+	if kind != kindQuickCreate {
+		writeRepositories(&b, ctx)
+	}
+
+	// Project Context: scoped to issue kinds. Chat / quick-create /
+	// autopilot do not operate on an issue belonging to a project, and
+	// even when they did, the project resources pointer would be noise
+	// for their workflows.
+	if kind.hasIssueContext() {
+		writeProjectContext(&b, ctx)
+	}
 
 	// Issue Metadata: only kinds that operate on a real Multica issue
 	// (comment-triggered / assignment-triggered) can read or pin metadata,
@@ -454,9 +503,31 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		writeSubIssueCreation(&b)
 	}
 
-	writeSkills(&b, provider, ctx)
-	writeMentions(&b)
-	writeAttachments(&b)
+	// Skills: kept for every kind that may chain into a discovered
+	// skill at runtime (comment / assignment / autopilot / chat).
+	// Quick-create is a one-shot `issue create` and never loads skills,
+	// so we drop the list. The helper still no-ops when ctx.AgentSkills
+	// is empty.
+	if kind != kindQuickCreate {
+		writeSkills(&b, provider, ctx)
+	}
+
+	// Mentions: only the kinds that produce a comment need the
+	// `@mention` side-effect discipline. Chat / quick-create / autopilot
+	// never emit a comment under their workflow, so the section is pure
+	// noise for them.
+	if kind == kindCommentTriggered || kind == kindAssignmentTriggered {
+		writeMentions(&b)
+	}
+
+	// Attachments: same shape as Comment Formatting / Mentions — only
+	// kinds that work on a real issue (and therefore could surface an
+	// attached file in the issue / comment timeline) need the CLI
+	// pointer.
+	if kind == kindCommentTriggered || kind == kindAssignmentTriggered {
+		writeAttachments(&b)
+	}
+
 	writeAlwaysUseCLI(&b)
 	writeOutput(&b, kind, ctx)
 

--- a/server/internal/daemon/execenv/runtime_config_kind.go
+++ b/server/internal/daemon/execenv/runtime_config_kind.go
@@ -82,8 +82,21 @@ func classifyTask(ctx TaskContextForEnv) taskKind {
 }
 
 // hasIssueContext returns true for the kinds that operate on a real Multica
-// issue and therefore can read / pin issue-scoped state (Issue Metadata,
-// Sub-issue Creation, Project Context). Equivalent to the pre-refactor
+// issue and therefore can read / pin issue-scoped state. As of MUL-3560
+// PR 0.6 the dispatcher gates these sections on this predicate:
+//
+//   - Project Context
+//   - Issue Metadata
+//   - Sub-issue Creation
+//
+// All three are meaningless without an issue id and would either render an
+// empty body or steer the agent into a guaranteed-failed CLI call. Mentions
+// / Comment Formatting / Attachments are NOT gated by this predicate even
+// though they look similar — those have their own dispatch rule because
+// they care about whether the kind posts a comment, not whether it has an
+// issue id (see runtime_config.go).
+//
+// Equivalent to the pre-refactor scattered check
 // `ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == ""`
 // — extracted so the predicate has a name and every call site agrees on its
 // meaning.

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -125,16 +125,17 @@ func TestTaskKindHasIssueContext(t *testing.T) {
 }
 
 // TestBuildMetaSkillContentKindMatrix locks in which sections each kind
-// emits today. This is the post-refactor structural canary for MUL-3560
-// PR 0.5: any later PR that drops a section from a kind must update the
-// negative expectations here in lockstep, and any PR that accidentally
-// adds a section back fails this test.
+// emits today, after MUL-3560 PR 0.6's content gating. This is the
+// single machine-checked source of truth for the Section × Kind matrix
+// documented on `buildMetaSkillContent` — any later PR that drops or
+// re-adds a section for a kind must update the expectations here in
+// lockstep, and any PR that accidentally regresses fails this test.
 //
 // The fixtures here intentionally use the minimal context required to
-// trigger each kind, with one repo and one skill so Repositories / Skills
-// fire. They are NOT meant to exercise every conditional inside each
-// section — that is covered by the dedicated per-section tests in the
-// rest of this package.
+// trigger each kind, with one repo and one skill so Repositories /
+// Skills can fire when the matrix allows them. They are NOT meant to
+// exercise every conditional inside each section — that is covered by
+// the dedicated per-section tests in the rest of this package.
 func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -149,6 +150,7 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 		// in mustHave should not have it)
 	}
 	checks := []sectionCheck{
+		// Always-on rows — every kind gets these.
 		{
 			heading:  "# Multica Agent Runtime",
 			mustHave: allKinds(),
@@ -157,9 +159,6 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 			heading:  "## Background Task Safety",
 			mustHave: allKinds(),
 		},
-		// Identity is only rendered when AgentName/ID/Instructions are
-		// present; the matrix tests below provide AgentName for every
-		// kind so it should fire across the board.
 		{
 			heading:  "## Agent Identity",
 			mustHave: allKinds(),
@@ -169,12 +168,34 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 			mustHave: allKinds(),
 		},
 		{
-			heading:  "## Comment Formatting",
+			heading:  "### Workflow",
 			mustHave: allKinds(),
 		},
 		{
-			heading:  "## Repositories",
+			heading:  "## Important: Always Use the `multica` CLI",
 			mustHave: allKinds(),
+		},
+		{
+			heading:  "## Output",
+			mustHave: allKinds(),
+		},
+
+		// Gated rows — present only on the kinds the matrix allows.
+		{
+			heading: "## Comment Formatting",
+			mustHave: map[taskKind]bool{
+				kindCommentTriggered:    true,
+				kindAssignmentTriggered: true,
+			},
+		},
+		{
+			heading: "## Repositories",
+			mustHave: map[taskKind]bool{
+				kindCommentTriggered:    true,
+				kindAssignmentTriggered: true,
+				kindAutopilotRunOnly:    true,
+				kindChat:                true,
+			},
 		},
 		{
 			heading: "## Issue Metadata",
@@ -190,10 +211,6 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 			},
 		},
 		{
-			heading:  "### Workflow",
-			mustHave: allKinds(),
-		},
-		{
 			heading: "## Sub-issue Creation",
 			mustHave: map[taskKind]bool{
 				kindCommentTriggered:    true,
@@ -201,24 +218,27 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 			},
 		},
 		{
-			heading:  "## Skills",
-			mustHave: allKinds(),
+			heading: "## Skills",
+			mustHave: map[taskKind]bool{
+				kindCommentTriggered:    true,
+				kindAssignmentTriggered: true,
+				kindAutopilotRunOnly:    true,
+				kindChat:                true,
+			},
 		},
 		{
-			heading:  "## Mentions",
-			mustHave: allKinds(),
+			heading: "## Mentions",
+			mustHave: map[taskKind]bool{
+				kindCommentTriggered:    true,
+				kindAssignmentTriggered: true,
+			},
 		},
 		{
-			heading:  "## Attachments",
-			mustHave: allKinds(),
-		},
-		{
-			heading:  "## Important: Always Use the `multica` CLI",
-			mustHave: allKinds(),
-		},
-		{
-			heading:  "## Output",
-			mustHave: allKinds(),
+			heading: "## Attachments",
+			mustHave: map[taskKind]bool{
+				kindCommentTriggered:    true,
+				kindAssignmentTriggered: true,
+			},
 		},
 	}
 
@@ -264,7 +284,19 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 	for kind, ctx := range fixtures {
 		out := buildMetaSkillContent("claude", ctx)
 		for _, c := range checks {
-			present := strings.Contains(out, c.heading)
+			// Match the heading as a discrete line (preceded by a
+			// newline and followed by the trailing blank line every
+			// section helper writes). A bare substring check would
+			// also fire on inline references like "See ## Comment
+			// Formatting below" inside Available Commands, which
+			// is a reference, not the heading itself.
+			//
+			// Special-case the very first line: the H1 banner has
+			// no leading newline, so an explicit prefix check
+			// covers it.
+			needle := "\n" + c.heading + "\n"
+			firstLine := c.heading + "\n"
+			present := strings.HasPrefix(out, firstLine) || strings.Contains(out, needle)
 			want := c.mustHave[kind]
 			if want && !present {
 				t.Errorf("kind=%d: expected heading %q in brief", kind, c.heading)
@@ -272,6 +304,56 @@ func TestBuildMetaSkillContentKindMatrix(t *testing.T) {
 			if !want && present {
 				t.Errorf("kind=%d: heading %q should NOT be in brief (matrix gating regression)", kind, c.heading)
 			}
+		}
+	}
+}
+
+// TestBuildMetaSkillContentQuickCreateAvailableCommands locks in the
+// quick-create-specific minimal Available Commands variant introduced in
+// MUL-3560 PR 0.6. Quick-create's hard guardrails forbid any CLI other
+// than `issue create`, so the full Core list (which advertises get /
+// status / metadata / comment add / etc.) is replaced with a single
+// `issue create` line plus the "everything else is `multica --help`"
+// escape hatch.
+func TestBuildMetaSkillContentQuickCreateAvailableCommands(t *testing.T) {
+	t.Parallel()
+	out := buildMetaSkillContent("codex", TaskContextForEnv{
+		QuickCreatePrompt: "create an issue about flaky tests",
+		AgentName:         "Agent X",
+		AgentID:           "agent-x",
+	})
+
+	// The minimal variant keeps the `issue create` line plus the help
+	// escape hatch...
+	for _, want := range []string{
+		"## Available Commands",
+		"multica issue create --title",
+		"`multica --help`",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("quick_create Available Commands missing %q", want)
+		}
+	}
+
+	// ...and intentionally drops every command quick-create's hard
+	// guardrails forbid. Listing them is pure noise the model is told
+	// not to call.
+	for _, banned := range []string{
+		"multica issue get <id>",
+		"multica issue comment list <issue-id>",
+		"multica issue update <id>",
+		"multica issue status <id> <status>",
+		"multica issue comment add <issue-id>",
+		"multica issue metadata list <issue-id>",
+		"multica issue metadata set <issue-id>",
+		"multica issue metadata delete <issue-id>",
+		"multica issue children <id>",
+		"multica repo checkout <url>",
+		"### Squad maintenance",
+		"multica squad member set-role",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("quick_create Available Commands should NOT advertise %q (hard guardrails forbid the call)", banned)
 		}
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -149,6 +149,26 @@ func writeAvailableCommands(b *strings.Builder) {
 	b.WriteString("- `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role> [--output json]` — Change a squad member role in place; use this instead of remove+add when only the role changes.\n\n")
 }
 
+// writeAvailableCommandsQuickCreate emits a minimal Available Commands
+// section for quick-create runs. Quick-create's hard workflow guardrails
+// require **exactly one** `multica issue create` invocation and forbid
+// `issue get` / `issue status` / `issue comment add`, so the full Core
+// list (4k+ chars) is pure noise — every other command would just tempt
+// the model to bend the guardrail. Squad maintenance is also dropped:
+// quick-create is a one-shot prompt-to-issue translator and cannot edit
+// squads.
+//
+// The shape mirrors writeAvailableCommands so a reader knows what they
+// are looking at, but the body is the single command line plus the
+// "everything else is `multica --help`" escape hatch. ~500 chars vs
+// ~4400 for the full variant.
+func writeAvailableCommandsQuickCreate(b *strings.Builder) {
+	b.WriteString("## Available Commands\n\n")
+	b.WriteString("**Use `--output json` for structured data.** For anything beyond `issue create`, run `multica --help` or `multica <command> --help`.\n\n")
+	b.WriteString("### Core\n")
+	b.WriteString("- `multica issue create --title \"...\" [--description \"...\" | --description-file <path> | --description-stdin] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--stage N] [--project <project-id>] [--due-date <RFC3339>] [--attachment <path>]` — Create a new issue; `--attachment` may be repeated. For agent-authored long descriptions, prefer `--description-file <path>` over `--description-stdin` (flags after a HEREDOC terminator can be silently swallowed, #4182).\n\n")
+}
+
 // writeCommentFormatting emits the cross-platform "write to file then post
 // with --content-file" guardrail. Windows branch uses Remove-Item; everything
 // else uses rm. See BuildCommentReplyInstructions for the canonical inline


### PR DESCRIPTION
## Summary

Apply per-kind section gating on top of PR 0.5's helper extraction
(#4446). Every section the task kind has no use for is now elided at
the dispatcher instead of rendered and ignored. This is PR 0.6 of the
MUL-3560 runtime-brief diet roadmap and depends on PR #4446 being
merged first (it stacks on `feature/runtime-brief-task-kind-switch`).

## Measured impact

Captured on `claude` provider with a realistic fixture: 2 repos, 10
skills, full identity. Comparing PR 0.5 baseline ↔ PR 0.6:

| kind                  | PR 0.5 | PR 0.6 |   Δ   |  Δ%  |
| --------------------- | -----: | -----: | ----: | ---: |
| comment-triggered     | 19462  | 19462  |     0 |   0% |
| assignment-triggered  | 18034  | 18034  |     0 |   0% |
| autopilot-run-only    | 11174  |  8442  | -2732 | -24% |
| **quick-create**      | 12497  | **4799** | **-7698** | **-62%** |
| chat                  | 11155  |  8423  | -2732 | -24% |

The headline win is quick-create: **12.5k → 4.8k chars (-62%)**. Its
hard guardrails forbid every command except `issue create`, so it now
renders only what it can act on. Comment- and assignment-triggered are
unchanged in this PR — their reduction is the per-section compression
PRs #1, #4, #5 on the roadmap.

## The matrix (now machine-checked)

```
Section               | comment | assign | autopilot | quick_create | chat
----------------------+---------+--------+-----------+--------------+------
Available Commands    |   full  |  full  |   full    |   minimal    | full
Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
Repositories          |    △    |   △    |     △     |      —       |  △
Project Context       |    △    |   △    |     —     |      —       |  —
Issue Metadata        |    ✓    |   ✓    |     —     |      —       |  —
Instruction Precedence|    —    |   ✓    |     —     |      —       |  —
Sub-issue Creation    |    ✓    |   ✓    |     —     |      —       |  —
Skills                |    ✓    |   ✓    |     ✓     |      —       |  ✓
Mentions              |    ✓    |   ✓    |     —     |      —       |  —
Attachments           |    ✓    |   ✓    |     —     |      —       |  —
```

✓ always; — never; △ data-driven inside the helper. Always-on rows
(Header, Background Task Safety, Agent Identity, Requesting User, Task
Initiator, Workspace Context, Workflow, Always Use CLI, Output) apply
to every kind and are unchanged.

This matrix is duplicated in two places **on purpose**, both
machine-checked:

1. `buildMetaSkillContent`'s doc comment (the spec).
2. `TestBuildMetaSkillContentKindMatrix` (the test that fails the moment
   the dispatcher diverges from the spec).

## What changed

- **`runtime_config.go`** — dispatcher rewritten so each section call
  is gated by `kind`. The matrix in the doc comment is the source of
  truth and matches the test asserter byte-for-byte by section name.
- **`runtime_config_sections.go`** — new
  `writeAvailableCommandsQuickCreate` minimal variant: just the
  `issue create` line and the "everything else is `multica --help`"
  escape hatch (~500 chars vs ~4400 for the full variant).
- **`runtime_config_kind.go`** — `hasIssueContext` doc comment
  narrowed to its three real call sites (Project Context, Issue
  Metadata, Sub-issue Creation) per GPT-Boy's PR 0.5 review nit.
- **`runtime_config_kind_test.go`** —
  - `TestBuildMetaSkillContentKindMatrix` updated to encode the new
    expected section set per kind. Heading match tightened so it
    only fires on the heading line (not inline references like
    "See ## Comment Formatting below" inside Available Commands).
  - **New** `TestBuildMetaSkillContentQuickCreateAvailableCommands`
    pins the minimal-variant content: `issue create` is present;
    every other Core command — get / status / metadata / comment
    add / children / repo checkout / squad — is asserted absent.
- **`execenv_test.go`** — `TestInjectRuntimeConfigIssueMetadataSectionScope`
  now asserts the metadata Core discovery lines are **absent** for
  quick-create (it uses the minimal Available Commands) and present
  for every other kind. Comment narrowed to match.

## Verification

```
$ go vet ./internal/daemon/...
$ go test ./internal/daemon/... ./internal/handler/...
ok      github.com/multica-ai/multica/server/internal/daemon
ok      github.com/multica-ai/multica/server/internal/daemon/execenv
ok      github.com/multica-ai/multica/server/internal/daemon/repocache
ok      github.com/multica-ai/multica/server/internal/handler
```

All existing tests still pass; the matrix test catches future
regressions in both directions (a kind that drops a section it needs,
or a kind that re-acquires a section it shouldn't).

## What this PR is NOT

- **No CLI signature changes.** `InjectRuntimeConfig` stays 2-tuple,
  no new ctx fields, no per-provider changes. Composes cleanly with
  PR #4439's `WithSizes` work.
- **No content compression for comment / assignment.** Those kinds
  still ~19k chars each; their reduction lands in PRs #1, #4, #5 of
  the original roadmap.
- **Known dangling reference.** The full Available Commands variant
  still contains "See ## Comment Formatting below" as an inline
  pointer. For autopilot/chat this now points at a section that
  doesn't exist in their brief. Cleanup is deferred to PR #1
  (Available Commands compression), which will introduce
  kind-specific Available Commands variants where the pointer can
  be conditional. Calling it out so it's not a review surprise.

## Stack

- depends on: #4446 (PR 0.5, structural prep)
- enables: PRs #1..#9 on MUL-3560 (per-section compression of the
  comment / assignment briefs)
