### PR TITLE
fix(agent): change Multica Helper visibility to private to prevent offline lock (#4558)

### DIFF
--- a/packages/views/workspace/welcome-after-onboarding.test.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.test.tsx
@@ -162,7 +162,7 @@ describe("WelcomeAfterOnboarding", () => {
         name: "Multica Helper",
         description: "Built-in workspace assistant.",
         avatar_url: null,
-        visibility: "workspace",
+        visibility: "private",
       });
       useWelcomeStore.getState().set({
         workspaceId: "ws-1",
@@ -204,7 +204,7 @@ describe("WelcomeAfterOnboarding", () => {
           name: "Multica Helper",
           description: "",
           avatar_url: null,
-          visibility: "workspace",
+          visibility: "private",
           archived_at: null,
         },
       ]);
@@ -229,7 +229,7 @@ describe("WelcomeAfterOnboarding", () => {
         name: "Multica Helper",
         description: "",
         avatar_url: null,
-        visibility: "workspace",
+        visibility: "private",
       });
       // Pick 2 cards — `intro` then `welcome_page`. Issues come back in
       // STARTER_CARD_IDS order (intro first), so navigate target is the
@@ -305,7 +305,7 @@ describe("WelcomeAfterOnboarding", () => {
         name: "Multica Helper",
         description: "",
         avatar_url: null,
-        visibility: "workspace",
+        visibility: "private",
       });
       mockCreateIssue.mockResolvedValueOnce({
         id: "issue-intro",
@@ -352,7 +352,7 @@ describe("WelcomeAfterOnboarding", () => {
         name: "Multica Helper",
         description: "",
         avatar_url: null,
-        visibility: "workspace",
+        visibility: "private",
       });
       mockCreateIssue.mockResolvedValueOnce({
         id: "issue-intro",

--- a/packages/views/workspace/welcome-after-onboarding.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.tsx
@@ -164,7 +164,7 @@ async function findOrCreateHelper(
     const found = agents.find(
       (a) =>
         a.name === HELPER_AGENT_NAME &&
-        a.visibility === "workspace" &&
+        a.visibility === "private" &&
         !a.archived_at,
     );
     if (found) return found;
@@ -175,7 +175,7 @@ async function findOrCreateHelper(
       instructions: HELPER_INSTRUCTIONS[lang],
       avatar_url: HELPER_AVATAR_URL,
       runtime_id: runtimeId,
-      visibility: "workspace",
+      visibility: "private",
       max_concurrent_tasks: 6,
       template: "multica_helper",
     });

--- a/server/internal/handler/onboarding_shim.go
+++ b/server/internal/handler/onboarding_shim.go
@@ -207,7 +207,7 @@ func (h *Handler) BootstrapOnboardingRuntime(w http.ResponseWriter, r *http.Requ
 	var assistant db.Agent
 	assistantCreated := false
 	for _, existing := range agents {
-		if existing.Name == onboardingAssistantName && existing.Visibility == "workspace" {
+		if existing.Name == onboardingAssistantName && existing.Visibility == "private" {
 			assistant = existing
 			break
 		}
@@ -221,7 +221,7 @@ func (h *Handler) BootstrapOnboardingRuntime(w http.ResponseWriter, r *http.Requ
 			RuntimeMode:        runtime.RuntimeMode,
 			RuntimeConfig:      []byte("{}"),
 			RuntimeID:          runtime.ID,
-			Visibility:         "workspace",
+			Visibility:         "private",
 			MaxConcurrentTasks: 6,
 			OwnerID:            parseUUID(userID),
 			Instructions:       onboardingAssistantInstructions,


### PR DESCRIPTION
## What does this PR do?

This PR fixes a critical UI and permission lock issue where the built-in "Multica Helper" remains permanently offline for secondary workspace members.

**The Problem:**
Currently, when the first member completes onboarding, the `Multica Helper` is created with `visibility: "workspace"` and bound to that creator's Local Daemon. When other members join the workspace, they see this shared Helper. However, if the creator's machine is offline, the Helper goes offline. Because regular members are not the `Owner` of the agent, they lack edit permissions (`packages/core/permissions/rules.ts`). Consequently, the Runtime Picker on the detail page degrades to read-only text, leaving secondary members with a permanently dead assistant they cannot "wake up" or rebind to their own daemon.

**The Solution:**
This approach changes the onboarding logic to create the Multica Helper with `visibility: "private"`. This ensures every user gets their own personal helper bound to their own local environment, cleanly resolving the shared-runtime deadlocks without requiring risky migrations to existing database rows or complex permission rule overrides.

## Related Issue

Closes #4558

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/workspace/welcome-after-onboarding.tsx`: Changed default visibility of Multica Helper from `workspace` to `private`.
- `server/internal/handler/onboarding_shim.go`: Applied the same visibility change to the legacy API for consistency.

## How to Test

1. Log in as **User A**, complete onboarding, and start a Local Daemon. A `private` Multica Helper is created.
2. Stop User A's Local Daemon (Agent goes offline).
3. Log in as **User B** to the same workspace and complete onboarding.
4. Verify that User B no longer sees User A's offline helper. Instead, User B gets their *own* private Multica Helper, which is successfully bound to User B's Local Daemon and fully editable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Antigravity IDE

**Prompt / approach:**
Used Antigravity IDE to deeply analyze the agent permissions architecture (`rules.ts` vs `welcome-after-onboarding.tsx`). We derived that the workspace-level visibility of a locally-bound helper causes a permission lock for non-creator members. Prompted the AI to modify the visibility to private to provide a smooth, per-user degradation.
