### PR TITLE
AOL-713: expose server version endpoint

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -164,6 +164,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		AllowSignup:              os.Getenv("ALLOW_SIGNUP") != "false",
 		AllowedEmails:            splitAndTrim(os.Getenv("ALLOWED_EMAILS")),
 		AllowedEmailDomains:      splitAndTrim(os.Getenv("ALLOWED_EMAIL_DOMAINS")),
+		ServerVersion:            version,
+		ServerCommit:             commit,
 		DisableWorkspaceCreation: os.Getenv("DISABLE_WORKSPACE_CREATION") == "true",
 		PublicURL:                strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_PUBLIC_URL")), "/"),
 		TrustedProxies:           parseTrustedProxies(os.Getenv("MULTICA_TRUSTED_PROXIES")),
@@ -552,6 +554,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 
 	// Public API
 	r.Get("/api/config", h.GetConfig)
+	r.Get("/api/version", h.GetVersion)
 	r.With(contactSalesRL).Post("/api/contact-sales", h.CreateContactSales)
 
 	// Webhook ingress for autopilots. Outside the authenticated group on

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -54,6 +54,8 @@ type Config struct {
 	AllowSignup         bool
 	AllowedEmails       []string
 	AllowedEmailDomains []string
+	ServerVersion       string
+	ServerCommit        string
 	// DisableWorkspaceCreation, when true, makes POST /api/workspaces return
 	// 403 for every caller. There is no role/owner exception because the repo
 	// has no platform-admin concept; operators bootstrap the workspace with

--- a/server/internal/handler/version.go
+++ b/server/internal/handler/version.go
@@ -1,0 +1,23 @@
+package handler
+
+import "net/http"
+
+type ServerVersionResponse struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+func (h *Handler) GetVersion(w http.ResponseWriter, r *http.Request) {
+	version := h.cfg.ServerVersion
+	if version == "" {
+		version = "dev"
+	}
+	commit := h.cfg.ServerCommit
+	if commit == "" {
+		commit = "unknown"
+	}
+	writeJSON(w, http.StatusOK, ServerVersionResponse{
+		Version: version,
+		Commit:  commit,
+	})
+}

--- a/server/internal/handler/version_test.go
+++ b/server/internal/handler/version_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetVersionReportsConfiguredServerBuildInfo(t *testing.T) {
+	h := &Handler{cfg: Config{ServerVersion: "v1.2.3", ServerCommit: "abc123"}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	w := httptest.NewRecorder()
+
+	h.GetVersion(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetVersion: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ServerVersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode version response: %v", err)
+	}
+	if resp.Version != "v1.2.3" {
+		t.Fatalf("version: want v1.2.3, got %q", resp.Version)
+	}
+	if resp.Commit != "abc123" {
+		t.Fatalf("commit: want abc123, got %q", resp.Commit)
+	}
+}
+
+func TestGetVersionDefaultsMissingBuildInfo(t *testing.T) {
+	h := &Handler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	w := httptest.NewRecorder()
+
+	h.GetVersion(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetVersion: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ServerVersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode version response: %v", err)
+	}
+	if resp.Version != "dev" {
+		t.Fatalf("version: want dev, got %q", resp.Version)
+	}
+	if resp.Commit != "unknown" {
+		t.Fatalf("commit: want unknown, got %q", resp.Commit)
+	}
+}


### PR DESCRIPTION
## Summary
- Add public GET /api/version endpoint returning the server binary version and commit
- Wire endpoint values from server ldflags and include handler tests

Closes AOL-713

## Tests
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./cmd/server
- GOCACHE=/tmp/go-build-cache go test ./internal/handler -run 'TestGetVersion|TestGetConfig'