### PR TITLE
fix(search): use semantic token for highlight

### DIFF
--- a/packages/views/search/highlight-text.tsx
+++ b/packages/views/search/highlight-text.tsx
@@ -35,7 +35,7 @@ export function HighlightText({ text, query }: { text: string; query: string }) 
     <>
       {parts.map((part, i) =>
         part.highlight ? (
-          <mark key={i} className="bg-yellow-200 dark:bg-yellow-900/60 text-inherit rounded-sm">
+          <mark key={i} className="rounded-sm bg-accent text-accent-foreground">
             {part.text}
           </mark>
         ) : (


### PR DESCRIPTION
## What does this PR do?

This PR updates search result highlighting to use Multica's semantic UI tokens instead of hardcoded Tailwind yellow colors.

The previous implementation used `bg-yellow-200 dark:bg-yellow-900/60`, which does not follow the project UI rule that shared web/desktop styles should prefer semantic tokens. Using `bg-accent text-accent-foreground` keeps the highlight aligned with the theme system across light and dark modes.

Risk is low because this only changes the visual styling of matched text in the shared search highlight component.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/search/highlight-text.tsx` to replace hardcoded yellow highlight classes with semantic UI token classes.

## How to Test

1. Run `pnpm install --filter @multica/views...`.
2. Run `pnpm --filter @multica/views test -- search/search-command.test.tsx`.
3. Confirm global search highlights matched text clearly in both light and dark mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
I used Cursor to inspect the contribution plan and the shared search highlight component, compare the implementation against the repository UI token rules, and make a focused styling update from hardcoded Tailwind yellow colors to semantic UI tokens. I then installed the relevant workspace dependencies and ran the views search test locally.

## Screenshots (optional)

N/A