### PR TITLE
MUL-3664: allow autopilot squad assignees in CLI

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -119,7 +119,9 @@ func init() {
 	// create
 	autopilotCreateCmd.Flags().String("title", "", "Autopilot title (required)")
 	autopilotCreateCmd.Flags().String("description", "", "Autopilot description (used as task prompt)")
-	autopilotCreateCmd.Flags().String("agent", "", "Assignee agent (name or ID) — required")
+	autopilotCreateCmd.Flags().String("agent", "", "Assignee agent (name or ID)")
+	autopilotCreateCmd.Flags().String("squad", "", "Assignee squad (name or ID)")
+	autopilotCreateCmd.Flags().String("squad-id", "", "Assignee squad ID (canonical UUID)")
 	autopilotCreateCmd.Flags().String("mode", "", "Execution mode: create_issue or run_only (required)")
 	autopilotCreateCmd.Flags().String("priority", "none", "Priority for created issues (none, low, medium, high, urgent)")
 	autopilotCreateCmd.Flags().String("project", "", "Project ID (optional)")
@@ -131,6 +133,8 @@ func init() {
 	autopilotUpdateCmd.Flags().String("title", "", "New title")
 	autopilotUpdateCmd.Flags().String("description", "", "New description")
 	autopilotUpdateCmd.Flags().String("agent", "", "New assignee agent (name or ID)")
+	autopilotUpdateCmd.Flags().String("squad", "", "New assignee squad (name or ID)")
+	autopilotUpdateCmd.Flags().String("squad-id", "", "New assignee squad ID (canonical UUID)")
 	autopilotUpdateCmd.Flags().String("project", "", "New project ID (use empty string to clear)")
 	autopilotUpdateCmd.Flags().String("priority", "", "New priority")
 	autopilotUpdateCmd.Flags().String("status", "", "New status (active, paused)")
@@ -214,7 +218,7 @@ func runAutopilotList(cmd *cobra.Command, _ []string) error {
 			strVal(a, "title"),
 			strVal(a, "status"),
 			strVal(a, "execution_mode"),
-			actors.agent(strVal(a, "assignee_id")),
+			formatAutopilotAssignee(a, actors),
 			strVal(a, "last_run_at"),
 		})
 	}
@@ -254,7 +258,7 @@ func runAutopilotGet(cmd *cobra.Command, args []string) error {
 		strVal(ap, "title"),
 		strVal(ap, "status"),
 		strVal(ap, "execution_mode"),
-		actors.agent(strVal(ap, "assignee_id")),
+		formatAutopilotAssignee(ap, actors),
 		strVal(ap, "last_run_at"),
 	}}
 	cli.PrintTable(os.Stdout, headers, rows)
