### PR TITLE
fix: restore issues board visibility

### DIFF
--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -69,6 +69,15 @@ describe("IssueSchema (via ListIssuesResponseSchema)", () => {
     expect(parsed.issues[0]?.metadata).toEqual({});
   });
 
+  it("accepts legacy null metadata values without dropping the whole issue list", () => {
+    const payload = {
+      issues: [{ ...baseIssue, metadata: { old_assignee_id: null } }],
+      total: 1,
+    };
+    const parsed = ListIssuesResponseSchema.parse(payload);
+    expect(parsed.issues[0]?.metadata).toEqual({ old_assignee_id: null });
+  });
+
   it("rejects metadata with non-primitive values (nested object)", () => {
     const payload = {
       issues: [{ ...baseIssue, metadata: { nested: { x: 1 } } }],

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -232,10 +232,11 @@ export const IssueTriggerPreviewSchema = z.object({
   total_count: z.number().default(0),
 }).loose();
 
-// Metadata is primitive-only by API/DB contract. Stay lenient on shape:
-// unknown keys land as `unknown` to a caller, but the field itself defaults
-// to {} so consumers never need to nil-guard `issue.metadata`.
-const IssueMetadataSchema = z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).default({});
+// Metadata is primitive-only by API/DB contract, but older rows may contain
+// null legacy values. Stay lenient on shape: unknown keys land as `unknown` to
+// a caller, but the field itself defaults to {} so consumers never need to
+// nil-guard `issue.metadata`.
+const IssueMetadataSchema = z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])).default({});
 
 export const IssueSchema = z.object({
   id: z.string(),

--- a/packages/core/issues/cache-helpers.ts
+++ b/packages/core/issues/cache-helpers.ts
@@ -44,7 +44,7 @@ export function addIssueToBuckets(
   const bucket = getBucket(resp, issue.status);
   if (bucket.issues.some((i) => i.id === issue.id)) return resp;
   return setBucket(resp, issue.status, {
-    issues: [...bucket.issues, issue],
+    issues: insertByPosition(bucket.issues, issue),
     total: bucket.total + 1,
   });
 }

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -112,6 +112,7 @@ describe("useLoadMoreByStatus", () => {
     });
 
     expect(listIssues).toHaveBeenCalledWith({
+      workspace_id: WS_ID,
       status: "todo",
       limit: 50,
       offset: 1,
@@ -197,6 +198,7 @@ describe("useLoadMoreByStatus", () => {
     });
 
     expect(listIssues).toHaveBeenCalledWith({
+      workspace_id: WS_ID,
       status: "in_progress",
       limit: 50,
       offset: 1,
@@ -303,6 +305,7 @@ describe("useLoadMoreByAssigneeGroup", () => {
     });
 
     expect(listGroupedIssues).toHaveBeenCalledWith({
+      workspace_id: WS_ID,
       group_by: "assignee",
       limit: 50,
       offset: 1,

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -91,6 +91,7 @@ export function useLoadMoreByStatus(
     setIsLoading(true);
     try {
       const res = await api.listIssues({
+        workspace_id: wsId,
         status,
         limit: ISSUE_PAGE_SIZE,
         offset: loaded,
@@ -110,7 +111,7 @@ export function useLoadMoreByStatus(
     } finally {
       setIsLoading(false);
     }
-  }, [qc, activeKey, status, loaded, hasMore, isLoading, myIssues?.filter, sort]);
+  }, [qc, activeKey, status, loaded, hasMore, isLoading, myIssues?.filter, sort, wsId]);
 
   return { loadMore, hasMore, isLoading, total };
 }
@@ -129,6 +130,7 @@ export function useLoadMoreByAssigneeGroup(
   sort?: IssueSortParam,
 ) {
   const qc = useQueryClient();
+  const wsId = useWorkspaceId();
   const [isLoading, setIsLoading] = useState(false);
 
   const cache = qc.getQueryData<GroupedIssuesResponse>(queryKey);
@@ -142,6 +144,7 @@ export function useLoadMoreByAssigneeGroup(
     setIsLoading(true);
     try {
       const res = await api.listGroupedIssues({
+        workspace_id: wsId,
         group_by: "assignee",
         limit: ISSUE_PAGE_SIZE,
         offset: loaded,
@@ -171,7 +174,7 @@ export function useLoadMoreByAssigneeGroup(
     } finally {
       setIsLoading(false);
     }
-  }, [filter, group.assignee_id, group.assignee_type, hasMore, isLoading, loaded, qc, queryKey, sort]);
+  }, [filter, group.assignee_id, group.assignee_type, hasMore, isLoading, loaded, qc, queryKey, sort, wsId]);
 
   return { loadMore, hasMore, isLoading, total };
 }

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -81,6 +81,7 @@ describe("projectGanttIssuesOptions", () => {
 
     expect(listIssues).toHaveBeenCalledTimes(1);
     expect(listIssues).toHaveBeenCalledWith({
+      workspace_id: WS_ID,
       project_id: PROJECT_ID,
       scheduled: true,
       limit: PROJECT_GANTT_PAGE_LIMIT,

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -139,10 +139,10 @@ export function flattenIssueBuckets(data: ListIssuesCache) {
   return out;
 }
 
-async function fetchFirstPages(filter: MyIssuesFilter = {}, sort?: IssueSortParam): Promise<ListIssuesCache> {
+async function fetchFirstPages(wsId: string, filter: MyIssuesFilter = {}, sort?: IssueSortParam): Promise<ListIssuesCache> {
   const responses = await Promise.all(
     PAGINATED_STATUSES.map((status) =>
-      api.listIssues({ status, limit: ISSUE_PAGE_SIZE, offset: 0, ...sort, ...filter }),
+      api.listIssues({ workspace_id: wsId, status, limit: ISSUE_PAGE_SIZE, offset: 0, ...sort, ...filter }),
     ),
   );
   const byStatus: ListIssuesCache["byStatus"] = {};
@@ -172,11 +172,11 @@ async function fetchFirstPages(filter: MyIssuesFilter = {}, sort?: IssueSortPara
  * total — pagination on the "All" scope is out of scope; the first
  * 50-per-status × 3 widening (deduped) is what the page renders.
  */
-async function fetchAllMyFirstPages(userId: string, sort?: IssueSortParam): Promise<ListIssuesCache> {
+async function fetchAllMyFirstPages(wsId: string, userId: string, sort?: IssueSortParam): Promise<ListIssuesCache> {
   const [byAssignee, byCreator, byInvolves] = await Promise.all([
-    fetchFirstPages({ assignee_id: userId }, sort),
-    fetchFirstPages({ creator_id: userId }, sort),
-    fetchFirstPages({ involves_user_id: userId }, sort),
+    fetchFirstPages(wsId, { assignee_id: userId }, sort),
+    fetchFirstPages(wsId, { creator_id: userId }, sort),
+    fetchFirstPages(wsId, { involves_user_id: userId }, sort),
   ]);
   const byStatus: ListIssuesCache["byStatus"] = {};
   for (const status of PAGINATED_STATUSES) {
@@ -204,6 +204,7 @@ async function fetchAllMyFirstPages(userId: string, sort?: IssueSortParam): Prom
  * pass through unchanged.
  */
 async function fetchAllMyAssigneeGroups(
+  wsId: string,
   userId: string,
   filter: AssigneeGroupedIssuesFilter,
   sort?: IssueSortParam,
@@ -216,6 +217,7 @@ async function fetchAllMyAssigneeGroups(
   const responses = await Promise.all(
     variants.map((f) =>
       api.listGroupedIssues({
+        workspace_id: wsId,
         group_by: "assignee",
         limit: ISSUE_PAGE_SIZE,
         offset: 0,
@@ -263,7 +265,7 @@ async function fetchAllMyAssigneeGroups(
 export function issueListOptions(wsId: string, sort?: IssueSortParam) {
   return queryOptions({
     queryKey: issueKeys.listSorted(wsId, sort),
-    queryFn: () => fetchFirstPages({}, sort),
+    queryFn: () => fetchFirstPages(wsId, {}, sort),
     select: flattenIssueBuckets,
     placeholderData: keepPreviousData,
   });
@@ -278,6 +280,7 @@ export function issueAssigneeGroupsOptions(
     queryKey: issueKeys.assigneeGroups(wsId, { ...filter, ...sort }),
     queryFn: () =>
       api.listGroupedIssues({
+        workspace_id: wsId,
         group_by: "assignee",
         limit: ISSUE_PAGE_SIZE,
         offset: 0,
@@ -307,8 +310,8 @@ export function myIssueListOptions(
     queryKey: issueKeys.myListSorted(wsId, scope, filter, sort),
     queryFn: () =>
       scope === "all" && userId
-        ? fetchAllMyFirstPages(userId, sort)
-        : fetchFirstPages(filter, sort),
+        ? fetchAllMyFirstPages(wsId, userId, sort)
+        : fetchFirstPages(wsId, filter, sort),
     select: flattenIssueBuckets,
     placeholderData: keepPreviousData,
   });
@@ -329,11 +332,12 @@ export const PROJECT_GANTT_PAGE_LIMIT = 500;
  */
 export const PROJECT_GANTT_MAX_ISSUES = 10_000;
 
-async function fetchProjectGanttIssues(projectId: string) {
+async function fetchProjectGanttIssues(wsId: string, projectId: string) {
   const issues = [];
   let offset = 0;
   while (offset < PROJECT_GANTT_MAX_ISSUES) {
     const res = await api.listIssues({
+      workspace_id: wsId,
       project_id: projectId,
       scheduled: true,
       limit: PROJECT_GANTT_PAGE_LIMIT,
@@ -363,7 +367,7 @@ async function fetchProjectGanttIssues(projectId: string) {
 export function projectGanttIssuesOptions(wsId: string, projectId: string) {
   return queryOptions({
     queryKey: issueKeys.projectGantt(wsId, projectId),
-    queryFn: () => fetchProjectGanttIssues(projectId),
+    queryFn: () => fetchProjectGanttIssues(wsId, projectId),
   });
 }
 
@@ -380,8 +384,9 @@ export function myIssueAssigneeGroupsOptions(
     queryKey: issueKeys.myAssigneeGroups(wsId, scope, { ...filter, ...sort }),
     queryFn: () =>
       scope === "all" && userId
-        ? fetchAllMyAssigneeGroups(userId, filter, sort)
+        ? fetchAllMyAssigneeGroups(wsId, userId, filter, sort)
         : api.listGroupedIssues({
+            workspace_id: wsId,
             group_by: "assignee",
             limit: ISSUE_PAGE_SIZE,
             offset: 0,

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -219,6 +219,26 @@ describe("onIssueMetadataChanged", () => {
   });
 });
 
+describe("onIssueCreated", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("inserts a created issue into the cached board column by position", () => {
+    const laterIssue: Issue = { ...baseIssue, id: "later", position: 0 };
+    const newTopIssue: Issue = { ...baseIssue, id: "new-top", position: -10 };
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), makeListCache(laterIssue));
+
+    onIssueCreated(qc, WS_ID, newTopIssue);
+
+    const list = qc.getQueryData<ListIssuesCache>(issueKeys.list(WS_ID));
+    expect(list?.byStatus.todo?.issues.map((i) => i.id)).toEqual(["new-top", "later"]);
+    expect(list?.byStatus.todo?.total).toBe(2);
+  });
+});
+
 describe("project progress invalidation", () => {
   let qc: QueryClient;
 

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -29,7 +29,7 @@ export interface IssueReaction {
  * present in responses (empty object when unset) so reads don't need a
  * nil guard on the parent field.
  */
-export type IssueMetadataValue = string | number | boolean;
+export type IssueMetadataValue = string | number | boolean | null;
 export type IssueMetadata = Record<string, IssueMetadataValue>;
 
 export interface Issue {


### PR DESCRIPTION
## Summary
- include the active workspace id in issue board list/grouped/pagination queries
- tolerate legacy `null` values in issue metadata so one old row cannot drop an entire response to the empty fallback
- keep realtime-created issue cards ordered by board position instead of appending them to the end of the cached column

## Why
The issues board could show empty/stale columns even when the backend had matching issues. Two frontend-side problems combined:

1. board queries did not pass `workspace_id`, while the backend requires a workspace scope;
2. the response schema rejected legacy metadata values like `{ "old_assignee_id": null }`, causing `parseWithFallback` to replace the whole issue list with `issues: []`.

## Verification
- `pnpm exec vitest packages/core/api/schemas.test.ts packages/core/issues/ws-updaters.test.ts --run`
- production frontend Docker build completed successfully (`next build`, including TypeScript)
- manually verified a self-hosted board request now includes `workspace_id` and renders backlog issues instead of an empty column
