### PR TITLE
fix(chat): refresh message caches on reconnect (MUL-3831)

### DIFF
--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -15,16 +15,16 @@ export const chatKeys = {
   sessions: (wsId: string) => [...chatKeys.all(wsId), "sessions"] as const,
   session: (wsId: string, id: string) => [...chatKeys.all(wsId), "session", id] as const,
   messagesAll: () => ["chat", "messages"] as const,
-  messages: (sessionId: string) => ["chat", "messages", sessionId] as const,
+  messages: (sessionId: string) => [...chatKeys.messagesAll(), sessionId] as const,
   messagesPageAll: () => ["chat", "messages-page"] as const,
-  messagesPage: (sessionId: string) => ["chat", "messages-page", sessionId] as const,
+  messagesPage: (sessionId: string) => [...chatKeys.messagesPageAll(), sessionId] as const,
   pendingTaskAll: () => ["chat", "pending-task"] as const,
-  pendingTask: (sessionId: string) => ["chat", "pending-task", sessionId] as const,
+  pendingTask: (sessionId: string) => [...chatKeys.pendingTaskAll(), sessionId] as const,
   /** Aggregate of in-flight chat tasks for the current user — FAB reads this. */
   pendingTasks: (wsId: string) => [...chatKeys.all(wsId), "pending-tasks"] as const,
   /** Per-task execution messages — shared with issue agent cards. */
   taskMessagesAll: () => ["task-messages"] as const,
-  taskMessages: (taskId: string) => ["task-messages", taskId] as const,
+  taskMessages: (taskId: string) => [...chatKeys.taskMessagesAll(), taskId] as const,
 };
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -14,12 +14,16 @@ export const chatKeys = {
   /** Full sessions list (active + archived); the dropdown splits locally. */
   sessions: (wsId: string) => [...chatKeys.all(wsId), "sessions"] as const,
   session: (wsId: string, id: string) => [...chatKeys.all(wsId), "session", id] as const,
+  messagesAll: () => ["chat", "messages"] as const,
   messages: (sessionId: string) => ["chat", "messages", sessionId] as const,
+  messagesPageAll: () => ["chat", "messages-page"] as const,
   messagesPage: (sessionId: string) => ["chat", "messages-page", sessionId] as const,
+  pendingTaskAll: () => ["chat", "pending-task"] as const,
   pendingTask: (sessionId: string) => ["chat", "pending-task", sessionId] as const,
   /** Aggregate of in-flight chat tasks for the current user — FAB reads this. */
   pendingTasks: (wsId: string) => [...chatKeys.all(wsId), "pending-tasks"] as const,
   /** Per-task execution messages — shared with issue agent cards. */
+  taskMessagesAll: () => ["task-messages"] as const,
   taskMessages: (taskId: string) => ["task-messages", taskId] as const,
 };
 

--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -102,9 +102,9 @@ describe("useRealtimeSync — ws instance change", () => {
     rerender({ ws: ws2 });
 
     // Should have called invalidateQueries for all workspace-scoped keys
-    // (15 workspace-scoped + 6 per-issue prefixes + 1 workspaceKeys.list()
-    // + 1 cross-workspace inbox unread summary = 23 calls)
-    expect(invalidateSpy).toHaveBeenCalledTimes(23);
+    // (15 workspace-scoped + 6 per-issue prefixes + 4 per-chat prefixes
+    // + 1 workspaceKeys.list() + 1 cross-workspace inbox unread summary = 27 calls)
+    expect(invalidateSpy).toHaveBeenCalledTimes(27);
   });
 
   it("does not re-invalidate when rerendered with the same ws instance", () => {
@@ -163,5 +163,27 @@ describe("useRealtimeSync — ws instance change", () => {
     expect(calls).toContainEqual(["issues", "usage"]);
     expect(calls).toContainEqual(["issues", "attachments"]);
     expect(calls).toContainEqual(["issues", "tasks"]);
+  });
+
+  it("invalidates per-chat-session caches (no wsId in key) on ws instance change", () => {
+    // These keys are not under the ["chat", wsId] prefix, so they need their
+    // own recovery invalidation when reconnecting after missed chat/task events.
+    const ws1 = createMockWs();
+    const { rerender } = renderHook(
+      ({ ws }) => useRealtimeSync(ws, stores),
+      { initialProps: { ws: ws1 as WSClient | null }, wrapper: createWrapper(qc) },
+    );
+
+    invalidateSpy.mockClear();
+    rerender({ ws: null });
+
+    const ws2 = createMockWs();
+    rerender({ ws: ws2 });
+
+    const calls = invalidateSpy.mock.calls.map((call: [{ queryKey?: unknown }, ...unknown[]]) => call[0].queryKey);
+    expect(calls).toContainEqual(["chat", "messages"]);
+    expect(calls).toContainEqual(["chat", "messages-page"]);
+    expect(calls).toContainEqual(["chat", "pending-task"]);
+    expect(calls).toContainEqual(["task-messages"]);
   });
 });

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -339,6 +339,14 @@ function invalidateWorkspaceScopedQueries(qc: QueryClient): void {
   qc.invalidateQueries({ queryKey: issueKeys.usageAll() });
   qc.invalidateQueries({ queryKey: issueKeys.attachmentsAll() });
   qc.invalidateQueries({ queryKey: issueKeys.tasksAll() });
+  // Per-chat-session caches are also keyed without wsId, so the
+  // chatKeys.all(wsId) prefix above only reaches session lists / aggregates.
+  // Message streams rely on WS invalidation with staleTime: Infinity; recover
+  // sessions that missed chat/task events while the socket was disconnected.
+  qc.invalidateQueries({ queryKey: chatKeys.messagesAll() });
+  qc.invalidateQueries({ queryKey: chatKeys.messagesPageAll() });
+  qc.invalidateQueries({ queryKey: chatKeys.pendingTaskAll() });
+  qc.invalidateQueries({ queryKey: chatKeys.taskMessagesAll() });
   qc.invalidateQueries({ queryKey: workspaceKeys.list() });
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes stale chat message caches after a websocket reconnect or WS client instance change.

Chat session lists are keyed under `["chat", wsId]`, but per-session message streams use keys like `["chat", "messages", sessionId]`, `["chat", "messages-page", sessionId]`, and `["chat", "pending-task", sessionId]`. The reconnect recovery path only invalidated the workspace-scoped chat prefix, so per-session caches could stay stale if chat/task events were missed while disconnected.

This PR adds explicit prefix keys for those per-session chat caches and invalidates them during reconnect recovery, matching the existing pattern used for per-issue caches that are also keyed without `wsId`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added prefix query keys for chat message, paginated message, pending task, and task message caches in `packages/core/chat/queries.ts`.
- Updated reconnect recovery in `packages/core/realtime/use-realtime-sync.ts` to invalidate per-chat-session caches that are not covered by `chatKeys.all(wsId)`.
- Extended `packages/core/realtime/use-realtime-sync-ws-instance.test.tsx` to assert those per-chat-session caches are invalidated on WS instance recovery.

## How to Test

1. Run `pnpm exec vitest run packages/core/realtime/use-realtime-sync-ws-instance.test.tsx`
2. Run `pnpm exec vitest run packages/core/realtime/use-realtime-sync.test.ts`
3. Confirm both test files pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Used Cursor to inspect the existing websocket reconnect invalidation path, compare chat query keys against the existing per-issue cache recovery pattern, implement targeted cache invalidation for chat message caches, and run the focused Vitest suites.

## Screenshots (optional)

N/A