### PR TITLE
docs: add agent runtime install page to zh nav

### DIFF
--- a/apps/docs/content/docs/meta.zh.json
+++ b/apps/docs/content/docs/meta.zh.json
@@ -19,6 +19,7 @@
     "squads",
     "---智能体怎么运行---",
     "daemon-runtimes",
+    "install-agent-runtime",
     "tasks",
     "providers",
     "---与智能体协作---",


### PR DESCRIPTION
## What does this PR do?

Adds the existing `install-agent-runtime` docs page to the Chinese documentation navigation.

The localized page already exists as `apps/docs/content/docs/install-agent-runtime.zh.mdx`, but it was missing from `meta.zh.json`, so Chinese readers could not discover it from the sidebar. This change keeps the Chinese docs navigation aligned with the English docs structure.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `install-agent-runtime` to `apps/docs/content/docs/meta.zh.json` under the “智能体怎么运行” section.

## How to Test

1. Confirm `apps/docs/content/docs/install-agent-runtime.zh.mdx` exists.
2. Confirm `install-agent-runtime` appears in `apps/docs/content/docs/meta.zh.json` between `daemon-runtimes` and `tasks`.
3. Run a JSON/navigation metadata check.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
I used Cursor to analyze the repository for beginner-friendly open source contribution opportunities, then selected a small documentation navigation fix. Cursor helped verify that the localized page existed and that the English docs navigation already included this page.

## Screenshots (optional)

N/A