### PR TITLE
fix(cli): setup self-host respects existing config and shows URL changes

### DIFF
--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -95,9 +95,13 @@ func printConfigLocation(profile string) {
 	fmt.Fprintf(os.Stderr, "  config:     %s\n", path)
 }
 
-// confirmOverwrite checks for an existing config and prompts the user.
-// Returns true if we should proceed, false if the user declined.
-func confirmOverwrite(profile string) (bool, error) {
+// confirmOverwrite checks for an existing config and prompts the user before
+// overwriting it. newServerURL/newAppURL are the values setup is about to
+// write; they are shown as "old -> new" when they differ from the current
+// config so the user can see the passed flags/env were received rather than
+// silently ignored. Returns true if we should proceed, false if the user
+// declined.
+func confirmOverwrite(profile, newServerURL, newAppURL string) (bool, error) {
 	cfg, err := cli.LoadCLIConfigForProfile(profile)
 	if err != nil {
 		return true, nil // can't load → treat as no config
@@ -107,8 +111,8 @@ func confirmOverwrite(profile string) (bool, error) {
 	}
 
 	fmt.Fprintln(os.Stderr, "Current configuration:")
-	fmt.Fprintf(os.Stderr, "  server_url: %s\n", cfg.ServerURL)
-	fmt.Fprintf(os.Stderr, "  app_url:    %s\n", cfg.AppURL)
+	fmt.Fprintf(os.Stderr, "  server_url: %s\n", formatURLChange(cfg.ServerURL, newServerURL))
+	fmt.Fprintf(os.Stderr, "  app_url:    %s\n", formatURLChange(cfg.AppURL, newAppURL))
 	if cfg.WorkspaceID != "" {
 		fmt.Fprintf(os.Stderr, "  workspace:  %s\n", cfg.WorkspaceID)
 	}
@@ -125,10 +129,24 @@ func confirmOverwrite(profile string) (bool, error) {
 	return true, nil
 }
 
+// formatURLChange renders "old -> new" when setup is about to change the value,
+// or just the current value when it stays the same.
+func formatURLChange(oldVal, newVal string) string {
+	if newVal != "" && newVal != oldVal {
+		return fmt.Sprintf("%s  ->  %s", oldVal, newVal)
+	}
+	return oldVal
+}
+
 func runSetupCloud(cmd *cobra.Command, args []string) error {
 	profile := resolveProfile(cmd)
 
-	ok, err := confirmOverwrite(profile)
+	cfg := cli.CLIConfig{
+		ServerURL: "https://api.multica.ai",
+		AppURL:    "https://multica.ai",
+	}
+
+	ok, err := confirmOverwrite(profile, cfg.ServerURL, cfg.AppURL)
 	if err != nil {
 		return err
 	}
@@ -136,10 +154,6 @@ func runSetupCloud(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	cfg := cli.CLIConfig{
-		ServerURL: "https://api.multica.ai",
-		AppURL:    "https://multica.ai",
-	}
 	if err := cli.SaveCLIConfigForProfile(cfg, profile); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
@@ -167,23 +181,27 @@ func runSetupCloud(cmd *cobra.Command, args []string) error {
 func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 	profile := resolveProfile(cmd)
 
-	ok, err := confirmOverwrite(profile)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
-
+	// Resolve the target URLs before confirming the overwrite so the prompt can
+	// show the incoming values ("old -> new"), making it clear the passed flags
+	// were received.
+	//
 	// Honor MULTICA_SERVER_URL / MULTICA_APP_URL when the matching flag is not
 	// set — consistent with the rest of the CLI (resolveServerURL) and with the
 	// env vars documented on the root --server-url flag and in `multica --help`.
 	// Before this, setup self-host read only the flags, so a self-hoster who set
 	// MULTICA_SERVER_URL still got the localhost default and an "unreachable"
 	// error (GitHub #3912).
-	serverURL, userProvidedServerURL := resolveSelfHostServerURL(cmd)
+	existing, _ := cli.LoadCLIConfigForProfile(profile)
+	serverURL, userProvidedServerURL := resolveSelfHostServerURL(cmd, existing)
 	appURL := cli.FlagOrEnv(cmd, "app-url", "MULTICA_APP_URL", "")
 	frontendPort, _ := cmd.Flags().GetInt("frontend-port")
+
+	// Keep the already-configured app_url (set via an earlier setup or `config
+	// set`) when no flag/env is given and --frontend-port wasn't passed, so
+	// re-running setup self-host doesn't reset a remote frontend to localhost.
+	if appURL == "" && !cmd.Flags().Changed("frontend-port") && existing.AppURL != "" {
+		appURL = existing.AppURL
+	}
 
 	if appURL == "" {
 		if userProvidedServerURL && !serverHostIsLocal(serverURL) {
@@ -201,6 +219,14 @@ func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 		} else {
 			appURL = fmt.Sprintf("http://localhost:%d", frontendPort)
 		}
+	}
+
+	ok, err := confirmOverwrite(profile, serverURL, appURL)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
 	}
 
 	// Probe before persisting anything. A failed setup must never overwrite a
@@ -261,19 +287,28 @@ func persistSelfHostConfigIfReachable(serverURL, appURL, profile string, probe f
 
 // resolveSelfHostServerURL picks the backend URL for `setup self-host`: the
 // --server-url flag wins, then the MULTICA_SERVER_URL env var (consistent with
-// the rest of the CLI and the env var documented on the root flag), then the
-// localhost default built from --port. userProvided is true when the URL came
-// from the user (flag or env) rather than the localhost fallback — the caller
-// uses it to decide whether a remote host needs an explicit app_url.
+// the rest of the CLI and the env var documented on the root flag), then an
+// already-configured server_url from the existing config, then the localhost
+// default built from --port. userProvided is true when the URL came from the
+// user (flag, env, or an existing config) rather than the localhost fallback —
+// the caller uses it to decide whether a remote host needs an explicit app_url.
+//
+// Falling back to existing.ServerURL means re-running setup self-host (e.g. to
+// re-login or restart the daemon) keeps a configured remote deployment instead
+// of silently resetting it to http://localhost:8080. An explicit --port opts
+// back into the localhost path for the local-dev case.
 //
 // A user-supplied URL is run through normalizeAPIBaseURL, the same path
 // resolveServerURL uses: MULTICA_SERVER_URL is documented as a ws:// daemon
 // address (e.g. ws://localhost:8080/ws), so the ws/wss form and a trailing /ws
 // are accepted and converted to the http(s) base that the reachability probe
 // and the stored server_url expect.
-func resolveSelfHostServerURL(cmd *cobra.Command) (serverURL string, userProvided bool) {
+func resolveSelfHostServerURL(cmd *cobra.Command, existing cli.CLIConfig) (serverURL string, userProvided bool) {
 	if v := cli.FlagOrEnv(cmd, "server-url", "MULTICA_SERVER_URL", ""); v != "" {
 		return normalizeAPIBaseURL(v), true
+	}
+	if !cmd.Flags().Changed("port") && existing.ServerURL != "" {
+		return existing.ServerURL, true
 	}
 	port, _ := cmd.Flags().GetInt("port")
 	return fmt.Sprintf("http://localhost:%d", port), false

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -193,15 +193,8 @@ func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 	// error (GitHub #3912).
 	existing, _ := cli.LoadCLIConfigForProfile(profile)
 	serverURL, userProvidedServerURL := resolveSelfHostServerURL(cmd, existing)
-	appURL := cli.FlagOrEnv(cmd, "app-url", "MULTICA_APP_URL", "")
+	appURL := resolveSelfHostAppURL(cmd, existing)
 	frontendPort, _ := cmd.Flags().GetInt("frontend-port")
-
-	// Keep the already-configured app_url (set via an earlier setup or `config
-	// set`) when no flag/env is given and --frontend-port wasn't passed, so
-	// re-running setup self-host doesn't reset a remote frontend to localhost.
-	if appURL == "" && !cmd.Flags().Changed("frontend-port") && existing.AppURL != "" {
-		appURL = existing.AppURL
-	}
 
 	if appURL == "" {
 		if userProvidedServerURL && !serverHostIsLocal(serverURL) {
@@ -308,10 +301,33 @@ func resolveSelfHostServerURL(cmd *cobra.Command, existing cli.CLIConfig) (serve
 		return normalizeAPIBaseURL(v), true
 	}
 	if !cmd.Flags().Changed("port") && existing.ServerURL != "" {
-		return existing.ServerURL, true
+		// `config set server_url` stores the value as-is, so it may be the
+		// documented ws:// daemon form; normalize it to the http(s) base the
+		// probe and stored server_url expect, like resolveServerURL does.
+		return normalizeAPIBaseURL(existing.ServerURL), true
 	}
 	port, _ := cmd.Flags().GetInt("port")
 	return fmt.Sprintf("http://localhost:%d", port), false
+}
+
+// resolveSelfHostAppURL resolves the frontend URL for `setup self-host`: the
+// --app-url flag wins, then MULTICA_APP_URL, then an already-configured app_url
+// from the existing config (unless --frontend-port was passed). Returns "" when
+// none of those is set, leaving the caller to infer it — prompt for a remote
+// host, or fall back to localhost:<frontend-port>.
+//
+// Mirrors resolveSelfHostServerURL so re-running setup self-host keeps a
+// configured remote frontend instead of resetting it to localhost. Unlike
+// server_url, app_url is a plain frontend URL rather than a ws:// daemon
+// address, so it is used as-is without normalizeAPIBaseURL.
+func resolveSelfHostAppURL(cmd *cobra.Command, existing cli.CLIConfig) string {
+	if v := cli.FlagOrEnv(cmd, "app-url", "MULTICA_APP_URL", ""); v != "" {
+		return v
+	}
+	if !cmd.Flags().Changed("frontend-port") && existing.AppURL != "" {
+		return existing.AppURL
+	}
+	return ""
 }
 
 // serverHostIsLocal reports whether serverURL points at the same machine as

--- a/server/cmd/multica/cmd_setup_test.go
+++ b/server/cmd/multica/cmd_setup_test.go
@@ -170,6 +170,22 @@ func TestResolveSelfHostServerURL(t *testing.T) {
 		}
 	})
 
+	// `config set server_url` stores the value as-is, so the config may hold
+	// the documented ws:// daemon form. The fallback must normalize it to the
+	// http(s) base — otherwise the probe hits the raw wss:// value and reports
+	// the server as unreachable.
+	t.Run("normalizes ws:// daemon form from existing config", func(t *testing.T) {
+		t.Setenv("MULTICA_SERVER_URL", "")
+		existing := cli.CLIConfig{ServerURL: "wss://api.internal.co/ws"}
+		serverURL, userProvided := resolveSelfHostServerURL(newCmd(), existing)
+		if serverURL != "https://api.internal.co" {
+			t.Fatalf("server_url: want normalized https base, got %q", serverURL)
+		}
+		if !userProvided {
+			t.Fatalf("userProvided: want true for config-sourced URL")
+		}
+	})
+
 	// MULTICA_SERVER_URL is documented as a ws:// daemon address; the probe and
 	// stored config need an http(s) base, so the ws/wss + /ws form must be
 	// normalized just like every other command does.
@@ -206,6 +222,66 @@ func TestSelfHostAppURLHonorsEnv(t *testing.T) {
 		}
 		if got := cli.FlagOrEnv(cmd, "app-url", "MULTICA_APP_URL", ""); got != "https://flag.example" {
 			t.Fatalf("app_url: want flag value, got %q", got)
+		}
+	})
+}
+
+// TestResolveSelfHostAppURL mirrors TestResolveSelfHostServerURL for the
+// frontend URL: flag wins, then env, then an already-configured app_url (so
+// re-running setup self-host keeps a remote frontend), then "" so the caller
+// infers it. An explicit --frontend-port opts out of the config fallback.
+func TestResolveSelfHostAppURL(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{}
+		c.Flags().String("app-url", "", "")
+		c.Flags().Int("frontend-port", 3000, "")
+		return c
+	}
+
+	t.Run("flag wins over env and config", func(t *testing.T) {
+		t.Setenv("MULTICA_APP_URL", "https://env.example")
+		existing := cli.CLIConfig{AppURL: "https://config.example"}
+		cmd := newCmd()
+		if err := cmd.Flags().Set("app-url", "https://flag.example"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		if got := resolveSelfHostAppURL(cmd, existing); got != "https://flag.example" {
+			t.Fatalf("app_url: want flag value, got %q", got)
+		}
+	})
+
+	t.Run("env wins over config when flag absent", func(t *testing.T) {
+		t.Setenv("MULTICA_APP_URL", "https://env.example")
+		existing := cli.CLIConfig{AppURL: "https://config.example"}
+		if got := resolveSelfHostAppURL(newCmd(), existing); got != "https://env.example" {
+			t.Fatalf("app_url: want env value, got %q", got)
+		}
+	})
+
+	t.Run("falls back to existing config when no flag, env, or --frontend-port", func(t *testing.T) {
+		t.Setenv("MULTICA_APP_URL", "")
+		existing := cli.CLIConfig{AppURL: "https://multica-console-fc.marmot-cloud.com"}
+		if got := resolveSelfHostAppURL(newCmd(), existing); got != "https://multica-console-fc.marmot-cloud.com" {
+			t.Fatalf("app_url: want existing config value, got %q", got)
+		}
+	})
+
+	t.Run("explicit --frontend-port skips config fallback", func(t *testing.T) {
+		t.Setenv("MULTICA_APP_URL", "")
+		existing := cli.CLIConfig{AppURL: "https://config.example"}
+		cmd := newCmd()
+		if err := cmd.Flags().Set("frontend-port", "4000"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		if got := resolveSelfHostAppURL(cmd, existing); got != "" {
+			t.Fatalf("app_url: want empty so caller infers localhost, got %q", got)
+		}
+	})
+
+	t.Run("empty when nothing set", func(t *testing.T) {
+		t.Setenv("MULTICA_APP_URL", "")
+		if got := resolveSelfHostAppURL(newCmd(), cli.CLIConfig{}); got != "" {
+			t.Fatalf("app_url: want empty, got %q", got)
 		}
 	})
 }

--- a/server/cmd/multica/cmd_setup_test.go
+++ b/server/cmd/multica/cmd_setup_test.go
@@ -88,7 +88,7 @@ func TestResolveSelfHostServerURL(t *testing.T) {
 
 	t.Run("env var honored when flag absent", func(t *testing.T) {
 		t.Setenv("MULTICA_SERVER_URL", "https://api.internal.co")
-		serverURL, userProvided := resolveSelfHostServerURL(newCmd())
+		serverURL, userProvided := resolveSelfHostServerURL(newCmd(), cli.CLIConfig{})
 		if serverURL != "https://api.internal.co" {
 			t.Fatalf("server_url: want env value, got %q", serverURL)
 		}
@@ -103,7 +103,7 @@ func TestResolveSelfHostServerURL(t *testing.T) {
 		if err := cmd.Flags().Set("server-url", "https://flag.example"); err != nil {
 			t.Fatalf("set flag: %v", err)
 		}
-		serverURL, userProvided := resolveSelfHostServerURL(cmd)
+		serverURL, userProvided := resolveSelfHostServerURL(cmd, cli.CLIConfig{})
 		if serverURL != "https://flag.example" {
 			t.Fatalf("server_url: want flag value, got %q", serverURL)
 		}
@@ -118,7 +118,7 @@ func TestResolveSelfHostServerURL(t *testing.T) {
 		if err := cmd.Flags().Set("port", "9090"); err != nil {
 			t.Fatalf("set flag: %v", err)
 		}
-		serverURL, userProvided := resolveSelfHostServerURL(cmd)
+		serverURL, userProvided := resolveSelfHostServerURL(cmd, cli.CLIConfig{})
 		if serverURL != "http://localhost:9090" {
 			t.Fatalf("server_url: want localhost default, got %q", serverURL)
 		}
@@ -127,12 +127,55 @@ func TestResolveSelfHostServerURL(t *testing.T) {
 		}
 	})
 
+	// Re-running `setup self-host` after `config set` (or an earlier setup)
+	// must keep the configured remote server instead of probing localhost.
+	t.Run("falls back to existing config server_url when no flag, env, or --port", func(t *testing.T) {
+		t.Setenv("MULTICA_SERVER_URL", "")
+		existing := cli.CLIConfig{ServerURL: "https://multica-prod-alb.marmot-cloud.com"}
+		serverURL, userProvided := resolveSelfHostServerURL(newCmd(), existing)
+		if serverURL != "https://multica-prod-alb.marmot-cloud.com" {
+			t.Fatalf("server_url: want existing config value, got %q", serverURL)
+		}
+		if !userProvided {
+			t.Fatalf("userProvided: want true for config-sourced URL")
+		}
+	})
+
+	t.Run("explicit --port overrides existing config server_url", func(t *testing.T) {
+		t.Setenv("MULTICA_SERVER_URL", "")
+		existing := cli.CLIConfig{ServerURL: "https://api.internal.co"}
+		cmd := newCmd()
+		if err := cmd.Flags().Set("port", "9090"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		serverURL, userProvided := resolveSelfHostServerURL(cmd, existing)
+		if serverURL != "http://localhost:9090" {
+			t.Fatalf("server_url: want localhost from --port, got %q", serverURL)
+		}
+		if userProvided {
+			t.Fatalf("userProvided: want false for localhost fallback")
+		}
+	})
+
+	t.Run("flag wins over existing config", func(t *testing.T) {
+		t.Setenv("MULTICA_SERVER_URL", "")
+		existing := cli.CLIConfig{ServerURL: "https://config.example"}
+		cmd := newCmd()
+		if err := cmd.Flags().Set("server-url", "https://flag.example"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		serverURL, _ := resolveSelfHostServerURL(cmd, existing)
+		if serverURL != "https://flag.example" {
+			t.Fatalf("server_url: want flag value, got %q", serverURL)
+		}
+	})
+
 	// MULTICA_SERVER_URL is documented as a ws:// daemon address; the probe and
 	// stored config need an http(s) base, so the ws/wss + /ws form must be
 	// normalized just like every other command does.
 	t.Run("normalizes the documented ws:// daemon form", func(t *testing.T) {
 		t.Setenv("MULTICA_SERVER_URL", "wss://api.internal.co/ws")
-		serverURL, userProvided := resolveSelfHostServerURL(newCmd())
+		serverURL, userProvided := resolveSelfHostServerURL(newCmd(), cli.CLIConfig{})
 		if serverURL != "https://api.internal.co" {
 			t.Fatalf("server_url: want normalized https base, got %q", serverURL)
 		}
@@ -198,6 +241,30 @@ func TestSetupHelpShowsCallbackHostFlag(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "--callback-host") {
 		t.Fatalf("setup help should show --%s, got:\n%s", callbackHostFlag, out.String())
+	}
+}
+
+// TestFormatURLChange covers the setup overwrite prompt: a changed value is
+// shown as "old -> new" so the passed --server-url/--app-url is visibly
+// received, while an unchanged value renders plain.
+func TestFormatURLChange(t *testing.T) {
+	cases := []struct {
+		name   string
+		oldVal string
+		newVal string
+		want   string
+	}{
+		{"changed", "http://localhost:8080", "https://api.internal.co", "http://localhost:8080  ->  https://api.internal.co"},
+		{"unchanged", "https://api.internal.co", "https://api.internal.co", "https://api.internal.co"},
+		{"empty new keeps old", "http://localhost:8080", "", "http://localhost:8080"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatURLChange(tc.oldVal, tc.newVal); got != tc.want {
+				t.Errorf("formatURLChange(%q, %q) = %q, want %q", tc.oldVal, tc.newVal, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes `multica setup self-host` silently resetting an already-configured remote server to `http://localhost:8080`.

The backend/frontend URLs were resolved only from `--server-url`/`--app-url` and their env vars, falling back to localhost otherwise — the existing config was never consulted. So re-running `setup self-host` without flags (e.g. to re-login or restart the daemon) after a `config set` probed localhost, failed with "not reachable", and bailed, while the confirmation prompt confusingly displayed the correct remote config.

This adds the existing config as a fallback step in the resolution chain, and surfaces the resolved target in the overwrite confirmation so the user can see what will be written.

## Related Issue

Closes #4536

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_setup.go`
  - `resolveSelfHostServerURL` now takes the existing `cli.CLIConfig` and falls back to its `server_url` when no `--server-url`/`MULTICA_SERVER_URL` is set and `--port` wasn't passed. New resolution chain: flag → env → existing config → `localhost:<port>`. An explicit `--port` still opts back into the localhost path; flag/env still win.
  - `runSetupSelfHost` loads the existing config once, falls back `app_url` to `existing.AppURL` under the same conditions, and resolves the target URLs **before** the overwrite confirmation.
  - `confirmOverwrite` takes the incoming `server_url`/`app_url` and renders them as `old -> new` via the new `formatURLChange` helper, so the passed values are visibly received instead of hidden behind the current-config display. `runSetupCloud` updated to pass its cloud target URLs.

- `server/cmd/multica/cmd_setup_test.go`
  - `TestResolveSelfHostServerURL`: updated for the new signature; added cases for existing-config fallback, `--port` override, and flag-wins-over-config.
  - Added `TestFormatURLChange` (changed / unchanged / empty-new).

## How to Test

1. `multica config set server_url https://your-remote.example`
2. `multica config set app_url https://app.your-remote.example`
3. `multica setup self-host` (no flags), confirm with `y`.
4. Before this PR: probes `http://localhost:8080` → "not reachable". After: probes the configured remote server and proceeds to login.
5. The confirmation now shows e.g. `server_url: http://localhost:8080  ->  https://...` when a flag/env does change the value.
6. `cd server && go test ./cmd/multica/ -run 'Setup|SelfHost|FormatURLChange|ServerHostIsLocal|PersistSelfHost'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: low. Behavior change is limited to the no-flag/no-env path of `setup self-host`; flags, env vars, and explicit `--port`/`--frontend-port` retain their prior precedence, and a fresh machine with no config still defaults to localhost.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Diagnosed from a self-host setup screenshot reporting "not reachable". Traced the URL resolution in `cmd_setup.go`, found the existing config was never used as a fallback, added the fallback step plus an `old -> new` confirmation display, and extended the unit tests to cover the new precedence cases.
