### PR TITLE
fix(editor): keep code-block selection stable during background re-renders (MUL-3621)

### DIFF
--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -425,21 +425,36 @@ export const ReadonlyContent = memo(function ReadonlyContent({
   // <Attachment>, which reads the surrounding AttachmentDownloadProvider.
   const components = useMemo(() => buildComponents(), []);
 
+  // Memoize the whole react-markdown subtree on its only real inputs
+  // (`processed` + `components`). Unrelated parent re-renders (e.g. a sibling
+  // agent task streaming over WebSocket fires one every ~100ms) would otherwise
+  // re-run react-markdown, which hands `<code>` a fresh `dangerouslySetInnerHTML`
+  // object each time; React then rewrites the highlighted innerHTML even though
+  // the HTML string is byte-identical, tearing down and rebuilding every hljs
+  // <span> — which collapses any active text selection inside a code block
+  // (MUL-3621). A stable element reference lets React bail out of the subtree.
+  const markdown = useMemo(
+    () => (
+      <ReactMarkdown
+        remarkPlugins={[
+          [remarkMath, { singleDollarTextMath: false }],
+          remarkBreaks,
+          [remarkGfm, { singleTilde: false }],
+        ]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
+        urlTransform={urlTransform}
+        components={components}
+      >
+        {processed}
+      </ReactMarkdown>
+    ),
+    [processed, components],
+  );
+
   return (
     <AttachmentDownloadProvider attachments={attachments}>
       <div ref={wrapperRef} className={cn("rich-text-editor readonly text-sm", className)}>
-        <ReactMarkdown
-          remarkPlugins={[
-            [remarkMath, { singleDollarTextMath: false }],
-            remarkBreaks,
-            [remarkGfm, { singleTilde: false }],
-          ]}
-          rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
-          urlTransform={urlTransform}
-          components={components}
-        >
-          {processed}
-        </ReactMarkdown>
+        {markdown}
         <LinkHoverCard {...hover} />
       </div>
     </AttachmentDownloadProvider>


### PR DESCRIPTION
## Problem

Selecting text inside a readonly code block (comment / issue markdown) loses the selection within seconds, so you can't copy it. It reproduces most reliably while an agent task is streaming over WebSocket — that fires a re-render of the surrounding view roughly every ~100ms.

## Root cause

The `code` renderer in `readonly-content.tsx` emits highlighted HTML via `dangerouslySetInnerHTML={{ __html }}` — a **fresh prop object every render**. Every unrelated parent re-render re-ran react-markdown, and React rewrote the `<code>` element's `innerHTML` **even though the HTML string was byte-identical**, tearing down and rebuilding all 161 `hljs` `<span>` nodes. The browser's native text selection is anchored to those nodes, so it collapsed.

This was confirmed with an instrumentation probe:
- `code html ... verdict=IDENTICAL-ref` — the highlighted HTML was unchanged, yet
- `CODE DOM mutated: -161/+161 under <code>` fired every ~100ms via React's `setProp → commitUpdate` path, each time clearing the selection.

## Fix

Memoize the entire `<ReactMarkdown>` subtree on its only real inputs (`processed` + `components`). A stable element reference lets React bail out of the subtree on unrelated re-renders, so the code-block DOM is never rebuilt while content is unchanged. Bonus: it also stops re-running the lowlight highlight pass on every background re-render.

After the fix the probe showed **zero `<code>` DOM mutations** during streaming, and selection/copy works.

## Scope / follow-up

This fixes the user-facing copy bug. A separate, lower-priority performance issue remains — the comment subtree is still re-rendered at high frequency during streaming (probe points at a Context whose value is recreated each render, which bypasses `memo`). It no longer has any visible effect after this fix and will be tracked separately.

## Testing

- Verified manually with the instrumentation probe (now removed): zero code-block DOM rebuilds during agent streaming; text selection persists and copy works.
- Not run locally: `pnpm typecheck` / `pnpm lint` (change is a small JSX→`useMemo` wrap) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)