### PR TITLE
MUL-3599: allow same-origin attachment previews

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -34,6 +34,14 @@ const maxUploadSize = 100 << 20 // 100 MB
 
 const defaultAttachmentDownloadURLTTL = 30 * time.Minute
 
+const attachmentPreviewCSPHeader = "default-src 'none'; " +
+	"img-src 'self' data:; " +
+	"media-src 'self'; " +
+	"frame-ancestors 'self'; " +
+	"object-src 'none'; " +
+	"base-uri 'none'; " +
+	"form-action 'none'"
+
 type attachmentDownloadMode string
 
 const (
@@ -145,17 +153,17 @@ func attachmentDownloadPath(id string) string {
 //
 //  1. Persist `a.Url` only when the deployment has signaled the storage
 //     backend serves URLs publicly without per-request auth:
-//       - `Storage.CdnDomain()` is non-empty (operator configured a
-//         public-facing base URL — `S3_CDN_DOMAIN` for the S3 backend or
-//         `LOCAL_UPLOAD_BASE_URL` for LocalStorage), AND
-//       - `h.CFSigner` is nil (no per-request CloudFront signing — when
-//         signing is on, the same CDN domain serves PRIVATE content via
-//         time-bounded signed URLs and the raw `a.Url` is unauth-deny),
-//         AND
-//       - `a.Url` is itself an absolute http(s) URL with no signature
-//         query — defends against legacy rows backfilled while baseURL
-//         was unset, and against a freshly-signed `download_url` ever
-//         leaking into `a.Url` (the original MUL-3130 bug).
+//     - `Storage.CdnDomain()` is non-empty (operator configured a
+//     public-facing base URL — `S3_CDN_DOMAIN` for the S3 backend or
+//     `LOCAL_UPLOAD_BASE_URL` for LocalStorage), AND
+//     - `h.CFSigner` is nil (no per-request CloudFront signing — when
+//     signing is on, the same CDN domain serves PRIVATE content via
+//     time-bounded signed URLs and the raw `a.Url` is unauth-deny),
+//     AND
+//     - `a.Url` is itself an absolute http(s) URL with no signature
+//     query — defends against legacy rows backfilled while baseURL
+//     was unset, and against a freshly-signed `download_url` ever
+//     leaking into `a.Url` (the original MUL-3130 bug).
 //
 //  2. Every other shape — CloudFront-signed mode, S3 presign /proxy
 //     against a private bucket without a CDN domain, raw S3 / R2 /
@@ -740,9 +748,17 @@ func (h *Handler) proxyAttachmentDownload(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Disposition", storage.ContentDisposition(att.ContentType, att.Filename))
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setAttachmentPreviewSecurityHeaders(w)
 	if _, err := io.Copy(w, reader); err != nil {
 		slog.Error("failed to stream attachment download", "id", uuidToString(att.ID), "error", err)
 	}
+}
+
+func setAttachmentPreviewSecurityHeaders(w http.ResponseWriter) {
+	// Attachment preview responses may be loaded in same-origin iframes
+	// (for example PDF previews) but must remain unembeddable by third-party
+	// sites. This intentionally overrides the app-wide frame-ancestors 'none'.
+	w.Header().Set("Content-Security-Policy", attachmentPreviewCSPHeader)
 }
 
 // ---------------------------------------------------------------------------
@@ -810,6 +826,7 @@ func (h *Handler) GetAttachmentContent(w http.ResponseWriter, r *http.Request) {
 	// when a user explicitly opens a preview.
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	setAttachmentPreviewSecurityHeaders(w)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
 	if _, err := w.Write(body); err != nil {
 		slog.Error("failed to write attachment preview body", "id", attachmentID, "error", err)

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -442,6 +442,28 @@ func newDownloadRequest(t *testing.T, attachmentID, workspaceID string) (*http.R
 	return req, httptest.NewRecorder()
 }
 
+func requireAttachmentPreviewCSP(t *testing.T, header http.Header) {
+	t.Helper()
+	csp := header.Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header is missing")
+	}
+	for _, directive := range []string{
+		"default-src 'none'",
+		"frame-ancestors 'self'",
+		"object-src 'none'",
+		"base-uri 'none'",
+		"form-action 'none'",
+	} {
+		if !strings.Contains(csp, directive) {
+			t.Fatalf("Content-Security-Policy missing %q; got %q", directive, csp)
+		}
+	}
+	if strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Fatalf("Content-Security-Policy still blocks same-origin previews: %q", csp)
+	}
+}
+
 func newDownloadRouter() http.Handler {
 	// Mirrors the production router after MUL-3130: the download
 	// route is registered under Auth-only with no
@@ -697,6 +719,7 @@ func TestDownloadAttachment_AutoInternalEndpointProxies(t *testing.T) {
 	id := seedAttachmentURL(t, "http://rustfs:9000/test-bucket/"+key, "report.txt", "text/plain", int64(len(body)))
 
 	req, w := newDownloadRequest(t, id, testWorkspaceID)
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
 	if w.Code != http.StatusOK {
@@ -717,6 +740,7 @@ func TestDownloadAttachment_AutoInternalEndpointProxies(t *testing.T) {
 	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
 	}
+	requireAttachmentPreviewCSP(t, w.Header())
 	if len(store.presignCalls) != 0 {
 		t.Fatalf("internal endpoint should not presign, calls=%v", store.presignCalls)
 	}
@@ -795,6 +819,7 @@ func TestDownloadAttachment_ExplicitProxyStreamsPublicEndpoint(t *testing.T) {
 	if got := w.Header().Get("Content-Disposition"); got != `inline; filename="image.png"` {
 		t.Fatalf("Content-Disposition = %q", got)
 	}
+	requireAttachmentPreviewCSP(t, w.Header())
 	if len(store.presignCalls) != 0 {
 		t.Fatalf("forced proxy should not presign, calls=%v", store.presignCalls)
 	}
@@ -833,6 +858,7 @@ func TestGetAttachmentContent_HappyPath_Markdown(t *testing.T) {
 	id := seedPreviewAttachment(t, store, "preview-md-key.md", "preview.md", "text/markdown", body)
 
 	req, w := newPreviewRequest(t, id, testWorkspaceID)
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.GetAttachmentContent(w, req)
 
 	if w.Code != http.StatusOK {
@@ -850,6 +876,7 @@ func TestGetAttachmentContent_HappyPath_Markdown(t *testing.T) {
 	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
 	}
+	requireAttachmentPreviewCSP(t, w.Header())
 }
 
 // Even when http.DetectContentType returned "text/plain" instead of "text/markdown"


### PR DESCRIPTION
Summary:
- Override CSP on attachment proxy preview responses so same-origin issue previews can frame attachments.
- Keep the app-wide CSP at frame-ancestors 'none' for normal pages.
- Add regression coverage for proxy download and text content preview headers.

Closes #4477

Tests:
- go test ./internal/handler -run 'TestDownloadAttachment_(AutoInternalEndpointProxies|ExplicitProxyStreamsPublicEndpoint)$|TestGetAttachmentContent_HappyPath_Markdown$'
- go test ./internal/handler ./internal/middleware (middleware passed; handler package is blocked by stale local DB schema missing columns such as handoff_note, planned_at, prepare_lease_expires_at)
