### PR TITLE
test(cli): cover additional subcommands (MUL-3676)

### DIFF
--- a/server/cmd/multica/cmd_attachment_test.go
+++ b/server/cmd/multica/cmd_attachment_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newAttachmentDownloadTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "download"}
+	cmd.Flags().StringP("output-dir", "o", ".", "")
+	return cmd
+}
+
+func TestRunAttachmentDownloadWritesBasenameIntoOutputDir(t *testing.T) {
+	const attachmentID = "att-123"
+	const fileBody = "attachment body"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/attachments/"+attachmentID:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           attachmentID,
+				"filename":     "../report.txt",
+				"download_url": "/downloads/report.txt",
+				"size_bytes":   "15",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/downloads/report.txt":
+			if r.Header.Get("Authorization") == "" {
+				t.Fatalf("relative download missing auth header")
+			}
+			_, _ = w.Write([]byte(fileBody))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	outputDir := t.TempDir()
+	cmd := newAttachmentDownloadTestCmd()
+	_ = cmd.Flags().Set("output-dir", outputDir)
+
+	stderr := captureStderr(t)
+	out, err := captureStdout(t, func() error { return runAttachmentDownload(cmd, []string{attachmentID}) })
+	errOut := stderr.read()
+	if err != nil {
+		t.Fatalf("runAttachmentDownload: %v", err)
+	}
+
+	dest := filepath.Join(outputDir, "report.txt")
+	data, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatalf("read downloaded file: %v", readErr)
+	}
+	if string(data) != fileBody {
+		t.Fatalf("downloaded body = %q, want %q", data, fileBody)
+	}
+	if strings.Contains(out, "../") {
+		t.Fatalf("stdout path should use sanitized basename, got %q", out)
+	}
+	if !strings.Contains(out, `"filename": "report.txt"`) || !strings.Contains(out, dest) {
+		t.Fatalf("stdout = %q, want JSON with sanitized file path", out)
+	}
+	if !strings.Contains(errOut, "Downloaded:") || !strings.Contains(errOut, dest) {
+		t.Fatalf("stderr = %q, want downloaded path", errOut)
+	}
+}
+
+func TestRunAttachmentDownloadRequiresDownloadURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/attachments/att-no-url" {
+			t.Fatalf("unexpected path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "att-no-url",
+			"filename": "missing.txt",
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newAttachmentDownloadTestCmd()
+	if err := runAttachmentDownload(cmd, []string{"att-no-url"}); err == nil || !strings.Contains(err.Error(), "no download URL") {
+		t.Fatalf("runAttachmentDownload error = %v, want missing download URL", err)
+	}
+}

