### PR TITLE
NEX-586: restore chat KST timestamps and progress selectors

### DIFF
--- a/packages/views/chat/components/chat-message-list.test.tsx
+++ b/packages/views/chat/components/chat-message-list.test.tsx
@@ -1,0 +1,120 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import enChat from "../../locales/en/chat.json";
+import enCommon from "../../locales/en/common.json";
+import type { ChatMessage, ChatPendingTask } from "@multica/core/types";
+import { ChatMessageList } from "./chat-message-list";
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: forwardRef(function MockVirtuoso(
+    {
+      data,
+      itemContent,
+      components,
+    }: {
+      data: unknown[];
+      itemContent: (i: number, item: unknown) => unknown;
+      components?: { Header?: () => React.ReactNode; Footer?: () => React.ReactNode };
+    },
+    ref: React.Ref<unknown>,
+  ) {
+    useImperativeHandle(ref, () => ({
+      scrollIntoView: vi.fn(),
+      scrollToIndex: vi.fn(),
+    }));
+    return (
+      <div data-testid="virtuoso-mock">
+        {components?.Header?.()}
+        {data.map((item, i) => (
+          <div key={i}>{itemContent(i, item) as React.ReactElement}</div>
+        ))}
+        {components?.Footer?.()}
+      </div>
+    );
+  }),
+}));
+
+const TEST_RESOURCES = { en: { common: enCommon, chat: enChat } };
+
+function renderList({
+  messages,
+  pendingTask = null,
+}: {
+  messages: ChatMessage[];
+  pendingTask?: ChatPendingTask | null;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider resources={TEST_RESOURCES} locale="en">
+        <ChatMessageList
+          messages={messages}
+          pendingTask={pendingTask}
+          availability="online"
+        />
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: "msg-1",
+    chat_session_id: "session-1",
+    role: "assistant",
+    content: "Done",
+    task_id: null,
+    created_at: "2026-06-23T13:31:02.000Z",
+    attachments: [],
+    failure_reason: null,
+    elapsed_ms: null,
+    ...overrides,
+  };
+}
+
+describe("ChatMessageList timing metadata", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders assistant message KST timestamp with response elapsed", () => {
+    renderList({
+      messages: [message({ elapsed_ms: 38000 })],
+    });
+
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByText("Replied in 38s")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-message-timestamp")).toHaveTextContent(
+      "2026-06-23 22:31:02",
+    );
+    expect(screen.getByTestId("chat-message-timestamp")).toHaveAttribute(
+      "aria-label",
+      "2026-06-23 22:31:02 KST",
+    );
+  });
+
+  it("keeps the live progress pill visible with elapsed time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-23T13:31:04.000Z"));
+
+    renderList({
+      messages: [],
+      pendingTask: {
+        task_id: "task-1",
+        status: "queued",
+        created_at: "2026-06-23T13:31:02.000Z",
+      },
+    });
+
+    const pill = screen.getByTestId("chat-task-status-pill");
+    expect(pill).toHaveAttribute("data-acceptance", "chat-response-in-progress");
+    expect(pill).toHaveTextContent("Queued");
+    expect(pill).toHaveTextContent("2s");
+  });
+});

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -352,6 +352,8 @@ function MessageCopyButton({
             className="text-muted-foreground/70 hover:text-foreground"
             onClick={handleCopy}
             aria-label={t(($) => $.message_list.copy_action)}
+            data-acceptance="copy-message"
+            data-testid="copy-message"
           />
         }
       >

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -29,7 +29,7 @@ import type { ChatTimelineItem } from "@multica/core/chat";
 import { failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { buildTimeline } from "../../common/task-transcript";
 import { TaskStatusPill } from "./task-status-pill";
-import { formatElapsedMs } from "../lib/format";
+import { formatElapsedMs, formatKstTimestamp } from "../lib/format";
 import { splitTimeline, extractCopyText } from "../lib/copy-text";
 import { useT } from "../../i18n";
 
@@ -192,19 +192,22 @@ function MessageBubble({ message, isPending }: { message: ChatMessage; isPending
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="rounded-2xl bg-muted px-3.5 py-2 text-sm max-w-[80%] break-words">
-          {/* User messages are authored as markdown in ContentEditor, so
-           * render them through the same pipeline as assistant replies.
-           * Neutralise prose's leading/trailing margin so single-line
-           * bubbles stay as compact as the plain-text version used to. */}
-          <div className="prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-            <Markdown attachments={message.attachments}>{message.content}</Markdown>
+        <div className="max-w-[80%] space-y-1">
+          <div className="rounded-2xl bg-muted px-3.5 py-2 text-sm break-words">
+            {/* User messages are authored as markdown in ContentEditor, so
+             * render them through the same pipeline as assistant replies.
+             * Neutralise prose's leading/trailing margin so single-line
+             * bubbles stay as compact as the plain-text version used to. */}
+            <div className="prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+              <Markdown attachments={message.attachments}>{message.content}</Markdown>
+            </div>
+            <AttachmentList
+              attachments={message.attachments}
+              content={message.content}
+              className="mt-1.5"
+            />
           </div>
-          <AttachmentList
-            attachments={message.attachments}
-            content={message.content}
-            className="mt-1.5"
-          />
+          <MessageTimestamp createdAt={message.created_at} className="text-right" />
         </div>
       </div>
     );
@@ -285,14 +288,42 @@ function MessageFooter({
   isPending: boolean;
 }) {
   const showCopy = !isPending;
-  if (message.elapsed_ms == null && !showCopy) return null;
+  const timestamp = formatKstTimestamp(message.created_at);
+  if (message.elapsed_ms == null && !showCopy && !timestamp) return null;
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex flex-wrap items-center gap-1.5">
       {message.elapsed_ms != null && (
         <ElapsedCaption variant="replied" elapsedMs={message.elapsed_ms} />
       )}
+      {message.elapsed_ms != null && timestamp && (
+        <span className="text-xs text-muted-foreground/50">·</span>
+      )}
+      <MessageTimestamp createdAt={message.created_at} />
       {showCopy && <MessageCopyButton message={message} timeline={timeline} />}
     </div>
+  );
+}
+
+function MessageTimestamp({
+  createdAt,
+  className,
+}: {
+  createdAt: string;
+  className?: string;
+}) {
+  const timestamp = formatKstTimestamp(createdAt);
+  if (!timestamp) return null;
+  return (
+    <time
+      dateTime={createdAt}
+      title="KST"
+      aria-label={`${timestamp} KST`}
+      data-acceptance="chat-message-timestamp"
+      data-testid="chat-message-timestamp"
+      className={cn("text-xs text-muted-foreground/70", className)}
+    >
+      {timestamp}
+    </time>
   );
 }
 

--- a/packages/views/chat/components/task-status-pill.tsx
+++ b/packages/views/chat/components/task-status-pill.tsx
@@ -164,6 +164,8 @@ export function TaskStatusPill({
 
   return (
     <div
+      data-acceptance="chat-response-in-progress"
+      data-testid="chat-task-status-pill"
       className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground"
       aria-live="polite"
     >

--- a/packages/views/chat/lib/format.ts
+++ b/packages/views/chat/lib/format.ts
@@ -17,3 +17,38 @@ export function formatElapsedSecs(secs: number): string {
 export function formatElapsedMs(ms: number): string {
   return formatElapsedSecs(Math.max(0, Math.round(ms / 1000)));
 }
+
+const KST_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Seoul",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+
+export function formatKstTimestamp(iso: string): string | null {
+  const date = new Date(iso);
+  if (!Number.isFinite(date.getTime())) return null;
+
+  const parts = Object.fromEntries(
+    KST_FORMATTER.formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+
+  if (
+    !parts.year ||
+    !parts.month ||
+    !parts.day ||
+    !parts.hour ||
+    !parts.minute ||
+    !parts.second
+  ) {
+    return null;
+  }
+
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second}`;
+}


### PR DESCRIPTION
## Summary
- Restore visible KST chat message timestamps using a fixed Asia/Seoul formatter.
- Add stable acceptance selectors for chat message timestamps and in-progress task status.
- Add regression coverage for timestamp + response elapsed and live progress pill rendering.

## Validation
- pnpm -C packages/views test chat/components/chat-message-list.test.tsx chat/components/task-status-pill.test.ts
- pnpm -C packages/views typecheck
- pnpm -C apps/web typecheck
- pnpm -C apps/web build

## Deployment note
Production deploy is intentionally not performed in this PR because NEX-583 is currently blocked by the FE deployment freeze pending NEX-584 deployment safety gates. Live before capture confirms current production image lacks chat timestamp/progress selectors while LLM gauge and dark theme remain intact.