### PR TITLE
ci(frontend): path-filter the frontend job to skip irrelevant PRs (MUL-3667)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,28 +11,98 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  frontend:
+  # Decides whether the (heavy, ~6min) frontend job has anything to do.
+  # The frontend job validates the web/desktop apps, the shared packages,
+  # the install graph, and the selfhost / reserved-slugs scripts it runs;
+  # a pure backend-only or docs-only PR touches none of those and gains
+  # nothing from a full web build. This job emits a single `frontend`
+  # output consumed by the frontend job below.
+  changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.decide.outputs.frontend }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          # apps/docs is excluded from the frontend turbo run, so a
+          # docs-only change does not need this job. apps/mobile has its
+          # own mobile-verify workflow. Everything else the frontend job
+          # touches is listed here; bias toward over-matching since a
+          # missed path silently skips validation.
+          filters: |
+            frontend:
+              - 'apps/web/**'
+              - 'apps/desktop/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - '.github/workflows/ci.yml'
+              - 'scripts/generate-reserved-slugs.mjs'
+              - 'server/internal/handler/reserved_slugs.json'
+              - 'scripts/selfhost-config.test.sh'
+              - 'scripts/check.sh'
+              - 'scripts/dev.sh'
+              - 'scripts/local-env.sh'
+              - '.env.example'
+              - 'docker-compose.selfhost.yml'
+
+      - name: Decide
+        id: decide
+        # Always run the frontend job on push to main (full validation);
+        # on pull_request, run only when frontend-relevant paths changed.
+        # The frontend job itself always runs and reports success — its
+        # steps are gated on this output rather than the job being skipped
+        # — so the required "frontend" status check is satisfied with a
+        # genuine green instead of being left pending on filtered PRs.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FRONTEND_CHANGED: ${{ steps.filter.outputs.frontend }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$FRONTEND_CHANGED" = "true" ]; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  frontend:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/checkout@v6
+
       - name: Setup pnpm
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
 
       - name: Test self-host env derivation
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: bash scripts/selfhost-config.test.sh
 
       - name: Verify reserved-slugs.ts is up to date
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         # Re-runs the generator and fails on any drift from the
         # checked-in TypeScript output. The Go side embeds the JSON
         # source directly, so a passing diff here proves both sides
@@ -42,8 +112,9 @@ jobs:
           git diff --exit-code -- packages/core/paths/reserved-slugs.ts
 
       - name: Build, type check, lint, and test
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         # Mobile lives in a parallel mobile-verify workflow (path-filtered
-        # to apps/mobile/** + packages/core/types/**) so it doesn't add
+        # to apps/mobile/** + packages/core/**) so it doesn't add
         # ~50s of expo-lint + tsc to every web/desktop PR. Keep this
         # filter in sync with the root package.json scripts, which also
         # exclude @multica/mobile.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
               - 'apps/desktop/**'
               - 'packages/**'
               - 'package.json'
+              - '.npmrc'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'turbo.json'


### PR DESCRIPTION
## What & why

The `frontend` job (~6min) is the CI pipeline's bottleneck, and it runs in full on **every** PR — including pure backend-only / docs-only ones that change no frontend code. This PR skips it on those PRs.

## Changes

**1. Path-filter the frontend job (job-level filter + no-op success)**
A new `changes` job (`dorny/paths-filter`) decides whether anything the frontend job validates changed.
- No top-level `paths:` on the workflow (that would also gate the shared `backend`/`installer` jobs, and a path-filtered required check is left pending forever).
- The `frontend` job *always runs*; its steps are individually gated on the filter output. When nothing relevant changed, all steps skip and the job reports a **genuine green** — so the required `frontend` check stays satisfied with **no branch-protection change**, rather than relying on "skipped == pass".
- **Push to `main` always runs the full job.** Filtering only applies to PRs.

Filter scope: `apps/web`, `apps/desktop`, all `packages/**`, the install graph (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`), this workflow, and the selfhost / reserved-slugs scripts + sources the job actually runs (`scripts/{selfhost-config.test,check,dev,local-env}.sh`, `.env.example`, `docker-compose.selfhost.yml`, `scripts/generate-reserved-slugs.mjs`, `server/internal/handler/reserved_slugs.json`). `apps/docs` is intentionally excluded (already filtered out of the turbo run); `apps/mobile` has its own `mobile-verify` workflow. Bias is toward over-matching — a missed path silently skips validation.

**2. Fix a stale comment**: `mobile-verify` filters `packages/core/**`, not `packages/core/types/**`.

## What this does and doesn't do

- ✅ A backend-only / docs-only PR skips the ~6min frontend build entirely.
- ❌ It does **not** speed up a frontend-touching PR — that's a separate problem (see below).

## Why no `.next/cache` (dropped from an earlier revision)

An earlier revision cached `apps/web/.next/cache`. Two back-to-back CI runs on the same commit (cold vs warm):

| | web build compile | frontend job wall |
|---|---|---|
| cold (`Cache not found`) | 4.3min | 6m13s |
| warm (85MB cache hit) | 2.0min | 6m14s |

The cache cut the web-build *compile* by 2.3min but **did not move the job wall**. Per-task timeline shows why: the last tasks to finish are a *cluster* — `web:build`, `web:typecheck` (~2m13s), `desktop:typecheck`, `views:test` — all within a ~35s window, **bound by the 4-vCPU runner**, not a single dominant task. Speeding up `web:build` alone just moves it from behind the cluster to inside it. So the cache is a no-op on its own and was dropped.

**The real levers to speed up a frontend-touching PR** (both need a small enablement, tracked separately):
- **Turbo remote cache** — highest leverage: skips unchanged tasks, collapsing the cluster. Needs a cache token/secret.
- **Larger runner** — the cluster is 4-vCPU-bound, so more cores would parallelize it. Needs org runner config.
- **Turbopack build** — blocked on fumadocs-mdx compat (fumadocs#2658).

## Notes for reviewers

- New action `dorny/paths-filter@v3` (verified creator). If the org restricts allowed actions it needs allowlisting — easy to swap for a native `git diff` detector.
- `changes` job is granted only `contents: read` + `pull-requests: read`.
- `actionlint` clean; `backend`/`installer` jobs unchanged.

MUL-3667
