### PR TITLE
ZED-14: add bounded shared-memory recall

### DIFF
--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -127,6 +127,35 @@ The tighter of the two wins. If your daemon is already running 20 tasks, new tas
 
 If you see tasks stuck in `queued` without moving to `dispatched`, one of these two limits is usually saturated.
 
+## Bounded shared-memory recall
+
+A local daemon can inject a bounded recall bundle from a canonical Ars Contexta vault before each agent task. Configure the vault on the machine that runs the daemon:
+
+```bash
+export MULTICA_SHARED_MEMORY_VAULT="/absolute/path/to/vault"
+multica recall index --vault "$MULTICA_SHARED_MEMORY_VAULT"
+multica daemon restart
+```
+
+The indexer reads only `notes/**/*.md`. It excludes `self/`, operational files, `MEMORY.md`, aggregated agent-memory indexes, unnamed files, and sync-conflict files. Every task receives a visible `hit`, `no_hit`, or `controlled_error` status; recall failure never blocks the task.
+
+Optional limits:
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `MULTICA_SHARED_MEMORY_MAX_HITS` | `5` | Maximum selected notes; values above 5 are rejected |
+| `MULTICA_SHARED_MEMORY_MAX_BYTES` | `12288` | Maximum rendered bundle size |
+| `MULTICA_SHARED_MEMORY_INDEX_MAX_AGE` | `168h` | Maximum accepted index age |
+| `MULTICA_SHARED_MEMORY_LOG` | profile-local `logs/recall.jsonl` | Append-only status and diagnostics log |
+
+Use the same engine manually for diagnosis:
+
+```bash
+multica recall query --vault "$MULTICA_SHARED_MEMORY_VAULT" --issue MUL-123 --comment "current request"
+```
+
+The query combines the issue title, description, and current comment. Output includes the index version plus each hit's path, filesystem recency, relevance score, and bounded excerpt.
+
 ## What happens to in-flight tasks after a daemon crash
 
 When the daemon crashes or is force-killed, the tasks it had picked up are left in `dispatched` or `running`. On the next start, the daemon tells the server: "these tasks are no longer mine, please mark them failed." The server flips them to `failed` with reason `runtime_recovery` — for retryable sources, the tasks are automatically requeued.

--- a/server/cmd/multica/cmd_recall.go
+++ b/server/cmd/multica/cmd_recall.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/multica-ai/multica/server/internal/recall"
+)
+
+var recallCmd = &cobra.Command{
+	Use:   "recall",
+	Short: "Diagnose and maintain shared-memory recall",
+}
+
+func init() {
+	recallCmd.AddCommand(newRecallQueryCommand())
+	recallCmd.AddCommand(newRecallIndexCommand())
+}
+
+func newRecallQueryCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "query",
+		Short: "Run the same bounded recall used before agent tasks",
+		RunE:  runRecallQuery,
+	}
+	flags := command.Flags()
+	flags.String("vault", "", "Canonical Ars Contexta vault root (env: MULTICA_SHARED_MEMORY_VAULT)")
+	flags.String("issue", "", "Issue ID or identifier used to load title and description")
+	flags.String("title", "", "Query title when --issue is omitted or needs an override")
+	flags.String("description", "", "Query description when --issue is omitted or needs an override")
+	flags.String("comment", "", "Current triggering comment text")
+	flags.Int("max-hits", 5, "Maximum number of notes (hard cap: 5)")
+	flags.Int("budget", 12*1024, "Maximum rendered bundle size in bytes")
+	flags.Duration("index-max-age", 7*24*time.Hour, "Maximum accepted index age")
+	flags.String("output", "json", "Output format: json")
+	return command
+}
+
+func newRecallIndexCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "index",
+		Short: "Atomically rebuild the canonical notes recall index",
+		RunE:  runRecallIndex,
+	}
+	command.Flags().String("vault", "", "Canonical Ars Contexta vault root (env: MULTICA_SHARED_MEMORY_VAULT)")
+	command.Flags().String("output", "json", "Output format: json")
+	return command
+}
+
+func runRecallQuery(command *cobra.Command, _ []string) error {
+	vault, _ := command.Flags().GetString("vault")
+	if strings.TrimSpace(vault) == "" {
+		vault = strings.TrimSpace(os.Getenv("MULTICA_SHARED_MEMORY_VAULT"))
+	}
+	issueTitle, _ := command.Flags().GetString("title")
+	issueDescription, _ := command.Flags().GetString("description")
+	issueReference, _ := command.Flags().GetString("issue")
+	if issueReference != "" {
+		loadedTitle, loadedDescription, err := loadRecallIssue(command, issueReference)
+		if err != nil {
+			return err
+		}
+		if issueTitle == "" {
+			issueTitle = loadedTitle
+		}
+		if issueDescription == "" {
+			issueDescription = loadedDescription
+		}
+	}
+	comment, _ := command.Flags().GetString("comment")
+	maxHits, _ := command.Flags().GetInt("max-hits")
+	budget, _ := command.Flags().GetInt("budget")
+	indexMaxAge, _ := command.Flags().GetDuration("index-max-age")
+	output, _ := command.Flags().GetString("output")
+	if output != "json" {
+		return fmt.Errorf("unsupported output format %q (expected json)", output)
+	}
+
+	result := recall.Run(command.Context(), recall.Options{
+		VaultRoot: vault, MaxHits: maxHits, MaxBundleBytes: budget, MaxIndexAge: indexMaxAge,
+	}, recall.Query{
+		IssueTitle: issueTitle, IssueDescription: issueDescription, TriggerComment: comment,
+	})
+	fmt.Fprintln(os.Stdout, result.Render())
+	return nil
+}
+
+func loadRecallIssue(command *cobra.Command, issueReference string) (string, string, error) {
+	client, err := newAPIClient(command)
+	if err != nil {
+		return "", "", err
+	}
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+	resolved, err := resolveIssueRef(ctx, client, issueReference)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve recall issue: %w", err)
+	}
+	var issue struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+	}
+	if err := client.GetJSON(ctx, "/api/issues/"+resolved.ID, &issue); err != nil {
+		return "", "", fmt.Errorf("get recall issue: %w", err)
+	}
+	return issue.Title, issue.Description, nil
+}
+
+func runRecallIndex(command *cobra.Command, _ []string) error {
+	vault, _ := command.Flags().GetString("vault")
+	if strings.TrimSpace(vault) == "" {
+		vault = strings.TrimSpace(os.Getenv("MULTICA_SHARED_MEMORY_VAULT"))
+	}
+	output, _ := command.Flags().GetString("output")
+	if output != "json" {
+		return fmt.Errorf("unsupported output format %q (expected json)", output)
+	}
+	index, err := recall.BuildIndex(command.Context(), recall.IndexOptions{VaultRoot: vault})
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(index)
+	if err != nil {
+		return fmt.Errorf("encode recall index result: %w", err)
+	}
+	fmt.Fprintln(os.Stdout, string(data))
+	return nil
+}

