### PR TITLE
feat(editor): MUL-3557 add one-click task-list toggle to bubble menu

### DIFF
--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -621,6 +621,19 @@ function EditorBubbleMenu({
             <Separator orientation="vertical" className="mx-0.5 h-5" />
             <HeadingDropdown editor={editor} onOpenChange={handleMenuOpenChange} activeLevel={fmt.heading1 ? 1 : fmt.heading2 ? 2 : fmt.heading3 ? 3 : undefined} />
             <ListDropdown editor={editor} onOpenChange={handleMenuOpenChange} isBullet={fmt.bulletList} isOrdered={fmt.orderedList} isTask={fmt.taskList} />
+            {/* Dedicated one-click toggle for checkbox task lists — turns the
+                current line(s) into a `- [ ]` task item or back to a paragraph.
+                The same toggle also lives in the List dropdown, but a direct
+                button keeps the common "make this a checklist" action one tap
+                away instead of two. */}
+            <Tooltip>
+              <TooltipTrigger render={
+                <Toggle size="sm" pressed={fmt.taskList} onPressedChange={() => editor.chain().focus().toggleTaskList().run()} onMouseDown={(e) => e.preventDefault()} />
+              }>
+                <ListTodo className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={8}>{t(($) => $.bubble_menu.task_list)}</TooltipContent>
+            </Tooltip>
             <Tooltip>
               <TooltipTrigger render={
                 <Toggle size="sm" pressed={fmt.blockquote} onPressedChange={() => editor.chain().focus().toggleBlockquote().run()} onMouseDown={(e) => e.preventDefault()} />

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -7,6 +7,7 @@
     "highlight": "Highlight",
     "link": "Link",
     "list": "List",
+    "task_list": "Task list",
     "quote": "Quote",
     "url_aria_label": "URL",
     "heading_dropdown": {

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -7,6 +7,7 @@
     "highlight": "ハイライト",
     "link": "リンク",
     "list": "リスト",
+    "task_list": "タスクリスト",
     "quote": "引用",
     "url_aria_label": "URL",
     "heading_dropdown": {

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -7,6 +7,7 @@
     "highlight": "강조",
     "link": "링크",
     "list": "목록",
+    "task_list": "체크리스트",
     "quote": "인용",
     "url_aria_label": "URL",
     "heading_dropdown": {

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -7,6 +7,7 @@
     "highlight": "高亮",
     "link": "链接",
     "list": "列表",
+    "task_list": "任务列表",
     "quote": "引用",
     "url_aria_label": "URL",
     "heading_dropdown": {


### PR DESCRIPTION
## What

Adds a dedicated one-click **task-list (checkbox) toggle** button to the editor bubble menu (the "edit quick actions" toolbar that floats over a text selection), placed between the **List** dropdown and **Quote**.

Clicking it turns the current line (or selected lines) into a `- [ ]` task item, or back into a normal paragraph. Previously this action was only reachable via the two-step **List ▾** dropdown; now it is a first-class button alongside bold / italic / quote.

## Implementation

- `packages/views/editor/bubble-menu.tsx` — new `Toggle` button using the `ListTodo` icon, reusing the existing `toggleTaskList()` command and the same `Toggle`/`Tooltip` pattern as the neighboring Quote button. Pressed state follows `fmt.taskList`. No new editor state or dependencies.
- `packages/views/locales/{en,zh-Hans,ja,ko}/editor.json` — new `bubble_menu.task_list` string (Task list / 任务列表 / タスクリスト / 체크리스트).

## Validation

- `pnpm --filter @multica/views typecheck` ✓ (run during code review)
- `git diff --check` ✓
- Manually tested in an isolated dev environment.

Code review: no blocking issues (MUL-3557).
