### PR TITLE
WS-1091: allow create_issue autopilots to queue while runtime offline

### DIFF
--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -528,7 +528,10 @@ func TestExpireStaleQueuedTasks(t *testing.T) {
 		t.Fatalf("failed to find test agent: %v", err)
 	}
 
-	// One ancient queued task (should expire) and one fresh queued task (should not).
+	// One ancient queued task (should expire), one fresh queued task (should
+	// not), and one ancient autopilot-created issue task (should stay queued
+	// so an offline create_issue autopilot remains claimable when its runtime
+	// returns).
 	// Constraint: idx_one_pending_task_per_issue_agent → use distinct issues.
 	mkIssue := func(label string) string {
 		var issueID string
@@ -548,12 +551,34 @@ func TestExpireStaleQueuedTasks(t *testing.T) {
 	}
 	oldIssueID := mkIssue("Queued TTL test (old)")
 	freshIssueID := mkIssue("Queued TTL test (fresh)")
+	autopilotIssueID := mkIssue("Queued TTL test (autopilot issue)")
+	var autopilotID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot (
+			workspace_id, title, assignee_type, assignee_id, status,
+			execution_mode, issue_title_template, created_by_type, created_by_id
+		)
+		SELECT $1, 'Queued TTL test autopilot', 'agent', $2, 'active',
+			'create_issue', 'Queued TTL test autopilot', 'member', m.user_id
+		FROM member m WHERE m.workspace_id = $1 LIMIT 1
+		RETURNING id
+	`, testWorkspaceID, agentID).Scan(&autopilotID); err != nil {
+		t.Fatalf("failed to create autopilot: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE issue
+		SET origin_type = 'autopilot', origin_id = $2
+		WHERE id = $1
+	`, autopilotIssueID, autopilotID); err != nil {
+		t.Fatalf("failed to stamp autopilot issue origin: %v", err)
+	}
 	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`, oldIssueID, freshIssueID)
-		testPool.Exec(ctx, `DELETE FROM issue WHERE id IN ($1, $2)`, oldIssueID, freshIssueID)
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2, $3)`, oldIssueID, freshIssueID, autopilotIssueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id IN ($1, $2, $3)`, oldIssueID, freshIssueID, autopilotIssueID)
+		testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
 	})
 
-	var oldTaskID, freshTaskID string
+	var oldTaskID, freshTaskID, autopilotTaskID string
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, created_at)
 		VALUES ($1, $2, $3, 'queued', 0, now() - interval '5 hours')
@@ -567,6 +592,13 @@ func TestExpireStaleQueuedTasks(t *testing.T) {
 		RETURNING id
 	`, agentID, runtimeID, freshIssueID).Scan(&freshTaskID); err != nil {
 		t.Fatalf("failed to insert fresh queued task: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, created_at)
+		VALUES ($1, $2, $3, 'queued', 0, now() - interval '5 hours')
+		RETURNING id
+	`, agentID, runtimeID, autopilotIssueID).Scan(&autopilotTaskID); err != nil {
+		t.Fatalf("failed to insert autopilot queued task: %v", err)
 	}
 
 	queries := db.New(testPool)
@@ -610,6 +642,16 @@ func TestExpireStaleQueuedTasks(t *testing.T) {
 	}
 	if freshStatus != "queued" {
 		t.Fatalf("fresh task: expected status=queued, got %q", freshStatus)
+	}
+
+	var autopilotStatus string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status FROM agent_task_queue WHERE id = $1
+	`, autopilotTaskID).Scan(&autopilotStatus); err != nil {
+		t.Fatalf("failed to read autopilot task: %v", err)
+	}
+	if autopilotStatus != "queued" {
+		t.Fatalf("autopilot issue task: expected status=queued, got %q", autopilotStatus)
 	}
 }
 

