### PR TITLE
fix(feedback): validate response and pass error kind (MUL-3768)

### DIFF
--- a/apps/desktop/src/renderer/src/components/route-error-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-page.test.tsx
@@ -84,7 +84,7 @@ describe("DesktopRouteErrorPage", () => {
     );
   });
 
-  it("documents the structured kind/context follow-up debt in the report template", () => {
+  it("documents the structured context follow-up debt in the report template", () => {
     const report = formatRouteErrorReport({
       error: new Error("bad route"),
       url: "app://desktop/acme/issues",
@@ -94,6 +94,6 @@ describe("DesktopRouteErrorPage", () => {
 
     expect(report).toContain("kind: desktop_route_error");
     expect(report).toContain("trigger: route-errorElement");
-    expect(report).toContain("TODO: promote kind/context to structured feedback fields");
+    expect(report).toContain("TODO: promote error context to structured feedback fields");
   });
 });

--- a/apps/desktop/src/renderer/src/components/route-error-page.test.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-page.test.tsx
@@ -79,6 +79,7 @@ describe("DesktopRouteErrorPage", () => {
       "feedback",
       expect.objectContaining({
         initialMessage: expect.stringContaining("kind: desktop_route_error"),
+        kind: "bug",
       }),
     );
   });

--- a/apps/desktop/src/renderer/src/components/route-error-page.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-page.tsx
@@ -106,6 +106,7 @@ export function DesktopRouteErrorPage() {
           onClick={() =>
             useModalStore.getState().open("feedback", {
               initialMessage: report,
+              kind: "bug",
             })
           }
         >

--- a/apps/desktop/src/renderer/src/components/route-error-page.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-page.tsx
@@ -38,7 +38,7 @@ export function formatRouteErrorReport({
     normalized.stack ?? "<no stack>",
     "```",
     "",
-    "TODO: promote kind/context to structured feedback fields once the feedback API supports them.",
+    "TODO: promote error context to structured feedback fields once the feedback API supports them.",
   ].join("\n");
 }
 

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -152,6 +152,59 @@ describe("ApiClient", () => {
     expect(headers["X-Client-OS"]).toBeUndefined();
   });
 
+  it("posts feedback kind and parses the response through the schema", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "feedback-1", created_at: "2026-06-26T00:00:00Z" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+    const response = await client.createFeedback({
+      message: "Desktop route crashed",
+      url: "app://desktop/acme/issues",
+      workspace_id: "ws-1",
+      kind: "bug",
+    });
+
+    expect(response).toEqual({
+      id: "feedback-1",
+      created_at: "2026-06-26T00:00:00Z",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/feedback",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          message: "Desktop route crashed",
+          url: "app://desktop/acme/issues",
+          workspace_id: "ws-1",
+          kind: "bug",
+        }),
+      }),
+    );
+  });
+
+  it("falls back to an empty feedback response when the server shape drifts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: 42, created_at: "2026-06-26T00:00:00Z" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const client = new ApiClient("https://api.example.test");
+    await expect(client.createFeedback({ message: "hello" })).resolves.toEqual({
+      id: "",
+      created_at: "",
+    });
+  });
+
   it("uses the expected HTTP contract for comment trigger preview and suppress", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -126,6 +126,7 @@ import type {
   CreateBillingPortalSessionResponse,
 } from "../types";
 import type { OnboardingCompletionPath } from "../onboarding/types";
+import type { CreateFeedbackResponse, FeedbackKind } from "../feedback/types";
 import type {
   CloudRuntimeNode,
   CreateCloudRuntimeNodeRequest,
@@ -206,6 +207,8 @@ import {
   EMPTY_BILLING_CHECKOUT_SESSION_STATUS,
   EMPTY_CREATE_BILLING_PORTAL_SESSION_RESPONSE,
   EMPTY_CANCEL_TASK_RESPONSE,
+  CreateFeedbackResponseSchema,
+  EMPTY_CREATE_FEEDBACK_RESPONSE,
   InboxUnreadSummarySchema,
   EMPTY_INBOX_UNREAD_SUMMARY,
 } from "./schemas";
@@ -610,10 +613,14 @@ export class ApiClient {
     message: string;
     url?: string;
     workspace_id?: string;
-  }): Promise<{ id: string; created_at: string }> {
-    return this.fetch("/api/feedback", {
+    kind?: FeedbackKind;
+  }): Promise<CreateFeedbackResponse> {
+    const raw = await this.fetch<unknown>("/api/feedback", {
       method: "POST",
       body: JSON.stringify(data),
+    });
+    return parseWithFallback(raw, CreateFeedbackResponseSchema, EMPTY_CREATE_FEEDBACK_RESPONSE, {
+      endpoint: "POST /api/feedback",
     });
   }
 

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -4,7 +4,9 @@ import {
   DashboardAgentRunTimeListSchema,
   DashboardUsageByAgentListSchema,
   DashboardUsageDailyListSchema,
+  CreateFeedbackResponseSchema,
   DuplicateIssueErrorBodySchema,
+  EMPTY_CREATE_FEEDBACK_RESPONSE,
   EMPTY_INBOX_UNREAD_SUMMARY,
   EMPTY_USER,
   InboxUnreadSummarySchema,
@@ -183,6 +185,38 @@ describe("TimelineEntriesSchema", () => {
     ]);
 
     expect(parsed[0]?.source_task_id).toBe("task-1");
+  });
+});
+
+describe("CreateFeedbackResponseSchema", () => {
+  const ENDPOINT = { endpoint: "POST /api/feedback" };
+
+  it("parses a well-formed response and preserves extra fields", () => {
+    const parsed = parseWithFallback(
+      { id: "feedback-1", created_at: "2026-06-26T00:00:00Z", future_field: true },
+      CreateFeedbackResponseSchema,
+      EMPTY_CREATE_FEEDBACK_RESPONSE,
+      ENDPOINT,
+    );
+    expect(parsed).toMatchObject({
+      id: "feedback-1",
+      created_at: "2026-06-26T00:00:00Z",
+      future_field: true,
+    });
+  });
+
+  it("returns the empty fallback for malformed feedback responses", () => {
+    expect(
+      parseWithFallback(
+        { id: 123, created_at: "2026-06-26T00:00:00Z" },
+        CreateFeedbackResponseSchema,
+        EMPTY_CREATE_FEEDBACK_RESPONSE,
+        ENDPOINT,
+      ),
+    ).toBe(EMPTY_CREATE_FEEDBACK_RESPONSE);
+    expect(
+      parseWithFallback(null, CreateFeedbackResponseSchema, EMPTY_CREATE_FEEDBACK_RESPONSE, ENDPOINT),
+    ).toBe(EMPTY_CREATE_FEEDBACK_RESPONSE);
   });
 });
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -26,6 +26,7 @@ import type {
   WebhookDelivery,
 } from "../types";
 import type { CloudRuntimeNode } from "../runtimes/cloud-runtime";
