### PR TITLE
feat(issues): add Remove parent issue action (MUL-3764)

### DIFF
--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -453,6 +453,97 @@ describe("useUpdateIssue — optimistic move keeps every bucketed board in sync"
   });
 });
 
+describe("useUpdateIssue — detaching a sub-issue prunes the old parent's children cache", () => {
+  const PARENT_ID = "parent-1";
+  const childKey = issueKeys.children(WS_ID, PARENT_ID);
+
+  let qc: QueryClient;
+  let updateIssue: ReturnType<typeof vi.fn<(id: string, data: unknown) => Promise<Issue>>>;
+
+  function childIds(): string[] {
+    return (qc.getQueryData<Issue[]>(childKey) ?? []).map((c) => c.id);
+  }
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    updateIssue = vi.fn();
+    setApiInstance({ updateIssue } as unknown as ApiClient);
+    // Seed the detail cache so onMutate resolves the old parent from the
+    // freshest source, plus the parent's children list rendered by the
+    // sub-issues section.
+    const child = makeIssue(1, { parent_issue_id: PARENT_ID, stage: 2 });
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, child.id), child);
+    qc.setQueryData<Issue[]>(childKey, [
+      child,
+      makeIssue(2, { parent_issue_id: PARENT_ID }),
+    ]);
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("optimistically removes the issue from the old parent's children array", async () => {
+    let resolve!: (issue: Issue) => void;
+    updateIssue.mockReturnValue(
+      new Promise<Issue>((r) => {
+        resolve = r;
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    act(() => {
+      result.current.mutate({ id: "issue-1", parent_issue_id: null, stage: null });
+    });
+
+    // Pruned immediately so the parent's sub-issues list drops it now, not
+    // after the settle refetch; the sibling is untouched.
+    expect(childIds()).toEqual(["issue-2"]);
+
+    await act(async () => {
+      resolve(makeIssue(1, { parent_issue_id: null, stage: null }));
+    });
+    expect(childIds()).not.toContain("issue-1");
+  });
+
+  it("restores the old parent's children when the request fails", async () => {
+    updateIssue.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ id: "issue-1", parent_issue_id: null, stage: null })
+        .catch(() => {});
+    });
+
+    expect(childIds()).toEqual(["issue-1", "issue-2"]);
+  });
+
+  it("keeps the issue under its parent for a non-reparenting update", async () => {
+    updateIssue.mockResolvedValue(
+      makeIssue(1, { parent_issue_id: PARENT_ID, status: "done" }),
+    );
+
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    act(() => {
+      result.current.mutate({ id: "issue-1", status: "done" });
+    });
+
+    // A status-only change patches in place — never prunes the relationship.
+    expect(childIds()).toEqual(["issue-1", "issue-2"]);
+  });
+});
+
 describe("useBatchUpdateIssues — optimistic patch covers filtered boards too", () => {
   const sort: IssueSortParam = { sort_by: "position", sort_direction: undefined };
   const myScope = "assigned";

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -278,10 +278,21 @@ export function useUpdateIssue() {
         old ? { ...old, ...patch } : old,
       );
       if (parentId) {
+        // When the write re-parents this issue away from `parentId` (detach
+        // to standalone, or move under a different parent), prune it from the
+        // old parent's children cache. The parent's sub-issues list renders
+        // that array directly, so a bare patch to parent_issue_id: null would
+        // leave an orphaned row in the list until the settle refetch lands.
+        // onError restores prevChildren, so the prune rolls back on failure.
+        const detachedFromParent =
+          Object.prototype.hasOwnProperty.call(patch, "parent_issue_id") &&
+          patch.parent_issue_id !== parentId;
         qc.setQueryData<Issue[]>(
           issueKeys.children(wsId, parentId),
           (old) =>
-            old?.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+            detachedFromParent
+              ? old?.filter((c) => c.id !== id)
+              : old?.map((c) => (c.id === id ? { ...c, ...patch } : c)),
         );
       }
       return { prevLists, prevDetail, prevChildren, parentId, id };

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -194,6 +194,41 @@ describe("IssueActionsDropdown", () => {
     expect(await screen.findByText("Test User")).toBeInTheDocument();
   });
 
+  it("shows 'Remove parent issue' in the More submenu only when the issue has a parent", async () => {
+    const childIssue = { ...mockIssue, parent_issue_id: "parent-1" } as Issue;
+    render(
+      wrap(
+        <IssueActionsDropdown
+          issue={childIssue}
+          trigger={<button data-testid="trigger">Menu</button>}
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    fireEvent.click(await screen.findByText("More"));
+
+    expect(await screen.findByText("Remove parent issue")).toBeInTheDocument();
+  });
+
+  it("hides 'Remove parent issue' when the issue has no parent", async () => {
+    render(
+      wrap(
+        <IssueActionsDropdown
+          issue={mockIssue}
+          trigger={<button data-testid="trigger">Menu</button>}
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    fireEvent.click(await screen.findByText("More"));
+
+    // The sibling "Set parent issue..." proves the submenu opened.
+    expect(await screen.findByText("Set parent issue...")).toBeInTheDocument();
+    expect(screen.queryByText("Remove parent issue")).not.toBeInTheDocument();
+  });
+
   it("clicking Delete issue opens the delete-confirm modal", async () => {
     render(
       wrap(

--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -74,6 +74,7 @@ vi.mock("sonner", () => ({
 }));
 
 // Import AFTER mocks are registered.
+import { toast } from "sonner";
 import { useIssueActions } from "../use-issue-actions";
 
 const mockIssue: Issue = {
@@ -109,6 +110,8 @@ beforeEach(() => {
   mockUpdateMutate.mockReset();
   mockCreatePinMutate.mockReset();
   mockDeletePinMutate.mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
   pinListRef.value = [];
   localStorage.clear();
   Object.defineProperty(navigator, "clipboard", {
@@ -230,6 +233,27 @@ describe("useIssueActions", () => {
       identifier: "TES-1",
       onDeletedNavigateTo: "/test/issues",
     });
+  });
+
+  it("removeParent clears parent_issue_id and stage in one write and toasts success", () => {
+    const childIssue = {
+      ...mockIssue,
+      parent_issue_id: "parent-1",
+      stage: 2,
+    } as Issue;
+    const { result } = renderHook(() => useIssueActions(childIssue), { wrapper });
+
+    act(() => {
+      result.current.removeParent();
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      { id: "issue-1", parent_issue_id: null, stage: null },
+      expect.any(Object),
+    );
+    expect(toast.success).toHaveBeenCalled();
+    // Detaching never routes through the run-confirm modal.
+    expect(mockOpenModal).not.toHaveBeenCalled();
   });
 
   it("togglePin calls createPin when not pinned and deletePin when pinned", async () => {

--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -235,7 +235,7 @@ describe("useIssueActions", () => {
     });
   });
 
-  it("removeParent clears parent_issue_id and stage in one write and toasts success", () => {
+  it("removeParent clears parent_issue_id and stage in one write, never via the run-confirm modal", () => {
     const childIssue = {
       ...mockIssue,
       parent_issue_id: "parent-1",
@@ -249,11 +249,47 @@ describe("useIssueActions", () => {
 
     expect(mockUpdateMutate).toHaveBeenCalledWith(
       { id: "issue-1", parent_issue_id: null, stage: null },
-      expect.any(Object),
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
     );
-    expect(toast.success).toHaveBeenCalled();
     // Detaching never routes through the run-confirm modal.
     expect(mockOpenModal).not.toHaveBeenCalled();
+  });
+
+  it("removeParent toasts success only from onSuccess — not eagerly, and not on failure", () => {
+    const childIssue = {
+      ...mockIssue,
+      parent_issue_id: "parent-1",
+    } as Issue;
+    const { result } = renderHook(() => useIssueActions(childIssue), { wrapper });
+
+    act(() => {
+      result.current.removeParent();
+    });
+
+    // mutate() is fire-and-forget here (mocked), so nothing is confirmed yet.
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+
+    const opts = mockUpdateMutate.mock.calls[0]![1] as {
+      onSuccess: () => void;
+      onError: (err: unknown) => void;
+    };
+
+    // A failed write surfaces the error, never a false "removed" confirmation.
+    act(() => {
+      opts.onError(new Error("forbidden"));
+    });
+    expect(toast.error).toHaveBeenCalledWith("forbidden");
+    expect(toast.success).not.toHaveBeenCalled();
+
+    // Only the server-confirmed success toasts.
+    act(() => {
+      opts.onSuccess();
+    });
+    expect(toast.success).toHaveBeenCalledTimes(1);
   });
 
   it("togglePin calls createPin when not pinned and deletePin when pinned", async () => {

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -15,6 +15,7 @@ import {
   PinOff,
   Plus,
   Trash2,
+  Unlink,
   UserMinus,
 } from "lucide-react";
 import type { AgentTask, Issue } from "@multica/core/types";
@@ -104,6 +105,7 @@ export function IssueActionsMenuItems({
     copyLink,
     openCreateSubIssue,
     openSetParent,
+    removeParent,
     openAddChild,
     openDeleteConfirm,
   } = actions;
@@ -284,6 +286,12 @@ export function IssueActionsMenuItems({
             <ArrowUp className="h-3.5 w-3.5" />
             {t(($) => $.actions.set_parent_issue)}
           </P.Item>
+          {issue.parent_issue_id && (
+            <P.Item onClick={removeParent}>
+              <Unlink className="h-3.5 w-3.5" />
+              {t(($) => $.actions.remove_parent_issue)}
+            </P.Item>
+          )}
           <P.Item onClick={openAddChild}>
             <ArrowDown className="h-3.5 w-3.5" />
             {t(($) => $.actions.add_sub_issue)}

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -21,6 +21,7 @@ export interface UseIssueActionsResult {
   copyLink: () => Promise<void>;
   openCreateSubIssue: () => void;
   openSetParent: () => void;
+  removeParent: () => void;
   openAddChild: () => void;
   openDeleteConfirm: (opts?: { onDeletedNavigateTo?: string }) => void;
 }
@@ -133,6 +134,27 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     openModal("issue-set-parent", { issueId });
   }, [openModal, issueId]);
 
+  // Detach from the parent and promote to a standalone issue. Reversible
+  // (Set parent re-links it), non-destructive, and mirrors the clear-date
+  // actions — so it applies directly with a success toast instead of a
+  // confirm modal. `stage` only orders sub-issues under a parent, so clear
+  // it in the same write to avoid an orphaned value on a standalone issue.
+  const removeParent = useCallback(() => {
+    if (!issueId) return;
+    updateIssue.mutate(
+      { id: issueId, parent_issue_id: null, stage: null },
+      {
+        onError: (err) =>
+          toast.error(
+            err instanceof Error && err.message
+              ? err.message
+              : t(($) => $.detail.update_failed),
+          ),
+      },
+    );
+    toast.success(t(($) => $.actions.remove_parent_issue_success));
+  }, [issueId, updateIssue, t]);
+
   const openAddChild = useCallback(() => {
     if (!issueId) return;
     openModal("issue-add-child", { issueId });
@@ -157,6 +179,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     copyLink,
     openCreateSubIssue,
     openSetParent,
+    removeParent,
     openAddChild,
     openDeleteConfirm,
   };

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -136,14 +136,19 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
 
   // Detach from the parent and promote to a standalone issue. Reversible
   // (Set parent re-links it), non-destructive, and mirrors the clear-date
-  // actions — so it applies directly with a success toast instead of a
-  // confirm modal. `stage` only orders sub-issues under a parent, so clear
-  // it in the same write to avoid an orphaned value on a standalone issue.
+  // actions — so it applies directly instead of a confirm modal. `stage`
+  // only orders sub-issues under a parent, so clear it in the same write to
+  // avoid an orphaned value on a standalone issue. The success toast fires
+  // from onSuccess, not eagerly after mutate() — otherwise a request that
+  // fails on permission/network/validation would flash "removed" before the
+  // error toast and the optimistic rollback (false confirmation).
   const removeParent = useCallback(() => {
     if (!issueId) return;
     updateIssue.mutate(
       { id: issueId, parent_issue_id: null, stage: null },
       {
+        onSuccess: () =>
+          toast.success(t(($) => $.actions.remove_parent_issue_success)),
         onError: (err) =>
           toast.error(
             err instanceof Error && err.message
@@ -152,7 +157,6 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
           ),
       },
     );
-    toast.success(t(($) => $.actions.remove_parent_issue_success));
   }, [issueId, updateIssue, t]);
 
   const openAddChild = useCallback(() => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -21,6 +21,7 @@ import {
   PinOff,
   Plus,
   Tag,
+  Unlink,
   Users,
 } from "lucide-react";
 import { BreadcrumbHeader, type BreadcrumbSegment } from "../../layout/breadcrumb-header";
@@ -1573,14 +1574,25 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${parentIssueOpen ? "rotate-90" : ""}`} />
           </button>
           {parentIssueOpen && <div className="pl-2">
-            <AppLink
-              href={paths.issueDetail(parentIssue.id)}
-              className="flex items-center gap-1.5 rounded-md px-2 py-1.5 -mx-2 text-xs hover:bg-accent/50 transition-colors group"
-            >
-              <StatusIcon status={parentIssue.status} className="h-3.5 w-3.5 shrink-0" />
-              <span className="text-muted-foreground shrink-0">{parentIssue.identifier}</span>
-              <span className="truncate group-hover:text-foreground">{parentIssue.title}</span>
-            </AppLink>
+            <div className="flex items-center gap-0.5 rounded-md px-2 -mx-2 hover:bg-accent/50 transition-colors group">
+              <AppLink
+                href={paths.issueDetail(parentIssue.id)}
+                className="flex flex-1 min-w-0 items-center gap-1.5 py-1.5 text-xs"
+              >
+                <StatusIcon status={parentIssue.status} className="h-3.5 w-3.5 shrink-0" />
+                <span className="text-muted-foreground shrink-0">{parentIssue.identifier}</span>
+                <span className="truncate group-hover:text-foreground">{parentIssue.title}</span>
+              </AppLink>
+              <button
+                type="button"
+                title={t(($) => $.actions.remove_parent_issue)}
+                aria-label={t(($) => $.actions.remove_parent_issue)}
+                onClick={() => actions.removeParent()}
+                className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+              >
+                <Unlink className="h-3.5 w-3.5" />
+              </button>
+            </div>
           </div>}
         </div>
       )}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -432,6 +432,8 @@
     "more": "More",
     "create_sub_issue": "Create sub-issue",
     "set_parent_issue": "Set parent issue...",
+    "remove_parent_issue": "Remove parent issue",
+    "remove_parent_issue_success": "Removed parent issue",
     "add_sub_issue": "Add sub-issue...",
     "delete_issue": "Delete issue"
   },

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -413,6 +413,8 @@
     "more": "その他",
     "create_sub_issue": "サブイシューを作成",
     "set_parent_issue": "親イシューを設定...",
+    "remove_parent_issue": "親イシューを解除",
+    "remove_parent_issue_success": "親イシューを解除しました",
     "add_sub_issue": "サブイシューを追加...",
     "delete_issue": "イシューを削除"
   },

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -431,6 +431,8 @@
     "more": "더 보기",
     "create_sub_issue": "하위 이슈 만들기",
     "set_parent_issue": "상위 이슈 설정...",
+    "remove_parent_issue": "상위 이슈 제거",
+    "remove_parent_issue_success": "상위 이슈를 제거했습니다",
     "add_sub_issue": "하위 이슈 추가...",
     "delete_issue": "이슈 삭제"
   },

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -418,6 +418,8 @@
     "more": "更多",
     "create_sub_issue": "创建子 issue",
     "set_parent_issue": "设置父 issue...",
+    "remove_parent_issue": "移除父 issue",
+    "remove_parent_issue_success": "已移除父 issue",
     "add_sub_issue": "添加子 issue...",
     "delete_issue": "删除 issue"
   },


### PR DESCRIPTION
## Summary

Adds a discoverable **"Remove parent issue"** action that promotes a sub-issue back to a standalone issue. The backend and CLI (`multica issue update --parent ""`) already support clearing `parent_issue_id`, but the Official App only exposed *Set parent* — so a sub-issue couldn't be detached from the normal UI. This closes that discoverability gap (MUL-3764).

## Changes

- **Issue actions menu** (`issue-actions-menu-items.tsx`): a new "Remove parent issue" item under *More*, rendered only when `issue.parent_issue_id` is set. Covers both the 3-dot dropdown and the right-click context menu, on list / board / detail surfaces.
- **Issue detail sidebar** (`issue-detail.tsx`): a hover-revealed unlink button on the parent card, right where users see the current parent.
- **`useIssueActions`** (`use-issue-actions.ts`): a `removeParent` handler that clears `parent_issue_id` **and** `stage` in one write (stage only orders sub-issues under a parent, so it's meaningless once detached) with a success toast. Non-destructive and reversible, so it applies directly — mirroring the existing clear-date actions — instead of a confirm modal.
- **i18n**: `remove_parent_issue` + `remove_parent_issue_success` added to all four locales (en / zh-Hans / ja / ko).

Web and desktop share these components, so the single change covers both Official App surfaces. The existing `useUpdateIssue` mutation already resolves the old parent and invalidates its children cache when `parent_issue_id` becomes null, so the issue drops out of the parent's sub-issue list optimistically.

## Testing

- `pnpm --filter @multica/views exec vitest run issues/actions/__tests__ locales/parity.test.ts` — 172 passed (new hook test for `removeParent`, two menu tests for conditional visibility, locale parity).
- `pnpm --filter @multica/views typecheck` — clean.
- `pnpm --filter @multica/views lint` — 0 errors (only pre-existing warnings in unrelated files).
- Verified the backend `UpdateIssue` handler treats `{ parent_issue_id: null, stage: null }` as explicit clears via its `rawFields` presence check.

Closes #4629
