### PR TITLE
MUL-3644 fix(chat): reset elapsed-time anchor when a new chat task starts

### DIFF
--- a/packages/views/chat/components/task-status-pill.test.tsx
+++ b/packages/views/chat/components/task-status-pill.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { ChatPendingTask } from "@multica/core/types";
+import enCommon from "../../locales/en/common.json";
+import enChat from "../../locales/en/chat.json";
+import { TaskStatusPill } from "./task-status-pill";
+
+const TEST_RESOURCES = { en: { common: enCommon, chat: enChat } };
+
+function pill(pendingTask: ChatPendingTask) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <TaskStatusPill
+        pendingTask={pendingTask}
+        taskMessages={[]}
+        availability={undefined}
+      />
+    </I18nProvider>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TaskStatusPill elapsed anchor", () => {
+  it("restarts the timer when a new task begins instead of inheriting the previous task's baseline", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T12:00:30.000Z"));
+
+    // Task A started 30s ago.
+    const { rerender, container } = render(
+      pill({ task_id: "task-a", status: "running", created_at: "2026-06-24T12:00:00.000Z" }),
+    );
+    expect(container.textContent).toContain("· 30s");
+
+    // Sending a new message starts task B "now" — the pill must restart at 0s,
+    // not keep counting from task A's 30s baseline (#4264).
+    rerender(
+      pill({ task_id: "task-b", status: "running", created_at: "2026-06-24T12:00:30.000Z" }),
+    );
+    expect(container.textContent).toContain("· 0s");
+    expect(container.textContent).not.toContain("· 30s");
+  });
+
+  it("keeps the anchor stable while the same task's created_at is refined (no backward snap)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T12:00:30.000Z"));
+
+    // Optimistic anchor seeded to ~now.
+    const { rerender, container } = render(
+      pill({ task_id: "task-a", status: "running", created_at: "2026-06-24T12:00:30.000Z" }),
+    );
+    expect(container.textContent).toContain("· 0s");
+
+    // Same task, server created_at refined a few seconds earlier — the anchor
+    // stays locked within a task so the timer never snaps backward/forward.
+    rerender(
+      pill({ task_id: "task-a", status: "running", created_at: "2026-06-24T12:00:25.000Z" }),
+    );
+    expect(container.textContent).toContain("· 0s");
+    expect(container.textContent).not.toContain("· 5s");
+  });
+});

--- a/packages/views/chat/components/task-status-pill.tsx
+++ b/packages/views/chat/components/task-status-pill.tsx
@@ -134,12 +134,19 @@ export function TaskStatusPill({
   availability,
 }: Props) {
   const resolveStage = useResolveStage();
-  // Anchor: locked on first render. Once set we never reassign — otherwise
-  // the timer would visibly snap backwards when an optimistic-seeded
-  // `Date.now()` anchor is later replaced by a server-side created_at that
-  // happened a few hundred ms earlier. Monotonic elapsed > strict accuracy.
+  // Anchor: locked per task, re-anchored when the pending task changes. Within
+  // a single task we never reassign — otherwise the timer would visibly snap
+  // backwards when an optimistic-seeded `Date.now()` anchor is later replaced
+  // by a server-side created_at that happened a few hundred ms earlier
+  // (monotonic elapsed > strict accuracy). But when a new chat message starts a
+  // new task, the anchor MUST reset so the counter restarts from the new task's
+  // created_at instead of inheriting the previous task's baseline — otherwise
+  // the pill opens showing the prior task's 20s/30s (#4264). task_id is the
+  // identity that distinguishes "same task, refined created_at" from "new task".
   const anchorRef = useRef<number | null>(null);
-  if (anchorRef.current === null) {
+  const anchoredTaskIdRef = useRef<string | undefined>(undefined);
+  if (anchorRef.current === null || pendingTask.task_id !== anchoredTaskIdRef.current) {
+    anchoredTaskIdRef.current = pendingTask.task_id;
     if (pendingTask.created_at) {
       const t = Date.parse(pendingTask.created_at);
       anchorRef.current = Number.isFinite(t) ? t : Date.now();


### PR DESCRIPTION
Fixes #4264

## Summary
The chat "thinking time" pill (`packages/views/chat/components/task-status-pill.tsx`) anchored its timer on the **first render** and never reassigned:

```ts
const anchorRef = useRef<number | null>(null);
if (anchorRef.current === null) { anchorRef.current = Date.parse(pendingTask.created_at) || Date.now(); }
```

When the pill instance persists across task boundaries (Virtuoso footer memoization / a race between `chat:done` invalidation and the optimistic write), sending a new message opened the counter at the **previous** task's elapsed (e.g. 20s/30s) instead of restarting at 0s.

Fix: re-anchor whenever `pendingTask.task_id` changes, tracked via a remembered-task-id ref and applied synchronously during render (no stale frame, no extra render). The anchor still stays locked while the **same** task's `created_at` is refined from an optimistic `Date.now()` to the server value, so the timer never snaps backward mid-task — preserving the original monotonic-within-a-task intent.

## Tests
- `pnpm --filter @multica/views test` — added `task-status-pill.test.tsx`:
  - new task (`task_id` change) restarts the timer at `0s` instead of inheriting the prior task's `30s` baseline (the #4264 repro; fails before the fix);
  - same-task `created_at` refinement keeps the anchor stable (no backward snap) — regression guard for the original locking behavior.
  - full views suite green (1473 tests).
- `pnpm --filter @multica/views typecheck` — clean.