### PR TITLE
MUL-3690: accept mention suggestions with Tab

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -209,6 +209,41 @@ describe("createMentionSuggestion", () => {
     ).toBe(true);
   });
 
+  it("uses Tab to commit the highlighted row without moving browser focus", () => {
+    const command = vi.fn<(item: MentionItem) => void>();
+    const ref = createRef<MentionListRef>();
+    const items: MentionItem[] = [
+      { id: "i-1", label: "MUL-1", type: "issue" },
+      { id: "i-2", label: "MUL-2", type: "issue" },
+    ];
+
+    render(
+      <I18nWrapper>
+        <MentionList ref={ref} items={items} query="" command={command} />
+      </I18nWrapper>,
+    );
+
+    const press = (event: KeyboardEvent) => {
+      let handled = false;
+      act(() => {
+        handled = ref.current?.onKeyDown({ event }) ?? false;
+      });
+      return handled;
+    };
+
+    press(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    const tab = new KeyboardEvent("keydown", { key: "Tab", cancelable: true });
+
+    expect(press(tab)).toBe(true);
+    expect(tab.defaultPrevented).toBe(true);
+    expect(command).toHaveBeenCalledTimes(1);
+    expect(command.mock.calls[0]?.[0]?.label).toBe("MUL-2");
+
+    const shiftTab = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, cancelable: true });
+    expect(press(shiftTab)).toBe(false);
+    expect(shiftTab.defaultPrevented).toBe(false);
+  });
+
   // MUL-3607: groupItems() re-buckets the list (current → recent → search →
   // users → issues), so an item that sits LATER in the data array can render
   // NEAR THE TOP. Selection must follow the rendered order — otherwise the

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -288,7 +288,8 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
           setSelectedKey(mentionItemKey(orderedItems[next]!));
           return true;
         }
-        if (event.key === "Enter") {
+        if (event.key === "Enter" || (event.key === "Tab" && !event.shiftKey)) {
+          if (event.key === "Tab") event.preventDefault();
           if (orderedItems.length === 0) return true;
           selectItem(orderedItems[selectedIndex]);
           return true;


### PR DESCRIPTION
## Summary
- Allow plain Tab to accept the currently highlighted @mention suggestion.
- Prevent the browser focus jump when Tab is used for completion while leaving Shift+Tab untouched.
- Add coverage for Tab completion behavior in the mention suggestion list.

## Testing
- pnpm --dir packages/views exec vitest run editor/extensions/mention-suggestion.test.tsx editor/extensions/suggestion-popup.test.tsx
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views lint