### PR TITLE
MUL-3848: fix(server): skip CLIENT SETNAME for managed Redis compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,11 @@ CORS_ALLOWED_ORIGINS=
 # startup. The same REDIS_URL is reused by the realtime fan-out hub,
 # the PAT cache, and the daemon-token cache.
 # REDIS_URL=redis://localhost:6379/0
+# Set to "true" to skip the CLIENT SETNAME handshake on every Redis
+# connection. Required for managed Redis providers that block the CLIENT
+# command (e.g. GCP Memorystore, AWS ElastiCache with restricted ACLs).
+# Default is false (client naming enabled for connection observability).
+# REDIS_DISABLE_CLIENT_NAME=true
 # Max requests per IP per minute. Defaults are 5 for send-code/google
 # and 20 for verify-code.
 # RATE_LIMIT_AUTH=5

--- a/apps/docs/content/docs/environment-variables.ja.mdx
+++ b/apps/docs/content/docs/environment-variables.ja.mdx
@@ -157,6 +157,7 @@ S3 の前段に CloudFront を置く場合、3 つの変数が適用されます
 | 変数 | デフォルト | 説明 |
 |---|---|---|
 | `REDIS_URL` | 空 | Redis 接続 URL（例: `redis://localhost:6379/0`）。設定しないと auth エンドポイントのレート制限が無効になります。同じ Redis はリアルタイムハブの fan-out、PAT キャッシュ、デーモントークンキャッシュでも使われます — 設定しない場合はすべてインメモリ / 直接 DB モードにフォールバックします |
+| `REDIS_DISABLE_CLIENT_NAME` | `false` | `true` に設定すると、すべての Redis 接続で `CLIENT SETNAME` ハンドシェイクをスキップします。`CLIENT` コマンドをブロックするマネージド Redis プロバイダー（GCP Memorystore や ACL 制限付きの AWS ElastiCache など）を使用する場合に**必須**です。有効にすると `CLIENT LIST` 出力で接続の説明的な名前が失われますが、制限付きプロバイダーとの互換性が得られます |
 | `RATE_LIMIT_AUTH` | `5` | `/auth/send-code` および `/auth/google` に対する IP あたり毎分の最大リクエスト数 |
 | `RATE_LIMIT_AUTH_VERIFY` | `20` | `/auth/verify-code` に対する IP あたり毎分の最大リクエスト数 |
 | `RATE_LIMIT_TRUSTED_PROXIES` | 空 | リミッターがその `X-Forwarded-For` ヘッダーを信頼することを許可する、カンマ区切りの CIDR。空（デフォルト）は **XFF を決して信頼しない**ことを意味します — リミッターは直接接続の `RemoteAddr` のみを使用します |

--- a/apps/docs/content/docs/environment-variables.ko.mdx
+++ b/apps/docs/content/docs/environment-variables.ko.mdx
@@ -157,6 +157,7 @@ S3 앞에 CloudFront를 두는 경우 세 가지 변수가 적용됩니다: `CLO
 | 변수 | 기본값 | 설명 |
 |---|---|---|
 | `REDIS_URL` | 비어 있음 | Redis 연결 URL (예: `redis://localhost:6379/0`). 설정하지 않으면 auth 엔드포인트의 속도 제한이 비활성화됩니다. 동일한 Redis는 실시간 허브 fan-out, PAT 캐시, 데몬 토큰 캐시에서도 사용됩니다 — 설정하지 않으면 모두 인메모리 / 직접 DB 모드로 폴백합니다 |
