### PR TITLE
MUL-3617: document Hermes profile custom args

### DIFF
--- a/apps/docs/content/docs/agents-create.ja.mdx
+++ b/apps/docs/content/docs/agents-create.ja.mdx
@@ -85,6 +85,14 @@ claude --model <model> --max-turns 100 --append-system-prompt "always respond in
 
 引数はシェルを介さずそのまま渡されるため（注入リスクなし）、特定のフラグが認識されるかどうかは AI コーディングツール自体に依存します。この部分はツールによって大きな差があります。
 
+Hermes profile を指定する場合は、profile フラグと profile 名を 2 つの独立した引数として追加します。たとえば `research` という Hermes profile で起動する場合:
+
+```json
+["-p", "research"]
+```
+
+`"-p research"` のように 1 つの文字列へまとめないでください。Multica は配列の各要素を 1 つの argv エントリとしてツールへ渡します。
+
 <Callout type="tip">
 `custom_env` と `custom_args` には厳格な上限はありませんが、実際には**それぞれ 10 個以内に抑えてください**。多すぎるとコマンドラインが長くなり、起動が遅くなり、メンテナンスも難しくなります。
 </Callout>

--- a/apps/docs/content/docs/agents-create.ko.mdx
+++ b/apps/docs/content/docs/agents-create.ko.mdx
@@ -85,6 +85,14 @@ claude --model <model> --max-turns 100 --append-system-prompt "always respond in
 
 인자는 셸을 거치지 않고 있는 그대로 전달되므로(주입 위험 없음), 특정 플래그가 인식되는지 여부는 AI 코딩 도구 자체에 달려 있습니다. 이 부분은 도구마다 상당한 차이가 있습니다.
 
+Hermes profile을 지정하려면 profile 플래그와 profile 이름을 두 개의 독립된 인자로 추가하세요. 예를 들어 `research`라는 Hermes profile로 실행하려면:
+
+```json
+["-p", "research"]
+```
+
+`"-p research"`처럼 하나의 문자열로 합치지 마세요. Multica는 배열의 각 항목을 하나의 argv 항목으로 도구에 전달합니다.
+
 <Callout type="tip">
 `custom_env`와 `custom_args`에는 엄격한 상한이 없지만, 실제로는 **각각 10개 이내로 유지하세요**. 너무 많으면 명령줄이 길어지고 시작이 느려지며 유지 관리도 어려워집니다.
 </Callout>

--- a/apps/docs/content/docs/agents-create.mdx
+++ b/apps/docs/content/docs/agents-create.mdx
@@ -85,6 +85,16 @@ claude --model <model> --max-turns 100 --append-system-prompt "always respond in
 
 Arguments are passed as-is, not through a shell (no injection risk), but whether a given flag is recognized is up to the AI coding tool itself — tools differ substantially here.
 
+For Hermes profiles, add the profile flag and profile name as two separate
+arguments. For example, to launch Hermes with a profile named `research`:
+
+```json
+["-p", "research"]
+```
+
+Do not combine them into one string like `"-p research"`; Multica passes each
+array item as one argv entry.
+
 <Callout type="tip">
 `custom_env` and `custom_args` have no hard caps, but in practice **keep each under 10 entries**. Too many makes the command line long, slows startup, and gets harder to maintain.
 </Callout>

--- a/apps/docs/content/docs/agents-create.zh.mdx
+++ b/apps/docs/content/docs/agents-create.zh.mdx
@@ -85,6 +85,14 @@ claude --model <model> --max-turns 100 --append-system-prompt "always respond in
 
 参数按原样传，不走 shell 解析（没有注入风险），但传什么 flag 能不能被识别看 AI 编程工具本身——不同工具差异很大。
 
+如果要让 Hermes 使用指定 profile，把 profile flag 和 profile 名写成两个独立参数。例如使用名为 `research` 的 Hermes profile：
+
+```json
+["-p", "research"]
+```
+
+不要合成一个字符串 `"-p research"`；Multica 会把数组里的每一项作为一个独立 argv 参数传给工具。
+
 <Callout type="tip">
 `custom_env` 和 `custom_args` 没有硬限制，但**实际使用建议控制在 10 条以内**。太多会让命令行变长、启动变慢，也更难维护。
 </Callout>


### PR DESCRIPTION
## Summary

- Document the Hermes profile workaround in the agent `custom_args` docs.
- Clarify that `-p` and the profile name must be entered as separate argv entries.
- Keep the guidance synchronized across English, Chinese, Japanese, and Korean docs.

## Related GitHub issues reviewed

- #2577 tracks the broader request for per-Agent Hermes profile selection/profile discovery.
- #3847 covered a related Hermes profile pipeline experiment and is closed.

## Verification

- `git diff --check`
- `pnpm --filter @multica/docs typecheck` could not run because this checkout has no `node_modules`; `fumadocs-mdx` was missing before TypeScript started.

MUL-3617
