### PR TITLE
fix(editor): keep Tab inside lists instead of escaping focus (MUL-3697)

### DIFF
--- a/packages/views/editor/extensions/list-item.test.ts
+++ b/packages/views/editor/extensions/list-item.test.ts
@@ -270,11 +270,13 @@ describe("PatchedListItem Tab indent (MUL-3697)", () => {
 
   const pressTab = (e: Editor) => pressShortcut(e, "listItem", "Tab");
 
-  it("is a no-op with the cursor in the first item (nothing to nest under)", () => {
+  it("leaves the doc unchanged but swallows Tab in the first item (stay put, do not escape focus)", () => {
     editor = makeEditor(flatList("bulletList", "listItem"));
     editor.commands.setTextSelection(itemPos(editor, "listItem", 0));
-    // C2: startIndex === 0 with a single item -> clean false, doc unchanged.
-    expect(pressTab(editor)).toBe(false);
+    // Nothing to nest under, so the structural indent is a no-op — but the caret
+    // is in a list, so Tab is swallowed (true) instead of leaking to the browser
+    // and moving focus to other controls. The doc must be untouched.
+    expect(pressTab(editor)).toBe(true);
     expect(outline(editor.getJSON() as JsonNode)).toBe("- aaa\n- bbb\n- ccc");
   });
 

--- a/packages/views/editor/extensions/list-item.ts
+++ b/packages/views/editor/extensions/list-item.ts
@@ -81,6 +81,14 @@ function sinkListItemRange(itemType: NodeType): Command {
  *
  * Tab indents the item(s) — see `sinkListItemRange` for the multi-item
  * first-item handling. Shift-Tab dedents via the stock command.
+ *
+ * Whenever the caret is inside a list item, Tab is the list's indent control
+ * and must be swallowed even when the structural indent is a no-op (first child
+ * with nothing to nest under, or already at max depth). Otherwise the unhandled
+ * Tab falls through to the browser and moves focus out of the editor to the
+ * next control. So the return value tracks "is the caret in this list?"
+ * (`editor.isActive(name)`), NOT "did the indent move anything?": indent
+ * best-effort, then swallow while in a list, fall through (focus nav) when not.
  */
 function listItemKeymap(editor: Editor, name: string) {
   return {
@@ -92,9 +100,10 @@ function listItemKeymap(editor: Editor, name: string) {
     Tab: () => {
       const itemType = editor.schema.nodes[name];
       if (!itemType) return false;
-      return sinkListItemRange(itemType)(editor.state, (tr) =>
+      sinkListItemRange(itemType)(editor.state, (tr) =>
         editor.view.dispatch(tr),
       );
+      return editor.isActive(name);
     },
     "Shift-Tab": () => editor.commands.liftListItem(name),
   };


### PR DESCRIPTION
## MUL-3697 follow-up — Tab escapes the editor on non-indentable list items

### Problem
PR #4587 fixed multi-item indentation but tied the keymap's return value to *whether the indent actually moved anything*. When the caret sits in a list item that cannot indent (the list's first child, or already at max depth), `sinkListItemRange` returns `false`, the `Tab` handler returns `false`, and the browser's **native Tab moves focus out of the editor onto adjacent controls** (toolbar / send buttons). Reported as "Tab triggers other buttons."

First-principle: in a ProseMirror/TipTap keymap, the boolean return is exactly `preventDefault`. Returning `false` lets Tab propagate to focus navigation.

### Fix
`packages/views/editor/extensions/list-item.ts` — decouple "swallow the key" from "did the indent move anything":

1. Run `sinkListItemRange` best-effort (ignore its boolean).
2. Return `editor.isActive(name)` — swallow Tab whenever the caret is inside this list item type (indent happened *or* was a no-op → stay put), fall through to focus nav only when **not** in a list.

The shared keymap means bullet, ordered and task lists are covered at once. `isActive(name)` also self-routes between the `listItem` and `taskItem` handlers: in a task context the `listItem` handler's `isActive("listItem")` is `false`, so it cleanly defers to the `taskItem` handler. No schema change, no new dependency. `Shift-Tab` is unaffected (`liftListItem` already lifts top-level items out of the list rather than returning `false`).

### Tests
`packages/views/editor/extensions/list-item.test.ts` — the first-item case now asserts the new contract: Tab is swallowed (`true`) and the doc is unchanged (stay put, do not escape focus). The "not in a list" case still returns `false` (Tab should escape).

### Verification
- `pnpm exec vitest run editor/` (in `packages/views`) → **479 passed** (incl. the MUL-3685 suggestion-Tab priority suite — popups intercept Tab at the plugin layer, above this keymap, so they're untouched)
- `pnpm exec tsc --noEmit` → clean
- `pnpm exec eslint` on both changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)