### PR TITLE
MUL-3599: allow framed attachment redirect responses

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -633,6 +633,7 @@ func (h *Handler) DownloadAttachment(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "cloudfront attachment downloads are not configured")
 			return
 		}
+		h.setAttachmentPreviewSecurityHeaders(w)
 		http.Redirect(
 			w,
 			r,
@@ -660,6 +661,7 @@ func (h *Handler) DownloadAttachment(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadGateway, "failed to create download URL")
 			return
 		}
+		h.setAttachmentPreviewSecurityHeaders(w)
 		http.Redirect(w, r, signedURL, http.StatusFound)
 	case attachmentDownloadModeProxy:
 		h.proxyAttachmentDownload(w, r, att, key)

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -561,6 +561,7 @@ func TestDownloadAttachment_CloudFrontRedirectSignsAttachmentDisposition(t *test
 	origSigner := testHandler.CFSigner
 	testHandler.Storage = &mockStorage{}
 	testHandler.cfg.AttachmentDownloadMode = "cloudfront"
+	testHandler.cfg.AttachmentFrameAncestors = []string{"https://app.example.test"}
 	testHandler.CFSigner = testCloudFrontSigner(t)
 	t.Cleanup(func() {
 		testHandler.Storage = origStorage
@@ -571,6 +572,7 @@ func TestDownloadAttachment_CloudFrontRedirectSignsAttachmentDisposition(t *test
 	id := seedAttachmentURL(t, "https://static.example.test/downloads/cloudfront.md", "cloud front.md", "text/markdown", 10)
 
 	req, w := newDownloadRequest(t, id, testWorkspaceID)
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
 	if w.Code != http.StatusFound {
@@ -587,6 +589,7 @@ func TestDownloadAttachment_CloudFrontRedirectSignsAttachmentDisposition(t *test
 	if got := parsed.Query().Get("Key-Pair-Id"); got != "KTEST" {
 		t.Fatalf("Key-Pair-Id = %q", got)
 	}
+	requireAttachmentPreviewCSP(t, w.Header(), "https://app.example.test")
 }
 
 func TestDownloadAttachment_BareNavigationWithWorkspaceSlugQueryPassesMiddleware(t *testing.T) {
@@ -788,6 +791,7 @@ func TestDownloadAttachment_AutoPublicEndpointPresigns(t *testing.T) {
 	origSigner := testHandler.CFSigner
 	testHandler.Storage = store
 	testHandler.cfg.AttachmentDownloadMode = "auto"
+	testHandler.cfg.AttachmentFrameAncestors = []string{"https://app.example.test"}
 	testHandler.CFSigner = nil
 	t.Cleanup(func() {
 		testHandler.Storage = origStorage
@@ -799,6 +803,7 @@ func TestDownloadAttachment_AutoPublicEndpointPresigns(t *testing.T) {
 	id := seedAttachmentURL(t, "https://s3.example.com/test-bucket/"+key, "public.txt", "text/plain", 10)
 
 	req, w := newDownloadRequest(t, id, testWorkspaceID)
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 	testHandler.DownloadAttachment(w, req)
 
 	if w.Code != http.StatusFound {
@@ -821,6 +826,7 @@ func TestDownloadAttachment_AutoPublicEndpointPresigns(t *testing.T) {
 	if len(store.presignDispositions) != 1 || store.presignDispositions[0] != `attachment; filename="public.txt"` {
 		t.Fatalf("presign dispositions = %v", store.presignDispositions)
 	}
+	requireAttachmentPreviewCSP(t, w.Header(), "https://app.example.test")
 }
 
 func TestDownloadAttachment_ExplicitProxyStreamsPublicEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary

- Apply the attachment-preview CSP before CloudFront attachment redirects.
- Apply the same preview CSP before presigned attachment redirects.
- Extend redirect tests so 302 responses override an existing global `frame-ancestors 'none'` header.

This is a follow-up to #4539. Proxy-streamed downloads and text preview responses were already covered, but redirect-mode downloads could still inherit the global CSP on the app container's 302 response.

Fixes MUL-3599
Closes #4477

## Test plan

- `go test ./internal/handler -run 'TestDownloadAttachment_(CloudFrontRedirectSignsAttachmentDisposition|AutoPublicEndpointPresigns|AutoInternalEndpointProxies|ExplicitProxyStreamsPublicEndpoint)$|TestGetAttachmentContent_HappyPath_Markdown$|TestAttachmentPreviewCSPHeader_AllowsConfiguredFrontendOrigins$'`
