### PR TITLE
fix(desktop): fall back to default health port when desktop profile daemon not found

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -310,7 +310,24 @@ async function fetchHealth(): Promise<DaemonStatus> {
   }
 
   const active = await ensureActiveProfile();
-  const data = await fetchHealthAtPort(active.port);
+  let data = await fetchHealthAtPort(active.port);
+
+  // Fallback: a daemon started via CLI without --profile runs on the
+  // default health port. Check it so the UI doesn't show "Daemon not
+  // running" when a daemon is serving the same backend on the default
+  // profile. The fallback is only consulted when the desktop-managed
+  // profile shows no running daemon. #4583
+  if ((!data || data.status !== "running") && active.name !== "") {
+    const fallback = await fetchHealthAtPort(DEFAULT_HEALTH_PORT);
+    if (
+      fallback?.status === "running" &&
+      (!targetApiBaseUrl ||
+        !fallback.server_url ||
+        urlsMatch(fallback.server_url, targetApiBaseUrl))
+    ) {
+      data = fallback;
+    }
+  }
 
   if (!data || data.status !== "running") {
     // A start that never reaches "running" is the symptom; an expired/invalid
@@ -831,6 +848,17 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
     // Let polling track it through to "running".
     pollOnce();
     return { success: true };
+  }
+
+  // Fallback: a daemon started via CLI without --profile runs on the default
+  // health port. If one is already alive there, don't start a second daemon on
+  // the desktop profile. #4583
+  if (active.name !== "") {
+    const fallback = await fetchHealthAtPort(DEFAULT_HEALTH_PORT);
+    if (daemonStatusAlive(fallback?.status)) {
+      pollOnce();
+      return { success: true };
+    }
   }
 
   currentState = "starting";


### PR DESCRIPTION
## Summary

Fixes #4583: Desktop app shows "Daemon not running" warning for CLI-started daemons even when the daemon is running and has registered runtimes.

## Root Cause

The desktop app's daemon manager (`daemon-manager.ts`) uses a dedicated `desktop-<host>` profile (e.g., `desktop-multica.ai`) to manage the daemon. The `fetchHealth()` function polls only this profile's health port (e.g., 20321). When the user starts the daemon via CLI (`multica daemon start`) without `--profile`, the daemon runs on the default profile's port (19514). The desktop app never detects it, so `useLocalDaemonStatus()` returns `{ running: false, daemonId: null }` permanently, causing the "Daemon not running" warning in the Create Project modal to persist even though:

- The daemon IS running (confirmed via `multica runtime list`)
- Runtimes ARE registered for the workspace

## Fix

Two changes in `apps/desktop/src/main/daemon-manager.ts`:

1. **`fetchHealth()`**: When the desktop-managed profile port shows no running daemon and the profile name is non-empty, also check the default health port (`DEFAULT_HEALTH_PORT = 19514`). If a running daemon is found there serving the same backend URL, report it as running. The server_url match check prevents cross-environment contamination.

2. **`startDaemon()`**: Before spawning a new daemon on the desktop profile, also check if one is already alive on the default port. This prevents duplicate daemon processes.

## Testing

- [ ] Start daemon via CLI: `multica daemon start` (no `--profile`)
- [ ] Launch desktop app, switch to a workspace, open Create Project modal
- [ ] Select local directory tab → no "Daemon not running" warning
- [ ] Directory picker and Create button are enabled
- [ ] Start daemon via desktop app normally (no regression)

## Affected Area

Desktop app daemon status detection only. No changes to web app, server, or CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
