### PR TITLE
fix(chat): distinguish thinking timeline rows

### DIFF
--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -640,12 +640,26 @@ function ThinkingRow({ item }: { item: ChatTimelineItem }) {
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger className="flex w-full items-start gap-1.5 rounded px-1 -mx-1 py-0.5 text-xs hover:bg-accent/30 transition-colors">
-        <Brain className="h-3 w-3 shrink-0 text-muted-foreground/60 mt-0.5" />
-        <span className="text-muted-foreground italic truncate">{preview}</span>
+      <CollapsibleTrigger
+        className={cn(
+          "flex w-full items-start gap-1.5 rounded-md border border-violet-500/20 bg-violet-500/10 px-2 py-1 text-xs text-violet-700 transition-colors hover:bg-violet-500/15 dark:text-violet-300",
+          open && "bg-violet-500/15",
+        )}
+      >
+        <ChevronRight
+          className={cn(
+            "h-3 w-3 shrink-0 text-violet-500/80 transition-transform mt-0.5",
+            open && "rotate-90",
+          )}
+        />
+        <Brain className="h-3 w-3 shrink-0 text-violet-500 mt-0.5" />
+        <span className="shrink-0 font-medium">Thinking</span>
+        <span className="min-w-0 flex-1 truncate italic text-violet-700/80 dark:text-violet-200/80">
+          {preview}
+        </span>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <pre className="ml-[18px] mt-0.5 max-h-40 overflow-auto rounded bg-muted/30 p-2 text-xs text-muted-foreground whitespace-pre-wrap break-words">
+        <pre className="ml-[18px] mt-1 max-h-40 overflow-auto rounded-md border border-violet-500/15 bg-violet-500/5 p-2 text-xs text-violet-900/80 whitespace-pre-wrap break-words dark:text-violet-100/80">
           {text}
         </pre>
       </CollapsibleContent>

--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -101,4 +101,43 @@ describe("task transcript timeline", () => {
 
     expect(items[0]?.created_at).toBe("2026-06-09T09:00:00.000Z");
   });
+
+  it("splits plain text thinking tags into separate thinking timeline items", () => {
+    const items = buildTimeline([
+      message(1, "text", "Before <thinking>reasoning</thinking> final answer"),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({ type: "text", content: "Before " }),
+      expect.objectContaining({ type: "thinking", content: "reasoning" }),
+      expect.objectContaining({ type: "text", content: " final answer" }),
+    ]);
+  });
+
+  it("splits thinking tags after streaming text chunks are coalesced", () => {
+    const items = buildTimeline([
+      message(1, "text", "Before <thinking>reason"),
+      message(2, "text", "ing</thinking> final"),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({ type: "text", content: "Before " }),
+      expect.objectContaining({ type: "thinking", content: "reasoning" }),
+      expect.objectContaining({ type: "text", content: " final" }),
+    ]);
+  });
+
+  it("leaves unmatched thinking tags as text while streaming", () => {
+    const items = buildTimeline([
+      message(1, "text", "Before <thinking>partial reasoning"),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        seq: 1,
+        type: "text",
+        content: "Before <thinking>partial reasoning",
+      }),
+    ]);
+  });
 });

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -16,6 +16,59 @@ function canMergeStreamingText(prev: TimelineItem, next: TimelineItem): boolean 
   return (prev.type === "thinking" || prev.type === "text") && prev.type === next.type;
 }
 
+function splitTextThinkingTags(item: TimelineItem): TimelineItem[] {
+  if (item.type !== "text" || !item.content) return [item];
+
+  const tagPattern = /<\/?thinking>/gi;
+  const matches = Array.from(item.content.matchAll(tagPattern));
+  if (matches.length === 0) return [item];
+
+  const hasBalancedPair = matches.some((match, index) => {
+    if (match[0].toLowerCase() !== "<thinking>") return false;
+    return matches.slice(index + 1).some((next) => next[0].toLowerCase() === "</thinking>");
+  });
+  if (!hasBalancedPair) return [item];
+
+  const out: TimelineItem[] = [];
+  let cursor = 0;
+  let inThinking = false;
+  let segment = 0;
+
+  const pushSegment = (type: "text" | "thinking", content: string) => {
+    if (!content) return;
+    out.push({
+      ...item,
+      seq: item.seq + segment / 1_000_000,
+      type,
+      content,
+    });
+    segment += 1;
+  };
+
+  for (const match of matches) {
+    const tag = match[0].toLowerCase();
+    const index = match.index ?? 0;
+
+    pushSegment(inThinking ? "thinking" : "text", item.content.slice(cursor, index));
+    cursor = index + match[0].length;
+
+    if (tag === "<thinking>") {
+      inThinking = true;
+    } else {
+      inThinking = false;
+    }
+  }
+
+  pushSegment(inThinking ? "thinking" : "text", item.content.slice(cursor));
+
+  return out.length > 0 ? out : [item];
+}
+
+function normalizeTimelineItems(items: TimelineItem[]): TimelineItem[] {
+  const coalesced = coalesceTimelineItems(items);
+  return coalesceTimelineItems(coalesced.flatMap(splitTextThinkingTags));
+}
+
 /** Merge adjacent text/thinking fragments that were split only by daemon flush timing. */
 export function coalesceTimelineItems(items: TimelineItem[]): TimelineItem[] {
   const sorted = [...items].sort((a, b) => a.seq - b.seq);
@@ -38,7 +91,7 @@ export function coalesceTimelineItems(items: TimelineItem[]): TimelineItem[] {
 }
 
 export function appendTimelineItem(items: TimelineItem[], item: TimelineItem): TimelineItem[] {
-  return coalesceTimelineItems([...items, item]);
+  return normalizeTimelineItems([...items, item]);
 }
 
 function redactTimelineItems(items: TimelineItem[]): TimelineItem[] {
@@ -63,5 +116,5 @@ export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
       created_at: msg.created_at,
     });
   }
-  return redactTimelineItems(coalesceTimelineItems(items));
+  return redactTimelineItems(normalizeTimelineItems(items));
 }


### PR DESCRIPTION
## Summary
- fixes #4011
- splits balanced inline `<thinking>...</thinking>` blocks from plain text task messages into dedicated thinking timeline items
- adds explicit Thinking labeling and violet-tinted row/detail styling so thinking content is visually distinct from final assistant text
- keeps unmatched streaming tags as text until a closing tag arrives, avoiding partial-output misclassification
- adds build-timeline tests for inline tags, split streaming chunks, and unmatched tags

## Validation
- git diff --check
- node --check packages/views/common/task-transcript/build-timeline.ts
- node one-off parser smoke check for balanced and unmatched thinking tags
- `pnpm --filter @multica/views test -- common/task-transcript` (3 test files passed, 28 tests passed)

## Follow-up
Maintainer feedback clarified that Multica should not add UI-layer parsing for special textual `<thinking>...</thinking>` tags. The longer-term direction is to have the upstream CLI emit structured thinking/final-answer events and keep Multica focused on rendering structured `TaskMessagePayload.type = "thinking"` messages.
