### PR TITLE
feat(views): centralize time & date display via Viewing Timezone and locale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,17 @@ Root-level reminders:
 - Handle overflow, long text, scrolling, alignment, and spacing deliberately.
 - If a component is identical between web and desktop, it belongs in a shared package.
 
+## Time & Date Display
+
+Web/desktop time display is centralized.
+
+- Instants (`*_at` / TIMESTAMPTZ): render with `<DateTime>` from `packages/views/common/`, or `useFormatDateTime()` when a string is needed. Never inline `new Date(x).toLocaleString()` — that uses the browser timezone and bypasses the user's Viewing Timezone.
+- Calendar days (`due_date` / `start_date`): floating, no timezone conversion — `useFormatCalendarDate()` (or `formatDateOnly`, which pins UTC internally).
+- Relative time ("3h ago"): `useTimeAgo()` only; don't fork it. The gradient lives in `@multica/core/i18n/relative-time` (`relativeTimeBucket(thenMs, nowMs, timeZone)`, shared with mobile). It is symmetric — future instants read "in 3h" / "in 2mo". Sub-day is elapsed; day granularity is calendar-day in the Viewing tz (so "2d ago" matches the shown date); past 30 calendar days it continues into calendar months then years (no absolute-date fallback).
+- Instant inside a translated sentence (e.g. `Updated {{time}}`): don't split the i18n string or use `<Trans>` (breaks ja/ko word order). Wrap the rendered phrase in `<InstantTooltip value={…}>` to add the full-time tooltip.
+- Locale always comes from the Language setting via the hooks; never hardcode `"en-US"`. Timezone comes from `useViewingTimezone()`.
+- Exceptions: Scheduling-axis displays (autopilot trigger/schedule previews) render in the scheduled object's explicit timezone, not Viewing — except the autopilot list's `next_run`, where the endpoint omits the trigger timezone, so it uses relative time (timezone-agnostic) with a UTC+offset tooltip. Runtime "last seen" keeps seconds-level compound precision via `useFormatLastSeen()` (liveness), not `useTimeAgo()`.
+
 ## Testing
 
 Tests follow the code:

--- a/apps/mobile/lib/time-ago.test.ts
+++ b/apps/mobile/lib/time-ago.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { timeAgo } from "./time-ago";
+
+// Fixed "now" at noon UTC; the comparison instants are also noon UTC so the
+// calendar-day difference is the same in any device timezone (both shift by the
+// same offset), keeping these assertions stable regardless of where the test
+// runner lives. Fake only Date so nothing else is affected.
+const NOW = "2026-03-15T12:00:00Z";
+
+describe("timeAgo (mobile)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buckets sub-day elapsed time", () => {
+    expect(timeAgo("2026-03-15T11:59:30Z")).toBe("Just now"); // 30s
+    expect(timeAgo("2026-03-15T11:55:00Z")).toBe("5m ago"); // 5m
+    expect(timeAgo("2026-03-15T09:00:00Z")).toBe("3h ago"); // 3h
+  });
+
+  it("counts day granularity by calendar days", () => {
+    expect(timeAgo("2026-03-14T12:00:00Z")).toBe("1d ago");
+    expect(timeAgo("2026-03-13T12:00:00Z")).toBe("2d ago");
+  });
+
+  it("continues into calendar months and years past the day cap", () => {
+    expect(timeAgo("2026-02-13T12:00:00Z")).toBe("30d ago"); // exactly 30d
+    expect(timeAgo("2026-02-12T12:00:00Z")).toBe("1mo ago"); // 31d → months
+    expect(timeAgo("2025-03-15T12:00:00Z")).toBe("1y ago"); // exactly 1 year
+  });
+
+  it("mirrors the gradient into the future direction", () => {
+    expect(timeAgo("2026-03-15T15:00:00Z")).toBe("in 3h"); // +3h
+    expect(timeAgo("2026-03-17T12:00:00Z")).toBe("in 2d"); // +2 calendar days
+    expect(timeAgo("2026-06-15T12:00:00Z")).toBe("in 3mo"); // +3 calendar months
+  });
+
+  it("renders a placeholder for an unparseable date", () => {
+    expect(timeAgo("not-a-date")).toBe("—");
+  });
+});

--- a/apps/mobile/lib/time-ago.ts
+++ b/apps/mobile/lib/time-ago.ts
@@ -1,24 +1,37 @@
+import { relativeTimeBucket } from "@multica/core/i18n/relative-time";
+
 /**
- * Mobile time-ago formatter. Mirrors the algorithm in
- * packages/views/inbox/components/inbox-list-item.tsx `useTimeAgo` so
- * "X minutes ago" reads identically across web/desktop and mobile (Behavioral
- * parity rule in apps/mobile/CLAUDE.md). The web version is i18n-driven via
- * useT; mobile v1 is English-only — when mobile ships i18n, mirror that
- * structure.
+ * Mobile time-ago formatter. The gradient and cutoffs are shared with
+ * web/desktop via `relativeTimeBucket` in @multica/core (Behavioral parity
+ * rule in apps/mobile/CLAUDE.md), so the labels read identically across
+ * platforms. It is symmetric: past instants read "3h ago", future ones "in
+ * 3h". Day granularity is calendar-based; the device timezone stands in for
+ * the viewer's Viewing Timezone (web reads `user.timezone`). Past the day cap
+ * the gradient continues into calendar months, then years — no absolute-date
+ * fallback. The web version is i18n-driven via useT; mobile v1 is English-only
+ * — when mobile ships i18n, map the same buckets to translations.
  */
 export function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "Just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return `${weeks}w ago`;
-  return new Date(dateStr).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const bucket = relativeTimeBucket(
+    new Date(dateStr).getTime(),
+    Date.now(),
+    timeZone,
+  );
+  switch (bucket.kind) {
+    case "just_now":
+      return "Just now";
+    case "minutes":
+      return bucket.future ? `in ${bucket.count}m` : `${bucket.count}m ago`;
+    case "hours":
+      return bucket.future ? `in ${bucket.count}h` : `${bucket.count}h ago`;
+    case "days":
+      return bucket.future ? `in ${bucket.count}d` : `${bucket.count}d ago`;
+    case "months":
+      return bucket.future ? `in ${bucket.count}mo` : `${bucket.count}mo ago`;
+    case "years":
+      return bucket.future ? `in ${bucket.count}y` : `${bucket.count}y ago`;
+    default:
+      return "—";
+  }
 }

