### PR TITLE
MUL-3834: harden daemon websocket reconnect

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -110,11 +110,28 @@ type Client struct {
 func NewClient(baseURL string) *Client {
 	return &Client{
 		baseURL:      baseURL,
-		client:       &http.Client{Timeout: 30 * time.Second},
+		client:       &http.Client{Timeout: 30 * time.Second, Transport: cloneDefaultTransport()},
 		bundleClient: &http.Client{},
 		platform:     "daemon",
 		os:           normalizeGOOS(runtime.GOOS),
 	}
+}
+
+func cloneDefaultTransport() http.RoundTripper {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone()
+	}
+	return http.DefaultTransport
+}
+
+// CloseIdleConnections drops pooled control-plane HTTP connections. The
+// daemon calls this after repeated heartbeat transport failures so a stale
+// keep-alive socket from a server restart cannot delay recovery indefinitely.
+func (c *Client) CloseIdleConnections() {
+	if c == nil || c.client == nil {
+		return
+	}
+	c.client.CloseIdleConnections()
 }
 
 // normalizeGOOS maps Go's runtime.GOOS values to the protocol vocabulary

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1905,7 +1905,19 @@ func (d *Daemon) runRuntimeHeartbeat(ctx context.Context, rid string) {
 		}
 	}
 
-	d.runHeartbeatTick(ctx, rid)
+	consecutiveTransientFailures := 0
+	tick := func() {
+		if d.runHeartbeatTick(ctx, rid) {
+			consecutiveTransientFailures++
+			if consecutiveTransientFailures == 2 {
+				d.client.CloseIdleConnections()
+			}
+			return
+		}
+		consecutiveTransientFailures = 0
+	}
+
+	tick()
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -1914,12 +1926,14 @@ func (d *Daemon) runRuntimeHeartbeat(ctx context.Context, rid string) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.runHeartbeatTick(ctx, rid)
+			tick()
 		}
 	}
 }
 
-func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) {
+// runHeartbeatTick returns true when the HTTP heartbeat hit a transient
+// failure that should count toward stale idle-connection cleanup.
+func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) bool {
 	// Skip HTTP heartbeat for runtimes that successfully acked a recent
 	// WebSocket heartbeat. The WS path keeps last_seen_at fresh and delivers
 	// actions, so the HTTP write would be a duplicate DB update. If the WS
@@ -1928,7 +1942,7 @@ func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) {
 	// relies on.
 	if d.wsHeartbeatRecentlyAcked(rid) {
 		d.logger.Debug("heartbeat: skipping HTTP tick, WS recently acked", "runtime_id", rid)
-		return
+		return false
 	}
 	d.logger.Debug("heartbeat: HTTP tick", "runtime_id", rid)
 	resp, err := d.client.SendHeartbeat(ctx, rid)
@@ -1941,20 +1955,21 @@ func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) {
 				// the daemon root context so notifyRuntimeSetChanged
 				// tearing down this heartbeat goroutine cannot abort it.
 				go d.handleRuntimeGone(rid)
-				return
+				return false
 			}
 			d.logger.Warn("heartbeat failed", "runtime_id", rid, "error", err)
 		}
-		return
+		return ctx.Err() == nil && isTransientError(err)
 	}
 	if resp != nil && resp.RuntimeGone {
 		// The WS path returns a successful ack with RuntimeGone=true for the
 		// same scenario; treat it the same way here in case HTTP starts
 		// surfacing this signal too.
 		go d.handleRuntimeGone(rid)
-		return
+		return false
 	}
 	d.handleHeartbeatActions(ctx, rid, resp)
