### PR TITLE
ci(frontend): also path-filter the frontend job on push to main (MUL-3667)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,21 +59,21 @@ jobs:
 
       - name: Decide
         id: decide
-        # Always run the frontend job on push to main (full validation);
-        # on pull_request, run only when frontend-relevant paths changed.
-        # The frontend job itself always runs and reports success — its
-        # steps are gated on this output rather than the job being skipped
-        # — so the required "frontend" status check is satisfied with a
-        # genuine green instead of being left pending on filtered PRs.
+        # Trust the path filter on both events. On pull_request it diffs
+        # against the base branch; on push it diffs against the previous
+        # tip (github.event.before), so a backend/docs-only commit landing
+        # on main skips the heavy frontend job just like the PR did. This
+        # is safe because the frontend build graph is independent of the
+        # backend — the only frontend/backend couplings (reserved_slugs.json
+        # and the selfhost scripts) are in the filter above, so a push that
+        # changes none of the listed paths has nothing new for the frontend
+        # job to validate. The frontend job itself always runs and reports
+        # success — its steps are gated on this output rather than the job
+        # being skipped — so the required "frontend" status check is
+        # satisfied with a genuine green instead of being left pending.
         env:
-          EVENT_NAME: ${{ github.event_name }}
           FRONTEND_CHANGED: ${{ steps.filter.outputs.frontend }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request" ] || [ "$FRONTEND_CHANGED" = "true" ]; then
-            echo "frontend=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "frontend=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "frontend=$FRONTEND_CHANGED" >> "$GITHUB_OUTPUT"
 
   frontend:
     needs: changes


### PR DESCRIPTION
## What

Follow-up to #4556 (MUL-3667). The frontend path filter from #4556 only applied to `pull_request` events — `push` to `main` always forced a full frontend run. This change lets the same filter govern `push` to `main` too, so a backend/docs-only commit landing on `main` skips the ~6min frontend job instead of re-running it.

## Why

#4556 made backend/docs-only **PRs** gate the frontend job to ~4s, but the post-merge `push` to `main` still ran the full ~6.5min frontend regardless of what changed (the `Decide` step forced `frontend=true` for any non-PR event). So every backend/docs commit on `main` kept burning the full frontend CI — the exact waste this effort set out to remove, just on the `main` side.

## Change

One line in the `changes` job's `Decide` step: stop special-casing non-PR events and trust `dorny/paths-filter` on both events.

- On `pull_request`: diffs against the base branch (unchanged behavior).
- On `push`: diffs against the previous tip (`github.event.before`), so the same path list decides.

## Why this is safe

The frontend build graph (web/desktop/shared packages, TS/webpack/turbo) is independent of the Go backend. The only frontend↔backend couplings — `server/internal/handler/reserved_slugs.json` and the selfhost scripts (`.env.example`, `docker-compose.selfhost.yml`, `scripts/*.sh`) — are already in the filter, so they still force a full frontend run when touched. A `main` push that changes none of the listed paths has nothing new for the frontend job to validate; it would only re-run the identical green from the last frontend PR.

The `frontend` job still always runs and reports a genuine green (steps gated on the output), so the required `frontend` status check is unaffected — no branch-protection change needed.

## Trade-off (reviewer's call)

The thing we give up is post-merge "always validate `main` fully" as a safety net against merge skew (two frontend PRs validated against different `main` tips). With squash merges + `cancel-in-progress` concurrency this is weak, and frontend PRs still run their own full frontend before merge. If you'd rather keep `main` always fully validated, this PR can be closed without affecting #4556's PR-side filtering.
