### PR TITLE
DH-163: add github issue-pr link backfill

### DIFF
--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -53,6 +53,18 @@ var workspaceUpdateCmd = &cobra.Command{
 	RunE:  runWorkspaceUpdate,
 }
 
+var workspaceGitHubCmd = &cobra.Command{
+	Use:   "github",
+	Short: "Manage workspace-scoped GitHub integration actions",
+}
+
+var workspaceGitHubBackfillIssuePRLinksCmd = &cobra.Command{
+	Use:   "backfill-issue-pr-links [workspace-id|slug|prefix]",
+	Short: "Backfill missing issue↔PR link rows from mirrored GitHub PRs for one repo",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runWorkspaceGitHubBackfillIssuePRLinks,
+}
+
 var workspaceSwitchCmd = &cobra.Command{
 	Use:   "switch <workspace-id|slug|prefix>",
 	Short: "Set the default workspace for this profile",
@@ -75,6 +87,8 @@ func init() {
 	workspaceCmd.AddCommand(workspaceMemberCmd)
 	workspaceMemberCmd.AddCommand(workspaceMemberListCmd)
 	workspaceCmd.AddCommand(workspaceUpdateCmd)
+	workspaceCmd.AddCommand(workspaceGitHubCmd)
+	workspaceGitHubCmd.AddCommand(workspaceGitHubBackfillIssuePRLinksCmd)
 	workspaceCmd.AddCommand(workspaceSwitchCmd)
 
 	workspaceListCmd.Flags().String("output", "table", "Output format: table or json")
@@ -89,6 +103,10 @@ func init() {
 	workspaceUpdateCmd.Flags().Bool("context-stdin", false, "Read context from stdin (preserves multi-line content verbatim)")
 	workspaceUpdateCmd.Flags().String("issue-prefix", "", "New issue prefix (uppercased server-side)")
 	workspaceUpdateCmd.Flags().String("output", "json", "Output format: table or json")
+
+	workspaceGitHubBackfillIssuePRLinksCmd.Flags().String("repo-owner", "", "GitHub repository owner/login to rescan")
+	workspaceGitHubBackfillIssuePRLinksCmd.Flags().String("repo-name", "", "GitHub repository name to rescan")
+	workspaceGitHubBackfillIssuePRLinksCmd.Flags().String("output", "json", "Output format: table or json")
 }
 
 // workspaceSummary is the subset of fields the CLI needs from /api/workspaces
@@ -469,4 +487,54 @@ func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
+}
+
+func runWorkspaceGitHubBackfillIssuePRLinks(cmd *cobra.Command, args []string) error {
+	wsID, err := resolveWorkspaceArg(cmd, args)
+	if err != nil {
+		return err
+	}
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass an id/slug/prefix as argument or set MULTICA_WORKSPACE_ID")
+	}
+
+	repoOwner, _ := cmd.Flags().GetString("repo-owner")
+	repoName, _ := cmd.Flags().GetString("repo-name")
+	repoOwner = strings.TrimSpace(repoOwner)
+	repoName = strings.TrimSpace(repoName)
+	if repoOwner == "" || repoName == "" {
+		return fmt.Errorf("--repo-owner and --repo-name are required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body := map[string]any{
+		"repo_owner": repoOwner,
+		"repo_name":  repoName,
+	}
+	var resp map[string]any
+	if err := client.PostJSON(ctx, "/api/workspaces/"+wsID+"/github/backfill-issue-pr-links", body, &resp); err != nil {
+		return fmt.Errorf("backfill issue PR links: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		headers := []string{"WORKSPACE ID", "REPO OWNER", "REPO NAME", "SCANNED PRS", "LINKED ISSUE-PR PAIRS"}
+		rows := [][]string{{
+			strVal(resp, "workspace_id"),
+			strVal(resp, "repo_owner"),
+			strVal(resp, "repo_name"),
+			strVal(resp, "scanned_prs"),
+			strVal(resp, "linked_issue_pr_pairs"),
+		}}
+		cli.PrintTable(os.Stdout, headers, rows)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, resp)
 }

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -253,6 +254,60 @@ func TestResolveWorkspaceByIDOrSlug(t *testing.T) {
 			t.Errorf("error = %q, want it to reference 'workspace list'", err)
 		}
 	})
