### PR TITLE
fix(daemon): bound runtime --version probe so one wedged CLI can't block all runtimes (MUL-3812)

### DIFF
--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -117,9 +119,28 @@ func TestDetectVersionTimesOutOnHang(t *testing.T) {
 
 	dir := t.TempDir()
 	script := filepath.Join(dir, "hang.sh")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
+	pidFile := filepath.Join(dir, "child.pid")
+	// The CLI hangs forever (`wait`) and backgrounds a child that inherits and
+	// holds our stdout pipe open even after the parent is killed on timeout —
+	// the exact case cmd.WaitDelay must cover. The child records its PID so we
+	// can reap it in Cleanup instead of leaking a 60s `sleep` into CI.
+	body := fmt.Sprintf("#!/bin/sh\nsleep 60 &\necho $! > %q\nwait\n", pidFile)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatalf("write hang script: %v", err)
 	}
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return // child never recorded its PID; nothing to reap
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return
+		}
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Kill()
+		}
+	})
 
 	orig := detectVersionTimeout
 	detectVersionTimeout = 200 * time.Millisecond

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -95,6 +98,50 @@ func TestDetectVersionFailsForMissingBinary(t *testing.T) {
 	_, err := DetectVersion(context.Background(), "/nonexistent/binary")
 	if err == nil {
 		t.Fatal("expected error for missing binary")
+	}
+}
+
+// TestDetectVersionTimesOutOnHang guards MUL-3812: a CLI whose `--version`
+// never returns (e.g. a brew-installed claude wedged by a bun regression) must
+// not stall version detection forever. The daemon detects every runtime's
+// version sequentially inside its blocking preflight, so an unbounded probe
+// would leave the daemon stuck "starting" and *every* runtime on the host
+// disconnected. detectCLIVersion must bound the probe and return an error so
+// the registration loop isolates the broken runtime and the rest still
+// register. The script also leaves an orphaned child holding the stdout pipe
+// open after the parent is killed, exercising the cmd.WaitDelay path.
+func TestDetectVersionTimesOutOnHang(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on a /bin/sh hang script")
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "hang.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
+		t.Fatalf("write hang script: %v", err)
+	}
+
+	orig := detectVersionTimeout
+	detectVersionTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { detectVersionTimeout = orig })
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := DetectVersion(context.Background(), script)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error from a hanging --version probe, got nil")
+		}
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Fatalf("detection took %v; expected it to be bounded by the timeout", elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("DetectVersion did not return: version probe is unbounded (regression of MUL-3812)")
 	}
 }
 

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -804,9 +804,30 @@ func writeMcpConfigToTemp(raw json.RawMessage) (string, error) {
 	return f.Name(), nil
 }
 
+// detectVersionTimeout bounds a single `<cli> --version` probe. Version
+// detection runs inside the daemon's blocking preflight (registerRuntimesForWorkspace),
+// so a CLI that never returns from `--version` — e.g. a brew-installed claude
+// wedged by a bun regression (MUL-3812) — would otherwise stall the whole
+// registration loop, the daemon would never flip /health from "starting" to
+// "running", and *every* runtime on the host would appear disconnected. A real
+// `--version` returns well under this bound even on a cold cache or with
+// Windows AV scanning; the timeout exists only to fail a wedged probe fast and
+// in isolation so the remaining runtimes still register. A var (not const) so
+// tests can shrink it without waiting out the real bound.
+var detectVersionTimeout = 10 * time.Second
+
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, execPath, "--version")
 	hideAgentWindow(cmd)
+	// exec.CommandContext only kills the direct child on timeout. A broken CLI
+	// (node/bun shim) can leave grandchildren that inherited and still hold our
+	// stdout pipe open, and cmd.Output() blocks in Wait() until that pipe
+	// closes — defeating the timeout above. WaitDelay forces the pipes shut and
+	// reaps shortly after the context fires so this call always returns.
+	cmd.WaitDelay = 2 * time.Second
 	data, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("detect version for %s: %w", execPath, err)


### PR DESCRIPTION
## Problem (MUL-3812)

A user on macOS reported that a brew-installed `claude` broken by a bun regression caused the Multica desktop app to hang on `starting` and **none** of their runtimes could connect — not just claude.

### Root cause

Runtime version detection had **no timeout** and runs inside the daemon's blocking startup preflight:

```
run() → preflightAuth(ctx) → syncWorkspacesFromAPI(ctx) → registerRuntimesForWorkspace(ctx) → detectAgentVersion(ctx) → detectCLIVersion → exec.CommandContext(ctx, claude, "--version").Output()
```

- `detectCLIVersion` relied entirely on the passed-in `ctx`, and the registration call is given the daemon's long-lived context (the 15s `apiCtx` in `syncWorkspacesFromAPI` is only used for `ListWorkspaces`, not registration). So `cmd.Output()` could block **forever**.
- The registration loop over `d.cfg.Agents` is **sequential**, and `d.ready.Store(true)` — the line that flips `/health` from `starting` to `running` — is only reached *after* preflight returns.

So when `claude --version` never returned, the whole loop wedged, preflight never completed, and **every** runtime on the host (all providers, all workspaces) stayed disconnected. The loop already skips runtimes whose version *errors* (`if err != nil { continue }`), so a clean failure was already isolated — the only gap was an unbounded **hang**, which is exactly what the bun breakage triggers.

## Fix

`detectCLIVersion` now:
1. Derives a **10s timeout context** internally, so any single `--version` probe fails fast instead of blocking indefinitely.
2. Sets **`cmd.WaitDelay = 2s`** — `exec.CommandContext` only kills the direct child on timeout, but a node/bun shim can leave a grandchild holding the stdout pipe open, which keeps `cmd.Output()`'s `Wait()` blocked and defeats the timeout. `WaitDelay` force-closes the pipes and reaps so the call always returns.

After a wedged probe times out, the existing per-agent `continue` isolates just the broken runtime; the healthy runtimes register and the daemon reaches `running`. The fix is centralized in `detectCLIVersion`, so it also covers custom runtime profiles (`appendProfileRuntimes`) and steady-state `workspaceSyncLoop` ticks (which hold `reloading.Lock`), not just startup.

## Test

`TestDetectVersionTimesOutOnHang` spawns a `--version` that never returns (and leaves an orphaned child holding the stdout pipe, exercising the `WaitDelay` path) and asserts detection returns an error fast instead of blocking. Passes in ~0.2s.

## Notes / follow-up (not in this PR)

Registration is still sequential, so in the pathological case where *several* CLIs are wedged the per-agent bounds add up (~12s each). Realistically only one CLI is broken among healthy ones (which return in <1s), so worst-case added startup delay is small and bounded. Parallelizing detection would be a larger change touching the shared `agentVersions` map and is out of scope here.
