### PR TITLE
fix(dashboard): hide deleted agents from usage leaderboard (MUL-3771)

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@multica/ui/components/ui/select";
 import { useWorkspaceId } from "@multica/core/hooks";
+import type { Agent } from "@multica/core/types";
 import { agentListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
@@ -99,6 +100,7 @@ const EMPTY_DAILY: import("@multica/core/types").DashboardUsageDaily[] = [];
 const EMPTY_BY_AGENT: import("@multica/core/types").DashboardUsageByAgent[] = [];
 const EMPTY_RUNTIME: import("@multica/core/types").DashboardAgentRunTime[] = [];
 const EMPTY_RUNTIME_DAILY: import("@multica/core/types").DashboardRunTimeDaily[] = [];
+const EMPTY_AGENTS: Agent[] = [];
 
 function fmtMoney(n: number): string {
   if (n >= 100) return `$${n.toFixed(0)}`;
@@ -171,7 +173,7 @@ export function DashboardPage() {
 
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const agentsQuery = useQuery(agentListOptions(wsId));
-  const agents = agentsQuery.data ?? [];
+  const agents = agentsQuery.data ?? EMPTY_AGENTS;
 
   // Validate the picked project against the current workspace's list. A
   // stale UUID — left over from a project that's been deleted, or from the

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -52,6 +52,7 @@ import {
   aggregateWeeklyTasks,
   aggregateWeeklyTime,
   computeDailyTotals,
+  filterKnownAgentRows,
   formatDuration,
   mergeAgentDashboardRows,
   type AgentDashboardRow,
@@ -169,7 +170,8 @@ export function DashboardPage() {
   useCustomPricingStore((s) => s.pricings);
 
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const agentsQuery = useQuery(agentListOptions(wsId));
+  const agents = agentsQuery.data ?? [];
 
   // Validate the picked project against the current workspace's list. A
   // stale UUID — left over from a project that's been deleted, or from the
@@ -310,6 +312,20 @@ export function DashboardPage() {
     [agentTokenRows, runTimeRows],
   );
 
+  // Hide rollup rows for agents that were hard-deleted from the workspace —
+  // they'd otherwise show up as a bare UUID on the leaderboard (MUL-3771).
+  // Archived agents stay (the agent list is fetched with archived included);
+  // only truly-removed agents drop out. Skip filtering until the agent list
+  // has loaded so a slow agents fetch doesn't transiently blank the list.
+  const knownAgentIds = useMemo(
+    () => (agentsQuery.isSuccess ? new Set(agents.map((a) => a.id)) : null),
+    [agentsQuery.isSuccess, agents],
+  );
+  const visibleAgentRows = useMemo(
+    () => filterKnownAgentRows(agentRows, knownAgentIds),
+    [agentRows, knownAgentIds],
+  );
+
   return (
     <div className="flex h-full flex-col">
       {/* h-auto + min-h-12 + flex-wrap: the toolbar (project filter,
@@ -411,7 +427,7 @@ export function DashboardPage() {
               {/* Per-agent leaderboard — user picks the ranking metric;
                   the progress bar and column emphasis follow the metric. */}
               <Leaderboard
-                rows={agentRows}
+                rows={visibleAgentRows}
                 agents={agents}
                 lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
               />

--- a/packages/views/dashboard/utils.test.ts
+++ b/packages/views/dashboard/utils.test.ts
@@ -5,6 +5,7 @@ import {
   aggregateWeeklyTasks,
   aggregateWeeklyTime,
   computeDailyTotals,
+  filterKnownAgentRows,
   formatDuration,
   mergeAgentDashboardRows,
 } from "./utils";
@@ -198,6 +199,29 @@ describe("mergeAgentDashboardRows", () => {
       ],
     );
     expect(merged.map((r) => r.agentId)).toEqual(["high", "low", "zero-cost-long"]);
+  });
+});
+
+describe("filterKnownAgentRows", () => {
+  const rows = [
+    { agentId: "live", tokens: 100, cost: 1, seconds: 10, taskCount: 1 },
+    { agentId: "deleted", tokens: 50, cost: 0.5, seconds: 5, taskCount: 1 },
+  ];
+
+  it("drops rows whose agent is no longer in the workspace", () => {
+    // "deleted" is absent from the known set — it's a hard-deleted agent whose
+    // legacy rollup row would otherwise render as a bare UUID.
+    const out = filterKnownAgentRows(rows, new Set(["live"]));
+    expect(out.map((r) => r.agentId)).toEqual(["live"]);
+  });
+
+  it("keeps every row while the agent list is still loading (null set)", () => {
+    const out = filterKnownAgentRows(rows, null);
+    expect(out.map((r) => r.agentId)).toEqual(["live", "deleted"]);
+  });
+
+  it("drops every row when the known set is empty", () => {
+    expect(filterKnownAgentRows(rows, new Set())).toEqual([]);
   });
 });
 

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -227,6 +227,23 @@ export function mergeAgentDashboardRows(
   });
 }
 
+// Drop usage rows whose agent no longer exists in the workspace. The agent
+// list is fetched with `include_archived: true`, so archived agents keep
+// their names and stay on the leaderboard; only hard-deleted agents fall out
+// of `knownAgentIds`. Those are legacy rollup rows that would otherwise
+// render as a bare UUID (MUL-3771).
+//
+// `knownAgentIds` is empty while the agent list is still loading; callers
+// pass `null` in that case so the rows pass through untouched instead of the
+// whole leaderboard blanking on a slow fetch.
+export function filterKnownAgentRows(
+  rows: AgentDashboardRow[],
+  knownAgentIds: ReadonlySet<string> | null,
+): AgentDashboardRow[] {
+  if (!knownAgentIds) return rows;
+  return rows.filter((r) => knownAgentIds.has(r.agentId));
+}
+
 // ---------------------------------------------------------------------------
 // Weekly fold for run-time + tasks. Mirrors `aggregateByWeek` in
 // `runtimes/utils.ts` which already covers cost / tokens — same calendar


### PR DESCRIPTION
## What

The usage leaderboard (Usage / dashboard page) listed hard-deleted agents as a bare UUID. The row builder fell back to the raw id when an agent wasn't found in the workspace agent list:

```tsx
{agent?.name ?? row.agentId}
```

Deleted agents survive only as legacy usage-rollup rows, so they have no name to resolve and rendered as a UUID.

## Fix

Filter the leaderboard rows to agents still present in the workspace before rendering. The agent list is fetched with `include_archived: true`, so **archived** agents keep their names and stay on the board; only **hard-deleted** agents drop out. Filtering is skipped until the agent list has loaded (`null` known-set) so a slow agents fetch doesn't transiently blank the board.

- New pure helper `filterKnownAgentRows(rows, knownAgentIds)` in `packages/views/dashboard/utils.ts`.
- Wired into `dashboard-page.tsx`; the leaderboard now receives the filtered rows, and the "N agents" caption reflects the visible count.
- Top-line KPI totals (cost / tokens / time / tasks) are untouched — only the per-agent list changes.

## Tests

- Added unit tests for `filterKnownAgentRows` (drops unknown agents, passes through while loading, empty set drops all).
- `pnpm --filter @multica/views test` — all pass.
- `pnpm --filter @multica/views typecheck` — clean.
- `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings only, none in touched files).

Closes MUL-3771.
