### PR TITLE
Make squad handoff role-aware

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -25,6 +25,18 @@ Your responsibilities, in order:
 
 1. **Read the issue** (title, description, latest comments, acceptance
    criteria) and decide which squad member is best suited to do the work.
+   - Infer the required role/discipline first (for example implementation,
+     review/validation, design, product, or operations), then choose from
+     roster members whose role or squad instructions fit that need.
+   - Treat availability/idleness as a tie-breaker only among role-suitable
+     candidates; never choose an idle mismatched member merely because they
+     are idle.
+   - For review, validation, QA, or sign-off, exclude the member who performed
+     the implementation (including yourself) unless the human explicitly asks
+     for self-review or no alternative exists.
+   - If the role need, ownership, or eligible recipient is ambiguous, ask the
+     reporter/leader a clarifying question instead of guessing or falling back
+     to any idle member.
 2. **Delegate by @mention.** Post a single comment on this issue that
    @mentions the chosen member(s) and tells them what to do.
    - **Be terse.** Every Multica agent already has full context of the
@@ -35,7 +47,11 @@ Your responsibilities, in order:
    - Say only what cannot be inferred from the issue: who you're
      picking, why them (one short clause), and any *additional*
      constraints, hints, or sequencing you want them to follow.
-     Two or three sentences is usually plenty.
+     Make the selection auditable with short fields: ` + "`" + `Required role:` + "`" + `,
+     ` + "`" + `Selected because:` + "`" + `, and ` + "`" + `Excluded:` + "`" + ` when you are deliberately
+     not using an otherwise tempting candidate (for example, a recent
+     implementer or mismatched-role member). Two or three sentences is
+     usually plenty; compact fields are fine.
    - Use the exact mention markdown shown in the Squad Roster below —
      typing a plain "@name" will not trigger anyone.
 3. **Record your evaluation.** After every trigger — whether you delegated,
@@ -71,6 +87,15 @@ Hard rules:
 - Do NOT do the implementation work yourself unless the squad has no
   other suitable members. The squad exists so work is split — bypassing
   it defeats the point.
+- Choose recipients role-first: required role and ownership come before
+  availability. Availability may break ties among qualified members; it
+  must not override a role mismatch.
+- For review/validation/QA, do not delegate to the original implementer
+  (including yourself) unless explicitly asked or no viable reviewer
+  exists; explain the exception if used.
+- If no role-eligible member is available, or if roles are missing or
+  ambiguous, ask a concise clarification or escalate rather than delegating
+  arbitrarily.
 - Do NOT @mention members who don't appear in the Squad Roster below;
   they are not part of this squad.
 - One delegation comment per turn is enough. Avoid spamming multiple

--- a/server/internal/handler/squad_briefing_test.go
+++ b/server/internal/handler/squad_briefing_test.go
@@ -31,6 +31,29 @@ func TestSquadOperatingProtocolWarnsAgainstDualTrigger(t *testing.T) {
 	}
 }
 
+// TestSquadOperatingProtocolRequiresRoleAwareDelegation locks in the
+// prompt-level routing contract: leaders must select by role fit before
+// availability, avoid self-review, ask when ambiguous, and leave an
+// auditable handoff trail. This intentionally asserts narrow substrings
+// rather than exact wording.
+func TestSquadOperatingProtocolRequiresRoleAwareDelegation(t *testing.T) {
+	compact := strings.Join(strings.Fields(squadOperatingProtocol), " ")
+	for _, want := range []string{
+		"required role/discipline first",
+		"availability/idleness as a tie-breaker only",
+		"idle mismatched member",
+		"For review, validation, QA, or sign-off, exclude the member who performed the implementation",
+		"ask the reporter/leader a clarifying question",
+		"`Required role:`",
+		"`Selected because:`",
+		"`Excluded:`",
+	} {
+		if !strings.Contains(compact, want) {
+			t.Errorf("expected squad operating protocol to contain %q\n--- protocol ---\n%s", want, squadOperatingProtocol)
+		}
+	}
+}
+
 // seedSquadForBriefing creates a squad with the seeded test agent as
 // leader. Returns the loaded db.Squad and a cleanup-registered ID.
 func seedSquadForBriefing(t *testing.T, leaderID string, name, instructions string) db.Squad {


### PR DESCRIPTION
## Summary
- Select squad delegates by required role/discipline before availability.
- Avoid self-review/implementer review when alternatives exist and ask for clarification when role fit is ambiguous.
- Add a focused prompt-contract test for role-aware delegation.

## Review
- Independent reviewer hh-mbp14-codex3 reported the change passed review with no blockers and scope/tests OK.

## Tests
- `git diff --check`
- `cd server && go test ./internal/handler -run TestSquadOperatingProtocolRequiresRoleAwareDelegation -count=1`
