### PR TITLE
fix(lark): use app URL for web links (MUL-3679)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -66,6 +66,10 @@ func allowedOrigins() []string {
 	return origins
 }
 
+func appURLFromEnv() string {
+	return strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_APP_URL")), "/")
+}
+
 // parseTrustedProxies parses a comma-separated list of CIDR prefixes from the
 // MULTICA_TRUSTED_PROXIES env var. Invalid entries are dropped with a single
 // warn-line per entry rather than crashing the server — a typo in one CIDR
@@ -296,7 +300,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					BindingSvc:  h.LarkBindingTokens,
 					Credentials: installSvc,
 					Queries:     queries,
-					PublicURL:   signupConfig.PublicURL,
+					AppURL:      appURLFromEnv(),
 					Logger:      slog.Default(),
 				})
 				var resolverReplier lark.OutcomeReplier

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -66,8 +66,15 @@ func allowedOrigins() []string {
 	return origins
 }
 
+// appURLFromEnv resolves the user-facing web app URL. It prefers
+// MULTICA_APP_URL and falls back to FRONTEND_ORIGIN, matching how the backend
+// resolves the app URL elsewhere (handler.daemonSetupURLsFromEnv) and the CLI
+// login flow (cmd/multica tryResolveAppURL). Empty when neither is set.
 func appURLFromEnv() string {
-	return strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_APP_URL")), "/")
+	if v := strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_APP_URL")), "/"); v != "" {
+		return v
+	}
+	return strings.TrimRight(strings.TrimSpace(os.Getenv("FRONTEND_ORIGIN")), "/")
 }
 
 // parseTrustedProxies parses a comma-separated list of CIDR prefixes from the

--- a/server/internal/integrations/lark/outcome_replier.go
+++ b/server/internal/integrations/lark/outcome_replier.go
@@ -36,6 +36,13 @@ type OutcomeReplierQueries interface {
 	GetAgent(ctx context.Context, id pgtype.UUID) (db.Agent, error)
 }
 
+// BindingTokenMinter is the narrow dependency the outcome replier needs from
+// BindingTokenService. Keeping this as an interface lets tests pin the Lark
+// binding URL without constructing a database-backed token service.
+type BindingTokenMinter interface {
+	Mint(ctx context.Context, workspaceID, installationID pgtype.UUID, openID OpenID) (BindingToken, error)
+}
+
 // noopReplier is the safe default when Lark is wired without an
 // outbound APIClient (stub) or without a BindingTokenService. It
 // logs each outcome that would have produced a reply so an operator
