### PR TITLE
fix(quick-create): track concurrent uploads with in-flight counter (MUL-3339)

### DIFF
--- a/packages/core/hooks/use-file-upload.test.ts
+++ b/packages/core/hooks/use-file-upload.test.ts
@@ -100,3 +100,116 @@ describe("useFileUpload — markdownLink picks the durable URL with three-layer 
     expect(api.uploadFile as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 });
+
+// MUL-3339 — `uploading` is an in-flight counter, not a single boolean.
+// The single-boolean shape silently regressed the quick-create multi-image
+// attach flow: callers fire N concurrent uploads (drag-drop, multi-image
+// paste), the first upload's `finally` would flip `uploading` back to false
+// while N-1 are still in flight, and the submit gate (which only reads
+// `uploading`) would unblock — `stripBlobUrls` then erased the still-pending
+// images from the markdown and their attachment ids never reached the
+// server. The fix tracks an in-flight counter and exposes
+// `uploading = count > 0`, so callers see "uploading" as long as ANY upload
+// is in flight.
+describe("useFileUpload — concurrent uploads (MUL-3339 regression)", () => {
+  it("keeps uploading=true until ALL concurrent uploads resolve", async () => {
+    // Hand-rolled deferreds so the test controls resolve order.
+    const att1 = makeAttachment({ id: "att-1" });
+    const att2 = makeAttachment({ id: "att-2" });
+    let resolve1: (v: Attachment) => void = () => {};
+    let resolve2: (v: Attachment) => void = () => {};
+    const p1 = new Promise<Attachment>((r) => {
+      resolve1 = r;
+    });
+    const p2 = new Promise<Attachment>((r) => {
+      resolve2 = r;
+    });
+    const uploadFile = vi
+      .fn<(file: File) => Promise<Attachment>>()
+      .mockReturnValueOnce(p1)
+      .mockReturnValueOnce(p2);
+    const api = { uploadFile } as unknown as ApiClient;
+
+    const { result } = renderHook(() => useFileUpload(api));
+    expect(result.current.uploading).toBe(false);
+
+    // Fire both uploads concurrently — same shape as the quick-create
+    // drag-drop path (`files.forEach((f) => editorRef.current?.uploadFile(f))`).
+    let pending1: Promise<UploadResult | null> = Promise.resolve(null);
+    let pending2: Promise<UploadResult | null> = Promise.resolve(null);
+    await act(async () => {
+      pending1 = result.current.upload(
+        new File(["1"], "a.png", { type: "image/png" }),
+      );
+      pending2 = result.current.upload(
+        new File(["2"], "b.png", { type: "image/png" }),
+      );
+    });
+    expect(result.current.uploading).toBe(true);
+
+    // Resolve the FIRST upload only. With the old single-boolean shape this
+    // would flip `uploading` back to false — that's the production bug.
+    // With the in-flight counter, `uploading` stays true because upload 2
+    // is still pending.
+    await act(async () => {
+      resolve1(att1);
+      await pending1;
+    });
+    expect(result.current.uploading).toBe(true);
+
+    // Now resolve the second upload — only at this point should the gate open.
+    await act(async () => {
+      resolve2(att2);
+      await pending2;
+    });
+    expect(result.current.uploading).toBe(false);
+  });
+
+  it("decrements correctly when one of the concurrent uploads throws", async () => {
+    // The `finally` block runs on rejection too — the counter must still
+    // decrement so a failed upload never leaves the flag stuck "uploading".
+    const att = makeAttachment();
+    let resolveOk: (v: Attachment) => void = () => {};
+    let rejectBad: (e: Error) => void = () => {};
+    const ok = new Promise<Attachment>((r) => {
+      resolveOk = r;
+    });
+    const bad = new Promise<Attachment>((_, j) => {
+      rejectBad = j;
+    });
+    const uploadFile = vi
+      .fn<(file: File) => Promise<Attachment>>()
+      .mockReturnValueOnce(ok)
+      .mockReturnValueOnce(bad);
+    const api = { uploadFile } as unknown as ApiClient;
+
+    const { result } = renderHook(() => useFileUpload(api));
+    let okPending: Promise<UploadResult | null> = Promise.resolve(null);
+    let badPending: Promise<UploadResult | null> = Promise.resolve(null);
+    await act(async () => {
+      okPending = result.current.upload(
+        new File(["a"], "a.png", { type: "image/png" }),
+      );
+      // uploadWithToast swallows errors via onError; we test the raw `upload`
+      // so the caller sees the rejection. Wrap in a catch so vitest doesn't
+      // surface an unhandled rejection from the act() boundary.
+      badPending = result.current.upload(
+        new File(["b"], "b.png", { type: "image/png" }),
+      ).catch(() => null);
+    });
+    expect(result.current.uploading).toBe(true);
+
+    await act(async () => {
+      rejectBad(new Error("boom"));
+      await badPending;
+    });
+    // One still in flight — must remain uploading.
+    expect(result.current.uploading).toBe(true);
+
+    await act(async () => {
+      resolveOk(att);
+      await okPending;
+    });
+    expect(result.current.uploading).toBe(false);
+  });
+});