--- a/docs/timezone-display-spec.md
+++ b/docs/timezone-display-spec.md
@@ -1,0 +1,215 @@
+# 时间显示与时区处理 Spec
+
+> 本文是 `docs/timezone-architecture-rfc.md` 在**展示层**和 **deadline 语义**上的延伸。
+> RFC 定义了「数据怎么存、报表怎么按 tz 切日界」的两轴模型;本 spec 定义「**任意时间在 UI 上怎么显示**」「**locale 从哪取**」「**逾期/deadline 怎么判**」,并给出需要抽象的公共方法 / 组件与落地差距清单。
+> 冲突时以 RFC 为准;本文只补 RFC 未覆盖的部分。
+
+## 0. 目标
+
+本 spec 服务于三个产品目标:
+
+1. **locale 统一**:所有时间(及其他本地化文本)的 locale 全部取自 Settings 的 **Language** 配置项,缺省回退 `en`(精确语义见 §7.1 订正)。
+2. **显示统一走 Viewing Timezone**:所有「用于显示的瞬时时间」一律按用户的 **Viewing Timezone**(`user.timezone`)转换后展示,覆盖 web、desktop 等所有应用。
+3. **tooltip 统一**:web / desktop 上所有时间显示都带 tooltip,展示**完整时间 + 时区信息**。
+
+---
+
+## 1. 时区轴模型(结论)
+
+延续 RFC,系统只有**两个时区轴**,外加一类**不属于任何轴**的浮动日历日。每个字段只回答一个问题。
+
+| 轴 / 类别 | 在回答什么 | 真值来源 | 典型字段 |
+|---|---|---|---|
+| **Scheduling(调度)** | 「这件事在**哪个 tz 的几点**触发 / 到期」——产出唯一绝对瞬间 | 挂在被调度对象上的 tz | `autopilot_trigger.timezone`;(将来)issue 的 deadline tz |
+| **Viewing(查看)** | 「把一个瞬时**渲染给某个查看者**时用哪个 tz」 | 查看者 `user.timezone`(NULL=跟随浏览器) | 一切 TIMESTAMPTZ 的显示 |
+| **浮动日历日(非轴)** | 「这是挂历上的**哪一天**」——对所有人恒定,**不带 tz** | `DATE` 字面值 | `issue.start_date` / `issue.due_date` |
+
+**核心判别**:一个字段是「瞬时」还是「日历日」,决定它走 Viewing 还是浮动。
+
+- **瞬时(instant)**:`created_at`、`updated_at`、`completed_at`、`received_at`、Inbox `created_at` 等所有 `TIMESTAMPTZ`。同一时刻在不同时区显示成不同钟点/日期是**正确**的 → 走 Viewing。
+- **日历日(floating date)**:`start_date` / `due_date`。「截止 March 1」对所有人就是 March 1,**不转 tz**(转了就是 GH #3618 / MUL-2925,见迁移 112)。其逾期标红是「今天 vs 该日历日」的比较,「今天」取查看者 Viewing tz(见 §4)。
+
+> **不引入 `workspace.timezone` 当 viewing 权威**(RFC §1.3.4 / §3.4)。它只能作为「新成员 Viewing tz 的默认种子」或「Scheduling 轴的默认值」,`user.timezone` 永远 override。
+
+---
+
+## 2. 存储约定(现状已满足,勿回退)
+
+- 所有时间瞬时列均为 `TIMESTAMPTZ`,Go 侧统一 `pgtype.Timestamptz`,API 一律 `RFC3339` 序列化(`util.TimestampToString` / `TimestampToPtr`)。**存储全 UTC,本 spec 不改存储。**
+- 日历日列为 `DATE`(`pgtype.Date`),经 `util.ParseCalendarDate` 写入,强制 UTC 午夜边界校验。当前**唯一**的 `DATE` 写入场景是 `issue.start_date` / `issue.due_date`。
+- 约束:新增「瞬时」字段必须 `TIMESTAMPTZ`;新增「用户选的纯日期」字段才用 `DATE`,且不得对其做 tz 转换显示。
+
+---
+
+## 3. 显示规则
+
+### 3.1 瞬时 → Viewing Timezone
+
+所有 `TIMESTAMPTZ` 的展示,必须经过统一格式化入口,内部用 `Intl.DateTimeFormat(locale, { timeZone })`,其中 `timeZone` = `useViewingTimezone()`。
+
+- 禁止在组件里直接 `new Date(x).toLocaleString(...)` / `toLocaleDateString(...)`(那是浏览器 tz,绕过设置)。
+- 覆盖 web 与 desktop:格式化入口放在 `packages/views`(共享层),两端复用。
+- **当年省略年份**:`mode:"date"`(纯日期,如 `<DateTime variant="date">`、`useFormatDateTime().formatDate`)在「该瞬时落在查看者当前日历年(按 Viewing tz 判定)」时**不显示年份**(`Mar 1`),跨年才带(`Mar 1, 2025`),消除同年冗余又保留跨年无歧义。`datetime`/`time` 模式与 tooltip(`formatInstantWithOffset`)**始终带年份**,不受影响。
+
+### 3.2 日历日 → 浮动,不转 tz
+
+`start_date` / `due_date` 继续走 `formatDateOnly`(`packages/core/issues/date.ts`,`timeZone:"UTC"` 锚定),**显示对所有人恒定**。不得接入 Viewing tz。
+
+### 3.3 相对时间 → 子日免疫时区,日级别按 Viewing tz 的日历日,双向对称
+
+- **方向对称**:梯度同时覆盖过去与未来。过去读 `3h ago`,未来读 `in 3h`;同一档位两个方向只差措辞,数值与边界一致。方向由 `relativeTimeBucket` 返回的 `future` 标志承载,`just_now` 无方向。
+- **子日(< 24h)**:`just now / Nm ago / Nh ago`(未来 `in Nm / in Nh`),按 `|now - t|` 经过时长计算,**与 tz 无关**。
+- **子分钟容差**:双向子分钟(`|now - t| < 1min`)都归 `just now`,顺带吸收时钟偏差——一个略微「未来」的服务器时间戳不会显示成 `in 30s`。
+- **日级别(≥ 24h)**:按**查看者 Viewing tz 下的日历日差**计算(`1d ago` = 昨天、`2d ago` = 前天;未来 `in 1d / in 2d`),使「2d ago」与旁边显示的日期一致——避免「相隔 2 个日历日却显示 1d ago」。代价:日级别档位**依赖 Viewing tz**(跨午夜、不同 tz 的查看者可能看到不同档位),这是有意为之。
+- **超过 30 个日历日 → 月,满 12 个月 → 年**:`Nmo ago` / `Ny ago`(未来 `in Nmo` / `in Ny`),**永远相对,不回退绝对日期**。月/年差按**查看者 Viewing tz 下的日历月/年**计算(满月计数,非 ÷30 天),与日级别的日历语义一致。
+- 单一来源:纯函数 `relativeTimeBucket(thenMs, nowMs, timeZone)`(`packages/core/i18n/relative-time.ts`,mobile 共享)+ 视图 hook `useTimeAgo()`。**原 5 个分叉已收敛**(见 §5/§6)。
+- **句中插值**:当时间嵌在已翻译整句里(`Updated {{time}}`),不拆句(会破坏 ja/ko 语序)、不引入 `<Trans>`,而是用 `<InstantTooltip value=…>` 把整条短语包一层 tooltip(见 §5)。
+- **Scheduling 轴可借相对时间规避缺失 tz**:相对时间是**纯时长 / 日历差,本身与 tz 无关**,因此能在「拿不到被调度对象 tz」的列表场景安全表达未来触发时间。典型:autopilot 列表的 **next run**——列表接口的 `next_run_at` 是裸 UTC 瞬间且不带 trigger tz,渲染绝对墙钟要么误报(Viewing tz),要么落成无意义的服务器进程偏移;改用 `useTimeAgo()` 显示 `in 3h`,既省空间又无歧义,hover tooltip 再以 **UTC + GMT 偏移**给出精确瞬间。详情页拿得到 trigger,仍按 trigger tz 显示绝对时间(见 §6「不在本清单」)。
+- **例外**:runtime「last seen」用 `useFormatLastSeen()`,保留**秒级 + 复合单位**(`2m 30s ago` / `2d 4h ago`)的连接活性精度,不并入 `useTimeAgo`(见 §6)。
+
+### 3.4 locale → Language 设置,`en-US` 兜底
+
+- 所有格式化入口的 `locale` 取自 **Language 设置**;未设置 / 非法时回退 `en`。
+- 取消现存的 `"en-US"` 硬编码与「不传 locale 跟随浏览器」两种写法,统一走同一个 locale 来源。
+- **current locale accessor** = `const { i18n } = useTranslation(); i18n.language`(短码 `en` / `zh-Hans` / `ko` / `ja`)。这些短码本身即合法 BCP-47,**直接传给 `Intl`,不做映射**(详见 §7.1)。
+
+### 3.5 tooltip → 完整时间 + 时区(web / desktop)
+
+- web / desktop 上**每一处**时间显示(含相对时间、日历日、绝对时间)都挂 tooltip。
+- **瞬时**:Viewing tz 渲染 + **GMT 偏移后缀**(已定,见 §7.5),不带 IANA 名、不并列 UTC:
+  - en:`Mar 1, 2026, 02:30:45 PM (GMT+8)`
+  - zh:`2026年3月1日 14:30:45(GMT+8)`
+- **日历日**(`due_date` / `start_date`):纯日期 tooltip,**无时分、无时区**(en `March 1, 2026` / zh `2026年3月1日`)。
+- **实现约束(`Intl` 实测坑,务必遵守)**:
+  - `timeZoneName` **不能**与 `dateStyle` / `timeStyle` 同用 → date+time 须用显式分量 opts(`year/month/day/hour/minute/second`)。
+  - zh-Hans 下内置 `timeZoneName` 会把时区**塞进日期与时间之间** → **偏移后缀手动追加**:`formatToParts` 取 `shortOffset` token 拼到末尾,保证跨语言排序一致。
+- mobile 无 hover,**不在本目标内**(如需等价能力另议长按方案)。
+
+---
+
+## 4. Deadline / 逾期 / 通知处理(补 RFC 未覆盖)
+
+**结论:前端逾期标红是一次「日历日比较」,在查看者 Viewing tz 的今天里判定 —— 走 Viewing,与屏幕上看到的 `due_date` 同一真值。**
+
+理由:标红是给「正在看屏的人」的提示,它要回答的是「对**这个查看者**而言,截止日是不是已经过去了」。`due_date` 本身是浮动日历日,但「今天是哪天」必须落在某个 tz 上才有意义;既然卡片上的 `due_date` 是按查看者展示的,标红就用同一个查看者的 Viewing tz,二者永远一致。
+
+### 4.1 标红 / 「逾期」前端判定
+
+- **「今天」锚点取查看者 Viewing tz**(`user.timezone`,NULL 跟随浏览器),与所有其它显示同源。
+- `isPastDateOnly(due_date, timeZone)`(`date.ts`):把 `due_date` 与「Viewing tz 下的今天」都归到 UTC 午夜做纯日历日比较;`timeZone` 由调用方传入 `useViewingTimezone()`。非法 tz 回退 UTC,不抛。
+- `due_date` 的存储不变:浮动 `DATE`,无时分、无 tz。
+
+### 4.2 过期 → Inbox 通知(将来功能)
+
+逾期一旦要被**后台物化**成一条通知,「**何时发**」就不能再是查看者属性 —— 后台 job 触发时没有「查看者」,必须是全队唯一的绝对瞬间。所以触发与标红是两件事:
+
+1. **触发瞬间** = `end-of-day(due_date) AT TIME ZONE <canonical deadline tz>`,**canonical deadline tz**:
+   - **v1 = `UTC`**(零 schema 改动)。
+   - 将来如需更贴近设置者,加 `issue.due_timezone`,**创建/设 due_date 时静默捕获设置者当时的 Viewing tz**(仿 `autopilot_trigger.timezone`),默认链 `setter Viewing tz → workspace 默认(若引入) → UTC`。
+2. **触发** = Scheduling:后台 job 在上述 canonical 瞬间写入一条 Inbox item,发一次,与查看者无关;assignee 是 agent / 为空也照常。
+3. **显示** = Viewing:该 Inbox item 的 `created_at`(TIMESTAMPTZ)按各查看者 `user.timezone` 渲染,与其它时间戳一致。
+4. **UI 不加 tz 选项**:create issue 表单只选日期。deadline tz 是后台静默捕获的元数据,不是用户决策(对比:cron 的 tz 是用户决策,因为「9 点」离开 tz 无意义;「截止 March 1」自带绝对感,用户无此意见)。
+
+> **标红(Viewing)与通知触发(canonical)可能不在同一天**:UTC 负偏移的查看者在当地午夜前后,卡片可能还没标红,而 canonical=UTC 的通知已经发出(反之亦然)。这是两个轴各司其职的结果 —— 标红服务「正在看屏的这个人」,通知触发服务「全队唯一一次」。若将来要让两者贴合,走 §4.2.1 的 `issue.due_timezone` 把 canonical 对齐到设置者 tz。
+
+---
+
+## 5. 需要抽象的公共方法 / 组件
+
+| 抽象 | 位置(建议) | 职责 |
+|---|---|---|
+| `useViewingTimezone()` | 已有 `packages/views/common/use-viewing-timezone.ts` | 读 `user.timezone`,NULL 回退浏览器 tz |
+| `useFormatDateTime()` | 新增 `packages/views/common/` | 基于 Viewing tz + Language locale 封装 `formatDateTime` / `formatDate` / `formatTime`;内部 memoized `Intl.DateTimeFormat`。**替换所有走浏览器 tz 的内联 `toLocaleString` 瞬时显示** |
+| `<DateTime>` 组件 | 新增 `packages/views/common/`,基于 `@multica/ui/components/ui/tooltip`(已有,§7.2) | 统一「可见文本(相对或绝对)+ tooltip(完整时间+tz)」成对模式;web/desktop 共用 |
+| 统一相对时间 hook | `packages/views/i18n/use-time-ago.ts` + 纯函数 `packages/core/i18n/relative-time.ts` | **已落地**:`relativeTimeBucket(thenMs, nowMs, timeZone)` 单一档位逻辑(子日经过时长 + 日级别日历日 + 日历月/年延伸,双向对称、不回退绝对日期),`useTimeAgo()` 注入 Viewing tz + locale。原 5 套分叉(i18n / inbox-list-item / projects `useFormatRelativeDate` / chat `useFormatTimeAgo` / mobile)已收敛 |
+| `<InstantTooltip>` | 新增 `packages/views/common/instant-tooltip.tsx` | 句中插值时间(`Updated {{time}}`)无法换成裸 `<DateTime>`(会破坏各 locale 语序)。把整条已翻译短语包一层 tooltip(完整时间 + GMT 偏移),零 i18n 改动、不引入 `<Trans>` |
+| `useFormatLastSeen()` | 新增 `packages/views/runtimes/use-format-last-seen.ts` | runtime「last seen」连接活性:保留**秒级 + 复合单位**(原 `runtimes/utils.ts:formatLastSeen` 第 4 套分叉),改为 i18n(runtimes namespace)+ 配 `<InstantTooltip>`,不并入 `useTimeAgo` |
+| `formatDateOnly` locale 收口 | 已有 `packages/core/issues/date.ts` | 调用方不再硬编码 `"en-US"`,locale 统一来自 Language 设置 |
+| Viewing-tz overdue helper | 已有 `packages/core/issues/date.ts` | `isPastDateOnly(due_date, timeZone)` 在查看者 Viewing tz 的今天里判逾期;`timeZone` 由调用方传 `useViewingTimezone()`(§4.1) |
+
+---
+
+## 6. 现状差距清单(待修)
+
+来自代码审计,按优先级:
+
+1. **约 20 处瞬时显示内联 `new Date().toLocaleString()` 走浏览器 tz** → 全部替换为 `useFormatDateTime()`。**这是 Viewing Timezone 失效的主因。** 覆盖文件:
+   - `settings/{lark-tab:258, tokens-tab:164/167/172}`
+   - `autopilots/{webhook-deliveries-section:77, autopilots-page:376/948, autopilot-detail-page:71}`
+   - `runtimes/cloud-runtime-dialog:393`、`runtimes/utils:855`
+   - `common/task-transcript/agent-transcript-dialog:517/795/796`
+   - `agents/agents-page:1177`、`squads/squads-page:991`
+   - **`issues/{comment-card:526/798, issue-detail:558}` —— 活动/评论 `created_at` 的 tooltip(原审计漏列)**
+   - `billing/billing-test-page:732`(仅此 `formatDate` helper;该文件其余 `toLocaleString` 都是数字,非时间)
+2. **`isPastDateOnly` 用浏览器 tz** → 改取查看者 Viewing tz(§4.1),`timeZone` 由调用方传 `useViewingTimezone()`。
+3. ~~**相对时间 5 个分叉实现** → 合并为单一 hook~~(**已完成**,§5)。审计原列 5 套,落地时另发现 runtime `formatLastSeen`(`runtimes/utils.ts`,秒级复合单位)第 6 套——按「保留秒级活性」处理为 `useFormatLastSeen` hook(i18n + tooltip),不并入 `useTimeAgo`。
+   - **遗留**:agents 列表「Last active」是 30 天活跃 sparkline 的**按天桶**(`lastActiveDaysAgo`),agent 上无精确瞬时,故只统一了文案(`Today / Nd ago`)、**挂不了完整时间 tooltip**;要彻底统一需后端给 agent 暴露 `last_active_at` 瞬时。
+4. **locale 不统一**:`formatDateOnly` **8 处**硬编码 `"en-US"`(list-row:30 / board-card:32 / issue-detail:183,233,238 / due-date-picker:54 / start-date-picker:58 / inbox-detail-label:41)+ `issues-header:119` 跟随浏览器 → 统一取 Language 设置。
+5. **tooltip 缺失**:多数绝对时间无 tooltip,相对时间基本无 tooltip → 由 `<DateTime>` 统一补齐。
+6. ~~app 层盲区~~:已扫描,**基本无**(见 §7.3)。产品时间显示全集中在 `packages/views`,app 层只有 landing/changelog 营销日期与 desktop 时长,不在改造范围。
+
+> **明确不在本清单(不要动)**:
+> - **Scheduling 轴显示**:`autopilots/pickers/timezone-picker:22`、`trigger-config:65/74`、`autopilot-dialog` 排程预览——用显式 tz 是对的,非 Viewing。autopilot 列表的 **next run** 是特例:列表接口不带 trigger tz,改用**相对时间**(tz 无关)+ UTC 偏移 tooltip 表达,见 §3.3。
+> - **日历日 chart 标签**:`issues/gantt-view`、`runtimes/charts/activity-heatmap` 的轴/格子是按天日期标签,走日历日规则(浮动、不转 tz),非瞬时;仅 locale 需随 Language 收口,不接 Viewing tz。
+> - **数字**:`runtimes/charts/*`、`billing` 里的 `total.toLocaleString()` 等是千分位数字格式化,与时间无关。
+
+---
+
+## 7. 落地前核实结论(已查实)
+
+> 原标「待核实」的项已通过代码审计确认。除 §7.5 一项产品决策外,其余均已落定。
+
+### 7.1 Language 设置 —— 已具备,可直接接入 ✅
+
+- 存在:`user.language`(migration 060,`VARCHAR(20)` nullable),`PATCH /api/me` 同步(`UpdateMeRequest.language`),客户端 cookie `multica-locale`。
+- 后端校验白名单 `supportedLanguages`:`en` / `zh-Hans` / `ko` / `ja`(`server/internal/handler/auth.go:47`,校验在 `:683`)。
+- 框架 react-i18next,**current locale accessor** = `useTranslation().i18n.language`(返回短码 `en` / `zh-Hans` / `ko` / `ja`)。
+- 短码是**翻译包 key**(语言 + script,故意不含 region:region 不改翻译文案),这是正确表示,不应改成区域限定形式。
+- **这四个短码本身即合法 BCP-47,可直接传给 `Intl.DateTimeFormat`**(已实测:`en→Mar 1, 2026`、`zh-Hans→2026年3月1日` 等均正常)。**不需要映射表。**
+  - 映射到 `en-US`/`zh-CN`/… 仅用于钉死某地区格式惯例(日期顺序、12/24h),而对这 4 个 locale 无实际差别(`en` 默认即美式)。故**默认直接透传 `i18n.language`**;仅当将来出现「同语言不同地区格式」需求(目前无)时再加可选映射。
+- 默认/兜底:`en`(i18next `fallbackLng: "en"`,`create-i18n.ts:16`)。
+- **订正**:目标 1 原写「`en-US` 兜底」,精确表述是「locale 取 `i18n.language`,缺省回退 `en`」。
+
+### 7.2 Tooltip 组件 —— 已具备 ✅
+
+- 共享组件:`packages/ui/components/ui/tooltip.tsx`(Base UI),导出 `Tooltip` / `TooltipTrigger` / `TooltipContent` / `TooltipProvider`,经 `@multica/ui/components/ui/tooltip` 引用。
+- **已在 `packages/views` 内被使用**(如 `issues/issue-detail:557`、`comment-card:525` 的活动/评论 tooltip),web/desktop 两端都在渲染它 → **renderer 可用性已被现网证明**。`<DateTime>` 直接基于它封装即可。
+
+### 7.3 app 层盲区 —— 基本无,产品时间显示集中在 packages/views ✅
+
+- `apps/web/app/**`、`apps/web/components/**`:无产品时间戳渲染。
+- `apps/web/features/**`(landing/changelog 营销页):仅 changelog 发布日(UTC 锚定的浮动日期,合理)、活动热力图(生成数据)、版权年——非产品数据,不在范围。
+- `apps/desktop/src/renderer/src/**`:仅 `formatUptime()`(时长,非时间戳),无 `*_at` 渲染。
+- 结论:**所有产品时间显示都在 `packages/views`(已盘点),app 层无需额外追查。**
+
+### 7.4 后端渲染时间 —— 不在范围 ✅
+
+- 服务端唯一拼人类可读时间的是 **autopilot 生成的 issue 描述/标题**(`service/autopilot.go:1258,1323`),已用 trigger 时区(Scheduling 轴),正确。
+- 其余均为 API JSON 的 `RFC3339` UTC 时间戳,前端按 Viewing tz 渲染;无 HTML / 邮件正文 / CSV / PDF 含格式化时间(邮件仅 SMTP `Date` 头,属协议元数据)。
+- 结论:**后端零改动。**
+
+### 7.5 tooltip 精确格式 —— 已定 ✅
+
+- 选定**仅 GMT 偏移**(不带 IANA 名、不并列 UTC):
+  - en:`Mar 1, 2026, 02:30:45 PM (GMT+8)`
+  - zh:`2026年3月1日 14:30:45(GMT+8)`
+- 日历日为纯日期 tooltip(无时分、无时区)。
+- 实现细节(`Intl` 坑)见 §3.5,写死在 `<DateTime>`。
+
+---
+
+## 8. 非目标 / 明确不做
+
+- **不**引入 `workspace.timezone` 当 viewing 渲染权威(可作默认种子 / Scheduling 默认值)。
+- **不**对日历日(`due_date` / `start_date`)做 tz 转换显示。
+- **不**在 create issue 表单为 due_date 增加 tz 选择器。
+- **不**为 mobile 做 hover tooltip(无 hover 场景)。
+- **不**改动存储层(已全 UTC)。
+
+---
+
+## 9. 一句话总览
+
+- **存**:全 UTC(瞬时 `TIMESTAMPTZ`)/ 纯日期(日历日 `DATE`),不动。
+- **显示**:瞬时按 **Viewing tz** + **Language locale** 格式化,日历日浮动不转,web/desktop 一律挂「完整时间+时区」tooltip。
+- **逾期/deadline**:前端**标红**按查看者 **Viewing tz** 的今天判定(与屏幕上 `due_date` 一致);将来的后台「逾期 → 通知」**触发**才走 canonical tz(v1=UTC,fire-once 与查看者无关),UI 不加 tz 选项。

--- a/packages/core/i18n/format-date-time.test.ts
+++ b/packages/core/i18n/format-date-time.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatInstant,
+  formatInstantWithOffset,
+  shortOffsetToken,
+} from "./format-date-time";
+
+// 2026-03-01T06:30:45Z == 14:30:45 in Asia/Shanghai (+8), 22:30:45 prev day in LA.
+const VALUE = "2026-03-01T06:30:45Z";
+
+describe("formatInstant", () => {
+  it("renders the same instant differently per timezone", () => {
+    const sh = formatInstant(VALUE, {
+      locale: "en",
+      timeZone: "Asia/Shanghai",
+    });
+    const la = formatInstant(VALUE, {
+      locale: "en",
+      timeZone: "America/Los_Angeles",
+    });
+    expect(sh).toBe("Mar 1, 2026, 02:30 PM");
+    expect(la).toContain("Feb 28, 2026");
+    expect(sh).not.toBe(la);
+  });
+
+  it("localizes the wall-clock rendering", () => {
+    expect(
+      formatInstant(VALUE, { locale: "zh-Hans", timeZone: "Asia/Shanghai" }),
+    ).toBe("2026年3月1日 14:30");
+  });
+
+  it("supports time-only mode", () => {
+    expect(
+      formatInstant(VALUE, {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+        mode: "time",
+      }),
+    ).toBe("02:30:45 PM");
+  });
+
+  it("returns empty string for empty/unparseable values", () => {
+    expect(formatInstant(null, { locale: "en", timeZone: "UTC" })).toBe("");
+    expect(formatInstant("not-a-date", { locale: "en", timeZone: "UTC" })).toBe(
+      "",
+    );
+  });
+
+  it("falls back to UTC instead of throwing on an invalid timezone", () => {
+    const utc = formatInstant(VALUE, { locale: "en", timeZone: "UTC" });
+    expect(() =>
+      formatInstant(VALUE, { locale: "en", timeZone: "Not/AZone" }),
+    ).not.toThrow();
+    expect(formatInstant(VALUE, { locale: "en", timeZone: "Not/AZone" })).toBe(
+      utc,
+    );
+  });
+
+  it("falls back to a neutral locale instead of throwing on an invalid locale", () => {
+    expect(() =>
+      formatInstant(VALUE, { locale: "not-a-locale!", timeZone: "UTC" }),
+    ).not.toThrow();
+    expect(
+      formatInstant(VALUE, { locale: "not-a-locale!", timeZone: "UTC" }),
+    ).toBe(formatInstant(VALUE, { locale: "en", timeZone: "UTC" }));
+  });
+
+  it("keeps the viewer's timezone when only the locale is unsupported", () => {
+    // A bad Language locale must not drag the timeZone to UTC: the instant
+    // still renders in the requested zone (Shanghai), just in the neutral
+    // language — not hours off in UTC.
+    const out = formatInstant(VALUE, {
+      locale: "not-a-locale!",
+      timeZone: "Asia/Shanghai",
+    });
+    expect(out).toBe(formatInstant(VALUE, { locale: "en", timeZone: "Asia/Shanghai" }));
+    expect(out).not.toBe(formatInstant(VALUE, { locale: "en", timeZone: "UTC" }));
+  });
+});
+
+// Date mode drops the year when the instant is in the viewer's CURRENT calendar
+// year (evaluated in the viewer's timezone), and keeps it otherwise so other
+// years stay unambiguous. Only "date" mode is affected — datetime/time/tooltip
+// keep the year. "Now" is mocked so the assertions are stable across real time.
+describe("formatInstant date mode — current-year suppression", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-26T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("omits the year for an instant in the current year", () => {
+    expect(
+      formatInstant("2026-03-01T06:30:45Z", {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+        mode: "date",
+      }),
+    ).toBe("Mar 1");
+  });
+
+  it("keeps the year for a past year", () => {
+    expect(
+      formatInstant("2025-12-20T06:30:45Z", {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+        mode: "date",
+      }),
+    ).toBe("Dec 20, 2025");
+  });
+
+  it("keeps the year for a future year", () => {
+    expect(
+      formatInstant("2027-01-05T06:30:45Z", {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+        mode: "date",
+      }),
+    ).toBe("Jan 5, 2027");
+  });
+
+  it("omits the year in zh-Hans too", () => {
+    expect(
+      formatInstant("2026-03-01T06:30:45Z", {
+        locale: "zh-Hans",
+        timeZone: "Asia/Shanghai",
+        mode: "date",
+      }),
+    ).toBe("3月1日");
+  });
+
+  it("evaluates the current year in the viewer's timezone, not UTC", () => {
+    // now is 2026-01-01T02:00:00Z == 2025-12-31 21:00 in America/New_York, so
+    // the current year THERE is 2025. An instant that is also 2025-12-31 in NY
+    // shares that year → the year is dropped. (A UTC comparison would see 2026
+    // vs 2025 and wrongly keep the year.)
+    vi.setSystemTime(new Date("2026-01-01T02:00:00Z"));
+    expect(
+      formatInstant("2026-01-01T02:30:00Z", {
+        locale: "en",
+        timeZone: "America/New_York",
+        mode: "date",
+      }),
+    ).toBe("Dec 31");
+  });
+
+  it("does not affect datetime mode", () => {
+    expect(
+      formatInstant("2026-03-01T06:30:45Z", {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("Mar 1, 2026, 02:30 PM");
+  });
+});
+
+describe("formatInstantWithOffset", () => {
+  it("appends a spaced half-width GMT offset for en", () => {
+    expect(
+      formatInstantWithOffset(VALUE, {
+        locale: "en",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("Mar 1, 2026, 02:30:45 PM (GMT+8)");
+  });
+
+  it("appends a full-width GMT offset for zh", () => {
+    expect(
+      formatInstantWithOffset(VALUE, {
+        locale: "zh-Hans",
+        timeZone: "Asia/Shanghai",
+      }),
+    ).toBe("2026年3月1日 14:30:45（GMT+8）");
+  });
+
+  it("reflects the offset of the chosen timezone", () => {
+    expect(
+      formatInstantWithOffset(VALUE, {
+        locale: "en",
+        timeZone: "America/Los_Angeles",
+      }),
+    ).toContain("(GMT-8)");
+    expect(
+      formatInstantWithOffset(VALUE, { locale: "en", timeZone: "UTC" }),
+    ).toContain("(GMT+0)");
+  });
+
+  it("renders the base time without a misleading offset on an invalid timezone", () => {
+    expect(() =>
+      formatInstantWithOffset(VALUE, { locale: "en", timeZone: "Not/AZone" }),
+    ).not.toThrow();
+    const out = formatInstantWithOffset(VALUE, {
+      locale: "en",
+      timeZone: "Not/AZone",
+    });
+    // Visible time degrades to UTC (must not white-screen), but the unknown
+    // zone has no knowable offset, so NO "(GMT…)" suffix is appended — never a
+    // misleading "(GMT+0)". The UTC variant is exactly this base plus "(GMT+0)".
+    expect(`${out} (GMT+0)`).toBe(
+      formatInstantWithOffset(VALUE, { locale: "en", timeZone: "UTC" }),
+    );
+    expect(out).not.toContain("GMT");
+  });
+
+  it("renders the base time (no offset) without throwing when the engine lacks shortOffset support", async () => {
+    // Older engines (Safari < 15.4 / old WebViews) support Intl but throw
+    // RangeError on the timeZoneName value "shortOffset" — regardless of
+    // locale/timeZone. Must degrade to the plain time, never white-screen.
+    vi.resetModules(); // fresh formatter cache so the mock is exercised
+    const RealDTF = Intl.DateTimeFormat;
+    const spy = vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      // Must be a `function` (not an arrow) so it works under `new`.
+      function (locale?: unknown, options?: Intl.DateTimeFormatOptions) {
+        if (options && "timeZoneName" in options) {
+          throw new RangeError("unsupported timeZoneName value");
+        }
+        return new RealDTF(locale as string, options);
+      } as unknown as typeof Intl.DateTimeFormat,
+    );
+    try {
+      const { formatInstantWithOffset: format } = await import(
+        "./format-date-time"
+      );
+      let out = "";
+      expect(() => {
+        out = format(VALUE, { locale: "en", timeZone: "Europe/Berlin" });
+      }).not.toThrow();
+      // Base time still rendered; just no "(GMT…)" suffix.
+      expect(out).toContain("2026");
+      expect(out).not.toContain("GMT");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("shortOffsetToken", () => {
+  const at = new Date(VALUE);
+
+  it("extracts the GMT offset token for a timezone", () => {
+    expect(shortOffsetToken(at, "en", "Asia/Shanghai")).toBe("GMT+8");
+    expect(shortOffsetToken(at, "en", "UTC")).toBe("GMT+0");
+    expect(shortOffsetToken(at, "en", "America/Los_Angeles")).toBe("GMT-8");
+  });
+
+  it("returns empty (not a misleading GMT+0) for an unknown timezone", () => {
+    expect(() => shortOffsetToken(at, "en", "Not/AZone")).not.toThrow();
+    // A stale/ICU-unsupported zone has no knowable offset; must degrade to ""
+    // so callers fall back to the raw zone name, never a wrong "GMT+0".
+    expect(shortOffsetToken(at, "en", "Not/AZone")).toBe("");
+  });
+
+  it("keeps the zone's offset when only the locale is unsupported", () => {
+    expect(shortOffsetToken(at, "not-a-locale!", "Asia/Shanghai")).toBe(
+      "GMT+8",
+    );
+  });
+});

--- a/packages/core/i18n/format-date-time.ts
+++ b/packages/core/i18n/format-date-time.ts
@@ -1,0 +1,227 @@
+// Pure Intl-based formatters for INSTANTS (TIMESTAMPTZ values). Both the
+// visible time and its tooltip render here so the timezone + locale enter in
+// exactly one place. No React / DOM, so this is testable and reusable by
+// mobile. Calendar days (issue start_date / due_date) are NOT instants and
+// must NOT pass through here — they stay in issues/date.ts `formatDateOnly`.
+
+export type InstantFormatMode = "datetime" | "date" | "time";
+
+export interface FormatInstantOptions {
+  /** BCP-47 locale, e.g. the i18next short code "en" / "zh-Hans". */
+  locale: string;
+  /** IANA timezone the instant is rendered in (the viewer's Viewing tz). */
+  timeZone: string;
+  /** Which components to show. Defaults to full date + time. */
+  mode?: InstantFormatMode;
+}
+
+function toDate(value: string | number | Date | null | undefined): Date | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+// Intl.DateTimeFormat construction is one of the costliest Intl ops, and lists
+// re-render per row per frame, so cache built formatters by (locale, options).
+// The locale/timeZone/mode space is tiny (≤4 locales × a handful of zones ×
+// 3 modes), so the cache stays small; the JSON key is far cheaper than the
+// construction it avoids.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+// Intl.DateTimeFormat throws RangeError on an unknown timeZone or locale. A
+// stale or ICU-unsupported user.timezone (Go tzdata and the browser's ICU do
+// not accept exactly the same zone set) — or a malformed Language locale —
+// must never white-screen every page that renders a timestamp. The fallback
+// ladder degrades the LOCALE before the timeZone: a wrong display language is
+// far less harmful than discarding the viewer's timezone and silently
+// rendering every instant in UTC, hours off the real wall-clock. So a bad
+// locale alone keeps the requested zone; only a genuinely unsupported zone
+// falls back to UTC. Exported because the scheduling-axis formatters reuse the
+// same cache + safe construction. Offset-token extraction does NOT route
+// through here — see shortOffsetToken, which must not mask a bad zone as UTC.
+export function safeDateTimeFormat(
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = `${locale}\u0000${JSON.stringify(options)}`;
+  const cached = formatterCache.get(key);
+  if (cached) return cached;
+  let fmt: Intl.DateTimeFormat;
+  try {
+    fmt = new Intl.DateTimeFormat(locale, options);
+  } catch {
+    try {
+      // Bad locale only: keep the requested timeZone, degrade language to "en".
+      fmt = new Intl.DateTimeFormat("en", options);
+    } catch {
+      try {
+        // Bad timeZone: keep the locale, fall back to UTC.
+        fmt = new Intl.DateTimeFormat(locale, { ...options, timeZone: "UTC" });
+      } catch {
+        // Both unsupported: neutral locale + UTC.
+        fmt = new Intl.DateTimeFormat("en", { ...options, timeZone: "UTC" });
+      }
+    }
+  }
+  formatterCache.set(key, fmt);
+  return fmt;
+}
+
+// Explicit component options, never dateStyle/timeStyle — the latter cannot be
+// combined with timeZoneName, which the offset tooltip needs. Visible
+// "datetime" omits seconds (noise for inline cells); the tooltip keeps full
+// precision via FULL_OPTS below.
+function componentOptions(mode: InstantFormatMode): Intl.DateTimeFormatOptions {
+  switch (mode) {
+    case "date":
+      return { year: "numeric", month: "short", day: "numeric" };
+    case "time":
+      return { hour: "2-digit", minute: "2-digit", second: "2-digit" };
+    default:
+      return {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      };
+  }
+}
+
+// Tooltip precision: full date + time WITH seconds.
+const FULL_OPTS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+};
+
+// The calendar year of an instant in a timezone. Uses this module's own safe
+// formatter (not issues/date.ts calendarPartsInTimeZone, which would form an
+// import cycle) so the year-of and the visible rendering share the same UTC
+// fallback for a bad zone.
+function yearInTimeZone(date: Date, timeZone: string): number {
+  const parts = safeDateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+  }).formatToParts(date);
+  return Number(parts.find((p) => p.type === "year")?.value);
+}
+
+/**
+ * Render an instant in the given timezone + locale. Returns "" for an
+ * empty/unparseable value so callers can render nothing without guarding.
+ *
+ * In "date" mode the year is dropped when the instant falls in the viewer's
+ * current calendar year (evaluated in `timeZone`) and kept otherwise, so a
+ * same-year date reads "Mar 1" while other years stay unambiguous ("Mar 1,
+ * 2025"). datetime/time modes always keep their full components.
+ */
+export function formatInstant(
+  value: string | number | Date | null | undefined,
+  { locale, timeZone, mode = "datetime" }: FormatInstantOptions,
+): string {
+  const date = toDate(value);
+  if (!date) return "";
+  let options = componentOptions(mode);
+  if (
+    mode === "date" &&
+    yearInTimeZone(date, timeZone) === yearInTimeZone(new Date(), timeZone)
+  ) {
+    options = { month: "short", day: "numeric" };
+  }
+  return safeDateTimeFormat(locale, { ...options, timeZone }).format(date);
+}
+
+// CJK locales use full-width parentheses; everything else uses spaced
+// half-width ones (the leading space keeps the en tooltip readable).
+function usesFullWidthPunctuation(locale: string): boolean {
+  return /^(zh|ja|ko)\b/i.test(locale);
+}
+
+// Offset extraction deliberately does NOT use safeDateTimeFormat: its UTC
+// fallback would yield a misleading "GMT+0" for a stale/ICU-unsupported zone,
+// hiding the failure from callers that want to degrade to the raw zone name. A
+// bad zone (or `shortOffset` rejected by an old engine: Safari < 15.4 / old
+// WebViews) means the offset is genuinely unknowable, so return null and let
+// the caller decide. Only the LOCALE degrades to "en" (the token's VALUE is
+// locale-independent). Cached per (locale, timeZone); null is cached too so a
+// rejected zone is not retried each render.
+const offsetFormatterCache = new Map<string, Intl.DateTimeFormat | null>();
+
+function offsetFormatter(
+  locale: string,
+  timeZone: string,
+): Intl.DateTimeFormat | null {
+  const key = `${locale} ${timeZone}`;
+  if (offsetFormatterCache.has(key)) {
+    return offsetFormatterCache.get(key) ?? null;
+  }
+  // timeZoneName needs at least one displayed field; hour is discarded, only
+  // the offset token is kept.
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone,
+    timeZoneName: "shortOffset",
+    hour: "numeric",
+  };
+  let fmt: Intl.DateTimeFormat | null;
+  try {
+    fmt = new Intl.DateTimeFormat(locale, options);
+  } catch {
+    try {
+      // Bad locale only: keep the zone, degrade language to "en".
+      fmt = new Intl.DateTimeFormat("en", options);
+    } catch {
+      // Unsupported zone or `shortOffset` value: no knowable offset.
+      fmt = null;
+    }
+  }
+  offsetFormatterCache.set(key, fmt);
+  return fmt;
+}
+
+/**
+ * The GMT-offset token (e.g. "GMT+8") for an instant in a timezone, or "" if
+ * the engine can't produce one (unknown zone, or no shortOffset support).
+ * Single source for offset extraction — the instant tooltip here plus the
+ * scheduling-axis timezone pickers all reuse it instead of re-implementing the
+ * formatToParts dance. "" lets callers fall back to the raw zone name rather
+ * than show a wrong offset.
+ */
+export function shortOffsetToken(
+  date: Date,
+  locale: string,
+  timeZone: string,
+): string {
+  const fmt = offsetFormatter(locale, timeZone);
+  if (!fmt) return "";
+  const parts = fmt.formatToParts(date);
+  return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
+}
+
+/**
+ * The tooltip string for an instant: full date-time in the viewer's timezone,
+ * with a GMT-offset suffix appended manually (built-in timeZoneName lands
+ * mid-string in CJK locales, breaking cross-locale ordering).
+ *   en → "Mar 1, 2026, 02:30:45 PM (GMT+8)"
+ *   zh → "2026年3月1日 14:30:45（GMT+8）"
+ */
+export function formatInstantWithOffset(
+  value: string | number | Date | null | undefined,
+  { locale, timeZone }: Omit<FormatInstantOptions, "mode">,
+): string {
+  const date = toDate(value);
+  if (!date) return "";
+  const base = safeDateTimeFormat(locale, {
+    ...FULL_OPTS,
+    timeZone,
+  }).format(date);
+  const offset = shortOffsetToken(date, locale, timeZone);
+  if (!offset) return base;
+  const [open, close] = usesFullWidthPunctuation(locale)
+    ? ["（", "）"]
+    : [" (", ")"];
+  return `${base}${open}${offset}${close}`;
+}

--- a/packages/core/i18n/relative-time.test.ts
+++ b/packages/core/i18n/relative-time.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { RELATIVE_DAYS_TO_MONTHS, relativeTimeBucket } from "./relative-time";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const ms = (iso: string) => new Date(iso).getTime();
+
+describe("relativeTimeBucket", () => {
+  it("collapses sub-minute and small-skew diffs to just_now (both directions)", () => {
+    const now = ms("2026-03-01T12:00:00Z");
+    expect(relativeTimeBucket(now, now, "UTC")).toEqual({ kind: "just_now" });
+    expect(relativeTimeBucket(now - (MINUTE - 1), now, "UTC")).toEqual({
+      kind: "just_now",
+    });
+    // A sub-minute future timestamp (clock skew) also collapses to just_now.
+    expect(relativeTimeBucket(now + (MINUTE - 1), now, "UTC")).toEqual({
+      kind: "just_now",
+    });
+  });
+
+  it("buckets minutes and hours by elapsed time, timezone-independent", () => {
+    const now = ms("2026-03-01T12:00:00Z");
+    expect(relativeTimeBucket(now - MINUTE, now, "UTC")).toEqual({
+      kind: "minutes",
+      count: 1,
+      future: false,
+    });
+    expect(relativeTimeBucket(now - 59 * MINUTE, now, "UTC")).toEqual({
+      kind: "minutes",
+      count: 59,
+      future: false,
+    });
+    expect(relativeTimeBucket(now - HOUR, now, "UTC")).toEqual({
+      kind: "hours",
+      count: 1,
+      future: false,
+    });
+    expect(relativeTimeBucket(now - 23 * HOUR, now, "UTC")).toEqual({
+      kind: "hours",
+      count: 23,
+      future: false,
+    });
+  });
+
+  it("mirrors the sub-day buckets into the future direction", () => {
+    const now = ms("2026-03-01T12:00:00Z");
+    expect(relativeTimeBucket(now + 5 * MINUTE, now, "UTC")).toEqual({
+      kind: "minutes",
+      count: 5,
+      future: true,
+    });
+    expect(relativeTimeBucket(now + 3 * HOUR, now, "UTC")).toEqual({
+      kind: "hours",
+      count: 3,
+      future: true,
+    });
+  });
+
+  it("counts day granularity by calendar days, not elapsed 24h windows", () => {
+    // The motivating bug: ~1d 23h59m apart but two calendar days → "2d ago",
+    // not "1d ago".
+    expect(
+      relativeTimeBucket(
+        ms("2026-06-23T15:05:52Z"),
+        ms("2026-06-25T15:05:50Z"),
+        "UTC",
+      ),
+    ).toEqual({ kind: "days", count: 2, future: false });
+
+    // 25h apart but one calendar day → "1d ago" (yesterday).
+    expect(
+      relativeTimeBucket(
+        ms("2026-03-01T10:00:00Z"),
+        ms("2026-03-02T11:00:00Z"),
+        "UTC",
+      ),
+    ).toEqual({ kind: "days", count: 1, future: false });
+  });
+
+  it("mirrors the day bucket into the future direction", () => {
+    expect(
+      relativeTimeBucket(
+        ms("2026-03-04T12:00:00Z"),
+        ms("2026-03-01T12:00:00Z"),
+        "UTC",
+      ),
+    ).toEqual({ kind: "days", count: 3, future: true });
+  });
+
+  it("computes calendar days in the supplied timezone", () => {
+    const then = ms("2026-03-01T20:00:00Z");
+    const now = ms("2026-03-03T02:00:00Z");
+    // UTC: Mar 1 → Mar 3 = 2 calendar days.
+    expect(relativeTimeBucket(then, now, "UTC")).toEqual({
+      kind: "days",
+      count: 2,
+      future: false,
+    });
+    // Asia/Shanghai (+8): Mar 2 04:00 → Mar 3 10:00 = 1 calendar day.
+    expect(relativeTimeBucket(then, now, "Asia/Shanghai")).toEqual({
+      kind: "days",
+      count: 1,
+      future: false,
+    });
+  });
+
+  it("keeps an hours label when a ≥24h gap stays on one DST fall-back day", () => {
+    // 2025-11-02 is a 25h day in America/New_York (clocks fall back 02:00→01:00).
+    // 00:30 EDT and 23:30 EST are both Nov 2 there, yet 24h apart in real ms.
+    // Must read "24h", not a contradictory "1d ago" beside a "today" date.
+    const then = ms("2025-11-02T04:30:00Z"); // 00:30 EDT, Nov 2
+    const now = ms("2025-11-03T04:30:00Z"); // 23:30 EST, still Nov 2
+    expect(relativeTimeBucket(then, now, "America/New_York")).toEqual({
+      kind: "hours",
+      count: 24,
+      future: false,
+    });
+  });
+
+  it("returns invalid for non-finite input instead of throwing", () => {
+    const now = ms("2026-03-01T12:00:00Z");
+    expect(relativeTimeBucket(NaN, now, "UTC")).toEqual({ kind: "invalid" });
+    expect(relativeTimeBucket(now, NaN, "UTC")).toEqual({ kind: "invalid" });
+  });
+
+  it("switches from days to calendar months past the day cap", () => {
+    const now = ms("2026-03-31T00:00:00Z");
+    // Exactly 30 calendar days → still days.
+    expect(
+      relativeTimeBucket(ms("2026-03-01T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "days", count: RELATIVE_DAYS_TO_MONTHS, future: false });
+    // 31 calendar days, spanning a month boundary → "1mo".
+    expect(
+      relativeTimeBucket(ms("2026-02-28T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "months", count: 1, future: false });
+  });
+
+  it("counts whole calendar months and rolls into years at 12", () => {
+    const now = ms("2026-06-15T00:00:00Z");
+    // Just under a year stays at 11 months.
+    expect(
+      relativeTimeBucket(ms("2025-06-16T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "months", count: 11, future: false });
+    // Exactly a year → "1y".
+    expect(
+      relativeTimeBucket(ms("2025-06-15T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "years", count: 1, future: false });
+    // Multiple years.
+    expect(
+      relativeTimeBucket(ms("2023-06-15T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "years", count: 3, future: false });
+  });
+
+  it("mirrors months and years into the future direction", () => {
+    const now = ms("2026-06-15T00:00:00Z");
+    expect(
+      relativeTimeBucket(ms("2026-09-15T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "months", count: 3, future: true });
+    expect(
+      relativeTimeBucket(ms("2028-06-15T00:00:00Z"), now, "UTC"),
+    ).toEqual({ kind: "years", count: 2, future: true });
+  });
+});

--- a/packages/core/i18n/relative-time.ts
+++ b/packages/core/i18n/relative-time.ts
@@ -1,0 +1,119 @@
+// Single source of truth for the relative-time gradient ("3h ago" / "in 3h").
+// Pure: no React, no i18n, no DOM — so the views hook (i18n strings) and mobile
+// (English strings) map the SAME bucketing to their own labels instead of
+// drifting copies.
+//
+// The gradient is symmetric: an instant in the past reads "3h ago", an instant
+// in the future reads "in 3h". Direction is carried by `future` on each bucket;
+// `just_now` has no direction (a sub-minute gap either way, which also absorbs
+// clock skew). The magnitude buckets are identical in both directions.
+//
+// Day granularity is CALENDAR-based: two instants on different calendar days
+// read as "1d ago" even when fewer than 24h apart, so the label agrees with the
+// date shown beside it. That makes the day+ bucket timezone-dependent by design
+// (a near-midnight instant can be "today" for one viewer and "1d ago" for
+// another), which is why callers pass the viewer's timezone. The sub-day
+// buckets (minutes/hours) stay elapsed-based and are timezone-independent.
+//
+// There is no absolute-date fallback: past the day cap the gradient continues
+// into calendar months, then calendar years, staying relative indefinitely.
+
+import { calendarPartsInTimeZone } from "../issues/date";
+
+export type RelativeTimeBucket =
+  | { kind: "just_now" }
+  | { kind: "minutes"; count: number; future: boolean }
+  | { kind: "hours"; count: number; future: boolean }
+  | { kind: "days"; count: number; future: boolean }
+  | { kind: "months"; count: number; future: boolean }
+  | { kind: "years"; count: number; future: boolean }
+  // Non-finite input (unparseable date): callers render a neutral placeholder
+  // instead of a blank or a thrown RangeError from the calendar-day math.
+  | { kind: "invalid" };
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+// At more than this many CALENDAR days apart, "Nd" stops being useful and the
+// gradient switches to calendar months.
+export const RELATIVE_DAYS_TO_MONTHS = 30;
+const MONTHS_PER_YEAR = 12;
+
+// The viewer-tz calendar parts of an instant, as returned by
+// calendarPartsInTimeZone: [year, month, day]. Resolving these is the costly
+// Intl op (formatToParts) and is NOT result-cached, so the day+ buckets compute
+// them once per instant and derive both the calendar-day and calendar-month
+// difference from the same tuples rather than re-formatting.
+type CalendarParts = [number, number, number];
+
+// Day number from calendar parts (whole days since the Unix epoch in that
+// zone). Lets us count calendar days between two instants the way a human
+// reading a wall calendar would, instead of dividing elapsed ms.
+function dayNumberFromParts([year, month, day]: CalendarParts): number {
+  return Math.floor(Date.UTC(year, month - 1, day) / DAY);
+}
+
+// Whole calendar months between an earlier and a later instant, counted the way
+// a wall calendar would: a month only counts once the later instant has reached
+// the earlier one's day-of-month. Mirrors the calendar-day logic one level up
+// so "1mo" means "roughly a month" rather than 30 elapsed days. Callers pass
+// earlier→later; direction is applied separately.
+function monthDiffFromParts(
+  [ey, em, ed]: CalendarParts,
+  [ly, lm, ld]: CalendarParts,
+): number {
+  let months = (ly - ey) * 12 + (lm - em);
+  if (ld < ed) months -= 1;
+  return months;
+}
+
+/**
+ * Bucket the gap between two instants into a relative-time label descriptor.
+ * The result is symmetric: `future` is true when `thenMs` is after `nowMs`.
+ *  - non-finite input (unparseable date) → `invalid`
+ *  - sub-minute either direction (incl. clock skew) → `just_now`
+ *  - `< 1h` → `minutes`, `< 24h` → `hours` (elapsed, timezone-independent)
+ *  - `≥ 24h` → calendar-day difference in `timeZone` up to
+ *    `RELATIVE_DAYS_TO_MONTHS`; beyond it → calendar `months`, then `years`.
+ */
+export function relativeTimeBucket(
+  thenMs: number,
+  nowMs: number,
+  timeZone: string,
+): RelativeTimeBucket {
+  if (!Number.isFinite(thenMs) || !Number.isFinite(nowMs)) {
+    return { kind: "invalid" };
+  }
+  const diff = nowMs - thenMs;
+  const elapsed = Math.abs(diff);
+  const future = diff < 0;
+  if (elapsed < MINUTE) return { kind: "just_now" };
+  if (elapsed < HOUR) {
+    return { kind: "minutes", count: Math.floor(elapsed / MINUTE), future };
+  }
+  if (elapsed < DAY) {
+    return { kind: "hours", count: Math.floor(elapsed / HOUR), future };
+  }
+  // Day+ buckets are calendar-based; order the pair earlier→later so the same
+  // arithmetic serves both directions. Resolve each instant's calendar parts
+  // once and derive both the day and month difference from them — formatToParts
+  // is the costly Intl op and this runs per row per render.
+  const earlier = future ? nowMs : thenMs;
+  const later = future ? thenMs : nowMs;
+  const earlierParts = calendarPartsInTimeZone(new Date(earlier), timeZone);
+  const laterParts = calendarPartsInTimeZone(new Date(later), timeZone);
+  const days = dayNumberFromParts(laterParts) - dayNumberFromParts(earlierParts);
+  // On a DST fall-back day (e.g. a 25h day in America/New_York) a ≥24h elapsed
+  // gap can still land on the SAME calendar day → days === 0. The date shown
+  // beside it reads "today", so keep an hours label rather than forcing a
+  // contradictory "1d".
+  if (days === 0) return { kind: "hours", count: Math.floor(elapsed / HOUR), future };
+  if (days <= RELATIVE_DAYS_TO_MONTHS) return { kind: "days", count: days, future };
+  // More than 30 days apart always spans at least one calendar month; clamp to
+  // 1 to guard the rare end-of-month edge where the day-of-month adjustment
+  // would otherwise drop a 31-day gap to 0 months.
+  const months = Math.max(1, monthDiffFromParts(earlierParts, laterParts));
+  if (months < MONTHS_PER_YEAR) return { kind: "months", count: months, future };
+  return { kind: "years", count: Math.floor(months / MONTHS_PER_YEAR), future };
+}

--- a/packages/core/issues/date.test.ts
+++ b/packages/core/issues/date.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   toDateOnly,
-  todayDateOnly,
-  addDaysDateOnly,
   dateOnlyToUTCDate,
   dateOnlyToLocalDate,
   formatDateOnly,
   isPastDateOnly,
+  todayDateOnlyInTimeZone,
+  addDaysDateOnlyInTimeZone,
 } from "./date";
 
 describe("issue date-only helpers", () => {
@@ -57,10 +57,43 @@ describe("issue date-only helpers", () => {
     expect(dateOnlyToLocalDate(null)).toBeUndefined();
   });
 
-  it("detects past calendar days relative to today", () => {
-    expect(isPastDateOnly(addDaysDateOnly(-1))).toBe(true);
-    expect(isPastDateOnly(todayDateOnly())).toBe(false);
-    expect(isPastDateOnly(addDaysDateOnly(1))).toBe(false);
-    expect(isPastDateOnly(null)).toBe(false);
+  it("offsets days from today in the viewer's timezone (calendar-day math)", () => {
+    const tz = "Asia/Shanghai";
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const [ty, tm, td] = todayDateOnlyInTimeZone(tz).split("-").map(Number);
+    const day = (offset: number): string => {
+      const d = new Date(Date.UTC(ty!, tm! - 1, td! + offset));
+      return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+    };
+    expect(addDaysDateOnlyInTimeZone(0, tz)).toBe(day(0));
+    expect(addDaysDateOnlyInTimeZone(1, tz)).toBe(day(1));
+    expect(addDaysDateOnlyInTimeZone(7, tz)).toBe(day(7));
+    expect(addDaysDateOnlyInTimeZone(-6, tz)).toBe(day(-6));
+    // An unknown timezone falls back to UTC instead of throwing.
+    expect(() => addDaysDateOnlyInTimeZone(1, "Not/AZone")).not.toThrow();
+  });
+
+  it("detects past calendar days relative to today in the viewer's timezone", () => {
+    const tz = "Asia/Shanghai";
+    const pad = (n: number) => String(n).padStart(2, "0");
+    // Anchor on "today" in the viewer's tz, then walk the calendar.
+    const [ty, tm, td] = todayDateOnlyInTimeZone(tz).split("-").map(Number);
+    const day = (offset: number): string => {
+      const d = new Date(Date.UTC(ty!, tm! - 1, td! + offset));
+      return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+    };
+    expect(isPastDateOnly(day(-1), tz)).toBe(true);
+    expect(isPastDateOnly(day(0), tz)).toBe(false);
+    expect(isPastDateOnly(day(1), tz)).toBe(false);
+    expect(isPastDateOnly(null, tz)).toBe(false);
+  });
+
+  it("anchors today in the requested timezone", () => {
+    expect(todayDateOnlyInTimeZone("UTC")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // An unknown timezone falls back to UTC instead of throwing.
+    expect(() => todayDateOnlyInTimeZone("Not/AZone")).not.toThrow();
+    expect(todayDateOnlyInTimeZone("Not/AZone")).toBe(
+      todayDateOnlyInTimeZone("UTC"),
+    );
   });
 });

--- a/packages/core/issues/date.ts
+++ b/packages/core/issues/date.ts
@@ -8,6 +8,8 @@
 //
 // Pure functions only (no React / DOM) so they can be shared with mobile.
 
+import { safeDateTimeFormat } from "../i18n/format-date-time";
+
 const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})/;
 
 function pad(n: number): string {
@@ -21,18 +23,6 @@ function pad(n: number): string {
  */
 export function toDateOnly(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-}
-
-/** Today as a "YYYY-MM-DD" string in the viewer's local calendar. */
-export function todayDateOnly(): string {
-  return toDateOnly(new Date());
-}
-
-/** "YYYY-MM-DD" of `days` from today in the viewer's local calendar. */
-export function addDaysDateOnly(days: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() + days);
-  return toDateOnly(d);
 }
 
 /**
@@ -88,10 +78,67 @@ export function formatDateOnly(
   return d.toLocaleDateString(locale, { ...options, timeZone: "UTC" });
 }
 
-/** True when the calendar day is strictly before today (viewer's local day). */
-export function isPastDateOnly(value: string | null | undefined): boolean {
+/**
+ * An instant's calendar [year, month, day] in an IANA timezone. Falls back to
+ * UTC for a stale/ICU-unsupported timezone (must not throw). Single source for
+ * "what calendar day is this instant in tz X" — both overdue judgment and the
+ * relative-time day bucket build on it so they never derive "today" differently.
+ * Reuses safeDateTimeFormat's cache + UTC fallback so this path can never drift
+ * from the instant formatters' handling of a bad zone.
+ */
+export function calendarPartsInTimeZone(
+  date: Date,
+  timeZone: string,
+): [number, number, number] {
+  const parts = safeDateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value);
+  return [get("year"), get("month"), get("day")];
+}
+
+/**
+ * Today as a "YYYY-MM-DD" string in the given IANA timezone. Falls back to UTC
+ * if the timezone is unknown (a stale/ICU-unsupported value must not throw).
+ */
+export function todayDateOnlyInTimeZone(timeZone: string): string {
+  const [y, m, d] = calendarPartsInTimeZone(new Date(), timeZone);
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
+/**
+ * "YYYY-MM-DD" of `days` from today (negative = past) in the given IANA
+ * timezone. Anchors on today-in-tz, then shifts by whole UTC days so a DST
+ * transition never nudges the result onto a neighbouring day. Falls back to
+ * UTC for a stale/ICU-unsupported timezone (must not throw). Use instead of a
+ * browser-local "today" so a "due today / next week" preset agrees with the
+ * Viewing-tz overdue judgment (`isPastDateOnly`).
+ */
+export function addDaysDateOnlyInTimeZone(
+  days: number,
+  timeZone: string,
+): string {
+  const [y, m, d] = calendarPartsInTimeZone(new Date(), timeZone);
+  const shifted = new Date(Date.UTC(y, m - 1, d) + days * 86_400_000);
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`;
+}
+
+/**
+ * True when the calendar day is strictly before today, where "today" is the
+ * calendar day in the viewer's Viewing timezone — so the overdue badge agrees
+ * with the due date the viewer sees on screen. See
+ * docs/timezone-display-spec.md §4.
+ */
+export function isPastDateOnly(
+  value: string | null | undefined,
+  timeZone: string,
+): boolean {
   const d = dateOnlyToUTCDate(value);
   if (!d) return false;
-  const today = dateOnlyToUTCDate(todayDateOnly());
+  const today = dateOnlyToUTCDate(todayDateOnlyInTimeZone(timeZone));
   return today != null && d.getTime() < today.getTime();
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,6 +105,8 @@
     "./i18n": "./i18n/index.ts",
     "./i18n/react": "./i18n/react.ts",
     "./i18n/browser": "./i18n/browser.ts",
+    "./i18n/format-date-time": "./i18n/format-date-time.ts",
+    "./i18n/relative-time": "./i18n/relative-time.ts",
     "./skills": "./skills/index.ts",
     "./skills/frontmatter": "./skills/frontmatter.ts",
     "./skills/stores": "./skills/stores/index.ts",

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -20,7 +20,7 @@ import {
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { isImeComposing } from "@multica/core/utils";
-import { useTimeAgo } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 import { Button } from "@multica/ui/components/ui/button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Input } from "@multica/ui/components/ui/input";
@@ -101,7 +101,6 @@ export function AgentDetailInspector({
   onShowIntegrations,
 }: InspectorProps) {
   const { t } = useT("agents");
-  const timeAgo = useTimeAgo();
   const update = (data: Record<string, unknown>) => onUpdate(agent.id, data);
   const isOnline = runtime?.status === "online";
 
@@ -180,14 +179,10 @@ export function AgentDetailInspector({
           </PropRow>
         )}
         <PropRow label={t(($) => $.inspector.prop_created)} interactive={false}>
-          <span className="text-muted-foreground">
-            {timeAgo(agent.created_at)}
-          </span>
+          <DateTime value={agent.created_at} variant="relative" className="text-muted-foreground" />
         </PropRow>
         <PropRow label={t(($) => $.inspector.prop_updated)} interactive={false}>
-          <span className="text-muted-foreground">
-            {timeAgo(agent.updated_at)}
-          </span>
+          <DateTime value={agent.updated_at} variant="relative" className="text-muted-foreground" />
         </PropRow>
       </Section>
 

--- a/packages/views/agents/components/agent-live-peek-card.test.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.test.tsx
@@ -28,6 +28,22 @@ vi.mock("@multica/core/api", () => ({
   },
 }));
 
+// The card's relative "last activity" time renders <DateTime>, which reads the
+// viewer's tz from the auth store. Provide a callable store (selector +
+// getState) with a fixed tz so useViewingTimezone resolves outside a real auth
+// context.
+const userRef = vi.hoisted(
+  () => ({ current: { timezone: "UTC" } as { timezone?: string | null } }),
+);
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: typeof userRef.current };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user: userRef.current }),
+    { getState: () => ({ user: userRef.current }) },
+  );
+  return { useAuthStore };
+});
+
 // AppLink is just a plain anchor here — wiring the navigation adapter would
 // add nothing to these assertions.
 vi.mock("../../navigation", () => ({

--- a/packages/views/agents/components/agent-live-peek-card.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.tsx
@@ -15,7 +15,8 @@ import { issueDetailOptions } from "@multica/core/issues";
 import type { AgentTask } from "@multica/core/types";
 import { AlertTriangle } from "lucide-react";
 import { AppLink } from "../../navigation";
-import { useT, useTimeAgo } from "../../i18n";
+import { useT } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 import { availabilityConfig, workloadConfig } from "../presence";
 
 interface AgentLivePeekCardProps {
@@ -215,13 +216,12 @@ function LastActivityRow({
   emptyLabel: string;
   failedLabel: string;
 }) {
-  const timeAgo = useTimeAgo();
   return (
     <div className="flex items-center gap-1.5">
       <span className="w-16 shrink-0 text-muted-foreground">{label}</span>
       {task && task.completed_at ? (
         <span className="inline-flex min-w-0 items-center gap-1 truncate">
-          <span className="truncate">{timeAgo(task.completed_at)}</span>
+          <DateTime value={task.completed_at} variant="relative" className="truncate" />
           {task.status === "failed" && (
             // Failed terminal state shows here only — workload above stays a
             // clean "what's on the plate now" reading (working/queued/idle),

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -74,6 +74,7 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { useNavigation, useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { DateTime } from "../../common/date-time";
 import { PageHeader } from "../../layout/page-header";
 import { availabilityConfig } from "../presence";
 import { CreateAgentDialog } from "./create-agent-dialog";
@@ -1172,9 +1173,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
                       )}
                       {isColVisible("created") ? (
                         <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-                          {new Date(
-                            row.agent.created_at,
-                          ).toLocaleDateString()}
+                          <DateTime value={row.agent.created_at} variant="relative" />
                         </ListGridCell>
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -40,6 +40,7 @@ import { taskStatusConfig } from "../../config";
 import { failureReasonLabel } from "./task-failure";
 import { Sparkline } from "../sparkline";
 import { useT, useTimeAgo } from "../../../i18n";
+import { InstantTooltip } from "../../../common/instant-tooltip";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 // Recent work pagination: small initial cohort to keep the section
@@ -416,12 +417,15 @@ function TaskRow({
         ? t(($) => $.tab_body.activity.source_autopilot)
         : t(($) => $.tab_body.activity.source_untracked);
 
-  const timeText =
-    timeMode === "active"
-      ? activeTaskTimeText(task, t, timeAgo)
-      : task.completed_at
-        ? timeAgo(task.completed_at)
-        : "—";
+  // One switch picks both the instant and its phrase key, so the visible text
+  // and its tooltip (full time + offset) can never point at different instants.
+  const activeTime = timeMode === "active" ? activeTaskTime(task) : null;
+  const timeText = activeTime
+    ? t(($) => $.tab_body.activity[activeTime.key], { when: timeAgo(activeTime.at) })
+    : task.completed_at
+      ? timeAgo(task.completed_at)
+      : "—";
+  const timeValue = activeTime ? activeTime.at : task.completed_at;
 
   // Failure reason. The back-end emits "" on non-failed tasks (omitempty
   // strips it on the wire) so the truthy guard is the right shape; the
@@ -500,7 +504,7 @@ function TaskRow({
           )}
         </div>
         <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-          <span>{timeText}</span>
+          <InstantTooltip value={timeValue}>{timeText}</InstantTooltip>
           {durationText && (
             <>
               <Sep />
@@ -599,17 +603,20 @@ function Sep() {
   return <span className="mx-1 text-muted-foreground/40">·</span>;
 }
 
-type AgentsT = ReturnType<typeof useT<"agents">>["t"];
-type TimeAgoFn = (dateStr: string) => string;
-
-function activeTaskTimeText(task: AgentTask, t: AgentsT, timeAgo: TimeAgoFn): string {
+// The instant an active row's time refers to, paired with its i18n phrase key.
+// Single source for both the visible "Started 2m ago" text and the tooltip's
+// exact instant — one branch set, so they cannot drift apart.
+function activeTaskTime(task: AgentTask): {
+  at: string;
+  key: "started_prefix" | "dispatched_prefix" | "queued_prefix";
+} {
   if (task.status === "running" && task.started_at) {
-    return t(($) => $.tab_body.activity.started_prefix, { when: timeAgo(task.started_at) });
+    return { at: task.started_at, key: "started_prefix" };
   }
   if (task.status === "dispatched" && task.dispatched_at) {
-    return t(($) => $.tab_body.activity.dispatched_prefix, { when: timeAgo(task.dispatched_at) });
+    return { at: task.dispatched_at, key: "dispatched_prefix" };
   }
-  return t(($) => $.tab_body.activity.queued_prefix, { when: timeAgo(task.created_at) });
+  return { at: task.created_at, key: "queued_prefix" };
 }
 
 /**

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -65,16 +65,10 @@ import { AutopilotDialog } from "./autopilot-dialog";
 import { WebhookPayloadPreview } from "./webhook-payload-preview";
 import { WebhookDeliveriesSection } from "./webhook-deliveries-section";
 import { ProjectIcon } from "../../projects/components/project-icon";
+import { formatInstantWithOffset } from "@multica/core/i18n/format-date-time";
+import { useViewingTimezone } from "../../common/use-viewing-timezone";
+import { DateTime } from "../../common/date-time";
 import { useT } from "../../i18n";
-
-function formatDate(date: string): string {
-  return new Date(date).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 type RunStatus = "issue_created" | "running" | "skipped" | "completed" | "failed";
 
@@ -153,9 +147,11 @@ function RunRow({ run, agentId, agentName }: { run: AutopilotRun; agentId: strin
           <span className="text-destructive">{run.failure_reason}</span>
         ) : null}
       </span>
-      <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-        {formatDate(run.triggered_at || run.created_at)}
-      </span>
+      <DateTime
+        value={run.triggered_at || run.created_at}
+        variant="datetime"
+        className="w-44 shrink-0 truncate text-right text-xs text-muted-foreground tabular-nums"
+      />
       {syntheticTask && !run.issue_id && (
         <TranscriptButton
           task={syntheticTask}
@@ -240,9 +236,11 @@ function SkippedRunsGroup({
           {t(($) => $.run.skipped_group.summary, { count: runs.length })}
         </span>
         {latestRun && (
-          <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-            {formatDate(latestRun.triggered_at || latestRun.created_at)}
-          </span>
+          <DateTime
+            value={latestRun.triggered_at || latestRun.created_at}
+            variant="datetime"
+            className="w-44 shrink-0 truncate text-right text-xs text-muted-foreground tabular-nums"
+          />
         )}
       </button>
       {open && (
@@ -257,7 +255,8 @@ function SkippedRunsGroup({
 }
 
 function TriggerRow({ trigger, autopilotId }: { trigger: AutopilotTrigger; autopilotId: string }) {
-  const { t } = useT("autopilots");
+  const { t, i18n } = useT("autopilots");
+  const viewTz = useViewingTimezone();
   const deleteTrigger = useDeleteAutopilotTrigger();
   const rotateToken = useRotateAutopilotTriggerWebhookToken();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -369,7 +368,12 @@ function TriggerRow({ trigger, autopilotId }: { trigger: AutopilotTrigger; autop
         )}
         {trigger.next_run_at && (
           <div className="text-xs text-muted-foreground">
-            {t(($) => $.trigger_row.next_label, { date: formatDate(trigger.next_run_at) })}
+            {t(($) => $.trigger_row.next_label, {
+              date: formatInstantWithOffset(trigger.next_run_at, {
+                locale: i18n.language || "en",
+                timeZone: trigger.timezone || viewTz,
+              }),
+            })}
           </div>
         )}
         {showWebhookUrlRow && (

--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -48,6 +48,7 @@ import {
   useUpdateAutopilotTrigger,
 } from "@multica/core/autopilots/mutations";
 import { buildAutopilotWebhookUrl } from "@multica/core/autopilots";
+import { safeDateTimeFormat } from "@multica/core/i18n/format-date-time";
 import { api } from "@multica/core/api";
 import type {
   AutopilotAssigneeType,
@@ -61,6 +62,7 @@ import { ProjectIcon } from "../../projects/components/project-icon";
 import { AgentPicker, type AssigneeSelection } from "./pickers/agent-picker";
 import { SubscriberMultiSelect } from "./subscriber-multi-select";
 import {
+  computeNextRun,
   getDefaultTriggerConfig,
   getLocalTimezone,
   parseCronExpression,
@@ -155,50 +157,9 @@ const OUTPUT_MODE_ICONS: Record<AutopilotExecutionMode, typeof FilePlus2> = {
 };
 
 // ---------------------------------------------------------------------------
-// Next-run computation (local approximation — server stores the authoritative value)
+// Next-run preview helpers (computeNextRun lives in trigger-config so it is
+// unit-tested and shares the schedule-domain types)
 // ---------------------------------------------------------------------------
-
-function computeNextRun(cfg: TriggerConfig, now: Date): Date | null {
-  const [hStr, mStr] = cfg.time.split(":");
-  const hour = parseInt(hStr ?? "9", 10);
-  const minute = parseInt(mStr ?? "0", 10);
-  const next = new Date(now);
-
-  switch (cfg.frequency) {
-    case "hourly": {
-      next.setMinutes(minute, 0, 0);
-      if (next <= now) next.setHours(next.getHours() + 1);
-      return next;
-    }
-    case "daily": {
-      next.setHours(hour, minute, 0, 0);
-      if (next <= now) next.setDate(next.getDate() + 1);
-      return next;
-    }
-    case "weekdays": {
-      next.setHours(hour, minute, 0, 0);
-      for (let i = 0; i < 8; i++) {
-        const dow = next.getDay();
-        if (next > now && dow >= 1 && dow <= 5) return next;
-        next.setDate(next.getDate() + 1);
-        next.setHours(hour, minute, 0, 0);
-      }
-      return null;
-    }
-    case "weekly": {
-      if (cfg.daysOfWeek.length === 0) return null;
-      next.setHours(hour, minute, 0, 0);
-      for (let i = 0; i < 8; i++) {
-        if (next > now && cfg.daysOfWeek.includes(next.getDay())) return next;
-        next.setDate(next.getDate() + 1);
-        next.setHours(hour, minute, 0, 0);
-      }
-      return null;
-    }
-    case "custom":
-      return null;
-  }
-}
 
 function useFormatCountdown(): (target: Date, now: Date) => string {
   const { t } = useT("autopilots");
@@ -215,20 +176,24 @@ function useFormatCountdown(): (target: Date, now: Date) => string {
   };
 }
 
-function formatNextRunAbsolute(date: Date, timezone: string): string {
-  try {
-    return new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    }).format(date);
-  } catch {
-    return date.toLocaleString();
-  }
+function formatNextRunAbsolute(
+  date: Date,
+  timezone: string,
+  locale: string,
+): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  };
+  // safeDateTimeFormat caches the formatter (this renders every ticker tick
+  // while the dialog is open) and falls back to UTC on an invalid/stale trigger
+  // timezone — deterministic, still on the scheduling axis, never the viewer's
+  // browser tz, which would misstate the scheduled wall-clock time.
+  return safeDateTimeFormat(locale, { ...opts, timeZone: timezone }).format(date);
 }
 
 // ---------------------------------------------------------------------------
@@ -923,7 +888,7 @@ function ScheduleSection({
   disabled?: boolean;
   disabledReason?: string;
 }) {
-  const { t } = useT("autopilots");
+  const { t, i18n } = useT("autopilots");
   const formatCountdown = useFormatCountdown();
   const now = useNowTicker();
   const next = useMemo(() => computeNextRun(config, now), [config, now]);
@@ -1024,7 +989,7 @@ function ScheduleSection({
             <span className="truncate">
               {t(($) => $.dialog.next_run_label)}{" "}
               <span className="text-foreground">
-                {formatNextRunAbsolute(next, config.timezone)}
+                {formatNextRunAbsolute(next, config.timezone, i18n.language || "en")}
               </span>
             </span>
             <span className="ml-auto rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-foreground shrink-0">

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -30,6 +30,7 @@ import {
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { formatInstantWithOffset } from "@multica/core/i18n/format-date-time";
 import type { Autopilot } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
@@ -46,6 +47,8 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { DateTime } from "../../common/date-time";
+import { HoverTooltip } from "../../common/instant-tooltip";
 import { PageHeader } from "../../layout/page-header";
 import { AutopilotDialog } from "./autopilot-dialog";
 import { AutopilotListToolbar, actorFilterValue } from "./autopilot-list-toolbar";
@@ -337,7 +340,6 @@ function runStatusDotClass(status: string | null | undefined): string {
 
 function LastRunCell({ autopilot }: { autopilot: Autopilot }) {
   const { t } = useT("autopilots");
-  const timeAgo = useTimeAgo();
   if (!autopilot.last_run_at) {
     return (
       <ListGridCell className="hidden @2xl:flex">
@@ -360,26 +362,41 @@ function LastRunCell({ autopilot }: { autopilot: Autopilot }) {
         title={knownStatus ? t(($) => $.run_status[knownStatus]) : status ?? undefined}
         className={`size-1.5 shrink-0 rounded-full ${runStatusDotClass(status)}`}
       />
-      <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
-        {timeAgo(autopilot.last_run_at)}
-      </span>
+      <DateTime
+        value={autopilot.last_run_at}
+        variant="relative"
+        className="whitespace-nowrap text-xs tabular-nums text-muted-foreground"
+      />
     </ListGridCell>
   );
 }
 
 function NextRunCell({ autopilot }: { autopilot: Autopilot }) {
+  const { i18n } = useT("autopilots");
+  const timeAgo = useTimeAgo();
   const next = autopilot.next_run_at;
   return (
     <ListGridCell className="hidden @2xl:flex">
       {next ? (
-        <span className="whitespace-nowrap text-xs tabular-nums text-muted-foreground">
-          {new Date(next).toLocaleString(undefined, {
-            month: "short",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </span>
+        // Relative time ("in 3h") is timezone-agnostic, so it sidesteps the
+        // list endpoint omitting the trigger timezone: the list's derived
+        // next_run_at is a bare UTC instant, and rendering an absolute wall
+        // clock for it would either misstate the scheduling-axis time (viewer
+        // tz) or read as the meaningless server-process offset. The hover
+        // tooltip keeps the exact instant as UTC + GMT offset — unambiguous and
+        // not mistaken for local time. The detail page, which has the trigger,
+        // shows the absolute time in the trigger timezone.
+        <HoverTooltip
+          className="whitespace-nowrap text-xs tabular-nums text-muted-foreground"
+          content={() =>
+            formatInstantWithOffset(next, {
+              locale: i18n.language || "en",
+              timeZone: "UTC",
+            })
+          }
+        >
+          {timeAgo(next)}
+        </HoverTooltip>
       ) : (
         <span className="text-xs text-muted-foreground/40">—</span>
       )}
@@ -945,7 +962,7 @@ export function AutopilotsPage() {
                       )}
                       {isColVisible("created") ? (
                         <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-                          {new Date(autopilot.created_at).toLocaleDateString()}
+                          <DateTime value={autopilot.created_at} variant="relative" />
                         </ListGridCell>
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -374,11 +374,14 @@ function LastRunCell({ autopilot }: { autopilot: Autopilot }) {
   );
 }
 
-function NextRunCell({ autopilot }: { autopilot: Autopilot }) {
+export function NextRunCell({ autopilot }: { autopilot: Autopilot }) {
   const { t, i18n } = useT("autopilots");
-  // next_run_at is always a scheduled future instant, so render imminent runs
-  // as "soon" rather than the direction-less "just now".
-  const timeAgo = useTimeAgo({ soonForFuture: true });
+  // next_run_at is a scheduled instant; `scheduled` renders imminent runs as
+  // "soon" — both a sub-minute-away future and an overdue slot the scheduler
+  // hasn't advanced yet. A still-past next_run_at would otherwise read "Xm ago",
+  // misreading an about-to-fire run as a previous one; the in-flight run shows
+  // in the Last run column, so this column stays purely about scheduling.
+  const timeAgo = useTimeAgo({ scheduled: true });
   const next = autopilot.next_run_at;
   // A paused autopilot won't fire, so any computed next_run_at is moot — surface
   // the paused state here instead of a misleading countdown. Mirror the amber

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -250,11 +250,14 @@ function NameCell({ autopilot }: { autopilot: Autopilot }) {
         {autopilot.title}
       </span>
       {/* Paused marker: in the "all" scope active and paused rows mix, so a
-          paused automation needs an inline signal. */}
+          paused automation needs an inline signal. Hidden at @2xl, where the
+          Next-run column shows an explicit "Paused" — keeping it only below the
+          breakpoint avoids duplicating the signal while preserving it on narrow
+          layouts (the Next-run column is hidden there). */}
       {autopilot.status === "paused" && (
         <span
           title={t(($) => $.status.paused)}
-          className="flex shrink-0 items-center text-amber-500"
+          className="flex shrink-0 items-center text-amber-500 @2xl:hidden"
         >
           <Pause className="size-3" />
         </span>
@@ -372,9 +375,24 @@ function LastRunCell({ autopilot }: { autopilot: Autopilot }) {
 }
 
 function NextRunCell({ autopilot }: { autopilot: Autopilot }) {
-  const { i18n } = useT("autopilots");
-  const timeAgo = useTimeAgo();
+  const { t, i18n } = useT("autopilots");
+  // next_run_at is always a scheduled future instant, so render imminent runs
+  // as "soon" rather than the direction-less "just now".
+  const timeAgo = useTimeAgo({ soonForFuture: true });
   const next = autopilot.next_run_at;
+  // A paused autopilot won't fire, so any computed next_run_at is moot — surface
+  // the paused state here instead of a misleading countdown. Mirror the amber
+  // Pause marker used beside the name.
+  if (autopilot.status === "paused") {
+    return (
+      <ListGridCell className="hidden gap-1.5 @2xl:flex">
+        <Pause className="size-3 shrink-0 text-amber-500" />
+        <span className="text-xs text-muted-foreground">
+          {t(($) => $.status.paused)}
+        </span>
+      </ListGridCell>
+    );
+  }
   return (
     <ListGridCell className="hidden @2xl:flex">
       {next ? (

--- a/packages/views/autopilots/components/next-run-cell.test.tsx
+++ b/packages/views/autopilots/components/next-run-cell.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithI18n } from "../../test/i18n";
+import type { Autopilot } from "@multica/core/types";
+
+// The cell renders relative time via useViewingTimezone → useAuthStore; pin the
+// viewer to UTC so next_run_at offsets read deterministically.
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: { timezone?: string | null } };
+  const user = { timezone: "UTC" };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user }),
+    { getState: () => ({ user }) },
+  );
+  return { useAuthStore };
+});
+
+import { NextRunCell } from "./autopilots-page";
+
+// Pin "now" so next_run_at offsets are deterministic across the future/overdue
+// boundary the cell branches on.
+const NOW = "2026-06-26T12:00:00Z";
+
+const autopilot = (overrides: Partial<Autopilot> = {}): Autopilot => ({
+  id: "ap-1",
+  workspace_id: "ws-1",
+  title: "Daily digest",
+  description: null,
+  assignee_type: "agent",
+  assignee_id: "agent-1",
+  status: "active",
+  execution_mode: "create_issue",
+  issue_title_template: null,
+  created_by_type: "user",
+  created_by_id: "user-1",
+  last_run_at: null,
+  created_at: NOW,
+  updated_at: NOW,
+  ...overrides,
+});
+
+describe("NextRunCell", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function freezeNow() {
+    // Fake only Date so React/i18next scheduling keeps real timers.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+  }
+
+  it("renders relative time for a genuinely future next run", () => {
+    freezeNow();
+    renderWithI18n(
+      <NextRunCell autopilot={autopilot({ next_run_at: "2026-06-26T15:00:00Z" })} />,
+    );
+    expect(screen.getByText("in 3h")).toBeTruthy();
+  });
+
+  it("shows 'soon' for an overdue slot the scheduler hasn't picked up yet", () => {
+    freezeNow();
+    // The slot fired a minute ago but next_run_at hasn't rolled forward — an
+    // imminent run, not a past one, so relative "Xm ago" would mislead.
+    renderWithI18n(
+      <NextRunCell
+        autopilot={autopilot({
+          next_run_at: "2026-06-26T11:59:00Z",
+          last_run_status: "completed",
+        })}
+      />,
+    );
+    expect(screen.getByText("soon")).toBeTruthy();
+  });
+
+  it("shows 'Paused' instead of a countdown for paused autopilots", () => {
+    freezeNow();
+    renderWithI18n(
+      <NextRunCell
+        autopilot={autopilot({
+          status: "paused",
+          next_run_at: "2026-06-26T15:00:00Z",
+        })}
+      />,
+    );
+    expect(screen.getByText("Paused")).toBeTruthy();
+  });
+
+  it("renders a dash when no next run is scheduled", () => {
+    freezeNow();
+    renderWithI18n(<NextRunCell autopilot={autopilot({ next_run_at: null })} />);
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/packages/views/autopilots/components/pickers/timezone-picker.tsx
+++ b/packages/views/autopilots/components/pickers/timezone-picker.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Check, ChevronDown, Globe } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { shortOffsetToken } from "@multica/core/i18n/format-date-time";
 import {
   PropertyPicker,
   PickerEmpty,
@@ -17,16 +18,9 @@ export interface TimezonePickerProps {
   className?: string;
 }
 
+// Scheduling axis: a fixed locale (the offset token is locale-independent).
 function offsetFor(tz: string): string {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      timeZoneName: "shortOffset",
-    }).formatToParts(new Date());
-    return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
-  } catch {
-    return "";
-  }
+  return shortOffsetToken(new Date(), "en-US", tz);
 }
 
 function cityLabel(tz: string): string {

--- a/packages/views/autopilots/components/trigger-config.test.ts
+++ b/packages/views/autopilots/components/trigger-config.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  computeNextRun,
   parseCronExpression,
   toCronExpression,
   getDefaultTriggerConfig,
+  type TriggerConfig,
 } from "./trigger-config";
 
 describe("parseCronExpression", () => {
@@ -64,5 +66,75 @@ describe("parseCronExpression", () => {
     expect(parsed.frequency).toBe("weekly");
     expect(parsed.time).toBe("14:45");
     expect(parsed.daysOfWeek).toEqual([0, 2, 6]);
+  });
+});
+
+// The configured time is wall-clock in cfg.timezone, never the host/browser
+// zone. Every case asserts the resulting INSTANT (toISOString) so it is
+// independent of where the test runs — exactly the property the old
+// browser-local computeNextRun violated (it read 09:00 as 09:00 host-local).
+describe("computeNextRun", () => {
+  const base = (over: Partial<TriggerConfig>): TriggerConfig => ({
+    ...getDefaultTriggerConfig(),
+    ...over,
+  });
+
+  it("daily resolves the time in the schedule timezone (DST, GMT-4)", () => {
+    // now = 2026-06-26 11:11 in Asia/Shanghai = 2026-06-25 23:11 EDT.
+    const now = new Date("2026-06-26T03:11:00Z");
+    const cfg = base({ frequency: "daily", time: "09:00", timezone: "America/New_York" });
+    // Next 09:00 EDT (UTC-4) = 13:00Z, NOT 09:00 host-local.
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-06-26T13:00:00.000Z");
+  });
+
+  it("daily resolves the time in a positive-offset zone", () => {
+    // 11:11 CST is past 09:00, so it rolls to the next day.
+    const now = new Date("2026-06-26T03:11:00Z");
+    const cfg = base({ frequency: "daily", time: "09:00", timezone: "Asia/Shanghai" });
+    // 2026-06-27 09:00 CST (UTC+8) = 2026-06-27T01:00:00Z.
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-06-27T01:00:00.000Z");
+  });
+
+  it("daily uses standard offset in winter (GMT-5)", () => {
+    const now = new Date("2026-01-15T20:00:00Z"); // 15:00 EST
+    const cfg = base({ frequency: "daily", time: "09:00", timezone: "America/New_York" });
+    // Next 09:00 EST (UTC-5) = 14:00Z — proves the offset tracks the season.
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-01-16T14:00:00.000Z");
+  });
+
+  it("daily rolls forward when today's time already passed in UTC", () => {
+    const now = new Date("2026-06-26T10:00:00Z");
+    const cfg = base({ frequency: "daily", time: "09:00", timezone: "UTC" });
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-06-27T09:00:00.000Z");
+  });
+
+  it("hourly fires at the configured minute in UTC", () => {
+    const now = new Date("2026-06-26T10:20:00Z");
+    const cfg = base({ frequency: "hourly", time: "00:15", timezone: "UTC" });
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-06-26T11:15:00.000Z");
+  });
+
+  it("weekdays skips the weekend in the schedule timezone", () => {
+    const now = new Date("2026-06-27T12:00:00Z"); // Saturday
+    const cfg = base({ frequency: "weekdays", time: "09:00", timezone: "UTC" });
+    // Next weekday is Monday 2026-06-29.
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-06-29T09:00:00.000Z");
+  });
+
+  it("weekly lands on the configured day in the schedule timezone", () => {
+    const now = new Date("2026-06-26T00:00:00Z"); // Friday
+    const cfg = base({ frequency: "weekly", time: "14:00", daysOfWeek: [3], timezone: "UTC" });
+    // Next Wednesday is 2026-07-01.
+    expect(computeNextRun(cfg, now)?.toISOString()).toBe("2026-07-01T14:00:00.000Z");
+  });
+
+  it("returns null for custom cron (server computes it)", () => {
+    const cfg = base({ frequency: "custom", timezone: "UTC" });
+    expect(computeNextRun(cfg, new Date("2026-06-26T00:00:00Z"))).toBeNull();
+  });
+
+  it("returns null for weekly with no days selected", () => {
+    const cfg = base({ frequency: "weekly", daysOfWeek: [], timezone: "UTC" });
+    expect(computeNextRun(cfg, new Date("2026-06-26T00:00:00Z"))).toBeNull();
   });
 });

--- a/packages/views/autopilots/components/trigger-config.tsx
+++ b/packages/views/autopilots/components/trigger-config.tsx
@@ -9,6 +9,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@multica/ui/components/ui/select";
+import { shortOffsetToken } from "@multica/core/i18n/format-date-time";
 import { useT } from "../../i18n";
 
 export type TriggerFrequency = "hourly" | "daily" | "weekdays" | "weekly" | "custom";
@@ -70,15 +71,9 @@ export function getLocalTimezone(): string {
 
 function getTimezoneOffset(tz: string): string {
   if (tz === "UTC") return "UTC";
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      timeZoneName: "shortOffset",
-    }).formatToParts(new Date());
-    return parts.find((p) => p.type === "timeZoneName")?.value ?? tz;
-  } catch {
-    return tz;
-  }
+  // Scheduling axis: a fixed locale (the offset token is locale-independent).
+  // Falls back to the raw tz name when the engine yields no offset token.
+  return shortOffsetToken(new Date(), "en-US", tz) || tz;
 }
 
 function getTimezoneLabel(tz: string): string {
@@ -166,6 +161,108 @@ export function parseCronExpression(cron: string, timezone: string): TriggerConf
     return { ...base, frequency: "weekly", time, daysOfWeek: days };
   }
   return { ...base, frequency: "custom" };
+}
+
+// ---------------------------------------------------------------------------
+// Next-run preview (local approximation — the server stores the authoritative
+// next_run_at). The configured time is wall-clock in cfg.timezone, so the
+// search runs on the calendar in that zone and the result is converted back to
+// an absolute instant. Computing this with the host clock (setHours/getDay)
+// would read 09:00 as the browser's 09:00, misstating the run by the
+// host↔schedule offset.
+// ---------------------------------------------------------------------------
+
+// Offset (wall − UTC, in ms) of `timeZone` at the given instant. Returns 0 for
+// an unknown zone so the preview degrades to UTC instead of throwing.
+function zoneOffsetMs(utcMs: number, timeZone: string): number {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(new Date(utcMs));
+    const f: Record<string, number> = {};
+    for (const p of parts) if (p.type !== "literal") f[p.type] = parseInt(p.value, 10);
+    const asUTC = Date.UTC(
+      f.year!,
+      f.month! - 1,
+      f.day!,
+      f.hour! % 24,
+      f.minute!,
+      f.second!,
+    );
+    return asUTC - utcMs;
+  } catch {
+    return 0;
+  }
+}
+
+// A Date whose UTC fields read as the wall clock in `timeZone` at `now`, so the
+// calendar search below can use getUTC*/setUTC* for tz-local arithmetic.
+function zonedCarrier(now: Date, timeZone: string): Date {
+  return new Date(now.getTime() + zoneOffsetMs(now.getTime(), timeZone));
+}
+
+// Convert a wall-clock carrier (UTC fields = wall time in `timeZone`) back to
+// the real instant. Re-checks the offset once so a DST transition between the
+// approximate and final instant is corrected.
+function carrierToInstant(carrier: Date, timeZone: string): Date {
+  const wallAsUTC = carrier.getTime();
+  const offset = zoneOffsetMs(wallAsUTC, timeZone);
+  const instant = wallAsUTC - offset;
+  const refined = zoneOffsetMs(instant, timeZone);
+  return new Date(refined === offset ? instant : wallAsUTC - refined);
+}
+
+export function computeNextRun(cfg: TriggerConfig, now: Date): Date | null {
+  const [hStr, mStr] = cfg.time.split(":");
+  const hour = parseInt(hStr ?? "9", 10);
+  const minute = parseInt(mStr ?? "0", 10);
+  const tz = cfg.timezone || "UTC";
+  const nowZoned = zonedCarrier(now, tz);
+  const next = new Date(nowZoned);
+
+  switch (cfg.frequency) {
+    case "hourly": {
+      next.setUTCMinutes(minute, 0, 0);
+      if (next <= nowZoned) next.setUTCHours(next.getUTCHours() + 1);
+      return carrierToInstant(next, tz);
+    }
+    case "daily": {
+      next.setUTCHours(hour, minute, 0, 0);
+      if (next <= nowZoned) next.setUTCDate(next.getUTCDate() + 1);
+      return carrierToInstant(next, tz);
+    }
+    case "weekdays": {
+      next.setUTCHours(hour, minute, 0, 0);
+      for (let i = 0; i < 8; i++) {
+        const dow = next.getUTCDay();
+        if (next > nowZoned && dow >= 1 && dow <= 5) return carrierToInstant(next, tz);
+        next.setUTCDate(next.getUTCDate() + 1);
+        next.setUTCHours(hour, minute, 0, 0);
+      }
+      return null;
+    }
+    case "weekly": {
+      if (cfg.daysOfWeek.length === 0) return null;
+      next.setUTCHours(hour, minute, 0, 0);
+      for (let i = 0; i < 8; i++) {
+        if (next > nowZoned && cfg.daysOfWeek.includes(next.getUTCDay())) {
+          return carrierToInstant(next, tz);
+        }
+        next.setUTCDate(next.getUTCDate() + 1);
+        next.setUTCHours(hour, minute, 0, 0);
+      }
+      return null;
+    }
+    case "custom":
+      return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/views/autopilots/components/webhook-deliveries-section.tsx
+++ b/packages/views/autopilots/components/webhook-deliveries-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import {
   CheckCircle2,
   XCircle,
@@ -31,6 +31,7 @@ import {
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { toast } from "sonner";
+import { DateTime } from "../../common/date-time";
 import { useT } from "../../i18n";
 import type {
   WebhookDelivery,
@@ -71,16 +72,6 @@ function visualForStatus(status: string): StatusVisual {
 }
 
 // --- Helpers --------------------------------------------------------------
-
-function formatDate(value: string): string {
-  if (!value) return "—";
-  return new Date(value).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 // A delivery is replayable when (a) the server allows it (signature is not
 // invalid AND the delivery itself wasn't rejected) and (b) we have something
@@ -203,9 +194,17 @@ function DeliveryRow({
             })}
           </Badge>
         )}
-        <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-          {formatDate(delivery.received_at || delivery.created_at)}
-        </span>
+        {delivery.received_at || delivery.created_at ? (
+          <DateTime
+            value={delivery.received_at || delivery.created_at}
+            variant="datetime"
+            className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums"
+          />
+        ) : (
+          <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+            —
+          </span>
+        )}
       </button>
       {open && (
         <DeliveryDetailDialog
@@ -283,11 +282,11 @@ function DeliveryDetailDialog({
           <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
             <MetaRow
               label={t(($) => $.deliveries.detail.received_at)}
-              value={formatDate(full.received_at)}
+              value={full.received_at ? <DateTime value={full.received_at} variant="datetime" /> : "—"}
             />
             <MetaRow
               label={t(($) => $.deliveries.detail.last_attempt_at)}
-              value={formatDate(full.last_attempt_at)}
+              value={full.last_attempt_at ? <DateTime value={full.last_attempt_at} variant="datetime" /> : "—"}
             />
             <MetaRow
               label={t(($) => $.deliveries.detail.attempt_count)}
@@ -355,7 +354,7 @@ function MetaRow({
   mono = false,
 }: {
   label: string;
-  value: string;
+  value: ReactNode;
   mono?: boolean;
 }) {
   return (
@@ -366,7 +365,7 @@ function MetaRow({
           "truncate text-foreground",
           mono && "font-mono",
         )}
-        title={value}
+        title={typeof value === "string" ? value : undefined}
       >
         {value}
       </dd>

--- a/packages/views/billing/billing-test-page.tsx
+++ b/packages/views/billing/billing-test-page.tsx
@@ -52,6 +52,7 @@ import {
   CardTitle,
 } from "@multica/ui/components/ui/card";
 import { useT } from "../i18n";
+import { useFormatDateTime } from "../common/use-format-date-time";
 import { useNavigation } from "../navigation";
 
 // 1 credit = 1_000_000 micro-credit; cents → dollars factor for the
@@ -208,6 +209,7 @@ function CheckoutSessionStatusBanner({
 
 function BalanceCard() {
   const { t } = useT("billing");
+  const { formatDateTime } = useFormatDateTime();
   const balance = useQuery(billingBalanceOptions());
 
   return (
@@ -241,7 +243,7 @@ function BalanceCard() {
               {t(($) => $.balance.meta, {
                 micro: balance.data?.balance_micro.toLocaleString() ?? 0,
                 owner: balance.data?.owner_id.slice(0, 8) ?? "",
-                updated: formatDate(balance.data?.updated_at, t),
+                updated: formatDate(balance.data?.updated_at, t, formatDateTime),
               })}
             </div>
           </div>
@@ -450,6 +452,7 @@ function TransactionsCard() {
 
 function TransactionRow({ row }: { row: BillingTransaction }) {
   const { t } = useT("billing");
+  const { formatDateTime } = useFormatDateTime();
   const credit = row.amount_micro / MICRO_PER_CREDIT;
   return (
     <li className="rounded-md border bg-background p-2.5">
@@ -477,7 +480,7 @@ function TransactionRow({ row }: { row: BillingTransaction }) {
       )}
       <div className="mt-1 font-mono text-[10px] text-muted-foreground/70">
         {t(($) => $.transactions.row_meta, {
-          date: formatDate(row.created_at, t),
+          date: formatDate(row.created_at, t, formatDateTime),
           balance: (row.balance_after / MICRO_PER_CREDIT).toLocaleString(),
           ref: row.reference_id || t(($) => $.transactions.ref_empty),
         })}
@@ -529,6 +532,7 @@ function BatchesCard() {
 
 function BatchRow({ row }: { row: BillingBatch }) {
   const { t } = useT("billing");
+  const { formatDateTime } = useFormatDateTime();
   const total = row.total_micro / MICRO_PER_CREDIT;
   const remaining = row.remaining_micro / MICRO_PER_CREDIT;
   const consumed = total - remaining;
@@ -551,7 +555,9 @@ function BatchRow({ row }: { row: BillingBatch }) {
       <div className="mt-1 text-xs text-muted-foreground">
         {t(($) => $.batches.consumed, { value: consumed.toLocaleString() })}
         {row.expires_at
-          ? t(($) => $.batches.expires_suffix, { value: formatDate(row.expires_at, t) })
+          ? t(($) => $.batches.expires_suffix, {
+              value: formatDate(row.expires_at, t, formatDateTime),
+            })
           : t(($) => $.batches.never_expires_suffix)}
       </div>
     </li>
@@ -601,6 +607,7 @@ function TopupsCard() {
 
 function TopupRow({ row }: { row: BillingTopup }) {
   const { t } = useT("billing");
+  const { formatDateTime } = useFormatDateTime();
   return (
     <li className="rounded-md border bg-background p-2.5">
       <div className="flex items-center justify-between gap-2">
@@ -633,7 +640,7 @@ function TopupRow({ row }: { row: BillingTopup }) {
       </div>
       <div className="mt-1 font-mono text-[10px] text-muted-foreground/70">
         {t(($) => $.topups.row_meta, {
-          date: formatDate(row.created_at, t),
+          date: formatDate(row.created_at, t, formatDateTime),
           checkout: row.stripe_checkout_id || t(($) => $.topups.stripe_empty),
         })}
       </div>
@@ -725,9 +732,10 @@ function formatMoney(amountCents: number, currency: string): string {
 function formatDate(
   value: string | undefined,
   t: ReturnType<typeof useT<"billing">>["t"],
+  format: (value: string) => string,
 ): string {
   if (!value) return t(($) => $.shared.date_dash);
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleString();
+  // format() renders in the viewer's Viewing tz + Language locale and returns
+  // "" for an unparseable value, where we fall back to the raw string.
+  return format(value) || value;
 }

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -53,6 +53,7 @@ import { useChatResize } from "./use-chat-resize";
 import { createLogger } from "@multica/core/logger";
 import type { Agent, Attachment, ChatMessage, ChatMessagesPage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { useT } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
@@ -996,7 +997,6 @@ function SessionDropdown({
   const updateSession = useUpdateChatSession();
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const queryClient = useQueryClient();
-  const formatTimeAgo = useFormatTimeAgo();
 
   // Aggregate "which sessions have an in-flight task right now". Reuses
   // the same workspace-scoped query the FAB consumes, so toggling the chat
@@ -1150,13 +1150,14 @@ function SessionDropdown({
     const isConfirmingStop = confirmingStopId === session.id && !!pendingTask;
     const isConfirmingAction = isConfirmingDelete || isConfirmingStop;
     const titleText = session.title?.trim() || t(($) => $.window.untitled);
+    const showRelativeTime = !isRunning && !showCompleted && !showUnread;
     const trailingStatus = isRunning
       ? t(($) => $.session_history.row_subtitle.working)
       : showCompleted
         ? t(($) => $.session_history.row_subtitle.completed)
         : showUnread
           ? t(($) => $.session_history.row_subtitle.new_reply)
-          : formatTimeAgo(session.updated_at);
+          : null;
 
     return (
       <div
@@ -1305,7 +1306,11 @@ function SessionDropdown({
                     className="size-1.5 rounded-full bg-brand"
                   />
                 )}
-                <span className={cn("truncate", (showUnread || showCompleted || isRunning) && "font-medium text-foreground")}>{trailingStatus}</span>
+                {showRelativeTime ? (
+                  <DateTime value={session.updated_at} variant="relative" className="truncate" />
+                ) : (
+                  <span className={cn("truncate", (showUnread || showCompleted || isRunning) && "font-medium text-foreground")}>{trailingStatus}</span>
+                )}
               </div>
               <div className="hidden h-7 items-center gap-0.5 group-hover/history-row:flex">
                 {isRunning && pendingTask && (
@@ -1517,23 +1522,6 @@ function SessionRenameInput({
   );
 }
 
-function useFormatTimeAgo(): (dateStr: string) => string {
-  const { t } = useT("chat");
-  return (dateStr: string) => {
-    const date = new Date(dateStr);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMins < 1) return t(($) => $.session_history.time.just_now);
-    if (diffMins < 60) return t(($) => $.session_history.time.minutes, { count: diffMins });
-    if (diffHours < 24) return t(($) => $.session_history.time.hours, { count: diffHours });
-    if (diffDays < 7) return t(($) => $.session_history.time.days, { count: diffDays });
-    return date.toLocaleDateString();
-  };
-}
 
 // Three starter prompts shown on the empty state. Each is keyed into the
 // chat namespace so labels translate per locale; the icon stays raw since

--- a/packages/views/common/date-time.test.tsx
+++ b/packages/views/common/date-time.test.tsx
@@ -1,0 +1,118 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import zhCommon from "../locales/zh-Hans/common.json";
+
+const userRef = vi.hoisted(
+  () => ({ current: { timezone: "Asia/Shanghai" } as { timezone?: string | null } }),
+);
+
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: typeof userRef.current };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user: userRef.current }),
+    { getState: () => ({ user: userRef.current }) },
+  );
+  return { useAuthStore };
+});
+
+vi.mock("./timezone-select", () => ({
+  browserTimezone: () => "America/New_York",
+}));
+
+// Render the tooltip eagerly so its content is assertable without a hover/portal
+// (Base UI mounts the real popup only while open).
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div role="tooltip">{children}</div>
+  ),
+}));
+
+import { DateTime } from "./date-time";
+
+const RESOURCES = {
+  en: { common: enCommon },
+  "zh-Hans": { common: zhCommon },
+};
+
+function renderDateTime(ui: ReactNode, locale: "en" | "zh-Hans" = "en") {
+  return render(
+    <I18nProvider locale={locale} resources={RESOURCES}>
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+// 2026-03-01T06:30:45Z == 14:30:45 in Asia/Shanghai (+8).
+const VALUE = "2026-03-01T06:30:45Z";
+
+describe("DateTime", () => {
+  beforeEach(() => {
+    userRef.current = { timezone: "Asia/Shanghai" };
+  });
+
+  it("shows the datetime in Viewing tz with a full time + offset tooltip", () => {
+    renderDateTime(<DateTime value={VALUE} />);
+    expect(screen.getByText("Mar 1, 2026, 02:30 PM")).toBeTruthy();
+    expect(screen.getByRole("tooltip").textContent).toBe(
+      "Mar 1, 2026, 02:30:45 PM (GMT+8)",
+    );
+  });
+
+  it("renders the date and time variants", () => {
+    // Pin "now" so the date variant's current-year suppression is deterministic.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-26T12:00:00Z"));
+    try {
+      const { rerender } = renderDateTime(<DateTime value={VALUE} variant="date" />);
+      // Same calendar year as "now" → the year is dropped; tooltip keeps it.
+      expect(screen.getByText("Mar 1")).toBeTruthy();
+      expect(screen.getByRole("tooltip").textContent).toContain("(GMT+8)");
+
+      rerender(
+        <I18nProvider locale="en" resources={RESOURCES}>
+          <DateTime value={VALUE} variant="time" />
+        </I18nProvider>,
+      );
+      expect(screen.getByText("02:30:45 PM")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives a calendar day a date-only tooltip with no timezone (spec §3.5)", () => {
+    renderDateTime(<DateTime value="2026-03-01" variant="calendarDate" />);
+    expect(screen.getByText("Mar 1")).toBeTruthy();
+    const tooltip = screen.getByRole("tooltip").textContent ?? "";
+    expect(tooltip).toBe("March 1, 2026");
+    expect(tooltip).not.toContain("GMT");
+  });
+
+  it("renders nothing for an empty value when hideWhenEmpty", () => {
+    const { container } = renderDateTime(<DateTime value={null} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  describe("relative variant", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-03-01T09:30:45Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows relative text with a full time + offset tooltip", () => {
+      renderDateTime(<DateTime value={VALUE} variant="relative" />);
+      expect(screen.getByText("3h ago")).toBeTruthy();
+      expect(screen.getByRole("tooltip").textContent).toBe(
+        "Mar 1, 2026, 02:30:45 PM (GMT+8)",
+      );
+    });
+  });
+});

--- a/packages/views/common/date-time.tsx
+++ b/packages/views/common/date-time.tsx
@@ -1,0 +1,150 @@
+import { type ReactNode } from "react";
+import { useTimeAgo } from "../i18n/use-time-ago";
+import { HoverTooltip } from "./instant-tooltip";
+import { useFormatCalendarDate } from "./use-format-calendar-date";
+import {
+  useFormatDateTime,
+  useFormatInstantTooltip,
+} from "./use-format-date-time";
+
+type InstantVariant = "datetime" | "date" | "time" | "relative";
+
+export type DateTimeVariant = InstantVariant | "calendarDate";
+
+interface DateTimeProps {
+  value: string | null | undefined;
+  /** What the visible text shows. Defaults to "datetime". */
+  variant?: DateTimeVariant;
+  className?: string;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
+  /** Render nothing when value is empty/unparseable (default true). */
+  hideWhenEmpty?: boolean;
+}
+
+// Full-date tooltip for floating calendar days: no time, no timezone.
+const CALENDAR_TOOLTIP_OPTS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+
+// Each variant is its own leaf so it calls ONLY the formatting hook it needs —
+// a relative row never builds the calendar formatter, a calendar row never
+// builds the instant/relative ones. In long lists (inbox, comments, board)
+// that drops one or two unused `useT` reads + memos per row. The thin DateTime
+// dispatcher below picks the leaf; all share the lazy-tooltip wrapper so the
+// full-precision tooltip is formatted only on hover.
+
+type LeafProps = Omit<DateTimeProps, "variant">;
+
+interface LeafChrome {
+  className?: string;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
+  enabled: boolean;
+  hideWhenEmpty: boolean;
+}
+
+// Shared tail every leaf ends with: drop an empty value, else wrap the visible
+// text in the lazy hover tooltip. One place so the empty-handling, `enabled`
+// gate, and tooltip wiring can't drift between variants.
+function renderLeaf(
+  visible: string,
+  content: () => string,
+  { className, tooltipSide, enabled, hideWhenEmpty }: LeafChrome,
+): ReactNode {
+  if (!visible && hideWhenEmpty) return null;
+  return (
+    <HoverTooltip
+      className={className}
+      tooltipSide={tooltipSide}
+      enabled={enabled}
+      content={content}
+    >
+      {visible}
+    </HoverTooltip>
+  );
+}
+
+function CalendarDateTime({
+  value,
+  className,
+  tooltipSide,
+  hideWhenEmpty = true,
+}: LeafProps) {
+  const formatCalendarDate = useFormatCalendarDate();
+  const visible = formatCalendarDate(value ?? undefined);
+  return renderLeaf(
+    visible,
+    () => formatCalendarDate(value ?? undefined, CALENDAR_TOOLTIP_OPTS),
+    { className, tooltipSide, enabled: value != null, hideWhenEmpty },
+  );
+}
+
+function RelativeDateTime({
+  value,
+  className,
+  tooltipSide,
+  hideWhenEmpty = true,
+}: LeafProps) {
+  const timeAgo = useTimeAgo();
+  const formatTooltip = useFormatInstantTooltip();
+  const visible = value ? timeAgo(value) : "";
+  return renderLeaf(visible, () => formatTooltip(value), {
+    className,
+    tooltipSide,
+    enabled: value != null,
+    hideWhenEmpty,
+  });
+}
+
+function InstantDateTime({
+  value,
+  variant,
+  className,
+  tooltipSide,
+  hideWhenEmpty = true,
+}: LeafProps & { variant: "datetime" | "date" | "time" }) {
+  const { formatDateTime, formatDate, formatTime, formatTooltip } =
+    useFormatDateTime();
+  let visible: string;
+  switch (variant) {
+    case "date":
+      visible = formatDate(value);
+      break;
+    case "time":
+      visible = formatTime(value);
+      break;
+    default:
+      visible = formatDateTime(value);
+  }
+  return renderLeaf(visible, () => formatTooltip(value), {
+    className,
+    tooltipSide,
+    enabled: value != null,
+    hideWhenEmpty,
+  });
+}
+
+/**
+ * Unified time display for web/desktop: visible text + a tooltip carrying the
+ * full time and timezone. Instants render in the viewer's Viewing Timezone +
+ * Language locale; the "calendarDate" variant renders a floating day (UTC
+ * anchored, no timezone) with a date-only tooltip.
+ */
+export function DateTime({
+  value,
+  variant = "datetime",
+  className,
+  tooltipSide = "top",
+  hideWhenEmpty = true,
+}: DateTimeProps) {
+  const common = { value, className, tooltipSide, hideWhenEmpty };
+  switch (variant) {
+    case "calendarDate":
+      return <CalendarDateTime {...common} />;
+    case "relative":
+      return <RelativeDateTime {...common} />;
+    default:
+      return <InstantDateTime {...common} variant={variant} />;
+  }
+}

--- a/packages/views/common/hover-tooltip.test.tsx
+++ b/packages/views/common/hover-tooltip.test.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Simulate a CLOSED tooltip: Base UI portals TooltipContent (and mounts its
+// children) only while open, so a closed tooltip renders no content. This is
+// what makes the lazy `content()` computation actually deferred in production.
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render: r }: { render: ReactNode }) => <>{r}</>,
+  TooltipContent: () => null,
+}));
+
+import { HoverTooltip } from "./instant-tooltip";
+
+describe("HoverTooltip", () => {
+  it("does not compute the tooltip text until the tooltip mounts (lazy)", () => {
+    const content = vi.fn(() => "full timestamp");
+    render(<HoverTooltip content={content}>visible text</HoverTooltip>);
+    // The visible trigger renders eagerly...
+    expect(screen.getByText("visible text")).toBeTruthy();
+    // ...but the expensive tooltip string lives inside TooltipContent, which is
+    // unmounted while closed — so compute must NOT run on first paint. Guards
+    // against regressing to an eager `content()` call in the parent render body.
+    expect(content).not.toHaveBeenCalled();
+  });
+
+  it("renders only the trigger (no tooltip, no compute) when disabled", () => {
+    const content = vi.fn(() => "full timestamp");
+    render(
+      <HoverTooltip content={content} enabled={false}>
+        plain text
+      </HoverTooltip>,
+    );
+    expect(screen.getByText("plain text")).toBeTruthy();
+    expect(content).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/common/instant-tooltip.test.tsx
+++ b/packages/views/common/instant-tooltip.test.tsx
@@ -1,0 +1,62 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+
+const userRef = vi.hoisted(
+  () => ({ current: { timezone: "Asia/Shanghai" } as { timezone?: string | null } }),
+);
+
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: typeof userRef.current };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user: userRef.current }),
+    { getState: () => ({ user: userRef.current }) },
+  );
+  return { useAuthStore };
+});
+
+vi.mock("./timezone-select", () => ({
+  browserTimezone: () => "America/New_York",
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div role="tooltip">{children}</div>
+  ),
+}));
+
+import { InstantTooltip } from "./instant-tooltip";
+
+function renderIt(ui: ReactNode) {
+  return render(
+    <I18nProvider locale="en" resources={{ en: { common: enCommon } }}>
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+const VALUE = "2026-03-01T06:30:45Z"; // 14:30:45 Asia/Shanghai (+8)
+
+describe("InstantTooltip", () => {
+  beforeEach(() => {
+    userRef.current = { timezone: "Asia/Shanghai" };
+  });
+
+  it("keeps the localized phrase visible and adds a full-time tooltip", () => {
+    renderIt(<InstantTooltip value={VALUE}>Updated 2d ago</InstantTooltip>);
+    expect(screen.getByText("Updated 2d ago")).toBeTruthy();
+    expect(screen.getByRole("tooltip").textContent).toBe(
+      "Mar 1, 2026, 02:30:45 PM (GMT+8)",
+    );
+  });
+
+  it("renders the phrase without a tooltip when value is empty", () => {
+    renderIt(<InstantTooltip value={null}>never</InstantTooltip>);
+    expect(screen.getByText("never")).toBeTruthy();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});

--- a/packages/views/common/instant-tooltip.tsx
+++ b/packages/views/common/instant-tooltip.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@multica/ui/components/ui/tooltip";
+import { useFormatInstantTooltip } from "./use-format-date-time";
+
+// Renders the tooltip text lazily. Base UI portals the popup only while open,
+// so this child mounts — and thus `compute()` runs — only on hover, keeping the
+// expensive Intl offset formatting out of the per-row render path of long lists.
+function TooltipText({ compute }: { compute: () => string }) {
+  return <>{compute()}</>;
+}
+
+interface HoverTooltipProps {
+  /** The already-rendered visible content the tooltip hangs off. */
+  children: ReactNode;
+  /** Tooltip text; invoked only when the tooltip mounts, never every render. */
+  content: () => string;
+  /** Cheap gate: when false, render the trigger alone with no tooltip. */
+  enabled?: boolean;
+  className?: string;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
+}
+
+/**
+ * Shared "visible span + hover tooltip" wrapper. Single source for the
+ * trigger/Tooltip/TooltipContent structure used by both <DateTime> and
+ * <InstantTooltip>, so hover behavior (delay, side, empty-skip, a11y) stays
+ * consistent across every time display.
+ */
+export function HoverTooltip({
+  children,
+  content,
+  enabled = true,
+  className,
+  tooltipSide = "top",
+}: HoverTooltipProps) {
+  const trigger = <span className={className}>{children}</span>;
+  if (!enabled) return trigger;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={trigger} />
+      <TooltipContent side={tooltipSide}>
+        <TooltipText compute={content} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+interface InstantTooltipProps {
+  /** The instant whose full time + GMT offset the tooltip reveals. */
+  value: string | null | undefined;
+  /** The already-rendered, localized phrase to show (e.g. "Updated 2d ago"). */
+  children: ReactNode;
+  className?: string;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
+}
+
+/**
+ * Wraps an already-rendered, localized phrase in a tooltip carrying the full
+ * timestamp + GMT offset of `value` (in the viewer's Viewing Timezone). Use
+ * when the instant is interpolated INTO a translated sentence and can't be
+ * swapped for a bare <DateTime> without breaking per-locale word order — the
+ * visible text stays whatever the caller rendered; only the hover is added.
+ * Renders the children untouched (no tooltip) when value is empty.
+ */
+export function InstantTooltip({
+  value,
+  children,
+  className,
+  tooltipSide = "top",
+}: InstantTooltipProps) {
+  const formatTooltip = useFormatInstantTooltip();
+  return (
+    <HoverTooltip
+      className={className}
+      tooltipSide={tooltipSide}
+      enabled={value != null}
+      content={() => formatTooltip(value)}
+    >
+      {children}
+    </HoverTooltip>
+  );
+}

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuItem,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { ActorAvatar } from "../actor-avatar";
+import { DateTime } from "../date-time";
 import { api } from "@multica/core/api";
 import { useTranscriptViewStore, type TranscriptSortDirection } from "@multica/core/agents/stores";
 import type { AgentTask, Agent, AgentRuntime } from "@multica/core/types/agent";
@@ -514,12 +515,7 @@ export function AgentTranscriptDialog({
             {/* Created time */}
             {task.created_at && (
               <MetadataChip>
-                {new Date(task.created_at).toLocaleString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
+                <DateTime value={task.created_at} variant="datetime" />
               </MetadataChip>
             )}
           </div>
@@ -729,10 +725,6 @@ const TranscriptEventRow = ({
   const color = getEventColor(item);
   const label = getEventLabel(item);
   const summary = getEventSummary(item);
-  const date = useMemo(
-    () => (item.created_at ? new Date(item.created_at) : null),
-    [item.created_at],
-  );
 
   const hasDetail =
     (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
@@ -791,14 +783,12 @@ const TranscriptEventRow = ({
           </span>
 
           {/* Timestamp */}
-          {date && (
-            <span className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1" title={date.toLocaleString()}>
-              {date.toLocaleTimeString(undefined, {
-                hour: "2-digit",
-                minute: "2-digit",
-                second: "2-digit",
-              })}
-            </span>
+          {item.created_at && (
+            <DateTime
+              value={item.created_at}
+              variant="time"
+              className="shrink-0 text-[10px] text-muted-foreground/50 tabular-nums mt-1"
+            />
           )}
         </div>
 

--- a/packages/views/common/use-format-calendar-date.test.tsx
+++ b/packages/views/common/use-format-calendar-date.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import zhCommon from "../locales/zh-Hans/common.json";
+import { useFormatCalendarDate } from "./use-format-calendar-date";
+
+const RESOURCES = {
+  en: { common: enCommon },
+  "zh-Hans": { common: zhCommon },
+};
+
+function wrapper(locale: "en" | "zh-Hans") {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nProvider locale={locale} resources={RESOURCES}>
+        {children}
+      </I18nProvider>
+    );
+  };
+}
+
+describe("useFormatCalendarDate", () => {
+  it("takes its locale from the Language setting", () => {
+    const en = renderHook(() => useFormatCalendarDate(), {
+      wrapper: wrapper("en"),
+    });
+    expect(en.result.current("2026-03-01")).toBe("Mar 1");
+
+    const zh = renderHook(() => useFormatCalendarDate(), {
+      wrapper: wrapper("zh-Hans"),
+    });
+    expect(zh.result.current("2026-03-01")).toBe("3月1日");
+  });
+
+  it("passes through explicit format options", () => {
+    const { result } = renderHook(() => useFormatCalendarDate(), {
+      wrapper: wrapper("en"),
+    });
+    expect(
+      result.current("2026-03-01", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }),
+    ).toBe("March 1, 2026");
+  });
+
+  it("stays floating — the day never shifts with a timezone (spec §3.2)", () => {
+    const { result } = renderHook(() => useFormatCalendarDate(), {
+      wrapper: wrapper("en"),
+    });
+    // A legacy RFC3339 instant is read as its UTC calendar day, NOT converted
+    // into the viewer's timezone (which would slide it to Mar 1 east of UTC).
+    expect(result.current("2026-02-28T16:00:00Z")).toBe("Feb 28");
+  });
+
+  it("returns an empty string for empty/unparseable values", () => {
+    const { result } = renderHook(() => useFormatCalendarDate(), {
+      wrapper: wrapper("en"),
+    });
+    expect(result.current(null)).toBe("");
+    expect(result.current("")).toBe("");
+  });
+});

--- a/packages/views/common/use-format-calendar-date.ts
+++ b/packages/views/common/use-format-calendar-date.ts
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+import { formatDateOnly } from "@multica/core/issues/date";
+import { useT } from "../i18n/use-t";
+
+/**
+ * Locale-aware formatter for FLOATING calendar days (issue start_date /
+ * due_date). It stays UTC-anchored (the day never shifts with timezone — that
+ * is `formatDateOnly`'s job); this hook only injects the Language locale so
+ * callers stop hardcoding "en-US".
+ */
+export function useFormatCalendarDate(): (
+  value: string | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+) => string {
+  const { i18n } = useT("common");
+  const locale = i18n.language || "en";
+  return useCallback(
+    (value, options) => formatDateOnly(value, options, locale),
+    [locale],
+  );
+}

--- a/packages/views/common/use-format-date-time.test.tsx
+++ b/packages/views/common/use-format-date-time.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import zhCommon from "../locales/zh-Hans/common.json";
+
+// Viewing tz is driven by the user setting, never the browser (spec §0 goal 2).
+const userRef = vi.hoisted(
+  () => ({ current: null as { timezone?: string | null } | null }),
+);
+
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: typeof userRef.current };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user: userRef.current }),
+    { getState: () => ({ user: userRef.current }) },
+  );
+  return { useAuthStore };
+});
+
+// If the hook ever fell back to the browser tz this distinctive value would
+// surface in an assertion, proving the fallback was NOT taken.
+vi.mock("./timezone-select", () => ({
+  browserTimezone: () => "America/New_York",
+}));
+
+import {
+  useFormatDateTime,
+  useFormatInstantTooltip,
+} from "./use-format-date-time";
+
+const RESOURCES = {
+  en: { common: enCommon },
+  "zh-Hans": { common: zhCommon },
+};
+
+function wrapper(locale: "en" | "zh-Hans") {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nProvider locale={locale} resources={RESOURCES}>
+        {children}
+      </I18nProvider>
+    );
+  };
+}
+
+// 2026-03-01T06:30:45Z == 14:30:45 Asia/Shanghai (+8), 22:30:45 prev day in LA.
+const VALUE = "2026-03-01T06:30:45Z";
+
+describe("useFormatDateTime", () => {
+  beforeEach(() => {
+    userRef.current = null;
+  });
+
+  it("renders an instant in the viewer's Viewing Timezone, not the browser", () => {
+    userRef.current = { timezone: "Asia/Shanghai" };
+    const sh = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("en"),
+    });
+    expect(sh.result.current.formatDateTime(VALUE)).toBe(
+      "Mar 1, 2026, 02:30 PM",
+    );
+
+    userRef.current = { timezone: "America/Los_Angeles" };
+    const la = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("en"),
+    });
+    // Same instant, different wall clock — and neither is the mocked browser tz.
+    expect(la.result.current.formatDateTime(VALUE)).toBe(
+      "Feb 28, 2026, 10:30 PM",
+    );
+  });
+
+  it("takes its locale from the Language setting", () => {
+    userRef.current = { timezone: "Asia/Shanghai" };
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("zh-Hans"),
+    });
+    expect(result.current.formatDateTime(VALUE)).toBe("2026年3月1日 14:30");
+  });
+
+  it("exposes date-only and time-only formatters", () => {
+    // Pin "now" so date mode's current-year suppression is deterministic.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-26T12:00:00Z"));
+    try {
+      userRef.current = { timezone: "Asia/Shanghai" };
+      const { result } = renderHook(() => useFormatDateTime(), {
+        wrapper: wrapper("en"),
+      });
+      // Same year as "now" → date mode drops the year.
+      expect(result.current.formatDate(VALUE)).toBe("Mar 1");
+      expect(result.current.formatTime(VALUE)).toBe("02:30:45 PM");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("builds a tooltip with full time + GMT offset of the Viewing tz", () => {
+    userRef.current = { timezone: "America/Los_Angeles" };
+    const en = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("en"),
+    });
+    expect(en.result.current.formatTooltip(VALUE)).toBe(
+      "Feb 28, 2026, 10:30:45 PM (GMT-8)",
+    );
+
+    userRef.current = { timezone: "Asia/Shanghai" };
+    const zh = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("zh-Hans"),
+    });
+    // CJK locales get full-width parentheses.
+    expect(zh.result.current.formatTooltip(VALUE)).toBe(
+      "2026年3月1日 14:30:45（GMT+8）",
+    );
+  });
+
+  it("returns empty strings for empty/unparseable values", () => {
+    userRef.current = { timezone: "UTC" };
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: wrapper("en"),
+    });
+    expect(result.current.formatDateTime(null)).toBe("");
+    expect(result.current.formatTooltip("not-a-date")).toBe("");
+  });
+});
+
+describe("useFormatInstantTooltip", () => {
+  beforeEach(() => {
+    userRef.current = null;
+  });
+
+  it("matches the full hook's tooltip, in the Viewing tz + Language locale", () => {
+    userRef.current = { timezone: "America/Los_Angeles" };
+    const en = renderHook(() => useFormatInstantTooltip(), {
+      wrapper: wrapper("en"),
+    });
+    expect(en.result.current(VALUE)).toBe("Feb 28, 2026, 10:30:45 PM (GMT-8)");
+
+    userRef.current = { timezone: "Asia/Shanghai" };
+    const zh = renderHook(() => useFormatInstantTooltip(), {
+      wrapper: wrapper("zh-Hans"),
+    });
+    expect(zh.result.current(VALUE)).toBe("2026年3月1日 14:30:45（GMT+8）");
+  });
+
+  it("returns an empty string for an empty/unparseable value", () => {
+    userRef.current = { timezone: "UTC" };
+    const { result } = renderHook(() => useFormatInstantTooltip(), {
+      wrapper: wrapper("en"),
+    });
+    expect(result.current(null)).toBe("");
+    expect(result.current("not-a-date")).toBe("");
+  });
+});

--- a/packages/views/common/use-format-date-time.ts
+++ b/packages/views/common/use-format-date-time.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import {
+  formatInstant,
+  formatInstantWithOffset,
+} from "@multica/core/i18n/format-date-time";
+import { useT } from "../i18n/use-t";
+import { useViewingTimezone } from "./use-viewing-timezone";
+
+export type InstantValue = string | number | Date | null | undefined;
+
+export interface InstantFormatters {
+  /** Full date + time in the viewer's timezone + locale. */
+  formatDateTime: (value: InstantValue) => string;
+  /** Date only in the viewer's timezone + locale. */
+  formatDate: (value: InstantValue) => string;
+  /** Time only in the viewer's timezone + locale. */
+  formatTime: (value: InstantValue) => string;
+  /** Tooltip string: full date-time + GMT offset suffix. */
+  formatTooltip: (value: InstantValue) => string;
+}
+
+/**
+ * Formatters for INSTANTS (TIMESTAMPTZ values), bound to the viewer's Viewing
+ * Timezone (`useViewingTimezone`) and Language locale (`i18n.language`). The
+ * i18next short codes ("en" / "zh-Hans" / ...) are valid BCP-47 and pass
+ * straight to Intl. This is the single replacement for inline
+ * `new Date(x).toLocaleString(...)`, which would use the browser timezone.
+ */
+export function useFormatDateTime(): InstantFormatters {
+  const timeZone = useViewingTimezone();
+  const { i18n } = useT("common");
+  const locale = i18n.language || "en";
+
+  return useMemo(() => {
+    const opts = { locale, timeZone };
+    return {
+      formatDateTime: (value) =>
+        formatInstant(value, { ...opts, mode: "datetime" }),
+      formatDate: (value) => formatInstant(value, { ...opts, mode: "date" }),
+      formatTime: (value) => formatInstant(value, { ...opts, mode: "time" }),
+      formatTooltip: (value) => formatInstantWithOffset(value, opts),
+    };
+  }, [locale, timeZone]);
+}
+
+/**
+ * The instant tooltip formatter alone — full date-time + GMT offset in the
+ * viewer's Viewing Timezone + Language locale. For callers that render their own
+ * visible text (relative time, an interpolated phrase) and only need the hover
+ * tooltip, so they don't build the unused date/time/datetime formatters the full
+ * `useFormatDateTime` would.
+ */
+export function useFormatInstantTooltip(): (value: InstantValue) => string {
+  const timeZone = useViewingTimezone();
+  const { i18n } = useT("common");
+  const locale = i18n.language || "en";
+
+  return useMemo(
+    () => (value: InstantValue) =>
+      formatInstantWithOffset(value, { locale, timeZone }),
+    [locale, timeZone],
+  );
+}

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -148,7 +148,8 @@ function Segmented<T extends string | number>({
  * and the runtime page using one pricing table.
  */
 export function DashboardPage() {
-  const { t } = useT("usage");
+  const { t, i18n } = useT("usage");
+  const locale = i18n.language || "en";
   const wsId = useWorkspaceId();
   const viewTZ = useViewingTimezone();
   const [dim, setDim] = useState<Dim>("daily");
@@ -251,20 +252,20 @@ export function DashboardPage() {
     [dailyUsageInWindow],
   );
   const dailyCost = useMemo(
-    () => aggregateDailyCost(dailyUsageInWindow),
-    [dailyUsageInWindow],
+    () => aggregateDailyCost(dailyUsageInWindow, locale),
+    [dailyUsageInWindow, locale],
   );
   const dailyTokens = useMemo(
-    () => aggregateDailyTokens(dailyUsageInWindow),
-    [dailyUsageInWindow],
+    () => aggregateDailyTokens(dailyUsageInWindow, locale),
+    [dailyUsageInWindow, locale],
   );
   const dailyTime = useMemo(
-    () => aggregateDailyTime(runTimeDailyInWindow),
-    [runTimeDailyInWindow],
+    () => aggregateDailyTime(runTimeDailyInWindow, locale),
+    [runTimeDailyInWindow, locale],
   );
   const dailyTasks = useMemo(
-    () => aggregateDailyTasks(runTimeDailyInWindow),
-    [runTimeDailyInWindow],
+    () => aggregateDailyTasks(runTimeDailyInWindow, locale),
+    [runTimeDailyInWindow, locale],
   );
 
   // Weekly aggregates — built from the over-fetched per-date queries so the
@@ -274,18 +275,18 @@ export function DashboardPage() {
   // instead of being dropped (MUL-2382 weekly window scoping). Week
   // boundaries follow the viewer's timezone.
   const weekly = useMemo(
-    () => aggregateByWeek(dailyUsage, viewTZ, weekCount),
-    [dailyUsage, viewTZ, weekCount],
+    () => aggregateByWeek(dailyUsage, viewTZ, weekCount, locale),
+    [dailyUsage, viewTZ, weekCount, locale],
   );
   const weeklyCost = weekly.weeklyCostStack;
   const weeklyTokens = weekly.weeklyTokens;
   const weeklyTime = useMemo(
-    () => aggregateWeeklyTime(runTimeDailyRows, viewTZ, weekCount),
-    [runTimeDailyRows, viewTZ, weekCount],
+    () => aggregateWeeklyTime(runTimeDailyRows, viewTZ, weekCount, locale),
+    [runTimeDailyRows, viewTZ, weekCount, locale],
   );
   const weeklyTasks = useMemo(
-    () => aggregateWeeklyTasks(runTimeDailyRows, viewTZ, weekCount),
-    [runTimeDailyRows, viewTZ, weekCount],
+    () => aggregateWeeklyTasks(runTimeDailyRows, viewTZ, weekCount, locale),
+    [runTimeDailyRows, viewTZ, weekCount, locale],
   );
   const agentTokenRows = useMemo(
     () => aggregateAgentTokens(byAgentUsage),

--- a/packages/views/dashboard/utils.test.ts
+++ b/packages/views/dashboard/utils.test.ts
@@ -32,7 +32,7 @@ describe("aggregateDailyCost", () => {
         cache_write_tokens: 0,
         task_count: 1,
       },
-    ]);
+    ], "en");
 
     // Sort: oldest day first.
     expect(result.map((r) => r.date)).toEqual(["2026-05-09", "2026-05-10"]);
@@ -55,7 +55,7 @@ describe("aggregateDailyCost", () => {
         cache_write_tokens: 0,
         task_count: 0,
       },
-    ]);
+    ], "en");
     expect(result[0]?.total).toBe(0);
   });
 });
@@ -246,7 +246,7 @@ describe("aggregateWeeklyTime", () => {
       { date: "2026-05-17", total_seconds: 50, task_count: 0, failed_count: 0 },
       { date: "2026-05-18", total_seconds: 25, task_count: 0, failed_count: 0 },
     ];
-    const result = aggregateWeeklyTime(rows, "UTC", 2);
+    const result = aggregateWeeklyTime(rows, "UTC", 2, "en");
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({
       weekStart: "2026-05-11",
@@ -273,7 +273,7 @@ describe("aggregateWeeklyTime", () => {
       // in-range week (Mon=04-20) for a 5-week trailing window.
       { date: "2026-04-13", total_seconds: 999, task_count: 0, failed_count: 0 },
     ];
-    const result = aggregateWeeklyTime(rows, "UTC", 5);
+    const result = aggregateWeeklyTime(rows, "UTC", 5, "en");
     expect(result.map((w) => w.weekStart)).toEqual([
       "2026-04-20",
       "2026-04-27",
@@ -299,7 +299,7 @@ describe("aggregateWeeklyTasks", () => {
       { date: "2026-05-12", total_seconds: 0, task_count: 5, failed_count: 1 },
       { date: "2026-05-18", total_seconds: 0, task_count: 3, failed_count: 0 },
     ];
-    const result = aggregateWeeklyTasks(rows, "UTC", 2);
+    const result = aggregateWeeklyTasks(rows, "UTC", 2, "en");
     expect(result[0]).toMatchObject({
       weekStart: "2026-05-11",
       completed: 4,

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -41,19 +41,13 @@ export interface DailyCostStack {
   total: number;
 }
 
-function formatDateLabel(d: string): string {
-  // Anchor to local midnight so the formatted label matches the bucket the
-  // server picked (which is already in workspace time). Pasting the raw
-  // date as the body of `new Date()` would interpret it as UTC and shift
-  // by the user's offset.
-  const date = new Date(d + "T00:00:00");
-  return `${date.getMonth() + 1}/${date.getDate()}`;
-}
-
 // Per-(date, model) rows → 1 row per date with cost broken into the three
 // segments the stacked bar chart consumes. Stable sort by date asc so the
 // chart x-axis is left-to-right oldest-to-newest.
-export function aggregateDailyCost(usage: DashboardUsageDaily[]): DailyCostStack[] {
+export function aggregateDailyCost(
+  usage: DashboardUsageDaily[],
+  locale: string,
+): DailyCostStack[] {
   const map = new Map<string, { input: number; output: number; cacheWrite: number }>();
   for (const u of usage) {
     const b = estimateCostBreakdown(u);
@@ -72,7 +66,7 @@ export function aggregateDailyCost(usage: DashboardUsageDaily[]): DailyCostStack
       const cacheWrite = round(s.cacheWrite);
       return {
         date,
-        label: formatDateLabel(date),
+        label: formatShortDate(date, locale),
         input,
         output,
         cacheWrite,
@@ -87,7 +81,10 @@ export function aggregateDailyCost(usage: DashboardUsageDaily[]): DailyCostStack
 // Mirrors `aggregateByDate(...).dailyTokens` from the runtimes utils so
 // the Tokens chart on the Usage page consumes the same shape as the one
 // on the runtime-detail page.
-export function aggregateDailyTokens(usage: DashboardUsageDaily[]): DailyTokenData[] {
+export function aggregateDailyTokens(
+  usage: DashboardUsageDaily[],
+  locale: string,
+): DailyTokenData[] {
   const map = new Map<
     string,
     { input: number; output: number; cacheRead: number; cacheWrite: number }
@@ -109,7 +106,7 @@ export function aggregateDailyTokens(usage: DashboardUsageDaily[]): DailyTokenDa
     .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([date, t]) => ({
       date,
-      label: formatDateLabel(date),
+      label: formatShortDate(date, locale),
       input: t.input,
       output: t.output,
       cacheRead: t.cacheRead,
@@ -249,7 +246,11 @@ interface WeekShell {
 // carries the labels and partial-week metadata the chart components consume;
 // downstream aggregators fold their own per-week values onto the matching
 // shell.
-function buildWeekShells(tz: string, weekCount: number): WeekShell[] {
+function buildWeekShells(
+  tz: string,
+  weekCount: number,
+  locale: string,
+): WeekShell[] {
   const count = Math.max(1, Math.floor(weekCount));
   const today = todayIso(tz);
   const currentWeekStart = weekStartIso(today);
@@ -267,8 +268,8 @@ function buildWeekShells(tz: string, weekCount: number): WeekShell[] {
     shells.push({
       weekStart,
       weekEnd,
-      label: formatShortDate(weekStart),
-      rangeLabel: `${formatShortDate(weekStart)} – ${formatShortDate(weekEnd)}`,
+      label: formatShortDate(weekStart, locale),
+      rangeLabel: `${formatShortDate(weekStart, locale)} – ${formatShortDate(weekEnd, locale)}`,
       partial,
       daysCovered: partial ? elapsed : 7,
     });
@@ -288,8 +289,9 @@ export function aggregateWeeklyTime(
   rows: DashboardRunTimeDaily[],
   tz: string,
   weekCount: number,
+  locale: string,
 ): WeeklyTimeData[] {
-  const shells = buildWeekShells(tz, weekCount);
+  const shells = buildWeekShells(tz, weekCount, locale);
   const totals = new Map<string, number>();
   for (const shell of shells) totals.set(shell.weekStart, 0);
   for (const r of rows) {
@@ -304,8 +306,9 @@ export function aggregateWeeklyTasks(
   rows: DashboardRunTimeDaily[],
   tz: string,
   weekCount: number,
+  locale: string,
 ): WeeklyTasksData[] {
-  const shells = buildWeekShells(tz, weekCount);
+  const shells = buildWeekShells(tz, weekCount, locale);
   const buckets = new Map<string, { completed: number; failed: number }>();
   for (const shell of shells)
     buckets.set(shell.weekStart, { completed: 0, failed: 0 });
@@ -327,11 +330,14 @@ export function aggregateWeeklyTasks(
 // Per-date run-time rows → one row per date with `totalSeconds` for the
 // DailyTimeChart. Sorted ascending so the x-axis reads oldest-to-newest,
 // matching the cost / tokens aggregators.
-export function aggregateDailyTime(rows: DashboardRunTimeDaily[]): DailyTimeData[] {
+export function aggregateDailyTime(
+  rows: DashboardRunTimeDaily[],
+  locale: string,
+): DailyTimeData[] {
   return rows.toSorted((a, b) => a.date.localeCompare(b.date))
     .map((r) => ({
       date: r.date,
-      label: formatDateLabel(r.date),
+      label: formatShortDate(r.date, locale),
       totalSeconds: r.total_seconds,
     }));
 }
@@ -339,14 +345,17 @@ export function aggregateDailyTime(rows: DashboardRunTimeDaily[]): DailyTimeData
 // Per-date run-time rows → one row per date with `completed` and `failed`
 // counts for the DailyTasksChart's stacked bar (failed_count is a subset
 // of task_count, so completed = task_count - failed_count).
-export function aggregateDailyTasks(rows: DashboardRunTimeDaily[]): DailyTasksData[] {
+export function aggregateDailyTasks(
+  rows: DashboardRunTimeDaily[],
+  locale: string,
+): DailyTasksData[] {
   return rows.toSorted((a, b) => a.date.localeCompare(b.date))
     .map((r) => {
       const failed = r.failed_count;
       const completed = Math.max(0, r.task_count - failed);
       return {
         date: r.date,
-        label: formatDateLabel(r.date),
+        label: formatShortDate(r.date, locale),
         completed,
         failed,
       };

--- a/packages/views/i18n/use-time-ago.test.tsx
+++ b/packages/views/i18n/use-time-ago.test.tsx
@@ -82,17 +82,21 @@ describe("useTimeAgo", () => {
     expect(timeAgo("2026-06-15T12:00:00Z")).toBe("in 3mo"); // +3 calendar months
   });
 
-  it("renders imminent future instants as 'soon' only with soonForFuture", () => {
+  it("renders imminent scheduled runs as 'soon' only with scheduled", () => {
     const plain = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
-    // Without the option a sub-minute future instant stays "just now".
+    // Without the option a sub-minute future instant stays "just now" and an
+    // overdue slot reads as relative past.
     expect(plain.result.current("2026-03-15T12:00:30Z")).toBe("just now"); // +30s
+    expect(plain.result.current("2026-03-15T11:55:00Z")).toBe("5m ago"); // -5m
 
-    const soon = renderHook(() => useTimeAgo({ soonForFuture: true }), {
+    const soon = renderHook(() => useTimeAgo({ scheduled: true }), {
       wrapper: wrapper("en"),
     });
+    // Sub-minute-away future → "soon" instead of the direction-less "just now".
     expect(soon.result.current("2026-03-15T12:00:30Z")).toBe("soon"); // +30s
-    // A past sub-minute instant keeps "just now" even with the option.
-    expect(soon.result.current("2026-03-15T11:59:30Z")).toBe("just now"); // -30s
+    // Overdue slot the scheduler hasn't advanced yet → imminent, not "Xm ago".
+    expect(soon.result.current("2026-03-15T11:55:00Z")).toBe("soon"); // -5m
+    expect(soon.result.current("2026-03-15T11:59:30Z")).toBe("soon"); // -30s
   });
 
   it("localizes the labels via the Language setting", () => {

--- a/packages/views/i18n/use-time-ago.test.tsx
+++ b/packages/views/i18n/use-time-ago.test.tsx
@@ -82,6 +82,19 @@ describe("useTimeAgo", () => {
     expect(timeAgo("2026-06-15T12:00:00Z")).toBe("in 3mo"); // +3 calendar months
   });
 
+  it("renders imminent future instants as 'soon' only with soonForFuture", () => {
+    const plain = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    // Without the option a sub-minute future instant stays "just now".
+    expect(plain.result.current("2026-03-15T12:00:30Z")).toBe("just now"); // +30s
+
+    const soon = renderHook(() => useTimeAgo({ soonForFuture: true }), {
+      wrapper: wrapper("en"),
+    });
+    expect(soon.result.current("2026-03-15T12:00:30Z")).toBe("soon"); // +30s
+    // A past sub-minute instant keeps "just now" even with the option.
+    expect(soon.result.current("2026-03-15T11:59:30Z")).toBe("just now"); // -30s
+  });
+
   it("localizes the labels via the Language setting", () => {
     const { result } = renderHook(() => useTimeAgo(), {
       wrapper: wrapper("zh-Hans"),

--- a/packages/views/i18n/use-time-ago.test.tsx
+++ b/packages/views/i18n/use-time-ago.test.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import zhCommon from "../locales/zh-Hans/common.json";
+
+// Calendar-day / month / year buckets all depend on the viewer's Viewing
+// Timezone, so the auth user's timezone drives these tests.
+const userRef = vi.hoisted(
+  () => ({ current: { timezone: "UTC" } as { timezone?: string | null } }),
+);
+
+vi.mock("@multica/core/auth", () => {
+  type AuthState = { user: typeof userRef.current };
+  const useAuthStore = Object.assign(
+    (sel: (s: AuthState) => unknown) => sel({ user: userRef.current }),
+    { getState: () => ({ user: userRef.current }) },
+  );
+  return { useAuthStore };
+});
+
+vi.mock("../common/timezone-select", () => ({
+  browserTimezone: () => "America/New_York",
+}));
+
+import { useTimeAgo } from "./use-time-ago";
+
+const RESOURCES = {
+  en: { common: enCommon },
+  "zh-Hans": { common: zhCommon },
+};
+
+function wrapper(locale: "en" | "zh-Hans") {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nProvider locale={locale} resources={RESOURCES}>
+        {children}
+      </I18nProvider>
+    );
+  };
+}
+
+// Fixed "now"; fake only Date so React/i18next scheduling keeps real timers.
+const NOW = "2026-03-15T12:00:00Z";
+
+describe("useTimeAgo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+    userRef.current = { timezone: "UTC" };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buckets sub-day diffs by elapsed minutes/hours", () => {
+    const { result } = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    const timeAgo = result.current;
+    expect(timeAgo("2026-03-15T11:59:30Z")).toBe("just now"); // 30s
+    expect(timeAgo("2026-03-15T11:55:00Z")).toBe("5m ago"); // 5m
+    expect(timeAgo("2026-03-15T09:00:00Z")).toBe("3h ago"); // 3h
+    expect(timeAgo("2026-03-14T13:00:00Z")).toBe("23h ago"); // 23h, still hours
+  });
+
+  it("counts day granularity by calendar days, not 24h windows", () => {
+    const { result } = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    const timeAgo = result.current;
+    // 25h ago but one calendar day → yesterday → "1d ago".
+    expect(timeAgo("2026-03-14T11:00:00Z")).toBe("1d ago");
+    // 47h ago (under 48h) but TWO calendar days → "2d ago", not "1d ago".
+    // This is the motivating bug from the user report.
+    expect(timeAgo("2026-03-13T13:00:00Z")).toBe("2d ago");
+  });
+
+  it("renders future instants in the opposite direction", () => {
+    const { result } = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    const timeAgo = result.current;
+    expect(timeAgo("2026-03-15T15:00:00Z")).toBe("in 3h"); // +3h
+    expect(timeAgo("2026-03-17T12:00:00Z")).toBe("in 2d"); // +2 calendar days
+    expect(timeAgo("2026-06-15T12:00:00Z")).toBe("in 3mo"); // +3 calendar months
+  });
+
+  it("localizes the labels via the Language setting", () => {
+    const { result } = renderHook(() => useTimeAgo(), {
+      wrapper: wrapper("zh-Hans"),
+    });
+    expect(result.current("2026-03-15T11:55:00Z")).toBe("5 分钟前");
+    expect(result.current("2026-03-13T13:00:00Z")).toBe("2 天前");
+    expect(result.current("2026-03-15T15:00:00Z")).toBe("3 小时后");
+  });
+
+  it("continues into calendar months and years past the day cap", () => {
+    const en = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    expect(en.result.current("2026-02-13T12:00:00Z")).toBe("30d ago"); // exactly 30d
+    expect(en.result.current("2026-02-12T12:00:00Z")).toBe("1mo ago"); // 31d → months
+    expect(en.result.current("2025-03-15T12:00:00Z")).toBe("1y ago"); // exactly 1 year
+
+    const zh = renderHook(() => useTimeAgo(), { wrapper: wrapper("zh-Hans") });
+    expect(zh.result.current("2026-02-12T12:00:00Z")).toBe("1 个月前");
+    expect(zh.result.current("2025-03-15T12:00:00Z")).toBe("1 年前");
+  });
+
+  it("renders a placeholder for an unparseable date instead of blank", () => {
+    const { result } = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    expect(result.current("not-a-date")).toBe("—");
+  });
+
+  it("makes the day bucket depend on the Viewing timezone", () => {
+    // 37h apart, straddling UTC midnight.
+    const then = "2026-03-13T23:00:00Z";
+    const utc = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    expect(utc.result.current(then)).toBe("2d ago"); // UTC: Mar 13 → Mar 15
+
+    userRef.current = { timezone: "Asia/Tokyo" };
+    const tokyo = renderHook(() => useTimeAgo(), { wrapper: wrapper("en") });
+    expect(tokyo.result.current(then)).toBe("1d ago"); // Tokyo: Mar 14 → Mar 15
+  });
+});

--- a/packages/views/i18n/use-time-ago.ts
+++ b/packages/views/i18n/use-time-ago.ts
@@ -1,17 +1,49 @@
+import { relativeTimeBucket } from "@multica/core/i18n/relative-time";
+import { useViewingTimezone } from "../common/use-viewing-timezone";
 import { useT } from "./use-t";
 
 // Localized relative-time formatter. Returns a function so call-site usage
 // stays terse: `const timeAgo = useTimeAgo(); ...timeAgo(dateStr)`.
+//
+// The gradient lives in `@multica/core/i18n/relative-time` (shared with
+// mobile) and is symmetric: a past instant reads "3h ago", a future one
+// "in 3h". Day granularity is calendar-based in the viewer's Viewing Timezone;
+// past the day cap it continues into calendar months, then years — there is no
+// absolute-date fallback.
 export function useTimeAgo() {
   const { t } = useT("common");
+  const timeZone = useViewingTimezone();
   return (dateStr: string): string => {
-    const diff = Date.now() - new Date(dateStr).getTime();
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) return t(($) => $.time.just_now);
-    if (minutes < 60) return t(($) => $.time.minutes_ago, { count: minutes });
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return t(($) => $.time.hours_ago, { count: hours });
-    const days = Math.floor(hours / 24);
-    return t(($) => $.time.days_ago, { count: days });
+    const bucket = relativeTimeBucket(
+      new Date(dateStr).getTime(),
+      Date.now(),
+      timeZone,
+    );
+    switch (bucket.kind) {
+      case "just_now":
+        return t(($) => $.time.just_now);
+      case "minutes":
+        return t(($) => (bucket.future ? $.time.in_minutes : $.time.minutes_ago), {
+          count: bucket.count,
+        });
+      case "hours":
+        return t(($) => (bucket.future ? $.time.in_hours : $.time.hours_ago), {
+          count: bucket.count,
+        });
+      case "days":
+        return t(($) => (bucket.future ? $.time.in_days : $.time.days_ago), {
+          count: bucket.count,
+        });
+      case "months":
+        return t(($) => (bucket.future ? $.time.in_months : $.time.months_ago), {
+          count: bucket.count,
+        });
+      case "years":
+        return t(($) => (bucket.future ? $.time.in_years : $.time.years_ago), {
+          count: bucket.count,
+        });
+      default:
+        return "—";
+    }
   };
 }

--- a/packages/views/i18n/use-time-ago.ts
+++ b/packages/views/i18n/use-time-ago.ts
@@ -10,18 +10,22 @@ import { useT } from "./use-t";
 // "in 3h". Day granularity is calendar-based in the viewer's Viewing Timezone;
 // past the day cap it continues into calendar months, then years — there is no
 // absolute-date fallback.
-export function useTimeAgo() {
+// `soonForFuture`: a sub-minute gap buckets to the direction-less "just now"
+// (it absorbs clock skew either way). For a genuinely scheduled future instant
+// — the autopilot next run — that past-tense label reads wrong, so callers can
+// opt into rendering imminent future times as "soon" instead.
+export function useTimeAgo(opts?: { soonForFuture?: boolean }) {
   const { t } = useT("common");
   const timeZone = useViewingTimezone();
   return (dateStr: string): string => {
-    const bucket = relativeTimeBucket(
-      new Date(dateStr).getTime(),
-      Date.now(),
-      timeZone,
-    );
+    const then = new Date(dateStr).getTime();
+    const now = Date.now();
+    const bucket = relativeTimeBucket(then, now, timeZone);
     switch (bucket.kind) {
       case "just_now":
-        return t(($) => $.time.just_now);
+        return opts?.soonForFuture && then > now
+          ? t(($) => $.time.soon)
+          : t(($) => $.time.just_now);
       case "minutes":
         return t(($) => (bucket.future ? $.time.in_minutes : $.time.minutes_ago), {
           count: bucket.count,

--- a/packages/views/i18n/use-time-ago.ts
+++ b/packages/views/i18n/use-time-ago.ts
@@ -10,20 +10,24 @@ import { useT } from "./use-t";
 // "in 3h". Day granularity is calendar-based in the viewer's Viewing Timezone;
 // past the day cap it continues into calendar months, then years — there is no
 // absolute-date fallback.
-// `soonForFuture`: a sub-minute gap buckets to the direction-less "just now"
-// (it absorbs clock skew either way). For a genuinely scheduled future instant
-// — the autopilot next run — that past-tense label reads wrong, so callers can
-// opt into rendering imminent future times as "soon" instead.
-export function useTimeAgo(opts?: { soonForFuture?: boolean }) {
+// `scheduled`: the instant is a scheduled run — the autopilot next run. Render
+// it from the scheduler's view: an already-due slot the scheduler hasn't
+// advanced yet (next_run_at in the past) is imminent, not bygone, so it reads
+// "soon" rather than a misleading "Xm ago"; likewise a sub-minute-away future
+// run reads "soon" instead of the direction-less "just now" (which otherwise
+// absorbs clock skew either way).
+export function useTimeAgo(opts?: { scheduled?: boolean }) {
   const { t } = useT("common");
   const timeZone = useViewingTimezone();
   return (dateStr: string): string => {
     const then = new Date(dateStr).getTime();
     const now = Date.now();
+    // Overdue scheduled slot the scheduler hasn't rolled forward yet → imminent.
+    if (opts?.scheduled && then <= now) return t(($) => $.time.soon);
     const bucket = relativeTimeBucket(then, now, timeZone);
     switch (bucket.kind) {
       case "just_now":
-        return opts?.soonForFuture && then > now
+        return opts?.scheduled && then > now
           ? t(($) => $.time.soon)
           : t(($) => $.time.just_now);
       case "minutes":

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
-import { formatDateOnly } from "@multica/core/issues/date";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { useFormatCalendarDate } from "../../common/use-format-calendar-date";
 import { StatusIcon, PriorityIcon } from "../../issues/components";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@multica/core/types";
 import { getQuickCreateFailureDetail } from "./inbox-display";
@@ -35,16 +35,14 @@ export function useTypeLabels(): Record<InboxItemType, string> {
   };
 }
 
-// start_date / due_date are calendar days — format timezone-safely so the day
-// never shifts with the viewer's offset (see @multica/core/issues/date).
-function shortDate(dateStr: string): string {
-  return formatDateOnly(dateStr, { month: "short", day: "numeric" }, "en-US");
-}
-
 export function InboxDetailLabel({ item }: { item: InboxItem }) {
   const { t } = useT("inbox");
   const typeLabels = useTypeLabels();
   const { getActorName } = useActorName();
+  // start_date / due_date are calendar days — formatCalendarDate keeps them
+  // timezone-safe (the day never shifts with the viewer's offset) while using
+  // the Language locale instead of a hardcoded one.
+  const shortDate = useFormatCalendarDate();
   const details = item.details ?? {};
 
   switch (item.type) {

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -7,23 +7,7 @@ import type { InboxItem } from "@multica/core/types";
 import { InboxDetailLabel } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
 import { useT } from "../../i18n";
-
-// Hook returning a localized relative-time formatter — the i18n equivalent
-// of the previous static `timeAgo` function. Returning a function (rather
-// than a string) keeps call-site usage identical: `timeAgo(dateStr)`.
-export function useTimeAgo() {
-  const { t } = useT("inbox");
-  return (dateStr: string): string => {
-    const diff = Date.now() - new Date(dateStr).getTime();
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) return t(($) => $.list.time.just_now);
-    if (minutes < 60) return t(($) => $.list.time.minutes, { count: minutes });
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return t(($) => $.list.time.hours, { count: hours });
-    const days = Math.floor(hours / 24);
-    return t(($) => $.list.time.days, { count: days });
-  };
-}
+import { DateTime } from "../../common/date-time";
 
 export function InboxListItem({
   item,
@@ -37,7 +21,6 @@ export function InboxListItem({
   onArchive: () => void;
 }) {
   const { t } = useT("inbox");
-  const timeAgo = useTimeAgo();
   const displayTitle = getInboxDisplayTitle(item);
 
   return (
@@ -94,9 +77,11 @@ export function InboxListItem({
           <p className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs ${item.read ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
             <InboxDetailLabel item={item} />
           </p>
-          <span className={`shrink-0 text-xs ${item.read ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
-            {timeAgo(item.created_at)}
-          </span>
+          <DateTime
+            value={item.created_at}
+            variant="relative"
+            className={`shrink-0 text-xs ${item.read ? "text-muted-foreground/60" : "text-muted-foreground"}`}
+          />
         </div>
       </div>
     </button>

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -51,10 +51,11 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { PageHeader } from "../../layout/page-header";
-import { InboxListItem, useTimeAgo } from "./inbox-list-item";
+import { InboxListItem } from "./inbox-list-item";
 import { useTypeLabels } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
-import { useT } from "../../i18n";
+import { useT, useTimeAgo } from "../../i18n";
+import { InstantTooltip } from "../../common/instant-tooltip";
 
 export function InboxPage() {
   const { t } = useT("inbox");
@@ -314,7 +315,10 @@ export function InboxPage() {
     <div className="p-6">
       <h2 className="text-lg font-semibold">{getInboxDisplayTitle(selected)}</h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        {typeLabels[selected.type]} · {timeAgo(selected.created_at)}
+        {typeLabels[selected.type]} ·{" "}
+        <InstantTooltip value={selected.created_at}>
+          {timeAgo(selected.created_at)}
+        </InstantTooltip>
       </p>
       {selected.body && (
         <div className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-foreground/80">

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -18,7 +18,10 @@ import {
   UserMinus,
 } from "lucide-react";
 import type { AgentTask, Issue } from "@multica/core/types";
-import { todayDateOnly, addDaysDateOnly } from "@multica/core/issues/date";
+import {
+  todayDateOnlyInTimeZone,
+  addDaysDateOnlyInTimeZone,
+} from "@multica/core/issues/date";
 import { api } from "@multica/core/api";
 import {
   ALL_STATUSES,
@@ -44,6 +47,7 @@ import {
 } from "@multica/ui/components/ui/context-menu";
 import { copyText } from "@multica/ui/lib/clipboard";
 import type { UseIssueActionsResult } from "./use-issue-actions";
+import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import { useT } from "../../i18n";
 
 // Both Dropdown and Context menu wrappers expose an API-compatible surface
@@ -97,6 +101,9 @@ export function IssueActionsMenuItems({
   onDeletedNavigateTo,
 }: IssueActionsMenuItemsProps) {
   const { t } = useT("issues");
+  // "Today / tomorrow / next week" presets anchor on the viewer's Viewing tz so
+  // a just-set due date agrees with the Viewing-tz overdue badge (spec §4).
+  const viewTz = useViewingTimezone();
   const {
     isPinned,
     updateField,
@@ -200,13 +207,13 @@ export function IssueActionsMenuItems({
           {t(($) => $.actions.start_date)}
         </P.SubTrigger>
         <P.SubContent>
-          <P.Item onClick={() => updateField({ start_date: todayDateOnly() })}>
+          <P.Item onClick={() => updateField({ start_date: todayDateOnlyInTimeZone(viewTz) })}>
             {t(($) => $.actions.start_today)}
           </P.Item>
-          <P.Item onClick={() => updateField({ start_date: addDaysDateOnly(1) })}>
+          <P.Item onClick={() => updateField({ start_date: addDaysDateOnlyInTimeZone(1, viewTz) })}>
             {t(($) => $.actions.start_tomorrow)}
           </P.Item>
-          <P.Item onClick={() => updateField({ start_date: addDaysDateOnly(7) })}>
+          <P.Item onClick={() => updateField({ start_date: addDaysDateOnlyInTimeZone(7, viewTz) })}>
             {t(($) => $.actions.start_next_week)}
           </P.Item>
           {issue.start_date && (
@@ -227,13 +234,13 @@ export function IssueActionsMenuItems({
           {t(($) => $.actions.due_date)}
         </P.SubTrigger>
         <P.SubContent>
-          <P.Item onClick={() => updateField({ due_date: todayDateOnly() })}>
+          <P.Item onClick={() => updateField({ due_date: todayDateOnlyInTimeZone(viewTz) })}>
             {t(($) => $.actions.due_today)}
           </P.Item>
-          <P.Item onClick={() => updateField({ due_date: addDaysDateOnly(1) })}>
+          <P.Item onClick={() => updateField({ due_date: addDaysDateOnlyInTimeZone(1, viewTz) })}>
             {t(($) => $.actions.due_tomorrow)}
           </P.Item>
-          <P.Item onClick={() => updateField({ due_date: addDaysDateOnly(7) })}>
+          <P.Item onClick={() => updateField({ due_date: addDaysDateOnlyInTimeZone(7, viewTz) })}>
             {t(($) => $.actions.due_next_week)}
           </P.Item>
           {issue.due_date && (

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -7,7 +7,9 @@ import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { toast } from "sonner";
 import type { Issue, UpdateIssueRequest } from "@multica/core/types";
-import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
+import { isPastDateOnly } from "@multica/core/issues/date";
+import { useFormatCalendarDate } from "../../common/use-format-calendar-date";
+import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import { CalendarClock, CalendarDays } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -16,6 +18,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useTimeAgo } from "../../i18n";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { PriorityIcon } from "./priority-icon";
@@ -27,10 +30,6 @@ import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { useT } from "../../i18n";
-
-function formatDate(date: string): string {
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
-}
 
 function descriptionPreview(markdown: string): string {
   return markdown
@@ -67,6 +66,8 @@ export const BoardCardContent = memo(function BoardCardContent({
 }) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
+  const formatDate = useFormatCalendarDate();
+  const viewTz = useViewingTimezone();
   const storeProperties = useViewStore((s) => s.cardProperties);
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery({
@@ -259,7 +260,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                       trigger={
                         <span
                           className={`flex items-center gap-1 text-xs ${
-                            isPastDateOnly(issue.due_date)
+                            isPastDateOnly(issue.due_date, viewTz)
                               ? "text-destructive"
                               : "text-muted-foreground"
                           }`}
@@ -273,7 +274,7 @@ export const BoardCardContent = memo(function BoardCardContent({
                 ) : (
                   <span
                     className={`flex shrink-0 items-center gap-1 text-xs ${
-                      isPastDateOnly(issue.due_date)
+                      isPastDateOnly(issue.due_date, viewTz)
                         ? "text-destructive"
                         : "text-muted-foreground"
                     }`}
@@ -292,9 +293,12 @@ export const BoardCardContent = memo(function BoardCardContent({
                 </div>
               )}
               {showUpdatedHint && (
-                <span className="shrink-0 text-xs text-muted-foreground">
+                <InstantTooltip
+                  value={issue.updated_at}
+                  className="shrink-0 text-xs text-muted-foreground"
+                >
                   {t(($) => $.card.updated_ago, { time: timeAgo(issue.updated_at) })}
-                </span>
+                </InstantTooltip>
               )}
             </div>
           )}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@multica/ui/components/ui/dropdown-menu";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,7 +28,7 @@ import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { cn } from "@multica/ui/lib/utils";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { useActorName } from "@multica/core/workspace/hooks";
-import { useTimeAgo } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 import { ContentEditor, type ContentEditorRef, ReadonlyContent, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -496,7 +495,6 @@ function CommentRow({
   onResolveToggle?: (commentId: string, resolved: boolean) => void;
 }) {
   const { t } = useT("issues");
-  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
 
   const edit = useEditAttachmentState(issueId, entry, onEdit);
@@ -522,18 +520,11 @@ function CommentRow({
         <span className="cursor-pointer text-sm font-medium">
           {getActorName(entry.actor_type, entry.actor_id)}
         </span>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <span className="text-xs text-muted-foreground cursor-default">
-                {timeAgo(entry.created_at)}
-              </span>
-            }
-          />
-          <TooltipContent side="top">
-            {new Date(entry.created_at).toLocaleString()}
-          </TooltipContent>
-        </Tooltip>
+        <DateTime
+          value={entry.created_at}
+          variant="relative"
+          className="text-xs text-muted-foreground cursor-default"
+        />
 
         {isResolution && (
           <span className="text-xs font-medium text-success">
@@ -709,7 +700,6 @@ function CommentCardImpl({
   highlightedCommentId,
 }: CommentCardProps) {
   const { t } = useT("issues");
-  const timeAgo = useTimeAgo();
   const { getActorName } = useActorName();
   const isCollapsed = useCommentCollapseStore((s) => s.isCollapsed(issueId, entry.id));
   const toggleCollapse = useCommentCollapseStore((s) => s.toggle);
@@ -797,18 +787,11 @@ function CommentCardImpl({
             <span className="shrink-0 cursor-pointer text-sm font-medium">
               {getActorName(entry.actor_type, entry.actor_id)}
             </span>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <span className="shrink-0 text-xs text-muted-foreground cursor-default">
-                    {timeAgo(entry.created_at)}
-                  </span>
-                }
-              />
-              <TooltipContent side="top">
-                {new Date(entry.created_at).toLocaleString()}
-              </TooltipContent>
-            </Tooltip>
+            <DateTime
+              value={entry.created_at}
+              variant="relative"
+              className="shrink-0 text-xs text-muted-foreground cursor-default"
+            />
 
             {!open && contentPreview && (
               <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { issueKeys } from "@multica/core/issues/queries";
 import type { AgentTask, TaskFailureReason } from "@multica/core/types";
-import { useTimeAgo } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 import {
   Tooltip,
   TooltipContent,
@@ -363,11 +363,9 @@ export function ActiveTaskRow({
 
 function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   const { t } = useT("issues");
-  const timeAgo = useTimeAgo();
   const [retrying, setRetrying] = useState(false);
   const label = useStatusLabel(task.status);
   const trigger = useTriggerText(task);
-  const time = task.completed_at ? timeAgo(task.completed_at) : "—";
   const failureLabel =
     task.status === "failed" && task.failure_reason
       ? failureReasonLabel[task.failure_reason as TaskFailureReason]
@@ -401,7 +399,15 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
       <RowStatus title={failureLabel ?? label}>
         <TaskStatusIcon status={task.status} />
         <span className="sr-only">{failureLabel ?? label}</span>
-        <span className="text-muted-foreground">{time}</span>
+        {task.completed_at ? (
+          <DateTime
+            value={task.completed_at}
+            variant="relative"
+            className="text-muted-foreground"
+          />
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
       </RowStatus>
       <RowActions>
         <TranscriptButton task={task} agentName="" title={t(($) => $.execution_log.transcript_tooltip)} />

--- a/packages/views/issues/components/gantt-view.tsx
+++ b/packages/views/issues/components/gantt-view.tsx
@@ -8,7 +8,7 @@ import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-
 import type { GanttZoom } from "@multica/core/issues/stores/view-store";
 import { projectListOptions } from "@multica/core/projects/queries";
 import type { Issue, IssueStatus } from "@multica/core/types";
-import { dateOnlyToUTCDate } from "@multica/core/issues/date";
+import { dateOnlyToUTCDate, formatDateOnly } from "@multica/core/issues/date";
 import { cn } from "@multica/ui/lib/utils";
 import {
   Tooltip,
@@ -123,7 +123,8 @@ function GanttAxis({
   todayOffsetDays: number;
   width: number;
 }) {
-  const locale = typeof navigator !== "undefined" ? navigator.language : "en";
+  const { i18n } = useT("issues");
+  const locale = i18n.language || "en";
   const totalDays = daysBetween(range.start, range.end);
 
   const monthBlocks = useMemo(() => {
@@ -315,7 +316,7 @@ function ScheduledRow({
   dayPx: number;
   totalDays: number;
 }) {
-  const { t } = useT("issues");
+  const { t, i18n } = useT("issues");
   const p = useWorkspacePaths();
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery({
@@ -349,14 +350,9 @@ function ScheduledRow({
     }
   }
 
-  const locale = typeof navigator !== "undefined" ? navigator.language : "en";
-  const fmt = (d: Date) =>
-    d.toLocaleDateString(locale, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      timeZone: "UTC",
-    });
+  const locale = i18n.language || "en";
+  const fmt = (iso: string | null) =>
+    formatDateOnly(iso, { month: "short", day: "numeric", year: "numeric" }, locale);
 
   return (
     <IssueActionsContextMenu issue={issue}>
@@ -419,7 +415,7 @@ function ScheduledRow({
                 <div className="flex flex-col gap-0.5 text-xs">
                   <span className="font-medium">{issue.title}</span>
                   <span className="text-muted-foreground">
-                    {start ? fmt(start) : "—"} → {due ? fmt(due) : "—"}
+                    {start ? fmt(issue.start_date) : "—"} → {due ? fmt(issue.due_date) : "—"}
                   </span>
                   {inverted && (
                     <span className="text-destructive">

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -43,10 +43,11 @@ import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, Command
 import { AvatarGroup, AvatarGroupCount } from "@multica/ui/components/ui/avatar";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PropRow } from "../../common/prop-row";
+import { DateTime } from "../../common/date-time";
+import { useFormatCalendarDate } from "../../common/use-format-calendar-date";
 import type { Attachment, Issue, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
-import { formatDateOnly } from "@multica/core/issues/date";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { toast } from "sonner";
 import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, StagePicker, StartDatePicker, DueDatePicker, AssigneePicker, LabelPicker } from ".";
@@ -82,7 +83,6 @@ import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
 import { ReactionBar } from "@multica/ui/components/common/reaction-bar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
-import { useTimeAgo } from "../../i18n";
 import { cn } from "@multica/ui/lib/utils";
 
 import { ProgressRing } from "./progress-ring";
@@ -178,11 +178,6 @@ function SubscriberPopoverContent({
   );
 }
 
-function shortDate(date: string | null): string {
-  if (!date) return "—";
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
-}
-
 type ActivityT = ReturnType<typeof useT<"issues">>["t"];
 
 function statusLabel(status: string, t: ActivityT): string {
@@ -202,6 +197,7 @@ function priorityLabel(priority: string, t: ActivityT): string {
 function formatActivity(
   entry: TimelineEntry,
   t: ActivityT,
+  formatDate: (value: string | null | undefined) => string,
   resolveActorName?: (type: string, id: string) => string,
 ): string {
   const details = (entry.details ?? {}) as Record<string, string>;
@@ -230,13 +226,11 @@ function formatActivity(
     }
     case "start_date_changed": {
       if (!details.to) return t(($) => $.activity.start_date_removed);
-      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, "en-US");
-      return t(($) => $.activity.start_date_set, { date: formatted });
+      return t(($) => $.activity.start_date_set, { date: formatDate(details.to) });
     }
     case "due_date_changed": {
       if (!details.to) return t(($) => $.activity.due_date_removed);
-      const formatted = formatDateOnly(details.to, { month: "short", day: "numeric" }, "en-US");
-      return t(($) => $.activity.due_date_set, { date: formatted });
+      return t(($) => $.activity.due_date_set, { date: formatDate(details.to) });
     }
     case "title_changed":
       return t(($) => $.activity.title_renamed, {
@@ -446,7 +440,7 @@ function ActivityBlock({
   onToggleShowOlder,
   getActorName,
   t,
-  timeAgo,
+  formatDate,
 }: {
   entries: TimelineEntry[];
   expanded: boolean;
@@ -459,7 +453,7 @@ function ActivityBlock({
   onToggleShowOlder: () => void;
   getActorName: (type: string, id: string) => string;
   t: ActivityT;
-  timeAgo: (dateStr: string) => string;
+  formatDate: (value: string | null | undefined) => string;
 }) {
   if (!expanded) {
     const count = entries.length;
@@ -538,7 +532,7 @@ function ActivityBlock({
             </div>
             <div className="flex min-w-0 flex-1 items-center gap-1">
               <span className="shrink-0 font-medium">{getActorName(entry.actor_type, entry.actor_id)}</span>
-              <span className="truncate">{formatActivity(entry, t, getActorName)}</span>
+              <span className="truncate">{formatActivity(entry, t, formatDate, getActorName)}</span>
               {(entry.coalesced_count ?? 1) > 1 &&
                 entry.action !== "task_completed" &&
                 entry.action !== "task_failed" && (
@@ -546,18 +540,11 @@ function ActivityBlock({
                     {t(($) => $.activity.coalesced_badge, { count: entry.coalesced_count ?? 1 })}
                   </span>
                 )}
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <span className="ml-auto shrink-0 cursor-default">
-                      {timeAgo(entry.created_at)}
-                    </span>
-                  }
-                />
-                <TooltipContent side="top">
-                  {new Date(entry.created_at).toLocaleString()}
-                </TooltipContent>
-              </Tooltip>
+              <DateTime
+                value={entry.created_at}
+                variant="relative"
+                className="ml-auto shrink-0 cursor-default"
+              />
             </div>
           </div>
         );
@@ -696,7 +683,7 @@ interface IssueDetailProps {
 
 export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const { t } = useT("issues");
-  const timeAgo = useTimeAgo();
+  const formatCalendarDate = useFormatCalendarDate();
   const id = issueId;
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
@@ -1618,10 +1605,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             <span className="cursor-pointer truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_created)}>
-            <span className="text-muted-foreground">{shortDate(issue.created_at)}</span>
+            <DateTime value={issue.created_at} variant="date" className="text-muted-foreground" />
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_updated)}>
-            <span className="text-muted-foreground">{shortDate(issue.updated_at)}</span>
+            <DateTime value={issue.updated_at} variant="date" className="text-muted-foreground" />
           </PropRow>
         </div>}
       </div>
@@ -1755,7 +1742,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         onToggleShowOlder={() => showOlderActivities(item.id)}
         getActorName={getActorName}
         t={t}
-        timeAgo={timeAgo}
+        formatDate={formatCalendarDate}
       />
     );
   };

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -72,7 +72,9 @@ import {
   type ViewMode,
 } from "@multica/core/issues/stores/view-store";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
-import { addDaysDateOnly, dateOnlyToLocalDate, formatDateOnly, toDateOnly, todayDateOnly } from "@multica/core/issues/date";
+import { addDaysDateOnlyInTimeZone, dateOnlyToLocalDate, toDateOnly, todayDateOnlyInTimeZone } from "@multica/core/issues/date";
+import { useFormatCalendarDate } from "../../common/use-format-calendar-date";
+import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import {
   useIssuesScopeStore,
   type IssuesScope,
@@ -115,9 +117,6 @@ function getActiveFilterCount(state: {
   return count;
 }
 
-function shortDateLabel(dateOnly: string) {
-  return formatDateOnly(dateOnly, { month: "short", day: "numeric" }) || dateOnly;
-}
 
 function normalizeDateRange(from: Date, to: Date) {
   return from <= to ? [from, to] as const : [to, from] as const;
@@ -516,6 +515,10 @@ function DateSubContent({
   onChange: (filter: IssueDateFilter | null) => void;
 }) {
   const { t } = useT("issues");
+  // Range presets anchor "today" on the viewer's Viewing tz so they line up
+  // with the dates shown on the issues (spec §4); a browser-local today could
+  // drop a day across the date boundary and miss today's issues.
+  const viewTz = useViewingTimezone();
   const [field, setField] = useState<IssueDateField>(value?.field ?? "created_at");
   const [range, setRange] = useState<LocalDateRange | undefined>(() => {
     if (!value) return undefined;
@@ -532,8 +535,8 @@ function DateSubContent({
   const applyPreset = (days: 1 | 3 | 7) => {
     onChange({
       field,
-      from: addDaysDateOnly(1 - days),
-      to: todayDateOnly(),
+      from: addDaysDateOnlyInTimeZone(1 - days, viewTz),
+      to: todayDateOnlyInTimeZone(viewTz),
     });
   };
 
@@ -756,6 +759,9 @@ export function IssueDisplayControls({
   allowGantt?: boolean;
 }) {
   const { t } = useT("issues");
+  const formatCalendarDate = useFormatCalendarDate();
+  const shortDateLabel = (dateOnly: string) =>
+    formatCalendarDate(dateOnly) || dateOnly;
   const viewMode = useViewStore((s) => s.viewMode);
   const statusFilters = useViewStore((s) => s.statusFilters);
   const priorityFilters = useViewStore((s) => s.priorityFilters);

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -7,7 +7,7 @@ import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
-import { formatDateOnly } from "@multica/core/issues/date";
+import { useFormatCalendarDate } from "../../common/use-format-calendar-date";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { useWorkspacePaths } from "@multica/core/paths";
@@ -24,10 +24,6 @@ import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 export interface ChildProgress {
   done: number;
   total: number;
-}
-
-function formatDate(date: string): string {
-  return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
 }
 
 function ListRowContent({
@@ -49,6 +45,7 @@ function ListRowContent({
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
+  const formatDate = useFormatCalendarDate();
   const p = useWorkspacePaths();
   const storeProperties = useViewStore((s) => s.cardProperties);
   const wsId = useWorkspaceId();

--- a/packages/views/issues/components/pickers/due-date-picker.tsx
+++ b/packages/views/issues/components/pickers/due-date-picker.tsx
@@ -6,9 +6,10 @@ import type { UpdateIssueRequest } from "@multica/core/types";
 import {
   toDateOnly,
   dateOnlyToLocalDate,
-  formatDateOnly,
   isPastDateOnly,
 } from "@multica/core/issues/date";
+import { useFormatCalendarDate } from "../../../common/use-format-calendar-date";
+import { useViewingTimezone } from "../../../common/use-viewing-timezone";
 import { Calendar } from "@multica/ui/components/ui/calendar";
 import {
   Popover,
@@ -36,9 +37,11 @@ export function DueDatePicker({
   defaultOpen?: boolean;
 }) {
   const { t } = useT("issues");
+  const formatCalendarDate = useFormatCalendarDate();
+  const viewTz = useViewingTimezone();
   const [open, setOpen] = useState(defaultOpen);
   const date = dateOnlyToLocalDate(dueDate);
-  const isOverdue = isPastDateOnly(dueDate);
+  const isOverdue = isPastDateOnly(dueDate, viewTz);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -51,7 +54,7 @@ export function DueDatePicker({
             <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
             {date ? (
               <span className={isOverdue ? "text-destructive" : ""}>
-                {formatDateOnly(dueDate, { month: "short", day: "numeric" }, "en-US")}
+                {formatCalendarDate(dueDate)}
               </span>
             ) : (
               <span className="text-muted-foreground">{t(($) => $.pickers.due_date.trigger_label)}</span>

--- a/packages/views/issues/components/pickers/start-date-picker.tsx
+++ b/packages/views/issues/components/pickers/start-date-picker.tsx
@@ -6,8 +6,8 @@ import type { UpdateIssueRequest } from "@multica/core/types";
 import {
   toDateOnly,
   dateOnlyToLocalDate,
-  formatDateOnly,
 } from "@multica/core/issues/date";
+import { useFormatCalendarDate } from "../../../common/use-format-calendar-date";
 import { Calendar } from "@multica/ui/components/ui/calendar";
 import {
   Popover,
@@ -39,6 +39,7 @@ export function StartDatePicker({
   defaultOpen?: boolean;
 }) {
   const { t } = useT("issues");
+  const formatCalendarDate = useFormatCalendarDate();
   const [internalOpen, setInternalOpen] = useState(defaultOpen);
   const open = controlledOpen ?? internalOpen;
   const setOpen = controlledOnOpenChange ?? setInternalOpen;
@@ -55,7 +56,7 @@ export function StartDatePicker({
             <CalendarClock className="h-3.5 w-3.5 text-muted-foreground" />
             {date ? (
               <span>
-                {formatDateOnly(startDate, { month: "short", day: "numeric" }, "en-US")}
+                {formatCalendarDate(startDate)}
               </span>
             ) : (
               <span className="text-muted-foreground">{t(($) => $.pickers.start_date.trigger_label)}</span>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -475,8 +475,8 @@
   },
   "last_active": {
     "today": "Today",
-    "days_ago_one": "{{count}} day ago",
-    "days_ago_other": "{{count}} days ago",
+    "days_ago_one": "{{count}}d ago",
+    "days_ago_other": "{{count}}d ago",
     "none": "No activity (30d)"
   },
   "toolbar": {

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -33,12 +33,6 @@
     "create_issue": "Create Issue",
     "run_only": "Run Only"
   },
-  "relative_date": {
-    "today": "Today",
-    "one_day_ago": "1d ago",
-    "days_ago": "{{count}}d ago",
-    "months_ago": "{{count}}mo ago"
-  },
   "templates": {
     "daily_news": {
       "title": "Daily news digest",

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -33,12 +33,6 @@
   },
   "session_history": {
     "untitled": "Untitled",
-    "time": {
-      "just_now": "just now",
-      "minutes": "{{count}}m ago",
-      "hours": "{{count}}h ago",
-      "days": "{{count}}d ago"
-    },
     "row_delete_aria": "Delete chat session",
     "row_rename_aria": "Rename chat session",
     "row_stop_aria": "Stop current run",

--- a/packages/views/locales/en/common.json
+++ b/packages/views/locales/en/common.json
@@ -6,6 +6,7 @@
   "loading": "Loading...",
   "time": {
     "just_now": "just now",
+    "soon": "soon",
     "minutes_ago": "{{count}}m ago",
     "hours_ago": "{{count}}h ago",
     "days_ago": "{{count}}d ago",

--- a/packages/views/locales/en/common.json
+++ b/packages/views/locales/en/common.json
@@ -8,7 +8,14 @@
     "just_now": "just now",
     "minutes_ago": "{{count}}m ago",
     "hours_ago": "{{count}}h ago",
-    "days_ago": "{{count}}d ago"
+    "days_ago": "{{count}}d ago",
+    "months_ago": "{{count}}mo ago",
+    "years_ago": "{{count}}y ago",
+    "in_minutes": "in {{count}}m",
+    "in_hours": "in {{count}}h",
+    "in_days": "in {{count}}d",
+    "in_months": "in {{count}}mo",
+    "in_years": "in {{count}}y"
   },
   "lark_bind": {
     "page_title": "Bind your Lark account",

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -12,13 +12,7 @@
   "list": {
     "empty": "No notifications",
     "mark_done_tooltip": "Mark as done",
-    "archive_tooltip": "Archive",
-    "time": {
-      "just_now": "just now",
-      "minutes": "{{count}}m",
-      "hours": "{{count}}h",
-      "days": "{{count}}d"
-    }
+    "archive_tooltip": "Archive"
   },
   "detail": {
     "select_prompt": "Select a notification to view details",

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -49,12 +49,6 @@
     "agents_group": "Agents",
     "no_results": "No results"
   },
-  "relative_date": {
-    "today": "Today",
-    "one_day_ago": "1d ago",
-    "days_ago": "{{count}}d ago",
-    "months_ago": "{{count}}mo ago"
-  },
   "detail": {
     "not_found": "Project not found",
     "breadcrumb_fallback": "Projects",

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -409,5 +409,16 @@
     "table_cache_r": "Cache R",
     "table_cache_w": "Cache W",
     "no_data": "No usage data yet"
+  },
+  "last_seen": {
+    "never": "Never",
+    "just_now": "Just now",
+    "seconds_ago": "{{count}}s ago",
+    "minutes_ago": "{{count}}m ago",
+    "minutes_seconds_ago": "{{minutes}}m {{seconds}}s ago",
+    "hours_ago": "{{count}}h ago",
+    "hours_minutes_ago": "{{hours}}h {{minutes}}m ago",
+    "days_ago": "{{count}}d ago",
+    "days_hours_ago": "{{days}}d {{hours}}h ago"
   }
 }

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -110,10 +110,9 @@
     "toast_create_failed": "Failed to create token",
     "toast_revoked": "Token revoked",
     "toast_revoke_failed": "Failed to revoke token",
-    "metadata_prefix": "{{prefix}}... · Created {{created}} · {{lastUsed}}",
     "last_used_with_date": "Last used {{date}}",
     "last_used_never": "Never used",
-    "expires_with_date": " · Expires {{date}}",
+    "expires_with_date": "Expires {{date}}",
     "revoke_aria": "Revoke {{name}}",
     "revoke_tooltip": "Revoke",
     "revoke_dialog": {
@@ -127,7 +126,8 @@
       "description": "Copy your personal access token now. You won't be able to see it again.",
       "copy_tooltip": "Copy token",
       "done": "Done"
-    }
+    },
+    "created_with_date": "Created {{date}}"
   },
   "workspace": {
     "section_general": "General",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -463,8 +463,8 @@
   },
   "last_active": {
     "today": "今日",
-    "days_ago_one": "{{count}} 日前",
-    "days_ago_other": "{{count}} 日前",
+    "days_ago_one": "{{count}}日前",
+    "days_ago_other": "{{count}}日前",
     "none": "30 日間アクティビティなし"
   },
   "toolbar": {

--- a/packages/views/locales/ja/autopilots.json
+++ b/packages/views/locales/ja/autopilots.json
@@ -33,12 +33,6 @@
     "create_issue": "イシューを作成",
     "run_only": "実行のみ"
   },
-  "relative_date": {
-    "today": "今日",
-    "one_day_ago": "1 日前",
-    "days_ago": "{{count}} 日前",
-    "months_ago": "{{count}} か月前"
-  },
   "templates": {
     "daily_news": {
       "title": "日次ニュースダイジェスト",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -30,12 +30,6 @@
   },
   "session_history": {
     "untitled": "無題",
-    "time": {
-      "just_now": "たった今",
-      "minutes": "{{count}}分前",
-      "hours": "{{count}}時間前",
-      "days": "{{count}}日前"
-    },
     "row_delete_aria": "チャットセッションを削除",
     "row_rename_aria": "チャットセッションの名前を変更",
     "delete_dialog": {

--- a/packages/views/locales/ja/common.json
+++ b/packages/views/locales/ja/common.json
@@ -8,7 +8,14 @@
     "just_now": "たった今",
     "minutes_ago": "{{count}}分前",
     "hours_ago": "{{count}}時間前",
-    "days_ago": "{{count}}日前"
+    "days_ago": "{{count}}日前",
+    "months_ago": "{{count}}か月前",
+    "years_ago": "{{count}}年前",
+    "in_minutes": "{{count}}分後",
+    "in_hours": "{{count}}時間後",
+    "in_days": "{{count}}日後",
+    "in_months": "{{count}}か月後",
+    "in_years": "{{count}}年後"
   },
   "lark_bind": {
     "page_title": "Lark アカウントを連携",

--- a/packages/views/locales/ja/common.json
+++ b/packages/views/locales/ja/common.json
@@ -6,6 +6,7 @@
   "loading": "読み込み中...",
   "time": {
     "just_now": "たった今",
+    "soon": "まもなく",
     "minutes_ago": "{{count}}分前",
     "hours_ago": "{{count}}時間前",
     "days_ago": "{{count}}日前",

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -12,13 +12,7 @@
   "list": {
     "empty": "通知はありません",
     "mark_done_tooltip": "完了にする",
-    "archive_tooltip": "アーカイブ",
-    "time": {
-      "just_now": "たった今",
-      "minutes": "{{count}}分",
-      "hours": "{{count}}時間",
-      "days": "{{count}}日"
-    }
+    "archive_tooltip": "アーカイブ"
   },
   "detail": {
     "select_prompt": "詳細を表示する通知を選択してください",

--- a/packages/views/locales/ja/projects.json
+++ b/packages/views/locales/ja/projects.json
@@ -49,12 +49,6 @@
     "agents_group": "エージェント",
     "no_results": "結果なし"
   },
-  "relative_date": {
-    "today": "今日",
-    "one_day_ago": "1日前",
-    "days_ago": "{{count}}日前",
-    "months_ago": "{{count}}か月前"
-  },
   "detail": {
     "not_found": "プロジェクトが見つかりません",
     "breadcrumb_fallback": "プロジェクト",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -394,5 +394,16 @@
     "table_cache_r": "キャッシュ R",
     "table_cache_w": "キャッシュ W",
     "no_data": "まだ使用量データがありません"
+  },
+  "last_seen": {
+    "never": "なし",
+    "just_now": "たった今",
+    "seconds_ago": "{{count}}秒前",
+    "minutes_ago": "{{count}}分前",
+    "minutes_seconds_ago": "{{minutes}}分{{seconds}}秒前",
+    "hours_ago": "{{count}}時間前",
+    "hours_minutes_ago": "{{hours}}時間{{minutes}}分前",
+    "days_ago": "{{count}}日前",
+    "days_hours_ago": "{{days}}日{{hours}}時間前"
   }
 }

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -110,10 +110,9 @@
     "toast_create_failed": "トークンを作成できませんでした",
     "toast_revoked": "トークンを失効しました",
     "toast_revoke_failed": "トークンを失効できませんでした",
-    "metadata_prefix": "{{prefix}}... · 作成 {{created}} · {{lastUsed}}",
     "last_used_with_date": "最終使用 {{date}}",
     "last_used_never": "未使用",
-    "expires_with_date": " · 有効期限 {{date}}",
+    "expires_with_date": "有効期限 {{date}}",
     "revoke_aria": "{{name}} を失効",
     "revoke_tooltip": "失効",
     "revoke_dialog": {
@@ -127,7 +126,8 @@
       "description": "今すぐ個人アクセストークンをコピーしてください。再表示はできません。",
       "copy_tooltip": "トークンをコピー",
       "done": "完了"
-    }
+    },
+    "created_with_date": "作成 {{date}}"
   },
   "workspace": {
     "section_general": "一般",

--- a/packages/views/locales/ko/autopilots.json
+++ b/packages/views/locales/ko/autopilots.json
@@ -33,12 +33,6 @@
     "create_issue": "이슈 생성",
     "run_only": "실행만"
   },
-  "relative_date": {
-    "today": "오늘",
-    "one_day_ago": "1일 전",
-    "days_ago": "{{count}}일 전",
-    "months_ago": "{{count}}개월 전"
-  },
   "templates": {
     "daily_news": {
       "title": "일일 뉴스 요약",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -33,12 +33,6 @@
   },
   "session_history": {
     "untitled": "제목 없음",
-    "time": {
-      "just_now": "방금 전",
-      "minutes": "{{count}}분 전",
-      "hours": "{{count}}시간 전",
-      "days": "{{count}}일 전"
-    },
     "row_delete_aria": "채팅 세션 삭제",
     "row_rename_aria": "채팅 세션 이름 변경",
     "row_stop_aria": "현재 실행 중지",

--- a/packages/views/locales/ko/common.json
+++ b/packages/views/locales/ko/common.json
@@ -8,7 +8,14 @@
     "just_now": "방금 전",
     "minutes_ago": "{{count}}분 전",
     "hours_ago": "{{count}}시간 전",
-    "days_ago": "{{count}}일 전"
+    "days_ago": "{{count}}일 전",
+    "months_ago": "{{count}}개월 전",
+    "years_ago": "{{count}}년 전",
+    "in_minutes": "{{count}}분 후",
+    "in_hours": "{{count}}시간 후",
+    "in_days": "{{count}}일 후",
+    "in_months": "{{count}}개월 후",
+    "in_years": "{{count}}년 후"
   },
   "lark_bind": {
     "page_title": "Lark 계정 연결",

--- a/packages/views/locales/ko/common.json
+++ b/packages/views/locales/ko/common.json
@@ -6,6 +6,7 @@
   "loading": "로딩 중...",
   "time": {
     "just_now": "방금 전",
+    "soon": "곧",
     "minutes_ago": "{{count}}분 전",
     "hours_ago": "{{count}}시간 전",
     "days_ago": "{{count}}일 전",

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -12,13 +12,7 @@
   "list": {
     "empty": "알림이 없습니다",
     "mark_done_tooltip": "완료로 표시",
-    "archive_tooltip": "보관",
-    "time": {
-      "just_now": "방금 전",
-      "minutes": "{{count}}분",
-      "hours": "{{count}}시간",
-      "days": "{{count}}일"
-    }
+    "archive_tooltip": "보관"
   },
   "detail": {
     "select_prompt": "자세히 볼 알림을 선택하세요",

--- a/packages/views/locales/ko/projects.json
+++ b/packages/views/locales/ko/projects.json
@@ -49,12 +49,6 @@
     "agents_group": "에이전트",
     "no_results": "결과 없음"
   },
-  "relative_date": {
-    "today": "오늘",
-    "one_day_ago": "1일 전",
-    "days_ago": "{{count}}일 전",
-    "months_ago": "{{count}}개월 전"
-  },
   "detail": {
     "not_found": "프로젝트를 찾을 수 없습니다",
     "breadcrumb_fallback": "프로젝트",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -409,5 +409,16 @@
     "table_cache_r": "캐시 R",
     "table_cache_w": "캐시 W",
     "no_data": "아직 사용량 데이터가 없습니다"
+  },
+  "last_seen": {
+    "never": "없음",
+    "just_now": "방금 전",
+    "seconds_ago": "{{count}}초 전",
+    "minutes_ago": "{{count}}분 전",
+    "minutes_seconds_ago": "{{minutes}}분 {{seconds}}초 전",
+    "hours_ago": "{{count}}시간 전",
+    "hours_minutes_ago": "{{hours}}시간 {{minutes}}분 전",
+    "days_ago": "{{count}}일 전",
+    "days_hours_ago": "{{days}}일 {{hours}}시간 전"
   }
 }

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -110,10 +110,9 @@
     "toast_create_failed": "토큰을 만들지 못했습니다",
     "toast_revoked": "토큰을 폐기했습니다",
     "toast_revoke_failed": "토큰을 폐기하지 못했습니다",
-    "metadata_prefix": "{{prefix}}... · {{created}} 생성 · {{lastUsed}}",
     "last_used_with_date": "마지막 사용 {{date}}",
     "last_used_never": "사용된 적 없음",
-    "expires_with_date": " · {{date}} 만료",
+    "expires_with_date": "{{date}} 만료",
     "revoke_aria": "{{name}} 폐기",
     "revoke_tooltip": "폐기",
     "revoke_dialog": {
@@ -127,7 +126,8 @@
       "description": "지금 개인 액세스 토큰을 복사하세요. 다시 볼 수 없습니다.",
       "copy_tooltip": "토큰 복사",
       "done": "완료"
-    }
+    },
+    "created_with_date": "{{date}} 생성"
   },
   "workspace": {
     "section_general": "일반",

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -33,12 +33,6 @@
     "create_issue": "创建 issue",
     "run_only": "仅运行"
   },
-  "relative_date": {
-    "today": "今天",
-    "one_day_ago": "1 天前",
-    "days_ago": "{{count}} 天前",
-    "months_ago": "{{count}} 个月前"
-  },
   "templates": {
     "daily_news": {
       "title": "每日新闻摘要",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -30,12 +30,6 @@
   },
   "session_history": {
     "untitled": "无标题",
-    "time": {
-      "just_now": "刚刚",
-      "minutes": "{{count}} 分钟前",
-      "hours": "{{count}} 小时前",
-      "days": "{{count}} 天前"
-    },
     "row_delete_aria": "删除对话",
     "row_rename_aria": "重命名对话",
     "row_stop_aria": "停止当前运行",

--- a/packages/views/locales/zh-Hans/common.json
+++ b/packages/views/locales/zh-Hans/common.json
@@ -8,7 +8,14 @@
     "just_now": "刚刚",
     "minutes_ago": "{{count}} 分钟前",
     "hours_ago": "{{count}} 小时前",
-    "days_ago": "{{count}} 天前"
+    "days_ago": "{{count}} 天前",
+    "months_ago": "{{count}} 个月前",
+    "years_ago": "{{count}} 年前",
+    "in_minutes": "{{count}} 分钟后",
+    "in_hours": "{{count}} 小时后",
+    "in_days": "{{count}} 天后",
+    "in_months": "{{count}} 个月后",
+    "in_years": "{{count}} 年后"
   },
   "lark_bind": {
     "page_title": "绑定飞书账号",

--- a/packages/views/locales/zh-Hans/common.json
+++ b/packages/views/locales/zh-Hans/common.json
@@ -6,6 +6,7 @@
   "loading": "加载中...",
   "time": {
     "just_now": "刚刚",
+    "soon": "即将",
     "minutes_ago": "{{count}} 分钟前",
     "hours_ago": "{{count}} 小时前",
     "days_ago": "{{count}} 天前",

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -12,13 +12,7 @@
   "list": {
     "empty": "暂无通知",
     "mark_done_tooltip": "标为已完成",
-    "archive_tooltip": "归档",
-    "time": {
-      "just_now": "刚刚",
-      "minutes": "{{count}} 分钟",
-      "hours": "{{count}} 小时",
-      "days": "{{count}} 天"
-    }
+    "archive_tooltip": "归档"
   },
   "detail": {
     "select_prompt": "选择一条通知查看详情",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -49,12 +49,6 @@
     "agents_group": "智能体",
     "no_results": "未找到结果"
   },
-  "relative_date": {
-    "today": "今天",
-    "one_day_ago": "1 天前",
-    "days_ago": "{{count}} 天前",
-    "months_ago": "{{count}} 个月前"
-  },
   "detail": {
     "not_found": "未找到该项目",
     "breadcrumb_fallback": "项目",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -394,5 +394,16 @@
     "table_cache_r": "缓存读",
     "table_cache_w": "缓存写",
     "no_data": "还没有使用数据"
+  },
+  "last_seen": {
+    "never": "从未",
+    "just_now": "刚刚",
+    "seconds_ago": "{{count}} 秒前",
+    "minutes_ago": "{{count}} 分钟前",
+    "minutes_seconds_ago": "{{minutes}} 分 {{seconds}} 秒前",
+    "hours_ago": "{{count}} 小时前",
+    "hours_minutes_ago": "{{hours}} 小时 {{minutes}} 分前",
+    "days_ago": "{{count}} 天前",
+    "days_hours_ago": "{{days}} 天 {{hours}} 小时前"
   }
 }

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -110,10 +110,9 @@
     "toast_create_failed": "创建 token 失败",
     "toast_revoked": "已吊销 token",
     "toast_revoke_failed": "吊销 token 失败",
-    "metadata_prefix": "{{prefix}}... · 创建于 {{created}} · {{lastUsed}}",
     "last_used_with_date": "最后使用 {{date}}",
     "last_used_never": "未使用",
-    "expires_with_date": " · {{date}} 过期",
+    "expires_with_date": "{{date}} 过期",
     "revoke_aria": "吊销 {{name}}",
     "revoke_tooltip": "吊销",
     "revoke_dialog": {
@@ -127,7 +126,8 @@
       "description": "立即复制你的个人访问 token——它不会再次显示。",
       "copy_tooltip": "复制 token",
       "done": "完成"
-    }
+    },
+    "created_with_date": "创建于 {{date}}"
   },
   "workspace": {
     "section_general": "通用",

--- a/packages/views/projects/components/labels.ts
+++ b/packages/views/projects/components/labels.ts
@@ -30,19 +30,3 @@ export function useProjectPriorityLabels(): Record<ProjectPriority, string> {
     none: t(($) => $.priority.none),
   };
 }
-
-// "1d ago" / "3mo ago" / "Today" — relative date helper that flows through
-// i18next. Returns a function so callers keep the previous
-// `formatRelativeDate(iso)` shape.
-export function useFormatRelativeDate(): (date: string) => string {
-  const { t } = useT("projects");
-  return (date: string) => {
-    const diff = Date.now() - new Date(date).getTime();
-    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-    if (days < 1) return t(($) => $.relative_date.today);
-    if (days === 1) return t(($) => $.relative_date.one_day_ago);
-    if (days < 30) return t(($) => $.relative_date.days_ago, { count: days });
-    const months = Math.floor(days / 30);
-    return t(($) => $.relative_date.months_ago, { count: months });
-  };
-}

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -98,7 +98,7 @@ import { PageHeader } from "../../layout/page-header";
 import { ProjectIcon } from "./project-icon";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
-import { useFormatRelativeDate } from "./labels";
+import { DateTime } from "../../common/date-time";
 import { ProjectStatusBadge, ProjectPriorityBadge } from "./project-badge";
 import { ProjectLeadPicker } from "./project-lead-picker";
 
@@ -355,7 +355,6 @@ function ProjectTableRow({
   rowHref: string;
   rowLink: ReturnType<typeof useRowLink>;
 }) {
-  const formatRelativeDate = useFormatRelativeDate();
   const updateProject = useUpdateProject();
   const handleUpdate = useCallback(
     (data: UpdateProjectRequest) => updateProject.mutate({ id: project.id, ...data }),
@@ -433,7 +432,7 @@ function ProjectTableRow({
 
       {isColVisible("created") ? (
         <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-          {formatRelativeDate(project.created_at)}
+          <DateTime value={project.created_at} variant="relative" />
         </ListGridCell>
       ) : (
         <ListGridCell className="hidden px-0 @2xl:flex" />
@@ -561,7 +560,6 @@ function ProjectCard({
 }) {
   const { t } = useT("projects");
   const wsPaths = useWorkspacePaths();
-  const formatRelativeDate = useFormatRelativeDate();
   const updateProject = useUpdateProject();
   const handleUpdate = useCallback(
     (data: UpdateProjectRequest) => updateProject.mutate({ id: project.id, ...data }),
@@ -636,7 +634,7 @@ function ProjectCard({
         <div className="flex items-center gap-2">
           <ProjectPriorityBadge project={project} handleUpdate={handleUpdate} align="start" />
           <span className="text-[10px] text-muted-foreground">
-            {formatRelativeDate(project.created_at)}
+            <DateTime value={project.created_at} variant="relative" />
           </span>
         </div>
       </div>

--- a/packages/views/runtimes/components/charts/activity-heatmap.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.tsx
@@ -1,7 +1,14 @@
 import { useMemo } from "react";
 import type { RuntimeUsage } from "@multica/core/types";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
-import { addDaysIso, estimateCost, todayIso, weekStartIso } from "../../utils";
+import {
+  addDaysIso,
+  estimateCost,
+  formatShortDate,
+  formatShortMonth,
+  todayIso,
+  weekStartIso,
+} from "../../utils";
 import { useT } from "../../../i18n";
 
 // 26 weeks (~6 months) gives the heatmap real presence in the wider chart
@@ -33,13 +40,6 @@ function fmtMoney(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
-function fmtDate(iso: string): string {
-  return new Date(iso + "T00:00:00").toLocaleString("en", {
-    month: "short",
-    day: "numeric",
-  });
-}
-
 interface Insights {
   busiestDay: { date: string; cost: number } | null;
   busyDayName: string | null;
@@ -57,7 +57,8 @@ export function ActivityHeatmap({
   usage: RuntimeUsage[];
   tz: string;
 }) {
-  const { t } = useT("runtimes");
+  const { t, i18n } = useT("runtimes");
+  const locale = i18n.language || "en";
   // Memo dep — estimateCost (called inside the body below) consults the
   // user-override store, so saving a custom rate must invalidate the cells.
   const pricings = useCustomPricingStore((s) => s.pricings);
@@ -125,12 +126,10 @@ export function ActivityHeatmap({
     const months: { label: string; week: number }[] = [];
     let lastMonth = -1;
     for (const c of cellsWithLevel) {
-      const month = new Date(c.date + "T00:00:00").getMonth();
+      const month = new Date(c.date + "T00:00:00Z").getUTCMonth();
       if (month !== lastMonth && c.dayOfWeek === 0) {
         months.push({
-          label: new Date(c.date + "T00:00:00").toLocaleString("en", {
-            month: "short",
-          }),
+          label: formatShortMonth(c.date, locale),
           week: c.week,
         });
         lastMonth = month;
@@ -189,7 +188,7 @@ export function ActivityHeatmap({
     };
 
     return { cells: cellsWithLevel, monthLabels: months, insights };
-  }, [usage, pricings, tz]);
+  }, [usage, pricings, tz, locale]);
 
   const labelWidth = 28;
   const svgWidth = labelWidth + HEATMAP_WEEKS * (CELL_SIZE + CELL_GAP);
@@ -261,7 +260,7 @@ export function ActivityHeatmap({
         </div>
       </div>
 
-      <InsightsRow insights={insights} />
+      <InsightsRow insights={insights} locale={locale} />
     </div>
   );
 }
@@ -269,7 +268,13 @@ export function ActivityHeatmap({
 // Horizontal stat strip beneath the heatmap. Mirrors the page-top KPI
 // hero pattern (label → big value → sub) but at smaller scale to stay
 // secondary. 4 columns on desktop, 2 on narrow screens.
-function InsightsRow({ insights }: { insights: Insights }) {
+function InsightsRow({
+  insights,
+  locale,
+}: {
+  insights: Insights;
+  locale: string;
+}) {
   const {
     busiestDay,
     busyDayName,
@@ -283,7 +288,7 @@ function InsightsRow({ insights }: { insights: Insights }) {
     <dl className="grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3 sm:grid-cols-4">
       <Insight
         label="Busiest day"
-        value={busiestDay ? fmtDate(busiestDay.date) : "—"}
+        value={busiestDay ? formatShortDate(busiestDay.date, locale) : "—"}
         sub={busiestDay ? fmtMoney(busiestDay.cost) : null}
       />
       <Insight

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -33,6 +33,7 @@ import {
 } from "@multica/ui/components/ui/select";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 
 const CLOUD_RUNTIME_INSTANCE_TYPES = ["t4g.medium", "t4g.large"] as const;
 const DEFAULT_INSTANCE_TYPE = CLOUD_RUNTIME_INSTANCE_TYPES[0];
@@ -298,7 +299,11 @@ function CloudRuntimeNodeRow({ node, wsId }: { node: CloudRuntimeNode; wsId: str
     node.name.trim() ||
     node.instance_id.trim() ||
     t(($) => $.cloud_runtime.node_fallback_name);
-  const created = formatDateTime(node.created_at);
+  // <DateTime> hides an unparseable value, but the "/" separator beside it is a
+  // sibling — gate both on validity so a malformed created_at can't leave a
+  // dangling separator with no date after it.
+  const hasCreatedAt =
+    !!node.created_at && !Number.isNaN(new Date(node.created_at).getTime());
   return (
     <div className="rounded-md border bg-background px-3 py-2.5">
       <div className="flex min-w-0 items-start justify-between gap-3">
@@ -311,10 +316,10 @@ function CloudRuntimeNodeRow({ node, wsId }: { node: CloudRuntimeNode; wsId: str
             <span>{node.instance_type}</span>
             <span className="text-muted-foreground/40">/</span>
             <span>{node.region}</span>
-            {created && (
+            {hasCreatedAt && (
               <>
                 <span className="text-muted-foreground/40">/</span>
-                <span>{created}</span>
+                <DateTime value={node.created_at} variant="datetime" />
               </>
             )}
           </div>
@@ -385,15 +390,4 @@ function CloudRuntimeStatusBadge({ status }: { status: string }) {
 function valueOrUndefined(value: string): string | undefined {
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
-}
-
-function formatDateTime(value: string): string | null {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
 }

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -39,7 +39,8 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { BreadcrumbHeader } from "../../layout/breadcrumb-header";
 import { AppLink, useNavigation } from "../../navigation";
 import { availabilityConfig, workloadConfig } from "../../agents/presence";
-import { formatLastSeen } from "../utils";
+import { useFormatLastSeen } from "../use-format-last-seen";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { HealthBadge } from "./shared";
 import { ProviderLogo } from "./provider-logo";
 import { UpdateSection } from "./update-section";
@@ -92,6 +93,7 @@ function useNowTick(intervalMs = 30_000): number {
 
 export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
   const { t } = useT("runtimes");
+  const formatLastSeen = useFormatLastSeen();
   const cliVersion =
     runtime.runtime_mode === "local" ? getCliVersion(runtime.metadata) : null;
   const launchedBy =
@@ -276,9 +278,12 @@ function HeroCard({
               {runtime.name}
             </h2>
             <HealthBadge health={health} />
-            <span className="text-xs text-muted-foreground">
+            <InstantTooltip
+              value={runtime.last_seen_at}
+              className="text-xs text-muted-foreground"
+            >
               {t(($) => $.detail.last_seen, { when: lastSeen })}
-            </span>
+            </InstantTooltip>
           </div>
         </div>
       </div>

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -55,11 +55,9 @@ import { ProviderLogo } from "./provider-logo";
 import { HealthIcon, useHealthLabel } from "./shared";
 import { DeleteRuntimeDialog } from "./delete-runtime-dialog";
 import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
-import {
-  computeCostInWindow,
-  formatLastSeen,
-  pctChange,
-} from "../utils";
+import { computeCostInWindow, pctChange } from "../utils";
+import { useFormatLastSeen } from "../use-format-last-seen";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { splitRuntimeName } from "./runtime-machines";
 import {
   customRuntimeRegistrationFailure,
@@ -274,6 +272,7 @@ function HealthCell({
   const { t } = useT("runtimes");
   const { t: tAgents } = useT("agents");
   const labelOf = useHealthLabel();
+  const formatLastSeen = useFormatLastSeen();
   const registrationFailure = customRuntimeRegistrationFailure(runtime);
   if (registrationFailure) {
     return (
@@ -317,7 +316,10 @@ function HealthCell({
       <span className="block min-w-0 truncate text-xs">
         {labelOf(health)}
         {health !== "online" && runtime.last_seen_at && (
-          <span className="text-muted-foreground"> · {lastSeen}</span>
+          <span className="text-muted-foreground">
+            {" · "}
+            <InstantTooltip value={runtime.last_seen_at}>{lastSeen}</InstantTooltip>
+          </span>
         )}
         {!offline && active > 0 && (
           <span className="text-muted-foreground">

--- a/packages/views/runtimes/components/usage-section.tsx
+++ b/packages/views/runtimes/components/usage-section.tsx
@@ -318,7 +318,8 @@ function WhenChart({
   dim: Dim;
   tz: string;
 }) {
-  const { t } = useT("runtimes");
+  const { t, i18n } = useT("runtimes");
+  const locale = i18n.language || "en";
   // Heatmap is the "independent" sibling — toggled here, not part of the
   // page-level dimension segmented (per the RFC).
   const [showHeatmap, setShowHeatmap] = useState(false);
@@ -330,8 +331,8 @@ function WhenChart({
   const pricings = useCustomPricingStore((s) => s.pricings);
 
   const { dailyCostStack, dailyTokens } = useMemo(
-    () => aggregateByDate(filtered),
-    [filtered, pricings],
+    () => aggregateByDate(filtered, locale),
+    [filtered, pricings, locale],
   );
   // Weekly aggregation builds exactly N trailing calendar weeks anchored at
   // today (in the runtime tz). Buckets are pre-zeroed inside aggregateByWeek
@@ -340,8 +341,8 @@ function WhenChart({
   // aggregate surfaced old populated weeks instead of in-range empty ones.
   const weekCount = Math.max(1, Math.ceil(days / 7));
   const { weeklyTokens, weeklyCostStack } = useMemo(
-    () => aggregateByWeek(usage, tz, weekCount),
-    [usage, tz, weekCount, pricings],
+    () => aggregateByWeek(usage, tz, weekCount, locale),
+    [usage, tz, weekCount, pricings, locale],
   );
 
   const metricToggleVisible = !showHeatmap;

--- a/packages/views/runtimes/use-format-last-seen.test.tsx
+++ b/packages/views/runtimes/use-format-last-seen.test.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enRuntimes from "../locales/en/runtimes.json";
+import { useFormatLastSeen } from "./use-format-last-seen";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={{ en: { runtimes: enRuntimes } }}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+const NOW = new Date("2026-03-15T12:00:00Z").getTime();
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("useFormatLastSeen", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps seconds-level precision and compound units (liveness)", () => {
+    const { result } = renderHook(() => useFormatLastSeen(), { wrapper });
+    const f = result.current;
+    expect(f(null)).toBe("Never");
+    expect(f(ago(3 * SEC))).toBe("Just now"); // < 5s
+    expect(f(ago(6 * SEC))).toBe("6s ago");
+    expect(f(ago(90 * SEC))).toBe("1m 30s ago"); // compound
+    expect(f(ago(2 * MIN))).toBe("2m ago");
+    expect(f(ago(HOUR + 1 * MIN))).toBe("1h 1m ago"); // compound
+    expect(f(ago(2 * HOUR))).toBe("2h ago");
+    expect(f(ago(2 * DAY + 3 * HOUR))).toBe("2d 3h ago"); // compound
+    expect(f(ago(3 * DAY))).toBe("3d ago");
+  });
+});

--- a/packages/views/runtimes/use-format-last-seen.ts
+++ b/packages/views/runtimes/use-format-last-seen.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import { useT } from "../i18n";
+
+// Runtime "last seen" formatter. Distinct from the shared useTimeAgo gradient:
+// it keeps SECONDS-level precision and compound units ("2m 30s ago",
+// "2d 4h ago") because runtime liveness is about connection freshness, where a
+// 30s-vs-5m difference matters. Localized via the runtimes namespace; the
+// visible value pairs with an <InstantTooltip> at the call site for the exact
+// instant.
+export function useFormatLastSeen(): (lastSeenAt: string | null) => string {
+  const { t } = useT("runtimes");
+  return useCallback((lastSeenAt) => {
+    if (!lastSeenAt) return t(($) => $.last_seen.never);
+    const diffMs = Date.now() - new Date(lastSeenAt).getTime();
+    if (diffMs < 5_000) return t(($) => $.last_seen.just_now);
+
+    const seconds = Math.floor(diffMs / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (minutes < 1) return t(($) => $.last_seen.seconds_ago, { count: seconds });
+    if (hours < 1) {
+      const s = seconds % 60;
+      return s > 0
+        ? t(($) => $.last_seen.minutes_seconds_ago, { minutes, seconds: s })
+        : t(($) => $.last_seen.minutes_ago, { count: minutes });
+    }
+    if (days < 1) {
+      const m = minutes % 60;
+      return m > 0
+        ? t(($) => $.last_seen.hours_minutes_ago, { hours, minutes: m })
+        : t(($) => $.last_seen.hours_ago, { count: hours });
+    }
+    const h = hours % 24;
+    return h > 0
+      ? t(($) => $.last_seen.days_hours_ago, { days, hours: h })
+      : t(($) => $.last_seen.days_ago, { count: days });
+  }, [t]);
+}

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -688,6 +688,14 @@ describe("todayIso", () => {
     expect(todayIso("America/Los_Angeles")).toBe("2026-05-19");
     expect(todayIso("UTC")).toBe("2026-05-19");
   });
+
+  it("falls back to UTC instead of throwing on a stale/invalid runtime tz", () => {
+    // A stale user/runtime tz must not white-screen the usage charts; it falls
+    // back to UTC (delegated to the shared core helper) instead of RangeError.
+    vi.setSystemTime(new Date("2026-05-19T16:00:00Z"));
+    expect(() => todayIso("Not/AZone")).not.toThrow();
+    expect(todayIso("Not/AZone")).toBe("2026-05-19");
+  });
 });
 
 describe("sliceWindow (timezone-aware)", () => {
@@ -780,7 +788,7 @@ describe("aggregateByWeek", () => {
       makeUsage("2026-05-17", 0, 1_000_000),
       makeUsage("2026-05-18", 2_000_000, 0),
     ];
-    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 2);
+    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 2, "en");
     expect(weeklyTokens).toHaveLength(2);
     expect(weeklyTokens[0]).toMatchObject({
       weekStart: "2026-05-11",
@@ -803,7 +811,7 @@ describe("aggregateByWeek", () => {
     // 2026-05-20 is a Wednesday (Mon=05-18, Sun=05-24).
     vi.setSystemTime(new Date("2026-05-20T08:00:00Z"));
     const rows = [makeUsage("2026-05-18", 1_000_000, 0)];
-    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 1);
+    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 1, "en");
     expect(weeklyTokens[0]).toMatchObject({
       weekStart: "2026-05-18",
       weekEnd: "2026-05-24",
@@ -822,7 +830,7 @@ describe("aggregateByWeek", () => {
       makeUsage("2026-05-11", 1_000_000, 1_000_000),
       makeUsage("2026-05-13", 1_000_000, 1_000_000),
     ];
-    const { weeklyCostStack } = aggregateByWeek(rows, "UTC", 1);
+    const { weeklyCostStack } = aggregateByWeek(rows, "UTC", 1, "en");
     expect(weeklyCostStack).toHaveLength(1);
     expect(weeklyCostStack[0]?.total).toBeCloseTo(36, 2);
   });
@@ -841,7 +849,7 @@ describe("aggregateByWeek", () => {
     // 05-04, 05-11, 05-18). 2026-04-13 (Mon) is one week earlier — outside
     // the window. No data in any of the 5 in-range weeks.
     const rows = [makeUsage("2026-04-13", 1_000_000, 1_000_000)];
-    const { weeklyTokens, weeklyCostStack } = aggregateByWeek(rows, "UTC", 5);
+    const { weeklyTokens, weeklyCostStack } = aggregateByWeek(rows, "UTC", 5, "en");
 
     expect(weeklyTokens.map((w) => w.weekStart)).toEqual([
       "2026-04-20",
@@ -868,7 +876,7 @@ describe("aggregateByWeek", () => {
     // collapsed to a single populated bar.
     vi.setSystemTime(new Date("2026-05-19T12:00:00Z"));
     const rows = [makeUsage("2026-04-22", 1_000_000, 1_000_000)]; // week of 04-20
-    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 5);
+    const { weeklyTokens } = aggregateByWeek(rows, "UTC", 5, "en");
     expect(weeklyTokens).toHaveLength(5);
     expect(weeklyTokens[0]).toMatchObject({
       weekStart: "2026-04-20",

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -4,6 +4,7 @@ import type {
   RuntimeUsageByAgent,
 } from "@multica/core/types";
 import { getCustomPricing } from "@multica/core/runtimes/custom-pricing-store";
+import { formatDateOnly, todayDateOnlyInTimeZone } from "@multica/core/issues/date";
 
 // A live local daemon re-registers itself within seconds of a server-side
 // delete (daemon self-heal, #2404), so deleting an online local runtime from
@@ -17,31 +18,9 @@ export function isSelfHealingRuntime(runtime: AgentRuntime): boolean {
 // Formatting helpers
 // ---------------------------------------------------------------------------
 
-// Compound-unit relative timestamp ("2m 14s ago", "1d 4h ago", "6d 19h ago")
-// — gives the user enough precision to tell "just lost" from "long lost"
-// at a glance without forcing them to mouse-over for a full timestamp.
-export function formatLastSeen(lastSeenAt: string | null): string {
-  if (!lastSeenAt) return "Never";
-  const diffMs = Date.now() - new Date(lastSeenAt).getTime();
-  if (diffMs < 5_000) return "Just now";
-
-  const seconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-
-  if (minutes < 1) return `${seconds}s ago`;
-  if (hours < 1) {
-    const s = seconds % 60;
-    return s > 0 ? `${minutes}m ${s}s ago` : `${minutes}m ago`;
-  }
-  if (days < 1) {
-    const m = minutes % 60;
-    return m > 0 ? `${hours}h ${m}m ago` : `${hours}h ago`;
-  }
-  const h = hours % 24;
-  return h > 0 ? `${days}d ${h}h ago` : `${days}d ago`;
-}
+// Runtime "last seen" formatting moved to the localized `useFormatLastSeen`
+// hook (runtimes/use-format-last-seen.ts); the compound seconds/minutes
+// gradient is preserved there.
 
 // Turns the back-end's `device_info` string ("MacBook-Pro · darwin-amd64",
 // "some-host · linux-amd64") into something humans recognise. We don't have
@@ -564,7 +543,7 @@ export interface WeeklyCostStackData {
   total: number;
 }
 
-export function aggregateByDate(usage: RuntimeUsage[]): {
+export function aggregateByDate(usage: RuntimeUsage[], locale: string): {
   dailyTokens: DailyTokenData[];
   dailyCost: DailyCostData[];
   dailyCostStack: DailyCostStackData[];
@@ -614,10 +593,7 @@ export function aggregateByDate(usage: RuntimeUsage[]): {
     modelMap.set(modelName, m);
   }
 
-  const formatLabel = (d: string) => {
-    const date = new Date(d + "T00:00:00");
-    return `${date.getMonth() + 1}/${date.getDate()}`;
-  };
+  const formatLabel = (d: string) => formatShortDate(d, locale);
 
   const dailyTokens = Array.from(dateMap.values())
     .toSorted((a, b) => a.date.localeCompare(b.date))
@@ -686,6 +662,7 @@ export function aggregateByWeek(
   usage: readonly WeeklyAggregable[],
   tz: string,
   weekCount: number,
+  locale: string,
 ): {
   weeklyTokens: WeeklyTokenData[];
   weeklyCostStack: WeeklyCostStackData[];
@@ -747,8 +724,8 @@ export function aggregateByWeek(
     return {
       weekStart,
       weekEnd,
-      label: formatShortDate(weekStart),
-      rangeLabel: `${formatShortDate(weekStart)} – ${formatShortDate(weekEnd)}`,
+      label: formatShortDate(weekStart, locale),
+      rangeLabel: `${formatShortDate(weekStart, locale)} – ${formatShortDate(weekEnd, locale)}`,
       partial,
       daysCovered: partial ? elapsedDays : 7,
     };
@@ -814,15 +791,12 @@ function diffDaysIso(from: string, to: string): number {
 // and runtime sit in different time zones.
 // ---------------------------------------------------------------------------
 
-// Today's calendar date (YYYY-MM-DD) in the given IANA timezone. `en-CA`
-// gives ISO-shaped output without us having to assemble Intl parts by hand.
+// Today's calendar date (YYYY-MM-DD) in the given IANA timezone. Delegates to
+// the shared core helper so a stale/ICU-unsupported runtime tz falls back to
+// UTC instead of throwing (a raw Intl.DateTimeFormat would RangeError here and
+// white-screen the usage charts).
 export function todayIso(tz: string): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: tz,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date());
+  return todayDateOnlyInTimeZone(tz);
 }
 
 // Pure date arithmetic on a YYYY-MM-DD string. Uses UTC under the hood so
@@ -848,15 +822,18 @@ export function weekStartIso(iso: string): string {
 }
 
 // "May 12" — short, locale-aware month/day for a YYYY-MM-DD string. Parsing
-// via UTC keeps the displayed day stable regardless of the browser's tz.
-export function formatShortDate(iso: string): string {
-  const [y, m, d] = iso.split("-").map(Number);
-  const dt = new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, d ?? 1));
-  return dt.toLocaleString("en", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+// via UTC keeps the displayed day stable regardless of the browser's tz. The
+// locale (from the Language setting, i18n.language) is required so a caller
+// that forgets it is a compile error, not a silent English-only label.
+export function formatShortDate(iso: string, locale: string): string {
+  return formatDateOnly(iso, { month: "short", day: "numeric" }, locale);
+}
+
+// "May" — short, locale-aware month name for a YYYY-MM-DD string. UTC-anchored
+// like formatShortDate so the displayed month never shifts with the browser's
+// tz (a calendar-day label must read the same for every viewer).
+export function formatShortMonth(iso: string, locale: string): string {
+  return formatDateOnly(iso, { month: "short" }, locale);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/views/settings/components/lark-tab.tsx
+++ b/packages/views/settings/components/lark-tab.tsx
@@ -41,6 +41,8 @@ import { larkInstallationsOptions, larkKeys } from "@multica/core/lark";
 import { api, ApiError } from "@multica/core/api";
 import type { LarkInstallation, LarkInstallStatusResponse } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { useFormatDateTime } from "../../common/use-format-date-time";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { useT } from "../../i18n";
 
 // MUL-3083: the Lark (international, open.larksuite.com) "connect a Bot"
@@ -220,6 +222,7 @@ function InstallationRow({
   onDisconnect: () => void;
 }) {
   const { t } = useT("settings");
+  const { formatDateTime } = useFormatDateTime();
   // The bot is bound 1:1 to a Multica Agent (per the (workspace_id,
   // agent_id) UNIQUE in lark_installation). Render the Multica agent's
   // identity here rather than the raw Lark app_id / bot_open_id — those
@@ -253,11 +256,14 @@ function InstallationRow({
               </span>
             )}
           </p>
-          <p className="text-[10px] text-muted-foreground">
+          <InstantTooltip
+            value={installation.installed_at}
+            className="block text-[10px] text-muted-foreground"
+          >
             {t(($) => $.lark.installed_at_label, {
-              when: new Date(installation.installed_at).toLocaleString(),
+              when: formatDateTime(installation.installed_at),
             })}
-          </p>
+          </InstantTooltip>
         </div>
       </div>
       {canManage && isActive && (

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -36,12 +36,17 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { useFormatDateTime } from "../../common/use-format-date-time";
+import { InstantTooltip } from "../../common/instant-tooltip";
+import { useTimeAgo } from "../../i18n/use-time-ago";
 import { useT } from "../../i18n";
 
 const EXPIRY_KEYS = ["30", "90", "365", "never"] as const;
 
 export function TokensTab() {
   const { t } = useT("settings");
+  const { formatDate } = useFormatDateTime();
+  const timeAgo = useTimeAgo();
   const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
   const [tokenName, setTokenName] = useState("");
   const [tokenExpiry, setTokenExpiry] = useState("90");
@@ -159,18 +164,32 @@ export function TokensTab() {
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-medium truncate">{token.name}</div>
                     <div className="text-xs text-muted-foreground">
-                      {t(($) => $.tokens.metadata_prefix, {
-                        prefix: token.token_prefix,
-                        created: new Date(token.created_at).toLocaleDateString(),
-                        lastUsed: token.last_used_at
-                          ? t(($) => $.tokens.last_used_with_date, {
-                              date: new Date(token.last_used_at!).toLocaleDateString(),
-                            })
-                          : t(($) => $.tokens.last_used_never),
-                      })}
-                      {token.expires_at && t(($) => $.tokens.expires_with_date, {
-                        date: new Date(token.expires_at!).toLocaleDateString(),
-                      })}
+                      {token.token_prefix}...{" · "}
+                      <InstantTooltip value={token.created_at}>
+                        {t(($) => $.tokens.created_with_date, {
+                          date: timeAgo(token.created_at),
+                        })}
+                      </InstantTooltip>
+                      {" · "}
+                      {token.last_used_at ? (
+                        <InstantTooltip value={token.last_used_at}>
+                          {t(($) => $.tokens.last_used_with_date, {
+                            date: timeAgo(token.last_used_at),
+                          })}
+                        </InstantTooltip>
+                      ) : (
+                        t(($) => $.tokens.last_used_never)
+                      )}
+                      {token.expires_at && (
+                        <>
+                          {" · "}
+                          <InstantTooltip value={token.expires_at}>
+                            {t(($) => $.tokens.expires_with_date, {
+                              date: formatDate(token.expires_at),
+                            })}
+                          </InstantTooltip>
+                        </>
+                      )}
                     </div>
                   </div>
                   <Tooltip>

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -26,6 +26,8 @@ import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
 import { useTimeAgo } from "../../i18n";
+import { DateTime } from "../../common/date-time";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import {
@@ -711,11 +713,11 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
               )}
               <span className="inline-flex items-center gap-2">
                 <span aria-hidden>·</span>
-                <span>
+                <InstantTooltip value={skill.updated_at}>
                   {t(($) => $.detail.subline.updated_label, {
                     when: timeAgo(skill.updated_at),
                   })}
-                </span>
+                </InstantTooltip>
               </span>
               {creator && (
                 <span className="inline-flex items-center gap-2">
@@ -818,7 +820,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
                   {t(($) => $.detail.sidebar.created)}
                 </dt>
                 <dd className="min-w-0 flex-1">
-                  {timeAgo(skill.created_at)}
+                  <DateTime value={skill.created_at} variant="relative" />
                 </dd>
               </div>
               <div className="flex gap-2">
@@ -826,7 +828,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
                   {t(($) => $.detail.sidebar.updated)}
                 </dt>
                 <dd className="min-w-0 flex-1">
-                  {timeAgo(skill.updated_at)}
+                  <DateTime value={skill.updated_at} variant="relative" />
                 </dd>
               </div>
               {creator && (

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -67,7 +67,8 @@ import {
   SkillRowActions,
   type SkillActionsContext,
 } from "./skill-list-actions";
-import { useT, useTimeAgo } from "../../i18n";
+import { useT } from "../../i18n";
+import { DateTime } from "../../common/date-time";
 
 // Column template — single source of truth for header, rows, and skeletons.
 // Tracks: [edge 0.75rem] [checkbox 1rem] [name, only fr track]
@@ -578,7 +579,6 @@ export default function SkillsPage() {
   const paths = useWorkspacePaths();
   const navigation = useNavigation();
   const rowLink = useRowLink();
-  const timeAgo = useTimeAgo();
   const currentUserId = useAuthStore((s) => s.user?.id ?? null);
 
   const {
@@ -912,14 +912,14 @@ export default function SkillsPage() {
                 )}
                 {isColVisible("updated") ? (
                   <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-                    {timeAgo(row.skill.updated_at)}
+                    <DateTime value={row.skill.updated_at} variant="relative" />
                   </ListGridCell>
                 ) : (
                   <ListGridCell className="hidden px-0 @2xl:flex" />
                 )}
                 {isColVisible("created") ? (
                   <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-                    {timeAgo(row.skill.created_at)}
+                    <DateTime value={row.skill.created_at} variant="relative" />
                   </ListGridCell>
                 ) : (
                   <ListGridCell className="hidden px-0 @2xl:flex" />

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -10,6 +10,8 @@ import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { isImeComposing } from "@multica/core/utils";
 import { useTimeAgo } from "../../i18n";
+import { DateTime } from "../../common/date-time";
+import { InstantTooltip } from "../../common/instant-tooltip";
 import { agentListOptions, memberListOptions, squadMemberStatusOptions, workspaceKeys } from "@multica/core/workspace/queries";
 import { runtimeListOptions } from "@multica/core/runtimes";
 import { CreateAgentDialog } from "../../agents/components/create-agent-dialog";
@@ -817,7 +819,6 @@ function SquadDetailInspector({
   onUpdateDescription: (next: string) => Promise<void>;
 }) {
   const { t } = useT("squads");
-  const timeAgo = useTimeAgo();
   const initials = squad.name
     .split(" ")
     .map((w) => w[0])
@@ -866,10 +867,10 @@ function SquadDetailInspector({
             </span>
           </InspectorRow>
           <InspectorRow label="Created">
-            <span className="text-muted-foreground">{timeAgo(squad.created_at)}</span>
+            <DateTime value={squad.created_at} variant="relative" className="text-muted-foreground" />
           </InspectorRow>
           <InspectorRow label="Updated">
-            <span className="text-muted-foreground">{timeAgo(squad.updated_at)}</span>
+            <DateTime value={squad.updated_at} variant="relative" className="text-muted-foreground" />
           </InspectorRow>
         </div>
       </div>
@@ -1265,9 +1266,11 @@ function SquadMembersTab({
                 )}
                 {showLastActive && (
                   <div className="mt-0.5 text-xs text-muted-foreground">
-                    {t(($) => $.members_tab.last_active_label, {
-                      time: timeAgo(status!.last_active_at!),
-                    })}
+                    <InstantTooltip value={status!.last_active_at!}>
+                      {t(($) => $.members_tab.last_active_label, {
+                        time: timeAgo(status!.last_active_at!),
+                      })}
+                    </InstantTooltip>
                   </div>
                 )}
               </div>

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -80,6 +80,7 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { DateTime } from "../../common/date-time";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { useRowLink } from "../../navigation";
 import { PageHeader } from "../../layout/page-header";
@@ -988,7 +989,7 @@ export function SquadsPage() {
                     )}
                     {isColVisible("created") ? (
                       <ListGridCell className="hidden whitespace-nowrap text-xs tabular-nums text-muted-foreground @2xl:flex">
-                        {new Date(squad.created_at).toLocaleDateString()}
+                        <DateTime value={squad.created_at} variant="relative" />
                       </ListGridCell>
                     ) : (
                       <ListGridCell className="hidden px-0 @2xl:flex" />


### PR DESCRIPTION
## What does this PR do?

Centralizes **all** instant time/date display on web & desktop so it respects the user's settings instead of the browser. Previously time rendering was scattered and inconsistent: ~20 spots inlined `new Date(x).toLocaleString()` (browser timezone) and ~8 hardcoded `"en-US"`, so the **Viewing Timezone** and **Language** settings effectively did nothing. After this change every instant flows through one pair of helpers — formatted in the viewer's **Viewing Timezone** (`user.timezone`, falling back to the browser) with the **Language** locale — and carries a full-time + GMT-offset tooltip.

This is a **frontend-only** change. Storage stays all-UTC and the backend is untouched (see *Known follow-up*).

Full design, two-axis model (Scheduling vs Viewing + floating calendar days), audit, and gap list: `docs/timezone-display-spec.md`.

## Related Issue

Closes #4599

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

**1. One source of truth for instant display — respects Viewing Timezone + Language.**
- New `useFormatDateTime()` and `<DateTime>` (`packages/views/common/`): format via Viewing tz + Language locale, with a memoized `Intl.DateTimeFormat` and a built-in "full time + GMT offset" tooltip.
- Replaced ~20 inline `toLocaleString()` instant displays (settings tokens/lark tabs, autopilot webhook-deliveries/pages/detail, runtime dialogs, agent-transcript-dialog, agents/squads pages, issue comment & activity tooltips, billing) — they now go through the new helpers.
- Locale is now taken from the Language setting everywhere (`i18n.language`, fallback `en`); removed the ~8 hardcoded `"en-US"` in `formatDateOnly` callers. Calendar days (`due_date` / `start_date`) stay floating (no tz conversion).
- Overdue/red judgement now uses the viewer's Viewing tz: `isPastDateOnly(due_date, timeZone)` (`packages/core/issues/date.ts`).

**2. Autopilot "next run" fixes.**
- Fixed the wrong "next run" preview in the **autopilot create dialog**.
- The autopilot **list** `next_run_at` arrives as a bare UTC instant with **no trigger timezone**. Rendering an absolute wall-clock there is either wrong (Viewing tz) or meaningless. Solution: show it as **relative time** (`in 3h`) — relative time is a pure duration/calendar-diff and is **timezone-agnostic**, so it sidesteps the missing tz entirely — with a precise **UTC + GMT-offset** tooltip on hover. The autopilot *detail* page still has the trigger, so it keeps absolute time in the trigger's tz (Scheduling axis, unchanged).

**3. List `*_at` → relative time.**
- List rows now render `created_at` / `updated_at` as relative time (`useTimeAgo()`), saving horizontal space while staying readable; the absolute time remains available in the tooltip.

**4. Unified relative-time + tooltips (per spec).**
- Converged the previously forked relative-time implementations into one: pure `relativeTimeBucket(thenMs, nowMs, timeZone)` (`packages/core/i18n/relative-time.ts`, shared with mobile) + `useTimeAgo()`. Symmetric past/future (`3h ago` / `in 3h`), sub-day elapsed, day-granularity by calendar day in Viewing tz, extending into months/years (no absolute-date fallback).
- Runtime "last seen" keeps seconds-level compound precision via a dedicated `useFormatLastSeen()` (liveness), not folded into `useTimeAgo()`.
- `<InstantTooltip>` for instants embedded in translated sentences (`Updated {{time}}`) — wraps the rendered phrase so it gets a tooltip without splitting the i18n string or using `<Trans>` (which would break ja/ko word order).

**5. Docs / tests.**
- Added `docs/timezone-display-spec.md`.
- Added/updated unit tests for the new helpers and pure functions (`format-date-time`, `relative-time`, `date`, `use-format-*`, `<DateTime>`, tooltips, etc.).

## How to Test

1. Set **Viewing Timezone** ≠ your OS zone (e.g. GMT+8) and **Language** = `zh-Hans` in Settings.
2. Open issue comments/activity, the agent transcript dialog, and settings → tokens tab → timestamps now render in **GMT+8** with the **zh** locale and show a full-time + `(GMT+8)` tooltip on hover.
3. Open the autopilot create dialog → "next run" preview is correct.
4. View the autopilot list "next run" → shows `in 3h`, with a UTC+offset tooltip; no ambiguous absolute time.
5. View any list with `*_at` columns → relative time, absolute time in tooltip.
6. `pnpm test` for the new unit tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — N/A (no new tab/runtime/tool)
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks / Known follow-up

- **Frontend-only — backend untouched.** Because of this, the **agents list "Last active"** could *not* be unified: it is a per-day bucket from a 30-day activity sparkline (`lastActiveDaysAgo`); the agent object exposes no precise instant, so only the wording was aligned (`Today` / `Nd ago`) and no full-time tooltip can be attached. Fully unifying it requires the backend to expose an agent `last_active_at` instant — **needs a separate PR**.
- Day-granularity relative buckets depend on Viewing tz by design (viewers across midnight in different zones can see a different bucket); spec §3.3 documents this as intentional.
- **Surfaced a latent backend bug — autopilot `next_run_at` is stale (#4613).** Switching the list "next run" to relative time made it visible that `next_run_at` can point to a *past* slot (e.g. shows "53m ago"). Root cause is backend: `next_run_at` is a display-only column that is never advanced after a run — the `AdvanceTriggerNextRun` query exists but has zero callers (dead code). The frontend here renders the value faithfully; fixing the staleness is **out of scope for this frontend PR** and tracked in #4613 (wire up `AdvanceTriggerNextRun` in the scheduler dispatch). The detail page shows the same stale value as an absolute time, just less obviously.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Audited every time/date display across `packages/views` and `packages/core`, designed the two-axis (Scheduling vs Viewing) + floating-calendar-day model in `docs/timezone-display-spec.md`, then centralized rendering into shared hooks/components and migrated all call sites, with unit tests for the pure functions and helpers.

