### PR TITLE
MUL-3567: add copy button to readonly code blocks

### DIFF
--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -276,6 +276,24 @@ describe("ReadonlyContent code styling", () => {
     expect(blockCode?.textContent?.trim()).toBe(token);
   });
 
+  it("copies the whole fenced code block from the readonly toolbar", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const source = ["pnpm install", "pnpm test"].join("\n");
+    const { getByRole } = render(
+      <ReadonlyContent content={["```bash", source, "```"].join("\n")} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Copy code" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(source);
+    });
+  });
+
   it("keeps editor code literal by disabling font ligatures", () => {
     const codeCss = readFileSync("editor/styles/code.css", "utf8");
 

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -16,11 +16,12 @@
  * - Rendering mentions with the same IssueMentionCard component and .mention class
  */
 
-import { isValidElement, memo, useMemo, useRef } from "react";
+import { isValidElement, memo, useMemo, useRef, useState } from "react";
 import ReactMarkdown, {
   defaultUrlTransform,
   type Components,
 } from "react-markdown";
+import type { ReactNode } from "react";
 import rehypeKatex from "rehype-katex";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
@@ -29,9 +30,12 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { createLowlight, common } from "lowlight";
 import { toHtml } from "hast-util-to-html";
+import { Check, Copy } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { copyText } from "@multica/ui/lib/clipboard";
 import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
 import type { Attachment } from "@multica/core/types";
+import { useT } from "../i18n";
 import { useNavigation } from "../navigation";
 import { IssueMentionCard } from "../issues/components/issue-mention-card";
 import { ProjectChip } from "../projects/components/project-chip";
@@ -153,6 +157,56 @@ function ProjectMentionLink({ projectId, label }: { projectId: string; label?: s
     >
       <ProjectChip projectId={projectId} fallbackLabel={label} className="cursor-pointer hover:bg-accent transition-colors" />
     </span>
+  );
+}
+
+function getTextContent(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(getTextContent).join("");
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    return getTextContent(props.children);
+  }
+  return "";
+}
+
+function ReadonlyCodeBlock({ children }: { children: ReactNode }) {
+  const { t } = useT("editor");
+  const [copied, setCopied] = useState(false);
+  const code = useMemo(
+    () => getTextContent(children).replace(/\n$/, ""),
+    [children],
+  );
+  const copyLabel = t(($) => $.code_block.copy_code) || "Copy code";
+
+  const handleCopy = async () => {
+    if (!code) return;
+    if (await copyText(code)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="code-block-wrapper group/code relative my-3">
+      <div className="absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          title={copyLabel}
+          aria-label={copyLabel}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      <pre className="!m-0 pr-12">{children}</pre>
+    </div>
   );
 }
 
@@ -304,7 +358,7 @@ function buildComponents(): Partial<Components> {
       );
     },
 
-    // Pre — pass through (CSS handles styling via .rich-text-editor pre).
+    // Pre — wrap regular code fences with copy chrome.
     // Special-case Mermaid / HtmlBlockPreview returned from the `code`
     // renderer above so the outer `<pre>` does not wrap them — this is the
     // standard two-layer pattern used to escape react-markdown's default
@@ -325,7 +379,7 @@ function buildComponents(): Partial<Components> {
           return <>{children}</>;
         }
       }
-      return <pre>{children}</pre>;
+      return <ReadonlyCodeBlock>{children}</ReadonlyCodeBlock>;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add a hover/focus copy button to readonly Markdown code blocks used in comments.
- Reuse the shared clipboard helper so copy works in secure and self-hosted HTTP contexts.
- Add a regression test for copying the full fenced code content.

## Verification
- pnpm -C packages/views exec vitest run editor/readonly-content.test.tsx
- pnpm -C packages/views typecheck
- pnpm -C packages/views lint

Closes MUL-3567