### PR TITLE
fix(slack): build the binding link from the web app URL, matching Lark (MUL-3666)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -469,10 +469,13 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			slackBindingSvc := slack.NewBindingTokenService(queries, pool)
 			h.SlackBindingTokens = slackBindingSvc
 			slackReplier := slack.NewOutboundReplier(slack.OutboundReplierConfig{
-				Binding:   slackBindingSvc,
-				Decrypt:   box.Open,
-				PublicURL: signupConfig.PublicURL,
-				Logger:    slog.Default(),
+				Binding: slackBindingSvc,
+				Decrypt: box.Open,
+				// The bind link (/slack/bind) is a web-app page, so it must use the
+				// app URL (MULTICA_APP_URL ?? FRONTEND_ORIGIN), NOT MULTICA_PUBLIC_URL
+				// (the backend/API URL). Mirrors the Lark replier (appURLFromEnv).
+				AppURL: appURLFromEnv(),
+				Logger: slog.Default(),
 			})
 			channelRouter.Register(slack.TypeSlack, slack.NewSlackResolverSet(queries, pool, slackReplier))
 			slack.NewOutbound(queries, box.Open, slog.Default()).Register(bus)

--- a/server/internal/integrations/slack/replier.go
+++ b/server/internal/integrations/slack/replier.go
@@ -46,18 +46,25 @@ type OutboundReplier struct {
 	binding     bindingMinter
 	decrypt     Decrypter
 	newSender   func(creds credentials) replySender
-	publicURL   string
+	appURL      string
 	bindingPath string
 	logger      *slog.Logger
 }
 
-// OutboundReplierConfig configures the replier. Binding + PublicURL are required
+// OutboundReplierConfig configures the replier. Binding + AppURL are required
 // for the NeedsBinding prompt to work; without them the prompt is skipped (the
 // offline/archived/issue notices still fire).
 type OutboundReplierConfig struct {
-	Binding     bindingMinter
-	Decrypt     Decrypter
-	PublicURL   string
+	Binding bindingMinter
+	Decrypt Decrypter
+	// AppURL is the Multica web app host the user clicks into to redeem the
+	// binding token (e.g. https://multica.example). It comes from MULTICA_APP_URL
+	// (falling back to FRONTEND_ORIGIN) and is intentionally separate from
+	// MULTICA_PUBLIC_URL, which is the backend/API public URL used for webhook and
+	// daemon-facing endpoints — the bind page (/slack/bind) is served by the web
+	// app, so the link must point at the app host, not the API host. Mirrors the
+	// Lark replier's AppURL.
+	AppURL      string
 	BindingPath string // default "/slack/bind"
 	Logger      *slog.Logger
 }
@@ -81,7 +88,7 @@ func NewOutboundReplier(cfg OutboundReplierConfig) *OutboundReplier {
 	r := &OutboundReplier{
 		binding:     cfg.Binding,
 		decrypt:     cfg.Decrypt,
-		publicURL:   strings.TrimRight(cfg.PublicURL, "/"),
+		appURL:      strings.TrimRight(cfg.AppURL, "/"),
 		bindingPath: bindingPath,
 		logger:      logger,
 	}
@@ -133,14 +140,14 @@ func (r *OutboundReplier) sendBindingPrompt(ctx context.Context, inst engine.Res
 	if r.binding == nil {
 		return errors.New("binding service not configured")
 	}
-	if r.publicURL == "" {
-		return errors.New("public url not configured")
+	if r.appURL == "" {
+		return errors.New("app url not configured")
 	}
 	token, err := r.binding.Mint(ctx, inst.WorkspaceID, inst.ID, sender)
 	if err != nil {
 		return fmt.Errorf("mint binding token: %w", err)
 	}
-	bindURL := r.publicURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
+	bindURL := r.appURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
 	// Wrap the URL as an explicit Slack link <url|label>: formatMrkdwn protects
 	// these from its markdown passes, so the base64url token's `_`/`-` chars are
 	// not mangled into italics.

--- a/server/internal/integrations/slack/replier_test.go
+++ b/server/internal/integrations/slack/replier_test.go
@@ -41,9 +41,9 @@ func (f *fakeBindingMinter) Mint(_ context.Context, ws, inst pgtype.UUID, user s
 
 func newTestReplier(binding bindingMinter, sender replySender) *OutboundReplier {
 	r := NewOutboundReplier(OutboundReplierConfig{
-		Binding:   binding,
-		Decrypt:   nil, // identity: stored bot token is base64 plaintext
-		PublicURL: "https://multica.example",
+		Binding: binding,
+		Decrypt: nil, // identity: stored bot token is base64 plaintext
+		AppURL:  "https://multica.example",
 	})
 	r.newSender = func(credentials) replySender { return sender }
 	return r


### PR DESCRIPTION
## Summary

The Slack "link your account" binding prompt built its redeem link from `MULTICA_PUBLIC_URL` — but `/slack/bind` is a **web-app page**, so the link needs the **web app URL**, not the backend/API URL.

`MULTICA_PUBLIC_URL` is intentionally the backend/API public URL (autopilot webhooks, daemon `server_url`, attachment downloads). The Lark replier was already migrated to use the web app URL via `appURLFromEnv()` (`MULTICA_APP_URL`, falling back to `FRONTEND_ORIGIN`). **Slack was never migrated**, so on any deployment that sets `FRONTEND_ORIGIN`/`MULTICA_APP_URL` but not `MULTICA_PUBLIC_URL` (e.g. our dev), the Slack binding prompt silently failed (`"public url not configured"`) and @-mentions to the bot got no response.

This makes Slack consistent with Lark:
- `slack.OutboundReplierConfig.PublicURL` → `AppURL`, fed from `appURLFromEnv()` in `router.go`.
- The backend/API-URL uses of `MULTICA_PUBLIC_URL` (webhooks, attachment URLs, daemon `server_url`) are intentionally left unchanged — those are correct.

Net effect: you no longer need `MULTICA_PUBLIC_URL` for Slack/Lark binding; the always-set `FRONTEND_ORIGIN` (or `MULTICA_APP_URL`) is used.

Relates to MUL-3666.

## How verified

- `go build ./...`, `go vet ./internal/integrations/slack/... ./cmd/server/...`, and `go test ./internal/integrations/slack/...` all pass.
- On dev (`FRONTEND_ORIGIN` set, `MULTICA_PUBLIC_URL` unset) the bind link now resolves to the web app URL, so the first @-mention yields a working "link your account" link.