+}
+
+func TestRunWorkspaceGitHubBackfillIssuePRLinks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/workspaces/11111111-1111-1111-1111-111111111111/github/backfill-issue-pr-links" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["repo_owner"] != "Wilson-G" || body["repo_name"] != "my-awesome-multica" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"workspace_id":          "11111111-1111-1111-1111-111111111111",
+			"repo_owner":            "Wilson-G",
+			"repo_name":             "my-awesome-multica",
+			"scanned_prs":           3,
+			"linked_issue_pr_pairs": 4,
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "11111111-1111-1111-1111-111111111111")
+
+	cmd := &cobra.Command{Use: "backfill-issue-pr-links"}
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("repo-owner", "", "")
+	cmd.Flags().String("repo-name", "", "")
+	cmd.Flags().String("output", "json", "")
+	_ = cmd.Flags().Set("repo-owner", "Wilson-G")
+	_ = cmd.Flags().Set("repo-name", "my-awesome-multica")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	if err := runWorkspaceGitHubBackfillIssuePRLinks(cmd, nil); err != nil {
+		t.Fatalf("runWorkspaceGitHubBackfillIssuePRLinks: %v", err)
+	}
+	w.Close()
+	out, _ := io.ReadAll(r)
+	if !strings.Contains(string(out), "\"linked_issue_pr_pairs\": 4") {
+		t.Fatalf("stdout = %s", string(out))
+	}
 }
 
 // resetWorkspaceUpdateFlags clears every flag on workspaceUpdateCmd and marks

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -613,6 +613,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				r.Group(func(r chi.Router) {
 					r.Use(middleware.RequireWorkspaceRoleFromURL(queries, "id", "owner", "admin"))
 					r.Get("/github/connect", h.GitHubConnect)
+					r.Post("/github/backfill-issue-pr-links", h.BackfillIssuePullRequestLinks)
 					r.Delete("/github/installations/{installationId}", h.DeleteGitHubInstallation)
 				})
 

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -98,6 +98,19 @@ type GitHubConnectResponse struct {
 	Configured bool   `json:"configured"`
 }
 
