### PR TITLE
fix(server): emit issue:updated when failed-task handler resets stuck issue (#4648)

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1833,15 +1833,23 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 							"error", checkErr,
 						)
 					} else if !hasActive {
-						if _, updateErr := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+						updatedIssue, updateErr := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 							ID:          t.IssueID,
 							Status:      "todo",
 							WorkspaceID: issue.WorkspaceID,
-						}); updateErr != nil {
+						})
+						if updateErr != nil {
 							slog.Warn("handle failed tasks: reset stuck issue failed",
 								"issue_id", issueKey,
 								"error", updateErr,
 							)
+						} else {
+							// This direct reset bypasses the HTTP UpdateIssue
+							// handler that normally emits issue:updated, so emit
+							// it here too. Without it the board / status-filter
+							// caches keep showing the issue as in_progress until
+							// the next write touches it (#4648 / MUL-3782).
+							s.broadcastIssueUpdated(updatedIssue, issue.Status)
 						}
 					}
 				}
@@ -2261,14 +2269,23 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 	})
 }
 
-func (s *TaskService) broadcastIssueUpdated(issue db.Issue) {
+// broadcastIssueUpdated publishes the issue:updated event the frontend's
+// realtime reconcile (onIssueUpdated) relies on to move an issue between status
+// columns / status filters and reconcile their bucket counts. prevStatus is the
+// issue's status before the write so the client can gate that reconcile on
+// status_changed, exactly like the HTTP UpdateIssue handler does.
+func (s *TaskService) broadcastIssueUpdated(issue db.Issue, prevStatus string) {
 	prefix := s.getIssuePrefix(issue.WorkspaceID)
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventIssueUpdated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
 		ActorType:   "system",
 		ActorID:     "",
-		Payload:     map[string]any{"issue": issueToMap(issue, prefix)},
+		Payload: map[string]any{
+			"issue":          issueToMap(issue, prefix),
+			"status_changed": prevStatus != issue.Status,
+			"prev_status":    prevStatus,
+		},
 	})
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2273,7 +2273,16 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 // realtime reconcile (onIssueUpdated) relies on to move an issue between status
 // columns / status filters and reconcile their bucket counts. prevStatus is the
 // issue's status before the write so the client can gate that reconcile on
