### PR TITLE
chore(channel): remove the one-time MULTICA_LARK_HUB_DISABLED cutover switch (MUL-3515)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -381,24 +381,6 @@ func main() {
 	// rows it simply idles. Lifecycle is bound to sweepCtx so it winds down
 	// alongside the other long-running workers, AFTER the HTTP server has
 	// drained.
-	// Cutover control (MUL-3515): MULTICA_LARK_HUB_DISABLED parks the inbound
-	// channel supervisor WITHOUT taking down the rest of the API — the process
-	// still serves HTTP normally, it just never claims a WS lease or opens a
-	// Feishu connection. The switch is generation-agnostic: in a pre-cutover
-	// build it parks the OLD (lark_*) hub, in this build it parks the NEW
-	// (channel_*) supervisor. The lark_*->channel_* rollout uses it twice —
-	// first to stop the old hub on the current build so migration 124 takes a
-	// clean snapshot, then to hold this build's new supervisor dormant until
-	// that migration has run and the old pods have drained, so the two never
-	// double-process the same bot. Nil-ing it here makes the start below and
-	// the shutdown join skip it. The operator flips it off last to bring the
-	// new supervisor up on channel_*. See migration 124's ROLLOUT note for the
-	// full order. The env var keeps its name for operator/runbook
-	// compatibility across the cutover.
-	if h.ChannelSupervisor != nil && os.Getenv("MULTICA_LARK_HUB_DISABLED") == "true" {
-		slog.Warn("Lark inbound supervisor disabled via MULTICA_LARK_HUB_DISABLED; API serves normally but no Feishu WebSocket is opened")
-		h.ChannelSupervisor = nil
-	}
 	if h.ChannelSupervisor != nil {
 		go h.ChannelSupervisor.Run(sweepCtx)
 	}

--- a/server/migrations/124_channel_generalization.up.sql
+++ b/server/migrations/124_channel_generalization.up.sql
@@ -39,25 +39,13 @@
 --     version upgrade is a clean cutover. Only a self-host re-tuned to
 --     multi-replica RollingUpdate needs the prd procedure below.
 --
---     PRD (rolling multica-api, maxUnavailable:0) overlaps old and new pods,
---     so use the MULTICA_LARK_HUB_DISABLED switch (cmd/server/main.go) to park
---     a hub while the API stays up. For a clean, drift-free cutover:
---       1. Pre-release the hub-park switch on the CURRENT build and set
---          MULTICA_LARK_HUB_DISABLED=true. The old hub stops everywhere (no
---          more lease/dedup/binding/thread writes to lark_*); the API stays up.
---       2. Run this migration — a clean snapshot, no live hub writing lark_*.
---       3. Deploy the channel build with the switch still ON. channel_* already
---          exists (step 2), so the new HTTP paths never 500, and the new hub
---          stays parked while old pods drain.
---       4. Flip MULTICA_LARK_HUB_DISABLED off — the new hub comes up on
---          channel_*. Only the Feishu bot is unavailable across steps 1-4; the
---          API stays up throughout.
---     The earlier "ship new code, THEN migrate after pods drain" order is
---     wrong: it serves channel_* HTTP before channel_* exists, violating (a).
---     Rollback to a pre-cutover build is not lossless once the new hub has
---     written Feishu state into channel_*. See the PR "Deployment / rollout"
---     section for the full runbook (incl. a lower-effort single-deploy variant
---     that trades a small transient drift for one fewer release).
+--     PRD (rolling multica-api, maxUnavailable:0) overlapped old and new pods.
+--     A one-time MULTICA_LARK_HUB_DISABLED park-switch existed during the
+--     cutover to hold a hub dormant while the API stayed up, so only one hub
+--     was ever live (invariant b). That cutover is complete and the switch has
+--     since been removed (MUL-3515); this note is kept as history. Rollback to
+--     a pre-cutover build is not lossless once the new hub has written Feishu
+--     state into channel_*.
 --
 -- app_secret_encrypted is BYTEA; it is carried into the JSONB config as a
 -- base64 string. PostgreSQL's encode(...,'base64') MIME-wraps the output


### PR DESCRIPTION
## Summary

Follow-up cleanup to MUL-3515. The `lark_*` → `channel_*` cutover is deployed to prod, so the one-time `MULTICA_LARK_HUB_DISABLED` park-switch has served its purpose and is removed.

- **`server/cmd/server/main.go`** — drop the env-gated branch that nil-ed `h.ChannelSupervisor` when `MULTICA_LARK_HUB_DISABLED=true`. The supervisor now always starts when built; its existing `!= nil` guard and the shutdown join are unchanged. (Prod never set the env, and the agreed end state doesn't want it — so this is a no-op for the live deployment.)
- **`server/migrations/124_channel_generalization.up.sql`** — the ROLLOUT note's PRD switch runbook referenced the now-deleted env var, so it's trimmed to a short historical note. **Comment-only**; migration 124 is already applied, so the change does not re-run anything. *(If the team prefers strictly immutable applied migrations, this one hunk can be dropped — the code removal stands on its own.)*

The two cutover invariants and the self-host explanation in the migration note are kept (still accurate and useful background).

## Why remove instead of keep as a kill-switch

Per repo convention (no one-time scaffolds / shims once they've served their purpose) and the explicit decision on MUL-3515 that the end state does not carry this switch. If an ongoing "park the Feishu hub without an API outage" kill-switch is ever wanted, it should be designed as a first-class operational control rather than left as cutover residue.

## Verification

```
gofmt -l server/cmd/server/main.go  → clean
go build ./cmd/server/              → ok
go vet ./cmd/server/               → clean
git grep MULTICA_LARK_HUB_DISABLED → only the historical line in migration 124
```

Behavioral change is limited to: the env var is no longer read. No tests referenced it.

Refs MUL-3515