@@ -81,26 +88,28 @@ func NewNoopOutcomeReplier(log *slog.Logger) OutcomeReplier {
 // (the standard implementations are).
 type LarkOutcomeReplier struct {
 	client       APIClient
-	bindingSvc   *BindingTokenService
+	bindingSvc   BindingTokenMinter
 	credentials  CredentialsResolver
 	queries      OutcomeReplierQueries
-	publicURL    string // e.g. https://multica.example, trailing slash trimmed
+	appURL       string // e.g. https://multica.example, trailing slash trimmed
 	bindingPath  string // path component of the binding URL, default "/lark/bind"
 	noticeHeader string // header text used by the offline/archived cards
 	log          *slog.Logger
 }
 
-// OutcomeReplierConfig wires the production replier. PublicURL is the
-// Multica HTTP host the user clicks into to redeem the binding token
-// (e.g. https://multica.example); empty means the binding flow can
-// only log the open_id, not produce a clickable card. The other
-// fields default at construction.
+// OutcomeReplierConfig wires the production replier. AppURL is the Multica web
+// app host the user clicks into to redeem the binding token or open an issue
+// (e.g. https://multica.example). It comes from MULTICA_APP_URL and is
+// intentionally separate from MULTICA_PUBLIC_URL, which is the backend/API
+// public URL used for webhook and daemon-facing endpoints. Empty means the
+// binding flow can only log the open_id, not produce a clickable card. The
+// other fields default at construction.
 type OutcomeReplierConfig struct {
 	APIClient   APIClient
-	BindingSvc  *BindingTokenService
+	BindingSvc  BindingTokenMinter
 	Credentials CredentialsResolver
 	Queries     OutcomeReplierQueries
-	PublicURL   string
+	AppURL      string
 	BindingPath string
 	Logger      *slog.Logger
 }
@@ -120,8 +129,8 @@ func NewLarkOutcomeReplier(cfg OutcomeReplierConfig) OutcomeReplier {
 		log.Warn("lark outcome replier: APIClient.IsConfigured()=false; downgrading to noop replier")
 		return NewNoopOutcomeReplier(log)
 	}
-	if cfg.PublicURL == "" {
-		log.Warn("lark outcome replier: MULTICA_PUBLIC_URL not set; binding prompt CTA will not work")
+	if cfg.AppURL == "" {
+		log.Warn("lark outcome replier: MULTICA_APP_URL not set; binding prompt CTA will not work")
 	}
 	bindingPath := cfg.BindingPath
 	if bindingPath == "" {
@@ -135,7 +144,7 @@ func NewLarkOutcomeReplier(cfg OutcomeReplierConfig) OutcomeReplier {
 		bindingSvc:   cfg.BindingSvc,
 		credentials:  cfg.Credentials,
 		queries:      cfg.Queries,
-		publicURL:    strings.TrimRight(cfg.PublicURL, "/"),
+		appURL:       strings.TrimRight(cfg.AppURL, "/"),
 		bindingPath:  bindingPath,
 		noticeHeader: "Multica",
 		log:          log,
@@ -200,14 +209,14 @@ func (r *LarkOutcomeReplier) sendBindingPrompt(ctx context.Context, inst Install
 	if res.SenderOpenID == "" {
 		return errors.New("missing sender open_id")
 	}
-	if r.publicURL == "" {
-		return errors.New("public_url not configured")
+	if r.appURL == "" {
+		return errors.New("app_url not configured")
 	}
 	token, err := r.bindingSvc.Mint(ctx, inst.WorkspaceID, inst.ID, res.SenderOpenID)
 	if err != nil {
 		return fmt.Errorf("mint binding token: %w", err)
 	}
-	bindURL := r.publicURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
+	bindURL := r.appURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
 	creds, err := r.installationCredentials(inst)
 	if err != nil {
 		return err
@@ -234,7 +243,7 @@ func (r *LarkOutcomeReplier) sendIssueCreated(ctx context.Context, inst Installa
 	if err != nil {
 		return err
 	}
-	text := issueCreatedText(res, r.publicURL)
+	text := issueCreatedText(res, r.appURL)
 	// Share the Patcher's classified fallback: a thread reply that
 	// fails because the topic cannot receive it (recalled trigger,
 	// topics disabled, aggregated message) falls back to a chat-level
@@ -266,11 +275,10 @@ func inboundReplyTarget(msg InboundMessage) ReplyTarget {
 
 // issueCreatedText composes the user-facing confirmation. Identifier
 // always wins over a bare number — DispatchResult.IssueIdentifier
-// already encodes the workspace prefix when available. PublicURL is
-// optional: when empty (self-host operators who haven't configured
-// MULTICA_PUBLIC_URL) the message still confirms the issue, just
-// without a deep link the user can tap.
-func issueCreatedText(res DispatchResult, publicURL string) string {
+// already encodes the workspace prefix when available. AppURL is optional:
+// when empty (self-host operators who haven't configured MULTICA_APP_URL) the
+// message still confirms the issue, just without a deep link the user can tap.
+func issueCreatedText(res DispatchResult, appURL string) string {
 	identifier := res.IssueIdentifier
 	if identifier == "" {
 		identifier = fmt.Sprintf("#%d", res.IssueNumber)
@@ -282,10 +290,10 @@ func issueCreatedText(res DispatchResult, publicURL string) string {
 	} else {
 		line = fmt.Sprintf("Created %s — %s", identifier, title)
 	}
-	if publicURL == "" {
+	if appURL == "" {
 		return line
 	}
-	return line + "\n" + strings.TrimRight(publicURL, "/") + "/issues/" + identifier
+	return line + "\n" + strings.TrimRight(appURL, "/") + "/issues/" + identifier
 }
 
 func (r *LarkOutcomeReplier) sendChatNotice(ctx context.Context, inst Installation, msg InboundMessage, body string) error {

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -123,23 +123,17 @@ func (s stubReplierQueries) GetAgent(ctx context.Context, id pgtype.UUID) (db.Ag
 	return s.agent, nil
 }
 
-// stubBindingMint is a minimal TxStarter stand-in: the real
-// BindingTokenService.Mint calls qx.CreateLarkBindingToken on the
-// non-tx queries handle when no transaction is started by the caller.
-// We bypass that path by constructing a BindingTokenService with a
-// fake DB query interface — but since BindingTokenService is a
-// concrete struct around *db.Queries, the cleanest seam in tests is
-// to swap the replier's bindingSvc field for a fake that satisfies
-// the narrow Mint method via an in-package alias.
+type fakeBindingMinter struct {
+	raw string
+	err error
+}
 
-// fakeBindingMinter substitutes for BindingTokenService.Mint in tests
-// — we cannot construct a real BindingTokenService without a live
-// *db.Queries, but the replier only calls .Mint on it, so a typed
-// wrapper around a function works.
-//
-// We monkey-patch by exposing a package-level seam on the replier in
-// the test file: the production path uses bindingSvc directly; the
-// test path wraps the replier so Reply can be exercised end-to-end.
+func (f fakeBindingMinter) Mint(ctx context.Context, workspaceID, installationID pgtype.UUID, openID OpenID) (BindingToken, error) {
+	if f.err != nil {
+		return BindingToken{}, f.err
+	}
+	return BindingToken{Raw: f.raw}, nil
+}
 
 // TestLarkOutcomeReplierFallsBackToNoopWhenStubAPI ensures the
 // production replier downgrades to noop when the supplied APIClient
@@ -154,7 +148,7 @@ func TestLarkOutcomeReplierFallsBackToNoopWhenStubAPI(t *testing.T) {
 		BindingSvc:  &BindingTokenService{}, // not nil so we exercise the IsConfigured guard
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 	if _, isNoop := rep.(*noopReplier); !isNoop {
@@ -195,7 +189,7 @@ func TestLarkOutcomeReplierAgentOfflineSendsCard(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{agent: db.Agent{Name: "Trump"}},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 	inst := Installation{AppID: "cli_x"}
@@ -230,7 +224,7 @@ func TestLarkOutcomeReplierAgentArchivedSendsCard(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 	msg := InboundMessage{ChatID: "oc_chat_arch"}
@@ -255,7 +249,7 @@ func TestLarkOutcomeReplierIngestedAndDroppedAreSilent(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 	msg := InboundMessage{ChatID: "oc_x"}
@@ -280,7 +274,7 @@ func TestLarkOutcomeReplierOfflineSwallowsAPIError(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 	// Should NOT panic.
@@ -291,6 +285,48 @@ func TestLarkOutcomeReplierOfflineSwallowsAPIError(t *testing.T) {
 // engine Router skips reply scheduling entirely when no OutboundReplier is
 // registered (boot registers one only when larkClient.IsConfigured()), and
 // NewLarkOutcomeReplier still falls back to its own noop when unconfigured.
+
+func TestLarkOutcomeReplierUsesAppURLForWebLinks(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	stub := &stubAPIClientWithRecorder{configured: true}
+	rep := NewLarkOutcomeReplier(OutcomeReplierConfig{
+		APIClient:   stub,
+		BindingSvc:  fakeBindingMinter{raw: "token with space"},
+		Credentials: stubCredentialsResolver{secret: "s"},
+		Queries:     stubReplierQueries{},
+		AppURL:      "https://app.multica.test/",
+		Logger:      log,
+	})
+
+	inst := Installation{AppID: "cli_x"}
+	inst.ID = mustUUID("11111111-1111-1111-1111-111111111111")
+	inst.WorkspaceID = mustUUID("33333333-3333-3333-3333-333333333333")
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+		DispatchResult{Outcome: OutcomeNeedsBinding, SenderOpenID: "ou_user"})
+	rep.Reply(context.Background(), inst, InboundMessage{ChatID: "oc_chat", SenderOpenID: "ou_user"},
+		DispatchResult{
+			Outcome:         OutcomeIngested,
+			IssueID:         mustUUID("22222222-2222-2222-2222-222222222222"),
+			IssueNumber:     42,
+			IssueIdentifier: "MUL-42",
+		})
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.bindingCalls) != 1 {
+		t.Fatalf("expected one binding prompt, got %d", len(stub.bindingCalls))
+	}
+	if got := stub.bindingCalls[0].BindURL; got != "https://app.multica.test/lark/bind?token=token+with+space" {
+		t.Fatalf("binding URL should use AppURL; got %q", got)
+	}
+	if len(stub.textOut) != 1 {
+		t.Fatalf("expected one issue-created text, got %d", len(stub.textOut))
+	}
+	if !strings.Contains(stub.textOut[0].Text, "https://app.multica.test/issues/MUL-42") {
+		t.Fatalf("issue-created text should use AppURL; got %q", stub.textOut[0].Text)
+	}
+}
 
 // TestLarkOutcomeReplierIssueCreatedSendsConfirmation pins the
 // recovered /issue confirmation path. Before the plain-text refactor
@@ -310,7 +346,7 @@ func TestLarkOutcomeReplierIssueCreatedSendsConfirmation(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 
@@ -364,7 +400,7 @@ func TestLarkOutcomeReplierOutcomeIngestedSilentWithoutIssue(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 
@@ -398,7 +434,7 @@ func TestLarkOutcomeReplierIssueCreatedThreadFallback(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 
@@ -435,7 +471,7 @@ func TestLarkOutcomeReplierIssueCreatedNoFallbackOnAmbiguous(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 
@@ -467,7 +503,7 @@ func TestLarkOutcomeReplierNoticeThreadFallback(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{agent: db.Agent{Name: "Trump"}},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 
@@ -497,7 +533,7 @@ func TestLarkOutcomeReplierNoticeNoFallbackOnAmbiguous(t *testing.T) {
 		BindingSvc:  &BindingTokenService{},
 		Credentials: stubCredentialsResolver{secret: "s"},
 		Queries:     stubReplierQueries{},
-		PublicURL:   "https://multica.test",
+		AppURL:      "https://multica.test",
 		Logger:      log,
 	})
 


### PR DESCRIPTION
## Summary

- Use `MULTICA_APP_URL` for Lark user-facing web links.
- Keep `MULTICA_PUBLIC_URL` scoped to backend/API-facing URLs.
- Add coverage for Lark binding and issue-created links using the app URL.

## Tests

- `go test ./internal/integrations/lark`
- `go test ./cmd/server`