-// status_changed, exactly like the HTTP UpdateIssue handler does.
+// status_changed.
+//
+// The `issue` payload is a map (issueToMap), which the workspace WS fanout
+// (listeners.go SubscribeAll) marshals and broadcasts as-is — that is what
+// drives the UI reconcile. Note this does NOT cover the full HTTP UpdateIssue
+// side effects: the activity-log and inbox listeners type-assert `issue` to a
+// handler.IssueResponse and skip a map, so a background status reset does not
+// emit status-change activity / notifications. That is intentional for the
+// realtime-staleness fix (#4648 / MUL-3782); folding those side effects in
+// would mean unifying the payload type and is left as a follow-up.
 func (s *TaskService) broadcastIssueUpdated(issue db.Issue, prevStatus string) {
 	prefix := s.getIssuePrefix(issue.WorkspaceID)
 	s.Bus.Publish(events.Event{

--- a/server/internal/service/task_issue_broadcast_test.go
+++ b/server/internal/service/task_issue_broadcast_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// noRowsDBTX makes every read return pgx.ErrNoRows so getIssuePrefix's
+// GetWorkspace lookup falls back to an empty prefix without needing a DB. The
+// helper under test still publishes regardless of the prefix result.
+type noRowsDBTX struct{}
+
+func (noRowsDBTX) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.NewCommandTag(""), nil
+}
+func (noRowsDBTX) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, pgx.ErrNoRows
+}
+func (noRowsDBTX) QueryRow(context.Context, string, ...any) pgx.Row { return noRow{} }
+
+type noRow struct{}
+
+func (noRow) Scan(...any) error { return pgx.ErrNoRows }
+
+// TestBroadcastIssueUpdated_EmitsStatusChange pins the realtime contract behind
+// #4648 / MUL-3782: when a background path resets an issue's status (e.g. the
+// failed-task handler flipping a stuck in_progress issue back to todo), it must
+// publish issue:updated with status_changed=true and the new status so the
+// frontend's onIssueUpdated reconcile moves the card between status columns /
+// filters instead of leaving it stale until the next unrelated write.
+func TestBroadcastIssueUpdated_EmitsStatusChange(t *testing.T) {
+	bus := events.New()
+	var got []events.Event
+	bus.SubscribeAll(func(e events.Event) { got = append(got, e) })
+
+	svc := &TaskService{
+		Queries: db.New(noRowsDBTX{}),
+		Bus:     bus,
+	}
+
+	issue := db.Issue{
+		ID:          testUUID(1),
+		WorkspaceID: testUUID(2),
+		Number:      7,
+		Status:      "todo",
+	}
+	svc.broadcastIssueUpdated(issue, "in_progress")
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 published event, got %d", len(got))
+	}
+	e := got[0]
+	if e.Type != protocol.EventIssueUpdated {
+		t.Fatalf("expected event type %q, got %q", protocol.EventIssueUpdated, e.Type)
+	}
+	if e.WorkspaceID != util.UUIDToString(issue.WorkspaceID) {
+		t.Fatalf("workspace mismatch: got %q want %q", e.WorkspaceID, util.UUIDToString(issue.WorkspaceID))
+	}
+
+	payload, ok := e.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload is not map[string]any: %T", e.Payload)
+	}
+	if payload["status_changed"] != true {
+		t.Errorf("expected status_changed=true, got %v", payload["status_changed"])
+	}
+	if payload["prev_status"] != "in_progress" {
+		t.Errorf("expected prev_status=in_progress, got %v", payload["prev_status"])
+	}
+	issueMap, ok := payload["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("issue payload is not map[string]any: %T", payload["issue"])
+	}
+	if issueMap["status"] != "todo" {
+		t.Errorf("expected issue.status=todo, got %v", issueMap["status"])
+	}
+	if issueMap["id"] != util.UUIDToString(issue.ID) {
+		t.Errorf("issue.id mismatch: got %v want %q", issueMap["id"], util.UUIDToString(issue.ID))
+	}
+}
+
+// TestBroadcastIssueUpdated_NoStatusChange guards the gate: a same-status
+// broadcast reports status_changed=false so the client skips the status-bucket
+// reconcile for non-status field updates.
+func TestBroadcastIssueUpdated_NoStatusChange(t *testing.T) {
+	bus := events.New()
+	var got []events.Event
+	bus.SubscribeAll(func(e events.Event) { got = append(got, e) })
+
+	svc := &TaskService{
+		Queries: db.New(noRowsDBTX{}),
+		Bus:     bus,
+	}
+
+	issue := db.Issue{
+		ID:          testUUID(1),
+		WorkspaceID: testUUID(2),
+		Status:      "todo",
+	}
+	svc.broadcastIssueUpdated(issue, "todo")
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 published event, got %d", len(got))
+	}
+	payload, ok := got[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload is not map[string]any: %T", got[0].Payload)
+	}
+	if payload["status_changed"] != false {
+		t.Errorf("expected status_changed=false, got %v", payload["status_changed"])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4648 (MUL-3782).

The reported symptom — an issue whose status was changed stays missing from status-filtered views until a later, unrelated write touches it — is real, but the root cause is **not** a stale server-side "filter index". There is no search index or cache for status filtering: `ListIssues` runs a live `WHERE i.status = ?` query against the same single Postgres that the status write hits, so a CLI `issue list --status` can't go persistently stale (which is why the reporter's later reproductions didn't reproduce).

The actual gap is on the **realtime / UI** side. Status-filtered board columns and lists are reconciled client-side by `onIssueUpdated` (`packages/core/issues/ws-updaters.ts`), which only runs when the backend publishes the `issue:updated` event. The normal write paths emit it correctly:

- HTTP `UpdateIssue` / `BatchUpdateIssues` (`server/internal/handler/issue.go`)
- GitHub PR-merged transition (`server/internal/handler/github.go` `advanceIssueToDone`)

But `TaskService.HandleFailedTasks` resets a stuck `in_progress` issue back to `todo` via a direct `UpdateIssueStatus`, bypassing that handler, and only publishes `task:failed`. So when a failed/expired task auto-resets an issue's status, the frontend never gets told to reconcile, and the issue keeps showing under `in_progress` in board columns / status filters until the next write triggers a refetch.

## Change

- Emit `issue:updated` (with `status_changed` and `prev_status`) right after the failed-task status reset, so the existing frontend reconcile fires immediately. The previously-unused `broadcastIssueUpdated` helper is repurposed for this and now carries the status-change flags, mirroring the HTTP handler payload.

No schema change, no index, no infra change.

### Note on the other call sites

- `server/cmd/server/runtime_sweeper.go` `broadcastFailedTasks` also contains a direct `UpdateIssueStatus`, but that branch is an explicit **test-only shim** (`taskSvc == nil` fallback); the production sweeper calls `TaskService.HandleFailedTasks`, so fixing the single funnel covers the production path. Left untouched to avoid changing test-only behavior.

## Testing

- `go build ./internal/service/`, `go vet ./internal/service/`, `gofmt` — clean.
- `go test ./internal/service/` — passes.
- Added `task_issue_broadcast_test.go`: pins the contract that a status reset publishes `issue:updated` with `status_changed=true` + the new status (and `status_changed=false` for a same-status broadcast). Runs without a DB.

The end-to-end realtime behavior (failed task → board/filter reconciles without a follow-up write) is best confirmed on staging.
