### PR TITLE
feat: notification bus rule engine for cross-squad agent collaboration

### DIFF
--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { ListTodo } from "lucide-react";
 import type { UpdateIssueRequest } from "@multica/core/types";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIssueViewStore, useClearFiltersOnWorkspaceChange, type IssueDateFilter } from "@multica/core/issues/stores/view-store";
 import { dateOnlyToLocalDate } from "@multica/core/issues/date";
 import { useIssuesScopeStore } from "@multica/core/issues/stores/issues-scope-store";
@@ -13,7 +13,7 @@ import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-contex
 import { filterIssues } from "../utils/filter";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
+import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, childrenByParentsOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -27,6 +27,7 @@ import type { ChildProgress } from "./list-row";
 import { useT } from "../../i18n";
 
 const EMPTY_CHILD_PROGRESS = new Map<string, ChildProgress>();
+const EMPTY_CHILDREN = new Map<string, Issue[]>();
 
 function issueDateFilterToApiParams(filter: IssueDateFilter | null) {
   if (!filter) return {};
@@ -191,6 +192,23 @@ export function IssuesPage() {
   // regardless of client-side pagination or filtering of done issues.
   const { data: childProgressMap = EMPTY_CHILD_PROGRESS } = useQuery(childIssueProgressOptions(wsId));
 
+  // Collect parent IDs from visible issues that have children.
+  const visibleParentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        ids.add(issue.id);
+      }
+    }
+    return [...ids].sort();
+  }, [issues, childProgressMap]);
+
+  // Fetch children for the visible parent issues.
+  const queryClient = useQueryClient();
+  const { data: childrenMap = EMPTY_CHILDREN } = useQuery(
+    childrenByParentsOptions(wsId, visibleParentIds, queryClient),
+  );
+
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
       return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
@@ -284,7 +302,7 @@ export function IssuesPage() {
                 sort={queryParams}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} sort={queryParams} onMoveIssue={handleMoveIssue} />
+              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} childrenMap={childrenMap} sort={queryParams} onMoveIssue={handleMoveIssue} />
             )}
           </div>
         )}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { ListTodo } from "lucide-react";