--- a/server/cmd/multica/cmd_recall_test.go
+++ b/server/cmd/multica/cmd_recall_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/recall"
+)
+
+func TestRunRecallQueryUsesSharedRecallEngine(t *testing.T) {
+	vault := t.TempDir()
+	notePath := filepath.Join(vault, "notes", "shared memory recall.md")
+	if err := os.MkdirAll(filepath.Dir(notePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notePath, []byte("---\ndescription: Shared memory recall is bounded\ntype: decision\ncreated: 2026-06-24\n---\n\n# Shared memory recall\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recall.BuildIndex(t.Context(), recall.IndexOptions{VaultRoot: vault}); err != nil {
+		t.Fatal(err)
+	}
+
+	command := newRecallQueryCommand()
+	command.SetArgs([]string{
+		"--vault", vault,
+		"--title", "implement shared memory recall",
+		"--max-hits", "5",
+		"--budget", "4096",
+		"--index-max-age", (24 * time.Hour).String(),
+		"--output", "json",
+	})
+	output, err := captureStdout(t, func() error {
+		return command.Execute()
+	})
+	if err != nil {
+		t.Fatalf("execute recall query: %v", err)
+	}
+
+	var result recall.Result
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode recall output: %v\n%s", err, output)
+	}
+	if result.Status != recall.StatusHit || result.HitCount != 1 {
+		t.Fatalf("recall result = %#v", result)
+	}
+	if result.Hits[0].Path != "notes/shared memory recall.md" {
+		t.Fatalf("hit path = %q", result.Hits[0].Path)
+	}
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -56,6 +56,7 @@ func init() {
 	// Runtime commands
 	daemonCmd.GroupID = groupRuntime
 	runtimeCmd.GroupID = groupRuntime
+	recallCmd.GroupID = groupRuntime
 
 	// Additional commands
 	authCmd.GroupID = groupAdditional
@@ -78,6 +79,7 @@ func init() {
 	rootCmd.AddCommand(squadCmd)
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(runtimeCmd)
+	rootCmd.AddCommand(recallCmd)
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(userCmd)
 	rootCmd.AddCommand(loginCmd)

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -60,6 +60,9 @@ const (
 	DefaultGCOrphanTTL             = 72 * time.Hour // 3 days — orphans with no meta (crashes, pre-GC leftovers)
 	DefaultGCArtifactTTL           = 12 * time.Hour // 12h — drop regenerable artifacts on completed but still-open issues
 	DefaultAutoUpdateCheckInterval = 6 * time.Hour  // how often the daemon polls GitHub for a newer CLI release
+	DefaultSharedMemoryMaxHits     = 5
+	DefaultSharedMemoryMaxBytes    = 12 * 1024
+	DefaultSharedMemoryIndexMaxAge = 7 * 24 * time.Hour
 )
 
 // DefaultGCArtifactPatterns lists basename matches that the GC loop treats as
@@ -102,6 +105,11 @@ type Config struct {
 	ClaudeArgs                     []string
 	CodexArgs                      []string
 	CodebuddyArgs                  []string
+	SharedMemoryVault              string
+	SharedMemoryMaxHits            int
+	SharedMemoryMaxBytes           int
+	SharedMemoryIndexMaxAge        time.Duration
+	SharedMemoryLogPath            string
 
 	// ProfileCommandOverrides maps a custom runtime profile_id -> the absolute
 	// executable path to use for that profile on THIS machine (MUL-3284).
@@ -436,6 +444,31 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	sharedMemoryVault := strings.TrimSpace(os.Getenv("MULTICA_SHARED_MEMORY_VAULT"))
+	sharedMemoryMaxHits, err := intFromEnv("MULTICA_SHARED_MEMORY_MAX_HITS", DefaultSharedMemoryMaxHits)
+	if err != nil {
+		return Config{}, err
+	}
+	if sharedMemoryMaxHits < 1 || sharedMemoryMaxHits > DefaultSharedMemoryMaxHits {
+		return Config{}, fmt.Errorf("MULTICA_SHARED_MEMORY_MAX_HITS must be between 1 and %d", DefaultSharedMemoryMaxHits)
+	}
+	sharedMemoryMaxBytes, err := intFromEnv("MULTICA_SHARED_MEMORY_MAX_BYTES", DefaultSharedMemoryMaxBytes)
+	if err != nil {
+		return Config{}, err
+	}
+	if sharedMemoryMaxBytes < 512 {
+		return Config{}, fmt.Errorf("MULTICA_SHARED_MEMORY_MAX_BYTES must be at least 512")
+	}
+	sharedMemoryIndexMaxAge, err := durationFromEnv("MULTICA_SHARED_MEMORY_INDEX_MAX_AGE", DefaultSharedMemoryIndexMaxAge)
+	if err != nil {
+		return Config{}, err
+	}
+	sharedMemoryLogPath := strings.TrimSpace(os.Getenv("MULTICA_SHARED_MEMORY_LOG"))
+	if sharedMemoryLogPath == "" {
+		if profileDir, profileErr := cli.ProfileDir(profile); profileErr == nil {
+			sharedMemoryLogPath = filepath.Join(profileDir, "logs", "recall.jsonl")
+		}
+	}
 
 	// Health port: override > default
 	healthPort := DefaultHealthPort
@@ -527,6 +560,11 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		ClaudeArgs:                     claudeArgs,
 		CodexArgs:                      codexArgs,
 		CodebuddyArgs:                  codebuddyArgs,
+		SharedMemoryVault:              sharedMemoryVault,
+		SharedMemoryMaxHits:            sharedMemoryMaxHits,
+		SharedMemoryMaxBytes:           sharedMemoryMaxBytes,
+		SharedMemoryIndexMaxAge:        sharedMemoryIndexMaxAge,
+		SharedMemoryLogPath:            sharedMemoryLogPath,
 		ProfileCommandOverrides:        profileCommandOverrides,
 	}, nil
 }

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -261,6 +261,28 @@ func TestLoadConfig_AutoUpdateDefault_SelfHostOff(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_SharedMemoryRecallFromEnvironment(t *testing.T) {
+	stageFakeAgent(t)
+	vault := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "recall.jsonl")
+	t.Setenv("MULTICA_SHARED_MEMORY_VAULT", vault)
+	t.Setenv("MULTICA_SHARED_MEMORY_MAX_HITS", "4")
+	t.Setenv("MULTICA_SHARED_MEMORY_MAX_BYTES", "8192")
+	t.Setenv("MULTICA_SHARED_MEMORY_INDEX_MAX_AGE", "48h")
+	t.Setenv("MULTICA_SHARED_MEMORY_LOG", logPath)
+
+	cfg, err := LoadConfig(Overrides{ServerURL: "http://localhost:8080", WorkspacesRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.SharedMemoryVault != vault || cfg.SharedMemoryMaxHits != 4 || cfg.SharedMemoryMaxBytes != 8192 {
+		t.Fatalf("shared memory config = %#v", cfg)
+	}
+	if cfg.SharedMemoryIndexMaxAge != 48*time.Hour || cfg.SharedMemoryLogPath != logPath {
+		t.Fatalf("shared memory age/log = %s/%q", cfg.SharedMemoryIndexMaxAge, cfg.SharedMemoryLogPath)
+	}
+}
+
 // TestLoadConfig_AutoUpdateDefault_CloudOn confirms the symmetric case: a
 // daemon pointed at Multica's hosted cloud keeps the historical opt-in
 // auto-update default. We pass the WSS form of the URL to also exercise that

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3543,7 +3543,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}()
 	}
 
-	prompt := BuildPrompt(task, provider)
+	recallResult := d.runSharedMemoryRecall(ctx, task)
+	prompt := prependRecallBundle(BuildPrompt(task, provider), &recallResult)
 
 	// Pass task-scoped auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).

--- a/server/internal/daemon/shared_memory_recall.go
+++ b/server/internal/daemon/shared_memory_recall.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/recall"
+)
+
+type recallLogRecord struct {
+	Timestamp    string        `json:"timestamp"`
+	TaskID       string        `json:"task_id"`
+	IssueID      string        `json:"issue_id,omitempty"`
+	Status       recall.Status `json:"status"`
+	HitCount     int           `json:"hit_count"`
+	QueryHash    string        `json:"query_hash"`
+	BytesUsed    int           `json:"bytes_used"`
+	IndexVersion int           `json:"index_version"`
+	SkippedFiles []string      `json:"skipped_files,omitempty"`
+	Reason       string        `json:"reason,omitempty"`
+}
+
+const sharedMemoryRecallTimeout = 2 * time.Second
+
+func (d *Daemon) runSharedMemoryRecall(ctx context.Context, task Task) recall.Result {
+	options := recall.Options{
+		VaultRoot:      d.cfg.SharedMemoryVault,
+		MaxHits:        d.cfg.SharedMemoryMaxHits,
+		MaxBundleBytes: d.cfg.SharedMemoryMaxBytes,
+		MaxIndexAge:    d.cfg.SharedMemoryIndexMaxAge,
+	}
+	query := recall.Query{
+		IssueTitle:       task.IssueTitle,
+		IssueDescription: task.IssueDescription,
+		TriggerComment:   task.TriggerCommentContent,
+	}
+	result := runRecallWithTimeout(ctx, sharedMemoryRecallTimeout, func() recall.Result {
+		return recall.Run(ctx, options, query)
+	})
+	if result.Reason == "recall_timeout" {
+		budget := d.cfg.SharedMemoryMaxBytes
+		if budget < 512 {
+			budget = DefaultSharedMemoryMaxBytes
+		}
+		result.Query = query.Text()
+		result.IndexVersion = recall.CurrentIndexVersion
+		result.ByteBudget = budget
+		result.Hits = []recall.Hit{}
+	}
+	result.Render()
+	if d.cfg.SharedMemoryLogPath != "" {
+		if err := writeRecallLog(d.cfg.SharedMemoryLogPath, task, result, time.Now()); err != nil {
+			d.logger.Warn("shared memory recall log failed", "task_id", task.ID, "error", err)
+		}
+	}
+	return result
+}
+
+func runRecallWithTimeout(ctx context.Context, timeout time.Duration, run func() recall.Result) recall.Result {
+	results := make(chan recall.Result, 1)
+	go func() {
+		results <- run()
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case result := <-results:
+		return result
+	case <-ctx.Done():
+		return recall.Result{Status: recall.StatusControlledError, Reason: "context_cancelled"}
+	case <-timer.C:
+		return recall.Result{Status: recall.StatusControlledError, Reason: "recall_timeout"}
+	}
+}
+
+func prependRecallBundle(prompt string, result *recall.Result) string {
+	return "<shared-memory-recall>\n" + result.Render() + "\n</shared-memory-recall>\n\n" + prompt
+}
+
+func writeRecallLog(logPath string, task Task, result recall.Result, now time.Time) error {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("create recall log directory: %w", err)
+	}
+	digest := sha256.Sum256([]byte(result.Query))
+	record := recallLogRecord{
+		Timestamp: now.UTC().Format(time.RFC3339), TaskID: task.ID, IssueID: task.IssueID,
+		Status: result.Status, HitCount: result.HitCount, QueryHash: hex.EncodeToString(digest[:]),
+		BytesUsed: result.BytesUsed, IndexVersion: result.IndexVersion,
+		SkippedFiles: result.SkippedFiles, Reason: result.Reason,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode recall log: %w", err)
+	}
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open recall log: %w", err)
+	}
+	defer file.Close()
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("append recall log: %w", err)
+	}
+	return nil
+}

