### PR TITLE
MUL-3635: fix: 修复agent并发领取任务超过max_concurrent_tasks上限竞态问题

### DIFF
--- a/docs/fix-reports/issue-4483-concurrent-claim.md
+++ b/docs/fix-reports/issue-4483-concurrent-claim.md
@@ -1,0 +1,73 @@
+# Issue #4483 修复分析报告
+
+## 问题概述
+
+并发任务 claim 请求可能突破 `agent.max_concurrent_tasks` 上限，导致同一 agent 同时运行超过配置允许数量的 active 任务。
+
+## 根因分析
+
+`TaskService.ClaimTask` 原先将 claim 流程拆成三次独立的数据库操作：
+
+1. `GetAgent` — 读取 agent 配置（含 `max_concurrent_tasks`）
+2. `CountRunningTasks` — 统计当前 active 任务数（`dispatched` / `running` / `waiting_local_directory`）
+3. `ClaimAgentTask` — 通过 `FOR UPDATE SKIP LOCKED` 领取下一条 queued 任务
+
+`ClaimAgentTask` 本身能防止**同一条 queue 行**被重复 claim，但**无法**在并发场景下保护 agent 级别的容量判断。两个并发请求可能同时观察到 `running = 0`（当 `max_concurrent_tasks = 1` 时），随后各自成功 claim 不同的 queued 任务，最终 active 任务数变为 2。
+
+这是典型的 **check-then-act 竞态**：容量检查与任务领取之间没有原子性保证。
+
+## 方案选择
+
+| 方案 | 描述 | 结论 |
+| --- | --- | --- |
+| A. 事务 + `SELECT ... FOR UPDATE` on agent | 在事务内锁定 agent 行，再 count + claim | 可行，但需 Go 层事务包装，增加往返 |
+| B. 单条 SQL 原子化 | 在 `ClaimAgentTask` 内用 CTE 锁定 agent 并内嵌容量检查 | **采用** — 与现有 sqlc 模式一致，单次 round-trip |
+| C. Advisory lock | 按 agent ID 使用 `pg_advisory_xact_lock` | 可行但不如 row lock 直观，且需额外 hash 约定 |
+
+**最终方案（B）**：扩展 `ClaimAgentTask` SQL：
+
+```sql
+WITH locked_agent AS (
+    SELECT id, max_concurrent_tasks FROM agent WHERE id = $1 FOR UPDATE
+)
+UPDATE agent_task_queue ...
+WHERE id = (
+    SELECT atq.id ...
+    CROSS JOIN locked_agent la
+    WHERE ... AND (active_count) < la.max_concurrent_tasks
+    ...
+)
+```
+
+- `locked_agent` CTE 在单条语句生命周期内对 agent 行加排他锁，串行化同一 agent 的所有 claim 请求
+- 容量检查与任务选取在同一 SQL 语句中完成，消除 TOCTOU 窗口
+- 保留原有 per-(issue, agent) 序列化逻辑与 `FOR UPDATE SKIP LOCKED` 行为
+
+Go 层 `ClaimTask` 移除独立的 `GetAgent` + `CountRunningTasks` 前置检查，直接调用增强后的 `ClaimAgentTask`。
+
+## 验证方式
+
+1. **单元/集成测试**：新增 `TestClaimTask_ConcurrentRespectsMaxConcurrentTasks`
+   - 创建 `max_concurrent_tasks = 1` 的 agent
+   - 为两个不同 issue 各入队一条 queued 任务（绕过 per-issue 序列化）
+   - 并发 8 个 goroutine 调用 `TaskService.ClaimTask`
+   - 断言：恰好 1 次 claim 成功，active 任务数 = 1
+
+2. **回归测试**：运行现有 claim 相关测试套件
+   ```bash
+   go test ./internal/handler/ -run 'ClaimTask' -count=1
+   make test
+   ```
+
+3. **手动复现（修复前）**：按 Issue 复现步骤，修复后应无法突破上限
+
+## 风险评估
+
+| 风险 | 影响 | 缓解措施 |
+| --- | --- | --- |
+| agent 行锁增加 claim 延迟 | 同一 agent 的高并发 claim 会串行等待 | claim 本身已是 per-agent 语义；锁仅在单条 SQL 语句内持有，范围可控 |
+| 死锁 | 与其他锁顺序冲突 | agent 锁 → task 行锁的单向顺序与现有 `FOR UPDATE SKIP LOCKED` 模式兼容；无交叉锁 agent 集合 |
+| `no_capacity` vs `no_tasks` 日志合并 | 调试粒度略降 | 合并为 `no_claim`；容量与空队列在业务上均返回 nil task |
+| sqlc 生成代码需同步 | CI 可能失败 | 修改 `agent.sql` 后运行 `make sqlc` |
+
+**总体风险：低。** 改动局部、行为与产品语义一致，且修复了明确的并发安全漏洞。

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -4420,4 +4421,94 @@ func TestClaimTaskByRuntime_CommentResumeDefaultOn(t *testing.T) {
 	if resp.Task.PriorSessionID != priorSession {
 		t.Errorf("prior_session_id = %q, want %q (comment resume is default-on)", resp.Task.PriorSessionID, priorSession)
 	}
+}
+
+// TestClaimTask_ConcurrentRespectsMaxConcurrentTasks is the regression test for
+// #4483: two concurrent claim requests for the same agent must not both succeed
+// when max_concurrent_tasks is 1.
+func TestClaimTask_ConcurrentRespectsMaxConcurrentTasks(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Concurrent claim runtime")
+	agentID, issueID1 := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Concurrent claim agent")
+
+	var issueID2 string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES (
+			$1, 'Concurrent claim issue 2', 'in_progress', 'none', $2, 'member',
+			(SELECT COALESCE(MAX(number), 82649) + 1 FROM issue WHERE workspace_id = $1),
+			0
+		)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID2); err != nil {
+		t.Fatalf("setup: create second issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID2) })
+
+	createQueuedClaimTaskForTest(t, ctx, agentID, runtimeID, issueID1)
+	createQueuedClaimTaskForTest(t, ctx, agentID, runtimeID, issueID2)
+
+	const contenders = 8
+	type claimResult struct {
+		task *db.AgentTaskQueue
+		err  error
+	}
+	results := make([]claimResult, contenders)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range contenders {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			task, err := testHandler.TaskService.ClaimTask(ctx, parseUUID(agentID))
+			results[i] = claimResult{task: task, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	claims := 0
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("contender %d: %v", i, r.err)
+		}
+		if r.task != nil {
+			claims++
+		}
+	}
+	if claims != 1 {
+		t.Fatalf("expected exactly 1 successful claim with max_concurrent_tasks=1, got %d", claims)
+	}
+
+	var active int64
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE agent_id = $1
+		  AND status IN ('dispatched', 'running', 'waiting_local_directory')
+	`, agentID).Scan(&active); err != nil {
+		t.Fatalf("count active tasks: %v", err)
+	}
+	if active != 1 {
+		t.Fatalf("active task count = %d, want 1", active)
+	}
+}
+
+func createQueuedClaimTaskForTest(t *testing.T, ctx context.Context, agentID, runtimeID, issueID string) {
+	t.Helper()
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create queued task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -953,39 +953,21 @@ func (s *TaskService) finalizeCancelledChatMessage(ctx context.Context, task db.
 }
 
 // ClaimTask atomically claims the next queued task for an agent,
-// respecting max_concurrent_tasks.
+// respecting max_concurrent_tasks. Capacity and per-(issue, agent)
+// serialization are enforced inside ClaimAgentTask's single SQL statement
+// (agent row lock + active count + task pick) so concurrent claim requests
+// cannot oversubscribe the agent (#4483).
 func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	start := time.Now()
 	var (
-		outcome                                                              = "unknown"
-		getAgentMs, countRunningMs, claimAgentMs, updateStatusMs, dispatchMs int64
+		outcome                                           = "unknown"
+		claimAgentMs, updateStatusMs, dispatchMs        int64
 	)
 	defer func() {
-		s.maybeLogClaimSlow(agentID, outcome, start, getAgentMs, countRunningMs, claimAgentMs, updateStatusMs, dispatchMs)
+		s.maybeLogClaimSlow(agentID, outcome, start, 0, 0, claimAgentMs, updateStatusMs, dispatchMs)
 	}()
 
-	t0 := start
-	agent, err := s.Queries.GetAgent(ctx, agentID)
-	getAgentMs = time.Since(t0).Milliseconds()
-	if err != nil {
-		outcome = "error_get_agent"
-		return nil, fmt.Errorf("agent not found: %w", err)
-	}
-
-	t0 = time.Now()
-	running, err := s.Queries.CountRunningTasks(ctx, agentID)
-	countRunningMs = time.Since(t0).Milliseconds()
-	if err != nil {
-		outcome = "error_count_running"
-		return nil, fmt.Errorf("count running tasks: %w", err)
-	}
-	if running >= int64(agent.MaxConcurrentTasks) {
-		slog.Debug("task claim: no capacity", "agent_id", util.UUIDToString(agentID), "running", running, "max", agent.MaxConcurrentTasks)
-		outcome = "no_capacity"
-		return nil, nil // No capacity
-	}
-
-	t0 = time.Now()
+	t0 := time.Now()
 	task, err := s.Queries.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
 		AgentID:          agentID,
 		PrepareLeaseSecs: prepareLeaseDuration.Seconds(),
@@ -993,9 +975,9 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 	claimAgentMs = time.Since(t0).Milliseconds()
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			slog.Debug("task claim: no tasks available", "agent_id", util.UUIDToString(agentID))
-			outcome = "no_tasks"
-			return nil, nil // No tasks available
+			slog.Debug("task claim: no claimable task", "agent_id", util.UUIDToString(agentID))
+			outcome = "no_claim"
+			return nil, nil // No capacity, no queued task, or agent missing
 		}
 		outcome = "error_claim"
 		return nil, fmt.Errorf("claim task: %w", err)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -533,13 +533,22 @@ func (q *Queries) CancelAgentTasksByTriggerComment(ctx context.Context, triggerC
 }
 
 const claimAgentTask = `-- name: ClaimAgentTask :one
+WITH locked_agent AS (
+    SELECT id, max_concurrent_tasks FROM agent WHERE id = $1 FOR UPDATE
+)
 UPDATE agent_task_queue
 SET status = 'dispatched',
     dispatched_at = now(),
     prepare_lease_expires_at = now() + make_interval(secs => $2::double precision)
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
-    WHERE atq.agent_id = $1 AND atq.status = 'queued'
+    CROSS JOIN locked_agent la
+    WHERE atq.agent_id = la.id AND atq.status = 'queued'
+      AND (
+          SELECT count(*) FROM agent_task_queue active
+          WHERE active.agent_id = atq.agent_id
+            AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+      ) < la.max_concurrent_tasks
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -569,15 +578,14 @@ type ClaimAgentTaskParams struct {
 	PrepareLeaseSecs float64     `json:"prepare_lease_secs"`
 }
 
-// Claims the next queued task for an agent, enforcing per-(issue, agent) serialization:
-// a task is only claimable when no other task for the same issue AND same agent is
-// already dispatched or running. This allows different agents to work on the same
-// issue in parallel while preventing a single agent from running duplicate tasks.
-// Chat tasks (issue_id IS NULL) use chat_session_id for serialization instead.
-// Quick-create tasks have no issue / chat / autopilot link, so they serialize on
-// "any other quick-create-shaped task" (all four FKs NULL) for the same agent —
-// otherwise a user mashing the create button could fire concurrent quick-creates
-// whose completion lookup would race over "most recent issue by this agent".
+// Claims the next queued task for an agent, atomically enforcing both
+// max_concurrent_tasks and per-(issue, agent) serialization.
+//
+// The locked_agent CTE takes a row lock on the agent so concurrent claim
+// requests for the same agent serialize the capacity check and task pick.
+// Without this, separate CountRunningTasks + ClaimAgentTask calls can both
+// observe spare capacity and dispatch more tasks than max_concurrent_tasks
+// allows (#4483).
 func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) (AgentTaskQueue, error) {
 	row := q.db.QueryRow(ctx, claimAgentTask, arg.AgentID, arg.PrepareLeaseSecs)
 	var i AgentTaskQueue

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -265,22 +265,41 @@ JOIN agent a ON a.id = atq.agent_id
 WHERE atq.id = $1 AND a.workspace_id = $2;
 
 -- name: ClaimAgentTask :one
--- Claims the next queued task for an agent, enforcing per-(issue, agent) serialization:
--- a task is only claimable when no other task for the same issue AND same agent is
--- already dispatched or running. This allows different agents to work on the same
--- issue in parallel while preventing a single agent from running duplicate tasks.
--- Chat tasks (issue_id IS NULL) use chat_session_id for serialization instead.
--- Quick-create tasks have no issue / chat / autopilot link, so they serialize on
--- "any other quick-create-shaped task" (all four FKs NULL) for the same agent —
--- otherwise a user mashing the create button could fire concurrent quick-creates
--- whose completion lookup would race over "most recent issue by this agent".
+-- Claims the next queued task for an agent, atomically enforcing both
+-- max_concurrent_tasks and per-(issue, agent) serialization.
+--
+-- The locked_agent CTE takes a row lock on the agent so concurrent claim
+-- requests for the same agent serialize the capacity check and task pick.
+-- Without this, separate CountRunningTasks + ClaimAgentTask calls can both
+-- observe spare capacity and dispatch more tasks than max_concurrent_tasks
+-- allows (#4483).
+--
+-- Per-(issue, agent) serialization: a task is only claimable when no other
+-- task for the same issue AND same agent is already dispatched or running.
+-- This allows different agents to work on the same issue in parallel while
+-- preventing a single agent from running duplicate tasks. Chat tasks
+-- (issue_id IS NULL) use chat_session_id for serialization instead.
+-- Quick-create tasks have no issue / chat / autopilot link, so they serialize
+-- on "any other quick-create-shaped task" (all four FKs NULL) for the same
+-- agent — otherwise a user mashing the create button could fire concurrent
+-- quick-creates whose completion lookup would race over "most recent issue
+-- by this agent".
+WITH locked_agent AS (
+    SELECT id, max_concurrent_tasks FROM agent WHERE id = $1 FOR UPDATE
+)
 UPDATE agent_task_queue
 SET status = 'dispatched',
     dispatched_at = now(),
     prepare_lease_expires_at = now() + make_interval(secs => @prepare_lease_secs::double precision)
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
-    WHERE atq.agent_id = $1 AND atq.status = 'queued'
+    CROSS JOIN locked_agent la
+    WHERE atq.agent_id = la.id AND atq.status = 'queued'
+      AND (
+          SELECT count(*) FROM agent_task_queue active
+          WHERE active.agent_id = atq.agent_id
+            AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+      ) < la.max_concurrent_tasks
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id


### PR DESCRIPTION
## Summary

Fixes #4483

- Atomically enforce `agent.max_concurrent_tasks` inside `ClaimAgentTask` by locking the agent row and checking active task count in a single SQL statement
- Remove the racy check-then-act split in `TaskService.ClaimTask` (`GetAgent` → `CountRunningTasks` → `ClaimAgentTask`)
- Add concurrent regression test `TestClaimTask_ConcurrentRespectsMaxConcurrentTasks`

## Root cause

Concurrent claim requests could both observe spare capacity before either dispatched a task, allowing more active tasks than `max_concurrent_tasks`.

## Test plan

- [ ] `go test ./internal/handler/ -run TestClaimTask_ConcurrentRespectsMaxConcurrentTasks -count=1`
- [ ] `go test ./internal/handler/ -run ClaimTask -count=1`
- [ ] `make sqlc` (regenerate if CI requires fresh generated code)
- [ ] `make test`