### PR TITLE
fix(editor): handle legacy squad links

### DIFF
--- a/packages/core/paths/consistency.test.ts
+++ b/packages/core/paths/consistency.test.ts
@@ -27,7 +27,6 @@ describe("paths.workspace() shape", () => {
         "myIssues",
         "runtimes",
         "skills",
-        "squads",
         "settings",
       ]),
     );
@@ -48,7 +47,6 @@ describe("paths.workspace() shape", () => {
       ["myIssues", "my-issues"],
       ["runtimes", "runtimes"],
       ["skills", "skills"],
-      ["squads", "squads"],
       ["settings", "settings"],
     ];
     const wsAsAny = ws as unknown as Record<string, () => string>;

--- a/packages/views/editor/utils/link-handler.test.ts
+++ b/packages/views/editor/utils/link-handler.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openLink } from "./link-handler";
+
+function lastNavigatedPath(): string | undefined {
+  const event = vi.mocked(window.dispatchEvent).mock.calls.at(-1)?.[0];
+  return event instanceof CustomEvent
+    ? (event.detail as { path?: string }).path
+    : undefined;
+}
+
+describe("openLink", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prepends the current workspace slug to legacy squad links", () => {
+    vi.spyOn(window, "dispatchEvent");
+
+    openLink("/squads/abc", "acme");
+
+    expect(lastNavigatedPath()).toBe("/acme/squads/abc");
+  });
+
+  it("does not prepend the workspace slug to already scoped squad links", () => {
+    vi.spyOn(window, "dispatchEvent");
+
+    openLink("/acme/squads/abc", "acme");
+
+    expect(lastNavigatedPath()).toBe("/acme/squads/abc");
+  });
+
+  it("does not prepend the workspace slug to global paths", () => {
+    vi.spyOn(window, "dispatchEvent");
+
+    openLink("/login", "acme");
+
+    expect(lastNavigatedPath()).toBe("/login");
+  });
+});

--- a/packages/views/editor/utils/link-handler.ts
+++ b/packages/views/editor/utils/link-handler.ts
@@ -24,6 +24,7 @@ const WORKSPACE_ROUTE_SEGMENTS = new Set([
   "projects",
   "autopilots",
   "agents",
+  "squads",
   "inbox",
   "my-issues",
   "runtimes",


### PR DESCRIPTION
## What does this PR do?

Fixes legacy editor links to squad routes that were authored without a workspace slug.

The editor link handler already rewrites legacy workspace-scoped links like `/issues/...` to `/{workspaceSlug}/issues/...`, but `squads` was missing from that allowlist even though `paths.workspace(slug).squads()` exists. As a result, clicking `/squads/...` from editor-rendered content could navigate to an unscoped path instead of the current workspace.

This PR adds `squads` to the conservative workspace route allowlist and adds focused tests for the intended rewrite behavior.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `squads` to `WORKSPACE_ROUTE_SEGMENTS` in `packages/views/editor/utils/link-handler.ts`.
- Added `packages/views/editor/utils/link-handler.test.ts` to cover:
  - legacy `/squads/abc` links being rewritten to `/{slug}/squads/abc`
  - already scoped `/acme/squads/abc` links not being rewritten again
  - global paths not being rewritten
- Removed duplicated `squads` expectations from `packages/core/paths/consistency.test.ts`.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run editor/utils/link-handler.test.ts`.
2. Run `pnpm --filter @multica/core exec vitest run paths/consistency.test.ts`.
3. Run `pnpm --filter @multica/views typecheck && pnpm --filter @multica/core typecheck`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Used Cursor to inspect the workspace path helpers and shared editor link handler. The change was scoped to the route allowlist drift: `paths.workspace(slug)` already exposes squad routes, while the editor legacy-link rewrite allowlist did not include `squads`. Added focused tests around the rewrite behavior and ran targeted Vitest suites plus package typechecks.

## Screenshots (optional)

N/A