+	return false
 }
 
 // handleHeartbeatActions dispatches the pending-action set returned by either

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -18,6 +18,14 @@ import (
 
 var errRuntimeSetChanged = errors.New("runtime set changed")
 
+const taskWakeupMaxBackoff = 30 * time.Second
+
+var (
+	taskWakeupPongWait          = 60 * time.Second
+	taskWakeupWriteWait         = 10 * time.Second
+	taskWakeupBackoffResetAfter = 10 * time.Second
+)
+
 type taskWakeup struct {
 	runtimeID string
 }
@@ -36,13 +44,16 @@ func (d *Daemon) taskWakeupLoop(ctx context.Context, taskWakeups chan<- taskWake
 			continue
 		}
 
-		err := d.runTaskWakeupConnection(ctx, runtimeIDs, taskWakeups, runtimeSetCh)
+		connectedFor, err := d.runTaskWakeupConnection(ctx, runtimeIDs, taskWakeups, runtimeSetCh)
 		if ctx.Err() != nil {
 			return
 		}
 		if errors.Is(err, errRuntimeSetChanged) {
 			backoff = time.Second
 			continue
+		}
+		if shouldResetTaskWakeupBackoff(connectedFor) {
+			backoff = time.Second
 		}
 		if err != nil {
 			d.logger.Debug("task wakeup websocket unavailable; polling fallback remains active", "error", err, "retry_in", backoff)
@@ -51,13 +62,20 @@ func (d *Daemon) taskWakeupLoop(ctx context.Context, taskWakeups chan<- taskWake
 		if err := sleepWithContextOrRuntimeChange(ctx, jitterDuration(backoff), runtimeSetCh); err != nil {
 			return
 		}
-		if backoff < 30*time.Second {
+		if backoff < taskWakeupMaxBackoff {
 			backoff *= 2
-			if backoff > 30*time.Second {
-				backoff = 30 * time.Second
+			if backoff > taskWakeupMaxBackoff {
+				backoff = taskWakeupMaxBackoff
 			}
 		}
 	}
+}
+
+func shouldResetTaskWakeupBackoff(connectedFor time.Duration) bool {
+	if connectedFor <= 0 {
+		return false
+	}
+	return taskWakeupBackoffResetAfter <= 0 || connectedFor >= taskWakeupBackoffResetAfter
 }
 
 func jitterDuration(d time.Duration) time.Duration {
@@ -72,10 +90,10 @@ func jitterDuration(d time.Duration) time.Duration {
 	return d + delta
 }
 
-func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []string, taskWakeups chan<- taskWakeup, runtimeSetCh <-chan struct{}) error {
+func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []string, taskWakeups chan<- taskWakeup, runtimeSetCh <-chan struct{}) (time.Duration, error) {
 	wsURL, err := taskWakeupURL(d.cfg.ServerBaseURL, runtimeIDs)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	headers := http.Header{}
@@ -95,8 +113,10 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
 	conn, _, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	connectedAt := time.Now()
+	uptime := func() time.Duration { return time.Since(connectedAt) }
 	defer conn.Close()
 	// HTTP heartbeats resume the moment WS detaches so the freshness window
 	// from a previous connection cannot keep them silenced past disconnect.
@@ -151,11 +171,11 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return uptime(), ctx.Err()
 	case <-runtimeSetCh:
-		return errRuntimeSetChanged
+		return uptime(), errRuntimeSetChanged
 	case err := <-errCh:
-		return err
+		return uptime(), err
 	}
 }
 
@@ -260,10 +280,13 @@ func (d *Daemon) handleWSHeartbeatAck(ctx context.Context, ack *HeartbeatRespons
 }
 
 func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<- taskWakeup) error {
-	conn.SetReadLimit(64 * 1024)
+	d.configureTaskWakeupReadLiveness(conn)
 	for {
 		_, raw, err := conn.ReadMessage()
 		if err != nil {
+			return err
+		}
+		if err := d.extendTaskWakeupReadDeadline(conn); err != nil {
 			return err
 		}
 		var msg protocol.Message
@@ -304,6 +327,26 @@ func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<-
 			d.handleWSHeartbeatAck(context.Background(), &ack)
 		}
 	}
+}
+
+func (d *Daemon) configureTaskWakeupReadLiveness(conn *websocket.Conn) {
+	conn.SetReadLimit(64 * 1024)
+	if err := d.extendTaskWakeupReadDeadline(conn); err != nil {
+		d.logger.Debug("task wakeup websocket read deadline failed", "error", err)
+	}
+	conn.SetPongHandler(func(string) error {
+		return d.extendTaskWakeupReadDeadline(conn)
+	})
+	conn.SetPingHandler(func(appData string) error {
+		if err := d.extendTaskWakeupReadDeadline(conn); err != nil {
+			return err
+		}
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(taskWakeupWriteWait))
+	})
+}
+
+func (d *Daemon) extendTaskWakeupReadDeadline(conn *websocket.Conn) error {
+	return conn.SetReadDeadline(time.Now().Add(taskWakeupPongWait))
 }
 
 func (d *Daemon) handleRuntimeProfilesChanged(payload protocol.RuntimeProfilesChangedPayload) {

--- a/server/internal/daemon/wakeup_test.go
+++ b/server/internal/daemon/wakeup_test.go
@@ -127,6 +127,15 @@ func TestReadTaskWakeupMessagesTimesOutWithoutPeerTraffic(t *testing.T) {
 func TestReadTaskWakeupMessagesExtendsDeadlineOnServerPing(t *testing.T) {
 	overrideTaskWakeupTimings(t, 120*time.Millisecond, 50*time.Millisecond, taskWakeupBackoffResetAfter)
 
+	clientReceived := make(chan struct{})
+	taskFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonTaskAvailable,
+		Payload: marshalRaw(protocol.TaskAvailablePayload{
+			RuntimeID: "runtime-1",
+			TaskID:    "task-1",
+		}),
+	})
+
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -143,19 +152,10 @@ func TestReadTaskWakeupMessagesExtendsDeadlineOnServerPing(t *testing.T) {
 			}
 		}
 
