### PR TITLE
MUL-3974: feat(issues): add keyboard navigation

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, memo } from "react";
+import { useCallback, memo, type HTMLAttributes } from "react";
 import { AppLink } from "../../navigation";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -60,10 +60,12 @@ export const BoardCardContent = memo(function BoardCardContent({
   issue,
   editable = false,
   childProgress,
+  isKeyboardActive = false,
 }: {
   issue: Issue;
   editable?: boolean;
   childProgress?: ChildProgress;
+  isKeyboardActive?: boolean;
 }) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
@@ -179,7 +181,11 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showRightMeta = !!showStartDate || !!showDueDate || !!showChildProgress || showUpdatedHint;
 
   return (
-    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
+    <div
+      className={`rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent ${
+        isKeyboardActive ? "border-ring bg-accent ring-1 ring-ring/30" : ""
+      }`}
+    >
       {/* Row 1: priority + identifier (left), agent activity + assignee (right) */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
@@ -310,7 +316,19 @@ const animateLayoutChanges: AnimateLayoutChanges = (args) => {
   return defaultAnimateLayoutChanges(args);
 };
 
-export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, childProgress, disableSorting }: { issue: Issue; childProgress?: ChildProgress; disableSorting?: boolean }) {
+export const DraggableBoardCard = memo(function DraggableBoardCard({
+  issue,
+  childProgress,
+  disableSorting,
+  isKeyboardActive,
+  keyboardProps,
+}: {
+  issue: Issue;
+  childProgress?: ChildProgress;
+  disableSorting?: boolean;
+  isKeyboardActive?: boolean;
+  keyboardProps?: HTMLAttributes<HTMLDivElement>;
+}) {
   const p = useWorkspacePaths();
   const {
     attributes,
@@ -336,6 +354,7 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
       <div
         ref={setNodeRef}
         style={style}
+        {...keyboardProps}
         {...attributes}
         {...listeners}
         className={`group/card ${isDragging ? "opacity-30" : ""}`}
@@ -344,7 +363,12 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
           href={p.issueDetail(issue.id)}
           className={`group block transition-colors ${isDragging ? "pointer-events-none" : ""}`}
         >
-          <BoardCardContent issue={issue} editable childProgress={childProgress} />
+          <BoardCardContent
+            issue={issue}
+            editable
+            childProgress={childProgress}
+            isKeyboardActive={isKeyboardActive}
+          />
         </AppLink>
       </div>
     </IssueActionsContextMenu>

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, type ReactNode } from "react";
+import { memo, useMemo, type HTMLAttributes, type ReactNode } from "react";
 import { EyeOff, MoreHorizontal, Plus, UserMinus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { useDroppable } from "@dnd-kit/core";
@@ -49,6 +49,8 @@ export const BoardColumn = memo(function BoardColumn({
   footer,
   projectId,
   sortLabel,
+  activeIssueId,
+  getIssueKeyboardProps,
 }: {
   group: BoardColumnGroup;
   issueIds: string[];
@@ -59,6 +61,8 @@ export const BoardColumn = memo(function BoardColumn({
   /** When set, the per-column "+" pre-fills the project on the create form. */
   projectId?: string;
   sortLabel?: string | null;
+  activeIssueId?: string | null;
+  getIssueKeyboardProps?: (issueId: string) => HTMLAttributes<HTMLDivElement>;
 }) {
   const status = group.status;
   const cfg = status ? STATUS_CONFIG[status] : null;
@@ -143,7 +147,14 @@ export const BoardColumn = memo(function BoardColumn({
         >
           <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
             {resolvedIssues.map((issue) => (
-              <DraggableBoardCard key={issue.id} issue={issue} childProgress={childProgressMap?.get(issue.id)} disableSorting={!!sortLabel} />
+              <DraggableBoardCard
+                key={issue.id}
+                issue={issue}
+                childProgress={childProgressMap?.get(issue.id)}
+                disableSorting={!!sortLabel}
+                isKeyboardActive={activeIssueId === issue.id}
+                keyboardProps={getIssueKeyboardProps?.(issue.id)}
+              />
             ))}
           </SortableContext>
           {issueIds.length === 0 && (

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect, useRef, memo } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef, memo, type HTMLAttributes } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -19,12 +19,15 @@ import type { AssigneeGroupedIssuesFilter, IssueSortParam, MyIssuesFilter } from
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { useWorkspacePaths } from "@multica/core/paths";
 import { BoardColumn, BOARD_CARD_WIDTH, type BoardColumnGroup } from "./board-column";
 import { BoardCardContent } from "./board-card";
 import { HiddenColumnsPanel, HiddenColumnRow } from "./hidden-columns-panel";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import type { ChildProgress } from "./list-row";
 import { useDragSettle } from "./use-drag-settle";
+import { useNavigation } from "../../navigation";
+import { useIssueKeyboardNavigation } from "../hooks";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
@@ -141,6 +144,8 @@ export function BoardView({
   projectId?: string;
 }) {
   const { t } = useT("issues");
+  const router = useNavigation();
+  const paths = useWorkspacePaths();
   const grouping = useViewStore((s) => s.grouping);
   const sortBy = useViewStore((s) => s.sortBy);
   const sortFieldKey = sortBy === "created_at" ? "created" : sortBy;
@@ -250,6 +255,19 @@ export function BoardView({
   if (!isDraggingRef.current && !isSettlingRef.current) {
     issueMapRef.current = issueMap;
   }
+
+  const keyboardIssueIds = useMemo(
+    () => groups.flatMap((group) => columns[group.id] ?? EMPTY_IDS),
+    [columns, groups],
+  );
+  const keyboardNav = useIssueKeyboardNavigation({
+    issueIds: keyboardIssueIds,
+    disabled: isDraggingRef.current,
+    onOpenIssue: useCallback(
+      (issueId: string) => router.push(paths.issueDetail(issueId)),
+      [paths, router],
+    ),
+  });
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -422,6 +440,8 @@ export function BoardView({
                 sort={sort}
                 projectId={projectId}
                 sortLabel={sortLabel}
+                activeIssueId={keyboardNav.activeIssueId}
+                getIssueKeyboardProps={keyboardNav.issueKeyboardProps}
               />
             ) : (
               assigneeGroupQueryKey && assigneeGroupFilter ? (
@@ -436,6 +456,8 @@ export function BoardView({
                   sort={sort}
                   projectId={projectId}
                   sortLabel={sortLabel}
+                  activeIssueId={keyboardNav.activeIssueId}
+                  getIssueKeyboardProps={keyboardNav.issueKeyboardProps}
                 />
               ) : (
                 <BoardColumn
@@ -447,6 +469,8 @@ export function BoardView({
                   projectId={projectId}
                   totalCount={group.totalCount}
                   sortLabel={sortLabel}
+                  activeIssueId={keyboardNav.activeIssueId}
+                  getIssueKeyboardProps={keyboardNav.issueKeyboardProps}
                 />
               )
             ),
@@ -483,6 +507,8 @@ const PaginatedAssigneeBoardColumn = memo(function PaginatedAssigneeBoardColumn(
   sort,
   projectId,
   sortLabel,
+  activeIssueId,
+  getIssueKeyboardProps,
 }: {
   group: BoardColumnGroup;
   issueIds: string[];
@@ -493,6 +519,8 @@ const PaginatedAssigneeBoardColumn = memo(function PaginatedAssigneeBoardColumn(
   sort?: IssueSortParam;
   projectId?: string;
   sortLabel?: string | null;
+  activeIssueId?: string | null;
+  getIssueKeyboardProps?: (issueId: string) => HTMLAttributes<HTMLDivElement>;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByAssigneeGroup(
     {
@@ -513,6 +541,8 @@ const PaginatedAssigneeBoardColumn = memo(function PaginatedAssigneeBoardColumn(
       totalCount={total}
       projectId={projectId}
       sortLabel={sortLabel}
+      activeIssueId={activeIssueId}
+      getIssueKeyboardProps={getIssueKeyboardProps}
       footer={
         hasMore ? (
           <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />
@@ -531,6 +561,8 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   sort,
   projectId,
   sortLabel,
+  activeIssueId,
+  getIssueKeyboardProps,
 }: {
   group: BoardColumnGroup & { status: IssueStatus };
   issueIds: string[];
@@ -540,6 +572,8 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   sort?: IssueSortParam;
   projectId?: string;
   sortLabel?: string | null;
+  activeIssueId?: string | null;
+  getIssueKeyboardProps?: (issueId: string) => HTMLAttributes<HTMLDivElement>;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     group.status,
@@ -555,6 +589,8 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
       totalCount={total}
       projectId={projectId}
       sortLabel={sortLabel}
+      activeIssueId={activeIssueId}
+      getIssueKeyboardProps={getIssueKeyboardProps}
       footer={
         hasMore ? (
           <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, type Ref } from "react";
+import { memo, type HTMLAttributes, type Ref } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
@@ -38,14 +38,16 @@ function ListRowContent({
   containerStyle,
   containerProps,
   checkboxProps,
+  isKeyboardActive = false,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   isDragging?: boolean;
   containerRef?: Ref<HTMLDivElement>;
   containerStyle?: React.CSSProperties;
-  containerProps?: Record<string, unknown>;
+  containerProps?: HTMLAttributes<HTMLDivElement>;
   checkboxProps?: Pick<React.HTMLAttributes<HTMLDivElement>, "onClick" | "onMouseDown" | "onPointerDown">;
+  isKeyboardActive?: boolean;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -74,6 +76,8 @@ function ListRowContent({
         {...containerProps}
         className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
+        } ${
+          isKeyboardActive ? "bg-accent/60 ring-1 ring-inset ring-ring/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
       >
         <div
@@ -158,11 +162,22 @@ function ListRowContent({
 export const ListRow = memo(function ListRow({
   issue,
   childProgress,
+  isKeyboardActive,
+  keyboardProps,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
+  isKeyboardActive?: boolean;
+  keyboardProps?: HTMLAttributes<HTMLDivElement>;
 }) {
-  return <ListRowContent issue={issue} childProgress={childProgress} />;
+  return (
+    <ListRowContent
+      issue={issue}
+      childProgress={childProgress}
+      isKeyboardActive={isKeyboardActive}
+      containerProps={keyboardProps}
+    />
+  );
 });
 
 const animateLayoutChanges: AnimateLayoutChanges = (args) => {
@@ -179,10 +194,14 @@ export const DraggableListRow = memo(function DraggableListRow({
   issue,
   childProgress,
   disableSorting,
+  isKeyboardActive,
+  keyboardProps,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   disableSorting?: boolean;
+  isKeyboardActive?: boolean;
+  keyboardProps?: HTMLAttributes<HTMLDivElement>;
 }) {
   const {
     attributes,
@@ -208,9 +227,10 @@ export const DraggableListRow = memo(function DraggableListRow({
       issue={issue}
       childProgress={childProgress}
       isDragging={isDragging}
+      isKeyboardActive={isKeyboardActive}
       containerRef={setNodeRef}
       containerStyle={style}
-      containerProps={{ ...attributes, ...listeners }}
+      containerProps={{ ...keyboardProps, ...attributes, ...listeners }}
       checkboxProps={{ onClick: stopDrag, onMouseDown: stopDrag, onPointerDown: stopDrag }}
     />
   );

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef, type HTMLAttributes } from "react";
 import { ChevronRight, Plus } from "lucide-react";
 import { Accordion } from "@base-ui/react/accordion";
 import {
@@ -23,10 +23,13 @@ import type { IssueSortParam, MyIssuesFilter } from "@multica/core/issues/querie
 import { useModalStore } from "@multica/core/modals";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { useWorkspacePaths } from "@multica/core/paths";
 import { StatusHeading } from "./status-heading";
 import { ListRow, DraggableListRow, type ChildProgress } from "./list-row";
 import { useDragSettle } from "./use-drag-settle";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
+import { useNavigation } from "../../navigation";
+import { useIssueKeyboardNavigation } from "../hooks";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
@@ -80,6 +83,8 @@ export function ListView({
   );
   const sortBy = useViewStore((s) => s.sortBy);
   const { t } = useT("issues");
+  const router = useNavigation();
+  const paths = useWorkspacePaths();
 
   const sortFieldKey = sortBy === "created_at" ? "created" : sortBy;
   const sortLabel = sortBy !== "position"
@@ -144,6 +149,20 @@ export function ListView({
   if (!isDraggingRef.current && !isSettlingRef.current) {
     issueMapRef.current = issueMap;
   }
+
+  const keyboardIssueIds = useMemo(
+    () =>
+      expandedStatuses.flatMap((status) => columns[statusGroupId(status)] ?? EMPTY_IDS),
+    [columns, expandedStatuses],
+  );
+  const keyboardNav = useIssueKeyboardNavigation({
+    issueIds: keyboardIssueIds,
+    disabled: isDraggingRef.current,
+    onOpenIssue: useCallback(
+      (issueId: string) => router.push(paths.issueDetail(issueId)),
+      [paths, router],
+    ),
+  });
 
   const collisionDetection = useMemo(
     () => makeKanbanCollision(groupIds),
@@ -321,6 +340,8 @@ export function ListView({
             isExpanded={isExpanded}
             sortLabel={sortLabel}
             sort={sort}
+            activeIssueId={keyboardNav.activeIssueId}
+            getIssueKeyboardProps={keyboardNav.issueKeyboardProps}
           />
         );
       })}
@@ -370,6 +391,8 @@ function StatusAccordionItem({
   isExpanded,
   sortLabel,
   sort,
+  activeIssueId,
+  getIssueKeyboardProps,
 }: {
   status: IssueStatus;
   issueIds: string[];
@@ -381,6 +404,8 @@ function StatusAccordionItem({
   isExpanded: boolean;
   sortLabel: string | null;
   sort?: IssueSortParam;
+  activeIssueId?: string | null;
+  getIssueKeyboardProps?: (issueId: string) => HTMLAttributes<HTMLDivElement>;
 }) {
   const { t } = useT("issues");
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
@@ -473,6 +498,8 @@ function StatusAccordionItem({
                   issue={issue}
                   childProgress={childProgressMap.get(issue.id)}
                   disableSorting={disableSorting}
+                  isKeyboardActive={activeIssueId === issue.id}
+                  keyboardProps={getIssueKeyboardProps?.(issue.id)}
                 />
               ))}
               {hasMore && (
@@ -482,7 +509,13 @@ function StatusAccordionItem({
           ) : (
             <>
               {issues.map((issue) => (
-                <ListRow key={issue.id} issue={issue} childProgress={childProgressMap.get(issue.id)} />
+                <ListRow
+                  key={issue.id}
+                  issue={issue}
+                  childProgress={childProgressMap.get(issue.id)}
+                  isKeyboardActive={activeIssueId === issue.id}
+                  keyboardProps={getIssueKeyboardProps?.(issue.id)}
+                />
               ))}
               {hasMore && (
                 <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/hooks/index.ts
+++ b/packages/views/issues/hooks/index.ts
@@ -2,3 +2,4 @@ export { useIssueTimeline } from "./use-issue-timeline";
 export { useIssueReactions } from "./use-issue-reactions";
 export { useIssueSubscribers } from "./use-issue-subscribers";
 export { useIssueDetailScrollRestore } from "./use-issue-detail-scroll-restore";
+export { useIssueKeyboardNavigation } from "./use-issue-keyboard-navigation";

--- a/packages/views/issues/hooks/use-issue-keyboard-navigation.test.tsx
+++ b/packages/views/issues/hooks/use-issue-keyboard-navigation.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isIssueKeyboardShortcutTarget,
+  nextIssueKeyboardIndex,
+  useIssueKeyboardNavigation,
+} from "./use-issue-keyboard-navigation";
+
+function dispatchKey(key: string, target: Document | HTMLElement = document) {
+  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+describe("nextIssueKeyboardIndex", () => {
+  it("starts from the first item when moving down with no active issue", () => {
+    expect(nextIssueKeyboardIndex(null, ["a", "b"], 1)).toBe(0);
+  });
+
+  it("starts from the last item when moving up with no active issue", () => {
+    expect(nextIssueKeyboardIndex(null, ["a", "b"], -1)).toBe(1);
+  });
+
+  it("clamps at the list bounds", () => {
+    expect(nextIssueKeyboardIndex("a", ["a", "b"], -1)).toBe(0);
+    expect(nextIssueKeyboardIndex("b", ["a", "b"], 1)).toBe(1);
+  });
+});
+
+describe("isIssueKeyboardShortcutTarget", () => {
+  it("ignores editable targets and overlays", () => {
+    const input = document.createElement("input");
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const button = document.createElement("button");
+    dialog.append(button);
+    document.body.append(input, dialog);
+
+    expect(isIssueKeyboardShortcutTarget(input)).toBe(true);
+    expect(isIssueKeyboardShortcutTarget(button)).toBe(true);
+    expect(isIssueKeyboardShortcutTarget(document.body)).toBe(false);
+  });
+});
+
+describe("useIssueKeyboardNavigation", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(performance.now());
+      return 1;
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("moves through issues with j/k and opens the active issue with Enter", () => {
+    document.body.innerHTML = `
+      <div data-issue-keyboard-id="a"></div>
+      <div data-issue-keyboard-id="b"></div>
+      <div data-issue-keyboard-id="c"></div>
+    `;
+    const onOpenIssue = vi.fn();
+    const { result } = renderHook(() =>
+      useIssueKeyboardNavigation({ issueIds: ["a", "b", "c"], onOpenIssue }),
+    );
+
+    act(() => dispatchKey("j"));
+    expect(result.current.activeIssueId).toBe("a");
+
+    act(() => dispatchKey("j"));
+    expect(result.current.activeIssueId).toBe("b");
+
+    act(() => dispatchKey("k"));
+    expect(result.current.activeIssueId).toBe("a");
+
+    act(() => dispatchKey("Enter"));
+    expect(onOpenIssue).toHaveBeenCalledWith("a");
+  });
+
+  it("does not navigate while typing in an input", () => {
+    const input = document.createElement("input");
+    document.body.append(input);
+    const onOpenIssue = vi.fn();
+    const { result } = renderHook(() =>
+      useIssueKeyboardNavigation({ issueIds: ["a", "b"], onOpenIssue }),
+    );
+
+    act(() => dispatchKey("j", input));
+
+    expect(result.current.activeIssueId).toBeNull();
+  });
+
+  it("syncs active issue when the visible issue list changes", () => {
+    const onOpenIssue = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ issueIds }) => useIssueKeyboardNavigation({ issueIds, onOpenIssue }),
+      { initialProps: { issueIds: ["a", "b"] } },
+    );
+
+    act(() => dispatchKey("j"));
+    expect(result.current.activeIssueId).toBe("a");
+
+    rerender({ issueIds: ["b", "c"] });
+
+    expect(result.current.activeIssueId).toBe("b");
+  });
+});

--- a/packages/views/issues/hooks/use-issue-keyboard-navigation.ts
+++ b/packages/views/issues/hooks/use-issue-keyboard-navigation.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const ISSUE_KEYBOARD_ATTR = "data-issue-keyboard-id";
+
+export function isIssueKeyboardShortcutTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea" || tagName === "select") {
+    return true;
+  }
+
+  return !!target.closest(
+    [
+      "[contenteditable='true']",
+      "[role='dialog']",
+      "[role='menu']",
+      "[role='listbox']",
+      "[role='combobox']",
+      "[data-radix-popper-content-wrapper]",
+    ].join(","),
+  );
+}
+
+export function nextIssueKeyboardIndex(
+  currentId: string | null,
+  issueIds: readonly string[],
+  direction: 1 | -1,
+): number {
+  if (issueIds.length === 0) return -1;
+
+  const currentIndex = currentId ? issueIds.indexOf(currentId) : -1;
+  if (currentIndex === -1) return direction === 1 ? 0 : issueIds.length - 1;
+
+  return Math.min(issueIds.length - 1, Math.max(0, currentIndex + direction));
+}
+
+function scrollIssueIntoView(issueId: string) {
+  document
+    .querySelector<HTMLElement>(`[${ISSUE_KEYBOARD_ATTR}="${issueId}"]`)
+    ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
+export function useIssueKeyboardNavigation({
+  issueIds,
+  onOpenIssue,
+  disabled = false,
+}: {
+  issueIds: readonly string[];
+  onOpenIssue: (issueId: string) => void;
+  disabled?: boolean;
+}) {
+  const [activeIssueId, setActiveIssueId] = useState<string | null>(null);
+  const stableIssueIds = useMemo(() => issueIds.filter(Boolean), [issueIds]);
+
+  useEffect(() => {
+    if (!activeIssueId) return;
+    if (!stableIssueIds.includes(activeIssueId)) {
+      setActiveIssueId(stableIssueIds[0] ?? null);
+    }
+  }, [activeIssueId, stableIssueIds]);
+
+  useEffect(() => {
+    if (disabled || stableIssueIds.length === 0) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.isComposing || isIssueKeyboardShortcutTarget(event.target)) return;
+
+      if (event.key === "j" || event.key === "k") {
+        event.preventDefault();
+        const direction = event.key === "j" ? 1 : -1;
+        setActiveIssueId((currentId) => {
+          const nextIndex = nextIssueKeyboardIndex(currentId, stableIssueIds, direction);
+          const nextId = nextIndex >= 0 ? stableIssueIds[nextIndex] ?? null : null;
+          if (nextId) requestAnimationFrame(() => scrollIssueIntoView(nextId));
+          return nextId;
+        });
+        return;
+      }
+
+      if (event.key === "Enter" && activeIssueId) {
+        event.preventDefault();
+        onOpenIssue(activeIssueId);
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [activeIssueId, disabled, onOpenIssue, stableIssueIds]);
+
+  const issueKeyboardProps = useCallback(
+    (issueId: string) => ({
+      [ISSUE_KEYBOARD_ATTR]: issueId,
+      onMouseEnter: () => setActiveIssueId(issueId),
+      onFocus: () => setActiveIssueId(issueId),
+    }),
+    [],
+  );
+
+  return {
+    activeIssueId,
+    issueKeyboardProps,
+    setActiveIssueId,
+  };
+}


### PR DESCRIPTION
## Summary

- add Linear-style `j` / `k` keyboard navigation across visible issues in board and list views
- press `Enter` to open the active issue
- keep the active issue visually highlighted and scrolled into view
- ignore shortcuts while typing or interacting with dialogs, menus, comboboxes, listboxes, and contenteditable surfaces

## Notes

This intentionally stays focused on list and board traversal. It does not duplicate #4168, which adds previous/next issue navigation inside the issue detail page. If #4168 lands, detail-page `j` / `k` can be added as a follow-up on top of that sibling-navigation model.

## Verification

- `corepack pnpm --filter @multica/views test -- use-issue-keyboard-navigation.test.tsx`
- `corepack pnpm --filter @multica/views typecheck`
- `corepack pnpm --filter @multica/views lint` (passes with existing warnings only)
