### PR TITLE
fix(autopilot): prevent scheduled double-fire under scheduler clock skew

### DIFF
--- a/server/cmd/server/autopilot_scheduler.go
+++ b/server/cmd/server/autopilot_scheduler.go
@@ -117,7 +117,15 @@ func advanceNextRun(ctx context.Context, queries *db.Queries, t db.ClaimDueSched
 		tz = t.Timezone.String
 	}
 
-	next, err := service.ComputeNextRun(t.CronExpression.String, tz)
+	// Anchor the next run to the occurrence we just fired so a node whose clock
+	// lags the database clock cannot recompute — and re-fire — the same one.
+	firedAt := time.Time{}
+	if t.FiredAt.Valid {
+		firedAt = t.FiredAt.Time
+	}
+	ref := service.NextScheduleReference(time.Now(), firedAt)
+
+	next, err := service.ComputeNextRunAfter(t.CronExpression.String, tz, ref)
 	if err != nil {
 		slog.Warn("autopilot scheduler: failed to compute next run",
 			"trigger_id", util.UUIDToString(t.ID),

--- a/server/internal/service/cron.go
+++ b/server/internal/service/cron.go
@@ -11,8 +11,19 @@ import (
 var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
 // ComputeNextRun parses a cron expression and returns the next fire time
-// in the given timezone.
+// in the given timezone, relative to the current process time.
 func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
+	return ComputeNextRunAfter(cronExpr, timezone, time.Now())
+}
+
+// ComputeNextRunAfter parses a cron expression and returns the next fire time
+// strictly after the given reference instant, evaluated in the given timezone.
+//
+// Callers advancing a schedule past an occurrence they just fired must pass a
+// reference that is at least that occurrence (see NextScheduleReference);
+// otherwise a node whose clock lags the database clock can land back on the
+// same occurrence and re-fire it.
+func ComputeNextRunAfter(cronExpr, timezone string, after time.Time) (time.Time, error) {
 	sched, err := cronParser.Parse(cronExpr)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse cron: %w", err)
@@ -21,7 +32,20 @@ func ComputeNextRun(cronExpr, timezone string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
 	}
-	return sched.Next(time.Now().In(loc)), nil
+	return sched.Next(after.In(loc)), nil
+}
+
+// NextScheduleReference returns the instant from which to compute a schedule's
+// next run after firing an occurrence. It is the later of the process clock
+// (now) and the occurrence that was just fired (firedAt), so a scheduler node
+// whose local clock lags the database clock never recomputes — and re-fires —
+// the same occurrence. A zero firedAt means there is no just-fired occurrence
+// to advance past, so now is used.
+func NextScheduleReference(now, firedAt time.Time) time.Time {
+	if firedAt.After(now) {
+		return firedAt
+	}
+	return now
 }
 
 // ValidateTimezone returns an error if the timezone string is not recognized.

--- a/server/internal/service/cron_test.go
+++ b/server/internal/service/cron_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNextScheduleReferenceAnchorsToFiredOccurrence reproduces the double-fire
+// bug: a scheduler node whose local clock lags behind the database clock claims
+// a trigger the DB already considers due, then recomputes next_run_at from its
+// own (still-earlier) clock and lands back on the SAME occurrence — leaving the
+// trigger immediately due again. The reference instant must therefore be at
+// least the occurrence that was just fired.
+func TestNextScheduleReferenceAnchorsToFiredOccurrence(t *testing.T) {
+	utc := time.UTC
+	fired := time.Date(2026, 6, 24, 9, 0, 0, 0, utc) // occurrence we just fired
+	laggingNow := fired.Add(-time.Minute)            // node clock behind DB clock
+
+	ref := NextScheduleReference(laggingNow, fired)
+	if !ref.Equal(fired) {
+		t.Fatalf("reference must anchor to fired occurrence when the clock lags: got %v, want %v", ref, fired)
+	}
+
+	next, err := ComputeNextRunAfter("0 9 * * *", "UTC", ref)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAfter: %v", err)
+	}
+	if !next.After(fired) {
+		t.Fatalf("next run %v must be strictly after the fired occurrence %v", next, fired)
+	}
+	want := time.Date(2026, 6, 25, 9, 0, 0, 0, utc)
+	if !next.Equal(want) {
+		t.Fatalf("next run = %v, want %v (the following day, not a re-fire of the same occurrence)", next, want)
+	}
+}
+
+func TestNextScheduleReferenceUsesNowWhenClockIsHealthy(t *testing.T) {
+	fired := time.Date(2026, 6, 24, 9, 0, 0, 0, time.UTC)
+	now := fired.Add(2 * time.Minute) // healthy node: clock past the fired occurrence
+
+	if ref := NextScheduleReference(now, fired); !ref.Equal(now) {
+		t.Fatalf("reference should be now when now is past the fired occurrence: got %v, want %v", ref, now)
+	}
+}
+
+func TestNextScheduleReferenceFallsBackToNowWithoutFiredOccurrence(t *testing.T) {
+	now := time.Date(2026, 6, 24, 9, 0, 0, 0, time.UTC)
+
+	if ref := NextScheduleReference(now, time.Time{}); !ref.Equal(now) {
+		t.Fatalf("reference should be now when there is no fired occurrence: got %v, want %v", ref, now)
+	}
+}
+
+func TestComputeNextRunAfterIsStrictlyAfterInput(t *testing.T) {
+	at := time.Date(2026, 6, 24, 9, 0, 0, 0, time.UTC) // exactly a fire time
+
+	next, err := ComputeNextRunAfter("0 9 * * *", "UTC", at)
+	if err != nil {
+		t.Fatalf("ComputeNextRunAfter: %v", err)
+	}
+	if !next.After(at) {
+		t.Fatalf("ComputeNextRunAfter must return a time strictly after its input: got %v for input %v", next, at)
+	}
+}

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -48,16 +48,25 @@ func (q *Queries) AdvanceTriggerNextRun(ctx context.Context, arg AdvanceTriggerN
 
 const claimDueScheduleTriggers = `-- name: ClaimDueScheduleTriggers :many
 
+WITH due AS (
+  SELECT t.id, t.next_run_at AS fired_at
+  FROM autopilot_trigger t
+  JOIN autopilot a ON t.autopilot_id = a.id
+  WHERE t.kind = 'schedule'
+    AND t.enabled = true
+    AND t.next_run_at IS NOT NULL
+    AND t.next_run_at <= now()
+    AND a.status = 'active'
+)
 UPDATE autopilot_trigger t
 SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
+FROM due, autopilot a
+WHERE t.id = due.id
+  AND t.autopilot_id = a.id
   AND t.next_run_at IS NOT NULL
   AND t.next_run_at <= now()
   AND a.status = 'active'
-RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
+RETURNING t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, due.fired_at, a.workspace_id AS autopilot_workspace_id
 `
 
 type ClaimDueScheduleTriggersRow struct {
@@ -76,6 +85,7 @@ type ClaimDueScheduleTriggersRow struct {
 	Provider             string             `json:"provider"`
 	SigningSecret        pgtype.Text        `json:"signing_secret"`
 	EventFilters         []byte             `json:"event_filters"`
+	FiredAt              pgtype.Timestamptz `json:"fired_at"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -84,6 +94,12 @@ type ClaimDueScheduleTriggersRow struct {
 // =====================
 // Atomically claim all due schedule triggers to prevent concurrent execution.
 // Joins the autopilot table to ensure only active autopilots are fired.
+// The CTE snapshots next_run_at as fired_at (the UPDATE clears it to NULL, so
+// RETURNING would otherwise lose it) so the scheduler can advance the schedule
+// strictly past the occurrence it just fired, even when the claiming node's
+// local clock lags behind the database clock. The due conditions are repeated
+// in the UPDATE so a concurrent claim that already nulled next_run_at fails the
+// recheck and the row is claimed exactly once.
 func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueScheduleTriggersRow, error) {
 	rows, err := q.db.Query(ctx, claimDueScheduleTriggers)
 	if err != nil {
@@ -109,6 +125,7 @@ func (q *Queries) ClaimDueScheduleTriggers(ctx context.Context) ([]ClaimDueSched
 			&i.Provider,
 			&i.SigningSecret,
 			&i.EventFilters,
+			&i.FiredAt,
 			&i.AutopilotWorkspaceID,
 		); err != nil {
 			return nil, err

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -255,16 +255,31 @@ RETURNING *;
 -- name: ClaimDueScheduleTriggers :many
 -- Atomically claim all due schedule triggers to prevent concurrent execution.
 -- Joins the autopilot table to ensure only active autopilots are fired.
+-- The CTE snapshots next_run_at as fired_at (the UPDATE clears it to NULL, so
+-- RETURNING would otherwise lose it) so the scheduler can advance the schedule
+-- strictly past the occurrence it just fired, even when the claiming node's
+-- local clock lags behind the database clock. The due conditions are repeated
+-- in the UPDATE so a concurrent claim that already nulled next_run_at fails the
+-- recheck and the row is claimed exactly once.
+WITH due AS (
+  SELECT t.id, t.next_run_at AS fired_at
+  FROM autopilot_trigger t
+  JOIN autopilot a ON t.autopilot_id = a.id
+  WHERE t.kind = 'schedule'
+    AND t.enabled = true
+    AND t.next_run_at IS NOT NULL
+    AND t.next_run_at <= now()
+    AND a.status = 'active'
+)
 UPDATE autopilot_trigger t
 SET next_run_at = NULL
-FROM autopilot a
-WHERE t.autopilot_id = a.id
-  AND t.kind = 'schedule'
-  AND t.enabled = true
+FROM due, autopilot a
+WHERE t.id = due.id
+  AND t.autopilot_id = a.id
   AND t.next_run_at IS NOT NULL
   AND t.next_run_at <= now()
   AND a.status = 'active'
-RETURNING t.*, a.workspace_id AS autopilot_workspace_id;
+RETURNING t.*, due.fired_at, a.workspace_id AS autopilot_workspace_id;
 
 -- =====================
 -- Task Queue (run_only mode)


### PR DESCRIPTION
Fixes #4384

## Summary
- A scheduled autopilot could fire twice for one occurrence in multi-node deployments when a scheduler node's clock lagged behind the database clock. The claim uses the DB clock (`next_run_at <= now()`), but `advanceNextRun` recomputed `next_run_at` from the node's process clock via `time.Now()`. A lagging node landed back on the just-fired occurrence and wrote a `next_run_at` still `<= now()`, leaving the trigger immediately due again on the next tick.
- `ClaimDueScheduleTriggers` now snapshots the claimed `next_run_at` as `fired_at` via a CTE (the `UPDATE` clears it to `NULL`, so `RETURNING` would otherwise lose it). The due conditions are repeated in the `UPDATE` so a concurrent claim that already nulled the row fails the recheck and each row is claimed exactly once.
- `advanceNextRun` computes the next run from `max(now, fired_at)` (`service.NextScheduleReference` + `service.ComputeNextRunAfter`), so the schedule always moves strictly past the occurrence it just fired regardless of node clock skew. The crash-recovery path keeps using `now()` since a lost trigger has no known fired occurrence.

## Tests
- `go test ./internal/service/` — added `cron_test.go` covering the clock-lag scenario (next run must be the following occurrence, not a re-fire), the healthy-clock path, the no-fired-occurrence fallback, and the strictly-after invariant.
- `go vet ./cmd/server/ ./internal/service/`, `gofmt`, `go build ./...` — clean.
- `sqlc generate` — regenerated `autopilot.sql.go`; the new query validates against the schema.
- Note: the `server/cmd/server` DB integration tests are skipped locally (no Postgres available), so the new claim query was not exercised end-to-end against a live database. The concurrency recheck relies on standard PostgreSQL `UPDATE` re-evaluation semantics and is documented inline.