### PR TITLE
MUL-3856: fix: allow newer Docker Compose versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,25 +37,27 @@ define REQUIRE_ENV
 	fi
 endef
 
-# Self-hosting requires Docker Compose v2 (the `docker compose` CLI plugin).
+# Self-hosting requires the Docker Compose CLI plugin (`docker compose`).
 # The self-host compose files use compose-spec syntax (top-level `name:`, no
 # `version:`) that the legacy v1 `docker-compose` standalone cannot parse, so we
 # fail early with an actionable message instead of a cryptic CLI parse error
 # (e.g. "unknown shorthand flag: 'f' in -f") when the plugin is missing or v1.
 # Keep the message short and OS-agnostic: per-OS install steps belong in docs.
 define REQUIRE_COMPOSE
-	@if ! $(COMPOSE) version >/dev/null 2>&1; then \
-		echo "Docker Compose v2 ('docker compose') was not found."; \
-		echo "Self-hosting requires the Compose v2 CLI plugin; legacy 'docker-compose' v1 is not supported."; \
+	@if ! compose_version=$$($(COMPOSE) version --short 2>/dev/null); then \
+		echo "Docker Compose ('docker compose') was not found."; \
+		echo "Self-hosting requires the Compose CLI plugin; legacy 'docker-compose' v1 is not supported."; \
 		echo "Install Docker Compose from https://docs.docker.com/compose/install/ and verify with: docker compose version"; \
 		exit 1; \
 	fi; \
-	if ! $(COMPOSE) version --short 2>/dev/null | grep -Eq '^v?2\.'; then \
-		echo "'$(COMPOSE)' is not Docker Compose v2."; \
-		echo "Self-hosting requires the Compose v2 CLI plugin; legacy 'docker-compose' v1 is not supported."; \
-		echo "Install Docker Compose from https://docs.docker.com/compose/install/ and verify with: docker compose version"; \
-		exit 1; \
-	fi
+	case "$$compose_version" in \
+		1.*|v1.*) \
+			echo "'$(COMPOSE)' is legacy Docker Compose v1 ($$compose_version)."; \
+			echo "Self-hosting requires the Compose CLI plugin; legacy 'docker-compose' v1 is not supported."; \
+			echo "Install Docker Compose from https://docs.docker.com/compose/install/ and verify with: docker compose version"; \
+			exit 1; \
+			;; \
+	esac
 endef
 
 # Default target changed from selfhost to help: bare `make` now prints this help


### PR DESCRIPTION
## Motivation

`make selfhost` was rejecting Docker Compose `5.1.4` because the preflight added in #4354 only accepted version strings beginning with `2.` or `v2.`. The intent of that preflight is still valid: fail early when the Compose CLI plugin is missing and reject legacy Compose v1 before users hit a cryptic Docker CLI parse error.

This keeps that behavior while allowing current and future non-v1 Compose plugin versions.

## Modifications

- Change the self-host Compose guard to use `docker compose version --short` as the required check.
- Reject only legacy `1.x` / `v1.x` Compose versions instead of requiring exactly Compose `2.x`.
- Update the error wording from "Compose v2" to "Compose CLI plugin" so it does not become stale as Compose major versions advance.

## Test

- `make -n selfhost-stop`
- `make selfhost-stop COMPOSE=__no_such_compose__`
- `docker compose version --short` -> `5.1.4`