-		frame, err := json.Marshal(protocol.Message{
-			Type: protocol.EventDaemonTaskAvailable,
-			Payload: marshalRaw(protocol.TaskAvailablePayload{
-				RuntimeID: "runtime-1",
-				TaskID:    "task-1",
-			}),
-		})
-		if err != nil {
-			t.Errorf("marshal task_available frame: %v", err)
+		if !writeWSMessage(t, conn, websocket.TextMessage, taskFrame) {
 			return
 		}
-		conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
-		_ = conn.WriteMessage(websocket.TextMessage, frame)
+		waitForClientWakeup(t, clientReceived)
 	}))
 	defer srv.Close()
 
@@ -177,6 +177,133 @@ func TestReadTaskWakeupMessagesExtendsDeadlineOnServerPing(t *testing.T) {
 		if wakeup.runtimeID != "runtime-1" {
 			t.Fatalf("wakeup runtimeID = %q, want runtime-1", wakeup.runtimeID)
 		}
+		close(clientReceived)
+	case err := <-errCh:
+		t.Fatalf("readTaskWakeupMessages returned before task frame: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for task wakeup")
+	}
+}
+
+func TestReadTaskWakeupMessagesExtendsDeadlineOnApplicationMessage(t *testing.T) {
+	overrideTaskWakeupTimings(t, 120*time.Millisecond, 50*time.Millisecond, taskWakeupBackoffResetAfter)
+
+	clientReceived := make(chan struct{})
+	ackFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonHeartbeatAck,
+		Payload: marshalRaw(HeartbeatResponse{
+			RuntimeID: "runtime-1",
+		}),
+	})
+	taskFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonTaskAvailable,
+		Payload: marshalRaw(protocol.TaskAvailablePayload{
+			RuntimeID: "runtime-1",
+			TaskID:    "task-1",
+		}),
+	})
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for i := 0; i < 3; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if !writeWSMessage(t, conn, websocket.TextMessage, ackFrame) {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		if !writeWSMessage(t, conn, websocket.TextMessage, taskFrame) {
+			return
+		}
+		waitForClientWakeup(t, clientReceived)
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(taskWakeupTestWSURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	d := New(Config{}, slog.Default())
+	taskWakeups := make(chan taskWakeup, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.readTaskWakeupMessages(conn, taskWakeups)
+	}()
+
+	select {
+	case wakeup := <-taskWakeups:
+		if wakeup.runtimeID != "runtime-1" {
+			t.Fatalf("wakeup runtimeID = %q, want runtime-1", wakeup.runtimeID)
+		}
+		close(clientReceived)
+	case err := <-errCh:
+		t.Fatalf("readTaskWakeupMessages returned before task frame: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for task wakeup")
+	}
+}
+
+func TestReadTaskWakeupMessagesExtendsDeadlineOnPong(t *testing.T) {
+	overrideTaskWakeupTimings(t, 120*time.Millisecond, 50*time.Millisecond, taskWakeupBackoffResetAfter)
+
+	clientReceived := make(chan struct{})
+	taskFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonTaskAvailable,
+		Payload: marshalRaw(protocol.TaskAvailablePayload{
+			RuntimeID: "runtime-1",
+			TaskID:    "task-1",
+		}),
+	})
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for i := 0; i < 3; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if !writeWSMessage(t, conn, websocket.PongMessage, []byte("keepalive")) {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		if !writeWSMessage(t, conn, websocket.TextMessage, taskFrame) {
+			return
+		}
+		waitForClientWakeup(t, clientReceived)
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(taskWakeupTestWSURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	d := New(Config{}, slog.Default())
+	taskWakeups := make(chan taskWakeup, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.readTaskWakeupMessages(conn, taskWakeups)
+	}()
+
+	select {
+	case wakeup := <-taskWakeups:
+		if wakeup.runtimeID != "runtime-1" {
+			t.Fatalf("wakeup runtimeID = %q, want runtime-1", wakeup.runtimeID)
+		}
+		close(clientReceived)
 	case err := <-errCh:
 		t.Fatalf("readTaskWakeupMessages returned before task frame: %v", err)
 	case <-time.After(time.Second):
@@ -272,4 +399,32 @@ func overrideTaskWakeupTimings(t *testing.T, pongWait, writeWait, backoffResetAf
 
 func taskWakeupTestWSURL(httpURL string) string {
 	return strings.Replace(httpURL, "http", "ws", 1)
+}
+
+func mustProtocolFrame(t *testing.T, msg protocol.Message) []byte {
+	t.Helper()
+	frame, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal websocket frame: %v", err)
+	}
+	return frame
+}
+
+func writeWSMessage(t *testing.T, conn *websocket.Conn, messageType int, frame []byte) bool {
+	t.Helper()
+	conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+	if err := conn.WriteMessage(messageType, frame); err != nil {
+		t.Errorf("write websocket frame: %v", err)
+		return false
+	}
+	return true
+}
+
+func waitForClientWakeup(t *testing.T, clientReceived <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-clientReceived:
+	case <-time.After(time.Second):
+		t.Errorf("server timed out waiting for client wakeup")
+	}
 }

--- a/server/internal/daemon/wakeup_test.go
+++ b/server/internal/daemon/wakeup_test.go
@@ -1,9 +1,20 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 func TestTaskWakeupURL(t *testing.T) {
@@ -74,4 +85,191 @@ func TestWSHeartbeatFreshnessSuppressesHTTP(t *testing.T) {
 	if d.wsHeartbeatRecentlyAcked("runtime-2") {
 		t.Fatalf("expected clearWSHeartbeatAcks to drop all entries")
 	}
+}
+
+func TestReadTaskWakeupMessagesTimesOutWithoutPeerTraffic(t *testing.T) {
+	overrideTaskWakeupTimings(t, 60*time.Millisecond, 20*time.Millisecond, taskWakeupBackoffResetAfter)
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(taskWakeupTestWSURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	d := New(Config{}, slog.Default())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.readTaskWakeupMessages(conn, make(chan taskWakeup, 1))
+	}()
+
+	select {
+	case err := <-errCh:
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("readTaskWakeupMessages error = %v, want timeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readTaskWakeupMessages did not time out")
+	}
+}
+
+func TestReadTaskWakeupMessagesExtendsDeadlineOnServerPing(t *testing.T) {
+	overrideTaskWakeupTimings(t, 120*time.Millisecond, 50*time.Millisecond, taskWakeupBackoffResetAfter)
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for i := 0; i < 3; i++ {
+			time.Sleep(50 * time.Millisecond)
+			conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+			if err := conn.WriteMessage(websocket.PingMessage, []byte("keepalive")); err != nil {
+				return
+			}
+		}
+
+		frame, err := json.Marshal(protocol.Message{
+			Type: protocol.EventDaemonTaskAvailable,
+			Payload: marshalRaw(protocol.TaskAvailablePayload{
+				RuntimeID: "runtime-1",
+				TaskID:    "task-1",
+			}),
+		})
+		if err != nil {
+			t.Errorf("marshal task_available frame: %v", err)
+			return
+		}
+		conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+		_ = conn.WriteMessage(websocket.TextMessage, frame)
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(taskWakeupTestWSURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	d := New(Config{}, slog.Default())
+	taskWakeups := make(chan taskWakeup, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.readTaskWakeupMessages(conn, taskWakeups)
+	}()
+
+	select {
+	case wakeup := <-taskWakeups:
+		if wakeup.runtimeID != "runtime-1" {
+			t.Fatalf("wakeup runtimeID = %q, want runtime-1", wakeup.runtimeID)
+		}
+	case err := <-errCh:
+		t.Fatalf("readTaskWakeupMessages returned before task frame: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for task wakeup")
+	}
+}
+
+func TestShouldResetTaskWakeupBackoffRequiresStableConnection(t *testing.T) {
+	old := taskWakeupBackoffResetAfter
+	taskWakeupBackoffResetAfter = 10 * time.Second
+	t.Cleanup(func() {
+		taskWakeupBackoffResetAfter = old
+	})
+
+	if shouldResetTaskWakeupBackoff(0) {
+		t.Fatal("zero connection uptime reset backoff")
+	}
+	if shouldResetTaskWakeupBackoff(9 * time.Second) {
+		t.Fatal("short connection uptime reset backoff")
+	}
+	if !shouldResetTaskWakeupBackoff(10 * time.Second) {
+		t.Fatal("stable connection uptime did not reset backoff")
+	}
+}
+
+func TestRuntimeHeartbeatClosesIdleConnectionsAfterRepeatedTransientFailures(t *testing.T) {
+	transport := &closeCountingTransport{}
+	client := NewClient("http://daemon.test")
+	client.client = &http.Client{
+		Timeout:   time.Second,
+		Transport: transport,
+	}
+	d := New(Config{HeartbeatInterval: 10 * time.Millisecond}, slog.Default())
+	d.client = client
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runRuntimeHeartbeat(ctx, "runtime-1")
+	}()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for transport.closeCount.Load() == 0 {
+		select {
+		case <-ticker.C:
+		case <-deadline:
+			cancel()
+			t.Fatal("CloseIdleConnections was not called")
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runRuntimeHeartbeat did not stop after context cancellation")
+	}
+	if got := transport.roundTrips.Load(); got < 2 {
+		t.Fatalf("RoundTrip count = %d, want at least 2", got)
+	}
+}
+
+type closeCountingTransport struct {
+	roundTrips atomic.Int32
+	closeCount atomic.Int32
+}
+
+func (t *closeCountingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.roundTrips.Add(1)
+	return nil, errors.New("dial failed")
+}
+
+func (t *closeCountingTransport) CloseIdleConnections() {
+	t.closeCount.Add(1)
+}
+
+func overrideTaskWakeupTimings(t *testing.T, pongWait, writeWait, backoffResetAfter time.Duration) {
+	t.Helper()
+	oldPongWait := taskWakeupPongWait
+	oldWriteWait := taskWakeupWriteWait
+	oldBackoffResetAfter := taskWakeupBackoffResetAfter
+	taskWakeupPongWait = pongWait
+	taskWakeupWriteWait = writeWait
+	taskWakeupBackoffResetAfter = backoffResetAfter
+	t.Cleanup(func() {
+		taskWakeupPongWait = oldPongWait
+		taskWakeupWriteWait = oldWriteWait
+		taskWakeupBackoffResetAfter = oldBackoffResetAfter
+	})
+}
+
+func taskWakeupTestWSURL(httpURL string) string {
+	return strings.Replace(httpURL, "http", "ws", 1)
 }


### PR DESCRIPTION
Closes MUL-3834

Summary:
- Adds daemon-side WebSocket read deadline handling, refreshes it on server pings/pongs/application messages, and replies to server pings so half-open wakeup sockets reconnect.
- Resets reconnect backoff only after a connection survives the stable-uptime threshold, avoiding max-backoff carryover after recovery without rewarding instant flaps.
- Closes idle control-plane HTTP connections after repeated transient heartbeat failures to clear stale keep-alive sockets after server restarts.

Tests:
- go test ./internal/daemon
- go test ./internal/daemon ./internal/daemonws