### PR TITLE
feat(composio): Stage 2 frontend polish — callback toast, last_used & expired UI, e2e (MUL-3718)

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -37,4 +37,79 @@ test.describe("Settings", () => {
     await expect(page.getByText("Workspace settings saved").first()).toBeVisible({ timeout: 5000 });
     await expect(page.getByRole("button", { name: new RegExp(originalName) }).first()).toBeVisible();
   });
+
+  // Composio connect flow, fully mocked at the network boundary so it runs
+  // without a configured COMPOSIO_API_KEY or a live Composio project. The
+  // backend redirect is simulated by pointing the init endpoint's redirect_url
+  // straight back at the settings page with ?connected=<slug> — exercising the
+  // frontend's callback toast + connections refresh (MUL-3718) end to end.
+  test("connecting a Composio toolkit shows a toast and refreshes the list", async ({
+    page,
+  }) => {
+    const workspaceSlug = await loginAsDefault(page);
+    const settingsUrl = `/${workspaceSlug}/settings?tab=integrations`;
+
+    // Stateful: connections is empty until the (mocked) connect flow lands.
+    let connected = false;
+
+    await page.route("**/api/integrations/composio/toolkits", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { slug: "notion", name: "Notion", connectable: true },
+        ]),
+      }),
+    );
+
+    await page.route("**/api/integrations/composio/connections", (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          connected
+            ? [
+                {
+                  id: "conn-notion-1",
+                  toolkit_slug: "notion",
+                  status: "active",
+                  connected_at: new Date().toISOString(),
+                  last_used_at: null,
+                },
+              ]
+            : [],
+        ),
+      });
+    });
+
+    await page.route("**/api/integrations/composio/connect/init", (route) => {
+      // Composio would 302 through its hosted consent and back to our callback;
+      // short-circuit straight to the success redirect the callback emits.
+      connected = true;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          redirect_url: `${settingsUrl}&connected=notion`,
+        }),
+      });
+    });
+
+    await page.goto(settingsUrl, { waitUntil: "domcontentloaded" });
+    await waitForPageText(page, "Composio");
+
+    // Notion starts disconnected → click Connect.
+    await page.getByRole("button", { name: /^Connect$/ }).first().click();
+
+    // Success toast from the simulated callback redirect.
+    await expect(page.getByText("Connected").first()).toBeVisible({ timeout: 10000 });
+
+    // List refreshed without a manual reload: the Notion card now offers
+    // Disconnect, and the one-shot ?connected param has been stripped.
+    await expect(
+      page.getByRole("button", { name: /Disconnect/ }).first(),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page).not.toHaveURL(/connected=notion/);
+  });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -84,14 +84,18 @@ test.describe("Settings", () => {
     });
 
     await page.route("**/api/integrations/composio/connect/init", (route) => {
-      // Composio would 302 through its hosted consent and back to our callback;
-      // short-circuit straight to the success redirect the callback emits.
+      // Composio would 302 through its hosted consent and back to our callback,
+      // which emits CallbackRedirect's slug-less shape:
+      // `/settings?tab=integrations&connected=<slug>`. The web proxy's
+      // legacy-route redirect then prepends the last workspace slug, landing on
+      // the real settings route. Mock that exact backend shape (NOT the final
+      // slugged URL) so the test exercises the same redirect path real users hit.
       connected = true;
       return route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          redirect_url: `${settingsUrl}&connected=notion`,
+          redirect_url: `/settings?tab=integrations&connected=notion`,
         }),
       });
     });

