### PR TITLE
fix(daemon): kick HTTP heartbeats immediately after WS reconnect

### DIFF
--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -104,6 +104,10 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 
 	d.logger.Info("task wakeup websocket connected", "runtimes", len(runtimeIDs))
 	signalTaskWakeup(taskWakeups, "")
+	// WS ack state was cleared on the prior connection's teardown; send HTTP
+	// heartbeats immediately so the server sees liveness without waiting for
+	// the next heartbeatLoop tick (up to HeartbeatInterval).
+	d.kickHeartbeatsAfterWSReconnect(ctx, runtimeIDs)
 
 	// Serialize all writes through a single channel: the gorilla/websocket
 	// Conn does not allow concurrent WriteMessage calls, and the heartbeat
@@ -322,6 +326,23 @@ func signalTaskWakeup(taskWakeups chan<- taskWakeup, runtimeID string) {
 	select {
 	case taskWakeups <- taskWakeup{runtimeID: runtimeID}:
 	default:
+	}
+}
+
+// kickHeartbeatsAfterWSReconnect sends one immediate HTTP heartbeat per
+// runtime after the task-wakeup WebSocket (re)connects. The prior connection's
+// defer clearWSHeartbeatAcks() drops WS freshness marks, but the HTTP
+// heartbeat loop only fires on its periodic ticker — so without this kick
+// the server may not observe liveness for up to HeartbeatInterval after
+// reconnect. That widens the window where server-side task state changes
+// (e.g. cancellation during a disconnect) are visible only via the slower
+// handleTask status poll.
+func (d *Daemon) kickHeartbeatsAfterWSReconnect(ctx context.Context, runtimeIDs []string) {
+	for _, rid := range runtimeIDs {
+		if ctx.Err() != nil {
+			return
+		}
+		d.runHeartbeatTick(ctx, rid)
 	}
 }
 

--- a/server/internal/daemon/wakeup_test.go
+++ b/server/internal/daemon/wakeup_test.go
@@ -1,7 +1,12 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -43,6 +48,36 @@ func TestTaskWakeupURL(t *testing.T) {
 				t.Fatalf("taskWakeupURL() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestKickHeartbeatsAfterWSReconnect verifies that reconnect triggers an
+// immediate HTTP heartbeat when WS freshness marks were cleared.
+func TestKickHeartbeatsAfterWSReconnect(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/daemon/heartbeat", func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	d := New(Config{HeartbeatInterval: 15 * time.Second}, slog.Default())
+	d.client = NewClient(srv.URL)
+
+	d.kickHeartbeatsAfterWSReconnect(context.Background(), []string{"rt-1", "rt-2"})
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 immediate heartbeats, got %d", got)
+	}
+
+	// When WS recently acked, runHeartbeatTick is a no-op for HTTP.
+	d.recordWSHeartbeatAck("rt-1")
+	calls.Store(0)
+	d.kickHeartbeatsAfterWSReconnect(context.Background(), []string{"rt-1", "rt-2"})
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 HTTP heartbeat (rt-2 only), got %d", got)
 	}
 }
 


### PR DESCRIPTION
# PR 描述模板（GitHub 创建 PR 时粘贴）

## Summary

Kick one immediate HTTP heartbeat per runtime after the task-wakeup WebSocket reconnects.

## Motivation

During fault analysis of WS reconnect state consistency we found:

- `clearWSHeartbeatAcks()` on disconnect correctly clears WS freshness so HTTP should resume.
- HTTP heartbeats only run on the periodic `heartbeatLoop` ticker (up to `HeartbeatInterval`, ~15s).
- After reconnect the server may not observe liveness until the next tick.

This PR narrows that post-reconnect gap by calling `runHeartbeatTick` once per runtime immediately after WS dial succeeds. Existing WS-vs-HTTP dedup (`wsHeartbeatRecentlyAcked`) is unchanged.

## Changes

- `server/internal/daemon/wakeup.go`: add `kickHeartbeatsAfterWSReconnect`, call on connect
- `server/internal/daemon/wakeup_test.go`: add `TestKickHeartbeatsAfterWSReconnect`

## Test plan

- [x] `go test ./internal/daemon/ -run 'TestKickHeartbeats|TestWSHeartbeat|TestTaskWakeup' -v`
- [ ] Manual: briefly block WS, confirm server sees HTTP heartbeat immediately after reconnect

## Related

Closes #4652

## Risk

Low — at most one extra HTTP heartbeat per runtime per reconnect; dedup logic prevents duplicate writes when WS already acked.
