### PR TITLE
STA-122: build digital workforce dashboard

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { BarChart3, FolderKanban } from "lucide-react";
+import {
+  BarChart3,
+  Bot,
+  CheckCircle2,
+  Clock3,
+  FolderKanban,
+  Loader2,
+  RadioTower,
+} from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { cn } from "@multica/ui/lib/utils";
 import {
   Select,
   SelectContent,
@@ -15,12 +24,23 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
+  summarizeActivityWindow,
+  useWorkspaceActivityMap,
+  useWorkspacePresenceMap,
+  type AgentActivity,
+  type AgentAvailability,
+  type AgentPresenceDetail,
+  type Workload,
+} from "@multica/core/agents";
+import {
   dashboardUsageDailyOptions,
   dashboardUsageByAgentOptions,
   dashboardAgentRunTimeOptions,
   dashboardRunTimeDailyOptions,
 } from "@multica/core/dashboard";
+import { runtimeListOptions } from "@multica/core/runtimes";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
+import type { Agent, AgentRuntime, Project } from "@multica/core/types";
 import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import { PageHeader } from "../../layout/page-header";
 import { KpiCard } from "../../runtimes/components/shared";
@@ -36,6 +56,7 @@ import {
 } from "../../runtimes/components/charts";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { Sparkline } from "../../agents/components/sparkline";
 import {
   addDaysIso,
   aggregateByWeek,
@@ -98,10 +119,120 @@ const EMPTY_DAILY: import("@multica/core/types").DashboardUsageDaily[] = [];
 const EMPTY_BY_AGENT: import("@multica/core/types").DashboardUsageByAgent[] = [];
 const EMPTY_RUNTIME: import("@multica/core/types").DashboardAgentRunTime[] = [];
 const EMPTY_RUNTIME_DAILY: import("@multica/core/types").DashboardRunTimeDaily[] = [];
+const EMPTY_AGENTS: Agent[] = [];
+const EMPTY_RUNTIMES: AgentRuntime[] = [];
+const EMPTY_PROJECTS: Project[] = [];
+
+const AVAILABILITY_DOT_CLASS: Record<AgentAvailability | "loading", string> = {
+  online: "bg-success",
+  unstable: "bg-warning",
+  offline: "bg-muted-foreground/40",
+  archived: "bg-muted-foreground/40",
+  loading: "bg-muted-foreground/30",
+};
+
+const AVAILABILITY_TEXT_CLASS: Record<AgentAvailability | "loading", string> = {
+  online: "text-success",
+  unstable: "text-warning",
+  offline: "text-muted-foreground",
+  archived: "text-muted-foreground",
+  loading: "text-muted-foreground",
+};
+
+const WORKLOAD_TEXT_CLASS: Record<Workload, string> = {
+  working: "text-brand",
+  queued: "text-warning",
+  idle: "text-muted-foreground",
+};
+
+interface WorkforceRow {
+  agent: Agent;
+  runtime: AgentRuntime | null;
+  presence: AgentPresenceDetail | null;
+  activity: AgentActivity | undefined;
+  activityWindow: ReturnType<typeof summarizeActivityWindow>;
+  metrics: AgentDashboardRow | null;
+  failedCount: number;
+}
+
+interface WorkforceSummary {
+  total: number;
+  archived: number;
+  online: number;
+  unstable: number;
+  offline: number;
+  working: number;
+  queued: number;
+  idle: number;
+  runningTasks: number;
+  queuedTasks: number;
+  capacity: number;
+  activeInWindow: number;
+}
 
 function fmtMoney(n: number): string {
   if (n >= 100) return `$${n.toFixed(0)}`;
   return `$${n.toFixed(2)}`;
+}
+
+function formatPercent(n: number): string {
+  return `${Math.round(n)}%`;
+}
+
+function activityDaysAgo(activity: AgentActivity | undefined): number | null {
+  if (!activity) return null;
+  for (let i = activity.buckets.length - 1; i >= 0; i--) {
+    const bucket = activity.buckets[i];
+    if (bucket && bucket.total > 0) return activity.buckets.length - 1 - i;
+  }
+  return null;
+}
+
+function rowSortScore(row: WorkforceRow): number {
+  const presence = row.presence;
+  if (!presence) return 50;
+  if (presence.workload === "working") return 0;
+  if (presence.workload === "queued") return 10;
+  if (presence.availability === "online") return 20;
+  if (presence.availability === "unstable") return 30;
+  return 40;
+}
+
+function buildWorkforceSummary(
+  rows: WorkforceRow[],
+  archived: number,
+): WorkforceSummary {
+  const summary: WorkforceSummary = {
+    total: rows.length,
+    archived,
+    online: 0,
+    unstable: 0,
+    offline: 0,
+    working: 0,
+    queued: 0,
+    idle: 0,
+    runningTasks: 0,
+    queuedTasks: 0,
+    capacity: 0,
+    activeInWindow: 0,
+  };
+
+  for (const row of rows) {
+    const p = row.presence;
+    if (p) {
+      if (p.availability === "online") summary.online += 1;
+      else if (p.availability === "unstable") summary.unstable += 1;
+      else summary.offline += 1;
+
+      summary[p.workload] += 1;
+      summary.runningTasks += p.runningCount;
+      summary.queuedTasks += p.queuedCount;
+      summary.capacity += p.capacity;
+    }
+    if (row.activityWindow.totalRuns > 0) summary.activeInWindow += 1;
+  }
+
+  return summary;
 }
 
 // Local segmented control — same visual language the runtime usage section
@@ -168,8 +299,21 @@ export function DashboardPage() {
   // they do so the dashboard reflects the new rates.
   useCustomPricingStore((s) => s.pricings);
 
-  const { data: projects = [] } = useQuery(projectListOptions(wsId));
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const projectsQuery = useQuery(projectListOptions(wsId));
+  const agentsQuery = useQuery(agentListOptions(wsId));
+  const runtimesQuery = useQuery(runtimeListOptions(wsId));
+  const { byAgent: presenceMap, loading: presenceLoading } =
+    useWorkspacePresenceMap(wsId);
+  const { byAgent: activityMap, loading: activityLoading } =
+    useWorkspaceActivityMap(wsId);
+  const projects = projectsQuery.data ?? EMPTY_PROJECTS;
+  const agents = agentsQuery.data ?? EMPTY_AGENTS;
+  const runtimes = runtimesQuery.data ?? EMPTY_RUNTIMES;
+  const activeAgents = useMemo(
+    () => agents.filter((a) => !a.archived_at),
+    [agents],
+  );
+  const archivedCount = agents.length - activeAgents.length;
 
   // Validate the picked project against the current workspace's list. A
   // stale UUID — left over from a project that's been deleted, or from the
@@ -230,16 +374,21 @@ export function DashboardPage() {
   );
 
   const isLoading =
+    agentsQuery.isLoading ||
+    runtimesQuery.isLoading ||
+    presenceLoading ||
+    activityLoading ||
     dailyQuery.isLoading ||
     byAgentQuery.isLoading ||
     runTimeQuery.isLoading ||
     runTimeDailyQuery.isLoading;
 
-  // Four independent rollups, but the empty-state is one decision — only
-  // show "no data yet" when ALL came back empty so a project with tokens
-  // but no runs (or vice-versa) doesn't look broken.
+  // Empty only when there are no active agents AND all rollups are empty.
+  // A workspace with configured digital employees but no recent tasks still
+  // deserves an operations board; it is an idle fleet, not a blank dashboard.
   const hasNoData =
     !isLoading &&
+    activeAgents.length === 0 &&
     dailyUsage.length === 0 &&
     byAgentUsage.length === 0 &&
     runTimeRows.length === 0 &&
@@ -309,6 +458,54 @@ export function DashboardPage() {
     () => mergeAgentDashboardRows(agentTokenRows, runTimeRows),
     [agentTokenRows, runTimeRows],
   );
+  const runtimesById = useMemo(
+    () => new Map(runtimes.map((r) => [r.id, r] as const)),
+    [runtimes],
+  );
+  const metricsByAgent = useMemo(
+    () => new Map(agentRows.map((r) => [r.agentId, r] as const)),
+    [agentRows],
+  );
+  const failuresByAgent = useMemo(
+    () => new Map(runTimeRows.map((r) => [r.agent_id, r.failed_count] as const)),
+    [runTimeRows],
+  );
+  const activityWindowDays = Math.min(days, 30);
+  const workforceRows = useMemo(() => {
+    return activeAgents
+      .map<WorkforceRow>((agent) => {
+        const activity = activityMap.get(agent.id);
+        return {
+          agent,
+          runtime: runtimesById.get(agent.runtime_id) ?? null,
+          presence: presenceMap.get(agent.id) ?? null,
+          activity,
+          activityWindow: summarizeActivityWindow(activity, activityWindowDays),
+          metrics: metricsByAgent.get(agent.id) ?? null,
+          failedCount: failuresByAgent.get(agent.id) ?? 0,
+        };
+      })
+      .toSorted((a, b) => {
+        const score = rowSortScore(a) - rowSortScore(b);
+        if (score !== 0) return score;
+        const taskDelta =
+          (b.metrics?.taskCount ?? 0) - (a.metrics?.taskCount ?? 0);
+        if (taskDelta !== 0) return taskDelta;
+        return b.activityWindow.totalRuns - a.activityWindow.totalRuns;
+      });
+  }, [
+    activeAgents,
+    activityMap,
+    activityWindowDays,
+    failuresByAgent,
+    metricsByAgent,
+    presenceMap,
+    runtimesById,
+  ]);
+  const workforceSummary = useMemo(
+    () => buildWorkforceSummary(workforceRows, archivedCount),
+    [workforceRows, archivedCount],
+  );
 
   return (
     <div className="flex h-full flex-col">
@@ -353,73 +550,542 @@ export function DashboardPage() {
             <DashboardEmpty />
           ) : (
             <>
-              {/* KPI row — same 3-divide-x card grid the runtime usage
-                  section uses, expanded to four tiles. */}
-              <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
-                <KpiCard
-                  label={t(($) => $.kpi.cost_label, { days })}
-                  value={fmtMoney(totals.cost)}
-                />
-                <KpiCard
-                  label={t(($) => $.kpi.tokens_label, { days })}
-                  value={formatTokens(
-                    totals.input + totals.output + totals.cacheRead + totals.cacheWrite,
-                  )}
-                  hint={t(($) => $.kpi.tokens_hint, {
-                    input: formatTokens(totals.input),
-                    output: formatTokens(totals.output),
-                  })}
-                />
-                <KpiCard
-                  label={t(($) => $.kpi.run_time_label, { days })}
-                  value={formatDuration(
-                    runTimeTotals.totalSeconds,
-                    t(($) => $.duration.less_than_minute),
-                  )}
-                  hint={t(($) => $.kpi.run_time_hint, {
-                    tasks: runTimeTotals.taskCount,
-                  })}
-                />
-                <KpiCard
-                  label={t(($) => $.kpi.tasks_label, { days })}
-                  value={String(runTimeTotals.taskCount)}
-                  hint={t(($) => $.kpi.tasks_hint, {
-                    failed: runTimeTotals.failedCount,
-                  })}
-                  accent={runTimeTotals.failedCount > 0 ? "default" : "default"}
-                />
-              </div>
-
-              {/* Trend chart — toggle picks Tokens / Cost / Time / Tasks
-                  and the parent's dim selector decides whether the bars are
-                  per-day or per-calendar-week. All four metrics share the
-                  same x-axis so the user can mentally overlay them by
-                  flipping the toggle. */}
-              <TrendBlock
-                dim={dim}
-                dailyCost={dailyCost}
-                dailyTokens={dailyTokens}
-                dailyTime={dailyTime}
-                dailyTasks={dailyTasks}
-                weeklyCost={weeklyCost}
-                weeklyTokens={weeklyTokens}
-                weeklyTime={weeklyTime}
-                weeklyTasks={weeklyTasks}
+              <WorkforceKpis
+                summary={workforceSummary}
+                totals={totals}
+                runTimeTotals={runTimeTotals}
+                days={days}
                 lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
               />
 
-              {/* Per-agent leaderboard — user picks the ranking metric;
-                  the progress bar and column emphasis follow the metric. */}
-              <Leaderboard
-                rows={agentRows}
-                agents={agents}
+              <WorkforceBoard
+                rows={workforceRows}
+                summary={workforceSummary}
+                days={days}
+                activityWindowDays={activityWindowDays}
                 lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
               />
+
+              <section className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="text-sm font-semibold">
+                    {t(($) => $.workforce.usage_detail_title)}
+                  </h2>
+                </div>
+                <TrendBlock
+                  dim={dim}
+                  dailyCost={dailyCost}
+                  dailyTokens={dailyTokens}
+                  dailyTime={dailyTime}
+                  dailyTasks={dailyTasks}
+                  weeklyCost={weeklyCost}
+                  weeklyTokens={weeklyTokens}
+                  weeklyTime={weeklyTime}
+                  weeklyTasks={weeklyTasks}
+                  lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
+                />
+                <Leaderboard
+                  rows={agentRows}
+                  agents={agents}
+                  lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
+                />
+              </section>
             </>
           )}
         </div>
       </div>
     </div>
+  );
+}
+
+function WorkforceKpis({
+  summary,
+  totals,
+  runTimeTotals,
+  days,
+  lessThanMinuteLabel,
+}: {
+  summary: WorkforceSummary;
+  totals: ReturnType<typeof computeDailyTotals>;
+  runTimeTotals: { totalSeconds: number; taskCount: number; failedCount: number };
+  days: TimeRange;
+  lessThanMinuteLabel: string;
+}) {
+  const { t } = useT("usage");
+  const totalTokens =
+    totals.input + totals.output + totals.cacheRead + totals.cacheWrite;
+  return (
+    <div className="grid grid-cols-1 divide-y rounded-lg border bg-card sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
+      <KpiCard
+        label={t(($) => $.workforce.kpi.employees)}
+        value={String(summary.total)}
+        hint={t(($) => $.workforce.kpi.employees_hint, {
+          online: summary.online,
+          archived: summary.archived,
+        })}
+      />
+      <KpiCard
+        label={t(($) => $.workforce.kpi.on_duty)}
+        value={String(summary.working + summary.queued)}
+        hint={t(($) => $.workforce.kpi.on_duty_hint, {
+          running: summary.runningTasks,
+          queued: summary.queuedTasks,
+        })}
+        accent={summary.working > 0 ? "brand" : "default"}
+      />
+      <KpiCard
+        label={t(($) => $.workforce.kpi.tasks, { days })}
+        value={String(runTimeTotals.taskCount)}
+        hint={t(($) => $.workforce.kpi.tasks_hint, {
+          failed: runTimeTotals.failedCount,
+          time: formatDuration(runTimeTotals.totalSeconds, lessThanMinuteLabel),
+        })}
+        accent={runTimeTotals.failedCount === 0 ? "success" : "default"}
+      />
+      <KpiCard
+        label={t(($) => $.workforce.kpi.tokens, { days })}
+        value={formatTokens(totalTokens)}
+        hint={t(($) => $.workforce.kpi.tokens_hint, {
+          cost: fmtMoney(totals.cost),
+        })}
+      />
+    </div>
+  );
+}
+
+function WorkforceBoard({
+  rows,
+  summary,
+  days,
+  activityWindowDays,
+  lessThanMinuteLabel,
+}: {
+  rows: WorkforceRow[];
+  summary: WorkforceSummary;
+  days: TimeRange;
+  activityWindowDays: number;
+  lessThanMinuteLabel: string;
+}) {
+  const { t } = useT("usage");
+  const topRows = useMemo(
+    () =>
+      rows
+        .toSorted((a, b) => {
+          const taskDelta =
+            (b.metrics?.taskCount ?? 0) - (a.metrics?.taskCount ?? 0);
+          if (taskDelta !== 0) return taskDelta;
+          return b.activityWindow.totalRuns - a.activityWindow.totalRuns;
+        })
+        .slice(0, 5),
+    [rows],
+  );
+
+  return (
+    <div className="grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.8fr)]">
+      <section className="rounded-lg border bg-card">
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b px-4 py-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <Bot className="h-4 w-4 text-muted-foreground" />
+              <h2 className="text-sm font-semibold">
+                {t(($) => $.workforce.board.title)}
+              </h2>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t(($) => $.workforce.board.subtitle, {
+                count: rows.length,
+                days,
+              })}
+            </p>
+          </div>
+          <div className="rounded-md border bg-background px-2.5 py-1.5 text-xs text-muted-foreground">
+            {t(($) => $.workforce.board.active_window, {
+              count: summary.activeInWindow,
+              days: activityWindowDays,
+            })}
+          </div>
+        </div>
+        <WorkforceRowsTable
+          rows={rows}
+          days={days}
+          activityWindowDays={activityWindowDays}
+          lessThanMinuteLabel={lessThanMinuteLabel}
+        />
+      </section>
+
+      <div className="space-y-5">
+        <StatusDistributionPanel summary={summary} />
+        <TopAgentsPanel
+          rows={topRows}
+          days={days}
+          lessThanMinuteLabel={lessThanMinuteLabel}
+        />
+      </div>
+    </div>
+  );
+}
+
+function WorkforceRowsTable({
+  rows,
+  days,
+  activityWindowDays,
+  lessThanMinuteLabel,
+}: {
+  rows: WorkforceRow[];
+  days: TimeRange;
+  activityWindowDays: number;
+  lessThanMinuteLabel: string;
+}) {
+  const { t } = useT("usage");
+  if (rows.length === 0) {
+    return (
+      <div className="px-4 py-10 text-center text-xs text-muted-foreground">
+        {t(($) => $.workforce.board.no_agents)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[760px]">
+        <div className="grid grid-cols-[minmax(0,1.55fr)_9.5rem_7rem_6rem_6.5rem] items-center gap-3 border-b px-4 py-2 text-xs font-medium text-muted-foreground">
+          <span>{t(($) => $.workforce.board.header_agent)}</span>
+          <span>{t(($) => $.workforce.board.header_status)}</span>
+          <span>{t(($) => $.workforce.board.header_activity)}</span>
+          <span className="text-right">
+            {t(($) => $.workforce.board.header_tasks, { days })}
+          </span>
+          <span className="text-right">
+            {t(($) => $.workforce.board.header_runtime)}
+          </span>
+        </div>
+        <div className="divide-y">
+          {rows.map((row) => {
+            const metrics = row.metrics;
+            const daysAgo = activityDaysAgo(row.activity);
+            const recentLabel =
+              daysAgo == null
+                ? t(($) => $.workforce.last_active.none)
+                : daysAgo === 0
+                  ? t(($) => $.workforce.last_active.today)
+                  : daysAgo === 1
+                    ? t(($) => $.workforce.last_active.yesterday)
+                    : t(($) => $.workforce.last_active.days_ago, {
+                        days: daysAgo,
+                      });
+            const taskCount = metrics?.taskCount ?? 0;
+            const failedCount = row.failedCount;
+            return (
+              <div
+                key={row.agent.id}
+                className="grid grid-cols-[minmax(0,1.55fr)_9.5rem_7rem_6rem_6.5rem] items-center gap-3 px-4 py-3"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <ActorAvatar
+                    actorType="agent"
+                    actorId={row.agent.id}
+                    size={26}
+                    enableHoverCard
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {row.agent.name}
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {row.runtime
+                        ? `${row.runtime.provider} · ${row.runtime.name}`
+                        : t(($) => $.workforce.board.no_runtime)}
+                    </div>
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <AvailabilityBadge availability={row.presence?.availability} />
+                  <WorkloadBadge presence={row.presence} />
+                </div>
+                <div className="space-y-1">
+                  <Sparkline
+                    buckets={row.activityWindow.buckets}
+                    width={84}
+                    height={20}
+                    className="block"
+                  />
+                  <div className="text-[11px] text-muted-foreground">
+                    {t(($) => $.workforce.board.runs_in_window, {
+                      count: row.activityWindow.totalRuns,
+                      days: activityWindowDays,
+                    })}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium tabular-nums">
+                    {taskCount}
+                  </div>
+                  <div
+                    className={cn(
+                      "text-[11px] tabular-nums",
+                      failedCount > 0
+                        ? "text-destructive"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {failedCount > 0
+                      ? t(($) => $.workforce.board.failed_count, {
+                          count: failedCount,
+                        })
+                      : recentLabel}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs tabular-nums">
+                    {formatDuration(metrics?.seconds ?? 0, lessThanMinuteLabel)}
+                  </div>
+                  <div className="text-[11px] tabular-nums text-muted-foreground">
+                    {fmtMoney(metrics?.cost ?? 0)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusDistributionPanel({ summary }: { summary: WorkforceSummary }) {
+  const { t } = useT("usage");
+  const utilization =
+    summary.capacity > 0 ? (summary.runningTasks / summary.capacity) * 100 : 0;
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-4 flex items-center gap-2">
+        <RadioTower className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-semibold">
+          {t(($) => $.workforce.status.title)}
+        </h3>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <DistributionBar
+            label={t(($) => $.workforce.availability.online)}
+            value={summary.online}
+            total={summary.total}
+            fillClassName="bg-success"
+          />
+          <DistributionBar
+            label={t(($) => $.workforce.availability.unstable)}
+            value={summary.unstable}
+            total={summary.total}
+            fillClassName="bg-warning"
+          />
+          <DistributionBar
+            label={t(($) => $.workforce.availability.offline)}
+            value={summary.offline}
+            total={summary.total}
+            fillClassName="bg-muted-foreground/40"
+          />
+        </div>
+        <div className="space-y-2 border-t pt-4">
+          <DistributionBar
+            label={t(($) => $.workforce.workload.working)}
+            value={summary.working}
+            total={summary.total}
+            fillClassName="bg-brand"
+          />
+          <DistributionBar
+            label={t(($) => $.workforce.workload.queued)}
+            value={summary.queued}
+            total={summary.total}
+            fillClassName="bg-warning"
+          />
+          <DistributionBar
+            label={t(($) => $.workforce.workload.idle)}
+            value={summary.idle}
+            total={summary.total}
+            fillClassName="bg-muted-foreground/40"
+          />
+        </div>
+        <div className="border-t pt-4">
+          <div className="mb-2 flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">
+              {t(($) => $.workforce.status.capacity)}
+            </span>
+            <span className="font-medium tabular-nums">
+              {summary.runningTasks}/{summary.capacity}
+            </span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-brand transition-[width] duration-300"
+              style={{ width: `${Math.min(100, utilization)}%` }}
+            />
+          </div>
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            {t(($) => $.workforce.status.capacity_hint, {
+              percent: formatPercent(utilization),
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TopAgentsPanel({
+  rows,
+  days,
+  lessThanMinuteLabel,
+}: {
+  rows: WorkforceRow[];
+  days: TimeRange;
+  lessThanMinuteLabel: string;
+}) {
+  const { t } = useT("usage");
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-semibold">
+          {t(($) => $.workforce.top.title, { days })}
+        </h3>
+      </div>
+      {rows.length === 0 ? (
+        <div className="py-8 text-center text-xs text-muted-foreground">
+          {t(($) => $.workforce.top.no_data)}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((row, index) => {
+            const tasks = row.metrics?.taskCount ?? 0;
+            return (
+              <div
+                key={row.agent.id}
+                className="grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-2"
+              >
+                <div className="font-mono text-xs text-muted-foreground">
+                  {index + 1}
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">
+                    {row.agent.name}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {formatDuration(row.metrics?.seconds ?? 0, lessThanMinuteLabel)}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium tabular-nums">{tasks}</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    {fmtMoney(row.metrics?.cost ?? 0)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DistributionBar({
+  label,
+  value,
+  total,
+  fillClassName,
+}: {
+  label: string;
+  value: number;
+  total: number;
+  fillClassName: string;
+}) {
+  const pct = total > 0 ? (value / total) * 100 : 0;
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-medium tabular-nums">{value}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-300",
+            fillClassName,
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AvailabilityBadge({
+  availability,
+}: {
+  availability: AgentAvailability | undefined;
+}) {
+  const { t } = useT("usage");
+  const key = availability ?? "loading";
+  const label =
+    key === "online"
+      ? t(($) => $.workforce.availability.online)
+      : key === "unstable"
+        ? t(($) => $.workforce.availability.unstable)
+        : key === "archived"
+          ? t(($) => $.workforce.availability.archived)
+          : key === "offline"
+            ? t(($) => $.workforce.availability.offline)
+            : t(($) => $.workforce.availability.loading);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs",
+        AVAILABILITY_TEXT_CLASS[key],
+      )}
+    >
+      <span
+        className={cn("h-1.5 w-1.5 rounded-full", AVAILABILITY_DOT_CLASS[key])}
+      />
+      {label}
+    </span>
+  );
+}
+
+function WorkloadBadge({
+  presence,
+}: {
+  presence: AgentPresenceDetail | null;
+}) {
+  const { t } = useT("usage");
+  const workload = presence?.workload ?? "idle";
+  const Icon =
+    workload === "working" ? Loader2 : workload === "queued" ? Clock3 : CheckCircle2;
+  const label =
+    workload === "working"
+      ? t(($) => $.workforce.workload.working)
+      : workload === "queued"
+        ? t(($) => $.workforce.workload.queued)
+        : t(($) => $.workforce.workload.idle);
+  const detail =
+    workload === "working"
+      ? `${presence?.runningCount ?? 0}/${presence?.capacity ?? 0}`
+      : workload === "queued"
+        ? String(presence?.queuedCount ?? 0)
+        : "";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 text-xs",
+        WORKLOAD_TEXT_CLASS[workload],
+      )}
+    >
+      <Icon
+        className={cn("h-3 w-3", workload === "working" && "animate-spin")}
+      />
+      <span>{label}</span>
+      {detail && <span className="tabular-nums text-muted-foreground">{detail}</span>}
+    </span>
   );
 }
 

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -7,7 +7,7 @@
     "autopilots": "Autopilot",
     "agents": "Agents",
     "squads": "Squads",
-    "usage": "Usage",
+    "usage": "Dashboard",
     "runtimes": "Runtimes",
     "skills": "Skills",
     "settings": "Settings"

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -1,6 +1,6 @@
 {
-  "title": "Usage",
-  "subtitle": "Token spend and agent activity across this workspace.",
+  "title": "Digital workforce",
+  "subtitle": "Live status, workload, and output across this workspace's agents.",
   "filter": {
     "project_label": "Project",
     "all_projects": "All projects",
@@ -48,9 +48,63 @@
     "header_tasks": "Tasks",
     "no_data": "No agent activity in this window."
   },
+  "workforce": {
+    "usage_detail_title": "Usage and trend detail",
+    "kpi": {
+      "employees": "Digital employees",
+      "employees_hint": "{{online}} online · {{archived}} archived",
+      "on_duty": "On duty now",
+      "on_duty_hint": "{{running}} running · {{queued}} queued",
+      "tasks": "Tasks · {{days}}D",
+      "tasks_hint": "{{failed}} failed · {{time}} run time",
+      "tokens": "Tokens · {{days}}D",
+      "tokens_hint": "{{cost}} estimated"
+    },
+    "board": {
+      "title": "All-employee operations board",
+      "subtitle": "{{count}} available agents · sorted by current state and {{days}}D output",
+      "active_window": "{{count}} active in {{days}}D",
+      "header_agent": "Digital employee",
+      "header_status": "Status",
+      "header_activity": "Recent activity",
+      "header_tasks": "{{days}}D tasks",
+      "header_runtime": "Time/cost",
+      "runs_in_window": "{{count}} in {{days}}D",
+      "failed_count": "{{count}} failed",
+      "no_runtime": "No runtime",
+      "no_agents": "No available digital employees yet."
+    },
+    "status": {
+      "title": "Operating distribution",
+      "capacity": "Concurrency used",
+      "capacity_hint": "{{percent}} occupied"
+    },
+    "top": {
+      "title": "High-frequency employees · {{days}}D",
+      "no_data": "No task data yet."
+    },
+    "availability": {
+      "online": "Online",
+      "unstable": "Unstable",
+      "offline": "Offline",
+      "archived": "Archived",
+      "loading": "Loading"
+    },
+    "workload": {
+      "working": "Working",
+      "queued": "Queued",
+      "idle": "Idle"
+    },
+    "last_active": {
+      "none": "No recent runs",
+      "today": "Ran today",
+      "yesterday": "Ran yesterday",
+      "days_ago": "Ran {{days}}d ago"
+    }
+  },
   "empty": {
-    "title": "No usage yet",
-    "body": "Once agents start running tasks here, their token spend and run time will appear in this view."
+    "title": "No workforce data yet",
+    "body": "Create and run agents to see their live status, task output, and usage here."
   },
   "duration": {
     "less_than_minute": "<1m"

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -7,7 +7,7 @@
     "autopilots": "オートパイロット",
     "agents": "エージェント",
     "squads": "スクワッド",
-    "usage": "使用量",
+    "usage": "ダッシュボード",
     "runtimes": "ランタイム",
     "skills": "スキル",
     "settings": "設定"

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -1,6 +1,6 @@
 {
-  "title": "使用量",
-  "subtitle": "このワークスペース全体のトークン消費とエージェントの活動です。",
+  "title": "デジタル従業員ダッシュボード",
+  "subtitle": "このワークスペースのエージェントの稼働状態、負荷、成果を確認します。",
   "filter": {
     "project_label": "プロジェクト",
     "all_projects": "すべてのプロジェクト",
@@ -48,9 +48,63 @@
     "header_tasks": "タスク",
     "no_data": "この期間にエージェントの活動はありません。"
   },
+  "workforce": {
+    "usage_detail_title": "使用量とトレンド",
+    "kpi": {
+      "employees": "デジタル従業員",
+      "employees_hint": "オンライン {{online}} · アーカイブ {{archived}}",
+      "on_duty": "現在稼働中",
+      "on_duty_hint": "実行 {{running}} · 待機 {{queued}}",
+      "tasks": "タスク · {{days}}日",
+      "tasks_hint": "失敗 {{failed}} · 実行時間 {{time}}",
+      "tokens": "トークン · {{days}}日",
+      "tokens_hint": "推定コスト {{cost}}"
+    },
+    "board": {
+      "title": "全従業員の運用ボード",
+      "subtitle": "利用可能なエージェント {{count}} 件 · 現在状態と {{days}}日成果で並び替え",
+      "active_window": "{{days}}日内に活動 {{count}}件",
+      "header_agent": "デジタル従業員",
+      "header_status": "状態",
+      "header_activity": "最近の活動",
+      "header_tasks": "{{days}}日タスク",
+      "header_runtime": "時間/コスト",
+      "runs_in_window": "{{days}}日 {{count}}回",
+      "failed_count": "失敗 {{count}}",
+      "no_runtime": "ランタイムなし",
+      "no_agents": "利用可能なデジタル従業員はまだありません。"
+    },
+    "status": {
+      "title": "稼働分布",
+      "capacity": "同時実行の使用量",
+      "capacity_hint": "{{percent}} 使用中"
+    },
+    "top": {
+      "title": "{{days}}日 高頻度従業員",
+      "no_data": "タスクデータはまだありません。"
+    },
+    "availability": {
+      "online": "オンライン",
+      "unstable": "不安定",
+      "offline": "オフライン",
+      "archived": "アーカイブ済み",
+      "loading": "読み込み中"
+    },
+    "workload": {
+      "working": "作業中",
+      "queued": "待機中",
+      "idle": "待機"
+    },
+    "last_active": {
+      "none": "最近の実行なし",
+      "today": "今日実行",
+      "yesterday": "昨日実行",
+      "days_ago": "{{days}}日前に実行"
+    }
+  },
   "empty": {
-    "title": "まだ使用量はありません",
-    "body": "ここでエージェントがタスクを実行し始めると、トークンの消費と実行時間がこの画面に表示されます。"
+    "title": "従業員データはまだありません",
+    "body": "エージェントを作成して実行すると、稼働状態、タスク成果、使用量がここに表示されます。"
   },
   "duration": {
     "less_than_minute": "1分未満"

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -7,7 +7,7 @@
     "autopilots": "오토파일럿",
     "agents": "에이전트",
     "squads": "스쿼드",
-    "usage": "사용량",
+    "usage": "대시보드",
     "runtimes": "런타임",
     "skills": "스킬",
     "settings": "설정"

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -1,6 +1,6 @@
 {
-  "title": "사용량",
-  "subtitle": "이 워크스페이스의 토큰 비용과 에이전트 활동입니다.",
+  "title": "디지털 직원 대시보드",
+  "subtitle": "이 워크스페이스 에이전트의 실시간 상태, 작업 부하, 산출 현황입니다.",
   "filter": {
     "project_label": "프로젝트",
     "all_projects": "모든 프로젝트",
@@ -48,9 +48,63 @@
     "header_tasks": "작업",
     "no_data": "이 기간에는 에이전트 활동이 없습니다."
   },
+  "workforce": {
+    "usage_detail_title": "사용량 및 추세",
+    "kpi": {
+      "employees": "디지털 직원",
+      "employees_hint": "온라인 {{online}} · 보관됨 {{archived}}",
+      "on_duty": "현재 작업 중",
+      "on_duty_hint": "실행 {{running}} · 대기 {{queued}}",
+      "tasks": "작업 · {{days}}일",
+      "tasks_hint": "실패 {{failed}} · 실행 시간 {{time}}",
+      "tokens": "토큰 · {{days}}일",
+      "tokens_hint": "예상 비용 {{cost}}"
+    },
+    "board": {
+      "title": "전체 직원 운영 보드",
+      "subtitle": "사용 가능한 에이전트 {{count}}개 · 현재 상태와 {{days}}일 산출 기준 정렬",
+      "active_window": "{{days}}일 내 활동 {{count}}개",
+      "header_agent": "디지털 직원",
+      "header_status": "상태",
+      "header_activity": "최근 활동",
+      "header_tasks": "{{days}}일 작업",
+      "header_runtime": "시간/비용",
+      "runs_in_window": "{{days}}일 {{count}}회",
+      "failed_count": "실패 {{count}}",
+      "no_runtime": "런타임 없음",
+      "no_agents": "사용 가능한 디지털 직원이 없습니다."
+    },
+    "status": {
+      "title": "운영 분포",
+      "capacity": "동시 실행 사용량",
+      "capacity_hint": "{{percent}} 사용 중"
+    },
+    "top": {
+      "title": "{{days}}일 고빈도 직원",
+      "no_data": "아직 작업 데이터가 없습니다."
+    },
+    "availability": {
+      "online": "온라인",
+      "unstable": "불안정",
+      "offline": "오프라인",
+      "archived": "보관됨",
+      "loading": "로드 중"
+    },
+    "workload": {
+      "working": "작업 중",
+      "queued": "대기 중",
+      "idle": "유휴"
+    },
+    "last_active": {
+      "none": "최근 실행 없음",
+      "today": "오늘 실행",
+      "yesterday": "어제 실행",
+      "days_ago": "{{days}}일 전 실행"
+    }
+  },
   "empty": {
-    "title": "아직 사용량이 없습니다",
-    "body": "여기에서 에이전트가 작업을 실행하기 시작하면 토큰 비용과 실행 시간이 이 화면에 표시됩니다."
+    "title": "아직 직원 데이터가 없습니다",
+    "body": "에이전트를 만들고 실행하면 실시간 상태, 작업 산출, 사용량이 여기에 표시됩니다."
   },
   "duration": {
     "less_than_minute": "1분 미만"

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -7,7 +7,7 @@
     "autopilots": "自动化",
     "agents": "智能体",
     "squads": "小队",
-    "usage": "用量",
+    "usage": "看板",
     "runtimes": "运行时",
     "skills": "Skills",
     "settings": "设置"

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -1,6 +1,6 @@
 {
-  "title": "用量",
-  "subtitle": "查看当前 Workspace 的 token 消耗和智能体运行情况。",
+  "title": "数字员工看板",
+  "subtitle": "查看当前 Workspace 的数字员工在线状态、负载和任务产出。",
   "filter": {
     "project_label": "项目",
     "all_projects": "全部项目",
@@ -48,9 +48,63 @@
     "header_tasks": "任务数",
     "no_data": "所选时间范围内暂无智能体活动。"
   },
+  "workforce": {
+    "usage_detail_title": "用量与趋势",
+    "kpi": {
+      "employees": "数字员工",
+      "employees_hint": "在线 {{online}} · 归档 {{archived}}",
+      "on_duty": "当前在岗",
+      "on_duty_hint": "运行 {{running}} · 排队 {{queued}}",
+      "tasks": "任务 · {{days}}天",
+      "tasks_hint": "失败 {{failed}} · 运行 {{time}}",
+      "tokens": "Token · {{days}}天",
+      "tokens_hint": "预估费用 {{cost}}"
+    },
+    "board": {
+      "title": "全员运行主看板",
+      "subtitle": "{{count}} 个可用数字员工 · 按当前状态和 {{days}} 天产出排序",
+      "active_window": "{{count}} 个近 {{days}}天有运行",
+      "header_agent": "数字员工",
+      "header_status": "状态",
+      "header_activity": "近期活动",
+      "header_tasks": "{{days}}天任务",
+      "header_runtime": "时长/费用",
+      "runs_in_window": "{{days}}天 {{count}} 次",
+      "failed_count": "失败 {{count}}",
+      "no_runtime": "未绑定运行时",
+      "no_agents": "暂无可用数字员工。"
+    },
+    "status": {
+      "title": "运行分布",
+      "capacity": "并发占用",
+      "capacity_hint": "{{percent}} 占用"
+    },
+    "top": {
+      "title": "{{days}}天高频员工",
+      "no_data": "暂无任务数据。"
+    },
+    "availability": {
+      "online": "在线",
+      "unstable": "不稳定",
+      "offline": "离线",
+      "archived": "已归档",
+      "loading": "加载中"
+    },
+    "workload": {
+      "working": "工作中",
+      "queued": "排队中",
+      "idle": "空闲"
+    },
+    "last_active": {
+      "none": "近期无运行",
+      "today": "今天运行",
+      "yesterday": "昨天运行",
+      "days_ago": "{{days}}天前运行"
+    }
+  },
   "empty": {
-    "title": "暂无消耗数据",
-    "body": "当智能体在这里开始执行任务后，它们的 token 消耗和运行时长将出现在此处。"
+    "title": "暂无数字员工数据",
+    "body": "创建并启动数字员工后，它们的在线状态、任务产出和消耗会出现在此处。"
   },
   "duration": {
     "less_than_minute": "<1分钟"


### PR DESCRIPTION
Closes STA-122

## Summary

- Rework `/usage` into a digital workforce dashboard with top-line employee, runtime, task, token, and estimated cost metrics.
- Add an all-employee operations board sorted by realtime workload, online state, and recent output, including activity sparklines, failures, duration, and cost context.
- Keep the usage trend and agent leaderboard analysis below the main board, and update sidebar/localized copy in zh-Hans, en, ja, and ko.

## Verification

- `corepack pnpm -C packages/views typecheck`
- `corepack pnpm -C packages/views exec vitest run dashboard-page`
- `corepack pnpm -C packages/views lint` passed with only existing warnings in unrelated files
- Local dev server `http://localhost:4312/test-workspace/usage` returned 200; the test slug stayed on the workspace loader because it had no usable auth/workspace data