--- a/server/internal/handler/autopilot_offline_create_issue_test.go
+++ b/server/internal/handler/autopilot_offline_create_issue_test.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestAutopilotCreateIssueOfflineRuntimeQueuesForLaterClaim(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	runtimeName := fmt.Sprintf("offline-create-issue-runtime-%d", suffix)
+	agentName := fmt.Sprintf("offline-create-issue-agent-%d", suffix)
+	autopilotTitle := fmt.Sprintf("offline create_issue autopilot %d", suffix)
+
+	var runtimeID, agentID, autopilotID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, $5, now())
+		RETURNING id
+	`, testWorkspaceID, runtimeName, runtimeName, "offline create_issue runtime", testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("create offline runtime: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
+		RETURNING id
+	`, testWorkspaceID, agentName, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("create offline-runtime agent: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot (
+			workspace_id, title, description, assignee_type, assignee_id, status,
+			execution_mode, issue_title_template, created_by_type, created_by_id
+		)
+		VALUES ($1, $2, 'daily report', 'agent', $3, 'active',
+			'create_issue', 'Daily report {{date}}', 'member', $4)
+		RETURNING id
+	`, testWorkspaceID, autopilotTitle, agentID, testUserID).Scan(&autopilotID); err != nil {
+		t.Fatalf("create autopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM inbox_item WHERE issue_id IN (SELECT id FROM issue WHERE origin_id = $1)`, autopilotID)
+		testPool.Exec(ctx, `DELETE FROM issue_subscriber WHERE issue_id IN (SELECT id FROM issue WHERE origin_id = $1)`, autopilotID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE origin_id = $1`, autopilotID)
+		testPool.Exec(ctx, `DELETE FROM autopilot_run WHERE autopilot_id = $1`, autopilotID)
+		testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	queries := db.New(testPool)
+	ap, err := queries.GetAutopilot(ctx, parseUUID(autopilotID))
+	if err != nil {
+		t.Fatalf("load autopilot: %v", err)
+	}
+	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if run == nil {
+		t.Fatal("DispatchAutopilot returned nil run")
+	}
+	if run.Status != "issue_created" {
+		t.Fatalf("run status = %q, want issue_created", run.Status)
+	}
+	if !run.IssueID.Valid {
+		t.Fatalf("run issue_id invalid; run = %+v", run)
+	}
+	if run.FailureReason.Valid {
+		t.Fatalf("failure_reason = %q, want empty", run.FailureReason.String)
+	}
+
+	issueID := uuidToString(run.IssueID)
+	var issueTitle, issueStatus, assigneeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT title, status, assignee_id::text
+		FROM issue
+		WHERE id = $1 AND origin_type = 'autopilot' AND origin_id = $2
+	`, issueID, autopilotID).Scan(&issueTitle, &issueStatus, &assigneeID); err != nil {
+		t.Fatalf("load created issue: %v", err)
+	}
+	if issueTitle == "" || issueStatus != "todo" || assigneeID != agentID {
+		t.Fatalf("created issue title/status/assignee = %q/%q/%q, want non-empty/todo/%q",
+			issueTitle, issueStatus, assigneeID, agentID)
+	}
+
+	var taskID, taskStatus, taskRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id::text, status, runtime_id::text
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2
+	`, issueID, agentID).Scan(&taskID, &taskStatus, &taskRuntimeID); err != nil {
+		t.Fatalf("load queued task: %v", err)
+	}
+	if taskStatus != "queued" || taskRuntimeID != runtimeID {
+		t.Fatalf("task status/runtime = %q/%q, want queued/%q", taskStatus, taskRuntimeID, runtimeID)
+	}
+
+	if _, err := testPool.Exec(ctx, `UPDATE agent_runtime SET status = 'online' WHERE id = $1`, runtimeID); err != nil {
+		t.Fatalf("bring runtime online: %v", err)
+	}
+	claimed, err := testHandler.TaskService.ClaimTaskForRuntime(ctx, parseUUID(runtimeID))
+	if err != nil {
+		t.Fatalf("ClaimTaskForRuntime: %v", err)
+	}
+	if claimed == nil {
+		t.Fatal("ClaimTaskForRuntime returned no task")
+	}
+	if got := uuidToString(claimed.ID); got != taskID {
+		t.Fatalf("claimed task = %s, want %s", got, taskID)
+	}
+	if claimed.Status != "dispatched" {
+		t.Fatalf("claimed task status = %q, want dispatched", claimed.Status)
+	}
+}

--- a/server/internal/metrics/business_sampler_queries.go
+++ b/server/internal/metrics/business_sampler_queries.go
@@ -107,14 +107,16 @@ func (c *BusinessSamplerCollector) queryTaskQueued(
 	const stmt = `
 SELECT
   CASE
-    WHEN chat_session_id IS NOT NULL THEN 'chat'
-    WHEN autopilot_run_id IS NOT NULL THEN 'autopilot'
-    WHEN issue_id IS NOT NULL THEN 'issue'
+    WHEN atq.chat_session_id IS NOT NULL THEN 'chat'
+    WHEN atq.autopilot_run_id IS NOT NULL THEN 'autopilot'
+    WHEN i.origin_type = 'autopilot' THEN 'autopilot_issue'
+    WHEN atq.issue_id IS NOT NULL THEN 'issue'
     ELSE 'other'
   END AS source,
   count(*) AS n
