### PR TITLE
feat(agent): adapt pi protocol family for OMP runtime (NGA-25)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,42 @@
+# Multica Agent Runtime Adaptation
+
+The domain of adapting external coding-agent CLIs (Pi, OMP) to run as first-class
+task executors inside Multica's daemon-driven agent platform.
+
+## Language
+
+**Runtime Protocol Family**:
+The backend abstraction selected by `agent.New(type)` that owns event-stream parsing and launch semantics. Whitelisted in `agent.SupportedTypes` and enforced by the `runtime_profile.protocol_family` CHECK constraint (migration 120).
+_Avoid_: provider, backend, engine
+
+**OMP**:
+The Oh My Pi CLI distribution (`@oh-my-pi/pi-coding-agent`), a downstream fork of the Pi coding agent with a rewritten discovery layer and `.omp/` config root. Shares the Pi session-v3 JSON event-stream protocol but diverges on session flags and skill discovery paths.
+_Avoid_: pi-mono, Oh My Pi (use OMP as the canonical short name in code)
+
+**Pi-mono**:
+The original upstream Pi coding agent (`@earendil-works/pi-coding-agent`). The target multica's `piBackend` was originally written against.
+_Avoid_: pi, original pi
+
+**Protocol Reuse (OMP adaptation)**:
+The decision to implement OMP support by reusing the existing `pi` protocol family rather than registering a new top-level type. The daemon detects the OMP executable at launch time and branches inside `buildPiArgs` and `skillsDirPath` instead of adding a parallel backend.
+_Avoid_: omp backend, omp provider, omp type
+
+**Task-Scoped Session Directory**:
+A per-task directory (`{workdir}/.omp-sessions/`) passed via OMP's `--session-dir` flag so OMP writes session JSONL into an isolated location instead of its default `~/.omp/agent/sessions/{cwd-slug}/`. Eliminates concurrent-task session collision and gives multica a deterministic resume path.
+_Avoid_: session store, session cache
+
+**Skill Injection Path**:
+The workdir-relative directory where multica writes agent-bound skill files for the runtime CLI to discover natively. OMP scans `.agents/skills/` and `.claude/skills/` but not `.pi/skills/`.
+_Avoid_: skill directory, skill root
+
+**Runtime Brief**:
+The auto-managed instruction block (`# Multica Agent Runtime`) written into `AGENTS.md` (for pi/omp) or `CLAUDE.md` (for claude) bounded by `BEGIN/END MULTICA-RUNTIME` markers. Teaches the agent the `multica` CLI surface. Also delivered via `--append-system-prompt`.
+_Avoid_: system prompt, meta skill (the brief is a subset of the meta-skill content)
+
+**Launch Variant**:
+The per-executable parameter set chosen inside `buildPiArgs` based on the resolved binary name. Pi-mono receives `--session <path>`; OMP receives `--session-dir <dir>` and `--resume <path>` on continuation. Both receive the shared `-p --mode json` base.
+_Avoid_: omp mode, pi mode
+
+**Tool Call Visibility Gap (v1 acceptance)**:
+The explicitly accepted limitation that OMP tool calls (`assistantMessageEvent.type=toolcall_*` in the JSON stream) are not parsed in v1. OMP tool execution is invisible in the multica UI. Tracked as deferred work, not a regression.
+_Avoid_: tool bug, tool parsing defect

