### PR TITLE
Show daemon IP metadata on runtime pages

### DIFF
--- a/packages/views/agents/components/runtime-machine-filter-dropdown.test.tsx
+++ b/packages/views/agents/components/runtime-machine-filter-dropdown.test.tsx
@@ -20,6 +20,7 @@ function makeMachine(
     title: "dev.local",
     subtitle: "x86_64 macOS",
     deviceInfo: "dev.local · x86_64 macOS",
+    ipAddresses: [],
     cliVersion: "1.0.0",
     mode: "local",
     section: "local",

--- a/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
@@ -232,6 +232,17 @@ describe("RuntimeDetail visibility section", () => {
     expect(btn.disabled).toBe(false);
   });
 
+  it("shows IP metadata in the runtime identity facts", () => {
+    renderDetail(
+      makeRuntime({
+        metadata: { ip_addresses: ["10.0.0.8", "192.168.1.20"] },
+      }),
+    );
+
+    expect(screen.getByText("IP")).toBeInTheDocument();
+    expect(screen.getByText("10.0.0.8 +1")).toBeInTheDocument();
+  });
+
   it("hides the Delete runtime button entirely for callers who cannot edit", () => {
     renderDetail(
       makeRuntime({

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -39,7 +39,11 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { BreadcrumbHeader } from "../../layout/breadcrumb-header";
 import { AppLink, useNavigation } from "../../navigation";
 import { availabilityConfig, workloadConfig } from "../../agents/presence";
-import { formatLastSeen } from "../utils";
+import {
+  formatLastSeen,
+  formatRuntimeIPSummary,
+  runtimeIPAddresses,
+} from "../utils";
 import { HealthBadge } from "./shared";
 import { ProviderLogo } from "./provider-logo";
 import { UpdateSection } from "./update-section";
@@ -261,6 +265,8 @@ function HeroCard({
   const { t } = useT("runtimes");
   const [showDetails, setShowDetails] = useState(false);
   const device = runtime.device_info ? parseDeviceInfo(runtime.device_info) : null;
+  const ipAddresses = runtimeIPAddresses(runtime);
+  const ipSummary = formatRuntimeIPSummary(ipAddresses);
   const hasTechDetails = !!cliVersion || !!daemonShort;
 
   return (
@@ -286,7 +292,7 @@ function HeroCard({
       {/* User-visible facts — Owner / Device / Runtime, each labelled.
           Replaces the older dense `·`-separated meta strip that mixed
           everything (including dev-only IDs) at the same visual weight. */}
-      <dl className="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+      <dl className="grid grid-cols-1 divide-y sm:grid-cols-4 sm:divide-x sm:divide-y-0">
         <Fact label="Owner">
           {ownerMember ? (
             <span className="inline-flex min-w-0 items-center gap-1.5">
@@ -313,6 +319,22 @@ function HeroCard({
                 }
               />
               <TooltipContent>{device.hostname}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-sm text-muted-foreground">—</span>
+          )}
+        </Fact>
+        <Fact label="IP">
+          {ipSummary ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span className="block truncate font-mono text-xs">
+                    {ipSummary}
+                  </span>
+                }
+              />
+              <TooltipContent>{ipAddresses.join(", ")}</TooltipContent>
             </Tooltip>
           ) : (
             <span className="text-sm text-muted-foreground">—</span>

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -58,7 +58,9 @@ import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
 import {
   computeCostInWindow,
   formatLastSeen,
+  formatRuntimeIPSummary,
   pctChange,
+  runtimeIPAddresses,
 } from "../utils";
 import { splitRuntimeName } from "./runtime-machines";
 import {
@@ -184,18 +186,30 @@ export function buildWorkloadIndex(
 
 function RuntimeNameCell({ runtime }: { runtime: AgentRuntime }) {
   const { base: baseName } = splitRuntimeName(runtime.name);
+  const ipAddresses = runtimeIPAddresses(runtime);
+  const ipSummary = formatRuntimeIPSummary(ipAddresses);
   return (
     <ListGridCell className="gap-2">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center">
         <ProviderLogo provider={runtime.provider} className="h-5 w-5" />
       </div>
-      <div className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span className="block min-w-0 shrink truncate text-sm font-medium">
-          {baseName}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="block min-w-0 shrink truncate text-sm font-medium">
+            {baseName}
+          </span>
+          <RuntimeKindBadge runtime={runtime} />
+          <PendingRuntimeBadge runtime={runtime} />
+          <VisibilityBadge runtime={runtime} />
         </span>
-        <RuntimeKindBadge runtime={runtime} />
-        <PendingRuntimeBadge runtime={runtime} />
-        <VisibilityBadge runtime={runtime} />
+        {ipSummary && (
+          <span
+            className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground"
+            title={ipAddresses.join(", ")}
+          >
+            IP {ipSummary}
+          </span>
+        )}
       </div>
     </ListGridCell>
   );

--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -105,6 +105,23 @@ describe("runtime machine grouping", () => {
     expect(subtitle).toMatch(/^daemon /);
   });
 
+  it("carries runtime IP metadata into machine search", () => {
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          metadata: {
+            cli_version: "0.3.0",
+            ip_addresses: ["10.0.0.8", "192.168.1.20"],
+          },
+        }),
+      ],
+      { now: NOW },
+    );
+
+    expect(machines[0]?.ipAddresses).toEqual(["10.0.0.8", "192.168.1.20"]);
+    expect(filterRuntimeMachines(machines, "192.168.1.20", "all")).toHaveLength(1);
+  });
+
   it("synthesizes a placeholder local machine when ensureLocalMachine is set and no runtime matches", () => {
     // Reproduces the "Start button disappears after stopping the daemon"
     // bug: the daemon is stopped (localDaemonId is null) and the server

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -1,6 +1,6 @@
 import { deriveRuntimeHealth, type RuntimeHealth } from "@multica/core/runtimes";
 import type { AgentRuntime } from "@multica/core/types";
-import { formatDeviceInfo } from "../utils";
+import { formatDeviceInfo, runtimeIPAddresses } from "../utils";
 
 export type RuntimeMachineSection = "local" | "remote" | "cloud";
 export type RuntimeMachineFilter = "all" | "online" | "issues";
@@ -16,6 +16,7 @@ export interface RuntimeMachine {
   title: string;
   subtitle: string | null;
   deviceInfo: string | null;
+  ipAddresses: string[];
   cliVersion: string | null;
   mode: AgentRuntime["runtime_mode"];
   section: RuntimeMachineSection;
@@ -118,6 +119,7 @@ function placeholderLocalMachine(
     title: options.localMachineName ?? "This machine",
     subtitle: null,
     deviceInfo: null,
+    ipAddresses: [],
     cliVersion: null,
     mode: "local",
     section: "local",
@@ -148,6 +150,7 @@ export function filterRuntimeMachines(
       machine.title,
       machine.subtitle,
       machine.deviceInfo,
+      machine.ipAddresses.join(" "),
       machine.daemonId,
       machine.providerNames.join(" "),
       machine.runtimes.map((runtime) => runtime.name).join(" "),
@@ -201,6 +204,7 @@ function finalizeRuntimeMachine(
     localMachineName: options.localMachineName,
   });
   const deviceInfo = first ? formatDeviceInfo(first.device_info ?? null) : null;
+  const ipAddresses = runtimeMachineIPAddresses(runtimes);
   const subtitle = machineSubtitle({
     title,
     deviceInfo,
@@ -237,6 +241,7 @@ function finalizeRuntimeMachine(
     title,
     subtitle,
     deviceInfo,
+    ipAddresses,
     cliVersion: commonCliVersion(runtimes),
     mode: draft.mode,
     section: isCurrent ? "local" : draft.mode === "cloud" ? "cloud" : "remote",
@@ -250,6 +255,19 @@ function finalizeRuntimeMachine(
     providerNames,
     lastSeenAt: latestLastSeenAt(runtimes),
   };
+}
+
+function runtimeMachineIPAddresses(runtimes: AgentRuntime[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const runtime of runtimes) {
+    for (const ip of runtimeIPAddresses(runtime)) {
+      if (seen.has(ip)) continue;
+      seen.add(ip);
+      result.push(ip);
+    }
+  }
+  return result;
 }
 
 function runtimeMachineId(runtime: AgentRuntime): string {

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -46,6 +46,7 @@ import {
   type RuntimeMachineFilter,
 } from "./runtime-machines";
 import { HealthDot, HealthIcon, useHealthLabel } from "./shared";
+import { formatRuntimeIPSummary } from "../utils";
 import { useT } from "../../i18n";
 
 const MACHINE_FILTERS: RuntimeMachineFilter[] = ["all", "online", "issues"];
@@ -599,6 +600,7 @@ function MachineRow({
   const { t } = useT("runtimes");
   const Icon = machine.section === "cloud" ? Cloud : Monitor;
   const busyCount = machine.runningCount + machine.queuedCount;
+  const ipSummary = formatRuntimeIPSummary(machine.ipAddresses);
   const runtimeCount = t(($) => $.machine.runtime_count, {
     count: machine.runtimes.length,
   });
@@ -636,6 +638,14 @@ function MachineRow({
             </span>
           )}
         </span>
+        {ipSummary && (
+          <span
+            className="mt-0.5 block truncate font-mono text-xs text-muted-foreground"
+            title={machine.ipAddresses.join(", ")}
+          >
+            IP {ipSummary}
+          </span>
+        )}
         <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
           <ProviderIconStack providers={machine.providerNames} />
           {busyCount > 0 ? (
@@ -728,6 +738,7 @@ function MachineDetail({
   const runtimesMeta = t(($) => $.machine.metrics.runtimes_hint, {
     count: machine.onlineCount,
   });
+  const ipSummary = formatRuntimeIPSummary(machine.ipAddresses);
   // Single inline meta strip replaces the old 4-card grid. Health is already
   // shown as a chip in the title row; CLI / daemon id are scanning-grade
   // info, not headline numbers — they belong in muted secondary text.
@@ -746,6 +757,17 @@ function MachineDetail({
     metaParts.push(
       <span key="cli" className="font-mono">
         {machine.cliVersion}
+      </span>,
+    );
+  }
+  if (ipSummary) {
+    metaParts.push(
+      <span
+        key="ip"
+        className="font-mono"
+        title={machine.ipAddresses.join(", ")}
+      >
+        IP {ipSummary}
       </span>,
     );
   }

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -9,8 +9,10 @@ import {
   collectUnmappedModels,
   computeCostInWindow,
   estimateCost,
+  formatRuntimeIPSummary,
   isModelPriced,
   isSelfHealingRuntime,
+  runtimeIPAddresses,
   sliceWindow,
   todayIso,
   weekStartIso,
@@ -80,6 +82,48 @@ describe("isSelfHealingRuntime", () => {
         makeRuntime({ runtime_mode: "cloud", status: "offline" }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("runtimeIPAddresses", () => {
+  function makeRuntime(metadata: Record<string, unknown>): AgentRuntime {
+    return {
+      id: "rt-1",
+      workspace_id: "ws-1",
+      daemon_id: "daemon-1",
+      name: "Claude (dev.local)",
+      runtime_mode: "local",
+      provider: "claude",
+      launch_header: "",
+      status: "online",
+      device_info: "dev.local",
+      metadata,
+      owner_id: "user-1",
+      visibility: "private",
+      last_seen_at: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  it("reads deduped IP metadata from list and legacy scalar shapes", () => {
+    const runtime = makeRuntime({
+      ip_addresses: ["10.0.0.8", " 10.0.0.8 ", "192.168.1.20"],
+      ip_address: "172.16.0.5",
+    });
+
+    expect(runtimeIPAddresses(runtime)).toEqual([
+      "10.0.0.8",
+      "192.168.1.20",
+      "172.16.0.5",
+    ]);
+  });
+
+  it("formats a compact address summary", () => {
+    expect(formatRuntimeIPSummary(["10.0.0.8", "192.168.1.20"])).toBe(
+      "10.0.0.8 +1",
+    );
+    expect(formatRuntimeIPSummary([])).toBeNull();
   });
 });
 

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -57,6 +57,43 @@ export function formatDeviceInfo(raw: string | null): string | null {
     .join(" · ");
 }
 
+export function runtimeIPAddresses(
+  runtime: Pick<AgentRuntime, "metadata">,
+): string[] {
+  const metadata = runtime.metadata;
+  if (!metadata || typeof metadata !== "object") return [];
+
+  const values: string[] = [];
+  const list = metadata.ip_addresses;
+  if (Array.isArray(list)) {
+    for (const value of list) {
+      if (typeof value === "string") values.push(value);
+    }
+  }
+
+  const single = metadata.ip_address;
+  if (typeof single === "string") values.push(single);
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+export function formatRuntimeIPSummary(
+  addresses: readonly string[],
+): string | null {
+  const first = addresses[0];
+  if (!first) return null;
+  const extra = addresses.length - 1;
+  return extra > 0 ? `${first} +${extra}` : first;
+}
+
 function prettifyOsArch(part: string): string {
   const lower = part.toLowerCase();
   // Pattern: <os>-<arch>; e.g. darwin-amd64, linux-arm64, windows-amd64.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -110,6 +110,8 @@ var (
 		}
 		return info.Mode().Perm()&0o111 != 0
 	}
+
+	collectLocalIPAddresses = localIPAddresses
 )
 
 // workspaceState tracks registered runtimes for a single workspace.
@@ -958,6 +960,7 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 		"daemon_id":         d.cfg.DaemonID,
 		"legacy_daemon_ids": d.cfg.LegacyDaemonIDs,
 		"device_name":       d.cfg.DeviceName,
+		"ip_addresses":      collectLocalIPAddresses(),
 		"cli_version":       d.cfg.CLIVersion,
 		"launched_by":       d.cfg.LaunchedBy,
 		"runtimes":          runtimes,

--- a/server/internal/daemon/network.go
+++ b/server/internal/daemon/network.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"net"
+	"sort"
+)
+
+func localIPAddresses() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+
+	var addrs []net.Addr
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		ifaceAddrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		addrs = append(addrs, ifaceAddrs...)
+	}
+	return visibleIPAddressesFromAddrs(addrs)
+}
+
+func visibleIPAddressesFromAddrs(addrs []net.Addr) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	result := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		ip := ipFromAddr(addr)
+		if ip == nil ||
+			ip.IsLoopback() ||
+			ip.IsUnspecified() ||
+			ip.IsMulticast() ||
+			ip.IsLinkLocalUnicast() {
+			continue
+		}
+		value := ip.String()
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		left4 := net.ParseIP(result[i]).To4() != nil
+		right4 := net.ParseIP(result[j]).To4() != nil
+		if left4 != right4 {
+			return left4
+		}
+		return result[i] < result[j]
+	})
+	return result
+}
+
+func ipFromAddr(addr net.Addr) net.IP {
+	switch v := addr.(type) {
+	case *net.IPNet:
+		return v.IP
+	case *net.IPAddr:
+		return v.IP
+	default:
+		return nil
+	}
+}

--- a/server/internal/daemon/network_test.go
+++ b/server/internal/daemon/network_test.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+)
+
+func TestVisibleIPAddressesFromAddrsFiltersAndSortsDiagnosticAddresses(t *testing.T) {
+	addrs := []net.Addr{
+		&net.IPNet{IP: net.ParseIP("fe80::1")},
+		&net.IPNet{IP: net.ParseIP("127.0.0.1")},
+		&net.IPNet{IP: net.ParseIP("10.0.0.8")},
+		&net.IPNet{IP: net.ParseIP("2001:db8::10")},
+		&net.IPNet{IP: net.ParseIP("192.168.1.20")},
+		&net.IPAddr{IP: net.ParseIP("10.0.0.8")},
+	}
+
+	got := visibleIPAddressesFromAddrs(addrs)
+	want := []string{"10.0.0.8", "192.168.1.20", "2001:db8::10"}
+	if len(got) != len(want) {
+		t.Fatalf("addresses = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("addresses = %v, want %v", got, want)
+		}
+	}
+}

--- a/server/internal/daemon/runtime_profile_test.go
+++ b/server/internal/daemon/runtime_profile_test.go
@@ -90,10 +90,11 @@ func TestClient_GetRuntimeProfiles_RequestShape(t *testing.T) {
 // configurable set of runtime profiles and captures the runtimes array sent
 // to /api/daemon/register.
 type profileRegisterFixture struct {
-	daemon       *Daemon
-	server       *httptest.Server
-	sentRuntimes []map[string]any
-	sentFailures []map[string]any
+	daemon          *Daemon
+	server          *httptest.Server
+	sentIPAddresses []string
+	sentRuntimes    []map[string]any
+	sentFailures    []map[string]any
 }
 
 func newProfileRegisterFixture(t *testing.T, profiles []RuntimeProfile, profilesStatus int) *profileRegisterFixture {
@@ -103,10 +104,12 @@ func newProfileRegisterFixture(t *testing.T, profiles []RuntimeProfile, profiles
 		switch {
 		case r.URL.Path == "/api/daemon/register":
 			var body struct {
+				IPAddresses    []string         `json:"ip_addresses"`
 				Runtimes       []map[string]any `json:"runtimes"`
 				FailedProfiles []map[string]any `json:"failed_profiles"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
+			fx.sentIPAddresses = body.IPAddresses
 			fx.sentRuntimes = body.Runtimes
 			fx.sentFailures = body.FailedProfiles
 			// Echo back a Runtime row per requested runtime, threading
@@ -204,6 +207,29 @@ func TestRegisterRuntimes_AppendsProfileRuntime(t *testing.T) {
 	// The response runtime carries the profile_id back.
 	if len(resp.Runtimes) != 1 || resp.Runtimes[0].ProfileID != "prof-1" {
 		t.Fatalf("response runtimes wrong: %+v", resp.Runtimes)
+	}
+}
+
+func TestRegisterRuntimes_SendsLocalIPAddresses(t *testing.T) {
+	t.Cleanup(stubAgentVersion(t))
+	orig := collectLocalIPAddresses
+	collectLocalIPAddresses = func() []string {
+		return []string{"10.0.0.8", "192.168.1.20"}
+	}
+	t.Cleanup(func() { collectLocalIPAddresses = orig })
+
+	fx := newProfileRegisterFixture(t, nil, http.StatusNotFound)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/bin/claude"},
+	}
+
+	if _, _, err := d.registerRuntimesForWorkspace(context.Background(), "ws-1"); err != nil {
+		t.Fatalf("registerRuntimesForWorkspace: %v", err)
+	}
+	want := []string{"10.0.0.8", "192.168.1.20"}
+	if strings.Join(fx.sentIPAddresses, ",") != strings.Join(want, ",") {
+		t.Fatalf("ip_addresses = %v, want %v", fx.sentIPAddresses, want)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -174,6 +175,7 @@ type DaemonRegisterRequest struct {
 	// and tasks keep working without manual intervention.
 	LegacyDaemonIDs []string `json:"legacy_daemon_ids"`
 	DeviceName      string   `json:"device_name"`
+	IPAddresses     []string `json:"ip_addresses"`
 	CLIVersion      string   `json:"cli_version"` // multica CLI version
 	LaunchedBy      string   `json:"launched_by"` // "desktop" when spawned by the Electron app
 	Runtimes        []struct {
@@ -267,6 +269,49 @@ func normalizeProvider(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
+const maxRuntimeIPAddresses = 8
+
+func normalizeRuntimeIPAddresses(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		addr, err := netip.ParseAddr(strings.TrimSpace(value))
+		if err != nil {
+			continue
+		}
+		addr = addr.Unmap()
+		if addr.IsLoopback() ||
+			addr.IsUnspecified() ||
+			addr.IsMulticast() ||
+			addr.IsLinkLocalUnicast() {
+			continue
+		}
+
+		normalized := addr.String()
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+		if len(result) >= maxRuntimeIPAddresses {
+			break
+		}
+	}
+	return result
+}
+
+func daemonRuntimeMetadata(version, cliVersion, launchedBy string, ipAddresses []string) map[string]any {
+	metadata := map[string]any{
+		"version":     version,
+		"cli_version": cliVersion,
+		"launched_by": launchedBy,
+	}
+	if normalized := normalizeRuntimeIPAddresses(ipAddresses); len(normalized) > 0 {
+		metadata["ip_addresses"] = normalized
+	}
+	return metadata
+}
+
 func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	var req DaemonRegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -277,6 +322,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	req.WorkspaceID = strings.TrimSpace(req.WorkspaceID)
 	req.DaemonID = strings.TrimSpace(req.DaemonID)
 	req.DeviceName = strings.TrimSpace(req.DeviceName)
+	req.IPAddresses = normalizeRuntimeIPAddresses(req.IPAddresses)
 
 	if req.DaemonID == "" {
 		writeError(w, http.StatusBadRequest, "daemon_id is required")
@@ -344,11 +390,12 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		if runtime.Status == "offline" {
 			status = "offline"
 		}
-		metadata, _ := json.Marshal(map[string]any{
-			"version":     runtime.Version,
-			"cli_version": req.CLIVersion,
-			"launched_by": req.LaunchedBy,
-		})
+		metadata, _ := json.Marshal(daemonRuntimeMetadata(
+			runtime.Version,
+			req.CLIVersion,
+			req.LaunchedBy,
+			req.IPAddresses,
+		))
 
 		var registered db.AgentRuntime
 		var inserted bool
@@ -536,14 +583,11 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		if commandName == "" {
 			commandName = profile.CommandName
 		}
-		metadata, _ := json.Marshal(map[string]any{
-			"version":                            "",
-			"cli_version":                        req.CLIVersion,
-			"launched_by":                        req.LaunchedBy,
-			"runtime_profile_registration_error": true,
-			"runtime_profile_failure_reason":     reason,
-			"command_name":                       commandName,
-		})
+		failureMetadata := daemonRuntimeMetadata("", req.CLIVersion, req.LaunchedBy, req.IPAddresses)
+		failureMetadata["runtime_profile_registration_error"] = true
+		failureMetadata["runtime_profile_failure_reason"] = reason
+		failureMetadata["command_name"] = commandName
+		metadata, _ := json.Marshal(failureMetadata)
 		if _, err := h.Queries.UpsertAgentRuntimeWithProfile(r.Context(), db.UpsertAgentRuntimeWithProfileParams{
 			WorkspaceID: wsUUID,
 			DaemonID:    strToText(req.DaemonID),

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -24,6 +24,32 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
+func TestNormalizeRuntimeIPAddressesKeepsDiagnosticAddressesOnly(t *testing.T) {
+	got := normalizeRuntimeIPAddresses([]string{
+		" 10.0.0.8 ",
+		"::ffff:192.168.1.20",
+		"127.0.0.1",
+		"fe80::1",
+		"not-an-ip",
+		"10.0.0.8",
+	})
+	want := []string{"10.0.0.8", "192.168.1.20"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("addresses = %v, want %v", got, want)
+	}
+}
+
+func TestDaemonRuntimeMetadataIncludesIPAddresses(t *testing.T) {
+	metadata := daemonRuntimeMetadata("codex 1.2.3", "v0.3.0", "desktop", []string{"10.0.0.8"})
+	if metadata["version"] != "codex 1.2.3" {
+		t.Fatalf("version = %v", metadata["version"])
+	}
+	got, ok := metadata["ip_addresses"].([]string)
+	if !ok || strings.Join(got, ",") != "10.0.0.8" {
+		t.Fatalf("ip_addresses = %#v, want [10.0.0.8]", metadata["ip_addresses"])
+	}
+}
+
 func TestLogClaimEndpointSlowIncludesPayloadFields(t *testing.T) {
 	var logs bytes.Buffer
 	prev := slog.Default()


### PR DESCRIPTION
## Summary
- collect non-loopback daemon IP addresses during runtime registration and store them in runtime metadata
- normalize registered IP metadata on the server without a schema migration
- show runtime IP information in the machine list, machine detail header, runtime rows, and runtime detail facts

Closes #4491

## Tests
- `go test ./internal/daemon ./internal/handler`
- `pnpm --filter @multica/views test`
- `pnpm --filter @multica/views typecheck`