### PR TITLE
fix(issues): apply filters to status board pagination

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -492,6 +492,8 @@ export class ApiClient {
     if (params?.workspace_id) search.set("workspace_id", params.workspace_id);
     if (params?.status) search.set("status", params.status);
     if (params?.priority) search.set("priority", params.priority);
+    if (params?.priorities?.length) search.set("priorities", params.priorities.join(","));
+    if (params?.assignee_types?.length) search.set("assignee_types", params.assignee_types.join(","));
     if (params?.assignee_id) search.set("assignee_id", params.assignee_id);
     if (params?.assignee_ids?.length) search.set("assignee_ids", params.assignee_ids.join(","));
     if (params?.creator_id) search.set("creator_id", params.creator_id);
@@ -502,6 +504,16 @@ export class ApiClient {
     }
     if (params?.open_only) search.set("open_only", "true");
     if (params?.scheduled) search.set("scheduled", "true");
+    if (params?.assignee_filters?.length) {
+      search.set("assignee_filters", params.assignee_filters.map((f) => `${f.type}:${f.id}`).join(","));
+    }
+    if (params?.include_no_assignee) search.set("include_no_assignee", "true");
+    if (params?.creator_filters?.length) {
+      search.set("creator_filters", params.creator_filters.map((f) => `${f.type}:${f.id}`).join(","));
+    }
+    if (params?.project_ids?.length) search.set("project_ids", params.project_ids.join(","));
+    if (params?.include_no_project) search.set("include_no_project", "true");
+    if (params?.label_ids?.length) search.set("label_ids", params.label_ids.join(","));
     if (params?.date_field) search.set("date_field", params.date_field);
     if (params?.date_start) search.set("date_start", params.date_start);
     if (params?.date_end) search.set("date_end", params.date_end);

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -451,6 +451,30 @@ describe("useUpdateIssue — optimistic move keeps every bucketed board in sync"
     const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(issueKeys.myAll(WS_ID));
   });
