### PR TITLE
fix(daemon): resume opencode session across run-only autopilot ticks

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1636,6 +1636,30 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		if run, err := h.Queries.GetAutopilotRun(r.Context(), task.AutopilotRunID); err == nil {
 			resp.AutopilotID = uuidToString(run.AutopilotID)
 			resp.AutopilotSource = run.Source
+
+			// Resume the prior session for this (agent, autopilot) pair. Run-only
+			// autopilot ticks carry no issue_id, so the (agent, issue) lookup
+			// above never matched them and every tick started a fresh agent
+			// session. For stateful backends like opencode -- which persist each
+			// run as a durable session in a shared DB the UI also reads -- that
+			// leaked one session per tick forever, bloating the DB until it
+			// thrashed the host. Keying the resume on the autopilot id lets a
+			// watchdog's consecutive ticks continue one session instead. Honor
+			// force_fresh_session (manual rerun) and require the same runtime,
+			// matching the issue-resume path above.
+			if !task.ForceFreshSession {
+				if prior, err := h.Queries.GetLastAutopilotTaskSession(r.Context(), db.GetLastAutopilotTaskSessionParams{
+					AgentID:     task.AgentID,
+					AutopilotID: run.AutopilotID,
+				}); err == nil && prior.SessionID.Valid {
+					if prior.RuntimeID == task.RuntimeID {
+						resp.PriorSessionID = prior.SessionID.String
+					}
+					if prior.WorkDir.Valid && resp.PriorWorkDir == "" {
+						resp.PriorWorkDir = prior.WorkDir.String
+					}
+				}
+			}
 			if run.TriggerPayload != nil {
 				resp.AutopilotTriggerPayload = json.RawMessage(run.TriggerPayload)
 			}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1580,6 +1580,50 @@ func (q *Queries) GetLastTaskSession(ctx context.Context, arg GetLastTaskSession
 	return i, err
 }
 
+const getLastAutopilotTaskSession = `-- name: GetLastAutopilotTaskSession :one
+SELECT atq.session_id, atq.work_dir, atq.runtime_id
+FROM agent_task_queue atq
+JOIN autopilot_run ar ON ar.id = atq.autopilot_run_id
+WHERE atq.agent_id = $1 AND ar.autopilot_id = $2
+  AND (
+    atq.status = completed
+    OR (
+      atq.status = failed
+      AND COALESCE(atq.failure_reason, ) NOT IN (iteration_limit, agent_fallback_message, api_invalid_request, codex_semantic_inactivity)
+      AND NOT (COALESCE(atq.error, ) ILIKE %400% AND COALESCE(atq.error, ) ILIKE %invalid_request_error%)
+    )
+  )
+  AND atq.session_id IS NOT NULL
+ORDER BY COALESCE(atq.completed_at, atq.started_at, atq.dispatched_at, atq.created_at) DESC
+LIMIT 1
+`
+
+type GetLastAutopilotTaskSessionParams struct {
+	AgentID     pgtype.UUID `json:"agent_id"`
+	AutopilotID pgtype.UUID `json:"autopilot_id"`
+}
+
+type GetLastAutopilotTaskSessionRow struct {
+	SessionID pgtype.Text `json:"session_id"`
+	WorkDir   pgtype.Text `json:"work_dir"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+}
+
+// Returns the session_id and work_dir from the most recent task spawned by a
+// given (agent_id, autopilot_id) pair, used for session resumption on the
+// autopilot path. Run-only autopilot ticks carry no issue_id, so the
+// (agent_id, issue_id) GetLastTaskSession lookup never matches them: every
+// watchdog tick would otherwise start a brand-new agent session and -- for
+// stateful backends like opencode that persist each run as a durable session
+// in a shared DB -- leak one session per tick forever. Keying on the autopilot
+// id instead lets consecutive ticks of the same autopilot resume one session.
+func (q *Queries) GetLastAutopilotTaskSession(ctx context.Context, arg GetLastAutopilotTaskSessionParams) (GetLastAutopilotTaskSessionRow, error) {
+	row := q.db.QueryRow(ctx, getLastAutopilotTaskSession, arg.AgentID, arg.AutopilotID)
+	var i GetLastAutopilotTaskSessionRow
+	err := row.Scan(&i.SessionID, &i.WorkDir, &i.RuntimeID)
+	return i, err
+}
+
 const getLastTaskStartedAtForIssueAndAgent = `-- name: GetLastTaskStartedAtForIssueAndAgent :one
 SELECT started_at FROM agent_task_queue
 WHERE agent_id = $1 AND issue_id = $2 AND started_at IS NOT NULL

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -424,6 +424,33 @@ WHERE agent_id = $1 AND issue_id = $2
 ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
 LIMIT 1;
 
+-- name: GetLastAutopilotTaskSession :one
+-- Returns the session_id and work_dir from the most recent task spawned by a
+-- given (agent_id, autopilot_id) pair, used for session resumption on the
+-- autopilot path. Run-only autopilot ticks carry no issue_id, so the
+-- (agent_id, issue_id) GetLastTaskSession lookup never matches them: every
+-- watchdog tick would otherwise start a brand-new agent session and -- for
+-- stateful backends like opencode that persist each run as a durable session
+-- in a shared DB -- leak one session per tick forever (MUL: autopilot opencode
+-- session leak). Keying on the autopilot id instead lets consecutive ticks of
+-- the same autopilot resume one session. Same poisoned-state exclusions as
+-- GetLastTaskSession.
+SELECT atq.session_id, atq.work_dir, atq.runtime_id
+FROM agent_task_queue atq
+JOIN autopilot_run ar ON ar.id = atq.autopilot_run_id
+WHERE atq.agent_id = $1 AND ar.autopilot_id = $2
+  AND (
+    atq.status = completed
+    OR (
+      atq.status = failed
+      AND COALESCE(atq.failure_reason, ) NOT IN (iteration_limit, agent_fallback_message, api_invalid_request, codex_semantic_inactivity)
+      AND NOT (COALESCE(atq.error, ) ILIKE %400% AND COALESCE(atq.error, ) ILIKE %invalid_request_error%)
+    )
+  )
+  AND atq.session_id IS NOT NULL
+ORDER BY COALESCE(atq.completed_at, atq.started_at, atq.dispatched_at, atq.created_at) DESC
+LIMIT 1;
+
 -- name: GetLastTaskStartedAtForIssueAndAgent :one
 -- Returns the started_at of the most recent prior task for this (agent, issue)
 -- pair, used as the "since" anchor for counting comments that arrived since the


### PR DESCRIPTION
## Problem

Run-only autopilot ticks (e.g. the 10-min capo-ops / tenanture-ops watchdogs) carry **no `issue_id`**. The session-resume lookup in `ClaimTaskByRuntime` keys exclusively on `(agent_id, issue_id)` (`GetLastTaskSession`), so it never matches a run-only autopilot task. As a result **every autopilot tick starts a brand-new agent session**.

For stateful backends like **opencode** — which persist each `opencode run` as a durable session in a shared `opencode.db` that the bui UI also reads — this leaks **one session per tick, forever**. In production this grew the DB to ~2,700 sessions / 388k parts / 1.2 GB, which exhausted host RAM, thrashed swap, and stalled opencode's SSE event loop (list latency 0.03s → 20s timeouts). The opencode adapter already honors `ResumeSessionID` via `--session`; the gap is purely that the daemon never supplies a prior session id for issue-less autopilot tasks.

## Fix

- Add `GetLastAutopilotTaskSession`, keyed on `(agent_id, autopilot_id)` (joining `agent_task_queue` → `autopilot_run`), with the same poisoned-state exclusions as `GetLastTaskSession`.
- Use it in the `task.AutopilotRunID.Valid` branch of `ClaimTaskByRuntime` so consecutive ticks of the same autopilot resume one session. Honors `force_fresh_session` (manual rerun) and the same-runtime guard, matching the issue-resume path.

Additive only (+95 lines, 3 files). `go build`, `go vet`, `gofmt` clean on the changed packages.

## Note on the generated file

`pkg/db/generated/agent.sql.go` was hand-authored to match sqlc output (sqlc wasn't available in the build env). A maintainer should re-run `sqlc generate` to confirm it's byte-identical.

🧙 Built with [WOZCODE](https://wozcode.com)
