### PR TITLE
fix(redact): cover GitHub fine-grained PATs and Google API keys

### DIFF
--- a/packages/views/common/task-transcript/redact.test.ts
+++ b/packages/views/common/task-transcript/redact.test.ts
@@ -25,6 +25,27 @@ describe("redactSecrets", () => {
     expect(result).not.toContain("ghp_");
   });
 
+  it("redacts GitHub fine-grained PATs (github_pat_)", () => {
+    const key = ["github_", "pat_", "11ABCDEFG0aBcDeFgHiJkL_mNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOpQrSt"].join("");
+    const result = redactSecrets(`the build left ${key} in the log`);
+    expect(result).not.toContain("github_pat_");
+    expect(result).toContain("[REDACTED GITHUB TOKEN]");
+  });
+
+  it("redacts Google API keys (AIza...)", () => {
+    const key = ["AIza", "SyD1234567890abcdefghijklmnopqrstuv"].join("");
+    const result = redactSecrets(`the config still had ${key} in it`);
+    expect(result).not.toContain("AIzaSy");
+    expect(result).toContain("[REDACTED GOOGLE API KEY]");
+  });
+
+  it("redacts Google API keys ending with dash", () => {
+    const key = ["AIza", "SyB1cD3fGhIjKlMnOpQrStUvWxYz012345-"].join("");
+    const result = redactSecrets(`the config still had "${key}" in it`);
+    expect(result).not.toContain("AIzaSy");
+    expect(result).toContain('"[REDACTED GOOGLE API KEY]" in it');
+  });
+
   it("redacts GitLab tokens", () => {
     const result = redactSecrets("glpat-AbCdEfGhIjKlMnOpQrStUvWx");
     expect(result).not.toContain("glpat-");

--- a/packages/views/common/task-transcript/redact.ts
+++ b/packages/views/common/task-transcript/redact.ts
@@ -10,8 +10,12 @@ const patterns: { re: RegExp; replacement: string }[] = [
   { re: /(?:aws_secret_access_key|secret_?access_?key)\s*[=:]\s*[A-Za-z0-9/+=]{40}/gi, replacement: "[REDACTED AWS SECRET]" },
   // PEM private keys
   { re: /-----BEGIN[A-Z\s]*PRIVATE KEY-----[\s\S]*?-----END[A-Z\s]*PRIVATE KEY-----/g, replacement: "[REDACTED PRIVATE KEY]" },
-  // GitHub tokens
+  // GitHub OAuth / classic tokens (ghp_/gho_/ghu_/ghs_/ghr_)
   { re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,255}\b/g, replacement: "[REDACTED GITHUB TOKEN]" },
+  // GitHub fine-grained PATs (github_pat_…, recommended since 2022)
+  { re: /\bgithub_pat_[A-Za-z0-9_]{20,255}\b/g, replacement: "[REDACTED GITHUB TOKEN]" },
+  // Google API keys (AIza…, e.g. Gemini / Maps / Firebase)
+  { re: /\bAIza[0-9A-Za-z_-]{35}([^0-9A-Za-z_-]|$)/g, replacement: "[REDACTED GOOGLE API KEY]$1" },
   // GitLab personal access tokens
   { re: /\bglpat-[A-Za-z0-9_-]{20,}\b/g, replacement: "[REDACTED GITLAB TOKEN]" },
   // OpenAI / Anthropic API keys

--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -51,8 +51,9 @@ var patterns = []secretPattern{
 	{regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`), "[REDACTED GITLAB TOKEN]"},
 
 	// Google API keys always start with the AIza prefix and are 39 chars total
-	// (AIza + 35). Not covered by any rule above, so they would otherwise leak.
-	{regexp.MustCompile(`\bAIza[0-9A-Za-z_\-]{35}\b`), "[REDACTED GOOGLE API KEY]"},
+	// (AIza + 35). Capture and restore the trailing delimiter so keys ending in
+	// a non-word character such as '-' are still redacted.
+	{regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}([^0-9A-Za-z_-]|$)`), "[REDACTED GOOGLE API KEY]$1"},
 
 	// Stripe secret / restricted live keys (sk_live_ / rk_live_). The sk-
 	// rule above only matches the hyphen form used by OpenAI/Anthropic; Stripe

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -70,6 +70,18 @@ func TestRedactGitHubFineGrainedToken(t *testing.T) {
 	}
 }
 
+func TestRedactGoogleAPIKeyEndingWithDash(t *testing.T) {
+	t.Parallel()
+	input := `the config file still had "` + asm("AIza", "SyB1cD3fGhIjKlMnOpQrStUvWxYz012345-") + `" in it`
+	got := Text(input)
+	if strings.Contains(got, asm("AIza", "SyB1cD3f")) {
+		t.Fatalf("Google API key ending with dash not redacted: %s", got)
+	}
+	if !strings.Contains(got, `"[REDACTED GOOGLE API KEY]" in it`) {
+		t.Fatalf("expected delimiter to be preserved, got: %s", got)
+	}
+}
+
 func TestRedactOpenAIKey(t *testing.T) {
 	t.Parallel()
 	input := "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345"


### PR DESCRIPTION
## Summary

`main` now has the primary server-side coverage for GitHub fine-grained PATs and standard Google API keys from #5274. After rebasing, this PR keeps only the remaining defense-in-depth value:

- add matching `github_pat_…` and fixed-length `AIza…` patterns to the client transcript display safety net, so previously stored or otherwise unredacted values are masked when rendered;
- fix the server and client Google-key rule for a valid key ending in `-`, while preserving the trailing delimiter.

This protects task transcript inputs, outputs, and timeline content without changing the user flow or requiring a coordinated server/client rollout.

## Implementation

- Client: redact GitHub fine-grained PATs and 39-character Google API keys.
- Server/client: match exactly `AIza` + 35 allowed characters, then capture and restore the following delimiter. This covers a final `-` without broadening the key length and false-positive surface.
- Tests: cover both client patterns plus the trailing-`-` regression on server and client, including delimiter preservation.

## Validation

- `cd server && go test ./pkg/redact -count=1`
- `pnpm --filter @multica/views exec vitest run common/task-transcript/redact.test.ts`
- `pnpm --filter @multica/views typecheck`
- `gofmt -d server/pkg/redact/redact.go server/pkg/redact/redact_test.go`
- `git diff --check origin/main...HEAD`
