### PR TITLE
fix(views): show issue top-level attachments in the detail sidebar

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -29,7 +29,7 @@ import { Button } from "@multica/ui/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
-import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
+import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import {
   Tooltip,
@@ -744,6 +744,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const [detailsOpen, setDetailsOpen] = useState(true);
   const [parentIssueOpen, setParentIssueOpen] = useState(true);
   const [pullRequestsOpen, setPullRequestsOpen] = useState(true);
+  const [attachmentsOpen, setAttachmentsOpen] = useState(true);
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [tokenUsageOpen, setTokenUsageOpen] = useState(true);
   const githubSettings = useGitHubSettings();
@@ -1557,6 +1558,53 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           )}
         </div>}
       </div>
+
+      {/* Issue attachments — standalone attachments the user uploaded to this issue.
+          Attachments already referenced in the description (e.g. inline images, file
+          cards in markdown) are filtered out so the sidebar only shows the user-
+          facing extras. Uses the same pattern as comment-card's AttachmentList. */}
+      {issueAttachments && issueAttachments.length > 0 && (() => {
+        const descMd = issue.description ?? "";
+        const standalone = issueAttachments.filter((a) => {
+          if (contentReferencesAttachment(descMd, a)) return false;
+          const hasSiblingInContent = issueAttachments.some(
+            (other) =>
+              other.id !== a.id &&
+              other.filename === a.filename &&
+              other.content_type === a.content_type &&
+              other.size_bytes === a.size_bytes &&
+              contentReferencesAttachment(descMd, other),
+          );
+          if (hasSiblingInContent) return false;
+          return true;
+        });
+        if (!standalone.length) return null;
+        return (
+          <div>
+            <button
+              type="button"
+              className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${attachmentsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+              onClick={() => setAttachmentsOpen(!attachmentsOpen)}
+            >
+              {t(($) => $.detail.section_attachments)}
+              <span className="tabular-nums"> · {standalone.length}</span>
+              <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${attachmentsOpen ? "rotate-90" : ""}`} />
+            </button>
+            {attachmentsOpen && (
+              <AttachmentDownloadProvider attachments={issueAttachments}>
+                <div className="flex flex-col gap-1 pl-2">
+                  {standalone.map((a) => (
+                    <AttachmentRenderer
+                      key={a.id}
+                      attachment={{ kind: "record", attachment: a }}
+                    />
+                  ))}
+                </div>
+              </AttachmentDownloadProvider>
+            )}
+          </div>
+        );
+      })()}
 
       {/* Parent issue — standalone section, only when the issue has a
           parent. Setting a parent is reachable via the issue actions menu;

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -170,6 +170,7 @@
     "add_sub_issue_aria": "Add sub-issue",
     "section_properties": "Properties",
     "section_parent_issue": "Parent issue",
+    "section_attachments": "Attachments",
     "section_pull_requests": "Pull requests",
     "section_metadata": "Metadata",
     "section_details": "Details",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -168,6 +168,7 @@
     "add_sub_issue_aria": "サブイシューを追加",
     "section_properties": "プロパティ",
     "section_parent_issue": "親イシュー",
+    "section_attachments": "添付ファイル",
     "section_pull_requests": "Pull requests",
     "section_metadata": "メタデータ",
     "section_details": "詳細",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -170,6 +170,7 @@
     "add_sub_issue_aria": "하위 이슈 추가",
     "section_properties": "속성",
     "section_parent_issue": "상위 이슈",
+    "section_attachments": "첨부 파일",
     "section_pull_requests": "Pull requests",
     "section_metadata": "메타데이터",
     "section_details": "세부 정보",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -168,6 +168,7 @@
     "add_sub_issue_aria": "添加子 issue",
     "section_properties": "属性",
     "section_parent_issue": "父 issue",
+    "section_attachments": "附件",
     "section_pull_requests": "Pull Request",
     "section_metadata": "元数据",
     "section_details": "详情",


### PR DESCRIPTION
## Summary

Issue top-level attachments were already fetched from the API but only passed to the ContentEditor for URL resolution — they were never rendered as a user-visible attachment list. This adds a collapsible "Attachments" section to the issue detail sidebar that renders standalone attachments (those not already referenced inline in the description markdown) using the same filter pattern as `comment-card`'s `AttachmentList`.

## Changes

- **`issue-detail.tsx`**: Import `Attachment` renderer and `AttachmentDownloadProvider`, add `attachmentsOpen` collapse state, insert a new collapsible sidebar section that shows standalone issue attachments
- **`en/issues.json`**, **`zh-Hans/issues.json`**: Add `section_attachments` locale key

## How to test

1. Create an issue with top-level attachments (via CLI or API)
2. Open the issue detail page
3. Look at the right sidebar — you should see an "Attachments" section with a count badge
4. Expand it to see each attachment with a download button
5. File types: images render inline with preview, other files show a download row

Closes #4617