### PR TITLE
docs(claude): note pnpm dev:desktop self-isolates per worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ pnpm exec playwright test
 pnpm ui:add badge     # shadcn/Base UI component into packages/ui
 ```
 
-Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`.
+Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. `pnpm dev:desktop` additionally self-isolates per worktree (its own renderer port + app name) automatically, independent of `.env.worktree`.
 
 CI runs Node 22, Go 1.26.1, and a `pgvector/pgvector:pg17` PostgreSQL service.
 


### PR DESCRIPTION
## What & why

One-line clarification in `CLAUDE.md`. The worktree note previously read as if all
per-worktree isolation flows through `.env.worktree`, but that only covers the
backend/frontend DB names and ports. After MUL-3724 (#4598), `pnpm dev:desktop`
self-isolates per worktree at runtime — deriving its own renderer port
(`5174 + offset`) and app name (`Multica Canary <folder>-<offset>`) — **without**
`.env.worktree` and without `make worktree-env`.

This adds a sentence so readers don't assume the desktop dev flow needs
`.env.worktree`.

## Change

```diff
-...use `make worktree-env`, `make setup-worktree`, and `make start-worktree`.
+...use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. `pnpm dev:desktop` additionally self-isolates per worktree (its own renderer port + app name) automatically, independent of `.env.worktree`.
```

## Test

Docs-only; no code paths affected. Not run: build/test (no source change).

## Breaking change

None.