--- a/packages/core/types/composio.ts
+++ b/packages/core/types/composio.ts
@@ -21,7 +21,10 @@ export interface ComposioToolkit {
 export interface ComposioConnection {
   id: string;
   toolkit_slug: string;
-  status: "active" | "revoked" | string;
+  /** Connection lifecycle state. `expired` surfaces a Reconnect affordance in
+   * the UI; the backend only starts emitting it once Stage 4 webhook handling
+   * lands (MUL-3719), but the client renders the branch ahead of that. */
+  status: "active" | "expired" | "revoked" | string;
   connected_at: string;
   last_used_at?: string | null;
 }

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -324,7 +324,13 @@
     "disconnect_confirm_title": "Disconnect this app?",
     "disconnect_confirm_description": "Your connected account will be revoked at Composio and your agents will lose access to this toolkit. You can reconnect later.",
     "disconnect_confirm_cancel": "Cancel",
-    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete."
+    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete.",
+    "toast_connected": "Connected",
+    "toast_connect_failed": "Couldn't complete the connection. Please try again.",
+    "last_used": "Last used {{when}}",
+    "last_used_never": "Never used",
+    "expired": "Token expired",
+    "reconnect": "Reconnect"
   },
   "repositories": {
     "section_title": "Repositories",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -324,7 +324,13 @@
     "disconnect_confirm_title": "Disconnect this app?",
     "disconnect_confirm_description": "Your connected account will be revoked at Composio and your agents will lose access to this toolkit. You can reconnect later.",
     "disconnect_confirm_cancel": "Cancel",
-    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete."
+    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete.",
+    "toast_connected": "接続しました",
+    "toast_connect_failed": "接続を完了できませんでした。もう一度お試しください。",
+    "last_used": "最終使用 {{when}}",
+    "last_used_never": "未使用",
+    "expired": "トークンの有効期限切れ",
+    "reconnect": "再接続"
   },
   "repositories": {
     "section_title": "リポジトリ",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -401,6 +401,12 @@
     "disconnect_confirm_title": "Disconnect this app?",
     "disconnect_confirm_description": "Your connected account will be revoked at Composio and your agents will lose access to this toolkit. You can reconnect later.",
     "disconnect_confirm_cancel": "Cancel",
-    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete."
+    "connections_load_failed": "Couldn't load your existing connections, so connected status may be incomplete.",
+    "toast_connected": "연결되었습니다",
+    "toast_connect_failed": "연결을 완료하지 못했습니다. 다시 시도해 주세요.",
+    "last_used": "마지막 사용 {{when}}",
+    "last_used_never": "사용한 적 없음",
+    "expired": "토큰 만료됨",
+    "reconnect": "다시 연결"
   }
 }

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -324,7 +324,13 @@
     "disconnect_confirm_title": "断开这个应用？",
     "disconnect_confirm_description": "你的已连接账号将在 Composio 侧被撤销，你的 agent 将失去对该 toolkit 的访问权限。你可以稍后重新连接。",
     "disconnect_confirm_cancel": "取消",
-    "connections_load_failed": "无法加载你已有的连接，连接状态可能不完整。"
+    "connections_load_failed": "无法加载你已有的连接，连接状态可能不完整。",
+    "toast_connected": "已连接",
+    "toast_connect_failed": "连接未能完成，请重试。",
+    "last_used": "最近使用 {{when}}",
+    "last_used_never": "从未使用",
+    "expired": "令牌已过期",
+    "reconnect": "重新连接"
   },
   "repositories": {
     "section_title": "代码仓库",

--- a/packages/views/settings/components/composio-tab.test.tsx
+++ b/packages/views/settings/components/composio-tab.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { StrictMode } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../locales/en/common.json";
@@ -70,6 +71,19 @@ function renderTab() {
     <I18nProvider locale="en" resources={{ en: { common: enCommon, settings: enSettings } }}>
       <ComposioTab />
     </I18nProvider>,
+  );
+}
+
+// StrictMode reproduces React's dev-mode mount → cleanup → mount double-invoke,
+// which is exactly what would double-fire the callback toast without the
+// consumed-key ref guard.
+function renderTabStrict() {
+  return render(
+    <StrictMode>
+      <I18nProvider locale="en" resources={{ en: { common: enCommon, settings: enSettings } }}>
+        <ComposioTab />
+      </I18nProvider>
+    </StrictMode>,
   );
 }
 
