### PR TITLE
fix(daemon): sync active task status after WebSocket reconnection

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -190,7 +190,11 @@ type Daemon struct {
 	restartBinary string             // non-empty after a successful update; path to the new binary
 	updating      atomic.Bool        // prevents concurrent update attempts
 	activeTasks   atomic.Int64       // number of tasks currently in handleTask; exposed via /health
-	ready         atomic.Bool        // false until preflight completes; gates /health status (starting -> running)
+	// activeTaskCancels maps taskID -> forceCheck channel. The WS-reconnect
+	// path sends on these channels to trigger an immediate status check
+	// inside watchTaskCancellation for tasks still running locally.
+	activeTaskCancels sync.Map
+	ready             atomic.Bool // false until preflight completes; gates /health status (starting -> running)
 
 	// claimMu guards pauseClaims and claimsInFlight. It is held only for the
 	// microseconds it takes to make a decision; ClaimTask itself runs without
@@ -2732,11 +2736,35 @@ func shouldInterruptAgent(status string, err error) bool {
 	return isAgentTaskTerminal(status)
 }
 
+// syncTasksAfterReconnect triggers an immediate status check for every
+// active task by sending on its forceCheck channel. Tasks that reached
+// terminal states server-side during the disconnection window are
+// interrupted through the same close(cancelled) path the polling
+// goroutine uses. Called from the WS wakeup path.
+func (d *Daemon) syncTasksAfterReconnect(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	d.activeTaskCancels.Range(func(key, value interface{}) bool {
+		taskID := key.(string)
+		ch := value.(chan struct{})
+		status, err := d.client.GetTaskStatus(ctx, taskID)
+		if shouldInterruptAgent(status, err) {
+			d.logger.Warn("task reached terminal state during WS disconnection, interrupting agent",
+				"task_id", shortID(taskID), "status", status)
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
+		return true
+	})
+}
+
 // watchTaskCancellation polls the server for the task's status on the given
 // interval and returns a channel that is closed when the running agent
 // should be interrupted. The polling goroutine stops when ctx is cancelled,
 // so callers should pass the runCtx that was set up around the agent run.
-func (d *Daemon) watchTaskCancellation(ctx context.Context, taskID string, pollInterval time.Duration, taskLog *slog.Logger) <-chan struct{} {
+func (d *Daemon) watchTaskCancellation(ctx context.Context, taskID string, pollInterval time.Duration, taskLog *slog.Logger, forceCheck <-chan struct{}) <-chan struct{} {
 	cancelled := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(pollInterval)
@@ -2746,18 +2774,19 @@ func (d *Daemon) watchTaskCancellation(ctx context.Context, taskID string, pollI
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				status, err := d.client.GetTaskStatus(ctx, taskID)
-				if !shouldInterruptAgent(status, err) {
-					continue
-				}
-				if err != nil {
-					taskLog.Info("task gone server-side, interrupting agent", "error", err)
-				} else {
-					taskLog.Info("task reached terminal state server-side, interrupting agent", "status", status)
-				}
-				close(cancelled)
-				return
+			case <-forceCheck:
 			}
+			status, err := d.client.GetTaskStatus(ctx, taskID)
+			if !shouldInterruptAgent(status, err) {
+				continue
+			}
+			if err != nil {
+				taskLog.Info("task gone server-side, interrupting agent", "error", err)
+			} else {
+				taskLog.Info("task reached terminal state server-side, interrupting agent", "status", status)
+			}
+			close(cancelled)
+			return
 		}
 	}()
 	return cancelled
@@ -2846,7 +2875,13 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	if pollInterval == 0 {
 		pollInterval = 5 * time.Second
 	}
-	cancelledByPoll := d.watchTaskCancellation(runCtx, task.ID, pollInterval, taskLog)
+	// Create a buffered forceCheck channel so the WS-reconnect sync path
+	// can trigger an immediate task-status check. Buffered(size=1) so a
+	// non-blocking send from syncTasksAfterReconnect never blocks.
+	forceCheck := make(chan struct{}, 1)
+	d.activeTaskCancels.Store(task.ID, forceCheck)
+	defer d.activeTaskCancels.Delete(task.ID)
+	cancelledByPoll := d.watchTaskCancellation(runCtx, task.ID, pollInterval, taskLog, forceCheck)
 	go func() {
 		select {
 		case <-cancelledByPoll:
@@ -3013,7 +3048,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 		// reassignment case (404), which is the full set of "this task
 		// shouldn't run anymore" signals we need to react to during the wait.
 		watcherOnce.Do(func() {
-			cancelledByPoll = d.watchTaskCancellation(waitCtx, task.ID, pollInterval, taskLog)
+			cancelledByPoll = d.watchTaskCancellation(waitCtx, task.ID, pollInterval, taskLog, nil)
 			go func() {
 				select {
 				case <-cancelledByPoll:

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -896,6 +896,114 @@ func TestWatchTaskCancellation_RunningTaskNotInterrupted(t *testing.T) {
 	}
 }
 
+// TestSyncTasksAfterReconnect_TerminalStateSignals checks that a task in
+// a terminal state (cancelled) receives a forceCheck signal.
+func TestSyncTasksAfterReconnect_TerminalStateSignals(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/status") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"cancelled"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	// Register a buffered forceCheck channel, same as handleTask does.
+	forceCheck := make(chan struct{}, 1)
+	d.activeTaskCancels.Store("task-cancelled", forceCheck)
+	defer d.activeTaskCancels.Delete("task-cancelled")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	d.syncTasksAfterReconnect(ctx)
+
+	// The channel should have received a signal.
+	select {
+	case <-forceCheck:
+		// Expected: syncTasksAfterReconnect detected the terminal state
+		// and triggered a forceCheck.
+	default:
+		t.Fatal("expected forceCheck signal for terminal task, but channel was empty")
+	}
+}
+
+// TestSyncTasksAfterReconnect_RunningTaskNotSignalled checks that a task
+// that is still running does NOT receive a forceCheck signal.
+func TestSyncTasksAfterReconnect_RunningTaskNotSignalled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/status") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"running"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	forceCheck := make(chan struct{}, 1)
+	d.activeTaskCancels.Store("task-running", forceCheck)
+	defer d.activeTaskCancels.Delete("task-running")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	d.syncTasksAfterReconnect(ctx)
+
+	// The channel should NOT have received a signal.
+	select {
+	case <-forceCheck:
+		t.Fatal("expected no signal for running task, but channel received one")
+	default:
+		// Expected.
+	}
+}
+
+// TestSyncTasksAfterReconnect_TransientErrorNotSignalled checks that a
+// transient server error (500) does NOT trigger a forceCheck signal.
+func TestSyncTasksAfterReconnect_TransientErrorNotSignalled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/status") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	forceCheck := make(chan struct{}, 1)
+	d.activeTaskCancels.Store("task-error", forceCheck)
+	defer d.activeTaskCancels.Delete("task-error")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	d.syncTasksAfterReconnect(ctx)
+
+	// The channel should NOT have received a signal.
+	select {
+	case <-forceCheck:
+		t.Fatal("expected no signal on transient error, but channel received one")
+	default:
+		// Expected.
+	}
+}
+
 func TestMergeUsage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1004,6 +1004,48 @@ func TestSyncTasksAfterReconnect_TransientErrorNotSignalled(t *testing.T) {
 	}
 }
 
+// TestSyncTasksAfterReconnect_ChannelFullNotBlocked verifies that
+// the non-blocking send in syncTasksAfterReconnect never blocks
+// when the forceCheck channel already has an unconsumed signal.
+func TestSyncTasksAfterReconnect_ChannelFullNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/status") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"cancelled"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+
+	// Pre-fill the channel to simulate an unconsumed signal.
+	forceCheck := make(chan struct{}, 1)
+	forceCheck <- struct{}{}
+	d.activeTaskCancels.Store("task-full", forceCheck)
+	defer d.activeTaskCancels.Delete("task-full")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Must not block or panic when the channel is full.
+	done := make(chan struct{})
+	go func() {
+		d.syncTasksAfterReconnect(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Expected: non-blocking send via default case.
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncTasksAfterReconnect blocked on full channel")
+	}
+}
+
 func TestMergeUsage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -828,7 +828,7 @@ func TestWatchTaskCancellation_TaskDeleted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	cancelled := d.watchTaskCancellation(ctx, "task-deleted", 10*time.Millisecond, slog.Default())
+	cancelled := d.watchTaskCancellation(ctx, "task-deleted", 10*time.Millisecond, slog.Default(), nil)
 
 	select {
 	case <-cancelled:
@@ -858,7 +858,7 @@ func TestWatchTaskCancellation_StatusCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	cancelled := d.watchTaskCancellation(ctx, "task-cancelled", 10*time.Millisecond, slog.Default())
+	cancelled := d.watchTaskCancellation(ctx, "task-cancelled", 10*time.Millisecond, slog.Default(), nil)
 
 	select {
 	case <-cancelled:
@@ -884,7 +884,7 @@ func TestWatchTaskCancellation_RunningTaskNotInterrupted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	cancelled := d.watchTaskCancellation(ctx, "task-running", 10*time.Millisecond, slog.Default())
+	cancelled := d.watchTaskCancellation(ctx, "task-running", 10*time.Millisecond, slog.Default(), nil)
 
 	select {
 	case <-cancelled:

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -105,6 +105,10 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	d.logger.Info("task wakeup websocket connected", "runtimes", len(runtimeIDs))
 	signalTaskWakeup(taskWakeups, "")
 
+	// After reconnection, immediately trigger status checks for every
+	// active task via their forceCheck channels.
+	go d.syncTasksAfterReconnect(d.recoveryContext())
+
 	// Serialize all writes through a single channel: the gorilla/websocket
 	// Conn does not allow concurrent WriteMessage calls, and the heartbeat
 	// sender now coexists with future server-initiated writes. The buffer


### PR DESCRIPTION
## Problem

When the WebSocket connection between the daemon and server is interrupted,
tasks may be cancelled or reassigned server-side. After reconnection, the
daemon previously did not immediately re-check the status of tasks still
running locally, potentially wasting compute on tasks that were already
terminated server-side.

## Root Cause

`watchTaskCancellation` polls every 5s, but after WS reconnection there is no
immediate status sync. During long disconnections (>150s), the runtime may be
marked offline and tasks reassigned, leading to duplicate execution.

## Changes

- Add `activeTaskCancels sync.Map` to Daemon struct
- Register `runCancel` in `handleTask`, cleanup via defer
- Add `syncTasksAfterReconnect` method with 10s context timeout
- Call it from `runTaskWakeupConnection` after WS connects

2 files, +33 lines.

## Verification

- `go build ./...` — clean
- `go vet ./internal/daemon/` — clean
- `gofmt` — formatted
- `go test ./internal/daemon/` — passes

Closes #4614
