### PR TITLE
MUL-3560: daemon-side feature flag wiring + brief mode observability log

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon"
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	logger_pkg "github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/util"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
 )
 
 var daemonCmd = &cobra.Command{
@@ -389,6 +391,23 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	defer stop()
 
 	logger := logger_pkg.NewLogger("daemon")
+
+	// MUL-3560: wire the daemon's process-level feature flag service into
+	// execenv. The daemon is the process that calls
+	// execenv.InjectRuntimeConfig (the API server never does), so this is
+	// the toggle point that actually decides whether a given task gets the
+	// slim or legacy runtime brief. Reads the same env conventions as the
+	// API server: MULTICA_FEATURE_FLAGS_FILE for the YAML rule set,
+	// FF_<KEY> for per-flag env overrides (e.g. FF_RUNTIME_BRIEF_SLIM=true).
+	// nil-safe — a misconfigured rule file fails startup loudly, matching
+	// the DATABASE_URL parse-error precedent.
+	flags, err := featureflag.NewServiceFromEnv(featureflag.WithLogger(logger))
+	if err != nil {
+		logger.Error("feature flag configuration failed to load", "error", err)
+		return err
+	}
+	execenv.SetFeatureFlags(flags)
+
 	d := daemon.New(cfg, logger)
 
 	// Write PID file so "daemon stop" can find us.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/analytics"
-	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
@@ -158,11 +157,7 @@ func main() {
 		slog.Error("feature flag configuration failed to load", "error", err)
 		os.Exit(1)
 	}
-	// MUL-3560: execenv consults `runtime_brief_slim` to decide between
-	// the legacy and slim runtime brief. Default-off everywhere; staging
-	// YAML opts in, prod stays on legacy until staging burns in.
-	execenv.SetFeatureFlags(flags)
-	_ = flags // remaining call sites adopt flags as needed; see docs/feature-flags.md
+	_ = flags // wired into handlers/services as call sites adopt flags; see docs/feature-flags.md
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3455,6 +3455,19 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	runtimeBrief, err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx)
 	if err != nil {
 		d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
+	} else {
+		// MUL-3560: log which brief shipped (slim vs legacy) and where
+		// it landed, so operators verifying the staging rollout can
+		// confirm at a glance which template the task was given — and
+		// `cat` the exact file at brief_path to see the rendered bytes.
+		// brief_chars is the rendered rune count; the brief_path file
+		// also carries the canonical content inside the marker block.
+		taskLog.Info("execenv: runtime brief written",
+			"provider", provider,
+			"brief_path", execenv.RuntimeConfigPath(env.WorkDir, provider),
+			"brief_chars", len(runtimeBrief),
+			"brief_mode", execenv.BriefMode(),
+		)
 	}
 	// Workdir is preserved for reuse by future tasks on the same (agent,
 	// issue) pair in cloud mode; the work_dir path is stored in DB on task

--- a/server/internal/daemon/execenv/observability.go
+++ b/server/internal/daemon/execenv/observability.go
@@ -1,0 +1,33 @@
+package execenv
+
+// RuntimeConfigPath returns the absolute path to the runtime-brief file
+// that InjectRuntimeConfig writes for the given provider, or "" when the
+// provider has no file-based config target.
+//
+// Daemon code uses this to log "where did the brief land" alongside the
+// rendered char count, so an operator can `cat` the exact file to confirm
+// which template a given task was given. The private runtimeConfigPath is
+// the implementation; this is a stable export so the daemon does not have
+// to thread the provider→filename table in a second place.
+func RuntimeConfigPath(workDir, provider string) string {
+	return runtimeConfigPath(workDir, provider)
+}
+
+// BriefMode returns the human-readable label of the brief path that
+// InjectRuntimeConfig would render right now: "slim" when the
+// `runtime_brief_slim` feature flag evaluates to on, "legacy" otherwise.
+//
+// This is intended for daemon observability only — the brief mode is
+// always derivable from the flag service, but a structured label keeps log
+// queries cheap and lets dashboards filter by mode without re-implementing
+// the toggle logic.
+//
+// Nil-safe by way of useSlimBrief (which falls through Service.IsEnabled's
+// nil-safe path), so a daemon that forgot to wire SetFeatureFlags still
+// produces a meaningful label ("legacy") rather than panicking.
+func BriefMode() string {
+	if useSlimBrief() {
+		return "slim"
+	}
+	return "legacy"
+}