--- a/server/internal/daemon/shared_memory_recall_test.go
+++ b/server/internal/daemon/shared_memory_recall_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/recall"
+)
+
+func TestRunRecallWithTimeoutNeverBlocksAgentLaunch(t *testing.T) {
+	t.Parallel()
+
+	blocked := make(chan struct{})
+	started := time.Now()
+	result := runRecallWithTimeout(context.Background(), 10*time.Millisecond, func() recall.Result {
+		<-blocked
+		return recall.Result{Status: recall.StatusHit}
+	})
+	close(blocked)
+
+	if elapsed := time.Since(started); elapsed > 200*time.Millisecond {
+		t.Fatalf("timed recall blocked for %s", elapsed)
+	}
+	if result.Status != recall.StatusControlledError || result.Reason != "recall_timeout" {
+		t.Fatalf("timeout result = %#v", result)
+	}
+}
+
+func TestPrependRecallBundleMakesStatusVisibleBeforeTaskPrompt(t *testing.T) {
+	t.Parallel()
+
+	result := recall.Result{
+		Status: recall.StatusNoHit, HitCount: 0, Query: "issue title", IndexVersion: 1,
+		ByteBudget: 4096, Reason: "index_missing", Hits: []recall.Hit{},
+	}
+	prompt := prependRecallBundle("original task prompt", &result)
+
+	if !strings.HasPrefix(prompt, "<shared-memory-recall>\n") {
+		t.Fatalf("prompt does not start with recall bundle: %s", prompt)
+	}
+	if !strings.Contains(prompt, `"recall_status":"no_hit"`) || !strings.Contains(prompt, `"reason":"index_missing"`) {
+		t.Fatalf("prompt does not expose recall status: %s", prompt)
+	}
+	if !strings.HasSuffix(prompt, "original task prompt") {
+		t.Fatalf("original prompt missing: %s", prompt)
+	}
+}
+
+func TestWriteRecallLogAppendsOneBoundedRecordPerRun(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "logs", "recall.jsonl")
+	now := time.Date(2026, time.June, 24, 9, 0, 0, 0, time.UTC)
+	result := recall.Result{
+		Status: recall.StatusHit, HitCount: 1, Query: "secret issue text", IndexVersion: 1,
+		ByteBudget: 4096, BytesUsed: 512, Hits: []recall.Hit{{Path: "notes/a.md"}},
+		SkippedFiles: []string{"notes/unreadable.md"},
+	}
+	if err := writeRecallLog(logPath, Task{ID: "task-1", IssueID: "issue-1"}, result, now); err != nil {
+		t.Fatalf("writeRecallLog() error = %v", err)
+	}
+	if err := writeRecallLog(logPath, Task{ID: "task-2", IssueID: "issue-1"}, result, now.Add(time.Minute)); err != nil {
+		t.Fatalf("second writeRecallLog() error = %v", err)
+	}
+
+	file, err := os.Open(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	var records []map[string]any
+	for scanner.Scan() {
+		var record map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			t.Fatalf("invalid JSONL record: %v", err)
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2", len(records))
+	}
+	first := records[0]
+	if first["status"] != "hit" || first["task_id"] != "task-1" || first["issue_id"] != "issue-1" {
+		t.Fatalf("unexpected record: %#v", first)
+	}
+	if first["query_hash"] == "" || first["query_hash"] == result.Query {
+		t.Fatalf("query_hash must be non-empty and irreversible: %#v", first["query_hash"])
+	}
+	if _, exists := first["query"]; exists {
+		t.Fatalf("raw query leaked into log: %#v", first)
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -41,11 +41,13 @@ type ProjectResourceData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID          string `json:"id"`
-	AgentID     string `json:"agent_id"`
-	RuntimeID   string `json:"runtime_id"`
-	IssueID     string `json:"issue_id"`
-	WorkspaceID string `json:"workspace_id"`
+	ID               string `json:"id"`
+	AgentID          string `json:"agent_id"`
+	RuntimeID        string `json:"runtime_id"`
+	IssueID          string `json:"issue_id"`
+	IssueTitle       string `json:"issue_title,omitempty"`
+	IssueDescription string `json:"issue_description,omitempty"`
+	WorkspaceID      string `json:"workspace_id"`
 	// WorkspaceContext mirrors workspace.context (the per-workspace system
 	// prompt set in Settings → General). Server populates this on every claim
 	// regardless of task kind so the daemon can inject `## Workspace Context`

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -224,11 +224,13 @@ type ProjectResourceData struct {
 }
 
 type AgentTaskResponse struct {
-	ID          string `json:"id"`
-	AgentID     string `json:"agent_id"`
-	RuntimeID   string `json:"runtime_id"`
-	IssueID     string `json:"issue_id"`
-	WorkspaceID string `json:"workspace_id"`
+	ID               string `json:"id"`
+	AgentID          string `json:"agent_id"`
+	RuntimeID        string `json:"runtime_id"`
+	IssueID          string `json:"issue_id"`
+	IssueTitle       string `json:"issue_title,omitempty"`
+	IssueDescription string `json:"issue_description,omitempty"`
+	WorkspaceID      string `json:"workspace_id"`
 	// WorkspaceContext is the workspace-level system prompt set in workspace
 	// settings (`workspace.context` DB column). Injected into the agent brief
 	// as `## Workspace Context` so every agent running in this workspace —

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1383,6 +1383,8 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
 			resp.WorkspaceID = uuidToString(issue.WorkspaceID)
 			resp.ThreadName = issue.Title
+			resp.IssueTitle = issue.Title
+			resp.IssueDescription = issue.Description.String
 
 			// Squad-leader briefing injection: when the issue is assigned
 			// to a squad and the claiming agent is that squad's current

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -690,6 +690,48 @@ func TestClaimTaskByRuntime_WorkspaceContextEmptyWhenUnset(t *testing.T) {
 	}
 }
 
+func TestClaimTaskByRuntime_PopulatesIssueRecallQueryFields(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Recall query claim runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Recall query claim agent")
+	const title = "Implement bounded shared-memory recall"
+	const description = "Load an index before selecting at most five relevant notes."
+	if _, err := testPool.Exec(ctx, `UPDATE issue SET title = $1, description = $2 WHERE id = $3`, title, description, issueID); err != nil {
+		t.Fatalf("update issue recall fields: %v", err)
+	}
+	taskID := createDispatchedClaimFixtureTask(t, ctx, agentID, runtimeID, issueID, "120 seconds", false)
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
+		testWorkspaceID, "recall-query-claim")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			ID               string `json:"id"`
+			IssueTitle       string `json:"issue_title"`
+			IssueDescription string `json:"issue_description"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode claim response: %v", err)
+	}
+	if resp.Task == nil || resp.Task.ID != taskID {
+		t.Fatalf("expected claimed task %s, got %#v", taskID, resp.Task)
+	}
+	if resp.Task.IssueTitle != title || resp.Task.IssueDescription != description {
+		t.Fatalf("issue recall fields = %q/%q, want %q/%q", resp.Task.IssueTitle, resp.Task.IssueDescription, title, description)
+	}
+}
+
 func TestClaimTaskByRuntime_MissingRuntimeOwnerCancelsAndRejects(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")

--- a/server/internal/recall/index.go
+++ b/server/internal/recall/index.go
@@ -1,0 +1,242 @@
+package recall
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func BuildIndex(ctx context.Context, options IndexOptions) (Index, error) {
+	if strings.TrimSpace(options.VaultRoot) == "" {
+		return Index{}, fmt.Errorf("vault root is required")
+	}
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	notesRoot := filepath.Join(options.VaultRoot, "notes")
+	entries := make([]Entry, 0)
+	err := filepath.WalkDir(notesRoot, func(filePath string, item fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if item.IsDir() {
+			return nil
+		}
+		relativePath, err := filepath.Rel(options.VaultRoot, filePath)
+		if err != nil {
+			return err
+		}
+		relativePath = filepath.ToSlash(relativePath)
+		candidate := Entry{Path: relativePath, FolderClass: "notes"}
+		if !isAllowedEntry(candidate) {
+			return nil
+		}
+		info, err := item.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() == 0 {
+			return nil
+		}
+		entry, err := indexEntry(filePath, relativePath, info)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return Index{}, fmt.Errorf("walk notes: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	index := Index{
+		IndexVersion: CurrentIndexVersion,
+		GeneratedAt:  options.Now().UTC().Format(time.RFC3339),
+		VaultCommit:  readVaultCommit(options.VaultRoot),
+		EntryCount:   len(entries),
+		Entries:      entries,
+	}
+	if err := writeIndexAtomically(options.VaultRoot, index); err != nil {
+		return Index{}, err
+	}
+	return index, nil
+}
+
+func indexEntry(filePath, relativePath string, info fs.FileInfo) (Entry, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return Entry{}, err
+	}
+	content := string(data)
+	frontmatter := parseFrontmatter(content)
+	title := firstHeading(content)
+	if title == "" {
+		title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	}
+	summary := strings.TrimSpace(frontmatter["description"])
+	if summary == "" {
+		summary = firstBodyLine(content)
+	}
+	if len([]rune(summary)) > 240 {
+		summary = string([]rune(summary)[:240])
+	}
+	return Entry{
+		Path: relativePath, Title: title, Tags: parseTopics(content),
+		MTime: info.ModTime().UTC().Format(time.RFC3339), Summary: summary,
+		FolderClass: "notes", SizeBytes: info.Size(),
+	}, nil
+}
+
+func parseFrontmatter(content string) map[string]string {
+	fields := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
+		return fields
+	}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "---" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if ok {
+			fields[strings.TrimSpace(key)] = strings.Trim(strings.TrimSpace(value), `"'`)
+		}
+	}
+	return fields
+}
+
+func firstHeading(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# "))
+		}
+	}
+	return ""
+}
+
+func firstBodyLine(content string) string {
+	inFrontmatter := false
+	for index, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if index == 0 && trimmed == "---" {
+			inFrontmatter = true
+			continue
+		}
+		if inFrontmatter {
+			if trimmed == "---" {
+				inFrontmatter = false
+			}
+			continue
+		}
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") && trimmed != "---" && trimmed != "Topics:" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseTopics(content string) []string {
+	topics := make([]string, 0)
+	inTopics := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "Topics:" {
+			inTopics = true
+			continue
+		}
+		if !inTopics {
+			continue
+		}
+		if trimmed == "" || !strings.HasPrefix(trimmed, "-") {
+			if trimmed != "" {
+				break
+			}
+			continue
+		}
+		start := strings.Index(trimmed, "[[")
+		end := strings.Index(trimmed, "]]")
+		if start >= 0 && end > start+2 {
+			topics = append(topics, strings.TrimSpace(trimmed[start+2:end]))
+		}
+	}
+	sort.Strings(topics)
+	return topics
+}
+
+func writeIndexAtomically(vaultRoot string, index Index) error {
+	opsDir := filepath.Join(vaultRoot, "ops")
+	if err := os.MkdirAll(opsDir, 0o755); err != nil {
+		return fmt.Errorf("create ops directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(opsDir, ".recall-index-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary index: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	encoder := json.NewEncoder(temporary)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(index); err != nil {
+		temporary.Close()
+		return fmt.Errorf("encode index: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return fmt.Errorf("sync index: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close index: %w", err)
+	}
+	if err := os.Rename(temporaryPath, filepath.Join(opsDir, "recall-index.json")); err != nil {
+		return fmt.Errorf("replace index: %w", err)
+	}
+	return nil
+}
+
+func readVaultCommit(vaultRoot string) string {
+	gitPath := filepath.Join(vaultRoot, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+	gitDir := gitPath
+	if !info.IsDir() {
+		data, err := os.ReadFile(gitPath)
+		if err != nil {
+			return ""
+		}
+		value := strings.TrimSpace(string(data))
+		if !strings.HasPrefix(value, "gitdir: ") {
+			return ""
+		}
+		gitDir = strings.TrimSpace(strings.TrimPrefix(value, "gitdir: "))
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(vaultRoot, gitDir)
+		}
+	}
+	head, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	value := strings.TrimSpace(string(head))
+	if !strings.HasPrefix(value, "ref: ") {
+		return value
+	}
+	reference := strings.TrimSpace(strings.TrimPrefix(value, "ref: "))
+	data, err := os.ReadFile(filepath.Join(gitDir, filepath.FromSlash(reference)))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/server/internal/recall/recall.go
+++ b/server/internal/recall/recall.go
@@ -1,0 +1,322 @@
+package recall
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	defaultMaxHits        = 5
+	defaultMaxBundleBytes = 12 * 1024
+	defaultMaxIndexAge    = 7 * 24 * time.Hour
+	maxExcerptBytes       = 2048
+	maxNoteReadBytes      = 64 * 1024
+)
+
+type scoredEntry struct {
+	entry Entry
+	score float64
+}
+
+func Run(ctx context.Context, options Options, query Query) Result {
+	options = normalizeOptions(options)
+	result := Result{
+		Status: StatusNoHit, Query: query.Text(), IndexVersion: CurrentIndexVersion,
+		ByteBudget: options.MaxBundleBytes, Hits: []Hit{},
+	}
+	fitResultWithinBudget(&result)
+	if strings.TrimSpace(options.VaultRoot) == "" {
+		result.Reason = "vault_not_configured"
+		fitResultWithinBudget(&result)
+		return result
+	}
+
+	index, status, reason := loadIndex(options)
+	if status != "" {
+		result.Status = status
+		result.Reason = reason
+		fitResultWithinBudget(&result)
+		return result
+	}
+	result.IndexVersion = index.IndexVersion
+
+	queryTokens := tokenize(result.Query)
+	if len(queryTokens) == 0 {
+		result.Reason = "query_empty"
+		fitResultWithinBudget(&result)
+		return result
+	}
+
+	candidates := make([]scoredEntry, 0, len(index.Entries))
+	for _, entry := range index.Entries {
+		if err := ctx.Err(); err != nil {
+			result.Status = StatusControlledError
+			result.Reason = "context_cancelled"
+			fitResultWithinBudget(&result)
+			return result
+		}
+		if !isAllowedEntry(entry) {
+			result.SkippedFiles = append(result.SkippedFiles, entry.Path)
+			continue
+		}
+		score := scoreEntry(queryTokens, entry)
+		if score > 0 {
+			candidates = append(candidates, scoredEntry{entry: entry, score: score})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		if candidates[i].entry.MTime != candidates[j].entry.MTime {
+			return candidates[i].entry.MTime > candidates[j].entry.MTime
+		}
+		return candidates[i].entry.Path < candidates[j].entry.Path
+	})
+
+	for _, candidate := range candidates {
+		if len(result.Hits) >= options.MaxHits {
+			break
+		}
+		excerpt, err := readExcerpt(options.VaultRoot, candidate.entry.Path)
+		if err != nil {
+			result.SkippedFiles = append(result.SkippedFiles, candidate.entry.Path)
+			continue
+		}
+		hit := Hit{
+			Path: candidate.entry.Path, Recency: candidate.entry.MTime,
+			Relevance: candidate.score, Excerpt: excerpt,
+		}
+		if !appendWithinBudget(&result, hit, options.MaxBundleBytes) {
+			break
+		}
+	}
+
+	result.HitCount = len(result.Hits)
+	if result.HitCount > 0 {
+		result.Status = StatusHit
+		result.Reason = ""
+	} else {
+		result.Reason = "no_relevant_notes"
+	}
+	fitResultWithinBudget(&result)
+	return result
+}
+
+func normalizeOptions(options Options) Options {
+	if options.MaxHits <= 0 || options.MaxHits > defaultMaxHits {
+		options.MaxHits = defaultMaxHits
+	}
+	if options.MaxBundleBytes < 512 {
+		options.MaxBundleBytes = defaultMaxBundleBytes
+	}
+	if options.MaxIndexAge <= 0 {
+		options.MaxIndexAge = defaultMaxIndexAge
+	}
+	if options.Now == nil {
+		options.Now = time.Now
+	}
+	return options
+}
+
+func fitResultWithinBudget(result *Result) {
+	if len([]byte(result.Render())) <= result.ByteBudget {
+		return
+	}
+	runes := []rune(result.Query)
+	low, high := 0, len(runes)
+	best := ""
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate := ""
+		if mid > 0 {
+			candidate = strings.TrimSpace(string(runes[:mid])) + "…[truncated]"
+		}
+		result.Query = candidate
+		if len([]byte(result.Render())) <= result.ByteBudget {
+			best = candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	result.Query = best
+	result.Render()
+}
+
+func loadIndex(options Options) (Index, Status, string) {
+	indexPath := filepath.Join(options.VaultRoot, "ops", "recall-index.json")
+	data, err := os.ReadFile(indexPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return Index{}, StatusNoHit, "index_missing"
+	}
+	if err != nil {
+		return Index{}, StatusControlledError, "index_unreadable"
+	}
+	var index Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return Index{}, StatusControlledError, "index_invalid"
+	}
+	if index.IndexVersion != CurrentIndexVersion {
+		return Index{}, StatusNoHit, "index_version_incompatible"
+	}
+	generatedAt, err := time.Parse(time.RFC3339, index.GeneratedAt)
+	if err != nil {
+		return Index{}, StatusControlledError, "index_invalid"
+	}
+	if options.Now().Sub(generatedAt) > options.MaxIndexAge {
+		return Index{}, StatusNoHit, "index_stale"
+	}
+	return index, "", ""
+}
+
+func isAllowedEntry(entry Entry) bool {
+	clean := path.Clean(strings.ReplaceAll(entry.Path, "\\", "/"))
+	if clean != entry.Path || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return false
+	}
+	if !strings.HasPrefix(clean, "notes/") || !strings.EqualFold(path.Ext(clean), ".md") {
+		return false
+	}
+	base := path.Base(clean)
+	lower := strings.ToLower(base)
+	return !strings.EqualFold(base, "MEMORY.md") &&
+		!strings.EqualFold(base, "agent-memory-index.md") &&
+		!strings.HasPrefix(lower, "unbenannt") &&
+		!strings.Contains(lower, "sync-conflict")
+}
+
+func tokenize(value string) map[string]struct{} {
+	tokens := map[string]struct{}{}
+	var current strings.Builder
+	flush := func() {
+		if current.Len() < 2 {
+			current.Reset()
+			return
+		}
+		tokens[current.String()] = struct{}{}
+		current.Reset()
+	}
+	for _, r := range strings.ToLower(value) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current.WriteRune(r)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+func scoreEntry(queryTokens map[string]struct{}, entry Entry) float64 {
+	weighted := []struct {
+		value  string
+		weight float64
+	}{
+		{value: entry.Title, weight: 4},
+		{value: strings.Join(entry.Tags, " "), weight: 3},
+		{value: entry.Summary, weight: 2},
+	}
+	var score float64
+	for _, field := range weighted {
+		for token := range tokenize(field.value) {
+			if _, ok := queryTokens[token]; ok {
+				score += field.weight
+			}
+		}
+	}
+	return score
+}
+
+func readExcerpt(vaultRoot, relativePath string) (string, error) {
+	fullPath := filepath.Join(vaultRoot, filepath.FromSlash(relativePath))
+	rootAbs, err := filepath.Abs(vaultRoot)
+	if err != nil {
+		return "", err
+	}
+	pathAbs, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", os.ErrPermission
+	}
+	file, err := os.Open(pathAbs)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	reader := bufio.NewReader(io.LimitReader(file, maxNoteReadBytes))
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	excerpt := strings.TrimSpace(string(data))
+	if excerpt == "" {
+		return "", io.EOF
+	}
+	return truncateUTF8(excerpt, maxExcerptBytes), nil
+}
+
+func appendWithinBudget(result *Result, hit Hit, budget int) bool {
+	result.Hits = append(result.Hits, hit)
+	result.HitCount = len(result.Hits)
+	if len([]byte(result.Render())) <= budget {
+		return true
+	}
+
+	runes := []rune(hit.Excerpt)
+	low, high := 0, len(runes)
+	best := ""
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate := ""
+		if mid > 0 {
+			candidate = strings.TrimSpace(string(runes[:mid])) + "…[truncated]"
+		}
+		result.Hits[len(result.Hits)-1].Excerpt = candidate
+		if len([]byte(result.Render())) <= budget {
+			best = candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if best != "" {
+		result.Hits[len(result.Hits)-1].Excerpt = best
+		result.Render()
+		return true
+	}
+	result.Hits = result.Hits[:len(result.Hits)-1]
+	result.HitCount = len(result.Hits)
+	result.Render()
+	return false
+}
+
+func truncateUTF8(value string, maxBytes int) string {
+	if len([]byte(value)) <= maxBytes {
+		return value
+	}
+	marker := "…[truncated]"
+	limit := maxBytes - len([]byte(marker))
+	if limit <= 0 {
+		return ""
+	}
+	data := []byte(value)
+	for limit > 0 && !utf8.Valid(data[:limit]) {
+		limit--
+	}
+	return strings.TrimSpace(string(data[:limit])) + marker
+}

--- a/server/internal/recall/recall_test.go
+++ b/server/internal/recall/recall_test.go
@@ -1,0 +1,257 @@
+package recall
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunReturnsRankedBoundedHitsWithProvenance(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 24, 9, 0, 0, 0, time.UTC)
+	vault := t.TempDir()
+	writeTestNote(t, vault, "notes/runtime recall is bounded.md", "Runtime recall uses a strict byte budget and at most five hits.")
+	writeTestNote(t, vault, "notes/unrelated cooking note.md", "Pasta needs salted water.")
+	writeTestIndex(t, vault, now, []map[string]any{
+		{
+			"path": "notes/unrelated cooking note.md", "title": "unrelated cooking note",
+			"tags": []string{"cooking"}, "mtime": now.Add(-time.Hour).Format(time.RFC3339),
+			"summary": "pasta recipes", "folder_class": "notes", "size_bytes": 24,
+		},
+		{
+			"path": "notes/runtime recall is bounded.md", "title": "runtime recall is bounded",
+			"tags": []string{"runtime", "memory"}, "mtime": now.Add(-2 * time.Hour).Format(time.RFC3339),
+			"summary": "bounded shared memory recall for agent runs", "folder_class": "notes", "size_bytes": 72,
+		},
+	})
+
+	result := Run(context.Background(), Options{
+		VaultRoot:      vault,
+		MaxHits:        5,
+		MaxBundleBytes: 900,
+		MaxIndexAge:    24 * time.Hour,
+		Now:            func() time.Time { return now },
+	}, Query{
+		IssueTitle:       "Implement bounded shared memory recall",
+		IssueDescription: "Agent runs need deterministic retrieval",
+		TriggerComment:   "Start with the runtime recall implementation",
+	})
+
+	if result.Status != StatusHit {
+		t.Fatalf("status = %q, want %q (reason=%q)", result.Status, StatusHit, result.Reason)
+	}
+	if result.HitCount != 1 || len(result.Hits) != 1 {
+		t.Fatalf("hits = %d/%d, want exactly one relevant hit", result.HitCount, len(result.Hits))
+	}
+	hit := result.Hits[0]
+	if hit.Path != "notes/runtime recall is bounded.md" {
+		t.Fatalf("first hit path = %q", hit.Path)
+	}
+	if hit.Recency != now.Add(-2*time.Hour).Format(time.RFC3339) {
+		t.Fatalf("recency = %q", hit.Recency)
+	}
+	if hit.Relevance <= 0 {
+		t.Fatalf("relevance = %f, want positive", hit.Relevance)
+	}
+	if hit.Excerpt == "" {
+		t.Fatal("excerpt is empty")
+	}
+	rendered := result.Render()
+	if len([]byte(rendered)) > 900 {
+		t.Fatalf("rendered bundle uses %d bytes, budget is 900", len([]byte(rendered)))
+	}
+	if result.BytesUsed != len([]byte(rendered)) {
+		t.Fatalf("bytes_used = %d, rendered bytes = %d", result.BytesUsed, len([]byte(rendered)))
+	}
+	for _, required := range []string{"recall_status", "index_version", "path", "recency", "relevance"} {
+		if !strings.Contains(rendered, required) {
+			t.Errorf("rendered bundle missing %q: %s", required, rendered)
+		}
+	}
+}
+
+func TestRunCapsHitCountAndExcludesUnsafeSources(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 24, 9, 0, 0, 0, time.UTC)
+	vault := t.TempDir()
+	entries := make([]map[string]any, 0, 10)
+	for i := 0; i < 7; i++ {
+		path := filepath.ToSlash(filepath.Join("notes", "memory recall "+string(rune('a'+i))+".md"))
+		writeTestNote(t, vault, path, "shared memory recall content")
+		entries = append(entries, map[string]any{
+			"path": path, "title": "shared memory recall", "tags": []string{"memory"},
+			"mtime": now.Format(time.RFC3339), "summary": "shared memory recall", "folder_class": "notes", "size_bytes": 28,
+		})
+	}
+	writeTestNote(t, vault, "notes/MEMORY.md", "must never be global")
+	writeTestNote(t, vault, "notes/agent-memory-index.md", "aggregated agent-local MEMORY.md content")
+	writeTestNote(t, vault, "self/private memory.md", "must never be global")
+	entries = append(entries,
+		map[string]any{"path": "notes/MEMORY.md", "title": "shared memory", "mtime": now.Format(time.RFC3339), "summary": "memory", "folder_class": "notes", "size_bytes": 20},
+		map[string]any{"path": "notes/agent-memory-index.md", "title": "shared agent memory", "mtime": now.Format(time.RFC3339), "summary": "memory", "folder_class": "notes", "size_bytes": 20},
+		map[string]any{"path": "self/private memory.md", "title": "shared memory", "mtime": now.Format(time.RFC3339), "summary": "memory", "folder_class": "self", "size_bytes": 20},
+		map[string]any{"path": "../outside.md", "title": "shared memory", "mtime": now.Format(time.RFC3339), "summary": "memory", "folder_class": "notes", "size_bytes": 20},
+	)
+	writeTestIndex(t, vault, now, entries)
+
+	result := Run(context.Background(), Options{
+		VaultRoot: vault, MaxHits: 3, MaxBundleBytes: 4096, MaxIndexAge: time.Hour,
+		Now: func() time.Time { return now },
+	}, Query{IssueTitle: "shared memory recall"})
+
+	if len(result.Hits) != 3 {
+		t.Fatalf("hit count = %d, want configured cap 3", len(result.Hits))
+	}
+	for _, hit := range result.Hits {
+		if hit.Path == "notes/MEMORY.md" || hit.Path == "notes/agent-memory-index.md" || strings.HasPrefix(hit.Path, "self/") || strings.Contains(hit.Path, "..") {
+			t.Fatalf("unsafe source included: %q", hit.Path)
+		}
+	}
+}
+
+func TestRunReturnsExplicitNonBlockingStatuses(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 24, 9, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		prepare    func(t *testing.T, vault string)
+		wantStatus Status
+		wantReason string
+	}{
+		{name: "unconfigured", wantStatus: StatusNoHit, wantReason: "vault_not_configured"},
+		{name: "missing index", prepare: func(t *testing.T, vault string) {}, wantStatus: StatusNoHit, wantReason: "index_missing"},
+		{name: "malformed index", prepare: func(t *testing.T, vault string) {
+			writeTestFile(t, filepath.Join(vault, "ops", "recall-index.json"), "not-json")
+		}, wantStatus: StatusControlledError, wantReason: "index_invalid"},
+		{name: "stale index", prepare: func(t *testing.T, vault string) {
+			writeTestIndex(t, vault, now.Add(-48*time.Hour), nil)
+		}, wantStatus: StatusNoHit, wantReason: "index_stale"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vault := ""
+			if tc.prepare != nil {
+				vault = t.TempDir()
+				tc.prepare(t, vault)
+			}
+			result := Run(context.Background(), Options{
+				VaultRoot: vault, MaxHits: 5, MaxBundleBytes: 2048, MaxIndexAge: 24 * time.Hour,
+				Now: func() time.Time { return now },
+			}, Query{IssueTitle: "memory"})
+			if result.Status != tc.wantStatus || result.Reason != tc.wantReason {
+				t.Fatalf("status/reason = %q/%q, want %q/%q", result.Status, result.Reason, tc.wantStatus, tc.wantReason)
+			}
+			if result.Render() == "" {
+				t.Fatal("status bundle must always be visible")
+			}
+		})
+	}
+}
+
+func TestRunBoundsLongQueryEvenWithoutHits(t *testing.T) {
+	t.Parallel()
+
+	result := Run(context.Background(), Options{
+		MaxBundleBytes: 512,
+	}, Query{IssueDescription: strings.Repeat("very long issue context ", 1000)})
+	rendered := result.Render()
+	if len([]byte(rendered)) > 512 {
+		t.Fatalf("no-hit bundle uses %d bytes, budget is 512", len([]byte(rendered)))
+	}
+	if result.Status != StatusNoHit {
+		t.Fatalf("status = %q", result.Status)
+	}
+}
+
+func TestBuildIndexUsesCanonicalNotesSchema(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.June, 24, 9, 0, 0, 0, time.UTC)
+	vault := t.TempDir()
+	writeTestNote(t, vault, "notes/shared recall stays bounded.md", "---\ndescription: Recall has deterministic limits\ntype: decision\ncreated: 2026-06-24\n---\n\n# Shared recall stays bounded\n\nBody.\n\n---\n\nTopics:\n- [[agent memory]]\n")
+	writeTestNote(t, vault, "notes/MEMORY.md", "excluded")
+	writeTestNote(t, vault, "notes/agent-memory-index.md", "excluded")
+	writeTestNote(t, vault, "notes/Unbenannt 1.md", "excluded")
+	writeTestNote(t, vault, "self/identity.md", "excluded")
+	writeTestNote(t, vault, "daily/2026-06-24.md", "excluded")
+	writeTestNote(t, vault, "notes/stale.sync-conflict-20260624.md", "excluded")
+
+	index, err := BuildIndex(context.Background(), IndexOptions{
+		VaultRoot: vault,
+		Now:       func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("BuildIndex() error = %v", err)
+	}
+	if index.IndexVersion != CurrentIndexVersion || index.EntryCount != 1 || len(index.Entries) != 1 {
+		t.Fatalf("index version/count = %d/%d entries=%d", index.IndexVersion, index.EntryCount, len(index.Entries))
+	}
+	entry := index.Entries[0]
+	if entry.Path != "notes/shared recall stays bounded.md" {
+		t.Fatalf("entry path = %q", entry.Path)
+	}
+	if entry.Summary != "Recall has deterministic limits" {
+		t.Fatalf("entry summary = %q", entry.Summary)
+	}
+	if len(entry.Tags) != 1 || entry.Tags[0] != "agent memory" {
+		t.Fatalf("entry tags = %#v", entry.Tags)
+	}
+
+	data, err := os.ReadFile(filepath.Join(vault, "ops", "recall-index.json"))
+	if err != nil {
+		t.Fatalf("read generated index: %v", err)
+	}
+	var persisted Index
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("generated index is invalid JSON: %v", err)
+	}
+	if persisted.EntryCount != 1 {
+		t.Fatalf("persisted entry_count = %d", persisted.EntryCount)
+	}
+	matches, err := filepath.Glob(filepath.Join(vault, "ops", ".recall-index-*.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary index files left behind: %#v", matches)
+	}
+}
+
+func writeTestIndex(t *testing.T, vault string, generatedAt time.Time, entries []map[string]any) {
+	t.Helper()
+	payload := map[string]any{
+		"index_version": CurrentIndexVersion,
+		"generated_at":  generatedAt.Format(time.RFC3339),
+		"vault_commit":  "test-commit",
+		"entry_count":   len(entries),
+		"entries":       entries,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(vault, "ops", "recall-index.json"), string(data))
+}
+
+func writeTestNote(t *testing.T, vault, relativePath, content string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(vault, filepath.FromSlash(relativePath)), content)
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/server/internal/recall/types.go
+++ b/server/internal/recall/types.go
@@ -1,0 +1,109 @@
+package recall
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const CurrentIndexVersion = 1
+
+type Status string
+
+const (
+	StatusHit             Status = "hit"
+	StatusNoHit           Status = "no_hit"
+	StatusControlledError Status = "controlled_error"
+)
+
+type Query struct {
+	IssueTitle       string
+	IssueDescription string
+	TriggerComment   string
+}
+
+func (q Query) Text() string {
+	parts := make([]string, 0, 3)
+	for _, value := range []string{q.IssueTitle, q.IssueDescription, q.TriggerComment} {
+		if value != "" {
+			parts = append(parts, value)
+		}
+	}
+	return joinWithNewlines(parts)
+}
+
+type Options struct {
+	VaultRoot      string
+	MaxHits        int
+	MaxBundleBytes int
+	MaxIndexAge    time.Duration
+	Now            func() time.Time
+}
+
+type Hit struct {
+	Path      string  `json:"path"`
+	Recency   string  `json:"recency"`
+	Relevance float64 `json:"relevance"`
+	Excerpt   string  `json:"excerpt"`
+}
+
+type Result struct {
+	Status       Status   `json:"recall_status"`
+	HitCount     int      `json:"hit_count"`
+	Query        string   `json:"query"`
+	IndexVersion int      `json:"index_version"`
+	ByteBudget   int      `json:"byte_budget"`
+	BytesUsed    int      `json:"bytes_used"`
+	Reason       string   `json:"reason,omitempty"`
+	Hits         []Hit    `json:"hits"`
+	SkippedFiles []string `json:"-"`
+}
+
+func (r *Result) Render() string {
+	for range 8 {
+		data, err := json.Marshal(r)
+		if err != nil {
+			return `{"recall_status":"controlled_error","reason":"render_failed"}`
+		}
+		bytesUsed := len(data)
+		if bytesUsed == r.BytesUsed {
+			return string(data)
+		}
+		r.BytesUsed = bytesUsed
+	}
+	data, _ := json.Marshal(r)
+	return string(data)
+}
+
+type Entry struct {
+	Path        string   `json:"path"`
+	Title       string   `json:"title"`
+	Tags        []string `json:"tags,omitempty"`
+	MTime       string   `json:"mtime"`
+	Summary     string   `json:"summary"`
+	FolderClass string   `json:"folder_class"`
+	SizeBytes   int64    `json:"size_bytes"`
+}
+
+type Index struct {
+	IndexVersion int     `json:"index_version"`
+	GeneratedAt  string  `json:"generated_at"`
+	VaultCommit  string  `json:"vault_commit,omitempty"`
+	EntryCount   int     `json:"entry_count"`
+	Entries      []Entry `json:"entries"`
+}
+
+type IndexOptions struct {
+	VaultRoot string
+	Now       func() time.Time
+}
+
+func joinWithNewlines(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	result := parts[0]
+	for _, part := range parts[1:] {
+		result += "\n" + part
+	}
+	return result
+}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1686,14 +1686,14 @@ func TestCodexExecuteLegacyFirstTurnMessageSatisfiesProgress(t *testing.T) {
 		`read line`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"task_started"}}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"agent_message","message":"legacy alive"}}}'`+"\n"+
