### PR TITLE
fix(issues): sync sticky comment header background with highlight fade (MUL-3759)

### DIFF
--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -46,8 +46,6 @@ import { deriveThreadResolution } from "./thread-utils";
 
 const highlightedCommentBackgroundClass =
   "bg-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]";
-const highlightedCommentFadeClass =
-  "after:from-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]";
 
 function StickyHeaderShell({
   className,
@@ -67,9 +65,8 @@ function StickyHeaderShell({
   return (
     <div
       className={cn(
-        "sticky top-0 z-10 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-1 after:bg-gradient-to-b after:to-transparent",
+        "sticky top-0 z-10 transition-colors duration-700 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-1 after:bg-[inherit] after:[mask-image:linear-gradient(to_bottom,#000,transparent)] after:[-webkit-mask-image:linear-gradient(to_bottom,#000,transparent)]",
         highlighted ? highlightedCommentBackgroundClass : "bg-card",
-        highlighted ? highlightedCommentFadeClass : "after:from-card",
       )}
     >
       <div className={className}>


### PR DESCRIPTION
## What

When you open a comment from the inbox deep-link, the target is briefly highlighted (tinted background + ring) and fades out over 700ms. The sticky comment header background did not fade with it:

- The **body** layers had `transition-colors duration-700`; the **sticky header** had none → header snapped to white while the body was still tinted.
- The header's 4px bottom `after` gradient band recolored via class-switching (`after:from-card` ↔ `after:from-[…]`), which `transition-colors` cannot animate (gradient color stops are custom properties) → after syncing the header, this band became the only un-synced element and showed as a pale seam between header and body.

## Fix

- Add `transition-colors duration-700` to the sticky shell so the header background fades in lockstep with the body.
- Replace the `after` band's per-state gradient color with `bg-[inherit]` (it now takes the header's transitioning background color) + a `mask-image` fade for the soft edge. The band is no longer a separate color to keep in sync — all three layers are driven by the single header background transition.

Net: `+1 −4`, pure className change. No state/UUID/Go/i18n surface touched.

## Test plan

- `pnpm typecheck` ✅ (6/6)
- Manual: open a comment via inbox deep-link, watch the 700ms fade-out — header and body fade together, no white seam.

Closes MUL-3759

🤖 Generated with [Claude Code](https://claude.com/claude-code)