### PR TITLE
fix(server): preserve agent output when task recovered by sweeper (MUL-3769)

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1303,6 +1303,19 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					"current_status", existing.Status,
 					"agent_id", util.UUIDToString(existing.AgentID),
 				)
+
+				// When the server-side sweeper recovered this task before the
+				// daemon could report completion (e.g. network partition caused
+				// the runtime to be marked offline), the agent's work output
+				// would be silently discarded. Save it as an issue comment so
+				// the user can still see what the agent produced.
+				if existing.FailureReason.Valid &&
+					(existing.FailureReason.String == "runtime_offline" ||
+						existing.FailureReason.String == "runtime_recovery") &&
+					existing.IssueID.Valid {
+					s.saveRecoveredOutputAsComment(ctx, existing, result)
+				}
+
 				return &existing, nil
 			}
 			slog.Warn("complete task failed",
@@ -2278,6 +2291,44 @@ func (s *TaskService) getIssuePrefix(workspaceID pgtype.UUID) string {
 		return ""
 	}
 	return ws.IssuePrefix
+}
+
+// saveRecoveredOutputAsComment persists the agent's work output as an issue
+// comment when the daemon's completion report arrived after the server-side
+// sweeper had already recovered the task (network partition → runtime offline →
+// auto-fail). Without this, the agent's output would be silently lost.
+//
+// The method is intentionally best-effort: errors are logged but not returned,
+// matching the pattern of the existing comment fallback in CompleteTask. The
+// durable recover-or-retry logic has already handled the task lifecycle; this
+// is purely about preserving the human-visible work product.
+func (s *TaskService) saveRecoveredOutputAsComment(ctx context.Context, task db.AgentTaskQueue, result []byte) {
+	var payload protocol.TaskCompletedPayload
+	if err := json.Unmarshal(result, &payload); err != nil || payload.Output == "" {
+		slog.Debug("saveRecoveredOutputAsComment: no output to save",
+			"task_id", util.UUIDToString(task.ID),
+			"issue_id", util.UUIDToString(task.IssueID),
+		)
+		return
+	}
+	// Apply the same unescaping as the main completion path so literal
+	// \n sequences from agent stdout render as real newlines.
+	body := util.UnescapeBackslashEscapes(payload.Output)
+	if body == "" {
+		return
+	}
+	slog.Info("saving recovered agent output as comment",
+		"task_id", util.UUIDToString(task.ID),
+		"issue_id", util.UUIDToString(task.IssueID),
+		"agent_id", util.UUIDToString(task.AgentID),
+		"failure_reason", task.FailureReason.String,
+	)
+	// The task's trigger_comment_id is threaded as the parent so the
+	// recovered output appears under the same conversation thread
+	// as the original trigger, matching the fallback comment path
+	// in CompleteTask.
+	s.createAgentComment(ctx, task.IssueID, task.AgentID,
+		redact.Text(body), "comment", task.TriggerCommentID, pgtype.UUID{})
 }
 
 func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID pgtype.UUID, content, commentType string, parentID, sourceTaskID pgtype.UUID) {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
When a network partition occurs between the daemon and server, the
   runtime sweeper marks the runtime offline and fails in-flight tasks
   with failure_reason='runtime_offline'. After connectivity restores,
   the daemon reports completion but the task is already finalized —
   the agent's work output is silently discarded.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
