### PR TITLE
fix(issue): sort sub-issues by number ASC instead of position (MUL-3362)

### DIFF
--- a/server/internal/handler/issue_children_for_parents_test.go
+++ b/server/internal/handler/issue_children_for_parents_test.go
@@ -217,3 +217,122 @@ func TestListChildrenByParents_IgnoresForeignWorkspaceParents(t *testing.T) {
 			len(got), got[0].ID)
 	}
 }
+
+// createChildIssue creates an issue via the handler under testWorkspaceID and
+// returns the decoded response. A nanosecond timestamp keeps titles unique
+// across repeated runs against the shared test database.
+func createChildIssue(t *testing.T, title, status, parentID string) IssueResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	body := map[string]any{
+		"title":  title + " " + time.Now().Format(time.RFC3339Nano),
+		"status": status,
+	}
+	if parentID != "" {
+		body["parent_issue_id"] = parentID
+	}
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, body)
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
+	}
+	var out IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode %q: %v", title, err)
+	}
+	return out
+}
+
+// newScrambledChildren creates a parent plus four children whose issue numbers
+// ascend in creation order while their position values are set in the opposite
+// order and their statuses are mixed. This reproduces the real-world layout:
+// NextTopPosition assigns MIN(position)-1 per (workspace, status), so newer
+// children get ever-smaller positions and different statuses draw from
+// different pools. A position-ordered query would interleave them; only a
+// number-ordered query returns them in creation order. Returns the parent and
+// the children in creation order (ascending number).
+func newScrambledChildren(t *testing.T) (IssueResponse, []IssueResponse) {
+	t.Helper()
+
+	parent := createChildIssue(t, "ordering parent", "in_progress", "")
+	c1 := createChildIssue(t, "ordering c1", "todo", parent.ID)
+	c2 := createChildIssue(t, "ordering c2", "in_progress", parent.ID)
+	c3 := createChildIssue(t, "ordering c3", "done", parent.ID)
+	c4 := createChildIssue(t, "ordering c4", "todo", parent.ID)
+	children := []IssueResponse{c1, c2, c3, c4}
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		for _, c := range append(children, parent) {
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, c.ID)
+		}
+	})
+
+	// Scramble positions so a position-ordered result (c4, c2, c3, c1) differs
+	// from a number-ordered result (c1, c2, c3, c4).
+	scrambled := map[string]float64{c1.ID: -1, c2.ID: -8, c3.ID: -4, c4.ID: -16}
+	ctx := context.Background()
+	for id, pos := range scrambled {
+		if _, err := testPool.Exec(ctx,
+			`UPDATE issue SET position = $1 WHERE id = $2`, pos, id); err != nil {
+			t.Fatalf("scramble position for %s: %v", id, err)
+		}
+	}
+
+	return parent, children
+}
+
+// assertNumberAscending checks the returned children match the expected
+// creation-order slice exactly and are strictly ascending by issue number.
+func assertNumberAscending(t *testing.T, got, want []IssueResponse) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d children, got %d", len(want), len(got))
+	}
+	for i := range got {
+		if got[i].ID != want[i].ID {
+			t.Fatalf("index %d: expected child %s (number %d), got %s (number %d)",
+				i, want[i].ID, want[i].Number, got[i].ID, got[i].Number)
+		}
+		if i > 0 && got[i].Number <= got[i-1].Number {
+			t.Fatalf("children not strictly ascending by number: index %d number %d <= index %d number %d",
+				i, got[i].Number, i-1, got[i-1].Number)
+		}
+	}
+}
+
+// TestListChildIssues_OrdersByNumberAsc pins the single-parent child listing
+// to number ASC order, independent of position and status. If a future change
+// reintroduces position-based ordering, this fails.
+func TestListChildIssues_OrdersByNumberAsc(t *testing.T) {
+	parent, children := newScrambledChildren(t)
+
+	w := httptest.NewRecorder()
+	req := withURLParam(
+		newRequest("GET", "/api/issues/"+parent.ID+"/children", nil),
+		"id", parent.ID,
+	)
+	testHandler.ListChildIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	assertNumberAscending(t, decodeIssueBatch(t, w), children)
+}
+
+// TestListChildrenByParents_OrdersByNumberAscWithinParent pins the batched
+// child listing to number ASC order within a parent, independent of position
+// and status.
+func TestListChildrenByParents_OrdersByNumberAscWithinParent(t *testing.T) {
+	parent, children := newScrambledChildren(t)
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids="+parent.ID, nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	assertNumberAscending(t, decodeIssueBatch(t, w), children)
+}

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -639,9 +639,15 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 const listChildIssues = `-- name: ListChildIssues :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC
+ORDER BY number ASC
 `
 