+| `REDIS_DISABLE_CLIENT_NAME` | `false` | `true`로 설정하면 모든 Redis 연결에서 `CLIENT SETNAME` 핸드셰이크를 건너뜁니다. `CLIENT` 명령을 차단하는 관리형 Redis 제공자(GCP Memorystore 또는 ACL이 제한된 AWS ElastiCache 등)를 사용할 때 **필수**입니다. 활성화하면 `CLIENT LIST` 출력에서 연결의 설명 이름이 사라지지만, 제한된 제공자와의 호환성을 얻을 수 있습니다 |
 | `RATE_LIMIT_AUTH` | `5` | `/auth/send-code` 및 `/auth/google`에 대한 IP당 분당 최대 요청 수 |
 | `RATE_LIMIT_AUTH_VERIFY` | `20` | `/auth/verify-code`에 대한 IP당 분당 최대 요청 수 |
 | `RATE_LIMIT_TRUSTED_PROXIES` | 비어 있음 | 리미터가 그 `X-Forwarded-For` 헤더를 신뢰하도록 허용하는, 쉼표로 구분된 CIDR. 비어 있음(기본값)은 **XFF를 절대 신뢰하지 않음**을 의미합니다 — 리미터는 직접 연결의 `RemoteAddr`만 사용합니다 |

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -157,6 +157,7 @@ Public auth endpoints — `/auth/send-code`, `/auth/verify-code`, `/auth/google`
 | Variable | Default | Description |
 |---|---|---|
 | `REDIS_URL` | empty | Redis connection URL (for example `redis://localhost:6379/0`). When unset, rate limiting on auth endpoints is disabled. The same Redis is also used by the realtime hub fan-out, the PAT cache, and the daemon-token cache — they all fall back to in-memory / direct-DB mode when unset |
+| `REDIS_DISABLE_CLIENT_NAME` | `false` | Set to `true` to skip the `CLIENT SETNAME` handshake on every Redis connection. **Required** for managed Redis providers that block the `CLIENT` command, such as GCP Memorystore or AWS ElastiCache with restricted ACLs. When enabled, connections lose their descriptive name in `CLIENT LIST` output but gain compatibility with restricted providers |
 | `RATE_LIMIT_AUTH` | `5` | Max requests per IP per minute against `/auth/send-code` and `/auth/google` |
 | `RATE_LIMIT_AUTH_VERIFY` | `20` | Max requests per IP per minute against `/auth/verify-code` |
 | `RATE_LIMIT_TRUSTED_PROXIES` | empty | Comma-separated CIDRs whose `X-Forwarded-For` header the limiter is allowed to trust. Empty (the default) means **never trust XFF** — the limiter only uses the direct connection's `RemoteAddr` |

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -157,6 +157,7 @@ API 返回的 `download_url` 在未配置 CloudFront 签名时会指向 `GET /ap
 | 环境变量 | 默认值 | 说明 |
 |---|---|---|
 | `REDIS_URL` | 空 | Redis 连接 URL（例如 `redis://localhost:6379/0`）。不设时认证端点的限流功能直接关闭。同一个 Redis 也被实时事件 fan-out、PAT 缓存、守护进程 token 缓存复用；不设时这些组件分别回落到内存模式 / 直查 DB |