+
+  it("invalidates filtered workspace lists when filter membership can change", async () => {
+    const filteredKey = issueKeys.listSorted(WS_ID, sort, { priorities: ["high"] });
+    qc.setQueryData<ListIssuesCache>(filteredKey, {
+      byStatus: {
+        todo: {
+          issues: [makeIssue(1, { priority: "high" })],
+          total: 1,
+        },
+      },
+    });
+    updateIssue.mockResolvedValue(makeIssue(1, { priority: "low" }));
+
+    const { result } = renderHook(() => useUpdateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "issue-1", priority: "low" });
+    });
+
+    expect(qc.getQueryState(filteredKey)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(wsKey)?.isInvalidated).toBe(false);
+  });
 });
 
 describe("useUpdateIssue — detaching a sub-issue prunes the old parent's children cache", () => {
@@ -673,6 +697,33 @@ describe("useBatchUpdateIssues — optimistic patch covers filtered boards too",
 
     const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(issueKeys.myAll(WS_ID));
+  });
+
+  it("invalidates filtered workspace lists when batch updates can change membership", async () => {
+    const filteredKey = issueKeys.listSorted(WS_ID, sort, { project_ids: ["project-1"] });
+    qc.setQueryData<ListIssuesCache>(filteredKey, {
+      byStatus: {
+        todo: {
+          issues: [makeIssue(1, { project_id: "project-1" })],
+          total: 1,
+        },
+      },
+    });
+    batchUpdateIssues.mockResolvedValue({ updated: 1 });
+
+    const { result } = renderHook(() => useBatchUpdateIssues(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        ids: ["issue-1"],
+        updates: { project_id: "project-9" },
+      });
+    });
+
+    expect(qc.getQueryState(filteredKey)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(wsKey)?.isInvalidated).toBe(false);
   });
 });
 

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient, type QueryKey } from "@tanstack/react-quer
 import { api } from "../api";
 import {
   issueKeys,
+  invalidateFilteredIssueLists,
   ISSUE_PAGE_SIZE,
   type AssigneeGroupedIssuesFilter,
   type IssueListFilter,
@@ -37,6 +38,19 @@ import type {
 } from "../types";
 import type { TimelineEntry, IssueSubscriber, Reaction } from "../types";
 import { sortTimelineEntriesAsc } from "./timeline-sort";
+
+function hasOwn(value: object, key: PropertyKey) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function updateAffectsFilteredIssueLists(update: Partial<UpdateIssueRequest>) {
+  return (
+    hasOwn(update, "priority") ||
+    hasOwn(update, "assignee_type") ||
+    hasOwn(update, "assignee_id") ||
+    hasOwn(update, "project_id")
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Shared mutation variable types — used by both mutation hooks and
@@ -334,10 +348,11 @@ export function useUpdateIssue() {
       );
     },
     onSettled: (_data, _err, vars, ctx) => {
-      // The issue's own list + detail caches are reconciled surgically in
+      // The unfiltered list + detail caches are reconciled surgically in
       // onSuccess / onError, so they are deliberately NOT invalidated here — a
-      // full-list refetch on settle is what made drags flicker. Only aggregate
-      // caches that cannot be patched from a single issue are refreshed below.
+      // full-list refetch on settle is what made drags flicker. Filtered
+      // workspace list variants are refreshed below only when the update can
+      // move a row in or out of their server-side filters.
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
@@ -355,6 +370,9 @@ export function useUpdateIssue() {
       // myAll whenever project_id was part of this update (MUL-3669 / #4548).
       if (Object.prototype.hasOwnProperty.call(vars, "project_id")) {
         qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      }
+      if (updateAffectsFilteredIssueLists(vars)) {
+        invalidateFilteredIssueLists(qc, wsId);
       }
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
@@ -530,13 +548,10 @@ export function useBatchUpdateIssues() {
       }
     },
     onSettled: (_data, _err, _vars, ctx) => {
-      // Deliberately NOT invalidating issueKeys.list / myAll here: the onMutate
-      // patch above is a complete surgical reconcile for these bucketed boards
-      // (batch changes status / priority / project — never a server-computed
-      // value), so a full-board refetch on settle would only re-introduce the
-      // flicker the single-issue update already removed. Aggregate / grouped
-      // caches that cannot be recomputed from a single-issue patch are still
-      // refreshed below.
+      // Deliberately NOT invalidating the unfiltered issueKeys.list / myAll
+      // caches here: the onMutate patch above is a complete surgical reconcile
+      // for those bucketed boards. Filtered workspace list variants are
+      // refreshed below when the batch update can change filter membership.
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
@@ -550,6 +565,9 @@ export function useBatchUpdateIssues() {
       // project's filtered list even if the WS echo is delayed (MUL-3669 / #4548).
       if (Object.prototype.hasOwnProperty.call(_vars.updates, "project_id")) {
         qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      }
+      if (updateAffectsFilteredIssueLists(_vars.updates)) {
+        invalidateFilteredIssueLists(qc, wsId);
       }
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -5,6 +5,7 @@ import {
   issueKeys,
   ISSUE_PAGE_SIZE,
   type AssigneeGroupedIssuesFilter,
+  type IssueListFilter,
   type IssueSortParam,
   type MyIssuesFilter,
 } from "./queries";
@@ -72,6 +73,7 @@ export function useLoadMoreByStatus(
   status: IssueStatus,
   myIssues?: { scope: string; filter: MyIssuesFilter },
   sort?: IssueSortParam,
+  listFilter?: IssueListFilter,
 ) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
@@ -79,7 +81,7 @@ export function useLoadMoreByStatus(
 
   const activeKey = myIssues
     ? issueKeys.myListSorted(wsId, myIssues.scope, myIssues.filter, sort)
-    : issueKeys.listSorted(wsId, sort);
+    : issueKeys.listSorted(wsId, sort, listFilter);
   const cache = qc.getQueryData<ListIssuesCache>(activeKey);
   const bucket = cache?.byStatus[status];
   const loaded = bucket?.issues.length ?? 0;
@@ -95,6 +97,7 @@ export function useLoadMoreByStatus(
         limit: ISSUE_PAGE_SIZE,
         offset: loaded,
         ...sort,
+        ...listFilter,
         ...myIssues?.filter,
       });
       qc.setQueryData<ListIssuesCache>(activeKey, (old) => {
@@ -110,7 +113,7 @@ export function useLoadMoreByStatus(
     } finally {
       setIsLoading(false);
     }
-  }, [qc, activeKey, status, loaded, hasMore, isLoading, myIssues?.filter, sort]);
+  }, [qc, activeKey, status, loaded, hasMore, isLoading, listFilter, myIssues?.filter, sort]);
 
   return { loadMore, hasMore, isLoading, total };
 }

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -134,6 +134,22 @@ export const issueKeys = {
   tasks: (issueId: string) => [...issueKeys.tasksAll(), issueId] as const,
 };
 
+function isIssueListPrefix(wsId: string, queryKey: readonly unknown[]) {
+  const prefix = issueKeys.list(wsId);
+  return prefix.every((part, index) => Object.is(queryKey[index], part));
+}
+
+export function isFilteredIssueListKey(wsId: string, queryKey: readonly unknown[]) {
+  const prefix = issueKeys.list(wsId);
+  return isIssueListPrefix(wsId, queryKey) && queryKey.length === prefix.length + 2;
+}
+
+export function invalidateFilteredIssueLists(qc: QueryClient, wsId: string) {
+  qc.invalidateQueries({
+    predicate: (query) => isFilteredIssueListKey(wsId, query.queryKey),
+  });
+}
+
 export type MyIssuesFilter = Pick<
   ListIssuesParams,
   | "assignee_id"

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -18,13 +18,34 @@ export interface IssueSortParam {
   date_end?: ListIssuesParams["date_end"];
 }
 
+export type IssueListFilter = Pick<
+  ListIssuesParams,
+  | "priorities"
+  | "assignee_types"
+  | "assignee_filters"
+  | "include_no_assignee"
+  | "creator_filters"
+  | "project_ids"
+  | "include_no_project"
+  | "label_ids"
+>;
+
+function hasIssueListFilter(filter?: IssueListFilter) {
+  if (!filter) return false;
+  return Object.values(filter).some((value) =>
+    Array.isArray(value) ? value.length > 0 : value === true,
+  );
+}
+
 export const issueKeys = {
   all: (wsId: string) => ["issues", wsId] as const,
   /** PREFIX for invalidation — no sort. */
   list: (wsId: string) => [...issueKeys.all(wsId), "list"] as const,
-  /** FULL KEY for queryOptions — includes sort. */
-  listSorted: (wsId: string, sort?: IssueSortParam) =>
-    [...issueKeys.list(wsId), sort ?? {}] as const,
+  /** FULL KEY for queryOptions — includes active server-side filter + sort. */
+  listSorted: (wsId: string, sort?: IssueSortParam, filter?: IssueListFilter) =>
+    hasIssueListFilter(filter)
+      ? [...issueKeys.list(wsId), filter, sort ?? {}] as const
+      : [...issueKeys.list(wsId), sort ?? {}] as const,
   assigneeGroupsAll: (wsId: string) =>
     [...issueKeys.all(wsId), "assignee-groups"] as const,
   assigneeGroups: (wsId: string, filter: AssigneeGroupedIssuesFilter) =>
@@ -115,7 +136,19 @@ export const issueKeys = {
 
 export type MyIssuesFilter = Pick<
   ListIssuesParams,
-  "assignee_id" | "assignee_ids" | "creator_id" | "project_id" | "involves_user_id"
+  | "assignee_id"
+  | "assignee_ids"
+  | "creator_id"
+  | "project_id"
+  | "involves_user_id"
+  | "priorities"
+  | "assignee_types"
+  | "assignee_filters"
+  | "include_no_assignee"
+  | "creator_filters"
+  | "project_ids"
+  | "include_no_project"
+  | "label_ids"
 >;
 
 export type AssigneeGroupedIssuesFilter = Omit<
@@ -139,7 +172,7 @@ export function flattenIssueBuckets(data: ListIssuesCache) {
   return out;
 }
 
-async function fetchFirstPages(filter: MyIssuesFilter = {}, sort?: IssueSortParam): Promise<ListIssuesCache> {
+async function fetchFirstPages(filter: ListIssuesParams = {}, sort?: IssueSortParam): Promise<ListIssuesCache> {
   const responses = await Promise.all(
     PAGINATED_STATUSES.map((status) =>
       api.listIssues({ status, limit: ISSUE_PAGE_SIZE, offset: 0, ...sort, ...filter }),
@@ -172,11 +205,15 @@ async function fetchFirstPages(filter: MyIssuesFilter = {}, sort?: IssueSortPara
  * total — pagination on the "All" scope is out of scope; the first
  * 50-per-status × 3 widening (deduped) is what the page renders.
  */
-async function fetchAllMyFirstPages(userId: string, sort?: IssueSortParam): Promise<ListIssuesCache> {
+async function fetchAllMyFirstPages(
+  userId: string,
+  filter: MyIssuesFilter = {},
+  sort?: IssueSortParam,
+): Promise<ListIssuesCache> {
   const [byAssignee, byCreator, byInvolves] = await Promise.all([
-    fetchFirstPages({ assignee_id: userId }, sort),
-    fetchFirstPages({ creator_id: userId }, sort),
-    fetchFirstPages({ involves_user_id: userId }, sort),
+    fetchFirstPages({ ...filter, assignee_id: userId }, sort),
+    fetchFirstPages({ ...filter, creator_id: userId }, sort),
+    fetchFirstPages({ ...filter, involves_user_id: userId }, sort),
   ]);
   const byStatus: ListIssuesCache["byStatus"] = {};
   for (const status of PAGINATED_STATUSES) {
@@ -260,12 +297,16 @@ async function fetchAllMyAssigneeGroups(
  * Fetches the first page of each paginated status in parallel. Use
  * {@link useLoadMoreByStatus} to paginate a specific status into the cache.
  */
-export function issueListOptions(wsId: string, sort?: IssueSortParam) {
+export function issueListOptions(
+  wsId: string,
+  sort?: IssueSortParam,
+  filter?: IssueListFilter,
+) {
   return queryOptions({
-    queryKey: issueKeys.listSorted(wsId, sort),
-    queryFn: () => fetchFirstPages({}, sort),
+    queryKey: issueKeys.listSorted(wsId, sort, filter),
+    queryFn: () => fetchFirstPages(filter ?? {}, sort),
     select: flattenIssueBuckets,
-    placeholderData: keepPreviousData,
+    placeholderData: hasIssueListFilter(filter) ? undefined : keepPreviousData,
   });
 }
 
@@ -307,7 +348,7 @@ export function myIssueListOptions(
     queryKey: issueKeys.myListSorted(wsId, scope, filter, sort),
     queryFn: () =>
       scope === "all" && userId
-        ? fetchAllMyFirstPages(userId, sort)
+        ? fetchAllMyFirstPages(userId, filter, sort)
         : fetchFirstPages(filter, sort),
     select: flattenIssueBuckets,
     placeholderData: keepPreviousData,

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -122,6 +122,39 @@ function expectInvalidated(qc: QueryClient, queryKey: readonly unknown[]) {
   expect(qc.getQueryState(queryKey)?.isInvalidated).toBe(true);
 }
 
+describe("filtered workspace list invalidation", () => {
+  let qc: QueryClient;
+  const unfilteredKey = issueKeys.listSorted(WS_ID, undefined);
+  const filteredKey = issueKeys.listSorted(WS_ID, undefined, { priorities: ["high"] });
+
+  beforeEach(() => {
+    qc = new QueryClient();
+    qc.setQueryData<ListIssuesCache>(unfilteredKey, makeListCache(baseIssue));
+    qc.setQueryData<ListIssuesCache>(filteredKey, makeListCache(baseIssue));
+  });
+
+  it("invalidates filtered workspace lists after issue creation", () => {
+    onIssueCreated(qc, WS_ID, { ...otherIssue, priority: "low" });
+
+    expectInvalidated(qc, filteredKey);
+    expect(qc.getQueryState(unfilteredKey)?.isInvalidated).toBe(false);
+  });
+
+  it("invalidates filtered workspace lists after issue updates", () => {
+    onIssueUpdated(qc, WS_ID, { ...baseIssue, title: "Renamed" });
+
+    expectInvalidated(qc, filteredKey);
+    expect(qc.getQueryState(unfilteredKey)?.isInvalidated).toBe(false);
+  });
+
+  it("invalidates filtered workspace lists after label changes", () => {
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    expectInvalidated(qc, filteredKey);
+    expect(qc.getQueryState(unfilteredKey)?.isInvalidated).toBe(false);
+  });
+});
+
 describe("onIssueLabelsChanged", () => {
   let qc: QueryClient;
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -1,5 +1,5 @@
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
-import { issueKeys } from "./queries";
+import { issueKeys, invalidateFilteredIssueLists } from "./queries";
 import { labelKeys } from "../labels/queries";
 import { projectKeys } from "../projects/queries";
 import {
@@ -19,6 +19,7 @@ export function onIssueCreated(
   for (const [key, data] of qc.getQueriesData<ListIssuesCache>({ queryKey: issueKeys.list(wsId) })) {
     if (data) qc.setQueryData<ListIssuesCache>(key, addIssueToBuckets(data, issue));
   }
+  invalidateFilteredIssueLists(qc, wsId);
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
@@ -102,12 +103,12 @@ export function onIssueUpdated(
   for (const [key, data] of listQueries) {
     if (data) patchOrRefetchCounts(key, data);
   }
-  // The workspace board (issueKeys.list) is NOT filtered: an issue is always a
-  // member, so patchIssueInBuckets above is a complete surgical reconcile —
-  // cross-status move, same-column reorder, and field updates all land in the
-  // right bucket/slot. The old `if (position) invalidateQueries(list)` re-pulled
-  // the entire board on top of that, which is the full-list refetch that made a
-  // drag (local or echoed back over WS) flicker. It is pure redundancy here.
+  invalidateFilteredIssueLists(qc, wsId);
+  // The unfiltered workspace board can be patched surgically: an issue is always
+  // a member, so cross-status moves, same-column reorders, and field updates all
+  // land in the right bucket/slot. Filtered workspace list variants are
+  // invalidated above because a blind patch cannot know whether priority,
+  // assignee, project, or label filters still include the row.
   //
   // myAll (My Issues / Project / actor lists) IS filtered. Surgically patch the
   // cards that already live in those caches too, so a non-membership change
@@ -184,6 +185,7 @@ export function onIssueLabelsChanged(
   for (const [key, data] of qc.getQueriesData<ListIssuesCache>({ queryKey: issueKeys.list(wsId) })) {
     if (data) qc.setQueryData<ListIssuesCache>(key, patchIssueInBuckets(data, issueId, { labels }));
   }
+  invalidateFilteredIssueLists(qc, wsId);
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -2,6 +2,11 @@ import type { Issue, IssueMetadata, IssueStatus, IssuePriority, IssueAssigneeTyp
 import type { MemberRole } from "./workspace";
 import type { Project } from "./project";
 
+export interface IssueActorRef {
+  type: IssueAssigneeType;
+  id: string;
+}
+
 // Issue API
 export interface CreateIssueRequest {
   title: string;
@@ -79,6 +84,8 @@ export interface ListIssuesParams {
   workspace_id?: string;
   status?: IssueStatus;
   priority?: IssuePriority;
+  priorities?: IssuePriority[];
+  assignee_types?: IssueAssigneeType[];
   assignee_id?: string;
   assignee_ids?: string[];
   creator_id?: string;
@@ -102,16 +109,17 @@ export interface ListIssuesParams {
    * majority on the client.
    */
   scheduled?: boolean;
+  assignee_filters?: IssueActorRef[];
+  include_no_assignee?: boolean;
+  creator_filters?: IssueActorRef[];
+  project_ids?: string[];
+  include_no_project?: boolean;
+  label_ids?: string[];
   date_field?: "created_at" | "updated_at";
   date_start?: string;
   date_end?: string;
   sort_by?: "position" | "priority" | "title" | "created_at" | "start_date" | "due_date";
   sort_direction?: "asc" | "desc";
-}
-
-export interface IssueActorRef {
-  type: IssueAssigneeType;
-  id: string;
 }
 
 export interface ListGroupedIssuesParams {

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -15,7 +15,7 @@ import type { QueryKey } from "@tanstack/react-query";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { Issue, IssueAssigneeGroup, IssueStatus } from "@multica/core/types";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
-import type { AssigneeGroupedIssuesFilter, IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
+import type { AssigneeGroupedIssuesFilter, IssueListFilter, IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { useActorName } from "@multica/core/workspace/hooks";
@@ -121,6 +121,7 @@ export function BoardView({
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  listFilter,
   sort,
   projectId,
 }: {
@@ -135,6 +136,8 @@ export function BoardView({
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  /** Server-side filters for the workspace status-board cache. Ignored for my-issues caches. */
+  listFilter?: IssueListFilter;
   /** Must match the sort the page queried with — embedded in the cache key. */
   sort?: IssueSortParam;
   /** When set, the per-column "+" pre-fills the project on the create form. */
@@ -419,6 +422,7 @@ export function BoardView({
                 issueMap={issueMapRef.current}
                 childProgressMap={childProgressMap}
                 myIssuesOpts={myIssuesOpts}
+                listFilter={listFilter}
                 sort={sort}
                 projectId={projectId}
                 sortLabel={sortLabel}
@@ -457,6 +461,7 @@ export function BoardView({
           <BoardHiddenColumnsPanel
             hiddenStatuses={hiddenStatuses}
             myIssuesOpts={myIssuesOpts}
+            listFilter={listFilter}
             sort={sort}
           />
         )}
@@ -528,6 +533,7 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   issueMap,
   childProgressMap,
   myIssuesOpts,
+  listFilter,
   sort,
   projectId,
   sortLabel,
@@ -537,6 +543,7 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   sort?: IssueSortParam;
   projectId?: string;
   sortLabel?: string | null;
@@ -545,6 +552,7 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
     group.status,
     myIssuesOpts,
     sort,
+    listFilter,
   );
   return (
     <BoardColumn
@@ -574,23 +582,27 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
 function BoardHiddenColumnRow({
   status,
   myIssuesOpts,
+  listFilter,
   sort,
 }: {
   status: IssueStatus;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   sort?: IssueSortParam;
 }) {
-  const { total } = useLoadMoreByStatus(status, myIssuesOpts, sort);
+  const { total } = useLoadMoreByStatus(status, myIssuesOpts, sort, listFilter);
   return <HiddenColumnRow status={status} total={total} />;
 }
 
 function BoardHiddenColumnsPanel({
   hiddenStatuses,
   myIssuesOpts,
+  listFilter,
   sort,
 }: {
   hiddenStatuses: IssueStatus[];
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   sort?: IssueSortParam;
 }) {
   return (
@@ -601,6 +613,7 @@ function BoardHiddenColumnsPanel({
           key={status}
           status={status}
           myIssuesOpts={myIssuesOpts}
+          listFilter={listFilter}
           sort={sort}
         />
       )}

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -487,6 +487,12 @@ describe("IssuesPage (shared)", () => {
     mockViewState.grouping = "status";
     mockViewState.statusFilters = [];
     mockViewState.priorityFilters = [];
+    mockViewState.assigneeFilters = [];
+    mockViewState.includeNoAssignee = false;
+    mockViewState.creatorFilters = [];
+    mockViewState.projectFilters = [];
+    mockViewState.includeNoProject = false;
+    mockViewState.labelFilters = [];
     mockScope = "all";
   });
 
@@ -525,6 +531,42 @@ describe("IssuesPage (shared)", () => {
     await screen.findByText("Backlog");
     expect(screen.getAllByText("Todo").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("In Progress").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("server-filters status board pages when an assignee filter is active", async () => {
+    mockViewState.assigneeFilters = [{ type: "member", id: "user-1" }];
+    mockListIssues.mockImplementation((params: any) => {
+      const assigneeFilters = params?.assignee_filters ?? [];
+      const filtered = mockIssues.filter((issue) => {
+        const statusMatches = issue.status === params?.status;
+        const assigneeMatches =
+          assigneeFilters.length === 0 ||
+          assigneeFilters.some(
+            (filter: { type: string; id: string }) =>
+              issue.assignee_type === filter.type && issue.assignee_id === filter.id,
+          );
+        return statusMatches && assigneeMatches;
+      });
+      return Promise.resolve({
+        issues: filtered,
+        total:
+          params?.status === "todo" && assigneeFilters.length === 0
+            ? 99
+            : filtered.length,
+      });
+    });
+
+    renderWithQuery(<IssuesPage />);
+
+    await screen.findByText("Implement auth");
+    expect(screen.queryByText("Squad task")).not.toBeInTheDocument();
+    expect(screen.queryByText("99")).not.toBeInTheDocument();
+    expect(mockListIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "todo",
+        assignee_filters: [{ type: "member", id: "user-1" }],
+      }),
+    );
   });
 
   it("groups board columns by assignee", async () => {

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -13,7 +13,7 @@ import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-contex
 import { filterIssues } from "../utils/filter";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter } from "@multica/core/issues/queries";
+import { issueAssigneeGroupsOptions, issueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter, type IssueListFilter } from "@multica/core/issues/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -116,9 +116,24 @@ export function IssuesPage() {
     return filter;
   }, [assigneeFilters, creatorFilters, includeNoAssignee, includeNoProject, labelFilters, priorityFilters, projectFilters, scope, statusFilters]);
 
+  const statusListFilter = useMemo<IssueListFilter>(() => {
+    const filter: IssueListFilter = {
+      priorities: priorityFilters,
+      assignee_filters: assigneeFilters,
+      include_no_assignee: includeNoAssignee,
+      creator_filters: creatorFilters,
+      project_ids: projectFilters,
+      include_no_project: includeNoProject,
+      label_ids: labelFilters,
+    };
+    if (scope === "members") filter.assignee_types = ["member"];
+    if (scope === "agents") filter.assignee_types = ["agent", "squad"];
+    return filter;
+  }, [assigneeFilters, creatorFilters, includeNoAssignee, includeNoProject, labelFilters, priorityFilters, projectFilters, scope]);
+
   const assigneeGroupsOptions = issueAssigneeGroupsOptions(wsId, assigneeGroupFilter, queryParams);
   const statusIssuesQuery = useQuery({
-    ...issueListOptions(wsId, queryParams),
+    ...issueListOptions(wsId, queryParams, statusListFilter),
     enabled: !usesAssigneeBoard,
   });
   const assigneeGroupsQuery = useQuery({
@@ -266,6 +281,7 @@ export function IssuesPage() {
                 assigneeGroups={usesAssigneeBoard ? assigneeGroupsQuery.data?.groups : undefined}
                 assigneeGroupQueryKey={usesAssigneeBoard ? assigneeGroupsOptions.queryKey : undefined}
                 assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
+                listFilter={usesAssigneeBoard ? undefined : statusListFilter}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
@@ -281,10 +297,11 @@ export function IssuesPage() {
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                listFilter={statusListFilter}
                 sort={queryParams}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} sort={queryParams} onMoveIssue={handleMoveIssue} />
+              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} listFilter={statusListFilter} sort={queryParams} onMoveIssue={handleMoveIssue} />
             )}
           </div>
         )}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -19,7 +19,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
-import type { IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
+import type { IssueListFilter, IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
 import { useModalStore } from "@multica/core/modals";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -59,6 +59,7 @@ export function ListView({
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  listFilter,
   projectId,
   onMoveIssue,
   sort,
@@ -68,6 +69,7 @@ export function ListView({
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  listFilter?: IssueListFilter;
   projectId?: string;
   onMoveIssue?: (issueId: string, updates: DragMoveUpdates, onSettled?: () => void) => void;
   sort?: IssueSortParam;
@@ -316,6 +318,7 @@ export function ListView({
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
             myIssuesOpts={myIssuesOpts}
+            listFilter={listFilter}
             projectId={projectId}
             dragEnabled={dragEnabled}
             isExpanded={isExpanded}
@@ -365,6 +368,7 @@ function StatusAccordionItem({
   issueMap,
   childProgressMap,
   myIssuesOpts,
+  listFilter,
   projectId,
   dragEnabled,
   isExpanded,
@@ -376,6 +380,7 @@ function StatusAccordionItem({
   issueMap: Map<string, Issue>;
   childProgressMap: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   projectId?: string;
   dragEnabled: boolean;
   isExpanded: boolean;
@@ -390,6 +395,7 @@ function StatusAccordionItem({
     status,
     myIssuesOpts,
     sort,
+    listFilter,
   );
 
   const issues = useMemo(

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -35,7 +35,7 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
-import { childrenByParentsOptions, issueKeys, type IssueSortParam, type MyIssuesFilter } from "@multica/core/issues/queries";
+import { childrenByParentsOptions, issueKeys, type IssueListFilter, type IssueSortParam, type MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -451,6 +451,7 @@ export function SwimLaneView({
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  listFilter,
   sort,
   projectId,
 }: {
@@ -475,6 +476,7 @@ export function SwimLaneView({
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  listFilter?: IssueListFilter;
   /** Must match the sort the page queried with — embedded in the cache key. */
   sort?: IssueSortParam;
   /** Pre-fills `project_id` on the create form for the in-cell "+" button. */
@@ -1206,6 +1208,7 @@ export function SwimLaneView({
             sortedStatuses={sortedStatuses}
             gridStyle={gridStyle}
             myIssuesOpts={myIssuesOpts}
+            listFilter={listFilter}
             sort={sort}
           />
         </div>
@@ -1499,11 +1502,13 @@ function SwimLaneLoadMoreRow({
   sortedStatuses,
   gridStyle,
   myIssuesOpts,
+  listFilter,
   sort,
 }: {
   sortedStatuses: IssueStatus[];
   gridStyle: React.CSSProperties;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   sort?: IssueSortParam;
 }) {
   return (
@@ -1513,6 +1518,7 @@ function SwimLaneLoadMoreRow({
           key={status}
           status={status}
           myIssuesOpts={myIssuesOpts}
+          listFilter={listFilter}
           sort={sort}
         />
       ))}
@@ -1523,13 +1529,15 @@ function SwimLaneLoadMoreRow({
 function SwimLaneLoadMoreCell({
   status,
   myIssuesOpts,
+  listFilter,
   sort,
 }: {
   status: IssueStatus;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  listFilter?: IssueListFilter;
   sort?: IssueSortParam;
 }) {
-  const { loadMore, hasMore, isLoading } = useLoadMoreByStatus(status, myIssuesOpts, sort);
+  const { loadMore, hasMore, isLoading } = useLoadMoreByStatus(status, myIssuesOpts, sort, listFilter);
   if (!hasMore) return <div />;
   return <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />;
 }

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -911,6 +911,24 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	if priorityFilter.Valid {
 		where = append(where, fmt.Sprintf("i.priority = %s", addArg(priorityFilter.String)))
 	}
+	if raw := r.URL.Query().Get("priorities"); raw != "" {
+		priorities := splitCommaParam(raw)
+		if len(priorities) > 0 {
+			where = append(where, fmt.Sprintf("i.priority = ANY(%s::text[])", addArg(priorities)))
+		}
+	}
+	if raw := r.URL.Query().Get("assignee_types"); raw != "" {
+		assigneeTypes := splitCommaParam(raw)
+		for _, assigneeType := range assigneeTypes {
+			if !isIssueActorType(assigneeType) {
+				writeError(w, http.StatusBadRequest, "invalid assignee_types")
+				return
+			}
+		}
+		if len(assigneeTypes) > 0 {
+			where = append(where, fmt.Sprintf("i.assignee_type = ANY(%s::text[])", addArg(assigneeTypes)))
+		}
+	}
 	if assigneeFilter.Valid {
 		where = append(where, fmt.Sprintf("i.assignee_id = %s::uuid", addArg(assigneeFilter)))
 	}
@@ -963,6 +981,69 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
           AND a.owner_id     = %[1]s::uuid
     ))
 )`, ref))
+	}
+
+	assigneeFilters, ok := parseActorFilterList(w, r.URL.Query().Get("assignee_filters"), "assignee_filters")
+	if !ok {
+		return
+	}
+	includeNoAssignee := r.URL.Query().Get("include_no_assignee") == "true"
+	if len(assigneeFilters) > 0 || includeNoAssignee {
+		ors := make([]string, 0, len(assigneeFilters)+1)
+		for _, filter := range assigneeFilters {
+			ors = append(ors, fmt.Sprintf(
+				"(i.assignee_type = %s::text AND i.assignee_id = %s::uuid)",
+				addArg(filter.actorType),
+				addArg(filter.actorID),
+			))
+		}
+		if includeNoAssignee {
+			ors = append(ors, "(i.assignee_type IS NULL AND i.assignee_id IS NULL)")
+		}
+		where = append(where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	creatorFilters, ok := parseActorFilterList(w, r.URL.Query().Get("creator_filters"), "creator_filters")
+	if !ok {
+		return
+	}
+	if len(creatorFilters) > 0 {
+		ors := make([]string, 0, len(creatorFilters))
+		for _, filter := range creatorFilters {
+			ors = append(ors, fmt.Sprintf(
+				"(i.creator_type = %s::text AND i.creator_id = %s::uuid)",
+				addArg(filter.actorType),
+				addArg(filter.actorID),
+			))
+		}
+		where = append(where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	projectIDs, ok := parseUUIDParamList(w, r.URL.Query().Get("project_ids"), "project_ids")
+	if !ok {
+		return
+	}
+	includeNoProject := r.URL.Query().Get("include_no_project") == "true"
+	if len(projectIDs) > 0 || includeNoProject {
+		ors := make([]string, 0, 2)
+		if len(projectIDs) > 0 {
+			ors = append(ors, fmt.Sprintf("i.project_id = ANY(%s::uuid[])", addArg(projectIDs)))
+		}
+		if includeNoProject {
+			ors = append(ors, "i.project_id IS NULL")
+		}
+		where = append(where, "("+strings.Join(ors, " OR ")+")")
+	}
+
+	labelIDs, ok := parseUUIDParamList(w, r.URL.Query().Get("label_ids"), "label_ids")
+	if !ok {
+		return
+	}
+	if len(labelIDs) > 0 {
+		where = append(where, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM issue_to_label itl WHERE itl.issue_id = i.id AND itl.label_id = ANY(%s::uuid[]))",
+			addArg(labelIDs),
+		))
 	}
 
 	whereSql := strings.Join(where, " AND ")

--- a/server/internal/handler/issue_list_filters_test.go
+++ b/server/internal/handler/issue_list_filters_test.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestListIssuesAppliesActorFiltersToRowsAndTotal(t *testing.T) {
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("List issue filters %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE project_id = $1`, projectID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
+	})
+
+	var assigneeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "List Issues Filter User", fmt.Sprintf("list-filter-%d@multica.ai", suffix)).Scan(&assigneeID); err != nil {
+		t.Fatalf("create assignee user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, assigneeID)
+	})
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, assigneeID); err != nil {
+		t.Fatalf("create assignee member: %v", err)
+	}
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
+		RETURNING id
+	`, testWorkspaceID, "List Issues Filter Agent", testRuntimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	createIssue := func(title string, position float64, assigneeType string, assigneeID string) {
+		t.Helper()
+		var number int32
+		if err := testPool.QueryRow(ctx, `
+			UPDATE workspace
+			SET issue_counter = GREATEST(
+				issue_counter,
+				(SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)
+			) + 1
+			WHERE id = $1
+			RETURNING issue_counter
+		`, testWorkspaceID).Scan(&number); err != nil {
+			t.Fatalf("next issue number: %v", err)
+		}
+
+		var assigneeTypeArg any
+		var assigneeIDArg any
+		if assigneeType != "" {
+			assigneeTypeArg = assigneeType
+			assigneeIDArg = assigneeID
+		}
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO issue (
+				workspace_id, title, description, status, priority,
+				assignee_type, assignee_id, creator_type, creator_id,
+				position, number, project_id
+			)
+			VALUES ($1, $2, NULL, 'todo', 'none', $3, $4, 'member', $5, $6, $7, $8)
+		`, testWorkspaceID, title, assigneeTypeArg, assigneeIDArg, testUserID, position, number, projectID); err != nil {
+			t.Fatalf("create issue %q: %v", title, err)
+		}
+	}
+
+	createIssue("List filter unassigned", 0, "", "")
+	createIssue("List filter member one", 1, "member", assigneeID)
+	createIssue("List filter member two", 2, "member", assigneeID)
+	createIssue("List filter agent", 3, "agent", agentID)
+
+	path := fmt.Sprintf(
+		"/api/issues?workspace_id=%s&status=todo&project_id=%s&limit=2&assignee_filters=member:%s,agent:%s",
+		testWorkspaceID,
+		projectID,
+		assigneeID,
+		agentID,
+	)
+	w := httptest.NewRecorder()
+	testHandler.ListIssues(w, newRequest("GET", path, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Issues []IssueResponse `json:"issues"`
+		Total  int64           `json:"total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Fatalf("filtered total: want 3, got %d", resp.Total)
+	}
+	if len(resp.Issues) != 2 {
+		t.Fatalf("page length: want 2, got %d", len(resp.Issues))
+	}
+	for _, issue := range resp.Issues {
+		if issue.Title == "List filter unassigned" {
+			t.Fatalf("unassigned issue should be filtered out: %#v", resp.Issues)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4643.

This applies the active issue filters to the status-board list query and its load-more requests, so per-status totals stay aligned with the filtered issue set.

## Changes

- Pass priority, assignee type/ref, creator ref, project, label, unassigned, and no-project filters into the workspace status-board list query.
- Serialize those filters in the API client and apply them in `GET /api/issues` before rows and totals are computed.
- Keep assignee-grouped board behavior intact while sharing the same sort/date params.
- Add regression coverage for filtered `/api/issues` rows and totals.

## Validation

- `packages/views`: `./node_modules/.bin/vitest run issues/components/issues-page.test.tsx issues/utils/filter.test.ts`
- `packages/core`: `./node_modules/.bin/vitest run issues/queries.test.ts issues/mutations.test.tsx`
- `packages/core`: `./node_modules/.bin/tsc --noEmit`
- `packages/views`: `./node_modules/.bin/tsc --noEmit`
- `server`: `go test ./internal/handler -run '^TestListIssuesAppliesActorFiltersToRowsAndTotal$'`
- `git diff --check`

Note: a broader `go test ./internal/handler ./internal/service ./cmd/server` currently fails locally on baseline test database schema drift unrelated to this change, with missing columns/tables such as `stage`, `planned_at`, `handoff_note`, and `autopilot_subscriber`.
