### PR TITLE
fix(squad): skip leader on reply that inherits parent @mention (MUL-3744)

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1382,7 +1382,7 @@ func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issu
 		}
 	}
 
-	if trigger, ok := h.computeAssignedSquadLeaderCommentTrigger(ctx, issue, content, actorType, actorID, opts); ok {
+	if trigger, ok := h.computeAssignedSquadLeaderCommentTrigger(ctx, issue, content, parentComment, actorType, actorID, opts); ok {
 		add(trigger)
 	}
 
@@ -1393,7 +1393,7 @@ func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issu
 	return triggers
 }
 
-func (h *Handler) computeAssignedSquadLeaderCommentTrigger(ctx context.Context, issue db.Issue, content, authorType, authorID string, opts commentTriggerComputeOptions) (commentAgentTrigger, bool) {
+func (h *Handler) computeAssignedSquadLeaderCommentTrigger(ctx context.Context, issue db.Issue, content string, parentComment *db.Comment, authorType, authorID string, opts commentTriggerComputeOptions) (commentAgentTrigger, bool) {
 	if !issue.AssigneeType.Valid || issue.AssigneeType.String != "squad" || !issue.AssigneeID.Valid {
 		return commentAgentTrigger{}, false
 	}
@@ -1408,7 +1408,15 @@ func (h *Handler) computeAssignedSquadLeaderCommentTrigger(ctx context.Context, 
 		h.lastTaskWasLeader(ctx, issue.ID, squad.LeaderID) {
 		return commentAgentTrigger{}, false
 	}
-	if authorType == "member" && commentMentionsAnyone(content) {
+	// Suppress the leader trigger when a member comment routes work to
+	// someone — either by an explicit @mention in this comment, or via the
+	// parent-inheritance path that the @mention trigger uses (a plain reply
+	// to a member-authored parent inherits the parent's mentions; see
+	// shouldInheritParentMentions). Without the inheritance check, a reply
+	// like "hello" to a parent that @mentions AgentX double-triggers: the
+	// squad leader wakes via this branch AND AgentX wakes via the mention
+	// branch's inheritance — see MUL-3744.
+	if authorType == "member" && commentRoutesViaMention(content, parentComment, authorType) {
 		return commentAgentTrigger{}, false
 	}
 	agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -204,6 +204,75 @@ func TestPreviewCommentTriggers_MatchesCreateForInheritedParentMention(t *testin
 	}
 }
 
+// TestPreviewCommentTriggers_SquadAssigneeReplyDoesNotDoubleTrigger is the
+// regression test for MUL-3744. Scenario:
+//
+//   - Issue is assigned to a SQUAD (leader L).
+//   - Member root comment @mentions another agent (Kim).
+//   - Member posts a plain reply with no mention of its own ("hello").
+//
+// Before the fix the trigger-preview returned BOTH L (squad leader, via the
+// assignee path because the reply itself had no routing mention) and Kim
+// (via parent-mention inheritance on the @mention path). After the fix the
+// leader stays out of the way — the @mention path is already routing the
+// reply to Kim, so only one agent fires.
+func TestPreviewCommentTriggers_SquadAssigneeReplyDoesNotDoubleTrigger(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	leaderID := createHandlerTestAgent(t, "Preview Squad Leader L", nil)
+	kimID := createHandlerTestAgent(t, "Preview Squad Mention Kim", nil)
+	squadID := createCommentTriggerPreviewSquad(t, "Preview Squad Reply Routing", leaderID)
+	issueID := createCommentTriggerPreviewIssue(t, "squad reply mention inheritance MUL-3744", "squad", squadID)
+
+	// Sanity: a plain top-level "hello" by a member on this squad-assigned
+	// issue wakes the leader (no @mention is routing the work).
+	topLevelPreview := previewCommentTriggersForTest(t, issueID, CommentTriggerPreviewRequest{
+		Content: "hello",
+	})
+	requirePreviewAgents(t, topLevelPreview, leaderID)
+
+	// Member root comment that @mentions Kim — leader is skipped here by
+	// the existing rule (MUL-2170: member @-mentioning anyone skips leader).
+	rootContent := fmt.Sprintf("[@Kim](mention://agent/%s) can you take a look?", kimID)
+	rootID := insertMemberRootCommentForTriggerPreviewTest(t, issueID, rootContent)
+	if got := countQueuedCommentTriggerTasks(t, issueID, leaderID); got != 0 {
+		t.Fatalf("fixture queued leader tasks = %d, want 0", got)
+	}
+	if got := countQueuedCommentTriggerTasks(t, issueID, kimID); got != 0 {
+		t.Fatalf("fixture queued Kim tasks = %d, want 0", got)
+	}
+
+	// Composer preview of a plain reply ("hello") to that root.
+	// Expected: only Kim fires — via parent-mention inheritance on the
+	// @mention path. The squad leader must NOT also be queued.
+	replyContent := "hello"
+	replyParentID := rootID
+	replyBody := map[string]any{
+		"content":   replyContent,
+		"parent_id": rootID,
+	}
+	replyPreview := previewCommentTriggersForTest(t, issueID, CommentTriggerPreviewRequest{
+		Content:  replyContent,
+		ParentID: &replyParentID,
+	})
+	requirePreviewAgents(t, replyPreview, kimID)
+	if replyPreview.Agents[0].Source != string(commentTriggerSourceMentionAgent) {
+		t.Fatalf("reply preview source = %q, want %q (mention path), got %+v",
+			replyPreview.Agents[0].Source, commentTriggerSourceMentionAgent, replyPreview.Agents)
+	}
+
+	// Verify the create path matches the preview — leader stays at 0.
+	postCommentForTriggerPreviewTest(t, issueID, replyBody)
+	if got := countQueuedCommentTriggerTasks(t, issueID, leaderID); got != 0 {
+		t.Fatalf("after plain reply on squad issue: expected 0 leader tasks, got %d (MUL-3744)", got)
+	}
+	if got := countQueuedCommentTriggerTasks(t, issueID, kimID); got != 1 {
+		t.Fatalf("after plain reply on squad issue: expected 1 Kim task (inherited mention), got %d", got)
+	}
+}
+
 func TestPreviewCommentTriggers_ReturnsMentionedAgentsAndSuppressFiltersCreate(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -937,6 +937,24 @@ func commentMentionsAnyone(content string) bool {
 	return false
 }
 
+// commentRoutesViaMention returns true when the comment will route work via
+// the @mention trigger path — either through its own routing mention, or by
+// inheriting the parent (thread root) mentions on a plain reply (see
+// shouldInheritParentMentions). The squad-leader skip rule treats inherited
+// mentions identically to direct ones: if the @mention path is going to fire,
+// the leader stays out of the way so the same comment never enqueues two
+// agents for the same intent (MUL-3744).
+func commentRoutesViaMention(content string, parentComment *db.Comment, authorType string) bool {
+	if commentMentionsAnyone(content) {
+		return true
+	}
+	own := util.ParseMentions(content)
+	if !shouldInheritParentMentions(parentComment, own, authorType) {
+		return false
+	}
+	return commentMentionsAnyone(parentComment.Content)
+}
+
 // The squad-leader assign/promotion readiness decision now lives in the single
 // service.IssueService.WillEnqueueRun predicate (MUL-3375), shared by the issue
 // write paths and the preview endpoint. The former handler-local mirrors

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -42,11 +42,106 @@ func TestCommentMentionsAnyone(t *testing.T) {
 	}
 }
 
+// TestCommentRoutesViaMention covers the parent-aware variant that drives the
+// squad-leader skip rule on REPLY (MUL-3744). It is a pure helper test that
+// runs without a database connection.
+func TestCommentRoutesViaMention(t *testing.T) {
+	memberRoot := func(body string) *db.Comment {
+		return &db.Comment{AuthorType: "member", Content: body}
+	}
+	agentRoot := func(body string) *db.Comment {
+		return &db.Comment{AuthorType: "agent", Content: body}
+	}
+
+	cases := []struct {
+		name       string
+		content    string
+		parent     *db.Comment
+		authorType string
+		want       bool
+	}{
+		{
+			name:       "own agent mention counts",
+			content:    "[@A](mention://agent/11111111-1111-1111-1111-111111111111) please",
+			parent:     nil,
+			authorType: "member",
+			want:       true,
+		},
+		{
+			name:       "plain top-level comment does not route",
+			content:    "please take a look",
+			parent:     nil,
+			authorType: "member",
+			want:       false,
+		},
+		{
+			name:       "plain reply to member parent with @agent inherits",
+			content:    "any update?",
+			parent:     memberRoot("[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this"),
+			authorType: "member",
+			want:       true,
+		},
+		{
+			name:       "plain reply to member parent with no routing mention does not inherit",
+			content:    "any update?",
+			parent:     memberRoot("see [MUL-1](mention://issue/33333333-3333-3333-3333-333333333333)"),
+			authorType: "member",
+			want:       false,
+		},
+		{
+			name:       "plain reply to agent parent does not inherit",
+			content:    "any update?",
+			parent:     agentRoot("[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this"),
+			authorType: "member",
+			want:       false,
+		},
+		{
+			name:       "agent reply never inherits",
+			content:    "noted",
+			parent:     memberRoot("[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this"),
+			authorType: "agent",
+			want:       false,
+		},
+		{
+			name:       "reply with own mention does not inherit",
+			content:    "[@B](mention://agent/22222222-2222-2222-2222-222222222222) over to you",
+			parent:     memberRoot("[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this"),
+			authorType: "member",
+			want:       true,
+		},
+		{
+			name:       "plain reply to member parent with @all inherits",
+			content:    "any update?",
+			parent:     memberRoot("[@all](mention://all/all) heads up"),
+			authorType: "member",
+			want:       true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commentRoutesViaMention(tc.content, tc.parent, tc.authorType); got != tc.want {
+				t.Fatalf("commentRoutesViaMention(%q, parent=%+v, %s) = %v, want %v",
+					tc.content, tc.parent, tc.authorType, got, tc.want)
+			}
+		})
+	}
+}
+
 // shouldEnqueueSquadLeaderOnCommentForTest reports whether the shared comment
 // trigger computation would wake the issue's assigned squad leader — the
-// boolean view these integration tests assert on.
+// boolean view these integration tests assert on. Use
+// shouldEnqueueSquadLeaderOnReplyForTest when the scenario is a reply that
+// might inherit parent mentions.
 func shouldEnqueueSquadLeaderOnCommentForTest(ctx context.Context, issue db.Issue, content, authorType, authorID string) bool {
-	_, ok := testHandler.computeAssignedSquadLeaderCommentTrigger(ctx, issue, content, authorType, authorID, commentTriggerComputeOptions{})
+	_, ok := testHandler.computeAssignedSquadLeaderCommentTrigger(ctx, issue, content, nil, authorType, authorID, commentTriggerComputeOptions{})
+	return ok
+}
+
+// shouldEnqueueSquadLeaderOnReplyForTest is the reply variant: it threads the
+// parent comment into computeAssignedSquadLeaderCommentTrigger so the helper
+// can see inherited routing mentions (MUL-3744).
+func shouldEnqueueSquadLeaderOnReplyForTest(ctx context.Context, issue db.Issue, content string, parent *db.Comment, authorType, authorID string) bool {
+	_, ok := testHandler.computeAssignedSquadLeaderCommentTrigger(ctx, issue, content, parent, authorType, authorID, commentTriggerComputeOptions{})
 	return ok
 }
 
@@ -293,7 +388,23 @@ func TestShouldEnqueueSquadLeaderOnComment_LeaderSelfTriggerByRole(t *testing.T)
 // The matching unit test above exercises the helper in isolation; this
 // test catches a class of regression where someone refactors comment.go
 // to pass the parent's content (or the merged thread content) by mistake.
-func TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention(t *testing.T) {
+// TestCreateComment_SquadLeaderSkipHonorsInheritedMention drives the full
+// CreateComment handler to lock the call-site wiring (comment.go) for the
+// squad-leader-skip rule across the reply path. Specifically it proves that:
+//
+//   - A member top-level comment that @mentions another agent does NOT
+//     enqueue the squad leader (the mentioned agent owns the next step).
+//   - A subsequent member REPLY in the same thread that has no mentions of
+//     its own does NOT re-wake the squad leader either, because the
+//     @mention path inherits the parent's mention and routes the reply to
+//     the originally mentioned agent. Without this rule the reply
+//     double-triggers — leader via this branch AND the mentioned agent via
+//     parent-mention inheritance (MUL-3744).
+//
+// The matching unit test above exercises the helper in isolation; this
+// test catches a class of regression where someone refactors comment.go
+// to drop the parent-aware leader-skip check.
+func TestCreateComment_SquadLeaderSkipHonorsInheritedMention(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -345,15 +456,31 @@ func TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention(t *testing.T) {
 		t.Fatalf("after parent (@OtherAgent): expected 1 OtherAgent task (mention path), got %d", got)
 	}
 
-	// 2. Member posts a reply in the same thread with NO mentions.
-	//    The leader-skip helper must inspect only the reply's body (empty),
-	//    NOT the parent's @OtherAgent mention. Leader must wake up.
+	// 2. Mark OtherAgent's parent task done so the @mention dedup
+	//    (HasPendingTaskForIssueAndAgent) does not mask whether the reply
+	//    re-fires the mention path via inheritance.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue SET status = 'completed'
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+	`, issueID, fx.OtherID); err != nil {
+		t.Fatalf("complete OtherAgent parent task: %v", err)
+	}
+
+	// 3. Member posts a reply in the same thread with NO mentions.
+	//    The leader-skip helper must see that the parent's @OtherAgent
+	//    mention is inherited into the @mention path, and stay out of the
+	//    way. Result:
+	//      - leader: still 0 queued tasks (no double-trigger)
+	//      - OtherAgent: re-queued via inherited mention (one new task)
 	postMemberComment(map[string]any{
 		"content":   "any update?",
 		"parent_id": parent.ID,
 	})
-	if got := countQueued(fx.LeaderID); got != 1 {
-		t.Fatalf("after plain reply: expected 1 leader task (no parent inheritance), got %d", got)
+	if got := countQueued(fx.LeaderID); got != 0 {
+		t.Fatalf("after plain reply: expected 0 leader tasks (inherited mention routes), got %d (MUL-3744)", got)
+	}
+	if got := countQueued(fx.OtherID); got != 1 {
+		t.Fatalf("after plain reply: expected 1 OtherAgent task (inherited mention path), got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Background

Reported on MUL-3744: an issue assigned to a squad would fire **two agents** for a single member reply — the squad leader (assignee path) *and* the parent-mentioned agent (@mention path). The composer chip showed "2 agents will start when sent" on a plain reply like "hello" under a root that @mentioned another agent.

## Root cause

`computeAssignedSquadLeaderCommentTrigger` only inspected the **current** comment via `commentMentionsAnyone`, while `computeMentionedAgentCommentTriggers` inherits parent mentions for plain member replies (`shouldInheritParentMentions`). The two paths disagreed on whether the @mention path was active, so both fired.

The symmetric **agent-assignee** path is already inheritance-aware via `isReplyToMemberThread` + `commentMentionsOthersButNotAssignee`. The squad path was the outlier.

## Fix

Introduce `commentRoutesViaMention(content, parent, authorType)` — true when the comment routes via @mention either directly or by parent inheritance — and use it in the leader-skip check.

```go
if authorType == "member" && commentRoutesViaMention(content, parentComment, authorType) {
    return commentAgentTrigger{}, false
}
```

## Tests

- **New unit test** `TestCommentRoutesViaMention` covers the 8 inheritance states (direct mention, plain top-level, member→member with/without routing parent, agent parent, agent reply, reply-with-own-mention, @all parent).
- **New DB-backed regression test** `TestPreviewCommentTriggers_SquadAssigneeReplyDoesNotDoubleTrigger` drives the trigger-preview endpoint with the exact MUL-3744 scenario (squad assignee + member root @-mentions Kim + plain "hello" reply) and asserts only Kim is returned; the create path matches.
- The previous prescriptive test `TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention` encoded the buggy "plain reply must wake leader" behavior. Renamed and re-pointed to the correct contract: `TestCreateComment_SquadLeaderSkipHonorsInheritedMention` now asserts the leader stays at zero on the inherited-mention reply (after marking the parent task done so the @mention dedup doesn't mask re-firing).

## Verification

```
go test ./internal/handler/ -count=1 -timeout 300s   # ok
go test ./internal/util/... ./internal/service/... -count=1 -timeout 300s   # ok
go test ./cmd/server/... -count=1 -timeout 300s   # ok
```

All targeted regression / inheritance tests pass; the new preview test reproduces the screenshot scenario and turns green after the fix.

Refs MUL-3744.
