### PR TITLE
Add agent thread conversations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev dev-desktop server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree start-desktop-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -257,6 +257,9 @@ setup-worktree: ## Ensure .env.worktree exists, then prepare this worktree
 start-worktree: ## Start this worktree using .env.worktree
 	@$(MAKE) start ENV_FILE=$(WORKTREE_ENV_FILE)
 
+start-desktop-worktree: ## Start this worktree's isolated backend + desktop app with hot reload
+	@bash scripts/dev-desktop.sh $(WORKTREE_ENV_FILE)
+
 stop-worktree: ## Stop this worktree's backend and frontend processes
 	@$(MAKE) stop ENV_FILE=$(WORKTREE_ENV_FILE)
 
@@ -268,6 +271,9 @@ check-worktree: ## Run the full verification pipeline for this worktree
 
 dev: ## Bootstrap this checkout end-to-end: create env if needed, ensure DB, migrate, start services
 	@bash scripts/dev.sh
+
+dev-desktop: ## Bootstrap this checkout and start backend + desktop app with hot reload
+	@bash scripts/dev-desktop.sh
 
 server: ## Run only the Go server for the current checkout
 	$(REQUIRE_ENV)

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -366,9 +366,10 @@ export default function App() {
     [systemLocale],
   );
   const locale = useMemo(() => pickLocale(localeAdapter), [localeAdapter]);
+  const localeResources = RESOURCES[locale];
   const resources = useMemo(
-    () => ({ [locale]: RESOURCES[locale] }),
-    [locale],
+    () => ({ [locale]: localeResources }),
+    [locale, localeResources],
   );
 
   // Keep <html lang> in sync with the resolved locale (index.html hardcodes

--- a/apps/desktop/src/renderer/src/pages/agent-chat-page.tsx
+++ b/apps/desktop/src/renderer/src/pages/agent-chat-page.tsx
@@ -1,0 +1,18 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { AgentChatPage as SharedAgentChatPage } from "@multica/views/chat";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { agentListOptions } from "@multica/core/workspace/queries";
+import { useDocumentTitle } from "@/hooks/use-document-title";
+
+export function AgentChatPage() {
+  const { id } = useParams<{ id: string }>();
+  const wsId = useWorkspaceId();
+  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const agent = agents.find((a) => a.id === id) ?? null;
+
+  useDocumentTitle(agent ? `${agent.name} Chat` : "Agent Chat");
+
+  if (!id) return null;
+  return <SharedAgentChatPage agentId={id} />;
+}

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -11,6 +11,7 @@ import { ProjectDetailPage } from "./pages/project-detail-page";
 import { AutopilotDetailPage } from "./pages/autopilot-detail-page";
 import { SkillDetailPage } from "./pages/skill-detail-page";
 import { AgentDetailPage } from "./pages/agent-detail-page";
+import { AgentChatPage } from "./pages/agent-chat-page";
 import { MemberDetailPage } from "./pages/member-detail-page";
 import { RuntimeDetailPage } from "./pages/runtime-detail-page";
 import { AttachmentPreviewRoute } from "./pages/attachment-preview-page";
@@ -169,6 +170,11 @@ export const appRoutes: RouteObject[] = [
             handle: { title: "Skill" },
           },
           { path: "agents", element: <DesktopAgentsPage />, handle: { title: "Agents" } },
