### PR TITLE
MUL-3828: fix Cursor and Kiro runtime completion transcripts

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -149,6 +149,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 				if evt.ResultText != "" && output.Len() == 0 {
 					output.WriteString(evt.ResultText)
+					trySend(msgCh, Message{Type: MessageText, Content: evt.ResultText})
 				}
 				b.accumulateResultUsage(resultUsage, &evt, configuredModel)
 				if evt.hasResultUsage() {

--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -30,6 +30,51 @@ sleep 10
 	}
 }
 
+func TestCursorExecuteEmitsTerminalResultText(t *testing.T) {
+	t.Parallel()
+
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-result-text"}'
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"final-only answer","session_id":"sess-result-text"}'
+`
+	fakePath := filepath.Join(t.TempDir(), "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), "hello", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var messages []Message
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for msg := range session.Messages {
+			messages = append(messages, msg)
+		}
+	}()
+
+	result := <-session.Result
+	<-done
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+	if result.Output != "final-only answer" {
+		t.Fatalf("output = %q, want final-only answer", result.Output)
+	}
+	for _, msg := range messages {
+		if msg.Type == MessageText && msg.Content == "final-only answer" {
+			return
+		}
+	}
+	t.Fatalf("expected terminal result text in message stream, got %+v", messages)
+}
+
 func TestCursorExecuteStopsAfterTerminalErrorResult(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -431,7 +431,14 @@ func isKiroIssueCommentAddTool(msg Message) bool {
 }
 
 func isKiroIssueCommentAddCommand(command string) bool {
-	parts := strings.Fields(command)
+	parts := trimLeadingEnvAssignments(strings.Fields(command))
+	// Some runtimes route terminal calls through a shell wrapper such as
+	// `sh -c "multica issue comment add ..."`; unwrap a single such layer so
+	// the real invocation is still recognized.
+	if len(parts) >= 3 && isPOSIXShellName(parts[0]) && parts[1] == "-c" {
+		inner := strings.Trim(strings.Join(parts[2:], " "), "\"'")
+		parts = trimLeadingEnvAssignments(strings.Fields(inner))
+	}
 	if len(parts) < 4 {
 		return false
 	}
@@ -440,6 +447,46 @@ func isKiroIssueCommentAddCommand(command string) bool {
 		return false
 	}
 	return parts[1] == "issue" && parts[2] == "comment" && parts[3] == "add"
+}
+
+// trimLeadingEnvAssignments drops leading `KEY=VALUE` tokens so an invocation
+// like `MULTICA_TOKEN=x multica issue comment add ...` is still recognized.
+func trimLeadingEnvAssignments(parts []string) []string {
+	for len(parts) > 0 && isEnvAssignment(parts[0]) {
+		parts = parts[1:]
+	}
+	return parts
+}
+
+// isEnvAssignment reports whether tok is a `NAME=value` shell env assignment.
+func isEnvAssignment(tok string) bool {
+	eq := strings.IndexByte(tok, '=')
+	if eq <= 0 {
+		return false
+	}
+	for i := 0; i < eq; i++ {
+		c := tok[i]
+		switch {
+		case c == '_', c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isPOSIXShellName reports whether tok names a shell that takes `-c <command>`.
+func isPOSIXShellName(tok string) bool {
+	if i := strings.LastIndexByte(tok, '/'); i >= 0 {
+		tok = tok[i+1:]
+	}
+	switch tok {
+	case "sh", "bash", "zsh", "dash":
+		return true
+	default:
+		return false
+	}
 }
 
 func kiroToolNameFromTitle(title string) string {

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -108,7 +108,9 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	var output strings.Builder
 	var streamingCurrentTurn atomic.Bool
 	var sawCompletedGoalComplete atomic.Bool
+	var sawCompletedIssueComment atomic.Bool
 	var goalCompleteCallIDs sync.Map
+	var issueCommentCallIDs sync.Map
 
 	promptDone := make(chan hermesPromptResult, 1)
 
@@ -129,10 +131,16 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				if msg.Tool == "goal_complete" && msg.CallID != "" {
 					goalCompleteCallIDs.Store(msg.CallID, struct{}{})
 				}
+				if msg.CallID != "" && isKiroIssueCommentAddTool(msg) {
+					issueCommentCallIDs.Store(msg.CallID, struct{}{})
+				}
 			}
 			if msg.Type == MessageToolResult {
 				if _, ok := goalCompleteCallIDs.LoadAndDelete(msg.CallID); ok {
 					sawCompletedGoalComplete.Store(msg.Status == "completed")
+				}
+				if _, ok := issueCommentCallIDs.LoadAndDelete(msg.CallID); ok {
+					sawCompletedIssueComment.Store(msg.Status == "completed")
 				}
 			}
 			if msg.Type == MessageText {
@@ -318,8 +326,8 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			} else {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("kiro session/prompt failed: %v", err)
-				if sawCompletedGoalComplete.Load() && isKiroGoalCompleteCloseError(err) {
-					b.cfg.Logger.Warn("kiro session/prompt failed after goal_complete; preserving completed task status", "error", err)
+				if (sawCompletedGoalComplete.Load() || sawCompletedIssueComment.Load()) && isKiroGoalCompleteCloseError(err) {
+					b.cfg.Logger.Warn("kiro session/prompt failed after completed task result; preserving completed task status", "error", err)
 					finalStatus = "completed"
 					finalError = ""
 				} else if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
@@ -412,6 +420,26 @@ func isKiroGoalCompleteCloseError(err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(rpcErr.Data), "failed to generate a response")
+}
+
+func isKiroIssueCommentAddTool(msg Message) bool {
+	if msg.Tool != "terminal" {
+		return false
+	}
+	command, _ := msg.Input["command"].(string)
+	return isKiroIssueCommentAddCommand(command)
+}
+
+func isKiroIssueCommentAddCommand(command string) bool {
+	parts := strings.Fields(command)
+	if len(parts) < 4 {
+		return false
+	}
+	executable := strings.TrimPrefix(parts[0], "./")
+	if executable != "multica" && !strings.HasSuffix(executable, "/multica") {
+		return false
+	}
+	return parts[1] == "issue" && parts[2] == "comment" && parts[3] == "add"
 }
 
 func kiroToolNameFromTitle(title string) string {

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -272,6 +272,98 @@ func TestKiroBackendDoesNotCompleteAfterFailedGoalComplete(t *testing.T) {
 	}
 }
 
+func fakeKiroACPIssueCommentCloseErrorScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_comment_done"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_comment_done","update":{"type":"ToolCall","toolCallId":"tc-comment","name":"Shell","status":"pending","parameters":{"command":"multica issue comment add issue-1 --content-file ./reply.md"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_comment_done","update":{"type":"ToolCallUpdate","toolCallId":"tc-comment","status":"completed","name":"Shell","output":"created comment"}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"Kiro failed to generate a response"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestKiroBackendTreatsCommentAddCloseErrorAsCompleted(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPIssueCommentCloseErrorScript()))
+
+	backend, err := New("kiro", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var messages []Message
+	messagesDone := make(chan struct{})
+	go func() {
+		defer close(messagesDone)
+		for msg := range session.Messages {
+			messages = append(messages, msg)
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		<-messagesDone
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed after issue comment close error, got %q (error=%q, messages=%+v)", result.Status, result.Error, messages)
+		}
+		if result.Error != "" {
+			t.Fatalf("expected close-handshake error to be suppressed, got %q", result.Error)
+		}
+		if result.SessionID != "ses_comment_done" {
+			t.Fatalf("session id = %q, want ses_comment_done", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestKiroIssueCommentAddCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{"multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"./multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"/usr/local/bin/multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"multica issue get issue-1", false},
+		{"echo multica issue comment add issue-1", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isKiroIssueCommentAddCommand(tt.command); got != tt.want {
+			t.Errorf("isKiroIssueCommentAddCommand(%q) = %v, want %v", tt.command, got, tt.want)
+		}
+	}
+}
+
 // fakeKiroACPStaleLoadSetModelScript impersonates kiro when a resumed
 // session is gone and the caller picked a model: session/load returns
 // an empty result (so the requested id is kept), then

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -353,8 +353,15 @@ func TestKiroIssueCommentAddCommand(t *testing.T) {
 		{"multica issue comment add issue-1 --content-file ./reply.md", true},
 		{"./multica issue comment add issue-1 --content-file ./reply.md", true},
 		{"/usr/local/bin/multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"MULTICA_TOKEN=x multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"FOO=1 BAR=2 ./multica issue comment add issue-1", true},
+		{`sh -c "multica issue comment add issue-1 --content-file ./reply.md"`, true},
+		{`bash -c 'multica issue comment add issue-1'`, true},
+		{`/bin/sh -c "multica issue comment add issue-1"`, true},
 		{"multica issue get issue-1", false},
 		{"echo multica issue comment add issue-1", false},
+		{`sh -c "echo multica issue comment add issue-1"`, false},
+		{"FOO=bar", false},
 		{"", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Emit Cursor terminal result text into the live task message stream when the final result is the first assistant text.
- Treat Kiro's known post-completion -32603 close error as completed after a successful `multica issue comment add` terminal tool, matching the existing `goal_complete` guard.
- Add regression coverage for Cursor result-only transcripts and Kiro comment-add close errors.

## Tests
- `go test ./pkg/agent -run 'TestCursor|TestKiro|TestAntigravity'`
- `go test ./internal/handler -run 'TestCompleteTask_(CommentTriggered|AssignmentTriggered)'`

Closes MUL-3828

Part of #4694 — fixes the reported Cursor and Kiro symptoms. The Antigravity empty-transcript in the same report has a different root cause (Antigravity already streams each output line into the transcript) and is tracked as a separate follow-up, so this PR intentionally does not auto-close #4694.