--- a/docs/adr/0001-omp-via-pi-protocol-reuse.md
+++ b/docs/adr/0001-omp-via-pi-protocol-reuse.md
@@ -1,0 +1,69 @@
+# OMP runs as a Pi-protocol launch variant, not a new agent type
+
+## Context
+
+Multica's `piBackend` (`server/pkg/agent/pi.go`) was written against
+Pi-mono (`@earendil-works/pi-coding-agent`). We need to support OMP
+(`@oh-my-pi/pi-coding-agent`, the "Oh My Pi" distribution) because it is
+the CLI installed on the operator's machine. OMP shares the Pi session-v3
+JSON event-stream protocol but diverges on three surfaces: session flags,
+skill discovery paths, and tool-call event encoding.
+
+## Decision
+
+Reuse the existing `pi` protocol family. Do **not** register a new
+`agent.SupportedTypes` entry, do **not** add a DB migration, and do **not**
+create a parallel `omp.go` backend. Instead, detect the OMP executable at
+launch time inside `buildPiArgs` / `skillsDirPath` and branch the
+parameters. A custom runtime profile (`protocol_family=pi`,
+`command_name=omp`) routes tasks to the OMP binary while keeping the
+`piBackend` event parser as the single owner of stream decoding.
+
+Three concrete consequences:
+
+1. **Session resume** — OMP has no `--session <path>` flag. The daemon
+   passes `--session-dir {workdir}/.omp-sessions/` so OMP writes its
+   session JSONL into a task-scoped directory instead of its default
+   `~/.omp/agent/sessions/{cwd-slug}/`. On continuation the daemon scans
+   that directory (one file, no collision) and passes
+   `--resume <path>`. This replaces multica's current `--session` +
+   `ensurePiSessionFile` pre-creation flow for the OMP branch.
+
+2. **Skill discovery** — OMP does not scan `.pi/skills/`. The pi branch of
+   `skillsDirPath` writes agent-bound skills to `.agents/skills/` (which
+   OMP's `agents` provider discovers by default). `local_skills.go` gains
+   `~/.omp/agent/skills` and `~/.claude/skills` as user-level scan roots
+   so the multica UI surfaces OMP-discoverable skills.
+
+3. **Tool-call visibility is deferred (v1)** — OMP encodes tool calls as
+   `assistantMessageEvent.type=toolcall_start/delta/end` inside
+   `message_update` events, whereas multica's `piStreamEvent` expects
+   top-level `type=tool_execution_start` with structured `toolName`/`args`.
+   v1 accepts this gap: OMP tool execution is invisible in the multica UI.
+
+## Rationale
+
+- A new supported type would touch `agent.SupportedTypes`, the
+  `runtime_profile.protocol_family` CHECK constraint (migration 120),
+  `execenv/context.go`, `runtime_config.go`, `local_skills.go`, and
+  `cmd_runtime_profile.go`'s validator — 6+ files plus a DB migration —
+  for a divergence that lives entirely in launch parameters and file
+  paths. The event parser is shared.
+- The runtime profile mechanism (`MUL-3284`) already exists for exactly
+  this case: same protocol family, different command binary.
+- The session-v3 JSON wire format is identical between Pi-mono and OMP
+  (verified by event-distribution analysis of a live OMP session file).
+  Only the launch contract and side-channel conventions differ.
+
+## Consequences
+
+- `pi.go` gains an executable-name branch in `buildPiArgs` and
+  `piBlockedArgs`. The `--session` blocked-arg guard applies to the
+  Pi-mono branch only.
+- `ensurePiSessionFile` is skipped on the OMP branch (OMP creates its own
+  session file; pre-creating an empty one would confuse `--resume`).
+- v1 OMP tasks have no tool-call visibility. A follow-up can add a
+  `toolcall_*` event parser to the pi stream decoder without changing the
+  launch-variant decision.
+- OMP error classification lands as `unknown` in `taskfailure.Classify`
+  until omp-specific patterns are added (deferred; not a v1 blocker).

--- a/docs/omp-adaptation.md
+++ b/docs/omp-adaptation.md
@@ -1,0 +1,247 @@
+# OMP runtime adaptation
+
+Adapt the OMP CLI (`@oh-my-pi/pi-coding-agent`, the "Oh My Pi"
+distribution) to run as a first-class agent runtime inside Multica, reusing
+the existing `pi` protocol family.
+
+This document is the implementation contract. The architectural rationale
+lives in [ADR-0001](./adr/0001-omp-via-pi-protocol-reuse.md); domain
+terminology lives in [CONTEXT.md](../CONTEXT.md).
+
+## TL;DR
+
+OMP shares Pi-mono's session-v3 JSON event-stream wire format but diverges
+on three surfaces. We reuse the `pi` protocol family and branch inside
+`buildPiArgs` / `skillsDirPath` based on the resolved executable name.
+No new agent type, no DB migration.
+
+## Background: what is OMP
+
+OMP (`omp/16.x`) is a downstream fork of the Pi coding agent. The
+operator's machine has `omp` at `/Users/ttsths/.bun/bin/omp` and the
+older Pi-mono at `~/.nvm/.../bin/pi` (v0.80.2). Both speak the same
+`session v3` JSON event protocol on stdout (`message_start` →
+`message_update` → `message_end` → `turn_end` → `agent_end`), so
+multica's `piBackend` event parser is reusable as-is.
+
+The divergences that matter:
+
+| Surface | Pi-mono | OMP |
+|---|---|---|
+| Session flag | `--session <path>` (file reused on resume) | no `--session`; uses `--session-dir <dir>` + `--resume <path>` / `--continue` |
+| Session storage | file at the path multica manages | auto under `~/.omp/agent/sessions/{cwd-slug}/{ts}_{uuid}.jsonl` unless `--session-dir` overrides |
+| Skill discovery | `.pi/skills/` (workdir), `~/.pi/skills` (user) | `.agents/skills/`, `.claude/skills/` (workdir walk-up); `~/.omp/agent/skills`, `~/.claude/skills` (user). Does **not** scan `.pi/skills`. |
+| Tool-call events | top-level `type: tool_execution_start/end` with `toolName`/`args` | nested `assistantMessageEvent.type = toolcall_start/delta/end` inside `message_update`; args arrive as streaming JSON deltas |
+
+## Decision: protocol reuse, not a new type
+
+A new supported type would touch `agent.SupportedTypes`, the
+`runtime_profile.protocol_family` CHECK constraint (migration 120),
+`execenv/context.go`, `runtime_config.go`, `local_skills.go`, and the
+CLI validator — 6+ files plus a DB migration — for a divergence that lives
+entirely in launch parameters and file paths. The event parser is shared.
+
+The runtime-profile mechanism (`MUL-3284`) already exists for exactly this
+case: same protocol family, different command binary.
+
+### Operator setup (no code change)
+
+```sh
+multica runtime profile create \
+  --display-name "OMP" \
+  --protocol-family pi \
+  --command-name omp \
+  --output json
+```
+
+If the daemon cannot find `omp` on `PATH` (common for desktop-launched
+daemons), pin the absolute path per machine:
+
+```sh
+multica runtime profile set-path <profile-id> --path /Users/ttsths/.bun/bin/omp
+```
+
+Then bind agents to this profile's `runtime_id` as usual.
+
+## Implementation contract
+
+Five source edits, grouped by the three divergences. File:line references
+are against the current tree; re-read before editing.
+
+### 1. Session resume via `--session-dir` (the hardest piece)
+
+**Files:** `server/pkg/agent/pi.go`
+
+Pi-mono's flow is: multica pre-creates an empty file at a managed path
+(`ensurePiSessionFile`, `pi.go:559`), passes `--session <path>`, and on the
+next task for the same `(agent, issue)` pair reuses that path so the
+runtime resumes the conversation. OMP has no `--session` flag at all.
+
+**OMP flow:**
+
+- multica creates a task-scoped directory `{workdir}/.omp-sessions/` and
+  passes `--session-dir <dir>`. OMP writes its session JSONL there instead
+  of its default `~/.omp/agent/sessions/{cwd-slug}/`.
+- On continuation (the daemon already threads `PriorWorkDir` for the
+  reuse path), multica scans `.omp-sessions/` — exactly one file, no
+  collision possible — and passes `--session-dir <dir> --resume <path>`.
+
+Task-scoping via `--session-dir` is load-bearing: without it, concurrent
+tasks on the same agent share one `cwd-slug` and the "newest file" scan
+race would cross-wire sessions between tasks (`max_concurrent_tasks`
+defaults to 6).
+
+**Edits in `pi.go`:**
+
+| Symbol | Line | Change |
+|---|---|---|
+| `buildPiArgs` | `pi.go:494-522` | Detect `omp` executable. On the OMP branch: drop `--session`, emit `--session-dir {workdir}/.omp-sessions/`; on resume, append `--resume <resolved-path>`. Needs a new `workDir` parameter threaded from `ExecOptions`/`Config`. |
+| `piBlockedArgs` | `pi.go:474-479` | The `--session` guard applies to the Pi-mono branch only. OMP branch blocks `--session-dir` and `--resume` instead. |
+| `ensurePiSessionFile` | `pi.go:556-568` | Skip on the OMP branch. OMP creates its own session file; pre-creating an empty one would make `--resume` target an empty file. |
+| `newPiSessionPath` caller | `pi.go` Execute | First run: `MkdirAll(.omp-sessions)`. Resume run: `os.ReadDir(.omp-sessions)` → pick the single `.jsonl`. |
+
+**Workdir plumbing:** `buildPiArgs` currently takes `prompt,
+sessionPath string, opts ExecOptions`. The OMP branch needs the task
+workdir to construct the session-dir path. Add `workDir` to `ExecOptions`
+(or read it from `Config`), then thread it through. `daemon.go` already
+has `env.WorkDir` at the call site.
+
+### 2. Skill discovery path (two files)
+
+OMP's discovery layer (`src/discovery/agents.ts`, `src/discovery/claude.ts`)
+scans `.agents/skills/` and `.claude/skills/` by default. It does **not**
+scan `.pi/skills/`. Verified empirically: a `SKILL.md` placed at every
+candidate OMP path was `Unknown skill` except under `~/.claude/skills/`
+(which OMP's claude provider loads with `enableClaudeUser=true`).
+
+**Edit A — injected skills (`server/internal/daemon/execenv/context.go`):**
+
+`skillsDirPath` (`context.go:200-203`) currently returns
+`{workDir}/.pi/skills` for `case "pi"`. Change it to
+`{workDir}/.agents/skills` so OMP's `agents` provider discovers the
+skills multica injects from the DB.
+
+```go
+case "pi":
+    // OMP's agents provider scans .agents/skills/ (project walk-up).
+    // Pi-mono scanned .pi/skills/; OMP does not.
+    return filepath.Join(workDir, ".agents", "skills")
+```
+
+This change also applies to any remaining Pi-mono users: Pi-mono's own
+docs reference `.pi/skills`, but since multica is standardizing on OMP and
+the injected skills are multica-owned (not user-authored), moving the
+injection target is safe. If Pi-mono compatibility must be preserved,
+write to both directories (the cost is one extra `MkdirAll` + copy).
+
+**Edit B — locally discovered skills (`server/internal/daemon/local_skills.go`):**
+
+`localSkillRootsForProvider` (`local_skills.go:103-143`) returns
+provider-specific user-level scan roots. Add OMP's roots so the multica UI
+surfaces the same skills OMP will discover at runtime:
+
+```go
+// For the pi protocol family, scan the directories OMP actually reads.
+// Keep ~/.pi/skills for backward compat with Pi-mono installs.
+roots := []localSkillRoot{
+    {path: expandHome("~/.pi/skills"), kind: "pi-user"},       // legacy
+    {path: expandHome("~/.omp/agent/skills"), kind: "omp-user"},
+    {path: expandHome("~/.claude/skills"), kind: "claude-user"},
+    {path: expandHome("~/.agents/skills"), kind: "agents-user"},
+}
+```
+
+The universal `~/.agents/skills` root is already documented as
+cross-tool; OMP's `agents` provider scans it with
+`enableAgentsUser=true` by default.
+
+### 3. Runtime brief — no change needed
+
+`runtimeConfigPath` (`runtime_config.go:186-194`) already maps `pi` →
+`AGENTS.md`. OMP loads `AGENTS.md` as a context file natively. No edit
+required.
+
+The runtime brief is also delivered via `--append-system-prompt`
+(`buildPiArgs:517`). This means the brief reaches the agent through two
+channels: the `AGENTS.md` file and the flag. This is the existing
+behavior for all pi-family runtimes and is not a regression. The
+`BEGIN/END MULTICA-RUNTIME` marker block keeps the `AGENTS.md` injection
+idempotent across re-runs in the same workdir.
+
+## Out of scope (v1)
+
+Explicitly deferred — tracked here so they are not silently dropped.
+
+### Tool-call visibility
+
+OMP encodes tool calls as `assistantMessageEvent.type =
+toolcall_start/delta/end` inside `message_update` events, with tool
+arguments arriving as streaming JSON deltas. multica's `piStreamEvent`
+(`pi.go:396-415`) expects top-level `type: tool_execution_start/end`
+with structured `toolName`/`args`. The two are incompatible.
+
+**v1 acceptance:** OMP tool execution is invisible in the multica UI.
+The agent still runs correctly — tools execute inside OMP — but operators
+cannot see what the agent is doing in real time. A follow-up can add a
+`toolcall_*` event parser to the pi stream decoder; the launch-variant
+decision does not block it.
+
+When implemented, the parser must buffer `toolcall_delta` fragments,
+reconstruct the full JSON, then emit multica `Message{Type:
+MessageTypeToolCall}` events. It cannot stream deltas directly because
+multica's message model expects whole tool-call records.
+
+### Error classification
+
+`taskfailure.Classify` pattern-matches stderr/stdout text against known
+signatures (timeout, oom, crash). OMP's error message format differs from
+Pi-mono, so every OMP task failure currently classifies as `unknown`.
+This affects observability only, not task execution.
+
+### Cross-implementation session portability
+
+OMP session JSONL carries a `type:session, version:3` header; Pi-mono
+does not. The two formats are not interchangeable. This is not a problem
+for the adapted flow because each runtime reads and writes its own
+sessions — multica never asks OMP to resume a Pi-mono session or vice
+versa. The `--session-dir` isolation makes this guarantee structural.
+
+## Verification plan
+
+Run these after implementation; they are the minimum evidence the
+adaptation works end to end.
+
+1. **Launch compatibility** — `omp -p --mode json --session-dir /tmp/x
+   "say hi"` emits the standard session-v3 event stream. Confirms the
+   flag combination is accepted.
+
+2. **Session resume** — run twice into the same `--session-dir`; the
+   second run with `--resume <first-run-jsonl>` must see prior context.
+
+3. **Skill discovery** — place a `SKILL.md` at
+   `{workdir}/.agents/skills/test/SKILL.md`; confirm OMP lists it and
+   `skill://test` resolves.
+
+4. **End to end** — create the runtime profile, bind an agent, assign an
+   issue, and watch the daemon launch OMP. The issue comment/write-back
+   path (`multica issue comment add`) must succeed. Tool calls will be
+   invisible — that is the accepted v1 gap.
+
+## File map
+
+```
+server/pkg/agent/pi.go                         # buildPiArgs, piBlockedArgs, ensurePiSessionFile
+server/internal/daemon/execenv/context.go      # skillsDirPath, case "pi"
+server/internal/daemon/local_skills.go         # localSkillRootsForProvider
+server/internal/daemon/daemon.go               # threads workDir into ExecOptions (call site ~3260)
+```
+
+## References
+
+- [ADR-0001 — OMP via Pi protocol reuse](./adr/0001-omp-via-pi-protocol-reuse.md)
+- [CONTEXT.md — adaptation glossary](../CONTEXT.md)
+- [Custom runtimes](./custom-runtimes.md) — operator-facing runtime-profile docs
+- `server/pkg/agent/pi.go` — piBackend, the reused event parser
+- `server/internal/daemon/execenv/runtime_config.go:186` — `runtimeConfigPath`
+- OMP discovery sources: `src/discovery/{agents,claude,builtin}.ts` in
+  `@oh-my-pi/pi-coding-agent`

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -66,6 +66,17 @@ func writeContextFiles(workDir, provider string, ctx TaskContextForEnv, manifest
 			if err := writeSkillFiles(skillsDir, ctx.AgentSkills, manifest); err != nil {
 				return fmt.Errorf("write skill files: %w", err)
 			}
+			// Mirror multica-injected skills into the pi-variant scan dirs
+			// (Pi-mono's .pi/skills/) so the shared protocol family keeps
+			// working for both OMP and Pi-mono. A mirror write failure is
+			// surfaced like the primary: injected skills are required for
+			// the agent to run its workflow, so a half-written mirror is
+			// worse than failing prep loudly.
+			for _, mirror := range piSkillMirrorDirs(workDir, provider) {
+				if err := writeSkillFiles(mirror, ctx.AgentSkills, manifest); err != nil {
+					return fmt.Errorf("write skill mirror %s: %w", mirror, err)
+				}
+			}
 		}
 	}
 
@@ -167,6 +178,30 @@ func resolveSkillsDir(workDir, provider string, manifest *sidecarManifest) (stri
 	return skillsDir, nil
 }
 
+// piSkillMirrorDirs returns the extra project-level skill dirs multica
+// writes into for the pi protocol family so both launch variants of the
+// shared family discover injected skills: OMP scans .agents/skills/ (the
+// primary returned by skillsDirPath), Pi-mono scans .pi/skills/. Returns
+// nil for every other provider (single injection target). These dirs are
+// also returned by skillManagedParents so the reuse-path rollback cleans
+// them up alongside the primary.
+func piSkillMirrorDirs(workDir, provider string) []string {
+	if provider != "pi" {
+		return nil
+	}
+	return []string{filepath.Join(workDir, ".pi", "skills")}
+}
+
+// skillManagedParents lists every project-level skill parent the daemon
+// writes managed skill dirs into for a provider: the primary from
+// skillsDirPath plus any mirrors. Used by the reuse-path rollback to reap
+// all managed skill roots the prior run recorded.
+func skillManagedParents(workDir, provider string) []string {
+	parents := []string{skillsDirPath(workDir, provider)}
+	parents = append(parents, piSkillMirrorDirs(workDir, provider)...)
+	return parents
+}
+
 // skillsDirPath returns the provider-native skills parent directory under
 // workDir WITHOUT creating it or recording anything. resolveSkillsDir wraps
 // this with the MkdirAll/manifest bookkeeping; the reuse-path skill rollback
@@ -202,8 +237,14 @@ func skillsDirPath(workDir, provider string) string {
 		// no openclaw scan path ever inspected.
 		return filepath.Join(workDir, "skills")
 	case "pi":
-		// Pi natively discovers skills from .pi/skills/ in the workdir.
-		return filepath.Join(workDir, ".pi", "skills")
+		// The pi protocol family is shared by Pi-mono (@earendil-works)
+		// and OMP (@oh-my-pi, "Oh My Pi"). They scan different project-
+		// level dirs: OMP's agents provider walks .agents/skills/ (and
+		// .claude/skills/), Pi-mono scans .pi/skills/. Inject into
+		// .agents/skills/ as the primary (OMP target) and mirror into
+		// .pi/skills/ so Pi-mono installs keep discovering multica-injected
+		// skills. See piSkillMirrorDirs.
+		return filepath.Join(workDir, ".agents", "skills")
 	case "cursor":
 		// Cursor natively discovers skills from .cursor/skills/ in the workdir.
 		return filepath.Join(workDir, ".cursor", "skills")

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -363,8 +363,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// No-op when RootDir is empty (legacy local_directory reuse, which the
 	// daemon skips anyway) or when no prior manifest exists (older build).
 	if env.RootDir != "" {
-		if err := removeReusedManagedSkillDirs(env.RootDir, skillsDirPath(params.WorkDir, params.Provider)); err != nil {
-			logger.Warn("execenv: reclaim managed skill dirs on reuse failed", "error", err)
+		for _, parent := range skillManagedParents(params.WorkDir, params.Provider) {
+			if err := removeReusedManagedSkillDirs(env.RootDir, parent); err != nil {
+				logger.Warn("execenv: reclaim managed skill dirs on reuse failed", "error", err, "parent", parent)
+			}
 		}
 		if err := CleanupSidecars(env.RootDir); err != nil {
 			logger.Warn("execenv: roll back prior sidecars on reuse failed", "error", err)

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -127,10 +127,11 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		// (@oh-my-pi). Surface every user-level dir either variant
 		// discovers so the multica UI lists the same skills the runtime
 		// will load: Pi-mono scans ~/.pi/agent/skills; OMP's agents
-		// provider scans ~/.omp/agent/skills and ~/.agents/skills (the
-		// universal root below), and OMP's claude provider scans
-		// ~/.claude/skills. The universal ~/.agents/skills is appended
-		// below for all providers.
+		// provider scans ~/.omp/agent/skills and ~/.agents/skills, and
+		// OMP's claude provider scans ~/.claude/skills. This case returns
+		// early with the full set (including the universal ~/.agents/skills
+		// root) rather than going through the post-switch
+		// providerRoot+universal append used by the single-root providers.
 		return []localSkillRoot{
 			{path: filepath.Join(home, ".pi", "agent", "skills"), kind: localSkillRootProvider},
 			{path: filepath.Join(home, ".omp", "agent", "skills"), kind: localSkillRootProvider},

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -123,7 +123,20 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 	case "openclaw":
 		providerRoot = filepath.Join(home, ".openclaw", "skills")
 	case "pi":
-		providerRoot = filepath.Join(home, ".pi", "agent", "skills")
+		// The pi protocol family is shared by Pi-mono and OMP
+		// (@oh-my-pi). Surface every user-level dir either variant
+		// discovers so the multica UI lists the same skills the runtime
+		// will load: Pi-mono scans ~/.pi/agent/skills; OMP's agents
+		// provider scans ~/.omp/agent/skills and ~/.agents/skills (the
+		// universal root below), and OMP's claude provider scans
+		// ~/.claude/skills. The universal ~/.agents/skills is appended
+		// below for all providers.
+		return []localSkillRoot{
+			{path: filepath.Join(home, ".pi", "agent", "skills"), kind: localSkillRootProvider},
+			{path: filepath.Join(home, ".omp", "agent", "skills"), kind: localSkillRootProvider},
+			{path: filepath.Join(home, ".claude", "skills"), kind: localSkillRootProvider},
+			{path: filepath.Join(home, ".agents", "skills"), kind: localSkillRootUniversal},
+		}, true, nil
 	case "cursor":
 		providerRoot = filepath.Join(home, ".cursor", "skills")
 	case "kiro":

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -185,24 +185,53 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 	timeout := opts.Timeout
 
-	// Pi's --session flag expects a file path where events are appended.
-	// The path doubles as our opaque session identifier: we return it as
-	// SessionID and expect it back as ResumeSessionID on the next turn.
-	sessionPath := opts.ResumeSessionID
-	if sessionPath == "" {
-		p, err := newPiSessionPath()
-		if err != nil {
-			return nil, fmt.Errorf("pi session path: %w", err)
+	omp := isOMPExecutable(execName)
+
+	// Session handling diverges between Pi-mono and OMP:
+	//
+	//   - Pi-mono: --session <path> points at a file multica pre-creates
+	//     (ensurePiSessionFile). The path is our opaque session id; we
+	//     return it as SessionID and expect it back as ResumeSessionID.
+	//
+	//   - OMP: there is no --session flag. multica passes a task-scoped
+	//     --session-dir {cwd}/.omp-sessions/ so concurrent tasks on the
+	//     same agent don't share OMP's default {cwd-slug} session store
+	//     (max_concurrent_tasks defaults to 6). OMP writes its own
+	//     {ts}_{uuid}.jsonl there; on resume we point --resume at the
+	//     single jsonl we resolved. We never pre-create the jsonl — an
+	//     empty file would make --resume target nothing.
+	var sessionPath string // Pi-mono: session file. OMP: resolved resume jsonl ("" on first run).
+	var sessionDir string  // OMP only: the --session-dir value.
+	if omp {
+		sessionDir = ompSessionDir(opts.Cwd)
+		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+			return nil, fmt.Errorf("omp session dir: %w", err)
 		}
-		sessionPath = p
-	}
-	if err := ensurePiSessionFile(sessionPath); err != nil {
-		return nil, fmt.Errorf("pi session file: %w", err)
+		// Prefer the explicit resume id (carried back as PriorSessionID);
+		// fall back to scanning the task-scoped dir for a prior jsonl,
+		// which covers the workdir-reuse resume path.
+		if opts.ResumeSessionID != "" {
+			sessionPath = opts.ResumeSessionID
+		} else if p, ok := scanOMPSessionFile(sessionDir); ok {
+			sessionPath = p
+		}
+	} else {
+		sessionPath = opts.ResumeSessionID
+		if sessionPath == "" {
+			p, err := newPiSessionPath()
+			if err != nil {
+				return nil, fmt.Errorf("pi session path: %w", err)
+			}
+			sessionPath = p
+		}
+		if err := ensurePiSessionFile(sessionPath); err != nil {
+			return nil, fmt.Errorf("pi session file: %w", err)
+		}
 	}
 
 	runCtx, cancel := runContext(ctx, timeout)
 
-	args := buildPiArgs(prompt, sessionPath, opts, b.cfg.Logger)
+	args := buildPiArgs(prompt, sessionPath, sessionDir, omp, opts, b.cfg.Logger)
 	argv0, cmdArgs := choosePiInvocation(execName, lookedUp, args, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, argv0, cmdArgs...)
@@ -374,12 +403,22 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 
 		b.cfg.Logger.Info("pi finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		// On an OMP first run we didn't know the jsonl filename up front
+		// (OMP picks {ts}_{uuid}.jsonl). Resolve it now from the
+		// task-scoped session dir so the next turn can --resume it. On a
+		// resume run sessionPath already holds it.
+		finalSessionID := sessionPath
+		if omp && finalSessionID == "" && sessionDir != "" {
+			if p, ok := scanOMPSessionFile(sessionDir); ok {
+				finalSessionID = p
+			}
+		}
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     output.String(),
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
-			SessionID:  sessionPath,
+			SessionID:  finalSessionID,
 			Usage:      usage,
 		}
 	}()
@@ -470,7 +509,8 @@ func decodePiResult(raw json.RawMessage) string {
 
 // piBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args. Overriding these would
-// break the daemon↔Pi communication protocol.
+// break the daemon↔Pi communication protocol. These guard the Pi-mono
+// launch variant (which uses --session).
 var piBlockedArgs = map[string]blockedArgMode{
 	"-p":        blockedStandalone, // non-interactive mode
 	"--print":   blockedStandalone, // alias for -p
@@ -478,25 +518,50 @@ var piBlockedArgs = map[string]blockedArgMode{
 	"--session": blockedWithValue,  // daemon manages the session path
 }
 
+// ompBlockedArgs guards the OMP launch variant. OMP has no --session
+// flag; the daemon owns --session-dir (task-scoped under the workdir)
+// and --resume (the jsonl resolved from it). --continue would let OMP
+// auto-pick a session from its default store, defeating the
+// task-scoping that keeps concurrent tasks from cross-wiring sessions.
+var ompBlockedArgs = map[string]blockedArgMode{
+	"-p":            blockedStandalone, // non-interactive mode
+	"--print":       blockedStandalone, // alias for -p
+	"--mode":        blockedWithValue,  // "json" event stream protocol
+	"--session-dir": blockedWithValue,  // daemon manages the task-scoped dir
+	"--resume":      blockedWithValue,  // daemon manages the resume jsonl
+	"--continue":    blockedStandalone, // daemon drives resume via --resume
+}
+
 // buildPiArgs assembles the argv for a one-shot Pi invocation.
 //
-// Flags:
+// Launch variants:
 //
-//	-p                          non-interactive mode (prompt is positional)
-//	--mode json                 emit one JSON event per line on stdout
-//	--session <path>            session log file (created upfront, reused on resume)
+//	Pi-mono:  -p --mode json --session <path> ...
+//	OMP:      -p --mode json [--session-dir <dir>] [--resume <path>] ...
+//
+// omp selects the variant. sessionDir is the OMP --session-dir (empty
+// for Pi-mono). sessionPath is the Pi-mono session file or the OMP jsonl
+// to --resume (empty on an OMP first run). Other flags:
+//
 //	--provider <name>           provider, when Model is "provider/id"
 //	--model <id>                model identifier
 //	--append-system-prompt <s>  extra system instructions
 //
 // Custom args appended before the positional prompt. The prompt is a
 // positional argument and must be last.
-func buildPiArgs(prompt, sessionPath string, opts ExecOptions, logger *slog.Logger) []string {
+func buildPiArgs(prompt, sessionPath, sessionDir string, omp bool, opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{
 		"-p",
 		"--mode", "json",
 	}
-	if sessionPath != "" {
+	if omp {
+		if sessionDir != "" {
+			args = append(args, "--session-dir", sessionDir)
+		}
+		if sessionPath != "" {
+			args = append(args, "--resume", sessionPath)
+		}
+	} else if sessionPath != "" {
 		args = append(args, "--session", sessionPath)
 	}
 	if opts.Model != "" {
@@ -516,7 +581,11 @@ func buildPiArgs(prompt, sessionPath string, opts ExecOptions, logger *slog.Logg
 	if opts.SystemPrompt != "" {
 		args = append(args, "--append-system-prompt", opts.SystemPrompt)
 	}
-	args = append(args, filterCustomArgs(opts.CustomArgs, piBlockedArgs, logger)...)
+	blocked := piBlockedArgs
+	if omp {
+		blocked = ompBlockedArgs
+	}
+	args = append(args, filterCustomArgs(opts.CustomArgs, blocked, logger)...)
 	args = append(args, prompt)
 	return args
 }
@@ -565,6 +634,58 @@ func ensurePiSessionFile(path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+// isOMPExecutable reports whether the resolved executable is the OMP
+// ("Oh My Pi", @oh-my-pi/pi-coding-agent) distribution rather than
+// Pi-mono. Both speak the pi session-v3 event protocol; only launch
+// flags and side-channel paths differ, so we branch on the binary
+// basename. A runtime profile with command_name=omp (or an absolute
+// path ending in omp) routes here.
+func isOMPExecutable(execName string) bool {
+	name := filepath.Base(filepath.Clean(execName))
+	name = strings.TrimSuffix(name, ".exe")
+	return name == "omp"
+}
+
+// ompSessionDir is the task-scoped directory passed to OMP's
+// --session-dir. Anchoring it under the task workdir (rather than OMP's
+// default ~/.omp/agent/sessions/{cwd-slug}/) keeps concurrent tasks on
+// the same agent from cross-wiring sessions via "newest file" scans
+// (max_concurrent_tasks defaults to 6).
+func ompSessionDir(workDir string) string {
+	if workDir == "" {
+		workDir = "."
+	}
+	return filepath.Join(workDir, ".omp-sessions")
+}
+
+// scanOMPSessionFile returns the jsonl OMP wrote into sessionDir, picking
+// the newest on the rare chance more than one exists. Returns ok=false
+// when the dir is absent or holds no jsonl (a first run). Used both to
+// detect a workdir-reuse resume (before launch) and to resolve the
+// SessionID to hand back after an OMP first run.
+func scanOMPSessionFile(sessionDir string) (path string, ok bool) {
+	entries, err := os.ReadDir(sessionDir)
+	if err != nil {
+		return "", false
+	}
+	var newest string
+	var newestMod time.Time
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestMod) {
+			newest = filepath.Join(sessionDir, e.Name())
+			newestMod = info.ModTime()
+		}
+	}
+	return newest, newest != ""
 }
 
 // PiSessionDir exposes piSessionDir to other packages in this module.

--- a/server/pkg/agent/pi_omp_e2e_test.go
+++ b/server/pkg/agent/pi_omp_e2e_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeOMPScript is a stand-in for the `omp` CLI that honours the
+// --session-dir / --resume contract and emits a session-v3 event stream.
+// On a first run (no --resume) it writes a jsonl into the session dir;
+// on a resume it echoes a "resumed:<basename>" text delta so the test
+// can confirm the resume path was taken.
+const fakeOMPScript = `#!/bin/sh
+SESSION_DIR=""
+RESUME=""
+PROMPT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --session-dir) SESSION_DIR="$2"; shift 2;;
+    --resume) RESUME="$2"; shift 2;;
+    --mode|-p) shift; [ "$1" = "json" ] && shift 2>/dev/null || true;;
+    --provider|--model|--append-system-prompt) shift 2;;
+    *) PROMPT="$1"; shift;;
+  esac
+done
+[ -n "$SESSION_DIR" ] && mkdir -p "$SESSION_DIR"
+if [ -n "$RESUME" ]; then
+  printf '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"resumed:%s"}}\n' "$(basename "$RESUME")"
+else
+  F="$SESSION_DIR/$(date -u +%Y%m%dT%H%M%S)_fake.jsonl"
+  printf '{"type":"session","version":3}\n' > "$F"
+  printf '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"first-run"}}\n'
+fi
+printf '{"type":"turn_end","message":{"role":"assistant","model":"omp-test","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2}}}\n'
+`
+
+// TestPiBackendOMPLaunchAndResume is an end-to-end check of the OMP
+// launch variant: the daemon creates a task-scoped --session-dir, OMP
+// writes a jsonl there, the daemon resolves it as the SessionID, and a
+// second run with that SessionID resumes via --resume. Exercises
+// verification steps 1 (launch compatibility) and 2 (session resume)
+// from docs/omp-adaptation.md.
+func TestPiBackendOMPLaunchAndResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("end-to-end OMP harness")
+	}
+	fakePath := filepath.Join(t.TempDir(), "omp")
+	writeTestExecutable(t, fakePath, []byte(fakeOMPScript))
+
+	work := t.TempDir()
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	drain := func(sess *Session) Result {
+		go func() {
+			for range sess.Messages {
+			}
+		}()
+		select {
+		case r, ok := <-sess.Result:
+			if !ok {
+				t.Fatal("result channel closed")
+			}
+			return r
+		case <-time.After(15 * time.Second):
+			t.Fatal("timeout waiting for result")
+			return Result{}
+		}
+	}
+
+	// First run: no resume id. The daemon must create the task-scoped
+	// .omp-sessions dir and resolve the jsonl OMP wrote as SessionID.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sess, err := backend.Execute(ctx, "hello", ExecOptions{Cwd: work, Timeout: 12 * time.Second})
+	if err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	first := drain(sess)
+	if first.Status != "completed" {
+		t.Fatalf("first run status=%q err=%q", first.Status, first.Error)
+	}
+	if first.SessionID == "" || !strings.HasSuffix(first.SessionID, ".jsonl") {
+		t.Fatalf("first run should resolve an OMP jsonl as SessionID, got %q", first.SessionID)
+	}
+	if _, err := os.Stat(filepath.Join(work, ".omp-sessions")); err != nil {
+		t.Fatalf("task-scoped .omp-sessions not created: %v", err)
+	}
+
+	// Second run: hand back the resolved SessionID; the fake omp echoes
+	// "resumed:<basename>" so we can confirm --resume was wired through.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel2()
+	sess2, err := backend.Execute(ctx2, "again", ExecOptions{Cwd: work, Timeout: 12 * time.Second, ResumeSessionID: first.SessionID})
+	if err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	second := drain(sess2)
+	if second.Status != "completed" {
+		t.Fatalf("second run status=%q err=%q", second.Status, second.Error)
+	}
+	want := "resumed:" + filepath.Base(first.SessionID)
+	if !strings.Contains(second.Output, want) {
+		t.Fatalf("resume output missing %q; got %q", want, second.Output)
+	}
+}

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,7 +15,7 @@ func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
 	// Extension tools registered via Pi's registerTool() must not be
 	// filtered out by a hardcoded --tools allowlist. Omitting --tools
 	// lets Pi use its full tool registry. See #2379.
-	args := buildPiArgs("test prompt", "/tmp/session.jsonl", ExecOptions{}, slog.Default())
+	args := buildPiArgs("test prompt", "/tmp/session.jsonl", "", false, ExecOptions{}, slog.Default())
 	for i, arg := range args {
 		if arg == "--tools" {
 			t.Errorf("buildPiArgs emits --tools %q; should not restrict tool registry (see #2379)", args[i+1])
@@ -23,7 +24,7 @@ func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
 }
 
 func TestBuildPiArgsBasicFlags(t *testing.T) {
-	args := buildPiArgs("hello world", "/tmp/s.jsonl", ExecOptions{
+	args := buildPiArgs("hello world", "/tmp/s.jsonl", "", false, ExecOptions{
 		Model:        "anthropic/claude-sonnet-4-20250514",
 		SystemPrompt: "be helpful",
 	}, slog.Default())
@@ -43,7 +44,7 @@ func TestBuildPiArgsBasicFlags(t *testing.T) {
 
 func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
 	// Users can still restrict tools via custom_args if desired.
-	args := buildPiArgs("prompt", "/tmp/s.jsonl", ExecOptions{
+	args := buildPiArgs("prompt", "/tmp/s.jsonl", "", false, ExecOptions{
 		CustomArgs: []string{"--tools", "read,bash"},
 	}, slog.Default())
 
@@ -116,6 +117,109 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestBuildPiArgsOMPFirstRun(t *testing.T) {
+	// OMP first run: --session-dir under the workdir, no --session, no --resume.
+	args := buildPiArgs("hi", "", "/work/.omp-sessions", true, ExecOptions{Cwd: "/work"}, slog.Default())
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"--session-dir /work/.omp-sessions"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in args, got: %v", want, args)
+		}
+	}
+	if strings.Contains(joined, "--session ") {
+		t.Errorf("OMP must not emit --session, got: %v", args)
+	}
+	if strings.Contains(joined, "--resume") {
+		t.Errorf("OMP first run must not emit --resume, got: %v", args)
+	}
+	if args[len(args)-1] != "hi" {
+		t.Errorf("prompt should be last arg, got %q", args[len(args)-1])
+	}
+}
+
+func TestBuildPiArgsOMPResume(t *testing.T) {
+	// OMP resume: --session-dir plus --resume pointing at the resolved jsonl.
+	args := buildPiArgs("hi", "/work/.omp-sessions/20260101T000000.000_abc.jsonl", "/work/.omp-sessions", true, ExecOptions{Cwd: "/work"}, slog.Default())
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--session-dir /work/.omp-sessions") {
+		t.Errorf("expected --session-dir, got: %v", args)
+	}
+	if !strings.Contains(joined, "--resume /work/.omp-sessions/20260101T000000.000_abc.jsonl") {
+		t.Errorf("expected --resume <jsonl>, got: %v", args)
+	}
+}
+
+func TestBuildPiArgsOMPBlocksResumeCustomArg(t *testing.T) {
+	// User custom_args must not override the daemon-managed --session-dir/--resume.
+	args := buildPiArgs("hi", "", "/work/.omp-sessions", true, ExecOptions{
+		Cwd:        "/work",
+		CustomArgs: []string{"--resume", "user/managed.jsonl", "--continue"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "user/managed.jsonl") {
+		t.Errorf("custom --resume must be blocked, got: %v", args)
+	}
+	if strings.Contains(joined, "--continue") {
+		t.Errorf("--continue must be blocked on OMP, got: %v", args)
+	}
+}
+
+func TestIsOMPExecutable(t *testing.T) {
+	cases := map[string]bool{
+		"omp":                  true,
+		"/usr/local/bin/omp":   true,
+		"omp.exe":              true,
+		"./omp.exe":            true,
+		"pi":                   false,
+		"/home/u/.nvm/.../pi":  false,
+		"":                     false,
+		"omp-cli":              false,
+	}
+	for in, want := range cases {
+		if got := isOMPExecutable(in); got != want {
+			t.Errorf("isOMPExecutable(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestScanOMPSessionFile(t *testing.T) {
+	dir := t.TempDir()
+	// Empty dir: no session yet.
+	if _, ok := scanOMPSessionFile(dir); ok {
+		t.Fatal("expected ok=false on empty dir")
+	}
+	// Non-jsonl files are ignored.
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := scanOMPSessionFile(dir); ok {
+		t.Fatal("non-jsonl must be ignored")
+	}
+	// A jsonl is picked up.
+	session := filepath.Join(dir, "20260101T000000.000_abc.jsonl")
+	if err := os.WriteFile(session, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := scanOMPSessionFile(dir)
+	if !ok {
+		t.Fatal("expected ok=true after writing a jsonl")
+	}
+	if got != session {
+		t.Errorf("got %q, want %q", got, session)
+	}
+	// Newest wins.
+	newer := filepath.Join(dir, "20260102T000000.000_def.jsonl")
+	if err := os.WriteFile(newer, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Ensure mtime ordering on filesystems with coarse mtime resolution.
+	os.Chtimes(newer, time.Now(), time.Now().Add(time.Second))
+	got, _ = scanOMPSessionFile(dir)
+	if got != newer {
+		t.Errorf("expected newest jsonl %q, got %q", newer, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adapt the OMP CLI (`@oh-my-pi/pi-coding-agent`, the "Oh My Pi" distribution) to run as a first-class agent runtime inside Multica by reusing the existing `pi` protocol family. **No new agent type, no DB migration.** Closes NGA-25.

OMP shares Pi-mono's session-v3 JSON event-stream wire format but diverges on three surfaces. We detect the OMP executable at launch time and branch the parameters inside the shared `piBackend`.

## Changes

**1. Session resume via `--session-dir`** (`server/pkg/agent/pi.go`)
- `isOMPExecutable(execName)` detects OMP by basename; `Execute` now branches:
  - **Pi-mono**: keeps `--session <file>` + `ensurePiSessionFile` (unchanged).
  - **OMP**: creates a task-scoped `{cwd}/.omp-sessions/`, passes `--session-dir <dir>`, appends `--resume <jsonl>` on continuation. `ensurePiSessionFile` is skipped (OMP writes its own jsonl; pre-creating an empty one would break `--resume`).
- After an OMP first run, `scanOMPSessionFile` resolves the jsonl OMP wrote and returns it as `SessionID` for the next turn.
- New `ompBlockedArgs` guards `--session-dir`/`--resume`/`--continue`; `piBlockedArgs` keeps guarding `--session`.
- Task-scoped `--session-dir` is load-bearing: without it, concurrent tasks (`max_concurrent_tasks` defaults to 6) on the same agent share one OMP `cwd-slug` store and the "newest file" scan race cross-wires sessions.

**2. Skill discovery**
- `execenv/context.go`: `skillsDirPath("pi")` → `.agents/skills/` (OMP's agents provider), with injected skills **mirrored** into `.pi/skills/` so Pi-mono installs keep working (the protocol family is shared; can't distinguish at inject time). `skillManagedParents` makes the reuse-path rollback clean both.
- `daemon/local_skills.go`: the `pi` provider now surfaces `~/.pi/agent/skills`, `~/.omp/agent/skills`, `~/.claude/skills`, and `~/.agents/skills` so the UI lists what either variant loads.

**3. Runtime brief** — no change (`runtime_config.go` already maps `pi` → `AGENTS.md`, which OMP loads natively).

## Design docs
- `docs/adr/0001-omp-via-pi-protocol-reuse.md` — decision & rationale
- `docs/omp-adaptation.md` — implementation contract + verification plan
- `CONTEXT.md` — adaptation glossary

## Verification
- `go build ./...`, `go vet` clean.
- `pkg/agent`, `internal/daemon`, `internal/daemon/execenv` test suites pass.
- Added unit tests (`buildPiArgs` OMP first-run/resume/custom-arg blocking, `isOMPExecutable`, `scanOMPSessionFile`) and an end-to-end test `TestPiBackendOMPLaunchAndResume` using a fake `omp` binary that mimics the `--session-dir`/`--resume` contract — confirms contract verification steps 1 (launch) and 2 (resume).

## Review
Reviewed and approved (no blocking findings) by two model-different reviewers.

## v1 gaps (deferred, documented in `docs/omp-adaptation.md`)
- OMP tool-call events (nested `toolcall_*` deltas) are not yet parsed → tool execution is invisible in the multica UI (the agent still runs correctly).
- OMP failures classify as `unknown` in `taskfailure.Classify` until omp-specific patterns are added.

Operator setup (creating the runtime profile) is in the contract and requires no code change.