--- a/packages/core/hooks/use-file-upload.ts
+++ b/packages/core/hooks/use-file-upload.ts
@@ -84,7 +84,20 @@ export function useFileUpload(
   api: ApiClient,
   onError?: (error: Error) => void,
 ) {
-  const [uploading, setUploading] = useState(false);
+  // In-flight counter, NOT a single boolean. Callers fire multiple uploads
+  // concurrently (drag-drop of N files, paste with multiple images) and the
+  // boolean shape would flip false as soon as the FIRST upload's finally ran
+  // — even though N-1 are still mid-request. Surfaces consuming `uploading`
+  // (the quick-create submit gate, the editor's "Uploading…" button label)
+  // would then unblock submit while uploads are still in flight, causing
+  // `stripBlobUrls` to erase the still-pending images from the markdown and
+  // their attachment ids never to be bound (MUL-3339).
+  //
+  // The exposed `uploading: boolean` keeps the existing call-site contract
+  // (`{ uploading } = useFileUpload(api)` everywhere); only the internal
+  // tracking shape changes.
+  const [inFlight, setInFlight] = useState(0);
+  const uploading = inFlight > 0;
 
   const upload = useCallback(
     async (file: File, ctx?: UploadContext): Promise<UploadResult | null> => {
@@ -92,7 +105,7 @@ export function useFileUpload(
         throw new Error("File exceeds 100 MB limit");
       }
 
-      setUploading(true);
+      setInFlight((n) => n + 1);
       try {
         const att: Attachment = await api.uploadFile(file, {
           issueId: ctx?.issueId,
@@ -101,7 +114,7 @@ export function useFileUpload(
         });
         return { ...att, link: att.url, markdownLink: pickMarkdownLink(att) };
       } finally {
-        setUploading(false);
+        setInFlight((n) => n - 1);
       }
     },
     [api],

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -154,6 +154,11 @@ vi.mock("../editor", () => {
       },
       uploadFile: vi.fn(),
       focus: vi.fn(),
+      // Real ContentEditor checks ProseMirror node attrs for any `uploading:
+      // true` marker. The mock returns false because none of these tests drive
+      // a real in-flight upload through the editor — the multi-upload race is
+      // covered as a unit test against useFileUpload directly (MUL-3339).
+      hasActiveUploads: () => false,
     }));
 
     return (

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -287,6 +287,14 @@ export function AgentCreatePanel({
   const submit = async () => {
     const md = editorRef.current?.getMarkdown()?.trim() ?? "";
     if (!md || !actor || submitting || versionBlocked || uploading) return;
+    // Belt-and-suspenders against the multi-file upload race fixed in
+    // useFileUpload (MUL-3339): `uploading` already tracks an in-flight
+    // counter now, but the editor's per-node `uploading` attr is the most
+    // direct truth — if any image node is still mid-upload, blocking submit
+    // here guarantees `getMarkdown()`'s blob-url strip never erases a
+    // pasted/dropped image whose attachment id hasn't reached
+    // `pendingAttachments` yet.
+    if (editorRef.current?.hasActiveUploads()) return;
     const activeAttachmentIds = pendingAttachments
       .filter((a) => contentReferencesAttachment(md, a))
       .map((a) => a.id);


### PR DESCRIPTION
## Summary

Closes MUL-3339. In Quick Create, dropping multiple images at once
sometimes produced an issue where only one screenshot was actually
attached and the rest came back as "Attachment doesn't exist". Tracing
the 5-hop chain (modal → `/api/issues/quick-create` → task context →
daemon env injection → CLI → `IssueService.linkAttachments`) pins the
defect to step 1: the frontend ships an incomplete `attachment_ids` set
and a markdown body missing the still-pending image references.

Root cause is in `useFileUpload`. It tracked progress as a single
`uploading: boolean` shared by all concurrent upload calls:

```ts
setUploading(true);
try { await api.uploadFile(file, ...); }
finally { setUploading(false); }   // first finally flips it false for everyone
```

When N uploads ran concurrently (drag-drop of multiple images is the
common path), the first upload's `finally` flipped the flag false while
N-1 uploads were still in flight. The quick-create submit gate only
checked `uploading`, so the Create button re-enabled. On submit:

1. `ContentEditor.getMarkdown()` runs `stripBlobUrls()` and erases every
   `![alt](blob:...)` placeholder still waiting for its real URL.
2. `pendingAttachments` only contains the first-completed upload — the
   others haven't called `setPendingAttachments` yet.
3. `activeAttachmentIds = pendingAttachments.filter(contentReferencesAttachment)`
   ships a single ID; the markdown references a single image.
4. Service-side `linkAttachments` only sees that one ID, the remaining
   attachment rows keep `issue_id IS NULL`, and the UI shows
   "Attachment doesn't exist".

Paste and single-file uploads were not affected: the editor's paste
handler uses `for...of + await`, so paste is serialized. The
`FileUploadButton` in the modal doesn't set `multiple`, so it's single-file.
Only the drag-drop path is concurrent in production today, but the bug
is fundamentally in the hook, so the fix lives there.

## Changes

1. **`packages/core/hooks/use-file-upload.ts`** — Replace the boolean
   with an in-flight counter. `uploading = inFlight > 0` so the flag
   stays true until ALL concurrent uploads resolve or reject. The
   exposed `{ upload, uploadWithToast, uploading }` shape is unchanged,
   so every existing call site (chat input, comment composers, avatar
   pickers, settings tabs, etc.) keeps working with no edit.

2. **`packages/views/modals/quick-create-issue.tsx`** — Add an
   `editorRef.current?.hasActiveUploads()` defense to the submit gate
   (belt-and-suspenders). The editor already tracks per-node
   `uploading: true` attrs as the source of truth for "is there a blob
   preview still resolving"; checking it on submit guarantees the
   blob-url strip can't run against an in-flight image even if a future
   code path mis-clears `uploading`.

## Testing

Regression coverage added to `packages/core/hooks/use-file-upload.test.ts`:

- Fire two concurrent uploads, resolve them out of order, assert
  `uploading` stays true until BOTH resolve. **Verified to fail against
  the pre-fix code** (stashed the hook fix and re-ran — the new
  assertions hit `expected true, received false` at exactly the
  first-resolve point).
- Reject one of the concurrent uploads, assert the counter still
  decrements correctly so the flag clears.

The mock `ContentEditor` in `packages/views/modals/quick-create-issue.test.tsx`
gets a `hasActiveUploads: () => false` stub so existing tests don't
crash on the new defense call.

Local verification:

```
packages/core:   pnpm test    → 67 files, 663 tests pass
packages/views:  pnpm test    → 145 files, 1471 tests pass
both:            pnpm typecheck && pnpm lint  → clean
```

## Manual reproduction (pre-fix)

1. Open Quick Create (agent mode).
2. Drag 2–3 images at once onto the prompt area (not paste — paste is
   serialized).
3. Press ⌘Enter during the brief window the button enables.
4. Created issue shows only the first image; the rest appear as
   "Attachment doesn't exist".

After the fix, the button stays disabled until every dropped image
finishes uploading.

## Out of scope

- Server-side: `IssueService.linkAttachments` is post-commit
  best-effort and silently swallows the SQL no-op case
  (`issue_id IS NOT NULL` or workspace mismatch). That path is not on
  the failure trace for this bug — every attachment that fell out was
  still `issue_id IS NULL`. Tightening that path can be a follow-up if
  we want create-time observability on bind failures.
- The CLI / daemon env-injection legs were verified clean by code
  review; no changes there.
