### PR TITLE
feat(docs): reusable VideoEmbed + Chinese intro video on zh docs homepage

### DIFF
--- a/apps/docs/app/[lang]/[...slug]/page.tsx
+++ b/apps/docs/app/[lang]/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import type { Metadata } from "next";
 import { docsAlternates } from "@/lib/site";
 import { i18n, type Lang } from "@/lib/i18n";
 import { DocsLocaleProvider, LocaleLink } from "@/components/locale-link";
+import { VideoEmbed } from "@/components/video-embed";
 import { docsSlugStaticParams } from "@/lib/static-params";
 
 function asLang(lang: string): Lang {
@@ -35,7 +36,9 @@ export default async function Page(props: {
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
         <DocsLocaleProvider lang={lang}>
-          <MDX components={{ ...defaultMdxComponents, a: LocaleLink }} />
+          <MDX
+            components={{ ...defaultMdxComponents, a: LocaleLink, VideoEmbed }}
+          />
         </DocsLocaleProvider>
       </DocsBody>
     </DocsPage>

--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -5,6 +5,7 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { Metadata } from "next";
 import { DocsHero } from "@/components/hero";
 import { Byline, NumberedCards, NumberedCard, NumberedSteps, Step } from "@/components/editorial";
+import { VideoEmbed } from "@/components/video-embed";
 import { i18n, type Lang } from "@/lib/i18n";
 import { homeCopy } from "@/lib/translations";
 import { docsAlternates } from "@/lib/site";
@@ -62,6 +63,7 @@ export default async function Page({
               NumberedCard,
               NumberedSteps,
               Step,
+              VideoEmbed,
             }}
           />
         </DocsLocaleProvider>

--- a/apps/docs/components/video-embed.tsx
+++ b/apps/docs/components/video-embed.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { Play } from "lucide-react";
+
+/**
+ * VideoEmbed — provider-agnostic, click-to-load video embed for docs MDX.
+ *
+ * Renders a lightweight facade (no third-party iframe on first paint) and only
+ * mounts the real player after a user click, so the docs first paint never
+ * pays for an external player or its trackers. `provider` is abstracted so a
+ * future English-docs YouTube embed is a one-line MDX change, not a second
+ * component.
+ *
+ * Usage in MDX (registered in the docs MDX components map):
+ *   <VideoEmbed provider="bilibili" id="BV1cv7Y6gEg7" title="Multica 介绍视频" />
+ */
+
+type Provider = "bilibili" | "youtube";
+
+interface ProviderConfig {
+  /** Embeddable player URL. Autoplay is only requested after a user gesture. */
+  embedUrl: (id: string, autoplay: boolean) => string;
+  /** Canonical watch page — the load-failure / slow-network fallback link. */
+  watchUrl: (id: string) => string;
+  /** Human label for the fallback link ("在 Bilibili 观看"). */
+  siteName: string;
+  /** Validates the id shape so a typo renders a notice, not a broken frame. */
+  isValidId: (id: string) => boolean;
+}
+
+const PROVIDERS: Record<Provider, ProviderConfig> = {
+  bilibili: {
+    embedUrl: (id, autoplay) =>
+      `https://player.bilibili.com/player.html?bvid=${id}&autoplay=${autoplay ? 1 : 0}&high_quality=1&danmaku=0`,
+    watchUrl: (id) => `https://www.bilibili.com/video/${id}/`,
+    siteName: "Bilibili",
+    isValidId: (id) => /^BV[0-9A-Za-z]+$/.test(id),
+  },
+  // Reserved for a future English-docs YouTube embed. Not wired into any page
+  // yet, but kept here so the second provider is config, not a new component.
+  youtube: {
+    embedUrl: (id, autoplay) =>
+      `https://www.youtube-nocookie.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&rel=0`,
+    watchUrl: (id) => `https://www.youtube.com/watch?v=${id}`,
+    siteName: "YouTube",
+    isValidId: (id) => /^[0-9A-Za-z_-]{11}$/.test(id),
+  },
+};
+
+export function VideoEmbed({
+  provider = "bilibili",
+  id,
+  title,
+}: {
+  provider?: Provider;
+  id: string;
+  title?: string;
+}) {
+  const [active, setActive] = useState(false);
+  const config = PROVIDERS[provider];
+
+  // Bad / missing id → a calm inline notice, never a broken or blank iframe.
+  if (!config || !id || !config.isValidId(id)) {
+    return (
+      <div className="not-prose my-7 rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        视频暂时无法加载{title ? `：${title}` : ""}。
+      </div>
+    );
+  }
+
+  const watchUrl = config.watchUrl(id);
+  const label = title ?? "观看视频";
+
+  return (
+    <figure className="not-prose my-7">
+      <div className="relative aspect-video w-full overflow-hidden rounded-lg border border-border bg-muted/40">
+        {active ? (
+          <iframe
+            src={config.embedUrl(id, true)}
+            title={label}
+            loading="lazy"
+            allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
+            allowFullScreen
+            className="absolute inset-0 size-full"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setActive(true)}
+            aria-label={`播放：${label}`}
+            className="group absolute inset-0 flex size-full flex-col items-center justify-center gap-3 bg-gradient-to-b from-muted/20 to-muted/60 transition-colors hover:from-muted/30 hover:to-muted/70"
+          >
+            <span className="flex size-16 items-center justify-center rounded-full bg-[var(--primary)] text-[var(--primary-foreground)] shadow-lg transition-transform group-hover:scale-105">
+              <Play className="size-7 translate-x-0.5 fill-current" />
+            </span>
+            <span className="px-6 text-center text-sm font-medium text-foreground">
+              {label}
+            </span>
+          </button>
+        )}
+      </div>
+      <figcaption className="mt-2 text-xs text-muted-foreground">
+        加载缓慢或无法播放？
+        <a
+          href={watchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          在 {config.siteName} 观看
+        </a>
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/content/docs/index.zh.mdx
+++ b/apps/docs/content/docs/index.zh.mdx
@@ -7,7 +7,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Multica 是一个任务协作平台，让人类和 AI [智能体](/agents) 在同一个 [工作区](/workspaces) 里共同工作。你可以像给同事派活一样，[把一个任务分配给智能体](/assigning-issues) ——由它去执行、汇报进展、在评论里回复你；也可以[打开聊天窗口直接和它对话](/chat)，让它帮你起草任务、回答问题、或完成一次性请求。
 
-<VideoEmbed provider="bilibili" id="BV1cv7Y6gEg7" title="3 分钟看懂 Multica：人和 AI 智能体的同一个团队" />
+<VideoEmbed provider="bilibili" id="BV1cv7Y6gEg7" title="Multica 中文介绍视频" />
 
 这一页讲清楚智能体在哪里运行，以及你有哪几种方式开始使用 Multica。
 

--- a/apps/docs/content/docs/index.zh.mdx
+++ b/apps/docs/content/docs/index.zh.mdx
@@ -7,6 +7,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Multica 是一个任务协作平台，让人类和 AI [智能体](/agents) 在同一个 [工作区](/workspaces) 里共同工作。你可以像给同事派活一样，[把一个任务分配给智能体](/assigning-issues) ——由它去执行、汇报进展、在评论里回复你；也可以[打开聊天窗口直接和它对话](/chat)，让它帮你起草任务、回答问题、或完成一次性请求。
 
+<VideoEmbed provider="bilibili" id="BV1cv7Y6gEg7" title="3 分钟看懂 Multica：人和 AI 智能体的同一个团队" />
+
 这一页讲清楚智能体在哪里运行，以及你有哪几种方式开始使用 Multica。
 
 ## 智能体在哪里运行


### PR DESCRIPTION
## What

Adds a reusable `VideoEmbed` component and embeds the Chinese intro video (`BV1cv7Y6gEg7`) at the top of the Chinese docs homepage (`apps/docs/content/docs/index.zh.mdx`).

## Why

We have a Chinese intro video on Bilibili, but Chinese users landing on docs never see it. This wires it into our own, durable entry point. Scope is intentionally minimal (onboarding content, not a product capability), per the PRD on MUL-3693.

## Changes

- **`apps/docs/components/video-embed.tsx`** — new client component. Provider-agnostic (`provider="bilibili" | "youtube"`, YouTube reserved for a future English-docs embed), 16:9 responsive (`aspect-video`), **click-to-load facade**: no third-party player iframe on first paint — it only mounts after a user click, so first paint pays nothing for the external player or its trackers. Validates the id shape (bad/missing id → calm inline notice, never a broken frame) and always renders a "在 Bilibili 观看" fallback link.
- Registered `VideoEmbed` in both docs MDX component maps (`app/[lang]/page.tsx` homepage + `app/[lang]/[...slug]/page.tsx` slug pages), so it is reusable on any docs page, not just the homepage.
- `index.zh.mdx` — one `<VideoEmbed …>` line under the intro paragraph.

## Out of scope (deliberately)

usecase embedding, en/ja/ko locales, analytics/tracking, video self-hosting. Bilibili player stays on Bilibili; we only embed.

## Verification

- `pnpm --filter @multica/docs typecheck` — passes.
- `pnpm --filter @multica/docs build` — `/zh` and all 145 pages compile successfully. The build fails only on Next's internal `/404` / `/_error` prerender (`<Html> should not be imported outside pages/_document`); confirmed identical on a clean tree (pre-existing, environmental — `NODE_ENV=development`), unrelated to this change.
- `pnpm dev:docs` → `http://localhost:4000/docs/zh` returns 200; rendered HTML shows the 16:9 facade, play button, title caption, and the `https://www.bilibili.com/video/BV1cv7Y6gEg7/` fallback link. `player.bilibili.com` is absent from first-paint HTML, confirming click-to-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