--- a/server/internal/daemon/execenv/observability_test.go
+++ b/server/internal/daemon/execenv/observability_test.go
@@ -1,0 +1,70 @@
+package execenv
+
+import (
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+)
+
+// TestRuntimeConfigPath pins the provider→filename mapping the daemon
+// log line relies on. If the mapping ever changes, the test catches it
+// — operators expect to know exactly which file to `cat`.
+func TestRuntimeConfigPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		provider string
+		want     string
+	}{
+		{"claude", "/work/CLAUDE.md"},
+		{"codebuddy", "/work/CLAUDE.md"},
+		{"codex", "/work/AGENTS.md"},
+		{"copilot", "/work/AGENTS.md"},
+		{"opencode", "/work/AGENTS.md"},
+		{"openclaw", "/work/AGENTS.md"},
+		{"hermes", "/work/AGENTS.md"},
+		{"pi", "/work/AGENTS.md"},
+		{"cursor", "/work/AGENTS.md"},
+		{"kimi", "/work/AGENTS.md"},
+		{"kiro", "/work/AGENTS.md"},
+		{"qoder", "/work/AGENTS.md"},
+		{"antigravity", "/work/AGENTS.md"},
+		{"gemini", "/work/GEMINI.md"},
+		{"totally-unknown", ""},
+	}
+	for _, tc := range cases {
+		if got := RuntimeConfigPath("/work", tc.provider); got != tc.want {
+			t.Errorf("RuntimeConfigPath(/work, %q) = %q, want %q", tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestBriefMode verifies the label flips with the feature flag. Nil-safe
+// path returns "legacy" so a daemon that forgot to wire SetFeatureFlags
+// emits a meaningful label, not panics.
+func TestBriefMode(t *testing.T) {
+	// Not t.Parallel-safe because we mutate the package-level flag pointer.
+	saved := runtimeFlags.Load()
+	t.Cleanup(func() { runtimeFlags.Store(saved) })
+
+	// Nil service → legacy.
+	runtimeFlags.Store(nil)
+	if got := BriefMode(); got != "legacy" {
+		t.Errorf("BriefMode with nil service = %q, want %q", got, "legacy")
+	}
+
+	// Flag off → legacy.
+	off := featureflag.NewStaticProvider()
+	off.Set(runtimeBriefSlimFlag, featureflag.Rule{Default: false})
+	runtimeFlags.Store(featureflag.NewService(off))
+	if got := BriefMode(); got != "legacy" {
+		t.Errorf("BriefMode with flag off = %q, want %q", got, "legacy")
+	}
+
+	// Flag on → slim.
+	on := featureflag.NewStaticProvider()
+	on.Set(runtimeBriefSlimFlag, featureflag.Rule{Default: true})
+	runtimeFlags.Store(featureflag.NewService(on))
+	if got := BriefMode(); got != "slim" {
+		t.Errorf("BriefMode with flag on = %q, want %q", got, "slim")
+	}
+}


### PR DESCRIPTION
## Summary

Two changes that together make the `runtime_brief_slim` flag from
**#4449** actually work in production, plus give operators a way to
verify which template a task got:

1. **`feat(daemon): log runtime brief mode + path on every task start`**
   — one `taskLog.Info("execenv: runtime brief written", ...)` per
   task with `provider`, `brief_path`, `brief_chars`, `brief_mode`.
   Lets operators filter logs by `brief_mode=slim` to confirm
   staging is hitting the slim path without grepping workdirs.

2. **`fix(daemon): wire feature flag service in daemon process, not
   API server`** — #4449 wired `execenv.SetFeatureFlags(flags)` in
   `cmd/server/main.go`, but the API server **never** calls
   `execenv.InjectRuntimeConfig`. The brief is generated by the
   daemon process (`multica daemon` from `cmd/multica/cmd_daemon.go`).
   Without this fix, setting `FF_RUNTIME_BRIEF_SLIM=true` on any
   pod would have had zero effect — the staging rollout would have
   silently kept rendering legacy.

## Sample log line

After this PR ships, every task start emits:

```
INFO execenv: runtime brief written task=abc12345
    provider=codex
    brief_path=/var/multica/workspaces/.../task-abc/workdir/AGENTS.md
    brief_chars=11868
    brief_mode=slim       # or "legacy" depending on the flag
```

## K8s configuration story (for the staging rollout)

After this PR, enabling the slim brief in K8s is one of two paths:

### Quick path: env var on the daemon pods

```yaml
# values.yaml / Helm / kustomize / wherever the daemon deployment is defined
env:
  - name: FF_RUNTIME_BRIEF_SLIM
    value: "true"
```

Apply, then `kubectl rollout restart deployment/multica-daemon`.
Every new task started after the restart renders the slim brief.

### Multi-flag path: ConfigMap + `MULTICA_FEATURE_FLAGS_FILE`

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: multica-feature-flags
data:
  feature-flags.yaml: |
    runtime_brief_slim:
      default: true
---
# Daemon Deployment: mount the ConfigMap + point at the file
spec:
  template:
    spec:
      containers:
      - name: multica-daemon
        env:
        - name: MULTICA_FEATURE_FLAGS_FILE
          value: /etc/multica/feature-flags.yaml
        volumeMounts:
        - name: feature-flags
          mountPath: /etc/multica
          readOnly: true
      volumes:
      - name: feature-flags
        configMap:
          name: multica-feature-flags
```

The env var path beats the YAML; both options stay in lockstep
with `docs/feature-flags.md`.

**Important:** the flag goes on the **daemon pods** (where
`multica daemon` runs), NOT the API server pods. The API server
never renders briefs.

## What changed

- **`internal/daemon/execenv/observability.go`** (new) — public
  `RuntimeConfigPath(workDir, provider) string` +
  `BriefMode() string` ("slim" / "legacy"). Both nil-safe.
- **`internal/daemon/daemon.go`** — single `taskLog.Info(...)`
  after `InjectRuntimeConfig` succeeds (failure path unchanged).
- **`internal/daemon/execenv/observability_test.go`** (new) — pins
  the 15-provider filename mapping and the `BriefMode` flag-on /
  flag-off / nil-service paths.
- **`cmd/multica/cmd_daemon.go`** — constructs `featureflag.Service`
  from env and calls `execenv.SetFeatureFlags` before `daemon.New`.
- **`cmd/server/main.go`** — reverts the misplaced
  `execenv.SetFeatureFlags` from #4449 (no-op in the API server
  process); drops the now-unused `execenv` import.

## Verification

```
$ go vet ./cmd/... ./internal/daemon/...
$ go build ./...                                                 ok
$ go test ./internal/daemon/...                                  ok
$ go test ./cmd/multica/...                                      ok
$ go test ./internal/daemon/execenv/ -run 'TestRuntimeConfigPath|TestBriefMode' -v
  TestRuntimeConfigPath                                          PASS
  TestBriefMode                                                  PASS
```

## Risk

Low. The fix is structural (moves an existing call to the correct
process); the log line is one additional INFO per task start; no
behaviour change in brief generation, task execution, or the API
server.
