### PR TITLE
MUL-3618: dispatch daemon feature flag snapshots

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -59,6 +59,55 @@ if err != nil {
 
 The provider chain is `EnvProvider → YAML StaticProvider`. The server can boot with zero flag config — every `IsEnabled` call falls back to the caller's default until someone authors a rule.
 
+### Daemon-bound flags
+
+Daemon-bound flags are evaluated by the server and delivered to local daemons
+over the daemon heartbeat ack. This is for process-level daemon behavior where
+operators need one rollout and kill-switch path across cloud runtimes, Desktop
+embedded daemons, and user-run CLI daemons.
+
+Only flags listed in `server/internal/featureflagdispatch/registry.go` are sent
+to daemons. The registry is intentionally short:
+
+```go
+var DaemonBoundFlags = []string{
+    "runtime_brief_slim",
+}
+```
+
+On each HTTP or WebSocket heartbeat, the server evaluates every registered key
+with an `EvalContext` containing `workspace_id`, `runtime_id`, and `daemon_id`.
+The heartbeat ack carries a full snapshot:
+
+```json
+{
+  "feature_flags": {
+    "version": 1,
+    "flags": {
+      "runtime_brief_slim": "on"
+    }
+  }
+}
+```
+
+The daemon installs that snapshot into its process-level feature flag service.
+The daemon provider order is:
+
+1. `EnvProvider` (`FF_*`) for local emergency overrides.
+2. `ServerSnapshotProvider` from the latest heartbeat ack.
+3. local YAML `StaticProvider` as a fallback for old servers or self-hosted rescue.
+4. the toggle point's caller-supplied default.
+
+That means `FF_RUNTIME_BRIEF_SLIM=false` always suppresses a server snapshot
+that enables `runtime_brief_slim`. New daemons talking to old servers receive no
+`feature_flags` field and automatically fall back to local env/YAML behavior.
+Old daemons talking to new servers ignore the unknown JSON field.
+
+To add another daemon-bound process-level flag, add its key to the registry and
+use the existing daemon feature flag service at the toggle point. Do not add
+task payload fields or task-scoped readers for daemon-bound flags unless a
+separate design explicitly introduces task-scoped daemon flag evaluation.
+
 ### YAML schema
 
 ```yaml

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -76,7 +76,9 @@ var DaemonBoundFlags = []string{
 ```
 
 On each HTTP or WebSocket heartbeat, the server evaluates every registered key
-with an `EvalContext` containing `workspace_id`, `runtime_id`, and `daemon_id`.
+as a daemon/process-level decision. The snapshot EvalContext exposes
+`daemon_id` only; workspace/runtime/task/user scoped rollout is intentionally
+not part of this channel because the daemon stores one process-global snapshot.
 The heartbeat ack carries a full snapshot:
 
 ```json
@@ -105,8 +107,9 @@ Old daemons talking to new servers ignore the unknown JSON field.
 
 To add another daemon-bound process-level flag, add its key to the registry and
 use the existing daemon feature flag service at the toggle point. Do not add
-task payload fields or task-scoped readers for daemon-bound flags unless a
-separate design explicitly introduces task-scoped daemon flag evaluation.
+workspace percent rollout, task payload fields, or task-scoped readers for
+daemon-bound flags unless a separate design explicitly introduces scoped daemon
+flag evaluation.
 
 ### YAML schema
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon"
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	logger_pkg "github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/util"
 )
@@ -389,6 +390,15 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	defer stop()
 
 	logger := logger_pkg.NewLogger("daemon")
+	serverSnapshotProvider, flags, err := execenv.NewDaemonFeatureFlagServiceFromEnv(logger)
+	if err != nil {
+		return err
+	}
+	execenv.SetServerSnapshotProvider(serverSnapshotProvider)
+	execenv.SetFeatureFlags(flags)
+	defer execenv.SetServerSnapshotProvider(nil)
+	defer execenv.SetFeatureFlags(nil)
+
 	d := daemon.New(cfg, logger)
 
 	// Write PID file so "daemon stop" can find us.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -341,6 +341,7 @@ func main() {
 		BusinessMetrics:    businessMetrics,
 		DaemonHub:          daemonHub,
 		DaemonWakeup:       daemonWakeup,
+		FeatureFlags:       flags,
 		HeartbeatScheduler: heartbeatScheduler,
 	})
 

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/cloudruntime"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/featureflagdispatch"
 	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/integrations/lark"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
@@ -31,6 +32,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 	"github.com/multica-ai/multica/server/internal/util/secretbox"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
 )
 
 var defaultOrigins = []string{
@@ -106,6 +108,7 @@ type RouterOptions struct {
 	BusinessMetrics *obsmetrics.BusinessMetrics
 	DaemonHub       *daemonws.Hub
 	DaemonWakeup    service.TaskWakeupNotifier
+	FeatureFlags    *featureflag.Service
 	// HeartbeatScheduler, when non-nil, replaces the default synchronous
 	// passthrough scheduler on the constructed Handler. main.go injects a
 	// BatchedHeartbeatScheduler here so the caller can also drive Run/Stop;
@@ -156,6 +159,9 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	h.Metrics = opts.BusinessMetrics
+	if opts.FeatureFlags != nil {
+		h.DaemonFeatureFlags = featureflagdispatch.NewEvaluator(opts.FeatureFlags)
+	}
 	h.TaskService.Metrics = opts.BusinessMetrics
 	h.IssueService.Metrics = opts.BusinessMetrics
 	if opts.BusinessMetrics != nil {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1923,6 +1923,7 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 	if resp == nil {
 		return
 	}
+	execenv.ApplyFeatureFlagSnapshot(resp.FeatureFlags)
 	if resp.PendingUpdate != nil || resp.PendingModelList != nil || resp.PendingLocalSkills != nil || resp.PendingLocalSkillImport != nil {
 		d.logger.Debug("heartbeat: pending actions",
 			"runtime_id", runtimeID,

--- a/server/internal/daemon/execenv/server_snapshot_provider.go
+++ b/server/internal/daemon/execenv/server_snapshot_provider.go
@@ -1,0 +1,172 @@
+package execenv
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// ServerSnapshot is the daemon-local copy of the server-evaluated
+// daemon-bound feature flag decisions.
+type ServerSnapshot struct {
+	Version uint64
+	Flags   map[string]string
+}
+
+// ServerSnapshotProvider serves decisions delivered by the server over daemon
+// heartbeat acks. Apply swaps the entire snapshot atomically.
+type ServerSnapshotProvider struct {
+	snap atomic.Pointer[ServerSnapshot]
+}
+
+var activeServerSnapshotProvider atomic.Pointer[ServerSnapshotProvider]
+
+func NewServerSnapshotProvider() *ServerSnapshotProvider {
+	return &ServerSnapshotProvider{}
+}
+
+// Name implements featureflag.Provider.
+func (*ServerSnapshotProvider) Name() string { return "server_snapshot" }
+
+// Lookup implements featureflag.Provider.
+func (p *ServerSnapshotProvider) Lookup(_ context.Context, key string) (featureflag.Decision, bool) {
+	if p == nil {
+		return featureflag.Decision{}, false
+	}
+	snap := p.snap.Load()
+	if snap == nil {
+		return featureflag.Decision{}, false
+	}
+	variant, ok := snap.Flags[key]
+	if !ok {
+		return featureflag.Decision{}, false
+	}
+	return featureflag.Decision{
+		Key:     key,
+		Enabled: snapshotVariantEnabled(variant),
+		Variant: variant,
+		Reason:  featureflag.ReasonStatic,
+		Source:  p.Name(),
+	}, true
+}
+
+// Apply atomically replaces the provider's current snapshot.
+func (p *ServerSnapshotProvider) Apply(snapshot ServerSnapshot) {
+	if p == nil {
+		return
+	}
+	clone := make(map[string]string, len(snapshot.Flags))
+	for key, variant := range snapshot.Flags {
+		clone[key] = variant
+	}
+	p.snap.Store(&ServerSnapshot{
+		Version: snapshot.Version,
+		Flags:   clone,
+	})
+}
+
+// Clear drops the current server snapshot so lookups fall through to the next
+// provider. This is how a new daemon behaves when an old server omits the
+// feature_flags heartbeat field.
+func (p *ServerSnapshotProvider) Clear() {
+	if p == nil {
+		return
+	}
+	p.snap.Store(nil)
+}
+
+// Snapshot returns a copy of the current snapshot for tests and diagnostics.
+func (p *ServerSnapshotProvider) Snapshot() (ServerSnapshot, bool) {
+	if p == nil {
+		return ServerSnapshot{}, false
+	}
+	snap := p.snap.Load()
+	if snap == nil {
+		return ServerSnapshot{}, false
+	}
+	clone := make(map[string]string, len(snap.Flags))
+	for key, variant := range snap.Flags {
+		clone[key] = variant
+	}
+	return ServerSnapshot{Version: snap.Version, Flags: clone}, true
+}
+
+// SetServerSnapshotProvider installs the provider that heartbeat acks update.
+// Passing nil disables heartbeat-driven updates.
+func SetServerSnapshotProvider(p *ServerSnapshotProvider) {
+	activeServerSnapshotProvider.Store(p)
+}
+
+// ApplyFeatureFlagSnapshot applies a protocol snapshot from a heartbeat ack to
+// the installed ServerSnapshotProvider. Old servers omit the field, so nil
+// clears any prior server snapshot and lets local env/YAML fallback win.
+func ApplyFeatureFlagSnapshot(snapshot *protocol.DaemonFeatureFlagSnapshot) {
+	p := activeServerSnapshotProvider.Load()
+	if p == nil {
+		return
+	}
+	if snapshot == nil {
+		p.Clear()
+		return
+	}
+	p.Apply(ServerSnapshot{
+		Version: snapshot.Version,
+		Flags:   snapshot.Flags,
+	})
+}
+
+// NewDaemonFeatureFlagServiceFromEnv builds the daemon-side provider chain:
+//
+//   - EnvProvider: local FF_* emergency overrides.
+//   - ServerSnapshotProvider: decisions delivered over heartbeat.
+//   - StaticProvider: local YAML fallback for old servers / self-hosted rescue.
+//   - Caller default.
+func NewDaemonFeatureFlagServiceFromEnv(logger *slog.Logger) (*ServerSnapshotProvider, *featureflag.Service, error) {
+	serverSnapshot := NewServerSnapshotProvider()
+	providers := []featureflag.Provider{
+		featureflag.NewEnvProvider(featureflag.EnvOverridePrefix),
+		serverSnapshot,
+	}
+
+	path := strings.TrimSpace(os.Getenv(featureflag.EnvFlagFile))
+	var loadedCount int
+	if path != "" {
+		rules, err := featureflag.LoadRulesFromYAMLFile(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		static := featureflag.NewStaticProvider()
+		static.LoadRules(rules)
+		providers = append(providers, static)
+		loadedCount = len(rules)
+	}
+
+	var opts []featureflag.Option
+	if logger != nil {
+		opts = append(opts, featureflag.WithLogger(logger))
+	}
+	svc := featureflag.NewService(featureflag.NewChainProvider(providers...), opts...)
+	if logger != nil {
+		logger.Info("daemon feature flags initialised",
+			slog.String("file", path),
+			slog.Int("rules", loadedCount),
+			slog.String("env_prefix", featureflag.EnvOverridePrefix),
+			slog.String("provider_order", "env,server_snapshot,static"),
+		)
+	}
+	return serverSnapshot, svc, nil
+}
+
+func snapshotVariantEnabled(v string) bool {
+	switch v {
+	case "", "off", "false", "0":
+		return false
+	default:
+		return true
+	}
+}

--- a/server/internal/daemon/execenv/server_snapshot_provider_test.go
+++ b/server/internal/daemon/execenv/server_snapshot_provider_test.go
@@ -1,0 +1,192 @@
+package execenv
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/featureflagdispatch"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func TestServerSnapshotProviderLookupAndCopy(t *testing.T) {
+	t.Parallel()
+
+	provider := NewServerSnapshotProvider()
+	flags := map[string]string{runtimeBriefSlimFlag: "on"}
+	provider.Apply(ServerSnapshot{Version: 7, Flags: flags})
+	flags[runtimeBriefSlimFlag] = "off"
+
+	decision, ok := provider.Lookup(context.Background(), runtimeBriefSlimFlag)
+	if !ok {
+		t.Fatal("Lookup did not find runtime_brief_slim")
+	}
+	if !decision.Enabled || decision.Variant != "on" || decision.Source != "server_snapshot" {
+		t.Fatalf("decision = %+v, want enabled on from server_snapshot", decision)
+	}
+
+	snapshot, ok := provider.Snapshot()
+	if !ok {
+		t.Fatal("Snapshot not found")
+	}
+	snapshot.Flags[runtimeBriefSlimFlag] = "off"
+	decision, _ = provider.Lookup(context.Background(), runtimeBriefSlimFlag)
+	if decision.Variant != "on" {
+		t.Fatalf("mutating Snapshot copy changed provider decision: %+v", decision)
+	}
+}
+
+func TestServerSnapshotProviderConcurrentSwapAndLookup(t *testing.T) {
+	t.Parallel()
+
+	provider := NewServerSnapshotProvider()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			provider.Apply(ServerSnapshot{
+				Version: uint64(i + 1),
+				Flags:   map[string]string{runtimeBriefSlimFlag: boolVariant(i%2 == 0)},
+			})
+		}()
+	}
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = provider.Lookup(context.Background(), runtimeBriefSlimFlag)
+		}()
+	}
+	wg.Wait()
+
+	if _, ok := provider.Snapshot(); !ok {
+		t.Fatal("provider lost snapshot after concurrent swaps")
+	}
+}
+
+func TestDaemonFeatureFlagProviderPrecedence(t *testing.T) {
+	savedFlags := runtimeFlags.Load()
+	savedProvider := activeServerSnapshotProvider.Load()
+	t.Cleanup(func() {
+		runtimeFlags.Store(savedFlags)
+		activeServerSnapshotProvider.Store(savedProvider)
+	})
+	t.Setenv("FF_RUNTIME_BRIEF_SLIM", "false")
+
+	serverSnapshot := NewServerSnapshotProvider()
+	serverSnapshot.Apply(ServerSnapshot{
+		Version: 1,
+		Flags:   map[string]string{runtimeBriefSlimFlag: "on"},
+	})
+	static := featureflag.NewStaticProvider()
+	static.Set(runtimeBriefSlimFlag, featureflag.Rule{Default: true})
+	SetServerSnapshotProvider(serverSnapshot)
+	SetFeatureFlags(featureflag.NewService(featureflag.NewChainProvider(
+		featureflag.NewEnvProvider(featureflag.EnvOverridePrefix),
+		serverSnapshot,
+		static,
+	)))
+
+	if useSlimBrief() {
+		t.Fatal("FF_RUNTIME_BRIEF_SLIM=false must override server snapshot and static defaults")
+	}
+}
+
+func TestHeartbeatSnapshotUpdatesUseSlimBrief(t *testing.T) {
+	savedFlags := runtimeFlags.Load()
+	savedProvider := activeServerSnapshotProvider.Load()
+	t.Cleanup(func() {
+		runtimeFlags.Store(savedFlags)
+		activeServerSnapshotProvider.Store(savedProvider)
+	})
+
+	serverSnapshot := NewServerSnapshotProvider()
+	SetServerSnapshotProvider(serverSnapshot)
+	SetFeatureFlags(featureflag.NewService(featureflag.NewChainProvider(serverSnapshot)))
+
+	serverProvider := featureflag.NewStaticProvider()
+	serverService := featureflag.NewService(serverProvider)
+	evaluator := featureflagdispatch.NewEvaluator(serverService)
+	rt := db.AgentRuntime{
+		ID:          util.MustParseUUID("20000000-0000-0000-0000-000000000001"),
+		WorkspaceID: util.MustParseUUID("20000000-0000-0000-0000-000000000002"),
+	}
+
+	serverProvider.Set(featureflagdispatch.RuntimeBriefSlimFlag, featureflag.Rule{Default: true})
+	ApplyFeatureFlagSnapshot(evaluator.EvaluateForRuntime(context.Background(), rt))
+	if !useSlimBrief() {
+		t.Fatal("server heartbeat snapshot default=true should enable slim brief")
+	}
+
+	serverProvider.Set(featureflagdispatch.RuntimeBriefSlimFlag, featureflag.Rule{Default: false})
+	ApplyFeatureFlagSnapshot(evaluator.EvaluateForRuntime(context.Background(), rt))
+	if useSlimBrief() {
+		t.Fatal("later server heartbeat snapshot default=false should disable slim brief")
+	}
+}
+
+func TestNilHeartbeatSnapshotFallsBackToStaticProvider(t *testing.T) {
+	savedFlags := runtimeFlags.Load()
+	savedProvider := activeServerSnapshotProvider.Load()
+	t.Cleanup(func() {
+		runtimeFlags.Store(savedFlags)
+		activeServerSnapshotProvider.Store(savedProvider)
+	})
+
+	serverSnapshot := NewServerSnapshotProvider()
+	serverSnapshot.Apply(ServerSnapshot{
+		Version: 1,
+		Flags:   map[string]string{runtimeBriefSlimFlag: "off"},
+	})
+	static := featureflag.NewStaticProvider()
+	static.Set(runtimeBriefSlimFlag, featureflag.Rule{Default: true})
+	SetServerSnapshotProvider(serverSnapshot)
+	SetFeatureFlags(featureflag.NewService(featureflag.NewChainProvider(serverSnapshot, static)))
+
+	if useSlimBrief() {
+		t.Fatal("server snapshot off should suppress static provider before old-server fallback")
+	}
+	ApplyFeatureFlagSnapshot(nil)
+	if !useSlimBrief() {
+		t.Fatal("missing heartbeat feature_flags should clear server snapshot and fall back to static provider")
+	}
+}
+
+func TestApplyFeatureFlagSnapshotNoProviderIsSafe(t *testing.T) {
+	savedProvider := activeServerSnapshotProvider.Load()
+	activeServerSnapshotProvider.Store(nil)
+	t.Cleanup(func() { activeServerSnapshotProvider.Store(savedProvider) })
+
+	ApplyFeatureFlagSnapshot(&protocol.DaemonFeatureFlagSnapshot{
+		Version: 1,
+		Flags:   map[string]string{runtimeBriefSlimFlag: "on"},
+	})
+}
+
+func TestApplyFeatureFlagSnapshotNilClearsProvider(t *testing.T) {
+	savedProvider := activeServerSnapshotProvider.Load()
+	provider := NewServerSnapshotProvider()
+	provider.Apply(ServerSnapshot{
+		Version: 1,
+		Flags:   map[string]string{runtimeBriefSlimFlag: "on"},
+	})
+	SetServerSnapshotProvider(provider)
+	t.Cleanup(func() { activeServerSnapshotProvider.Store(savedProvider) })
+
+	ApplyFeatureFlagSnapshot(nil)
+	if _, ok := provider.Lookup(context.Background(), runtimeBriefSlimFlag); ok {
+		t.Fatal("nil heartbeat snapshot should clear the server snapshot provider")
+	}
+}
+
+func boolVariant(enabled bool) string {
+	if enabled {
+		return "on"
+	}
+	return "off"
+}

--- a/server/internal/featureflagdispatch/evaluator.go
+++ b/server/internal/featureflagdispatch/evaluator.go
@@ -1,0 +1,57 @@
+package featureflagdispatch
+
+import (
+	"context"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const defaultSnapshotVersion uint64 = 1
+
+// Evaluator renders the current server-side decisions for daemon-bound flags.
+type Evaluator struct {
+	flags   *featureflag.Service
+	version uint64
+}
+
+// NewEvaluator returns an evaluator for the currently loaded server feature
+// flag configuration. The first implementation has no live reload path, so
+// version starts at 1 for the process lifetime.
+func NewEvaluator(flags *featureflag.Service) *Evaluator {
+	return &Evaluator{flags: flags, version: defaultSnapshotVersion}
+}
+
+// EvaluateForRuntime returns the complete daemon-bound flag snapshot for rt.
+// Missing server config is still an explicit "off" decision for registered
+// daemon-bound flags; the daemon's local StaticProvider is only a fallback when
+// it is talking to an old server that sends no snapshot field at all.
+func (e *Evaluator) EvaluateForRuntime(ctx context.Context, rt db.AgentRuntime) *protocol.DaemonFeatureFlagSnapshot {
+	if e == nil {
+		return nil
+	}
+	version := e.version
+	if version == 0 {
+		version = defaultSnapshotVersion
+	}
+	flags := make(map[string]string, len(DaemonBoundFlags))
+	evalCtx := featureflag.EvalContext{
+		WorkspaceID: util.UUIDToString(rt.WorkspaceID),
+		Attributes: map[string]string{
+			"runtime_id": util.UUIDToString(rt.ID),
+		},
+	}
+	if rt.DaemonID.Valid {
+		evalCtx.Attributes["daemon_id"] = rt.DaemonID.String
+	}
+	ctx = featureflag.WithEvalContext(ctx, evalCtx)
+	for _, key := range DaemonBoundFlags {
+		flags[key] = e.flags.Variant(ctx, key, "off")
+	}
+	return &protocol.DaemonFeatureFlagSnapshot{
+		Version: version,
+		Flags:   flags,
+	}
+}

--- a/server/internal/featureflagdispatch/evaluator.go
+++ b/server/internal/featureflagdispatch/evaluator.go
@@ -3,7 +3,6 @@ package featureflagdispatch
 import (
 	"context"
 
-	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/featureflag"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -37,12 +36,7 @@ func (e *Evaluator) EvaluateForRuntime(ctx context.Context, rt db.AgentRuntime) 
 		version = defaultSnapshotVersion
 	}
 	flags := make(map[string]string, len(DaemonBoundFlags))
-	evalCtx := featureflag.EvalContext{
-		WorkspaceID: util.UUIDToString(rt.WorkspaceID),
-		Attributes: map[string]string{
-			"runtime_id": util.UUIDToString(rt.ID),
-		},
-	}
+	evalCtx := featureflag.EvalContext{Attributes: map[string]string{}}
 	if rt.DaemonID.Valid {
 		evalCtx.Attributes["daemon_id"] = rt.DaemonID.String
 	}

--- a/server/internal/featureflagdispatch/evaluator_test.go
+++ b/server/internal/featureflagdispatch/evaluator_test.go
@@ -2,7 +2,6 @@ package featureflagdispatch
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -33,7 +32,7 @@ func TestEvaluateForRuntimeWritesDaemonBoundSnapshot(t *testing.T) {
 	}
 }
 
-func TestEvaluateForRuntimeIncludesRuntimeContext(t *testing.T) {
+func TestEvaluateForRuntimeIncludesDaemonContext(t *testing.T) {
 	t.Parallel()
 
 	provider := featureflag.NewStaticProvider()
@@ -50,29 +49,41 @@ func TestEvaluateForRuntimeIncludesRuntimeContext(t *testing.T) {
 	}
 }
 
-func TestEvaluateForRuntimeWorkspacePercentRollout(t *testing.T) {
+func TestEvaluateForRuntimeIsDaemonProcessScoped(t *testing.T) {
 	t.Parallel()
 
 	provider := featureflag.NewStaticProvider()
 	provider.Set(RuntimeBriefSlimFlag, featureflag.Rule{
 		Default: false,
-		Percent: &featureflag.PercentRollout{
-			Percent: 25,
-			By:      "workspace_id",
-		},
+		Allow:   []string{"daemon-a"},
+		AllowBy: "daemon_id",
 	})
 	evaluator := NewEvaluator(featureflag.NewService(provider))
 
-	var enabled int
-	for i := 0; i < 1000; i++ {
-		workspaceID := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
-		snapshot := evaluator.EvaluateForRuntime(context.Background(), testRuntime(workspaceID, "daemon-a"))
-		if snapshot.Flags[RuntimeBriefSlimFlag] == "on" {
-			enabled++
-		}
+	snapshotA := evaluator.EvaluateForRuntime(context.Background(), testRuntime("00000000-0000-0000-0000-0000000000aa", "daemon-a"))
+	snapshotB := evaluator.EvaluateForRuntime(context.Background(), testRuntime("00000000-0000-0000-0000-0000000000bb", "daemon-a"))
+	if got := snapshotA.Flags[RuntimeBriefSlimFlag]; got != "on" {
+		t.Fatalf("workspace A %s = %q, want on", RuntimeBriefSlimFlag, got)
 	}
-	if enabled < 200 || enabled > 300 {
-		t.Fatalf("25%% workspace rollout enabled %d/1000 workspaces, want roughly 250", enabled)
+	if got := snapshotB.Flags[RuntimeBriefSlimFlag]; got != "on" {
+		t.Fatalf("workspace B %s = %q, want on", RuntimeBriefSlimFlag, got)
+	}
+}
+
+func TestEvaluateForRuntimeDoesNotUseWorkspaceContext(t *testing.T) {
+	t.Parallel()
+
+	provider := featureflag.NewStaticProvider()
+	provider.Set(RuntimeBriefSlimFlag, featureflag.Rule{
+		Default: false,
+		Allow:   []string{"00000000-0000-0000-0000-0000000000aa"},
+		AllowBy: "workspace_id",
+	})
+	evaluator := NewEvaluator(featureflag.NewService(provider))
+
+	snapshot := evaluator.EvaluateForRuntime(context.Background(), testRuntime("00000000-0000-0000-0000-0000000000aa", "daemon-a"))
+	if got := snapshot.Flags[RuntimeBriefSlimFlag]; got != "off" {
+		t.Fatalf("%s = %q, want off because daemon snapshots are process-scoped, not workspace-scoped", RuntimeBriefSlimFlag, got)
 	}
 }
 

--- a/server/internal/featureflagdispatch/evaluator_test.go
+++ b/server/internal/featureflagdispatch/evaluator_test.go
@@ -1,0 +1,85 @@
+package featureflagdispatch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+)
+
+func TestEvaluateForRuntimeWritesDaemonBoundSnapshot(t *testing.T) {
+	t.Parallel()
+
+	provider := featureflag.NewStaticProvider()
+	provider.Set(RuntimeBriefSlimFlag, featureflag.Rule{Default: true})
+	evaluator := NewEvaluator(featureflag.NewService(provider))
+
+	snapshot := evaluator.EvaluateForRuntime(context.Background(), testRuntime("00000000-0000-0000-0000-000000000001", "daemon-a"))
+	if snapshot == nil {
+		t.Fatal("snapshot is nil")
+	}
+	if snapshot.Version != defaultSnapshotVersion {
+		t.Fatalf("snapshot version = %d, want %d", snapshot.Version, defaultSnapshotVersion)
+	}
+	if got := snapshot.Flags[RuntimeBriefSlimFlag]; got != "on" {
+		t.Fatalf("%s = %q, want on", RuntimeBriefSlimFlag, got)
+	}
+	if len(snapshot.Flags) != len(DaemonBoundFlags) {
+		t.Fatalf("snapshot flags = %#v, want exactly daemon-bound registry", snapshot.Flags)
+	}
+}
+
+func TestEvaluateForRuntimeIncludesRuntimeContext(t *testing.T) {
+	t.Parallel()
+
+	provider := featureflag.NewStaticProvider()
+	provider.Set(RuntimeBriefSlimFlag, featureflag.Rule{
+		Default: false,
+		Allow:   []string{"daemon-allowed"},
+		AllowBy: "daemon_id",
+	})
+	evaluator := NewEvaluator(featureflag.NewService(provider))
+
+	snapshot := evaluator.EvaluateForRuntime(context.Background(), testRuntime("00000000-0000-0000-0000-000000000002", "daemon-allowed"))
+	if got := snapshot.Flags[RuntimeBriefSlimFlag]; got != "on" {
+		t.Fatalf("%s = %q, want on for daemon_id allow", RuntimeBriefSlimFlag, got)
+	}
+}
+
+func TestEvaluateForRuntimeWorkspacePercentRollout(t *testing.T) {
+	t.Parallel()
+
+	provider := featureflag.NewStaticProvider()
+	provider.Set(RuntimeBriefSlimFlag, featureflag.Rule{
+		Default: false,
+		Percent: &featureflag.PercentRollout{
+			Percent: 25,
+			By:      "workspace_id",
+		},
+	})
+	evaluator := NewEvaluator(featureflag.NewService(provider))
+
+	var enabled int
+	for i := 0; i < 1000; i++ {
+		workspaceID := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
+		snapshot := evaluator.EvaluateForRuntime(context.Background(), testRuntime(workspaceID, "daemon-a"))
+		if snapshot.Flags[RuntimeBriefSlimFlag] == "on" {
+			enabled++
+		}
+	}
+	if enabled < 200 || enabled > 300 {
+		t.Fatalf("25%% workspace rollout enabled %d/1000 workspaces, want roughly 250", enabled)
+	}
+}
+
+func testRuntime(workspaceID, daemonID string) db.AgentRuntime {
+	return db.AgentRuntime{
+		ID:          util.MustParseUUID("10000000-0000-0000-0000-000000000001"),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+		DaemonID:    pgtype.Text{String: daemonID, Valid: daemonID != ""},
+	}
+}

--- a/server/internal/featureflagdispatch/registry.go
+++ b/server/internal/featureflagdispatch/registry.go
@@ -1,0 +1,11 @@
+package featureflagdispatch
+
+// RuntimeBriefSlimFlag is the daemon-bound flag that switches runtime brief
+// rendering between the legacy verbose prompt and the slim prompt.
+const RuntimeBriefSlimFlag = "runtime_brief_slim"
+
+// DaemonBoundFlags lists every feature flag whose evaluated decision is safe
+// and useful to send to daemons. Flags not listed here stay server-only.
+var DaemonBoundFlags = []string{
+	RuntimeBriefSlimFlag,
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -907,6 +907,9 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if len(ack.PendingLocalSkillImports) > 0 {
 		resp["pending_local_skill_imports"] = ack.PendingLocalSkillImports
 	}
+	if ack.FeatureFlags != nil {
+		resp["feature_flags"] = ack.FeatureFlags
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -1020,6 +1023,9 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime, supp
 	ack := &protocol.DaemonHeartbeatAckPayload{
 		RuntimeID: runtimeID,
 		Status:    "ok",
+	}
+	if h.DaemonFeatureFlags != nil {
+		ack.FeatureFlags = h.DaemonFeatureFlags.EvaluateForRuntime(ctx, rt)
 	}
 
 	probeUpdateCtx, cancelProbeUpdate := context.WithTimeout(ctx, heartbeatHasPendingTimeout)

--- a/server/internal/handler/daemon_feature_flags_test.go
+++ b/server/internal/handler/daemon_feature_flags_test.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/featureflagdispatch"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
+)
+
+func TestProcessHeartbeatIncludesDaemonFeatureFlagSnapshot(t *testing.T) {
+	t.Parallel()
+
+	provider := featureflag.NewStaticProvider()
+	provider.Set(featureflagdispatch.RuntimeBriefSlimFlag, featureflag.Rule{Default: true})
+	h := &Handler{
+		UpdateStore:           NewInMemoryUpdateStore(),
+		ModelListStore:        NewInMemoryModelListStore(),
+		LocalSkillListStore:   NewInMemoryLocalSkillListStore(),
+		LocalSkillImportStore: NewInMemoryLocalSkillImportStore(),
+		LivenessStore:         NewNoopLivenessStore(),
+		HeartbeatScheduler:    noopHeartbeatScheduler{},
+		DaemonFeatureFlags:    featureflagdispatch.NewEvaluator(featureflag.NewService(provider)),
+	}
+	rt := db.AgentRuntime{
+		ID:          util.MustParseUUID("30000000-0000-0000-0000-000000000001"),
+		WorkspaceID: util.MustParseUUID("30000000-0000-0000-0000-000000000002"),
+	}
+
+	ack, _, err := h.processHeartbeat(context.Background(), rt, false)
+	if err != nil {
+		t.Fatalf("processHeartbeat: %v", err)
+	}
+	if ack.FeatureFlags == nil {
+		t.Fatal("FeatureFlags snapshot is nil")
+	}
+	if got := ack.FeatureFlags.Flags[featureflagdispatch.RuntimeBriefSlimFlag]; got != "on" {
+		t.Fatalf("runtime_brief_slim = %q, want on", got)
+	}
+}
+
+type noopHeartbeatScheduler struct{}
+
+func (noopHeartbeatScheduler) Schedule(context.Context, db.AgentRuntime) error {
+	return nil
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/cloudruntime"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/featureflagdispatch"
 	"github.com/multica-ai/multica/server/internal/integrations/lark"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -111,6 +112,7 @@ type Handler struct {
 	ModelListStore        ModelListStore
 	LocalSkillListStore   LocalSkillListStore
 	LocalSkillImportStore LocalSkillImportStore
+	DaemonFeatureFlags    *featureflagdispatch.Evaluator
 	LivenessStore         LivenessStore
 	HeartbeatScheduler    HeartbeatScheduler
 	Storage               storage.Storage

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -152,11 +152,20 @@ type DaemonHeartbeatAckPayload struct {
 	PendingModelList        *DaemonHeartbeatPendingModelList        `json:"pending_model_list,omitempty"`
 	PendingLocalSkills      *DaemonHeartbeatPendingLocalSkills      `json:"pending_local_skills,omitempty"`
 	PendingLocalSkillImport *DaemonHeartbeatPendingLocalSkillImport `json:"pending_local_skill_import,omitempty"`
+	FeatureFlags            *DaemonFeatureFlagSnapshot              `json:"feature_flags,omitempty"`
 	// PendingLocalSkillImports carries multiple import requests in a single
 	// heartbeat so the daemon can process them concurrently. Old daemons
 	// that don't know this field silently ignore it (standard JSON behavior)
 	// and fall back to the singular PendingLocalSkillImport above.
 	PendingLocalSkillImports []DaemonHeartbeatPendingLocalSkillImport `json:"pending_local_skill_imports,omitempty"`
+}
+
+// DaemonFeatureFlagSnapshot carries the full server-evaluated decision set for
+// daemon-bound feature flags. It is sent on every heartbeat ack so the daemon
+// can atomically replace its local server snapshot without negotiating deltas.
+type DaemonFeatureFlagSnapshot struct {
+	Version uint64            `json:"version"`
+	Flags   map[string]string `json:"flags"`
 }
 
 // HeartbeatStatusRuntimeGone is the ack Status used when the runtime row no


### PR DESCRIPTION
Summary:
- Add a server daemon-bound flag registry/evaluator and carry the evaluated snapshot on HTTP and WS heartbeat acks.
- Narrow snapshot evaluation to daemon/process-level context only: daemon_id is exposed; workspace/runtime/task/user scoped rollout is intentionally out of this channel.
- Wire daemon runtime flags as Env > ServerSnapshot > Static > default, applying heartbeat snapshots globally and clearing them for old-server fallback.
- Document daemon-bound flags and add evaluator, provider, precedence, fallback, and heartbeat snapshot tests.

Tests:
- go test ./internal/featureflagdispatch ./internal/daemon/execenv ./internal/daemon ./pkg/protocol ./cmd/multica
- go test ./internal/handler -run ^TestProcessHeartbeatIncludesDaemonFeatureFlagSnapshot
- go test ./cmd/server -run ^

Note:
- A broader go test ./internal/handler ./cmd/server run hit local environment/schema failures unrelated to this patch: missing channel_installation relation, member-delete DB failures, and readiness 503 in this workspace.

Closes MUL-3618