+| `REDIS_DISABLE_CLIENT_NAME` | `false` | 设为 `true` 可跳过每次 Redis 连接时的 `CLIENT SETNAME` 握手。使用托管 Redis（如 GCP Memorystore 或限制了 ACL 的 AWS ElastiCache）等封禁 `CLIENT` 命令的服务时**必须开启**。启用后连接在 `CLIENT LIST` 输出中会失去描述性名称，但能兼容受限的托管服务 |
 | `RATE_LIMIT_AUTH` | `5` | 单 IP 每分钟对 `/auth/send-code` 和 `/auth/google` 的最大请求数 |
 | `RATE_LIMIT_AUTH_VERIFY` | `20` | 单 IP 每分钟对 `/auth/verify-code` 的最大请求数 |
 | `RATE_LIMIT_TRUSTED_PROXIES` | 空 | 逗号分隔的 CIDR 列表，列在内的来源 IP 才允许通过 `X-Forwarded-For` 标识客户端。默认空 = **永不信任 XFF**，限流器只看直连的 `RemoteAddr` |

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -34,7 +34,9 @@ var (
 
 func newNamedRedisClient(base *redis.Options, suffix string) *redis.Client {
 	opts := *base
-	opts.ClientName = redisClientName(opts.ClientName, suffix)
+	if !envBool("REDIS_DISABLE_CLIENT_NAME", false) {
+		opts.ClientName = redisClientName(opts.ClientName, suffix)
+	}
 	return redis.NewClient(&opts)
 }
 
@@ -115,6 +117,19 @@ func envDuration(name string, def time.Duration) time.Duration {
 	v, err := time.ParseDuration(raw)
 	if err != nil || v <= 0 {
 		slog.Warn("invalid env var, using default", "name", name, "value", raw, "default", def.String(), "error", err)
+		return def
+	}
+	return v
+}
+
+func envBool(name string, def bool) bool {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		slog.Warn("invalid env var, using default", "name", name, "value", raw, "default", def, "error", err)
 		return def
 	}
 	return v
@@ -224,6 +239,9 @@ func main() {
 		if err != nil {
 			slog.Error("invalid REDIS_URL — falling back to in-memory hub", "error", err)
 		} else {
+			if envBool("REDIS_DISABLE_CLIENT_NAME", false) {
+				slog.Info("redis: CLIENT SETNAME disabled (REDIS_DISABLE_CLIENT_NAME=true) for managed Redis compatibility")
+			}
 			storeRedis = newNamedRedisClient(opts, "store")
 			relayWriteRedis = newNamedRedisClient(opts, "realtime-write")
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -34,7 +34,9 @@ var (
 
 func newNamedRedisClient(base *redis.Options, suffix string) *redis.Client {
 	opts := *base
-	if !envBool("REDIS_DISABLE_CLIENT_NAME", false) {
+	if envBool("REDIS_DISABLE_CLIENT_NAME", false) {
+		opts.ClientName = ""
+	} else {
 		opts.ClientName = redisClientName(opts.ClientName, suffix)
 	}
 	return redis.NewClient(&opts)

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -53,6 +53,19 @@ func TestNewNamedRedisClient_DisableClientName(t *testing.T) {
 	}
 }
 
+func TestNewNamedRedisClient_DisableClientName_ClearsPreExistingName(t *testing.T) {
+	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "true")
+	// Simulate REDIS_URL with ?client_name=foo — ParseURL sets ClientName.
+	base := &redis.Options{Addr: "localhost:6379", ClientName: "foo"}
+	client := newNamedRedisClient(base, "store")
+	defer client.Close()
+
+	opts := client.Options()
+	if opts.ClientName != "" {
+		t.Errorf("ClientName = %q, want empty: REDIS_DISABLE_CLIENT_NAME must clear pre-existing name from URL", opts.ClientName)
+	}
+}
+
 func TestNewNamedRedisClient_DisableClientName_InvalidValue(t *testing.T) {
 	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "not-a-bool")
 	base := &redis.Options{Addr: "localhost:6379"}

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestRedisClientName(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		suffix   string
+		want     string
+	}{
+		{"empty_suffix_returns_existing", "multica-api:store", "", "multica-api:store"},
+		{"empty_existing_uses_default_prefix", "", "store", "multica-api:store"},
+		{"both_set_joins_with_colon", "custom", "store", "custom:store"},
+		{"empty_both_returns_empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redisClientName(tt.existing, tt.suffix)
+			if got != tt.want {
+				t.Errorf("redisClientName(%q, %q) = %q, want %q", tt.existing, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewNamedRedisClient_SetsClientName(t *testing.T) {
+	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "")
+	base := &redis.Options{Addr: "localhost:6379"}
+	client := newNamedRedisClient(base, "store")
+	defer client.Close()
+
+	opts := client.Options()
+	if opts.ClientName != "multica-api:store" {
+		t.Errorf("ClientName = %q, want %q", opts.ClientName, "multica-api:store")
+	}
+}
+
+func TestNewNamedRedisClient_DisableClientName(t *testing.T) {
+	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "true")
+	base := &redis.Options{Addr: "localhost:6379"}
+	client := newNamedRedisClient(base, "store")
+	defer client.Close()
+
+	opts := client.Options()
+	if opts.ClientName != "" {
+		t.Errorf("ClientName = %q, want empty when REDIS_DISABLE_CLIENT_NAME=true", opts.ClientName)
+	}
+}
+
+func TestNewNamedRedisClient_DisableClientName_InvalidValue(t *testing.T) {
+	t.Setenv("REDIS_DISABLE_CLIENT_NAME", "not-a-bool")
+	base := &redis.Options{Addr: "localhost:6379"}
+	client := newNamedRedisClient(base, "store")
+	defer client.Close()
+
+	opts := client.Options()
+	// Invalid value falls back to default (false), so ClientName IS set
+	if opts.ClientName != "multica-api:store" {
+		t.Errorf("ClientName = %q, want %q (invalid env should fall back to naming enabled)", opts.ClientName, "multica-api:store")
+	}
+}
+
+func TestEnvBool(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		def   bool
+		want  bool
+	}{
+		{"empty_returns_default_false", "TEST_ENV_BOOL_1", "", false, false},
+		{"empty_returns_default_true", "TEST_ENV_BOOL_2", "", true, true},
+		{"true_string", "TEST_ENV_BOOL_3", "true", false, true},
+		{"false_string", "TEST_ENV_BOOL_4", "false", true, false},
+		{"one_is_true", "TEST_ENV_BOOL_5", "1", false, true},
+		{"zero_is_false", "TEST_ENV_BOOL_6", "0", true, false},
+		{"invalid_returns_default", "TEST_ENV_BOOL_7", "maybe", false, false},
+		{"invalid_returns_default_true", "TEST_ENV_BOOL_8", "maybe", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "" {
+				t.Setenv(tt.key, tt.value)
+			} else {
+				os.Unsetenv(tt.key)
+			}
+			got := envBool(tt.key, tt.def)
+			if got != tt.want {
+				t.Errorf("envBool(%q, %v) = %v, want %v", tt.key, tt.def, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Managed Redis providers such as GCP Memorystore and AWS ElastiCache (with restricted ACLs) block the `CLIENT` command. The `go-redis/v9` library automatically sends `CLIENT SETNAME` on every new connection when `ClientName` is set in `redis.Options`, which causes **all** Redis-backed features to fail: rate limiting, realtime fan-out, PAT cache, daemon-token cache, membership cache, and more.

This PR adds a `REDIS_DISABLE_CLIENT_NAME` environment variable. When set to `true`, the `ClientName` field is left empty so `go-redis` skips the `CLIENT SETNAME` handshake entirely.

## Related Issue

Closes #4627

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Tests
- [ ] CI / Infrastructure

## Changes Made

- **`server/cmd/server/main.go`**: Added `envBool` helper (consistent with existing `envPositiveInt`/`envDuration` pattern). Modified `newNamedRedisClient` to skip `ClientName` when `REDIS_DISABLE_CLIENT_NAME=true`. Added startup log when the flag is active.
- **`server/cmd/server/main_test.go`**: 16 test cases covering `redisClientName`, `newNamedRedisClient` (default / disabled / invalid env), and `envBool`.
- **`.env.example`**: Documented `REDIS_DISABLE_CLIENT_NAME` with usage guidance.
- **`apps/docs/content/docs/environment-variables.{mdx,zh.mdx,ja.mdx,ko.mdx}`**: Added env var to all 4 language variants of the docs table.

## How to Test

1. Set `REDIS_URL` to a managed Redis endpoint that blocks the `CLIENT` command (e.g. GCP Memorystore).
2. Set `REDIS_DISABLE_CLIENT_NAME=true`.
3. Start the server and verify the startup log contains: `redis: CLIENT SETNAME disabled (REDIS_DISABLE_CLIENT_NAME=true) for managed Redis compatibility`.
4. Verify all Redis-backed features work: rate limiting on `/auth/send-code`, realtime WebSocket events, PAT cache, daemon-token cache.
5. Run the unit tests: `go test -v -count=1 -run "TestRedisClientName|TestNewNamedRedisClient|TestEnvBool" ./cmd/server/`

## Checklist

- [x] I have traced my reasoning and the thinking path is clear
- [x] I have run local tests and they pass (`go build`, `go vet`, `gofmt` all clean)
- [x] I have updated relevant tests
- [x] I have updated relevant documentation (all 4 language variants)
- [x] I have checked Chinese copy conventions where applicable
- [x] I have documented any risks or migration notes
- [x] I will respond to reviewer comments

## AI Disclosure

- **AI tool used**: QoderWork
- **Prompt / approach**: Analyzed the `go-redis/v9` `ClientName` behavior, identified that `newNamedRedisClient` unconditionally sets `opts.ClientName` causing `CLIENT SETNAME` on every connection. Designed a minimal env-var guard following the project's existing `envPositiveInt`/`envDuration` pattern.

## Screenshots

N/A — server-side change, no UI impact.
