### PR TITLE
feat(agent): add native omp (Oh My Pi) ACP runtime backend

### DIFF
--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -12,6 +12,7 @@ const MCP_SUPPORTED_PROVIDERS = new Set([
   "hermes",
   "kimi",
   "kiro",
+  "omp",
   "opencode",
   "openclaw",
 ]);

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -68,6 +68,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "kimi",
   "kiro",
   "antigravity",
+  "omp",
 ] as const;
 
 export type RuntimeProtocolFamily =

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -247,6 +247,27 @@ function KiroLogo({ className }: { className: string }) {
   );
 }
 
+// Oh My Pi (omp CLI) — wordmark mark in a dark rounded tile with a white
+// Greek pi (π) glyph, matching the inline-wordmark style used by KimiLogo.
+function OmpLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <rect width="24" height="24" rx="5" fill="#111827" />
+      <text
+        x="12"
+        y="17"
+        textAnchor="middle"
+        fontSize="15"
+        fontWeight="700"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fill="#FFFFFF"
+      >
+        π
+      </text>
+    </svg>
+  );
+}
+
 export function ProviderLogo({
   provider,
   className = "h-4 w-4",
@@ -281,6 +302,8 @@ export function ProviderLogo({
       return <QoderLogo className={className} />;
     case "antigravity":
       return <AntigravityLogo className={className} />;
+    case "omp":
+      return <OmpLogo className={className} />;
     default:
       return <Monitor className={className} />;
   }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -272,6 +272,12 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if e, ok := probe("MULTICA_HERMES_PATH", "hermes", "MULTICA_HERMES_MODEL"); ok {
 		agents["hermes"] = e
 	}
+	if e, ok := probe("MULTICA_OMP_PATH", "omp", "MULTICA_OMP_MODEL"); ok {
+		agents["omp"] = e
+	}
+	if e, ok := probe("MULTICA_GEMINI_PATH", "gemini", "MULTICA_GEMINI_MODEL"); ok {
+		agents["gemini"] = e
+	}
 	if e, ok := probe("MULTICA_PI_PATH", "pi", "MULTICA_PI_MODEL"); ok {
 		agents["pi"] = e
 	}
@@ -305,7 +311,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		}
 	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor-agent, kimi, kiro-cli, agy, or qodercli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, openclaw, hermes, omp, gemini, pi, cursor-agent, kimi, kiro-cli, agy, or qodercli and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
@@ -653,8 +659,8 @@ func shellArgsFromEnv(name string) ([]string, error) {
 // list to pre-fetch canonical paths for every known agent in a single shell
 // invocation, instead of paying the cost-per-miss.
 var defaultAgentCommandNames = []string{
-	"claude", "codex", "opencode", "openclaw", "hermes",
-	"pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "codebuddy", "agy",
+	"claude", "codex", "opencode", "openclaw", "hermes", "omp",
+	"gemini", "pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "codebuddy", "agy",
 }
 
 var codexDesktopAppBundlePaths = func() []string {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -187,7 +187,7 @@ func runtimeConfigPath(workDir, provider string) string {
 	switch provider {
 	case "claude", "codebuddy":
 		return filepath.Join(workDir, "CLAUDE.md")
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "omp", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder":
 		return filepath.Join(workDir, "AGENTS.md")
 	default:
 		return ""
@@ -760,9 +760,10 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 			// Antigravity inherits Gemini CLI's workspace skill layout —
 			// {workDir}/.agents/skills/ — see resolveSkillsDir.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "hermes":
-			// Hermes has no native skill discovery path wired up in resolveSkillsDir;
-			// fall back to referencing the files explicitly under .agent_context/skills/.
+		case "gemini", "hermes", "omp":
+			// Gemini reads GEMINI.md directly. Hermes and omp have no native
+			// skill discovery path wired up in resolveSkillsDir; all fall back
+			// to referencing the files explicitly under .agent_context/skills/.
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")

--- a/server/migrations/128_runtime_profile_protocol_family_omp.down.sql
+++ b/server/migrations/128_runtime_profile_protocol_family_omp.down.sql
@@ -1,0 +1,25 @@
+-- Reverse 128_runtime_profile_protocol_family_omp.up.sql.
+--
+-- Restores the post-126 (drop_gemini) allow-list without 'omp', re-using
+-- migration 126's NOT VALID semantics. A runtime_profile row already using
+-- protocol_family = 'omp' is NOT validated by this rollback (NOT VALID skips
+-- existing rows), but such rows would fail future writes — remove them before
+-- downgrading.
+
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity'
+    )) NOT VALID;

--- a/server/migrations/128_runtime_profile_protocol_family_omp.up.sql
+++ b/server/migrations/128_runtime_profile_protocol_family_omp.up.sql
@@ -1,0 +1,33 @@
+-- Add 'omp' (Oh My Pi, ACP backend) to the runtime_profile.protocol_family
+-- allow-list. See MUL omp-backend rollout.
+--
+-- protocol_family must stay in lockstep with the agent.New() switch /
+-- SupportedTypes in server/pkg/agent/agent.go, which now includes 'omp'. A
+-- profile may only be based on a backend Multica officially supports and tests.
+--
+-- Migration 126 (drop_gemini) re-declared this CHECK as a NOT VALID table
+-- constraint with 'gemini' removed. There is no ALTER ... ALTER CONSTRAINT for
+-- CHECK predicates, so we drop and re-add it with 'omp' appended. We preserve
+-- 126's post-removal list (no 'gemini') and its NOT VALID semantics — enforce
+-- the whitelist for future writes without validating historical rows — so this
+-- migration does not silently re-introduce 'gemini' or block upgrades for
+-- workspaces with legacy profiles.
+
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity',
+        'omp'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -133,7 +133,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder".
+// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "antigravity", "omp", "qoder".
 //
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
@@ -154,6 +154,7 @@ var SupportedTypes = []string{
 	"kimi",
 	"kiro",
 	"antigravity",
+	"omp",
 }
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.
@@ -200,8 +201,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &antigravityBackend{cfg: cfg}, nil
 	case "qoder":
 		return &qoderBackend{cfg: cfg}, nil
+	case "omp":
+		return &ompBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, kiro, antigravity, qoder)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, antigravity, omp, qoder)", agentType)
 	}
 }
 
