### PR TITLE
feat(issues): add sub-issues sidebar panel to issue detail page

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -744,6 +744,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const [detailsOpen, setDetailsOpen] = useState(true);
   const [parentIssueOpen, setParentIssueOpen] = useState(true);
   const [pullRequestsOpen, setPullRequestsOpen] = useState(true);
+  const [subIssuesSidebarOpen, setSubIssuesSidebarOpen] = useState(true);
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [tokenUsageOpen, setTokenUsageOpen] = useState(true);
   const githubSettings = useGitHubSettings();
@@ -1584,6 +1585,43 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           </div>}
         </div>
       )}
+
+      {/* Sub-issues — sidebar counterpart to the inline list. Stays fixed
+          while the user scrolls through the conversation, so sub-issues
+          remain one click away regardless of scroll position. */}
+      {childIssues.length > 0 && (() => {
+        const doneCount = childIssues.filter((c) => c.status === "done").length;
+        return (
+          <div>
+            <button
+              type="button"
+              className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${subIssuesSidebarOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+              onClick={() => setSubIssuesSidebarOpen(!subIssuesSidebarOpen)}
+            >
+              {t(($) => $.detail.sub_issues_label)}
+              <span className="tabular-nums text-muted-foreground">
+                · {doneCount}/{childIssues.length}
+              </span>
+              <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ml-auto ${subIssuesSidebarOpen ? "rotate-90" : ""}`} />
+            </button>
+            {subIssuesSidebarOpen && (
+              <div className="pl-2 space-y-0.5">
+                {childIssues.map((child) => (
+                  <AppLink
+                    key={child.id}
+                    href={paths.issueDetail(child.id)}
+                    className="flex items-center gap-1.5 rounded-md px-2 py-1.5 -mx-2 text-xs hover:bg-accent/50 transition-colors group"
+                  >
+                    <StatusIcon status={child.status} className="h-3.5 w-3.5 shrink-0" />
+                    <span className="text-muted-foreground shrink-0">{child.identifier}</span>
+                    <span className="truncate group-hover:text-foreground">{child.title}</span>
+                  </AppLink>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       {/* Pull requests — hidden when the workspace disables the PR sidebar
           (or the GitHub master switch is off). Backend data is kept either


### PR DESCRIPTION
## Summary

Closes #4525

Add a collapsible "Sub-issues" section to the right sidebar of the issue detail page. Stays visible while scrolling through the conversation, so sub-issues remain one click away regardless of scroll position.

## Changes

- Added `subIssuesSidebarOpen` state variable (defaults to `true`)
- Added "Sub-issues" sidebar section between "Parent issue" and "Pull requests"
- Each row shows: status icon + identifier + title, linked to child issue detail
- Header shows progress count (done/total)
- Renders only when child issues exist (`childIssues.length > 0`)
- Reuses existing `childIssues` data from `childIssuesOptions`, zero additional network requests
- Follows same UI pattern as other collapsible sidebar sections

The inline sub-issue list below the description is preserved unchanged — this is a supplementary panel for quick access while browsing comments.

1 file changed, 38 insertions(+)