### PR TITLE
fix(issues): sort child issues by number

### DIFF
--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -639,7 +639,7 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 const listChildIssues = `-- name: ListChildIssues :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC
+ORDER BY number ASC
 `
 
 func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID) ([]Issue, error) {
@@ -692,7 +692,7 @@ const listChildrenByParents = `-- name: ListChildrenByParents :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id = ANY($2::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC
+ORDER BY parent_issue_id, number ASC
 `
 
 type ListChildrenByParentsParams struct {

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -239,7 +239,7 @@ WHERE i.workspace_id = $1
 -- name: ListChildIssues :many
 SELECT * FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC;
+ORDER BY number ASC;
 
 -- name: ListChildrenByParents :many
 -- Batched variant of ListChildIssues: returns all children for the given
@@ -250,7 +250,7 @@ ORDER BY position ASC, created_at DESC;
 SELECT * FROM issue
 WHERE workspace_id = sqlc.arg('workspace_id')
   AND parent_issue_id = ANY(sqlc.arg('parent_ids')::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC;
+ORDER BY parent_issue_id, number ASC;
 
 -- name: GetIssueByOrigin :one
 -- Finds the issue stamped with a specific (origin_type, origin_id) pair.


### PR DESCRIPTION
## Summary
- sort single-parent child issue queries by issue number
- keep batched child issue queries ordered by parent and issue number
- addresses sub-issue list order becoming unstable after additional sub-issues are appended

Fixes #4232

## Validation
- Not run: local Windows environment does not have Go, pnpm, or Docker installed.
- Change is limited to sqlc query ordering and the generated query constant.