### PR TITLE
fix(daemon): resolve skill bundles in bounded batches

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3135,6 +3135,15 @@ func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, e
 	return reused
 }
 
+// skillBundleResolveBatchSize bounds how many skill bundles the daemon resolves
+// per request when filling cache misses. A single request for every miss makes
+// a slow or jittery link time out on the whole-body read, failing the task
+// before it starts and caching nothing (#4505). Small batches keep each request
+// within the client timeout and let completed batches persist, so an agent
+// bound to many skills still converges. Sized below the empirically-observed
+// "~6 skills fit, ~15 time out" threshold from the report.
+const skillBundleResolveBatchSize = 4
+
 func (d *Daemon) ensureTaskSkillBundles(ctx context.Context, task *Task) error {
 	if task == nil || task.Agent == nil || len(task.Agent.SkillRefs) == 0 {
 		return nil
@@ -3159,8 +3168,20 @@ func (d *Daemon) ensureTaskSkillBundles(ctx context.Context, task *Task) error {
 		}
 	}
 
-	if len(misses) > 0 {
-		bundles, err := d.client.ResolveSkillBundles(ctx, task.RuntimeID, task.ID, misses)
+	// Resolve cache misses in bounded batches, persisting each batch as it
+	// lands. Fetching every miss in one request makes a slow link time out
+	// reading the whole body, so the task fails and nothing is cached — the
+	// next dispatch re-fetches everything and fails identically (#4505).
+	// Batching keeps each request small enough to finish within the client
+	// timeout, and a completed batch stays cached even if a later one fails, so
+	// progress accumulates across dispatches instead of restarting from zero.
+	for start := 0; start < len(misses); start += skillBundleResolveBatchSize {
+		end := start + skillBundleResolveBatchSize
+		if end > len(misses) {
+			end = len(misses)
+		}
+		batch := misses[start:end]
+		bundles, err := d.client.ResolveSkillBundles(ctx, task.RuntimeID, task.ID, batch)
 		if err != nil {
 			return fmt.Errorf("resolve skill bundles: %w", err)
 		}

--- a/server/internal/daemon/ensure_skill_bundles_test.go
+++ b/server/internal/daemon/ensure_skill_bundles_test.go
@@ -1,0 +1,158 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// indexedSkillBundle builds a valid SkillData bundle distinguished by idx, with
+// its ref hash/size filled in so it passes validateSkillBundle.
+func indexedSkillBundle(idx string) SkillData {
+	bundle := SkillData{
+		ID:      "skill-" + idx,
+		Source:  "workspace",
+		Name:    "skill-" + idx,
+		Content: "content-" + idx,
+		Files:   []SkillFileData{{Path: "rules.md", Content: "rules-" + idx}},
+	}
+	ref := skillRefFromBundle(bundle)
+	bundle.Hash = ref.Hash
+	bundle.SizeBytes = ref.SizeBytes
+	bundle.Files[0].SHA256 = ref.Files[0].SHA256
+	bundle.Files[0].SizeBytes = ref.Files[0].SizeBytes
+	return bundle
+}
+
+// skillResolveFixture stands up a daemon wired to a fake resolve endpoint and a
+// real on-disk skill cache. failAfter, if >0, makes the endpoint return 500 on
+// the failAfter-th request onward, simulating a slow-link body-read timeout that
+// only some batches survive.
+type skillResolveFixture struct {
+	daemon       *Daemon
+	cache        *SkillBundleCache
+	refs         []SkillRefData
+	mu           sync.Mutex
+	requestSizes []int
+}
+
+func newSkillResolveFixture(t *testing.T, count, failAfter int) *skillResolveFixture {
+	t.Helper()
+	fx := &skillResolveFixture{}
+	byID := make(map[string]SkillData, count)
+	for i := 0; i < count; i++ {
+		b := indexedSkillBundle(string(rune('a' + i)))
+		byID[b.ID] = b
+		fx.refs = append(fx.refs, skillRefFromBundle(b))
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Skills []SkillRefData `json:"skills"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		fx.mu.Lock()
+		fx.requestSizes = append(fx.requestSizes, len(body.Skills))
+		reqNum := len(fx.requestSizes)
+		fx.mu.Unlock()
+
+		if failAfter > 0 && reqNum >= failAfter {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		out := struct {
+			Bundles []SkillData `json:"bundles"`
+		}{}
+		for _, ref := range body.Skills {
+			if b, ok := byID[ref.ID]; ok {
+				out.Bundles = append(out.Bundles, b)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := freshDaemon(srv.URL)
+	d.skillCache = NewSkillBundleCache(t.TempDir())
+	fx.daemon = d
+	fx.cache = d.skillCache
+	return fx
+}
+
+func (fx *skillResolveFixture) task() *Task {
+	return &Task{ID: "task-1", RuntimeID: "rt-1", WorkspaceID: "ws-1", Agent: &AgentData{SkillRefs: fx.refs}}
+}
+
+func (fx *skillResolveFixture) maxRequestSize() int {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	max := 0
+	for _, n := range fx.requestSizes {
+		if n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+func (fx *skillResolveFixture) cachedCount() int {
+	n := 0
+	for _, ref := range fx.refs {
+		if _, ok := fx.cache.Load("ws-1", ref); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestEnsureTaskSkillBundlesChunksMisses verifies the daemon resolves a large
+// set of skill-bundle cache misses in bounded batches rather than one atomic
+// request. Resolving every miss in a single request means a slow link times out
+// reading the whole body and the task never starts (#4505).
+func TestEnsureTaskSkillBundlesChunksMisses(t *testing.T) {
+	fx := newSkillResolveFixture(t, 12, 0)
+
+	if err := fx.daemon.ensureTaskSkillBundles(context.Background(), fx.task()); err != nil {
+		t.Fatalf("ensureTaskSkillBundles: %v", err)
+	}
+
+	fx.mu.Lock()
+	reqCount := len(fx.requestSizes)
+	fx.mu.Unlock()
+	if reqCount < 2 {
+		t.Fatalf("expected misses to be resolved in multiple batched requests, got %d request(s)", reqCount)
+	}
+	if max := fx.maxRequestSize(); max >= len(fx.refs) {
+		t.Fatalf("a single resolve request carried %d/%d skills; expected bounded batches", max, len(fx.refs))
+	}
+	if got := fx.cachedCount(); got != len(fx.refs) {
+		t.Fatalf("expected all %d bundles cached after a clean resolve, got %d", len(fx.refs), got)
+	}
+}
+
+// TestEnsureTaskSkillBundlesPersistsCompletedBatchesOnFailure verifies that when
+// a later batch fails (the slow-link timeout case), the batches that already
+// succeeded are persisted to the cache. Without this, every dispatch re-fetches
+// the full bundle and fails identically; with it, progress accumulates and a
+// later dispatch only fetches the remaining misses (#4505).
+func TestEnsureTaskSkillBundlesPersistsCompletedBatchesOnFailure(t *testing.T) {
+	fx := newSkillResolveFixture(t, 12, 2) // first batch succeeds, second batch onward fails
+
+	err := fx.daemon.ensureTaskSkillBundles(context.Background(), fx.task())
+	if err == nil {
+		t.Fatal("expected ensureTaskSkillBundles to fail when a batch errors")
+	}
+
+	cached := fx.cachedCount()
+	if cached == 0 {
+		t.Fatal("expected the successfully-resolved batch to be cached despite a later batch failing")
+	}
+	if cached == len(fx.refs) {
+		t.Fatalf("did not expect all bundles cached when a batch failed, got %d", cached)
+	}
+}


### PR DESCRIPTION
Fixes #4505

## Summary
An agent bound to many skills failed **every** dispatch with `resolve skill bundles: context deadline exceeded` on a slow or jittery link, before the agent even started. The reporter measured 6 skills ✅ / 15 ❌ / 41 ❌ on the same network — i.e. the bottleneck is the size of the bundle download, not connectivity.

Root cause: even though the daemon already caches resolved bundles (`SkillBundleCache`), `ensureTaskSkillBundles` resolved **all** cache misses in a single request (`ResolveSkillBundles(misses)`). On a slow link the whole-body read exceeds the client timeout, the call fails, and the store loop never runs — so **nothing is cached**, and the next dispatch re-fetches everything and fails identically. The failure is self-perpetuating.

Fix: resolve misses in bounded batches of `skillBundleResolveBatchSize` (4), persisting each completed batch to the cache before fetching the next. Each request stays small enough to finish within the client timeout, and a batch that already landed survives a later batch's failure — so progress accumulates across dispatches and a many-skill agent converges instead of failing forever. The batch size sits below the report's observed "~6 fit / ~15 time out" threshold.

This is the root fix from the issue's suggestion #1+#3 (reuse the existing cache across dispatches + don't fail atomically on one large body read). It is intentionally minimal and self-contained; the issue's other ideas (configurable/size-scaled timeout, parallel/resumable downloads, progress UI) are left as follow-ups.

## Tests
- `go test ./internal/daemon/ -run TestEnsureTaskSkillBundles` — new:
  - `TestEnsureTaskSkillBundlesChunksMisses`: a 12-skill cold cache is resolved in multiple batched requests (no single request carries all skills) and all bundles end up cached.
  - `TestEnsureTaskSkillBundlesPersistsCompletedBatchesOnFailure`: when a later batch errors, the batch that already succeeded stays cached, so a subsequent dispatch only fetches the remainder.
- `go test ./internal/daemon/ -race`, `go vet ./internal/daemon/`, `gofmt`, `go build ./...` — clean.