### PR TITLE
fix(cache): invalidate per-project issue list when project_id changes on settle

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -333,6 +333,9 @@ export function useUpdateIssue() {
       ) {
         qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
       }
+      if (Object.prototype.hasOwnProperty.call(vars, "project_id")) {
+        qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      }
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
       // to resolve text-preview Eye gates, and unlike other mutations this
@@ -522,6 +525,11 @@ export function useBatchUpdateIssues() {
         Object.prototype.hasOwnProperty.call(_vars.updates, "project_id")
       ) {
         qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(_vars.updates, "project_id")
+      ) {
+        qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
       }
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {


### PR DESCRIPTION
## Summary

When an issue's `project_id` is updated (moved to another project), the mutation `onSettled` callbacks only invalidated `projectKeys.all(wsId)` but not `issueKeys.myAll(wsId)`. This left stale cache entries in the old project's issue list.

## Changes

`packages/core/issues/mutations.ts` — two `onSettled` callbacks:

- **`useUpdateIssue.onSettled`**: Added `qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) })` when `project_id` is in `vars`
- **`useBatchUpdateIssues.onSettled`**: Same

This matches the existing behavior in the WebSocket handler (`ws-updaters.ts`), which already invalidates `issueKeys.myAll(wsId)` on `projectChanged`.

Closes #4548
