### PR TITLE
feat(issue): enforce squad-parent ownership and active-dependency guards (UMC-288)

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1757,11 +1757,19 @@ func (h *Handler) ReportTaskProgress(w http.ResponseWriter, r *http.Request) {
 }
 
 // CompleteTask marks a running task as completed.
+//
+// BranchName is the structured artifact the daemon actually reports on
+// completion (daemon/client.go CompleteTask). It was previously dropped because
+// the struct only carried pr_url, so readback could not deterministically tell
+// what a finished run produced (UMC-288). Capturing it here is additive and
+// backward-compatible: the whole request is marshalled into the stored result,
+// and both pr_url and branch_name now survive for artifact readback.
 type TaskCompleteRequest struct {
-	PRURL     string `json:"pr_url"`
-	Output    string `json:"output"`
-	SessionID string `json:"session_id"` // Claude session ID for future resumption
-	WorkDir   string `json:"work_dir"`   // working directory used during execution
+	PRURL      string `json:"pr_url"`
+	BranchName string `json:"branch_name"`
+	Output     string `json:"output"`
+	SessionID  string `json:"session_id"` // Claude session ID for future resumption
+	WorkDir    string `json:"work_dir"`   // working directory used during execution
 }
 
 func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2044,6 +2044,19 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		if req.ProjectID == nil {
 			projectID = parent.ProjectID
 		}