-FROM agent_task_queue
-WHERE status = 'queued'
+FROM agent_task_queue atq
+LEFT JOIN issue i ON i.id = atq.issue_id
+WHERE atq.status = 'queued'
 GROUP BY 1
 LIMIT 100
 `
@@ -158,6 +160,7 @@ SELECT
   CASE
     WHEN atq.chat_session_id IS NOT NULL THEN 'chat'
     WHEN atq.autopilot_run_id IS NOT NULL THEN 'autopilot'
+    WHEN i.origin_type = 'autopilot' THEN 'autopilot_issue'
     WHEN atq.issue_id IS NOT NULL THEN 'issue'
     ELSE 'other'
   END AS source,
@@ -165,6 +168,7 @@ SELECT
   count(*) AS n
 FROM in_flight atq
 LEFT JOIN agent_runtime ar ON ar.id = atq.runtime_id
+LEFT JOIN issue i ON i.id = atq.issue_id
 GROUP BY 1, 2
 LIMIT 100
 `
@@ -196,16 +200,18 @@ func (c *BusinessSamplerCollector) queryTaskStuck(
 	stmt := `
 SELECT
   CASE
-    WHEN chat_session_id IS NOT NULL THEN 'chat'
-    WHEN autopilot_run_id IS NOT NULL THEN 'autopilot'
-    WHEN issue_id IS NOT NULL THEN 'issue'
+    WHEN atq.chat_session_id IS NOT NULL THEN 'chat'
+    WHEN atq.autopilot_run_id IS NOT NULL THEN 'autopilot'
+    WHEN i.origin_type = 'autopilot' THEN 'autopilot_issue'
+    WHEN atq.issue_id IS NOT NULL THEN 'issue'
     ELSE 'other'
   END AS source,
   count(*) AS n
-FROM agent_task_queue
-WHERE status = 'running'
-  AND started_at IS NOT NULL
-  AND started_at < now() - interval '` + stuckRunningInterval + `'
+FROM agent_task_queue atq
+LEFT JOIN issue i ON i.id = atq.issue_id
+WHERE atq.status = 'running'
+  AND atq.started_at IS NOT NULL
+  AND atq.started_at < now() - interval '` + stuckRunningInterval + `'
 GROUP BY 1
 LIMIT 100
 `

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -47,11 +47,17 @@ func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *
 // It creates a run and either creates an issue or enqueues a direct agent task
 // depending on execution_mode.
 //
-// Before any work is queued we run an admission check against the assignee
-// agent's runtime: if it is not online, we record a `skipped` run with a
-// failure_reason and return without enqueueing. This is the "触发时准入" gate
-// from MUL-1899 — without it a paused laptop / offline daemon causes scheduled
-// autopilots to pile thousands of doomed tasks onto agent_task_queue.
+// Before run_only work is queued we run an admission check against the
+// assignee agent's runtime: if it is not online, we record a `skipped` run
+// with a failure_reason and return without enqueueing. This is the "触发时准入"
+// gate from MUL-1899 — without it a paused laptop / offline daemon causes
+// scheduled autopilots to pile thousands of invisible doomed direct tasks onto
+// agent_task_queue.
+//
+// create_issue dispatch still uses the same admission path for hard-invalid
+// assignees (missing / archived / no runtime / inaccessible private leader),
+// but it allows an offline runtime through so the visible issue and queued task
+// exist for delayed claim when the runtime comes back online.
 //
 // When assignee_type='squad' the gate runs against the squad leader (Path A
 // from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), so an offline or
@@ -158,14 +164,11 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 //   - It is in a terminal state (completed / failed / skipped). Nothing
 //     more to do downstream; the caller can return it as-is.
 //
-//   - It is in-flight in a state whose downstream side effect is
-//     observable:
+//   - It is issue_created with a valid issue_id — the issue exists and the
+//     issue-event listener owns task creation from here.
 //
-//     * issue_created with a valid issue_id — the issue exists and
-//       the issue-event listener owns task creation from here.
-//
-//     * running with a valid task_id — the task is queued, the
-//       listener will close the run when the task terminates.
+//   - It is running with a valid task_id — the task is queued, and the
+//     listener will close the run when the task terminates.
 //
 // Anything else — most importantly issue_created/running with NULL
 // issue_id/task_id, or the brief 'pending' state — is a partial run:
@@ -197,7 +200,8 @@ func (s *AutopilotService) dispatchAutopilot(
 	payload []byte,
 	plannedAt pgtype.Timestamptz,
 ) (*db.AutopilotRun, error) {
-	if reason, skip := s.shouldSkipDispatch(ctx, autopilot); skip {
+	allowOfflineRuntime := autopilot.ExecutionMode == "create_issue"
+	if reason, skip := s.shouldSkipDispatch(ctx, autopilot, allowOfflineRuntime); skip {
 		return s.recordSkippedRun(ctx, autopilot, triggerID, source, payload, plannedAt, reason)
 	}
 
@@ -809,7 +813,10 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 // Returns (reason, true) when dispatching now would only enqueue a doomed
 // task — i.e. the assignee (or, for squad autopilots, the squad leader) is
 // gone, archived, has no runtime bound, or its runtime is not currently
-// online. Returns ("", false) on the happy path.
+// online. For create_issue callers, allowOfflineRuntime=true lets runtime
+// offline/starting states through while still rejecting hard-invalid assignees:
+// the resulting issue is visible durable work, and the queued task can be
+// claimed when the runtime returns. Returns ("", false) on the happy path.
 //
 // Errors are split into two classes:
 //   - pgx.ErrNoRows / errSquadArchived (the row truly doesn't exist or is
@@ -820,7 +827,7 @@ func (s *AutopilotService) failRun(ctx context.Context, runID pgtype.UUID, reaso
 //     scheduled run. Migration 096 removed the agent FK on autopilot, so an
 //     agent assignee being missing is now a real condition the gate must
 //     handle (previously cascade-deleted).
-func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopilot) (string, bool) {
+func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopilot, allowOfflineRuntime bool) (string, bool) {
 	if !ap.AssigneeID.Valid {
 		return "autopilot has no assignee", true
 	}
@@ -868,6 +875,9 @@ func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopil
 		return "", false
 	}
 	if !ready {
+		if allowOfflineRuntime && strings.HasPrefix(reason, "agent runtime is ") {
+			return "", false
+		}
 		return formatAdmissionReason(ap, reason), true
 	}
 	// Private-agent gate at the autopilot layer. Caller identity = the

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -23,13 +23,17 @@ Do not run `trigger`, `delete`, `trigger-delete`, or `trigger-rotate-url` to tes
 
 An autopilot is not an agent. It is a rule that dispatches work to an agent, or to a squad's leader agent.
 
-The chain is: trigger fires (`schedule`, `webhook`, or `manual`) -> `autopilot_run` row -> `execution_mode` decides output -> assignee readiness check -> issue/task execution -> run status sync.
+The chain is: trigger fires (`schedule`, `webhook`, or `manual`) -> admission check -> `autopilot_run` row -> `execution_mode` decides output -> issue/task execution -> run status sync.
 
 Execution modes:
 
 - `create_issue` creates a Multica issue, making the run visible as issue state.
+  It still rejects hard-invalid assignees, but an offline runtime is allowed so
+  the assigned issue/task can wait for the runtime to come back online.
 - `run_only` creates an agent task directly. No issue is created; any durable
-  report location has to come from other task context or instructions.
+  report location has to come from other task context or instructions. Because
+  it has no issue artifact, `run_only` is skipped when the target runtime is
+  offline at dispatch time.
 
 `issue-title-template` only supports `{{date}}`. Do not invent `{{trigger_id}}`, `{{branch}}`, or other variables.
 

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -2,8 +2,10 @@
 
 - `server/cmd/multica/cmd_autopilot.go` registers `list`, `get`, `create`, `update`, `delete`, `trigger`, `runs`, `trigger-add`, `trigger-update`, `trigger-delete`, and `trigger-rotate-url`.
 - The CLI maps reads/writes to `/api/autopilots`, `/api/autopilots/{id}`, `/api/autopilots/{id}/trigger`, `/api/autopilots/{id}/runs`, and trigger subroutes.
-- `server/internal/service/autopilot.go` has `DispatchAutopilot`, creates `autopilot_run`, and switches on `execution_mode`.
-- `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
+- `server/internal/service/autopilot.go` has `DispatchAutopilot`, applies the mode-aware admission check, creates `autopilot_run`, and switches on `execution_mode`.
+- `create_issue` calls `dispatchCreateIssue`; an offline runtime is allowed through so the issue and queued task can wait for later claim.
+- `run_only` calls `dispatchRunOnly`; offline runtimes are recorded as skipped because no durable issue artifact exists.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
-- `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
+- `AgentReadiness` backs the shared archived/no-runtime/runtime-status gates.
+- `server/pkg/db/queries/agent.sql` keeps autopilot-origin issue tasks out of the queued-task TTL expiry path.
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1052,10 +1052,15 @@ func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTas
 
 const expireStaleQueuedTasks = `-- name: ExpireStaleQueuedTasks :many
 WITH victims AS (
-    SELECT id FROM agent_task_queue
-    WHERE status = 'queued'
-      AND created_at < now() - make_interval(secs => $1::double precision)
-    ORDER BY created_at ASC
+    SELECT t.id FROM agent_task_queue t
+    WHERE t.status = 'queued'
+      AND t.created_at < now() - make_interval(secs => $1::double precision)
+      AND NOT EXISTS (
+        SELECT 1 FROM issue i
+        WHERE i.id = t.issue_id
+          AND i.origin_type = 'autopilot'
+      )
+    ORDER BY t.created_at ASC
     LIMIT $2::int
     FOR UPDATE SKIP LOCKED
 )
@@ -1069,6 +1074,11 @@ FROM victims v
 WHERE t.id = v.id
   AND t.status = 'queued'
   AND t.created_at < now() - make_interval(secs => $1::double precision)
+  AND NOT EXISTS (
+    SELECT 1 FROM issue i
+    WHERE i.id = t.issue_id
+      AND i.origin_type = 'autopilot'
+  )
 RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id
 `
 

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -516,11 +516,17 @@ RETURNING *;
 -- name: ExpireStaleQueuedTasks :many
 -- Fails tasks that have been sitting in 'queued' for longer than the TTL.
 -- This is the cleanup arm of the MUL-1899 "queued backlog" fix: even with the
--- new dispatch-time admission gate that refuses to enqueue when the runtime
--- is offline, we still need to drain the historical 87k+ doomed rows and
--- handle edge cases where a runtime goes offline AFTER a task is already
+-- run_only dispatch-time admission gate that refuses to enqueue when the
+-- runtime is offline, we still need to drain the historical 87k+ doomed rows
+-- and handle edge cases where a runtime goes offline AFTER a task is already
 -- queued (the admission check protects new enqueues, not in-flight queue
 -- depth).
+--
+-- create_issue autopilots are intentionally excluded. Their issue row is the
+-- durable audit artifact, and the linked queued task is the delayed-claim path
+-- for employee machines that come back online hours later. Expiring those rows
+-- would recreate the silent daily-report loss in a different form: the issue
+-- would remain, but no runtime could claim it without manual recreation.
 --
 -- Concurrency safety: the daemon's claim path may race with this sweeper to
 -- transition the same row out of 'queued'. We protect against that two
@@ -537,10 +543,15 @@ RETURNING *;
 -- the DB when the backlog is large — the sweeper drains the rest on
 -- subsequent ticks.
 WITH victims AS (
-    SELECT id FROM agent_task_queue
-    WHERE status = 'queued'
-      AND created_at < now() - make_interval(secs => @ttl_secs::double precision)
-    ORDER BY created_at ASC
+    SELECT t.id FROM agent_task_queue t
+    WHERE t.status = 'queued'
+      AND t.created_at < now() - make_interval(secs => @ttl_secs::double precision)
+      AND NOT EXISTS (
+        SELECT 1 FROM issue i
+        WHERE i.id = t.issue_id
+          AND i.origin_type = 'autopilot'
+      )
+    ORDER BY t.created_at ASC
     LIMIT @max_per_tick::int
     FOR UPDATE SKIP LOCKED
 )
@@ -554,6 +565,11 @@ FROM victims v
 WHERE t.id = v.id
   AND t.status = 'queued'
   AND t.created_at < now() - make_interval(secs => @ttl_secs::double precision)
+  AND NOT EXISTS (
+    SELECT 1 FROM issue i
+    WHERE i.id = t.issue_id
+      AND i.origin_type = 'autopilot'
+  )
 RETURNING t.*;
 
 -- name: CancelAgentTask :one


### PR DESCRIPTION
## Summary

- Let `create_issue` autopilots create the visible issue and queued task when the target runtime is offline, while still skipping hard-invalid assignees.
- Keep autopilot-origin issue tasks out of queued-task TTL expiry so delayed claim remains possible.
- Classify queued/running/stuck autopilot-origin issue tasks as `autopilot_issue` in business sampler metrics.
- Add regression coverage for offline `create_issue` dispatch and stale queue expiry.

## Verification

- `git diff --check`
- `go test ./internal/service ./internal/handler ./cmd/server ./internal/metrics -count=1`
- `go test ./... -count=1` fails in `server/cmd/multica`: existing `TestRunLoginTokenAutoWatchesDiscoveredWorkspaces` failure, reproduced isolated without the worktree DB env and outside the touched code.
- `make sqlc` fails locally because `sqlc` is not installed; generated query code was updated manually to match `agent.sql`.

Closes WS-1091
