### PR TITLE
https://github.com/luvkun/multica/pull/new/fix/ws-reconnect-cancel-pushfix(daemon): push cancelled tasks to daemon on WS reconnect

### DIFF
--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -284,6 +284,23 @@ func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<-
 				d.logger.Debug("task wakeup received", "runtime_id", payload.RuntimeID, "task_id", payload.TaskID)
 			}
 			signalTaskWakeup(taskWakeups, payload.RuntimeID)
+		case protocol.EventDaemonTaskCancelled:
+			var payload protocol.TaskCancelledPayload
+			if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+				d.logger.Debug("task cancel websocket invalid payload", "error", err)
+				continue
+			}
+			if payload.TaskID == "" || payload.RuntimeID == "" {
+				d.logger.Debug("task cancel websocket missing ids")
+				continue
+			}
+			d.logger.Info("task cancelled via websocket push",
+				"runtime_id", payload.RuntimeID,
+				"task_id", payload.TaskID,
+			)
+			// Trigger an immediate task poll so the daemon discovers the
+			// cancelled status without waiting for the next 5 s poll cycle.
+			signalTaskWakeup(taskWakeups, payload.RuntimeID)
 		case protocol.EventDaemonRuntimeProfilesChanged:
 			var payload protocol.RuntimeProfilesChangedPayload
 			if err := json.Unmarshal(msg.Payload, &payload); err != nil {

--- a/server/internal/daemonws/hub.go
+++ b/server/internal/daemonws/hub.go
@@ -250,6 +250,21 @@ func (h *Hub) NotifyTaskAvailable(runtimeID, taskID string) {
 	h.notifyTaskAvailable(runtimeID, taskID, "")
 }
 
+// NotifyTaskCancelled pushes a daemon:task_cancelled frame to every daemon
+// watching runtimeID so the daemon can abort the task immediately instead of
+// waiting for the next watchTaskCancellation poll (up to 5 s). This is the
+// server-side half of the Scenario-C fix: WS reconnect → proactive cancel push.
+func (h *Hub) NotifyTaskCancelled(runtimeID, taskID string) {
+	if h == nil || runtimeID == "" || taskID == "" {
+		return
+	}
+	data, err := taskCancelledFrame(runtimeID, taskID)
+	if err != nil {
+		return
+	}
+	h.notifyFrame(runtimeID, data, "")
+}
+
 // NotifyRuntimeProfilesChanged asks connected daemons in workspaceID to pull
 // runtime profiles now instead of waiting for their periodic sync loop.
 func (h *Hub) NotifyRuntimeProfilesChanged(workspaceID, profileID string) {
@@ -387,6 +402,16 @@ func taskAvailableFrame(runtimeID, taskID string) ([]byte, error) {
 	return json.Marshal(protocol.Message{
 		Type: protocol.EventDaemonTaskAvailable,
 		Payload: mustMarshalRaw(protocol.TaskAvailablePayload{
+			RuntimeID: runtimeID,
+			TaskID:    taskID,
+		}),
+	})
+}
+
+func taskCancelledFrame(runtimeID, taskID string) ([]byte, error) {
+	return json.Marshal(protocol.Message{
+		Type: protocol.EventDaemonTaskCancelled,
+		Payload: mustMarshalRaw(protocol.TaskCancelledPayload{
 			RuntimeID: runtimeID,
 			TaskID:    taskID,
 		}),

--- a/server/internal/handler/daemon_ws.go
+++ b/server/internal/handler/daemon_ws.go
@@ -1,11 +1,15 @@
 package handler
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 func (h *Handler) DaemonWebSocket(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +57,37 @@ func (h *Handler) DaemonWebSocket(w http.ResponseWriter, r *http.Request) {
 		RuntimeIDs:    runtimeIDs,
 		ClientVersion: r.Header.Get("X-Client-Version"),
 	})
+
+	// Scenario-C fix: after WS registration, query for tasks that were
+	// cancelled while the daemon was disconnected and proactively push
+	// daemon:task_cancelled frames. The daemon can then abort those tasks
+	// immediately instead of waiting for watchTaskCancellation (up to 5 s).
+	go h.pushCancelledTasksOnReconnect(r.Context(), runtimeIDs)
+}
+
+// pushCancelledTasksOnReconnect queries for tasks cancelled during the
+// disconnection window and pushes daemon:task_cancelled frames so the
+// daemon can abort them without waiting for the next poll cycle.
+func (h *Handler) pushCancelledTasksOnReconnect(ctx context.Context, runtimeIDs []string) {
+	uuids := make([]pgtype.UUID, 0, len(runtimeIDs))
+	for _, id := range runtimeIDs {
+		uuids = append(uuids, parseUUID(id))
+	}
+
+	cancelled, err := h.Queries.ListCancelledTasksForRuntimes(ctx, db.ListCancelledTasksForRuntimesParams{
+		RuntimeIds: uuids,
+	})
+	if err != nil {
+		slog.Debug("push-cancelled-on-reconnect: query failed", "error", err)
+		return
+	}
+
+	for _, task := range cancelled {
+		h.DaemonHub.NotifyTaskCancelled(
+			uuidToString(task.RuntimeID),
+			uuidToString(task.ID),
+		)
+	}
 }
 
 func parseRuntimeIDs(r *http.Request) []string {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2610,6 +2610,71 @@ func (q *Queries) ReclaimStaleDispatchedTaskForRuntime(ctx context.Context, arg 
 	return i, err
 }
 
+const listCancelledTasksForRuntimes = `-- name: ListCancelledTasksForRuntimes :many
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id FROM agent_task_queue
+WHERE runtime_id = ANY($1::uuid[])
+  AND status = 'cancelled'
+  AND completed_at > now() - make_interval(secs => 3600)
+`
+
+type ListCancelledTasksForRuntimesParams struct {
+	RuntimeIds []pgtype.UUID `json:"runtime_ids"`
+}
+
+// ListCancelledTasksForRuntimes returns tasks that were cancelled while the
+// daemon's WebSocket was disconnected. Called on WS reconnect so the server
+// can proactively push daemon:task_cancelled frames.
+func (q *Queries) ListCancelledTasksForRuntimes(ctx context.Context, arg ListCancelledTasksForRuntimesParams) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, listCancelledTasksForRuntimes, arg.RuntimeIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const recoverOrphanedTasksForRuntime = `-- name: RecoverOrphanedTasksForRuntime :many
 UPDATE agent_task_queue
 SET status = 'failed',

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -631,6 +631,18 @@ SELECT * FROM agent_task_queue
 WHERE runtime_id = $1 AND status = 'queued'
 ORDER BY priority DESC, created_at ASC;
 
+-- name: ListCancelledTasksForRuntimes :many
+-- Returns tasks that were cancelled server-side while the daemon's WebSocket
+-- was disconnected. Called on WS reconnect so the server can proactively push
+-- daemon:task_cancelled frames — the daemon can then abort those tasks
+-- immediately instead of waiting for the watchTaskCancellation poll (up to 5 s).
+-- Limited to tasks cancelled within the last hour so we don't re-notify for
+-- ancient cancelled rows on every reconnect.
+SELECT * FROM agent_task_queue
+WHERE runtime_id = ANY(@runtime_ids::uuid[])
+  AND status = 'cancelled'
+  AND completed_at > now() - make_interval(secs => 3600);
+
 -- name: ListActiveTasksByIssue :many
 -- Backs the issue-detail "agent live" banner. Includes 'queued' so the
 -- banner shows up the moment a task is enqueued — not only after a runtime

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -117,6 +117,7 @@ const (
 	EventDaemonHeartbeatAck           = "daemon:heartbeat_ack"
 	EventDaemonRegister               = "daemon:register"
 	EventDaemonTaskAvailable          = "daemon:task_available"
+	EventDaemonTaskCancelled          = "daemon:task_cancelled"
 	EventDaemonRuntimeProfilesChanged = "daemon:runtime_profiles_changed"
 
 	// GitHub integration events

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -27,6 +27,17 @@ type TaskAvailablePayload struct {
 	TaskID    string `json:"task_id,omitempty"`
 }
 
+// TaskCancelledPayload is sent from server to daemon when the server detects
+// that a task was cancelled while the daemon's WebSocket connection was
+// interrupted. This allows the daemon to abort the task immediately instead
+// of waiting for the next watchTaskCancellation poll cycle (up to 5 s).
+// The payload is intentionally lean — just the task and runtime IDs — because
+// the daemon already fetches full task state from the server on receipt.
+type TaskCancelledPayload struct {
+	TaskID    string `json:"task_id"`
+	RuntimeID string `json:"runtime_id"`
+}
+
 // RuntimeProfilesChangedPayload is sent from server to daemon as a wakeup hint
 // when a workspace custom runtime profile is created, edited, disabled, or
 // deleted. The daemon still fetches profiles and registers runtimes through the


### PR DESCRIPTION
When the daemon's WebSocket disconnects and reconnects, tasks cancelled server-side during the disconnection window previously relied solely on watchTaskCancellation's 5-second poll to be discovered. This adds proactive push of daemon:task_cancelled frames on reconnect so the daemon can abort those tasks immediately.

Changes:
- New protocol event: daemon:task_cancelled with TaskCancelledPayload
- New SQL query: ListCancelledTasksForRuntimes (cancelled within 1h)
- Hub.NotifyTaskCancelled pushes frames to daemon clients by runtime
- Handler.pushCancelledTasksOnReconnect queries DB after WS registration
- Daemon readTaskWakeupMessages handles daemon:task_cancelled frames

Related: Scenario C from fault-analysis (WS reconnect state consistency)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
