### PR TITLE
fix(server): allow disabling the Redis client name for managed Redis

### DIFF
--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -157,6 +157,7 @@ Public auth endpoints — `/auth/send-code`, `/auth/verify-code`, `/auth/google`
 | Variable | Default | Description |
 |---|---|---|
 | `REDIS_URL` | empty | Redis connection URL (for example `redis://localhost:6379/0`). When unset, rate limiting on auth endpoints is disabled. The same Redis is also used by the realtime hub fan-out, the PAT cache, and the daemon-token cache — they all fall back to in-memory / direct-DB mode when unset |
+| `REDIS_DISABLE_CLIENT_NAME` | empty | Set to `true` (or `1`) for **managed Redis that blocks the `CLIENT` command** (GCP Memorystore, AWS ElastiCache in restricted-command configs). By default the backend sets a per-connection client name, which makes go-redis issue `CLIENT SETNAME` on connect; on those providers that handshake fails and every Redis-backed feature (realtime fan-out, model-list reply, rate limiting) errors. Enabling this skips the client name so managed Redis works |
 | `RATE_LIMIT_AUTH` | `5` | Max requests per IP per minute against `/auth/send-code` and `/auth/google` |
 | `RATE_LIMIT_AUTH_VERIFY` | `20` | Max requests per IP per minute against `/auth/verify-code` |
 | `RATE_LIMIT_TRUSTED_PROXIES` | empty | Comma-separated CIDRs whose `X-Forwarded-For` header the limiter is allowed to trust. Empty (the default) means **never trust XFF** — the limiter only uses the direct connection's `RemoteAddr` |

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -34,8 +34,30 @@ var (
 
 func newNamedRedisClient(base *redis.Options, suffix string) *redis.Client {
 	opts := *base
-	opts.ClientName = redisClientName(opts.ClientName, suffix)
+	if redisClientNameDisabled() {
+		// Managed Redis (GCP Memorystore, AWS ElastiCache in restricted-command
+		// configs) blocks the CLIENT command. go-redis issues CLIENT SETNAME on
+		// connection init whenever ClientName != "", so that handshake fails and
+		// every Redis-backed feature (realtime fanout, model-list reply, rate
+		// limiting) errors. Leaving ClientName empty suppresses the handshake so
+		// managed Redis works. See #4627.
+		opts.ClientName = ""
+	} else {
+		opts.ClientName = redisClientName(opts.ClientName, suffix)
+	}
 	return redis.NewClient(&opts)
+}
+
+// redisClientNameDisabled reports whether the operator opted out of setting a
+// Redis client name (REDIS_DISABLE_CLIENT_NAME=true|1), needed for managed
+// Redis that blocks the CLIENT command and therefore CLIENT SETNAME.
+func redisClientNameDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("REDIS_DISABLE_CLIENT_NAME"))) {
+	case "true", "1":
+		return true
+	default:
+		return false
+	}
 }
 
 func redisClientName(existing, suffix string) string {

--- a/server/cmd/server/redis_client_name_test.go
+++ b/server/cmd/server/redis_client_name_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestNewNamedRedisClientClientName verifies the REDIS_DISABLE_CLIENT_NAME
+// opt-out: managed Redis (GCP Memorystore, AWS ElastiCache restricted-command)
+// blocks the CLIENT command, so go-redis's CLIENT SETNAME handshake — sent
+// whenever ClientName != "" — must be suppressible by leaving ClientName empty.
+// See #4627.
+func TestNewNamedRedisClientClientName(t *testing.T) {
+	base := &redis.Options{Addr: "localhost:6379"}
+
+	// Default: a client name is set, so go-redis issues CLIENT SETNAME.
+	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "")
+	if got := newNamedRedisClient(base, "realtime-read").Options().ClientName; got == "" {
+		t.Fatalf("default: expected a non-empty client name, got empty")
+	}
+
+	// Opt-out keeps ClientName empty so no CLIENT SETNAME is sent.
+	for _, v := range []string{"true", "1", "TRUE", " True "} {
+		t.Setenv("REDIS_DISABLE_CLIENT_NAME", v)
+		if got := newNamedRedisClient(base, "realtime-read").Options().ClientName; got != "" {
+			t.Fatalf("REDIS_DISABLE_CLIENT_NAME=%q: expected empty client name, got %q", v, got)
+		}
+	}
+
+	// Only true/1 disable; other values keep the default named behavior.
+	for _, v := range []string{"false", "0", "no"} {
+		t.Setenv("REDIS_DISABLE_CLIENT_NAME", v)
+		if got := newNamedRedisClient(base, "realtime-read").Options().ClientName; got == "" {
+			t.Fatalf("REDIS_DISABLE_CLIENT_NAME=%q: expected a non-empty client name, got empty", v)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4627

## Summary
On a self-hosted instance whose `REDIS_URL` points at **managed Redis** (GCP Memorystore, AWS ElastiCache in restricted-command configs), every Redis-backed feature fails — realtime fan-out, model-list / local-skill request-reply, and rate limiting — with:

```
realtime/sharded-redis: XREAD failed error="ERR unknown command 'client', with args beginning with: 'setname' ..."
```

Root cause: `newNamedRedisClient` (`server/cmd/server/main.go`) sets `opts.ClientName` on every Redis client, so go-redis issues `CLIENT SETNAME` on connection init. Managed Redis blocks the entire `CLIENT` command, so init fails and all subsequent commands on that connection error. There was no way to turn the client name off.

Fix: add `REDIS_DISABLE_CLIENT_NAME=true|1`. When set, `newNamedRedisClient` leaves `ClientName` empty, so go-redis never sends `CLIENT SETNAME` and managed Redis works out of the box. Default behavior (named clients) is unchanged.

## Tests
- Added `server/cmd/server/redis_client_name_test.go`: with the flag set (`true`/`1`/`TRUE`/` True `) the resolved client's `Options().ClientName` is empty (no `CLIENT SETNAME`); unset or unrelated values (`false`/`0`/`no`) keep the default named client.
- `go build ./cmd/server/`, `go vet ./cmd/server/`, `gofmt` — clean.
- Note: `server/cmd/server` tests are DB-gated (they self-skip without Postgres, which isn't available locally), so this unit test executes in CI. I separately verified the go-redis `Options().ClientName` round-trip and the `true/1`-only env parsing in an isolated unit test to confirm the assertion mechanism.
- Documented `REDIS_DISABLE_CLIENT_NAME` in `apps/docs/content/docs/environment-variables.mdx` (English; localized copies can follow).