### PR TITLE
Add one-click squad invite CTA

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -65,6 +65,7 @@ import type {
   ChatPendingTask,
   PendingChatTasksResponse,
   SendChatMessageResponse,
+  ChatSquadInviteStatus,
   Project,
   CreateProjectRequest,
   UpdateProjectRequest,
@@ -1642,6 +1643,22 @@ export class ApiClient {
 
   async getPendingChatTask(sessionId: string): Promise<ChatPendingTask> {
     return this.fetch(`/api/chat/sessions/${sessionId}/pending-task`);
+  }
+
+  async getChatSquadInviteStatus(
+    sessionId: string,
+    squadId: string,
+  ): Promise<ChatSquadInviteStatus | undefined> {
+    return this.fetch(`/api/chat/sessions/${sessionId}/squads/${squadId}/invite-status`);
+  }
+
+  async inviteSquadToChat(
+    sessionId: string,
+    squadId: string,
+  ): Promise<ChatSquadInviteStatus> {
+    return this.fetch(`/api/chat/sessions/${sessionId}/squads/${squadId}/invite`, {
+      method: "POST",
+    });
   }
 
   async listPendingChatTasks(): Promise<PendingChatTasksResponse> {

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -79,6 +79,12 @@ export interface SendChatMessageResponse {
   created_at: string;
 }
 
+export interface ChatSquadInviteStatus {
+  wakeable_count: number;
+  missing_count: number;
+  can_invite: boolean;
+}
+
 /**
  * Response from GET /api/chat/sessions/{id}/pending-task.
  * All fields are absent when the session has no in-flight task.

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -65,7 +65,7 @@ export type { IssueSubscriber } from "./subscriber";
 export type * from "./events";
 export type * from "./api";
 export type { Attachment } from "./attachment";
-export type { ChatSession, ChatMessage, ChatMessagesPage, ChatPendingTask, PendingChatTaskItem, PendingChatTasksResponse, SendChatMessageResponse } from "./chat";
+export type { ChatSession, ChatMessage, ChatMessagesPage, ChatPendingTask, PendingChatTaskItem, PendingChatTasksResponse, SendChatMessageResponse, ChatSquadInviteStatus } from "./chat";
 export type { StorageAdapter } from "./storage";
 export type {
   Project,

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -234,6 +234,7 @@ export function ChatInput({
             // Chat is short-form — the floating formatting toolbar is
             // more distraction than feature here.
             showBubbleMenu={false}
+            mentionChatSessionId={activeSessionId}
             // Chat intentionally leaves submitOnEnter at its default false:
             // Mod+Enter submits, while bare Enter falls through to Tiptap's
             // default behavior for lists, quotes, and paragraph breaks.

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -98,6 +98,8 @@ interface ContentEditorProps {
   disableMentions?: boolean;
   /** Enable the chat-only `/` skill picker. Defaults false. */
   enableSlashCommands?: boolean;
+  /** Chat session context for channel-aware @mention squad invite CTAs. */
+  mentionChatSessionId?: string | null;
   /**
    * Attachments referenced by this content. The download buttons on file
    * cards and images inside the editor look up an attachment by `url` and
@@ -142,6 +144,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       currentIssueId,
       disableMentions = false,
       enableSlashCommands = false,
+      mentionChatSessionId,
       attachments,
     },
     ref,
@@ -152,6 +155,9 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     const onBlurRef = useRef(onBlur);
     const onUploadFileRef = useRef(onUploadFile);
     const lastEmittedRef = useRef<string | null>(null);
+    const mentionChatSessionIdRef = useRef<string | null>(
+      mentionChatSessionId ?? null,
+    );
 
     // Current workspace slug kept in a ref so the click handler always sees the
     // latest value without recreating the editor. Used by openLink to prefix
@@ -165,6 +171,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     onSubmitRef.current = onSubmit;
     onBlurRef.current = onBlur;
     onUploadFileRef.current = onUploadFile;
+    mentionChatSessionIdRef.current = mentionChatSessionId ?? null;
 
     const queryClient = useQueryClient();
 
@@ -186,6 +193,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         submitOnEnter,
         disableMentions,
         enableSlashCommands,
+        mentionChatSessionIdRef,
       }),
       onUpdate: ({ editor: ed }) => {
         if (!onUpdateRef.current) return;

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -110,6 +110,8 @@ export interface EditorExtensionsOptions {
   disableMentions?: boolean;
   /** When true, attach the `/` skill picker. Default false. */
   enableSlashCommands?: boolean;
+  /** Current chat session ref, when this editor is a channel-backed chat input. */
+  mentionChatSessionIdRef?: RefObject<string | null>;
 }
 
 export function createEditorExtensions(
@@ -157,7 +159,12 @@ export function createEditorExtensions(
       ...(options.disableMentions
         ? { suggestion: { allow: () => false } }
         : options.queryClient
-          ? { suggestion: createMentionSuggestion(options.queryClient) }
+          ? {
+              suggestion: createMentionSuggestion(options.queryClient, {
+                getChatSessionId: () =>
+                  options.mentionChatSessionIdRef?.current ?? null,
+              }),
+            }
           : {}),
     }),
     SlashCommandExtension.configure({

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -9,7 +9,12 @@ import {
   useRef,
   useState,
 } from "react";
-import type { QueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import { getCurrentWsId } from "@multica/core/platform";
 import { flattenIssueBuckets, issueKeys } from "@multica/core/issues/queries";
 import { workspaceKeys } from "@multica/core/workspace/queries";
@@ -57,6 +62,7 @@ interface MentionListProps {
   items: MentionItem[];
   query: string;
   command: (item: MentionItem) => void;
+  chatSessionId?: string | null;
 }
 
 export interface MentionListRef {
@@ -98,6 +104,9 @@ const MAX_ITEMS = 20;
 const SERVER_ISSUE_SEARCH_LIMIT = 20;
 const SERVER_SEARCH_DEBOUNCE_MS = 150;
 
+const chatSquadInviteStatusKey = (sessionId: string, squadId: string) =>
+  ["chat", "squad-invite-status", sessionId, squadId] as const;
+
 function mentionItemKey(item: MentionItem): string {
   return `${item.type}:${item.id}`;
 }
@@ -120,13 +129,13 @@ function mergeMentionItems(
 }
 
 export const MentionList = forwardRef<MentionListRef, MentionListProps>(
-  function MentionList({ items, query, command }, ref) {
+  function MentionList({ items, query, command, chatSessionId }, ref) {
     const { t } = useT("editor");
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [serverIssueItems, setServerIssueItems] = useState<MentionItem[]>([]);
     const [isSearchingIssues, setIsSearchingIssues] = useState(false);
     const [searchedIssueQuery, setSearchedIssueQuery] = useState("");
-    const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+    const itemRefs = useRef<(HTMLElement | null)[]>([]);
     const normalizedQuery = query.trim();
 
     useEffect(() => {
@@ -268,6 +277,7 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
                 <MentionRow
                   key={`${item.type}-${item.id}`}
                   item={item}
+                  chatSessionId={chatSessionId}
                   selected={idx === selectedIndex}
                   onSelect={() => selectItem(idx)}
                   buttonRef={(el) => { itemRefs.current[idx] = el; }}
@@ -287,14 +297,16 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
 
 function MentionRow({
   item,
+  chatSessionId,
   selected,
   onSelect,
   buttonRef,
 }: {
   item: MentionItem;
+  chatSessionId?: string | null;
   selected: boolean;
   onSelect: () => void;
-  buttonRef: (el: HTMLButtonElement | null) => void;
+  buttonRef: (el: HTMLElement | null) => void;
 }) {
   const { t } = useT("editor");
   if (item.type === "issue") {
@@ -325,13 +337,16 @@ function MentionRow({
     );
   }
 
+  const rowClasses = `flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
+    selected ? "bg-accent" : "hover:bg-accent/50"
+  }`;
+
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={-1}
       ref={buttonRef}
-      className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
-        selected ? "bg-accent" : "hover:bg-accent/50"
-      }`}
+      className={rowClasses}
       onClick={onSelect}
     >
       <ActorAvatar
@@ -348,12 +363,73 @@ function MentionRow({
         // eslint-disable-next-line i18next/no-literal-string
         <Badge variant="outline" className="ml-auto text-[10px] h-4 px-1.5">Agent</Badge>
       )}
-      {item.type === "squad" && (
+      {item.type === "squad" && chatSessionId && (
+        <SquadInviteStatus chatSessionId={chatSessionId} squadId={item.id} />
+      )}
+      {item.type === "squad" && !chatSessionId && (
         // "Squad" is a glossary-protected product term — kept un-translated.
         // eslint-disable-next-line i18next/no-literal-string
         <Badge variant="outline" className="ml-auto text-[10px] h-4 px-1.5">Squad</Badge>
       )}
-    </button>
+    </div>
+  );
+}
+
+function SquadInviteStatus({
+  chatSessionId,
+  squadId,
+}: {
+  chatSessionId: string;
+  squadId: string;
+}) {
+  const { t } = useT("editor");
+  const qc = useQueryClient();
+  const statusQuery = useQuery({
+    queryKey: chatSquadInviteStatusKey(chatSessionId, squadId),
+    queryFn: () => api.getChatSquadInviteStatus(chatSessionId, squadId),
+    staleTime: 15_000,
+    retry: false,
+  });
+  const inviteMutation = useMutation({
+    mutationFn: () => api.inviteSquadToChat(chatSessionId, squadId),
+    onSuccess: (status) => {
+      qc.setQueryData(chatSquadInviteStatusKey(chatSessionId, squadId), status);
+    },
+  });
+
+  const status = statusQuery.data;
+  if (!status) {
+    // "Squad" is a glossary-protected product term — kept un-translated.
+    // eslint-disable-next-line i18next/no-literal-string
+    return <Badge variant="outline" className="ml-auto text-[10px] h-4 px-1.5">Squad</Badge>;
+  }
+  if (status.can_invite) {
+    return (
+      <button
+        type="button"
+        className="ml-auto shrink-0 rounded-md border border-brand/40 px-2 py-0.5 text-[10px] font-medium text-brand transition-colors hover:bg-brand/10 disabled:opacity-60"
+        disabled={inviteMutation.isPending}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          inviteMutation.mutate();
+        }}
+      >
+        {t(($) => $.mention.one_click_invite)}
+      </button>
+    );
+  }
+  if (status.wakeable_count > 0) {
+    return (
+      <span className="ml-auto shrink-0 text-muted-foreground">
+        {t(($) => $.mention.wake_agents, { count: status.wakeable_count })}
+      </span>
+    );
+  }
+  return (
+    <span className="ml-auto shrink-0 text-muted-foreground">
+      {t(($) => $.mention.no_wakeable_agents)}
+    </span>
   );
 }
 
@@ -371,7 +447,10 @@ function issueToMention(i: Pick<Issue, "id" | "identifier" | "title" | "status">
   };
 }
 
-export function createMentionSuggestion(qc: QueryClient): Omit<
+export function createMentionSuggestion(
+  qc: QueryClient,
+  options: { getChatSessionId?: () => string | null } = {},
+): Omit<
   SuggestionOptions<MentionItem>,
   "editor"
 > {
@@ -466,6 +545,7 @@ export function createMentionSuggestion(qc: QueryClient): Omit<
         items: props.items,
         query: props.query,
         command: props.command,
+        chatSessionId: options.getChatSessionId?.() ?? null,
       }),
       onKeyDown: (ref, props) => ref?.onKeyDown(props) ?? false,
     }),

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -56,7 +56,10 @@
     "group_issues": "Issues",
     "all_members": "All members",
     "searching": "Searching...",
-    "no_results": "No results"
+    "no_results": "No results",
+    "one_click_invite": "Invite",
+    "wake_agents": "Will wake {{count}} agent(s)",
+    "no_wakeable_agents": "No wakeable agents in this channel"
   },
   "slash_command": {
     "no_skills_configured": "No skills configured",

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -56,7 +56,10 @@
     "group_issues": "イシュー",
     "all_members": "すべてのメンバー",
     "searching": "検索中...",
-    "no_results": "結果なし"
+    "no_results": "結果なし",
+    "one_click_invite": "一括招待",
+    "wake_agents": "{{count}} 件のエージェントを起動",
+    "no_wakeable_agents": "現在のチャンネルに起動できるエージェントはいません"
   },
   "code_block": {
     "copy_code": "コードをコピー",

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -56,7 +56,10 @@
     "group_issues": "이슈",
     "all_members": "모든 멤버",
     "searching": "검색 중...",
-    "no_results": "결과 없음"
+    "no_results": "결과 없음",
+    "one_click_invite": "한 번에 초대",
+    "wake_agents": "에이전트 {{count}}명을 깨웁니다",
+    "no_wakeable_agents": "현재 채널에 깨울 수 있는 에이전트가 없습니다"
   },
   "code_block": {
     "copy_code": "코드 복사",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -56,7 +56,10 @@
     "group_issues": "Issues",
     "all_members": "所有成员",
     "searching": "搜索中...",
-    "no_results": "无结果"
+    "no_results": "无结果",
+    "one_click_invite": "一键邀请",
+    "wake_agents": "将唤醒 {{count}} 个智能体",
+    "no_wakeable_agents": "当前频道没有可唤醒的智能体"
   },
   "slash_command": {
     "no_skills_configured": "暂无配置的技能",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -900,6 +900,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Get("/messages", h.ListChatMessages)
 					r.Get("/messages/page", h.ListChatMessagesPage)
 					r.Get("/pending-task", h.GetPendingChatTask)
+					r.Get("/squads/{squadId}/invite-status", h.GetChatSquadInviteStatus)
+					r.Post("/squads/{squadId}/invite", h.InviteSquadToChat)
 					r.Post("/read", h.MarkChatSessionRead)
 				})
 			})

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/integrations/lark"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -31,6 +33,12 @@ const chatSessionTitleMaxLen = 200
 type CreateChatSessionRequest struct {
 	AgentID string `json:"agent_id"`
 	Title   string `json:"title"`
+}
+
+type ChatSquadInviteStatusResponse struct {
+	WakeableCount int  `json:"wakeable_count"`
+	MissingCount  int  `json:"missing_count"`
+	CanInvite     bool `json:"can_invite"`
 }
 
 func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
@@ -240,6 +248,196 @@ func (h *Handler) GetChatSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, chatSessionToResponse(session))
+}
+
+func (h *Handler) GetChatSquadInviteStatus(w http.ResponseWriter, r *http.Request) {
+	plan, ok := h.chatSquadInvitePlan(w, r, false)
+	if !ok {
+		return
+	}
+	if !plan.supported {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeJSON(w, http.StatusOK, plan.response())
+}
+
+func (h *Handler) InviteSquadToChat(w http.ResponseWriter, r *http.Request) {
+	plan, ok := h.chatSquadInvitePlan(w, r, true)
+	if !ok {
+		return
+	}
+	if len(plan.missingOpenIDs) > 0 {
+		if err := h.LarkAPIClient.AddChatMembers(r.Context(), lark.AddChatMembersParams{
+			InstallationID: plan.creds,
+			ChatID:         plan.chatID,
+			OpenIDs:        plan.missingOpenIDs,
+		}); err != nil {
+			slog.Warn("lark squad one-click invite failed", "error", err, "chat_session_id", chi.URLParam(r, "sessionId"), "squad_id", chi.URLParam(r, "squadId"))
+			writeError(w, http.StatusBadGateway, "failed to invite squad members")
+			return
+		}
+		plan.wakeableCount += len(plan.missingOpenIDs)
+		plan.missingOpenIDs = nil
+	}
+	writeJSON(w, http.StatusOK, plan.response())
+}
+
+type chatSquadInvitePlan struct {
+	supported      bool
+	creds          lark.InstallationCredentials
+	chatID         lark.ChatID
+	wakeableCount  int
+	missingOpenIDs []lark.OpenID
+}
+
+func (p chatSquadInvitePlan) response() ChatSquadInviteStatusResponse {
+	return ChatSquadInviteStatusResponse{
+		WakeableCount: p.wakeableCount,
+		MissingCount:  len(p.missingOpenIDs),
+		CanInvite:     len(p.missingOpenIDs) > 0,
+	}
+}
+
+func (h *Handler) chatSquadInvitePlan(w http.ResponseWriter, r *http.Request, requireConfigured bool) (chatSquadInvitePlan, bool) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return chatSquadInvitePlan{}, false
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return chatSquadInvitePlan{}, false
+	}
+	sessionID := chi.URLParam(r, "sessionId")
+	if _, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID); !ok {
+		return chatSquadInvitePlan{}, false
+	}
+
+	squadID := chi.URLParam(r, "squadId")
+	squadUUID, ok := parseUUIDOrBadRequest(w, squadID, "squad id")
+	if !ok {
+		return chatSquadInvitePlan{}, false
+	}
+	squad, err := h.Queries.GetSquadInWorkspace(r.Context(), db.GetSquadInWorkspaceParams{
+		ID:          squadUUID,
+		WorkspaceID: workspaceUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "squad not found")
+		return chatSquadInvitePlan{}, false
+	}
+
+	if h.LarkInstallations == nil || h.LarkAPIClient == nil || !h.LarkAPIClient.IsConfigured() {
+		if requireConfigured {
+			writeError(w, http.StatusServiceUnavailable, "lark integration not configured")
+			return chatSquadInvitePlan{}, false
+		}
+		return chatSquadInvitePlan{}, true
+	}
+
+	sessionUUID, ok := parseUUIDOrBadRequest(w, sessionID, "chat session id")
+	if !ok {
+		return chatSquadInvitePlan{}, false
+	}
+	binding, err := h.Queries.GetLarkChatSessionBindingBySession(r.Context(), sessionUUID)
+	if err != nil {
+		if requireConfigured {
+			writeError(w, http.StatusBadRequest, "chat session is not linked to a Lark channel")
+			return chatSquadInvitePlan{}, false
+		}
+		return chatSquadInvitePlan{}, true
+	}
+	if binding.LarkChatType != string(lark.ChatTypeGroup) {
+		if requireConfigured {
+			writeError(w, http.StatusBadRequest, "one-click invite is only available in Lark group chats")
+			return chatSquadInvitePlan{}, false
+		}
+		return chatSquadInvitePlan{}, true
+	}
+
+	install, err := h.LarkInstallations.GetInWorkspace(r.Context(), binding.InstallationID, workspaceUUID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load lark installation")
+		return chatSquadInvitePlan{}, false
+	}
+	appSecret, err := h.LarkInstallations.DecryptAppSecret(install)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load lark installation credentials")
+		return chatSquadInvitePlan{}, false
+	}
+	creds := lark.InstallationCredentials{
+		AppID:     install.AppID,
+		AppSecret: appSecret,
+	}
+	if install.TenantKey.Valid {
+		creds.TenantKey = install.TenantKey.String
+	}
+	currentOpenIDs, err := h.LarkAPIClient.ListChatMemberOpenIDs(r.Context(), lark.ListChatMemberParams{
+		InstallationID: creds,
+		ChatID:         lark.ChatID(binding.LarkChatID),
+	})
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to load lark channel members")
+		return chatSquadInvitePlan{}, false
+	}
+
+	targetOpenIDs, err := h.squadLarkBotOpenIDs(r.Context(), workspaceUUID, squad)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load squad members")
+		return chatSquadInvitePlan{}, false
+	}
+	current := make(map[lark.OpenID]struct{}, len(currentOpenIDs))
+	for _, id := range currentOpenIDs {
+		current[id] = struct{}{}
+	}
+	plan := chatSquadInvitePlan{supported: true, creds: creds, chatID: lark.ChatID(binding.LarkChatID)}
+	for _, id := range targetOpenIDs {
+		if _, ok := current[id]; ok {
+			plan.wakeableCount++
+		} else {
+			plan.missingOpenIDs = append(plan.missingOpenIDs, id)
+		}
+	}
+	return plan, true
+}
+
+func (h *Handler) squadLarkBotOpenIDs(ctx context.Context, workspaceID pgtype.UUID, squad db.Squad) ([]lark.OpenID, error) {
+	members, err := h.Queries.ListSquadMembers(ctx, squad.ID)
+	if err != nil {
+		return nil, err
+	}
+	agentIDs := map[string]pgtype.UUID{uuidToString(squad.LeaderID): squad.LeaderID}
+	for _, m := range members {
+		if m.MemberType == "agent" {
+			agentIDs[uuidToString(m.MemberID)] = m.MemberID
+		}
+	}
+	out := make([]lark.OpenID, 0, len(agentIDs))
+	seen := make(map[lark.OpenID]struct{}, len(agentIDs))
+	for _, agentID := range agentIDs {
+		agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          agentID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil || agent.ArchivedAt.Valid {
+			continue
+		}
+		install, err := h.Queries.GetLarkInstallationByAgent(ctx, db.GetLarkInstallationByAgentParams{
+			WorkspaceID: workspaceID,
+			AgentID:     agentID,
+		})
+		if err != nil || install.Status != string(lark.InstallationActive) || install.BotOpenID == "" {
+			continue
+		}
+		openID := lark.OpenID(install.BotOpenID)
+		if _, ok := seen[openID]; ok {
+			continue
+		}
+		seen[openID] = struct{}{}
+		out = append(out, openID)
+	}
+	return out, nil
 }
 
 type UpdateChatSessionRequest struct {

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -69,6 +69,14 @@ type APIClient interface {
 	// is then frozen into lark_installation alongside the app_id /
 	// app_secret in the same transaction as the installer-bind.
 	GetBotInfo(ctx context.Context, creds InstallationCredentials) (BotInfo, error)
+
+	// ListChatMemberOpenIDs returns the open_ids that are already in a group
+	// chat. Used by the in-app @squad picker to decide whether a compact
+	// "invite" CTA should be shown before attempting to wake squad members.
+	ListChatMemberOpenIDs(ctx context.Context, p ListChatMemberParams) ([]OpenID, error)
+
+	// AddChatMembers invites the supplied open_ids into a group chat.
+	AddChatMembers(ctx context.Context, p AddChatMembersParams) error
 }
 
 // BotInfo is the slice of /open-apis/bot/v3/info (+ a follow-up
@@ -150,6 +158,23 @@ type BindingPromptParams struct {
 	BindURL string
 }
 
+// ListChatMemberParams asks Lark for the members of a group chat. The
+// production client returns member open_ids so callers can compare them with
+// bot_open_id values stored on lark_installation rows.
+type ListChatMemberParams struct {
+	InstallationID InstallationCredentials
+	ChatID         ChatID
+}
+
+// AddChatMembersParams invites one or more Lark users/bots into a group chat.
+// OpenIDs must be per-installation open_ids (the same identifier family as
+// lark_installation.bot_open_id).
+type AddChatMembersParams struct {
+	InstallationID InstallationCredentials
+	ChatID         ChatID
+	OpenIDs        []OpenID
+}
+
 // InstallationCredentials is the per-installation transport context the
 // client needs to authenticate against Lark on behalf of a workspace's
 // bot. Passing these explicitly to each call (rather than constructing
@@ -226,4 +251,14 @@ func (s *stubAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 func (s *stubAPIClient) GetBotInfo(ctx context.Context, creds InstallationCredentials) (BotInfo, error) {
 	s.log.Warn("lark stub client: GetBotInfo called", "app_id", creds.AppID)
 	return BotInfo{}, ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) ListChatMemberOpenIDs(ctx context.Context, p ListChatMemberParams) ([]OpenID, error) {
+	s.log.Warn("lark stub client: ListChatMemberOpenIDs called", "chat_id", string(p.ChatID))
+	return nil, ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) AddChatMembers(ctx context.Context, p AddChatMembersParams) error {
+	s.log.Warn("lark stub client: AddChatMembers called", "chat_id", string(p.ChatID), "count", len(p.OpenIDs))
+	return ErrAPIClientNotConfigured
 }

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -434,6 +434,111 @@ func (c *httpAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 	return nil
 }
 
+// ListChatMemberOpenIDs returns the current open_id membership of a Lark group
+// chat. Lark paginates this endpoint; the UI only needs a small squad-size
+// comparison, but we still follow page_token to avoid hiding the invite CTA in
+// larger rooms.
+func (c *httpAPIClient) ListChatMemberOpenIDs(ctx context.Context, p ListChatMemberParams) ([]OpenID, error) {
+	if p.ChatID == "" {
+		return nil, errors.New("lark http client: missing chat_id")
+	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []OpenID
+	pageToken := ""
+	for {
+		q := url.Values{}
+		q.Set("member_id_type", "open_id")
+		q.Set("page_size", "100")
+		if pageToken != "" {
+			q.Set("page_token", pageToken)
+		}
+		var resp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items []struct {
+					MemberID string `json:"member_id"`
+					OpenID   string `json:"open_id"`
+					UserID   string `json:"user_id"`
+				} `json:"items"`
+				HasMore   bool   `json:"has_more"`
+				PageToken string `json:"page_token"`
+			} `json:"data"`
+		}
+		path := "/open-apis/im/v1/chats/" + url.PathEscape(string(p.ChatID)) + "/members?" + q.Encode()
+		if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &resp); err != nil {
+			return nil, fmt.Errorf("lark http client: list chat members: %w", err)
+		}
+		if resp.Code != 0 {
+			if isTokenError(resp.Code) {
+				c.invalidateToken(p.InstallationID.AppID)
+			}
+			return nil, fmt.Errorf("lark http client: list chat members: code=%d msg=%q", resp.Code, resp.Msg)
+		}
+		for _, item := range resp.Data.Items {
+			id := item.MemberID
+			if id == "" {
+				id = item.OpenID
+			}
+			if id == "" {
+				id = item.UserID
+			}
+			if id != "" {
+				out = append(out, OpenID(id))
+			}
+		}
+		if !resp.Data.HasMore || resp.Data.PageToken == "" {
+			return out, nil
+		}
+		pageToken = resp.Data.PageToken
+	}
+}
+
+// AddChatMembers invites the supplied open_ids into a Lark group chat.
+func (c *httpAPIClient) AddChatMembers(ctx context.Context, p AddChatMembersParams) error {
+	if p.ChatID == "" {
+		return errors.New("lark http client: missing chat_id")
+	}
+	if len(p.OpenIDs) == 0 {
+		return errors.New("lark http client: missing open_ids")
+	}
+	token, err := c.tenantAccessToken(ctx, p.InstallationID)
+	if err != nil {
+		return err
+	}
+	ids := make([]string, 0, len(p.OpenIDs))
+	for _, id := range p.OpenIDs {
+		if id != "" {
+			ids = append(ids, string(id))
+		}
+	}
+	if len(ids) == 0 {
+		return errors.New("lark http client: missing open_ids")
+	}
+	q := url.Values{}
+	q.Set("member_id_type", "open_id")
+	body := map[string][]string{"id_list": ids}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	path := "/open-apis/im/v1/chats/" + url.PathEscape(string(p.ChatID)) + "/members?" + q.Encode()
+	if err := c.doJSON(ctx, http.MethodPost, path, token, body, &resp); err != nil {
+		return fmt.Errorf("lark http client: add chat members: %w", err)
+	}
+	if resp.Code != 0 {
+		if isTokenError(resp.Code) {
+			c.invalidateToken(p.InstallationID.AppID)
+		}
+		return fmt.Errorf("lark http client: add chat members: code=%d msg=%q", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
 // GetBotInfo calls /open-apis/bot/v3/info to learn the Bot's
 // per-installation `open_id` and then /open-apis/contact/v3/users/
 // {open_id}?user_id_type=open_id to resolve its stable `union_id`.

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -119,6 +119,12 @@ func (f *fakeAPIClient) SendBindingPromptCard(ctx context.Context, p BindingProm
 func (f *fakeAPIClient) GetBotInfo(ctx context.Context, creds InstallationCredentials) (BotInfo, error) {
 	return BotInfo{}, nil
 }
+func (f *fakeAPIClient) ListChatMemberOpenIDs(ctx context.Context, p ListChatMemberParams) ([]OpenID, error) {
+	return nil, nil
+}
+func (f *fakeAPIClient) AddChatMembers(ctx context.Context, p AddChatMembersParams) error {
+	return nil
+}
 
 func newTestPatcher(t *testing.T) (*Patcher, *fakePatcherQueries, *fakeAPIClient) {
 	t.Helper()

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -72,6 +72,14 @@ func (s *stubAPIClientWithRecorder) GetBotInfo(ctx context.Context, creds Instal
 	return BotInfo{}, nil
 }
 
+func (s *stubAPIClientWithRecorder) ListChatMemberOpenIDs(ctx context.Context, p ListChatMemberParams) ([]OpenID, error) {
+	return nil, nil
+}
+
+func (s *stubAPIClientWithRecorder) AddChatMembers(ctx context.Context, p AddChatMembersParams) error {
+	return nil
+}
+
 // stubCredentialsResolver returns a fixed plaintext secret.
 type stubCredentialsResolver struct{ secret string }
 


### PR DESCRIPTION
## Summary
- add Lark-backed chat squad invite status/invite endpoints
- show compact 一键邀请 CTA in squad mention rows when agents are missing from the current channel
- refresh the mention row status after invite while preserving wake-count/no-wakeable states

## Verification
- GOCACHE=/tmp/loop-go-cache go test ./... (server)
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views test -- mention-suggestion.test.tsx
- pnpm --filter @multica/views lint (warnings only in unrelated existing files)
- pnpm --filter @multica/core lint