### PR TITLE
DH-263: 收紧 opencode /new reset 短路

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
@@ -90,6 +90,7 @@ export default function ChatTab() {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [agentPickerOpen, setAgentPickerOpen] = useState(false);
+  const activeSessionIdRef = useRef<string | null>(null);
 
   // Bridge to the chat-sessions formSheet route. Mirror local
   // activeSessionId into the store so the picker can render the current
@@ -102,6 +103,7 @@ export default function ChatTab() {
   const consumeSelect = useChatSessionPickerStore((s) => s.consumeSelect);
   useEffect(() => {
     setStoreActiveSessionId(activeSessionId);
+    activeSessionIdRef.current = activeSessionId;
   }, [activeSessionId, setStoreActiveSessionId]);
 
   // ── Server state ───────────────────────────────────────────────────────
@@ -269,9 +271,23 @@ export default function ChatTab() {
       }
 
       try {
-        const result = await api.sendChatMessage(sessionId, content, {
+        const result: Awaited<ReturnType<typeof api.sendChatMessage>> = await api.sendChatMessage(sessionId, content, {
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
         });
+        if (!result) {
+          qc.setQueryData<ChatMessage[]>(chatKeys.messages(sessionId), (old) =>
+            old ? old.filter((m) => m.id !== optimistic.id) : old,
+          );
+          qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+          qc.setQueryData(chatKeys.sessions(wsId), (old) =>
+            old ? old.filter((s) => s.id !== sessionId) : old,
+          );
+          clearDraft(sessionId);
+          if (activeSessionIdRef.current === sessionId) {
+            setActiveSessionId(null);
+          }
+          return;
+        }
         qc.setQueryData<ChatPendingTask>(chatKeys.pendingTask(sessionId), {
           task_id: result.task_id,
           status: "queued",

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -1040,7 +1040,7 @@ class ApiClient {
     sessionId: string,
     content: string,
     opts?: { attachmentIds?: string[] },
-  ): Promise<SendChatMessageResponse> {
+  ): Promise<SendChatMessageResponse | undefined> {
     // Strict parse — we need task_id + created_at to anchor the optimistic
     // StatusPill. Fallback would silently break the elapsed-time timer.
     //
@@ -1059,6 +1059,9 @@ class ApiClient {
         body: JSON.stringify(body),
       },
     );
+    if (raw === undefined) {
+      return undefined;
+    }
     const parsed = SendChatMessageResponseSchema.safeParse(raw);
     if (!parsed.success) {
       console.error("[api] ← shape mismatch POST /api/chat/sessions/:id/messages", {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1798,7 +1798,7 @@ export class ApiClient {
     sessionId: string,
     content: string,
     attachmentIds?: string[],
-  ): Promise<SendChatMessageResponse> {
+  ): Promise<SendChatMessageResponse | undefined> {
     const body: { content: string; attachment_ids?: string[] } = { content };
     if (attachmentIds && attachmentIds.length > 0) {
       body.attachment_ids = attachmentIds;

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -503,7 +503,7 @@ export function ChatWindow() {
       commitInput?.({ extraDraftKeys: [sessionId], clearEditor: stillOnSourceSession });
       apiLogger.debug("sendChatMessage.optimistic", { sessionId, optimisticId: optimistic.id });
 
-      let result;
+      let result: Awaited<ReturnType<typeof api.sendChatMessage>>;
       try {
         result = await api.sendChatMessage(sessionId, finalContent, attachmentIds);
       } catch (err) {
@@ -522,6 +522,24 @@ export function ChatWindow() {
         });
         toast.error(t(($) => $.input.send_failed_toast));
         return false;
+      }
+      if (!result) {
+        apiLogger.info("sendChatMessage.reset", {
+          sessionId,
+          optimisticId: optimistic.id,
+        });
+        stopRequestedBeforeTaskRef.current = false;
+        removeChatMessageFromCaches(qc, sessionId, optimistic.id);
+        qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+        qc.setQueryData<ChatSession[]>(
+          chatKeys.sessions(wsId),
+          (old) => old?.filter((s) => s.id !== sessionId),
+        );
+        if (stillOnSourceSession) {
+          setActiveSession(null);
+        }
+        commitInput?.({ clearEditor: stillOnSourceSession });
+        return true;
       }
       apiLogger.info("sendChatMessage.success", {
         sessionId,

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -23,6 +25,43 @@ import (
 // chatSessionTitleMaxLen caps the rename input. Long enough to fit a
 // meaningful summary, short enough to keep the dropdown row scannable.
 const chatSessionTitleMaxLen = 200
+
+func isChatResetShortcut(content string) bool {
+	switch strings.TrimSpace(content) {
+	case "new", "/new":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) chatSessionUsesOpenCode(ctx context.Context, session db.ChatSession) (bool, error) {
+	agent, err := h.Queries.GetAgent(ctx, session.AgentID)
+	if err != nil {
+		if !isNotFound(err) {
+			return false, err
+		}
+	} else if agent.RuntimeID.Valid {
+		runtime, err := h.Queries.GetAgentRuntime(ctx, agent.RuntimeID)
+		if err == nil {
+			return runtime.Provider == "opencode", nil
+		}
+		if !isNotFound(err) {
+			return false, err
+		}
+	}
+
+	if session.RuntimeID.Valid {
+		runtime, err := h.Queries.GetAgentRuntime(ctx, session.RuntimeID)
+		if err == nil {
+			return runtime.Provider == "opencode", nil
+		}
+		if !isNotFound(err) {
+			return false, err
+		}
+	}
+	return false, nil
+}
 
 // ---------------------------------------------------------------------------
 // Chat Sessions
@@ -320,66 +359,67 @@ func (h *Handler) DeleteChatSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tx, err := h.TxStarter.Begin(r.Context())
+	cancelled, err := h.deleteChatSessionTx(r.Context(), session)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		if errors.Is(err, pgx.ErrNoRows) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	defer tx.Rollback(r.Context())
+	h.TaskService.BroadcastCancelledTasks(r.Context(), cancelled)
+	resolvedSessionID := uuidToString(session.ID)
+	h.publishChat(protocol.EventChatSessionDeleted, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionDeletedPayload{
+		ChatSessionID: resolvedSessionID,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) deleteChatSessionTx(ctx context.Context, session db.ChatSession) ([]db.AgentTaskQueue, error) {
+	tx, err := h.TxStarter.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start transaction")
+	}
+	defer tx.Rollback(ctx)
 	qtx := h.Queries.WithTx(tx)
 
 	// FOR UPDATE on the chat_session row blocks any concurrent INSERT into
 	// agent_task_queue that references it (the FK validation needs a
 	// KEY SHARE lock). After we commit the delete, the blocked INSERT
 	// fails its FK check, so it can't land an orphaned task.
-	if _, err := qtx.LockChatSessionForDelete(r.Context(), session.ID); err != nil {
+	if _, err := qtx.LockChatSessionForDelete(ctx, session.ID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			// Already gone — treat as idempotent success.
-			w.WriteHeader(http.StatusNoContent)
-			return
+			return nil, pgx.ErrNoRows
 		}
-		writeError(w, http.StatusInternalServerError, "failed to lock chat session")
-		return
+		return nil, fmt.Errorf("failed to lock chat session")
 	}
 
-	cancelled, err := qtx.CancelAgentTasksByChatSession(r.Context(), session.ID)
+	cancelled, err := qtx.CancelAgentTasksByChatSession(ctx, session.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to cancel chat session tasks")
-		return
+		return nil, fmt.Errorf("failed to cancel chat session tasks")
 	}
 
 	// channel_chat_session_binding used to carry a chat_session FK with
 	// ON DELETE CASCADE; MUL-3515 §4 dropped every channel_* foreign key, so
 	// prune the binding here in the same tx that deletes its chat_session.
-	if err := qtx.DeleteChannelChatSessionBindingBySession(r.Context(), session.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete chat session binding")
-		return
+	if err := qtx.DeleteChannelChatSessionBindingBySession(ctx, session.ID); err != nil {
+		return nil, fmt.Errorf("failed to delete chat session binding")
 	}
 
-	if err := qtx.DeleteChatSession(r.Context(), db.DeleteChatSessionParams{
+	if err := qtx.DeleteChatSession(ctx, db.DeleteChatSessionParams{
 		ID:          session.ID,
 		WorkspaceID: session.WorkspaceID,
 	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to delete chat session")
-		return
+		return nil, fmt.Errorf("failed to delete chat session")
 	}
 
-	if err := tx.Commit(r.Context()); err != nil {
-		slog.Warn("commit chat session delete failed", "session_id", sessionID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to commit chat session delete")
-		return
+	if err := tx.Commit(ctx); err != nil {
+		slog.Warn("commit chat session delete failed", "session_id", uuidToString(session.ID), "error", err)
+		return nil, fmt.Errorf("failed to commit chat session delete")
 	}
 
-	// Post-commit broadcasts. Subscribers should never observe events for a
-	// tx that didn't actually persist.
-	h.TaskService.BroadcastCancelledTasks(r.Context(), cancelled)
-
-	resolvedSessionID := uuidToString(session.ID)
-	h.publishChat(protocol.EventChatSessionDeleted, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionDeletedPayload{
-		ChatSessionID: resolvedSessionID,
-	})
-
-	w.WriteHeader(http.StatusNoContent)
+	return cancelled, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -392,8 +432,8 @@ type SendChatMessageRequest struct {
 }
 
 type SendChatMessageResponse struct {
-	MessageID string `json:"message_id"`
-	TaskID    string `json:"task_id"`
+	MessageID string `json:"message_id,omitempty"`
+	TaskID    string `json:"task_id,omitempty"`
 	// AttachmentIDs are the attachment rows actually bound to this message by
 	// the server. The client diffs these against the ids it requested so it
 	// can warn the user when an attachment silently failed to bind — no extra
@@ -454,6 +494,32 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	if session.Status != "active" {
 		writeError(w, http.StatusBadRequest, "chat session is archived")
 		return
+	}
+
+	if len(attachmentIDs) == 0 && isChatResetShortcut(req.Content) {
+		usesOpenCode, err := h.chatSessionUsesOpenCode(r.Context(), session)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve chat runtime")
+			return
+		}
+		if usesOpenCode {
+			cancelled, err := h.deleteChatSessionTx(r.Context(), session)
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			h.TaskService.BroadcastCancelledTasks(r.Context(), cancelled)
+			resolvedSessionID := uuidToString(session.ID)
+			h.publishChat(protocol.EventChatSessionDeleted, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionDeletedPayload{
+				ChatSessionID: resolvedSessionID,
+			})
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 	}
 
 	// Create the user message first so the daemon can always find it.

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -32,6 +32,58 @@ func withChatTestWorkspaceCtx(t *testing.T, req *http.Request) *http.Request {
 	return req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, memberRow))
 }
 
+func sendChatMessageRequest(t *testing.T, sessionID, content string, attachmentIDs []string) *http.Request {
+	t.Helper()
+	payload := map[string]any{"content": content}
+	if len(attachmentIDs) > 0 {
+		payload["attachment_ids"] = attachmentIDs
+	}
+	req := newRequest("POST", "/api/chat-sessions/"+sessionID+"/messages", payload)
+	req = withURLParam(req, "sessionId", sessionID)
+	return withChatTestWorkspaceCtx(t, req)
+}
+
+func createHandlerTestOpencodeRuntime(t *testing.T) string {
+	t.Helper()
+
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, visibility, last_seen_at
+		)
+		VALUES ($1, NULL, 'Handler Test OpenCode Runtime', 'cloud', 'opencode', 'online', 'handler test opencode', '{}'::jsonb, $2, 'private', now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("create opencode runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+	return runtimeID
+}
+
+func createHandlerTestAgentOnRuntime(t *testing.T, runtimeID, name string) string {
+	t.Helper()
+
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args, mcp_config
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, name, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent on runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+	return agentID
+}
+
 // TestSendChatMessage_LinksAttachments verifies that attachments uploaded
 // against a chat_session (chat_message_id NULL) are back-filled with the
 // message_id when SendChatMessage receives the matching attachment_ids.
@@ -283,6 +335,93 @@ func TestSendChatMessage_InvalidAttachmentIDs(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("expected 0 chat_message rows after rejected send, got %d", count)
+	}
+}
+
+func TestSendChatMessage_ResetShortcutDeletesOpencodeSession(t *testing.T) {
+	runtimeID := createHandlerTestOpencodeRuntime(t)
+	agentID := createHandlerTestAgentOnRuntime(t, runtimeID, "ChatResetOpenCodeAgent")
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	req := sendChatMessageRequest(t, sessionID, "/new", nil)
+	w := httptest.NewRecorder()
+	testHandler.SendChatMessage(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("SendChatMessage reset: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var sessionCount int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM chat_session WHERE id = $1`,
+		sessionID,
+	).Scan(&sessionCount); err != nil {
+		t.Fatalf("count chat_session: %v", err)
+	}
+	if sessionCount != 0 {
+		t.Fatalf("expected chat session to be deleted, got %d rows", sessionCount)
+	}
+
+	var messageCount int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM chat_message WHERE chat_session_id = $1`,
+		sessionID,
+	).Scan(&messageCount); err != nil {
+		t.Fatalf("count chat_message: %v", err)
+	}
+	if messageCount != 0 {
+		t.Fatalf("expected no chat_message rows for reset shortcut, got %d", messageCount)
+	}
+}
+
+func TestSendChatMessage_ResetShortcutKeepsNonOpenCodeSession(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatResetNonOpenCodeAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	req := sendChatMessageRequest(t, sessionID, "/new", nil)
+	w := httptest.NewRecorder()
+	testHandler.SendChatMessage(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("SendChatMessage non-opencode reset: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var sendResp SendChatMessageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &sendResp); err != nil {
+		t.Fatalf("decode send: %v", err)
+	}
+	if sendResp.MessageID == "" || sendResp.TaskID == "" {
+		t.Fatalf("expected normal send response, got %#v", sendResp)
+	}
+}
+
+func TestSendChatMessage_ResetShortcutWithExtraTextStaysNormal(t *testing.T) {
+	runtimeID := createHandlerTestOpencodeRuntime(t)
+	agentID := createHandlerTestAgentOnRuntime(t, runtimeID, "ChatResetExtraTextAgent")
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	req := sendChatMessageRequest(t, sessionID, "new 需求", nil)
+	w := httptest.NewRecorder()
+	testHandler.SendChatMessage(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("SendChatMessage extra text: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var sendResp SendChatMessageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &sendResp); err != nil {
+		t.Fatalf("decode send: %v", err)
+	}
+	if sendResp.MessageID == "" || sendResp.TaskID == "" {
+		t.Fatalf("expected normal send response, got %#v", sendResp)
+	}
+
+	var messageCount int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM chat_message WHERE chat_session_id = $1`,
+		sessionID,
+	).Scan(&messageCount); err != nil {
+		t.Fatalf("count chat_message: %v", err)
+	}
+	if messageCount != 1 {
+		t.Fatalf("expected one persisted chat message, got %d", messageCount)
 	}
 }
 


### PR DESCRIPTION
Closes DH-263

## 变更
- 仅在 opencode runtime 下，把纯 `new` / `/new` 短路为删除当前 chat session。
- 204 reset 路径会清掉 optimistic 消息、pending task 和 active session。
- 补了 opencode / non-opencode / extra text 的回归测试。

## 验证
- `cd server && go test ./internal/handler -run 'TestSendChatMessage_(ResetShortcutDeletesOpencodeSession|ResetShortcutKeepsNonOpenCodeSession|ResetShortcutWithExtraTextStaysNormal)' -count=1`
