### PR TITLE
fix(dashboard): show deleted-agent placeholder on usage leaderboards (MUL-3771)

### DIFF
--- a/packages/views/common/agent-usage-cell.test.tsx
+++ b/packages/views/common/agent-usage-cell.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentUsageCell } from "./agent-usage-cell";
+
+// The live ActorAvatar pulls in workspace hooks, navigation, and hover cards;
+// stub it down to a marker that exposes the actorId so we can assert it links
+// through to the agent profile rather than the deleted placeholder.
+vi.mock("./actor-avatar", () => ({
+  ActorAvatar: ({ actorId }: { actorId: string }) => (
+    <span data-testid="live-avatar" data-actor-id={actorId} />
+  ),
+}));
+
+// The base avatar is what the deleted placeholder renders directly.
+vi.mock("@multica/ui/components/common/actor-avatar", () => ({
+  ActorAvatar: ({ name }: { name: string }) => (
+    <span data-testid="base-avatar" data-name={name} />
+  ),
+}));
+
+describe("AgentUsageCell", () => {
+  it("renders the live avatar and name for a resolved agent", () => {
+    render(
+      <AgentUsageCell
+        agentId="agent-1"
+        agent={{ name: "Atlas" }}
+        agentsLoaded
+        deletedLabel="Deleted agent"
+      />,
+    );
+
+    expect(screen.getByTestId("live-avatar")).toHaveAttribute(
+      "data-actor-id",
+      "agent-1",
+    );
+    expect(screen.getByText("Atlas")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-avatar")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deleted agent")).not.toBeInTheDocument();
+  });
+
+  it("renders the deleted placeholder once the list has loaded without the agent", () => {
+    render(
+      <AgentUsageCell
+        agentId="agent-gone"
+        agent={undefined}
+        agentsLoaded
+        deletedLabel="Deleted agent"
+      />,
+    );
+
+    expect(screen.getByTestId("base-avatar")).toHaveAttribute(
+      "data-name",
+      "Deleted agent",
+    );
+    expect(screen.getByText("Deleted agent")).toBeInTheDocument();
+    // No live avatar — a deleted agent must not link through to a 404 profile.
+    expect(screen.queryByTestId("live-avatar")).not.toBeInTheDocument();
+  });
+
+  it("keeps the live avatar for an absent agent while the list is still loading", () => {
+    render(
+      <AgentUsageCell
+        agentId="agent-2"
+        agent={undefined}
+        agentsLoaded={false}
+        deletedLabel="Deleted agent"
+      />,
+    );
+
+    // Absent + not loaded only means the agent list is still resolving, so we
+    // keep the live avatar rather than flashing the deleted placeholder.
+    expect(screen.getByTestId("live-avatar")).toHaveAttribute(
+      "data-actor-id",
+      "agent-2",
+    );
+    // Falls back to the id so the row stays identifiable instead of blank
+    // while the agent list is still resolving.
+    expect(screen.getByText("agent-2")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-avatar")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deleted agent")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/common/agent-usage-cell.tsx
+++ b/packages/views/common/agent-usage-cell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ActorAvatar } from "./actor-avatar";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+
+interface AgentUsageCellProps {
+  agentId: string;
+  /** The resolved agent, or `undefined` when it was hard-deleted. */
+  agent: { name: string } | undefined;
+  /**
+   * Whether the workspace agent list has finished loading. Until it has, an
+   * absent `agent` only means the list is still resolving — not that the agent
+   * was deleted — so we keep the live avatar instead of flashing the deleted
+   * placeholder on every row.
+   */
+  agentsLoaded: boolean;
+  /** Localised "Deleted agent" label, supplied by the caller's namespace. */
+  deletedLabel: string;
+}
+
+// Agent identity cell shared by the dashboard and runtime usage leaderboards.
+// A hard-deleted agent has no row in the workspace agent list, so the live
+// ActorAvatar would link through to a now-removed profile (404) and resolve
+// "UA" initials that contradict the label. Deleted agents therefore get a
+// neutral, non-interactive placeholder instead. Only the loaded list can prove
+// deletion, so an absent agent before then keeps the live avatar.
+export function AgentUsageCell({
+  agentId,
+  agent,
+  agentsLoaded,
+  deletedLabel,
+}: AgentUsageCellProps) {
+  if (!agent && agentsLoaded) {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
+        <ActorAvatarBase name={deletedLabel} initials="" isAgent size={22} />
+        <span className="truncate text-sm font-medium text-muted-foreground">
+          {deletedLabel}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <ActorAvatar actorType="agent" actorId={agentId} size={22} enableHoverCard />
+      <span className="cursor-pointer truncate text-sm font-medium">
+        {agent?.name ?? agentId}
+      </span>
+    </div>
+  );
+}

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -36,7 +36,7 @@ import {
   WeeklyTasksChart,
 } from "../../runtimes/components/charts";
 import { ProjectIcon } from "../../projects/components/project-icon";
-import { ActorAvatar } from "../../common/actor-avatar";
+import { AgentUsageCell } from "../../common/agent-usage-cell";
 import {
   addDaysIso,
   aggregateByWeek,
@@ -53,7 +53,6 @@ import {
   aggregateWeeklyTasks,
   aggregateWeeklyTime,
   computeDailyTotals,
-  filterKnownAgentRows,
   formatDuration,
   mergeAgentDashboardRows,
   type AgentDashboardRow,
@@ -314,20 +313,6 @@ export function DashboardPage() {
     [agentTokenRows, runTimeRows],
   );
 
-  // Hide rollup rows for agents that were hard-deleted from the workspace —
-  // they'd otherwise show up as a bare UUID on the leaderboard (MUL-3771).
-  // Archived agents stay (the agent list is fetched with archived included);
-  // only truly-removed agents drop out. Skip filtering until the agent list
-  // has loaded so a slow agents fetch doesn't transiently blank the list.
-  const knownAgentIds = useMemo(
-    () => (agentsQuery.isSuccess ? new Set(agents.map((a) => a.id)) : null),
-    [agentsQuery.isSuccess, agents],
-  );
-  const visibleAgentRows = useMemo(
-    () => filterKnownAgentRows(agentRows, knownAgentIds),
-    [agentRows, knownAgentIds],
-  );
-
   return (
     <div className="flex h-full flex-col">
       {/* h-auto + min-h-12 + flex-wrap: the toolbar (project filter,
@@ -429,8 +414,9 @@ export function DashboardPage() {
               {/* Per-agent leaderboard — user picks the ranking metric;
                   the progress bar and column emphasis follow the metric. */}
               <Leaderboard
-                rows={visibleAgentRows}
+                rows={agentRows}
                 agents={agents}
+                agentsLoaded={agentsQuery.isSuccess}
                 lessThanMinuteLabel={t(($) => $.duration.less_than_minute)}
               />
             </>
@@ -640,10 +626,12 @@ const SORT_METRIC: Record<LeaderboardSort, (r: AgentDashboardRow) => number> = {
 function Leaderboard({
   rows,
   agents,
+  agentsLoaded,
   lessThanMinuteLabel,
 }: {
   rows: AgentDashboardRow[];
   agents: { id: string; name: string }[];
+  agentsLoaded: boolean;
   lessThanMinuteLabel: string;
 }) {
   const { t } = useT("usage");
@@ -671,6 +659,13 @@ function Leaderboard({
     const metric = SORT_METRIC[sortBy];
     return sortedRows.reduce((m, r) => Math.max(m, metric(r)), 0);
   }, [sortedRows, sortBy]);
+
+  // Resolve each row's agent in O(1); a per-row `agents.find` would be
+  // O(rows×agents) on every re-sort.
+  const agentById = useMemo(
+    () => new Map(agents.map((a) => [a.id, a])),
+    [agents],
+  );
 
   // Active column gets foreground text; others stay muted. Helps the user
   // see "this is what the bar is measuring" at a glance.
@@ -704,7 +699,7 @@ function Leaderboard({
           </div>
           <div className="divide-y">
             {sortedRows.map((row) => {
-              const agent = agents.find((a) => a.id === row.agentId);
+              const agent = agentById.get(row.agentId);
               const value = SORT_METRIC[sortBy](row);
               const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
               return (
@@ -712,17 +707,12 @@ function Leaderboard({
                   key={row.agentId}
                   className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_5rem_5rem_5rem_4rem] items-center gap-3 px-4 py-2"
                 >
-                  <div className="flex min-w-0 items-center gap-2">
-                    <ActorAvatar
-                      actorType="agent"
-                      actorId={row.agentId}
-                      size={22}
-                      enableHoverCard
-                    />
-                    <span className="cursor-pointer truncate text-sm font-medium">
-                      {agent?.name ?? row.agentId}
-                    </span>
-                  </div>
+                  <AgentUsageCell
+                    agentId={row.agentId}
+                    agent={agent}
+                    agentsLoaded={agentsLoaded}
+                    deletedLabel={t(($) => $.leaderboard.deleted_agent)}
+                  />
                   <div className="relative h-2 overflow-hidden rounded-full bg-muted">
                     <div
                       className="h-full rounded-full bg-chart-1 transition-[width] duration-300 ease-out"

--- a/packages/views/dashboard/utils.test.ts
+++ b/packages/views/dashboard/utils.test.ts
@@ -5,7 +5,6 @@ import {
   aggregateWeeklyTasks,
   aggregateWeeklyTime,
   computeDailyTotals,
-  filterKnownAgentRows,
   formatDuration,
   mergeAgentDashboardRows,
 } from "./utils";
@@ -199,29 +198,6 @@ describe("mergeAgentDashboardRows", () => {
       ],
     );
     expect(merged.map((r) => r.agentId)).toEqual(["high", "low", "zero-cost-long"]);
-  });
-});
-
-describe("filterKnownAgentRows", () => {
-  const rows = [
-    { agentId: "live", tokens: 100, cost: 1, seconds: 10, taskCount: 1 },
-    { agentId: "deleted", tokens: 50, cost: 0.5, seconds: 5, taskCount: 1 },
-  ];
-
-  it("drops rows whose agent is no longer in the workspace", () => {
-    // "deleted" is absent from the known set — it's a hard-deleted agent whose
-    // legacy rollup row would otherwise render as a bare UUID.
-    const out = filterKnownAgentRows(rows, new Set(["live"]));
-    expect(out.map((r) => r.agentId)).toEqual(["live"]);
-  });
-
-  it("keeps every row while the agent list is still loading (null set)", () => {
-    const out = filterKnownAgentRows(rows, null);
-    expect(out.map((r) => r.agentId)).toEqual(["live", "deleted"]);
-  });
-
-  it("drops every row when the known set is empty", () => {
-    expect(filterKnownAgentRows(rows, new Set())).toEqual([]);
   });
 });
 

--- a/packages/views/dashboard/utils.ts
+++ b/packages/views/dashboard/utils.ts
@@ -227,23 +227,6 @@ export function mergeAgentDashboardRows(
   });
 }
 
-// Drop usage rows whose agent no longer exists in the workspace. The agent
-// list is fetched with `include_archived: true`, so archived agents keep
-// their names and stay on the leaderboard; only hard-deleted agents fall out
-// of `knownAgentIds`. Those are legacy rollup rows that would otherwise
-// render as a bare UUID (MUL-3771).
-//
-// `knownAgentIds` is empty while the agent list is still loading; callers
-// pass `null` in that case so the rows pass through untouched instead of the
-// whole leaderboard blanking on a slow fetch.
-export function filterKnownAgentRows(
-  rows: AgentDashboardRow[],
-  knownAgentIds: ReadonlySet<string> | null,
-): AgentDashboardRow[] {
-  if (!knownAgentIds) return rows;
-  return rows.filter((r) => knownAgentIds.has(r.agentId));
-}
-
 // ---------------------------------------------------------------------------
 // Weekly fold for run-time + tasks. Mirrors `aggregateByWeek` in
 // `runtimes/utils.ts` which already covers cost / tokens — same calendar

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -401,6 +401,7 @@
     "cost_by_caption_agent_other": "{{count}} agents on this runtime",
     "cost_by_caption_model_one": "{{count}} model used",
     "cost_by_caption_model_other": "{{count}} models used",
+    "deleted_agent": "Deleted agent",
     "daily_breakdown_toggle": "Daily breakdown table",
     "table_date": "Date",
     "table_model": "Model",

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -46,7 +46,8 @@
     "header_cost": "Cost",
     "header_time": "Time",
     "header_tasks": "Tasks",
-    "no_data": "No agent activity in this window."
+    "no_data": "No agent activity in this window.",
+    "deleted_agent": "Deleted agent"
   },
   "empty": {
     "title": "No usage yet",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -386,6 +386,7 @@
     "cost_by_tab_model": "モデル別",
     "cost_by_caption_agent_other": "このランタイムのエージェント {{count}} 個",
     "cost_by_caption_model_other": "使用されたモデル {{count}} 個",
+    "deleted_agent": "削除済みエージェント",
     "daily_breakdown_toggle": "日別内訳テーブル",
     "table_date": "日付",
     "table_model": "モデル",

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -46,7 +46,8 @@
     "header_cost": "コスト",
     "header_time": "時間",
     "header_tasks": "タスク",
-    "no_data": "この期間にエージェントの活動はありません。"
+    "no_data": "この期間にエージェントの活動はありません。",
+    "deleted_agent": "削除済みエージェント"
   },
   "empty": {
     "title": "まだ使用量はありません",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -401,6 +401,7 @@
     "cost_by_caption_agent_other": "이 런타임의 에이전트 {{count}}개",
     "cost_by_caption_model_one": "사용된 모델 {{count}}개",
     "cost_by_caption_model_other": "사용된 모델 {{count}}개",
+    "deleted_agent": "삭제된 에이전트",
     "daily_breakdown_toggle": "일별 상세 테이블",
     "table_date": "날짜",
     "table_model": "모델",

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -46,7 +46,8 @@
     "header_cost": "비용",
     "header_time": "시간",
     "header_tasks": "작업",
-    "no_data": "이 기간에는 에이전트 활동이 없습니다."
+    "no_data": "이 기간에는 에이전트 활동이 없습니다.",
+    "deleted_agent": "삭제된 에이전트"
   },
   "empty": {
     "title": "아직 사용량이 없습니다",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -386,6 +386,7 @@
     "cost_by_tab_model": "按模型",
     "cost_by_caption_agent_other": "{{count}} 个智能体使用此运行时",
     "cost_by_caption_model_other": "{{count}} 个模型已使用",
+    "deleted_agent": "已删除的智能体",
     "daily_breakdown_toggle": "每日明细表",
     "table_date": "日期",
     "table_model": "模型",

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -46,7 +46,8 @@
     "header_cost": "费用",
     "header_time": "运行时长",
     "header_tasks": "任务数",
-    "no_data": "所选时间范围内暂无智能体活动。"
+    "no_data": "所选时间范围内暂无智能体活动。",
+    "deleted_agent": "已删除的智能体"
   },
   "empty": {
     "title": "暂无消耗数据",

--- a/packages/views/runtimes/components/usage-section.tsx
+++ b/packages/views/runtimes/components/usage-section.tsx
@@ -28,7 +28,7 @@ import {
   type CostByKey,
 } from "../utils";
 import { KpiCard } from "./shared";
-import { ActorAvatar } from "../../common/actor-avatar";
+import { AgentUsageCell } from "../../common/agent-usage-cell";
 import {
   DailyCostChart,
   DailyTokensChart,
@@ -621,7 +621,8 @@ function CostByBlock({
   });
 
   const wsId = useWorkspaceId();
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const { data: agents = [], isSuccess: agentsLoaded } =
+    useQuery(agentListOptions(wsId));
 
   const byAgent = useMemo(
     () => aggregateCostByAgent(byAgentRows),
@@ -663,17 +664,14 @@ function CostByBlock({
         {tab === "agent" && (
           <CostByList
             rows={byAgent}
-            renderKey={(key) => {
-              const agent = agents.find((a) => a.id === key);
-              return (
-                <div className="flex min-w-0 items-center gap-2">
-                  <ActorAvatar actorType="agent" actorId={key} size={22} enableHoverCard />
-                  <span className="cursor-pointer truncate text-sm font-medium">
-                    {agent?.name ?? key}
-                  </span>
-                </div>
-              );
-            }}
+            renderKey={(key) => (
+              <AgentUsageCell
+                agentId={key}
+                agent={agents.find((a) => a.id === key)}
+                agentsLoaded={agentsLoaded}
+                deletedLabel={t(($) => $.usage.deleted_agent)}
+              />
+            )}
           />
         )}
         {tab === "model" && (


### PR DESCRIPTION
## What does this PR do?

The previous MUL-3771 fix hid hard-deleted agents from the usage leaderboards by dropping their rows entirely. That erased their historical usage and was inconsistent — a slow agents fetch could also transiently blank rows. This PR replaces row-filtering with a shared `AgentUsageCell` that renders a neutral, non-interactive **"Deleted agent"** placeholder, keeping the agent's historical usage visible while avoiding a bare-UUID label and a live `ActorAvatar` that would link through to a removed profile (404).

An absent agent is only treated as deleted once the workspace agent list has finished loading, so a slow agents fetch no longer flashes the placeholder on every row.

## Related Issue

Closes #4640

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/common/agent-usage-cell.tsx` — new shared cell: live avatar + name for a resolved agent, neutral placeholder for a deleted one, id fallback while the list loads.
- `packages/views/common/agent-usage-cell.test.tsx` — covers resolved / deleted / still-loading states.
- `packages/views/dashboard/components/dashboard-page.tsx` — leaderboard now passes `agentsLoaded` and renders `AgentUsageCell`; removes the `filterKnownAgentRows` call and adds an `agentById` map (O(1) lookup instead of per-row `find`).
- `packages/views/dashboard/utils.ts` / `utils.test.ts` — remove the now-unused `filterKnownAgentRows` helper and its tests.
- `packages/views/runtimes/components/usage-section.tsx` — cost-by-agent list reuses `AgentUsageCell`.
- `packages/views/locales/{en,ja,ko,zh-Hans}/{usage,runtimes}.json` — add `deleted_agent` label.

## How to Test

1. Open the dashboard / runtime usage leaderboards in a workspace that has usage rows for a hard-deleted agent.
2. Confirm the deleted agent shows a muted "Deleted agent" placeholder with no hover card / profile link, instead of a bare UUID.
3. Confirm live and archived agents still render their avatar, name, and hover card.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` (`智能体` for agent)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Refactored the prior MUL-3771 row-filtering fix into a shared placeholder cell; tests and typecheck run locally.

