### PR TITLE
fix(chat): stop cancelled-run drafts resurrecting after deletion

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -110,8 +110,11 @@ export function ChatInput({
   //
   // `editorKey` — React `key` on the ContentEditor. Used to force a
   // remount when the user explicitly switches agent (so Tiptap's
-  // Placeholder, which only reads on mount, refreshes to "Tell {agent}…")
-  // or when a cancelled empty run restores a draft from the server.
+  // Placeholder, which only reads on mount, refreshes to "Tell {agent}…").
+  // A cancelled-run draft restore does NOT bump this key: it just writes
+  // the restored text into `inputDraft`, and the editor's own
+  // defaultValue-sync effect (content-editor.tsx) pushes it into the live
+  // instance. There is no second copy of the draft to drift or resurface.
   // Crucially this does NOT include `activeSessionId`: when the user
   // uploads a file in a brand-new chat, `handleUploadFile` first awaits
   // `ensureSession` which lazily creates the session and flips
@@ -134,14 +137,8 @@ export function ChatInput({
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
   const [isEmpty, setIsEmpty] = useState(!inputDraft.trim());
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [editorRestore, setEditorRestore] = useState<{
-    id: string;
-    content: string;
-    draftKey: string;
-  } | null>(null);
   const consumedRestoreIdRef = useRef<string | null>(null);
-  const activeRestore = editorRestore?.draftKey === draftKey ? editorRestore : null;
-  const editorKey = `${selectedAgentId ?? "no-agent"}:${activeRestore?.id ?? "base"}`;
+  const editorKey = selectedAgentId ?? "no-agent";
   // Number of in-flight uploads. We track this explicitly (rather than
   // peeking at the editor on every render) so the SubmitButton visibly
   // disables the instant an upload starts and re-enables the instant it
@@ -190,11 +187,6 @@ export function ChatInput({
     setInputDraft(draftKey, restoreDraftRequest.content);
     setInputDraftAttachments(draftKey, restoreDraftRequest.attachments ?? []);
     setIsEmpty(!restoreDraftRequest.content.trim());
-    setEditorRestore({
-      id: restoreDraftRequest.id,
-      content: restoreDraftRequest.content,
-      draftKey,
-    });
     onRestoreDraftConsumed?.();
   }, [
     draftKey,
@@ -366,7 +358,7 @@ export function ChatInput({
             // intentionally does not depend on activeSessionId.
             key={editorKey}
             ref={editorRef}
-            defaultValue={activeRestore?.content ?? inputDraft}
+            defaultValue={inputDraft}
             placeholder={placeholder}
             onUpdate={(md) => {
               setIsEmpty(!md.trim());


### PR DESCRIPTION
## What

Cancelling a chat task and getting the message restored into the input left a ghost: if you then **deleted** the restored text, navigated away and came back, the deleted text reappeared.

## Root cause

Restore wrote the content into **two** places:
- ✅ `inputDraft` — the normal, persisted draft (correct).
- ❌ `editorRestore` — a separate component state holding a private copy of the content, used to bump `editorKey` and force an editor remount.

`editorRestore` was never cleared, and `activeRestore` re-derived on every return to that session's `draftKey`. So `defaultValue={activeRestore?.content ?? inputDraft}` kept re-injecting the stale copy — deleting the text cleared `inputDraft` but not the second copy. (In-memory only, hence a full page refresh "fixed" it.)

## Fix (delete, not patch)

`ContentEditor` already absorbs external `defaultValue` changes into a live instance via its defaultValue-sync effect (`content-editor.tsx`, the same path WS-driven issue-description updates use). The remount + `editorRestore` mechanism was a redundant parallel implementation.

- Remove `editorRestore` state, `activeRestore`, and the restore-id segment of `editorKey`.
- `defaultValue={inputDraft}` — single source of truth.
- Restore effect just writes the draft; the editor's own sync displays it.

Cancel-restore now behaves identically to normal typing: delete the text and it stays gone across navigation.

Net: **-15 / +7**, one whole state mechanism removed.

## Test plan

- [ ] Send a chat message, cancel it → text returns to the input.
- [ ] Delete the restored text, switch sessions, switch back → input stays empty (previously: text resurrected).
- [ ] Normal draft persistence (type, switch, return) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)