-		`sleep 0.07`+"\n"+
+		`sleep 0.7`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"task_complete"}}}'`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 100 * time.Millisecond,
+		SemanticInactivityTimeout: time.Second,
 	})
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
@@ -1718,16 +1718,16 @@ func TestCodexExecuteSemanticInactivityAllowsContinuousMessages(t *testing.T) {
 		`read line`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-progress","turn":{"id":"turn-progress"}}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-progress","item":{"type":"agentMessage","id":"msg-1","text":"still working"}}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-progress","item":{"type":"commandExecution","id":"cmd-1","aggregatedOutput":"ok"}}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-progress","turn":{"id":"turn-progress","status":"completed"}}}'`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 90 * time.Millisecond,
+		SemanticInactivityTimeout: time.Second,
 	})
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
@@ -1752,19 +1752,19 @@ func TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress(t *testing.
 		`read line`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-delta","turn":{"id":"turn-delta"}}}'`+"\n"+
-		`echo '{"jsonrpc":"2.0","method":"item/commandExecution/outputDelta","params":{"threadId":"thr-delta","item":{"type":"commandExecution","id":"cmd-1"},"delta":"line 1\n"}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/commandExecution/outputDelta","params":{"threadId":"thr-delta","item":{"type":"commandExecution","id":"cmd-1"},"delta":"line 1"}}'`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"thr-delta","item":{"type":"agentMessage","id":"msg-1"},"delta":"thinking"}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/fileChange/outputDelta","params":{"threadId":"thr-delta","item":{"type":"fileChange","id":"patch-1"},"delta":"patched"}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"item/mcpToolCall/progress","params":{"threadId":"thr-delta","item":{"type":"mcpToolCall","id":"mcp-1"},"progress":{"message":"still running"}}}'`+"\n"+
-		`sleep 0.05`+"\n"+
+		`sleep 0.4`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-delta","turn":{"id":"turn-delta","status":"completed"}}}'`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
-		SemanticInactivityTimeout: 150 * time.Millisecond,
+		SemanticInactivityTimeout: time.Second,
 	})
 	if result.Status != "completed" {
 		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)


### PR DESCRIPTION
## Summary

- add bounded shared-memory recall before daemon agent runs
- expose matching recall index/query diagnostics through the CLI
- record deterministic recall status and provenance without blocking runs on recall failures
- stabilize unrelated Codex inactivity timing fixtures required by the repository-wide quality gate

## Verification

- `go test ./...`
- `go vet ./...`
- hook regression tests
- real-vault end-to-end recall within the 4096-byte budget

Closes ZED-14
