### PR TITLE
feat(sidebar): dot the workspace switcher when other workspaces have unread inbox (MUL-3695)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -28,6 +28,7 @@ import type {
   CreateRuntimeProfileRequest,
   UpdateRuntimeProfileRequest,
   InboxItem,
+  InboxWorkspaceUnread,
   IssueSubscriber,
   Comment,
   CommentTriggerPreview,
@@ -201,6 +202,8 @@ import {
   EMPTY_BILLING_CHECKOUT_SESSION_STATUS,
   EMPTY_CREATE_BILLING_PORTAL_SESSION_RESPONSE,
   EMPTY_CANCEL_TASK_RESPONSE,
+  InboxUnreadSummarySchema,
+  EMPTY_INBOX_UNREAD_SUMMARY,
 } from "./schemas";
 
 /** Identifies the calling client to the server.
@@ -1457,6 +1460,17 @@ export class ApiClient {
 
   async getUnreadInboxCount(): Promise<{ count: number }> {
     return this.fetch("/api/inbox/unread-count");
+  }
+
+  // Cross-workspace unread summary: one entry per workspace the user belongs
+  // to that has unread inbox items. Backs the workspace-switcher dot for
+  // OTHER workspaces. Schema-guarded so a contract drift hides the dot rather
+  // than crashing the sidebar.
+  async getInboxUnreadSummary(): Promise<InboxWorkspaceUnread[]> {
+    const raw = await this.fetch<unknown>("/api/inbox/unread-summary");
+    return parseWithFallback(raw, InboxUnreadSummarySchema, EMPTY_INBOX_UNREAD_SUMMARY, {
+      endpoint: "GET /api/inbox/unread-summary",
+    });
   }
 
   async markAllInboxRead(): Promise<{ count: number }> {

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -5,7 +5,9 @@ import {
   DashboardUsageByAgentListSchema,
   DashboardUsageDailyListSchema,
   DuplicateIssueErrorBodySchema,
+  EMPTY_INBOX_UNREAD_SUMMARY,
   EMPTY_USER,
+  InboxUnreadSummarySchema,
   IssueTriggerPreviewSchema,
   ListIssuesResponseSchema,
   RuntimeHourlyActivityListSchema,
@@ -413,5 +415,45 @@ describe("AppConfigSchema cdn_signed drift", () => {
   it("keeps cdn_signed=true from a signing-enabled server", () => {
     const parsed = AppConfigSchema.parse({ cdn_signed: true });
     expect(parsed.cdn_signed).toBe(true);
+  });
+});
+
+describe("InboxUnreadSummarySchema", () => {
+  const ENDPOINT = { endpoint: "GET /api/inbox/unread-summary" };
+
+  it("parses a well-formed summary and tolerates extra fields", () => {
+    const parsed = parseWithFallback(
+      [
+        { workspace_id: "ws-1", count: 2 },
+        { workspace_id: "ws-2", count: 0, future_field: "ignored" },
+      ],
+      InboxUnreadSummarySchema,
+      EMPTY_INBOX_UNREAD_SUMMARY,
+      ENDPOINT,
+    );
+    expect(parsed).toEqual([
+      { workspace_id: "ws-1", count: 2 },
+      { workspace_id: "ws-2", count: 0, future_field: "ignored" },
+    ]);
+  });
+
+  it("returns the empty fallback (dot hidden) for a non-array body", () => {
+    expect(
+      parseWithFallback({ rows: [] }, InboxUnreadSummarySchema, EMPTY_INBOX_UNREAD_SUMMARY, ENDPOINT),
+    ).toBe(EMPTY_INBOX_UNREAD_SUMMARY);
+    expect(
+      parseWithFallback(null, InboxUnreadSummarySchema, EMPTY_INBOX_UNREAD_SUMMARY, ENDPOINT),
+    ).toBe(EMPTY_INBOX_UNREAD_SUMMARY);
+  });
+
+  it("returns the empty fallback when an entry has a wrong-typed count", () => {
+    expect(
+      parseWithFallback(
+        [{ workspace_id: "ws-1", count: "lots" }],
+        InboxUnreadSummarySchema,
+        EMPTY_INBOX_UNREAD_SUMMARY,
+        ENDPOINT,
+      ),
+    ).toBe(EMPTY_INBOX_UNREAD_SUMMARY);
   });
 });

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -15,6 +15,7 @@ import type {
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
   GroupedIssuesResponse,
+  InboxWorkspaceUnread,
   ListIssuesResponse,
   ListWebhookDeliveriesResponse,
   Squad,
@@ -862,6 +863,25 @@ export const EMPTY_USER: User = {
   created_at: "",
   updated_at: "",
 };
+
+// ---------------------------------------------------------------------------
+// Cross-workspace unread inbox summary (`/api/inbox/unread-summary` GET).
+// One entry per workspace the user belongs to that has unread items; the
+// sidebar derives the workspace-switcher dot from it. Lenient per the usual
+// rules so a future field addition can't blank the dot — on malformed JSON
+// parseWithFallback returns the empty list, which simply hides the dot.
+// ---------------------------------------------------------------------------
+
+export const InboxUnreadSummarySchema = z.array(
+  z
+    .object({
+      workspace_id: z.string(),
+      count: z.number(),
+    })
+    .loose(),
+);
+
+export const EMPTY_INBOX_UNREAD_SUMMARY: InboxWorkspaceUnread[] = [];
 
 // ---------------------------------------------------------------------------
 // Billing schemas (cloud-billing proxy surface)

--- a/packages/core/inbox/queries.test.ts
+++ b/packages/core/inbox/queries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { InboxItem } from "../types";
-import { deduplicateInboxItems } from "./queries";
+import type { InboxItem, InboxWorkspaceUnread } from "../types";
+import { deduplicateInboxItems, hasOtherWorkspaceUnread, inboxKeys } from "./queries";
 
 function item(overrides: Partial<InboxItem>): InboxItem {
   return {
@@ -70,5 +70,67 @@ describe("deduplicateInboxItems", () => {
     expect(merged).toHaveLength(1);
     expect(merged[0]?.id).toBe("newer-comment");
     expect(merged[0]?.details?.comment_id).toBe("comment-2");
+  });
+});
+
+describe("hasOtherWorkspaceUnread", () => {
+  const summary = (entries: InboxWorkspaceUnread[]) => entries;
+
+  it("is true when a workspace other than the active one has unread", () => {
+    expect(
+      hasOtherWorkspaceUnread(
+        summary([{ workspace_id: "ws-2", count: 3 }]),
+        "ws-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("excludes the active workspace's own unread", () => {
+    expect(
+      hasOtherWorkspaceUnread(
+        summary([{ workspace_id: "ws-1", count: 5 }]),
+        "ws-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores other workspaces whose count is zero", () => {
+    expect(
+      hasOtherWorkspaceUnread(
+        summary([{ workspace_id: "ws-2", count: 0 }]),
+        "ws-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when at least one non-active workspace has unread", () => {
+    expect(
+      hasOtherWorkspaceUnread(
+        summary([
+          { workspace_id: "ws-1", count: 4 },
+          { workspace_id: "ws-2", count: 1 },
+        ]),
+        "ws-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an empty summary", () => {
+    expect(hasOtherWorkspaceUnread([], "ws-1")).toBe(false);
+  });
+
+  it("counts every workspace as 'other' when there is no active workspace", () => {
+    expect(
+      hasOtherWorkspaceUnread(
+        summary([{ workspace_id: "ws-1", count: 2 }]),
+        null,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("inboxKeys.unreadSummary", () => {
+  it("is a stable account-level key independent of any workspace", () => {
+    expect(inboxKeys.unreadSummary()).toEqual(["inbox", "unread-summary"]);
   });
 });

--- a/packages/core/inbox/queries.ts
+++ b/packages/core/inbox/queries.ts
@@ -1,10 +1,13 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { api } from "../api";
-import type { InboxItem } from "../types";
+import type { InboxItem, InboxWorkspaceUnread } from "../types";
 
 export const inboxKeys = {
   all: (wsId: string) => ["inbox", wsId] as const,
   list: (wsId: string) => [...inboxKeys.all(wsId), "list"] as const,
+  // Account-level (not workspace-scoped): a single shared cache entry that
+  // holds unread counts for every workspace the user belongs to.
+  unreadSummary: () => ["inbox", "unread-summary"] as const,
 };
 
 export function inboxListOptions(wsId: string) {
@@ -12,6 +15,31 @@ export function inboxListOptions(wsId: string) {
     queryKey: inboxKeys.list(wsId),
     queryFn: () => api.listInbox(),
   });
+}
+
+/**
+ * Cross-workspace unread inbox summary. One cache entry shared across all
+ * workspaces — the data is account-level, so switching workspaces does not
+ * refetch it; only the derived "is this for another workspace" view changes.
+ */
+export function inboxUnreadSummaryOptions() {
+  return queryOptions({
+    queryKey: inboxKeys.unreadSummary(),
+    queryFn: () => api.getInboxUnreadSummary(),
+  });
+}
+
+/**
+ * Whether any workspace OTHER than `currentWsId` has unread inbox items.
+ * Drives the workspace-switcher dot: the active workspace's own unread is
+ * already surfaced by the Inbox nav count, so it is excluded here to avoid a
+ * duplicate signal.
+ */
+export function hasOtherWorkspaceUnread(
+  summary: InboxWorkspaceUnread[],
+  currentWsId: string | null | undefined,
+): boolean {
+  return summary.some((s) => s.workspace_id !== currentWsId && s.count > 0);
 }
 
 /**

--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
-import { onInboxIssueDeleted, onInboxIssueStatusChanged } from "./ws-updaters";
+import { onInboxIssueDeleted, onInboxIssueStatusChanged, onInboxSummaryInvalidate } from "./ws-updaters";
 import { inboxKeys } from "./queries";
 import type { InboxItem } from "../types";
 
@@ -53,6 +53,28 @@ describe("onInboxIssueDeleted", () => {
     const qc = new QueryClient();
     expect(() => onInboxIssueDeleted(qc, wsId, "issue-a")).not.toThrow();
     expect(qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))).toBeUndefined();
+  });
+});
+
+describe("onInboxSummaryInvalidate", () => {
+  it("invalidates the account-level summary key regardless of active workspace", () => {
+    const qc = new QueryClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    onInboxSummaryInvalidate(qc);
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: inboxKeys.unreadSummary() });
+  });
+
+  it("does not disturb a workspace-scoped inbox list cache", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), [makeItem("i1", "issue-a")]);
+
+    onInboxSummaryInvalidate(qc);
+
+    // The list cache entry is untouched (different key); only the summary
+    // query is marked stale.
+    expect(qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))?.[0]?.id).toBe("i1");
   });
 });
 

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -41,3 +41,12 @@ export function onInboxIssueDeleted(
 export function onInboxInvalidate(qc: QueryClient, wsId: string) {
   qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
 }
+
+// Refresh the cross-workspace unread summary (workspace-switcher dot). The
+// summary spans every workspace, so it is invalidated on ANY inbox event
+// regardless of which workspace the event came from — including read/archive
+// events from a workspace other than the active one, which the workspace-
+// scoped list invalidation cannot reach.
+export function onInboxSummaryInvalidate(qc: QueryClient) {
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadSummary() });
+}

--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -103,8 +103,8 @@ describe("useRealtimeSync — ws instance change", () => {
 
     // Should have called invalidateQueries for all workspace-scoped keys
     // (15 workspace-scoped + 6 per-issue prefixes + 1 workspaceKeys.list()
-    // = 22 calls)
-    expect(invalidateSpy).toHaveBeenCalledTimes(22);
+    // + 1 cross-workspace inbox unread summary = 23 calls)
+    expect(invalidateSpy).toHaveBeenCalledTimes(23);
   });
 
   it("does not re-invalidate when rerendered with the same ws instance", () => {

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -30,7 +30,7 @@ import {
   onIssueLabelsChanged,
   onIssueMetadataChanged,
 } from "../issues/ws-updaters";
-import { onInboxNew, onInboxInvalidate, onInboxIssueStatusChanged, onInboxIssueDeleted } from "../inbox/ws-updaters";
+import { onInboxNew, onInboxInvalidate, onInboxIssueStatusChanged, onInboxIssueDeleted, onInboxSummaryInvalidate } from "../inbox/ws-updaters";
 import { inboxKeys } from "../inbox/queries";
 import {
   notificationPreferenceOptions,
@@ -230,6 +230,9 @@ export async function handleInboxNew(
 ): Promise<void> {
   const sourceWsId = item.workspace_id;
   if (sourceWsId) onInboxNew(qc, sourceWsId, item);
+  // A new item in ANY workspace can light the workspace-switcher dot, so
+  // refresh the cross-workspace summary regardless of the active workspace.
+  onInboxSummaryInvalidate(qc);
   // Fire a native OS notification only when the app isn't focused. When
   // the user is already looking at Multica, the inbox sidebar's unread
   // styling is enough — no need to interrupt with a banner. `desktopAPI`
@@ -320,6 +323,9 @@ function invalidateWorkspaceScopedQueries(qc: QueryClient): void {
     qc.invalidateQueries({ queryKey: chatKeys.all(wsId) });
     qc.invalidateQueries({ queryKey: labelKeys.all(wsId) });
   }
+  // Cross-workspace, so outside the wsId guard: a reconnect may have missed
+  // inbox events from any workspace, so re-pull the switcher-dot summary.
+  onInboxSummaryInvalidate(qc);
   // Per-issue caches are keyed without wsId, so the issueKeys.all(wsId)
   // prefix above does not reach them. They rely entirely on WS events for
   // freshness (staleTime: Infinity), so events missed while disconnected
@@ -394,6 +400,12 @@ export function useRealtimeSync(
       inbox: () => {
         const wsId = getCurrentWsId();
         if (wsId) onInboxInvalidate(qc, wsId);
+        // inbox:read / inbox:archived / batch events arrive here. They can
+        // originate from a workspace other than the active one (personal
+        // events fan out to all the user's connections), so always refresh
+        // the cross-workspace summary — its dot must clear when another
+        // workspace's items are read/archived.
+        onInboxSummaryInvalidate(qc);
       },
       agent: () => {
         const wsId = getCurrentWsId();

--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -22,6 +22,17 @@ export type InboxItemType =
   | "quick_create_done"
   | "quick_create_failed";
 
+/**
+ * One workspace's unread inbox count in the cross-workspace summary
+ * (`GET /api/inbox/unread-summary`). The sidebar uses this to light a dot on
+ * the workspace switcher when a workspace OTHER than the active one has
+ * unread items.
+ */
+export interface InboxWorkspaceUnread {
+  workspace_id: string;
+  count: number;
+}
+
 export interface InboxItem {
   id: string;
   workspace_id: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -61,7 +61,7 @@ export type {
 } from "./agent";
 export { RUNTIME_PROFILE_PROTOCOL_FAMILIES } from "./agent";
 export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
-export type { InboxItem, InboxSeverity, InboxItemType } from "./inbox";
+export type { InboxItem, InboxSeverity, InboxItemType, InboxWorkspaceUnread } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";
 export type { Comment, CommentType, CommentAuthorType, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, Reaction } from "./comment";
 export type { Label, CreateLabelRequest, UpdateLabelRequest, ListLabelsResponse, IssueLabelsResponse } from "./label";

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -3,10 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
 
-const { detail, deletePin, navigation, pins } = vi.hoisted(() => ({
+const { detail, deletePin, navigation, pins, summary } = vi.hoisted(() => ({
   detail: { current: { isPending: false, isError: false, data: null as unknown, error: null as unknown } },
   deletePin: vi.fn(),
   navigation: { current: { pathname: "/acme/issues" } },
+  summary: { current: [] as { workspace_id: string; count: number }[] },
   pins: {
     current: [
       {
@@ -122,7 +123,15 @@ vi.mock("@multica/core/api", async (importOriginal) => {
     },
   };
 });
-vi.mock("@multica/core/inbox/queries", () => ({ deduplicateInboxItems: (items: unknown[]) => items, inboxKeys: { list: () => ["inbox"] } }));
+vi.mock("@multica/core/inbox/queries", () => ({
+  deduplicateInboxItems: (items: unknown[]) => items,
+  inboxKeys: { list: () => ["inbox"], unreadSummary: () => ["inbox", "unread-summary"] },
+  inboxUnreadSummaryOptions: () => ({ queryKey: ["inbox", "unread-summary"] }),
+  hasOtherWorkspaceUnread: (
+    entries: { workspace_id: string; count: number }[],
+    currentWsId: string | null,
+  ) => entries.some((s) => s.workspace_id !== currentWsId && s.count > 0),
+}));
 vi.mock("@multica/core/issues/queries", () => ({ issueDetailOptions: () => ({ queryKey: ["issue"] }) }));
 vi.mock("@multica/core/issues/stores/create-mode-store", () => ({
   useCreateModeStore: { getState: () => ({ lastMode: "agent" }) },
@@ -145,6 +154,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
   useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
     if (queryKey[0] === "pins") return { data: pins.current };
     if (queryKey[0] === "issue") return detail.current;
+    if (queryKey[0] === "inbox" && queryKey[1] === "unread-summary") return { data: summary.current };
     return { data: [] };
   },
   useQueryClient: () => ({ fetchQuery: vi.fn(), invalidateQueries: vi.fn() }),
@@ -155,6 +165,7 @@ describe("PinRow", () => {
     deletePin.mockReset();
     navigation.current.pathname = "/acme/issues";
     detail.current = { isPending: false, isError: false, data: null, error: null };
+    summary.current = [];
   });
 
   it("unpins missing details", async () => {
@@ -192,5 +203,34 @@ describe("PinRow", () => {
       "true",
     );
     expect(container.querySelector('button[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+  });
+});
+
+describe("workspace-switcher unread dot", () => {
+  beforeEach(() => {
+    summary.current = [];
+  });
+
+  // The dot is the only `.ring-sidebar` span in the tree (DraftDot is null
+  // when there's no draft, and there are no pending invitations here).
+  const dot = (container: HTMLElement) => container.querySelector("span.bg-brand.ring-sidebar");
+
+  it("shows a dot when another workspace has unread inbox items", () => {
+    summary.current = [{ workspace_id: "ws-2", count: 3 }];
+    const { container } = render(<AppSidebar />);
+    expect(dot(container)).not.toBeNull();
+  });
+
+  it("does not show a dot when only the active workspace has unread", () => {
+    // Active workspace is ws-1 (see useCurrentWorkspace mock).
+    summary.current = [{ workspace_id: "ws-1", count: 3 }];
+    const { container } = render(<AppSidebar />);
+    expect(dot(container)).toBeNull();
+  });
+
+  it("does not show a dot when no workspace has unread", () => {
+    summary.current = [];
+    const { container } = render(<AppSidebar />);
+    expect(dot(container)).toBeNull();
   });
 });

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -70,7 +70,7 @@ import { useCurrentWorkspace, useWorkspacePaths, paths } from "@multica/core/pat
 import { workspaceListOptions, myInvitationListOptions, workspaceKeys } from "@multica/core/workspace/queries";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
+import { inboxKeys, deduplicateInboxItems, inboxUnreadSummaryOptions, hasOtherWorkspaceUnread } from "@multica/core/inbox/queries";
 import { api, ApiError } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { useConfigStore } from "@multica/core/config";
@@ -101,6 +101,7 @@ const EMPTY_PINS: PinnedItem[] = [];
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
 const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
 const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
+const EMPTY_INBOX_SUMMARY: Awaited<ReturnType<typeof api.getInboxUnreadSummary>> = [];
 
 // Nav items reference WorkspacePaths method names so they can be resolved
 // against the current workspace slug at render time (see AppSidebar body).
@@ -364,6 +365,17 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     () => deduplicateInboxItems(inboxItems).filter((i) => !i.read).length,
     [inboxItems],
   );
+  // Cross-workspace unread summary backs the workspace-switcher dot. One
+  // shared cache entry across workspaces; gated on an active workspace since
+  // the endpoint resolves through the workspace-member middleware.
+  const { data: unreadSummary = EMPTY_INBOX_SUMMARY } = useQuery({
+    ...inboxUnreadSummaryOptions(),
+    enabled: !!wsId,
+  });
+  const otherWorkspaceUnread = React.useMemo(
+    () => hasOtherWorkspaceUnread(unreadSummary, wsId),
+    [unreadSummary, wsId],
+  );
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
   const { data: pinnedItems = EMPTY_PINS } = useQuery({
     ...pinListOptions(wsId ?? "", userId ?? ""),
@@ -486,7 +498,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                     <SidebarMenuButton>
                       <span className="relative">
                         <WorkspaceAvatar name={workspace?.name ?? "M"} avatarUrl={workspace?.avatar_url} size="sm" />
-                        {myInvitations.length > 0 && (
+                        {/* Shared brand dot: a pending invitation OR another
+                            workspace with unread inbox items. The active
+                            workspace's own unread stays on the Inbox nav count
+                            (below), so it is deliberately excluded here. */}
+                        {(myInvitations.length > 0 || otherWorkspaceUnread) && (
                           <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-brand ring-1 ring-sidebar" />
                         )}
                       </span>

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -793,6 +793,61 @@ func TestInboxThroughRouter(t *testing.T) {
 	}
 }
 
+func TestInboxUnreadSummaryThroughRouter(t *testing.T) {
+	ctx := context.Background()
+
+	// Seed one unread inbox item for the test user in the test workspace.
+	var itemID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO inbox_item (workspace_id, recipient_type, recipient_id, type, title)
+		VALUES ($1, 'member', $2, 'issue_assigned', 'Summary fixture')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&itemID); err != nil {
+		t.Fatalf("failed to seed inbox item: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM inbox_item WHERE id = $1`, itemID)
+	})
+
+	resp := authRequest(t, "GET", "/api/inbox/unread-summary", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("UnreadInboxSummary: expected 200, got %d", resp.StatusCode)
+	}
+	var summary []struct {
+		WorkspaceID string `json:"workspace_id"`
+		Count       int64  `json:"count"`
+	}
+	readJSON(t, resp, &summary)
+
+	var found bool
+	for _, s := range summary {
+		if s.WorkspaceID == testWorkspaceID {
+			found = true
+			if s.Count < 1 {
+				t.Fatalf("expected unread count >= 1 for test workspace, got %d", s.Count)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected test workspace %s in unread summary, got %+v", testWorkspaceID, summary)
+	}
+
+	// After marking it read, the workspace should drop out of the summary.
+	if _, err := testPool.Exec(ctx, `UPDATE inbox_item SET read = true WHERE id = $1`, itemID); err != nil {
+		t.Fatalf("failed to mark item read: %v", err)
+	}
+	resp = authRequest(t, "GET", "/api/inbox/unread-summary", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("UnreadInboxSummary (after read): expected 200, got %d", resp.StatusCode)
+	}
+	readJSON(t, resp, &summary)
+	for _, s := range summary {
+		if s.WorkspaceID == testWorkspaceID && s.Count > 0 {
+			t.Fatalf("expected no unread for test workspace after read, got count %d", s.Count)
+		}
+	}
+}
+
 // ---- 404 for non-existent resources ----
 
 func TestNonExistentResources(t *testing.T) {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1066,6 +1066,9 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			r.Route("/api/inbox", func(r chi.Router) {
 				r.Get("/", h.ListInbox)
 				r.Get("/unread-count", h.CountUnreadInbox)
+				// Cross-workspace unread summary: account-level, keyed on the
+				// user. Backs the workspace-switcher dot for OTHER workspaces.
+				r.Get("/unread-summary", h.UnreadInboxSummary)
 				r.Post("/mark-all-read", h.MarkAllInboxRead)
 				r.Post("/archive-all", h.ArchiveAllInbox)
 				r.Post("/archive-all-read", h.ArchiveAllReadInbox)

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -195,6 +195,42 @@ func (h *Handler) CountUnreadInbox(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]int64{"count": count})
 }
 
+// InboxWorkspaceUnreadResponse is one workspace's unread inbox count in the
+// cross-workspace summary.
+type InboxWorkspaceUnreadResponse struct {
+	WorkspaceID string `json:"workspace_id"`
+	Count       int64  `json:"count"`
+}
+
+// UnreadInboxSummary returns per-workspace unread inbox counts across every
+// workspace the user belongs to. The sidebar uses it to light a dot on the
+// workspace switcher when a workspace OTHER than the active one has unread
+// items, without fetching each workspace's full inbox list. It is
+// account-level by nature: it ignores the active workspace and keys only on
+// the authenticated user.
+func (h *Handler) UnreadInboxSummary(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	rows, err := h.Queries.CountUnreadInboxByWorkspace(r.Context(), parseUUID(userID))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to summarize unread inbox")
+		return
+	}
+
+	resp := make([]InboxWorkspaceUnreadResponse, len(rows))
+	for i, row := range rows {
+		resp[i] = InboxWorkspaceUnreadResponse{
+			WorkspaceID: uuidToString(row.WorkspaceID),
+			Count:       row.Count,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (h *Handler) MarkAllInboxRead(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -175,6 +175,48 @@ func (q *Queries) CountUnreadInbox(ctx context.Context, arg CountUnreadInboxPara
 	return count, err
 }
 
+const countUnreadInboxByWorkspace = `-- name: CountUnreadInboxByWorkspace :many
+SELECT i.workspace_id, count(*) AS count
+FROM inbox_item i
+JOIN member m ON m.workspace_id = i.workspace_id AND m.user_id = i.recipient_id
+WHERE i.recipient_type = 'member'
+  AND i.recipient_id = $1
+  AND i.read = false
+  AND i.archived = false
+GROUP BY i.workspace_id
+`
+
+type CountUnreadInboxByWorkspaceRow struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Count       int64       `json:"count"`
+}
+
+// Per-workspace unread (non-archived) inbox counts for a recipient member,
+// across every workspace they currently belong to. Powers the sidebar
+// "other workspaces have unread" dot without fetching each workspace's full
+// inbox list. The member join keeps counts scoped to workspaces the user is
+// still a member of, so a stale item left behind in a workspace the user
+// has since left cannot light the dot.
+func (q *Queries) CountUnreadInboxByWorkspace(ctx context.Context, recipientID pgtype.UUID) ([]CountUnreadInboxByWorkspaceRow, error) {
+	rows, err := q.db.Query(ctx, countUnreadInboxByWorkspace, recipientID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CountUnreadInboxByWorkspaceRow{}
+	for rows.Next() {
+		var i CountUnreadInboxByWorkspaceRow
+		if err := rows.Scan(&i.WorkspaceID, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const createInboxItem = `-- name: CreateInboxItem :one
 INSERT INTO inbox_item (
     workspace_id, recipient_type, recipient_id,

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -45,6 +45,22 @@ RETURNING recipient_type, recipient_id;
 SELECT count(*) FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;
 
+-- name: CountUnreadInboxByWorkspace :many
+-- Per-workspace unread (non-archived) inbox counts for a recipient member,
+-- across every workspace they currently belong to. Powers the sidebar
+-- "other workspaces have unread" dot without fetching each workspace's full
+-- inbox list. The member join keeps counts scoped to workspaces the user is
+-- still a member of, so a stale item left behind in a workspace the user
+-- has since left cannot light the dot.
+SELECT i.workspace_id, count(*) AS count
+FROM inbox_item i
+JOIN member m ON m.workspace_id = i.workspace_id AND m.user_id = i.recipient_id
+WHERE i.recipient_type = 'member'
+  AND i.recipient_id = $1
+  AND i.read = false
+  AND i.archived = false
+GROUP BY i.workspace_id;
+
 -- name: MarkAllInboxRead :execrows
 UPDATE inbox_item SET read = true
 WHERE workspace_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND archived = false AND read = false;


### PR DESCRIPTION
## Summary

Implements multica-ai/multica#3773 (MUL-3695): the workspace switcher in the sidebar now shows a small brand-colored dot when a workspace **other than the active one** has unread inbox items, so people who juggle multiple workspaces notice pending items without switching around or relying on OS notifications.

- The active workspace's own unread continues to be shown by the **Inbox nav count** — it is deliberately excluded from the dot to avoid a duplicate signal.
- The dot **reuses the existing pending-invitation indicator** (same `bg-brand` dot). When an invitation and another-workspace-unread coexist, they share the one dot, per the issue's "share the same indicator" option.
- Web and Desktop share `packages/views/layout/app-sidebar.tsx`, so behavior is identical on both.

## Approach

**Backend — one account-level query, not N per-workspace fetches**

- New `GET /api/inbox/unread-summary` returns per-workspace unread (non-archived) counts for the authenticated user.
- A `JOIN member` keeps counts scoped to workspaces the user still belongs to, so a stale item in a workspace they've left can't light the dot.
- New `CountUnreadInboxByWorkspace` sqlc query (regenerated, not hand-edited).

**Frontend**

- `api.getInboxUnreadSummary()` parses through a zod schema (`InboxUnreadSummarySchema`) with `parseWithFallback`, so a contract drift hides the dot instead of crashing the sidebar.
- A single **account-level** TanStack Query (`["inbox", "unread-summary"]`, shared across workspaces). Switching workspaces doesn't refetch it — only the derived "is this for another workspace" view changes.
- `AppSidebar` derives `hasOtherWorkspaceUnread(summary, currentWsId)` and lights the shared dot.

**Realtime (appears + clears automatically)**

Inbox events are personal events fanned out to all of the user's connections, so a client viewing workspace A receives B's events. The summary is invalidated on:
- `inbox:new` (in `handleInboxNew`),
- `inbox:read` / `inbox:archived` / batch events (the generic `inbox` refresh — these can originate from a non-active workspace, which the workspace-scoped list invalidation can't reach),
- reconnect (to recover events missed while disconnected).

So the dot appears when another workspace gets a new item and clears when those items are read/archived, even while the user stays on the current workspace.

## Acceptance criteria mapping (from #3773)

- ✅ Member of A and B, on A, B has unread → switcher shows the dot.
- ✅ Only A has unread → no extra "other workspace" dot; Inbox nav keeps its count.
- ✅ B's unread read/archived while on A → dot disappears (realtime).
- ✅ Pending-invitation dot behavior preserved; the two share one indicator.
- ✅ Web and Desktop consistent (shared `packages/views`).

Mobile is independent per repo rules and out of scope for this sidebar change.

## Testing

- `go build ./...`, `go vet` — clean.
- New backend integration test `TestInboxUnreadSummaryThroughRouter`: seeds an unread item → asserts it appears with the right `workspace_id` and `count >= 1`, then marks it read → asserts the workspace drops out. Full `server` inbox/handler suites pass (after applying pending local migrations).
- Core unit tests: `hasOtherWorkspaceUnread` (excludes active ws, requires count>0, empty/no-active-ws cases), `inboxKeys.unreadSummary` key, `onInboxSummaryInvalidate`, and `InboxUnreadSummarySchema` malformed-response fallback.
- View test: `app-sidebar` renders the dot only when another workspace has unread.
- `pnpm exec vitest run` — core 683 passed, views 1486 passed. `tsc --noEmit` and `eslint` clean on `packages/core` and `packages/views`.