+		// Squad-parent ownership invariant (UMC-288): a child of a squad-owned
+		// parent stays owned by the same squad. An omitted assignee inherits the
+		// parent squad; an explicit agent/member/other-squad owner is rejected so
+		// a role-owned child cannot be used as a handoff bypass.
+		if parent.AssigneeType.Valid && parent.AssigneeType.String == "squad" {
+			if !assigneeType.Valid && !assigneeID.Valid {
+				assigneeType = parent.AssigneeType
+				assigneeID = parent.AssigneeID
+			} else if msg := squadParentChildOwnershipError(parent.AssigneeType, parent.AssigneeID, assigneeType, assigneeID); msg != "" {
+				writeError(w, http.StatusBadRequest, msg)
+				return
+			}
+		}
 	}
 
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
@@ -2448,6 +2461,23 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Squad-parent ownership invariant (UMC-288). Enforce only when this update
+	// could change the (parent, assignee) pairing, so unrelated edits on a
+	// pre-existing issue are not retroactively rejected. A squad-owned parent
+	// requires a same-squad child; an explicit agent/member/other-squad owner
+	// is rejected.
+	if _, touchedParent := rawFields["parent_issue_id"]; (touchedType || touchedID || touchedParent) && params.ParentIssueID.Valid {
+		if parent, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+			ID:          params.ParentIssueID,
+			WorkspaceID: prevIssue.WorkspaceID,
+		}); err == nil {
+			if msg := squadParentChildOwnershipError(parent.AssigneeType, parent.AssigneeID, params.AssigneeType, params.AssigneeID); msg != "" {
+				writeError(w, http.StatusBadRequest, msg)
+				return
+			}
+		}
+	}
+
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
 	if !ok {
 		return
@@ -2833,6 +2863,71 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+
+	// Squad-parent ownership invariant (UMC-288), pre-pass. Unlike the other
+	// per-issue validations in the loop below, which skip an offending issue
+	// silently, an ownership violation fails the whole batch with an explicit
+	// 400 — a silently lower `updated` count would hide that a role-owned child
+	// slipped past the guard. Validate every target up front so nothing is
+	// applied when any one violates.
+	_, bTouchedType := rawUpdates["assignee_type"]
+	_, bTouchedID := rawUpdates["assignee_id"]
+	_, bTouchedParent := rawUpdates["parent_issue_id"]
+	if bTouchedType || bTouchedID || bTouchedParent {
+		for _, issueID := range req.IssueIDs {
+			issueUUID, err := util.ParseUUID(issueID)
+			if err != nil {
+				continue
+			}
+			prev, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{ID: issueUUID, WorkspaceID: wsUUID})
+			if err != nil {
+				continue
+			}
+			childType, childID := prev.AssigneeType, prev.AssigneeID
+			if bTouchedType {
+				if req.Updates.AssigneeType != nil {
+					childType = pgtype.Text{String: *req.Updates.AssigneeType, Valid: true}
+				} else {
+					childType = pgtype.Text{}
+				}
+			}
+			if bTouchedID {
+				if req.Updates.AssigneeID != nil {
+					if u, err := util.ParseUUID(*req.Updates.AssigneeID); err == nil {
+						childID = u
+					} else {
+						childID = pgtype.UUID{}
+					}
+				} else {
+					childID = pgtype.UUID{}
+				}
+			}
+			parentID := prev.ParentIssueID
+			if bTouchedParent {
+				if req.Updates.ParentIssueID != nil {
+					if u, err := util.ParseUUID(*req.Updates.ParentIssueID); err == nil {
+						parentID = u
+					} else {
+						parentID = pgtype.UUID{}
+					}
+				} else {
+					parentID = pgtype.UUID{}
+				}
+			}
+			if !parentID.Valid {
+				continue
+			}
+			parent, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{ID: parentID, WorkspaceID: wsUUID})
+			if err != nil {
+				continue
+			}
+			if msg := squadParentChildOwnershipError(parent.AssigneeType, parent.AssigneeID, childType, childID); msg != "" {
+				writeError(w, http.StatusBadRequest, msg)
+				return
+			}
+		}
+	}
+
 	updated := 0
 	for _, issueID := range req.IssueIDs {
 		issueUUID, err := util.ParseUUID(issueID)

--- a/server/internal/handler/issue_metadata.go
+++ b/server/internal/handler/issue_metadata.go
@@ -172,6 +172,14 @@ func (h *Handler) SetIssueMetadataKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Active-dependency invariant (UMC-288): a parent must not record a
+	// dependency (e.g. linked_child) on a ghost/inert child. Reject before the
+	// write so prior metadata is preserved.
+	if msg := h.activeDependencyMetadataError(r.Context(), issue, key, []byte(req.Value)); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
 	updated, err := h.Queries.SetIssueMetadataKey(r.Context(), db.SetIssueMetadataKeyParams{
 		ID:          issue.ID,
 		WorkspaceID: issue.WorkspaceID,

--- a/server/internal/handler/issue_parent_guard.go
+++ b/server/internal/handler/issue_parent_guard.go
@@ -1,0 +1,171 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Squad-parent ownership + active-dependency guards (UMC-288).
+//
+// A squad-owned issue keeps its delegation in-place on the squad issue:
+// downstream work is routed through the squad leader / tasks / comments, never
+// by minting a role-owned child issue as a handoff. The incidents this guards
+// against:
+//   - UMC-307: a squad-owned parent created a role-owned (agent/member) child
+//     as an architecture/review/handoff shortcut.
+//   - UMC-251 / UMC-293: a role-owned backlog follow-up under a squad parent
+//     with no launched/deferred lifecycle.
+//   - UMC-305: a parent recorded an active dependency (`linked_child`) pointing
+//     at a ghost child — backlog, unassigned, no run, no comment.
+//
+// These run server-side in the create/update/link path so an API caller cannot
+// bypass them by skipping the CLI. They never auto-correct: on violation the
+// caller gets a stable 400 naming the broken invariant.
+
+// Stable validation messages. Kept as constants so tests and API clients can
+// assert on a fixed substring instead of brittle inline strings.
+const (
+	errChildMustBeSquadOwned = "child of a squad-owned parent must be owned by the same squad as the parent; explicit agent/member or a different squad is not allowed (omit the assignee to inherit the parent squad)"
+	errLinkedChildMustBeRef  = "active dependency metadata must be an issue id or identifier string"
+	errLinkedChildNotFound   = "active dependency metadata does not refer to an issue in this workspace"
+	errLinkedChildOwnership  = "active dependency child must be owned by the same squad as this issue"
+	errLinkedChildInert      = "active dependency child is inert: it must be LAUNCHED (active or completed run, or a comment) or explicitly DEFERRED (deferred_until / blocked_by / waiting_on / deferred_reason)"
+)
+
+// activeDependencyMetadataKeys are the metadata keys that record a parent->child
+// active dependency. Writing one must point at a coherent child, not a ghost.
+// v1 guards the canonical key only; widening this set is a deliberate decision,
+// not an inference from prose.
+var activeDependencyMetadataKeys = map[string]bool{
+	"linked_child": true,
+}
+
+// deferredMetadataKeys are the explicit signals that a child is parked on
+// purpose (DEFERRED), so a parent may depend on it without it being active.
+var deferredMetadataKeys = []string{"deferred_until", "blocked_by", "waiting_on", "deferred_reason"}
+
+// squadParentChildOwnershipError enforces that a child of a squad-owned parent
+// stays owned by the same squad. It returns "" when the (parent, child)
+// ownership pair is allowed, or a stable error string when it must be rejected.
+//
+// Only squad-owned parents constrain their children. An unset child assignee is
+// allowed here: create defaults it to the parent squad before calling, and
+// update treats an explicit unassign as a non-handoff (an unowned child is not
+// a role handoff, and the active-dependency guard catches it if a parent later
+// tries to depend on it while it is still inert).
+func squadParentChildOwnershipError(parentType pgtype.Text, parentID pgtype.UUID, childType pgtype.Text, childID pgtype.UUID) string {
+	if !(parentType.Valid && parentType.String == "squad") {
+		return ""
+	}
+	if !childType.Valid && !childID.Valid {
+		return ""
+	}
+	if childType.String != "squad" || childID != parentID {
+		return errChildMustBeSquadOwned
+	}
+	return ""
+}
+
+// activeDependencyMetadataError validates an active-dependency metadata write
+// (e.g. `linked_child`) before it lands. It returns "" when the write is
+// allowed, or a stable error string to reject with — the handler returns 400
+// and writes nothing, so prior metadata is preserved.
+//
+// parent is the issue whose metadata is being set; rawValue is the JSON value
+// for key. Ownership is enforced only when the parent is squad-owned; the
+// lifecycle (LAUNCHED or DEFERRED, never inert) is always enforced because a
+// ghost active dependency is the core UMC-305 failure regardless of owner.
+func (h *Handler) activeDependencyMetadataError(ctx context.Context, parent db.Issue, key string, rawValue []byte) string {
+	if !activeDependencyMetadataKeys[key] {
+		return ""
+	}
+	var childRef string
+	if err := json.Unmarshal(rawValue, &childRef); err != nil || strings.TrimSpace(childRef) == "" {
+		return errLinkedChildMustBeRef
+	}
+	child, ok := h.resolveIssueRef(ctx, childRef, uuidToString(parent.WorkspaceID))
+	if !ok {
+		return errLinkedChildNotFound
+	}
+	if parent.AssigneeType.Valid && parent.AssigneeType.String == "squad" {
+		if !(child.AssigneeType.Valid && child.AssigneeType.String == "squad" && child.AssigneeID == parent.AssigneeID) {
+			return errLinkedChildOwnership
+		}
+	}
+	if h.issueIsLaunched(ctx, child) || issueIsDeferred(child) {
+		return ""
+	}
+	return errLinkedChildInert
+}
+
+// issueIsLaunched reports whether a child shows a non-inert execution/readback
+// signal: an active or completed agent run, or at least one comment. A ghost
+// child (no run, no comment) returns false.
+func (h *Handler) issueIsLaunched(ctx context.Context, child db.Issue) bool {
+	if tasks, err := h.Queries.ListTasksByIssue(ctx, child.ID); err == nil {
+		for _, t := range tasks {
+			switch t.Status {
+			case "queued", "dispatched", "running", "waiting_local_directory", "completed":
+				return true
+			}
+		}
+	}
+	if n, err := h.Queries.CountComments(ctx, db.CountCommentsParams{
+		IssueID:     child.ID,
+		WorkspaceID: child.WorkspaceID,
+	}); err == nil && n > 0 {
+		return true
+	}
+	return false
+}
+
+// issueIsDeferred reports whether a child is explicitly parked: any of the
+// deferred metadata keys is present with a non-empty value.
+func issueIsDeferred(child db.Issue) bool {
+	md := parseIssueMetadata(child.Metadata)
+	for _, k := range deferredMetadataKeys {
+		v, ok := md[k]
+		if !ok {
+			continue
+		}
+		if s, isStr := v.(string); isStr {
+			if strings.TrimSpace(s) != "" {
+				return true
+			}
+			continue
+		}
+		// Non-string present value (number/bool) counts as an explicit signal.
+		return true
+	}
+	return false
+}
+
+// resolveIssueRef looks up an issue by "PREFIX-NUMBER" identifier or by UUID
+// within a workspace, without writing to a response. Used by the active-
+// dependency guard to resolve a `linked_child` reference.
+func (h *Handler) resolveIssueRef(ctx context.Context, ref, workspaceID string) (db.Issue, bool) {
+	if issue, ok := h.resolveIssueByIdentifier(ctx, ref, workspaceID); ok {
+		return issue, true
+	}
+	issueUUID, err := util.ParseUUID(ref)
+	if err != nil {
+		return db.Issue{}, false
+	}
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return db.Issue{}, false
+	}
+	issue, err := h.Queries.GetIssueInWorkspace(ctx, db.GetIssueInWorkspaceParams{
+		ID:          issueUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		return db.Issue{}, false
+	}
+	return issue, true
+}

--- a/server/internal/handler/issue_parent_guard.go
+++ b/server/internal/handler/issue_parent_guard.go
@@ -30,11 +30,12 @@ import (
 // Stable validation messages. Kept as constants so tests and API clients can
 // assert on a fixed substring instead of brittle inline strings.
 const (
-	errChildMustBeSquadOwned = "child of a squad-owned parent must be owned by the same squad as the parent; explicit agent/member or a different squad is not allowed (omit the assignee to inherit the parent squad)"
-	errLinkedChildMustBeRef  = "active dependency metadata must be an issue id or identifier string"
-	errLinkedChildNotFound   = "active dependency metadata does not refer to an issue in this workspace"
-	errLinkedChildOwnership  = "active dependency child must be owned by the same squad as this issue"
-	errLinkedChildInert      = "active dependency child is inert: it must be LAUNCHED (active or completed run, or a comment) or explicitly DEFERRED (deferred_until / blocked_by / waiting_on / deferred_reason)"
+	errChildMustBeSquadOwned           = "child of a squad-owned parent must be owned by the same squad as the parent; explicit agent/member or a different squad is not allowed (omit the assignee to inherit the parent squad)"
+	errChildUnassignedUnderSquadParent = "child of a squad-owned parent cannot be left unassigned; it must stay owned by the same squad (omit the assignee on create to inherit it, or assign the parent squad explicitly)"
+	errLinkedChildMustBeRef            = "active dependency metadata must be an issue id or identifier string"
+	errLinkedChildNotFound             = "active dependency metadata does not refer to an issue in this workspace"
+	errLinkedChildOwnership            = "active dependency child must be owned by the same squad as this issue"
+	errLinkedChildInert                = "active dependency child is inert: it must be LAUNCHED (active or completed run, or a comment) or explicitly DEFERRED (deferred_until / blocked_by / waiting_on / deferred_reason)"
 )
 
 // activeDependencyMetadataKeys are the metadata keys that record a parent->child
@@ -53,17 +54,20 @@ var deferredMetadataKeys = []string{"deferred_until", "blocked_by", "waiting_on"
 // stays owned by the same squad. It returns "" when the (parent, child)
 // ownership pair is allowed, or a stable error string when it must be rejected.
 //
-// Only squad-owned parents constrain their children. An unset child assignee is
-// allowed here: create defaults it to the parent squad before calling, and
-// update treats an explicit unassign as a non-handoff (an unowned child is not
-// a role handoff, and the active-dependency guard catches it if a parent later
-// tries to depend on it while it is still inert).
+// Only squad-owned parents constrain their children. A child of a squad-owned
+// parent must NOT be left unassigned: an unset child assignee is a ghost surface
+// (the parent-child link records an active dependency while the child has no
+// owner). Create handles its own default — it inherits the parent squad before
+// calling this helper, so create never reaches the unset branch here. Every
+// other caller (update / batch reparent, link, explicit unassign) that would
+// leave the child unassigned under a squad parent is rejected, so the only way
+// to keep such a child is same-squad ownership.
 func squadParentChildOwnershipError(parentType pgtype.Text, parentID pgtype.UUID, childType pgtype.Text, childID pgtype.UUID) string {
 	if !(parentType.Valid && parentType.String == "squad") {
 		return ""
 	}
 	if !childType.Valid && !childID.Valid {
-		return ""
+		return errChildUnassignedUnderSquadParent
 	}
 	if childType.String != "squad" || childID != parentID {
 		return errChildMustBeSquadOwned
@@ -124,23 +128,18 @@ func (h *Handler) issueIsLaunched(ctx context.Context, child db.Issue) bool {
 	return false
 }
 
-// issueIsDeferred reports whether a child is explicitly parked: any of the
-// deferred metadata keys is present with a non-empty value.
+// issueIsDeferred reports whether a child is explicitly parked. v1 contract: a
+// deferral signal is a non-empty (trimmed) STRING value on one of the deferred
+// metadata keys. A bool or number — e.g. waiting_on=false, deferred_reason=0 —
+// is NOT a valid deferral; accepting it would let an inert child masquerade as
+// DEFERRED through metadata type sniffing, which is the prose-bypass this guard
+// must close.
 func issueIsDeferred(child db.Issue) bool {
 	md := parseIssueMetadata(child.Metadata)
 	for _, k := range deferredMetadataKeys {
-		v, ok := md[k]
-		if !ok {
-			continue
+		if s, isStr := md[k].(string); isStr && strings.TrimSpace(s) != "" {
+			return true
 		}
-		if s, isStr := v.(string); isStr {
-			if strings.TrimSpace(s) != "" {
-				return true
-			}
-			continue
-		}
-		// Non-string present value (number/bool) counts as an explicit signal.
-		return true
 	}
 	return false
 }

--- a/server/internal/handler/issue_parent_guard_test.go
+++ b/server/internal/handler/issue_parent_guard_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -169,6 +170,23 @@ func TestSquadParentChildOwnershipGuard_Update(t *testing.T) {
 
 	// An unrelated edit on a coherent squad child is not retroactively rejected.
 	updateIssueExpect(t, child.ID, map[string]any{"title": "renamed"}, http.StatusOK)
+
+	// Review gap: reparenting an UNASSIGNED orphan under a squad parent must not
+	// leave it unassigned — fail closed (no ghost surface).
+	unassignedOrphan, _ := createIssueExpect(t, map[string]any{
+		"title": "unassigned orphan", "status": "backlog",
+	}, http.StatusCreated)
+	ub := updateIssueExpect(t, unassignedOrphan.ID, map[string]any{"parent_issue_id": parent.ID}, http.StatusBadRequest)
+	if !strings.Contains(ub, "unassigned") {
+		t.Errorf("reparent unassigned orphan: expected unassigned error, got %s", ub)
+	}
+
+	// Review gap: an explicit unassign of a same-squad child under a squad parent
+	// must fail (do not silently drop ownership into a ghost).
+	eub := updateIssueExpect(t, child.ID, map[string]any{"assignee_type": nil, "assignee_id": nil}, http.StatusBadRequest)
+	if !strings.Contains(eub, "unassigned") {
+		t.Errorf("explicit unassign under squad parent: expected unassigned error, got %s", eub)
+	}
 }
 
 func TestSquadParentChildOwnershipGuard_Batch(t *testing.T) {
@@ -208,6 +226,38 @@ func TestSquadParentChildOwnershipGuard_Batch(t *testing.T) {
 	testHandler.BatchUpdateIssues(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("non-ownership batch: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Review gap: batch reparent of an UNASSIGNED orphan under a squad parent
+	// must fail the whole batch explicitly (no ghost surface).
+	orphan, _ := createIssueExpect(t, map[string]any{
+		"title": "batch unassigned orphan", "status": "backlog",
+	}, http.StatusCreated)
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{orphan.ID},
+		"updates":   map[string]any{"parent_issue_id": parent.ID},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("batch reparent unassigned orphan: want 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Review gap: batch explicit unassign of a same-squad child must fail.
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{child.ID},
+		"updates":   map[string]any{"assignee_type": nil, "assignee_id": nil},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("batch explicit unassign: want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	// The child stays squad-owned after the rejected batch.
+	var stillType string
+	testPool.QueryRow(context.Background(), `SELECT assignee_type FROM issue WHERE id = $1`, child.ID).Scan(&stillType)
+	if stillType != "squad" {
+		t.Fatalf("child assignee_type after rejected unassign batch = %q, want squad", stillType)
 	}
 }
 
@@ -277,6 +327,25 @@ func TestActiveDependencyMetadataGuard(t *testing.T) {
 	}, http.StatusCreated)
 	setMetaExpect(t, deferred.ID, "deferred_reason", `"waiting upstream contract"`, http.StatusOK)
 	setMetaExpect(t, parent.ID, "linked_child", `"`+deferred.ID+`"`, http.StatusOK)
+
+	// Review gap: a non-string (or empty) deferred value must NOT count as
+	// DEFERRED — no metadata type-sniffing bypass. waiting_on=false /
+	// deferred_reason=0 / deferred_reason="" leave the child inert, so linking
+	// it is rejected.
+	for i, neg := range []struct{ key, val string }{
+		{"waiting_on", `false`},
+		{"deferred_reason", `0`},
+		{"deferred_reason", `""`},
+	} {
+		bad, _ := createIssueExpect(t, map[string]any{
+			"title": fmt.Sprintf("bad-deferred-%d", i), "status": "backlog", "parent_issue_id": parent.ID,
+		}, http.StatusCreated)
+		setMetaExpect(t, bad.ID, neg.key, neg.val, http.StatusOK)
+		nb := setMetaExpect(t, parent.ID, "linked_child", `"`+bad.ID+`"`, http.StatusBadRequest)
+		if !strings.Contains(nb, "inert") {
+			t.Errorf("deferred %s=%s should be inert (not a valid deferral), got %s", neg.key, neg.val, nb)
+		}
+	}
 }
 
 // TestCompleteTaskCapturesBranchName locks the readback fix: the branch_name

--- a/server/internal/handler/issue_parent_guard_test.go
+++ b/server/internal/handler/issue_parent_guard_test.go
@@ -1,0 +1,349 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Incident replays + positives for the UMC-288 squad-parent ownership and
+// active-dependency guards. These lock the server-side enforcement so a
+// role-owned child cannot be used as a handoff bypass and a parent cannot
+// record an active dependency on a ghost child.
+
+type guardIssue struct {
+	ID            string  `json:"id"`
+	Identifier    string  `json:"identifier"`
+	Status        string  `json:"status"`
+	AssigneeType  *string `json:"assignee_type"`
+	AssigneeID    *string `json:"assignee_id"`
+	ParentIssueID *string `json:"parent_issue_id"`
+}
+
+func createIssueExpect(t *testing.T, body map[string]any, wantCode int) (guardIssue, string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues", body)
+	testHandler.CreateIssue(w, req)
+	if w.Code != wantCode {
+		t.Fatalf("CreateIssue %v: want %d, got %d: %s", body, wantCode, w.Code, w.Body.String())
+	}
+	var out guardIssue
+	if w.Code == http.StatusCreated {
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode create response: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, out.ID) })
+	}
+	return out, w.Body.String()
+}
+
+func updateIssueExpect(t *testing.T, issueID string, body map[string]any, wantCode int) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/issues/"+issueID, body)
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != wantCode {
+		t.Fatalf("UpdateIssue %v: want %d, got %d: %s", body, wantCode, w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+func setMetaExpect(t *testing.T, issueID, key, rawValue string, wantCode int) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID+"/metadata/"+key, json.RawMessage(`{"value":`+rawValue+`}`))
+	req = withURLParams(req, "id", issueID, "key", key)
+	testHandler.SetIssueMetadataKey(w, req)
+	if w.Code != wantCode {
+		t.Fatalf("SetIssueMetadataKey %s=%s: want %d, got %d: %s", key, rawValue, wantCode, w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+func getMeta(t *testing.T, issueID string) map[string]any {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/"+issueID+"/metadata", nil)
+	req = withURLParam(req, "id", issueID)
+	testHandler.ListIssueMetadata(w, req)
+	var resp struct {
+		Metadata map[string]any `json:"metadata"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp.Metadata
+}
+
+// seedGuardSquad creates a squad with a fresh leader agent and returns the
+// squad id (string) and leader agent id.
+func seedGuardSquad(t *testing.T, name string) (string, string) {
+	t.Helper()
+	leaderID := createHandlerTestAgent(t, name+"-leader", []byte("{}"))
+	squad := seedSquadForBriefing(t, leaderID, name, "")
+	return uuidToString(squad.ID), leaderID
+}
+
+func createSquadParent(t *testing.T, squadID, title string) guardIssue {
+	t.Helper()
+	p, _ := createIssueExpect(t, map[string]any{
+		"title":         title,
+		"status":        "backlog",
+		"assignee_type": "squad",
+		"assignee_id":   squadID,
+	}, http.StatusCreated)
+	return p
+}
+
+func TestSquadParentChildOwnershipGuard_Create(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	squadID, leaderID := seedGuardSquad(t, "umc288-create")
+	squadB, _ := seedGuardSquad(t, "umc288-create-b")
+	parent := createSquadParent(t, squadID, "umc288 create parent")
+
+	// UMC-307: role-owned (agent) child under a squad parent must fail.
+	_, body := createIssueExpect(t, map[string]any{
+		"title": "role-owned agent child", "status": "backlog",
+		"parent_issue_id": parent.ID, "assignee_type": "agent", "assignee_id": leaderID,
+	}, http.StatusBadRequest)
+	if !strings.Contains(body, "same squad") {
+		t.Errorf("agent child: expected same-squad error, got %s", body)
+	}
+
+	// Member-owned child under a squad parent must fail.
+	createIssueExpect(t, map[string]any{
+		"title": "role-owned member child", "status": "backlog",
+		"parent_issue_id": parent.ID, "assignee_type": "member", "assignee_id": testUserID,
+	}, http.StatusBadRequest)
+
+	// A different squad under the squad parent must fail.
+	createIssueExpect(t, map[string]any{
+		"title": "different squad child", "status": "backlog",
+		"parent_issue_id": parent.ID, "assignee_type": "squad", "assignee_id": squadB,
+	}, http.StatusBadRequest)
+
+	// Omitted assignee inherits the parent squad (stays squad-owned).
+	child, _ := createIssueExpect(t, map[string]any{
+		"title": "inherits squad", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+	if child.AssigneeType == nil || *child.AssigneeType != "squad" || child.AssigneeID == nil || *child.AssigneeID != squadID {
+		t.Fatalf("omitted assignee should inherit parent squad, got type=%v id=%v", child.AssigneeType, child.AssigneeID)
+	}
+
+	// Explicit same-squad child is accepted.
+	createIssueExpect(t, map[string]any{
+		"title": "same squad child", "status": "backlog", "parent_issue_id": parent.ID,
+		"assignee_type": "squad", "assignee_id": squadID,
+	}, http.StatusCreated)
+}
+
+func TestSquadParentChildOwnershipGuard_Update(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	squadID, leaderID := seedGuardSquad(t, "umc288-update")
+	parent := createSquadParent(t, squadID, "umc288 update parent")
+	child, _ := createIssueExpect(t, map[string]any{
+		"title": "squad child", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+
+	// Re-owning a squad child to an agent under a squad parent must fail.
+	body := updateIssueExpect(t, child.ID, map[string]any{
+		"assignee_type": "agent", "assignee_id": leaderID,
+	}, http.StatusBadRequest)
+	if !strings.Contains(body, "same squad") {
+		t.Errorf("update to agent: expected same-squad error, got %s", body)
+	}
+
+	// Re-parenting an agent-owned top-level issue under a squad parent must fail.
+	orphan, _ := createIssueExpect(t, map[string]any{
+		"title": "agent orphan", "status": "backlog",
+		"assignee_type": "agent", "assignee_id": leaderID,
+	}, http.StatusCreated)
+	updateIssueExpect(t, orphan.ID, map[string]any{"parent_issue_id": parent.ID}, http.StatusBadRequest)
+
+	// An unrelated edit on a coherent squad child is not retroactively rejected.
+	updateIssueExpect(t, child.ID, map[string]any{"title": "renamed"}, http.StatusOK)
+}
+
+func TestSquadParentChildOwnershipGuard_Batch(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	squadID, leaderID := seedGuardSquad(t, "umc288-batch")
+	parent := createSquadParent(t, squadID, "umc288 batch parent")
+	child, _ := createIssueExpect(t, map[string]any{
+		"title": "squad child", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+
+	// Batch re-owning the child to an agent must fail explicitly (not a silent
+	// skip that lowers `updated`).
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{child.ID},
+		"updates":   map[string]any{"assignee_type": "agent", "assignee_id": leaderID},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("batch ownership violation: want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	// The child must be untouched (still squad-owned).
+	var atype string
+	testPool.QueryRow(context.Background(), `SELECT assignee_type FROM issue WHERE id = $1`, child.ID).Scan(&atype)
+	if atype != "squad" {
+		t.Fatalf("child assignee_type after rejected batch = %q, want squad", atype)
+	}
+
+	// A batch that does not touch ownership still applies.
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{child.ID},
+		"updates":   map[string]any{"priority": "high"},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("non-ownership batch: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActiveDependencyMetadataGuard(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	squadID, leaderID := seedGuardSquad(t, "umc288-meta")
+	parent := createSquadParent(t, squadID, "umc288 meta parent")
+
+	// UMC-305: linked_child pointing at a ghost child (squad-owned but inert —
+	// no run, no comment) must fail and write nothing.
+	ghost, _ := createIssueExpect(t, map[string]any{
+		"title": "ghost child", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+	// Pre-existing unrelated metadata must survive the rejected write.
+	setMetaExpect(t, parent.ID, "pipeline_status", `"waiting"`, http.StatusOK)
+	body := setMetaExpect(t, parent.ID, "linked_child", `"`+ghost.ID+`"`, http.StatusBadRequest)
+	if !strings.Contains(body, "inert") {
+		t.Errorf("ghost linked_child: expected inert error, got %s", body)
+	}
+	md := getMeta(t, parent.ID)
+	if _, present := md["linked_child"]; present {
+		t.Errorf("rejected linked_child must not be written; metadata=%v", md)
+	}
+	if md["pipeline_status"] != "waiting" {
+		t.Errorf("rejected write must preserve prior metadata; metadata=%v", md)
+	}
+
+	// Ownership: linked_child to an issue owned by a role agent (not the squad)
+	// under a squad-owned parent must fail.
+	foreign, _ := createIssueExpect(t, map[string]any{
+		"title": "agent-owned foreign", "status": "backlog",
+		"assignee_type": "agent", "assignee_id": leaderID,
+	}, http.StatusCreated)
+	ownBody := setMetaExpect(t, parent.ID, "linked_child", `"`+foreign.ID+`"`, http.StatusBadRequest)
+	if !strings.Contains(ownBody, "same squad") {
+		t.Errorf("foreign linked_child: expected same-squad error, got %s", ownBody)
+	}
+
+	// Non-existent reference fails.
+	setMetaExpect(t, parent.ID, "linked_child", `"UMC-99999999"`, http.StatusBadRequest)
+	// Non-string reference fails.
+	setMetaExpect(t, parent.ID, "linked_child", `123`, http.StatusBadRequest)
+
+	// Positive LAUNCHED: same-squad child with a comment readback is accepted.
+	// (Backlog keeps the fixture free of a squad-leader enqueue side effect; the
+	// comment is the non-inert readback signal the guard keys on.)
+	launched, _ := createIssueExpect(t, map[string]any{
+		"title": "launched child", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+	var commentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'agent', $3, 'kickoff', 'comment') RETURNING id
+	`, launched.ID, testWorkspaceID, leaderID).Scan(&commentID); err != nil {
+		t.Fatalf("seed launched comment: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE id = $1`, commentID) })
+	setMetaExpect(t, parent.ID, "linked_child", `"`+launched.Identifier+`"`, http.StatusOK)
+
+	// Positive DEFERRED: same-squad backlog child with an explicit deferred
+	// reason is accepted.
+	deferred, _ := createIssueExpect(t, map[string]any{
+		"title": "deferred child", "status": "backlog", "parent_issue_id": parent.ID,
+	}, http.StatusCreated)
+	setMetaExpect(t, deferred.ID, "deferred_reason", `"waiting upstream contract"`, http.StatusOK)
+	setMetaExpect(t, parent.ID, "linked_child", `"`+deferred.ID+`"`, http.StatusOK)
+}
+
+// TestCompleteTaskCapturesBranchName locks the readback fix: the branch_name
+// the daemon reports on completion is captured into the stored result (it was
+// previously dropped), and the visible-comment fallback still fires.
+func TestCompleteTaskCapturesBranchName(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'umc288 readback fixture', 'in_progress', 'none', $2, 'member', 88288, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now()) RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
+		map[string]any{"output": "done; opened PR", "branch_name": "feat/umc-288-guard", "pr_url": "https://example.test/pr/1"},
+		testWorkspaceID, "legit-daemon")
+	req = withURLParams(req, "taskId", taskID)
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// branch_name (and pr_url) survive into the stored result.
+	var result []byte
+	if err := testPool.QueryRow(ctx, `SELECT result FROM agent_task_queue WHERE id = $1`, taskID).Scan(&result); err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(result, &stored); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if stored["branch_name"] != "feat/umc-288-guard" {
+		t.Errorf("branch_name not captured in result: %v", stored)
+	}
+	if stored["pr_url"] != "https://example.test/pr/1" {
+		t.Errorf("pr_url not captured in result: %v", stored)
+	}
+
+	// Visible-comment fallback remains: a silent agent run still surfaces output.
+	var comments int
+	testPool.QueryRow(ctx, `SELECT count(*) FROM comment WHERE issue_id = $1 AND author_type = 'agent'`, issueID).Scan(&comments)
+	if comments < 1 {
+		t.Errorf("expected the visible-comment fallback to synthesize a comment, got %d", comments)
+	}
+}


### PR DESCRIPTION
## Summary

Routes the UMC-288 platform guard from IvanMMM/multica fork into the upstream Multica repository for manual review/merge.

This PR enforces the squad-parent child/follow-up lifecycle at the server-side issue mutation boundary:
- squad-owned parents cannot get role-owned children as ordinary handoff bypasses;
- parent `linked_child` / active dependency metadata cannot point at inert ghost children;
- `LAUNCHED` and `DEFERRED` are treated as explicit valid child states;
- `branch_name` is captured in task completion readback.

## Incident Replays Covered

- UMC-305: created child was never launched, while parent treated it as active work.
- UMC-307: role-owned child used as handoff bypass under squad-owned parent.
- UMC-251 / UMC-293: inert follow-up children under active squad parents.
- Positive `LAUNCHED` and `DEFERRED` cases.

## Verification

Reported by Multica QA on UMC-288 against head `6a5e7cff59d6aef23658fcec9d3e4be581b82551`:

```bash
go test -v ./internal/handler -run 'TestSquadParentChildOwnershipGuard|TestActiveDependencyMetadataGuard|TestCompleteTaskCapturesBranchName'
```

QA stated this was run on live local PostgreSQL with migrations, not a skipped fixture pass.

## Notes

No schema migration. Rollback is code redeploy/revert.

UMC-288 Multica issue metadata currently points at the fork PR because the upstream PR did not exist yet; this PR is the intended upstream manual-merge surface.
