### PR TITLE
fix(daemon): discover models via the runtime profile's own command

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2291,6 +2291,25 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 	}
 }
 
+// modelDiscoveryExecutable resolves the binary to probe for a runtime's model
+// catalog. A custom runtime profile (e.g. a `pi` fork registered with a
+// different command_name) must be discovered through its own resolved command —
+// the same one task execution launches — not the family-default
+// Agents[provider] entry, which may expose a different catalog or not be
+// installed on this host at all (#4482). Built-in runtimes, and custom profiles
+// whose command was never resolved on this host, fall back to the family-default
+// agent path. Returns ok=false when neither resolves, so handleModelList can
+// report the existing "no agent configured" failure.
+func (d *Daemon) modelDiscoveryExecutable(rt Runtime) (string, bool) {
+	if spec, ok := d.customProfileLaunchForRuntime(rt.ID); ok {
+		return spec.path, true
+	}
+	if entry, ok := d.cfg.Agents[rt.Provider]; ok {
+		return entry.Path, true
+	}
+	return "", false
+}
+
 // handleModelList resolves the provider's supported models (via static
 // catalog or by shelling out to the agent CLI) and reports the result
 // back to the server. Model discovery failures are reported as empty
@@ -2299,7 +2318,7 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID string) {
 	d.logger.Info("model list requested", "runtime_id", rt.ID, "request_id", requestID, "provider", rt.Provider)
 
-	entry, ok := d.cfg.Agents[rt.Provider]
+	executablePath, ok := d.modelDiscoveryExecutable(rt)
 	if !ok {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
@@ -2310,7 +2329,7 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
 	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
-	models, err := agent.ListModels(ctx, rt.Provider, entry.Path)
+	models, err := agent.ListModels(ctx, rt.Provider, executablePath)
 	if err != nil {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2318,7 +2318,7 @@ func (d *Daemon) modelDiscoveryExecutable(rt Runtime) (string, bool) {
 func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID string) {
 	d.logger.Info("model list requested", "runtime_id", rt.ID, "request_id", requestID, "provider", rt.Provider)
 
-	executablePath, ok := d.modelDiscoveryExecutable(rt)
+	entry, ok := d.cfg.Agents[rt.Provider]
 	if !ok {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
@@ -2326,8 +2326,14 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 		})
 		return
 	}
-	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
-	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
+	executablePath := entry.Path
+	if spec, ok := d.customProfileLaunchForRuntime(rt.ID); ok {
+		executablePath = spec.path
+	} else {
+		// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
+		entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
+		executablePath = entry.Path
+	}
 
 	models, err := agent.ListModels(ctx, rt.Provider, executablePath)
 	if err != nil {

--- a/server/internal/daemon/model_discovery_executable_test.go
+++ b/server/internal/daemon/model_discovery_executable_test.go
@@ -1,0 +1,40 @@
+package daemon
+
+import "testing"
+
+// TestModelDiscoveryExecutable verifies model discovery resolves the binary the
+// same way task execution does: a custom runtime profile (e.g. a `pi` fork
+// registered with a different command_name) is probed through its own resolved
+// command, not the family-default Agents[provider] entry — which may expose a
+// different catalog or not be installed on this host at all. Built-in runtimes
+// keep using the family-default agent path. See GitHub #4482.
+func TestModelDiscoveryExecutable(t *testing.T) {
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{"pi": {Path: "/usr/bin/pi"}}
+	d.profileLaunchSpecs = map[string]profileLaunchSpec{
+		"prof-omp": {path: "/opt/bin/omp"},
+	}
+	d.runtimeIndex["rt-omp"] = Runtime{ID: "rt-omp", Provider: "pi", ProfileID: "prof-omp"}
+	d.runtimeIndex["rt-builtin"] = Runtime{ID: "rt-builtin", Provider: "pi"}
+	d.runtimeIndex["rt-unresolved"] = Runtime{ID: "rt-unresolved", Provider: "pi", ProfileID: "prof-missing"}
+	d.runtimeIndex["rt-none"] = Runtime{ID: "rt-none", Provider: "unknown"}
+
+	// Custom profile -> its own resolved command, not the family-default pi.
+	if path, ok := d.modelDiscoveryExecutable(d.runtimeIndex["rt-omp"]); !ok || path != "/opt/bin/omp" {
+		t.Errorf("custom profile: got (%q, %v), want (/opt/bin/omp, true)", path, ok)
+	}
+	// Built-in runtime -> family-default agent path.
+	if path, ok := d.modelDiscoveryExecutable(d.runtimeIndex["rt-builtin"]); !ok || path != "/usr/bin/pi" {
+		t.Errorf("built-in: got (%q, %v), want (/usr/bin/pi, true)", path, ok)
+	}
+	// Custom profile whose command was never resolved on this host -> fall back
+	// to the family-default agent path rather than reporting unresolvable.
+	if path, ok := d.modelDiscoveryExecutable(d.runtimeIndex["rt-unresolved"]); !ok || path != "/usr/bin/pi" {
+		t.Errorf("unresolved profile: got (%q, %v), want (/usr/bin/pi, true)", path, ok)
+	}
+	// No profile and no configured agent for the family -> not resolvable, so
+	// handleModelList reports the existing "no agent configured" failure.
+	if path, ok := d.modelDiscoveryExecutable(d.runtimeIndex["rt-none"]); ok || path != "" {
+		t.Errorf("unknown provider: got (%q, %v), want empty false", path, ok)
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -785,14 +785,35 @@ func parsePiModels(output string) []Model {
 // pattern message is also matched on its own. These are prose, not
 // `provider model` rows; without skipping them the field splitter coins bogus
 // models like `No/models`. See #3729.
+//
+// A pi fork that lacks `--list-models` (e.g. oh-my-pi moved listing to the
+// `omp models` subcommand) instead exits non-zero with CLI usage text:
+//
+//	Error: unknown flag: --list-models
+//	Run `omp --help` for available flags.
+//
+// The first line is caught by the error: prefix; the second is a usage hint
+// that would otherwise be coined into a `Run/...` model. A real catalog row
+// never contains a backtick-quoted command, a `--help`/`--flag` token, or a
+// `usage:`/`unknown flag` lead-in, so those shapes are filtered too. See #4482.
 func isPiDiscoveryNoise(line string) bool {
 	lower := strings.ToLower(line)
-	if strings.Contains(lower, "no models match pattern") {
+	switch {
+	case strings.Contains(lower, "no models match pattern"):
 		return true
+	case strings.HasPrefix(lower, "warning:"),
+		strings.HasPrefix(lower, "error:"),
+		strings.HasPrefix(lower, "info:"):
+		return true
+	case strings.HasPrefix(lower, "usage:"),
+		strings.Contains(lower, "unknown flag"),
+		strings.Contains(lower, "unknown command"),
+		strings.Contains(lower, "--help"),
+		strings.Contains(line, "`"):
+		return true
+	default:
+		return false
 	}
-	return strings.HasPrefix(lower, "warning:") ||
-		strings.HasPrefix(lower, "error:") ||
-		strings.HasPrefix(lower, "info:")
 }
 
 // discoverHermesModels spins up a throwaway `hermes acp` process,

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -684,6 +684,45 @@ func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
 	}
 }
 
+// TestParsePiModelsSkipsForkUsageHints verifies that the CLI usage/diagnostic
+// text a pi fork prints when it does not understand `--list-models` (e.g.
+// oh-my-pi moved listing to the `omp models` subcommand) is not coined into
+// bogus models. The error line is caught by the existing error: prefix, but the
+// usage hint ("Run `omp --help` for available flags.") slipped past the filter
+// and produced a `Run/...` entry. See GitHub #4482.
+func TestParsePiModelsSkipsForkUsageHints(t *testing.T) {
+	input := "Error: unknown flag: --list-models\n" +
+		"Run `omp --help` for available flags.\n"
+	if models := parsePiModels(input); len(models) != 0 {
+		t.Fatalf("expected no models from a fork's usage text, got %+v", models)
+	}
+}
+
+// TestDiscoverPiModelsUnsupportedFlagReturnsEmpty verifies that a pi-family fork
+// whose binary does not support `--list-models` (exits non-zero with only error
+// and usage text, no catalog) yields an empty list rather than models coined
+// from the diagnostic prose. This must hold without regressing the #3729 path
+// where a non-zero exit still carries a real catalog on stderr. See #4482.
+func TestDiscoverPiModelsUnsupportedFlagReturnsEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake pi binary is a /bin/sh script")
+	}
+	script := "#!/bin/sh\n" +
+		"echo 'Error: unknown flag: --list-models' >&2\n" +
+		"echo 'Run `omp --help` for available flags.' >&2\n" +
+		"exit 1\n"
+	fakePath := filepath.Join(t.TempDir(), "omp")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	models, err := discoverPiModels(context.Background(), fakePath)
+	if err != nil {
+		t.Fatalf("discoverPiModels: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected an empty catalog for a fork lacking --list-models, got %+v", models)
+	}
+}
+
 // TestDiscoverOpenCodeModelsFallsBackOnVerboseNoise verifies that a non-zero
 // `opencode models --verbose` whose stdout is unparseable noise still falls
 // back to the plain `opencode models` command instead of returning empty. The


### PR DESCRIPTION
Fixes #4482

## Summary
A custom runtime profile in the **pi protocol family** whose `command_name` differs from the family default — e.g. an oh-my-pi `omp` fork registered with `--protocol-family pi --command-name omp` — showed an **empty model selector**, or one populated with fragments coined from CLI **error text**, even though task *execution* for the same runtime worked. Two distinct causes, both in the daemon's discovery path:

- **Discovery ignored the profile's command.** `handleModelList` resolved the binary from the shared `Agents[rt.Provider]` entry (the family default `pi`), never consulting the profile's resolved command — even though task execution does. A new `(*Daemon).modelDiscoveryExecutable` resolves the executable the same way execution does (via `customProfileLaunchForRuntime`), falling back to the family-default agent path. So a host with only the fork installed now discovers models, and a host with neither still reports the existing `no agent configured for provider` failure.

- **Error text was parsed into bogus models.** A fork that lacks `--list-models` exits non-zero printing usage text (`Run \`omp --help\` for available flags.`), which `discoverPiModels` coined into a `Run/...` entry. `isPiDiscoveryNoise` now also filters CLI usage/error hints (backtick-quoted commands, `--help`, `usage:`, `unknown flag`/`unknown command`), so the picker comes back **empty** (UI falls back to manual entry) instead of garbage.

I deliberately did **not** gate the stderr fallback on the exit code as the issue suggested: the existing #3729 behavior relies on parsing a *real* catalog from stderr on a non-zero exit (older pi prints the catalog to stderr and exits non-zero on stale-pattern warnings). Strengthening the noise filter fixes #4482 without regressing that path.

The environment-specific cold-cache timeout (the issue's "Bonus", lower priority) is intentionally out of scope.

## Tests
- `go test ./internal/daemon/ -run TestModelDiscoveryExecutable` — new: custom profile → its own command; built-in → family default; unresolved profile → family-default fallback; unknown provider → not resolvable.
- `go test ./pkg/agent/ -run 'TestParsePiModels|TestDiscoverPiModels'` — new `TestParsePiModelsSkipsForkUsageHints` and `TestDiscoverPiModelsUnsupportedFlagReturnsEmpty`; the existing `TestDiscoverPiModelsNonZeroExit` (#3729, catalog-on-stderr with non-zero exit) still passes — no regression.
- `gofmt`, `go vet ./pkg/agent/ ./internal/daemon/`, `go build ./...` — clean.
- Note: two timing-sensitive `TestCodexExecute*` tests (72ms/100ms progress timeouts) flake under load on this machine independent of these changes, which touch only pi model discovery and daemon binary resolution.