### PR TITLE
fix(daemon): forbid mid-run progress comments in runtime brief (MUL-3605)

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -826,6 +826,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		} else {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output, assistant chat text, or run logs — only comments on the issue. A task that finishes without a result comment is invisible to the user, even if the work itself was correct.\n\n")
 		}
+		b.WriteString("**Post exactly ONE comment per run — your final result, before this turn exits.** Do NOT post progress updates, plans, or \"here's what I'm about to do next\" as comments while you work; keep all planning and progress in your own reasoning.\n\n")
 		b.WriteString("Keep comments concise and natural — state the outcome, not the process.\n")
 		b.WriteString("Good: \"Fixed the login redirect. PR: https://...\"\n")
 		b.WriteString("Bad: \"1. Read the issue 2. Found the bug in auth.go 3. Created branch 4. ...\"\n")

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -439,6 +439,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 		} else {
 			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output, assistant chat text, or run logs — only comments on the issue. A task that finishes without a result comment is invisible to the user, even if the work itself was correct.\n\n")
 		}
+		b.WriteString("**Post exactly ONE comment per run — your final result, before this turn exits.** Do NOT post progress updates, plans, or \"here's what I'm about to do next\" as comments while you work; keep all planning and progress in your own reasoning.\n\n")
 		b.WriteString("Keep comments concise and natural — state the outcome, not the process (good: \"Fixed the login redirect. PR: https://...\"; bad: numbered process logs).\n")
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -369,6 +369,52 @@ func TestChatOutputDoesNotRequireIssueComment(t *testing.T) {
 	}
 }
 
+// The Output section for issue tasks must forbid mid-run progress
+// comments and require the single final result comment. Guards the
+// MUL-3605 regression where a review agent surfaced its progress
+// narration as the result instead of posting a conclusion. (The
+// pre-existing "Final results MUST be delivered … invisible without it"
+// and "state the outcome, not the process" lines already carry the
+// mandatory-comment and no-process-dump halves.) Chat / quick-create /
+// autopilot kinds keep their own delivery channels and must NOT inherit
+// this rule. Runs both the legacy and slim paths.
+func TestOutputForbidsMidRunProgressComments(t *testing.T) {
+	wantPhrases := []string{
+		"Post exactly ONE comment per run",
+		"Do NOT post progress updates",
+	}
+	issueCtxs := map[string]TaskContextForEnv{
+		"assignment": {IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+		"comment":    {IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TriggerCommentID: "tc-1"},
+	}
+
+	run := func(t *testing.T, label string) {
+		for name, ctx := range issueCtxs {
+			out := buildMetaSkillContent("claude", ctx)
+			for _, want := range wantPhrases {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s/%s brief missing output rule %q\n---\n%s", label, name, want, out)
+				}
+			}
+		}
+		// Chat keeps its own delivery channel; it must not inherit the
+		// issue-task "post a final comment" rules.
+		chat := buildMetaSkillContent("claude", TaskContextForEnv{ChatSessionID: "chat-1"})
+		for _, banned := range wantPhrases {
+			if strings.Contains(chat, banned) {
+				t.Errorf("%s chat brief must not inherit issue output rule %q", label, banned)
+			}
+		}
+	}
+
+	// Not parallel: the slim subtest toggles a process-wide feature flag.
+	t.Run("legacy", func(t *testing.T) { run(t, "legacy") })
+	t.Run("slim", func(t *testing.T) {
+		withSlimBrief(t)
+		run(t, "slim")
+	})
+}
+
 // The sub-issue creation rule must reach top-level parents that have no
 // `parent_issue_id` of their own — that is where the `todo` vs `backlog`
 // decision matters most. The section must not gate on this issue being


### PR DESCRIPTION
## What & why

The runtime brief's `## Output` section never told agents to keep their plan/progress **out** of issue comments. A run could post running "here's what I'm about to do" narration as comments, and a review run surfaced its in-progress narration as the "result" instead of posting a conclusion. (MUL-3605)

## Change

One rule added to the Output section's issue-task branch, in **both** the legacy (`runtime_config.go`) and slim (`runtime_config_sections.go`) briefs so behavior is identical regardless of the `runtime_brief_slim` rollout state:

> **Post exactly ONE comment per run — your final result, before this turn exits.** Do NOT post progress updates, plans, or "here's what I'm about to do next" as comments while you work; keep all planning and progress in your own reasoning.

Deliberately kept to a single line. The other two halves of the failure are already covered by existing text in the same section, so adding more would be redundant:

- **Mandatory final comment / no silent ending** — the existing line *"Final results MUST be delivered via `multica issue comment add` … a task that finishes without a result comment is invisible"* already requires it.
- **Progress narration isn't the result** — the existing line *"state the outcome, not the process (bad: numbered process logs)"* already rules out progress dumps.

Chat / quick-create / autopilot kinds keep their own delivery channels and do **not** inherit this rule.

## Testing

- `go test ./internal/daemon/execenv/... ./internal/daemon/` — pass.
- `TestOutputForbidsMidRunProgressComments` asserts the rule appears for comment- and assignment-triggered tasks across the legacy and slim paths, and that chat does not inherit it.
- `gofmt` / `go vet` clean.

MUL-3605
