### PR TITLE
fix(issues): reconcile board column counts on off-screen status change

### DIFF
--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -324,6 +324,91 @@ describe("onIssueUpdated — position move is surgical, not a list refetch", () 
   });
 });
 
+// A board column header shows `byStatus[status].total`. On a status change the
+// surgical patch shifts both bucket totals — but only if it can find the card in
+// a loaded page. A paginated column loads just its first page, so an off-screen
+// issue (very common when an agent flips the status of something the viewer
+// never scrolled to) is absent: patchIssueInBuckets no-ops and the count would
+// silently drift, with no refetch to recover it. The status-changed no-op has to
+// fall back to a single-list refetch.
+describe("onIssueUpdated — off-screen status change reconciles column counts", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("refetches the workspace list when a status-changed issue is not in the loaded page", () => {
+    // First page only: the totals say these columns have items, but the issues
+    // arrays are the loaded window — the moved issue lives beyond it.
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {
+      byStatus: {
+        in_review: { issues: [], total: 1 },
+        done: { issues: [], total: 60 },
+      },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { id: "off-screen", status: "done" },
+      { statusChanged: true },
+    );
+
+    expectInvalidated(qc, issueKeys.list(WS_ID));
+  });
+
+  it("refetches the filtered myAll list under the same condition", () => {
+    qc.setQueryData<ListIssuesCache>(issueKeys.myAll(WS_ID), {
+      byStatus: { done: { issues: [], total: 60 } },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { id: "off-screen", status: "done" },
+      { statusChanged: true },
+    );
+
+    expectInvalidated(qc, issueKeys.myAll(WS_ID));
+  });
+
+  it("does NOT refetch when the status-changed issue is loaded (surgical patch suffices)", () => {
+    const loaded: Issue = { ...baseIssue, id: "loaded", status: "in_review" };
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {
+      byStatus: {
+        in_review: { issues: [loaded], total: 1 },
+        done: { issues: [], total: 60 },
+      },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { ...loaded, status: "done" },
+      { statusChanged: true },
+    );
+
+    const list = qc.getQueryData<ListIssuesCache>(issueKeys.list(WS_ID));
+    expect(list?.byStatus.in_review?.total).toBe(0);
+    expect(list?.byStatus.done?.total).toBe(61);
+    // Reconciled in place — the no-flicker fast path from #4415 must hold.
+    expect(qc.getQueryState(issueKeys.list(WS_ID))?.isInvalidated).toBe(false);
+  });
+
+  it("does NOT refetch an absent issue when the status did not change", () => {
+    // A title/label edit of an off-screen issue cannot affect any count, so it
+    // must not trigger a fallback refetch.
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {
+      byStatus: { done: { issues: [], total: 60 } },
+    });
+
+    onIssueUpdated(qc, WS_ID, { id: "off-screen", title: "renamed" });
+
+    expect(qc.getQueryState(issueKeys.list(WS_ID))?.isInvalidated).toBe(false);
+  });
+});
+
 describe("onIssueDeleted", () => {
   let qc: QueryClient;
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
 import { projectKeys } from "../projects/queries";
@@ -40,10 +40,11 @@ export function onIssueUpdated(
   qc: QueryClient,
   wsId: string,
   issue: Partial<Issue> & { id: string },
-  // assigneeChanged comes from the server's issue:updated flags. It gates the
-  // filtered-list (myAll) invalidate so a non-membership change keeps those
-  // lists in place instead of refetching.
-  meta: { assigneeChanged?: boolean } = {},
+  // assigneeChanged / statusChanged come from the server's issue:updated flags.
+  // assigneeChanged gates the filtered-list (myAll) invalidate so a
+  // non-membership change keeps those lists in place instead of refetching.
+  // statusChanged gates the off-screen count reconcile below.
+  meta: { assigneeChanged?: boolean; statusChanged?: boolean } = {},
 ) {
   // Look up the OLD parent before mutating list state, so we can keep
   // the parent's children cache in sync (powers the sub-issues list
@@ -69,8 +70,25 @@ export function onIssueUpdated(
   const projectChanged =
     issue.project_id !== undefined && (issue.project_id ?? null) !== oldProjectId;
 
+  // A status change shifts two bucket totals (the column header counts).
+  // patchIssueInBuckets does that surgically, but only when it can find the card
+  // in a loaded page; a paginated column holds just its first page, so an issue
+  // outside that window — common when an agent flips the status of something the
+  // viewer never scrolled to — makes the patch a no-op (it returns the same
+  // reference) and the totals silently drift. A status change otherwise never
+  // refetches the list (that refetch was the drag flicker removed by the
+  // optimistic-update work), so recover the one case the patch cannot: on a
+  // status-changed no-op, refetch just that single list to reconcile its counts.
+  const patchOrRefetchCounts = (key: QueryKey, data: ListIssuesCache) => {
+    const next = patchIssueInBuckets(data, issue.id, issue);
+    qc.setQueryData<ListIssuesCache>(key, next);
+    if (next === data && meta.statusChanged) {
+      qc.invalidateQueries({ queryKey: key });
+    }
+  };
+
   for (const [key, data] of listQueries) {
-    if (data) qc.setQueryData<ListIssuesCache>(key, patchIssueInBuckets(data, issue.id, issue));
+    if (data) patchOrRefetchCounts(key, data);
   }
   // The workspace board (issueKeys.list) is NOT filtered: an issue is always a
   // member, so patchIssueInBuckets above is a complete surgical reconcile —
@@ -85,9 +103,7 @@ export function onIssueUpdated(
   // refetch, no flicker — exactly like the workspace board above.
   const myListQueries = qc.getQueriesData<ListIssuesCache>({ queryKey: issueKeys.myAll(wsId) });
   for (const [key, data] of myListQueries) {
-    if (data?.byStatus) {
-      qc.setQueryData<ListIssuesCache>(key, patchIssueInBuckets(data, issue.id, issue));
-    }
+    if (data?.byStatus) patchOrRefetchCounts(key, data);
   }
   // Only refetch the filtered lists when the change can actually move an issue
   // in/out of one. My-Issues / actor-panel membership keys on the assignee (the

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -588,6 +588,7 @@ export function useRealtimeSync(
       if (wsId) {
         onIssueUpdated(qc, wsId, issue, {
           assigneeChanged: payload.assignee_changed,
+          statusChanged: payload.status_changed,
         });
         if (issue.status) {
           onInboxIssueStatusChanged(qc, wsId, issue.id, issue.status);

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -95,11 +95,13 @@ export interface IssueCreatedPayload {
 export interface IssueUpdatedPayload {
   issue: Issue;
   // The server stamps issue:updated with which fields actually changed
-  // (server/internal/handler/issue.go publish). Only assignee_changed is read
-  // today: it lets the realtime layer keep filtered myList caches in place on a
-  // non-membership change instead of refetching. Other change flags are present
-  // on the wire too and can be surfaced here when needed.
+  // (server/internal/handler/issue.go publish). assignee_changed lets the
+  // realtime layer keep filtered myList caches in place on a non-membership
+  // change instead of refetching; status_changed lets it reconcile board column
+  // counts when a status change lands on an off-screen (unloaded) issue. Other
+  // change flags are present on the wire too and can be surfaced here when needed.
   assignee_changed?: boolean;
+  status_changed?: boolean;
 }
 
 export interface IssueDeletedPayload {


### PR DESCRIPTION
## What does this PR do?

Board column headers (e.g. **Done 60**) frequently failed to update when an issue's status changed into that column — near-deterministic for agent-driven changes, intermittent on manual drag — and only corrected after a full page reload.

Root cause is a regression from #4415. Column counts read `byStatus[status].total`, which #4415 began maintaining purely client-side via `patchIssueInBuckets` (±1 on the source/target buckets). That patch can only adjust the totals when it locates the issue in a **loaded page**; a paginated column holds just its first page, so a status change on an issue **outside the loaded window** (very common when an agent flips the status of something the viewer never scrolled to) is a silent no-op. #4415 also removed the `issueKeys.list` invalidation that used to reconcile counts, so once a total drifted nothing recovered it until a reload.

This threads the server's existing `status_changed` flag through `onIssueUpdated` and, when a status-changing patch **can't be applied surgically** (no-op because the issue is off-screen), refetches just that **one** list to reconcile its counts. The loaded/echoed fast path is untouched, so #4415's no-flicker drag behavior is fully preserved (a dragged or echoed card is always loaded and never hits the fallback).

## Related Issue

Closes #4554

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/ws-updaters.ts` — `onIssueUpdated` now accepts a `statusChanged` meta flag; a new `patchOrRefetchCounts` helper applies the surgical patch and, when it no-ops on a status change, invalidates that single list query. Applied to both the workspace list and the filtered `myAll` lists.
- `packages/core/realtime/use-realtime-sync.ts` — pass `payload.status_changed` into `onIssueUpdated`.
- `packages/core/types/events.ts` — surface `status_changed` on `IssueUpdatedPayload` (already on the wire from `server/internal/handler/issue.go`).
- `packages/core/issues/ws-updaters.test.ts` — regression coverage.

## How to Test

Reproduction (before this PR):

1. Open an Issues board (e.g. *My Issues*) with a column holding more issues than one page — e.g. **Done** with ~60 items.
2. Have an agent move/complete an issue whose card is **not in the loaded first page** of its source column (or manually drag such a card into Done).
3. The card moves, but the **Done** header count does not increment — and stays wrong until a full reload.

Automated proof:

```bash
pnpm --filter @multica/core test -- issues/ws-updaters.test.ts
```

New tests cover: off-screen status change refetches the workspace list and the filtered `myAll` list; a **loaded** status change still reconciles in place with **no** refetch (no-flicker fast path held); a non-status field change on an off-screen issue does **not** refetch.

Verification run locally:

- `pnpm --filter @multica/core test` → 665 passed
- `pnpm --filter @multica/core typecheck` → clean
- `pnpm --filter @multica/core lint` → clean

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risks / notes

- For the **unfiltered** workspace list, a no-op always means "off-screen member", so the fallback refetch is exact. For **filtered** `myAll` lists, a no-op can also mean the issue isn't a member of that list; the refetch is still correct (the server returns authoritative membership + counts), it just costs one first-page refetch on a status change of an off-screen issue. This only fires for status changes (a deliberate, low-frequency action) and is scoped to the single affected cache key, so it does not reintroduce drag flicker.
- A fully refetch-free alternative would thread the issue's **previous** status on the wire so the unfiltered board could do exact ±1 even off-screen; that is a larger server + protocol change and can be a follow-up. This PR keeps the fix minimal and client-side.

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.8)

**Prompt / approach:** Started from the observed symptom ("Done column count sometimes doesn't increment, especially via agents, recently"). Mapped the count's data flow (header → `useLoadMoreByStatus` → `byStatus[status].total` → `patchIssueInBuckets`), traced the intermittency to `findIssueLocation` only scanning loaded pages, and used `git log` to pin the regression to #4415 (which removed the reconciling invalidation). Wrote a failing regression test first, then implemented the minimal fallback that restores correctness without undoing #4415's no-flicker behavior. Verified with the package's test/typecheck/lint.
