### PR TITLE
fix(cli): resolveToken() daemon 信号守护，防止静默回退到用户 PAT

### DIFF
--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -144,6 +144,17 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 			t.Fatalf("resolveToken() = %q, want MULTICA_TOKEN", got)
 		}
 	})
+
+	t.Run("daemon context without agent env never reads config", func(t *testing.T) {
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_TOKEN", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "19001")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty in daemon context without MULTICA_TOKEN", got)
+		}
+	})
 }
 
 func TestNewAPIClient_AgentContextRequiresTaskToken(t *testing.T) {

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -77,6 +77,15 @@ func resolveToken(cmd *cobra.Command) string {
 	if inAgentExecutionContext() {
 		return ""
 	}
+	// Daemon-managed processes carry MULTICA_DAEMON_PORT. Even if the
+	// agent identity env vars (MULTICA_AGENT_ID / MULTICA_TASK_ID) were
+	// stripped by a deeply nested subprocess, the daemon port signals we
+	// are still inside a daemon context. Falling through to the user PAT
+	// in ~/.multica/config.json would misattribute agent actions to the
+	// human user. Fail closed instead.
+	if os.Getenv("MULTICA_DAEMON_PORT") != "" {
+		return ""
+	}
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	return cfg.Token

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -13,6 +13,7 @@ func TestMain(m *testing.M) {
 	os.Unsetenv("MULTICA_AGENT_ID")
 	os.Unsetenv("MULTICA_TASK_ID")
 	os.Unsetenv("MULTICA_TOKEN")
+	os.Unsetenv("MULTICA_DAEMON_PORT")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## 问题

Agent 子进程在深层嵌套时可能丢失 `MULTICA_AGENT_ID` / `MULTICA_TASK_ID` 环境变量，此时 `resolveToken()` 的 `inAgentExecutionContext()` 检查返回 false，函数会继续走到 config.json 的 fallback 逻辑，静默使用用户 PAT。这导致 agent 发出的评论被错误归因到人类用户，而不是 agent 自身。

相关 issue: #4204

## 修复

在 `resolveToken()` 中 `inAgentExecutionContext()` 检查之后、config.json fallback 之前，插入对 `MULTICA_DAEMON_PORT` 的检查。daemon 在启动 agent 子进程时会在同一个 agentEnv map 中设置这个变量，即使 agent 标识变量被深层子进程剥离，daemon 端口信号仍然存在，可以作为守护上下文的兜底判断。

改动量很小，只加了 5 行逻辑 + 对应的测试用例。

## Trade-off（fail-closed vs fail-open）

这是 fail-closed 设计：如果用户的 shell profile 里意外设置了 `MULTICA_DAEMON_PORT`，CLI 会拒绝认证。但相比当前 fail-open 的行为（静默使用错误身份），主动拒绝认证是更安全的选择。正常用户不会设置这个变量，它只在 daemon 管理的 agent 进程中出现。

## CI 说明

前端 CI（`@multica/core#typecheck`）如果失败，与本次改动无关——PR 只动了 `server/cmd/multica/` 下的 Go 文件，不涉及任何 TypeScript 包。

## 测试

```
=== RUN   TestResolveToken_AgentContextSkipsConfig
=== RUN   TestResolveToken_AgentContextSkipsConfig/outside_agent_context_falls_back_to_config
=== RUN   TestResolveToken_AgentContextSkipsConfig/agent_context_without_env_never_reads_config
=== RUN   TestResolveToken_AgentContextSkipsConfig/agent_context_uses_explicit_task_token_env
=== RUN   TestResolveToken_AgentContextSkipsConfig/daemon_context_without_agent_env_never_reads_config
--- PASS: TestResolveToken_AgentContextSkipsConfig (0.00s)
```
