### PR TITLE
fix(views): count tasks, not agents, in activity hover header (MUL-3872)

### DIFF
--- a/packages/views/agents/components/agent-activity-hover-content.test.tsx
+++ b/packages/views/agents/components/agent-activity-hover-content.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+
+// The hover card renders one row per task and counts tasks, so its header
+// must describe tasks — not agents. A single agent can run several tasks at
+// once (e.g. the workspace chip reads "2 working" for two unique agents while
+// the card lists three task rows). An agent-worded header here would print
+// "3 agents working" for those two agents, contradicting the chip. MUL-3872.
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: (_type: string, id: string) =>
+      ({ "agent-1": "Niko", "agent-2": "J" })[id] ?? "Unknown Agent",
+    getActorInitials: (_type: string, id: string) =>
+      ({ "agent-1": "NI", "agent-2": "J" })[id] ?? "UA",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+// The card only reads these query results for avatars / availability, never
+// for the header count, so empty lists keep the row chrome inert while the
+// header still derives from the task array.
+vi.mock("@multica/core/runtimes/queries", () => ({
+  runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  deriveAgentAvailability: () => "online",
+}));
+
+vi.mock("@multica/ui/components/common/actor-avatar", () => ({
+  ActorAvatar: ({ name }: { name: string }) => (
+    <span data-testid="actor-avatar">{name}</span>
+  ),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return { ...actual, useQuery: () => ({ data: [] }) };
+});
+
+import { AgentActivityHoverContent } from "./agent-activity-hover-content";
+
+function makeTask(overrides: Partial<AgentTask>): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "issue-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-06-08T08:00:00Z",
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-06-08T08:00:00Z",
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe("AgentActivityHoverContent", () => {
+  // Two agents, three running tasks (Niko runs two at once). The header must
+  // count the three task rows, not the two agents.
+  const threeTasksTwoAgents = [
+    makeTask({ id: "t1", agent_id: "agent-1" }),
+    makeTask({ id: "t2", agent_id: "agent-1" }),
+    makeTask({ id: "t3", agent_id: "agent-2" }),
+  ];
+
+  it("counts tasks, not agents, in the header", () => {
+    renderWithI18n(<AgentActivityHoverContent tasks={threeTasksTwoAgents} />);
+
+    expect(screen.getByText("3 tasks working")).toBeInTheDocument();
+    // The old agent-worded copy would have read "3 agents working" here and
+    // disagreed with the chip's unique-agent count.
+    expect(screen.queryByText(/agents? working/)).not.toBeInTheDocument();
+    // One row per task — three avatars for three tasks.
+    expect(screen.getAllByTestId("actor-avatar")).toHaveLength(3);
+  });
+
+  it("uses the singular task copy for a single task", () => {
+    renderWithI18n(<AgentActivityHoverContent tasks={[makeTask({})]} />);
+
+    expect(screen.getByText("1 task working")).toBeInTheDocument();
+  });
+
+  it("renders the requested Chinese task copy", () => {
+    renderWithI18n(<AgentActivityHoverContent tasks={threeTasksTwoAgents} />, {
+      locale: "zh-Hans",
+    });
+
+    expect(screen.getByText("3 个 task 工作中")).toBeInTheDocument();
+  });
+});

--- a/packages/views/agents/components/agent-activity-hover-content.tsx
+++ b/packages/views/agents/components/agent-activity-hover-content.tsx
@@ -61,7 +61,11 @@ export function AgentActivityHoverContent({
   return (
     <div className="flex flex-col gap-2">
       <div className="text-xs font-medium text-muted-foreground">
-        {t(($) => $.agent_activity.hover_header, { count: tasks.length })}
+        {/* One row per task, so count tasks — not agents. A single agent can
+            run several tasks at once, so an agent-worded header here would
+            disagree with the workspace chip's unique-agent count (e.g. chip
+            "2 working" but header "3 agents working"). */}
+        {t(($) => $.agent_activity.hover_header_tasks, { count: tasks.length })}
       </div>
       <div className="flex flex-col gap-1.5">
         {tasks.map((task) => {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -332,6 +332,8 @@
   "agent_activity": {
     "hover_header_one": "{{count}} agent working",
     "hover_header_other": "{{count}} agents working",
+    "hover_header_tasks_one": "{{count}} task working",
+    "hover_header_tasks_other": "{{count}} tasks working",
     "hover_header_queued_one": "{{count}} agent queued",
     "hover_header_queued_other": "{{count}} agents queued",
     "status_running": "Working",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -319,6 +319,7 @@
   },
   "agent_activity": {
     "hover_header_other": "作業中のエージェント {{count}} 件",
+    "hover_header_tasks_other": "作業中のタスク {{count}} 件",
     "hover_header_queued_other": "待機中のエージェント {{count}} 件",
     "status_running": "作業中",
     "status_queued": "待機中",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -331,6 +331,8 @@
   "agent_activity": {
     "hover_header_one": "작업 중인 에이전트 {{count}}개",
     "hover_header_other": "작업 중인 에이전트 {{count}}개",
+    "hover_header_tasks_one": "작업 중인 태스크 {{count}}개",
+    "hover_header_tasks_other": "작업 중인 태스크 {{count}}개",
     "hover_header_queued_one": "대기 중인 에이전트 {{count}}개",
     "hover_header_queued_other": "대기 중인 에이전트 {{count}}개",
     "status_running": "작업 중",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -324,6 +324,7 @@
   },
   "agent_activity": {
     "hover_header_other": "{{count}} 个智能体正在工作",
+    "hover_header_tasks_other": "{{count}} 个 task 工作中",
     "hover_header_queued_other": "{{count}} 个智能体排队中",
     "status_running": "正在工作",
     "status_queued": "排队中",


### PR DESCRIPTION
## Summary

The agent-activity hover card renders **one row per task** and its header counts `tasks.length`, but it reused the agent-worded `hover_header` copy ("N agents working"). When a single agent runs several tasks at once, the count and the wording disagree with the workspace chip:

- Workspace chip: `2 working` — counts **unique agents** (`agentIds.length`).
- Hover card header: `3 agents working` — counts **task rows** (Niko appears twice for two concurrent tasks).

So the same panel says "2" outside and "3 agents" inside. The "agents" wording is the bug — the count is genuinely a task count.

## Fix

- Add a dedicated `hover_header_tasks` i18n key (en / zh-Hans / ja / ko) describing the count by tasks.
- Point `AgentActivityHoverContent` at it, so the header now reads `3 tasks working` / `3 个 task 工作中`.
- `IssueAgentHeaderChip` keeps `hover_header`, because it genuinely passes the unique-agent count — changing that shared key would have broken the per-issue chip. The two surfaces now use the right unit each.

The agent rows themselves are unchanged (one agent can still appear on multiple rows).

## Testing

- New `agent-activity-hover-content.test.tsx`: 3 tasks across 2 agents → header reads `3 tasks working` (not `… agents working`), 3 rows render; singular `1 task working`; zh-Hans `3 个 task 工作中`.
- `pnpm exec vitest run` over the new test, the existing `issue-agent-header-chip.test.tsx`, and `locales/parity.test.ts` — 166 passed.
- `pnpm typecheck` (confirms the new plural selector resolves), `pnpm exec eslint` on the changed files — clean.

MUL-3872