--- a/server/cmd/multica/cmd_config_test.go
+++ b/server/cmd/multica/cmd_config_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+func newConfigTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "config"}
+	cmd.Flags().String("profile", "", "")
+	return cmd
+}
+
+func TestRunConfigSetPersistsSupportedKeysInProfile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newConfigTestCmd()
+	_ = cmd.Flags().Set("profile", "dev")
+
+	stderr := captureStderr(t)
+	defer stderr.restore()
+	if err := runConfigSet(cmd, []string{"server_url", "http://127.0.0.1:8080"}); err != nil {
+		t.Fatalf("runConfigSet server_url: %v", err)
+	}
+	if err := runConfigSet(cmd, []string{"app_url", "http://127.0.0.1:3000"}); err != nil {
+		t.Fatalf("runConfigSet app_url: %v", err)
+	}
+	if err := runConfigSet(cmd, []string{"workspace_id", "ws-123"}); err != nil {
+		t.Fatalf("runConfigSet workspace_id: %v", err)
+	}
+	_ = stderr.read()
+
+	cfg, err := cli.LoadCLIConfigForProfile("dev")
+	if err != nil {
+		t.Fatalf("LoadCLIConfigForProfile: %v", err)
+	}
+	if cfg.ServerURL != "http://127.0.0.1:8080" || cfg.AppURL != "http://127.0.0.1:3000" || cfg.WorkspaceID != "ws-123" {
+		t.Fatalf("config = %#v, want persisted supported keys", cfg)
+	}
+}
+
+func TestRunConfigShowIncludesProfileAndDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newConfigTestCmd()
+	_ = cmd.Flags().Set("profile", "empty")
+
+	out, err := captureStdout(t, func() error { return runConfigShow(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runConfigShow: %v", err)
+	}
+	for _, want := range []string{
+		"Profile:      empty",
+		"server_url:   (not set)",
+		"app_url:      (not set)",
+		"workspace_id: (not set)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("runConfigShow output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunConfigSetRejectsUnknownKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newConfigTestCmd()
+	err := runConfigSet(cmd, []string{"token", "secret"})
+	if err == nil || !strings.Contains(err.Error(), "unknown config key") {
+		t.Fatalf("runConfigSet error = %v, want unknown key", err)
+	}
+}

--- a/server/cmd/multica/cmd_label_test.go
+++ b/server/cmd/multica/cmd_label_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const testLabelUUID = "11111111-1111-1111-1111-111111111111"
+
+func newLabelCreateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("color", "", "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func newLabelUpdateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("color", "", "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func newLabelDeleteTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func setCLITestServerEnv(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("MULTICA_SERVER_URL", serverURL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+}
+
+func TestRunLabelCreateSendsExpectedRequest(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/labels" {
+			t.Fatalf("path = %q, want /api/labels", r.URL.Path)
+		}
+		if r.Header.Get("X-Workspace-ID") != "ws-1" {
+			t.Fatalf("X-Workspace-ID = %q, want ws-1", r.Header.Get("X-Workspace-ID"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    testLabelUUID,
+			"name":  body["name"],
+			"color": body["color"],
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newLabelCreateTestCmd()
+	_ = cmd.Flags().Set("name", "Bug")
+	_ = cmd.Flags().Set("color", "#ef4444")
+
+	out, err := captureStdout(t, func() error { return runLabelCreate(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runLabelCreate: %v", err)
+	}
+	if body["name"] != "Bug" || body["color"] != "#ef4444" {
+		t.Fatalf("body = %#v, want name/color", body)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v\n%s", err, out)
+	}
+	if got["id"] != testLabelUUID || got["name"] != "Bug" {
+		t.Fatalf("stdout = %#v, want created label", got)
+	}
+}
+
+func TestRunLabelUpdateSendsOnlyChangedFields(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/api/labels/"+testLabelUUID {
+			t.Fatalf("path = %q, want label path", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    testLabelUUID,
+			"name":  body["name"],
+			"color": "#3b82f6",
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newLabelUpdateTestCmd()
+	_ = cmd.Flags().Set("name", "Feature")
+
+	if _, err := captureStdout(t, func() error { return runLabelUpdate(cmd, []string{testLabelUUID}) }); err != nil {
+		t.Fatalf("runLabelUpdate: %v", err)
+	}
+	if len(body) != 1 || body["name"] != "Feature" {
+		t.Fatalf("body = %#v, want only name field", body)
+	}
+}
+
+func TestRunLabelDeletePrintsJsonConfirmation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/api/labels/"+testLabelUUID {
+			t.Fatalf("path = %q, want label path", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newLabelDeleteTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	out, err := captureStdout(t, func() error { return runLabelDelete(cmd, []string{testLabelUUID}) })
+	if err != nil {
+		t.Fatalf("runLabelDelete: %v", err)
+	}
+	if !strings.Contains(out, `"deleted": true`) || !strings.Contains(out, testLabelUUID) {
+		t.Fatalf("stdout = %q, want deleted JSON confirmation", out)
+	}
+}
+
+func TestRunLabelCreateRequiresNameAndColor(t *testing.T) {
+	cmd := newLabelCreateTestCmd()
+	if err := runLabelCreate(cmd, nil); err == nil || !strings.Contains(err.Error(), "--name is required") {
+		t.Fatalf("runLabelCreate error = %v, want missing name", err)
+	}
+
+	_ = cmd.Flags().Set("name", "Bug")
+	if err := runLabelCreate(cmd, nil); err == nil || !strings.Contains(err.Error(), "--color is required") {
+		t.Fatalf("runLabelCreate error = %v, want missing color", err)
+	}
+}

--- a/server/cmd/multica/cmd_login_test.go
+++ b/server/cmd/multica/cmd_login_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+func newLoginTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "login"}
+	cmd.Flags().String("token", "", "")
+	cmd.Flags().String("profile", "", "")
+	return cmd
+}
+
+func TestRunLoginTokenAutoWatchesDiscoveredWorkspaces(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "")
+	t.Setenv("MULTICA_WORKSPACE_ID", "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer mul_test_token" {
+			t.Fatalf("Authorization = %q, want bearer token", r.Header.Get("Authorization"))
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":  "Ada",
+				"email": "ada@example.com",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "ws-1", "name": "Alpha"},
+				{"id": "ws-2", "name": "Beta"},
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := newLoginTestCmd()
+	_ = cmd.Flags().Set("token", "mul_test_token")
+
+	stderr := captureStderr(t)
+	err := runLogin(cmd, nil)
+	errOut := stderr.read()
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+	if !strings.Contains(errOut, "Found 2 workspace(s):") || !strings.Contains(errOut, "daemon start") {
+		t.Fatalf("stderr = %q, want workspace discovery and daemon hint", errOut)
+	}
+
+	cfg, err := cli.LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig: %v", err)
+	}
+	if cfg.Token != "mul_test_token" || cfg.ServerURL != srv.URL || cfg.WorkspaceID != "ws-1" {
+		t.Fatalf("config = %#v, want token, server URL, and first workspace", cfg)
+	}
+}

--- a/server/cmd/multica/cmd_update_test.go
+++ b/server/cmd/multica/cmd_update_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunUpdateRejectsNonPositiveDownloadTimeout(t *testing.T) {
+	orig := updateDownloadTimeout
+	updateDownloadTimeout = 0
+	t.Cleanup(func() { updateDownloadTimeout = orig })
+
+	err := runUpdate(nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "download timeout must be greater than zero") {
+		t.Fatalf("runUpdate error = %v, want download timeout validation", err)
+	}
+}
+
+func TestUpdateCommandRegistersDownloadTimeoutFlag(t *testing.T) {
+	flag := updateCmd.Flags().Lookup("download-timeout")
+	if flag == nil {
+		t.Fatal("updateCmd is missing --download-timeout")
+	}
+	if got := flag.DefValue; got != (120 * time.Second).String() {
+		t.Fatalf("--download-timeout default = %q, want %q", got, (120 * time.Second).String())
+	}
+}

--- a/server/cmd/multica/cmd_user_test.go
+++ b/server/cmd/multica/cmd_user_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newUserProfileGetTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "get"}
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func newUserProfileUpdateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().Bool("description-stdin", false, "")
+	cmd.Flags().String("description-file", "", "")
+	cmd.Flags().Bool("clear", false, "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func TestRunUserProfileGetPrintsMeJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("path = %q, want /api/me", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                  "user-1",
+			"name":                "Ada",
+			"email":               "ada@example.com",
+			"profile_description": "Maintainer",
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newUserProfileGetTestCmd()
+	out, err := captureStdout(t, func() error { return runUserProfileGet(cmd, nil) })
+	if err != nil {
+		t.Fatalf("runUserProfileGet: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v\n%s", err, out)
+	}
+	if got["profile_description"] != "Maintainer" {
+		t.Fatalf("stdout = %#v, want profile description", got)
+	}
+}
+
+func TestRunUserProfileUpdateSendsResolvedDescription(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("path = %q, want /api/me", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                  "user-1",
+			"name":                "Ada",
+			"email":               "ada@example.com",
+			"profile_description": body["profile_description"],
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newUserProfileUpdateTestCmd()
+	_ = cmd.Flags().Set("description", `Reviewer\nTypeScript`)
+
+	if _, err := captureStdout(t, func() error { return runUserProfileUpdate(cmd, nil) }); err != nil {
+		t.Fatalf("runUserProfileUpdate: %v", err)
+	}
+	if body["profile_description"] != "Reviewer\nTypeScript" {
+		t.Fatalf("body = %#v, want decoded description", body)
+	}
+}
+
+func TestRunUserProfileUpdateClearSendsEmptyDescription(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                  "user-1",
+			"profile_description": body["profile_description"],
+		})
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+
+	cmd := newUserProfileUpdateTestCmd()
+	_ = cmd.Flags().Set("clear", "true")
+
+	if _, err := captureStdout(t, func() error { return runUserProfileUpdate(cmd, nil) }); err != nil {
+		t.Fatalf("runUserProfileUpdate: %v", err)
+	}
+	if body["profile_description"] != "" {
+		t.Fatalf("profile_description = %#v, want empty string", body["profile_description"])
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds focused test coverage for previously under-covered Multica CLI subcommands. This does not change CLI behavior; it locks in existing command contracts around flag validation, API request shape, config persistence, output formatting, and safe local side effects.

The approach follows the existing `issue` / `agent` command tests: call Cobra `RunE` handlers directly, use `httptest.Server` for fake backend responses, isolate config with temporary `HOME`, and capture stdout/stderr for output assertions.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added CLI tests for `label` create/update/delete in `server/cmd/multica/cmd_label_test.go`.
- Added attachment download tests in `server/cmd/multica/cmd_attachment_test.go`.
- Added user profile get/update/clear tests in `server/cmd/multica/cmd_user_test.go`.
- Added config set/show tests in `server/cmd/multica/cmd_config_test.go`.
- Added update flag/timeout validation tests in `server/cmd/multica/cmd_update_test.go`.
- Added login token + workspace auto-discovery coverage in `server/cmd/multica/cmd_login_test.go`.

## How to Test

1. Checkout this branch.
2. Run `cd server && go test ./cmd/multica/ -v`.
3. Confirm all CLI command tests pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
I used Cursor to inspect the existing CLI command tests, especially the `issue`, `agent`, and `skill` test patterns. The implementation follows those patterns by adding narrow Go tests around Cobra handlers with `httptest.Server`, temporary config directories, and stdout/stderr capture. I kept the change test-only and verified it with `cd server && go test ./cmd/multica/ -v`.

## Screenshots (optional)

N/A. Test-only CLI change.