+          {
+            path: "agents/:id/chat",
+            element: <AgentChatPage />,
+            handle: { title: "Agent Chat" },
+          },
           {
             path: "agents/:id",
             element: <AgentDetailPage />,

--- a/apps/mobile/app/(app)/[workspace]/more/pins.tsx
+++ b/apps/mobile/app/(app)/[workspace]/more/pins.tsx
@@ -5,20 +5,20 @@
  *
  * Architecture invariant (matches web): `PinnedItem` only carries metadata
  * (`item_type` + `item_id`). Title / status / icon are fetched per-row via
- * `issueDetailOptions` / `projectDetailOptions`, so when an issue's status
- * or a project's title changes via `issue:updated` / `project:updated`,
- * this list updates automatically — no cross-entity invalidate on pinKeys
- * is needed. Do NOT inline the display fields into the pin row; that
- * couples this view to a stale snapshot. See packages/core/types/pin.ts
- * top comment.
+ * entity detail/list queries, so entity update events flow into the list
+ * naturally — no cross-entity invalidate on pinKeys is needed. Do NOT inline
+ * the display fields into the pin row; that couples this view to a stale
+ * snapshot. See packages/core/types/pin.ts top comment.
  *
  * Rendering split by `item_type`:
  *   - issue → existing `<IssueRow>` (used by my-issues / more/issues /
  *     project-related-issues), `showStatus` because pins are heterogeneous
  *     (no section grouping by status).
  *   - project → existing `<ProjectRow>` (used by more/projects).
+ *   - agent → compatibility fallback row; mobile does not yet have the web
+ *     sidebar's direct chat affordance here, but users can still unpin.
  *
- * Missing / no-permission rows: the detail query may 404 (issue/project
+ * Missing / no-permission rows: the detail query may 404 (issue/project/agent
  * deleted, user lost access, server returned a parseWithFallback fallback
  * with an empty id). We render a low-emphasis placeholder so the user can
  * unpin it from here — otherwise a dead pin stays forever.
@@ -133,6 +133,9 @@ function PinRow({
       <IssuePinRow pin={pin} wsId={wsId} wsSlug={wsSlug} />
     );
   }
+  if (pin.item_type === "agent") {
+    return <MissingPinRow itemType="agent" itemId={pin.item_id} />;
+  }
   return <ProjectPinRow pin={pin} wsId={wsId} wsSlug={wsSlug} />;
 }
 
@@ -211,7 +214,7 @@ function MissingPinRow({
   itemType,
   itemId,
 }: {
-  itemType: "issue" | "project";
+  itemType: "issue" | "project" | "agent";
   itemId: string;
 }) {
   const { colorScheme } = useColorScheme();

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -479,13 +479,13 @@ export const WorkspaceListSchema = z.array(WorkspaceSchema).default([]);
 export const EMPTY_WORKSPACE_LIST: Workspace[] = [];
 
 /** Pin metadata only — display fields (title / status / icon) are NOT here,
- *  consumers derive them from `issueDetailOptions` / `projectDetailOptions`.
+ *  consumers derive them from entity detail/list queries.
  *  Matches the design in packages/core/types/pin.ts. */
 export const PinnedItemSchema: z.ZodType<PinnedItem> = z.object({
   id: z.string(),
   workspace_id: z.string().default(""),
   user_id: z.string().default(""),
-  item_type: z.enum(["issue", "project"]).catch("issue"),
+  item_type: z.enum(["issue", "project", "agent"]).catch("issue"),
   item_id: z.string(),
   position: z.number().default(0),
   created_at: z.string().default(""),

--- a/apps/web/app/[workspaceSlug]/(dashboard)/agents/[id]/chat/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/agents/[id]/chat/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { AgentChatPage } from "@multica/views/chat";
+
+export default function AgentChatRoute({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  return <AgentChatPage agentId={id} />;
+}

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -662,6 +662,30 @@ describe("ApiClient", () => {
       });
     });
 
+    it("sendChatMessage serialises reply thread identifiers onto the JSON body when present", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message_id: "m1", task_id: "t1", thread_task_id: "root-task", created_at: "" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new ApiClient("https://api.example.test");
+      await client.sendChatMessage("session-1", "hello", ["att-1"], {
+        replyToTaskId: "root-task",
+        chatThreadId: "thread-1",
+      });
+
+      const [, init] = fetchMock.mock.calls[0]!;
+      expect(JSON.parse(init?.body as string)).toEqual({
+        content: "hello",
+        attachment_ids: ["att-1"],
+        chat_thread_id: "thread-1",
+        reply_to_task_id: "root-task",
+      });
+    });
+
     it("sendChatMessage omits attachment_ids when the list is empty or undefined", async () => {
       const fetchMock = vi.fn().mockImplementation(() =>
         Promise.resolve(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1798,10 +1798,22 @@ export class ApiClient {
     sessionId: string,
     content: string,
     attachmentIds?: string[],
+    options?: { replyToTaskId?: string; chatThreadId?: string },
   ): Promise<SendChatMessageResponse> {
-    const body: { content: string; attachment_ids?: string[] } = { content };
+    const body: {
+      content: string;
+      attachment_ids?: string[];
+      reply_to_task_id?: string;
+      chat_thread_id?: string;
+    } = { content };
     if (attachmentIds && attachmentIds.length > 0) {
       body.attachment_ids = attachmentIds;
+    }
+    if (options?.chatThreadId) {
+      body.chat_thread_id = options.chatThreadId;
+    }
+    if (options?.replyToTaskId) {
+      body.reply_to_task_id = options.replyToTaskId;
     }
     return this.fetch(`/api/chat/sessions/${sessionId}/messages`, {
       method: "POST",

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -524,6 +524,7 @@ const AgentTaskResponseSchema = z.object({
   failure_reason: z.string().optional(),
   created_at: z.string().default(""),
   chat_session_id: z.string().optional(),
+  chat_thread_id: z.string().optional(),
   autopilot_run_id: z.string().optional(),
   parent_task_id: z.string().optional(),
   attempt: z.number().optional(),

--- a/packages/core/i18n/provider.tsx
+++ b/packages/core/i18n/provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { I18nextProvider } from "react-i18next";
 import { createI18n } from "./create-i18n";
 import type { LocaleResources, SupportedLocale } from "./types";
@@ -17,8 +17,18 @@ export function I18nProvider({
   children,
 }: I18nProviderProps) {
   // Lazy init via useState so the instance survives re-renders.
-  // Locale + resources are determined at boot and never change at runtime —
-  // language switching goes through window.location.reload().
+  // Locale is determined at boot; language switching goes through
+  // window.location.reload(). Resource objects can change during Vite HMR,
+  // so the effect below refreshes bundles without recreating the provider.
   const [instance] = useState(() => createI18n(locale, resources));
+
+  useEffect(() => {
+    for (const [lng, namespaces] of Object.entries(resources)) {
+      for (const [namespace, bundle] of Object.entries(namespaces)) {
+        instance.addResourceBundle(lng, namespace, bundle, true, true);
+      }
+    }
+  }, [instance, resources]);
+
   return <I18nextProvider i18n={instance}>{children}</I18nextProvider>;
 }

--- a/packages/core/paths/index.ts
+++ b/packages/core/paths/index.ts
@@ -1,4 +1,4 @@
-export { paths, isGlobalPath } from "./paths";
+export { paths, isAgentChatPath, isGlobalPath } from "./paths";
 export type { WorkspacePaths } from "./paths";
 export { RESERVED_SLUGS, isReservedSlug } from "./reserved-slugs";
 export { resolvePostAuthDestination, useHasOnboarded } from "./resolve";

--- a/packages/core/paths/paths.test.ts
+++ b/packages/core/paths/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { paths, isGlobalPath } from "./paths";
+import { paths, isAgentChatPath, isGlobalPath } from "./paths";
 
 describe("paths.workspace(slug)", () => {
   const ws = paths.workspace("acme");
@@ -13,6 +13,7 @@ describe("paths.workspace(slug)", () => {
     expect(ws.autopilots()).toBe("/acme/autopilots");
     expect(ws.autopilotDetail("a1")).toBe("/acme/autopilots/a1");
     expect(ws.agents()).toBe("/acme/agents");
+    expect(ws.agentChat("agent-1")).toBe("/acme/agents/agent-1/chat");
     expect(ws.memberDetail("u1")).toBe("/acme/members/u1");
     expect(ws.inbox()).toBe("/acme/inbox");
     expect(ws.myIssues()).toBe("/acme/my-issues");
@@ -50,5 +51,17 @@ describe("isGlobalPath", () => {
   it("returns false for workspace-scoped paths", () => {
     expect(isGlobalPath("/acme/issues")).toBe(false);
     expect(isGlobalPath("/")).toBe(false);
+  });
+});
+
+describe("isAgentChatPath", () => {
+  it("matches workspace-scoped agent chat pages", () => {
+    expect(isAgentChatPath("/acme/agents/agent-1/chat")).toBe(true);
+    expect(isAgentChatPath("/acme/agents/agent-1/chat/")).toBe(true);
+  });
+
+  it("does not match the agent profile page", () => {
+    expect(isAgentChatPath("/acme/agents/agent-1")).toBe(false);
+    expect(isAgentChatPath("/acme/agents")).toBe(false);
   });
 });

--- a/packages/core/paths/paths.ts
+++ b/packages/core/paths/paths.ts
@@ -27,6 +27,7 @@ function workspaceScoped(slug: string) {
     autopilotDetail: (id: string) => `${ws}/autopilots/${encode(id)}`,
     agents: () => `${ws}/agents`,
     agentDetail: (id: string) => `${ws}/agents/${encode(id)}`,
+    agentChat: (id: string) => `${ws}/agents/${encode(id)}/chat`,
     memberDetail: (id: string) => `${ws}/members/${encode(id)}`,
     squads: () => `${ws}/squads`,
     squadDetail: (id: string) => `${ws}/squads/${encode(id)}`,
@@ -55,6 +56,11 @@ export const paths = {
 };
 
 export type WorkspacePaths = ReturnType<typeof workspaceScoped>;
+
+export function isAgentChatPath(path: string): boolean {
+  const pathname = path.split("?")[0]?.replace(/\/+$/, "") ?? path;
+  return /^\/[^/]+\/agents\/[^/]+\/chat$/.test(pathname);
+}
 
 // Prefixes — not slug names — because we match against full URL paths.
 // A path is global if it equals or begins with any of these.

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -80,9 +80,11 @@ describe("applyChatDoneToCache", () => {
       {
         id: "msg-assistant",
         chat_session_id: sessionId,
+        chat_thread_id: null,
         role: "assistant",
         content: "done",
         task_id: taskId,
+        thread_task_id: taskId,
         created_at: "2026-05-13T05:00:02Z",
         elapsed_ms: 1234,
       },

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -109,9 +109,11 @@ export function applyChatDoneToCache(
     const assistant: ChatMessage = {
       id: messageId,
       chat_session_id: sessionId,
+      chat_thread_id: payload.chat_thread_id ?? null,
       role: "assistant",
       content,
       task_id: taskId,
+      thread_task_id: payload.thread_task_id ?? taskId,
       created_at: payload.created_at ?? new Date().toISOString(),
       elapsed_ms: payload.elapsed_ms ?? null,
     };

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -178,6 +178,8 @@ export interface AgentTask {
   created_at: string;
   /** Non-empty when the task was spawned from a chat session. */
   chat_session_id?: string;
+  /** Non-empty when the task is scoped to a specific chat thread. */
+  chat_thread_id?: string;
   /** Non-empty when the task was spawned by an autopilot run. */
   autopilot_run_id?: string;
   /** Set when this task was created as an auto-retry of a parent task. */

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -26,9 +26,17 @@ export interface PendingChatTasksResponse {
 export interface ChatMessage {
   id: string;
   chat_session_id: string;
+  chat_thread_id?: string | null;
+  /**
+   * Client-only optimistic grouping key. The backend never sends this field.
+   * It keeps an in-flight thread reply visually attached to the selected
+   * thread even when the historical root row is grouped by a task-id fallback.
+   */
+  client_thread_id?: string | null;
   role: "user" | "assistant";
   content: string;
   task_id: string | null;
+  thread_task_id?: string | null;
   created_at: string;
   /**
    * Attachments linked to this message via the attachment table's
@@ -72,6 +80,8 @@ export interface ChatMessagesPage {
 export interface SendChatMessageResponse {
   message_id: string;
   task_id: string;
+  thread_task_id: string;
+  thread_id?: string;
   /**
    * Server-authoritative task creation time. Optimistic StatusPill seed
    * uses this as its anchor so the timer starts from the real `0s` —

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -229,6 +229,7 @@ export interface TaskMessagePayload {
   task_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   seq: number;
   type: "text" | "thinking" | "tool_use" | "tool_result" | "error";
   tool?: string;
@@ -243,6 +244,7 @@ export interface TaskQueuedPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
 }
 
@@ -252,6 +254,7 @@ export interface TaskDispatchPayload {
   issue_id: string;
   runtime_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
 }
 
 export interface TaskRunningPayload {
@@ -259,6 +262,7 @@ export interface TaskRunningPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
 }
 
@@ -272,6 +276,7 @@ export interface TaskWaitingLocalDirectoryPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
   wait_reason?: string;
 }
@@ -281,6 +286,7 @@ export interface TaskCompletedPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
 }
 
@@ -289,6 +295,7 @@ export interface TaskFailedPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
 }
 
@@ -297,6 +304,7 @@ export interface TaskCancelledPayload {
   agent_id: string;
   issue_id: string;
   chat_session_id?: string;
+  chat_thread_id?: string;
   status: string;
 }
 
@@ -327,15 +335,18 @@ export interface IssueReactionRemovedPayload {
 
 export interface ChatMessageEventPayload {
   chat_session_id: string;
+  chat_thread_id?: string;
   message_id: string;
   role: "user" | "assistant";
   content: string;
   task_id?: string;
+  thread_task_id?: string;
   created_at: string;
 }
 
 export interface ChatDonePayload {
   chat_session_id: string;
+  chat_thread_id?: string;
   task_id: string;
   /**
    * Server populates these from the freshly-persisted assistant ChatMessage
@@ -345,6 +356,7 @@ export interface ChatDonePayload {
    */
   message_id?: string;
   content?: string;
+  thread_task_id?: string;
   elapsed_ms?: number;
   created_at?: string;
 }

--- a/packages/core/types/pin.ts
+++ b/packages/core/types/pin.ts
@@ -1,9 +1,9 @@
-export type PinnedItemType = "issue" | "project";
+export type PinnedItemType = "issue" | "project" | "agent";
 
 /**
  * Pin metadata only. Title / status / identifier / icon are NOT here —
- * consumers derive them from `issueDetailOptions` / `projectDetailOptions`
- * so the sidebar reacts to `issue:updated` / `project:updated` events
+ * consumers derive them from issue / project / agent query caches
+ * so the sidebar reacts to entity update events
  * automatically, without needing a cross-entity invalidate on `pinKeys`.
  */
 export interface PinnedItem {

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -6,6 +6,8 @@ import {
   ArrowLeft,
   Lock,
   MoreHorizontal,
+  Pin,
+  PinOff,
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -19,6 +21,7 @@ import { api, ApiError } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { pinListOptions, useCreatePin, useDeletePin } from "@multica/core/pins";
 import {
   agentListOptions,
   memberListOptions,
@@ -69,14 +72,21 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
     error: agentsError,
     refetch: refetchAgents,
   } = useQuery(agentListOptions(wsId));
+  const { data: pinnedItems = [] } = useQuery({
+    ...pinListOptions(wsId, currentUser?.id ?? ""),
+    enabled: !!wsId && !!currentUser?.id,
+  });
   const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
   const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const createPin = useCreatePin();
+  const deletePin = useDeletePin();
 
   // Single workspace-level presence pass; this page just reads its slot.
   // The hook owns the 30s tick so the failed-window auto-clears here too.
   const { byAgent: presenceMap } = useWorkspacePresenceMap(wsId);
 
   const agent = agents.find((a) => a.id === agentId) ?? null;
+  const isPinned = pinnedItems.some((p) => p.item_type === "agent" && p.item_id === agentId);
   const presence: AgentPresenceDetail | null =
     agent ? presenceMap.get(agent.id) ?? null : null;
 
@@ -250,6 +260,14 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
         agent={agent}
         presence={presence}
         backHref={paths.agents()}
+        isPinned={isPinned}
+        onTogglePin={() => {
+          if (isPinned) {
+            deletePin.mutate({ itemType: "agent", itemId: agent.id });
+          } else {
+            createPin.mutate({ item_type: "agent", item_id: agent.id });
+          }
+        }}
         canArchive={canEdit.allowed}
         onArchive={() => setConfirmArchive(true)}
       />
@@ -356,12 +374,16 @@ function DetailHeader({
   agent,
   presence,
   backHref,
+  isPinned,
+  onTogglePin,
   canArchive,
   onArchive,
 }: {
   agent: Agent;
   presence: AgentPresenceDetail | null;
   backHref: string;
+  isPinned: boolean;
+  onTogglePin: () => void;
   canArchive: boolean;
   onArchive: () => void;
 }) {
@@ -392,23 +414,36 @@ function DetailHeader({
         </>
       }
       actions={
-        !isArchived && canArchive ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button variant="ghost" size="icon-sm" />}
+        !isArchived ? (
+          <>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={`text-muted-foreground ${isPinned ? "text-foreground" : ""}`}
+              title={isPinned ? t(($) => $.detail.unpin_tooltip) : t(($) => $.detail.pin_tooltip)}
+              onClick={onTogglePin}
             >
-              <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-auto">
-              <DropdownMenuItem
-                variant="destructive"
-                onClick={onArchive}
+              {isPinned ? <PinOff /> : <Pin />}
+            </Button>
+            {canArchive ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={<Button variant="ghost" size="icon-sm" />}
               >
-                <Trash2 className="h-3.5 w-3.5" />
-                {t(($) => $.detail.more_archive)}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-auto">
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={onArchive}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {t(($) => $.detail.more_archive)}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            ) : null}
+          </>
         ) : null
       }
     />

--- a/packages/views/agents/components/agent-row-actions.tsx
+++ b/packages/views/agents/components/agent-row-actions.tsx
@@ -5,6 +5,8 @@ import {
   AlertCircle,
   Copy,
   MoreHorizontal,
+  Pin,
+  PinOff,
   RotateCcw,
   Square,
   Trash2,
@@ -43,6 +45,8 @@ interface AgentRowActionsProps {
   // the server is still the source of truth, this only hides UI for ops
   // the user can't perform.
   canManage: boolean;
+  isPinned: boolean;
+  onTogglePin: (agent: Agent) => void;
   // Called when the user picks "Duplicate" — the page opens a Create
   // dialog pre-populated with this agent's config as a template.
   onDuplicate: (agent: Agent) => void;
@@ -64,6 +68,8 @@ export function AgentRowActions({
   agent,
   presence,
   canManage,
+  isPinned,
+  onTogglePin,
   onDuplicate,
 }: AgentRowActionsProps) {
   const { t } = useT("agents");
@@ -82,11 +88,12 @@ export function AgentRowActions({
   // below a flat list of conditionals rather than a tangle of role/state
   // branches.
   const showStop = canManage && !isArchived && hasActiveWork;
+  const showPin = !isArchived;
   const showDuplicate = !isArchived; // any workspace member can duplicate
   const showArchive = canManage && !isArchived;
   const showRestore = canManage && isArchived;
 
-  const hasAnyAction = showStop || showDuplicate || showArchive || showRestore;
+  const hasAnyAction = showStop || showPin || showDuplicate || showArchive || showRestore;
 
   const invalidateAgents = () => {
     qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
@@ -145,6 +152,16 @@ export function AgentRowActions({
           }
         />
         <DropdownMenuContent align="end" className="w-auto">
+          {showPin && (
+            <DropdownMenuItem onClick={() => onTogglePin(agent)}>
+              {isPinned ? (
+                <PinOff className="h-3.5 w-3.5" />
+              ) : (
+                <Pin className="h-3.5 w-3.5" />
+              )}
+              {isPinned ? t(($) => $.row_actions.unpin_from_sidebar) : t(($) => $.row_actions.pin_to_sidebar)}
+            </DropdownMenuItem>
+          )}
           {showStop && (
             <DropdownMenuItem
               onClick={() => setConfirmCancel(true)}

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -19,6 +19,7 @@ import type {
   AgentRuntime,
   CreateAgentRequest,
   MemberWithUser,
+  PinnedItem,
 } from "@multica/core/types";
 import {
   type AgentActivity,
@@ -40,6 +41,7 @@ import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { pinListOptions, useCreatePin, useDeletePin } from "@multica/core/pins";
 import {
   agentListOptions,
   memberListOptions,
@@ -115,6 +117,7 @@ const COLUMN_WIDTHS: Record<AgentColumnKey, number> = {
 // 11 gap-x-3 gaps between the wide template's 12 tracks (zero-width tracks
 // still carry gaps).
 const FIXED_TRACKS_WIDTH = 268 + 11 * 12;
+const EMPTY_PINS: PinnedItem[] = [];
 
 function columnTrackVars(
   isVisible: (key: AgentColumnKey) => boolean,
@@ -804,6 +807,10 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
     error: listError,
     refetch: refetchList,
   } = useQuery(agentListOptions(wsId));
+  const { data: pins = EMPTY_PINS } = useQuery({
+    ...pinListOptions(wsId, currentUser?.id ?? ""),
+    enabled: !!wsId && !!currentUser?.id,
+  });
   const { data: runtimes = [], isLoading: runtimesLoading } = useQuery(
     runtimeListOptions(wsId),
   );
@@ -811,6 +818,8 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
   const { data: runCountsRaw = [] } = useQuery(agentRunCounts30dOptions(wsId));
   const { byAgent: presenceMap } = useWorkspacePresenceMap(wsId);
   const { byAgent: activityMap } = useWorkspaceActivityMap(wsId);
+  const createPin = useCreatePin();
+  const deletePin = useDeletePin();
 
   const [showCreate, setShowCreate] = useState(false);
   const [duplicateTemplate, setDuplicateTemplate] = useState<Agent | null>(
@@ -885,6 +894,25 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
     }
     return { mine, all, archived };
   }, [agents, currentUser]);
+
+  const pinnedAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const pin of pins) {
+      if (pin.item_type === "agent") ids.add(pin.item_id);
+    }
+    return ids;
+  }, [pins]);
+
+  const handleToggleAgentPin = useCallback(
+    (agent: Agent) => {
+      if (pinnedAgentIds.has(agent.id)) {
+        deletePin.mutate({ itemType: "agent", itemId: agent.id });
+      } else {
+        createPin.mutate({ item_type: "agent", item_id: agent.id });
+      }
+    },
+    [createPin, deletePin, pinnedAgentIds],
+  );
 
   // Rows within the current scope, unfiltered, fully assembled — the
   // toolbar's option lists and the "n / total" denominator derive from
@@ -1188,6 +1216,8 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
                             agent={row.agent}
                             presence={row.presence}
                             canManage={row.canManage}
+                            isPinned={pinnedAgentIds.has(row.agent.id)}
+                            onTogglePin={handleToggleAgentPin}
                             onDuplicate={handleDuplicate}
                           />
                         </span>

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -6,6 +6,7 @@ import { cn } from "@multica/ui/lib/utils";
 import { useChatStore } from "@multica/core/chat";
 import { chatSessionsOptions, pendingChatTasksOptions } from "@multica/core/chat/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { isAgentChatPath } from "@multica/core/paths";
 import { createLogger } from "@multica/core/logger";
 import {
   Tooltip,
@@ -13,18 +14,20 @@ import {
   TooltipContent,
 } from "@multica/ui/components/ui/tooltip";
 import { useT } from "../../i18n";
+import { useNavigation } from "../../navigation";
 
 const logger = createLogger("chat.ui");
 
 export function ChatFab() {
   const { t } = useT("chat");
   const wsId = useWorkspaceId();
+  const { pathname } = useNavigation();
   const isOpen = useChatStore((s) => s.isOpen);
   const toggle = useChatStore((s) => s.toggle);
   const { data: sessions = [] } = useQuery(chatSessionsOptions(wsId));
   const { data: pending } = useQuery(pendingChatTasksOptions(wsId));
 
-  if (isOpen) return null;
+  if (isOpen || isAgentChatPath(pathname)) return null;
 
   const unreadSessionCount = sessions.filter((s) => s.has_unread).length;
   const isRunning = (pending?.tasks ?? []).length > 0;

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -71,6 +71,8 @@ interface ChatInputProps {
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
   onStop?: () => void;
   isRunning?: boolean;
+  /** Blocks sending without switching the button into stop mode. */
+  sendBlocked?: boolean;
   disabled?: boolean;
   /** True when the user has no agent available — disables the editor and
    *  surfaces a distinct placeholder. Kept separate from `disabled` so
@@ -94,6 +96,7 @@ export function ChatInput({
   onUploadFile,
   onStop,
   isRunning,
+  sendBlocked,
   disabled,
   noAgent,
   agentName,
@@ -235,10 +238,11 @@ export function ChatInput({
 
   const handleSend = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
-    if (!content || isRunning || isSubmitting || disabled || noAgent) {
+    if (!content || isRunning || sendBlocked || isSubmitting || disabled || noAgent) {
       logger.debug("input.send skipped", {
         emptyContent: !content,
         isRunning,
+        sendBlocked,
         isSubmitting,
         disabled,
         noAgent,
@@ -413,7 +417,7 @@ export function ChatInput({
           )}
           <SubmitButton
             onClick={handleSend}
-            disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
+            disabled={isEmpty || isSubmitting || !!sendBlocked || !!disabled || !!noAgent || pendingUploads > 0}
             loading={isSubmitting}
             running={isRunning}
             onStop={onStop}

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -59,6 +59,7 @@ interface ChatInputProps {
      * navigated to. Omit to restore into the current draft (legacy behavior).
      */
     sessionId?: string;
+    draftKeyScope?: string;
   } | null;
   onRestoreDraftConsumed?: () => void;
   /** Receives a File and returns the attachment row (with id + CDN link).
@@ -77,6 +78,9 @@ interface ChatInputProps {
   noAgent?: boolean;
   /** Name of the currently selected agent, used in the placeholder. */
   agentName?: string;
+  /** Optional draft namespace for multiple composers in the same chat session. */
+  draftKeyScope?: string;
+  placeholder?: string;
   /** Rendered at the bottom-left of the input bar — typically the agent picker. */
   leftAdornment?: ReactNode;
   /** Chat @ suggestions: current/recent issue/project entries. */
@@ -93,6 +97,8 @@ export function ChatInput({
   disabled,
   noAgent,
   agentName,
+  draftKeyScope,
+  placeholder,
   leftAdornment,
   contextItems,
 }: ChatInputProps) {
@@ -125,7 +131,8 @@ export function ChatInput({
   // user would see the image flash on then disappear. Keeping editor
   // identity stable across the lazy-create event is what makes
   // first-upload-creates-session work the same as second-upload.
-  const draftKey = activeSessionId ?? newSessionDraftKey(selectedAgentId);
+  const baseDraftKey = activeSessionId ?? newSessionDraftKey(selectedAgentId);
+  const draftKey = draftKeyScope ? `${baseDraftKey}:${draftKeyScope}` : baseDraftKey;
   // Select a primitive — empty-string fallback keeps referential stability.
   const inputDraft = useChatStore((s) => s.inputDrafts[draftKey] ?? "");
   const draftAttachments = useChatStore(
@@ -138,7 +145,7 @@ export function ChatInput({
   const [isEmpty, setIsEmpty] = useState(!inputDraft.trim());
   const [isSubmitting, setIsSubmitting] = useState(false);
   const consumedRestoreIdRef = useRef<string | null>(null);
-  const editorKey = selectedAgentId ?? "no-agent";
+  const editorKey = `${selectedAgentId ?? "no-agent"}:${draftKeyScope ?? "main"}`;
   // Number of in-flight uploads. We track this explicitly (rather than
   // peeking at the editor on every render) so the SubmitButton visibly
   // disables the instant an upload starts and re-enables the instant it
@@ -172,8 +179,11 @@ export function ChatInput({
     // failed after the user navigated away must not dump its content into the
     // session they're now looking at — the request stays pending until they
     // return to the source session (draftKey then matches).
-    if (restoreDraftRequest.sessionId && restoreDraftRequest.sessionId !== draftKey) {
-      return;
+    if (restoreDraftRequest.sessionId) {
+      const restoreDraftKey = restoreDraftRequest.draftKeyScope
+        ? `${restoreDraftRequest.sessionId}:${restoreDraftRequest.draftKeyScope}`
+        : restoreDraftRequest.sessionId;
+      if (restoreDraftKey !== draftKey) return;
     }
     consumedRestoreIdRef.current = restoreDraftRequest.id;
     if (inputDraft.trim()) {
@@ -317,13 +327,13 @@ export function ChatInput({
     if (!committed) commitInput();
   };
 
-  const placeholder = noAgent
+  const resolvedPlaceholder = placeholder ?? (noAgent
     ? t(($) => $.input.placeholder_no_agent)
     : disabled
       ? t(($) => $.input.placeholder_archived)
       : agentName
         ? t(($) => $.input.placeholder_named, { name: agentName })
-        : t(($) => $.input.placeholder_default);
+        : t(($) => $.input.placeholder_default));
 
   const uploadEnabled = !!onUploadFile && !disabled && !noAgent;
 
@@ -359,7 +369,7 @@ export function ChatInput({
             key={editorKey}
             ref={editorRef}
             defaultValue={inputDraft}
-            placeholder={placeholder}
+            placeholder={resolvedPlaceholder}
             onUpdate={(md) => {
               setIsEmpty(!md.trim());
               setInputDraft(draftKey, md);

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -129,7 +129,7 @@ export function ChatMessageList({
             </div>
           ),
           Footer: () => (
-            <div className="mx-auto w-full max-w-4xl px-5 pb-4 space-y-4">
+            <div className="mx-auto w-full max-w-4xl px-5 pb-3 space-y-3">
               {hasLive && (
                 <div className="w-full space-y-1.5">
                   <TimelineView items={liveTimeline} isStreaming />
@@ -146,7 +146,7 @@ export function ChatMessageList({
           ),
         }}
         itemContent={(_, msg) => (
-          <div className="mx-auto w-full max-w-4xl px-5 py-2">
+          <div className="mx-auto w-full max-w-4xl px-5 py-1.5">
             <MessageBubble
               message={msg}
               isPending={!!pendingTaskId && msg.task_id === pendingTaskId}
@@ -197,7 +197,7 @@ function MessageBubble({ message, isPending }: { message: ChatMessage; isPending
            * render them through the same pipeline as assistant replies.
            * Neutralise prose's leading/trailing margin so single-line
            * bubbles stay as compact as the plain-text version used to. */}
-          <div className="prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+          <div className="min-w-0 overflow-x-auto prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
             <Markdown attachments={message.attachments}>{message.content}</Markdown>
           </div>
           <AttachmentList
@@ -213,7 +213,7 @@ function MessageBubble({ message, isPending }: { message: ChatMessage; isPending
   return <AssistantMessage message={message} isPending={isPending} />;
 }
 
-function AssistantMessage({
+export function AssistantMessage({
   message,
   isPending,
 }: {
@@ -253,7 +253,7 @@ function AssistantMessage({
       {timeline.length > 0 ? (
         <TimelineView items={timeline} attachments={message.attachments} />
       ) : (
-        <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
+        <div className="min-w-0 overflow-x-auto text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
           <Markdown attachments={message.attachments}>{message.content}</Markdown>
         </div>
       )}
@@ -445,7 +445,7 @@ function TimelineView({
   return (
     <>
       {preface.length > 0 && (
-        <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
+        <div className="min-w-0 overflow-x-auto text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
           <Markdown attachments={attachments}>
             {preface.map((t) => t.content ?? "").join("")}
           </Markdown>
@@ -459,7 +459,7 @@ function TimelineView({
         />
       )}
       {final.length > 0 && (
-        <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
+        <div className="min-w-0 overflow-x-auto text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
           <Markdown attachments={attachments}>
             {final.map((t) => t.content ?? "").join("")}
           </Markdown>
@@ -520,7 +520,7 @@ function MiddleTextRow({
   attachments?: import("@multica/core/types").Attachment[];
 }) {
   return (
-    <div className="py-0.5 text-xs text-muted-foreground prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+    <div className="min-w-0 overflow-x-auto py-0.5 text-xs text-muted-foreground prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
       <Markdown attachments={attachments}>{item.content ?? ""}</Markdown>
     </div>
   );

--- a/packages/views/chat/components/chat-window.thread-timeline.test.ts
+++ b/packages/views/chat/components/chat-window.thread-timeline.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "@multica/core/types";
+
+// chat-window.tsx pulls in actor-avatar at module load; stub it so importing
+// the pure buildThreadTimeline helper doesn't drag in avatar rendering deps.
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => null,
+}));
+
+import { buildThreadTimeline } from "./chat-window";
+
+function msg(overrides: Partial<ChatMessage> & Pick<ChatMessage, "id" | "role">): ChatMessage {
+  return {
+    chat_session_id: "s1",
+    content: overrides.id,
+    task_id: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as ChatMessage;
+}
+
+function countSurfaced(timeline: ReturnType<typeof buildThreadTimeline>): number {
+  return timeline.reduce((sum, entry) => {
+    if (entry.kind === "thread") return sum + 1 + entry.thread.replies.length;
+    return sum + 1;
+  }, 0);
+}
+
+describe("buildThreadTimeline", () => {
+  it("groups a root with its thread replies under one thread", () => {
+    const messages: ChatMessage[] = [
+      msg({ id: "u1", role: "user", task_id: "t1", thread_task_id: "t1", chat_thread_id: "th1" }),
+      msg({ id: "a1", role: "assistant", task_id: "t1", thread_task_id: "t1", chat_thread_id: "th1" }),
+      msg({ id: "u2", role: "user", task_id: "t2", thread_task_id: "t1", chat_thread_id: "th1" }),
+    ];
+    const timeline = buildThreadTimeline(messages);
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]?.kind).toBe("thread");
+    expect(countSurfaced(timeline)).toBe(messages.length);
+  });
+
+  it("never drops a reply whose thread key never matches a surfaced root (message conservation)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Reply keyed only by chat_thread_id 'orphan-th', but no root ever carries
+    // that key — the legacy/racy mismatch the fallback must catch.
+    const messages: ChatMessage[] = [
+      msg({ id: "u1", role: "user", task_id: "t1", thread_task_id: "t1", chat_thread_id: "th1" }),
+      msg({
+        id: "a1",
+        role: "assistant",
+        task_id: "t2",
+        thread_task_id: "t99",
+        chat_thread_id: "orphan-th",
+      }),
+    ];
+    const timeline = buildThreadTimeline(messages);
+    // Both messages remain visible even though the assistant reply orphaned.
+    expect(countSurfaced(timeline)).toBe(messages.length);
+    warn.mockRestore();
+  });
+});

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -2,8 +2,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import { motion } from "motion/react";
-import { Minus, Maximize2, Minimize2, ChevronDown, Plus, Check, Trash2, Pencil, Loader2, Square } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { Minus, Maximize2, Minimize2, ChevronDown, Plus, Check, Trash2, Pencil, Loader2, Square, X } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { cn } from "@multica/ui/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
@@ -15,12 +15,15 @@ import {
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useAuthStore } from "@multica/core/auth";
+import { isAgentChatPath, useWorkspacePaths } from "@multica/core/paths";
 import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
 import { canAssignAgent } from "@multica/views/issues/components";
 import { api } from "@multica/core/api";
-import { useAgentPresenceDetail, useWorkspaceAgentAvailability } from "@multica/core/agents";
-import { useFileUpload } from "@multica/core/hooks/use-file-upload";
+import { useAgentPresenceDetail, useWorkspaceAgentAvailability, type AgentAvailability } from "@multica/core/agents";
+import { useFileUpload, type UploadResult } from "@multica/core/hooks/use-file-upload";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { Markdown } from "../../common/markdown";
+import { AttachmentList } from "../../issues/components/comment-card";
 import {
   PickerEmpty,
   PickerItem,
@@ -28,6 +31,7 @@ import {
   PropertyPicker,
 } from "../../issues/components/pickers/property-picker";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
+import type { MentionItem } from "../../editor/extensions/mention-suggestion";
 import { OfflineBanner } from "./offline-banner";
 import { NoAgentBanner } from "./no-agent-banner";
 import {
@@ -35,6 +39,7 @@ import {
   chatMessagesPageOptions,
   pendingChatTaskOptions,
   pendingChatTasksOptions,
+  taskMessagesOptions,
   chatKeys,
   isTaskMessageTaskId,
 } from "@multica/core/chat/queries";
@@ -45,18 +50,24 @@ import {
   useUpdateChatSession,
 } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
-import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
+import { AssistantMessage, ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import { ChatResizeHandles } from "./chat-resize-handles";
+import { TaskStatusPill } from "./task-status-pill";
 import { useChatContextItems } from "./use-chat-context-items";
 import { useChatResize } from "./use-chat-resize";
 import { createLogger } from "@multica/core/logger";
-import type { Agent, Attachment, ChatMessage, ChatMessagesPage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
+import type { Agent, Attachment, ChatMessage, ChatMessagesPage, ChatPendingTask, ChatSession, PendingChatTasksResponse, TaskMessagePayload, User } from "@multica/core/types";
 import { useT } from "../../i18n";
+import { AppLink, useNavigation } from "../../navigation";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
 const CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX = 1_000_000;
+const THREAD_PANEL_DEFAULT_WIDTH = 560;
+const THREAD_PANEL_MIN_WIDTH = 380;
+const THREAD_PANEL_MAX_WIDTH = 760;
+const THREAD_MAIN_MIN_WIDTH = 360;
 
 function appendChatMessageToLatestPageCache(
   qc: ReturnType<typeof useQueryClient>,
@@ -128,6 +139,8 @@ function replaceOptimisticChatMessageId(
   optimisticId: string,
   messageId: string,
   taskId: string,
+  threadTaskId: string,
+  chatThreadId?: string | null,
 ) {
   const replace = (messages: ChatMessage[] | undefined) => {
     if (!messages) return messages;
@@ -135,7 +148,9 @@ function replaceOptimisticChatMessageId(
       return messages.filter((m) => m.id !== optimisticId);
     }
     return messages.map((m) =>
-      m.id === optimisticId ? { ...m, id: messageId, task_id: taskId } : m,
+      m.id === optimisticId
+        ? { ...m, id: messageId, task_id: taskId, thread_task_id: threadTaskId, chat_thread_id: chatThreadId ?? m.chat_thread_id ?? null }
+        : m,
     );
   };
 
@@ -158,9 +173,34 @@ function replaceOptimisticChatMessageId(
   );
 }
 
+type ChatSurfaceMode = "floating" | "page";
+
+interface SendChatMessageOptions {
+  replyToThreadTaskId?: string;
+  chatThreadId?: string;
+  clientThreadKey?: string;
+  draftKeyScope?: string;
+}
+
+interface ChatSurfaceProps {
+  mode: ChatSurfaceMode;
+  routeAgentId?: string;
+}
+
 export function ChatWindow() {
+  return <ChatSurface mode="floating" />;
+}
+
+export function AgentChatPage({ agentId }: { agentId: string }) {
+  return <ChatSurface mode="page" routeAgentId={agentId} />;
+}
+
+function ChatSurface({ mode, routeAgentId }: ChatSurfaceProps) {
+  const pageMode = mode === "page";
   const { t } = useT("chat");
   const wsId = useWorkspaceId();
+  const workspacePaths = useWorkspacePaths();
+  const { pathname } = useNavigation();
   const isOpen = useChatStore((s) => s.isOpen);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
   const selectedAgentId = useChatStore((s) => s.selectedAgentId);
@@ -168,25 +208,35 @@ export function ChatWindow() {
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const setSelectedAgentId = useChatStore((s) => s.setSelectedAgentId);
   const user = useAuthStore((s) => s.user);
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
-  const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const { data: agents = [], isPending: agentsPending } = useQuery(agentListOptions(wsId));
+  const { data: members = [], isPending: membersPending } = useQuery(memberListOptions(wsId));
   // Single sessions cache — eliminates the separate active/all queries
   // that used to drift during the WS-invalidate window.
-  const { data: sessions = [] } = useQuery(chatSessionsOptions(wsId));
+  const { data: sessions = [], isPending: sessionsPending } = useQuery(chatSessionsOptions(wsId));
+  const storedActiveSession = activeSessionId
+    ? sessions.find((s) => s.id === activeSessionId)
+    : null;
+  const effectiveActiveSessionId =
+    pageMode &&
+    (!storedActiveSession ||
+      storedActiveSession.agent_id !== routeAgentId ||
+      storedActiveSession.status === "archived")
+      ? null
+      : activeSessionId;
   const {
     data: rawMessagePages,
     isLoading: messagesLoading,
     fetchNextPage: fetchOlderMessages,
     hasNextPage: hasOlderMessages,
     isFetchingNextPage: isFetchingOlderMessages,
-  } = useInfiniteQuery(chatMessagesPageOptions(activeSessionId ?? ""));
+  } = useInfiniteQuery(chatMessagesPageOptions(effectiveActiveSessionId ?? ""));
   // When no active session, always show empty — don't use stale cache.
   // Page 0 contains the latest chronological window; later cursor pages are
   // older chronological windows. Reverse pages so older fetched pages render
   // above the initial latest page. The Virtuoso firstItemIndex is client-owned:
   // it starts from a large stable base and only subtracts the count of loaded
   // prepended rows, so concurrent server inserts cannot drift the scroll anchor.
-  const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
+  const messagePages = effectiveActiveSessionId ? rawMessagePages?.pages ?? [] : [];
   const messages = [...messagePages].reverse().flatMap((page) => page.messages);
   const olderMessageCount = messagePages.slice(1).reduce((sum, page) => sum + page.messages.length, 0);
   const firstItemIndex = messages.length > 0
@@ -195,7 +245,7 @@ export function ChatWindow() {
   // Skeleton only shows for an un-cached session fetch. Cached switches
   // return data synchronously — no flash. `enabled: false` (new chat)
   // keeps isLoading false so the starter prompts aren't hidden.
-  const showSkeleton = !!activeSessionId && messagesLoading;
+  const showSkeleton = !!effectiveActiveSessionId && messagesLoading;
 
   // Server-authoritative pending task. Survives refresh / reopen / session
   // switch because it's keyed on sessionId in the Query cache; WS events
@@ -203,7 +253,7 @@ export function ChatWindow() {
   //
   // This is the SOLE source for pendingTaskId — no mirror in the store.
   const { data: pendingTask } = useQuery(
-    pendingChatTaskOptions(activeSessionId ?? ""),
+    pendingChatTaskOptions(effectiveActiveSessionId ?? ""),
   );
   const pendingTaskId = pendingTask?.task_id ?? null;
   const stopRequestedBeforeTaskRef = useRef(false);
@@ -212,6 +262,7 @@ export function ChatWindow() {
     content: string;
     attachments?: Attachment[];
     sessionId?: string;
+    draftKeyScope?: string;
   } | null>(null);
   const handleRestoreDraftConsumed = useCallback(() => {
     setRestoreDraftRequest(null);
@@ -221,8 +272,8 @@ export function ChatWindow() {
   // pre-existing rows with status='archived' may still exist) are excluded
   // from the history dropdown. If one is still the active session, ChatInput
   // is disabled and the server still rejects POST /messages for it.
-  const currentSession = activeSessionId
-    ? sessions.find((s) => s.id === activeSessionId)
+  const currentSession = effectiveActiveSessionId
+    ? sessions.find((s) => s.id === effectiveActiveSessionId)
     : null;
   const isSessionArchived = currentSession?.status === "archived";
 
@@ -237,17 +288,61 @@ export function ChatWindow() {
   );
 
   // Resolve selected agent: stored preference → first available
-  const activeAgent =
-    availableAgents.find((a) => a.id === selectedAgentId) ??
-    availableAgents[0] ??
-    null;
+  const routeAgent = routeAgentId
+    ? agents.find((a) => a.id === routeAgentId) ?? null
+    : null;
+  const routedAvailableAgent = routeAgentId
+    ? availableAgents.find((a) => a.id === routeAgentId) ?? null
+    : null;
+  const activeAgent = pageMode
+    ? routedAvailableAgent
+    : availableAgents.find((a) => a.id === selectedAgentId) ??
+      availableAgents[0] ??
+      null;
+  const displayAgent = routeAgent ?? activeAgent;
 
   // Three-state availability — "loading" stays neutral (no banner, no
   // disable) so the input doesn't flash a fake "no agent" state in the
   // few hundred ms before the agent list query resolves. Only `"none"`
   // (server confirmed: zero usable agents) drives the disabled UI.
   const agentAvailability = useWorkspaceAgentAvailability();
-  const noAgent = agentAvailability === "none";
+  const noAgent = pageMode ? !agentsPending && !membersPending && !activeAgent : agentAvailability === "none";
+
+  useEffect(() => {
+    if (!pageMode || !routeAgentId) return;
+
+    // The route owns the page chat target. Keep the legacy floating panel
+    // closed here so this page is the only visible chat surface.
+    if (isOpen) setOpen(false);
+    if (selectedAgentId !== routeAgentId) setSelectedAgentId(routeAgentId);
+    if (sessionsPending) return;
+
+    const activeSession = activeSessionId
+      ? sessions.find((s) => s.id === activeSessionId)
+      : null;
+    if (activeSession?.agent_id === routeAgentId && activeSession.status !== "archived") {
+      return;
+    }
+
+    const latestSession = sessions
+      .filter((s) => s.agent_id === routeAgentId && s.status !== "archived")
+      .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))[0] ?? null;
+    const nextSessionId = latestSession?.id ?? null;
+    if (nextSessionId !== activeSessionId) {
+      setActiveSession(nextSessionId);
+    }
+  }, [
+    activeSessionId,
+    isOpen,
+    pageMode,
+    routeAgentId,
+    selectedAgentId,
+    sessions,
+    sessionsPending,
+    setActiveSession,
+    setOpen,
+    setSelectedAgentId,
+  ]);
 
   // Presence drives both the avatar status dot (via ActorAvatar) and the
   // OfflineBanner / TaskStatusPill availability copy. `useAgentPresenceDetail`
@@ -292,14 +387,14 @@ export function ChatWindow() {
   // chat:done so a reply arriving while the user watches triggers this
   // effect again and is instantly cleared.
   const currentHasUnread =
-    sessions.find((s) => s.id === activeSessionId)?.has_unread ?? false;
+    sessions.find((s) => s.id === effectiveActiveSessionId)?.has_unread ?? false;
   useEffect(() => {
-    if (!isOpen || !activeSessionId) return;
+    if ((!isOpen && !pageMode) || !effectiveActiveSessionId) return;
     if (!currentHasUnread) return;
-    uiLogger.info("auto markRead", { sessionId: activeSessionId });
-    markRead.mutate(activeSessionId);
+    uiLogger.info("auto markRead", { sessionId: effectiveActiveSessionId });
+    markRead.mutate(effectiveActiveSessionId);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- markRead ref stable
-  }, [isOpen, activeSessionId, currentHasUnread]);
+  }, [isOpen, pageMode, effectiveActiveSessionId, currentHasUnread]);
 
   const { uploadWithToast } = useFileUpload(api);
 
@@ -330,7 +425,7 @@ export function ChatWindow() {
   const sessionPromiseRef = useRef<Promise<string | null> | null>(null);
   const ensureSession = useCallback(
     async (titleSeed: string): Promise<string | null> => {
-      if (activeSessionId) return activeSessionId;
+      if (effectiveActiveSessionId) return effectiveActiveSessionId;
       if (!activeAgent) return null;
       if (sessionPromiseRef.current) return sessionPromiseRef.current;
 
@@ -348,7 +443,7 @@ export function ChatWindow() {
       sessionPromiseRef.current = promise;
       return promise;
     },
-    [activeSessionId, activeAgent, createSession],
+    [effectiveActiveSessionId, activeAgent, createSession],
   );
 
   const handleUploadFile = useCallback(
@@ -367,7 +462,7 @@ export function ChatWindow() {
     async (
       taskId: string,
       sessionId: string,
-      options: { restoreDraftToInput: boolean; source: string },
+      options: { restoreDraftToInput: boolean; source: string; draftKeyScope?: string },
     ) => {
       apiLogger.info("cancelTask.start", {
         taskId,
@@ -387,6 +482,7 @@ export function ChatWindow() {
               content: restored.content,
               attachments: restored.attachments,
               sessionId: restored.chat_session_id,
+              draftKeyScope: options.draftKeyScope,
             });
           }
         }
@@ -418,6 +514,7 @@ export function ChatWindow() {
       attachmentIds?: string[],
       commitInput?: (options?: { extraDraftKeys?: string[]; clearEditor?: boolean }) => void,
       draftAttachments: Attachment[] = [],
+      options: SendChatMessageOptions = {},
     ): Promise<boolean> => {
       if (!activeAgent) {
         apiLogger.warn("sendChatMessage skipped: no active agent");
@@ -426,12 +523,15 @@ export function ChatWindow() {
 
       const finalContent = content;
 
-      const isNewSession = !activeSessionId;
+      const isNewSession = !effectiveActiveSessionId;
 
       apiLogger.info("sendChatMessage.start", {
-        sessionId: activeSessionId,
+        sessionId: effectiveActiveSessionId,
         isNewSession,
         agentId: activeAgent.id,
+        replyToThreadTaskId: options.replyToThreadTaskId,
+        chatThreadId: options.chatThreadId,
+        clientThreadKey: options.clientThreadKey,
         contentLength: finalContent.length,
         attachmentCount: attachmentIds?.length ?? 0,
       });
@@ -455,12 +555,18 @@ export function ChatWindow() {
       // sendChatMessage` and the pill blinked in a few hundred ms after the
       // user's message — small but visible "did it actually send?" gap.
       const sentAt = new Date().toISOString();
+      const optimisticId = `optimistic-${Date.now()}`;
+      const optimisticTaskId = `optimistic-${optimisticId}`;
+      const optimisticThreadTaskId = options.replyToThreadTaskId ?? optimisticTaskId;
       const optimistic: ChatMessage = {
-        id: `optimistic-${Date.now()}`,
+        id: optimisticId,
         chat_session_id: sessionId,
+        chat_thread_id: options.chatThreadId ?? null,
+        client_thread_id: options.clientThreadKey ?? null,
         role: "user",
         content: finalContent,
-        task_id: null,
+        task_id: optimisticTaskId,
+        thread_task_id: optimisticThreadTaskId,
         created_at: sentAt,
         attachments: draftAttachments,
       };
@@ -481,7 +587,7 @@ export function ChatWindow() {
       // is anchored to the local clock (drift is the request RTT, ~50–200ms,
       // which doesn't change the rendered "Ns" value).
       qc.setQueryData<ChatPendingTask>(chatKeys.pendingTask(sessionId), {
-        task_id: `optimistic-${optimistic.id}`,
+        task_id: optimisticTaskId,
         status: "queued",
         created_at: sentAt,
       });
@@ -495,17 +601,23 @@ export function ChatWindow() {
       // must also count as "navigated away" even though both sides are null.
       const live = useChatStore.getState();
       const stillOnSourceSession =
-        live.activeSessionId === activeSessionId &&
-        (activeSessionId !== null || live.selectedAgentId === selectedAgentId);
+        live.activeSessionId === effectiveActiveSessionId &&
+        (effectiveActiveSessionId !== null || live.selectedAgentId === selectedAgentId);
       if (stillOnSourceSession) {
         setActiveSession(sessionId);
       }
-      commitInput?.({ extraDraftKeys: [sessionId], clearEditor: stillOnSourceSession });
+      commitInput?.({
+        extraDraftKeys: options.draftKeyScope ? [] : [sessionId],
+        clearEditor: stillOnSourceSession,
+      });
       apiLogger.debug("sendChatMessage.optimistic", { sessionId, optimisticId: optimistic.id });
 
       let result;
       try {
-        result = await api.sendChatMessage(sessionId, finalContent, attachmentIds);
+        result = await api.sendChatMessage(sessionId, finalContent, attachmentIds, {
+          replyToTaskId: options.replyToThreadTaskId,
+          chatThreadId: options.chatThreadId,
+        });
       } catch (err) {
         apiLogger.error("sendChatMessage.error.rollback", { sessionId, optimisticId: optimistic.id, err });
         stopRequestedBeforeTaskRef.current = false;
@@ -519,6 +631,7 @@ export function ChatWindow() {
           // navigated away (fire-and-forget) the request waits until they
           // return rather than dumping content into another session.
           sessionId,
+          draftKeyScope: options.draftKeyScope,
         });
         toast.error(t(($) => $.input.send_failed_toast));
         return false;
@@ -527,8 +640,18 @@ export function ChatWindow() {
         sessionId,
         messageId: result.message_id,
         taskId: result.task_id,
+        threadTaskId: result.thread_task_id,
+        chatThreadId: result.thread_id,
       });
-      replaceOptimisticChatMessageId(qc, sessionId, optimistic.id, result.message_id, result.task_id);
+      replaceOptimisticChatMessageId(
+        qc,
+        sessionId,
+        optimistic.id,
+        result.message_id,
+        result.task_id,
+        result.thread_task_id ?? result.task_id,
+        result.thread_id ?? null,
+      );
       // Replace the temporary task_id with the server's real one (so the WS
       // task: handlers can match against it) and snap the anchor to the
       // server's created_at — keeping the elapsed-seconds reading stable.
@@ -566,7 +689,7 @@ export function ChatWindow() {
       return true;
     },
     [
-      activeSessionId,
+      effectiveActiveSessionId,
       selectedAgentId,
       activeAgent,
       ensureSession,
@@ -577,8 +700,28 @@ export function ChatWindow() {
     ],
   );
 
-  const handleStop = useCallback(() => {
-    if (!pendingTaskId || !activeSessionId) {
+  const handleThreadReplySend = useCallback(
+    (
+      chatThreadId: string | null,
+      threadTaskId: string | null,
+      clientThreadKey: string,
+      draftKeyScope: string,
+      content: string,
+      attachmentIds?: string[],
+      commitInput?: (options?: { extraDraftKeys?: string[]; clearEditor?: boolean }) => void,
+      draftAttachments: Attachment[] = [],
+    ) =>
+      handleSend(content, attachmentIds, commitInput, draftAttachments, {
+        chatThreadId: chatThreadId ?? undefined,
+        replyToThreadTaskId: threadTaskId ?? undefined,
+        clientThreadKey,
+        draftKeyScope,
+      }),
+    [handleSend],
+  );
+
+  const handleStop = useCallback((options: { draftKeyScope?: string } = {}) => {
+    if (!pendingTaskId || !effectiveActiveSessionId) {
       apiLogger.debug("cancelTask skipped: no pending task");
       return;
     }
@@ -586,15 +729,16 @@ export function ChatWindow() {
       stopRequestedBeforeTaskRef.current = true;
       apiLogger.info("cancelTask.deferred until server task id", {
         taskId: pendingTaskId,
-        sessionId: activeSessionId,
+        sessionId: effectiveActiveSessionId,
       });
       return;
     }
-    void cancelChatTask(pendingTaskId, activeSessionId, {
+    void cancelChatTask(pendingTaskId, effectiveActiveSessionId, {
       restoreDraftToInput: true,
       source: "active-input",
+      draftKeyScope: options.draftKeyScope,
     });
-  }, [pendingTaskId, activeSessionId, cancelChatTask]);
+  }, [pendingTaskId, effectiveActiveSessionId, cancelChatTask]);
 
   const handleSelectAgent = useCallback(
     (agent: Agent) => {
@@ -606,22 +750,22 @@ export function ChatWindow() {
       uiLogger.info("selectAgent", {
         from: selectedAgentId,
         to: agent.id,
-        previousSessionId: activeSessionId,
+        previousSessionId: effectiveActiveSessionId,
       });
       setSelectedAgentId(agent.id);
       // Reset session when switching agent
       setActiveSession(null);
     },
-    [activeAgent, selectedAgentId, activeSessionId, setSelectedAgentId, setActiveSession],
+    [activeAgent, selectedAgentId, effectiveActiveSessionId, setSelectedAgentId, setActiveSession],
   );
 
   const handleNewChat = useCallback(() => {
     uiLogger.info("newChat", {
-      previousSessionId: activeSessionId,
+      previousSessionId: effectiveActiveSessionId,
       previousPendingTask: pendingTaskId,
     });
     setActiveSession(null);
-  }, [activeSessionId, pendingTaskId, setActiveSession]);
+  }, [effectiveActiveSessionId, pendingTaskId, setActiveSession]);
 
   const handleSelectSession = useCallback(
     (session: ChatSession) => {
@@ -642,11 +786,11 @@ export function ChatWindow() {
 
   const handleMinimize = useCallback(() => {
     uiLogger.info("minimize (close)", {
-      activeSessionId,
+      activeSessionId: effectiveActiveSessionId,
       pendingTaskId,
     });
     setOpen(false);
-  }, [activeSessionId, pendingTaskId, setOpen]);
+  }, [effectiveActiveSessionId, pendingTaskId, setOpen]);
 
   const isExpanded = useChatStore((s) => s.isExpanded);
 
@@ -667,27 +811,79 @@ export function ChatWindow() {
 
   const contextItems = useChatContextItems(wsId);
 
-  return (
-    <motion.div
-      ref={windowRef}
-      className={containerClass}
-      style={containerStyle}
-      initial={{ opacity: 0, scale: 0.95, width: renderWidth, height: renderHeight }}
-      animate={{
-        opacity: isVisible ? 1 : 0,
-        scale: isVisible ? 1 : 0.95,
-        width: renderWidth,
-        height: renderHeight,
-      }}
-      transition={{
-        width: isDragging ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 },
-        height: isDragging ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 },
-        opacity: { duration: 0.15 },
-        scale: { type: "spring", duration: 0.2, bounce: 0 },
-      }}
-    >
+  const statusBanner = noAgent ? (
+    <NoAgentBanner />
+  ) : (
+    <OfflineBanner agentName={activeAgent?.name} availability={availability} />
+  );
+
+  const composer = (
+    <ChatInput
+      onSend={handleSend}
+      restoreDraftRequest={restoreDraftRequest}
+      onRestoreDraftConsumed={handleRestoreDraftConsumed}
+      onUploadFile={handleUploadFile}
+      onStop={() => handleStop()}
+      isRunning={!!pendingTaskId}
+      disabled={isSessionArchived}
+      noAgent={noAgent}
+      agentName={displayAgent?.name ?? activeAgent?.name}
+      leftAdornment={pageMode ? undefined : (
+        <AgentDropdown
+          agents={availableAgents}
+          activeAgent={activeAgent}
+          userId={user?.id}
+          onSelect={handleSelectAgent}
+        />
+      )}
+      contextItems={contextItems}
+    />
+  );
+
+  const chatBody = (
+    <>
+      {/* Messages / skeleton / empty state */}
+      {showSkeleton ? (
+        <ChatMessageSkeleton />
+      ) : hasMessages ? (
+        <ChatMessageList
+          key={effectiveActiveSessionId}
+          messages={messages}
+          pendingTask={pendingTask}
+          availability={availability}
+          firstItemIndex={firstItemIndex}
+          hasOlderMessages={!!hasOlderMessages}
+          isFetchingOlderMessages={isFetchingOlderMessages}
+          onLoadOlderMessages={() => void fetchOlderMessages()}
+        />
+      ) : (
+        <EmptyState
+          hasSessions={sessions.length > 0}
+          agentName={displayAgent?.name ?? activeAgent?.name}
+          onPickPrompt={(text) => handleSend(text)}
+        />
+      )}
+
+      {/* Status banner above the input — single mutually-exclusive slot.
+       *  Priority: no-agent > offline / unstable. Agent presence is the
+       *  hard prerequisite (you can't send anything without one), so it
+       *  always wins over a presence hint. Recent issue/project navigation
+       *  lives in the input action row; it is not message/session state.
+       *
+       *  We key off `noAgent` (the resolved-empty state) rather than
+       *  `!activeAgent`, so the loading window between mount and the
+       *  first agent-list response stays banner-free. */}
+      {statusBanner}
+
+      {/* Input — disabled for legacy archived sessions; locked out entirely
+       *  when there's no agent (the EmptyState above carries the CTA). */}
+      {composer}
+    </>
+  );
+
+  const floatingHeader = (
+    <>
       <ChatResizeHandles onDragStart={startDrag} />
-      {/* Header — ⊕ new + session dropdown | window tools */}
       <div className="flex items-center justify-between border-b px-4 py-2.5 gap-2">
         <div className="flex items-center gap-1 min-w-0">
           <Tooltip>
@@ -710,7 +906,7 @@ export function ChatWindow() {
             // Use the full agent list (incl. archived) so historical
             // sessions can still resolve their avatar.
             agents={agents}
-            activeSessionId={activeSessionId}
+            activeSessionId={effectiveActiveSessionId}
             onSelectSession={handleSelectSession}
           />
         </div>
@@ -749,67 +945,904 @@ export function ChatWindow() {
           </Tooltip>
         </div>
       </div>
+    </>
+  );
 
-      {/* Messages / skeleton / empty state */}
-      {showSkeleton ? (
-        <ChatMessageSkeleton />
-      ) : hasMessages ? (
-        <ChatMessageList
-          key={activeSessionId}
+  if (pageMode) {
+    return (
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <div className="shrink-0 border-b bg-background">
+          <div className="flex min-h-14 items-center justify-between gap-3 px-5 py-2.5">
+            <div className="flex min-w-0 items-center gap-2.5">
+              {displayAgent ? (
+                <ActorAvatar
+                  actorType="agent"
+                  actorId={displayAgent.id}
+                  size={28}
+                  enableHoverCard
+                  showStatusDot={!displayAgent.archived_at}
+                />
+              ) : (
+                <span className="size-7 rounded-md bg-muted" />
+              )}
+              <div className="min-w-0">
+                <h1 className="truncate text-sm font-semibold leading-5">
+                  {displayAgent?.name ?? t(($) => $.window.no_agents)}
+                </h1>
+              </div>
+            </div>
+            {displayAgent && (
+              <AppLink
+                href={workspacePaths.agentDetail(displayAgent.id)}
+                className="shrink-0 rounded-md px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                {t(($) => $.page.show_profile)}
+              </AppLink>
+            )}
+          </div>
+          <div className="flex h-9 items-end gap-5 px-5">
+            <div className="border-b-2 border-foreground pb-2 text-sm font-medium">
+              {t(($) => $.page.chat_tab)}
+            </div>
+          </div>
+        </div>
+        <ThreadedChatPageBody
           messages={messages}
           pendingTask={pendingTask}
           availability={availability}
-          firstItemIndex={firstItemIndex}
+          agent={displayAgent}
+          user={user}
+          showSkeleton={showSkeleton}
           hasOlderMessages={!!hasOlderMessages}
           isFetchingOlderMessages={isFetchingOlderMessages}
           onLoadOlderMessages={() => void fetchOlderMessages()}
+          emptyState={(
+            <EmptyState
+              hasSessions={sessions.length > 0}
+              agentName={displayAgent?.name ?? activeAgent?.name}
+              onPickPrompt={(text) => handleSend(text)}
+            />
+          )}
+          statusBanner={statusBanner}
+          composer={composer}
+          onSendThreadReply={handleThreadReplySend}
+          restoreDraftRequest={restoreDraftRequest}
+          onRestoreDraftConsumed={handleRestoreDraftConsumed}
+          onUploadFile={handleUploadFile}
+          onStop={handleStop}
+          isRunning={!!pendingTaskId}
+          disabled={isSessionArchived}
+          noAgent={noAgent}
+          agentName={displayAgent?.name ?? activeAgent?.name}
+          contextItems={contextItems}
         />
-      ) : (
-        <EmptyState
-          hasSessions={sessions.length > 0}
-          agentName={activeAgent?.name}
-          onPickPrompt={(text) => handleSend(text)}
-        />
-      )}
+      </div>
+    );
+  }
 
-      {/* Status banner above the input — single mutually-exclusive slot.
-       *  Priority: no-agent > offline / unstable. Agent presence is the
-       *  hard prerequisite (you can't send anything without one), so it
-       *  always wins over a presence hint. Recent issue/project navigation
-       *  lives in the input action row; it is not message/session state.
-       *
-       *  We key off `noAgent` (the resolved-empty state) rather than
-       *  `!activeAgent`, so the loading window between mount and the
-       *  first agent-list response stays banner-free. */}
-      {noAgent ? (
-        <NoAgentBanner />
-      ) : (
-        <OfflineBanner agentName={activeAgent?.name} availability={availability} />
-      )}
+  if (isAgentChatPath(pathname)) return null;
 
-      {/* Input — disabled for legacy archived sessions; locked out entirely
-       *  when there's no agent (the EmptyState above carries the CTA). */}
-      <ChatInput
-        onSend={handleSend}
-        restoreDraftRequest={restoreDraftRequest}
-        onRestoreDraftConsumed={handleRestoreDraftConsumed}
-        onUploadFile={handleUploadFile}
-        onStop={handleStop}
-        isRunning={!!pendingTaskId}
-        disabled={isSessionArchived}
-        noAgent={noAgent}
-        agentName={activeAgent?.name}
-        leftAdornment={
-          <AgentDropdown
-            agents={availableAgents}
-            activeAgent={activeAgent}
-            userId={user?.id}
-            onSelect={handleSelectAgent}
-          />
-        }
-        contextItems={contextItems}
-      />
+  return (
+    <motion.div
+      ref={windowRef}
+      className={containerClass}
+      style={containerStyle}
+      initial={{ opacity: 0, scale: 0.95, width: renderWidth, height: renderHeight }}
+      animate={{
+        opacity: isVisible ? 1 : 0,
+        scale: isVisible ? 1 : 0.95,
+        width: renderWidth,
+        height: renderHeight,
+      }}
+      transition={{
+        width: isDragging ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 },
+        height: isDragging ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 },
+        opacity: { duration: 0.15 },
+        scale: { type: "spring", duration: 0.2, bounce: 0 },
+      }}
+    >
+      {floatingHeader}
+      {chatBody}
     </motion.div>
+  );
+}
+
+interface ChatThread {
+  id: string;
+  chatThreadId: string | null;
+  threadTaskId: string | null;
+  root: ChatMessage;
+  replies: ChatMessage[];
+}
+
+type ThreadReplySendHandler = (
+  chatThreadId: string | null,
+  threadTaskId: string | null,
+  clientThreadKey: string,
+  draftKeyScope: string,
+  content: string,
+  attachmentIds?: string[],
+  commitInput?: (options?: { extraDraftKeys?: string[]; clearEditor?: boolean }) => void,
+  draftAttachments?: Attachment[],
+) => Promise<boolean>;
+
+type ThreadTimelineEntry =
+  | { kind: "standalone-assistant"; message: ChatMessage }
+  | { kind: "thread"; thread: ChatThread };
+
+function messageThreadTaskId(message: ChatMessage): string | null {
+  return message.thread_task_id ?? message.task_id ?? null;
+}
+
+function messageThreadKey(message: ChatMessage): string | null {
+  return message.client_thread_id ?? message.chat_thread_id ?? messageThreadTaskId(message);
+}
+
+function isThreadReplyMessage(message: ChatMessage): boolean {
+  const threadTaskId = message.thread_task_id;
+  return !!threadTaskId && !!message.task_id && threadTaskId !== message.task_id;
+}
+
+function buildThreadTimeline(messages: ChatMessage[]): ThreadTimelineEntry[] {
+  const timeline: ThreadTimelineEntry[] = [];
+  const threadsByThreadKey = new Map<string, ChatThread>();
+  const pendingRepliesByThreadKey = new Map<string, ChatMessage[]>();
+
+  const addPendingReply = (threadKey: string, message: ChatMessage) => {
+    const pending = pendingRepliesByThreadKey.get(threadKey);
+    if (pending) {
+      pending.push(message);
+    } else {
+      pendingRepliesByThreadKey.set(threadKey, [message]);
+    }
+  };
+
+  const attachPendingReplies = (threadKey: string, thread: ChatThread) => {
+    const pending = pendingRepliesByThreadKey.get(threadKey);
+    if (!pending) return;
+    thread.replies.push(...pending);
+    pendingRepliesByThreadKey.delete(threadKey);
+  };
+
+  for (const message of messages) {
+    const threadKey = messageThreadKey(message);
+    const threadTaskId = messageThreadTaskId(message);
+    if (message.role === "user") {
+      const existingThread = threadKey ? threadsByThreadKey.get(threadKey) : null;
+      if (existingThread) {
+        existingThread.replies.push(message);
+        continue;
+      }
+      if (threadKey && isThreadReplyMessage(message)) {
+        addPendingReply(threadKey, message);
+        continue;
+      }
+
+      const thread: ChatThread = {
+        id: threadKey ?? message.id,
+        chatThreadId: message.chat_thread_id ?? null,
+        threadTaskId,
+        root: message,
+        replies: [],
+      };
+      timeline.push({ kind: "thread", thread });
+      if (threadKey) {
+        threadsByThreadKey.set(threadKey, thread);
+        attachPendingReplies(threadKey, thread);
+      }
+      continue;
+    }
+
+    const thread = threadKey ? threadsByThreadKey.get(threadKey) : null;
+    if (thread) {
+      thread.replies.push(message);
+    } else if (threadKey && isThreadReplyMessage(message)) {
+      addPendingReply(threadKey, message);
+    } else {
+      timeline.push({ kind: "standalone-assistant", message });
+    }
+  }
+
+  return timeline;
+}
+
+function threadContainsTask(thread: ChatThread, taskId: string): boolean {
+  return thread.root.task_id === taskId || thread.replies.some((message) => message.task_id === taskId);
+}
+
+function formatMessageTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function sameCalendarDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+}
+
+function formatThreadTimestamp(value: string, todayAt: (time: string) => string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const time = formatMessageTime(value);
+  if (sameCalendarDay(date, new Date())) return todayAt(time);
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function ThreadedChatPageBody({
+  messages,
+  pendingTask,
+  availability,
+  agent,
+  user,
+  showSkeleton,
+  hasOlderMessages,
+  isFetchingOlderMessages,
+  onLoadOlderMessages,
+  emptyState,
+  statusBanner,
+  composer,
+  onSendThreadReply,
+  restoreDraftRequest,
+  onRestoreDraftConsumed,
+  onUploadFile,
+  onStop,
+  isRunning,
+  disabled,
+  noAgent,
+  agentName,
+  contextItems,
+}: {
+  messages: ChatMessage[];
+  pendingTask: ChatPendingTask | null | undefined;
+  availability: AgentAvailability | undefined;
+  agent: Agent | null;
+  user: User | null;
+  showSkeleton: boolean;
+  hasOlderMessages: boolean;
+  isFetchingOlderMessages: boolean;
+  onLoadOlderMessages: () => void;
+  emptyState: React.ReactNode;
+  statusBanner: React.ReactNode;
+  composer: React.ReactNode;
+  onSendThreadReply: ThreadReplySendHandler;
+  restoreDraftRequest?: {
+    id: string;
+    content: string;
+    attachments?: Attachment[];
+    sessionId?: string;
+    draftKeyScope?: string;
+  } | null;
+  onRestoreDraftConsumed?: () => void;
+  onUploadFile?: (file: File) => Promise<UploadResult | null>;
+  onStop?: (options?: { draftKeyScope?: string }) => void;
+  isRunning: boolean;
+  disabled: boolean;
+  noAgent: boolean;
+  agentName?: string;
+  contextItems?: MentionItem[];
+}) {
+  const { t } = useT("chat");
+  const timeline = useMemo(() => buildThreadTimeline(messages), [messages]);
+  const threads = useMemo(
+    () => timeline.filter((entry): entry is { kind: "thread"; thread: ChatThread } => entry.kind === "thread"),
+    [timeline],
+  );
+  const pendingTaskId = pendingTask?.task_id ?? null;
+  const canFetchPendingTaskMessages = isTaskMessageTaskId(pendingTaskId);
+  const { data: pendingTaskMessages } = useQuery({
+    ...taskMessagesOptions(pendingTaskId ?? ""),
+    enabled: canFetchPendingTaskMessages,
+  });
+  const pendingAlreadyPersisted = !!pendingTaskId && messages.some(
+    (m) => m.role === "assistant" && m.task_id === pendingTaskId,
+  );
+  const activePendingThreadId = pendingTaskId
+    ? threads.find(({ thread }) => threadContainsTask(thread, pendingTaskId))?.thread.id ?? null
+    : null;
+  const pendingPlaceholderThreadId = activePendingThreadId && !pendingAlreadyPersisted
+    ? activePendingThreadId
+    : null;
+  const latestThreadId = threads[threads.length - 1]?.thread.id ?? null;
+  const previousLatestThreadIdRef = useRef<string | null>(null);
+  const previousActivePendingThreadIdRef = useRef<string | null>(null);
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [panelClosed, setPanelClosed] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [threadPanelWidth, setThreadPanelWidth] = useState(THREAD_PANEL_DEFAULT_WIDTH);
+  const [isResizingThreadPanel, setIsResizingThreadPanel] = useState(false);
+
+  useEffect(() => {
+    const selectedStillExists = selectedThreadId
+      ? threads.some(({ thread }) => thread.id === selectedThreadId)
+      : false;
+    const latestChanged =
+      !!latestThreadId &&
+      !!previousLatestThreadIdRef.current &&
+      previousLatestThreadIdRef.current !== latestThreadId;
+    previousLatestThreadIdRef.current = latestThreadId;
+    const activePendingThreadChanged =
+      !!activePendingThreadId &&
+      previousActivePendingThreadIdRef.current !== activePendingThreadId;
+    previousActivePendingThreadIdRef.current = activePendingThreadId;
+
+    if (activePendingThreadChanged && selectedThreadId !== activePendingThreadId) {
+      setSelectedThreadId(activePendingThreadId);
+      setPanelClosed(false);
+      return;
+    }
+
+    if (latestChanged && selectedThreadId !== latestThreadId) {
+      setSelectedThreadId(latestThreadId);
+      setPanelClosed(false);
+      return;
+    }
+
+    if (!selectedStillExists && latestThreadId && !panelClosed) {
+      setSelectedThreadId(latestThreadId);
+      return;
+    }
+
+    if (selectedThreadId && !selectedStillExists) {
+      setSelectedThreadId(panelClosed ? null : latestThreadId);
+    }
+  }, [activePendingThreadId, latestThreadId, panelClosed, selectedThreadId, threads]);
+
+  const handleThreadResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = threadPanelWidth;
+      const containerWidth = containerRef.current?.getBoundingClientRect().width ?? window.innerWidth;
+      const maxWidth = Math.max(
+        THREAD_PANEL_MIN_WIDTH,
+        Math.min(THREAD_PANEL_MAX_WIDTH, containerWidth - THREAD_MAIN_MIN_WIDTH),
+      );
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+
+      setIsResizingThreadPanel(true);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const nextWidth = startWidth + startX - moveEvent.clientX;
+        setThreadPanelWidth(Math.max(THREAD_PANEL_MIN_WIDTH, Math.min(maxWidth, nextWidth)));
+      };
+      const handlePointerUp = () => {
+        setIsResizingThreadPanel(false);
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerUp);
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+    },
+    [threadPanelWidth],
+  );
+
+  const selectedThread = selectedThreadId
+    ? threads.find(({ thread }) => thread.id === selectedThreadId)?.thread ?? null
+    : null;
+
+  const selectThread = useCallback((threadId: string) => {
+    setSelectedThreadId(threadId);
+    setPanelClosed(false);
+  }, []);
+
+  const closeThread = useCallback(() => {
+    setSelectedThreadId(null);
+    setPanelClosed(true);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex min-h-0 flex-1 overflow-hidden">
+      <div className={cn(
+        "flex min-w-0 flex-1 flex-col",
+        selectedThread && "hidden lg:flex",
+      )}
+      >
+        <div data-tab-scroll-root className="min-h-0 flex-1 overflow-y-auto">
+          {showSkeleton ? (
+            <ChatMessageSkeleton />
+          ) : timeline.length > 0 ? (
+            <div className="mx-auto w-full max-w-4xl space-y-5 px-6 py-4">
+              {hasOlderMessages && (
+                <div className="flex justify-center">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={isFetchingOlderMessages}
+                    onClick={onLoadOlderMessages}
+                  >
+                    {isFetchingOlderMessages
+                      ? t(($) => $.message_list.loading_older)
+                      : t(($) => $.thread.load_older)}
+                  </Button>
+                </div>
+              )}
+              {timeline.map((entry) => entry.kind === "standalone-assistant" ? (
+                <ThreadStandaloneAssistant
+                  key={entry.message.id}
+                  message={entry.message}
+                  agent={agent}
+                />
+              ) : (
+                <ThreadRootItem
+                  key={entry.thread.id}
+                  thread={entry.thread}
+                  agent={agent}
+                  user={user}
+                  selected={selectedThreadId === entry.thread.id}
+                  pending={pendingPlaceholderThreadId === entry.thread.id}
+                  pendingTask={pendingPlaceholderThreadId === entry.thread.id ? pendingTask : null}
+                  pendingTaskMessages={pendingTaskMessages ?? []}
+                  availability={availability}
+                  onSelect={() => selectThread(entry.thread.id)}
+                />
+              ))}
+            </div>
+          ) : (
+            emptyState
+          )}
+        </div>
+        {statusBanner}
+        {composer}
+      </div>
+      <AnimatePresence initial={false}>
+        {selectedThread && (
+          <motion.div
+            key="thread-panel-shell"
+            className="flex min-w-0 flex-1 lg:flex-none lg:w-[var(--thread-panel-width)]"
+            style={{ "--thread-panel-width": `${threadPanelWidth}px` } as React.CSSProperties}
+            initial={{ opacity: 0, x: 28 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 28 }}
+            transition={{ type: "spring", duration: 0.28, bounce: 0 }}
+          >
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label={t(($) => $.thread.resize)}
+              className="group hidden w-3 shrink-0 cursor-col-resize touch-none select-none items-stretch justify-center lg:flex"
+              onPointerDown={handleThreadResizePointerDown}
+            >
+              <span
+                className={cn(
+                  "w-px bg-border transition-colors group-hover:bg-foreground/30",
+                  isResizingThreadPanel && "bg-brand",
+                )}
+              />
+            </div>
+            <ThreadPanel
+              thread={selectedThread}
+              agent={agent}
+              user={user}
+              pendingTask={activePendingThreadId === selectedThread.id ? pendingTask : null}
+              pendingTaskMessages={pendingTaskMessages ?? []}
+              availability={availability}
+              onClose={closeThread}
+              onSendThreadReply={onSendThreadReply}
+              restoreDraftRequest={restoreDraftRequest}
+              onRestoreDraftConsumed={onRestoreDraftConsumed}
+              onUploadFile={onUploadFile}
+              onStop={onStop}
+              isRunning={isRunning}
+              disabled={disabled}
+              noAgent={noAgent}
+              agentName={agentName}
+              contextItems={contextItems}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function ThreadStandaloneAssistant({
+  message,
+  agent,
+}: {
+  message: ChatMessage;
+  agent: Agent | null;
+}) {
+  return (
+    <div className="flex items-start gap-2.5">
+      {agent ? (
+        <ActorAvatar actorType="agent" actorId={agent.id} size={34} showStatusDot={!agent.archived_at} profileLink={false} />
+      ) : (
+        <span className="size-8 rounded-full bg-muted" />
+      )}
+      <div className="min-w-0 flex-1">
+        <MessageAuthorLine
+          name={agent?.name ?? "Agent"}
+          time={message.created_at}
+        />
+        <AssistantMessage message={message} isPending={false} />
+      </div>
+    </div>
+  );
+}
+
+function ThreadRootItem({
+  thread,
+  agent,
+  user,
+  selected,
+  pending,
+  pendingTask,
+  pendingTaskMessages,
+  availability,
+  onSelect,
+}: {
+  thread: ChatThread;
+  agent: Agent | null;
+  user: User | null;
+  selected: boolean;
+  pending: boolean;
+  pendingTask: ChatPendingTask | null | undefined;
+  pendingTaskMessages: readonly TaskMessagePayload[];
+  availability: AgentAvailability | undefined;
+  onSelect: () => void;
+}) {
+  const { t } = useT("chat");
+  const replyCount = thread.replies.length + (pending ? 1 : 0);
+  const latestReply = thread.replies[thread.replies.length - 1] ?? null;
+  const summaryTime = latestReply?.created_at ?? thread.root.created_at;
+  const hasReplySummary = replyCount > 0;
+  const replyText = pending
+    ? t(($) => $.thread.replying)
+    : t(($) => $.thread.reply, { count: replyCount });
+
+  return (
+    <div className={cn("rounded-lg py-0.5 transition-colors", selected && "bg-accent/30")}>
+      <div className="flex items-start gap-2.5 px-1">
+        <ActorAvatar
+          actorType="member"
+          actorId={user?.id ?? ""}
+          size={36}
+          profileLink={false}
+        />
+        <div className="min-w-0 flex-1">
+          <MessageAuthorLine
+            name={user?.name || user?.email || "You"}
+            time={thread.root.created_at}
+          />
+          <UserMessageContent message={thread.root} />
+          {hasReplySummary && (
+            <button
+              type="button"
+              onClick={onSelect}
+              className="mt-2 flex items-center gap-2 rounded-md py-0.5 pr-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/70 hover:text-foreground"
+            >
+              <span className="ml-2 h-6 w-7 rounded-bl-xl border-b border-l border-border" />
+              {pending && pendingTask ? (
+                <ThreadPendingInlineStatus
+                  agent={agent}
+                  pendingTask={pendingTask}
+                  taskMessages={pendingTaskMessages}
+                  availability={availability}
+                />
+              ) : (
+                <>
+                  {agent ? (
+                    <ActorAvatar actorType="agent" actorId={agent.id} size={18} profileLink={false} />
+                  ) : (
+                    <span className="size-4 rounded-full bg-muted" />
+                  )}
+                  <span className="font-medium">{replyText}</span>
+                  <span>{formatThreadTimestamp(summaryTime, (time) => t(($) => $.thread.today_at, { time }))}</span>
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ThreadPanel({
+  thread,
+  agent,
+  user,
+  pendingTask,
+  pendingTaskMessages,
+  availability,
+  onClose,
+  onSendThreadReply,
+  restoreDraftRequest,
+  onRestoreDraftConsumed,
+  onUploadFile,
+  onStop,
+  isRunning,
+  disabled,
+  noAgent,
+  agentName,
+  contextItems,
+}: {
+  thread: ChatThread;
+  agent: Agent | null;
+  user: User | null;
+  pendingTask: ChatPendingTask | null | undefined;
+  pendingTaskMessages: readonly TaskMessagePayload[];
+  availability: AgentAvailability | undefined;
+  onClose: () => void;
+  onSendThreadReply: ThreadReplySendHandler;
+  restoreDraftRequest?: {
+    id: string;
+    content: string;
+    attachments?: Attachment[];
+    sessionId?: string;
+    draftKeyScope?: string;
+  } | null;
+  onRestoreDraftConsumed?: () => void;
+  onUploadFile?: (file: File) => Promise<UploadResult | null>;
+  onStop?: (options?: { draftKeyScope?: string }) => void;
+  isRunning: boolean;
+  disabled: boolean;
+  noAgent: boolean;
+  agentName?: string;
+  contextItems?: MentionItem[];
+}) {
+  const { t } = useT("chat");
+  const threadTaskId = thread.threadTaskId ?? messageThreadTaskId(thread.root);
+  const chatThreadId = thread.chatThreadId ?? thread.root.chat_thread_id ?? null;
+  const draftKeyScope = `thread-${thread.id}`;
+  const pendingTaskId = pendingTask?.task_id ?? null;
+  const pendingReplyAlreadyPersisted = !!pendingTaskId && thread.replies.some(
+    (reply) => reply.role === "assistant" && reply.task_id === pendingTaskId,
+  );
+  const replyCount = thread.replies.length + (pendingTaskId && !pendingReplyAlreadyPersisted ? 1 : 0);
+  const titleName = user?.name || user?.email || "You";
+
+  return (
+    <aside className="flex min-w-0 flex-1 flex-col bg-background">
+      <div className="flex min-h-14 shrink-0 items-start justify-between gap-3 border-b px-5 py-2.5">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold">
+            {t(($) => $.thread.title, { name: titleName })}
+          </h2>
+          <div className="mt-1 text-sm text-muted-foreground">
+            {t(($) => $.thread.reply, { count: replyCount })}
+          </div>
+        </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0 rounded-full text-muted-foreground"
+                onClick={onClose}
+                aria-label={t(($) => $.thread.close)}
+              />
+            }
+          >
+            <X />
+          </TooltipTrigger>
+          <TooltipContent side="left">{t(($) => $.thread.close)}</TooltipContent>
+        </Tooltip>
+      </div>
+      <div data-tab-scroll-root className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        <div className="space-y-4">
+          <div className="flex items-start gap-2.5">
+            <ActorAvatar
+              actorType="member"
+              actorId={user?.id ?? ""}
+              size={34}
+              profileLink={false}
+            />
+            <div className="min-w-0 flex-1">
+              <MessageAuthorLine
+                name={user?.name || user?.email || "You"}
+                time={thread.root.created_at}
+              />
+              <UserMessageContent message={thread.root} />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2.5 text-sm text-muted-foreground">
+            <span className="whitespace-nowrap">
+              {t(($) => $.thread.reply, { count: replyCount })}
+            </span>
+            <span className="h-px flex-1 bg-border" />
+          </div>
+
+          {thread.replies.map((reply) => (
+            <ThreadReplyMessage
+              key={reply.id}
+              message={reply}
+              agent={agent}
+              user={user}
+              pendingTaskId={pendingTaskId}
+            />
+          ))}
+
+          {pendingTask?.task_id && !pendingReplyAlreadyPersisted && (
+            <ThreadPendingReply
+              agent={agent}
+              pendingTask={pendingTask}
+              taskMessages={pendingTaskMessages}
+              availability={availability}
+            />
+          )}
+        </div>
+      </div>
+      {(chatThreadId || threadTaskId) && (
+        <ChatInput
+          onSend={(content, attachmentIds, commitInput, draftAttachments) =>
+            onSendThreadReply(
+              chatThreadId,
+              threadTaskId,
+              thread.id,
+              draftKeyScope,
+              content,
+              attachmentIds,
+              commitInput,
+              draftAttachments,
+            )}
+          restoreDraftRequest={restoreDraftRequest}
+          onRestoreDraftConsumed={onRestoreDraftConsumed}
+          onUploadFile={onUploadFile}
+          onStop={onStop ? () => onStop({ draftKeyScope }) : undefined}
+          isRunning={isRunning}
+          disabled={disabled}
+          noAgent={noAgent}
+          agentName={agentName}
+          draftKeyScope={draftKeyScope}
+          placeholder={t(($) => $.thread.input_placeholder)}
+          contextItems={contextItems}
+        />
+      )}
+    </aside>
+  );
+}
+
+function ThreadReplyMessage({
+  message,
+  agent,
+  user,
+  pendingTaskId,
+}: {
+  message: ChatMessage;
+  agent: Agent | null;
+  user: User | null;
+  pendingTaskId: string | null;
+}) {
+  if (message.role === "user") {
+    return (
+      <div className="flex items-start gap-2.5">
+        <ActorAvatar
+          actorType="member"
+          actorId={user?.id ?? ""}
+          size={34}
+          profileLink={false}
+        />
+        <div className="min-w-0 flex-1">
+          <MessageAuthorLine
+            name={user?.name || user?.email || "You"}
+            time={message.created_at}
+          />
+          <UserMessageContent message={message} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-2.5">
+      {agent ? (
+        <ActorAvatar actorType="agent" actorId={agent.id} size={34} showStatusDot={!agent.archived_at} profileLink={false} />
+      ) : (
+        <span className="size-8 rounded-full bg-muted" />
+      )}
+      <div className="min-w-0 flex-1">
+        <MessageAuthorLine
+          name={agent?.name ?? "Agent"}
+          time={message.created_at}
+        />
+        <AssistantMessage message={message} isPending={message.task_id === pendingTaskId} />
+      </div>
+    </div>
+  );
+}
+
+function ThreadPendingReply({
+  agent,
+  pendingTask,
+  taskMessages,
+  availability,
+}: {
+  agent: Agent | null;
+  pendingTask: ChatPendingTask;
+  taskMessages: readonly TaskMessagePayload[];
+  availability: AgentAvailability | undefined;
+}) {
+  return (
+    <div className="flex items-start gap-2.5">
+      {agent ? (
+        <ActorAvatar actorType="agent" actorId={agent.id} size={34} showStatusDot={!agent.archived_at} profileLink={false} />
+      ) : (
+        <span className="size-8 rounded-full bg-muted" />
+      )}
+      <div className="min-w-0 flex-1 pt-0.5">
+        <TaskStatusPill
+          pendingTask={pendingTask}
+          taskMessages={taskMessages}
+          availability={availability}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ThreadPendingInlineStatus({
+  agent,
+  pendingTask,
+  taskMessages,
+  availability,
+}: {
+  agent: Agent | null;
+  pendingTask: ChatPendingTask;
+  taskMessages: readonly TaskMessagePayload[];
+  availability: AgentAvailability | undefined;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-1.5 rounded-full bg-muted px-1.5 py-1">
+      {agent ? (
+        <ActorAvatar actorType="agent" actorId={agent.id} size={22} profileLink={false} />
+      ) : (
+        <span className="size-5 rounded-full bg-background" />
+      )}
+      <TaskStatusPill
+        pendingTask={pendingTask}
+        taskMessages={taskMessages}
+        availability={availability}
+      />
+    </div>
+  );
+}
+
+function MessageAuthorLine({
+  name,
+  time,
+}: {
+  name: string;
+  time: string;
+}) {
+  return (
+    <div className="mb-0.5 flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+      <span className="truncate text-sm font-semibold">{name}</span>
+      <span className="text-sm text-muted-foreground">{formatMessageTime(time)}</span>
+    </div>
+  );
+}
+
+function UserMessageContent({ message }: { message: ChatMessage }) {
+  return (
+    <div className="min-w-0 overflow-x-auto text-sm leading-normal prose prose-sm dark:prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+      <Markdown attachments={message.attachments}>{message.content}</Markdown>
+      <AttachmentList
+        attachments={message.attachments}
+        content={message.content}
+        className="mt-1.5"
+      />
+    </div>
   );
 }
 

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -987,6 +987,7 @@ function ChatSurface({ mode, routeAgentId }: ChatSurfaceProps) {
           </div>
         </div>
         <ThreadedChatPageBody
+          key={effectiveActiveSessionId ?? routeAgentId ?? "agent-chat"}
           messages={messages}
           pendingTask={pendingTask}
           availability={availability}
@@ -1439,7 +1440,8 @@ function ThreadedChatPageBody({
               onRestoreDraftConsumed={onRestoreDraftConsumed}
               onUploadFile={onUploadFile}
               onStop={onStop}
-              isRunning={isRunning}
+              isRunning={activePendingThreadId === selectedThread.id && isRunning}
+              sendBlocked={!!pendingTaskId && activePendingThreadId !== selectedThread.id}
               disabled={disabled}
               noAgent={noAgent}
               agentName={agentName}
@@ -1569,6 +1571,7 @@ function ThreadPanel({
   onUploadFile,
   onStop,
   isRunning,
+  sendBlocked,
   disabled,
   noAgent,
   agentName,
@@ -1593,6 +1596,7 @@ function ThreadPanel({
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
   onStop?: (options?: { draftKeyScope?: string }) => void;
   isRunning: boolean;
+  sendBlocked?: boolean;
   disabled: boolean;
   noAgent: boolean;
   agentName?: string;
@@ -1701,6 +1705,7 @@ function ThreadPanel({
           onUploadFile={onUploadFile}
           onStop={onStop ? () => onStop({ draftKeyScope }) : undefined}
           isRunning={isRunning}
+          sendBlocked={sendBlocked}
           disabled={disabled}
           noAgent={noAgent}
           agentName={agentName}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -349,7 +349,11 @@ function ChatSurface({ mode, routeAgentId }: ChatSurfaceProps) {
   // returns "loading" while queries are still resolving — pass `undefined`
   // downstream so banners and pill copy stay silent during loading rather
   // than flash speculative offline text.
-  const presenceDetail = useAgentPresenceDetail(wsId, activeAgent?.id);
+  // Key presence on the DISPLAYED agent, not the assignable one: in page mode
+  // an agent the viewer can't assign (e.g. someone else's private agent) still
+  // resolves as `routeAgent`, so its real online/offline state surfaces in the
+  // header dot and OfflineBanner instead of falling back to neutral.
+  const presenceDetail = useAgentPresenceDetail(wsId, displayAgent?.id);
   const availability =
     presenceDetail === "loading" ? undefined : presenceDetail.availability;
 
@@ -814,7 +818,7 @@ function ChatSurface({ mode, routeAgentId }: ChatSurfaceProps) {
   const statusBanner = noAgent ? (
     <NoAgentBanner />
   ) : (
-    <OfflineBanner agentName={activeAgent?.name} availability={availability} />
+    <OfflineBanner agentName={displayAgent?.name ?? activeAgent?.name} availability={availability} />
   );
 
   const composer = (
@@ -1084,7 +1088,7 @@ function isThreadReplyMessage(message: ChatMessage): boolean {
   return !!threadTaskId && !!message.task_id && threadTaskId !== message.task_id;
 }
 
-function buildThreadTimeline(messages: ChatMessage[]): ThreadTimelineEntry[] {
+export function buildThreadTimeline(messages: ChatMessage[]): ThreadTimelineEntry[] {
   const timeline: ThreadTimelineEntry[] = [];
   const threadsByThreadKey = new Map<string, ChatThread>();
   const pendingRepliesByThreadKey = new Map<string, ChatMessage[]>();
@@ -1142,6 +1146,36 @@ function buildThreadTimeline(messages: ChatMessage[]): ThreadTimelineEntry[] {
     } else {
       timeline.push({ kind: "standalone-assistant", message });
     }
+  }
+
+  // Fallback: any reply we buffered but never matched to a root (a legacy /
+  // racy keying mismatch where a reply's thread key never resolves to a
+  // surfaced root) must still be visible — a persisted message is never
+  // silently dropped. Surface each orphan in chronological order as its own
+  // entry, and warn so the mismatch is observable rather than a black hole.
+  if (pendingRepliesByThreadKey.size > 0) {
+    const orphans = [...pendingRepliesByThreadKey.values()]
+      .flat()
+      .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+    for (const message of orphans) {
+      if (message.role === "user") {
+        timeline.push({
+          kind: "thread",
+          thread: {
+            id: messageThreadKey(message) ?? message.id,
+            chatThreadId: message.chat_thread_id ?? null,
+            threadTaskId: messageThreadTaskId(message),
+            root: message,
+            replies: [],
+          },
+        });
+      } else {
+        timeline.push({ kind: "standalone-assistant", message });
+      }
+    }
+    uiLogger.warn("buildThreadTimeline: unmatched thread replies surfaced as fallback", {
+      orphanCount: orphans.length,
+    });
   }
 
   return timeline;

--- a/packages/views/chat/index.ts
+++ b/packages/views/chat/index.ts
@@ -1,2 +1,2 @@
 export { ChatFab } from "./components/chat-fab";
-export { ChatWindow } from "./components/chat-window";
+export { AgentChatPage, ChatWindow } from "./components/chat-window";

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
 
-const { detail, deletePin, navigation, pins, summary, workspaces } = vi.hoisted(() => ({
+const { agents, detail, deletePin, navigation, pins, summary, workspaces } = vi.hoisted(() => ({
+  agents: {
+    current: [] as { id: string; name: string; archived_at: string | null }[],
+  },
   detail: { current: { isPending: false, isError: false, data: null as unknown, error: null as unknown } },
   deletePin: vi.fn(),
   navigation: { current: { pathname: "/acme/issues" } },
@@ -17,7 +20,7 @@ const { detail, deletePin, navigation, pins, summary, workspaces } = vi.hoisted(
         id: "pin-1",
         workspace_id: "ws-1",
         user_id: "user-1",
-        item_type: "issue" as const,
+        item_type: "issue" as "issue" | "project" | "agent",
         item_id: "issue-1",
         position: 0,
         created_at: "2026-05-06T00:00:00Z",
@@ -51,13 +54,15 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
   SidebarMenuButton: ({
     children,
     isActive,
+    onClick,
     render,
   }: {
     children: React.ReactNode;
     isActive?: boolean;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
     render?: React.ReactElement<{ href?: string }>;
   }) => (
-    <button type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href}>
+    <button type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href} onClick={onClick}>
       {children}
     </button>
   ),
@@ -92,6 +97,7 @@ vi.mock("../navigation", () => ({
 }));
 vi.mock("../projects/components/project-icon", () => ({ ProjectIcon: () => <span /> }));
 vi.mock("../workspace/workspace-avatar", () => ({ WorkspaceAvatar: () => <span /> }));
+vi.mock("../common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 vi.mock("@multica/ui/components/common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
 
 vi.mock("@multica/core/auth", () => ({
@@ -114,6 +120,7 @@ vi.mock("@multica/core/paths", () => ({
     settings: () => "/acme/settings",
     issueDetail: (id: string) => `/acme/issues/${id}`,
     projectDetail: (id: string) => `/acme/projects/${id}`,
+    agentChat: (id: string) => `/acme/agents/${id}/chat`,
   }),
 }));
 vi.mock("@multica/core/api", async (importOriginal) => {
@@ -149,6 +156,7 @@ vi.mock("@multica/core/pins/queries", () => ({ pinListOptions: () => ({ queryKey
 vi.mock("@multica/core/projects/queries", () => ({ projectDetailOptions: () => ({ queryKey: ["project"] }) }));
 vi.mock("@multica/core/runtimes/hooks", () => ({ useMyRuntimesNeedUpdate: () => false }));
 vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: () => ({ queryKey: ["agents"] }),
   myInvitationListOptions: () => ({ queryKey: ["invitations"] }),
   workspaceKeys: { myInvitations: () => ["invitations"] },
   workspaceListOptions: () => ({ queryKey: ["workspaces"] }),
@@ -159,6 +167,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
   useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
     if (queryKey[0] === "pins") return { data: pins.current };
     if (queryKey[0] === "issue") return detail.current;
+    if (queryKey[0] === "agents") return { data: agents.current, isPending: false, isError: false };
     if (queryKey[0] === "inbox" && queryKey[1] === "unread-summary") return { data: summary.current };
     if (queryKey[0] === "workspaces") return { data: workspaces.current };
     return { data: [] };
@@ -168,9 +177,21 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
 
 describe("PinRow", () => {
   beforeEach(() => {
+    agents.current = [];
     deletePin.mockReset();
     navigation.current.pathname = "/acme/issues";
     detail.current = { isPending: false, isError: false, data: null, error: null };
+    pins.current = [
+      {
+        id: "pin-1",
+        workspace_id: "ws-1",
+        user_id: "user-1",
+        item_type: "issue",
+        item_id: "issue-1",
+        position: 0,
+        created_at: "2026-05-06T00:00:00Z",
+      },
+    ];
     summary.current = [];
     workspaces.current = [];
   });
@@ -210,6 +231,28 @@ describe("PinRow", () => {
       "true",
     );
     expect(container.querySelector('button[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+  });
+
+  it("links an agent pin to the agent chat page", async () => {
+    pins.current = [
+      {
+        id: "pin-agent-1",
+        workspace_id: "ws-1",
+        user_id: "user-1",
+        item_type: "agent",
+        item_id: "agent-1",
+        position: 0,
+        created_at: "2026-05-06T00:00:00Z",
+      },
+    ];
+    agents.current = [{ id: "agent-1", name: "Onboarding Assistant", archived_at: null }];
+
+    render(<AppSidebar />);
+
+    expect((await screen.findByText("Onboarding Assistant")).closest("button")).toHaveAttribute(
+      "data-href",
+      "/acme/agents/agent-1/chat",
+    );
   });
 });
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -37,7 +37,8 @@ import {
   Users,
 } from "lucide-react";
 import { WorkspaceAvatar } from "../workspace/workspace-avatar";
-import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
+import { ActorAvatar as UiActorAvatar } from "@multica/ui/components/common/actor-avatar";
+import { ActorAvatar } from "../common/actor-avatar";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@multica/ui/components/ui/collapsible";
 import { StatusIcon } from "../issues/components/status-icon";
@@ -67,7 +68,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths, paths } from "@multica/core/paths";
-import { workspaceListOptions, myInvitationListOptions, workspaceKeys } from "@multica/core/workspace/queries";
+import { workspaceListOptions, myInvitationListOptions, workspaceKeys, agentListOptions } from "@multica/core/workspace/queries";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { inboxKeys, deduplicateInboxItems, inboxUnreadSummaryOptions, hasOtherWorkspaceUnread, unreadWorkspaceIds } from "@multica/core/inbox/queries";
@@ -79,7 +80,7 @@ import { pinListOptions } from "@multica/core/pins/queries";
 import { useDeletePin, useReorderPins } from "@multica/core/pins/mutations";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { projectDetailOptions } from "@multica/core/projects/queries";
-import type { PinnedItem } from "@multica/core/types";
+import type { Agent, PinnedItem } from "@multica/core/types";
 import { useLogout } from "../auth";
 import { ProjectIcon } from "../projects/components/project-icon";
 import { useT } from "../i18n";
@@ -98,6 +99,7 @@ function isNavActive(pathname: string, href: string): boolean {
 // `useEffect`/`useMemo` that depends on the value, and can trigger infinite
 // re-render loops when the effect itself calls `setState`.
 const EMPTY_PINS: PinnedItem[] = [];
+const EMPTY_AGENTS: Agent[] = [];
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
 const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
 const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
@@ -152,6 +154,20 @@ const configureNav: { key: NavKey; labelKey: NavLabelKey; icon: typeof Inbox }[]
   { key: "skills", labelKey: "skills", icon: BookOpenText },
   { key: "settings", labelKey: "settings", icon: Settings },
 ];
+
+type NonAgentPin = PinnedItem & { item_type: "issue" | "project" };
+type AgentPin = PinnedItem & { item_type: "agent" };
+
+function isAgentPin(pin: PinnedItem): pin is AgentPin {
+  return pin.item_type === "agent";
+}
+
+function isNonAgentPin(pin: PinnedItem): pin is NonAgentPin {
+  return !isAgentPin(pin);
+}
+
+const EMPTY_NON_AGENT_PINS: NonAgentPin[] = [];
+const EMPTY_AGENT_PINS: AgentPin[] = [];
 
 function DraftDot() {
   const hasDraft = useIssueDraftStore((s) => !!(s.draft.title || s.draft.description));
@@ -321,6 +337,131 @@ function PinRow({
   );
 }
 
+function SortableAgentPinItem({
+  pin,
+  agent,
+  href,
+  active,
+  onUnpin,
+}: {
+  pin: AgentPin;
+  agent: Agent;
+  href: string;
+  active: boolean;
+  onUnpin: () => void;
+}) {
+  const { t } = useT("layout");
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: pin.id });
+  const wasDragged = useRef(false);
+  const isArchived = !!agent.archived_at;
+
+  useEffect(() => {
+    if (isDragging) wasDragged.current = true;
+  }, [isDragging]);
+
+  const style = { transform: CSS.Transform.toString(transform), transition };
+
+  return (
+    <SidebarMenuItem
+      ref={setNodeRef}
+      style={style}
+      className={cn("group/pin", isDragging && "opacity-30")}
+      {...attributes}
+      {...listeners}
+    >
+      <SidebarMenuButton
+        size="sm"
+        isActive={active}
+        render={<AppLink href={href} draggable={false} />}
+        onClick={(event) => {
+          if (wasDragged.current) {
+            wasDragged.current = false;
+            event.preventDefault();
+            return;
+          }
+          if (isArchived) {
+            event.preventDefault();
+          }
+        }}
+        className={cn(
+          "text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground",
+          isDragging && "pointer-events-none",
+          isArchived && "opacity-50",
+        )}
+      >
+        <ActorAvatar
+          actorType="agent"
+          actorId={agent.id}
+          size={18}
+          className="shrink-0 rounded-md"
+          showStatusDot={!isArchived}
+        />
+        <span
+          className="min-w-0 flex-1 overflow-hidden whitespace-nowrap"
+          style={{
+            maskImage: "linear-gradient(to right, black calc(100% - 12px), transparent)",
+            WebkitMaskImage: "linear-gradient(to right, black calc(100% - 12px), transparent)",
+          }}
+        >{agent.name}</span>
+        <Tooltip>
+          <TooltipTrigger
+            render={<span role="button" />}
+            className="hidden size-2.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground group-hover/pin:flex hover:text-foreground"
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onUnpin();
+            }}
+          >
+            <X className="size-1" />
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>{t(($) => $.sidebar.unpin_tooltip)}</TooltipContent>
+        </Tooltip>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+function AgentPinRow({
+  pin,
+  wsId,
+  href,
+  active,
+  onUnpin,
+}: {
+  pin: AgentPin;
+  wsId: string;
+  href: string;
+  active: boolean;
+  onUnpin: () => void;
+}) {
+  const { data: agents = EMPTY_AGENTS, isPending, isError } = useQuery({
+    ...agentListOptions(wsId),
+    enabled: !!wsId,
+  });
+  const agent = agents.find((a) => a.id === pin.item_id) ?? null;
+  const triggeredRef = useRef(false);
+
+  useEffect(() => {
+    if (isPending || isError || agent || triggeredRef.current) return;
+    triggeredRef.current = true;
+    onUnpin();
+  }, [agent, isError, isPending, onUnpin]);
+
+  if (isPending) return <PinSkeleton />;
+  if (isError || !agent) return null;
+
+  return (
+    <SortableAgentPinItem
+      pin={pin}
+      agent={agent}
+      href={href}
+      active={active}
+      onUnpin={onUnpin}
+    />
+  );
+}
+
 function PinSkeleton() {
   return (
     <SidebarMenuItem>
@@ -330,6 +471,21 @@ function PinSkeleton() {
       </div>
     </SidebarMenuItem>
   );
+}
+
+function reorderPinnedSubset(
+  pins: PinnedItem[],
+  activeId: string,
+  overId: string,
+  predicate: (pin: PinnedItem) => boolean,
+) {
+  const subset = pins.filter(predicate);
+  const oldIndex = subset.findIndex((p) => p.id === activeId);
+  const newIndex = subset.findIndex((p) => p.id === overId);
+  if (oldIndex === -1 || newIndex === -1) return null;
+  const reorderedSubset = arrayMove(subset, oldIndex, newIndex);
+  let cursor = 0;
+  return pins.map((pin) => (predicate(pin) ? reorderedSubset[cursor++] ?? pin : pin));
 }
 
 interface AppSidebarProps {
@@ -390,7 +546,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const sidebarScrollRef = useRef<HTMLDivElement>(null);
   const sidebarFadeStyle = useScrollFade(sidebarScrollRef, 24);
   const getPinHref = useCallback(
-    (pin: PinnedItem) => (pin.item_type === "issue" ? p.issueDetail(pin.item_id) : p.projectDetail(pin.item_id)),
+    (pin: NonAgentPin) => (pin.item_type === "issue" ? p.issueDetail(pin.item_id) : p.projectDetail(pin.item_id)),
+    [p],
+  );
+  const getAgentPinHref = useCallback(
+    (pin: AgentPin) => p.agentChat(pin.item_id),
     [p],
   );
 
@@ -409,21 +569,28 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   useEffect(() => {
     setLocalPinnedWsId(wsId ?? null);
   }, [wsId]);
-  const visiblePinned = localPinnedWsId === (wsId ?? null) ? localPinned : EMPTY_PINS;
-  const isActivePinnedRoute = visiblePinned.some((pin) => pathname === getPinHref(pin));
+  const visiblePinned = localPinnedWsId === (wsId ?? null) ? localPinned.filter(isNonAgentPin) : EMPTY_NON_AGENT_PINS;
+  const visibleAgentPins = localPinnedWsId === (wsId ?? null) ? localPinned.filter(isAgentPin) : EMPTY_AGENT_PINS;
+  const isActivePinnedRoute =
+    visiblePinned.some((pin) => pathname === getPinHref(pin)) ||
+    visibleAgentPins.some((pin) => pathname === getAgentPinHref(pin));
 
   const handleDragStart = useCallback(() => {
     isDraggingRef.current = true;
   }, []);
-  const handleDragEnd = useCallback(
+  const handleDragEndFor = useCallback(
+    (predicate: (pin: PinnedItem) => boolean) =>
     (event: DragEndEvent) => {
       isDraggingRef.current = false;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      const oldIndex = localPinned.findIndex((p) => p.id === active.id);
-      const newIndex = localPinned.findIndex((p) => p.id === over.id);
-      if (oldIndex === -1 || newIndex === -1) return;
-      const reordered = arrayMove(localPinned, oldIndex, newIndex);
+      const reordered = reorderPinnedSubset(
+        localPinned,
+        String(active.id),
+        String(over.id),
+        predicate,
+      );
+      if (!reordered) return;
       setLocalPinned(reordered);
       reorderPins.mutate(reordered);
     },
@@ -523,7 +690,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   sideOffset={4}
                 >
                   <div className="flex items-center gap-2.5 px-2 py-1.5">
-                    <ActorAvatar
+                    <UiActorAvatar
                       name={user?.name ?? ""}
                       initials={(user?.name ?? "U").charAt(0).toUpperCase()}
                       avatarUrl={resolvePublicFileUrl(user?.avatar_url)}
@@ -690,10 +857,10 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                 </SidebarGroupLabel>
                 <CollapsibleContent>
                   <SidebarGroupContent>
-                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEndFor(isNonAgentPin)}>
                       <SortableContext items={visiblePinned.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                         <SidebarMenu className="gap-0.5">
-                          {visiblePinned.map((pin: PinnedItem) => (
+                          {visiblePinned.map((pin) => (
                             <PinRow
                               key={pin.id}
                               pin={pin}
@@ -701,6 +868,41 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                               pathname={pathname}
                               onUnpin={() => deletePin.mutate({ itemType: pin.item_type, itemId: pin.item_id })}
                               wsId={wsId ?? ""}
+                            />
+                          ))}
+                        </SidebarMenu>
+                      </SortableContext>
+                    </DndContext>
+                  </SidebarGroupContent>
+                </CollapsibleContent>
+              </SidebarGroup>
+            </Collapsible>
+          )}
+
+          {visibleAgentPins.length > 0 && (
+            <Collapsible defaultOpen>
+              <SidebarGroup className="group/pinned">
+                <SidebarGroupLabel
+                  render={<CollapsibleTrigger />}
+                  className="group/trigger cursor-pointer hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground"
+                >
+                  <span>{t(($) => $.sidebar.agents_label)}</span>
+                  <ChevronRight className="!size-3 ml-1 stroke-[2.5] transition-transform duration-200 group-data-[panel-open]/trigger:rotate-90" />
+                  <span className="ml-auto text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/pinned:opacity-100">{visibleAgentPins.length}</span>
+                </SidebarGroupLabel>
+                <CollapsibleContent>
+                  <SidebarGroupContent>
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEndFor(isAgentPin)}>
+                      <SortableContext items={visibleAgentPins.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+                        <SidebarMenu className="gap-0.5">
+                          {visibleAgentPins.map((pin) => (
+                            <AgentPinRow
+                              key={pin.id}
+                              pin={pin}
+                              wsId={wsId ?? ""}
+                              href={getAgentPinHref(pin)}
+                              active={pathname === getAgentPinHref(pin)}
+                              onUnpin={() => deletePin.mutate({ itemType: pin.item_type, itemId: pin.item_id })}
                             />
                           ))}
                         </SidebarMenu>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -94,6 +94,8 @@
     "failed_suffix": " · {{count}} failed ({{percent}}%)"
   },
   "row_actions": {
+    "pin_to_sidebar": "Pin to sidebar",
+    "unpin_from_sidebar": "Unpin from sidebar",
     "cancel_all_tasks": "Cancel all tasks",
     "duplicate": "Duplicate",
     "restore": "Restore",
@@ -136,6 +138,8 @@
     "archive_dialog_cancel": "Cancel",
     "archive_dialog_confirm": "Archive",
     "more_archive": "Archive Agent",
+    "pin_tooltip": "Pin to sidebar",
+    "unpin_tooltip": "Unpin from sidebar",
     "agent_updated_toast": "Agent updated",
     "update_failed_toast": "Failed to update agent",
     "agent_archived_toast": "Agent archived",

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -82,6 +82,21 @@
     "history_group": "Chat history",
     "agent_filter_placeholder": "Search agents..."
   },
+  "page": {
+    "chat_tab": "Chat",
+    "show_profile": "Show profile"
+  },
+  "thread": {
+    "title": "{{name}}'s Thread",
+    "replying": "Replying",
+    "reply_one": "1 reply",
+    "reply_other": "{{count}} replies",
+    "today_at": "Today at {{time}}",
+    "input_placeholder": "Reply in thread…",
+    "load_older": "Load older messages",
+    "close": "Close thread",
+    "resize": "Resize thread panel"
+  },
   "empty_state": {
     "first_time_title": "Chat with your agents",
     "first_time_intro": "✨ They know your workspace —",

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -35,6 +35,7 @@
     "new_issue": "New Issue",
     "new_issue_shortcut": "C",
     "pinned_label": "Pinned",
+    "agents_label": "Agents",
     "workspace_group": "Workspace",
     "configure_group": "Configure",
     "unread_overflow": "99+",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -83,6 +83,8 @@
     "failed_suffix": " · {{count}} 回失敗（{{percent}}%）"
   },
   "row_actions": {
+    "pin_to_sidebar": "サイドバーにピン留め",
+    "unpin_from_sidebar": "サイドバーからピン留めを解除",
     "cancel_all_tasks": "すべてのタスクをキャンセル",
     "duplicate": "複製",
     "restore": "復元",
@@ -123,6 +125,8 @@
     "archive_dialog_cancel": "キャンセル",
     "archive_dialog_confirm": "アーカイブ",
     "more_archive": "エージェントをアーカイブ",
+    "pin_tooltip": "サイドバーにピン留め",
+    "unpin_tooltip": "サイドバーからピン留めを解除",
     "agent_updated_toast": "エージェントを更新しました",
     "update_failed_toast": "エージェントを更新できませんでした",
     "agent_archived_toast": "エージェントをアーカイブしました",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -79,6 +79,21 @@
     "history_group": "チャット履歴",
     "agent_filter_placeholder": "エージェントを検索..."
   },
+  "page": {
+    "chat_tab": "チャット",
+    "show_profile": "プロフィールを表示"
+  },
+  "thread": {
+    "title": "{{name}} のスレッド",
+    "replying": "返信中",
+    "reply_one": "1 件の返信",
+    "reply_other": "{{count}} 件の返信",
+    "today_at": "今日 {{time}}",
+    "input_placeholder": "スレッドに返信…",
+    "load_older": "以前のメッセージを読み込む",
+    "close": "スレッドを閉じる",
+    "resize": "スレッドパネルの幅を変更"
+  },
   "empty_state": {
     "first_time_title": "エージェントとチャット",
     "first_time_intro": "✨ エージェントはあなたのワークスペースを把握しています —",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -35,6 +35,7 @@
     "new_issue": "新規イシュー",
     "new_issue_shortcut": "C",
     "pinned_label": "ピン留め済み",
+    "agents_label": "エージェント",
     "workspace_group": "ワークスペース",
     "configure_group": "設定",
     "unread_overflow": "99+",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -94,6 +94,8 @@
     "failed_suffix": " · 실패 {{count}}회({{percent}}%)"
   },
   "row_actions": {
+    "pin_to_sidebar": "사이드바에 고정",
+    "unpin_from_sidebar": "사이드바에서 고정 해제",
     "cancel_all_tasks": "모든 작업 취소",
     "duplicate": "복제",
     "restore": "복원",
@@ -136,6 +138,8 @@
     "archive_dialog_cancel": "취소",
     "archive_dialog_confirm": "보관",
     "more_archive": "에이전트 보관",
+    "pin_tooltip": "사이드바에 고정",
+    "unpin_tooltip": "사이드바에서 고정 해제",
     "agent_updated_toast": "에이전트를 업데이트했습니다",
     "update_failed_toast": "에이전트를 업데이트하지 못했습니다",
     "agent_archived_toast": "에이전트를 보관했습니다",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -82,6 +82,21 @@
     "history_group": "채팅 기록",
     "agent_filter_placeholder": "에이전트 검색..."
   },
+  "page": {
+    "chat_tab": "채팅",
+    "show_profile": "프로필 보기"
+  },
+  "thread": {
+    "title": "{{name}}의 스레드",
+    "replying": "답변 중",
+    "reply_one": "답글 1개",
+    "reply_other": "답글 {{count}}개",
+    "today_at": "오늘 {{time}}",
+    "input_placeholder": "스레드에 답글 쓰기…",
+    "load_older": "이전 메시지 불러오기",
+    "close": "스레드 닫기",
+    "resize": "스레드 패널 너비 조절"
+  },
   "empty_state": {
     "first_time_title": "에이전트와 채팅하기",
     "first_time_intro": "✨ 에이전트는 내 워크스페이스를 알고 있습니다 —",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -35,6 +35,7 @@
     "new_issue": "새 이슈",
     "new_issue_shortcut": "C",
     "pinned_label": "고정됨",
+    "agents_label": "에이전트",
     "workspace_group": "워크스페이스",
     "configure_group": "설정",
     "unread_overflow": "99+",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -91,6 +91,8 @@
     "failed_suffix": " · {{count}} 次失败（{{percent}}%）"
   },
   "row_actions": {
+    "pin_to_sidebar": "固定到侧边栏",
+    "unpin_from_sidebar": "从侧边栏取消固定",
     "cancel_all_tasks": "取消全部 task",
     "duplicate": "复制",
     "restore": "恢复",
@@ -131,6 +133,8 @@
     "archive_dialog_cancel": "取消",
     "archive_dialog_confirm": "归档",
     "more_archive": "归档智能体",
+    "pin_tooltip": "固定到侧边栏",
+    "unpin_tooltip": "从侧边栏取消固定",
     "agent_updated_toast": "已更新智能体",
     "update_failed_toast": "更新智能体失败",
     "agent_archived_toast": "已归档智能体",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -79,6 +79,20 @@
     "history_group": "历史对话",
     "agent_filter_placeholder": "搜索智能体..."
   },
+  "page": {
+    "chat_tab": "对话",
+    "show_profile": "查看资料"
+  },
+  "thread": {
+    "title": "{{name}} 的 Thread",
+    "replying": "回复中",
+    "reply_other": "{{count}} 条回复",
+    "today_at": "今天 {{time}}",
+    "input_placeholder": "在 Thread 中回复…",
+    "load_older": "加载更早的消息",
+    "close": "关闭 Thread",
+    "resize": "调整 Thread 面板宽度"
+  },
   "empty_state": {
     "first_time_title": "和你的智能体对话",
     "first_time_intro": "✨ 它们了解你的工作区——",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -35,6 +35,7 @@
     "new_issue": "新建 issue",
     "new_issue_shortcut": "C",
     "pinned_label": "固定",
+    "agents_label": "智能体",
     "workspace_group": "工作区",
     "configure_group": "配置",
     "unread_overflow": "99+",

--- a/scripts/dev-desktop.sh
+++ b/scripts/dev-desktop.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+missing=()
+command -v node >/dev/null 2>&1 || missing+=("node")
+command -v go >/dev/null 2>&1 || missing+=("go")
+command -v docker >/dev/null 2>&1 || missing+=("docker")
+command -v curl >/dev/null 2>&1 || missing+=("curl")
+
+PNPM_BIN="${PNPM_BIN:-}"
+if [ -z "$PNPM_BIN" ]; then
+  package_manager="$(node -p "require('./package.json').packageManager || ''" 2>/dev/null || true)"
+  if [[ "$package_manager" == pnpm@* ]]; then
+    pnpm_version="${package_manager#pnpm@}"
+    candidate="$HOME/Library/pnpm/.tools/pnpm/${pnpm_version}/bin/pnpm"
+    if [ -x "$candidate" ]; then
+      PNPM_BIN="$candidate"
+    fi
+  fi
+fi
+if [ -z "$PNPM_BIN" ]; then
+  PNPM_BIN="$(command -v pnpm 2>/dev/null || true)"
+fi
+if [ -z "$PNPM_BIN" ]; then
+  missing+=("pnpm")
+fi
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "Missing prerequisites: ${missing[*]}"
+  echo "Install Node.js, pnpm, Go, and Docker before running desktop dev."
+  exit 1
+fi
+
+ENV_FILE="${1:-}"
+if [ -z "$ENV_FILE" ]; then
+  if [ -f .git ]; then
+    ENV_FILE=".env.worktree"
+  else
+    ENV_FILE=".env"
+  fi
+fi
+
+if [ "$ENV_FILE" = ".env.worktree" ] && [ ! -f "$ENV_FILE" ]; then
+  echo "==> Generating $ENV_FILE with isolated worktree ports..."
+  bash scripts/init-worktree-env.sh "$ENV_FILE"
+elif [ "$ENV_FILE" = ".env" ] && [ ! -f "$ENV_FILE" ]; then
+  echo "==> Creating $ENV_FILE from .env.example..."
+  cp .env.example "$ENV_FILE"
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing env file: $ENV_FILE"
+  exit 1
+fi
+
+echo "==> Using $ENV_FILE"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+# shellcheck disable=SC1091
+. scripts/local-env.sh
+
+desktop_api_url="${NEXT_PUBLIC_API_URL:-http://localhost:${PORT:-8080}}"
+desktop_ws_url="${NEXT_PUBLIC_WS_URL:-ws://localhost:${PORT:-8080}/ws}"
+desktop_app_url="${MULTICA_APP_URL:-${FRONTEND_ORIGIN:-http://localhost:${FRONTEND_PORT:-3000}}}"
+backend_ready_url="${desktop_api_url%/}/readyz"
+
+cat > apps/desktop/.env.development.local <<EOF
+VITE_API_URL=${desktop_api_url}
+VITE_WS_URL=${desktop_ws_url}
+VITE_APP_URL=${desktop_app_url}
+EOF
+
+if [ ! -d node_modules ]; then
+  echo "==> Installing dependencies..."
+  "$PNPM_BIN" install
+fi
+
+bash scripts/ensure-postgres.sh "$ENV_FILE"
+
+echo "==> Running migrations..."
+(cd server && go run ./cmd/migrate up)
+
+server_fingerprint() {
+  find server \
+    \( -path "server/bin" -o -path "server/bin/*" -o -path "server/tmp" -o -path "server/tmp/*" \) -prune -o \
+    -type f \( -name "*.go" -o -name "*.sql" -o -name "*.json" -o -name "go.mod" -o -name "go.sum" \) -print |
+    LC_ALL=C sort |
+    while IFS= read -r file; do
+      shasum "$file"
+    done |
+    shasum
+}
+
+SERVER_PID=""
+WATCH_PID=""
+DESKTOP_PID=""
+SERVER_PID_FILE="${TMPDIR:-/tmp}/multica-dev-desktop-${PORT:-8080}-$$.server.pid"
+
+child_pids() {
+  local pid="$1"
+  pgrep -P "$pid" 2>/dev/null || true
+}
+
+descendant_pids() {
+  local pid="$1"
+  local child
+  for child in $(child_pids "$pid"); do
+    echo "$child"
+    descendant_pids "$child"
+  done
+}
+
+terminate_pid_tree() {
+  local pid="$1"
+  if [ -z "${pid:-}" ] || ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  local pids
+  pids="$(descendant_pids "$pid" | awk 'NF { seen[$1] = 1 } END { for (p in seen) print p }')"
+  pids="${pids}
+${pid}"
+
+  # Terminate children first so wrappers such as pnpm/turbo do not leave
+  # electron-vite or Electron helper processes behind after Ctrl+C.
+  echo "$pids" | awk 'NF' | while IFS= read -r p; do
+    kill "$p" 2>/dev/null || true
+  done
+
+  local deadline=$((SECONDS + 5))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    local alive=""
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      if kill -0 "$p" 2>/dev/null; then
+        alive=1
+        break
+      fi
+    done <<EOF
+$pids
+EOF
+    [ -z "$alive" ] && return 0
+    sleep 0.2
+  done
+
+  echo "$pids" | awk 'NF' | while IFS= read -r p; do
+    kill -9 "$p" 2>/dev/null || true
+  done
+}
+
+cleanup_checkout_desktop_processes() {
+  ps -axo pid=,command= |
+    awk -v root="$REPO_ROOT" '
+      index($0, root) > 0 &&
+      ($0 ~ /pnpm dev:desktop/ || $0 ~ /turbo dev --filter=@multica\/desktop/ ||
+       $0 ~ /electron-vite.* dev/ || $0 ~ /Electron \./ ||
+       $0 ~ /apps\/desktop\/resources\/bin\/multica daemon start --foreground/) {
+        print $1
+      }
+    ' |
+    while IFS= read -r pid; do
+      terminate_pid_tree "$pid"
+    done
+}
+
+pid_cwd_under_repo() {
+  local pid="$1"
+  local cwd
+  cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
+  [ -n "$cwd" ] && [[ "$cwd" == "$REPO_ROOT"* ]]
+}
+
+cleanup_checkout_backend_processes() {
+  local port="${PORT:-8080}"
+  local pid
+  while IFS= read -r pid; do
+    [ -z "$pid" ] && continue
+    if pid_cwd_under_repo "$pid"; then
+      echo "==> Stopping stale backend process on port ${port}: ${pid}"
+      terminate_pid_tree "$pid"
+    fi
+  done < <(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+}
+
+start_server() {
+  echo "==> Starting backend on http://localhost:${PORT:-8080}"
+  (cd server && go run ./cmd/server) &
+  SERVER_PID=$!
+  printf "%s\n" "$SERVER_PID" >"$SERVER_PID_FILE"
+}
+
+stop_server() {
+  local pid="${SERVER_PID:-}"
+  if [ -z "$pid" ] && [ -f "$SERVER_PID_FILE" ]; then
+    pid="$(cat "$SERVER_PID_FILE" 2>/dev/null || true)"
+  fi
+
+  terminate_pid_tree "$pid"
+  if [ -n "$pid" ]; then
+    wait "$pid" 2>/dev/null || true
+  fi
+  rm -f "$SERVER_PID_FILE"
+}
+
+wait_for_backend_ready() {
+  local timeout="${BACKEND_READY_TIMEOUT:-90}"
+  local deadline=$((SECONDS + timeout))
+
+  echo "==> Waiting for backend to be ready at ${backend_ready_url}..."
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if curl -sf "$backend_ready_url" >/dev/null 2>&1; then
+      echo "==> Backend is ready."
+      return 0
+    fi
+
+    if [ -n "${WATCH_PID:-}" ] && ! kill -0 "$WATCH_PID" 2>/dev/null; then
+      wait "$WATCH_PID" 2>/dev/null || true
+      echo "Backend exited before it became ready."
+      return 1
+    fi
+
+    sleep 1
+  done
+
+  echo "Backend did not become ready within ${timeout}s."
+  echo "Check the backend output above, then retry."
+  return 1
+}
+
+cleanup() {
+  trap - INT TERM EXIT
+  stop_server
+  terminate_pid_tree "${WATCH_PID:-}"
+  wait "${WATCH_PID:-}" 2>/dev/null || true
+  terminate_pid_tree "${DESKTOP_PID:-}"
+  wait "${DESKTOP_PID:-}" 2>/dev/null || true
+  cleanup_checkout_desktop_processes
+  rm -f "$SERVER_PID_FILE"
+}
+
+watch_server() {
+  local last
+  local next
+  last="$(server_fingerprint)"
+  start_server
+
+  while true; do
+    sleep "${SERVER_RELOAD_POLL_INTERVAL:-1}"
+
+    if [ -n "${SERVER_PID:-}" ] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      wait "$SERVER_PID"
+      exit $?
+    fi
+
+    next="$(server_fingerprint)"
+    if [ "$next" != "$last" ]; then
+      echo "==> Backend files changed. Restarting server..."
+      stop_server
+      (cd server && go run ./cmd/migrate up)
+      start_server
+      last="$next"
+    fi
+  done
+}
+
+trap cleanup INT TERM EXIT
+
+echo ""
+echo "Desktop dev is starting with hot reload:"
+echo "  Backend:  http://localhost:${PORT:-8080} (restarts on server file changes)"
+echo "  Desktop:  pnpm dev:desktop (Electron/Vite HMR)"
+echo "  API env:  ${desktop_api_url}"
+echo ""
+
+other_desktops="$(
+  ps -axo pid=,command= |
+    awk -v root="$REPO_ROOT" '
+      /pnpm dev:desktop|electron-vite.* dev|Electron \.$/ {
+        if (index($0, root) == 0) print
+      }
+    ' || true
+)"
+if [ -n "$other_desktops" ]; then
+  echo "Warning: another desktop dev process from a different checkout is running."
+  echo "Make sure you use this worktree app window, not the other one:"
+  echo "$other_desktops"
+  echo ""
+fi
+
+cleanup_checkout_backend_processes
+
+watch_server &
+WATCH_PID=$!
+
+wait_for_backend_ready
+
+CI=true "$PNPM_BIN" dev:desktop &
+DESKTOP_PID=$!
+
+wait "$DESKTOP_PID"

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -221,7 +221,11 @@ func buildChatPrompt(task Task) string {
 			}
 		}
 	}
-	fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
+	if task.ChatThreadID != "" {
+		fmt.Fprintf(&b, "Thread context and latest user request:\n%s\n", task.ChatMessage)
+	} else {
+		fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
+	}
 	// List attachments by id + filename so the agent can fetch them via
 	// the CLI. We deliberately do NOT inline the URL: chat attachments
 	// live behind a signed CDN with a short TTL, so by the time the agent

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -68,6 +68,7 @@ type Task struct {
 	NewCommentCount          int                   `json:"new_comment_count,omitempty"`           // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
 	NewCommentsSince         string                `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	ChatSessionID            string                `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatThreadID             string                `json:"chat_thread_id,omitempty"`              // non-empty for threaded chat tasks
 	ChatMessage              string                `json:"chat_message,omitempty"`                // user message content for chat tasks
 	ChatMessageAttachments   []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
 	AutopilotRunID           string                `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -277,6 +277,7 @@ type AgentTaskResponse struct {
 	NewCommentCount          int                  `json:"new_comment_count,omitempty"`           // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
 	NewCommentsSince         string               `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
 	ChatSessionID            string               `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatThreadID             string               `json:"chat_thread_id,omitempty"`              // non-empty for threaded chat tasks
 	ChatMessage              string               `json:"chat_message,omitempty"`                // user message for chat tasks
 	ChatMessageAttachments   []ChatAttachmentMeta `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
 	AutopilotRunID           string               `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks
@@ -412,6 +413,7 @@ func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 		// from chat-spawned or autopilot-spawned ones; all three may arrive
 		// with issue_id = "" once a task has no linked issue.
 		ChatSessionID:  uuidToString(t.ChatSessionID),
+		ChatThreadID:   uuidToString(t.ChatThreadID),
 		AutopilotRunID: uuidToString(t.AutopilotRunID),
 		Kind:           computeTaskKind(t),
 	}

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -77,6 +78,18 @@ func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 	if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
 		writeError(w, http.StatusForbidden, "you do not have access to this agent")
+		return
+	}
+
+	if existing, err := h.Queries.GetPrivateChatSessionForAgentCreator(r.Context(), db.GetPrivateChatSessionForAgentCreatorParams{
+		WorkspaceID: workspaceUUID,
+		AgentID:     agentID,
+		CreatorID:   parseUUID(userID),
+	}); err == nil {
+		writeJSON(w, http.StatusOK, chatSessionToResponse(existing))
+		return
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		writeError(w, http.StatusInternalServerError, "failed to resolve chat session")
 		return
 	}
 
@@ -389,11 +402,15 @@ func (h *Handler) DeleteChatSession(w http.ResponseWriter, r *http.Request) {
 type SendChatMessageRequest struct {
 	Content       string   `json:"content"`
 	AttachmentIDs []string `json:"attachment_ids"`
+	ChatThreadID string   `json:"chat_thread_id"`
+	ReplyToTaskID string   `json:"reply_to_task_id"`
 }
 
 type SendChatMessageResponse struct {
-	MessageID string `json:"message_id"`
-	TaskID    string `json:"task_id"`
+	MessageID    string `json:"message_id"`
+	TaskID       string `json:"task_id"`
+	ThreadTaskID string `json:"thread_task_id"`
+	ThreadID     string `json:"thread_id"`
 	// AttachmentIDs are the attachment rows actually bound to this message by
 	// the server. The client diffs these against the ids it requested so it
 	// can warn the user when an attachment silently failed to bind — no extra
@@ -456,11 +473,85 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	threadTaskID := pgtype.UUID{}
+	chatThreadID := pgtype.UUID{}
+	if req.ChatThreadID != "" {
+		requestedChatThreadID, ok := parseUUIDOrBadRequest(w, req.ChatThreadID, "chat_thread_id")
+		if !ok {
+			return
+		}
+		if _, err := h.Queries.GetChatThreadInSession(r.Context(), db.GetChatThreadInSessionParams{
+			ID:            requestedChatThreadID,
+			ChatSessionID: session.ID,
+		}); errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusBadRequest, "reply thread not found")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve reply thread")
+			return
+		}
+		resolvedThreadTaskID, err := h.Queries.ResolveChatThreadTaskIDByThreadID(r.Context(), db.ResolveChatThreadTaskIDByThreadIDParams{
+			ChatSessionID: session.ID,
+			ChatThreadID:  requestedChatThreadID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusBadRequest, "reply thread not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve reply thread")
+			return
+		}
+		threadTaskID = resolvedThreadTaskID
+		chatThreadID = requestedChatThreadID
+	} else if req.ReplyToTaskID != "" {
+		requestedThreadTaskID, ok := parseUUIDOrBadRequest(w, req.ReplyToTaskID, "reply_to_task_id")
+		if !ok {
+			return
+		}
+		resolvedThreadTaskID, err := h.Queries.ResolveChatThreadTaskID(r.Context(), db.ResolveChatThreadTaskIDParams{
+			ChatSessionID: session.ID,
+			TaskID:        requestedThreadTaskID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusBadRequest, "reply thread not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve reply thread")
+			return
+		}
+		threadTaskID = resolvedThreadTaskID
+		resolvedChatThreadID, err := h.resolveOrCreateChatThreadForTaskID(r.Context(), session, resolvedThreadTaskID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusBadRequest, "reply thread not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve reply thread")
+			return
+		}
+		chatThreadID = resolvedChatThreadID
+	} else {
+		thread, err := h.Queries.CreateChatThread(r.Context(), db.CreateChatThreadParams{
+			ChatSessionID: session.ID,
+			Title:         strings.TrimSpace(req.Content),
+			CreatedBy:     parseUUID(userID),
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to create chat thread")
+			return
+		}
+		chatThreadID = thread.ID
+	}
+
 	// Create the user message first so the daemon can always find it.
 	msg, err := h.Queries.CreateChatMessage(r.Context(), db.CreateChatMessageParams{
 		ChatSessionID: session.ID,
+		ChatThreadID:  chatThreadID,
 		Role:          "user",
 		Content:       req.Content,
+		ThreadTaskID:  threadTaskID,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create chat message")
@@ -497,14 +588,15 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	// Enqueue a chat task after the message exists. For web chat the sender is
 	// the authenticated request user (sessions are creator-only), so they are
 	// the task initiator — surfaced to the agent under `## Task Initiator`.
-	task, err := h.TaskService.EnqueueChatTask(r.Context(), session, parseUUID(userID), false)
+	task, err := h.TaskService.EnqueueChatTask(r.Context(), session, chatThreadID, parseUUID(userID), false)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to enqueue chat task: "+err.Error())
 		return
 	}
 	if err := h.Queries.LinkChatMessageToTask(r.Context(), db.LinkChatMessageToTaskParams{
-		ID:     msg.ID,
-		TaskID: task.ID,
+		ID:           msg.ID,
+		TaskID:       task.ID,
+		ChatThreadID: chatThreadID,
 	}); err != nil {
 		// Don't fail the send: the task already exists and the user message
 		// is persisted. The link is only needed for precise empty-cancel
@@ -535,21 +627,93 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 
 	// Broadcast the user message.
 	resolvedSessionID := uuidToString(session.ID)
+	resolvedThreadTaskID := task.ID
+	if threadTaskID.Valid {
+		resolvedThreadTaskID = threadTaskID
+	} else if err := h.Queries.SetChatThreadRootMessage(r.Context(), db.SetChatThreadRootMessageParams{
+		ID:            chatThreadID,
+		RootMessageID: msg.ID,
+		Title:         req.Content,
+	}); err != nil {
+		slog.Warn("set chat thread root message failed",
+			"chat_thread_id", uuidToString(chatThreadID),
+			"message_id", uuidToString(msg.ID),
+			"error", err,
+		)
+	}
 	h.publishChat(protocol.EventChatMessage, workspaceID, "member", userID, resolvedSessionID, protocol.ChatMessagePayload{
 		ChatSessionID: resolvedSessionID,
+		ChatThreadID:  uuidToString(chatThreadID),
 		MessageID:     uuidToString(msg.ID),
 		Role:          "user",
 		Content:       req.Content,
 		TaskID:        uuidToString(task.ID),
+		ThreadTaskID:  uuidToString(resolvedThreadTaskID),
 		CreatedAt:     timestampToString(msg.CreatedAt),
 	})
 
 	writeJSON(w, http.StatusCreated, SendChatMessageResponse{
 		MessageID:     uuidToString(msg.ID),
 		TaskID:        uuidToString(task.ID),
+		ThreadTaskID:  uuidToString(resolvedThreadTaskID),
+		ThreadID:      uuidToString(chatThreadID),
 		CreatedAt:     timestampToString(task.CreatedAt),
 		AttachmentIDs: boundAttachmentIDs,
 	})
+}
+
+func (h *Handler) resolveOrCreateChatThreadForTaskID(ctx context.Context, session db.ChatSession, threadTaskID pgtype.UUID) (pgtype.UUID, error) {
+	chatThreadID, err := h.Queries.ResolveChatThreadByTaskID(ctx, db.ResolveChatThreadByTaskIDParams{
+		ChatSessionID: session.ID,
+		TaskID:        threadTaskID,
+	})
+	if err == nil {
+		return chatThreadID, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return pgtype.UUID{}, err
+	}
+
+	rootMessage, err := h.Queries.GetChatThreadRootMessageByTaskID(ctx, db.GetChatThreadRootMessageByTaskIDParams{
+		ChatSessionID: session.ID,
+		TaskID:        threadTaskID,
+	})
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+
+	thread, err := h.Queries.CreateChatThread(ctx, db.CreateChatThreadParams{
+		ChatSessionID: session.ID,
+		Title:         strings.TrimSpace(rootMessage.Content),
+		CreatedBy:     session.CreatorID,
+	})
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+
+	if err := h.Queries.SetChatThreadRootMessage(ctx, db.SetChatThreadRootMessageParams{
+		ID:            thread.ID,
+		RootMessageID: rootMessage.ID,
+		Title:         rootMessage.Content,
+	}); err != nil {
+		return pgtype.UUID{}, err
+	}
+	if err := h.Queries.BackfillChatThreadForTaskID(ctx, db.BackfillChatThreadForTaskIDParams{
+		ChatSessionID: session.ID,
+		ThreadTaskID:  threadTaskID,
+		ChatThreadID:  thread.ID,
+	}); err != nil {
+		return pgtype.UUID{}, err
+	}
+	if err := h.Queries.BackfillChatTaskThreadID(ctx, db.BackfillChatTaskThreadIDParams{
+		ID:            threadTaskID,
+		ChatThreadID:  thread.ID,
+		ChatSessionID: session.ID,
+	}); err != nil {
+		return pgtype.UUID{}, err
+	}
+
+	return thread.ID, nil
 }
 
 type ChatMessagesCursorResponse struct {
@@ -981,9 +1145,11 @@ type ChatSessionResponse struct {
 type ChatMessageResponse struct {
 	ID            string  `json:"id"`
 	ChatSessionID string  `json:"chat_session_id"`
+	ChatThreadID  *string `json:"chat_thread_id"`
 	Role          string  `json:"role"`
 	Content       string  `json:"content"`
 	TaskID        *string `json:"task_id"`
+	ThreadTaskID  *string `json:"thread_task_id"`
 	CreatedAt     string  `json:"created_at"`
 	// FailureReason flags an assistant row synthesized by FailTask's chat
 	// fallback. Front-end uses it to switch to the destructive bubble.
@@ -1016,9 +1182,11 @@ func chatMessageToResponse(m db.ChatMessage, attachments []AttachmentResponse) C
 	return ChatMessageResponse{
 		ID:            uuidToString(m.ID),
 		ChatSessionID: uuidToString(m.ChatSessionID),
+		ChatThreadID:  uuidToPtr(m.ChatThreadID),
 		Role:          m.Role,
 		Content:       m.Content,
 		TaskID:        uuidToPtr(m.TaskID),
+		ThreadTaskID:  uuidToPtr(m.ThreadTaskID),
 		CreatedAt:     timestampToString(m.CreatedAt),
 		FailureReason: textToPtr(m.FailureReason),
 		ElapsedMs:     int8ToPtr(m.ElapsedMs),

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -402,7 +402,7 @@ func (h *Handler) DeleteChatSession(w http.ResponseWriter, r *http.Request) {
 type SendChatMessageRequest struct {
 	Content       string   `json:"content"`
 	AttachmentIDs []string `json:"attachment_ids"`
-	ChatThreadID string   `json:"chat_thread_id"`
+	ChatThreadID  string   `json:"chat_thread_id"`
 	ReplyToTaskID string   `json:"reply_to_task_id"`
 }
 
@@ -494,15 +494,13 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 			ChatSessionID: session.ID,
 			ChatThreadID:  requestedChatThreadID,
 		})
-		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusBadRequest, "reply thread not found")
-			return
-		}
-		if err != nil {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusInternalServerError, "failed to resolve reply thread")
 			return
 		}
-		threadTaskID = resolvedThreadTaskID
+		if err == nil {
+			threadTaskID = resolvedThreadTaskID
+		}
 		chatThreadID = requestedChatThreadID
 	} else if req.ReplyToTaskID != "" {
 		requestedThreadTaskID, ok := parseUUIDOrBadRequest(w, req.ReplyToTaskID, "reply_to_task_id")

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -100,6 +100,18 @@ func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
 		Title:       req.Title,
 	})
 	if err != nil {
+		// A concurrent create can win the unique scope index
+		// (idx_chat_session_scope) in the window between the GetPrivate check
+		// above and this insert. Re-resolve before failing so the loser of the
+		// race returns the canonical session (200) instead of a spurious 500.
+		if existing, reErr := h.Queries.GetPrivateChatSessionForAgentCreator(r.Context(), db.GetPrivateChatSessionForAgentCreatorParams{
+			WorkspaceID: workspaceUUID,
+			AgentID:     agentID,
+			CreatorID:   parseUUID(userID),
+		}); reErr == nil {
+			writeJSON(w, http.StatusOK, chatSessionToResponse(existing))
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "failed to create chat session")
 		return
 	}

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -198,6 +198,87 @@ func TestSendChatMessage_LinksUnattachedAttachments(t *testing.T) {
 	}
 }
 
+func TestSendChatMessage_RepliesToThreadWithoutExistingTask(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatLegacyThreadNoTaskAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+	ctx := context.Background()
+
+	var threadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_thread (chat_session_id, title, created_by)
+		VALUES ($1, 'legacy unthreaded root', $2)
+		RETURNING id
+	`, sessionID, testUserID).Scan(&threadID); err != nil {
+		t.Fatalf("create legacy chat thread: %v", err)
+	}
+
+	var rootMessageID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_message (chat_session_id, chat_thread_id, role, content)
+		VALUES ($1, $2, 'user', 'legacy root without task')
+		RETURNING id
+	`, sessionID, threadID).Scan(&rootMessageID); err != nil {
+		t.Fatalf("create legacy root message: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE chat_thread SET root_message_id = $1 WHERE id = $2
+	`, rootMessageID, threadID); err != nil {
+		t.Fatalf("link legacy root message: %v", err)
+	}
+
+	sendReq := newRequest("POST", "/api/chat-sessions/"+sessionID+"/messages", map[string]any{
+		"content":        "reply inside the legacy thread",
+		"chat_thread_id": threadID,
+	})
+	sendReq = withURLParam(sendReq, "sessionId", sessionID)
+	sendReq = withChatTestWorkspaceCtx(t, sendReq)
+	sendW := httptest.NewRecorder()
+	testHandler.SendChatMessage(sendW, sendReq)
+	if sendW.Code != http.StatusCreated {
+		t.Fatalf("SendChatMessage legacy thread reply: expected 201, got %d: %s", sendW.Code, sendW.Body.String())
+	}
+
+	var sendResp SendChatMessageResponse
+	if err := json.Unmarshal(sendW.Body.Bytes(), &sendResp); err != nil {
+		t.Fatalf("decode send: %v", err)
+	}
+	if sendResp.ThreadID != threadID {
+		t.Fatalf("thread id: want existing %s, got %s", threadID, sendResp.ThreadID)
+	}
+	if sendResp.ThreadTaskID != sendResp.TaskID {
+		t.Fatalf("thread task id: want new task %s, got %s", sendResp.TaskID, sendResp.ThreadTaskID)
+	}
+
+	var threadCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM chat_thread WHERE chat_session_id = $1
+	`, sessionID).Scan(&threadCount); err != nil {
+		t.Fatalf("count chat threads: %v", err)
+	}
+	if threadCount != 1 {
+		t.Fatalf("expected reply to reuse existing thread, found %d threads", threadCount)
+	}
+
+	var messageThreadID, messageThreadTaskID, taskThreadID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT
+			COALESCE(cm.chat_thread_id::text, ''),
+			COALESCE(cm.thread_task_id::text, ''),
+			COALESCE(atq.chat_thread_id::text, '')
+		FROM chat_message cm
+		JOIN agent_task_queue atq ON atq.id = cm.task_id
+		WHERE cm.id = $1
+	`, sendResp.MessageID).Scan(&messageThreadID, &messageThreadTaskID, &taskThreadID); err != nil {
+		t.Fatalf("query reply thread linkage: %v", err)
+	}
+	if messageThreadID != threadID || taskThreadID != threadID {
+		t.Fatalf("reply linkage thread mismatch: message=%s task=%s want %s", messageThreadID, taskThreadID, threadID)
+	}
+	if messageThreadTaskID != sendResp.TaskID {
+		t.Fatalf("reply thread_task_id: want %s, got %s", sendResp.TaskID, messageThreadTaskID)
+	}
+}
+
 // TestUpdateChatSession_RenamesTitle confirms PATCH writes the new title,
 // returns the updated row, and the server-side row reflects it.
 func TestUpdateChatSession_RenamesTitle(t *testing.T) {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1571,7 +1571,37 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 					resp.Repos = repos
 				}
 			}
-			if !task.ForceFreshSession {
+			if task.ChatThreadID.Valid {
+				resp.ChatThreadID = uuidToString(task.ChatThreadID)
+				if thread, err := h.Queries.GetChatThreadInSession(r.Context(), db.GetChatThreadInSessionParams{
+					ID:            task.ChatThreadID,
+					ChatSessionID: cs.ID,
+				}); err == nil && strings.TrimSpace(thread.Title) != "" {
+					resp.ThreadName = thread.Title
+				}
+			}
+			if !task.ForceFreshSession && task.ChatThreadID.Valid {
+				if session, err := h.Queries.GetChatAgentSessionByThread(r.Context(), db.GetChatAgentSessionByThreadParams{
+					ChatThreadID: task.ChatThreadID,
+					AgentID:      task.AgentID,
+					RuntimeID:    task.RuntimeID,
+				}); err == nil {
+					if session.ProviderSessionID.Valid {
+						resp.PriorSessionID = session.ProviderSessionID.String
+					}
+					if session.WorkDir.Valid {
+						resp.PriorWorkDir = session.WorkDir.String
+					}
+				}
+				if prior, err := h.Queries.GetLastChatTaskSessionByThread(r.Context(), task.ChatThreadID); err == nil && prior.SessionID.Valid {
+					if resp.PriorSessionID == "" && prior.RuntimeID == task.RuntimeID {
+						resp.PriorSessionID = prior.SessionID.String
+					}
+					if prior.WorkDir.Valid && resp.PriorWorkDir == "" {
+						resp.PriorWorkDir = prior.WorkDir.String
+					}
+				}
+			} else if !task.ForceFreshSession {
 				// Resume chat sessions only when the stored pointer was produced
 				// by the same runtime as the claiming task. When the chat_session
 				// pointer is missing (legacy NULL runtime_id), stale (last task
@@ -1595,25 +1625,26 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
-			// Build the chat prompt from EVERY user message that has arrived
-			// since the agent's last reply — not just the most recent one. A
-			// short-window debounce (MUL-2968) can land several user messages
-			// before a single run fires; the agent resumes its prior session
-			// and only learns of new input through resp.ChatMessage, so
-			// delivering just the latest message would silently drop the
-			// earlier ones (e.g. "看上海天气" then "还有青岛" → only Qingdao
-			// answered). The unanswered set is the trailing run of user
-			// messages after the last assistant message (every completed or
-			// failed run writes an assistant row, so that anchor advances each
-			// turn). Attachments are collected from each included message so
-			// the agent can `multica attachment download <id>` — the markdown
-			// URL alone is signed and 30-min expiring on the private CDN.
-			if msgs, err := h.Queries.ListChatMessages(r.Context(), cs.ID); err == nil && len(msgs) > 0 {
-				unanswered := trailingUserMessages(msgs)
+			// Threaded chat prompt: when a task is bound to a chat_thread, the
+			// thread is the context boundary. Legacy/channel tasks without a
+			// thread id keep the old session-level trailing-user window.
+			if msgs, err := func() ([]db.ChatMessage, error) {
+				if task.ChatThreadID.Valid {
+					return h.Queries.ListChatMessagesByThread(r.Context(), db.ListChatMessagesByThreadParams{
+						ChatSessionID: cs.ID,
+						ChatThreadID:  task.ChatThreadID,
+					})
+				}
+				return h.Queries.ListChatMessages(r.Context(), cs.ID)
+			}(); err == nil && len(msgs) > 0 {
+				unanswered := msgs
+				if !task.ChatThreadID.Valid {
+					unanswered = trailingUserMessages(msgs)
+				}
 				parts := make([]string, 0, len(unanswered))
 				for _, m := range unanswered {
 					if strings.TrimSpace(m.Content) != "" {
-						parts = append(parts, m.Content)
+						parts = append(parts, formatChatPromptMessage(m))
 					}
 					if atts, attErr := h.Queries.ListAttachmentsByChatMessage(r.Context(), db.ListAttachmentsByChatMessageParams{
 						ChatMessageID: m.ID,
@@ -1998,6 +2029,14 @@ func trailingUserMessages(msgs []db.ChatMessage) []db.ChatMessage {
 		}
 	}
 	return msgs[start:]
+}
+
+func formatChatPromptMessage(msg db.ChatMessage) string {
+	label := "User"
+	if msg.Role == "assistant" {
+		label = "Assistant"
+	}
+	return fmt.Sprintf("%s:\n%s", label, msg.Content)
 }
 
 // ListPendingTasksByRuntime returns queued/dispatched tasks for a runtime.

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1637,8 +1637,18 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				}
 				return h.Queries.ListChatMessages(r.Context(), cs.ID)
 			}(); err == nil && len(msgs) > 0 {
+				// Pick the prompt window. When a provider session was resumed
+				// (resp.PriorSessionID populated above, for either threaded or
+				// legacy chat), the model already retains prior turns, so we
+				// send only the trailing run of unanswered user messages — the
+				// same economy the session path always used. We replay the FULL
+				// thread transcript only when starting a fresh/poisoned session
+				// (no PriorSessionID) so the new session can rebuild context.
+				// Without this split, threaded resume double-fed history
+				// (resumed memory + full transcript), bloating tokens as the
+				// thread grew.
 				unanswered := msgs
-				if !task.ChatThreadID.Valid {
+				if !task.ChatThreadID.Valid || resp.PriorSessionID != "" {
 					unanswered = trailingUserMessages(msgs)
 				}
 				parts := make([]string, 0, len(unanswered))

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1644,7 +1644,11 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				parts := make([]string, 0, len(unanswered))
 				for _, m := range unanswered {
 					if strings.TrimSpace(m.Content) != "" {
-						parts = append(parts, formatChatPromptMessage(m))
+						if task.ChatThreadID.Valid {
+							parts = append(parts, formatChatPromptMessage(m))
+						} else {
+							parts = append(parts, m.Content)
+						}
 					}
 					if atts, attErr := h.Queries.ListAttachmentsByChatMessage(r.Context(), db.ListAttachmentsByChatMessageParams{
 						ChatMessageID: m.ID,

--- a/server/internal/handler/daemon_chat_thread_resume_test.go
+++ b/server/internal/handler/daemon_chat_thread_resume_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestClaimTask_ThreadResumeSendsOnlyNewUserMessage pins the threaded-chat
+// prompt window when the provider session is resumed. A thread carries prior
+// user/assistant history AND an active chat_agent_session resume pointer; a new
+// user message then arrives. The claim must hand the agent ONLY the new user
+// message — the resumed provider session already holds the earlier turns, so
+// replaying the whole transcript would double-feed context and grow unbounded
+// as the thread lengthens. Guards the daemon.go resume-window split.
+func TestClaimTask_ThreadResumeSendsOnlyNewUserMessage(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	const (
+		oldUserContent = "历史问题：上海天气如何"
+		oldAsstContent = "历史回答：上海今天晴。"
+		newUserContent = "新的追问：那青岛呢"
+		priorSessionID = "resume-provider-session-xyz"
+	)
+
+	// Private DM chat session for this agent + creator.
+	var sessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, runtime_id, status, scope_type, source, visibility)
+		VALUES ($1, $2, $3, 'thread resume fixture', $4, 'active', 'private_dm', 'app', 'private')
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&sessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, sessionID) })
+
+	// One thread holding the prior history.
+	var threadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_thread (chat_session_id, title, created_by)
+		VALUES ($1, 'thread resume fixture', $2)
+		RETURNING id
+	`, sessionID, testUserID).Scan(&threadID); err != nil {
+		t.Fatalf("setup: create chat thread: %v", err)
+	}
+
+	// Prior user → assistant turn, then the new unanswered user message. A
+	// random thread_task_id stands in for the completed prior turn's task; the
+	// window logic keys off role ordering, not the task id.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO chat_message (chat_session_id, chat_thread_id, role, content, thread_task_id, created_at)
+		VALUES
+			($1, $2, 'user',      $3, gen_random_uuid(), now() - interval '3 minutes'),
+			($1, $2, 'assistant', $4, gen_random_uuid(), now() - interval '2 minutes'),
+			($1, $2, 'user',      $5, NULL,              now() - interval '1 minute')
+	`, sessionID, threadID, oldUserContent, oldAsstContent, newUserContent); err != nil {
+		t.Fatalf("setup: insert thread messages: %v", err)
+	}
+
+	// Active per-thread resume pointer: this is what makes the claim resume the
+	// prior provider session instead of starting fresh.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO chat_agent_session (chat_session_id, chat_thread_id, agent_id, runtime_id, provider_session_id, work_dir, status)
+		VALUES ($1, $2, $3, $4, $5, '/tmp/thread-resume-workdir', 'active')
+	`, sessionID, threadID, agentID, runtimeID, priorSessionID); err != nil {
+		t.Fatalf("setup: insert chat_agent_session: %v", err)
+	}
+
+	// Queued chat task bound to the session + thread for the claim to pick up.
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, chat_session_id, chat_thread_id, initiator_user_id)
+		VALUES ($1, $2, NULL, 'queued', 2, $3, $4, $5)
+		RETURNING id
+	`, agentID, runtimeID, sessionID, threadID, testUserID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create queued chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	claimed := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+
+	// Resume hit: the prior provider session is handed back.
+	if claimed.PriorSessionID != priorSessionID {
+		t.Fatalf("prior_session_id = %q, want %q (resume should hit the chat_agent_session pointer)", claimed.PriorSessionID, priorSessionID)
+	}
+
+	// Only the new user message is delivered — no transcript replay.
+	if !strings.Contains(claimed.ChatMessage, newUserContent) {
+		t.Fatalf("chat_message must contain the new user message %q, got %q", newUserContent, claimed.ChatMessage)
+	}
+	if strings.Contains(claimed.ChatMessage, oldUserContent) {
+		t.Fatalf("chat_message must NOT replay the prior user message %q, got %q", oldUserContent, claimed.ChatMessage)
+	}
+	if strings.Contains(claimed.ChatMessage, oldAsstContent) {
+		t.Fatalf("chat_message must NOT replay the prior assistant message %q, got %q", oldAsstContent, claimed.ChatMessage)
+	}
+}

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1888,6 +1888,31 @@ func TestCreatePinRejectsMalformedItemID(t *testing.T) {
 	}
 }
 
+func TestCreatePinAllowsAgent(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Agent Pin", nil)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/pins", map[string]any{
+		"item_type": "agent",
+		"item_id":   agentID,
+	})
+	testHandler.CreatePin(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreatePin: expected 201 for agent pin, got %d: %s", w.Code, w.Body.String())
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM pinned_item WHERE item_type = 'agent' AND item_id = $1`, agentID)
+	})
+
+	var resp PinnedItemResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode pin response: %v", err)
+	}
+	if resp.ItemType != "agent" || resp.ItemID != agentID {
+		t.Fatalf("CreatePin response = (%q, %q), want agent %q", resp.ItemType, resp.ItemID, agentID)
+	}
+}
+
 func TestUpdateWorkspaceRejectsMalformedID(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/workspaces/not-a-uuid", map[string]any{

--- a/server/internal/handler/pin.go
+++ b/server/internal/handler/pin.go
@@ -11,7 +11,7 @@ import (
 
 // PinnedItemResponse carries pin metadata only. Title / status / identifier /
 // icon are intentionally NOT included — clients derive them from their own
-// issue / project query cache so that an `issue:updated` event flows naturally
+// issue / project / agent query cache so entity update events flow naturally
 // into the sidebar without needing a cross-entity invalidate on `pinKeys`.
 type PinnedItemResponse struct {
 	ID          string  `json:"id"`
@@ -49,6 +49,10 @@ type ReorderItem struct {
 	Position float64 `json:"position"`
 }
 
+func isPinnedItemType(itemType string) bool {
+	return itemType == "issue" || itemType == "project" || itemType == "agent"
+}
+
 func (h *Handler) ListPins(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -84,8 +88,8 @@ func (h *Handler) CreatePin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if req.ItemType != "issue" && req.ItemType != "project" {
-		writeError(w, http.StatusBadRequest, "item_type must be 'issue' or 'project'")
+	if !isPinnedItemType(req.ItemType) {
+		writeError(w, http.StatusBadRequest, "item_type must be 'issue', 'project', or 'agent'")
 		return
 	}
 	if req.ItemID == "" {
@@ -116,6 +120,19 @@ func (h *Handler) CreatePin(w http.ResponseWriter, r *http.Request) {
 			ID: itemUUID, WorkspaceID: wsUUID,
 		}); err != nil {
 			writeError(w, http.StatusNotFound, "project not found")
+			return
+		}
+	case "agent":
+		agent, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
+			ID: itemUUID, WorkspaceID: wsUUID,
+		})
+		if err != nil {
+			writeError(w, http.StatusNotFound, "agent not found")
+			return
+		}
+		actorType, actorID := h.resolveActor(r, userID, workspaceID)
+		if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
+			writeError(w, http.StatusForbidden, "you do not have access to this agent")
 			return
 		}
 	}
@@ -159,6 +176,11 @@ func (h *Handler) DeletePin(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 	itemType := chi.URLParam(r, "itemType")
 	itemID := chi.URLParam(r, "itemId")
+
+	if !isPinnedItemType(itemType) {
+		writeError(w, http.StatusBadRequest, "item_type must be 'issue', 'project', or 'agent'")
+		return
+	}
 
 	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
 	if !ok {

--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -206,7 +206,7 @@ type IssueCreator interface {
 // TaskEnqueuer is the narrow subset of service.TaskService the Router needs to
 // trigger a chat run. Shared across platforms.
 type TaskEnqueuer interface {
-	EnqueueChatTask(ctx context.Context, session db.ChatSession, initiatorUserID pgtype.UUID, forceFreshSession bool) (db.AgentTaskQueue, error)
+	EnqueueChatTask(ctx context.Context, session db.ChatSession, chatThreadID pgtype.UUID, initiatorUserID pgtype.UUID, forceFreshSession bool) (db.AgentTaskQueue, error)
 }
 
 // SessionReader reads the rows the debounced flush + /issue identifier need.

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -350,7 +350,7 @@ func (r *Router) flushChatRun(set ResolverSet, inst ResolvedInstallation, msg ch
 			"chat_session_id", uuidString(sessionID), "err", err.Error())
 		return
 	}
-	if _, err := r.tasks.EnqueueChatTask(ctx, session, initiatorUserID, forceFresh); err != nil {
+	if _, err := r.tasks.EnqueueChatTask(ctx, session, pgtype.UUID{}, initiatorUserID, forceFresh); err != nil {
 		switch {
 		case errors.Is(err, service.ErrChatTaskAgentNoRuntime):
 			r.emitFlushReply(ctx, set, inst, msg, sessionID, OutcomeAgentOffline)

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -154,7 +154,7 @@ type fakeTasks struct {
 	err        error
 }
 
-func (f *fakeTasks) EnqueueChatTask(_ context.Context, _ db.ChatSession, initiator pgtype.UUID, forceFresh bool) (db.AgentTaskQueue, error) {
+func (f *fakeTasks) EnqueueChatTask(_ context.Context, _ db.ChatSession, _ pgtype.UUID, initiator pgtype.UUID, forceFresh bool) (db.AgentTaskQueue, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.called = true

--- a/server/internal/integrations/channel/engine/session.go
+++ b/server/internal/integrations/channel/engine/session.go
@@ -194,6 +194,10 @@ func (s *ChatSession) createSessionAndBinding(ctx context.Context, in EnsureSess
 		AgentID:     in.AgentID,
 		CreatorID:   in.Sender,
 		Title:       s.titles.forType(in.ChatType),
+		ScopeType:   pgtype.Text{String: "channel", Valid: true},
+		ScopeID:     in.InstallationID,
+		Source:      pgtype.Text{String: string(s.channelType), Valid: true},
+		Visibility:  pgtype.Text{String: "shared", Valid: true},
 	})
 	if err != nil {
 		return pgtype.UUID{}, fmt.Errorf("create chat session: %w", err)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -731,7 +731,7 @@ var ErrChatTaskAgentNoRuntime = errors.New("chat task: agent has no runtime")
 // forceFreshSession applies only to the task created by this call. The daemon
 // uses it to skip prior chat-session resume for this dispatch without clearing
 // the chat session's stored resume pointer for future normal messages.
-func (s *TaskService) EnqueueChatTask(ctx context.Context, chatSession db.ChatSession, initiatorUserID pgtype.UUID, forceFreshSession bool) (db.AgentTaskQueue, error) {
+func (s *TaskService) EnqueueChatTask(ctx context.Context, chatSession db.ChatSession, chatThreadID pgtype.UUID, initiatorUserID pgtype.UUID, forceFreshSession bool) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, chatSession.AgentID)
 	if err != nil {
 		slog.Error("chat task enqueue failed", "chat_session_id", util.UUIDToString(chatSession.ID), "error", err)
@@ -749,6 +749,7 @@ func (s *TaskService) EnqueueChatTask(ctx context.Context, chatSession db.ChatSe
 		RuntimeID:       agent.RuntimeID,
 		Priority:        2, // medium priority for chat
 		ChatSessionID:   chatSession.ID,
+		ChatThreadID:    chatThreadID,
 		InitiatorUserID: initiatorUserID,
 		ForceFreshSession: pgtype.Bool{
 			Bool:  forceFreshSession,
@@ -939,11 +940,21 @@ func (s *TaskService) finalizeCancelledChatMessage(ctx context.Context, task db.
 			}
 			return nil
 		}
+		threadTaskID, err := qtx.GetChatThreadTaskIDByTask(ctx, task.ID)
+		if err != nil {
+			slog.Warn("failed to resolve cancelled chat thread id",
+				"task_id", util.UUIDToString(task.ID),
+				"error", err,
+			)
+			threadTaskID = task.ID
+		}
 		if _, err := qtx.CreateChatMessage(ctx, db.CreateChatMessageParams{
 			ChatSessionID: task.ChatSessionID,
+			ChatThreadID:  task.ChatThreadID,
 			Role:          "assistant",
 			Content:       "Stopped.",
 			TaskID:        task.ID,
+			ThreadTaskID:  threadTaskID,
 			ElapsedMs:     computeChatElapsedMs(task),
 		}); err != nil {
 			return fmt.Errorf("create cancelled chat message: %w", err)
@@ -1283,6 +1294,18 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 			}); err != nil {
 				return fmt.Errorf("update chat session resume pointer: %w", err)
 			}
+			if t.ChatThreadID.Valid {
+				if err := qtx.UpsertChatAgentSession(ctx, db.UpsertChatAgentSessionParams{
+					ChatSessionID:     t.ChatSessionID,
+					ChatThreadID:      t.ChatThreadID,
+					AgentID:           t.AgentID,
+					RuntimeID:         t.RuntimeID,
+					ProviderSessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
+					WorkDir:           pgtype.Text{String: workDir, Valid: workDir != ""},
+				}); err != nil {
+					return fmt.Errorf("update chat thread resume pointer: %w", err)
+				}
+			}
 		}
 		return nil
 	}); err != nil {
@@ -1387,9 +1410,11 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 			body := util.UnescapeBackslashEscapes(payload.Output)
 			row, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
 				ChatSessionID: task.ChatSessionID,
+				ChatThreadID:  task.ChatThreadID,
 				Role:          "assistant",
 				Content:       redact.Text(body),
 				TaskID:        task.ID,
+				ThreadTaskID:  s.chatThreadTaskID(ctx, task.ID),
 				ElapsedMs:     computeChatElapsedMs(task),
 			})
 			if err != nil {
@@ -1477,6 +1502,18 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 			}); err != nil {
 				return fmt.Errorf("update chat session resume pointer: %w", err)
 			}
+			if t.ChatThreadID.Valid {
+				if err := qtx.UpsertChatAgentSession(ctx, db.UpsertChatAgentSessionParams{
+					ChatSessionID:     t.ChatSessionID,
+					ChatThreadID:      t.ChatThreadID,
+					AgentID:           t.AgentID,
+					RuntimeID:         t.RuntimeID,
+					ProviderSessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
+					WorkDir:           pgtype.Text{String: workDir, Valid: workDir != ""},
+				}); err != nil {
+					return fmt.Errorf("update chat thread resume pointer: %w", err)
+				}
+			}
 		}
 		return nil
 	}); err != nil {
@@ -1530,9 +1567,11 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	if task.ChatSessionID.Valid && retried == nil {
 		if _, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
 			ChatSessionID: task.ChatSessionID,
+			ChatThreadID:  task.ChatThreadID,
 			Role:          "assistant",
 			Content:       redact.Text(errMsg),
 			TaskID:        pgtype.UUID{Bytes: task.ID.Bytes, Valid: true},
+			ThreadTaskID:  s.chatThreadTaskID(ctx, task.ID),
 			FailureReason: pgtype.Text{String: failureReason, Valid: failureReason != ""},
 			ElapsedMs:     computeChatElapsedMs(task),
 		}); err != nil {
@@ -2150,6 +2189,9 @@ func (s *TaskService) broadcastTaskDispatch(ctx context.Context, task db.AgentTa
 	if task.ChatSessionID.Valid {
 		payload["chat_session_id"] = util.UUIDToString(task.ChatSessionID)
 	}
+	if task.ChatThreadID.Valid {
+		payload["chat_thread_id"] = util.UUIDToString(task.ChatThreadID)
+	}
 
 	workspaceID := s.ResolveTaskWorkspaceID(ctx, task)
 	if workspaceID == "" {
@@ -2177,6 +2219,9 @@ func (s *TaskService) broadcastTaskEvent(ctx context.Context, eventType string, 
 	}
 	if task.ChatSessionID.Valid {
 		payload["chat_session_id"] = util.UUIDToString(task.ChatSessionID)
+	}
+	if task.ChatThreadID.Valid {
+		payload["chat_thread_id"] = util.UUIDToString(task.ChatThreadID)
 	}
 	s.Bus.Publish(events.Event{
 		Type:        eventType,
@@ -2227,11 +2272,15 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 	}
 	payload := protocol.ChatDonePayload{
 		ChatSessionID: util.UUIDToString(task.ChatSessionID),
+		ChatThreadID:  util.UUIDToString(task.ChatThreadID),
 		TaskID:        util.UUIDToString(task.ID),
 	}
 	if msg != nil {
 		payload.MessageID = util.UUIDToString(msg.ID)
 		payload.Content = msg.Content
+		if msg.ThreadTaskID.Valid {
+			payload.ThreadTaskID = util.UUIDToString(msg.ThreadTaskID)
+		}
 		if msg.CreatedAt.Valid {
 			payload.CreatedAt = msg.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
 		}
@@ -2247,6 +2296,18 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 		ChatSessionID: util.UUIDToString(task.ChatSessionID),
 		Payload:       payload,
 	})
+}
+
+func (s *TaskService) chatThreadTaskID(ctx context.Context, taskID pgtype.UUID) pgtype.UUID {
+	threadTaskID, err := s.Queries.GetChatThreadTaskIDByTask(ctx, taskID)
+	if err != nil {
+		slog.Warn("failed to resolve chat thread id",
+			"task_id", util.UUIDToString(taskID),
+			"error", err,
+		)
+		return taskID
+	}
+	return threadTaskID
 }
 
 func (s *TaskService) broadcastIssueUpdated(issue db.Issue) {

--- a/server/migrations/127_pinned_item_agent.down.sql
+++ b/server/migrations/127_pinned_item_agent.down.sql
@@ -1,0 +1,7 @@
+DELETE FROM pinned_item WHERE item_type = 'agent';
+
+ALTER TABLE pinned_item DROP CONSTRAINT IF EXISTS pinned_item_item_type_check;
+
+ALTER TABLE pinned_item
+  ADD CONSTRAINT pinned_item_item_type_check
+  CHECK (item_type IN ('issue', 'project'));

--- a/server/migrations/127_pinned_item_agent.up.sql
+++ b/server/migrations/127_pinned_item_agent.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE pinned_item DROP CONSTRAINT IF EXISTS pinned_item_item_type_check;
+
+ALTER TABLE pinned_item
+  ADD CONSTRAINT pinned_item_item_type_check
+  CHECK (item_type IN ('issue', 'project', 'agent'));

--- a/server/migrations/128_chat_message_thread_task.down.sql
+++ b/server/migrations/128_chat_message_thread_task.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_chat_message_session_thread_task;
+ALTER TABLE chat_message DROP COLUMN IF EXISTS thread_task_id;

--- a/server/migrations/128_chat_message_thread_task.up.sql
+++ b/server/migrations/128_chat_message_thread_task.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE chat_message ADD COLUMN thread_task_id UUID;
+
+UPDATE chat_message
+SET thread_task_id = task_id
+WHERE task_id IS NOT NULL;
+
+CREATE INDEX idx_chat_message_session_thread_task
+  ON chat_message(chat_session_id, thread_task_id, created_at)
+  WHERE thread_task_id IS NOT NULL;

--- a/server/migrations/129_chat_conversation_threads.down.sql
+++ b/server/migrations/129_chat_conversation_threads.down.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS chat_agent_session;
+
+DROP INDEX IF EXISTS idx_agent_task_queue_chat_thread_pending;
+DROP INDEX IF EXISTS idx_chat_message_session_thread;
+
+ALTER TABLE agent_task_queue
+  DROP COLUMN IF EXISTS chat_thread_id;
+
+ALTER TABLE chat_thread
+  DROP CONSTRAINT IF EXISTS chat_thread_root_message_fkey;
+
+ALTER TABLE chat_message
+  DROP COLUMN IF EXISTS chat_thread_id;
+
+DROP TABLE IF EXISTS chat_thread;
+
+DROP INDEX IF EXISTS idx_chat_session_scope;
+
+ALTER TABLE chat_session
+  DROP COLUMN IF EXISTS superseded_by_chat_session_id,
+  DROP COLUMN IF EXISTS external_ref,
+  DROP COLUMN IF EXISTS visibility,
+  DROP COLUMN IF EXISTS source,
+  DROP COLUMN IF EXISTS scope_id,
+  DROP COLUMN IF EXISTS scope_type;

--- a/server/migrations/129_chat_conversation_threads.down.sql
+++ b/server/migrations/129_chat_conversation_threads.down.sql
@@ -1,3 +1,15 @@
+-- Reverse the private-DM merge first, while the bookkeeping columns still
+-- exist: the up-migration archived every non-canonical private DM session and
+-- pointed it at its canonical via superseded_by_chat_session_id. Restore those
+-- rows to 'active' so the set of usable conversations is the same as before the
+-- migration. (Message/task/attachment rows that were re-parented onto the
+-- canonical conversation are not moved back — that history stays consolidated —
+-- but no conversation is left silently archived by a rollback.)
+UPDATE chat_session
+SET status = 'active'
+WHERE superseded_by_chat_session_id IS NOT NULL
+  AND status = 'archived';
+
 DROP TABLE IF EXISTS chat_agent_session;
 
 DROP INDEX IF EXISTS idx_agent_task_queue_chat_thread_pending;

--- a/server/migrations/129_chat_conversation_threads.up.sql
+++ b/server/migrations/129_chat_conversation_threads.up.sql
@@ -32,10 +32,6 @@ SET scope_type = 'channel',
 FROM channel_chat_session_binding ccb
 WHERE ccb.chat_session_id = cs.id;
 
-CREATE INDEX idx_chat_session_scope
-  ON chat_session(workspace_id, agent_id, scope_type, scope_id, source)
-  WHERE status = 'active' AND superseded_by_chat_session_id IS NULL;
-
 CREATE TABLE chat_thread (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     chat_session_id UUID NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
@@ -82,6 +78,10 @@ SET superseded_by_chat_session_id = cp.canonical_id,
 FROM canonical_private cp
 WHERE cs.id = cp.id
   AND cs.id <> cp.canonical_id;
+
+CREATE UNIQUE INDEX idx_chat_session_scope
+  ON chat_session(workspace_id, agent_id, scope_type, scope_id, source)
+  WHERE status = 'active' AND superseded_by_chat_session_id IS NULL;
 
 -- Create one thread for every legacy thread-task group inside every old
 -- session. The thread lives under the canonical conversation when a private DM

--- a/server/migrations/129_chat_conversation_threads.up.sql
+++ b/server/migrations/129_chat_conversation_threads.up.sql
@@ -1,0 +1,288 @@
+-- Introduce explicit conversation/thread/session boundaries for agent chat.
+--
+-- `chat_session` remains the persisted conversation container for API
+-- compatibility. New rows are scoped so product code can keep one private DM
+-- conversation per (workspace, user, agent) while still allowing channel/shared
+-- conversations later.
+
+ALTER TABLE chat_session
+  ADD COLUMN scope_type TEXT NOT NULL DEFAULT 'private_dm'
+    CHECK (scope_type IN ('private_dm', 'channel', 'group', 'legacy', 'custom')),
+  ADD COLUMN scope_id UUID,
+  ADD COLUMN source TEXT NOT NULL DEFAULT 'app',
+  ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private'
+    CHECK (visibility IN ('private', 'shared')),
+  ADD COLUMN external_ref JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN superseded_by_chat_session_id UUID REFERENCES chat_session(id) ON DELETE SET NULL;
+
+UPDATE chat_session
+SET scope_id = creator_id
+WHERE scope_id IS NULL;
+
+UPDATE chat_session cs
+SET scope_type = 'channel',
+    scope_id = ccb.id,
+    source = ccb.channel_type,
+    visibility = 'shared',
+    external_ref = jsonb_build_object(
+      'channel_chat_id', ccb.channel_chat_id,
+      'chat_type', ccb.chat_type,
+      'binding_id', ccb.id
+    )
+FROM channel_chat_session_binding ccb
+WHERE ccb.chat_session_id = cs.id;
+
+CREATE INDEX idx_chat_session_scope
+  ON chat_session(workspace_id, agent_id, scope_type, scope_id, source)
+  WHERE status = 'active' AND superseded_by_chat_session_id IS NULL;
+
+CREATE TABLE chat_thread (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    chat_session_id UUID NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
+    legacy_chat_session_id UUID REFERENCES chat_session(id) ON DELETE SET NULL,
+    legacy_thread_task_id UUID,
+    root_message_id UUID,
+    title TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'resolved', 'archived')),
+    created_by UUID REFERENCES "user"(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_chat_thread_session_updated
+  ON chat_thread(chat_session_id, updated_at DESC);
+CREATE INDEX idx_chat_thread_legacy_session
+  ON chat_thread(legacy_chat_session_id);
+CREATE INDEX idx_chat_thread_legacy_task
+  ON chat_thread(legacy_thread_task_id)
+  WHERE legacy_thread_task_id IS NOT NULL;
+
+ALTER TABLE chat_message
+  ADD COLUMN chat_thread_id UUID REFERENCES chat_thread(id) ON DELETE SET NULL;
+
+ALTER TABLE agent_task_queue
+  ADD COLUMN chat_thread_id UUID REFERENCES chat_thread(id) ON DELETE SET NULL;
+
+-- Pick the canonical private DM conversation per (workspace, agent, creator).
+-- Channel conversations are intentionally excluded and stay independent.
+WITH canonical_private AS (
+  SELECT id,
+         FIRST_VALUE(id) OVER (
+           PARTITION BY workspace_id, agent_id, creator_id
+           ORDER BY created_at ASC, id ASC
+         ) AS canonical_id
+  FROM chat_session
+  WHERE scope_type = 'private_dm'
+    AND source = 'app'
+    AND superseded_by_chat_session_id IS NULL
+)
+UPDATE chat_session cs
+SET superseded_by_chat_session_id = cp.canonical_id,
+    status = 'archived'
+FROM canonical_private cp
+WHERE cs.id = cp.id
+  AND cs.id <> cp.canonical_id;
+
+-- Create one thread for every legacy thread-task group inside every old
+-- session. The thread lives under the canonical conversation when a private DM
+-- session was superseded; channel/shared sessions keep their own container.
+WITH thread_groups AS (
+  SELECT DISTINCT
+      cm.chat_session_id AS legacy_chat_session_id,
+      COALESCE(cm.thread_task_id, cm.task_id) AS legacy_thread_task_id
+  FROM chat_message cm
+  WHERE COALESCE(cm.thread_task_id, cm.task_id) IS NOT NULL
+),
+roots AS (
+  SELECT
+      tg.legacy_chat_session_id,
+      tg.legacy_thread_task_id,
+      root.id AS root_message_id,
+      root.content AS root_content,
+      root.created_at AS root_created_at
+  FROM thread_groups tg
+  JOIN LATERAL (
+    SELECT cm.*
+    FROM chat_message cm
+    WHERE cm.chat_session_id = tg.legacy_chat_session_id
+      AND COALESCE(cm.thread_task_id, cm.task_id) = tg.legacy_thread_task_id
+    ORDER BY (cm.role = 'user') DESC, cm.created_at ASC, cm.id ASC
+    LIMIT 1
+  ) root ON TRUE
+),
+targets AS (
+  SELECT
+      r.*,
+      COALESCE(cs.superseded_by_chat_session_id, cs.id) AS chat_session_id,
+      cs.creator_id,
+      cs.title AS session_title
+  FROM roots r
+  JOIN chat_session cs ON cs.id = r.legacy_chat_session_id
+)
+INSERT INTO chat_thread (
+    chat_session_id, legacy_chat_session_id, legacy_thread_task_id,
+    root_message_id, title, created_by, created_at, updated_at
+)
+SELECT
+    chat_session_id,
+    legacy_chat_session_id,
+    legacy_thread_task_id,
+    root_message_id,
+    COALESCE(NULLIF(session_title, ''), LEFT(root_content, 120), ''),
+    creator_id,
+    root_created_at,
+    root_created_at
+FROM targets;
+
+-- Sessions with unthreaded legacy messages need one fallback thread.
+WITH sessions_with_unthreaded_messages AS (
+  SELECT DISTINCT cm.chat_session_id AS legacy_chat_session_id
+  FROM chat_message cm
+  WHERE COALESCE(cm.thread_task_id, cm.task_id) IS NULL
+),
+roots AS (
+  SELECT
+      s.legacy_chat_session_id,
+      root.id AS root_message_id,
+      root.content AS root_content,
+      root.created_at AS root_created_at
+  FROM sessions_with_unthreaded_messages s
+  JOIN LATERAL (
+    SELECT cm.*
+    FROM chat_message cm
+    WHERE cm.chat_session_id = s.legacy_chat_session_id
+      AND COALESCE(cm.thread_task_id, cm.task_id) IS NULL
+    ORDER BY (cm.role = 'user') DESC, cm.created_at ASC, cm.id ASC
+    LIMIT 1
+  ) root ON TRUE
+),
+targets AS (
+  SELECT
+      r.*,
+      COALESCE(cs.superseded_by_chat_session_id, cs.id) AS chat_session_id,
+      cs.creator_id,
+      cs.title AS session_title
+  FROM roots r
+  JOIN chat_session cs ON cs.id = r.legacy_chat_session_id
+)
+INSERT INTO chat_thread (
+    chat_session_id, legacy_chat_session_id, root_message_id,
+    title, created_by, created_at, updated_at
+)
+SELECT
+    chat_session_id,
+    legacy_chat_session_id,
+    root_message_id,
+    COALESCE(NULLIF(session_title, ''), LEFT(root_content, 120), ''),
+    creator_id,
+    root_created_at,
+    root_created_at
+FROM targets;
+
+-- Attach messages to their new thread and move superseded private DM history
+-- onto the canonical conversation.
+UPDATE chat_message cm
+SET chat_thread_id = ct.id
+FROM chat_thread ct
+WHERE ct.legacy_chat_session_id = cm.chat_session_id
+  AND ct.legacy_thread_task_id IS NOT NULL
+  AND COALESCE(cm.thread_task_id, cm.task_id) = ct.legacy_thread_task_id;
+
+UPDATE chat_message cm
+SET chat_thread_id = ct.id
+FROM chat_thread ct
+WHERE ct.legacy_chat_session_id = cm.chat_session_id
+  AND ct.legacy_thread_task_id IS NULL
+  AND cm.chat_thread_id IS NULL;
+
+UPDATE chat_message cm
+SET chat_session_id = ct.chat_session_id
+FROM chat_thread ct
+WHERE cm.chat_thread_id = ct.id
+  AND cm.chat_session_id <> ct.chat_session_id;
+
+ALTER TABLE chat_thread
+  ADD CONSTRAINT chat_thread_root_message_fkey
+  FOREIGN KEY (root_message_id) REFERENCES chat_message(id) ON DELETE SET NULL;
+
+-- Bind tasks to threads via their user/assistant chat message link, then move
+-- superseded private DM tasks onto the canonical conversation id.
+UPDATE agent_task_queue atq
+SET chat_thread_id = cm.chat_thread_id
+FROM chat_message cm
+WHERE cm.task_id = atq.id
+  AND cm.chat_thread_id IS NOT NULL
+  AND atq.chat_session_id IS NOT NULL;
+
+UPDATE agent_task_queue atq
+SET chat_session_id = ct.chat_session_id
+FROM chat_thread ct
+WHERE atq.chat_thread_id = ct.id
+  AND atq.chat_session_id IS DISTINCT FROM ct.chat_session_id;
+
+-- Move unattached chat uploads that were scoped only to a superseded private
+-- DM conversation so restored drafts can still re-bind in the canonical one.
+UPDATE attachment a
+SET chat_session_id = cs.superseded_by_chat_session_id
+FROM chat_session cs
+WHERE a.chat_session_id = cs.id
+  AND cs.superseded_by_chat_session_id IS NOT NULL
+  AND a.chat_message_id IS NULL;
+
+CREATE INDEX idx_chat_message_session_thread
+  ON chat_message(chat_session_id, chat_thread_id, created_at)
+  WHERE chat_thread_id IS NOT NULL;
+CREATE INDEX idx_agent_task_queue_chat_thread_pending
+  ON agent_task_queue(chat_thread_id, created_at DESC)
+  WHERE chat_thread_id IS NOT NULL
+    AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');
+
+CREATE TABLE chat_agent_session (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    chat_session_id UUID NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
+    chat_thread_id UUID REFERENCES chat_thread(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+    runtime_id UUID NOT NULL REFERENCES agent_runtime(id) ON DELETE CASCADE,
+    provider_session_id TEXT,
+    work_dir TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'poisoned')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_chat_agent_session_thread_runtime
+  ON chat_agent_session(chat_thread_id, agent_id, runtime_id)
+  WHERE chat_thread_id IS NOT NULL;
+
+CREATE INDEX idx_chat_agent_session_session
+  ON chat_agent_session(chat_session_id, updated_at DESC);
+
+INSERT INTO chat_agent_session (
+    chat_session_id, chat_thread_id, agent_id, runtime_id,
+    provider_session_id, work_dir, updated_at
+)
+SELECT DISTINCT ON (atq.chat_thread_id, atq.agent_id, atq.runtime_id)
+    atq.chat_session_id,
+    atq.chat_thread_id,
+    atq.agent_id,
+    atq.runtime_id,
+    atq.session_id,
+    atq.work_dir,
+    COALESCE(atq.completed_at, atq.started_at, atq.dispatched_at, atq.created_at)
+FROM agent_task_queue atq
+WHERE atq.chat_thread_id IS NOT NULL
+  AND atq.chat_session_id IS NOT NULL
+  AND atq.session_id IS NOT NULL
+  AND (
+    atq.status = 'completed'
+    OR (
+      atq.status = 'failed'
+      AND COALESCE(atq.failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity')
+      AND NOT (COALESCE(atq.error, '') ILIKE '%400%' AND COALESCE(atq.error, '') ILIKE '%invalid_request_error%')
+    )
+  )
+ORDER BY
+    atq.chat_thread_id,
+    atq.agent_id,
+    atq.runtime_id,
+    COALESCE(atq.completed_at, atq.started_at, atq.dispatched_at, atq.created_at) DESC;

--- a/server/migrations/129_chat_conversation_threads.up.sql
+++ b/server/migrations/129_chat_conversation_threads.up.sql
@@ -59,8 +59,15 @@ ALTER TABLE chat_message
 ALTER TABLE agent_task_queue
   ADD COLUMN chat_thread_id UUID REFERENCES chat_thread(id) ON DELETE SET NULL;
 
--- Pick the canonical private DM conversation per (workspace, agent, creator).
--- Channel conversations are intentionally excluded and stay independent.
+-- PRODUCT DECISION (not a side effect): collapse to exactly ONE private DM
+-- conversation per (workspace, agent, creator). Any extra historical private DM
+-- sessions a user accumulated with the same agent are merged into the earliest
+-- (canonical) one; the others are archived and pointed at it via
+-- superseded_by_chat_session_id. Channel conversations are intentionally
+-- excluded and stay independent. The reverse of this archival is restored by
+-- the down-migration. Validate against a production snapshot before shipping:
+-- assert the post-migration active-session count and message/attachment
+-- re-parenting match expectations.
 WITH canonical_private AS (
   SELECT id,
          FIRST_VALUE(id) OVER (

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -178,7 +178,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -214,6 +214,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -222,7 +223,7 @@ const cancelAgentTasksByAgent = `-- name: CancelAgentTasksByAgent :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE agent_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Bulk-cancel every active (queued/dispatched/running) task for an agent.
@@ -269,6 +270,7 @@ func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UU
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -284,7 +286,7 @@ const cancelAgentTasksByChatSession = `-- name: CancelAgentTasksByChatSession :m
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Cancels active tasks belonging to a chat session. Called from
@@ -331,6 +333,7 @@ func (q *Queries) CancelAgentTasksByChatSession(ctx context.Context, chatSession
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -346,7 +349,7 @@ const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Cancels every active task on the issue and returns the affected rows so the
@@ -393,6 +396,7 @@ func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UU
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -408,7 +412,7 @@ const cancelAgentTasksByIssueAndAgent = `-- name: CancelAgentTasksByIssueAndAgen
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CancelAgentTasksByIssueAndAgentParams struct {
@@ -459,6 +463,7 @@ func (q *Queries) CancelAgentTasksByIssueAndAgent(ctx context.Context, arg Cance
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -474,7 +479,7 @@ const cancelAgentTasksByTriggerComment = `-- name: CancelAgentTasksByTriggerComm
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE trigger_comment_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Cancels active tasks whose trigger is the given comment. Called when a
@@ -521,6 +526,7 @@ func (q *Queries) CancelAgentTasksByTriggerComment(ctx context.Context, triggerC
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -561,7 +567,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type ClaimAgentTaskParams struct {
@@ -611,6 +617,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -694,7 +701,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4, prepare_lease_expires_at = NULL
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CompleteAgentTaskParams struct {
@@ -742,6 +749,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -845,7 +853,7 @@ VALUES (
     COALESCE($8::boolean, FALSE),
     $9
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CreateAgentTaskParams struct {
@@ -903,6 +911,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -910,7 +919,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 const createQuickCreateTask = `-- name: CreateQuickCreateTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
 VALUES ($1, $2, NULL, 'queued', $3, $4)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CreateQuickCreateTaskParams struct {
@@ -961,6 +970,7 @@ func (q *Queries) CreateQuickCreateTask(ctx context.Context, arg CreateQuickCrea
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -982,7 +992,7 @@ SELECT
     p.is_leader_task
 FROM agent_task_queue p
 WHERE p.id = $1
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Clones a parent task into a fresh queued attempt. Carries forward the
@@ -1028,6 +1038,7 @@ func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -1051,7 +1062,7 @@ FROM victims v
 WHERE t.id = v.id
   AND t.status = 'queued'
   AND t.created_at < now() - make_interval(secs => $1::double precision)
-RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at
+RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.chat_thread_id
 `
 
 type ExpireStaleQueuedTasksParams struct {
@@ -1121,6 +1132,7 @@ func (q *Queries) ExpireStaleQueuedTasks(ctx context.Context, arg ExpireStaleQue
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1139,7 +1151,7 @@ WHERE id = $1
   AND runtime_id = $2
   AND status IN ('dispatched', 'waiting_local_directory')
   AND started_at IS NULL
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type ExtendAgentTaskPrepareLeaseParams struct {
@@ -1185,6 +1197,7 @@ func (q *Queries) ExtendAgentTaskPrepareLease(ctx context.Context, arg ExtendAge
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -1199,7 +1212,7 @@ SET status = 'failed',
     work_dir = COALESCE($5, work_dir),
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type FailAgentTaskParams struct {
@@ -1258,6 +1271,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -1273,7 +1287,7 @@ WHERE (
     AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
   )
    OR (status = 'running' AND started_at < now() - make_interval(secs => $2::double precision))
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type FailStaleTasksParams struct {
@@ -1331,6 +1345,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -1454,7 +1469,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -1491,12 +1506,13 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
 
 const getAgentTaskInWorkspace = `-- name: GetAgentTaskInWorkspace :one
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.chat_thread_id FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE atq.id = $1 AND a.workspace_id = $2
 `
@@ -1546,6 +1562,7 @@ func (q *Queries) GetAgentTaskInWorkspace(ctx context.Context, arg GetAgentTaskI
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -1975,7 +1992,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 ORDER BY created_at DESC
 `
@@ -2024,6 +2041,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2036,7 +2054,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -2080,6 +2098,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2190,7 +2209,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -2234,6 +2253,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2246,7 +2266,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE runtime_id = $1 AND status = 'queued'
 ORDER BY priority DESC, created_at ASC
 `
@@ -2298,6 +2318,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2310,7 +2331,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -2354,6 +2375,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2366,15 +2388,15 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 }
 
 const listWorkspaceAgentTaskSnapshot = `-- name: ListWorkspaceAgentTaskSnapshot :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.chat_thread_id FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE a.workspace_id = $1
   AND atq.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 
 UNION ALL
 
-SELECT t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at FROM (
-  SELECT DISTINCT ON (atq.agent_id) atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at
+SELECT t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.chat_thread_id FROM (
+  SELECT DISTINCT ON (atq.agent_id) atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.chat_thread_id
   FROM agent_task_queue atq
   JOIN agent a ON a.id = atq.agent_id
   WHERE a.workspace_id = $1
@@ -2440,6 +2462,7 @@ func (q *Queries) ListWorkspaceAgentTaskSnapshot(ctx context.Context, workspaceI
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2457,7 +2480,7 @@ SET status = 'waiting_local_directory',
     wait_reason = $2,
     prepare_lease_expires_at = now() + make_interval(secs => $3::double precision)
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type MarkAgentTaskWaitingLocalDirectoryParams struct {
@@ -2508,6 +2531,7 @@ func (q *Queries) MarkAgentTaskWaitingLocalDirectory(ctx context.Context, arg Ma
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -2527,7 +2551,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type ReclaimStaleDispatchedTaskForRuntimeParams struct {
@@ -2574,6 +2598,7 @@ func (q *Queries) ReclaimStaleDispatchedTaskForRuntime(ctx context.Context, arg 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -2587,7 +2612,7 @@ SET status = 'failed',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE runtime_id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Called by the daemon at startup. Atomically fails any dispatched/running/
@@ -2635,6 +2660,7 @@ func (q *Queries) RecoverOrphanedTasksForRuntime(ctx context.Context, runtimeID 
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -2730,7 +2756,7 @@ SET status = 'running',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Transitions a task to running. Accepts either 'dispatched' (the normal
@@ -2772,6 +2798,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -176,7 +176,7 @@ const createAutopilotTask = `-- name: CreateAutopilotTask :one
 
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id, trigger_summary)
 VALUES ($1, $2, NULL, 'queued', $3, $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CreateAutopilotTaskParams struct {
@@ -229,6 +229,7 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -226,7 +226,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 
 const createChatThread = `-- name: CreateChatThread :one
 INSERT INTO chat_thread (chat_session_id, title, created_by)
-VALUES ($1, $2, $3)
+VALUES ($1, LEFT($2::text, 120), $3)
 RETURNING id, chat_session_id, legacy_chat_session_id, legacy_thread_task_id, root_message_id, title, status, created_by, created_at, updated_at
 `
 
@@ -236,6 +236,8 @@ type CreateChatThreadParams struct {
 	CreatedBy     pgtype.UUID `json:"created_by"`
 }
 
+// Title is capped at 120 chars here so the cap lives in one place (DB), matching
+// SetChatThreadRootMessage's LEFT(...,120); callers may pass the full message.
 func (q *Queries) CreateChatThread(ctx context.Context, arg CreateChatThreadParams) (ChatThread, error) {
 	row := q.db.QueryRow(ctx, createChatThread, arg.ChatSessionID, arg.Title, arg.CreatedBy)
 	var i ChatThread

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -11,17 +11,59 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const backfillChatTaskThreadID = `-- name: BackfillChatTaskThreadID :exec
+UPDATE agent_task_queue
+SET chat_thread_id = $2
+WHERE id = $1
+  AND chat_session_id = $3
+`
+
+type BackfillChatTaskThreadIDParams struct {
+	ID            pgtype.UUID `json:"id"`
+	ChatThreadID  pgtype.UUID `json:"chat_thread_id"`
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+}
+
+func (q *Queries) BackfillChatTaskThreadID(ctx context.Context, arg BackfillChatTaskThreadIDParams) error {
+	_, err := q.db.Exec(ctx, backfillChatTaskThreadID, arg.ID, arg.ChatThreadID, arg.ChatSessionID)
+	return err
+}
+
+const backfillChatThreadForTaskID = `-- name: BackfillChatThreadForTaskID :exec
+UPDATE chat_message
+SET chat_thread_id = $3,
+    thread_task_id = COALESCE(thread_task_id, $2)
+WHERE chat_session_id = $1
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+`
+
+type BackfillChatThreadForTaskIDParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	ThreadTaskID  pgtype.UUID `json:"thread_task_id"`
+	ChatThreadID  pgtype.UUID `json:"chat_thread_id"`
+}
+
+func (q *Queries) BackfillChatThreadForTaskID(ctx context.Context, arg BackfillChatThreadForTaskIDParams) error {
+	_, err := q.db.Exec(ctx, backfillChatThreadForTaskID, arg.ChatSessionID, arg.ThreadTaskID, arg.ChatThreadID)
+	return err
+}
+
 const createChatMessage = `-- name: CreateChatMessage :one
-INSERT INTO chat_message (chat_session_id, role, content, task_id, failure_reason, elapsed_ms)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms
+INSERT INTO chat_message (chat_session_id, chat_thread_id, role, content, task_id, thread_task_id, failure_reason, elapsed_ms)
+VALUES ($1, $4, $2, $3, $5, $6, $7, $8)
+RETURNING id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id
 `
 
 type CreateChatMessageParams struct {
 	ChatSessionID pgtype.UUID `json:"chat_session_id"`
 	Role          string      `json:"role"`
 	Content       string      `json:"content"`
+	ChatThreadID  pgtype.UUID `json:"chat_thread_id"`
 	TaskID        pgtype.UUID `json:"task_id"`
+	ThreadTaskID  pgtype.UUID `json:"thread_task_id"`
 	FailureReason pgtype.Text `json:"failure_reason"`
 	ElapsedMs     pgtype.Int8 `json:"elapsed_ms"`
 }
@@ -31,7 +73,9 @@ func (q *Queries) CreateChatMessage(ctx context.Context, arg CreateChatMessagePa
 		arg.ChatSessionID,
 		arg.Role,
 		arg.Content,
+		arg.ChatThreadID,
 		arg.TaskID,
+		arg.ThreadTaskID,
 		arg.FailureReason,
 		arg.ElapsedMs,
 	)
@@ -45,14 +89,25 @@ func (q *Queries) CreateChatMessage(ctx context.Context, arg CreateChatMessagePa
 		&i.CreatedAt,
 		&i.FailureReason,
 		&i.ElapsedMs,
+		&i.ThreadTaskID,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
 
 const createChatSession = `-- name: CreateChatSession :one
-INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, runtime_id)
-VALUES ($1, $2, $3, $4, (SELECT runtime_id FROM agent WHERE id = $2))
-RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id
+INSERT INTO chat_session (
+    workspace_id, agent_id, creator_id, title, runtime_id,
+    scope_type, scope_id, source, visibility
+)
+VALUES (
+    $1, $2, $3, $4, (SELECT runtime_id FROM agent WHERE id = $2),
+    COALESCE($5::text, 'private_dm'),
+    COALESCE($6::uuid, $3),
+    COALESCE($7::text, 'app'),
+    COALESCE($8::text, 'private')
+)
+RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id, scope_type, scope_id, source, visibility, external_ref, superseded_by_chat_session_id
 `
 
 type CreateChatSessionParams struct {
@@ -60,6 +115,10 @@ type CreateChatSessionParams struct {
 	AgentID     pgtype.UUID `json:"agent_id"`
 	CreatorID   pgtype.UUID `json:"creator_id"`
 	Title       string      `json:"title"`
+	ScopeType   pgtype.Text `json:"scope_type"`
+	ScopeID     pgtype.UUID `json:"scope_id"`
+	Source      pgtype.Text `json:"source"`
+	Visibility  pgtype.Text `json:"visibility"`
 }
 
 func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionParams) (ChatSession, error) {
@@ -68,6 +127,10 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 		arg.AgentID,
 		arg.CreatorID,
 		arg.Title,
+		arg.ScopeType,
+		arg.ScopeID,
+		arg.Source,
+		arg.Visibility,
 	)
 	var i ChatSession
 	err := row.Scan(
@@ -83,6 +146,12 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 		&i.UpdatedAt,
 		&i.UnreadSince,
 		&i.RuntimeID,
+		&i.ScopeType,
+		&i.ScopeID,
+		&i.Source,
+		&i.Visibility,
+		&i.ExternalRef,
+		&i.SupersededByChatSessionID,
 	)
 	return i, err
 }
@@ -90,13 +159,13 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 const createChatTask = `-- name: CreateChatTask :one
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, status, priority, chat_session_id,
-    initiator_user_id, force_fresh_session
+    chat_thread_id, initiator_user_id, force_fresh_session
 )
 VALUES (
-    $1, $2, NULL, 'queued', $3, $4, $5,
-    COALESCE($6::boolean, FALSE)
+    $1, $2, NULL, 'queued', $3, $4, $6, $5,
+    COALESCE($7::boolean, FALSE)
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CreateChatTaskParams struct {
@@ -105,6 +174,7 @@ type CreateChatTaskParams struct {
 	Priority          int32       `json:"priority"`
 	ChatSessionID     pgtype.UUID `json:"chat_session_id"`
 	InitiatorUserID   pgtype.UUID `json:"initiator_user_id"`
+	ChatThreadID      pgtype.UUID `json:"chat_thread_id"`
 	ForceFreshSession pgtype.Bool `json:"force_fresh_session"`
 }
 
@@ -115,6 +185,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		arg.Priority,
 		arg.ChatSessionID,
 		arg.InitiatorUserID,
+		arg.ChatThreadID,
 		arg.ForceFreshSession,
 	)
 	var i AgentTaskQueue
@@ -148,6 +219,37 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.ChatThreadID,
+	)
+	return i, err
+}
+
+const createChatThread = `-- name: CreateChatThread :one
+INSERT INTO chat_thread (chat_session_id, title, created_by)
+VALUES ($1, $2, $3)
+RETURNING id, chat_session_id, legacy_chat_session_id, legacy_thread_task_id, root_message_id, title, status, created_by, created_at, updated_at
+`
+
+type CreateChatThreadParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	Title         string      `json:"title"`
+	CreatedBy     pgtype.UUID `json:"created_by"`
+}
+
+func (q *Queries) CreateChatThread(ctx context.Context, arg CreateChatThreadParams) (ChatThread, error) {
+	row := q.db.QueryRow(ctx, createChatThread, arg.ChatSessionID, arg.Title, arg.CreatedBy)
+	var i ChatThread
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.LegacyChatSessionID,
+		&i.LegacyThreadTaskID,
+		&i.RootMessageID,
+		&i.Title,
+		&i.Status,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -177,7 +279,7 @@ func (q *Queries) DeleteChatSession(ctx context.Context, arg DeleteChatSessionPa
 const deleteUserChatMessageByTask = `-- name: DeleteUserChatMessageByTask :one
 DELETE FROM chat_message
 WHERE task_id = $1 AND role = 'user'
-RETURNING id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms
+RETURNING id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id
 `
 
 func (q *Queries) DeleteUserChatMessageByTask(ctx context.Context, taskID pgtype.UUID) (ChatMessage, error) {
@@ -192,12 +294,47 @@ func (q *Queries) DeleteUserChatMessageByTask(ctx context.Context, taskID pgtype
 		&i.CreatedAt,
 		&i.FailureReason,
 		&i.ElapsedMs,
+		&i.ThreadTaskID,
+		&i.ChatThreadID,
+	)
+	return i, err
+}
+
+const getChatAgentSessionByThread = `-- name: GetChatAgentSessionByThread :one
+SELECT id, chat_session_id, chat_thread_id, agent_id, runtime_id, provider_session_id, work_dir, status, created_at, updated_at FROM chat_agent_session
+WHERE chat_thread_id = $1
+  AND agent_id = $2
+  AND runtime_id = $3
+  AND status = 'active'
+LIMIT 1
+`
+
+type GetChatAgentSessionByThreadParams struct {
+	ChatThreadID pgtype.UUID `json:"chat_thread_id"`
+	AgentID      pgtype.UUID `json:"agent_id"`
+	RuntimeID    pgtype.UUID `json:"runtime_id"`
+}
+
+func (q *Queries) GetChatAgentSessionByThread(ctx context.Context, arg GetChatAgentSessionByThreadParams) (ChatAgentSession, error) {
+	row := q.db.QueryRow(ctx, getChatAgentSessionByThread, arg.ChatThreadID, arg.AgentID, arg.RuntimeID)
+	var i ChatAgentSession
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.ChatThreadID,
+		&i.AgentID,
+		&i.RuntimeID,
+		&i.ProviderSessionID,
+		&i.WorkDir,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
 
 const getChatMessage = `-- name: GetChatMessage :one
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
 WHERE id = $1
 `
 
@@ -213,12 +350,14 @@ func (q *Queries) GetChatMessage(ctx context.Context, id pgtype.UUID) (ChatMessa
 		&i.CreatedAt,
 		&i.FailureReason,
 		&i.ElapsedMs,
+		&i.ThreadTaskID,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
 
 const getChatSession = `-- name: GetChatSession :one
-SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id FROM chat_session
+SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id, scope_type, scope_id, source, visibility, external_ref, superseded_by_chat_session_id FROM chat_session
 WHERE id = $1
 `
 
@@ -238,12 +377,18 @@ func (q *Queries) GetChatSession(ctx context.Context, id pgtype.UUID) (ChatSessi
 		&i.UpdatedAt,
 		&i.UnreadSince,
 		&i.RuntimeID,
+		&i.ScopeType,
+		&i.ScopeID,
+		&i.Source,
+		&i.Visibility,
+		&i.ExternalRef,
+		&i.SupersededByChatSessionID,
 	)
 	return i, err
 }
 
 const getChatSessionInWorkspace = `-- name: GetChatSessionInWorkspace :one
-SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id FROM chat_session
+SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id, scope_type, scope_id, source, visibility, external_ref, superseded_by_chat_session_id FROM chat_session
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -268,8 +413,92 @@ func (q *Queries) GetChatSessionInWorkspace(ctx context.Context, arg GetChatSess
 		&i.UpdatedAt,
 		&i.UnreadSince,
 		&i.RuntimeID,
+		&i.ScopeType,
+		&i.ScopeID,
+		&i.Source,
+		&i.Visibility,
+		&i.ExternalRef,
+		&i.SupersededByChatSessionID,
 	)
 	return i, err
+}
+
+const getChatThreadInSession = `-- name: GetChatThreadInSession :one
+SELECT id, chat_session_id, legacy_chat_session_id, legacy_thread_task_id, root_message_id, title, status, created_by, created_at, updated_at FROM chat_thread
+WHERE id = $1 AND chat_session_id = $2
+`
+
+type GetChatThreadInSessionParams struct {
+	ID            pgtype.UUID `json:"id"`
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+}
+
+func (q *Queries) GetChatThreadInSession(ctx context.Context, arg GetChatThreadInSessionParams) (ChatThread, error) {
+	row := q.db.QueryRow(ctx, getChatThreadInSession, arg.ID, arg.ChatSessionID)
+	var i ChatThread
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.LegacyChatSessionID,
+		&i.LegacyThreadTaskID,
+		&i.RootMessageID,
+		&i.Title,
+		&i.Status,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getChatThreadRootMessageByTaskID = `-- name: GetChatThreadRootMessageByTaskID :one
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
+WHERE chat_session_id = $1
+  AND role = 'user'
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+type GetChatThreadRootMessageByTaskIDParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	TaskID        pgtype.UUID `json:"task_id"`
+}
+
+func (q *Queries) GetChatThreadRootMessageByTaskID(ctx context.Context, arg GetChatThreadRootMessageByTaskIDParams) (ChatMessage, error) {
+	row := q.db.QueryRow(ctx, getChatThreadRootMessageByTaskID, arg.ChatSessionID, arg.TaskID)
+	var i ChatMessage
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.Role,
+		&i.Content,
+		&i.TaskID,
+		&i.CreatedAt,
+		&i.FailureReason,
+		&i.ElapsedMs,
+		&i.ThreadTaskID,
+		&i.ChatThreadID,
+	)
+	return i, err
+}
+
+const getChatThreadTaskIDByTask = `-- name: GetChatThreadTaskIDByTask :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE task_id = $1
+ORDER BY role = 'user' DESC, created_at ASC
+LIMIT 1
+`
+
+func (q *Queries) GetChatThreadTaskIDByTask(ctx context.Context, taskID pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getChatThreadTaskIDByTask, taskID)
+	var column_1 pgtype.UUID
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const getLastChatTaskSession = `-- name: GetLastChatTaskSession :one
@@ -308,8 +537,37 @@ func (q *Queries) GetLastChatTaskSession(ctx context.Context, chatSessionID pgty
 	return i, err
 }
 
+const getLastChatTaskSessionByThread = `-- name: GetLastChatTaskSessionByThread :one
+SELECT session_id, work_dir, runtime_id FROM agent_task_queue
+WHERE chat_thread_id = $1
+  AND (
+    status = 'completed'
+    OR (
+      status = 'failed'
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity')
+      AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
+    )
+  )
+  AND session_id IS NOT NULL
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
+LIMIT 1
+`
+
+type GetLastChatTaskSessionByThreadRow struct {
+	SessionID pgtype.Text `json:"session_id"`
+	WorkDir   pgtype.Text `json:"work_dir"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+}
+
+func (q *Queries) GetLastChatTaskSessionByThread(ctx context.Context, chatThreadID pgtype.UUID) (GetLastChatTaskSessionByThreadRow, error) {
+	row := q.db.QueryRow(ctx, getLastChatTaskSessionByThread, chatThreadID)
+	var i GetLastChatTaskSessionByThreadRow
+	err := row.Scan(&i.SessionID, &i.WorkDir, &i.RuntimeID)
+	return i, err
+}
+
 const getMostRecentUserChatMessage = `-- name: GetMostRecentUserChatMessage :one
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
 WHERE chat_session_id = $1 AND role = 'user'
 ORDER BY created_at DESC
 LIMIT 1
@@ -332,6 +590,8 @@ func (q *Queries) GetMostRecentUserChatMessage(ctx context.Context, chatSessionI
 		&i.CreatedAt,
 		&i.FailureReason,
 		&i.ElapsedMs,
+		&i.ThreadTaskID,
+		&i.ChatThreadID,
 	)
 	return i, err
 }
@@ -361,27 +621,76 @@ func (q *Queries) GetPendingChatTask(ctx context.Context, chatSessionID pgtype.U
 	return i, err
 }
 
+const getPrivateChatSessionForAgentCreator = `-- name: GetPrivateChatSessionForAgentCreator :one
+SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id, scope_type, scope_id, source, visibility, external_ref, superseded_by_chat_session_id FROM chat_session
+WHERE workspace_id = $1
+  AND agent_id = $2
+  AND creator_id = $3
+  AND scope_type = 'private_dm'
+  AND source = 'app'
+  AND status = 'active'
+  AND superseded_by_chat_session_id IS NULL
+ORDER BY created_at ASC, id ASC
+LIMIT 1
+`
+
+type GetPrivateChatSessionForAgentCreatorParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	AgentID     pgtype.UUID `json:"agent_id"`
+	CreatorID   pgtype.UUID `json:"creator_id"`
+}
+
+func (q *Queries) GetPrivateChatSessionForAgentCreator(ctx context.Context, arg GetPrivateChatSessionForAgentCreatorParams) (ChatSession, error) {
+	row := q.db.QueryRow(ctx, getPrivateChatSessionForAgentCreator, arg.WorkspaceID, arg.AgentID, arg.CreatorID)
+	var i ChatSession
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.AgentID,
+		&i.CreatorID,
+		&i.Title,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.UnreadSince,
+		&i.RuntimeID,
+		&i.ScopeType,
+		&i.ScopeID,
+		&i.Source,
+		&i.Visibility,
+		&i.ExternalRef,
+		&i.SupersededByChatSessionID,
+	)
+	return i, err
+}
+
 const linkChatMessageToTask = `-- name: LinkChatMessageToTask :exec
 UPDATE chat_message
-SET task_id = $2
+SET task_id = $2,
+    thread_task_id = COALESCE(thread_task_id, $2),
+    chat_thread_id = COALESCE(chat_thread_id, $3::uuid)
 WHERE id = $1 AND role = 'user'
 `
 
 type LinkChatMessageToTaskParams struct {
-	ID     pgtype.UUID `json:"id"`
-	TaskID pgtype.UUID `json:"task_id"`
+	ID           pgtype.UUID `json:"id"`
+	TaskID       pgtype.UUID `json:"task_id"`
+	ChatThreadID pgtype.UUID `json:"chat_thread_id"`
 }
 
 func (q *Queries) LinkChatMessageToTask(ctx context.Context, arg LinkChatMessageToTaskParams) error {
-	_, err := q.db.Exec(ctx, linkChatMessageToTask, arg.ID, arg.TaskID)
+	_, err := q.db.Exec(ctx, linkChatMessageToTask, arg.ID, arg.TaskID, arg.ChatThreadID)
 	return err
 }
 
 const listAllChatSessionsByCreator = `-- name: ListAllChatSessionsByCreator :many
-SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.unread_since, cs.runtime_id,
+SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.unread_since, cs.runtime_id, cs.scope_type, cs.scope_id, cs.source, cs.visibility, cs.external_ref, cs.superseded_by_chat_session_id,
        (cs.unread_since IS NOT NULL)::bool AS has_unread
 FROM chat_session cs
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2
+  AND cs.superseded_by_chat_session_id IS NULL
 ORDER BY cs.updated_at DESC
 `
 
@@ -391,19 +700,25 @@ type ListAllChatSessionsByCreatorParams struct {
 }
 
 type ListAllChatSessionsByCreatorRow struct {
-	ID          pgtype.UUID        `json:"id"`
-	WorkspaceID pgtype.UUID        `json:"workspace_id"`
-	AgentID     pgtype.UUID        `json:"agent_id"`
-	CreatorID   pgtype.UUID        `json:"creator_id"`
-	Title       string             `json:"title"`
-	SessionID   pgtype.Text        `json:"session_id"`
-	WorkDir     pgtype.Text        `json:"work_dir"`
-	Status      string             `json:"status"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	UnreadSince pgtype.Timestamptz `json:"unread_since"`
-	RuntimeID   pgtype.UUID        `json:"runtime_id"`
-	HasUnread   bool               `json:"has_unread"`
+	ID                        pgtype.UUID        `json:"id"`
+	WorkspaceID               pgtype.UUID        `json:"workspace_id"`
+	AgentID                   pgtype.UUID        `json:"agent_id"`
+	CreatorID                 pgtype.UUID        `json:"creator_id"`
+	Title                     string             `json:"title"`
+	SessionID                 pgtype.Text        `json:"session_id"`
+	WorkDir                   pgtype.Text        `json:"work_dir"`
+	Status                    string             `json:"status"`
+	CreatedAt                 pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                 pgtype.Timestamptz `json:"updated_at"`
+	UnreadSince               pgtype.Timestamptz `json:"unread_since"`
+	RuntimeID                 pgtype.UUID        `json:"runtime_id"`
+	ScopeType                 string             `json:"scope_type"`
+	ScopeID                   pgtype.UUID        `json:"scope_id"`
+	Source                    string             `json:"source"`
+	Visibility                string             `json:"visibility"`
+	ExternalRef               []byte             `json:"external_ref"`
+	SupersededByChatSessionID pgtype.UUID        `json:"superseded_by_chat_session_id"`
+	HasUnread                 bool               `json:"has_unread"`
 }
 
 func (q *Queries) ListAllChatSessionsByCreator(ctx context.Context, arg ListAllChatSessionsByCreatorParams) ([]ListAllChatSessionsByCreatorRow, error) {
@@ -428,6 +743,12 @@ func (q *Queries) ListAllChatSessionsByCreator(ctx context.Context, arg ListAllC
 			&i.UpdatedAt,
 			&i.UnreadSince,
 			&i.RuntimeID,
+			&i.ScopeType,
+			&i.ScopeID,
+			&i.Source,
+			&i.Visibility,
+			&i.ExternalRef,
+			&i.SupersededByChatSessionID,
 			&i.HasUnread,
 		); err != nil {
 			return nil, err
@@ -441,7 +762,7 @@ func (q *Queries) ListAllChatSessionsByCreator(ctx context.Context, arg ListAllC
 }
 
 const listChatMessages = `-- name: ListChatMessages :many
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
 WHERE chat_session_id = $1
 ORDER BY created_at ASC
 `
@@ -464,6 +785,51 @@ func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUI
 			&i.CreatedAt,
 			&i.FailureReason,
 			&i.ElapsedMs,
+			&i.ThreadTaskID,
+			&i.ChatThreadID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChatMessagesByThread = `-- name: ListChatMessagesByThread :many
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id = $2
+ORDER BY created_at ASC
+`
+
+type ListChatMessagesByThreadParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	ChatThreadID  pgtype.UUID `json:"chat_thread_id"`
+}
+
+func (q *Queries) ListChatMessagesByThread(ctx context.Context, arg ListChatMessagesByThreadParams) ([]ChatMessage, error) {
+	rows, err := q.db.Query(ctx, listChatMessagesByThread, arg.ChatSessionID, arg.ChatThreadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ChatMessage{}
+	for rows.Next() {
+		var i ChatMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatSessionID,
+			&i.Role,
+			&i.Content,
+			&i.TaskID,
+			&i.CreatedAt,
+			&i.FailureReason,
+			&i.ElapsedMs,
+			&i.ThreadTaskID,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -476,7 +842,7 @@ func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUI
 }
 
 const listChatMessagesPage = `-- name: ListChatMessagesPage :many
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms FROM chat_message
+SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, thread_task_id, chat_thread_id FROM chat_message
 WHERE chat_session_id = $1
   AND (
     $3::timestamptz IS NULL
@@ -516,6 +882,8 @@ func (q *Queries) ListChatMessagesPage(ctx context.Context, arg ListChatMessages
 			&i.CreatedAt,
 			&i.FailureReason,
 			&i.ElapsedMs,
+			&i.ThreadTaskID,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -528,10 +896,11 @@ func (q *Queries) ListChatMessagesPage(ctx context.Context, arg ListChatMessages
 }
 
 const listChatSessionsByCreator = `-- name: ListChatSessionsByCreator :many
-SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.unread_since, cs.runtime_id,
+SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.unread_since, cs.runtime_id, cs.scope_type, cs.scope_id, cs.source, cs.visibility, cs.external_ref, cs.superseded_by_chat_session_id,
        (cs.unread_since IS NOT NULL)::bool AS has_unread
 FROM chat_session cs
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2 AND cs.status = 'active'
+  AND cs.superseded_by_chat_session_id IS NULL
 ORDER BY cs.updated_at DESC
 `
 
@@ -541,19 +910,25 @@ type ListChatSessionsByCreatorParams struct {
 }
 
 type ListChatSessionsByCreatorRow struct {
-	ID          pgtype.UUID        `json:"id"`
-	WorkspaceID pgtype.UUID        `json:"workspace_id"`
-	AgentID     pgtype.UUID        `json:"agent_id"`
-	CreatorID   pgtype.UUID        `json:"creator_id"`
-	Title       string             `json:"title"`
-	SessionID   pgtype.Text        `json:"session_id"`
-	WorkDir     pgtype.Text        `json:"work_dir"`
-	Status      string             `json:"status"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	UnreadSince pgtype.Timestamptz `json:"unread_since"`
-	RuntimeID   pgtype.UUID        `json:"runtime_id"`
-	HasUnread   bool               `json:"has_unread"`
+	ID                        pgtype.UUID        `json:"id"`
+	WorkspaceID               pgtype.UUID        `json:"workspace_id"`
+	AgentID                   pgtype.UUID        `json:"agent_id"`
+	CreatorID                 pgtype.UUID        `json:"creator_id"`
+	Title                     string             `json:"title"`
+	SessionID                 pgtype.Text        `json:"session_id"`
+	WorkDir                   pgtype.Text        `json:"work_dir"`
+	Status                    string             `json:"status"`
+	CreatedAt                 pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                 pgtype.Timestamptz `json:"updated_at"`
+	UnreadSince               pgtype.Timestamptz `json:"unread_since"`
+	RuntimeID                 pgtype.UUID        `json:"runtime_id"`
+	ScopeType                 string             `json:"scope_type"`
+	ScopeID                   pgtype.UUID        `json:"scope_id"`
+	Source                    string             `json:"source"`
+	Visibility                string             `json:"visibility"`
+	ExternalRef               []byte             `json:"external_ref"`
+	SupersededByChatSessionID pgtype.UUID        `json:"superseded_by_chat_session_id"`
+	HasUnread                 bool               `json:"has_unread"`
 }
 
 // Returns active sessions with a boolean unread flag. Unread is strictly
@@ -581,6 +956,12 @@ func (q *Queries) ListChatSessionsByCreator(ctx context.Context, arg ListChatSes
 			&i.UpdatedAt,
 			&i.UnreadSince,
 			&i.RuntimeID,
+			&i.ScopeType,
+			&i.ScopeID,
+			&i.Source,
+			&i.Visibility,
+			&i.ExternalRef,
+			&i.SupersededByChatSessionID,
 			&i.HasUnread,
 		); err != nil {
 			return nil, err
@@ -668,6 +1049,97 @@ func (q *Queries) MarkChatSessionRead(ctx context.Context, id pgtype.UUID) error
 	return err
 }
 
+const resolveChatThreadByTaskID = `-- name: ResolveChatThreadByTaskID :one
+SELECT chat_thread_id
+FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id IS NOT NULL
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+type ResolveChatThreadByTaskIDParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	TaskID        pgtype.UUID `json:"task_id"`
+}
+
+func (q *Queries) ResolveChatThreadByTaskID(ctx context.Context, arg ResolveChatThreadByTaskIDParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, resolveChatThreadByTaskID, arg.ChatSessionID, arg.TaskID)
+	var chat_thread_id pgtype.UUID
+	err := row.Scan(&chat_thread_id)
+	return chat_thread_id, err
+}
+
+const resolveChatThreadTaskID = `-- name: ResolveChatThreadTaskID :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE chat_session_id = $1
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+type ResolveChatThreadTaskIDParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	TaskID        pgtype.UUID `json:"task_id"`
+}
+
+func (q *Queries) ResolveChatThreadTaskID(ctx context.Context, arg ResolveChatThreadTaskIDParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, resolveChatThreadTaskID, arg.ChatSessionID, arg.TaskID)
+	var column_1 pgtype.UUID
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const resolveChatThreadTaskIDByThreadID = `-- name: ResolveChatThreadTaskIDByThreadID :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id = $2
+  AND role = 'user'
+  AND (thread_task_id IS NOT NULL OR task_id IS NOT NULL)
+ORDER BY created_at ASC
+LIMIT 1
+`
+
+type ResolveChatThreadTaskIDByThreadIDParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	ChatThreadID  pgtype.UUID `json:"chat_thread_id"`
+}
+
+func (q *Queries) ResolveChatThreadTaskIDByThreadID(ctx context.Context, arg ResolveChatThreadTaskIDByThreadIDParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, resolveChatThreadTaskIDByThreadID, arg.ChatSessionID, arg.ChatThreadID)
+	var column_1 pgtype.UUID
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const setChatThreadRootMessage = `-- name: SetChatThreadRootMessage :exec
+UPDATE chat_thread
+SET root_message_id = COALESCE(root_message_id, $2),
+    title = CASE WHEN title = '' THEN LEFT($3, 120) ELSE title END,
+    updated_at = now()
+WHERE id = $1
+`
+
+type SetChatThreadRootMessageParams struct {
+	ID            pgtype.UUID `json:"id"`
+	RootMessageID pgtype.UUID `json:"root_message_id"`
+	Title         string      `json:"title"`
+}
+
+func (q *Queries) SetChatThreadRootMessage(ctx context.Context, arg SetChatThreadRootMessageParams) error {
+	_, err := q.db.Exec(ctx, setChatThreadRootMessage, arg.ID, arg.RootMessageID, arg.Title)
+	return err
+}
+
 const setUnreadSinceIfNull = `-- name: SetUnreadSinceIfNull :exec
 UPDATE chat_session SET unread_since = now()
 WHERE id = $1 AND unread_since IS NULL
@@ -725,7 +1197,7 @@ func (q *Queries) UpdateChatSessionSession(ctx context.Context, arg UpdateChatSe
 const updateChatSessionTitle = `-- name: UpdateChatSessionTitle :one
 UPDATE chat_session SET title = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id
+RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, unread_since, runtime_id, scope_type, scope_id, source, visibility, external_ref, superseded_by_chat_session_id
 `
 
 type UpdateChatSessionTitleParams struct {
@@ -749,6 +1221,51 @@ func (q *Queries) UpdateChatSessionTitle(ctx context.Context, arg UpdateChatSess
 		&i.UpdatedAt,
 		&i.UnreadSince,
 		&i.RuntimeID,
+		&i.ScopeType,
+		&i.ScopeID,
+		&i.Source,
+		&i.Visibility,
+		&i.ExternalRef,
+		&i.SupersededByChatSessionID,
 	)
 	return i, err
+}
+
+const upsertChatAgentSession = `-- name: UpsertChatAgentSession :exec
+INSERT INTO chat_agent_session (
+    chat_session_id, chat_thread_id, agent_id, runtime_id,
+    provider_session_id, work_dir, status, updated_at
+)
+VALUES (
+    $1, $2, $3, $4,
+    $5, $6, 'active', now()
+)
+ON CONFLICT (chat_thread_id, agent_id, runtime_id)
+WHERE chat_thread_id IS NOT NULL
+DO UPDATE SET
+    provider_session_id = COALESCE(EXCLUDED.provider_session_id, chat_agent_session.provider_session_id),
+    work_dir = COALESCE(EXCLUDED.work_dir, chat_agent_session.work_dir),
+    status = 'active',
+    updated_at = now()
+`
+
+type UpsertChatAgentSessionParams struct {
+	ChatSessionID     pgtype.UUID `json:"chat_session_id"`
+	ChatThreadID      pgtype.UUID `json:"chat_thread_id"`
+	AgentID           pgtype.UUID `json:"agent_id"`
+	RuntimeID         pgtype.UUID `json:"runtime_id"`
+	ProviderSessionID pgtype.Text `json:"provider_session_id"`
+	WorkDir           pgtype.Text `json:"work_dir"`
+}
+
+func (q *Queries) UpsertChatAgentSession(ctx context.Context, arg UpsertChatAgentSessionParams) error {
+	_, err := q.db.Exec(ctx, upsertChatAgentSession,
+		arg.ChatSessionID,
+		arg.ChatThreadID,
+		arg.AgentID,
+		arg.RuntimeID,
+		arg.ProviderSessionID,
+		arg.WorkDir,
+	)
+	return err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -101,6 +101,7 @@ type AgentTaskQueue struct {
 	InitiatorUserID       pgtype.UUID        `json:"initiator_user_id"`
 	HandoffNote           pgtype.Text        `json:"handoff_note"`
 	PrepareLeaseExpiresAt pgtype.Timestamptz `json:"prepare_lease_expires_at"`
+	ChatThreadID          pgtype.UUID        `json:"chat_thread_id"`
 }
 
 type Attachment struct {
@@ -262,6 +263,19 @@ type ChannelUserBinding struct {
 	BoundAt        pgtype.Timestamptz `json:"bound_at"`
 }
 
+type ChatAgentSession struct {
+	ID                pgtype.UUID        `json:"id"`
+	ChatSessionID     pgtype.UUID        `json:"chat_session_id"`
+	ChatThreadID      pgtype.UUID        `json:"chat_thread_id"`
+	AgentID           pgtype.UUID        `json:"agent_id"`
+	RuntimeID         pgtype.UUID        `json:"runtime_id"`
+	ProviderSessionID pgtype.Text        `json:"provider_session_id"`
+	WorkDir           pgtype.Text        `json:"work_dir"`
+	Status            string             `json:"status"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+}
+
 type ChatMessage struct {
 	ID            pgtype.UUID        `json:"id"`
 	ChatSessionID pgtype.UUID        `json:"chat_session_id"`
@@ -271,21 +285,42 @@ type ChatMessage struct {
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	FailureReason pgtype.Text        `json:"failure_reason"`
 	ElapsedMs     pgtype.Int8        `json:"elapsed_ms"`
+	ThreadTaskID  pgtype.UUID        `json:"thread_task_id"`
+	ChatThreadID  pgtype.UUID        `json:"chat_thread_id"`
 }
 
 type ChatSession struct {
-	ID          pgtype.UUID        `json:"id"`
-	WorkspaceID pgtype.UUID        `json:"workspace_id"`
-	AgentID     pgtype.UUID        `json:"agent_id"`
-	CreatorID   pgtype.UUID        `json:"creator_id"`
-	Title       string             `json:"title"`
-	SessionID   pgtype.Text        `json:"session_id"`
-	WorkDir     pgtype.Text        `json:"work_dir"`
-	Status      string             `json:"status"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	UnreadSince pgtype.Timestamptz `json:"unread_since"`
-	RuntimeID   pgtype.UUID        `json:"runtime_id"`
+	ID                        pgtype.UUID        `json:"id"`
+	WorkspaceID               pgtype.UUID        `json:"workspace_id"`
+	AgentID                   pgtype.UUID        `json:"agent_id"`
+	CreatorID                 pgtype.UUID        `json:"creator_id"`
+	Title                     string             `json:"title"`
+	SessionID                 pgtype.Text        `json:"session_id"`
+	WorkDir                   pgtype.Text        `json:"work_dir"`
+	Status                    string             `json:"status"`
+	CreatedAt                 pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                 pgtype.Timestamptz `json:"updated_at"`
+	UnreadSince               pgtype.Timestamptz `json:"unread_since"`
+	RuntimeID                 pgtype.UUID        `json:"runtime_id"`
+	ScopeType                 string             `json:"scope_type"`
+	ScopeID                   pgtype.UUID        `json:"scope_id"`
+	Source                    string             `json:"source"`
+	Visibility                string             `json:"visibility"`
+	ExternalRef               []byte             `json:"external_ref"`
+	SupersededByChatSessionID pgtype.UUID        `json:"superseded_by_chat_session_id"`
+}
+
+type ChatThread struct {
+	ID                  pgtype.UUID        `json:"id"`
+	ChatSessionID       pgtype.UUID        `json:"chat_session_id"`
+	LegacyChatSessionID pgtype.UUID        `json:"legacy_chat_session_id"`
+	LegacyThreadTaskID  pgtype.UUID        `json:"legacy_thread_task_id"`
+	RootMessageID       pgtype.UUID        `json:"root_message_id"`
+	Title               string             `json:"title"`
+	Status              string             `json:"status"`
+	CreatedBy           pgtype.UUID        `json:"created_by"`
+	CreatedAt           pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
 }
 
 type Comment struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -16,7 +16,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE (runtime_id = ANY($1::uuid[]) OR agent_id = ANY($2::uuid[]))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 type CancelAgentTasksByRuntimeOrAgentParams struct {
@@ -77,6 +77,7 @@ func (q *Queries) CancelAgentTasksByRuntimeOrAgent(ctx context.Context, arg Canc
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}
@@ -196,7 +197,7 @@ WHERE status IN ('dispatched', 'running', 'waiting_local_directory')
   AND runtime_id IN (
     SELECT id FROM agent_runtime WHERE status = 'offline'
   )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, chat_thread_id
 `
 
 // Marks dispatched/running/waiting_local_directory tasks as failed when
@@ -241,6 +242,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.ChatThreadID,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -1,7 +1,28 @@
 -- name: CreateChatSession :one
-INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, runtime_id)
-VALUES ($1, $2, $3, $4, (SELECT runtime_id FROM agent WHERE id = $2))
+INSERT INTO chat_session (
+    workspace_id, agent_id, creator_id, title, runtime_id,
+    scope_type, scope_id, source, visibility
+)
+VALUES (
+    $1, $2, $3, $4, (SELECT runtime_id FROM agent WHERE id = $2),
+    COALESCE(sqlc.narg('scope_type')::text, 'private_dm'),
+    COALESCE(sqlc.narg('scope_id')::uuid, $3),
+    COALESCE(sqlc.narg('source')::text, 'app'),
+    COALESCE(sqlc.narg('visibility')::text, 'private')
+)
 RETURNING *;
+
+-- name: GetPrivateChatSessionForAgentCreator :one
+SELECT * FROM chat_session
+WHERE workspace_id = $1
+  AND agent_id = $2
+  AND creator_id = $3
+  AND scope_type = 'private_dm'
+  AND source = 'app'
+  AND status = 'active'
+  AND superseded_by_chat_session_id IS NULL
+ORDER BY created_at ASC, id ASC
+LIMIT 1;
 
 -- name: GetChatSession :one
 SELECT * FROM chat_session
@@ -19,6 +40,7 @@ SELECT cs.*,
        (cs.unread_since IS NOT NULL)::bool AS has_unread
 FROM chat_session cs
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2 AND cs.status = 'active'
+  AND cs.superseded_by_chat_session_id IS NULL
 ORDER BY cs.updated_at DESC;
 
 -- name: ListAllChatSessionsByCreator :many
@@ -26,6 +48,7 @@ SELECT cs.*,
        (cs.unread_since IS NOT NULL)::bool AS has_unread
 FROM chat_session cs
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2
+  AND cs.superseded_by_chat_session_id IS NULL
 ORDER BY cs.updated_at DESC;
 
 -- name: UpdateChatSessionTitle :one
@@ -73,15 +96,100 @@ DELETE FROM chat_session WHERE id = $1 AND workspace_id = $2;
 UPDATE chat_session SET updated_at = now()
 WHERE id = $1;
 
+-- name: CreateChatThread :one
+INSERT INTO chat_thread (chat_session_id, title, created_by)
+VALUES ($1, $2, $3)
+RETURNING *;
+
+-- name: GetChatThreadInSession :one
+SELECT * FROM chat_thread
+WHERE id = $1 AND chat_session_id = $2;
+
+-- name: ResolveChatThreadTaskIDByThreadID :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id = $2
+  AND role = 'user'
+  AND (thread_task_id IS NOT NULL OR task_id IS NOT NULL)
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: ResolveChatThreadByTaskID :one
+SELECT chat_thread_id
+FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id IS NOT NULL
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: GetChatThreadRootMessageByTaskID :one
+SELECT * FROM chat_message
+WHERE chat_session_id = $1
+  AND role = 'user'
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: BackfillChatThreadForTaskID :exec
+UPDATE chat_message
+SET chat_thread_id = $3,
+    thread_task_id = COALESCE(thread_task_id, $2)
+WHERE chat_session_id = $1
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  );
+
+-- name: BackfillChatTaskThreadID :exec
+UPDATE agent_task_queue
+SET chat_thread_id = $2
+WHERE id = $1
+  AND chat_session_id = $3;
+
+-- name: SetChatThreadRootMessage :exec
+UPDATE chat_thread
+SET root_message_id = COALESCE(root_message_id, $2),
+    title = CASE WHEN title = '' THEN LEFT(sqlc.arg('title'), 120) ELSE title END,
+    updated_at = now()
+WHERE id = $1;
+
 -- name: CreateChatMessage :one
-INSERT INTO chat_message (chat_session_id, role, content, task_id, failure_reason, elapsed_ms)
-VALUES ($1, $2, $3, sqlc.narg(task_id), sqlc.narg(failure_reason), sqlc.narg(elapsed_ms))
+INSERT INTO chat_message (chat_session_id, chat_thread_id, role, content, task_id, thread_task_id, failure_reason, elapsed_ms)
+VALUES ($1, sqlc.narg(chat_thread_id), $2, $3, sqlc.narg(task_id), sqlc.narg(thread_task_id), sqlc.narg(failure_reason), sqlc.narg(elapsed_ms))
 RETURNING *;
 
 -- name: LinkChatMessageToTask :exec
 UPDATE chat_message
-SET task_id = $2
+SET task_id = $2,
+    thread_task_id = COALESCE(thread_task_id, $2),
+    chat_thread_id = COALESCE(chat_thread_id, sqlc.narg('chat_thread_id')::uuid)
 WHERE id = $1 AND role = 'user';
+
+-- name: ResolveChatThreadTaskID :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE chat_session_id = $1
+  AND (
+    task_id = $2
+    OR thread_task_id = $2
+  )
+ORDER BY created_at ASC
+LIMIT 1;
+
+-- name: GetChatThreadTaskIDByTask :one
+SELECT COALESCE(thread_task_id, task_id)::uuid
+FROM chat_message
+WHERE task_id = $1
+ORDER BY role = 'user' DESC, created_at ASC
+LIMIT 1;
 
 -- name: DeleteUserChatMessageByTask :one
 DELETE FROM chat_message
@@ -91,6 +199,12 @@ RETURNING *;
 -- name: ListChatMessages :many
 SELECT * FROM chat_message
 WHERE chat_session_id = $1
+ORDER BY created_at ASC;
+
+-- name: ListChatMessagesByThread :many
+SELECT * FROM chat_message
+WHERE chat_session_id = $1
+  AND chat_thread_id = $2
 ORDER BY created_at ASC;
 
 -- name: ListChatMessagesPage :many
@@ -110,13 +224,53 @@ WHERE id = $1;
 -- name: CreateChatTask :one
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, status, priority, chat_session_id,
-    initiator_user_id, force_fresh_session
+    chat_thread_id, initiator_user_id, force_fresh_session
 )
 VALUES (
-    $1, $2, NULL, 'queued', $3, $4, $5,
+    $1, $2, NULL, 'queued', $3, $4, sqlc.narg('chat_thread_id'), $5,
     COALESCE(sqlc.narg('force_fresh_session')::boolean, FALSE)
 )
 RETURNING *;
+
+-- name: UpsertChatAgentSession :exec
+INSERT INTO chat_agent_session (
+    chat_session_id, chat_thread_id, agent_id, runtime_id,
+    provider_session_id, work_dir, status, updated_at
+)
+VALUES (
+    $1, $2, $3, $4,
+    sqlc.narg('provider_session_id'), sqlc.narg('work_dir'), 'active', now()
+)
+ON CONFLICT (chat_thread_id, agent_id, runtime_id)
+WHERE chat_thread_id IS NOT NULL
+DO UPDATE SET
+    provider_session_id = COALESCE(EXCLUDED.provider_session_id, chat_agent_session.provider_session_id),
+    work_dir = COALESCE(EXCLUDED.work_dir, chat_agent_session.work_dir),
+    status = 'active',
+    updated_at = now();
+
+-- name: GetChatAgentSessionByThread :one
+SELECT * FROM chat_agent_session
+WHERE chat_thread_id = $1
+  AND agent_id = $2
+  AND runtime_id = $3
+  AND status = 'active'
+LIMIT 1;
+
+-- name: GetLastChatTaskSessionByThread :one
+SELECT session_id, work_dir, runtime_id FROM agent_task_queue
+WHERE chat_thread_id = $1
+  AND (
+    status = 'completed'
+    OR (
+      status = 'failed'
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity')
+      AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
+    )
+  )
+  AND session_id IS NOT NULL
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
+LIMIT 1;
 
 -- name: GetLastChatTaskSession :one
 -- Returns the most recent task in this chat session that managed to record a

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -97,8 +97,10 @@ UPDATE chat_session SET updated_at = now()
 WHERE id = $1;
 
 -- name: CreateChatThread :one
+-- Title is capped at 120 chars here so the cap lives in one place (DB), matching
+-- SetChatThreadRootMessage's LEFT(...,120); callers may pass the full message.
 INSERT INTO chat_thread (chat_session_id, title, created_by)
-VALUES ($1, $2, $3)
+VALUES ($1, LEFT(sqlc.arg(title)::text, 120), sqlc.arg(created_by))
 RETURNING *;
 
 -- name: GetChatThreadInSession :one

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -81,10 +81,12 @@ type RuntimeInfo struct {
 // ChatMessagePayload is broadcast when a new chat message is created.
 type ChatMessagePayload struct {
 	ChatSessionID string `json:"chat_session_id"`
+	ChatThreadID  string `json:"chat_thread_id,omitempty"`
 	MessageID     string `json:"message_id"`
 	Role          string `json:"role"`
 	Content       string `json:"content"`
 	TaskID        string `json:"task_id,omitempty"`
+	ThreadTaskID  string `json:"thread_task_id,omitempty"`
 	CreatedAt     string `json:"created_at"`
 }
 
@@ -95,9 +97,11 @@ type ChatMessagePayload struct {
 // a visible flicker (#2123).
 type ChatDonePayload struct {
 	ChatSessionID string `json:"chat_session_id"`
+	ChatThreadID  string `json:"chat_thread_id,omitempty"`
 	TaskID        string `json:"task_id"`
 	MessageID     string `json:"message_id,omitempty"`
 	Content       string `json:"content,omitempty"`
+	ThreadTaskID  string `json:"thread_task_id,omitempty"`
 	ElapsedMs     int64  `json:"elapsed_ms,omitempty"`
 	CreatedAt     string `json:"created_at,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add an Agents collection in pinned/sidebar flows and route pinned agents to dedicated agent chat pages.
- Rework agent chat around thread-style conversations with a resizable reply pane, reply composer, optimistic thread state, and agent avatar/status rendering.
- Add chat conversation/thread database migrations plus backend compatibility for legacy messages that only have `reply_to_task_id`.
- Update agent runtime/session context plumbing so replies stay attached to the selected chat thread.
- Add `make start-desktop-worktree` support through `scripts/dev-desktop.sh`, including backend readiness before Electron starts.

## Verification
- `make sqlc`
- `go test ./internal/handler ./internal/service ./internal/daemon ./internal/integrations/channel/engine ./pkg/protocol -run '^$'`
- `./node_modules/.bin/tsc -p packages/core/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/views/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run packages/core/api/client.test.ts`
- `bash -n scripts/dev-desktop.sh`
- `git diff --check`
- Manual local DB/API verification: posting a thread reply against legacy data with only `reply_to_task_id` backfills `chat_thread_id` and appends the agent reply to the same thread instead of opening a new one.

## Notes
- `pnpm-lock.yaml` and `pnpm-workspace.yaml` were left out of this PR because they contain local pnpm-generated noise unrelated to this feature.
