### PR TITLE
fix(channel): eliminate WaitGroup Add/Wait data race in engine.Supervisor (MUL-3620)

### DIFF
--- a/server/internal/integrations/channel/engine/supervisor.go
+++ b/server/internal/integrations/channel/engine/supervisor.go
@@ -287,10 +287,19 @@ func (s *Supervisor) Run(ctx context.Context) {
 // Wait blocks until every supervisor goroutine the Supervisor started has
 // exited. Call this AFTER cancelling Run's context.
 //
+// It first waits for Run to return (stopChan closed) and only then joins the
+// supervisor WaitGroup. This ordering is load-bearing: Run is the sole caller
+// of startSupervisor, which does s.wg.Add(1), and calling WaitGroup.Add
+// concurrently with WaitGroup.Wait is a data race (and undefined per the
+// WaitGroup contract). Once Run has returned no further Add can happen, so the
+// wg.Wait below is race-free. (Run always closes stopChan via defer, even on
+// panic; callers always pair Wait with a started Run + cancelled ctx.)
+//
 // Prefer WaitWithTimeout in shutdown paths so a stuck supervisor (typically
 // a hung lease release on a frozen DB pool) cannot block process exit
 // indefinitely.
 func (s *Supervisor) Wait() {
+	<-s.stopChan
 	s.wg.Wait()
 }
 


### PR DESCRIPTION
## Summary

Fixes the flaky backend CI failure on `main` after #4512 merged (passes on retry — it's a real data race, not infra flakiness).

The `-race` backend job caught a **DATA RACE** in `engine.Supervisor`:

```
WARNING: DATA RACE
Read at ... by goroutine 71:
  engine.(*Supervisor).startSupervisor()  supervisor.go:398   // s.wg.Add(1)
  engine.(*Supervisor).sweep() / Run()
Previous write at ... by goroutine 70:
  engine.(*Supervisor).Wait()             supervisor.go:294   // s.wg.Wait()
--- FAIL: TestSupervisorSkipsWhenAnotherReplicaHoldsLease
```

`startSupervisor` does `s.wg.Add(1)` (under `s.mu`) while `Wait` does `s.wg.Wait()` (no lock). Calling `WaitGroup.Add` concurrently with `WaitGroup.Wait` is a data race and undefined per the WaitGroup contract, so it only trips occasionally — it passed locally and in the PR's CI, then flaked once on `main`. (The same latent race existed in the original `lark.Hub.Wait`; this fixes it properly in the generalized Supervisor.)

## Fix

`Wait` now blocks on `stopChan` (closed by `Run`'s `defer` when `Run` returns) before calling `wg.Wait()`. `Run` is the sole caller of `startSupervisor`, so once `Run` has returned no further `Add` can happen and `wg.Wait` is race-free. `WaitWithTimeout` inherits the fix (it calls `Wait`) and its timer still bounds shutdown. Every caller pairs `Wait` with a started `Run` + cancelled ctx, so there is no deadlock; `Run` always closes `stopChan` (defer, even on panic).

9-line change to `supervisor.go` (the `Wait` method).

## How verified

- `go test -race -count=300` on the flagged test `TestSupervisorSkipsWhenAnotherReplicaHoldsLease`: clean.
- `go test -race -count=12` on the whole `engine` package (also rules out a deadlock from the `stopChan` gate): clean.
- `go build ./...` clean.

MUL-3620
