### PR TITLE
feat(slack): link the Slack integration guide from the Connect dialog (MUL-3666)

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -335,6 +335,7 @@
     "byo_dialog_title": "Connect a Slack bot",
     "byo_dialog_intro": "Create your own Slack app, install it to your workspace, then paste its two tokens below. You can connect a different app for each agent in the same workspace.",
     "byo_video_cta": "Watch the setup walkthrough",
+    "byo_docs_link": "Read the setup guide",
     "byo_bot_token_label": "Bot token (xoxb-)",
     "byo_bot_token_hint": "Slack app → OAuth & Permissions → Bot User OAuth Token.",
     "byo_app_token_label": "App-level token (xapp-)",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -335,6 +335,7 @@
     "byo_dialog_title": "Slack ボットを接続",
     "byo_dialog_intro": "自分の Slack アプリを作成してワークスペースにインストールし、その 2 つのトークンを下に貼り付けてください。同じワークスペース内でエージェントごとに別のアプリを接続できます。",
     "byo_video_cta": "セットアップ手順の動画を見る",
+    "byo_docs_link": "セットアップガイドを読む",
     "byo_bot_token_label": "Bot トークン（xoxb-）",
     "byo_bot_token_hint": "Slack アプリ → OAuth & Permissions → Bot User OAuth Token。",
     "byo_app_token_label": "App レベルトークン（xapp-）",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -412,6 +412,7 @@
     "byo_dialog_title": "Slack 봇 연결",
     "byo_dialog_intro": "직접 만든 Slack 앱을 워크스페이스에 설치한 뒤, 두 개의 토큰을 아래에 붙여넣으세요. 같은 워크스페이스에서 에이전트마다 다른 앱을 연결할 수 있습니다.",
     "byo_video_cta": "설정 안내 영상 보기",
+    "byo_docs_link": "설정 가이드 읽기",
     "byo_bot_token_label": "Bot 토큰(xoxb-)",
     "byo_bot_token_hint": "Slack 앱 → OAuth & Permissions → Bot User OAuth Token.",
     "byo_app_token_label": "App 레벨 토큰(xapp-)",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -335,6 +335,7 @@
     "byo_dialog_title": "连接 Slack 机器人",
     "byo_dialog_intro": "创建你自己的 Slack app，安装到你的工作区，然后把它的两个 token 粘贴到下面。同一个工作区里，每个 agent 可以连接不同的 app。",
     "byo_video_cta": "观看配置教程视频",
+    "byo_docs_link": "查看配置指南",
     "byo_bot_token_label": "Bot token（xoxb-）",
     "byo_bot_token_hint": "Slack app → OAuth & Permissions → Bot User OAuth Token。",
     "byo_app_token_label": "App-level token（xapp-）",

--- a/packages/views/settings/components/slack-tab.tsx
+++ b/packages/views/settings/components/slack-tab.tsx
@@ -242,6 +242,21 @@ function InstallationRow({
 // shows how to create the Slack app + copy its two tokens is recorded.
 const SLACK_BYO_VIDEO_URL = "";
 
+// slackDocsUrl points at the Slack integration guide on the docs site,
+// localized to the viewer's language. The docs site uses /<lang>/ path
+// prefixes (English has none), matching the convention used elsewhere in the
+// app for doc links (e.g. the autopilots webhook docs link).
+function slackDocsUrl(lang: string | undefined): string {
+  const prefix = lang?.startsWith("zh")
+    ? "/zh"
+    : lang?.startsWith("ja")
+      ? "/ja"
+      : lang?.startsWith("ko")
+        ? "/ko"
+        : "";
+  return `https://multica.ai/docs${prefix}/slack-bot-integration`;
+}
+
 // SlackAgentBindButton is the per-agent CTA exposed from the agent detail page.
 // Slack uses the bring-your-own-app model: the button opens a dialog where the
 // admin pastes the bot token (xoxb-) + app-level token (xapp-) of the Slack app
@@ -267,7 +282,7 @@ export function SlackAgentBindButton({
    */
   onShowConnectedDetails?: () => void;
 }) {
-  const { t } = useT("settings");
+  const { t, i18n } = useT("settings");
   const wsId = useWorkspaceId();
   const qc = useQueryClient();
   const user = useAuthStore((s) => s.user);
@@ -385,6 +400,16 @@ export function SlackAgentBindButton({
               {t(($) => $.slack.byo_video_cta)}
             </button>
           ) : null}
+
+          <button
+            type="button"
+            onClick={() => openExternal(slackDocsUrl(i18n.language))}
+            className="inline-flex w-fit items-center gap-1.5 text-xs font-medium text-primary underline-offset-2 hover:underline"
+            data-testid="slack-byo-docs-link"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            {t(($) => $.slack.byo_docs_link)}
+          </button>
 
           <p className="rounded-md bg-muted px-3 py-2 text-[11px] text-muted-foreground">
             {t(($) => $.slack.byo_scopes_hint)}


### PR DESCRIPTION
## Summary

The bring-your-own-app **Connect Slack** dialog only had a (currently hidden) video CTA, so there was no in-product pointer to the setup instructions. This adds an always-visible **"Read the setup guide"** link in the dialog that opens the Slack integration docs page, localized to the viewer's language:

`https://multica.ai/docs[/<lang>]/slack-bot-integration`

following the existing doc-link convention in the app (e.g. the autopilots webhook docs link). Adds the `byo_docs_link` string to all four locales (en / zh-Hans / ja / ko).

The doc page this points to ships in the docs PR **#4693**.

Relates to MUL-3666.

## How verified

- `pnpm --filter @multica/views exec vitest run locales/parity.test.ts settings/components/slack-tab.test.tsx` → 164 passed (locale key parity holds across all four locales; the dialog still renders).
- All four `settings.json` validated as JSON.
- Local `tsc` couldn't run (TypeScript isn't installed in this checkout), but the change mirrors an existing typed pattern (`const { t, i18n } = useT(...)` + the `t($ => $.slack.byo_docs_link)` accessor, now backed by the en JSON), so CI typecheck will confirm.