+type GitHubBackfillIssuePRLinksRequest struct {
+	RepoOwner string `json:"repo_owner"`
+	RepoName  string `json:"repo_name"`
+}
+
+type GitHubBackfillIssuePRLinksResponse struct {
+	WorkspaceID        string `json:"workspace_id"`
+	RepoOwner          string `json:"repo_owner"`
+	RepoName           string `json:"repo_name"`
+	ScannedPRs         int    `json:"scanned_prs"`
+	LinkedIssuePRPairs int    `json:"linked_issue_pr_pairs"`
+}
+
 func githubInstallationToResponse(i db.GithubInstallation) GitHubInstallationResponse {
 	instID := i.InstallationID
 	return GitHubInstallationResponse{
@@ -555,6 +568,50 @@ func (h *Handler) DeleteGitHubInstallation(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// BackfillIssuePullRequestLinks rescans mirrored PR rows for one workspace/repo
+// and recreates missing issue↔PR link rows. This is an explicit admin repair
+// path for workspaces whose link table drifted after the PR mirror was already
+// populated. It intentionally reconstructs only the broad link rows: the PR
+// mirror stores title + branch but not body, so historical close_intent cannot
+// be recovered reliably here.
+func (h *Handler) BackfillIssuePullRequestLinks(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	var req GitHubBackfillIssuePRLinksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	req.RepoOwner = strings.TrimSpace(req.RepoOwner)
+	req.RepoName = strings.TrimSpace(req.RepoName)
+	if req.RepoOwner == "" || req.RepoName == "" {
+		writeError(w, http.StatusBadRequest, "repo_owner and repo_name are required")
+		return
+	}
+
+	scanned, linked, err := h.backfillIssuePullRequestLinks(r.Context(), wsUUID, req.RepoOwner, req.RepoName)
+	if err != nil {
+		slog.Error("github: issue-pr backfill failed",
+			"workspace_id", workspaceID,
+			"repo_owner", req.RepoOwner,
+			"repo_name", req.RepoName,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "failed to backfill issue pull request links")
+		return
+	}
+	writeJSON(w, http.StatusOK, GitHubBackfillIssuePRLinksResponse{
+		WorkspaceID:        workspaceID,
+		RepoOwner:          req.RepoOwner,
+		RepoName:           req.RepoName,
+		ScannedPRs:         scanned,
+		LinkedIssuePRPairs: linked,
+	})
+}
+
 // ── List PRs for an issue ───────────────────────────────────────────────────
 
 func (h *Handler) ListPullRequestsForIssue(w http.ResponseWriter, r *http.Request) {
@@ -572,6 +629,64 @@ func (h *Handler) ListPullRequestsForIssue(w http.ResponseWriter, r *http.Reques
 		out = append(out, issuePullRequestRowToResponse(row))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"pull_requests": out})
+}
+
+func (h *Handler) backfillIssuePullRequestLinks(ctx context.Context, workspaceID pgtype.UUID, repoOwner, repoName string) (int, int, error) {
+	if !h.workspaceAutoLinkPRsEnabled(ctx, workspaceID) {
+		return 0, 0, nil
+	}
+	rows, err := h.DB.Query(ctx, `
+SELECT id, title, branch
+FROM github_pull_request
+WHERE workspace_id = $1
+  AND repo_owner = $2
+  AND repo_name = $3
+ORDER BY pr_number ASC
+`, workspaceID, repoOwner, repoName)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer rows.Close()
+
+	prefix := h.getIssuePrefix(ctx, workspaceID)
+	type mirroredPR struct {
+		ID     pgtype.UUID
+		Title  string
+		Branch pgtype.Text
+	}
+	prs := make([]mirroredPR, 0)
+	for rows.Next() {
+		var pr mirroredPR
+		if err := rows.Scan(&pr.ID, &pr.Title, &pr.Branch); err != nil {
+			return 0, 0, err
+		}
+		prs = append(prs, pr)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, err
+	}
+
+	linked := 0
+	for _, pr := range prs {
+		for _, ident := range extractIdentifiers(pr.Title, "", pr.Branch.String) {
+			issue, ok := h.lookupIssueByIdentifier(ctx, workspaceID, prefix, ident)
+			if !ok {
+				continue
+			}
+			if err := h.Queries.LinkIssueToPullRequest(ctx, db.LinkIssueToPullRequestParams{
+				IssueID:             issue.ID,
+				PullRequestID:       pr.ID,
+				CloseIntent:         false,
+				PreserveCloseIntent: true,
+				LinkedByType:        strToText("system"),
+				LinkedByID:          pgtype.UUID{},
+			}); err != nil {
+				return len(prs), linked, err
+			}
+			linked++
+		}
+	}
+	return len(prs), linked, nil
 }
 
 // ── Webhook ─────────────────────────────────────────────────────────────────

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -411,6 +411,127 @@ func TestWebhook_MergedPR_PreservesCancelled(t *testing.T) {
 	}
 }
 
+func TestBackfillIssuePullRequestLinks_RebuildsMissingLinksFromMirroredPRs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`SELECT 1 FROM github_installation LIMIT 0`,
+		`SELECT 1 FROM github_pull_request LIMIT 0`,
+		`SELECT close_intent FROM issue_pull_request LIMIT 0`,
+	} {
+		if _, err := testPool.Exec(ctx, stmt); err != nil {
+			t.Skipf("github schema not available in test database: %v", err)
+		}
+	}
+	issueTitle := "Backfill target"
+	var (
+		issueID         string
+		issueIdentifier string
+	)
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title, status, priority, number, position)
+		VALUES ($1, 'member', $2, $3, 'in_progress', 'none', 439, -439)
+		RETURNING id, number
+	`, testWorkspaceID, testUserID, issueTitle).Scan(&issueID, new(int32)); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	issueIdentifier = "HAN-439"
+
+	const (
+		installationID int64 = 7654321
+		repoOwner            = "acme"
+		repoName             = "widget"
+		prNumber       int32 = 43
+	)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1 AND repo_owner = $2 AND repo_name = $3`, testWorkspaceID, repoOwner, repoName)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1 AND installation_id = $2`, testWorkspaceID, installationID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   repoOwner,
+		AccountType:    "Organization",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	pr, err := testHandler.Queries.UpsertGitHubPullRequest(ctx, db.UpsertGitHubPullRequestParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		RepoOwner:      repoOwner,
+		RepoName:       repoName,
+		PrNumber:       prNumber,
+		Title:          issueIdentifier + ": restore links",
+		State:          "merged",
+		HtmlUrl:        "https://github.com/acme/widget/pull/43",
+		Branch:         strToText("agent/executor/" + strings.ToLower(issueIdentifier)),
+		PrCreatedAt:    parseGHTimeRequired("2026-06-23T16:00:00Z"),
+		PrUpdatedAt:    parseGHTimeRequired("2026-06-23T16:10:00Z"),
+		HeadSha:        "deadbeef",
+		Additions:      10,
+		Deletions:      2,
+		ChangedFiles:   1,
+	})
+	if err != nil {
+		t.Fatalf("UpsertGitHubPullRequest: %v", err)
+	}
+	if linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(issueID)); err != nil {
+		t.Fatalf("ListPullRequestsByIssue before backfill: %v", err)
+	} else if len(linked) != 0 {
+		t.Fatalf("expected no links before backfill, got %d", len(linked))
+	}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/github/backfill-issue-pr-links", map[string]any{
+		"repo_owner": repoOwner,
+		"repo_name":  repoName,
+	}), "id", testWorkspaceID)
+	testHandler.BackfillIssuePullRequestLinks(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BackfillIssuePullRequestLinks: %d %s", w.Code, w.Body.String())
+	}
+	var resp GitHubBackfillIssuePRLinksResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ScannedPRs != 1 {
+		t.Errorf("ScannedPRs = %d, want 1", resp.ScannedPRs)
+	}
+	if resp.LinkedIssuePRPairs != 1 {
+		t.Errorf("LinkedIssuePRPairs = %d, want 1", resp.LinkedIssuePRPairs)
+	}
+
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue after backfill: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked PR after backfill, got %d", len(linked))
+	}
+	if linked[0].ID != pr.ID {
+		t.Errorf("linked PR id = %s, want %s", uuidToString(linked[0].ID), uuidToString(pr.ID))
+	}
+
+	var closeIntent bool
+	if err := testPool.QueryRow(ctx, `
+SELECT close_intent
+FROM issue_pull_request
+WHERE issue_id = $1 AND pull_request_id = $2
+`, issueID, pr.ID).Scan(&closeIntent); err != nil {
+		t.Fatalf("query close_intent: %v", err)
+	}
+	if closeIntent {
+		t.Error("expected backfill to leave close_intent=false when PR body is unavailable")
+	}
+}
+
 // TestWebhook_UninstallReturnsWorkspaceForBroadcast guards #4: the uninstall
 // path must look up the workspace_id BEFORE deleting the row so the
 // resulting `github_installation:deleted` event is broadcast scoped to that


### PR DESCRIPTION
## Summary
- add an admin-only workspace/repo issue↔PR link backfill endpoint backed by mirrored GitHub PR rows
- add a matching `multica workspace github backfill-issue-pr-links` CLI entrypoint
- cover the CLI path and backfill handler path with focused tests

## Testing
- go test ./cmd/multica -run "TestRunWorkspaceGitHubBackfillIssuePRLinks"
- go test ./internal/handler -run "TestBackfillIssuePullRequestLinks_RebuildsMissingLinksFromMirroredPRs"