### PR TITLE
fix: 评论框快捷键优化 — Enter 发送，Shift+Enter 换行

### DIFF
--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -620,6 +620,7 @@ function CommentRow({
                 else edit.clearDraft(edit.draftKey);
               }}
               onSubmit={edit.saveEdit}
+              submitOnEnter
               onUploadFile={edit.handleUpload}
               debounceMs={100}
               currentIssueId={issueId}
@@ -910,6 +911,7 @@ function CommentCardImpl({
                       else edit.clearDraft(edit.draftKey);
                     }}
                     onSubmit={edit.saveEdit}
+                    submitOnEnter
                     onUploadFile={edit.handleUpload}
                     debounceMs={100}
                     currentIssueId={issueId}

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -9,7 +9,7 @@ import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
-import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
+import { enterKey } from "@multica/core/platform";
 import { useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
@@ -163,6 +163,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
             else clearDraft(draftKey);
           }}
           onSubmit={handleSubmit}
+          submitOnEnter
           onUploadFile={handleUpload}
           debounceMs={100}
           currentIssueId={issueId}
@@ -188,7 +189,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onClick={handleSubmit}
           disabled={isEmpty}
           loading={submitting}
-          tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+          tooltip={`${t(($) => $.comment.send_tooltip)} · ${enterKey}`}
         />
       </div>
       {isDragOver && <FileDropOverlay />}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -190,6 +190,7 @@ function ReplyInput({
               }
             }}
             onSubmit={handleSubmit}
+            submitOnEnter
             onUploadFile={handleUpload}
             debounceMs={100}
             currentIssueId={issueId}


### PR DESCRIPTION
## 改动

将评论框键盘快捷键从 Enter=换行 改为 Enter=发送。

### 修改文件 (3 files, +6/-2)

| 文件 | 改动 |
|---|---|
| `packages/views/issues/components/comment-input.tsx` | 加 `submitOnEnter` prop；发送按钮 tooltip 从 `Mod+Enter` 改为 `Enter` |
| `packages/views/issues/components/reply-input.tsx` | 加 `submitOnEnter` prop |
| `packages/views/issues/components/comment-card.tsx` | 两个编辑模式各加 `submitOnEnter` prop |

### 行为变化

| 按键 | 之前 | 之后 |
|---|---|---|
| Enter | 插入换行 | **发送评论**（含 IME guard + codeBlock guard） |
| Shift+Enter | 插入换行 | 插入换行（不变） |
| Cmd/Ctrl+Enter | 发送评论 | 发送评论（保持不变，作为备用） |

### 验证

- ESLint: clean
- submit-shortcut tests: 5/5 passed
- issues/components tests: 139/139 passed (14 test files)