+// Order by number ASC so sub-issues display in stable creation order
+// (oldest first), matching how a parent's plan reads top-to-bottom. The
+// position column is computed per-(workspace, status) by NextTopPosition,
+// not relative to siblings, so ordering by it interleaves children
+// unpredictably across batches and statuses; number is a per-workspace
+// monotonic counter and is sibling-stable.
 func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID) ([]Issue, error) {
 	rows, err := q.db.Query(ctx, listChildIssues, parentIssueID)
 	if err != nil {
@@ -692,7 +698,7 @@ const listChildrenByParents = `-- name: ListChildrenByParents :many
 SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id = ANY($2::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC
+ORDER BY parent_issue_id, number ASC
 `
 
 type ListChildrenByParentsParams struct {
@@ -705,6 +711,8 @@ type ListChildrenByParentsParams struct {
 // (one request per visible parent lane). Result is grouped client-side by
 // parent_issue_id; the workspace filter is also enforced so callers can't
 // enumerate children of parents in workspaces they don't belong to.
+// Within each parent, order by number ASC for the same sibling-stable
+// creation order as ListChildIssues.
 func (q *Queries) ListChildrenByParents(ctx context.Context, arg ListChildrenByParentsParams) ([]Issue, error) {
 	rows, err := q.db.Query(ctx, listChildrenByParents, arg.WorkspaceID, arg.ParentIds)
 	if err != nil {

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -237,9 +237,15 @@ WHERE i.workspace_id = $1
   );
 
 -- name: ListChildIssues :many
+-- Order by number ASC so sub-issues display in stable creation order
+-- (oldest first), matching how a parent's plan reads top-to-bottom. The
+-- position column is computed per-(workspace, status) by NextTopPosition,
+-- not relative to siblings, so ordering by it interleaves children
+-- unpredictably across batches and statuses; number is a per-workspace
+-- monotonic counter and is sibling-stable.
 SELECT * FROM issue
 WHERE parent_issue_id = $1
-ORDER BY position ASC, created_at DESC;
+ORDER BY number ASC;
 
 -- name: ListChildrenByParents :many
 -- Batched variant of ListChildIssues: returns all children for the given
@@ -247,10 +253,12 @@ ORDER BY position ASC, created_at DESC;
 -- (one request per visible parent lane). Result is grouped client-side by
 -- parent_issue_id; the workspace filter is also enforced so callers can't
 -- enumerate children of parents in workspaces they don't belong to.
+-- Within each parent, order by number ASC for the same sibling-stable
+-- creation order as ListChildIssues.
 SELECT * FROM issue
 WHERE workspace_id = sqlc.arg('workspace_id')
   AND parent_issue_id = ANY(sqlc.arg('parent_ids')::uuid[])
-ORDER BY parent_issue_id, position ASC, created_at DESC;
+ORDER BY parent_issue_id, number ASC;
 
 -- name: GetIssueByOrigin :one
 -- Finds the issue stamped with a specific (origin_type, origin_id) pair.


### PR DESCRIPTION
## What does this PR do?

Fixes the display order of sub-issues in a parent's child list (issue detail page and Swimlane).

`ListChildIssues` and `ListChildrenByParents` ordered by `position ASC, created_at DESC`. `position` is assigned by `NextTopPosition` as `MIN(position) - 1` scoped to `(workspace_id, status)` — **not** relative to sibling sub-issues. So a parent's children draw positions from a workspace-global, per-status pool, and the list interleaves unpredictably across creation batches and across statuses.

This changes both queries to `ORDER BY number ASC`. `number` is a per-workspace monotonic counter (`IncrementIssueCounter`), so children display in stable **creation order, oldest first** — a parent's plan reads top-to-bottom in the order tasks were added, which matches Multica's ordered sub-issue / `stage` semantics.

## Why ASC (oldest-first) rather than DESC

Sub-issues are an ordered decomposition of a single parent (often Step 1 → 2 → 3, reinforced by `stage`), so reading top-to-bottom should follow creation/execution order. This intentionally differs from the main issue list (newest-first); the two lists have different semantics (ordered plan vs. independent backlog).

## Changes

- `server/pkg/db/queries/issue.sql` — `ListChildIssues` and `ListChildrenByParents` now `ORDER BY number ASC` (with a comment explaining why position is unsuitable).
- `server/pkg/db/generated/issue.sql.go` — regenerated via `sqlc generate` (v1.31.1); only the two ORDER BY lines changed.
- `server/internal/handler/issue_children_for_parents_test.go` — adds `TestListChildIssues_OrdersByNumberAsc` and `TestListChildrenByParents_OrdersByNumberAscWithinParent`. Both create children whose numbers ascend while positions are scrambled in the opposite order and statuses are mixed, so a position-based sort would fail and only a number-based sort passes.

## How tested

- `go test ./internal/handler/ -run 'ListChild'` — passes (new + existing child-listing tests).
- `gofmt` / `go vet ./internal/handler/` — clean.

## Notes

- Supersedes community PR #4243, which made the same query change but landed on `number DESC` and shipped without tests.
- After this, sub-issue lists no longer honor manual `position` ordering. That is intentional: the current `position` is workspace+status-global and was never sibling-relative, so it could not express manual sub-issue ordering anyway. A real per-parent manual order would need a sibling-scoped position — out of scope here.

Closes #4232
MUL-3362