+import type { CreateFeedbackResponse } from "../feedback/types";
 
 export interface AppConfigResponse {
   cdn_domain: string;
@@ -192,6 +193,16 @@ export const EMPTY_APP_CONFIG: AppConfigResponse = {
   daemon_server_url: "",
   daemon_app_url: "",
   workspace_creation_disabled: false,
+};
+
+export const CreateFeedbackResponseSchema = z.object({
+  id: z.string(),
+  created_at: z.string(),
+}).loose();
+
+export const EMPTY_CREATE_FEEDBACK_RESPONSE: CreateFeedbackResponse = {
+  id: "",
+  created_at: "",
 };
 
 export const CommentSchema = z.object({

--- a/packages/core/feedback/index.ts
+++ b/packages/core/feedback/index.ts
@@ -1,2 +1,3 @@
 export * from "./mutations";
+export type { CreateFeedbackResponse, FeedbackKind } from "./types";
 export { useFeedbackDraftStore } from "./draft-store";

--- a/packages/core/feedback/index.ts
+++ b/packages/core/feedback/index.ts
@@ -1,3 +1,4 @@
 export * from "./mutations";
+export { FEEDBACK_KINDS } from "./types";
 export type { CreateFeedbackResponse, FeedbackKind } from "./types";
 export { useFeedbackDraftStore } from "./draft-store";

--- a/packages/core/feedback/mutations.ts
+++ b/packages/core/feedback/mutations.ts
@@ -1,10 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { api } from "../api";
+import type { FeedbackKind } from "./types";
 
 export interface CreateFeedbackInput {
   message: string;
   url?: string;
   workspace_id?: string;
+  kind?: FeedbackKind;
 }
 
 export function useCreateFeedback() {

--- a/packages/core/feedback/types.ts
+++ b/packages/core/feedback/types.ts
@@ -1,4 +1,6 @@
-export type FeedbackKind = "bug" | "feature" | "general" | "praise";
+export const FEEDBACK_KINDS = ["bug", "feature", "general", "praise"] as const;
+
+export type FeedbackKind = (typeof FEEDBACK_KINDS)[number];
 
 export interface CreateFeedbackResponse {
   id: string;

--- a/packages/core/feedback/types.ts
+++ b/packages/core/feedback/types.ts
@@ -1,0 +1,6 @@
+export type FeedbackKind = "bug" | "feature" | "general" | "praise";
+
+export interface CreateFeedbackResponse {
+  id: string;
+  created_at: string;
+}

--- a/packages/views/modals/feedback.test.tsx
+++ b/packages/views/modals/feedback.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@multica/core/platform", () => ({
   enterKey: "enter",
 }));
 vi.mock("@multica/core/feedback", () => ({
+  FEEDBACK_KINDS: ["bug", "feature", "general", "praise"] as const,
   useCreateFeedback: () => ({ isPending: false, mutateAsync: vi.fn() }),
   useFeedbackDraftStore: (selector: any) =>
     selector({ draft: { message: storedDraftMessage }, setDraft: vi.fn(), clearDraft: vi.fn() }),

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -16,7 +16,12 @@ import {
   useFileDropZone,
   FileDropOverlay,
 } from "../editor";
-import { useCreateFeedback, useFeedbackDraftStore, type FeedbackKind } from "@multica/core/feedback";
+import {
+  useCreateFeedback,
+  useFeedbackDraftStore,
+  FEEDBACK_KINDS,
+  type FeedbackKind,
+} from "@multica/core/feedback";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -26,7 +31,7 @@ import { formatShortcut, modKey, enterKey } from "@multica/core/platform";
 
 const MAX_MESSAGE_LEN = 10000;
 
-const FEEDBACK_KINDS = new Set<FeedbackKind>(["bug", "feature", "general", "praise"]);
+const FEEDBACK_KIND_SET = new Set<FeedbackKind>(FEEDBACK_KINDS);
 
 function composeFeedbackInitialMessage(draftMessage: string, incomingInitialMessage: string) {
   const draft = draftMessage.trim();
@@ -59,7 +64,7 @@ export function FeedbackModal({
   const editorRef = useRef<ContentEditorRef>(null);
   const incomingInitialMessage =
     initialMessage ?? (typeof data?.initialMessage === "string" ? data.initialMessage : "");
-  const kind = typeof data?.kind === "string" && FEEDBACK_KINDS.has(data.kind as FeedbackKind)
+  const kind = typeof data?.kind === "string" && FEEDBACK_KIND_SET.has(data.kind as FeedbackKind)
     ? (data.kind as FeedbackKind)
     : undefined;
   const seededMessage = composeFeedbackInitialMessage(draft.message, incomingInitialMessage);

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -16,7 +16,7 @@ import {
   useFileDropZone,
   FileDropOverlay,
 } from "../editor";
-import { useCreateFeedback, useFeedbackDraftStore } from "@multica/core/feedback";
+import { useCreateFeedback, useFeedbackDraftStore, type FeedbackKind } from "@multica/core/feedback";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -25,6 +25,8 @@ import { useT } from "../i18n";
 import { formatShortcut, modKey, enterKey } from "@multica/core/platform";
 
 const MAX_MESSAGE_LEN = 10000;
+
+const FEEDBACK_KINDS = new Set<FeedbackKind>(["bug", "feature", "general", "praise"]);
 
 function composeFeedbackInitialMessage(draftMessage: string, incomingInitialMessage: string) {
   const draft = draftMessage.trim();
@@ -57,6 +59,9 @@ export function FeedbackModal({
   const editorRef = useRef<ContentEditorRef>(null);
   const incomingInitialMessage =
     initialMessage ?? (typeof data?.initialMessage === "string" ? data.initialMessage : "");
+  const kind = typeof data?.kind === "string" && FEEDBACK_KINDS.has(data.kind as FeedbackKind)
+    ? (data.kind as FeedbackKind)
+    : undefined;
   const seededMessage = composeFeedbackInitialMessage(draft.message, incomingInitialMessage);
   const [message, setMessage] = useState(seededMessage);
   const { isDragOver, dropZoneProps } = useFileDropZone({
@@ -99,6 +104,7 @@ export function FeedbackModal({
         message: latest,
         url: typeof window !== "undefined" ? window.location.href : undefined,
         workspace_id: workspace?.id,
+        kind,
       });
       clearDraft();
       toast.success(t(($) => $.feedback.toast_sent));


### PR DESCRIPTION
## What does this PR do?

This PR tightens the feedback submission contract and wires the existing backend feedback category through the client.

The backend already accepts `kind` on `POST /api/feedback` and uses it for feedback metrics, but the shared frontend API did not expose that field. Desktop route-renderer errors were therefore submitted through the generic feedback path without a machine-readable bug category. This change adds a typed feedback kind, validates the feedback response with zod/`parseWithFallback`, and marks desktop route-error reports as `bug`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `FeedbackKind` and `CreateFeedbackResponse` types in `packages/core/feedback/types.ts`.
- Updated `packages/core/api/client.ts` to send `kind` and parse `POST /api/feedback` responses with `CreateFeedbackResponseSchema`.
- Added feedback response schema/fallback coverage in `packages/core/api/schemas.ts` and `packages/core/api/schemas.test.ts`.
- Updated `packages/core/feedback/mutations.ts` and `packages/views/modals/feedback.tsx` so feedback submissions can carry a validated `kind`.
- Updated desktop route error reporting in `apps/desktop/src/renderer/src/components/route-error-page.tsx` to open feedback with `kind: "bug"`.
- Added/updated tests in `packages/core/api/client.test.ts` and `apps/desktop/src/renderer/src/components/route-error-page.test.tsx`.

## How to Test

1. `pnpm --filter @multica/core exec vitest run api/client.test.ts api/schemas.test.ts`
2. `pnpm --filter @multica/desktop exec vitest run src/renderer/src/components/route-error-page.test.tsx`
3. `pnpm --filter @multica/core typecheck && pnpm --filter @multica/views typecheck && pnpm --filter @multica/desktop typecheck`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Used Cursor to inspect the feedback API path, compare frontend/core behavior with the backend `CreateFeedbackRequest.Kind` contract, implement the smallest non-conflicting PR candidate, and run focused tests/typechecks.

## Screenshots (optional)

N/A