### PR TITLE
feat(desktop): on-hang renderer CPU profiling + route attribution (MUL-3738)

### DIFF
--- a/apps/desktop/src/main/freeze-breadcrumb.test.ts
+++ b/apps/desktop/src/main/freeze-breadcrumb.test.ts
@@ -24,7 +24,13 @@ afterEach(() => {
 
 const sample: FreezeBreadcrumb = {
   kind: "unresponsive",
-  context: { desktopRoute: { path: "/acme/issues" } },
+  context: {
+    desktopRoute: {
+      surface: "tab",
+      path: "/acme/issues",
+      reportedAt: "2026-06-15T00:00:00.000Z",
+    },
+  },
   ts: 1_700_000_000_000,
   version: "0.3.1",
 };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,10 +19,16 @@ import {
   type RendererRouteContext,
 } from "../shared/renderer-route-context";
 import {
+  DIAGNOSTICS_CONTROL_CHANNEL,
+  sanitizeDiagnosticsControl,
+  type DiagnosticsControl,
+} from "../shared/diagnostics-control";
+import {
   createElectronReloadPrompt,
   installRendererRecoveryHandlers,
   type RendererRecoveryWindow,
 } from "./renderer-recovery";
+import { captureRendererCpuProfile } from "./renderer-cpu-profile";
 import {
   writeFreezeBreadcrumb,
   readAndClearFreezeBreadcrumb,
@@ -80,6 +86,10 @@ function freezeBreadcrumbPath(): string {
 
 let mainWindow: BrowserWindow | null = null;
 let latestRendererRouteContext: RendererRouteContext | null = null;
+// Last-known diagnostics gate pushed by the renderer (MUL-3738). null until the
+// renderer's first push — treated as "do not capture" so a hang before the
+// push, a disabled flag, or an opted-out user never triggers CPU profiling.
+let latestDiagnosticsControl: DiagnosticsControl | null = null;
 let runtimeConfigResult: RuntimeConfigResult = {
   ok: false,
   error: { message: "Runtime config has not loaded yet" },
@@ -185,11 +195,13 @@ function createWindow(): void {
   });
   const window = mainWindow;
   latestRendererRouteContext = null;
+  latestDiagnosticsControl = null;
 
   window.on("closed", () => {
     if (mainWindow === window) {
       mainWindow = null;
       latestRendererRouteContext = null;
+      latestDiagnosticsControl = null;
     }
   });
 
@@ -302,6 +314,25 @@ function createWindow(): void {
     clearBreadcrumb: is.dev
       ? undefined
       : () => clearFreezeBreadcrumb(freezeBreadcrumbPath()),
+    // Best-effort renderer CPU profile on hang (P0① / MUL-3738). Gated three
+    // ways: dev is excluded; the backend flag must be on; and the user must not
+    // be opted out. The control object is pushed by the renderer before any
+    // hang — null/unknown means "do not capture". Only the V8 sampling profiler
+    // is driven (Profiler.* allowlist enforced in renderer-cpu-profile.ts).
+    captureCpuProfile: is.dev
+      ? undefined
+      : async () => {
+          const control = latestDiagnosticsControl;
+          if (
+            !control ||
+            control.cpuProfileEnabled !== true ||
+            control.optOut !== false
+          ) {
+            return null;
+          }
+          if (!mainWindow || mainWindow.isDestroyed()) return null;
+          return captureRendererCpuProfile(mainWindow.webContents.debugger);
+        },
   });
 
   installContextMenu(window.webContents);
@@ -460,6 +491,16 @@ if (!gotTheLock) {
       const sanitized = sanitizeRendererRouteContext(context);
       if (!sanitized) return;
       latestRendererRouteContext = sanitized;
+    });
+
+    // Renderer pushes the CPU-profiling gate (backend flag + analytics opt-out)
+    // so the main process can decide at hang time, when it can no longer ask
+    // the frozen renderer anything (MUL-3738).
+    ipcMain.on(DIAGNOSTICS_CONTROL_CHANNEL, (event, control: unknown) => {
+      if (!mainWindow || event.sender !== mainWindow.webContents) return;
+      const sanitized = sanitizeDiagnosticsControl(control);
+      if (!sanitized) return;
+      latestDiagnosticsControl = sanitized;
     });
 
     // IPC: toggle immersive mode — hides the macOS traffic lights so full-screen

--- a/apps/desktop/src/main/renderer-cpu-profile.test.ts
+++ b/apps/desktop/src/main/renderer-cpu-profile.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  captureRendererCpuProfile,
+  sanitizeCpuProfile,
+  sendProfilerCommand,
+  type CdpDebugger,
+} from "./renderer-cpu-profile";
+
+// A realistic raw V8 profile with content-bearing extras (deoptReason,
+// positionTicks, scriptId, a stray top-level key) the sanitizer must drop.
+const RAW_PROFILE = {
+  nodes: [
+    {
+      id: 1,
+      callFrame: {
+        functionName: "parseMarkdown",
+        scriptId: "42",
+        url: "https://cdn.example/_next/static/chunks/4231.js?token=secret",
+        lineNumber: 10,
+        columnNumber: 5,
+      },
+      hitCount: 90,
+      children: [2],
+      deoptReason: "should be dropped",
+      positionTicks: [{ line: 1, ticks: 3 }],
+    },
+    {
+      id: 2,
+      callFrame: { functionName: "", scriptId: "7", url: "", lineNumber: -1, columnNumber: -1 },
+      hitCount: 5,
+    },
+  ],
+  startTime: 1000,
+  endTime: 2200,
+  samples: [1, 1, 2],
+  timeDeltas: [100, 100, 100],
+  extra: "should be dropped",
+};
+
+function makeFakeDebugger(opts: { failOn?: string; alreadyAttached?: boolean } = {}) {
+  let attached = opts.alreadyAttached ?? false;
+  const sent: string[] = [];
+  const attach = vi.fn((_protocol?: string) => {
+    attached = true;
+  });
+  const detach = vi.fn(() => {
+    attached = false;
+  });
+  const sendCommand = vi.fn(async (method: string) => {
+    sent.push(method);
+    if (opts.failOn && method === opts.failOn) throw new Error("cdp failure");
+    if (method === "Profiler.stop") return { profile: RAW_PROFILE };
+    return {};
+  });
+  const dbg: CdpDebugger = {
+    isAttached: () => attached,
+    attach,
+    detach,
+    sendCommand,
+  };
+  return { dbg, sent, attach, detach, sendCommand };
+}
+
+const noSleep = async () => {};
+
+describe("sendProfilerCommand allowlist", () => {
+  it("forwards Profiler.* commands", async () => {
+    const { dbg, sent } = makeFakeDebugger();
+    await sendProfilerCommand(dbg, "Profiler.start");
+    expect(sent).toEqual(["Profiler.start"]);
+  });
+
+  it.each([
+    "HeapProfiler.takeHeapSnapshot",
+    "HeapProfiler.startSampling",
+    "Runtime.evaluate",
+    "Runtime.getProperties",
+    "Runtime.callFunctionOn",
+    "Debugger.enable",
+    "Page.captureScreenshot",
+  ])("rejects forbidden CDP method %s without sending it", async (method) => {
+    const { dbg, sent } = makeFakeDebugger();
+    await expect(sendProfilerCommand(dbg, method)).rejects.toThrow(/Forbidden CDP method/);
+    expect(sent).toEqual([]);
+  });
+});
+
+describe("captureRendererCpuProfile", () => {
+  it("attaches, drives ONLY Profiler.* commands, and returns a sanitized profile", async () => {
+    const { dbg, sent, attach, detach } = makeFakeDebugger();
+
+    const profile = await captureRendererCpuProfile(dbg, { delayMs: noSleep });
+
+    // Every CDP command sent during a full capture is in the Profiler.* domain.
+    expect(sent.length).toBeGreaterThan(0);
+    for (const method of sent) expect(method.startsWith("Profiler.")).toBe(true);
+    expect(attach).toHaveBeenCalledTimes(1);
+    expect(detach).toHaveBeenCalledTimes(1);
+
+    // Content-bearing fields are gone; only code locations + counts remain.
+    expect(profile).toEqual({
+      nodes: [
+        {
+          id: 1,
+          callFrame: {
+            functionName: "parseMarkdown",
+            url: "https://cdn.example/_next/static/chunks/4231.js?token=secret",
+            lineNumber: 10,
+            columnNumber: 5,
+          },
+          hitCount: 90,
+          children: [2],
+        },
+        {
+          id: 2,
+          callFrame: { functionName: "", url: "", lineNumber: -1, columnNumber: -1 },
+          hitCount: 5,
+        },
+      ],
+      startTime: 1000,
+      endTime: 2200,
+      samples: [1, 1, 2],
+      timeDeltas: [100, 100, 100],
+    });
+  });
+
+  it("does not detach a debugger it found already attached", async () => {
+    const { dbg, attach, detach } = makeFakeDebugger({ alreadyAttached: true });
+    await captureRendererCpuProfile(dbg, { delayMs: noSleep });
+    expect(attach).not.toHaveBeenCalled();
+    expect(detach).not.toHaveBeenCalled();
+  });
+
+  it("is best-effort: a CDP failure yields null and still detaches", async () => {
+    const { dbg, detach } = makeFakeDebugger({ failOn: "Profiler.start" });
+    const profile = await captureRendererCpuProfile(dbg, { delayMs: noSleep });
+    expect(profile).toBeNull();
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards an over-size profile whole rather than truncating", async () => {
+    const { dbg } = makeFakeDebugger();
+    const profile = await captureRendererCpuProfile(dbg, { delayMs: noSleep, maxBytes: 10 });
+    expect(profile).toBeNull();
+  });
+
+  it("resolves to null via the hard timeout if capture stalls (never wedges recovery)", async () => {
+    const { dbg } = makeFakeDebugger();
+    const neverResolve = () => new Promise<void>(() => {});
+    const profile = await captureRendererCpuProfile(dbg, {
+      delayMs: neverResolve,
+      hardTimeoutMs: 20,
+    });
+    expect(profile).toBeNull();
+  });
+});
+
+describe("sanitizeCpuProfile", () => {
+  it("returns null for non-object / missing nodes", () => {
+    expect(sanitizeCpuProfile(null, 1_000)).toBeNull();
+    expect(sanitizeCpuProfile({}, 1_000)).toBeNull();
+    expect(sanitizeCpuProfile({ nodes: "nope" }, 1_000)).toBeNull();
+  });
+
+  it("coerces malformed numeric/string fields to safe defaults", () => {
+    const out = sanitizeCpuProfile(
+      { nodes: [{ id: "x", callFrame: null, hitCount: undefined }], startTime: NaN, endTime: 5 },
+      10_000,
+    );
+    expect(out).toEqual({
+      nodes: [
+        { id: 0, callFrame: { functionName: "", url: "", lineNumber: 0, columnNumber: 0 }, hitCount: 0 },
+      ],
+      startTime: 0,
+      endTime: 5,
+    });
+  });
+});
+
+// CI guard (Howard's required fix ①): the profiling module must drive only the
+// CDP Profiler.* domain. Rather than grep for forbidden method strings (the
+// file documents them in comments), pin the structural invariant: there is
+// exactly ONE `.sendCommand(` call in the module, and it lives inside
+// `sendProfilerCommand`, which enforces the Profiler.* prefix. No other code
+// path can reach CDP, so a future "just read a bit of context" edit can't slip
+// a HeapProfiler.* / Runtime.* / Debugger.* command past review.
+describe("CDP allowlist is structurally enforced", () => {
+  // Vitest runs with cwd = the desktop package root.
+  const source = readFileSync(
+    resolve(process.cwd(), "src/main/renderer-cpu-profile.ts"),
+    "utf8",
+  );
+
+  it("calls debugger.sendCommand from exactly one site (the allowlist wrapper)", () => {
+    const matches = source.match(/\.sendCommand\(/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("that single site is guarded by the Profiler.* prefix check", () => {
+    const wrapper = source.slice(
+      source.indexOf("export function sendProfilerCommand"),
+      source.indexOf(".sendCommand("),
+    );
+    expect(wrapper).toContain("ALLOWED_CDP_METHOD_PREFIX");
+  });
+});

--- a/apps/desktop/src/main/renderer-cpu-profile.ts
+++ b/apps/desktop/src/main/renderer-cpu-profile.ts
@@ -1,0 +1,213 @@
+import type {
+  CpuProfileNode,
+  CpuProfilePayload,
+} from "../shared/cpu-profile";
+
+// CPU sampling profile capture for a hung renderer (MUL-3738, P0①).
+//
+// When the renderer hangs, the main process is still alive. It attaches the
+// Chrome DevTools Protocol (CDP) debugger to the renderer's webContents and
+// runs the V8 sampling profiler. The sampler runs on its own thread, so it
+// records the JS call stack of the blocked main thread even while that thread
+// is 100% stuck in synchronous JS — which is exactly the case we can't see any
+// other way (the in-thread freeze watchdog only reports a duration, never the
+// stack).
+//
+// PRIVACY — hard constraints (Kim v2 RFC + Howard APPROVED, MUL-3738):
+//
+//   * CDP ALLOWLIST: only the `Profiler.*` domain may ever be sent. Every CDP
+//     call goes through `sendProfilerCommand`, which throws on any other
+//     method. `HeapProfiler.*` (object/heap content), `Runtime.evaluate` /
+//     `Runtime.getProperties` / `Runtime.callFunctionOn` (arbitrary reads), and
+//     `Debugger.*` are forbidden. A source-level test pins the allowlist so a
+//     future "just grab a bit of context" edit can't widen it past CI.
+//
+//   * CONTENT-FREE PAYLOAD: a CPU sampling profile is code-location data only
+//     (function name, script URL, line/column, hit counts). We still copy out
+//     only the whitelisted fields below, dropping anything the engine adds
+//     (e.g. `deoptReason`, `positionTicks`). `url` is redacted by the renderer
+//     before egress (shared `$exception` redaction); see App.tsx flush.
+//
+//   * DISCARD, NEVER TRUNCATE: an over-size profile is dropped whole. Truncating
+//     a structured profile would yield invalid JSON and could strand a partial
+//     frame.
+//
+//   * BEST-EFFORT: any failure (attach denied, renderer already gone, CDP
+//     error) resolves to null and never throws into the recovery path.
+
+/** The single CDP domain this module is permitted to drive. */
+export const ALLOWED_CDP_METHOD_PREFIX = "Profiler.";
+
+/** Minimal CDP debugger surface — matches Electron's `webContents.debugger`. */
+export interface CdpDebugger {
+  isAttached(): boolean;
+  attach(protocolVersion?: string): void;
+  detach(): void;
+  sendCommand(method: string, commandParams?: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface CaptureCpuProfileOptions {
+  /** How long to sample the hung renderer. Bounded so the recovery path can't stall. */
+  sampleDurationMs?: number;
+  /**
+   * Hard ceiling on the whole capture (real wall-clock timer). If CDP itself
+   * hangs on a fully-stuck renderer, the capture resolves to null at this
+   * bound so it can never wedge the reload prompt. Always longer than the
+   * sample window.
+   */
+  hardTimeoutMs?: number;
+  /** Serialized-size ceiling; a larger profile is discarded whole. */
+  maxBytes?: number;
+  /** Injected sleep for the sample window, overridable in tests. */
+  delayMs?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_SAMPLE_DURATION_MS = 1200;
+const DEFAULT_HARD_TIMEOUT_MS = 3000;
+const DEFAULT_MAX_BYTES = 256 * 1024;
+
+/**
+ * Send a single CDP command, enforcing the `Profiler.*` allowlist. This is the
+ * ONLY path to `debugger.sendCommand` in this module — nothing here may call
+ * `sendCommand` directly. Throws (rejects) for any non-`Profiler.` method so a
+ * forbidden command fails loudly in tests instead of silently exfiltrating.
+ */
+export function sendProfilerCommand(
+  dbg: CdpDebugger,
+  method: string,
+  commandParams?: Record<string, unknown>,
+): Promise<unknown> {
+  if (!method.startsWith(ALLOWED_CDP_METHOD_PREFIX)) {
+    return Promise.reject(
+      new Error(
+        `Forbidden CDP method "${method}": renderer profiling may only send ${ALLOWED_CDP_METHOD_PREFIX}* commands`,
+      ),
+    );
+  }
+  return dbg.sendCommand(method, commandParams);
+}
+
+/**
+ * Attach, sample, and detach — returning a sanitized, content-free CPU profile
+ * or null. Best-effort: returns null rather than throwing on any failure, and
+ * always detaches if it attached.
+ */
+export async function captureRendererCpuProfile(
+  dbg: CdpDebugger,
+  options: CaptureCpuProfileOptions = {},
+): Promise<CpuProfilePayload | null> {
+  const hardTimeoutMs = options.hardTimeoutMs ?? DEFAULT_HARD_TIMEOUT_MS;
+
+  // Real wall-clock guard so a hung CDP can never block the recovery prompt:
+  // whichever finishes first wins, and the timer is cleared on completion.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<null>((resolveGuard) => {
+    timer = setTimeout(() => resolveGuard(null), hardTimeoutMs);
+  });
+  try {
+    return await Promise.race([runCpuProfileCapture(dbg, options), guard]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function runCpuProfileCapture(
+  dbg: CdpDebugger,
+  options: CaptureCpuProfileOptions,
+): Promise<CpuProfilePayload | null> {
+  const sampleDurationMs = options.sampleDurationMs ?? DEFAULT_SAMPLE_DURATION_MS;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const sleep = options.delayMs ?? defaultDelay;
+
+  let attachedHere = false;
+  try {
+    if (!dbg.isAttached()) {
+      dbg.attach("1.3");
+      attachedHere = true;
+    }
+    await sendProfilerCommand(dbg, "Profiler.enable");
+    await sendProfilerCommand(dbg, "Profiler.start");
+    await sleep(sampleDurationMs);
+    const stopped = (await sendProfilerCommand(dbg, "Profiler.stop")) as
+      | { profile?: unknown }
+      | undefined;
+    return sanitizeCpuProfile(stopped?.profile, maxBytes);
+  } catch {
+    // Best-effort: a hung/gone renderer or a denied attach must not break the
+    // reload prompt. Drop the profile and move on.
+    return null;
+  } finally {
+    try {
+      await sendProfilerCommand(dbg, "Profiler.disable");
+    } catch {
+      // ignore — disable is best-effort cleanup
+    }
+    if (attachedHere) {
+      try {
+        dbg.detach();
+      } catch {
+        // ignore — detach is best-effort cleanup
+      }
+    }
+  }
+}
+
+/**
+ * Copy a raw V8 profile into the content-free whitelist shape, or return null
+ * if the profile is malformed or serializes larger than `maxBytes` (discarded
+ * whole — never truncated).
+ */
+export function sanitizeCpuProfile(
+  rawProfile: unknown,
+  maxBytes: number,
+): CpuProfilePayload | null {
+  if (!rawProfile || typeof rawProfile !== "object") return null;
+  const raw = rawProfile as Record<string, unknown>;
+  if (!Array.isArray(raw.nodes)) return null;
+
+  const nodes: CpuProfileNode[] = [];
+  for (const rawNode of raw.nodes) {
+    if (!rawNode || typeof rawNode !== "object") continue;
+    const node = rawNode as Record<string, unknown>;
+    const frame = (node.callFrame ?? {}) as Record<string, unknown>;
+    nodes.push({
+      id: toNumber(node.id),
+      callFrame: {
+        functionName: toStringValue(frame.functionName),
+        url: toStringValue(frame.url),
+        lineNumber: toNumber(frame.lineNumber),
+        columnNumber: toNumber(frame.columnNumber),
+      },
+      hitCount: toNumber(node.hitCount),
+      ...(Array.isArray(node.children)
+        ? { children: node.children.map(toNumber) }
+        : {}),
+    });
+  }
+
+  const payload: CpuProfilePayload = {
+    nodes,
+    startTime: toNumber(raw.startTime),
+    endTime: toNumber(raw.endTime),
+    ...(Array.isArray(raw.samples) ? { samples: raw.samples.map(toNumber) } : {}),
+    ...(Array.isArray(raw.timeDeltas)
+      ? { timeDeltas: raw.timeDeltas.map(toNumber) }
+      : {}),
+  };
+
+  // Discard whole when over budget — never truncate a structured profile.
+  if (JSON.stringify(payload).length > maxBytes) return null;
+  return payload;
+}
+
+function toNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/desktop/src/main/renderer-recovery.test.ts
+++ b/apps/desktop/src/main/renderer-recovery.test.ts
@@ -84,7 +84,7 @@ describe("installRendererRecoveryHandlers", () => {
     const fixture = makeWindow();
     const showReloadPrompt = vi.fn(async () => "dismiss" as const);
     const desktopRoute = {
-      surface: "tab",
+      surface: "tab" as const,
       path: "/acme/issues/MUL-3239",
       workspaceSlug: "acme",
       tabId: "tab-1",
@@ -267,5 +267,81 @@ describe("freeze/crash breadcrumb state machine", () => {
     fixture.webContentsHandlers.get("render-process-gone")?.({}, { reason: "clean-exit" });
 
     expect(persistBreadcrumb).not.toHaveBeenCalled();
+  });
+});
+
+describe("on-hang CPU profile capture (MUL-3738)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  const cpuProfile = { nodes: [], startTime: 0, endTime: 1 };
+
+  it("folds a captured CPU profile into the unresponsive breadcrumb", async () => {
+    vi.useFakeTimers();
+    const fixture = makeWindow();
+    const persistBreadcrumb = vi.fn();
+    installRendererRecoveryHandlers(fixture.window, {
+      isDev: false,
+      showReloadPrompt: vi.fn(async () => "dismiss" as const),
+      persistBreadcrumb,
+      captureCpuProfile: vi.fn(async () => cpuProfile),
+      unresponsivePromptDelayMs: 100,
+    });
+
+    fixture.windowHandlers.get("unresponsive")?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(persistBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "unresponsive", context: { cpuProfile } }),
+    );
+  });
+
+  it("omits cpuProfile when capture returns null (disabled / opted out)", async () => {
+    vi.useFakeTimers();
+    const fixture = makeWindow();
+    const persistBreadcrumb = vi.fn();
+    installRendererRecoveryHandlers(fixture.window, {
+      isDev: false,
+      showReloadPrompt: vi.fn(async () => "dismiss" as const),
+      persistBreadcrumb,
+      captureCpuProfile: vi.fn(async () => null),
+      unresponsivePromptDelayMs: 100,
+    });
+
+    fixture.windowHandlers.get("unresponsive")?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(persistBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "unresponsive", context: {} }),
+    );
+  });
+
+  it("does not persist if the window recovers while still sampling", async () => {
+    vi.useFakeTimers();
+    const fixture = makeWindow();
+    const persistBreadcrumb = vi.fn();
+    const clearBreadcrumb = vi.fn();
+    let resolveProfile!: (value: typeof cpuProfile | null) => void;
+    const pending = new Promise<typeof cpuProfile | null>((resolve) => {
+      resolveProfile = resolve;
+    });
+    installRendererRecoveryHandlers(fixture.window, {
+      isDev: false,
+      showReloadPrompt: vi.fn(async () => "dismiss" as const),
+      persistBreadcrumb,
+      clearBreadcrumb,
+      captureCpuProfile: vi.fn(() => pending),
+      unresponsivePromptDelayMs: 100,
+    });
+
+    fixture.windowHandlers.get("unresponsive")?.();
+    await vi.advanceTimersByTimeAsync(100); // timer fired; now awaiting the profile
+    fixture.windowHandlers.get("responsive")?.(); // recovered mid-sample
+    resolveProfile(cpuProfile);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(persistBreadcrumb).not.toHaveBeenCalled();
+    expect(clearBreadcrumb).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/renderer-recovery.ts
+++ b/apps/desktop/src/main/renderer-recovery.ts
@@ -1,3 +1,8 @@
+import type {
+  FreezeDiagnosticContext,
+} from "../shared/freeze-breadcrumb";
+import type { CpuProfilePayload } from "../shared/cpu-profile";
+
 export type RendererRecoveryWindow = {
   isDestroyed: () => boolean;
   on: (event: "unresponsive" | "responsive", handler: () => void) => unknown;
@@ -9,7 +14,7 @@ export type RendererRecoveryWindow = {
 
 type ReloadPromptPayload = {
   kind: "render-process-gone" | "preload-error" | "unresponsive";
-  context: Record<string, unknown>;
+  context: FreezeDiagnosticContext;
 };
 
 type ReloadPromptResult = "reload" | "dismiss";
@@ -17,7 +22,7 @@ type ReloadPromptResult = "reload" | "dismiss";
 type RendererRecoveryOptions = {
   isDev: boolean;
   showReloadPrompt: (payload: ReloadPromptPayload) => Promise<ReloadPromptResult>;
-  getDiagnosticContext?: () => Record<string, unknown>;
+  getDiagnosticContext?: () => FreezeDiagnosticContext;
   /**
    * Persist a freeze/crash breadcrumb to disk. The renderer can't report a
    * true hang or process death itself (blocked / gone), so the main process
@@ -33,6 +38,13 @@ type RendererRecoveryOptions = {
    * process never recovers.
    */
   clearBreadcrumb?: () => void;
+  /**
+   * Best-effort CPU sampling profile of the hung renderer, captured while the
+   * window is unresponsive (P0① / MUL-3738). Resolves to null when disabled,
+   * opted out, or capture failed. Omitted (or returning null) keeps the
+   * existing reload-prompt path exactly as-is — profiling never gates recovery.
+   */
+  captureCpuProfile?: () => Promise<CpuProfilePayload | null>;
   log?: (tag: string, ...args: unknown[]) => void;
   unresponsivePromptDelayMs?: number;
 };
@@ -45,6 +57,7 @@ export function installRendererRecoveryHandlers(
     getDiagnosticContext,
     persistBreadcrumb,
     clearBreadcrumb,
+    captureCpuProfile,
     log = defaultDevLog,
     unresponsivePromptDelayMs = 1500,
   }: RendererRecoveryOptions,
@@ -53,7 +66,13 @@ export function installRendererRecoveryHandlers(
   // True once a breadcrumb has been written for the current hang. A later
   // `responsive` clears it; only a hang that never returns survives to report.
   let unresponsiveBreadcrumbWritten = false;
-  const mergeDiagnosticContext = (context: Record<string, unknown>) => ({
+  // True from `unresponsive` until the matching `responsive`. Guards the async
+  // CPU-profile path: if the window recovers while we're still sampling, we
+  // must not resurrect a breadcrumb for a freeze that already resolved.
+  let hangActive = false;
+  const mergeDiagnosticContext = (
+    context: Partial<FreezeDiagnosticContext>,
+  ): FreezeDiagnosticContext => ({
     ...readDiagnosticContext(getDiagnosticContext),
     ...context,
   });
@@ -71,7 +90,7 @@ export function installRendererRecoveryHandlers(
     if (!isRecoverableRendererExit(details)) return;
     const payload: ReloadPromptPayload = {
       kind: "render-process-gone",
-      context: mergeDiagnosticContext({ details }),
+      context: mergeDiagnosticContext({ details: narrowExitDetails(details) }),
     };
     persistBreadcrumb?.(payload);
     maybePromptReload(payload);
@@ -89,21 +108,42 @@ export function installRendererRecoveryHandlers(
     });
   });
 
+  // Persist + prompt once the hang has lasted `unresponsivePromptDelayMs`,
+  // folding in a CPU profile when one was captured. Bails if the window
+  // recovered in the meantime (the async profile path can outlive recovery).
+  const finalizeUnresponsive = (cpuProfile: CpuProfilePayload | null) => {
+    if (!hangActive) return;
+    const payload: ReloadPromptPayload = {
+      kind: "unresponsive",
+      context: mergeDiagnosticContext(cpuProfile ? { cpuProfile } : {}),
+    };
+    persistBreadcrumb?.(payload);
+    unresponsiveBreadcrumbWritten = true;
+    maybePromptReload(payload);
+  };
+
   window.on("unresponsive", () => {
     if (isDev || unresponsivePromptTimer) return;
+    hangActive = true;
+    // Start sampling immediately so it overlaps the prompt delay and doesn't
+    // push the dialog back. Best-effort: resolves null when disabled / opted
+    // out / capture failed. Without a capturer, the path stays fully
+    // synchronous (unchanged behavior).
+    const profilePromise = captureCpuProfile
+      ? captureCpuProfile().catch(() => null)
+      : null;
     unresponsivePromptTimer = setTimeout(() => {
       unresponsivePromptTimer = null;
-      const payload: ReloadPromptPayload = {
-        kind: "unresponsive",
-        context: mergeDiagnosticContext({}),
-      };
-      persistBreadcrumb?.(payload);
-      unresponsiveBreadcrumbWritten = true;
-      maybePromptReload(payload);
+      if (!profilePromise) {
+        finalizeUnresponsive(null);
+        return;
+      }
+      void profilePromise.then(finalizeUnresponsive);
     }, unresponsivePromptDelayMs);
   });
 
   window.on("responsive", () => {
+    hangActive = false;
     if (unresponsivePromptTimer) {
       clearTimeout(unresponsivePromptTimer);
       unresponsivePromptTimer = null;
@@ -115,6 +155,21 @@ export function installRendererRecoveryHandlers(
       unresponsiveBreadcrumbWritten = false;
     }
   });
+}
+
+/**
+ * Narrow Electron's `render-process-gone` details to the whitelisted shape —
+ * reason + exit code only, never any other field the platform might attach.
+ */
+function narrowExitDetails(
+  details: unknown,
+): { reason?: string; exitCode?: number } | undefined {
+  if (!details || typeof details !== "object") return undefined;
+  const d = details as { reason?: unknown; exitCode?: unknown };
+  return {
+    ...(typeof d.reason === "string" ? { reason: d.reason } : {}),
+    ...(typeof d.exitCode === "number" ? { exitCode: d.exitCode } : {}),
+  };
 }
 
 export function createElectronReloadPrompt(
@@ -191,8 +246,8 @@ function defaultDevLog(tag: string, ...args: unknown[]) {
 }
 
 function readDiagnosticContext(
-  getDiagnosticContext: (() => Record<string, unknown>) | undefined,
-) {
+  getDiagnosticContext: (() => FreezeDiagnosticContext) | undefined,
+): FreezeDiagnosticContext {
   if (!getDiagnosticContext) return {};
   try {
     return getDiagnosticContext();

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -3,6 +3,7 @@ import type { RuntimeConfigResult } from "../shared/runtime-config";
 import type { NavigationGesture } from "../shared/navigation-gestures";
 import type { RendererRouteContextInput } from "../shared/renderer-route-context";
 import type { FreezeBreadcrumb } from "../shared/freeze-breadcrumb";
+import type { DiagnosticsControl } from "../shared/diagnostics-control";
 
 interface DesktopAPI {
   /** App version + normalized OS, captured synchronously at preload time. */
@@ -52,6 +53,8 @@ interface DesktopAPI {
   onNavigationGesture: (callback: (gesture: NavigationGesture) => void) => () => void;
   /** Report the renderer's memory-router path for recovery diagnostics. */
   setRendererRouteContext: (context: RendererRouteContextInput) => void;
+  /** Push the CPU-profiling gate (backend flag + analytics opt-out) to main. */
+  setDiagnosticsControl: (control: DiagnosticsControl) => void;
   /** Open the OS folder picker and return the chosen absolute path.
    *  Used by the Project settings "Add local directory" flow. */
   pickDirectory: (

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,6 +7,10 @@ import {
   type RendererRouteContextInput,
 } from "../shared/renderer-route-context";
 import {
+  DIAGNOSTICS_CONTROL_CHANNEL,
+  type DiagnosticsControl,
+} from "../shared/diagnostics-control";
+import {
   isNavigationGesture,
   NAVIGATION_GESTURE_CHANNEL,
   type NavigationGesture,
@@ -174,6 +178,10 @@ const desktopAPI = {
   /** Report the renderer's memory-router path for recovery diagnostics. */
   setRendererRouteContext: (context: RendererRouteContextInput) =>
     ipcRenderer.send(RENDERER_ROUTE_CONTEXT_CHANNEL, context),
+  /** Push the CPU-profiling gate (backend flag + analytics opt-out) to main so
+   *  it can decide whether to sample a future hang (MUL-3738). */
+  setDiagnosticsControl: (control: DiagnosticsControl) =>
+    ipcRenderer.send(DIAGNOSTICS_CONTROL_CHANNEL, control),
   /** Open the OS folder picker and return the chosen absolute path. */
   pickDirectory: (defaultPath?: string) =>
     ipcRenderer.invoke("local-directory:pick", defaultPath),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -14,12 +14,14 @@ import { Toaster } from "@multica/ui/components/ui/sonner";
 import { DesktopLoginPage } from "./pages/login";
 import { DesktopShell } from "./components/desktop-layout";
 import { PageviewTracker } from "./components/pageview-tracker";
+import { DiagnosticsControlBridge } from "./components/diagnostics-control-bridge";
 import { UpdateNotification } from "./components/update-notification";
 import { useTabStore } from "./stores/tab-store";
 import { useWindowOverlayStore } from "./stores/window-overlay-store";
 import { useDaemonIPCBridge } from "./platform/daemon-ipc-bridge";
 import { createDesktopLocaleAdapter } from "./platform/i18n-adapter";
 import { captureEvent } from "@multica/core/analytics";
+import { buildFreezeEventProps } from "./freeze-flush";
 import { RESOURCES } from "@multica/views/locales";
 
 // BCP-47 region tags for the <html lang> attribute, mirroring
@@ -283,6 +285,7 @@ function AppContent() {
   return (
     <>
       <PageviewTracker />
+      <DiagnosticsControlBridge />
       {user ? <DesktopShell /> : <DesktopLoginPage />}
     </>
   );
@@ -341,16 +344,11 @@ export default function App() {
   useEffect(() => {
     const last = window.desktopAPI.getLastFreeze();
     if (!last) return;
-    const crashed = last.kind === "render-process-gone";
-    captureEvent(crashed ? "client_crash" : "client_unresponsive", {
-      // Spread context FIRST so our explicit fields below always win — a
-      // future context key (e.g. its own `source`) must not silently override.
-      ...last.context,
-      source: crashed ? "render-process-gone" : "main-unresponsive",
-      recovered: false,
-      breadcrumb_ts: last.ts,
-      crashed_version: last.version,
-    });
+    // buildFreezeEventProps owns the event shape: it buckets the route to a
+    // template and redacts CPU-profile script URLs before anything leaves the
+    // client (MUL-3738). See freeze-flush.ts.
+    const { name, props } = buildFreezeEventProps(last);
+    captureEvent(name, props);
   }, []);
 
   // Stable identity reference so downstream effects (WS reconnect) don't

--- a/apps/desktop/src/renderer/src/components/diagnostics-control-bridge.tsx
+++ b/apps/desktop/src/renderer/src/components/diagnostics-control-bridge.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { hasOptedOutCapturing } from "@multica/core/analytics";
+import { useConfigStore } from "@multica/core/config";
+
+/**
+ * Pushes the CPU-profiling gate to the Electron main process (MUL-3738).
+ *
+ * The main process samples a hung renderer only when BOTH the backend flag is
+ * on AND the user hasn't opted out of analytics — but at hang time it can no
+ * longer ask the frozen renderer either fact. So the renderer pre-pushes the
+ * combined gate here; main holds the last value and decides synchronously when
+ * a hang fires. Re-pushes whenever the flag changes (it arrives async from
+ * `/api/config`); the opt-out value is re-read on each push.
+ *
+ * No-op on web — `window.desktopAPI` is undefined there.
+ */
+export function DiagnosticsControlBridge() {
+  const cpuProfileEnabled = useConfigStore((s) => s.cpuProfileEnabled);
+
+  useEffect(() => {
+    window.desktopAPI?.setDiagnosticsControl?.({
+      cpuProfileEnabled,
+      optOut: hasOptedOutCapturing(),
+    });
+  }, [cpuProfileEnabled]);
+
+  return null;
+}

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
@@ -16,6 +16,13 @@ const state = vi.hoisted(() => ({
 
 vi.mock("@multica/core/analytics", () => ({
   capturePageview: state.capturePageview,
+  // Identity is enough here — these tests assert pageview emission, not route
+  // bucketing (covered by analytics' own normalizePageviewPath tests).
+  normalizePageviewPath: (path?: string) => path,
+}));
+
+vi.mock("@multica/core/diagnostics/diagnostic-route", () => ({
+  setDiagnosticRoute: vi.fn(),
 }));
 
 // Auth store — single selector pattern (`s => s.user`).

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
-import { capturePageview } from "@multica/core/analytics";
+import { capturePageview, normalizePageviewPath } from "@multica/core/analytics";
+import { setDiagnosticRoute } from "@multica/core/diagnostics/diagnostic-route";
 import { useAuthStore } from "@multica/core/auth";
 import {
   getActiveTab,
@@ -91,15 +92,24 @@ export function PageviewTracker() {
     const last = lastSurfaceRef.current;
     const next = { kind, key, path };
 
+    // Bucket the route to its template (drops resource ids: `/acme/issues/123`
+    // → `/acme/issues`) BEFORE it leaves the renderer, so neither the recovery
+    // breadcrumb (main) nor the longtask watchdog ever sees a raw resource id
+    // (MUL-3738, P0②). `capturePageview` below still receives the raw path and
+    // buckets it itself.
+    const routeTemplate = normalizePageviewPath(path) ?? path;
     const routeContext: RendererRouteContextInput = {
       surface: kind,
-      path,
+      path: routeTemplate,
     };
     if (kind === "tab") {
       routeContext.workspaceSlug = activeWorkspaceSlug ?? undefined;
       routeContext.tabId = activeTabId ?? undefined;
     }
     reportRendererRouteContext(routeContext);
+    // Feed the in-thread freeze watchdog the same template — on desktop
+    // `location.pathname` is the asar path, not the app route.
+    setDiagnosticRoute(routeTemplate);
 
     if (kind === "tab" && key !== null) {
       const knownPath = observed.get(key);

--- a/apps/desktop/src/renderer/src/freeze-flush.test.ts
+++ b/apps/desktop/src/renderer/src/freeze-flush.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { buildFreezeEventProps } from "./freeze-flush";
+import type { FreezeBreadcrumb } from "../../shared/freeze-breadcrumb";
+
+function breadcrumb(overrides: Partial<FreezeBreadcrumb> = {}): FreezeBreadcrumb {
+  return {
+    kind: "unresponsive",
+    context: {},
+    ts: 1_700_000_000_000,
+    version: "0.3.30",
+    ...overrides,
+  };
+}
+
+describe("buildFreezeEventProps", () => {
+  it("maps an unresponsive breadcrumb to a client_unresponsive event", () => {
+    const { name, props } = buildFreezeEventProps(breadcrumb());
+    expect(name).toBe("client_unresponsive");
+    expect(props).toMatchObject({
+      source: "main-unresponsive",
+      recovered: false,
+      breadcrumb_ts: 1_700_000_000_000,
+      crashed_version: "0.3.30",
+    });
+  });
+
+  it("maps a render-process-gone breadcrumb to a client_crash event with reason", () => {
+    const { name, props } = buildFreezeEventProps(
+      breadcrumb({ kind: "render-process-gone", context: { details: { reason: "oom" } } }),
+    );
+    expect(name).toBe("client_crash");
+    expect(props.source).toBe("render-process-gone");
+    expect(props.crash_reason).toBe("oom");
+  });
+
+  it("buckets the route to a template, dropping resource ids (P0②)", () => {
+    const { props } = buildFreezeEventProps(
+      breadcrumb({
+        context: {
+          desktopRoute: {
+            surface: "tab",
+            path: "/hazelkahlil/issues/019ed13f-5d22-78f3-ad92-76922fa96263",
+            reportedAt: "2026-06-25T12:00:00.000Z",
+          },
+        },
+      }),
+    );
+    expect(props.path).toBe("/hazelkahlil/issues");
+  });
+
+  it("keeps the asar window URL out of the route field", () => {
+    const { props } = buildFreezeEventProps(
+      breadcrumb({
+        context: { windowUrl: "file:///Applications/Multica.app/.../index.html" },
+      }),
+    );
+    expect(props.window_url).toBe("file:///Applications/Multica.app/.../index.html");
+    expect(props.path).toBeUndefined();
+  });
+
+  it("redacts query tokens from CPU-profile script URLs before egress (P0①)", () => {
+    const { props } = buildFreezeEventProps(
+      breadcrumb({
+        context: {
+          cpuProfile: {
+            nodes: [
+              {
+                id: 1,
+                callFrame: {
+                  functionName: "render",
+                  url: "https://cdn.example/_next/chunk.js?token=supersecretvalue1234567890",
+                  lineNumber: 1,
+                  columnNumber: 2,
+                },
+                hitCount: 9,
+              },
+            ],
+            startTime: 0,
+            endTime: 1,
+          },
+        },
+      }),
+    );
+    const profile = props.cpu_profile as { nodes: Array<{ callFrame: { url: string } }> };
+    expect(profile.nodes[0].callFrame.url).toContain("[redacted]");
+    expect(profile.nodes[0].callFrame.url).not.toContain("supersecretvalue");
+    // The result is still valid structured data (functionName/line preserved).
+    expect(profile.nodes[0].callFrame).toMatchObject({ functionName: "render", lineNumber: 1 });
+  });
+});

--- a/apps/desktop/src/renderer/src/freeze-flush.ts
+++ b/apps/desktop/src/renderer/src/freeze-flush.ts
@@ -1,0 +1,60 @@
+import { normalizePageviewPath, redactText } from "@multica/core/analytics";
+import type { FreezeBreadcrumb } from "../../shared/freeze-breadcrumb";
+import type { CpuProfilePayload } from "../../shared/cpu-profile";
+
+// Build the telemetry event for a freeze/crash breadcrumb parked by the main
+// process in a previous session (MUL-3738). Pure so it can be unit-tested
+// without the renderer; App.tsx wires the result into captureEvent on boot.
+//
+// Two privacy transforms happen HERE, at the "before reporting" boundary:
+//   * route → bucketed template (`/:slug/inbox`, no resource ids) for P0②
+//     attribution. The breadcrumb already carries a bucketed route, but we
+//     re-normalize idempotently so a raw path can never slip through.
+//   * cpuProfile script URLs → the same redaction the `$exception` pipeline
+//     uses (strips emails / query tokens / long opaque ids) for P0①.
+
+export interface FreezeEvent {
+  name: "client_crash" | "client_unresponsive";
+  props: Record<string, unknown>;
+}
+
+export function buildFreezeEventProps(last: FreezeBreadcrumb): FreezeEvent {
+  const crashed = last.kind === "render-process-gone";
+  const ctx = last.context ?? {};
+
+  const props: Record<string, unknown> = {
+    source: crashed ? "render-process-gone" : "main-unresponsive",
+    recovered: false,
+    breadcrumb_ts: last.ts,
+    crashed_version: last.version,
+  };
+
+  const route = normalizePageviewPath(ctx.desktopRoute?.path);
+  if (route) props.path = route;
+  if (ctx.windowUrl) props.window_url = ctx.windowUrl;
+  if (crashed && ctx.details?.reason) props.crash_reason = ctx.details.reason;
+  if (ctx.cpuProfile) props.cpu_profile = redactCpuProfileUrls(ctx.cpuProfile);
+
+  return {
+    name: crashed ? "client_crash" : "client_unresponsive",
+    props,
+  };
+}
+
+function redactCpuProfileUrls(profile: CpuProfilePayload): CpuProfilePayload {
+  return {
+    ...profile,
+    nodes: profile.nodes.map((node) => ({
+      ...node,
+      callFrame: {
+        ...node.callFrame,
+        url: redactScriptUrl(node.callFrame.url),
+      },
+    })),
+  };
+}
+
+function redactScriptUrl(url: string): string {
+  const redacted = redactText(url);
+  return typeof redacted === "string" ? redacted : "";
+}

--- a/apps/desktop/src/shared/cpu-profile.ts
+++ b/apps/desktop/src/shared/cpu-profile.ts
@@ -1,0 +1,47 @@
+// Sanitized V8 CPU sampling profile, captured by the main process from a hung
+// renderer and carried to telemetry through the freeze breadcrumb (MUL-3738).
+//
+// Shared across main (producer), preload, and renderer (flush) because all
+// three touch it via FreezeBreadcrumb. This file is types only — the capture
+// logic and the CDP-command allowlist live in main/renderer-cpu-profile.ts.
+//
+// PRIVACY: a CPU sampling profile is code-location data only — function names,
+// script URLs, and line/column positions with hit counts. It never carries
+// variable values, function arguments, user content, or heap objects. The
+// producer keeps only the fields below; `url` is additionally run through the
+// shared `$exception` redaction before the renderer reports it.
+
+export interface CpuProfileCallFrame {
+  /** Function name as it appears in the (possibly minified) bundle. */
+  functionName: string;
+  /** Script URL. Redacted (query/token-stripped) before it leaves the client. */
+  url: string;
+  /** 0-based line number of the function in its script. */
+  lineNumber: number;
+  /** 0-based column number of the function in its script. */
+  columnNumber: number;
+}
+
+export interface CpuProfileNode {
+  /** Node id, referenced by `samples` and parents' `children`. */
+  id: number;
+  /** Code location for this node. The only content-bearing risk is `url`. */
+  callFrame: CpuProfileCallFrame;
+  /** Number of samples that landed directly in this node. */
+  hitCount: number;
+  /** Child node ids, present for non-leaf nodes. */
+  children?: number[];
+}
+
+export interface CpuProfilePayload {
+  /** Call tree, each node a code location with a hit count. */
+  nodes: CpuProfileNode[];
+  /** Profiler start timestamp (µs, monotonic). */
+  startTime: number;
+  /** Profiler stop timestamp (µs, monotonic). */
+  endTime: number;
+  /** Per-sample node ids (the sampled stacks), if the engine reported them. */
+  samples?: number[];
+  /** Per-sample time deltas (µs), parallel to `samples`. */
+  timeDeltas?: number[];
+}

--- a/apps/desktop/src/shared/diagnostics-control.test.ts
+++ b/apps/desktop/src/shared/diagnostics-control.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeDiagnosticsControl } from "./diagnostics-control";
+
+describe("sanitizeDiagnosticsControl", () => {
+  it("accepts a well-formed control", () => {
+    expect(
+      sanitizeDiagnosticsControl({ cpuProfileEnabled: true, optOut: false }),
+    ).toEqual({ cpuProfileEnabled: true, optOut: false });
+  });
+
+  it("copies only the two known fields, dropping extras", () => {
+    expect(
+      sanitizeDiagnosticsControl({
+        cpuProfileEnabled: false,
+        optOut: true,
+        sneaky: "ignored",
+      }),
+    ).toEqual({ cpuProfileEnabled: false, optOut: true });
+  });
+
+  it.each([
+    ["null", null],
+    ["a primitive", 1],
+    ["a missing flag", { optOut: false }],
+    ["a missing optOut", { cpuProfileEnabled: true }],
+    ["a non-boolean flag", { cpuProfileEnabled: "yes", optOut: false }],
+    ["a non-boolean optOut", { cpuProfileEnabled: true, optOut: 0 }],
+  ])("rejects %s so a malformed push can't flip the gate open", (_label, value) => {
+    expect(sanitizeDiagnosticsControl(value)).toBeNull();
+  });
+});

--- a/apps/desktop/src/shared/diagnostics-control.ts
+++ b/apps/desktop/src/shared/diagnostics-control.ts
@@ -1,0 +1,39 @@
+// Renderer → main push of the diagnostics gate for on-hang CPU profiling
+// (MUL-3738). The renderer owns the two signals that decide whether the main
+// process may sample a hung renderer:
+//
+//   1. cpuProfileEnabled — the backend `/api/config` feature flag
+//      (`diagnostics_cpu_profile_enabled`, default false).
+//   2. optOut — the analytics opt-out state (posthog
+//      `has_opted_out_capturing()`, treated true when analytics isn't running).
+//
+// Both live in the renderer, but the profile is captured by the main process
+// at hang time — when it can no longer ask the (frozen) renderer anything. So
+// the renderer PRE-PUSHES this state; main holds the last-known value and
+// captures only when `cpuProfileEnabled === true && optOut === false`. A hang
+// before the first push leaves main with no control object, which it treats as
+// "do not capture" (see main/index.ts).
+
+export const DIAGNOSTICS_CONTROL_CHANNEL = "renderer:diagnostics-control";
+
+export interface DiagnosticsControl {
+  /** Backend feature flag — main never captures a profile when this is false. */
+  cpuProfileEnabled: boolean;
+  /** Analytics opt-out — main never captures a profile when this is true. */
+  optOut: boolean;
+}
+
+/**
+ * Validate an IPC-delivered control payload. Returns null for any non-
+ * conforming shape so a malformed push can't flip the gate open.
+ */
+export function sanitizeDiagnosticsControl(value: unknown): DiagnosticsControl | null {
+  if (!value || typeof value !== "object") return null;
+  const input = value as Record<string, unknown>;
+  if (typeof input.cpuProfileEnabled !== "boolean") return null;
+  if (typeof input.optOut !== "boolean") return null;
+  return {
+    cpuProfileEnabled: input.cpuProfileEnabled,
+    optOut: input.optOut,
+  };
+}

--- a/apps/desktop/src/shared/freeze-breadcrumb.ts
+++ b/apps/desktop/src/shared/freeze-breadcrumb.ts
@@ -1,3 +1,30 @@
+import type { RendererRouteContext } from "./renderer-route-context";
+import type { CpuProfilePayload } from "./cpu-profile";
+
+/**
+ * Diagnostic context captured at failure time and carried in a freeze/crash
+ * breadcrumb. This is an EXPLICIT whitelist (MUL-3738): every field below is a
+ * known, low-sensitivity diagnostic, and nothing else is allowed in. It
+ * replaces the previous `Record<string, unknown>` free bag, which let any
+ * caller-supplied key flow to telemetry unchecked. To add a field, add it here
+ * and confirm it carries no user content — code locations and bucketed routes
+ * only, never bodies, parameters, variable values, resource ids, or heap data.
+ */
+export interface FreezeDiagnosticContext {
+  /** Renderer window URL at failure time — an asar/file path, not an app route. */
+  windowUrl?: string;
+  /** Sanitized renderer route context (bucketed app route + surface). */
+  desktopRoute?: RendererRouteContext;
+  /** `render-process-gone` crash details (reason / exit code). */
+  details?: { reason?: string; exitCode?: number };
+  /** `preload-error` script path (our own preload, an asar/file path). */
+  preloadPath?: string;
+  /** `preload-error` formatted error (stack — code locations). */
+  error?: string;
+  /** CPU sampling profile of the hung renderer (P0① / MUL-3738). */
+  cpuProfile?: CpuProfilePayload;
+}
+
 /**
  * A freeze/crash breadcrumb persisted by the main process and flushed to
  * telemetry by the next renderer boot. Shared across main, preload, and
@@ -7,8 +34,8 @@
 export interface FreezeBreadcrumb {
   /** "unresponsive" (hang) or "render-process-gone" (crash). */
   kind: string;
-  /** Diagnostic context captured at failure time (route, window url, …). */
-  context: Record<string, unknown>;
+  /** Diagnostic context captured at failure time — explicit whitelist above. */
+  context: FreezeDiagnosticContext;
   /** Epoch ms when the failure was recorded. */
   ts: number;
   /** App version at failure time. */

--- a/packages/core/analytics/index.ts
+++ b/packages/core/analytics/index.ts
@@ -14,6 +14,8 @@
 
 import posthog from "posthog-js";
 import { redactExceptionProperties } from "./redact-exception";
+
+export { redactText } from "./redact-exception";
 import { shouldDropException } from "./exception-dedupe";
 import { isBenignException } from "./benign-exceptions";
 
@@ -309,6 +311,23 @@ export function captureException(
     return;
   }
   posthog.captureException(error, withClientEventProperties(props));
+}
+
+/**
+ * Whether analytics capture is opted out for this client. Used by the desktop
+ * diagnostics gate (MUL-3738): the renderer pushes this to the main process so
+ * a hung-renderer CPU profile is never captured for an opted-out user. When
+ * analytics isn't running (no key / pre-init / SSR), this returns `true` —
+ * "no telemetry sink" is treated as opted out, so we never sample a profile we
+ * couldn't send anyway.
+ */
+export function hasOptedOutCapturing(): boolean {
+  if (!initialized) return true;
+  try {
+    return posthog.has_opted_out_capturing() === true;
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -42,6 +42,9 @@ export interface AppConfigResponse {
   daemon_server_url?: string;
   daemon_app_url?: string;
   workspace_creation_disabled?: boolean;
+  // Desktop on-hang CPU profiling feature flag (MUL-3738). Older servers omit
+  // it; treat absent as false (feature off).
+  diagnostics_cpu_profile_enabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -182,6 +185,7 @@ export const AppConfigSchema = z.object({
   daemon_server_url: OptionalStringSchema,
   daemon_app_url: OptionalStringSchema,
   workspace_creation_disabled: BooleanWithDefaultSchema(false).optional(),
+  diagnostics_cpu_profile_enabled: BooleanWithDefaultSchema(false).optional(),
 }).loose();
 
 export const EMPTY_APP_CONFIG: AppConfigResponse = {

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -15,6 +15,10 @@ interface ConfigState {
   // must be hidden. Defaults to false so unknown / older servers behave like
   // the managed-cloud case.
   workspaceCreationDisabled: boolean;
+  // Desktop on-hang CPU profiling feature flag (MUL-3738). Defaults false;
+  // unknown / older servers behave as off. Read by the desktop diagnostics
+  // bridge, which pushes it to the Electron main process.
+  cpuProfileEnabled: boolean;
   setCdnConfig: (config: { cdnDomain: string; cdnSigned?: boolean }) => void;
   setAuthConfig: (config: {
     allowSignup: boolean;
@@ -25,6 +29,7 @@ interface ConfigState {
     daemonServerUrl?: string;
     daemonAppUrl?: string;
   }) => void;
+  setDiagnosticsConfig: (config: { cpuProfileEnabled?: boolean }) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
@@ -35,11 +40,13 @@ export const configStore = createStore<ConfigState>((set) => ({
   daemonServerUrl: "",
   daemonAppUrl: "",
   workspaceCreationDisabled: false,
+  cpuProfileEnabled: false,
   setCdnConfig: ({ cdnDomain, cdnSigned = false }) => set({ cdnDomain, cdnSigned }),
   setAuthConfig: ({ allowSignup, googleClientId = "", workspaceCreationDisabled = false }) =>
     set({ allowSignup, googleClientId, workspaceCreationDisabled }),
   setDaemonConfig: ({ daemonServerUrl = "", daemonAppUrl = "" }) =>
     set({ daemonServerUrl, daemonAppUrl }),
+  setDiagnosticsConfig: ({ cpuProfileEnabled = false }) => set({ cpuProfileEnabled }),
 }));
 
 export function useConfigStore(): ConfigState;

--- a/packages/core/diagnostics/diagnostic-route.test.ts
+++ b/packages/core/diagnostics/diagnostic-route.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getDiagnosticRoute, setDiagnosticRoute } from "./diagnostic-route";
+
+afterEach(() => setDiagnosticRoute(undefined));
+
+describe("diagnostic route holder", () => {
+  it("defaults to undefined", () => {
+    expect(getDiagnosticRoute()).toBeUndefined();
+  });
+
+  it("stores and returns the last set template", () => {
+    setDiagnosticRoute("/:slug/inbox");
+    expect(getDiagnosticRoute()).toBe("/:slug/inbox");
+    setDiagnosticRoute("/:slug/issues");
+    expect(getDiagnosticRoute()).toBe("/:slug/issues");
+  });
+
+  it("normalizes empty string back to undefined", () => {
+    setDiagnosticRoute("/:slug/inbox");
+    setDiagnosticRoute("");
+    expect(getDiagnosticRoute()).toBeUndefined();
+  });
+});

--- a/packages/core/diagnostics/diagnostic-route.ts
+++ b/packages/core/diagnostics/diagnostic-route.ts
@@ -1,0 +1,25 @@
+// Last-known app route for freeze diagnostics, shared by web and desktop.
+//
+// The freeze watchdog runs outside React (a PerformanceObserver callback), so
+// it can't read the router. On WEB, `location.pathname` IS the app route, so no
+// one needs to set this. On DESKTOP the renderer uses an in-memory router
+// (`createMemoryRouter`), so `location.pathname` is the asar file path, not the
+// route — the desktop pageview tracker therefore pushes the bucketed route
+// template here, and the watchdog reads it to attribute longtask events to the
+// real route instead of the asar path (MUL-3738, P0②).
+//
+// The value is already a bucketed route TEMPLATE (e.g. `/:slug/inbox`), set by
+// the same code that reports the renderer route context — never a raw path with
+// resource ids.
+
+let currentRouteTemplate: string | undefined;
+
+/** Set the current bucketed app route template (desktop pageview tracker). */
+export function setDiagnosticRoute(routeTemplate: string | undefined): void {
+  currentRouteTemplate = routeTemplate || undefined;
+}
+
+/** Read the current bucketed app route template, or undefined if none set. */
+export function getDiagnosticRoute(): string | undefined {
+  return currentRouteTemplate;
+}

--- a/packages/core/diagnostics/freeze-watchdog.test.ts
+++ b/packages/core/diagnostics/freeze-watchdog.test.ts
@@ -26,9 +26,11 @@ function fireLongTask(duration: number) {
 async function load() {
   vi.resetModules();
   const mod = await import("./freeze-watchdog");
+  const route = await import("./diagnostic-route");
   const { captureEvent } = await import("../analytics");
   return {
     installFreezeWatchdog: mod.installFreezeWatchdog,
+    setDiagnosticRoute: route.setDiagnosticRoute,
     captureEvent: captureEvent as unknown as ReturnType<typeof vi.fn>,
   };
 }
@@ -60,6 +62,22 @@ describe("installFreezeWatchdog", () => {
       source: "longtask",
       duration_ms: 2300,
       path: "/acme/issues",
+    });
+  });
+
+  it("prefers the pushed app route template over location.pathname (desktop)", async () => {
+    // On desktop location.pathname is the asar file path, so the route comes
+    // from setDiagnosticRoute (the bucketed template the pageview tracker pushes).
+    const { installFreezeWatchdog, setDiagnosticRoute, captureEvent } = await load();
+    setDiagnosticRoute("/:slug/inbox");
+    installFreezeWatchdog();
+
+    fireLongTask(2300);
+
+    expect(captureEvent).toHaveBeenCalledWith("client_unresponsive", {
+      source: "longtask",
+      duration_ms: 2300,
+      path: "/:slug/inbox",
     });
   });
 

--- a/packages/core/diagnostics/freeze-watchdog.ts
+++ b/packages/core/diagnostics/freeze-watchdog.ts
@@ -18,6 +18,7 @@
 // platform branch here.
 
 import { captureEvent } from "../analytics";
+import { getDiagnosticRoute } from "./diagnostic-route";
 
 // 2s is well above the normal switch/render cost (measured 50–600ms) and just
 // under Electron's renderer-hang threshold, so an event here means "the user
@@ -59,7 +60,13 @@ export function installFreezeWatchdog(): void {
         captureEvent("client_unresponsive", {
           source: "longtask",
           duration_ms: Math.round(entry.duration),
-          path: typeof location !== "undefined" ? location.pathname : undefined,
+          // Desktop's in-memory router makes `location.pathname` the asar file
+          // path, so prefer the bucketed app route template the desktop pushes
+          // via setDiagnosticRoute (MUL-3738, P0②). Web sets nothing here, so
+          // it keeps using `location.pathname` (already the app route) — no
+          // change to web longtask attribution.
+          path: getDiagnosticRoute() ??
+            (typeof location !== "undefined" ? location.pathname : undefined),
         });
       }
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,6 +104,7 @@
     "./feature-flags": "./feature-flags/index.ts",
     "./platform": "./platform/index.ts",
     "./analytics": "./analytics/index.ts",
+    "./diagnostics/diagnostic-route": "./diagnostics/diagnostic-route.ts",
     "./i18n": "./i18n/index.ts",
     "./i18n/react": "./i18n/react.ts",
     "./i18n/browser": "./i18n/browser.ts",

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -67,6 +67,10 @@ export function AuthInitializer({
           daemonServerUrl: cfg.daemon_server_url,
           daemonAppUrl: cfg.daemon_app_url,
         });
+        configStore.getState().setDiagnosticsConfig({
+          // Old servers omit this — treat absent as off (feature ships dark).
+          cpuProfileEnabled: cfg.diagnostics_cpu_profile_enabled === true,
+        });
         if (cfg.posthog_key) {
           initAnalytics({
             key: cfg.posthog_key,

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -44,6 +44,14 @@ type AppConfig struct {
 	PosthogKey           string `json:"posthog_key"`
 	PosthogHost          string `json:"posthog_host"`
 	AnalyticsEnvironment string `json:"analytics_environment"`
+
+	// DiagnosticsCpuProfileEnabled gates the desktop "capture a CPU sampling
+	// profile when the renderer hangs" diagnostic (MUL-3738). Defaults to false
+	// and is omitted from the JSON when off, so the feature ships dark and can
+	// be turned on (and off again, as a runtime kill switch) by flipping the
+	// DIAGNOSTICS_CPU_PROFILE_ENABLED env var without a client release. Only
+	// ever true when analytics is enabled.
+	DiagnosticsCpuProfileEnabled bool `json:"diagnostics_cpu_profile_enabled,omitempty"`
 }
 
 // GetConfig is mounted on the public (unauthenticated) route group because
@@ -71,6 +79,10 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 		if config.PosthogHost == "" && config.PosthogKey != "" {
 			config.PosthogHost = "https://us.i.posthog.com"
 		}
+		// Tied to analytics being enabled: a CPU profile is telemetry, so it
+		// only ships when the rest of the analytics pipeline is on. Defaults
+		// off; flip DIAGNOSTICS_CPU_PROFILE_ENABLED=true to enable.
+		config.DiagnosticsCpuProfileEnabled = os.Getenv("DIAGNOSTICS_CPU_PROFILE_ENABLED") == "true"
 	}
 
 	writeJSON(w, http.StatusOK, config)

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -237,6 +237,51 @@ func TestGetConfigOmitsCloudDaemonSetupForAppSubdomain(t *testing.T) {
 	}
 }
 
+// TestGetConfigGatesCpuProfileFlag verifies the MUL-3738 diagnostics flag:
+// off by default (and omitted from JSON), on only when the env var is "true",
+// and never set when analytics is disabled — a CPU profile is telemetry, so it
+// rides on the same kill switch.
+func TestGetConfigGatesCpuProfileFlag(t *testing.T) {
+	fetch := func() AppConfig {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+		w := httptest.NewRecorder()
+		testHandler.GetConfig(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var cfg AppConfig
+		if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+			t.Fatalf("decode config: %v", err)
+		}
+		return cfg
+	}
+
+	// Default: feature ships dark.
+	if cfg := fetch(); cfg.DiagnosticsCpuProfileEnabled {
+		t.Fatalf("diagnostics_cpu_profile_enabled: want false by default, got true")
+	}
+
+	// Explicitly on.
+	t.Setenv("DIAGNOSTICS_CPU_PROFILE_ENABLED", "true")
+	if cfg := fetch(); !cfg.DiagnosticsCpuProfileEnabled {
+		t.Fatalf("diagnostics_cpu_profile_enabled: want true with env on, got false")
+	}
+
+	// Any non-"true" value stays off.
+	t.Setenv("DIAGNOSTICS_CPU_PROFILE_ENABLED", "1")
+	if cfg := fetch(); cfg.DiagnosticsCpuProfileEnabled {
+		t.Fatalf("diagnostics_cpu_profile_enabled: want false for non-\"true\" value, got true")
+	}
+
+	// Disabling analytics also disables the profile flag, even with it set on.
+	t.Setenv("DIAGNOSTICS_CPU_PROFILE_ENABLED", "true")
+	t.Setenv("ANALYTICS_DISABLED", "true")
+	if cfg := fetch(); cfg.DiagnosticsCpuProfileEnabled {
+		t.Fatalf("diagnostics_cpu_profile_enabled: want false when analytics disabled, got true")
+	}
+}
+
 func TestURLHostEqualsCanonicalizesCommonHostForms(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## MUL-3738 — desktop hang diagnostics

Adds the two diagnostics the investigation concluded were missing for desktop inbox hangs, plus the mandatory supporting change, under the privacy constraints from Kim v2 RFC + Howard `APPROVED` + Naiyuan go-ahead. Scope is exactly the approved three items; non-goals untouched.

### What changed

**P0② — route attribution**
- Desktop `pageview-tracker` buckets the app route to its template (`/:slug/inbox`, no resource ids) at the source and pushes it both to main (recovery breadcrumb) and to a new `diagnostic-route` holder the freeze watchdog reads. On desktop `location.pathname` is the asar file path; web sets no diagnostic route and keeps `location.pathname` unchanged (no web longtask change).
- `freeze-flush.buildFreezeEventProps` emits an explicit event with a bucketed top-level `path`.

**P0① — on-hang renderer CPU sampling profile**
- main attaches CDP to the hung renderer and runs the V8 sampling profiler, folding a content-free profile into the breadcrumb. Started concurrently with the prompt delay so it doesn't push the dialog back.
- **CDP allowlist**: all commands go through `sendProfilerCommand`, which rejects anything outside `Profiler.*`. `HeapProfiler.*` / `Runtime.evaluate` / `Runtime.getProperties` / `Runtime.callFunctionOn` / `Debugger.*` are forbidden.
- **Gates**: dev excluded; backend config flag `diagnostics_cpu_profile_enabled` (default `false`, env `DIAGNOSTICS_CPU_PROFILE_ENABLED`, tied to analytics being enabled — runtime kill switch); renderer pre-pushes analytics opt-out, so main captures only when `cpuProfileEnabled && !optOut`. Unknown control state = do not capture.
- **Payload**: code locations only (`functionName` / `url` / line / column / hit counts); `url` redacted with the shared `$exception` redaction before egress; over-size profiles discarded whole (never truncated); a hard wall-clock timeout guarantees capture never wedges the reload prompt; `HeapProfiler` permanently forbidden.

**Mandatory supporting**
- `FreezeBreadcrumb.context` converged from `Record<string, unknown>` to an explicit `FreezeDiagnosticContext` whitelist.

### Non-goals (unchanged)
source maps · context labels · exception fuse · support/debug content channel · posthog feature-flag wiring · EU region gate · web longtask attribution · heap snapshots.

### Acceptance results

| Item | Result |
| --- | --- |
| route归因 → bucketed template, memory-router covered | ✅ `freeze-watchdog.test.ts` (diagnostic-route preferred over `location.pathname`), `freeze-flush.test.ts` (`/hazelkahlil/issues/<uuid>` → `/hazelkahlil/issues`) |
| CPU profile fields = functionName/scriptURL/line/column/hit/samples; redaction strips email/JWT/long token; scriptURL query stripped | ✅ `renderer-cpu-profile.test.ts` (sanitize whitelist) + `freeze-flush.test.ts` (`redactText`, token gone) |
| heap禁止 → no `HeapProfiler` / Runtime.* / Debugger.* | ✅ allowlist rejects each; source-level CI guard pins single `sendCommand` site behind the `Profiler.` prefix check |
| flag默认关 → no CDP attach when off / unknown | ✅ main gate requires explicit `cpuProfileEnabled && optOut===false`; `TestGetConfigGatesCpuProfileFlag` (default false, off when analytics disabled) |
| opt-out生效 → not captured | ✅ renderer pre-pushes opt-out; gate skips; `renderer-recovery.test.ts` (null capture → no `cpuProfile`) |
| 体积/丢弃 → discard whole, valid JSON | ✅ `renderer-cpu-profile.test.ts` over-size → null; hard-timeout → null |
| best-effort, context whitelist | ✅ recovery never throws on capture failure; `FreezeDiagnosticContext` is an explicit type |
| typecheck + core/desktop tests | ✅ `pnpm typecheck` 6/6; core 698, desktop 281; Go `TestGetConfig*` pass |

### Howard's non-blocking reminders
1. Unknown opt-out state handled explicitly — main requires an explicit control with `optOut===false`; bridge ships `cpuProfileEnabled:false` until config loads.
2. Line numbers re-checked against current `main` HEAD (`658e63d9b`).
3. `has_opted_out_capturing()` wrapped in `hasOptedOutCapturing()` (returns opted-out when analytics isn't running).

### Notes / revert path
- CPU-profile block is isolated in its own modules (`renderer-cpu-profile.ts`, `shared/cpu-profile.ts`, `shared/diagnostics-control.ts`, `diagnostics-control-bridge.tsx`) and runtime-gated — disable instantly via the backend flag, no revert needed.
- The desktop `main-unresponsive` / `client_crash` telemetry shape is intentionally tightened: it no longer emits the raw nested `desktopRoute` (which carried resource ids) — it now emits a bucketed top-level `path` (slug kept, like `$pageview`), `window_url`, and `crash_reason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