@@ -164,5 +178,16 @@ describe("ComposioTab", () => {
       expect(mockToastError).toHaveBeenCalledWith(enSettings.composio.toast_connect_failed);
     });
     expect(mockReplace).toHaveBeenCalledWith("/acme/settings?tab=integrations");
+  });
+
+  it("fires the success callback exactly once under StrictMode double-invoke", async () => {
+    searchParamsRef.current = new URLSearchParams("tab=integrations&connected=notion");
+    renderTabStrict();
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalled();
+    });
+    // The consumed-key ref must suppress the second (cleanup → re-mount) run.
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/views/settings/components/composio-tab.test.tsx
+++ b/packages/views/settings/components/composio-tab.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enSettings from "../../locales/en/settings.json";
+import type { ComposioConnection, ComposioToolkit } from "@multica/core/types";
+
+// --- Mutable refs the mocked hooks read from, so each test can shape the data
+// without re-mocking the modules. ---
+const toolkitsRef = vi.hoisted(() => ({
+  current: { data: [] as ComposioToolkit[], isLoading: false, isError: false },
+}));
+const connectionsRef = vi.hoisted(() => ({
+  current: { data: [] as ComposioConnection[], isError: false },
+}));
+const searchParamsRef = vi.hoisted(() => ({ current: new URLSearchParams("tab=integrations") }));
+
+const mockInvalidate = vi.hoisted(() => vi.fn());
+const mockReplace = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (opts: { queryKey: unknown[] }) => {
+    const key = JSON.stringify(opts.queryKey);
+    if (key.includes("toolkits")) return toolkitsRef.current;
+    if (key.includes("connections")) return connectionsRef.current;
+    return { data: undefined };
+  },
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+  queryOptions: <T,>(opts: T) => opts,
+}));
+
+vi.mock("@multica/core/composio", () => ({
+  composioKeys: {
+    all: ["composio"],
+    toolkits: () => ["composio", "toolkits"],
+    connections: () => ["composio", "connections"],
+  },
+  composioToolkitsOptions: () => ({ queryKey: ["composio", "toolkits"], queryFn: vi.fn() }),
+  composioConnectionsOptions: () => ({ queryKey: ["composio", "connections"], queryFn: vi.fn() }),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    beginComposioConnect: vi.fn(),
+    deleteComposioConnection: vi.fn(),
+  },
+}));
+
+vi.mock("../../navigation", () => ({
+  useNavigation: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    back: vi.fn(),
+    pathname: "/acme/settings",
+    searchParams: searchParamsRef.current,
+    getShareableUrl: (p: string) => `https://app.example${p}`,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+
+import { ComposioTab } from "./composio-tab";
+
+function renderTab() {
+  return render(
+    <I18nProvider locale="en" resources={{ en: { common: enCommon, settings: enSettings } }}>
+      <ComposioTab />
+    </I18nProvider>,
+  );
+}
+
+const NOTION: ComposioToolkit = {
+  slug: "notion",
+  name: "Notion",
+  connectable: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  toolkitsRef.current = { data: [NOTION], isLoading: false, isError: false };
+  connectionsRef.current = { data: [], isError: false };
+  searchParamsRef.current = new URLSearchParams("tab=integrations");
+});
+
+describe("ComposioTab", () => {
+  it("renders a connected card with a 'never used' placeholder when last_used_at is null", () => {
+    connectionsRef.current = {
+      data: [
+        {
+          id: "conn-1",
+          toolkit_slug: "notion",
+          status: "active",
+          connected_at: "2026-06-01T00:00:00Z",
+          last_used_at: null,
+        },
+      ],
+      isError: false,
+    };
+    renderTab();
+    expect(screen.getByText(enSettings.composio.connected)).toBeInTheDocument();
+    expect(screen.getByText(enSettings.composio.last_used_never)).toBeInTheDocument();
+  });
+
+  it("renders a 'Last used' line when last_used_at is present", () => {
+    connectionsRef.current = {
+      data: [
+        {
+          id: "conn-1",
+          toolkit_slug: "notion",
+          status: "active",
+          connected_at: "2026-06-01T00:00:00Z",
+          last_used_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+        },
+      ],
+      isError: false,
+    };
+    renderTab();
+    // "Last used {{when}}" → relative time formatter yields "2m ago"
+    expect(screen.getByText(/Last used/)).toBeInTheDocument();
+    expect(screen.queryByText(enSettings.composio.last_used_never)).not.toBeInTheDocument();
+  });
+
+  it("renders the expired branch with a Reconnect button", () => {
+    connectionsRef.current = {
+      data: [
+        {
+          id: "conn-1",
+          toolkit_slug: "notion",
+          status: "expired",
+          connected_at: "2026-06-01T00:00:00Z",
+          last_used_at: null,
+        },
+      ],
+      isError: false,
+    };
+    renderTab();
+    expect(screen.getByText(enSettings.composio.expired)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: new RegExp(enSettings.composio.reconnect) }),
+    ).toBeInTheDocument();
+    // Not treated as connected, so no Connected badge.
+    expect(screen.queryByText(enSettings.composio.connected)).not.toBeInTheDocument();
+  });
+
+  it("toasts success and clears the ?connected param on a successful callback", async () => {
+    searchParamsRef.current = new URLSearchParams("tab=integrations&connected=notion");
+    renderTab();
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(enSettings.composio.toast_connected);
+    });
+    expect(mockInvalidate).toHaveBeenCalledWith({ queryKey: ["composio", "connections"] });
+    // The one-shot param is stripped while ?tab is preserved.
+    expect(mockReplace).toHaveBeenCalledWith("/acme/settings?tab=integrations");
+  });
+
+  it("toasts error on a failed callback", async () => {
+    searchParamsRef.current = new URLSearchParams("tab=integrations&error=composio_connect_failed");
+    renderTab();
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(enSettings.composio.toast_connect_failed);
+    });
+    expect(mockReplace).toHaveBeenCalledWith("/acme/settings?tab=integrations");
+  });
+});

