### PR TITLE
fix(server): add mention trigger idempotency at (trigger_comment, agent) level

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1322,6 +1322,27 @@ func filterSuppressedCommentAgentTriggers(triggers []commentAgentTrigger, suppre
 
 func (h *Handler) enqueueCommentAgentTriggers(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, triggers []commentAgentTrigger) {
 	for _, trigger := range triggers {
+		// Idempotency guard: if this trigger comment already has an active
+		// task for this agent (queued, dispatched, running, or waiting),
+		// skip enqueue to prevent duplicate runs from a single @mention event.
+		// The application check covers the window between task completion and
+		// the next trigger; a matching unique partial index on (trigger_comment_id,
+		// agent_id) in 126_mention_trigger_idempotency catches concurrent races.
+		if triggerCommentID.Valid {
+			hasActive, err := h.Queries.HasActiveTaskForTriggerCommentAndAgent(ctx, db.HasActiveTaskForTriggerCommentAndAgentParams{
+				TriggerCommentID: triggerCommentID,
+				AgentID:          trigger.Agent.ID,
+			})
+			if err != nil {
+				slog.Warn("trigger idempotency check failed, falling through to db constraint",
+					"trigger_comment_id", uuidToString(triggerCommentID),
+					"agent_id", uuidToString(trigger.Agent.ID),
+					"error", err)
+			} else if hasActive {
+				continue
+			}
+		}
+
 		switch trigger.Source {
 		case commentTriggerSourceIssueAssignee:
 			if trigger.Squad != nil {

--- a/server/migrations/126_mention_trigger_idempotency.down.sql
+++ b/server/migrations/126_mention_trigger_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_one_active_task_per_trigger_comment_agent;

--- a/server/migrations/126_mention_trigger_idempotency.up.sql
+++ b/server/migrations/126_mention_trigger_idempotency.up.sql
@@ -1,0 +1,10 @@
+-- Prevent duplicate agent runs from the same trigger comment.
+-- The existing idx_one_pending_task_per_issue_agent dedup at (issue, agent)
+-- does not guard against a trigger comment firing twice when the first task
+-- has already transitioned past 'dispatched' (e.g. into 'running').
+-- This index ensures at most one active task per (trigger_comment, agent) pair,
+-- covering the full non-terminal lifecycle so that a second dispatch while
+-- the first is still running is rejected at the database level.
+CREATE UNIQUE INDEX idx_one_active_task_per_trigger_comment_agent
+    ON agent_task_queue (trigger_comment_id, agent_id)
+    WHERE status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1781,6 +1781,28 @@ func (q *Queries) HasActiveTaskForIssue(ctx context.Context, issueID pgtype.UUID
 	return has_active, err
 }
 
+const hasActiveTaskForTriggerCommentAndAgent = `-- name: HasActiveTaskForTriggerCommentAndAgent :one
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE trigger_comment_id = $1 AND agent_id = $2
+  AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+`
+
+type HasActiveTaskForTriggerCommentAndAgentParams struct {
+	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
+	AgentID          pgtype.UUID `json:"agent_id"`
+}
+
+// Returns true if an active (non-terminal) task already exists for the
+// same (trigger_comment, agent) pair. Used by @mention idempotency to
+// prevent duplicate agent runs from a single trigger event — even when
+// the first run has already transitioned past 'dispatched' into 'running'.
+func (q *Queries) HasActiveTaskForTriggerCommentAndAgent(ctx context.Context, arg HasActiveTaskForTriggerCommentAndAgentParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveTaskForTriggerCommentAndAgent, arg.TriggerCommentID, arg.AgentID)
+	var has_active bool
+	err := row.Scan(&has_active)
+	return has_active, err
+}
+
 const hasPendingTaskForIssue = `-- name: HasPendingTaskForIssue :one
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched')

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -596,6 +596,15 @@ WHERE issue_id = @issue_id
   AND status IN ('queued', 'dispatched')
   AND trigger_comment_id IS DISTINCT FROM @exclude_trigger_comment_id::uuid;
 
+-- name: HasActiveTaskForTriggerCommentAndAgent :one
+-- Returns true if an active (non-terminal) task already exists for the
+-- same (trigger_comment, agent) pair. Used by @mention idempotency to
+-- prevent duplicate agent runs from a single trigger event — even when
+-- the first run has already transitioned past 'dispatched' into 'running'.
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE trigger_comment_id = $1 AND agent_id = $2
+  AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');
+
 -- name: GetLatestTaskIsLeaderForIssueAndAgent :one
 -- Returns the is_leader_task flag of the agent's most recent task on this
 -- issue, or NULL if the agent has never had a task on this issue. Used by


### PR DESCRIPTION
## Problem

`mention://agent/` trigger dispatching lacks idempotency protection at the `(trigger_comment_id, agent_id)` level. The existing dedup operates at `(issue_id, agent_id)` for `queued`/`dispatched` tasks only. When a task transitions to `running`, a concurrent or re-processed trigger event can create a second run for the same trigger comment — each run independently executes and produces duplicate comments.

Closes: #4528

## Root Cause

| Protection | Level | Statuses Covered | Gap |
|---|---|---|---|
| `hasPendingTaskForIssueAndAgent` | application | `queued`, `dispatched` | Misses `running`/`waiting_local_directory` |
| `idx_one_pending_task_per_issue_agent` | database | `queued`, `dispatched` | Same gap |

When task A (trigger_comment=C1, agent=X) transitions to `running`, both checks pass for a second dispatch with the same (C1, X) → duplicate task created → duplicate comments.

## Fix

Two-layer idempotency at `(trigger_comment_id, agent_id)`:

### 1. Application check (`comment.go`)

`enqueueCommentAgentTriggers` now calls `HasActiveTaskForTriggerCommentAndAgent` before dispatching. If an active task already exists for this `(trigger_comment, agent)` pair in any non-terminal state, skip.

### 2. Database constraint (`migration 126`)

```sql
CREATE UNIQUE INDEX idx_one_active_task_per_trigger_comment_agent
    ON agent_task_queue (trigger_comment_id, agent_id)
    WHERE status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');
```

Catches concurrent races that slip past the application check.

### 3. Suggested monitoring

Add a metric for duplicate dispatch attempts — this signals the idempotency layer is being exercised and may indicate upstream event pipeline races.