@@ -274,10 +278,6 @@ func runAutopilotCreate(cmd *cobra.Command, _ []string) error {
 	if title == "" {
 		return fmt.Errorf("--title is required")
 	}
-	agent, _ := cmd.Flags().GetString("agent")
-	if agent == "" {
-		return fmt.Errorf("--agent is required (agent name or ID)")
-	}
 	mode, _ := cmd.Flags().GetString("mode")
 	if mode == "" {
 		return fmt.Errorf("--mode is required (create_issue or run_only)")
@@ -289,14 +289,18 @@ func runAutopilotCreate(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cli.APIContext(context.Background())
 	defer cancel()
 
-	agentID, err := resolveAgent(ctx, client, agent)
+	assigneeType, assigneeID, hasAssignee, err := resolveAutopilotAssigneeFromFlags(ctx, client, cmd, true)
 	if err != nil {
-		return fmt.Errorf("resolve agent: %w", err)
+		return err
+	}
+	if !hasAssignee {
+		return fmt.Errorf("--agent, --squad, or --squad-id is required")
 	}
 
 	body := map[string]any{
 		"title":          title,
-		"assignee_id":    agentID,
+		"assignee_type":  assigneeType,
+		"assignee_id":    assigneeID,
 		"execution_mode": mode,
 	}
 	if v, _ := cmd.Flags().GetString("description"); v != "" {
@@ -360,13 +364,13 @@ func runAutopilotUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("description")
 		body["description"] = v
 	}
-	if cmd.Flags().Changed("agent") {
-		v, _ := cmd.Flags().GetString("agent")
-		agentID, resolveErr := resolveAgent(ctx, client, v)
-		if resolveErr != nil {
-			return fmt.Errorf("resolve agent: %w", resolveErr)
-		}
-		body["assignee_id"] = agentID
+	assigneeType, assigneeID, hasAssignee, err := resolveAutopilotAssigneeFromFlags(ctx, client, cmd, false)
+	if err != nil {
+		return err
+	}
+	if hasAssignee {
+		body["assignee_type"] = assigneeType
+		body["assignee_id"] = assigneeID
 	}
 	if cmd.Flags().Changed("project") {
 		v, _ := cmd.Flags().GetString("project")
@@ -764,6 +768,59 @@ func resolveAutopilotSubscriberInputs(ctx context.Context, client *cli.APIClient
 	return inputs, nil
 }
 
+func resolveAutopilotAssigneeFromFlags(ctx context.Context, client *cli.APIClient, cmd *cobra.Command, required bool) (string, string, bool, error) {
+	agentSet := cmd.Flags().Changed("agent")
+	squadSet := cmd.Flags().Changed("squad")
+	squadIDSet := cmd.Flags().Changed("squad-id")
+
+	setCount := 0
+	for _, set := range []bool{agentSet, squadSet, squadIDSet} {
+		if set {
+			setCount++
+		}
+	}
+	if setCount > 1 {
+		return "", "", false, fmt.Errorf("--agent, --squad, and --squad-id are mutually exclusive")
+	}
+	if setCount == 0 {
+		if required {
+			return "", "", false, fmt.Errorf("--agent, --squad, or --squad-id is required")
+		}
+		return "", "", false, nil
+	}
+
+	if agentSet {
+		ref, _ := cmd.Flags().GetString("agent")
+		if strings.TrimSpace(ref) == "" {
+			return "", "", true, fmt.Errorf("--agent cannot be empty")
+		}
+		agentID, err := resolveAgent(ctx, client, ref)
+		if err != nil {
+			return "", "", true, fmt.Errorf("resolve agent: %w", err)
+		}
+		return "agent", agentID, true, nil
+	}
+
+	if squadIDSet {
+		id, _ := cmd.Flags().GetString("squad-id")
+		id = strings.TrimSpace(id)
+		if !uuidRegexp.MatchString(id) {
+			return "", "", true, fmt.Errorf("--squad-id must be a canonical UUID")
+		}
+		return "squad", id, true, nil
+	}
+
+	ref, _ := cmd.Flags().GetString("squad")
+	if strings.TrimSpace(ref) == "" {
+		return "", "", true, fmt.Errorf("--squad cannot be empty")
+	}
+	squadID, err := resolveSquad(ctx, client, ref)
+	if err != nil {
+		return "", "", true, fmt.Errorf("resolve squad: %w", err)
+	}
+	return "squad", squadID, true, nil
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -809,4 +866,33 @@ func resolveAgent(ctx context.Context, client *cli.APIClient, nameOrID string) (
 		}
 		return "", fmt.Errorf("ambiguous agent %q; matches:\n%s", nameOrID, strings.Join(parts, "\n"))
 	}
+}
+
+// resolveSquad accepts either a UUID or a squad name (case-insensitive, with
+// exact matches preferred by resolveAssignee) and returns the squad UUID.
+func resolveSquad(ctx context.Context, client *cli.APIClient, nameOrID string) (string, error) {
+	if uuidRegexp.MatchString(nameOrID) {
+		return nameOrID, nil
+	}
+	squadOnly := assigneeKinds{squad: true}
+	kind, id, err := resolveAssignee(ctx, client, nameOrID, squadOnly)
+	if err != nil {
+		return "", err
+	}
+	if kind != "squad" {
+		return "", fmt.Errorf("%q resolved to %s; autopilot assignee must be an agent or squad", nameOrID, kind)
+	}
+	return id, nil
+}
+
+func formatAutopilotAssignee(autopilot map[string]any, actors actorDisplayLookup) string {
+	aID := strVal(autopilot, "assignee_id")
+	if aID == "" {
+		return ""
+	}
+	aType := strVal(autopilot, "assignee_type")
+	if aType == "" {
+		aType = "agent"
+	}
+	return actors.actor(aType, aID)
 }

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -18,6 +18,8 @@ func newAutopilotCreateTestCmd() *cobra.Command {
 	cmd.Flags().String("title", "", "")
 	cmd.Flags().String("description", "", "")
 	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("squad", "", "")
+	cmd.Flags().String("squad-id", "", "")
 	cmd.Flags().String("mode", "", "")
 	cmd.Flags().String("priority", "none", "")
 	cmd.Flags().String("project", "", "")
@@ -32,6 +34,8 @@ func newAutopilotUpdateTestCmd() *cobra.Command {
 	cmd.Flags().String("title", "", "")
 	cmd.Flags().String("description", "", "")
 	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("squad", "", "")
+	cmd.Flags().String("squad-id", "", "")
 	cmd.Flags().String("project", "", "")
 	cmd.Flags().String("priority", "", "")
 	cmd.Flags().String("status", "", "")
@@ -131,6 +135,64 @@ func TestResolveAgent(t *testing.T) {
 	})
 }
 
+func TestResolveSquad(t *testing.T) {
+	squadsResp := []map[string]any{
+		{"id": "11111111-1111-1111-1111-111111111111", "name": "Platform Squad"},
+		{"id": "22222222-2222-2222-2222-222222222222", "name": "CLI Squad"},
+		{"id": "33333333-3333-3333-3333-333333333333", "name": "Archived Squad", "archived_at": "2026-01-01T00:00:00Z"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/squads" {
+			json.NewEncoder(w).Encode(squadsResp)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx := context.Background()
+
+	t.Run("passes through a UUID without lookup", func(t *testing.T) {
+		id := "44444444-4444-4444-4444-444444444444"
+		got, err := resolveSquad(ctx, client, id)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != id {
+			t.Errorf("got %q, want %q", got, id)
+		}
+	})
+
+	t.Run("exact name match", func(t *testing.T) {
+		got, err := resolveSquad(ctx, client, "CLI Squad")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "22222222-2222-2222-2222-222222222222" {
+			t.Errorf("got %q, want CLI Squad's UUID", got)
+		}
+	})
+
+	t.Run("short id match", func(t *testing.T) {
+		got, err := resolveSquad(ctx, client, "11111111")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "11111111-1111-1111-1111-111111111111" {
+			t.Errorf("got %q, want Platform Squad's UUID", got)
+		}
+	})
+
+	t.Run("archived squad is ignored", func(t *testing.T) {
+		_, err := resolveSquad(ctx, client, "Archived Squad")
+		if err == nil {
+			t.Fatal("expected error for archived squad")
+		}
+	})
+}
+
 func TestRunAutopilotCreateSendsProjectID(t *testing.T) {
 	const (
 		agentID   = "11111111-1111-1111-1111-111111111111"
@@ -172,6 +234,58 @@ func TestRunAutopilotCreateSendsProjectID(t *testing.T) {
 	}
 	if got := body["project_id"]; got != projectID {
 		t.Fatalf("project_id = %#v, want %q", got, projectID)
+	}
+	if got := body["assignee_type"]; got != "agent" {
+		t.Fatalf("assignee_type = %#v, want agent", got)
+	}
+}
+
+func TestRunAutopilotCreateSendsSquadAssignee(t *testing.T) {
+	const squadID = "22222222-2222-2222-2222-222222222222"
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/squads":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": squadID, "name": "CLI Squad"},
+			})
+		case "/api/autopilots":
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":            "autopilot-1",
+				"title":         "Squad planner",
+				"assignee_type": body["assignee_type"],
+				"assignee_id":   body["assignee_id"],
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Squad planner")
+	_ = cmd.Flags().Set("squad", "CLI Squad")
+	_ = cmd.Flags().Set("mode", "create_issue")
+
+	if err := runAutopilotCreate(cmd, nil); err != nil {
+		t.Fatalf("runAutopilotCreate: %v", err)
+	}
+	if got := body["assignee_type"]; got != "squad" {
+		t.Fatalf("assignee_type = %#v, want squad", got)
+	}
+	if got := body["assignee_id"]; got != squadID {
+		t.Fatalf("assignee_id = %#v, want %q", got, squadID)
 	}
 }
 
@@ -279,6 +393,70 @@ func TestRunAutopilotUpdateSendsProjectIDChanges(t *testing.T) {
 			t.Fatalf("project_id = %#v, want nil", got)
 		}
 	})
+}
+
+func TestRunAutopilotUpdateSendsSquadAssigneePair(t *testing.T) {
+	const (
+		autopilotID = "33333333-3333-3333-3333-333333333333"
+		squadID     = "22222222-2222-2222-2222-222222222222"
+	)
+
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":            autopilotID,
+			"title":         "Daily planner",
+			"assignee_type": body["assignee_type"],
+			"assignee_id":   body["assignee_id"],
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotUpdateTestCmd()
+	_ = cmd.Flags().Set("squad-id", squadID)
+	if err := runAutopilotUpdate(cmd, []string{autopilotID}); err != nil {
+		t.Fatalf("runAutopilotUpdate: %v", err)
+	}
+	if got := body["assignee_type"]; got != "squad" {
+		t.Fatalf("assignee_type = %#v, want squad", got)
+	}
+	if got := body["assignee_id"]; got != squadID {
+		t.Fatalf("assignee_id = %#v, want %q", got, squadID)
+	}
+}
+
+func TestRunAutopilotRejectsMultipleAssigneeFlags(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newAutopilotCreateTestCmd()
+	_ = cmd.Flags().Set("title", "Daily planner")
+	_ = cmd.Flags().Set("agent", "11111111-1111-1111-1111-111111111111")
+	_ = cmd.Flags().Set("squad-id", "22222222-2222-2222-2222-222222222222")
+	_ = cmd.Flags().Set("mode", "create_issue")
+
+	err := runAutopilotCreate(cmd, nil)
+	if err == nil {
+		t.Fatal("expected mutually exclusive assignee flags error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive", err)
+	}
 }
 
 func TestRunAutopilotUpdateSendsSubscriberReplacement(t *testing.T) {


### PR DESCRIPTION
Summary:
- Added `--squad` and `--squad-id` to `multica autopilot create/update`.
- Send `assignee_type` with `assignee_id` so agent/squad assignment changes match the API contract.
- Render autopilot table assignees with polymorphic actor labels instead of always treating them as agents.

Testing:
- `go test ./cmd/multica`

Closes MUL-3664