@@ -228,6 +231,7 @@ var launchHeaders = map[string]string{
 	"kiro":        "kiro-cli acp",
 	"openclaw":    "openclaw agent (json)",
 	"opencode":    "opencode run (json)",
+	"omp":         "omp acp",
 	"pi":          "pi (json mode)",
 	"qoder":       "qodercli --acp",
 }

--- a/server/pkg/agent/agent_supported_types_test.go
+++ b/server/pkg/agent/agent_supported_types_test.go
@@ -40,6 +40,7 @@ func TestSupportedTypesMatchesMigrationWhitelist(t *testing.T) {
 		"claude": true, "codebuddy": true, "codex": true, "copilot": true,
 		"opencode": true, "openclaw": true, "hermes": true,
 		"pi": true, "cursor": true, "kimi": true, "kiro": true, "antigravity": true,
+		"omp": true,
 	}
 	if len(SupportedTypes) != len(want) {
 		t.Fatalf("SupportedTypes has %d entries, migration whitelist has %d; keep them in lockstep", len(SupportedTypes), len(want))

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -583,10 +583,13 @@ func (c *hermesClient) handleLine(line string) {
 // handleAgentRequest replies to JSON-RPC requests the agent sends
 // us (agent → client direction). The only one we care about today is
 // `session/request_permission`: the daemon is headless and cannot
-// actually prompt a user, so we auto-approve every action. Using
-// `approve_for_session` rather than `approve` means subsequent
-// identical actions (every Shell invocation, every file write) don't
-// round-trip through us — the agent remembers them locally.
+// actually prompt a user, so we auto-approve every action. The option
+// id is selected dynamically from the request's offered options (see
+// selectAllowOption) so each ACP backend's own "allow" wording is
+// honoured — kimi offers `approve_for_session`, omp offers
+// `allow_always`/`allow_once`. Picking a session-scoped allow means
+// subsequent identical actions (every Shell invocation, every file
+// write) don't round-trip through us — the agent remembers them locally.
 func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var method string
 	_ = json.Unmarshal(raw["method"], &method)
@@ -599,17 +602,18 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
+		optionID := selectAllowOption(raw["params"])
 		resp = map[string]any{
 			"jsonrpc": "2.0",
 			"id":      json.RawMessage(rawID),
 			"result": map[string]any{
 				"outcome": map[string]any{
 					"outcome":  "selected",
-					"optionId": "approve_for_session",
+					"optionId": optionID,
 				},
 			},
 		}
-		c.cfg.Logger.Debug("auto-approved agent permission request", "method", method)
+		c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "option_id", optionID)
 	default:
 		// Unknown agent→client method — reply with standard "method
 		// not found" so the agent doesn't block waiting for us. Better
@@ -634,6 +638,53 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	if err := c.writeLine(data); err != nil {
 		c.cfg.Logger.Warn("write agent-request response", "method", method, "error", err)
 	}
+}
+
+// selectAllowOption picks the option id to reply with for an ACP
+// `session/request_permission` request. The daemon is headless, so it
+// always grants — the only question is *which* allow-flavoured option a
+// given backend offers. ACP-standard backends (omp) advertise
+// `allow_always`/`allow_once`; legacy kimi advertises
+// `approve_for_session`. We prefer a session-scoped grant
+// (kind=="allow_always") so repeat actions don't round-trip, then a
+// one-shot allow (kind=="allow_once"), then any option whose kind or id
+// looks like an allow/approve, and finally fall back to the literal
+// "approve_for_session" when params/options are absent or none match
+// (preserving the original kimi behaviour with zero regression).
+func selectAllowOption(rawParams json.RawMessage) string {
+	const fallback = "approve_for_session"
+	if len(rawParams) == 0 {
+		return fallback
+	}
+	var params struct {
+		Options []struct {
+			OptionID string `json:"optionId"`
+			Name     string `json:"name"`
+			Kind     string `json:"kind"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(rawParams, &params); err != nil || len(params.Options) == 0 {
+		return fallback
+	}
+	for _, o := range params.Options {
+		if o.Kind == "allow_always" {
+			return o.OptionID
+		}
+	}
+	for _, o := range params.Options {
+		if o.Kind == "allow_once" {
+			return o.OptionID
+		}
+	}
+	for _, o := range params.Options {
+		k := strings.ToLower(o.Kind)
+		id := strings.ToLower(o.OptionID)
+		if strings.Contains(k, "allow") || strings.Contains(k, "approve") ||
+			strings.Contains(id, "allow") || strings.Contains(id, "approve") {
+			return o.OptionID
+		}
+	}
+	return fallback
 }
 
 // acpRPCError is a JSON-RPC error frame returned by the agent process.

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -2239,3 +2239,61 @@ func TestHermesKeepsRemoteMcpWhenCapabilityAdvertised(t *testing.T) {
 		t.Fatalf("session/new.mcpServers: got %d entries, want 3", len(servers))
 	}
 }
+
+func TestSelectAllowOption(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			name: "omp standard kinds prefer allow_always",
+			params: `{"options":[
+				{"optionId":"allow_once","name":"Allow once","kind":"allow_once"},
+				{"optionId":"allow_always","name":"Always allow","kind":"allow_always"},
+				{"optionId":"reject_once","name":"Reject once","kind":"reject_once"},
+				{"optionId":"reject_always","name":"Always reject","kind":"reject_always"}
+			]}`,
+			want: "allow_always",
+		},
+		{
+			name: "omp without allow_always falls to allow_once",
+			params: `{"options":[
+				{"optionId":"allow_once","name":"Allow once","kind":"allow_once"},
+				{"optionId":"reject_once","name":"Reject once","kind":"reject_once"}
+			]}`,
+			want: "allow_once",
+		},
+		{
+			name: "legacy kimi approve_for_session matched by id",
+			params: `{"options":[
+				{"optionId":"approve_for_session","name":"Approve for session","kind":"other"},
+				{"optionId":"reject","name":"Reject","kind":"reject"}
+			]}`,
+			want: "approve_for_session",
+		},
+		{
+			name:   "empty options falls back",
+			params: `{"options":[]}`,
+			want:   "approve_for_session",
+		},
+		{
+			name:   "absent options falls back",
+			params: `{}`,
+			want:   "approve_for_session",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectAllowOption(json.RawMessage(tt.params))
+			if got != tt.want {
+				t.Errorf("selectAllowOption(%s) = %q, want %q", tt.params, got, tt.want)
+			}
+		})
+	}
+	// Nil params (no params key in the request) must also fall back.
+	if got := selectAllowOption(nil); got != "approve_for_session" {
+		t.Errorf("selectAllowOption(nil) = %q, want approve_for_session", got)
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -140,6 +140,10 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverPiModels(ctx, executablePath)
 		})
+	case "omp":
+		return cachedDiscovery(providerType, func() ([]Model, error) {
+			return discoverOmpModels(ctx, executablePath)
+		})
 	case "openclaw":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenclawAgents(ctx, executablePath)
@@ -696,6 +700,90 @@ func parsePiModels(output string) []Model {
 			provider = id[:i]
 		}
 		models = append(models, Model{ID: id, Label: id, Provider: provider})
+	}
+	return models
+}
+
+// discoverOmpModels runs `omp models` and parses its provider-grouped
+// box-drawing table. omp's `session/new` returns models in a non-standard
+// configOptions entry rather than models.availableModels, so we discover
+// from the CLI instead. Any failure (binary missing, parse error, timeout)
+// returns an empty list so the UI falls back to manual model entry;
+// cachedDiscovery never caches empty results, so this retries once the
+// cause clears.
+func discoverOmpModels(ctx context.Context, executablePath string) ([]Model, error) {
+	if executablePath == "" {
+		executablePath = "omp"
+	}
+	if _, err := exec.LookPath(executablePath); err != nil {
+		return []Model{}, nil
+	}
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, executablePath, "models")
+	hideAgentWindow(cmd)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil && len(stdout) == 0 && stderr.Len() == 0 {
+		return []Model{}, nil
+	}
+	text := string(stdout)
+	if strings.TrimSpace(text) == "" {
+		text = stderr.String()
+	}
+	return parseOmpModels(text), nil
+}
+
+// ompProviderHeaderRe matches an `omp models` provider section header like
+// `anthropic (26)` — a provider slug followed by a parenthesised count.
+var ompProviderHeaderRe = regexp.MustCompile(`^(\S+)\s+\(\d+\)$`)
+
+// parseOmpModels parses `omp models` output. The CLI groups models by
+// provider: a header line (`<provider> (<n>)`) sets the current provider,
+// then a box-drawing table lists one model per `│ <model> │ … │` row. We
+// emit `<provider>/<model>` ids to match the `--model` slug and the ACP
+// currentValue form. The table header row (`model | context | …`),
+// box-border lines, and blanks are skipped. No Thinking, no Default.
+func parseOmpModels(output string) []Model {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var models []Model
+	seen := map[string]bool{}
+	provider := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if m := ompProviderHeaderRe.FindStringSubmatch(line); m != nil {
+			provider = m[1]
+			continue
+		}
+		// Only data rows start with the vertical box separator. Border
+		// lines start with corner/junction glyphs (┌ ├ └ ┬ …) and are
+		// skipped here.
+		if !strings.HasPrefix(line, "│") {
+			continue
+		}
+		cells := strings.Split(line, "│")
+		if len(cells) < 2 {
+			continue
+		}
+		model := strings.TrimSpace(cells[1])
+		if model == "" || model == "model" {
+			// blank cell or the header row (`model | context | …`).
+			continue
+		}
+		if provider == "" {
+			continue
+		}
+		id := provider + "/" + model
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		models = append(models, Model{ID: id, Label: model, Provider: provider})
 	}
 	return models
 }

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1011,3 +1011,40 @@ func TestCachedDiscovery(t *testing.T) {
 		t.Errorf("expected 1 underlying call due to cache, got %d", calls)
 	}
 }
+
+func TestParseOmpModels(t *testing.T) {
+	t.Parallel()
+	// Inline fixture mirroring `omp models`: two provider sections with a
+	// box-drawing table each (anthropic: 2 rows, openai: 1 row).
+	fixture := strings.Join([]string{
+		"anthropic (2)",
+		"┌─────────────────┬─────────┬─────────┬──────────────────┬────────┐",
+		"│ model           │ context │ max-out │ thinking         │ images │",
+		"├─────────────────┼─────────┼─────────┼──────────────────┼────────┤",
+		"│ claude-opus-4-8 │ 1M      │ 128K    │ minimal,low,high │ yes    │",
+		"│ claude-sonnet-4 │ 1M      │ 64K     │ minimal,low      │ yes    │",
+		"└─────────────────┴─────────┴─────────┴──────────────────┴────────┘",
+		"",
+		"openai (1)",
+		"┌──────────┬─────────┬─────────┬──────────┬────────┐",
+		"│ model    │ context │ max-out │ thinking │ images │",
+		"├──────────┼─────────┼─────────┼──────────┼────────┤",
+		"│ gpt-5    │ 400K    │ 128K    │          │ yes    │",
+		"└──────────┴─────────┴─────────┴──────────┴────────┘",
+	}, "\n")
+
+	got := parseOmpModels(fixture)
+	want := []Model{
+		{ID: "anthropic/claude-opus-4-8", Label: "claude-opus-4-8", Provider: "anthropic"},
+		{ID: "anthropic/claude-sonnet-4", Label: "claude-sonnet-4", Provider: "anthropic"},
+		{ID: "openai/gpt-5", Label: "gpt-5", Provider: "openai"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseOmpModels returned %d models, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("model[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/server/pkg/agent/omp.go
+++ b/server/pkg/agent/omp.go
@@ -1,0 +1,360 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ompBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. `acp` is the protocol
+// subcommand that drives the ACP JSON-RPC transport for the Oh My Pi
+// CLI; overriding it would break the daemon↔omp communication contract.
+var ompBlockedArgs = map[string]blockedArgMode{
+	"acp": blockedStandalone,
+}
+
+// ompBackend implements Backend by spawning `omp acp` and communicating
+// via the ACP (Agent Client Protocol) JSON-RPC 2.0 over stdin/stdout.
+//
+// Oh My Pi CLI (binary `omp`) supports ACP out of the box via the
+// `omp acp` subcommand. We reuse the existing hermesClient ACP transport
+// since both runtimes speak the same protocol — only the binary, env, and
+// model handling differ. Unlike kimi, omp does NOT support
+// `session/set_model`; the model is selected via the launch `--model`
+// flag (see Execute below) and discovered via the `omp models` CLI.
+type ompBackend struct {
+	cfg Config
+}
+
+func (b *ompBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "omp"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("omp executable not found at %q: %w", execPath, err)
+	}
+
+	// Translate the agent's mcp_config (Claude-style object of objects)
+	// into the array shape ACP `session/new` expects. Fail closed on
+	// malformed JSON so the launch surfaces the real error instead of
+	// silently dropping all MCP servers.
+	mcpServers, err := buildACPMcpServers(opts.McpConfig, b.cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("omp: invalid mcp_config: %w", err)
+	}
+
+	timeout := opts.Timeout
+	runCtx, cancel := runContext(ctx, timeout)
+
+	// `omp acp` takes no flags on the subcommand except the daemon-controlled
+	// model. We auto-approve in hermesClient.handleAgentRequest by replying
+	// with omp's allow_always option to every session/request_permission
+	// request. omp does NOT support session/set_model, so the chosen model is
+	// passed as a launch flag and appended LAST so the daemon-controlled model
+	// wins over any user-supplied --model in custom_args.
+	ompArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, ompBlockedArgs, b.cfg.Logger)...)
+	if opts.Model != "" {
+		ompArgs = append(ompArgs, "--model", opts.Model)
+	}
+	cmd := exec.CommandContext(runCtx, execPath, ompArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", ompArgs)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("omp stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("omp stdin pipe: %w", err)
+	}
+	// Forward stderr to the daemon log *and* sniff provider-level
+	// errors out of it so we can surface them in the task result.
+	// omp's session/prompt still reports stopReason=end_turn when
+	// the underlying HTTP call to the provider returns 4xx/5xx, so
+	// without this the daemon reports a misleading "empty output"
+	// and the actionable error (expired token, rate limit, upstream
+	// 5xx, …) stays buried in the daemon log.
+	//
+	// StderrPipe + an explicit copier give us a join point
+	// (`stderrDone`) that fires before the failure-promotion
+	// decision; see the matching comment in hermes.go for why the
+	// io.MultiWriter form races with stopReason=end_turn under load.
+	providerErr := newACPProviderErrorSniffer("omp")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("omp stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start omp: %w", err)
+	}
+
+	stderrSink := io.MultiWriter(newLogWriter(b.cfg.Logger, "[omp:stderr] "), providerErr)
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(stderrSink, stderr)
+	}()
+
+	b.cfg.Logger.Info("omp acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var outputMu sync.Mutex
+	var output strings.Builder
+
+	promptDone := make(chan hermesPromptResult, 1)
+
+	// Reuse the hermesClient ACP transport — omp speaks the same protocol.
+	c := &hermesClient{
+		cfg:          b.cfg,
+		stdin:        stdin,
+		pending:      make(map[int]*pendingRPC),
+		pendingTools: make(map[string]*pendingToolCall),
+		onMessage: func(msg Message) {
+			// omp's ACP tool titles are already clean snake_case
+			// identifiers, so unlike kimi we do not re-map the tool
+			// name here.
+			if msg.Type == MessageText {
+				outputMu.Lock()
+				output.WriteString(msg.Content)
+				outputMu.Unlock()
+			}
+			trySend(msgCh, msg)
+		},
+		onPromptDone: func(result hermesPromptResult) {
+			select {
+			case promptDone <- result:
+			default:
+			}
+		},
+	}
+
+	// Start reading stdout in background.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("omp process exited"))
+	}()
+
+	// Drive the ACP session lifecycle in a goroutine.
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+		var sessionID string
+
+		// 1. Initialize handshake.
+		initResult, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("omp initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// Drop MCP entries whose remote transport the runtime didn't
+		// advertise. See the matching comment in hermes.go for the why —
+		// shipping an http/sse entry to a stdio-only runtime tanks the
+		// whole session/new.
+		mcpServers = filterACPMcpServersByCapability(mcpServers, extractACPMcpCapabilities(initResult), "omp", b.cfg.Logger)
+
+		// 2. Create or resume a session.
+		cwd := opts.Cwd
+		if cwd == "" {
+			cwd = "."
+		}
+
+		if opts.ResumeSessionID != "" {
+			// Per ACP Session Setup, session/resume accepts mcpServers and
+			// the runtime re-connects them as part of the resume. Without
+			// this, a resumed omp task lost access to MCP tools that a
+			// fresh task on the same agent would have.
+			result, err := c.request(runCtx, "session/resume", map[string]any{
+				"cwd":        cwd,
+				"sessionId":  opts.ResumeSessionID,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("omp session/resume failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "omp",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
+		} else {
+			result, err := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("omp session/new failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			sessionID = extractACPSessionID(result)
+			if sessionID == "" {
+				finalStatus = "failed"
+				finalError = "omp session/new returned no session ID"
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+		}
+
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("omp session created", "session_id", sessionID)
+
+		// 3. Build the prompt content. If we have a system prompt, prepend it.
+		// omp selects its model via the launch `--model` flag (see above) and
+		// does not support session/set_model, so there is no model RPC here.
+		// The daemon does not set SystemPrompt for omp, so this prepend is a
+		// harmless no-op kept for parity with the other ACP backends.
+		userText := prompt
+		if opts.SystemPrompt != "" {
+			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
+		}
+
+		// 4. Send the prompt and wait for PromptResponse.
+		_, err = c.request(runCtx, "session/prompt", map[string]any{
+			"sessionId": sessionID,
+			"prompt": []map[string]any{
+				{"type": "text", "text": userText},
+			},
+		})
+		if err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("omp timed out after %s", timeout)
+			} else if runCtx.Err() == context.Canceled {
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			} else {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("omp session/prompt failed: %v", err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// See the hermes backend: the runtime echoes the
+					// requested id back from session/resume even when
+					// the session is gone, so the stale id only fails
+					// here, at prompt time. Empty SessionID lets the
+					// daemon's resume-failure fallback retry fresh and
+					// store the replacement id.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "omp",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
+			}
+		} else {
+			select {
+			case pr := <-promptDone:
+				if pr.stopReason == "cancelled" {
+					finalStatus = "aborted"
+					finalError = "omp cancelled the prompt"
+				}
+				c.usageMu.Lock()
+				c.usage.InputTokens += pr.usage.InputTokens
+				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usageMu.Unlock()
+			default:
+			}
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("omp finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		stdin.Close()
+		cancel()
+
+		<-readerDone
+		// Ensure the stderr copier has drained before consulting the
+		// provider-error sniffer; see hermes.go for the failure mode.
+		<-stderrDone
+
+		outputMu.Lock()
+		finalOutput := output.String()
+		outputMu.Unlock()
+
+		// Promote completed→failed when stderr or the agent text
+		// stream show a terminal upstream-LLM failure (HTTP 4xx /
+		// rate-limit / expired token). See the helper docs for the
+		// full signal set; the key safety property is that transient
+		// per-attempt warnings followed by a successful retry stay
+		// "completed".
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		var usageMap map[string]TokenUsage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     finalOutput,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      usageMap,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}


### PR DESCRIPTION
## Summary

Registers **Oh My Pi (`omp`)** as a first-class agent runtime provider instead of routing it through a hermes-family custom profile. The daemon probes the `omp` CLI on PATH and registers a `provider=omp` runtime; execution runs the ACP flow via `omp acp` (`initialize → session/new → session/prompt`).

## Changes

- **`server/pkg/agent`** — new `omp.go` backend; `SupportedTypes`/`New()` wiring in `agent.go`; model discovery in `models.go`; shared ACP launch in `hermes.go`.
- **`server/internal/daemon`** — probe `omp` in `config.go`; `runtime_config` plumbing.
- **Migration `128_runtime_profile_protocol_family_omp`** — adds `'omp'` to the `runtime_profile.protocol_family` CHECK. Renumbered from a colliding `122` to the next free slot (`128`, after `127`). Preserves migration `126`'s `NOT VALID` semantics and its post-`gemini`-removal list, so it does **not** silently re-introduce `gemini`.
- **Frontend** — provider type (`agent.ts`), logo (`provider-logo.tsx`), MCP support (`mcp-support.ts`).

## Verification

- `pnpm typecheck` — green (6/6 packages).
- `go test ./...` (incl. `-race`) — green (exit 0) on a fresh DB.
- Migration applies clean **in-order** on a fresh database; resulting CHECK has 13 values (no `gemini`, `+omp`, `NOT VALID`); `down` restores the post-`126` list.
- **End-to-end**: a UI task assigned to the native `omp` runtime (model left empty) completed via the ACP flow, posted its result, and moved to `in_review`.

## Notes

- Model dropdown is empty for `omp` by design (ACP `session/new` returns `configOptions`/`modes`, no `models` block); leave model empty so no `session/set_model` is sent.
