### PR TITLE
MUL-3674: Preserve Kiro goal completion on close error

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -994,6 +994,7 @@ func (c *hermesClient) handleToolCallUpdate(data json.RawMessage) {
 			Type:   MessageToolResult,
 			CallID: msg.ToolCallID,
 			Output: output,
+			Status: msg.Status,
 		})
 	}
 }

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -832,6 +832,9 @@ func TestHermesClientHandleSessionNotificationToolCall(t *testing.T) {
 	if got[1].Output != "/tmp/project\n" {
 		t.Errorf("second output: got %q", got[1].Output)
 	}
+	if got[1].Status != "completed" {
+		t.Errorf("second status: got %q, want completed", got[1].Status)
+	}
 }
 
 func TestHermesClientHandleSessionNotificationTurnEnd(t *testing.T) {

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -132,7 +132,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			}
 			if msg.Type == MessageToolResult {
 				if _, ok := goalCompleteCallIDs.LoadAndDelete(msg.CallID); ok {
-					sawCompletedGoalComplete.Store(true)
+					sawCompletedGoalComplete.Store(msg.Status == "completed")
 				}
 			}
 			if msg.Type == MessageText {

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -106,6 +107,8 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	var outputMu sync.Mutex
 	var output strings.Builder
 	var streamingCurrentTurn atomic.Bool
+	var sawCompletedGoalComplete atomic.Bool
+	var goalCompleteCallIDs sync.Map
 
 	promptDone := make(chan hermesPromptResult, 1)
 
@@ -123,6 +126,14 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			}
 			if msg.Type == MessageToolUse {
 				msg.Tool = kiroToolNameFromTitle(msg.Tool)
+				if msg.Tool == "goal_complete" && msg.CallID != "" {
+					goalCompleteCallIDs.Store(msg.CallID, struct{}{})
+				}
+			}
+			if msg.Type == MessageToolResult {
+				if _, ok := goalCompleteCallIDs.LoadAndDelete(msg.CallID); ok {
+					sawCompletedGoalComplete.Store(true)
+				}
 			}
 			if msg.Type == MessageText {
 				outputMu.Lock()
@@ -307,7 +318,11 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro session/prompt failed: %v", err)
-				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+				if sawCompletedGoalComplete.Load() && isKiroGoalCompleteCloseError(err) {
+					b.cfg.Logger.Warn("kiro session/prompt failed after goal_complete; preserving completed task status", "error", err)
+					finalStatus = "completed"
+					finalError = ""
+				} else if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
 					// See the hermes backend: the runtime echoes the
 					// requested id back from session/resume even when
 					// the session is gone, so the stale id only fails
@@ -383,6 +398,20 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func isKiroGoalCompleteCloseError(err error) bool {
+	var rpcErr *acpRPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	if rpcErr.Method != "session/prompt" || rpcErr.Code != -32603 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(rpcErr.Message), "Internal error") {
+		return false
+	}
+	return strings.Contains(strings.ToLower(rpcErr.Data), "failed to generate a response")
 }
 
 func kiroToolNameFromTitle(title string) string {

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -162,6 +162,72 @@ func TestKiroBackendSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
+func fakeKiroACPGoalCompleteCloseErrorScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_goal_done"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCall","toolCallId":"tc-goal","name":"goal_complete","status":"pending","parameters":{}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCallUpdate","toolCallId":"tc-goal","status":"completed","name":"goal_complete","output":"ok"}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"Kiro failed to generate a response"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestKiroBackendTreatsGoalCompleteCloseErrorAsCompleted(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPGoalCompleteCloseErrorScript()))
+
+	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed after goal_complete close error, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Error != "" {
+			t.Fatalf("expected close-handshake error to be suppressed, got %q", result.Error)
+		}
+		if result.SessionID != "ses_goal_done" {
+			t.Fatalf("session id = %q, want ses_goal_done", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // fakeKiroACPStaleLoadSetModelScript impersonates kiro when a resumed
 // session is gone and the caller picked a model: session/load returns
 // an empty result (so the requested id is kept), then

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -162,7 +162,7 @@ func TestKiroBackendSetModelFailureFailsTask(t *testing.T) {
 	}
 }
 
-func fakeKiroACPGoalCompleteCloseErrorScript() string {
+func fakeKiroACPGoalCompleteCloseErrorScript(goalStatus string) string {
 	return `#!/bin/sh
 while IFS= read -r line; do
   id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
@@ -175,7 +175,7 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/prompt"'*)
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCall","toolCallId":"tc-goal","name":"goal_complete","status":"pending","parameters":{}}}}\n'
-      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCallUpdate","toolCallId":"tc-goal","status":"completed","name":"goal_complete","output":"ok"}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCallUpdate","toolCallId":"tc-goal","status":"` + goalStatus + `","name":"goal_complete","output":"ok"}}}\n'
       printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"Kiro failed to generate a response"}}\n' "$id"
       exit 0
       ;;
@@ -188,7 +188,7 @@ func TestKiroBackendTreatsGoalCompleteCloseErrorAsCompleted(t *testing.T) {
 	t.Parallel()
 
 	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
-	writeTestExecutable(t, fakePath, []byte(fakeKiroACPGoalCompleteCloseErrorScript()))
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPGoalCompleteCloseErrorScript("completed")))
 
 	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
 	if err != nil {
@@ -219,6 +219,50 @@ func TestKiroBackendTreatsGoalCompleteCloseErrorAsCompleted(t *testing.T) {
 		}
 		if result.Error != "" {
 			t.Fatalf("expected close-handshake error to be suppressed, got %q", result.Error)
+		}
+		if result.SessionID != "ses_goal_done" {
+			t.Fatalf("session id = %q, want ses_goal_done", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestKiroBackendDoesNotCompleteAfterFailedGoalComplete(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPGoalCompleteCloseErrorScript("failed")))
+
+	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed after failed goal_complete, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "Kiro failed to generate a response") {
+			t.Fatalf("expected original prompt error to be preserved, got %q", result.Error)
 		}
 		if result.SessionID != "ses_goal_done" {
 			t.Fatalf("session id = %q, want ses_goal_done", result.SessionID)


### PR DESCRIPTION
Summary:
- Treat Kiro ACP session/prompt -32603 close-handshake errors as completed only after a completed goal_complete tool call.
- Preserve normal Kiro prompt failures, timeout/cancel behavior, and stale-session retry behavior.
- Add a regression test for the reported post-goal_complete Kiro error shape.

Tests:
- go test ./pkg/agent (from server/)

Closes MUL-3674
Fixes #4553