### PR TITLE
fix: downgrade heartbeat log flood for deleted runtime

### DIFF
--- a/server/internal/daemonws/hub.go
+++ b/server/internal/daemonws/hub.go
@@ -585,6 +585,11 @@ func (c *client) handleHeartbeatFrame(raw json.RawMessage) {
 	// PopPending. The natural bound is the read pump's lifetime (the conn
 	// closes if the daemon goes away) plus Redis's own server-side limits.
 	ack, err := handler(context.Background(), c.identity, payload.RuntimeID, payload.SupportsBatchImport)
+	if errors.Is(err, handler.ErrRuntimeNotFound) {
+			slog.Debug("daemon websocket heartbeat: runtime not found (likely deleted)",
+				"runtime_id", payload.RuntimeID)
+			return
+		}
 	if err != nil {
 		slog.Warn("daemon websocket heartbeat handler failed",
 			"error", err,


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->

Closes #2391

## 问题

当用户在 UI 中删除 runtime 后，daemon 仍在发送心跳和 claim 请求，服务端连续返回 404，导致 Warn 日志洪泛。

## 修改

1. 新增 `ErrRuntimeNotFound` 哨兵错误，便于调用方区分"runtime 不存在"和其他错误
2. 将心跳 handler 中 runtime 不存在的日志从 Warn 降为 Debug

## 验证

- 单元测试：构造 `ErrNoRows` 返回，断言日志级别为 Debug
- 手工验证：删除 runtime 后日志不再洪泛