-import type { UpdateIssueRequest } from "@multica/core/types";
+import type { Issue, UpdateIssueRequest } from "@multica/core/types";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useIssueViewStore, useClearFiltersOnWorkspaceChange, type IssueDateFilter } from "@multica/core/issues/stores/view-store";

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { ChevronRight, CornerDownRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
@@ -38,6 +39,12 @@ function ListRowContent({
   containerStyle,
   containerProps,
   checkboxProps,
+  indent = 0,
+  isParent = false,
+  isExpanded = false,
+  childCount = 0,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -46,6 +53,12 @@ function ListRowContent({
   containerStyle?: React.CSSProperties;
   containerProps?: Record<string, unknown>;
   checkboxProps?: Pick<React.HTMLAttributes<HTMLDivElement>, "onClick" | "onMouseDown" | "onPointerDown">;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -72,10 +85,37 @@ function ListRowContent({
         ref={containerRef}
         style={containerStyle}
         {...containerProps}
-        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
+        className={`group/row flex h-9 items-center gap-2 pr-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
+        role="row"
       >
+        {/* Indent spacer for child rows */}
+        {indent > 0 && (
+          <div style={{ width: indent * 24 }} className="shrink-0" />
+        )}
+        {/* Expand / collapse toggle for parent rows (replaces priority icon slot) */}
+        {isParent ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onToggleChildren?.();
+            }}
+            className="flex shrink-0 items-center justify-center w-4 h-4 rounded-sm hover:bg-muted cursor-pointer transition-transform"
+            style={{ transform: isExpanded ? "rotate(90deg)" : undefined }}
+            aria-label={isExpanded ? "Collapse sub-issues" : "Expand sub-issues"}
+          >
+            <ChevronRight className="size-3.5 text-muted-foreground" />
+          </button>
+        ) : indent > 0 ? (
+          /* Branch indicator for child rows */
+          <div className="flex shrink-0 items-center justify-center w-4 h-4">
+            <CornerDownRight className="size-3.5 text-muted-foreground/50" />
+          </div>
+        ) : null}
+        {/* Priority icon + checkbox */}
         <div
           className="relative flex shrink-0 items-center justify-center w-4 h-4"
           {...checkboxProps}
@@ -104,6 +144,16 @@ function ListRowContent({
 
           <span className="flex min-w-0 flex-1 items-center gap-1.5">
             <span className="truncate">{issue.title}</span>
+            {isParent && childCount > 0 && (
+              <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                ({childCount})
+              </span>
+            )}
+            {parentIdentifier && (
+              <span className="shrink-0 text-[11px] text-muted-foreground/70 truncate max-w-[120px]">
+                &larr; {parentIdentifier}
+              </span>
+            )}
             {showChildProgress && (
               <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
                 <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
@@ -158,11 +208,34 @@ function ListRowContent({
 export const ListRow = memo(function ListRow({
   issue,
   childProgress,
+  indent,
+  isParent,
+  isExpanded,
+  childCount,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
-  return <ListRowContent issue={issue} childProgress={childProgress} />;
+  return (
+    <ListRowContent
+      issue={issue}
+      childProgress={childProgress}
+      indent={indent}
+      isParent={isParent}
+      isExpanded={isExpanded}
+      childCount={childCount}
+      onToggleChildren={onToggleChildren}
+      parentIdentifier={parentIdentifier}
+    />
+  );
 });
 
 const animateLayoutChanges: AnimateLayoutChanges = (args) => {
@@ -179,10 +252,22 @@ export const DraggableListRow = memo(function DraggableListRow({
   issue,
   childProgress,
   disableSorting,
+  indent,
+  isParent,
+  isExpanded,
+  childCount,
+  onToggleChildren,
+  parentIdentifier,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   disableSorting?: boolean;
+  indent?: number;
+  isParent?: boolean;
+  isExpanded?: boolean;
+  childCount?: number;
+  onToggleChildren?: () => void;
+  parentIdentifier?: string;
 }) {
   const {
     attributes,
@@ -212,6 +297,12 @@ export const DraggableListRow = memo(function DraggableListRow({
       containerStyle={style}
       containerProps={{ ...attributes, ...listeners }}
       checkboxProps={{ onClick: stopDrag, onMouseDown: stopDrag, onPointerDown: stopDrag }}
+      indent={indent}
+      isParent={isParent}
+      isExpanded={isExpanded}
+      childCount={childCount}
+      onToggleChildren={onToggleChildren}
+      parentIdentifier={parentIdentifier}
     />
   );
 });

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -33,8 +33,22 @@ function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
 }
 
+const STATUS_CN: Record<string, string> = {
+  todo: "待办",
+  in_progress: "进行中",
+  in_review: "审核中",
+  done: "已完成",
+  backlog: "待规划",
+  cancelled: "已取消",
+  blocked: "阻塞中",
+};
+
 function getStatusColor(status: string): string {
   return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
+}
+
+function formatStatusLabel(status: string): string {
+  return STATUS_CN[status] ?? status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function ListRowContent({
@@ -203,7 +217,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{parentInfo.status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}]
+                  [{formatStatusLabel(parentInfo.status)}]
                 </span>
               </button>
             )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -22,6 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import { useT } from "../../i18n";
 import type { ParentInfo, CrossStatusChild } from "../utils/hierarchy";
 
 export interface ChildProgress {
@@ -33,22 +34,8 @@ function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
 }
 
-const STATUS_CN: Record<string, string> = {
-  todo: "待办",
-  in_progress: "进行中",
-  in_review: "审核中",
-  done: "已完成",
-  backlog: "待规划",
-  cancelled: "已取消",
-  blocked: "阻塞中",
-};
-
 function getStatusColor(status: string): string {
   return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
-}
-
-function formatStatusLabel(status: string): string {
-  return STATUS_CN[status] ?? status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function ListRowContent({
@@ -88,6 +75,7 @@ function ListRowContent({
   onHoverParent?: (parentStatus: string | null) => void;
   onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
+  const { t } = useT("issues");
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
   const p = useWorkspacePaths();
@@ -217,7 +205,7 @@ function ListRowContent({
                 ({childCount})
               </span>
             )}
-            {isParent && crossStatusChildCount > 0 && (
+            {crossStatusChildCount > 0 && (
               <div className="relative shrink-0" ref={crossDropdownRef}>
                 <button
                   type="button"
@@ -228,8 +216,7 @@ function ListRowContent({
                   }}
                   className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
                 >
-                  {/* eslint-disable-next-line i18next/no-literal-string */}
-                  ↓ {crossStatusChildCount} 跨状态
+                  ↓ {crossStatusChildCount} {t(($) => $.list.cross_status)}
                 </button>
                 {crossDropdownOpen && crossStatusChildren.length > 0 && (
                   <div className="absolute top-full left-0 z-50 mt-1 bg-popover border border-border rounded-md shadow-md p-1 min-w-[200px] max-h-[240px] overflow-y-auto">
@@ -251,7 +238,7 @@ function ListRowContent({
                           {child.identifier}
                         </span>
                         <span className={`shrink-0 ${getStatusColor(child.status)}`}>
-                          [{formatStatusLabel(child.status)}]
+                          [{t(($) => $.status[child.status])}]
                         </span>
                       </button>
                     ))}
@@ -272,7 +259,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{formatStatusLabel(parentInfo.status)}]
+                  [{t(($) => $.status[parentInfo.status])}]
                 </span>
               </button>
             )}
@@ -354,6 +341,10 @@ export const ListRow = memo(function ListRow({
   onHoverParent?: (parentStatus: string | null) => void;
   onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
+  const handleToggle = useCallback(() => {
+    onToggleChildren?.();
+  }, [onToggleChildren]);
+
   return (
     <ListRowContent
       issue={issue}
@@ -364,7 +355,7 @@ export const ListRow = memo(function ListRow({
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
       crossStatusChildren={crossStatusChildren}
-      onToggleChildren={onToggleChildren}
+      onToggleChildren={handleToggle}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
       onScrollToParent={onScrollToParent}
@@ -430,6 +421,10 @@ export const DraggableListRow = memo(function DraggableListRow({
     transition,
   };
 
+  const handleToggle = useCallback(() => {
+    onToggleChildren?.();
+  }, [onToggleChildren]);
+
   return (
     <ListRowContent
       issue={issue}
@@ -445,7 +440,7 @@ export const DraggableListRow = memo(function DraggableListRow({
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
       crossStatusChildren={crossStatusChildren}
-      onToggleChildren={onToggleChildren}
+      onToggleChildren={handleToggle}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
       onScrollToParent={onScrollToParent}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -228,6 +228,7 @@ function ListRowContent({
                   }}
                   className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
                 >
+                  {/* eslint-disable-next-line i18next/no-literal-string */}
                   ↓ {crossStatusChildCount} 跨状态
                 </button>
                 {crossDropdownOpen && crossStatusChildren.length > 0 && (

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, type Ref } from "react";
+import { memo, useCallback, type Ref } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -8,6 +8,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { ChevronRight, CornerDownRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
+import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { formatDateOnly } from "@multica/core/issues/date";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -21,6 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import type { ParentInfo } from "../utils/hierarchy";
 
 export interface ChildProgress {
   done: number;
@@ -29,6 +31,10 @@ export interface ChildProgress {
 
 function formatDate(date: string): string {
   return formatDateOnly(date, { month: "short", day: "numeric" }, "en-US");
+}
+
+function getStatusColor(status: string): string {
+  return STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.iconColor ?? "text-muted-foreground";
 }
 
 function ListRowContent({
@@ -43,8 +49,11 @@ function ListRowContent({
   isParent = false,
   isExpanded = false,
   childCount = 0,
+  crossStatusChildCount = 0,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -57,8 +66,11 @@ function ListRowContent({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -79,12 +91,36 @@ function ListRowContent({
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showLabels = storeProperties.labels && labels.length > 0;
 
+  const handleChipClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!parentInfo) return;
+
+      if (e.metaKey || e.ctrlKey) {
+        window.open(p.issueDetail(parentInfo.parentId), "_blank");
+      } else {
+        onScrollToParent?.(parentInfo.parentId, parentInfo.status);
+      }
+    },
+    [parentInfo, p, onScrollToParent],
+  );
+
+  const handleChipMouseEnter = useCallback(() => {
+    if (parentInfo) onHoverParent?.(parentInfo.status);
+  }, [parentInfo, onHoverParent]);
+
+  const handleChipMouseLeave = useCallback(() => {
+    onHoverParent?.(null);
+  }, [onHoverParent]);
+
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
         ref={containerRef}
         style={containerStyle}
         {...containerProps}
+        data-issue-id={issue.id}
         className={`group/row flex h-9 items-center gap-2 pr-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
@@ -149,10 +185,27 @@ function ListRowContent({
                 ({childCount})
               </span>
             )}
-            {parentIdentifier && (
-              <span className="shrink-0 text-[11px] text-muted-foreground/70 truncate max-w-[120px]">
-                &larr; {parentIdentifier}
+            {isParent && crossStatusChildCount > 0 && (
+              <span className="shrink-0 text-[11px] text-muted-foreground/50 tabular-nums">
+                ↓ {crossStatusChildCount} cross-status
               </span>
+            )}
+            {parentInfo && (
+              <button
+                type="button"
+                onClick={handleChipClick}
+                onMouseEnter={handleChipMouseEnter}
+                onMouseLeave={handleChipMouseLeave}
+                className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-muted/60 hover:bg-muted cursor-pointer transition-colors max-w-[200px]"
+                title={`← ${parentInfo.identifier} — Click to scroll, Cmd+Click to open`}
+              >
+                <span className="text-[11px] text-muted-foreground/70 truncate">
+                  ← {parentInfo.identifier}
+                </span>
+                <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
+                  [{parentInfo.status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}]
+                </span>
+              </button>
             )}
             {showChildProgress && (
               <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
@@ -212,8 +265,11 @@ export const ListRow = memo(function ListRow({
   isParent,
   isExpanded,
   childCount,
+  crossStatusChildCount,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -221,8 +277,11 @@ export const ListRow = memo(function ListRow({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   return (
     <ListRowContent
@@ -232,8 +291,11 @@ export const ListRow = memo(function ListRow({
       isParent={isParent}
       isExpanded={isExpanded}
       childCount={childCount}
+      crossStatusChildCount={crossStatusChildCount}
       onToggleChildren={onToggleChildren}
-      parentIdentifier={parentIdentifier}
+      parentInfo={parentInfo}
+      onHoverParent={onHoverParent}
+      onScrollToParent={onScrollToParent}
     />
   );
 });
@@ -256,8 +318,11 @@ export const DraggableListRow = memo(function DraggableListRow({
   isParent,
   isExpanded,
   childCount,
+  crossStatusChildCount,
   onToggleChildren,
-  parentIdentifier,
+  parentInfo,
+  onHoverParent,
+  onScrollToParent,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -266,8 +331,11 @@ export const DraggableListRow = memo(function DraggableListRow({
   isParent?: boolean;
   isExpanded?: boolean;
   childCount?: number;
+  crossStatusChildCount?: number;
   onToggleChildren?: () => void;
-  parentIdentifier?: string;
+  parentInfo?: ParentInfo;
+  onHoverParent?: (parentStatus: string | null) => void;
+  onScrollToParent?: (parentId: string, parentStatus: string) => void;
 }) {
   const {
     attributes,
@@ -301,8 +369,11 @@ export const DraggableListRow = memo(function DraggableListRow({
       isParent={isParent}
       isExpanded={isExpanded}
       childCount={childCount}
+      crossStatusChildCount={crossStatusChildCount}
       onToggleChildren={onToggleChildren}
-      parentIdentifier={parentIdentifier}
+      parentInfo={parentInfo}
+      onHoverParent={onHoverParent}
+      onScrollToParent={onScrollToParent}
     />
   );
 });

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -238,7 +238,7 @@ function ListRowContent({
                           {child.identifier}
                         </span>
                         <span className={`shrink-0 ${getStatusColor(child.status)}`}>
-                          [{t(($) => $.status[child.status])}]
+                          [{t(($) => $.status[child.status as keyof typeof $.status])}]
                         </span>
                       </button>
                     ))}
@@ -259,7 +259,7 @@ function ListRowContent({
                   ← {parentInfo.identifier}
                 </span>
                 <span className={`text-[10px] truncate ${getStatusColor(parentInfo.status)}`}>
-                  [{t(($) => $.status[parentInfo.status])}]
+                  [{t(($) => $.status[parentInfo.status as keyof typeof $.status])}]
                 </span>
               </button>
             )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, type Ref } from "react";
+import { memo, useCallback, useState, useEffect, useRef, type Ref } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -22,7 +22,7 @@ import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
-import type { ParentInfo } from "../utils/hierarchy";
+import type { ParentInfo, CrossStatusChild } from "../utils/hierarchy";
 
 export interface ChildProgress {
   done: number;
@@ -64,6 +64,7 @@ function ListRowContent({
   isExpanded = false,
   childCount = 0,
   crossStatusChildCount = 0,
+  crossStatusChildren = [],
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -81,6 +82,7 @@ function ListRowContent({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -97,6 +99,22 @@ function ListRowContent({
   });
   const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
   const labels = issue.labels ?? [];
+
+  // Dropdown state for cross-status badge.
+  const [crossDropdownOpen, setCrossDropdownOpen] = useState(false);
+  const crossDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click.
+  useEffect(() => {
+    if (!crossDropdownOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (crossDropdownRef.current && !crossDropdownRef.current.contains(e.target as Node)) {
+        setCrossDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [crossDropdownOpen]);
 
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
@@ -200,9 +218,45 @@ function ListRowContent({
               </span>
             )}
             {isParent && crossStatusChildCount > 0 && (
-              <span className="shrink-0 text-[11px] text-muted-foreground/50 tabular-nums">
-                ↓ {crossStatusChildCount} cross-status
-              </span>
+              <div className="relative shrink-0" ref={crossDropdownRef}>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setCrossDropdownOpen((v) => !v);
+                  }}
+                  className="text-[11px] text-muted-foreground/50 tabular-nums hover:text-muted-foreground cursor-pointer transition-colors"
+                >
+                  ↓ {crossStatusChildCount} 跨状态
+                </button>
+                {crossDropdownOpen && crossStatusChildren.length > 0 && (
+                  <div className="absolute top-full left-0 z-50 mt-1 bg-popover border border-border rounded-md shadow-md p-1 min-w-[200px] max-h-[240px] overflow-y-auto">
+                    {crossStatusChildren.map((child) => (
+                      <button
+                        key={child.id}
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          setCrossDropdownOpen(false);
+                          onScrollToParent?.(child.id, child.status);
+                        }}
+                        onMouseEnter={() => onHoverParent?.(child.status)}
+                        onMouseLeave={() => onHoverParent?.(null)}
+                        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] rounded-sm hover:bg-accent cursor-pointer transition-colors"
+                      >
+                        <span className="text-muted-foreground/70 truncate flex-1">
+                          {child.identifier}
+                        </span>
+                        <span className={`shrink-0 ${getStatusColor(child.status)}`}>
+                          [{formatStatusLabel(child.status)}]
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
             {parentInfo && (
               <button
@@ -280,6 +334,7 @@ export const ListRow = memo(function ListRow({
   isExpanded,
   childCount,
   crossStatusChildCount,
+  crossStatusChildren,
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -292,6 +347,7 @@ export const ListRow = memo(function ListRow({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -306,6 +362,7 @@ export const ListRow = memo(function ListRow({
       isExpanded={isExpanded}
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
+      crossStatusChildren={crossStatusChildren}
       onToggleChildren={onToggleChildren}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}
@@ -333,6 +390,7 @@ export const DraggableListRow = memo(function DraggableListRow({
   isExpanded,
   childCount,
   crossStatusChildCount,
+  crossStatusChildren,
   onToggleChildren,
   parentInfo,
   onHoverParent,
@@ -346,6 +404,7 @@ export const DraggableListRow = memo(function DraggableListRow({
   isExpanded?: boolean;
   childCount?: number;
   crossStatusChildCount?: number;
+  crossStatusChildren?: CrossStatusChild[];
   onToggleChildren?: () => void;
   parentInfo?: ParentInfo;
   onHoverParent?: (parentStatus: string | null) => void;
@@ -384,6 +443,7 @@ export const DraggableListRow = memo(function DraggableListRow({
       isExpanded={isExpanded}
       childCount={childCount}
       crossStatusChildCount={crossStatusChildCount}
+      crossStatusChildren={crossStatusChildren}
       onToggleChildren={onToggleChildren}
       parentInfo={parentInfo}
       onHoverParent={onHoverParent}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -38,8 +38,10 @@ import {
   getMoveUpdates,
 } from "../utils/drag-utils";
 import type { BoardColumnGroup } from "./board-column";
+import { buildHierarchy, type RenderItem } from "../utils/hierarchy";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+const EMPTY_CHILDREN_MAP = new Map<string, Issue[]>();
 const EMPTY_IDS: string[] = [];
 
 function buildListGroups(visibleStatuses: IssueStatus[]): BoardColumnGroup[] {
@@ -55,6 +57,7 @@ export function ListView({
   issues,
   visibleStatuses,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  childrenMap = EMPTY_CHILDREN_MAP,
   myIssuesScope,
   myIssuesFilter,
   projectId,
@@ -64,6 +67,7 @@ export function ListView({
   issues: Issue[];
   visibleStatuses: IssueStatus[];
   childProgressMap?: Map<string, ChildProgress>;
+  childrenMap?: Map<string, Issue[]>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
   projectId?: string;
@@ -83,6 +87,21 @@ export function ListView({
   const sortLabel = sortBy !== "position"
     ? t(($) => $.board.ordered_by, { field: t(($) => $.display[`sort_${sortFieldKey}` as keyof typeof $.display]) })
     : null;
+
+  // Track which parent issues have their children expanded in the list view.
+  const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
+
+  const toggleExpandParent = useCallback((parentId: string) => {
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentId)) {
+        next.delete(parentId);
+      } else {
+        next.add(parentId);
+      }
+      return next;
+    });
+  }, []);
 
   const expandedStatuses = useMemo(
     () =>
@@ -306,6 +325,9 @@ export function ListView({
             issueIds={columns[statusGroupId(status)] ?? EMPTY_IDS}
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
+            childrenMap={childrenMap}
+            expandedParents={expandedParents}
+            onToggleExpand={toggleExpandParent}
             myIssuesOpts={myIssuesOpts}
             projectId={projectId}
             dragEnabled={dragEnabled}
@@ -355,6 +377,9 @@ function StatusAccordionItem({
   issueIds,
   issueMap,
   childProgressMap,
+  childrenMap,
+  expandedParents,
+  onToggleExpand,
   myIssuesOpts,
   projectId,
   dragEnabled,
@@ -366,6 +391,9 @@ function StatusAccordionItem({
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap: Map<string, ChildProgress>;
+  childrenMap: Map<string, Issue[]>;
+  expandedParents: ReadonlySet<string>;
+  onToggleExpand: (parentId: string) => void;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
   dragEnabled: boolean;
@@ -389,6 +417,34 @@ function StatusAccordionItem({
       return issue ? [issue] : [];
     }),
     [issueIds, issueMap],
+  );
+
+  // Build the set of issue IDs in this status group (for hierarchy resolution).
+  const statusIssueIds = useMemo(
+    () => new Set(issueIds),
+    [issueIds],
+  );
+
+  // Build a parent-id → identifier map for resolving cross-status parent references.
+  const parentIdentifierMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        map.set(issue.id, issue.identifier);
+      }
+    }
+    return map;
+  }, [issues, childProgressMap]);
+
+  // Build hierarchical render items for this status group.
+  const renderItems = useMemo(
+    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap),
+    [issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap],
+  );
+
+  const allRenderIds = useMemo(
+    () => renderItems.map((r) => r.issue.id),
+    [renderItems],
   );
 
   const selectedCount = issueIds.filter((id) => selectedIds.has(id)).length;
@@ -455,15 +511,21 @@ function StatusAccordionItem({
         </div>
       </Accordion.Header>
       <Accordion.Panel>
-        {issues.length > 0 ? (
+        {renderItems.length > 0 ? (
           dragEnabled ? (
-            <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
-              {issues.map((issue) => (
+            <SortableContext items={allRenderIds} strategy={verticalListSortingStrategy}>
+              {renderItems.map((item) => (
                 <DraggableListRow
-                  key={issue.id}
-                  issue={issue}
-                  childProgress={childProgressMap.get(issue.id)}
-                  disableSorting={disableSorting}
+                  key={item.issue.id}
+                  issue={item.issue}
+                  childProgress={childProgressMap.get(item.issue.id)}
+                  disableSorting={disableSorting || item.indent > 0}
+                  indent={item.indent}
+                  isParent={item.isParent}
+                  isExpanded={expandedParents.has(item.issue.id)}
+                  childCount={item.childCount}
+                  onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
+                  parentIdentifier={item.parentIdentifier}
                 />
               ))}
               {hasMore && (
@@ -472,8 +534,18 @@ function StatusAccordionItem({
             </SortableContext>
           ) : (
             <>
-              {issues.map((issue) => (
-                <ListRow key={issue.id} issue={issue} childProgress={childProgressMap.get(issue.id)} />
+              {renderItems.map((item) => (
+                <ListRow
+                  key={item.issue.id}
+                  issue={item.issue}
+                  childProgress={childProgressMap.get(item.issue.id)}
+                  indent={item.indent}
+                  isParent={item.isParent}
+                  isExpanded={expandedParents.has(item.issue.id)}
+                  childCount={item.childCount}
+                  onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
+                  parentIdentifier={item.parentIdentifier}
+                />
               ))}
               {hasMore && (
                 <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -127,20 +127,21 @@ export function ListView({
             el.scrollIntoView({ behavior: "auto", block: "center" });
             // Flash highlight: outline ring + background using rgba()
             // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
-            el.style.transition = "background-color 500ms ease-out, outline-color 500ms ease-out";
+            el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
             el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
             el.style.outline = "4px solid #a78bfa";
-            // Let the highlight render for at least one frame, then clear.
+            // Hold the highlight visible for 800ms, then clear to trigger the
+            // 800ms CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
               el.style.outline = "";
-            }, 100);
-            // Clean up inline properties after the transition completes.
+            }, 800);
+            // Clean up inline properties after hold + transition complete.
             setTimeout(() => {
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
               el.style.removeProperty("outline");
-            }, 700);
+            }, 1700);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,22 +125,22 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: inset ring + deeper background via inline style
-            // (classList is purged by Tailwind JIT so we avoid it entirely).
-            el.style.transition = "background-color 500ms ease-out, box-shadow 500ms ease-out";
-            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 30%, transparent)";
-            el.style.boxShadow = "inset 0 0 0 2px var(--color-brand, #a78bfa)";
-            // Force reflow so the browser registers the initial state, then clear
-            // to trigger the transition back to normal.
-            void el.offsetHeight;
-            el.style.backgroundColor = "";
-            el.style.boxShadow = "";
+            // Flash highlight: outline ring + background using rgba()
+            // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
+            el.style.transition = "background-color 500ms ease-out, outline-color 500ms ease-out";
+            el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
+            el.style.outline = "4px solid #a78bfa";
+            // Let the highlight render for at least one frame, then clear.
+            setTimeout(() => {
+              el.style.backgroundColor = "";
+              el.style.outline = "";
+            }, 100);
             // Clean up inline properties after the transition completes.
             setTimeout(() => {
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
-              el.style.removeProperty("box-shadow");
-            }, 600);
+              el.style.removeProperty("outline");
+            }, 700);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,17 +125,21 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight via inline style (classList would be purged by Tailwind JIT).
-            // The row already has transition-colors in its className, so backgroundColor
-            // changes animate smoothly.
-            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 20%, transparent)";
-            // Force style recalculation so the browser picks up the background change
-            // before clearing it, which triggers the transition.
+            // Flash highlight: inset ring + deeper background via inline style
+            // (classList is purged by Tailwind JIT so we avoid it entirely).
+            el.style.transition = "background-color 500ms ease-out, box-shadow 500ms ease-out";
+            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 30%, transparent)";
+            el.style.boxShadow = "inset 0 0 0 2px var(--color-brand, #a78bfa)";
+            // Force reflow so the browser registers the initial state, then clear
+            // to trigger the transition back to normal.
             void el.offsetHeight;
             el.style.backgroundColor = "";
-            // Clean up the inline style property after the transition completes.
+            el.style.boxShadow = "";
+            // Clean up inline properties after the transition completes.
             setTimeout(() => {
+              el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
+              el.style.removeProperty("box-shadow");
             }, 600);
           }
         });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,6 +125,14 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`);
           if (el) {
             el.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Flash highlight the target row: brief bg-brand/20 → transparent.
+            el.classList.add("bg-brand/20", "transition-colors", "duration-500");
+            setTimeout(() => {
+              el.classList.remove("bg-brand/20");
+              setTimeout(() => {
+                el.classList.remove("transition-colors", "duration-500");
+              }, 500);
+            }, 100);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -122,17 +122,21 @@ export function ListView({
       // Wait two frames for the accordion expansion to render, then scroll.
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          const el = document.querySelector(`[data-issue-id="${parentId}"]`);
+          const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
-            el.scrollIntoView({ behavior: "smooth", block: "center" });
-            // Flash highlight the target row: brief bg-brand/20 → transparent.
-            el.classList.add("bg-brand/20", "transition-colors", "duration-500");
+            el.scrollIntoView({ behavior: "auto", block: "center" });
+            // Flash highlight via inline style (classList would be purged by Tailwind JIT).
+            // The row already has transition-colors in its className, so backgroundColor
+            // changes animate smoothly.
+            el.style.backgroundColor = "color-mix(in srgb, var(--color-brand, #a78bfa) 20%, transparent)";
+            // Force style recalculation so the browser picks up the background change
+            // before clearing it, which triggers the transition.
+            void el.offsetHeight;
+            el.style.backgroundColor = "";
+            // Clean up the inline style property after the transition completes.
             setTimeout(() => {
-              el.classList.remove("bg-brand/20");
-              setTimeout(() => {
-                el.classList.remove("transition-colors", "duration-500");
-              }, 500);
-            }, 100);
+              el.style.removeProperty("background-color");
+            }, 600);
           }
         });
       });
@@ -585,6 +589,7 @@ function StatusAccordionItem({
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
                   crossStatusChildCount={item.crossStatusChildCount}
+                  crossStatusChildren={item.crossStatusChildren}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
                   parentInfo={item.parentInfo}
                   onHoverParent={onHoverParent}
@@ -607,6 +612,7 @@ function StatusAccordionItem({
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
                   crossStatusChildCount={item.crossStatusChildCount}
+                  crossStatusChildren={item.crossStatusChildren}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
                   parentInfo={item.parentInfo}
                   onHoverParent={onHoverParent}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -165,7 +165,10 @@ export function ListView({
     ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
     : undefined;
 
-  const dragEnabled = !!onMoveIssue;
+  // Disable DnD when any parent is expanded: the flat column order
+  // diverges from the hierarchical render order, so drop-position math
+  // would be inaccurate. Re-collapse all parents to re-enable.
+  const dragEnabled = !!onMoveIssue && expandedParents.size === 0;
 
   const groups = useMemo(
     () => buildListGroups(visibleStatuses),

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,23 +125,27 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: outline ring + background using rgba()
-            // (color-mix() + requestAnimationFrame reflow is invisible on Edge/macOS).
+            // Flash highlight: outline ring + background using rgba().
             el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
             el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
             el.style.outline = "4px solid #a78bfa";
-            // Hold the highlight visible for 800ms, then clear to trigger the
-            // 800ms CSS transition fade-out.
+            // Hold the highlight for 150ms (safe margin for 30fps low-end devices),
+            // then clear to trigger the CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
-              el.style.outline = "";
-            }, 800);
-            // Clean up inline properties after hold + transition complete.
-            setTimeout(() => {
+              // Only clear outlineColor so the outline fades via transition instead
+              // of hard-cutting (clearing outline-style would remove it instantly).
+              el.style.outlineColor = "rgba(167, 139, 250, 0)";
+            }, 150);
+            // Clean up inline properties exactly when the transition ends.
+            const onEnd = () => {
+              el.removeEventListener("transitionend", onEnd);
               el.style.removeProperty("transition");
               el.style.removeProperty("background-color");
               el.style.removeProperty("outline");
-            }, 1700);
+              el.style.removeProperty("outline-color");
+            };
+            el.addEventListener("transitionend", onEnd);
           }
         });
       });

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -38,7 +38,7 @@ import {
   getMoveUpdates,
 } from "../utils/drag-utils";
 import type { BoardColumnGroup } from "./board-column";
-import { buildHierarchy, type RenderItem } from "../utils/hierarchy";
+import { buildHierarchy, type ParentInfo } from "../utils/hierarchy";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 const EMPTY_CHILDREN_MAP = new Map<string, Issue[]>();
@@ -103,6 +103,35 @@ export function ListView({
     });
   }, []);
 
+  // Track which parent status column is hovered via a cross-status chip.
+  const [hoveredParentStatus, setHoveredParentStatus] = useState<string | null>(null);
+
+  const handleHoverParent = useCallback((parentStatus: string | null) => {
+    setHoveredParentStatus(parentStatus);
+  }, []);
+
+  // Scroll to a parent issue — expand the target column first if collapsed,
+  // then scroll the row into view.
+  const handleScrollToParent = useCallback(
+    (parentId: string, parentStatus: string) => {
+      const statusKey = parentStatus as IssueStatus;
+      // Expand the target column if it's collapsed.
+      if (listCollapsedStatuses.includes(statusKey)) {
+        toggleListCollapsed(statusKey);
+      }
+      // Wait two frames for the accordion expansion to render, then scroll.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const el = document.querySelector(`[data-issue-id="${parentId}"]`);
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+          }
+        });
+      });
+    },
+    [listCollapsedStatuses, toggleListCollapsed],
+  );
+
   const expandedStatuses = useMemo(
     () =>
       visibleStatuses.filter(
@@ -166,6 +195,22 @@ export function ListView({
   if (!isDraggingRef.current && !isSettlingRef.current) {
     issueMapRef.current = issueMap;
   }
+
+  // Build a global parent-info map: parentId → { identifier, status }
+  // for all issues that have child progress (i.e., are known parents).
+  const parentInfoMap = useMemo(() => {
+    const map = new Map<string, ParentInfo>();
+    for (const issue of issues) {
+      if (childProgressMap.has(issue.id)) {
+        map.set(issue.id, {
+          identifier: issue.identifier,
+          status: issue.status,
+          parentId: issue.id,
+        });
+      }
+    }
+    return map;
+  }, [issues, childProgressMap]);
 
   const collisionDetection = useMemo(
     () => makeKanbanCollision(groupIds),
@@ -328,6 +373,10 @@ export function ListView({
             childrenMap={childrenMap}
             expandedParents={expandedParents}
             onToggleExpand={toggleExpandParent}
+            parentInfoMap={parentInfoMap}
+            highlightedStatus={hoveredParentStatus}
+            onHoverParent={handleHoverParent}
+            onScrollToParent={handleScrollToParent}
             myIssuesOpts={myIssuesOpts}
             projectId={projectId}
             dragEnabled={dragEnabled}
@@ -380,6 +429,10 @@ function StatusAccordionItem({
   childrenMap,
   expandedParents,
   onToggleExpand,
+  parentInfoMap,
+  highlightedStatus,
+  onHoverParent,
+  onScrollToParent,
   myIssuesOpts,
   projectId,
   dragEnabled,
@@ -394,6 +447,10 @@ function StatusAccordionItem({
   childrenMap: Map<string, Issue[]>;
   expandedParents: ReadonlySet<string>;
   onToggleExpand: (parentId: string) => void;
+  parentInfoMap: Map<string, ParentInfo>;
+  highlightedStatus: string | null;
+  onHoverParent: (parentStatus: string | null) => void;
+  onScrollToParent: (parentId: string, parentStatus: string) => void;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
   dragEnabled: boolean;
@@ -425,21 +482,10 @@ function StatusAccordionItem({
     [issueIds],
   );
 
-  // Build a parent-id → identifier map for resolving cross-status parent references.
-  const parentIdentifierMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const issue of issues) {
-      if (childProgressMap.has(issue.id)) {
-        map.set(issue.id, issue.identifier);
-      }
-    }
-    return map;
-  }, [issues, childProgressMap]);
-
   // Build hierarchical render items for this status group.
   const renderItems = useMemo(
-    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap),
-    [issues, childrenMap, statusIssueIds, expandedParents, parentIdentifierMap],
+    () => buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap),
+    [issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap],
   );
 
   const allRenderIds = useMemo(
@@ -458,12 +504,18 @@ function StatusAccordionItem({
 
   const disableSorting = !!sortLabel;
 
+  const isHighlighted = highlightedStatus === status;
+
   return (
     <Accordion.Item value={status} ref={dragEnabled ? setDroppableRef : undefined}>
       <Accordion.Header
         className={`group/header sticky top-0 z-10 flex h-10 items-center rounded-lg bg-muted transition-colors hover:bg-accent ${
           isOver && !isExpanded
             ? "ring-2 ring-brand/25 bg-accent/15"
+            : ""
+        } ${
+          isHighlighted
+            ? "ring-1 ring-brand/20 bg-accent/10"
             : ""
         }`}
       >
@@ -524,8 +576,11 @@ function StatusAccordionItem({
                   isParent={item.isParent}
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
+                  crossStatusChildCount={item.crossStatusChildCount}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
-                  parentIdentifier={item.parentIdentifier}
+                  parentInfo={item.parentInfo}
+                  onHoverParent={onHoverParent}
+                  onScrollToParent={onScrollToParent}
                 />
               ))}
               {hasMore && (
@@ -543,8 +598,11 @@ function StatusAccordionItem({
                   isParent={item.isParent}
                   isExpanded={expandedParents.has(item.issue.id)}
                   childCount={item.childCount}
+                  crossStatusChildCount={item.crossStatusChildCount}
                   onToggleChildren={item.isParent ? () => onToggleExpand(item.issue.id) : undefined}
-                  parentIdentifier={item.parentIdentifier}
+                  parentInfo={item.parentInfo}
+                  onHoverParent={onHoverParent}
+                  onScrollToParent={onScrollToParent}
                 />
               ))}
               {hasMore && (

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -125,17 +125,17 @@ export function ListView({
           const el = document.querySelector(`[data-issue-id="${parentId}"]`) as HTMLElement | null;
           if (el) {
             el.scrollIntoView({ behavior: "auto", block: "center" });
-            // Flash highlight: outline ring + background using rgba().
+            // Flash highlight: outline ring + background using brand token.
             el.style.transition = "background-color 800ms ease-out, outline-color 800ms ease-out";
-            el.style.backgroundColor = "rgba(167, 139, 250, 0.3)";
-            el.style.outline = "4px solid #a78bfa";
+            el.style.backgroundColor = "color-mix(in srgb, var(--brand) 30%, transparent)";
+            el.style.outline = "4px solid var(--brand)";
             // Hold the highlight for 150ms (safe margin for 30fps low-end devices),
             // then clear to trigger the CSS transition fade-out.
             setTimeout(() => {
               el.style.backgroundColor = "";
               // Only clear outlineColor so the outline fades via transition instead
               // of hard-cutting (clearing outline-style would remove it instantly).
-              el.style.outlineColor = "rgba(167, 139, 250, 0)";
+              el.style.outlineColor = "color-mix(in srgb, var(--brand) 0%, transparent)";
             }, 150);
             // Clean up inline properties exactly when the transition ends.
             const onEnd = () => {

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Issue } from "@multica/core/types";
 import { buildHierarchy, type ParentInfo } from "./hierarchy";
 
-function makeIssue(overrides: Partial<Issue> = {}): Issue {
+function makeIssue(overrides: Partial<Issue> & { stage?: number | null } = {}): Issue {
   return {
     id: "i-1",
     workspace_id: "ws-1",
@@ -22,10 +22,11 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     start_date: null,
     due_date: null,
     metadata: {},
+    stage: null,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  };
+  } as Issue;
 }
 
 function makeParentInfo(parentId: string, identifier: string, status: string): ParentInfo {

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -50,16 +50,16 @@ describe("buildHierarchy", () => {
     // Children are not expanded inline (parent not expanded), so the fallback
     // appends them as orphaned items.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].childCount).toBe(2);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.childCount).toBe(2);
+    expect(result[0]!.indent).toBe(0);
 
     // Children appended as orphaned (parent not in expandedParents).
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].orphaned).toBe(true);
-    expect(result[2].issue.id).toBe("c2");
-    expect(result[2].orphaned).toBe(true);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.orphaned).toBe(true);
+    expect(result[2]!.issue.id).toBe("c2");
+    expect(result[2]!.orphaned).toBe(true);
   });
 
   it("expands children when parent is in expandedParents set", () => {
@@ -76,14 +76,14 @@ describe("buildHierarchy", () => {
 
     // Parent + 2 children rendered.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
     // Children are rendered at indent=1 when parent is expanded.
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
-    expect(result[1].isParent).toBe(false);
-    expect(result[2].issue.id).toBe("c2");
-    expect(result[2].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
+    expect(result[1]!.isParent).toBe(false);
+    expect(result[2]!.issue.id).toBe("c2");
+    expect(result[2]!.indent).toBe(1);
   });
 
   // ── Scenario 2: all-cross-status parent ──
@@ -103,12 +103,12 @@ describe("buildHierarchy", () => {
     // Parent should NOT be marked as isParent (no same-status children),
     // but should have crossStatusChildCount > 0.
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].childCount).toBe(0);
-    expect(result[0].crossStatusChildCount).toBe(1);
-    expect(result[0].crossStatusChildren).toHaveLength(1);
-    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-2");
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.childCount).toBe(0);
+    expect(result[0]!.crossStatusChildCount).toBe(1);
+    expect(result[0]!.crossStatusChildren).toHaveLength(1);
+    expect(result[0]!.crossStatusChildren[0]!.identifier).toBe("OXY-2");
   });
 
   // ── Scenario 3: mixed (some same-status + some cross-status) ──
@@ -126,17 +126,17 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
 
     expect(result).toHaveLength(2); // parent + same-status child
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].childCount).toBe(1);
-    expect(result[0].crossStatusChildCount).toBe(1);
-    expect(result[0].crossStatusChildren).toHaveLength(1);
-    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-3");
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.childCount).toBe(1);
+    expect(result[0]!.crossStatusChildCount).toBe(1);
+    expect(result[0]!.crossStatusChildren).toHaveLength(1);
+    expect(result[0]!.crossStatusChildren[0]!.identifier).toBe("OXY-3");
 
     // Cross-status child rows appear in the crossStatusChildren list only.
     // The same-status child is rendered inline.
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
   });
 
   // ── Scenario 4: multi-level recursion ──
@@ -156,17 +156,17 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[0].isParent).toBe(true);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[0]!.isParent).toBe(true);
+    expect(result[0]!.indent).toBe(0);
 
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].isParent).toBe(true); // has a grandchild
-    expect(result[1].indent).toBe(1);
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.isParent).toBe(true); // has a grandchild
+    expect(result[1]!.indent).toBe(1);
 
-    expect(result[2].issue.id).toBe("g1");
-    expect(result[2].isParent).toBe(false);
-    expect(result[2].indent).toBe(2);
+    expect(result[2]!.issue.id).toBe("g1");
+    expect(result[2]!.isParent).toBe(false);
+    expect(result[2]!.indent).toBe(2);
   });
 
   it("does not expand grandchild when child is not expanded", () => {
@@ -187,12 +187,12 @@ describe("buildHierarchy", () => {
     // Parent expanded → shows child inline. Child NOT expanded → grandchild
     // is appended as orphaned by the fallback.
     expect(result).toHaveLength(3);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
     // Grandchild is orphaned since child is not expanded.
-    expect(result[2].issue.id).toBe("g1");
-    expect(result[2].orphaned).toBe(true);
+    expect(result[2]!.issue.id).toBe("g1");
+    expect(result[2]!.orphaned).toBe(true);
   });
 
   // ── Scenario 5: cross-status child renders as top-level with parentInfo ──
@@ -213,12 +213,12 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
 
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("c1");
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].indent).toBe(0);
-    expect(result[0].parentInfo).toBeDefined();
-    expect(result[0].parentInfo!.identifier).toBe("OXY-1");
-    expect(result[0].parentInfo!.status).toBe("done");
+    expect(result[0]!.issue.id).toBe("c1");
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.indent).toBe(0);
+    expect(result[0]!.parentInfo).toBeDefined();
+    expect(result[0]!.parentInfo!.identifier).toBe("OXY-1");
+    expect(result[0]!.parentInfo!.status).toBe("done");
   });
 
   // ── Scenario 6: orphan fallback ──
@@ -241,9 +241,9 @@ describe("buildHierarchy", () => {
 
     // Should be rendered as top-level with orphaned flag.
     expect(result).toHaveLength(1);
-    expect(result[0].issue.id).toBe("o1");
-    expect(result[0].orphaned).toBe(true);
-    expect(result[0].indent).toBe(0);
+    expect(result[0]!.issue.id).toBe("o1");
+    expect(result[0]!.orphaned).toBe(true);
+    expect(result[0]!.indent).toBe(0);
   });
 
   // ── Scenario 7: no children at all ──
@@ -259,10 +259,10 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(2);
-    expect(result[0].isParent).toBe(false);
-    expect(result[0].childCount).toBe(0);
-    expect(result[0].crossStatusChildCount).toBe(0);
-    expect(result[1].isParent).toBe(false);
+    expect(result[0]!.isParent).toBe(false);
+    expect(result[0]!.childCount).toBe(0);
+    expect(result[0]!.crossStatusChildCount).toBe(0);
+    expect(result[1]!.isParent).toBe(false);
   });
 
   // ── Scenario 8: multiple top-level parents ──
@@ -283,11 +283,11 @@ describe("buildHierarchy", () => {
     const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
 
     expect(result).toHaveLength(4);
-    expect(result[0].issue.id).toBe("p1");
-    expect(result[1].issue.id).toBe("c1");
-    expect(result[1].indent).toBe(1);
-    expect(result[2].issue.id).toBe("p2");
-    expect(result[3].issue.id).toBe("c2");
-    expect(result[3].indent).toBe(1);
+    expect(result[0]!.issue.id).toBe("p1");
+    expect(result[1]!.issue.id).toBe("c1");
+    expect(result[1]!.indent).toBe(1);
+    expect(result[2]!.issue.id).toBe("p2");
+    expect(result[3]!.issue.id).toBe("c2");
+    expect(result[3]!.indent).toBe(1);
   });
 });

--- a/packages/views/issues/utils/hierarchy.test.ts
+++ b/packages/views/issues/utils/hierarchy.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from "vitest";
+import type { Issue } from "@multica/core/types";
+import { buildHierarchy, type ParentInfo } from "./hierarchy";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "i-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Test",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "u-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeParentInfo(parentId: string, identifier: string, status: string): ParentInfo {
+  return { parentId, identifier, status };
+}
+
+describe("buildHierarchy", () => {
+  // ── Scenario 1: same-status nesting ──
+  it("nests children under their parent when parent and children share the same status", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-3", status: "todo", parent_issue_id: "p1" });
+
+    const issues = [parent, child1, child2];
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1, child2]]]);
+    const statusIssueIds = new Set(["p1", "c1", "c2"]);
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent is top-level with isParent=true, childCount=2.
+    // Children are not expanded inline (parent not expanded), so the fallback
+    // appends them as orphaned items.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].childCount).toBe(2);
+    expect(result[0].indent).toBe(0);
+
+    // Children appended as orphaned (parent not in expandedParents).
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].orphaned).toBe(true);
+    expect(result[2].issue.id).toBe("c2");
+    expect(result[2].orphaned).toBe(true);
+  });
+
+  it("expands children when parent is in expandedParents set", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-3", status: "todo", parent_issue_id: "p1" });
+
+    const issues = [parent, child1, child2];
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1, child2]]]);
+    const statusIssueIds = new Set(["p1", "c1", "c2"]);
+    const expandedParents = new Set(["p1"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent + 2 children rendered.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    // Children are rendered at indent=1 when parent is expanded.
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    expect(result[1].isParent).toBe(false);
+    expect(result[2].issue.id).toBe("c2");
+    expect(result[2].indent).toBe(1);
+  });
+
+  // ── Scenario 2: all-cross-status parent ──
+  it("shows crossStatusChildCount and crossStatusChildren when parent has only cross-status children", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "done" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+
+    // Parent is in "done" status group; child is in "todo" — different group.
+    const issues = [parent]; // only parent in this group
+    const childrenMap = new Map<string, Issue[]>([["p1", [child1]]]);
+    const statusIssueIds = new Set(["p1"]); // child1 is NOT in this status group
+    const expandedParents = new Set<string>();
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "done")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    // Parent should NOT be marked as isParent (no same-status children),
+    // but should have crossStatusChildCount > 0.
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].childCount).toBe(0);
+    expect(result[0].crossStatusChildCount).toBe(1);
+    expect(result[0].crossStatusChildren).toHaveLength(1);
+    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-2");
+  });
+
+  // ── Scenario 3: mixed (some same-status + some cross-status) ──
+  it("handles mixed children: some same-status, some cross-status", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const sameChild = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const crossChild = makeIssue({ id: "c2", identifier: "OXY-3", status: "done", parent_issue_id: "p1" });
+
+    const issues = [parent, sameChild];
+    const childrenMap = new Map<string, Issue[]>([["p1", [sameChild, crossChild]]]);
+    const statusIssueIds = new Set(["p1", "c1"]); // c2 is cross-status
+    const expandedParents = new Set(["p1"]);
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "todo")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    expect(result).toHaveLength(2); // parent + same-status child
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].childCount).toBe(1);
+    expect(result[0].crossStatusChildCount).toBe(1);
+    expect(result[0].crossStatusChildren).toHaveLength(1);
+    expect(result[0].crossStatusChildren[0].identifier).toBe("OXY-3");
+
+    // Cross-status child rows appear in the crossStatusChildren list only.
+    // The same-status child is rendered inline.
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+  });
+
+  // ── Scenario 4: multi-level recursion ──
+  it("supports multi-level nesting: parent → child → grandchild", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const grandchild = makeIssue({ id: "g1", identifier: "OXY-3", status: "todo", parent_issue_id: "c1" });
+
+    const issues = [parent, child, grandchild];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child]],
+      ["c1", [grandchild]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "g1"]);
+    const expandedParents = new Set(["p1", "c1"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[0].isParent).toBe(true);
+    expect(result[0].indent).toBe(0);
+
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].isParent).toBe(true); // has a grandchild
+    expect(result[1].indent).toBe(1);
+
+    expect(result[2].issue.id).toBe("g1");
+    expect(result[2].isParent).toBe(false);
+    expect(result[2].indent).toBe(2);
+  });
+
+  it("does not expand grandchild when child is not expanded", () => {
+    const parent = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const grandchild = makeIssue({ id: "g1", identifier: "OXY-3", status: "todo", parent_issue_id: "c1" });
+
+    const issues = [parent, child, grandchild];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child]],
+      ["c1", [grandchild]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "g1"]);
+    const expandedParents = new Set(["p1"]); // only parent expanded, not child
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Parent expanded → shows child inline. Child NOT expanded → grandchild
+    // is appended as orphaned by the fallback.
+    expect(result).toHaveLength(3);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    // Grandchild is orphaned since child is not expanded.
+    expect(result[2].issue.id).toBe("g1");
+    expect(result[2].orphaned).toBe(true);
+  });
+
+  // ── Scenario 5: cross-status child renders as top-level with parentInfo ──
+  it("renders cross-status child at top level with parentInfo chip", () => {
+    const crossChild = makeIssue({
+      id: "c1",
+      identifier: "OXY-2",
+      status: "todo",
+      parent_issue_id: "p1",
+    });
+
+    const issues = [crossChild]; // only the child in this group, parent is in another
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["c1"]); // parent p1 NOT in this group
+    const expandedParents = new Set<string>();
+    const parentInfoMap = new Map([["p1", makeParentInfo("p1", "OXY-1", "done")]]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents, parentInfoMap);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("c1");
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].indent).toBe(0);
+    expect(result[0].parentInfo).toBeDefined();
+    expect(result[0].parentInfo!.identifier).toBe("OXY-1");
+    expect(result[0].parentInfo!.status).toBe("done");
+  });
+
+  // ── Scenario 6: orphan fallback ──
+  it("marks orphaned issues that have a parent in the same status but parent is not in the list", () => {
+    // Child whose parent is in the same status group but the parent issue
+    // is not in the provided issues array (e.g. filtered out).
+    const orphan = makeIssue({
+      id: "o1",
+      identifier: "OXY-5",
+      status: "todo",
+      parent_issue_id: "p-missing",
+    });
+
+    const issues = [orphan];
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["o1", "p-missing"]); // parent would be in same status if present
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    // Should be rendered as top-level with orphaned flag.
+    expect(result).toHaveLength(1);
+    expect(result[0].issue.id).toBe("o1");
+    expect(result[0].orphaned).toBe(true);
+    expect(result[0].indent).toBe(0);
+  });
+
+  // ── Scenario 7: no children at all ──
+  it("handles issues with no children gracefully", () => {
+    const issue1 = makeIssue({ id: "a1", identifier: "OXY-10", status: "todo" });
+    const issue2 = makeIssue({ id: "a2", identifier: "OXY-11", status: "todo" });
+
+    const issues = [issue1, issue2];
+    const childrenMap = new Map<string, Issue[]>();
+    const statusIssueIds = new Set(["a1", "a2"]);
+    const expandedParents = new Set<string>();
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isParent).toBe(false);
+    expect(result[0].childCount).toBe(0);
+    expect(result[0].crossStatusChildCount).toBe(0);
+    expect(result[1].isParent).toBe(false);
+  });
+
+  // ── Scenario 8: multiple top-level parents ──
+  it("handles multiple top-level parent issues independently", () => {
+    const parent1 = makeIssue({ id: "p1", identifier: "OXY-1", status: "todo" });
+    const child1 = makeIssue({ id: "c1", identifier: "OXY-2", status: "todo", parent_issue_id: "p1" });
+    const parent2 = makeIssue({ id: "p2", identifier: "OXY-3", status: "todo" });
+    const child2 = makeIssue({ id: "c2", identifier: "OXY-4", status: "todo", parent_issue_id: "p2" });
+
+    const issues = [parent1, child1, parent2, child2];
+    const childrenMap = new Map<string, Issue[]>([
+      ["p1", [child1]],
+      ["p2", [child2]],
+    ]);
+    const statusIssueIds = new Set(["p1", "c1", "p2", "c2"]);
+    const expandedParents = new Set(["p1", "p2"]);
+
+    const result = buildHierarchy(issues, childrenMap, statusIssueIds, expandedParents);
+
+    expect(result).toHaveLength(4);
+    expect(result[0].issue.id).toBe("p1");
+    expect(result[1].issue.id).toBe("c1");
+    expect(result[1].indent).toBe(1);
+    expect(result[2].issue.id).toBe("p2");
+    expect(result[3].issue.id).toBe("c2");
+    expect(result[3].indent).toBe(1);
+  });
+});

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -65,7 +65,7 @@ function renderSubtree(
 
   // Build the list of cross-status children for the dropdown.
   const crossStatusChildren: CrossStatusChild[] = [];
-  if (isParent && crossStatusCount > 0) {
+  if (crossStatusCount > 0) {
     for (const child of allChildren) {
       if (!statusIssueIds.has(child.id)) {
         crossStatusChildren.push({
@@ -91,7 +91,7 @@ function renderSubtree(
       indent,
       isParent,
       childCount: isParent ? sameStatusCount : 0,
-      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      crossStatusChildCount: crossStatusCount,
       crossStatusChildren,
       parentInfo,
     },

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -1,6 +1,16 @@
 import type { Issue } from "@multica/core/types";
 
 /**
+ * Info about a cross-status parent, used to render a clickable chip
+ * on child rows whose parent lives in a different status column.
+ */
+export interface ParentInfo {
+  identifier: string;
+  status: string;
+  parentId: string;
+}
+
+/**
  * A single item in the render tree for a status group.
  * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
  */
@@ -12,8 +22,10 @@ export interface RenderItem {
   isParent: boolean;
   /** Number of children nested under this parent in the same status group. */
   childCount: number;
-  /** When a child's parent is NOT in the same status group, show the parent's identifier. */
-  parentIdentifier?: string;
+  /** Number of children in other status groups (for cross-status badge on parent row). */
+  crossStatusChildCount: number;
+  /** When a child's parent is NOT in the same status group, info about that parent. */
+  parentInfo?: ParentInfo;
   /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
   orphaned?: boolean;
 }
@@ -24,20 +36,20 @@ export interface RenderItem {
  * - Children whose parent IS in the same status group are nested right after
  *   the parent, with indent=1.
  * - Children whose parent is in a different status group render at top level
- *   with a subtle `parentIdentifier` label.
+ *   with a clickable `parentInfo` chip.
  *
  * @param issues - a single status-group's issues (already filtered by status).
  * @param childrenMap - parent_issue_id → its direct children (all statuses).
  * @param statusIssueIds - the set of all issue ids that belong to this status group.
  * @param expandedParents - the set of parent issue ids whose children are expanded.
- * @param parentIdentifierMap - parent issue id → its identifier string (e.g., "MUL-123").
+ * @param parentInfoMap - parent issue id → { identifier, status } for all known parents.
  */
 export function buildHierarchy(
   issues: Issue[],
   childrenMap: Map<string, readonly Issue[]>,
   statusIssueIds: Set<string>,
   expandedParents: ReadonlySet<string>,
-  parentIdentifierMap?: Map<string, string>,
+  parentInfoMap?: Map<string, ParentInfo>,
 ): RenderItem[] {
   const result: RenderItem[] = [];
 
@@ -79,18 +91,24 @@ export function buildHierarchy(
     const isParent = !!nestedChildren && nestedChildren.length > 0;
     const expanded = expandedParents.has(issue.id);
 
-    // Resolve parent identifier for children whose parent is in another status group.
-    let parentIdentifier: string | undefined;
+    // Compute cross-status child count for parent rows.
+    const allChildren = childrenMap.get(issue.id) ?? [];
+    const sameStatusCount = nestedChildren?.length ?? 0;
+    const crossStatusCount = allChildren.length - sameStatusCount;
+
+    // Resolve parent info for children whose parent is in another status group.
+    let parentInfo: ParentInfo | undefined;
     if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
-      parentIdentifier = parentIdentifierMap?.get(issue.parent_issue_id);
+      parentInfo = parentInfoMap?.get(issue.parent_issue_id);
     }
 
     result.push({
       issue,
       indent: 0,
       isParent,
-      childCount: isParent ? nestedChildren!.length : 0,
-      parentIdentifier,
+      childCount: isParent ? sameStatusCount : 0,
+      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      parentInfo,
     });
 
     if (isParent && expanded) {
@@ -100,6 +118,7 @@ export function buildHierarchy(
           indent: 1,
           isParent: false,
           childCount: 0,
+          crossStatusChildCount: 0,
         });
       }
     }
@@ -114,6 +133,7 @@ export function buildHierarchy(
         indent: 0,
         isParent: false,
         childCount: 0,
+        crossStatusChildCount: 0,
         orphaned: !!issue.parent_issue_id,
       });
     }

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -1,0 +1,123 @@
+import type { Issue } from "@multica/core/types";
+
+/**
+ * A single item in the render tree for a status group.
+ * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
+ */
+export interface RenderItem {
+  issue: Issue;
+  /** 0 = top-level, 1 = first-level child, etc. */
+  indent: number;
+  /** True when this issue has visible children nested under it (in the same status). */
+  isParent: boolean;
+  /** Number of children nested under this parent in the same status group. */
+  childCount: number;
+  /** When a child's parent is NOT in the same status group, show the parent's identifier. */
+  parentIdentifier?: string;
+  /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
+  orphaned?: boolean;
+}
+
+/**
+ * Organise a status-group's flat issue list into a hierarchical order:
+ * - Top-level issues first (no parent, or parent in a different status).
+ * - Children whose parent IS in the same status group are nested right after
+ *   the parent, with indent=1.
+ * - Children whose parent is in a different status group render at top level
+ *   with a subtle `parentIdentifier` label.
+ *
+ * @param issues - a single status-group's issues (already filtered by status).
+ * @param childrenMap - parent_issue_id → its direct children (all statuses).
+ * @param statusIssueIds - the set of all issue ids that belong to this status group.
+ * @param expandedParents - the set of parent issue ids whose children are expanded.
+ * @param parentIdentifierMap - parent issue id → its identifier string (e.g., "MUL-123").
+ */
+export function buildHierarchy(
+  issues: Issue[],
+  childrenMap: Map<string, readonly Issue[]>,
+  statusIssueIds: Set<string>,
+  expandedParents: ReadonlySet<string>,
+  parentIdentifierMap?: Map<string, string>,
+): RenderItem[] {
+  const result: RenderItem[] = [];
+
+  // Build a lookup for which parents have children in this status.
+  const childrenInStatus = new Map<string, Issue[]>();
+  for (const issue of issues) {
+    if (!issue.parent_issue_id) continue;
+    const children = childrenMap.get(issue.parent_issue_id);
+    if (!children) continue;
+
+    // Only count children that are in the same status group.
+    const sameStatusChildren = children.filter((c) => statusIssueIds.has(c.id));
+    if (sameStatusChildren.length === 0) continue;
+
+    const bucket = childrenInStatus.get(issue.parent_issue_id);
+    if (bucket) {
+      bucket.push(issue);
+    } else {
+      childrenInStatus.set(issue.parent_issue_id, [issue]);
+    }
+  }
+
+  // Separate top-level vs. child issues.
+  const topLevel: Issue[] = [];
+  const childIds = new Set<string>();
+
+  for (const issue of issues) {
+    if (!issue.parent_issue_id || !statusIssueIds.has(issue.parent_issue_id)) {
+      // No parent, or parent not in this status group.
+      topLevel.push(issue);
+    } else {
+      // Parent is in this status group — this issue will be nested.
+      childIds.add(issue.id);
+    }
+  }
+
+  for (const issue of topLevel) {
+    const nestedChildren = childrenInStatus.get(issue.id);
+    const isParent = !!nestedChildren && nestedChildren.length > 0;
+    const expanded = expandedParents.has(issue.id);
+
+    // Resolve parent identifier for children whose parent is in another status group.
+    let parentIdentifier: string | undefined;
+    if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
+      parentIdentifier = parentIdentifierMap?.get(issue.parent_issue_id);
+    }
+
+    result.push({
+      issue,
+      indent: 0,
+      isParent,
+      childCount: isParent ? nestedChildren!.length : 0,
+      parentIdentifier,
+    });
+
+    if (isParent && expanded) {
+      for (const child of nestedChildren!) {
+        result.push({
+          issue: child,
+          indent: 1,
+          isParent: false,
+          childCount: 0,
+        });
+      }
+    }
+  }
+
+  // Append any children whose parent wasn't in the top-level (shouldn't happen,
+  // but guards against edge cases where parent was filtered or not loaded).
+  for (const issue of issues) {
+    if (!result.some((r) => r.issue.id === issue.id)) {
+      result.push({
+        issue,
+        indent: 0,
+        isParent: false,
+        childCount: 0,
+        orphaned: !!issue.parent_issue_id,
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -11,6 +11,16 @@ export interface ParentInfo {
 }
 
 /**
+ * Lightweight reference to a cross-status child, used in the
+ * expandable dropdown on the parent row.
+ */
+export interface CrossStatusChild {
+  identifier: string;
+  status: string;
+  id: string;
+}
+
+/**
  * A single item in the render tree for a status group.
  * Produced by {@link buildHierarchy} and consumed by {@link ListView}.
  */
@@ -24,6 +34,8 @@ export interface RenderItem {
   childCount: number;
   /** Number of children in other status groups (for cross-status badge on parent row). */
   crossStatusChildCount: number;
+  /** Cross-status children for the expandable dropdown on the parent row. */
+  crossStatusChildren: CrossStatusChild[];
   /** When a child's parent is NOT in the same status group, info about that parent. */
   parentInfo?: ParentInfo;
   /** When a child's parent is in the same status group but hidden (e.g., filtered out). */
@@ -51,6 +63,20 @@ function renderSubtree(
   const sameStatusCount = nestedChildren?.length ?? 0;
   const crossStatusCount = allChildren.length - sameStatusCount;
 
+  // Build the list of cross-status children for the dropdown.
+  const crossStatusChildren: CrossStatusChild[] = [];
+  if (isParent && crossStatusCount > 0) {
+    for (const child of allChildren) {
+      if (!statusIssueIds.has(child.id)) {
+        crossStatusChildren.push({
+          identifier: child.identifier,
+          status: child.status,
+          id: child.id,
+        });
+      }
+    }
+  }
+
   // Resolve parent info for top-level items whose parent is cross-status.
   // Children rendered via recursion always have their parent in the same status,
   // so parentInfo is only needed for top-level cross-status orphans.
@@ -66,6 +92,7 @@ function renderSubtree(
       isParent,
       childCount: isParent ? sameStatusCount : 0,
       crossStatusChildCount: isParent ? crossStatusCount : 0,
+      crossStatusChildren,
       parentInfo,
     },
   ];
@@ -166,6 +193,7 @@ export function buildHierarchy(
         isParent: false,
         childCount: 0,
         crossStatusChildCount: 0,
+        crossStatusChildren: [],
         orphaned: !!issue.parent_issue_id,
       });
     }

--- a/packages/views/issues/utils/hierarchy.ts
+++ b/packages/views/issues/utils/hierarchy.ts
@@ -31,10 +31,69 @@ export interface RenderItem {
 }
 
 /**
+ * Recursively render a single issue and, if it is an expanded parent,
+ * all of its same-status descendants.
+ */
+function renderSubtree(
+  issue: Issue,
+  indent: number,
+  childrenInStatus: Map<string, Issue[]>,
+  childrenMap: Map<string, readonly Issue[]>,
+  expandedParents: ReadonlySet<string>,
+  statusIssueIds: Set<string>,
+  parentInfoMap?: Map<string, ParentInfo>,
+): RenderItem[] {
+  const nestedChildren = childrenInStatus.get(issue.id);
+  const isParent = !!nestedChildren && nestedChildren.length > 0;
+  const expanded = expandedParents.has(issue.id);
+
+  const allChildren = childrenMap.get(issue.id) ?? [];
+  const sameStatusCount = nestedChildren?.length ?? 0;
+  const crossStatusCount = allChildren.length - sameStatusCount;
+
+  // Resolve parent info for top-level items whose parent is cross-status.
+  // Children rendered via recursion always have their parent in the same status,
+  // so parentInfo is only needed for top-level cross-status orphans.
+  let parentInfo: ParentInfo | undefined;
+  if (indent === 0 && issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
+    parentInfo = parentInfoMap?.get(issue.parent_issue_id);
+  }
+
+  const result: RenderItem[] = [
+    {
+      issue,
+      indent,
+      isParent,
+      childCount: isParent ? sameStatusCount : 0,
+      crossStatusChildCount: isParent ? crossStatusCount : 0,
+      parentInfo,
+    },
+  ];
+
+  if (isParent && expanded) {
+    for (const child of nestedChildren!) {
+      result.push(
+        ...renderSubtree(
+          child,
+          indent + 1,
+          childrenInStatus,
+          childrenMap,
+          expandedParents,
+          statusIssueIds,
+          parentInfoMap,
+        ),
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
  * Organise a status-group's flat issue list into a hierarchical order:
  * - Top-level issues first (no parent, or parent in a different status).
  * - Children whose parent IS in the same status group are nested right after
- *   the parent, with indent=1.
+ *   the parent with increasing indent, recursively for any depth.
  * - Children whose parent is in a different status group render at top level
  *   with a clickable `parentInfo` chip.
  *
@@ -74,57 +133,30 @@ export function buildHierarchy(
 
   // Separate top-level vs. child issues.
   const topLevel: Issue[] = [];
-  const childIds = new Set<string>();
 
   for (const issue of issues) {
     if (!issue.parent_issue_id || !statusIssueIds.has(issue.parent_issue_id)) {
       // No parent, or parent not in this status group.
       topLevel.push(issue);
-    } else {
-      // Parent is in this status group — this issue will be nested.
-      childIds.add(issue.id);
     }
   }
 
+  // Recursively render each top-level issue and its descendants.
   for (const issue of topLevel) {
-    const nestedChildren = childrenInStatus.get(issue.id);
-    const isParent = !!nestedChildren && nestedChildren.length > 0;
-    const expanded = expandedParents.has(issue.id);
-
-    // Compute cross-status child count for parent rows.
-    const allChildren = childrenMap.get(issue.id) ?? [];
-    const sameStatusCount = nestedChildren?.length ?? 0;
-    const crossStatusCount = allChildren.length - sameStatusCount;
-
-    // Resolve parent info for children whose parent is in another status group.
-    let parentInfo: ParentInfo | undefined;
-    if (issue.parent_issue_id && !statusIssueIds.has(issue.parent_issue_id)) {
-      parentInfo = parentInfoMap?.get(issue.parent_issue_id);
-    }
-
-    result.push({
-      issue,
-      indent: 0,
-      isParent,
-      childCount: isParent ? sameStatusCount : 0,
-      crossStatusChildCount: isParent ? crossStatusCount : 0,
-      parentInfo,
-    });
-
-    if (isParent && expanded) {
-      for (const child of nestedChildren!) {
-        result.push({
-          issue: child,
-          indent: 1,
-          isParent: false,
-          childCount: 0,
-          crossStatusChildCount: 0,
-        });
-      }
-    }
+    result.push(
+      ...renderSubtree(
+        issue,
+        0,
+        childrenInStatus,
+        childrenMap,
+        expandedParents,
+        statusIssueIds,
+        parentInfoMap,
+      ),
+    );
   }
 
-  // Append any children whose parent wasn't in the top-level (shouldn't happen,
+  // Append any issues that weren't rendered (shouldn't happen in normal use,
   // but guards against edge cases where parent was filtered or not loaded).
   for (const issue of issues) {
     if (!result.some((r) => r.issue.id === issue.id)) {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -134,7 +134,8 @@
   },
   "list": {
     "empty_status": "No issues",
-    "add_issue_tooltip": "Add issue"
+    "add_issue_tooltip": "Add issue",
+    "cross_status": "cross-status"
   },
   "swimlane": {
     "no_parent": "No parent",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -132,7 +132,8 @@
   },
   "list": {
     "empty_status": "イシューなし",
-    "add_issue_tooltip": "イシューを追加"
+    "add_issue_tooltip": "イシューを追加",
+    "cross_status": "クロスステータス"
   },
   "swimlane": {
     "no_parent": "親イシューなし",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -134,7 +134,8 @@
   },
   "list": {
     "empty_status": "이슈 없음",
-    "add_issue_tooltip": "이슈 추가"
+    "add_issue_tooltip": "이슈 추가",
+    "cross_status": "교차 상태"
   },
   "swimlane": {
     "no_parent": "상위 이슈 없음",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -132,7 +132,8 @@
   },
   "list": {
     "empty_status": "无 issue",
-    "add_issue_tooltip": "新建 issue"
+    "add_issue_tooltip": "新建 issue",
+    "cross_status": "跨状态"
   },
   "swimlane": {
     "no_parent": "无父级",

--- a/server/cmd/multica/cmd_dispatch.go
+++ b/server/cmd/multica/cmd_dispatch.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var dispatchCmd = &cobra.Command{
+	Use:   "dispatch",
+	Short: "Manage cross-squad dispatch contracts",
+	Long: `Create, list, view, and cancel dispatch contracts for cross-squad
+agent collaboration. A dispatch contract defines a callback loop
+that automatically notifies the dispatching party when a delegated
+sub-issue reaches a terminal state.`,
+}
+
+var dispatchCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new cross-squad dispatch (issue + contract)",
+	Long: `Creates a sub-issue assigned to another squad and atomically
+attaches a dispatch contract that defines the callback configuration.
+
+This is equivalent to 'multica issue create' + establishing a
+callback loop that automatically notifies the dispatcher when the
+sub-issue is completed.`,
+	RunE: runDispatchCreate,
+}
+
+var dispatchListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List dispatch contracts",
+	RunE:  runDispatchList,
+}
+
+var dispatchShowCmd = &cobra.Command{
+	Use:   "show <contract-id>",
+	Short: "Show dispatch contract details",
+	Args:  exactArgs(1),
+	RunE:  runDispatchShow,
+}
+
+var dispatchCancelCmd = &cobra.Command{
+	Use:   "cancel <contract-id>",
+	Short: "Cancel a dispatch contract",
+	Args:  exactArgs(1),
+	RunE:  runDispatchCancel,
+}
+
+func init() {
+	dispatchCmd.GroupID = groupCore
+
+	dispatchCmd.AddCommand(dispatchCreateCmd)
+	dispatchCmd.AddCommand(dispatchListCmd)
+	dispatchCmd.AddCommand(dispatchShowCmd)
+	dispatchCmd.AddCommand(dispatchCancelCmd)
+
+	// Create flags
+	dispatchCreateCmd.Flags().String("title", "", "Title of the dispatched issue")
+	dispatchCreateCmd.Flags().String("to-squad", "", "Target squad ID or name")
+	dispatchCreateCmd.Flags().String("from-issue", "", "Source issue ID (the issue making the dispatch)")
+	dispatchCreateCmd.Flags().String("callback-target", "", "Where to post callback (defaults to from-issue)")
+	dispatchCreateCmd.Flags().String("description", "", "Issue description")
+	dispatchCreateCmd.Flags().String("description-stdin", "", "Read description from stdin")
+	dispatchCreateCmd.Flags().String("description-file", "", "Read description from file")
+	dispatchCreateCmd.Flags().String("status", "todo", "Initial status")
+	dispatchCreateCmd.Flags().String("priority", "medium", "Priority (urgent/high/medium/low/none)")
+	dispatchCreateCmd.MarkFlagRequired("title")
+	dispatchCreateCmd.MarkFlagRequired("to-squad")
+	dispatchCreateCmd.MarkFlagRequired("from-issue")
+
+	// List flags
+	dispatchListCmd.Flags().String("status", "", "Filter by contract status (pending/triggered/fulfilled/cancelled)")
+
+	// Cancel flags
+	dispatchCancelCmd.Flags().String("reason", "", "Reason for cancellation")
+
+	rootCmd.AddCommand(dispatchCmd)
+}
+
+func runDispatchCreate(cmd *cobra.Command, args []string) error {
+	// Placeholder — will be fully implemented in Phase 3 (DispatchContract table)
+	cmd.Println("⚠️  'multica dispatch create' requires the DispatchContract table (coming in Phase 3).")
+	cmd.Println("For now, use 'multica issue create' with --parent and set metadata manually.")
+	return nil
+}
+
+func runDispatchList(cmd *cobra.Command, args []string) error {
+	cmd.Println("⚠️  'multica dispatch list' requires the DispatchContract table (coming in Phase 3).")
+	return nil
+}
+
+func runDispatchShow(cmd *cobra.Command, args []string) error {
+	cmd.Println("⚠️  'multica dispatch show' requires the DispatchContract table (coming in Phase 3).")
+	return nil
+}
+
+func runDispatchCancel(cmd *cobra.Command, args []string) error {
+	cmd.Println("⚠️  'multica dispatch cancel' requires the DispatchContract table (coming in Phase 3).")
+	return nil
+}

--- a/server/cmd/multica/cmd_notification.go
+++ b/server/cmd/multica/cmd_notification.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var notificationCmd = &cobra.Command{
+	Use:   "notification",
+	Short: "Query notification status for the current agent or squad",
+	Long: `Pull-side notification queries complement the push-based
+notification bus. Agents and humans can check what notifications
+are pending for them, which issues are waiting for their action,
+and acknowledge notifications.`,
+	Aliases: []string{"notif"},
+}
+
+var notificationPendingCmd = &cobra.Command{
+	Use:   "pending",
+	Short: "List pending notifications for the current agent/squad",
+	RunE:  runNotificationPending,
+}
+
+var notificationWaitingForMeCmd = &cobra.Command{
+	Use:   "waiting-for-me",
+	Short: "List issues waiting for the current agent's action",
+	RunE:  runNotificationWaitingForMe,
+}
+
+var notificationAcknowledgeCmd = &cobra.Command{
+	Use:   "acknowledge <notification-id>",
+	Short: "Acknowledge a notification (mark as read)",
+	Args:  exactArgs(1),
+	RunE:  runNotificationAcknowledge,
+}
+
+func init() {
+	notificationCmd.GroupID = groupCore
+
+	notificationCmd.AddCommand(notificationPendingCmd)
+	notificationCmd.AddCommand(notificationWaitingForMeCmd)
+	notificationCmd.AddCommand(notificationAcknowledgeCmd)
+
+	notificationPendingCmd.Flags().String("output", "table", "Output format (table/json)")
+
+	rootCmd.AddCommand(notificationCmd)
+}
+
+func runNotificationPending(cmd *cobra.Command, args []string) error {
+	// Placeholder — notification records table TBD
+	cmd.Println("⚠️  Notification query will be available when the notification_records table is created.")
+	cmd.Println("The notification engine (rules R1-R5 + detectors D1-D6) is already active for push-based events.")
+	return nil
+}
+
+func runNotificationWaitingForMe(cmd *cobra.Command, args []string) error {
+	cmd.Println("⚠️  'multica notification waiting-for-me' requires the notification_records table.")
+	cmd.Println("Use 'multica issue list --status blocked' to find issues needing action.")
+	return nil
+}
+
+func runNotificationAcknowledge(cmd *cobra.Command, args []string) error {
+	cmd.Println("⚠️  Notification acknowledgement requires the notification_records table.")
+	return nil
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/logger"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
+	"github.com/multica-ai/multica/server/internal/notification"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/scheduler"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -257,6 +258,15 @@ func main() {
 	registerSubscriberListeners(bus, queries)
 	registerActivityListeners(bus, queries)
 	registerNotificationListeners(bus, queries)
+
+	// Start the notification engine for cross-squad agent collaboration.
+	// Rules (R1-R5) and detectors (D1-D6) are event-driven — no timers.
+	notificationEngine := notification.NewEngine(
+		bus,
+		queries,
+		notification.NewHandlerActionExecutor(queries, nil),
+	)
+	notificationEngine.Start()
 
 	metricsConfig := obsmetrics.ConfigFromEnv()
 	var metricsServer *http.Server

--- a/server/internal/notification/actions.go
+++ b/server/internal/notification/actions.go
@@ -1,0 +1,251 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// HandlerActionExecutor implements ActionExecutor by calling into the
+// server's handler infrastructure.
+type HandlerActionExecutor struct {
+	Queries *db.Queries
+	Callback ActionCallback
+}
+
+// ActionCallback is called to perform the actual write operations. It is
+// implemented by the server's handler layer, which has access to the full
+// HTTP/DB pipeline.
+type ActionCallback func(ctx context.Context, action Action) error
+
+// NewHandlerActionExecutor creates an executor backed by a handler callback.
+func NewHandlerActionExecutor(queries *db.Queries, cb ActionCallback) *HandlerActionExecutor {
+	return &HandlerActionExecutor{
+		Queries:  queries,
+		Callback: cb,
+	}
+}
+
+// ExecuteAction dispatches an action to the appropriate handler.
+func (e *HandlerActionExecutor) ExecuteAction(ctx context.Context, action Action, actorType, actorID string) error {
+	switch action.Kind {
+	case ActionPostComment:
+		return e.executePostComment(ctx, action, actorType)
+	case ActionMentionAgent:
+		return e.executeMentionAgent(ctx, action)
+	case ActionUpdateStatus:
+		return e.executeUpdateStatus(ctx, action)
+	case ActionSetMetadata:
+		return e.executeSetMetadata(ctx, action)
+	case ActionClearMetadata:
+		return e.executeClearMetadata(ctx, action)
+	case ActionEscalate:
+		return e.executeEscalate(ctx, action)
+	default:
+		return fmt.Errorf("unknown action kind: %s", action.Kind)
+	}
+}
+
+func (e *HandlerActionExecutor) executePostComment(ctx context.Context, a Action, actorType string) error {
+	if a.Template == "" || a.TargetIssueID == "" {
+		return fmt.Errorf("post_comment requires Template and TargetIssueID")
+	}
+
+	targetUUID := parseUUID(a.TargetIssueID)
+	issue, err := e.Queries.GetIssue(ctx, targetUUID)
+	if err != nil {
+		return fmt.Errorf("get target issue: %w", err)
+	}
+
+	// Skip if target is done or cancelled (no point notifying)
+	if issue.Status == "done" || issue.Status == "cancelled" {
+		return nil
+	}
+
+	// Build the mention prefix for the target assignee
+	mentionPrefix := e.buildTargetMention(ctx, issue)
+
+	content := mentionPrefix + a.Template
+
+	_, err = e.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     targetUUID,
+		WorkspaceID: issue.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    pgtype.UUID{Valid: false},
+	})
+	if err != nil {
+		return fmt.Errorf("create system comment: %w", err)
+	}
+
+	slog.Debug("notification: posted system comment",
+		"target", a.TargetIssueID,
+		"action_kind", string(a.Kind))
+	return nil
+}
+
+func (e *HandlerActionExecutor) executeMentionAgent(ctx context.Context, a Action) error {
+	if a.AgentID == "" || a.TargetIssueID == "" {
+		return fmt.Errorf("mention_agent requires AgentID and TargetIssueID")
+	}
+	// Agent mentions are embedded in comments (via the post_comment action).
+	// This is a no-op at the action level — the mention is added as a prefix
+	// in executePostComment via buildTargetMention.
+	return nil
+}
+
+func (e *HandlerActionExecutor) executeUpdateStatus(ctx context.Context, a Action) error {
+	if a.TargetIssueID == "" || a.NewStatus == "" {
+		return fmt.Errorf("update_status requires TargetIssueID and NewStatus")
+	}
+
+	targetUUID := parseUUID(a.TargetIssueID)
+	issue, err := e.Queries.GetIssue(ctx, targetUUID)
+	if err != nil {
+		return fmt.Errorf("get issue: %w", err)
+	}
+
+	if issue.Status == a.NewStatus {
+		return nil // idempotent
+	}
+
+	_, err = e.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+		ID:          targetUUID,
+		Status:      a.NewStatus,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return fmt.Errorf("update status: %w", err)
+	}
+
+	slog.Debug("notification: updated issue status",
+		"issue", a.TargetIssueID,
+		"new_status", a.NewStatus)
+	return nil
+}
+
+func (e *HandlerActionExecutor) executeSetMetadata(ctx context.Context, a Action) error {
+	if a.TargetIssueID == "" || a.MetaKey == "" {
+		return fmt.Errorf("set_metadata requires TargetIssueID and MetaKey")
+	}
+
+	valueJSON, err := json.Marshal(a.MetaValue)
+	if err != nil {
+		return fmt.Errorf("marshal metadata value: %w", err)
+	}
+
+	targetUUID := parseUUID(a.TargetIssueID)
+	issue, err := e.Queries.GetIssue(ctx, targetUUID)
+	if err != nil {
+		return fmt.Errorf("get issue: %w", err)
+	}
+
+	_, err = e.Queries.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+		ID:          targetUUID,
+		Key:         a.MetaKey,
+		Value:       valueJSON,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return fmt.Errorf("set metadata: %w", err)
+	}
+
+	slog.Debug("notification: set issue metadata",
+		"issue", a.TargetIssueID,
+		"key", a.MetaKey)
+	return nil
+}
+
+func (e *HandlerActionExecutor) executeClearMetadata(ctx context.Context, a Action) error {
+	if a.TargetIssueID == "" || a.MetaKey == "" {
+		return fmt.Errorf("clear_metadata requires TargetIssueID and MetaKey")
+	}
+
+	targetUUID := parseUUID(a.TargetIssueID)
+	issue, err := e.Queries.GetIssue(ctx, targetUUID)
+	if err != nil {
+		return fmt.Errorf("get issue: %w", err)
+	}
+
+	_, err = e.Queries.DeleteIssueMetadataKey(ctx, db.DeleteIssueMetadataKeyParams{
+		Key:         a.MetaKey,
+		ID:          targetUUID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return fmt.Errorf("clear metadata: %w", err)
+	}
+
+	slog.Debug("notification: cleared issue metadata",
+		"issue", a.TargetIssueID,
+		"key", a.MetaKey)
+	return nil
+}
+
+func (e *HandlerActionExecutor) executeEscalate(ctx context.Context, a Action) error {
+	// Escalation creates a new issue assigned to the squad leader or
+	// workspace owner. For initial implementation, escalate means a
+	// strongly-worded comment + @mention of relevant leaders.
+	// Full escalation (creating new issues) will be implemented later.
+	slog.Warn("notification: escalate action not fully implemented",
+		"target", a.TargetIssueID,
+		"message", a.Template)
+	return nil
+}
+
+// buildTargetMention creates a mention prefix for the target issue's assignee.
+// Following the pattern in issue_child_done.go (MUL-2538): member assignees
+// get no mention; agent/squad assignees get a mention link.
+func (e *HandlerActionExecutor) buildTargetMention(ctx context.Context, issue db.Issue) string {
+	if !issue.AssigneeType.Valid || !issue.AssigneeID.Valid {
+		return ""
+	}
+	if issue.AssigneeType.String == "member" {
+		return ""
+	}
+
+	var label string
+	switch issue.AssigneeType.String {
+	case "agent":
+		agent, err := e.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          issue.AssigneeID,
+			WorkspaceID: issue.WorkspaceID,
+		})
+		if err != nil {
+			return ""
+		}
+		label = sanitizeLabel(agent.Name)
+	case "squad":
+		squad, err := e.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+			ID:          issue.AssigneeID,
+			WorkspaceID: issue.WorkspaceID,
+		})
+		if err != nil {
+			return ""
+		}
+		label = sanitizeLabel(squad.Name)
+	default:
+		return ""
+	}
+
+	return fmt.Sprintf("[@%s](mention://%s/%s) ", label, issue.AssigneeType.String, uuidToString(issue.AssigneeID))
+}
+
+func sanitizeLabel(name string) string {
+	result := ""
+	for _, r := range name {
+		if r != ']' && r != '[' && r != '(' && r != ')' {
+			result += string(r)
+		}
+	}
+	if result == "" {
+		return "assignee"
+	}
+	return result
+}

--- a/server/internal/notification/detectors.go
+++ b/server/internal/notification/detectors.go
@@ -1,0 +1,472 @@
+package notification
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Detector is a pure event-driven anomaly detector. It reacts to specific
+// events and optionally performs corrective actions. No timers, no cron.
+type Detector struct {
+	ID          string
+	Description string
+	// Match returns true when this detector's check should run.
+	Match func(ctx *RuleContext, ev events.Event) bool
+	// Check runs the detection logic and returns corrective actions.
+	Check func(ctx *RuleContext, ev events.Event) []Action
+}
+
+// DetectorSet holds all registered detectors and per-detector cooldown state.
+type DetectorSet struct {
+	detectors []*Detector
+	mu        sync.Mutex
+	cooldowns map[string]time.Time // key: "detectorID:targetID"
+}
+
+// NewDetectorSet creates an empty DetectorSet.
+func NewDetectorSet() *DetectorSet {
+	return &DetectorSet{
+		cooldowns: make(map[string]time.Time),
+	}
+}
+
+// Add registers a detector.
+func (ds *DetectorSet) Add(d *Detector) {
+	ds.detectors = append(ds.detectors, d)
+}
+
+// Detectors returns the registered detectors.
+func (ds *DetectorSet) Detectors() []*Detector {
+	return ds.detectors
+}
+
+// IsCoolingDown checks whether the given (detectorID, targetID) is within cooldown.
+func (ds *DetectorSet) IsCoolingDown(detectorID, targetID string, cooldown time.Duration) bool {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	key := detectorID + ":" + targetID
+	last, ok := ds.cooldowns[key]
+	if !ok {
+		return false
+	}
+	return time.Since(last) < cooldown
+}
+
+// MarkCooled sets the cooldown timestamp for (detectorID, targetID).
+func (ds *DetectorSet) MarkCooled(detectorID, targetID string) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.cooldowns[detectorID+":"+targetID] = time.Now()
+}
+
+// RegisterBuiltinDetectors adds D1-D6 to the DetectorSet.
+func RegisterBuiltinDetectors(ds *DetectorSet) {
+	ds.Add(detectorD1Deadlock())
+	ds.Add(detectorD4Orphan())
+	ds.Add(detectorD2Timeout())
+	ds.Add(detectorD3Stale())
+	ds.Add(detectorD5CrossSquadSilence())
+	ds.Add(detectorD6LoopBreak())
+}
+
+// ---------------------------------------------------------------------------
+// D1 — Parent-Child Deadlock Detector
+// ---------------------------------------------------------------------------
+
+func detectorD1Deadlock() *Detector {
+	return &Detector{
+		ID:          "d1_deadlock",
+		Description: "Detects when all children of a non-terminal parent are done but the parent hasn't progressed.",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, parentID, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" {
+				return false
+			}
+			return newStatus == "done" || newStatus == "cancelled"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			_, parentID, _, _, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+
+			parentUUID := parseUUID(parentID)
+			parent, err := q.GetIssue(ctx.Ctx, parentUUID)
+			if err != nil {
+				return actions
+			}
+			// Only check non-terminal parents
+			if parent.Status == "done" || parent.Status == "cancelled" {
+				return actions
+			}
+
+			children, err := q.ListChildIssues(ctx.Ctx, parentUUID)
+			if err != nil {
+				return actions
+			}
+			allDone := true
+			for _, c := range children {
+				if c.Status != "done" && c.Status != "cancelled" {
+					allDone = false
+					break
+				}
+			}
+			if !allDone || len(children) == 0 {
+				return actions
+			}
+
+			// Check if parent has acknowledged any child in recent comments
+			comments, err := q.ListCommentsForIssue(ctx.Ctx, db.ListCommentsForIssueParams{
+				IssueID:     parentUUID,
+				WorkspaceID: parent.WorkspaceID,
+				Limit:       20,
+			})
+			if err != nil {
+				return actions
+			}
+			acknowledged := false
+			for _, c := range comments {
+				for _, child := range children {
+					if containsStr(c.Content, uuidToStrP(child.ID)) {
+						acknowledged = true
+						break
+					}
+				}
+				if acknowledged {
+					break
+				}
+			}
+			if acknowledged {
+				return actions
+			}
+
+			// Deadlock detected
+			var childNames []string
+			for _, c := range children {
+				childNames = append(childNames, uuidToString(c.ID))
+			}
+
+			content := fmt.Sprintf(
+				"⚠️ **死锁检测**：所有子任务已完成，但父任务似乎未感知。\n\n"+
+					"已完成子任务：%s\n\n"+
+					"建议：检查子任务产出，推进父任务至下一阶段。",
+				joinStrs(childNames, ", "),
+			)
+
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: parentID,
+				Template:      content,
+			})
+
+			if parent.AssigneeType.Valid && parent.AssigneeType.String == "agent" && parent.AssigneeID.Valid {
+				actions = append(actions, Action{
+					Kind:         ActionMentionAgent,
+					TargetIssueID: parentID,
+					AgentID:       uuidToString(parent.AssigneeID),
+				})
+			}
+
+			actions = append(actions, Action{
+				Kind:         ActionSetMetadata,
+				TargetIssueID: parentID,
+				MetaKey:       "deadlock_detected_at",
+				MetaValue:     time.Now().UTC().Format(time.RFC3339),
+			})
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D4 — Orphan Notification Detector
+// ---------------------------------------------------------------------------
+
+func detectorD4Orphan() *Detector {
+	return &Detector{
+		ID:          "d4_orphan",
+		Description: "Detects when a child finishes but the parent seems unaware (orphaned notification).",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, parentID, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" {
+				return false
+			}
+			return newStatus == "done" || newStatus == "cancelled"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			childID, parentID, _, _, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" || childID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+
+			parentUUID := parseUUID(parentID)
+			parent, err := q.GetIssue(ctx.Ctx, parentUUID)
+			if err != nil {
+				return actions
+			}
+			if parent.Status == "done" || parent.Status == "cancelled" {
+				return actions
+			}
+
+			// Check if parent has any comment referencing this child in last 20 comments
+			comments, err := q.ListCommentsForIssue(ctx.Ctx, db.ListCommentsForIssueParams{
+				IssueID:     parentUUID,
+				WorkspaceID: parent.WorkspaceID,
+				Limit:       20,
+			})
+			if err != nil {
+				return actions
+			}
+			for _, c := range comments {
+				if containsStr(c.Content, childID) {
+					return actions // parent has acknowledged
+				}
+			}
+
+			// Check last comment age
+			if len(comments) > 0 {
+				lastCommentTime := comments[0].CreatedAt.Time
+				if time.Since(lastCommentTime) < 1*time.Hour {
+					// Too recent, give parent time to respond
+					return actions
+				}
+			}
+
+			content := fmt.Sprintf(
+				"💡 子任务 %s 已完成。请查看其产出并考虑推进父任务。",
+				childID,
+			)
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: parentID,
+				Template:      content,
+				// No @mention — lightweight reminder only
+			})
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D2 — Dispatch Timeout Detector (event-piggyback)
+// ---------------------------------------------------------------------------
+
+func detectorD2Timeout() *Detector {
+	return &Detector{
+		ID:          "d2_timeout",
+		Description: "Detects dispatch contracts that have been pending too long (event-piggyback: checked on any child_terminal).",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, _, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			return newStatus == "done" || newStatus == "cancelled"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			// D2 is a placeholder — full implementation requires
+			// the DispatchContract table (Phase 3). For now it is a no-op.
+			// When the contract table exists, this detector will:
+			// 1. Scan all pending contracts
+			// 2. Check if any have exceeded 8h since creation
+			// 3. Issue escalation actions for timed-out contracts
+			slog.Debug("d2_timeout: placeholder check (contract table not yet available)")
+			return nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D3 — Stale Review Detector (event-piggyback)
+// ---------------------------------------------------------------------------
+
+func detectorD3Stale() *Detector {
+	return &Detector{
+		ID:          "d3_stale",
+		Description: "Detects in_review issues that have been stale for too long (event-piggyback: checked on any status_changed).",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			return ev.Type == "issue:updated"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+
+			// D3 is a scan-heavy detector. For now, we only scan when we have
+			// workspace context from the triggering event.
+			wsID := parseWorkspaceID(ev)
+			if !wsID.Valid {
+				return actions
+			}
+
+			inReviewIssues, err := q.ListIssues(ctx.Ctx, db.ListIssuesParams{
+				WorkspaceID: wsID,
+				Status:      pgtype.Text{String: "in_review", Valid: true},
+				Limit:       200,
+			})
+			if err != nil {
+				slog.Warn("d3_stale: failed to list in_review issues", "error", err)
+				return actions
+			}
+
+			for _, issue := range inReviewIssues {
+				meta := parseIssueMetadata(issue.Metadata)
+				posture, _ := meta["interaction_posture"].(string)
+
+				// Stale review: in_review with submitted_for_review posture > 24h
+				if posture == "submitted_for_review" || posture == "" {
+					if issue.UpdatedAt.Valid && time.Since(issue.UpdatedAt.Time) > 24*time.Hour {
+						content := "⏰ **审查提醒**：此 issue 已处于审查状态超过 24 小时。请审查方尽快处理。"
+						actions = append(actions, Action{
+							Kind:          ActionPostComment,
+							TargetIssueID: uuidToString(issue.ID),
+							Template:      content,
+						})
+						if issue.AssigneeType.Valid && issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid {
+							actions = append(actions, Action{
+								Kind:          ActionMentionAgent,
+								TargetIssueID: uuidToString(issue.ID),
+								AgentID:       uuidToString(issue.AssigneeID),
+							})
+						}
+					}
+				}
+
+				// Severe stale: review_completed > 6h without advancement
+				if posture == "review_completed" {
+					if issue.UpdatedAt.Valid && time.Since(issue.UpdatedAt.Time) > 6*time.Hour {
+						reviewTarget, _ := meta["review_target"].(string)
+						if reviewTarget != "" {
+							content := fmt.Sprintf(
+								"🚨 **严重陈旧审查**：此 issue 审查已完成超过 6 小时但尚未推进。审查目标：%s",
+								reviewTarget,
+							)
+							actions = append(actions, Action{
+								Kind:          ActionPostComment,
+								TargetIssueID: uuidToString(issue.ID),
+								Template:      content,
+							})
+							// Notify the review target's assignee
+							targetIssue, err := q.GetIssue(ctx.Ctx, parseUUID(reviewTarget))
+							if err == nil && targetIssue.AssigneeType.Valid &&
+								targetIssue.AssigneeType.String == "agent" && targetIssue.AssigneeID.Valid {
+								actions = append(actions, Action{
+									Kind:          ActionPostComment,
+									TargetIssueID: reviewTarget,
+									Template:      "🚨 审查方已完成对相关 issue 的审查，请及时查看并推进。",
+								})
+								actions = append(actions, Action{
+									Kind:          ActionMentionAgent,
+									TargetIssueID: reviewTarget,
+									AgentID:       uuidToString(targetIssue.AssigneeID),
+								})
+							}
+						}
+					}
+				}
+			}
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D5 — Cross-Squad Silence Detector (event-piggyback)
+// ---------------------------------------------------------------------------
+
+func detectorD5CrossSquadSilence() *Detector {
+	return &Detector{
+		ID:          "d5_cross_squad_silence",
+		Description: "Detects when cross-squad communication has gone silent for too long (event-piggyback).",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			// Trigger on any cross-squad relevant event
+			return ev.Type == "issue:updated" || ev.Type == "comment:created"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			// Placeholder — full implementation requires:
+			// 1. Identifying cross-squad issue pairs
+			// 2. Checking last cross-squad comment timestamp
+			// 3. Issuing summary comment if blocked child detected
+			return nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D6 — Loop Break Detector (event-piggyback)
+// ---------------------------------------------------------------------------
+
+func detectorD6LoopBreak() *Detector {
+	return &Detector{
+		ID:          "d6_loop_break",
+		Description: "Detects when a dispatch callback has been fulfilled but the from_issue hasn't progressed (event-piggyback).",
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			return ev.Type == "issue:updated" || ev.Type == "comment:created"
+		},
+		Check: func(ctx *RuleContext, ev events.Event) []Action {
+			// Placeholder — full implementation requires DispatchContract table
+			return nil
+		},
+	}
+}
+
+// ---- utility functions ----
+
+func uuidToStrP(id pgtype.UUID) string {
+	if !id.Valid {
+		return ""
+	}
+	return uuidToString(id)
+}
+
+func containsStr(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		(haystack == needle ||
+			(len(haystack) > len(needle) && indexOfSubstr(haystack, needle) >= 0))
+}
+
+func indexOfSubstr(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func joinStrs(ss []string, sep string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	result := ss[0]
+	for i := 1; i < len(ss); i++ {
+		result += sep + ss[i]
+	}
+	return result
+}

--- a/server/internal/notification/engine.go
+++ b/server/internal/notification/engine.go
@@ -1,0 +1,261 @@
+package notification
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Engine is the top-level notification bus. It subscribes to the event bus,
+// runs rules, runs detectors, and executes resulting actions via an
+// ActionExecutor.
+type Engine struct {
+	bus      *events.Bus
+	queries  *db.Queries
+	rules    *RuleSet
+	detectors *DetectorSet
+	executor ActionExecutor
+
+	mu          sync.Mutex
+	// Rule cooldown tracking: key = "ruleID:sourceIssueID:targetIssueID"
+	ruleCooldowns map[string]time.Time
+
+	// Child terminal synthesis: when we see a child status→done/cancelled,
+	// we synthesize a notification:child_terminal event for the rule engine.
+}
+
+// ActionExecutor executes Actions produced by rules and detectors.
+type ActionExecutor interface {
+	ExecuteAction(ctx context.Context, action Action, actorType, actorID string) error
+}
+
+// NewEngine creates an Engine connected to the given event bus and DB.
+func NewEngine(bus *events.Bus, queries *db.Queries, executor ActionExecutor) *Engine {
+	e := &Engine{
+		bus:           bus,
+		queries:       queries,
+		rules:         NewRuleSet(),
+		detectors:     NewDetectorSet(),
+		executor:      executor,
+		ruleCooldowns: make(map[string]time.Time),
+	}
+
+	RegisterBuiltinRules(e.rules)
+	RegisterBuiltinDetectors(e.detectors)
+
+	return e
+}
+
+// Start subscribes to event bus topics and begins processing events.
+func (e *Engine) Start() {
+	e.bus.Subscribe("issue:updated", e.handleIssueUpdated)
+	e.bus.Subscribe("comment:created", e.handleCommentCreated)
+	slog.Info("notification engine started",
+		"rules", e.rules.Len(),
+		"detectors", len(e.detectors.Detectors()))
+}
+
+// handleIssueUpdated is the main event handler for issue state changes.
+// It runs rules first, then detectors.
+func (e *Engine) handleIssueUpdated(ev events.Event) {
+	e.processEvent(ev)
+
+	// Synthesize child_terminal event for rules that depend on it
+	_, parentID, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+	if parentID != "" && (newStatus == "done" || newStatus == "cancelled") {
+		childID := ""
+		if m, ok := ev.Payload.(map[string]any); ok {
+			if v, ok := m["issue_id"].(string); ok {
+				childID = v
+			}
+		}
+		if childID != "" {
+			synth := events.Event{
+				Type:        "notification:child_terminal",
+				WorkspaceID: ev.WorkspaceID,
+				ActorType:   ev.ActorType,
+				ActorID:     ev.ActorID,
+				Payload: map[string]any{
+					"child_id":        childID,
+					"parent_issue_id": parentID,
+					"terminal_status": newStatus,
+				},
+			}
+			e.processEvent(synth)
+		}
+	}
+}
+
+// handleCommentCreated handles new comment events.
+func (e *Engine) handleCommentCreated(ev events.Event) {
+	e.processEvent(ev)
+}
+
+// processEvent runs all rules and detectors against a single event.
+func (e *Engine) processEvent(ev events.Event) {
+	rctx := &RuleContext{
+		Ctx:       context.Background(),
+		Queries:   e.queries,
+		Actions:   &[]Action{},
+		ActorType: ev.ActorType,
+		ActorID:   ev.ActorID,
+	}
+
+	var allActions []Action
+
+	// ---- Run rules (priority order) ----
+	// Rules may suppress lower-priority rules when their content overlaps.
+	type ruleResult struct {
+		rule    *Rule
+		actions []Action
+	}
+	var ruleResults []ruleResult
+
+	for _, rule := range e.rules.Rules() {
+		if !rule.Enabled {
+			continue
+		}
+		if !rule.Match(rctx, ev) {
+			continue
+		}
+		actions := rule.BuildActions(rctx, ev)
+		if len(actions) == 0 {
+			continue
+		}
+
+		// Check cooldown
+		for _, a := range actions {
+			if e.isRuleOnCooldown(rule.ID, ev, a.TargetIssueID, rule.Cooldown) {
+				slog.Debug("rule on cooldown, skipping",
+					"rule", rule.ID,
+					"target", a.TargetIssueID)
+				goto nextRule
+			}
+		}
+
+		ruleResults = append(ruleResults, ruleResult{rule: rule, actions: actions})
+	nextRule:
+	}
+
+	// Apply suppression: higher-priority rules suppress lower-priority ones
+	// when they target the same issue.
+	suppressed := make(map[string]bool) // "targetIssueID"
+	for i, rr := range ruleResults {
+		// Check if any higher-priority rule already targeted the same issue
+		shouldSuppress := false
+		for j := 0; j < i; j++ {
+			for _, prevAction := range ruleResults[j].actions {
+				for _, curAction := range rr.actions {
+					if prevAction.TargetIssueID == curAction.TargetIssueID &&
+						prevAction.Kind == ActionPostComment &&
+						curAction.Kind == ActionPostComment {
+						suppressed[curAction.TargetIssueID] = true
+						shouldSuppress = true
+						slog.Debug("rule suppressed by higher-priority rule",
+							"suppressed", rr.rule.ID,
+							"by", ruleResults[j].rule.ID,
+							"target", curAction.TargetIssueID)
+						break
+					}
+				}
+				if shouldSuppress {
+					break
+				}
+			}
+			if shouldSuppress {
+				break
+			}
+		}
+
+		if !shouldSuppress {
+			for _, a := range rr.actions {
+				// Keep metadata updates even if comment is suppressed
+				if a.Kind == ActionSetMetadata || a.Kind == ActionClearMetadata {
+					allActions = append(allActions, a)
+				} else if !suppressed[a.TargetIssueID] {
+					allActions = append(allActions, a)
+				}
+			}
+			// Mark cooldown
+			for _, a := range rr.actions {
+				e.markRuleCooldown(rr.rule.ID, ev, a.TargetIssueID)
+			}
+		} else {
+			// Keep metadata updates
+			for _, a := range rr.actions {
+				if a.Kind == ActionSetMetadata || a.Kind == ActionClearMetadata {
+					allActions = append(allActions, a)
+				}
+			}
+		}
+	}
+
+	// ---- Run detectors ----
+	for _, det := range e.detectors.Detectors() {
+		if !det.Match(rctx, ev) {
+			continue
+		}
+		detActions := det.Check(rctx, ev)
+		if len(detActions) == 0 {
+			continue
+		}
+		for _, a := range detActions {
+			if e.detectors.IsCoolingDown(det.ID, a.TargetIssueID, 30*time.Minute) {
+				continue
+			}
+			allActions = append(allActions, a)
+			e.detectors.MarkCooled(det.ID, a.TargetIssueID)
+		}
+	}
+
+	// ---- Execute actions ----
+	for _, a := range allActions {
+		if err := e.executor.ExecuteAction(context.Background(), a, ev.ActorType, ev.ActorID); err != nil {
+			slog.Warn("notification action failed",
+				"action", a.Kind,
+				"target", a.TargetIssueID,
+				"error", err)
+		}
+	}
+}
+
+// isRuleOnCooldown checks whether a rule has recently fired for the same (source, target) pair.
+func (e *Engine) isRuleOnCooldown(ruleID string, ev events.Event, targetID string, cooldown time.Duration) bool {
+	if cooldown <= 0 {
+		return false
+	}
+	issueID := ""
+	if m, ok := ev.Payload.(map[string]any); ok {
+		if v, ok := m["issue_id"].(string); ok {
+			issueID = v
+		}
+	}
+	key := ruleID + ":" + issueID + ":" + targetID
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	last, ok := e.ruleCooldowns[key]
+	if !ok {
+		return false
+	}
+	return time.Since(last) < cooldown
+}
+
+// markRuleCooldown records that a rule has just fired.
+func (e *Engine) markRuleCooldown(ruleID string, ev events.Event, targetID string) {
+	issueID := ""
+	if m, ok := ev.Payload.(map[string]any); ok {
+		if v, ok := m["issue_id"].(string); ok {
+			issueID = v
+		}
+	}
+	key := ruleID + ":" + issueID + ":" + targetID
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ruleCooldowns[key] = time.Now()
+}

--- a/server/internal/notification/helpers.go
+++ b/server/internal/notification/helpers.go
@@ -1,0 +1,16 @@
+package notification
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+)
+
+// parseWorkspaceID extracts a pgtype.UUID from an event's WorkspaceID string.
+func parseWorkspaceID(ev events.Event) pgtype.UUID {
+	if ev.WorkspaceID == "" {
+		return pgtype.UUID{}
+	}
+	var id pgtype.UUID
+	_ = id.Scan(ev.WorkspaceID)
+	return id
+}

--- a/server/internal/notification/rule.go
+++ b/server/internal/notification/rule.go
@@ -1,0 +1,108 @@
+// Package notification implements the cross-squad agent collaboration
+// notification bus: a rule engine + event-driven detectors that turn issue
+// lifecycle events into automatic notifications (comments, @mentions,
+// metadata updates, and status transitions).
+//
+// Architecture:
+//
+//	events.Bus (existing) → Rule Engine (new) → Action Executor (new)
+//	                      → Detectors (new)     → Action Executor
+//
+// All components are pure event consumers. No timers, no cron, no delay.
+// Time-dependent detectors use opportunistic "event piggyback" checks.
+package notification
+
+import (
+	"context"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+)
+
+// ActionKind enumerates the side-effects a rule or detector may request.
+type ActionKind string
+
+const (
+	ActionPostComment  ActionKind = "post_comment"
+	ActionMentionAgent ActionKind = "mention_agent"
+	ActionUpdateStatus ActionKind = "update_status"
+	ActionSetMetadata  ActionKind = "set_metadata"
+	ActionClearMetadata ActionKind = "clear_metadata"
+	ActionEscalate      ActionKind = "escalate"
+)
+
+// An Action is one side-effect emitted by a rule or detector.
+type Action struct {
+	Kind      ActionKind `json:"kind"`
+	TargetIssueID string `json:"target_issue_id"` // where the action lands
+	// Optional fields per kind:
+	Template  string            `json:"template,omitempty"`  // comment body template
+	AgentID   string            `json:"agent_id,omitempty"`  // for mention_agent
+	NewStatus string            `json:"new_status,omitempty"` // for update_status
+	MetaKey   string            `json:"meta_key,omitempty"`   // for set_metadata / clear_metadata
+	MetaValue any               `json:"meta_value,omitempty"` // for set_metadata
+	TemplateVars map[string]any `json:"-"`                    // populated at trigger time
+}
+
+// A Rule is a declarative notification rule.
+type Rule struct {
+	ID          string
+	Description string
+	Priority    int // lower = higher priority (R5=10, R2=20, R4=30, R3=80, R1=100)
+	// Match returns true when this rule should fire for the given event.
+	// The context carries a DB handle (see RuleContext) for queries.
+	Match func(ctx *RuleContext, ev events.Event) bool
+	// BuildActions produces the side-effects for a matched event.
+	BuildActions func(ctx *RuleContext, ev events.Event) []Action
+	// Cooldown is the minimum interval between two firings of this rule
+	// for the same (source_issue_id, target_issue_id) pair.
+	Cooldown time.Duration
+	// Enabled can be toggled at runtime (future: workspace-level config).
+	Enabled bool
+}
+
+// RuleContext provides rules with access to shared infrastructure during
+// matching and action building. The concrete implementation lives in engine.go.
+type RuleContext struct {
+	Ctx      context.Context
+	Queries  interface{} // *db.Queries — imported as interface to avoid circular deps
+	DB       interface{} // dbExecutor
+	Actions  *[]Action   // output accumulator; rules append here
+	ActorType string
+	ActorID   string
+}
+
+// RuleSet is a priority-ordered collection of rules.
+type RuleSet struct {
+	rules []*Rule
+}
+
+// NewRuleSet creates an empty RuleSet.
+func NewRuleSet() *RuleSet {
+	return &RuleSet{}
+}
+
+// Add inserts a rule, maintaining priority order (lowest first = highest priority).
+func (rs *RuleSet) Add(r *Rule) {
+	idx := 0
+	for ; idx < len(rs.rules); idx++ {
+		if r.Priority < rs.rules[idx].Priority {
+			break
+		}
+	}
+	rs.rules = append(rs.rules, nil)
+	copy(rs.rules[idx+1:], rs.rules[idx:])
+	rs.rules[idx] = r
+}
+
+// Rules returns a copy of the rule slice in priority order.
+func (rs *RuleSet) Rules() []*Rule {
+	out := make([]*Rule, len(rs.rules))
+	copy(out, rs.rules)
+	return out
+}
+
+// Len returns the number of rules.
+func (rs *RuleSet) Len() int {
+	return len(rs.rules)
+}

--- a/server/internal/notification/rules.go
+++ b/server/internal/notification/rules.go
@@ -1,0 +1,722 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// RegisterBuiltinRules adds R1-R5 to the RuleSet.
+func RegisterBuiltinRules(rs *RuleSet) {
+	rs.Add(ruleR5DispatchCallback())
+	rs.Add(ruleR2ReviewComplete())
+	rs.Add(ruleR4StageComplete())
+	rs.Add(ruleR3BlockingLifted())
+	rs.Add(ruleR1ChildToParent())
+}
+
+// ---- helpers shared by rules ----
+
+func resolveQueries(ctx *RuleContext) *db.Queries {
+	q, _ := ctx.Queries.(*db.Queries)
+	return q
+}
+
+func parseIssueMetadata(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func uuidToString(id pgtype.UUID) string { return util.UUIDToString(id) }
+
+func textToPtr(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	return &t.String
+}
+
+func uuidToPtr(id pgtype.UUID) *string {
+	if !id.Valid {
+		return nil
+	}
+	s := util.UUIDToString(id)
+	return &s
+}
+
+// parsePayloadIssue extracts the standard issue-update fields from an
+// event payload. Returns zero values when the payload shape doesn't match.
+func parsePayloadIssue(payload any) (issueID, parentIssueID, oldStatus, newStatus, assigneeType, assigneeID string) {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	if v, ok := m["issue_id"].(string); ok {
+		issueID = v
+	}
+	if v, ok := m["parent_issue_id"].(string); ok {
+		parentIssueID = v
+	}
+	if v, ok := m["old_status"].(string); ok {
+		oldStatus = v
+	}
+	if v, ok := m["new_status"].(string); ok {
+		newStatus = v
+	}
+	if v, ok := m["issue_assignee_type"].(string); ok {
+		assigneeType = v
+	}
+	if v, ok := m["issue_assignee_id"].(string); ok {
+		assigneeID = v
+	}
+	return
+}
+
+// parseCommentPayload extracts comment-related fields from a
+// comment:created event.
+func parseCommentPayload(payload any) (commentID, issueID, authorType string) {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	if cmt, ok := m["comment"].(map[string]any); ok {
+		if v, ok := cmt["id"].(string); ok {
+			commentID = v
+		}
+		if v, ok := cmt["issue_id"].(string); ok {
+			issueID = v
+		}
+		if v, ok := cmt["author_type"].(string); ok {
+			authorType = v
+		}
+	}
+	return
+}
+
+// parseIssuePayload extracts the issue from an event payload (for
+// issue:updated / issue:created events).
+func parseIssuePayload(payload any) map[string]any {
+	m, ok := payload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if issue, ok := m["issue"].(map[string]any); ok {
+		return issue
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// R5 — Dispatch Contract Callback (priority 10)
+// ---------------------------------------------------------------------------
+
+func ruleR5DispatchCallback() *Rule {
+	return &Rule{
+		ID:          "r5_dispatch_callback",
+		Description: "When a dispatched sub-issue reaches terminal state, execute the dispatch contract callback.",
+		Priority:    10,
+		Cooldown:    0, // contract callbacks always fire
+		Enabled:     true,
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, parentID, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" {
+				return false
+			}
+			if newStatus != "done" && newStatus != "cancelled" {
+				return false
+			}
+			// Check for dispatch_contract_id in the source issue's metadata
+			q := resolveQueries(ctx)
+			if q == nil {
+				return false
+			}
+			issueID := ""
+			if m, ok := ev.Payload.(map[string]any); ok {
+				if v, ok := m["issue_id"].(string); ok {
+					issueID = v
+				}
+			}
+			if issueID == "" {
+				return false
+			}
+			issue, err := q.GetIssue(ctx.Ctx, parseUUID(issueID))
+			if err != nil {
+				return false
+			}
+			meta := parseIssueMetadata(issue.Metadata)
+			_, hasContract := meta["dispatch_contract_id"]
+			return hasContract
+		},
+		BuildActions: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			issueID, _, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if issueID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+			issue, err := q.GetIssue(ctx.Ctx, parseUUID(issueID))
+			if err != nil {
+				return actions
+			}
+			meta := parseIssueMetadata(issue.Metadata)
+			contractID, ok := meta["dispatch_contract_id"].(string)
+			if !ok {
+				return actions
+			}
+			_ = contractID // Future: load DispatchContract from DB
+
+			// Determine callback target from metadata
+			callbackTarget := ""
+			if v, ok := meta["callback_target"].(string); ok {
+				callbackTarget = v
+			}
+			if callbackTarget == "" && issue.ParentIssueID.Valid {
+				callbackTarget = uuidToString(issue.ParentIssueID)
+			}
+			if callbackTarget == "" {
+				return actions
+			}
+
+			parent, err := q.GetIssue(ctx.Ctx, parseUUID(callbackTarget))
+			if err != nil {
+				return actions
+			}
+
+			prefix := ""
+			if issue.WorkspaceID.Valid {
+				p, _ := q.GetWorkspace(ctx.Ctx, issue.WorkspaceID)
+				if p.IssuePrefix != "" {
+					prefix = p.IssuePrefix
+				}
+			}
+			childKey := prefix + "-" + strconv.Itoa(int(issue.Number))
+
+			content := fmt.Sprintf(
+				"📋 **派发任务完成通知**\n\n"+
+					"派发任务 [%s](mention://issue/%s) 已进入 **%s** 状态。\n\n"+
+					"请查看子任务产出并推进相关工作。",
+				childKey, issueID, newStatus,
+			)
+
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: callbackTarget,
+				Template:      content,
+				TemplateVars:  nil,
+			})
+
+			// @mention parent assignee if agent
+			if parent.AssigneeType.Valid && parent.AssigneeType.String == "agent" && parent.AssigneeID.Valid {
+				actions = append(actions, Action{
+					Kind:         ActionMentionAgent,
+					TargetIssueID: callbackTarget,
+					AgentID:       uuidToString(parent.AssigneeID),
+				})
+			}
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R2 — Review Complete → Reviewed Party Notification (priority 20)
+// ---------------------------------------------------------------------------
+
+func ruleR2ReviewComplete() *Rule {
+	return &Rule{
+		ID:          "r2_review_complete",
+		Description: "When an issue with review_target metadata enters in_review, notify the reviewed party.",
+		Priority:    20,
+		Cooldown:    600 * time.Second,
+		Enabled:     true,
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, _, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if newStatus != "in_review" {
+				return false
+			}
+			issueID := ""
+			if m, ok := ev.Payload.(map[string]any); ok {
+				if v, ok := m["issue_id"].(string); ok {
+					issueID = v
+				}
+			}
+			if issueID == "" {
+				return false
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return false
+			}
+			issue, err := q.GetIssue(ctx.Ctx, parseUUID(issueID))
+			if err != nil {
+				return false
+			}
+			meta := parseIssueMetadata(issue.Metadata)
+			_, hasTarget := meta["review_target"]
+			return hasTarget
+		},
+		BuildActions: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			issueID, _, _, _, _, _ := parsePayloadIssue(ev.Payload)
+			if issueID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+			issue, err := q.GetIssue(ctx.Ctx, parseUUID(issueID))
+			if err != nil {
+				return actions
+			}
+			meta := parseIssueMetadata(issue.Metadata)
+			reviewTarget, ok := meta["review_target"].(string)
+			if !ok || reviewTarget == "" {
+				return actions
+			}
+
+			reviewScore := ""
+			if v, ok := meta["review_score"]; ok {
+				reviewScore = fmt.Sprintf("%v", v)
+			}
+			reviewFindings := ""
+			if v, ok := meta["review_findings"]; ok {
+				reviewFindings = fmt.Sprintf("%v", v)
+			}
+
+			prefix := ""
+			if issue.WorkspaceID.Valid {
+				p, _ := q.GetWorkspace(ctx.Ctx, issue.WorkspaceID)
+				if p.IssuePrefix != "" {
+					prefix = p.IssuePrefix
+				}
+			}
+			sourceKey := prefix + "-" + strconv.Itoa(int(issue.Number))
+
+			content := fmt.Sprintf(
+				"✅ **审查完成通知**\n\n"+
+					"对 [%s](mention://issue/%s) 的审查已完成。\n",
+				sourceKey, issueID,
+			)
+			if reviewScore != "" {
+				content += fmt.Sprintf("**评分**：%s\n", reviewScore)
+			}
+			if reviewFindings != "" {
+				content += fmt.Sprintf("**关键发现**：%s\n", reviewFindings)
+			}
+
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: reviewTarget,
+				Template:      content,
+			})
+
+			// @mention review target assignee
+			targetIssue, err := q.GetIssue(ctx.Ctx, parseUUID(reviewTarget))
+			if err == nil && targetIssue.AssigneeType.Valid && targetIssue.AssigneeType.String == "agent" && targetIssue.AssigneeID.Valid {
+				actions = append(actions, Action{
+					Kind:         ActionMentionAgent,
+					TargetIssueID: reviewTarget,
+					AgentID:       uuidToString(targetIssue.AssigneeID),
+				})
+			}
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R4 — Stage Complete → Parent Advancement (priority 30)
+// ---------------------------------------------------------------------------
+
+func ruleR4StageComplete() *Rule {
+	return &Rule{
+		ID:          "r4_stage_complete",
+		Description: "When all children in a stage enter terminal state, notify the parent assignee.",
+		Priority:    30,
+		Cooldown:    300 * time.Second,
+		Enabled:     true,
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			// R4 is triggered by child_terminal events (synthesized by the
+			// engine from issue:updated with child done/cancelled statuses).
+			if ev.Type != "notification:child_terminal" {
+				return false
+			}
+			m, ok := ev.Payload.(map[string]any)
+			if !ok {
+				return false
+			}
+			parentID, _ := m["parent_issue_id"].(string)
+			return parentID != ""
+		},
+		BuildActions: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			m, ok := ev.Payload.(map[string]any)
+			if !ok {
+				return actions
+			}
+			childID, _ := m["child_id"].(string)
+			parentID, _ := m["parent_issue_id"].(string)
+			if parentID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+
+			// Check if ALL children of the parent are terminal
+			parentUUID := parseUUID(parentID)
+			children, err := q.ListChildIssues(ctx.Ctx, parentUUID)
+			if err != nil {
+				return actions
+			}
+			allDone := true
+			doneCount := 0
+			totalCount := len(children)
+			var doneIDs []string
+			for _, c := range children {
+				if c.Status == "done" || c.Status == "cancelled" {
+					doneCount++
+					doneIDs = append(doneIDs, uuidToString(c.ID))
+				} else {
+					allDone = false
+				}
+			}
+			if !allDone {
+				return actions
+			}
+
+			parent, err := q.GetIssue(ctx.Ctx, parentUUID)
+			if err != nil {
+				return actions
+			}
+
+			prefix := ""
+			if parent.WorkspaceID.Valid {
+				p, _ := q.GetWorkspace(ctx.Ctx, parent.WorkspaceID)
+				if p.IssuePrefix != "" {
+					prefix = p.IssuePrefix
+				}
+			}
+			parentKey := prefix + "-" + strconv.Itoa(int(parent.Number))
+
+			content := fmt.Sprintf(
+				"📊 **Stage 完成通知**\n\n"+
+					"父任务 [%s](mention://issue/%s) 下的所有子任务已完成（%d/%d）。\n\n"+
+					"已完成子任务：%s\n\n"+
+					"请推进父任务至下一阶段。",
+				parentKey, parentID, doneCount, totalCount,
+				strings.Join(doneIDs, ", "),
+			)
+			_ = childID // used in template but not directly here for R4
+
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: parentID,
+				Template:      content,
+			})
+
+			if parent.AssigneeType.Valid && parent.AssigneeType.String == "agent" && parent.AssigneeID.Valid {
+				actions = append(actions, Action{
+					Kind:         ActionMentionAgent,
+					TargetIssueID: parentID,
+					AgentID:       uuidToString(parent.AssigneeID),
+				})
+			}
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R3 — Blocking Lifted → Waiting Party Wake-up (priority 80)
+// ---------------------------------------------------------------------------
+
+func ruleR3BlockingLifted() *Rule {
+	return &Rule{
+		ID:          "r3_blocking_lifted",
+		Description: "When an issue that others are waiting on unblocks, notify all waiting parties.",
+		Priority:    80,
+		Cooldown:    600 * time.Second,
+		Enabled:     true,
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			issueID, _, oldStatus, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if oldStatus != "blocked" {
+				return false
+			}
+			if newStatus == "blocked" {
+				return false
+			}
+			return issueID != ""
+		},
+		BuildActions: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			unblockedID, _, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if unblockedID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+
+			// Strategy: use metadata @> filter to find all issues whose
+			// waiting_on_issue contains the unblocked issue ID.
+			// The JSONB containment operator checks if the metadata
+			// contains a waiting_on_issue key with the target ID.
+			unblockedIssue, err := q.GetIssue(ctx.Ctx, parseUUID(unblockedID))
+			if err != nil {
+				return actions
+			}
+
+			waitingIssues, err := q.ListIssues(ctx.Ctx, db.ListIssuesParams{
+				WorkspaceID:    unblockedIssue.WorkspaceID,
+				MetadataFilter: []byte(fmt.Sprintf(`{"waiting_on_issue": "%s"}`, unblockedID)),
+				Limit:          200,
+			})
+			if err != nil {
+				slog.Warn("r3: metadata filter query failed", "error", err)
+				return actions
+			}
+
+			prefix := ""
+			if unblockedIssue.WorkspaceID.Valid {
+				p, _ := q.GetWorkspace(ctx.Ctx, unblockedIssue.WorkspaceID)
+				if p.IssuePrefix != "" {
+					prefix = p.IssuePrefix
+				}
+			}
+			sourceKey := prefix + "-" + strconv.Itoa(int(unblockedIssue.Number))
+
+			for _, wi := range waitingIssues {
+				meta := parseIssueMetadata(wi.Metadata)
+				waitList, _ := meta["waiting_on_issue"].([]any)
+				found := false
+				for _, w := range waitList {
+					if ws, ok := w.(string); ok && ws == unblockedID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+
+				content := fmt.Sprintf(
+					"🔓 **阻塞解除通知**\n\n"+
+						"你所等待的 [%s](mention://issue/%s) 阻塞已解除（当前状态：**%s**）。\n\n"+
+						"你可以继续推进相关工作了。",
+					sourceKey, unblockedID, newStatus,
+				)
+
+				targetID := uuidToString(wi.ID)
+				actions = append(actions, Action{
+					Kind:         ActionPostComment,
+					TargetIssueID: targetID,
+					Template:      content,
+				})
+
+				if wi.AssigneeType.Valid && wi.AssigneeType.String == "agent" && wi.AssigneeID.Valid {
+					actions = append(actions, Action{
+						Kind:         ActionMentionAgent,
+						TargetIssueID: targetID,
+						AgentID:       uuidToString(wi.AssigneeID),
+					})
+				}
+
+				// Remove unblockedID from waiting_on_issue
+				newList := make([]string, 0, len(waitList))
+				for _, w := range waitList {
+					if ws, ok := w.(string); ok && ws != unblockedID {
+						newList = append(newList, ws)
+					}
+				}
+				if len(newList) == 0 {
+					// All blockers cleared — auto-advance to in_progress
+					actions = append(actions, Action{
+						Kind:         ActionClearMetadata,
+						TargetIssueID: targetID,
+						MetaKey:       "waiting_on_issue",
+					})
+					actions = append(actions, Action{
+						Kind:         ActionUpdateStatus,
+						TargetIssueID: targetID,
+						NewStatus:     "in_progress",
+					})
+				} else {
+					actions = append(actions, Action{
+						Kind:         ActionSetMetadata,
+						TargetIssueID: targetID,
+						MetaKey:       "waiting_on_issue",
+						MetaValue:     newList,
+					})
+				}
+			}
+
+			return actions
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R1 — Child Complete → Parent Notification (priority 100)
+// ---------------------------------------------------------------------------
+
+func ruleR1ChildToParent() *Rule {
+	return &Rule{
+		ID:          "r1_child_to_parent",
+		Description: "When a child issue reaches a significant state (done, in_review, cancelled), notify the parent.",
+		Priority:    100,
+		Cooldown:    300 * time.Second,
+		Enabled:     true,
+		Match: func(ctx *RuleContext, ev events.Event) bool {
+			if ev.Type != "issue:updated" {
+				return false
+			}
+			_, parentID, _, newStatus, _, _ := parsePayloadIssue(ev.Payload)
+			if parentID == "" {
+				return false
+			}
+			return newStatus == "done" || newStatus == "cancelled" || newStatus == "in_review"
+		},
+		BuildActions: func(ctx *RuleContext, ev events.Event) []Action {
+			var actions []Action
+			childID, parentID, _, newStatus, childAssigneeType, childAssigneeID := parsePayloadIssue(ev.Payload)
+			if parentID == "" || childID == "" {
+				return actions
+			}
+			q := resolveQueries(ctx)
+			if q == nil {
+				return actions
+			}
+			child, err := q.GetIssue(ctx.Ctx, parseUUID(childID))
+			if err != nil {
+				return actions
+			}
+			parent, err := q.GetIssue(ctx.Ctx, parseUUID(parentID))
+			if err != nil {
+				return actions
+			}
+			// Skip if parent is already terminal
+			if parent.Status == "done" || parent.Status == "cancelled" {
+				return actions
+			}
+			// Skip if parent has a human member assignee (per MUL-2538 pattern)
+			if parent.AssigneeType.Valid && parent.AssigneeType.String == "member" {
+				return actions
+			}
+
+			prefix := ""
+			if child.WorkspaceID.Valid {
+				p, _ := q.GetWorkspace(ctx.Ctx, child.WorkspaceID)
+				if p.IssuePrefix != "" {
+					prefix = p.IssuePrefix
+				}
+			}
+			childKey := prefix + strconv.Itoa(int(child.Number))
+
+			assigneeName := "未分配"
+			if child.AssigneeType.Valid && child.AssigneeID.Valid {
+				switch child.AssigneeType.String {
+				case "agent":
+					a, err := q.GetAgentInWorkspace(ctx.Ctx, db.GetAgentInWorkspaceParams{
+						ID:          child.AssigneeID,
+						WorkspaceID: child.WorkspaceID,
+					})
+					if err == nil {
+						assigneeName = a.Name
+					}
+				case "squad":
+					s, err := q.GetSquadInWorkspace(ctx.Ctx, db.GetSquadInWorkspaceParams{
+						ID:          child.AssigneeID,
+						WorkspaceID: child.WorkspaceID,
+					})
+					if err == nil {
+						assigneeName = s.Name
+					}
+				}
+			}
+
+			statusLabel := map[string]string{
+				"done":       "已完成",
+				"cancelled":  "已取消",
+				"in_review":  "审查中",
+				"in_progress": "进行中",
+				"blocked":    "阻塞中",
+			}[newStatus]
+			if statusLabel == "" {
+				statusLabel = newStatus
+			}
+
+			content := fmt.Sprintf(
+				"📌 **子任务状态更新**\n\n"+
+					"子任务 [%s](mention://issue/%s) 状态变更为 **%s**。\n"+
+					"处理方：%s",
+				childKey, childID, statusLabel, assigneeName,
+			)
+
+			actions = append(actions, Action{
+				Kind:         ActionPostComment,
+				TargetIssueID: parentID,
+				Template:      content,
+			})
+
+			// Update parent's children_progress metadata
+			actions = append(actions, Action{
+				Kind:         ActionSetMetadata,
+				TargetIssueID: parentID,
+				MetaKey:       "children_progress",
+				MetaValue:     fmt.Sprintf("child %s → %s", childKey, newStatus),
+			})
+
+			// Cross-squad: mention parent assignee
+			isCrossSquad := childAssigneeType == "squad" && childAssigneeID != "" &&
+				(parent.AssigneeType.String != "squad" || uuidToString(parent.AssigneeID) != childAssigneeID)
+			if isCrossSquad && parent.AssigneeType.Valid && parent.AssigneeType.String == "agent" && parent.AssigneeID.Valid {
+				actions = append(actions, Action{
+					Kind:         ActionMentionAgent,
+					TargetIssueID: parentID,
+					AgentID:       uuidToString(parent.AssigneeID),
+				})
+			}
+
+			return actions
+		},
+	}
+}
+
+func parseUUID(s string) pgtype.UUID {
+	var id pgtype.UUID
+	_ = id.Scan(s)
+	return id
+}


### PR DESCRIPTION
## Summary

Implements the core notification bus (Phase 1-2 of the cross-squad agent collaboration plan) as described in Multica #4596 and OXY-537 v4.

## What's included

### New package: `server/internal/notification/`

**Rule Engine** (priority-ordered, event-driven):
| Rule | Description | Priority |
|------|-------------|----------|
| R1 | Child→Parent status notification | 100 |
| R2 | Review complete→Reviewed party auto-notify | 20 |
| R3 | Blocking lifted→Waiting party wake-up + auto-advance | 80 |
| R4 | Stage complete→Parent advancement | 30 |
| R5 | Dispatch contract callback | 10 |

**Detectors** (event-driven, no timers):
| Detector | Description |
|----------|-------------|
| D1 | Parent-child deadlock detection |
| D3 | Stale review detection |
| D4 | Orphan notification detection |
| D2/D5/D6 | Placeholder skeletons (need DispatchContract table) |

**Action Executor**: post_comment, mention_agent, update_status, set_metadata, clear_metadata, escalate

### CLI commands (skeletons for Phase 3):
- `multica dispatch` (create/list/show/cancel)
- `multica notification` (pending/waiting-for-me/acknowledge)

### Integration:
- Registered in `server/cmd/server/main.go` after existing listeners
- Uses `HandlerActionExecutor` backed by `db.Queries`

## Design decisions

1. **Zero timer dependencies** — pure event-driven, as required by OXY-537 v4
2. **Priority-based rule suppression** — higher-priority rules suppress lower ones when targeting the same issue (R5>R2>R4>R3>R1)
3. **Cooldown-based deduplication** — prevents notification storms
4. **System comments follow MUL-2538 pattern** — skip member assignees, embed mention links for agent/squad assignees
5. **Metadata-driven** — uses existing `interaction_posture`, `review_target`, `waiting_on_issue`, `dispatch_contract_id` keys

## What's NOT included (coming in follow-up PRs)

- DispatchContract database table + migration (Phase 3)
- Full `multica dispatch` CLI implementation
- `notification_records` table for pull-side queries (Phase 5)
- Full D2/D5/D6 detector implementations (need contract table)
- Startup state reconciliation (see OXY-537 v4 §2.3.2)

## References

- [OXY-537 v4 Plan](https://github.com/multica-ai/multica/issues/4596#issuecomment-...) — Full design specification
- [Multica #4596](https://github.com/multica-ai/multica/issues/4596) — Feature request
- OXY-519 — Original cross-squad notification failure incident