--- a/packages/views/settings/components/composio-tab.tsx
+++ b/packages/views/settings/components/composio-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { AlertTriangle, Check, Loader2, Plug, RefreshCw, Trash2 } from "lucide-react";
@@ -58,8 +58,22 @@ export function ComposioTab() {
   // browser refresh doesn't re-toast.
   const connectedParam = navigation.searchParams.get("connected");
   const errorParam = navigation.searchParams.get("error");
+  // React Strict Mode (dev / Next) double-invokes mount effects as
+  // mount → cleanup → mount. On the second invoke the `replace` from the first
+  // hasn't committed yet, so the closure still sees the same params and would
+  // toast + invalidate twice. Guard with a ref keyed on the callback we already
+  // consumed; a genuinely new callback (different slug, or the redirect being a
+  // full page load that resets this ref) still fires.
+  const consumedCallbackKey = useRef<string | null>(null);
   useEffect(() => {
-    if (!connectedParam && errorParam !== "composio_connect_failed") return;
+    const callbackKey = connectedParam
+      ? `connected:${connectedParam}`
+      : errorParam === "composio_connect_failed"
+        ? "error:composio_connect_failed"
+        : null;
+    if (!callbackKey) return;
+    if (consumedCallbackKey.current === callbackKey) return;
+    consumedCallbackKey.current = callbackKey;
     if (connectedParam) {
       toast.success(t(($) => $.composio.toast_connected));
       void qc.invalidateQueries({ queryKey: composioKeys.connections() });

--- a/packages/views/settings/components/composio-tab.tsx
+++ b/packages/views/settings/components/composio-tab.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Check, Loader2, Plug, Trash2 } from "lucide-react";
+import { AlertTriangle, Check, Loader2, Plug, RefreshCw, Trash2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { Input } from "@multica/ui/components/ui/input";
@@ -24,7 +24,8 @@ import {
   composioToolkitsOptions,
 } from "@multica/core/composio";
 import type { ComposioToolkit } from "@multica/core/types";
-import { useT } from "../../i18n";
+import { useT, useTimeAgo } from "../../i18n";
+import { useNavigation } from "../../navigation";
 
 // ComposioTab renders the full Composio toolkit catalog and lets the user
 // connect / disconnect the apps their agents can act on.
@@ -35,6 +36,7 @@ import { useT } from "../../i18n";
 export function ComposioTab() {
   const { t } = useT("settings");
   const qc = useQueryClient();
+  const navigation = useNavigation();
 
   const toolkitsQuery = useQuery(composioToolkitsOptions());
   const connectionsQuery = useQuery(composioConnectionsOptions());
@@ -47,12 +49,62 @@ export function ComposioTab() {
   } | null>(null);
   const [disconnecting, setDisconnecting] = useState(false);
 
+  // The hosted Composio consent flow is a full-page redirect that lands back
+  // on the settings page carrying either `?connected=<slug>` (success) or
+  // `?error=composio_connect_failed` (any backend-side failure — see
+  // Service.CallbackRedirect, MUL-3720). Consume it exactly once: fire a toast,
+  // refresh the connections list so the freshly-linked card flips to Connected
+  // without a manual reload, then strip the one-shot params via `replace` so a
+  // browser refresh doesn't re-toast.
+  const connectedParam = navigation.searchParams.get("connected");
+  const errorParam = navigation.searchParams.get("error");
+  useEffect(() => {
+    if (!connectedParam && errorParam !== "composio_connect_failed") return;
+    if (connectedParam) {
+      toast.success(t(($) => $.composio.toast_connected));
+      void qc.invalidateQueries({ queryKey: composioKeys.connections() });
+    } else {
+      toast.error(t(($) => $.composio.toast_connect_failed));
+    }
+    // Drop only the Composio one-shot params; keep everything else (notably
+    // ?tab=integrations) so the user stays on this tab.
+    const params = new URLSearchParams(navigation.searchParams);
+    params.delete("connected");
+    params.delete("error");
+    const qs = params.toString();
+    navigation.replace(qs ? `${navigation.pathname}?${qs}` : navigation.pathname);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectedParam, errorParam]);
+
   // Map active connections by toolkit slug so each card knows whether it is
   // already connected (and which connection id to disconnect).
   const connectionBySlug = useMemo(() => {
     const m = new Map<string, string>();
     for (const c of connectionsQuery.data ?? []) {
       if (c.status === "active") m.set(c.toolkit_slug, c.id);
+    }
+    return m;
+  }, [connectionsQuery.data]);
+
+  // Toolkits whose latest connection is expired render a Reconnect affordance
+  // instead of Connected/Connect. Backend only emits `expired` once Stage 4
+  // (MUL-3719) lands, but the branch is wired up now so it lights up for free.
+  const expiredBySlug = useMemo(() => {
+    const m = new Set<string>();
+    for (const c of connectionsQuery.data ?? []) {
+      if (c.status === "expired") m.add(c.toolkit_slug);
+    }
+    return m;
+  }, [connectionsQuery.data]);
+
+  // Last-used timestamp per active connection, for the "Last used …" line on a
+  // connected card. Backend leaves this null until tool-call dispatch starts
+  // stamping it (Stage 3, MUL-3721); the card shows a "never used" placeholder
+  // until then.
+  const lastUsedBySlug = useMemo(() => {
+    const m = new Map<string, string | null>();
+    for (const c of connectionsQuery.data ?? []) {
+      if (c.status === "active") m.set(c.toolkit_slug, c.last_used_at ?? null);
     }
     return m;
   }, [connectionsQuery.data]);
@@ -151,6 +203,8 @@ export function ComposioTab() {
                 key={tk.slug}
                 toolkit={tk}
                 connectionId={connectionBySlug.get(tk.slug)}
+                expired={expiredBySlug.has(tk.slug)}
+                lastUsedAt={lastUsedBySlug.get(tk.slug) ?? null}
                 connecting={connectingSlug === tk.slug}
                 anyConnecting={connectingSlug !== null}
                 onConnect={() => handleConnect(tk)}
@@ -195,6 +249,8 @@ export function ComposioTab() {
 function ToolkitCard({
   toolkit,
   connectionId,
+  expired,
+  lastUsedAt,
   connecting,
   anyConnecting,
   onConnect,
@@ -202,12 +258,15 @@ function ToolkitCard({
 }: {
   toolkit: ComposioToolkit;
   connectionId?: string;
+  expired: boolean;
+  lastUsedAt: string | null;
   connecting: boolean;
   anyConnecting: boolean;
   onConnect: () => void;
   onDisconnect: (connectionId: string, name: string) => void;
 }) {
   const { t } = useT("settings");
+  const timeAgo = useTimeAgo();
   const isConnected = !!connectionId;
 
   return (
@@ -216,7 +275,16 @@ function ToolkitCard({
         <ToolkitLogo toolkit={toolkit} />
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium">{toolkit.name || toolkit.slug}</p>
-          {toolkit.category ? (
+          {isConnected ? (
+            // Last-used line. Backend leaves last_used_at null until Stage 3
+            // dispatch stamps it, so show a localized "never used" placeholder
+            // rather than hiding the line entirely.
+            <p className="truncate text-[10px] text-muted-foreground">
+              {lastUsedAt
+                ? t(($) => $.composio.last_used, { when: timeAgo(lastUsedAt) })
+                : t(($) => $.composio.last_used_never)}
+            </p>
+          ) : toolkit.category ? (
             <p className="truncate text-[10px] uppercase tracking-wide text-muted-foreground">
               {toolkit.category}
             </p>
@@ -236,6 +304,23 @@ function ToolkitCard({
               aria-label={t(($) => $.composio.disconnect)}
             >
               <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        ) : expired ? (
+          // Token-expired connection: surface the failure and let the user
+          // re-run the same connect flow in one click (no disconnect step).
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+              <AlertTriangle className="h-3 w-3" />
+              {t(($) => $.composio.expired)}
+            </span>
+            <Button size="sm" variant="outline" onClick={onConnect} disabled={anyConnecting}>
+              {connecting ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3" />
+              )}
+              {connecting ? t(($) => $.composio.connecting) : t(($) => $.composio.reconnect)}
             </Button>
           </div>
         ) : toolkit.connectable ? (

--- a/server/internal/integrations/composio/service.go
+++ b/server/internal/integrations/composio/service.go
@@ -439,15 +439,20 @@ func (s *Service) CreateMCPSession(ctx context.Context, userID pgtype.UUID) (*MC
 }
 
 // CallbackRedirect builds the browser redirect target for the callback handler.
-// On success it points at the settings page with the connected toolkit slug; on
-// failure it carries a stable error code. When FrontendBaseURL is unset it
+// On success it points at the settings page (Integrations tab) with the
+// connected toolkit slug; on failure it carries a stable error code. The path
+// is the slug-less `/settings?tab=integrations&...` form on purpose: the web
+// proxy's legacy-route redirect prepends the user's last workspace slug, so it
+// resolves to the real `/{slug}/settings?tab=integrations` route that mounts
+// the Composio tab. The older `/settings/integrations` path was NOT a real
+// route and 404'd after the legacy rewrite. When FrontendBaseURL is unset it
 // returns a site-relative path.
 func (s *Service) CallbackRedirect(slug string, success bool) string {
 	var path string
 	if success {
-		path = "/settings/integrations?connected=" + url.QueryEscape(slug)
+		path = "/settings?tab=integrations&connected=" + url.QueryEscape(slug)
 	} else {
-		path = "/settings/integrations?error=composio_connect_failed"
+		path = "/settings?tab=integrations&error=composio_connect_failed"
 	}
 	return s.frontendURL + path
 }

--- a/server/internal/integrations/composio/service_test.go
+++ b/server/internal/integrations/composio/service_test.go
@@ -673,10 +673,10 @@ func TestCreateMCPSession_PinsConnectedAccounts(t *testing.T) {
 func TestCallbackRedirect(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t, &fakeSDK{}, newFakeStore())
-	if got := svc.CallbackRedirect("notion", true); got != "https://app.multica.ai/settings/integrations?connected=notion" {
+	if got := svc.CallbackRedirect("notion", true); got != "https://app.multica.ai/settings?tab=integrations&connected=notion" {
 		t.Errorf("success redirect = %q", got)
 	}
-	if got := svc.CallbackRedirect("notion", false); got != "https://app.multica.ai/settings/integrations?error=composio_connect_failed" {
+	if got := svc.CallbackRedirect("notion", false); got != "https://app.multica.ai/settings?tab=integrations&error=composio_connect_failed" {
 		t.Errorf("failure redirect = %q", got)
 	}
 }


### PR DESCRIPTION
## What

Finishes the Composio Stage 2 frontend (MUL-3718) on top of the skeleton that shipped with PR #4608. Targets `feature/composio-integration` (not main) so the epic merges as one unit.

Implements the 5 items from Eve's plan (§2):

1. **Callback toast + list refresh** — `ComposioTab` now consumes the `?connected=<slug>` / `?error=composio_connect_failed` params the backend redirect lands with (see `Service.CallbackRedirect`). On success it toasts + invalidates the connections query so the card flips to *Connected* without a manual reload; on failure it toasts an error. The one-shot params are stripped via `navigation.replace` (preserving `?tab=integrations`) so a refresh doesn't re-toast.
2. **`last_used_at` rendering** — connected cards show a localized "Last used …" line via `useTimeAgo`. Backend leaves this `null` until Stage 3 (MUL-3721) stamps it, so it renders a "Never used" placeholder for now (per Eve's call).
3. **`expired` branch** — a connection with `status === "expired"` renders `⚠ Token expired` + a one-click **Reconnect** button (re-runs the connect flow, no disconnect step). Backend only emits `expired` once Stage 4 (MUL-3719) lands; the UI branch is wired ahead of it. `ComposioConnection.status` union gains `"expired"`.
4. **E2E** — `e2e/settings.spec.ts` gets a fully network-mocked Composio connect flow: mock toolkits/connections/init, simulate the success redirect, assert the toast fires and the list refreshes to a Connected/Disconnect card.
5. **i18n** — added `composio.toast_connected`, `toast_connect_failed`, `last_used`, `last_used_never`, `expired`, `reconnect` across en / ja / ko / zh-Hans.

## Verification

- `pnpm --filter @multica/web build` ✅
- `pnpm --filter @multica/views test` ✅ (1512 passed, incl. new `composio-tab.test.tsx` — 5 tests covering toast/expired/last-used)
- `pnpm --filter @multica/views typecheck` + `@multica/core typecheck` ✅
- eslint on changed files ✅
- `playwright test settings.spec.ts --list` ✅ (spec compiles; full run needs a live backend + `COMPOSIO_API_KEY`, validated at integration time)

## Notes / decisions

- Kept the **full-page redirect** the skeleton uses (not the popup + `setInterval` from the original issue spec) — fewer COOP/popup-blocker edge cases, and the flow is server-side 302 so it never needed `postMessage`.
- This polish does **not** make the end-to-end demo work on its own: agents can't see the connected tools until Stage 3 (MUL-3721) injects the MCP overlay into task runtime. That's the next unblock.
