### PR TITLE
fix(server): add waiting_local_directory timeout to FailStaleTasks

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -43,6 +43,15 @@ const (
 	// watchdog), so this only needs to sit generously above any realistic single
 	// run rather than track a per-run wall-clock cap (MUL-3064).
 	runningTimeoutSeconds = 9000.0
+	// waitingLocalDirectoryTimeoutSeconds fails tasks stuck in
+	// 'waiting_local_directory' beyond this threshold. This is a coarse
+	// server-side backstop for the case where a daemon is alive (runtime stays
+	// online) but its lock-acquisition goroutine is hung — e.g. filesystem
+	// unavailability, deadlock, or a daemon bug that leaks a local-directory
+	// lock. The daemon's own ctx-driven timeout handles the common case;
+	// this catches the tail. 30 minutes is generously above any realistic
+	// lock-wait duration, only triggering when something is genuinely stuck.
+	waitingLocalDirectoryTimeoutSeconds = 1800.0
 	// queuedTTLSeconds expires tasks that have been sitting in 'queued'
 	// for longer than this without ever being claimed. This is the cleanup
 	// arm of the MUL-1899 backlog fix: even with the dispatch-time
@@ -246,7 +255,8 @@ func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 func sweepStaleTasks(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus) {
 	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
 		DispatchTimeoutSecs: dispatchTimeoutSeconds,
-		RunningTimeoutSecs:  runningTimeoutSeconds,
+		RunningTimeoutSecs:                runningTimeoutSeconds,
+		WaitingLocalDirectoryTimeoutSecs:  waitingLocalDirectoryTimeoutSeconds,
 	})
 	if err != nil {
 		slog.Warn("task sweeper: failed to clean up stale tasks", "error", err)

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -148,7 +148,8 @@ func TestSweepStaleTasksBroadcastsWithWorkspaceID(t *testing.T) {
 	// Use very short timeouts to trigger the sweep on our test task
 	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
 		DispatchTimeoutSecs: 300.0,
-		RunningTimeoutSecs:  1.0, // 1 second — our task is 3 hours old
+		RunningTimeoutSecs:               1.0, // 1 second — our task is 3 hours old
+			WaitingLocalDirectoryTimeoutSecs: 1800.0,
 	})
 	if err != nil {
 		t.Fatalf("FailStaleTasks query failed: %v", err)
@@ -230,6 +231,7 @@ func TestSweepStaleTasksReconcileAgentStatus(t *testing.T) {
 	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
 		DispatchTimeoutSecs: 300.0,
 		RunningTimeoutSecs:  1.0,
+		WaitingLocalDirectoryTimeoutSecs: 1800.0,
 	})
 	if err != nil {
 		t.Fatalf("FailStaleTasks failed: %v", err)
@@ -291,6 +293,7 @@ func TestSweepDispatchedStaleTask(t *testing.T) {
 	failedTasks, err := queries.FailStaleTasks(context.Background(), db.FailStaleTasksParams{
 		DispatchTimeoutSecs: 1.0,
 		RunningTimeoutSecs:  9000.0,
+		WaitingLocalDirectoryTimeoutSecs: 1800.0,
 	})
 	if err != nil {
 		t.Fatalf("FailStaleTasks failed: %v", err)
@@ -403,6 +406,7 @@ func TestSweepResetsInProgressIssueToTodo(t *testing.T) {
 	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
 		DispatchTimeoutSecs: 300.0,
 		RunningTimeoutSecs:  1.0,
+		WaitingLocalDirectoryTimeoutSecs: 1800.0,
 	})
 	if err != nil {
 		t.Fatalf("FailStaleTasks failed: %v", err)
@@ -487,6 +491,7 @@ func TestSweepDoesNotResetIssueAlreadyInReview(t *testing.T) {
 	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
 		DispatchTimeoutSecs: 300.0,
 		RunningTimeoutSecs:  1.0,
+		WaitingLocalDirectoryTimeoutSecs: 1800.0,
 	})
 	if err != nil {
 		t.Fatalf("FailStaleTasks failed: %v", err)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1294,12 +1294,14 @@ WHERE (
     AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
   )
    OR (status = 'running' AND started_at < now() - make_interval(secs => $2::double precision))
+   OR (status = 'waiting_local_directory' AND dispatched_at < now() - make_interval(secs => $3::double precision))
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id
 `
 
 type FailStaleTasksParams struct {
-	DispatchTimeoutSecs float64 `json:"dispatch_timeout_secs"`
-	RunningTimeoutSecs  float64 `json:"running_timeout_secs"`
+	DispatchTimeoutSecs              float64 `json:"dispatch_timeout_secs"`
+	RunningTimeoutSecs               float64 `json:"running_timeout_secs"`
+	WaitingLocalDirectoryTimeoutSecs float64 `json:"waiting_local_directory_timeout_secs"`
 }
 
 // Fails tasks stuck in dispatched/running beyond the given thresholds.
@@ -1308,13 +1310,14 @@ type FailStaleTasksParams struct {
 // Dispatched tasks with an active prepare lease are excluded because the
 // daemon is still proving liveness while resolving/cache/preparing startup
 // inputs before StartTask.
-// waiting_local_directory rows are intentionally excluded: the daemon owns
-// the wait (with its own ctx-driven timeout) and a legitimate queue ahead
-// of this task can exceed the dispatch / running timeouts without being
-// "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
-// those rows at restart.
+// waiting_local_directory rows have their own coarse timeout as a backstop
+// for the case where the daemon is alive (runtime stays online) but its
+// lock-acquisition goroutine is hung. The daemon's own ctx-driven timeout
+// handles the common case; this catches the tail. If the daemon dies,
+// RecoverOrphanedTasksForRuntime or FailTasksForOfflineRuntimes reclaims
+// those rows at restart / runtime-offline sweep.
 func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) ([]AgentTaskQueue, error) {
-	rows, err := q.db.Query(ctx, failStaleTasks, arg.DispatchTimeoutSecs, arg.RunningTimeoutSecs)
+	rows, err := q.db.Query(ctx, failStaleTasks, arg.DispatchTimeoutSecs, arg.RunningTimeoutSecs, arg.WaitingLocalDirectoryTimeoutSecs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -496,11 +496,12 @@ RETURNING *;
 -- Dispatched tasks with an active prepare lease are excluded because the
 -- daemon is still proving liveness while resolving/cache/preparing startup
 -- inputs before StartTask.
--- waiting_local_directory rows are intentionally excluded: the daemon owns
--- the wait (with its own ctx-driven timeout) and a legitimate queue ahead
--- of this task can exceed the dispatch / running timeouts without being
--- "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
--- those rows at restart.
+-- waiting_local_directory rows have their own coarse timeout as a backstop
+-- for the case where the daemon is alive (runtime stays online) but its
+-- lock-acquisition goroutine is hung. The daemon's own ctx-driven timeout
+-- handles the common case; this catches the tail. If the daemon dies,
+-- RecoverOrphanedTasksForRuntime or FailTasksForOfflineRuntimes reclaims
+-- those rows at restart / runtime-offline sweep.
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout',
@@ -511,6 +512,7 @@ WHERE (
     AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
   )
    OR (status = 'running' AND started_at < now() - make_interval(secs => @running_timeout_secs::double precision))
+   OR (status = 'waiting_local_directory' AND dispatched_at < now() - make_interval(secs => @waiting_local_directory_timeout_secs::double precision))
 RETURNING *;
 
 -- name: ExpireStaleQueuedTasks :many


### PR DESCRIPTION
## Summary

  Add timeout for `waiting_local_directory` tasks in `FailStaleTasks`, closing a gap where tasks stuck in this state
  with an online runtime had no recovery path.

  ## Problem

  `FailStaleTasks` handles `dispatched` (300s) and `running` (9000s) but explicitly excludes `waiting_local_directory`.
  If the daemon process is alive but its lock goroutine is hung (filesystem issue, deadlock, lock leak), the task is
  stuck forever.

  | Status | Runtime offline | FailStaleTasks |
  |--------|----------------|----------------|
  | dispatched | Yes | Yes (300s) |
  | running | Yes | Yes (9000s) |
  | waiting_local_directory | Yes | **No** |

  ## Fix

  Add a third timeout condition to `FailStaleTasks` with **1800s (30 min)** timeout -- generous enough to avoid false
  positives, but provides meaningful recovery for hung locks.

  ### Changed files

  - `server/cmd/server/runtime_sweeper.go` -- add constant
  - `server/pkg/db/queries/agent.sql` -- add third OR condition
  - `server/pkg/db/generated/agent.sql.go` -- sqlc generated code
  - `server/cmd/server/runtime_sweeper_test.go` -- update test call sites

  ## Verification

  - `go build ./...` passes
  - `go test ./cmd/server/` passes
  - No schema migration, no API changes, fully backward compatible
  
 Closes #4658