### PR TITLE
feat(desktop): show top-bar update button only when an update is available

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -21,6 +21,7 @@ import { useDesktopUnreadBadge } from "@multica/views/platform";
 import { DesktopNavigationProvider } from "@/platform/navigation";
 import { TabBar } from "./tab-bar";
 import { TabContent } from "./tab-content";
+import { UpdateButton } from "./update-button";
 import { WindowOverlay } from "./window-overlay";
 
 const TOP_BAR_HEIGHT_CLASS = "h-12";
@@ -76,6 +77,9 @@ function WindowToolbar() {
           >
             <ChevronRight className="size-4" />
           </button>
+          {/* Renders only when the background update check has found a newer
+              version; otherwise it is hidden. */}
+          <UpdateButton />
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/update-button.test.tsx
+++ b/apps/desktop/src/renderer/src/components/update-button.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, act } from "@testing-library/react";
+
+type DownloadedCb = (info: { version: string }) => void;
+type AvailableCb = (info: { version: string }) => void;
+
+const handlers = vi.hoisted(() => ({
+  available: null as AvailableCb | null,
+  downloaded: null as DownloadedCb | null,
+  check: vi.fn(),
+}));
+
+// Keep the heavy workspace modules out of the test graph (core/paths pulls in
+// i18next), mirroring tab-bar.test.tsx.
+vi.mock("@multica/core/paths", () => ({
+  paths: {
+    workspace: (slug: string) => ({
+      settings: () => `/${slug}/settings`,
+    }),
+  },
+}));
+
+vi.mock("@/stores/tab-store", () => {
+  const store = { activeWorkspaceSlug: "acme" as string | null };
+  const useTabStore = Object.assign(() => store, { getState: () => store });
+  return { useTabStore };
+});
+
+import { UpdateButton } from "./update-button";
+
+function installUpdaterMock() {
+  Object.defineProperty(window, "updater", {
+    configurable: true,
+    value: {
+      checkForUpdates: handlers.check,
+      onUpdateAvailable: (cb: AvailableCb) => {
+        handlers.available = cb;
+        return () => {
+          handlers.available = null;
+        };
+      },
+      onUpdateDownloaded: (cb: DownloadedCb) => {
+        handlers.downloaded = cb;
+        return () => {
+          handlers.downloaded = null;
+        };
+      },
+      onDownloadProgress: () => () => {},
+      downloadUpdate: vi.fn(),
+      installUpdate: vi.fn(),
+    },
+  });
+}
+
+describe("UpdateButton", () => {
+  beforeEach(() => {
+    handlers.available = null;
+    handlers.downloaded = null;
+    handlers.check = vi.fn().mockResolvedValue({ ok: true, available: false });
+    installUpdaterMock();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing while the app is up to date", async () => {
+    render(<UpdateButton />);
+    await waitFor(() => expect(handlers.check).toHaveBeenCalled());
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("shows the button when the on-mount check reports an update", async () => {
+    handlers.check = vi
+      .fn()
+      .mockResolvedValue({ ok: true, available: true, latestVersion: "1.2.3" });
+    installUpdaterMock();
+
+    render(<UpdateButton />);
+
+    expect(
+      await screen.findByRole("button", { name: /update available: v1\.2\.3/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the button when a background update-available event fires", async () => {
+    render(<UpdateButton />);
+    await waitFor(() => expect(handlers.check).toHaveBeenCalled());
+    expect(screen.queryByRole("button")).toBeNull();
+
+    act(() => handlers.available?.({ version: "2.0.0" }));
+
+    expect(
+      await screen.findByRole("button", { name: /update available: v2\.0\.0/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a restart once the update has downloaded", async () => {
+    render(<UpdateButton />);
+    await waitFor(() => expect(handlers.check).toHaveBeenCalled());
+
+    act(() => handlers.downloaded?.({ version: "3.1.0" }));
+
+    expect(
+      await screen.findByRole("button", { name: /restart to update to v3\.1\.0/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/components/update-button.tsx
+++ b/apps/desktop/src/renderer/src/components/update-button.tsx
@@ -1,0 +1,60 @@
+import { RefreshCw } from "lucide-react";
+import { cn } from "@multica/ui/lib/utils";
+import { paths } from "@multica/core/paths";
+import { useAppUpdate } from "@/hooks/use-app-update";
+import { useTabStore } from "@/stores/tab-store";
+
+/**
+ * Top-bar update affordance.
+ *
+ * Renders nothing while the app is up to date — the auto-update check runs in
+ * the background (see `src/main/updater.ts`) and this button only appears once
+ * that check reports a newer version. Clicking it installs the update when it
+ * has finished downloading, or opens Settings → Updates (where the download
+ * progress lives) while it is still being fetched.
+ */
+export function UpdateButton() {
+  const update = useAppUpdate();
+
+  // Hidden when up to date. This is the whole point: no update, no button.
+  if (!update) return null;
+
+  const handleClick = () => {
+    if (update.downloaded) {
+      // Package is staged — quit and apply it now.
+      void window.updater.installUpdate();
+      return;
+    }
+    // Still downloading in the background: send the user to Settings → Updates,
+    // which shows live progress and the install affordance.
+    const slug = useTabStore.getState().activeWorkspaceSlug;
+    if (!slug) return;
+    window.dispatchEvent(
+      new CustomEvent("multica:navigate", {
+        detail: { path: paths.workspace(slug).settings() },
+      }),
+    );
+  };
+
+  const label = update.downloaded
+    ? `Restart to update to v${update.version}`
+    : `Update available: v${update.version}`;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={label}
+      title={label}
+      // Tinted with the brand color so an available update reads as a live
+      // affordance rather than another muted nav control.
+      className={cn(
+        "flex size-7 items-center justify-center rounded-md text-primary transition-colors",
+        "hover:bg-sidebar-accent hover:text-primary",
+      )}
+      style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+    >
+      <RefreshCw className="size-4" />
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/hooks/use-app-update.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-app-update.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+
+export type AppUpdateState = {
+  /** Newest version the background updater has found. */
+  version: string;
+  /**
+   * True once the package is fully downloaded and a restart will apply it.
+   * False while it is still downloading in the background.
+   */
+  downloaded: boolean;
+};
+
+/**
+ * Tracks whether the background auto-updater has found a newer version, so the
+ * top-bar update affordance can stay hidden while the app is up to date and
+ * only appear when there is something to install.
+ *
+ * Returns `null` when the app is up to date (caller renders nothing).
+ *
+ * The main process already checks on a schedule — 5s after boot and hourly
+ * thereafter, see `src/main/updater.ts`. This hook mirrors that background
+ * result into the renderer by:
+ *   1. asking once on mount for the authoritative current verdict, which
+ *      covers a check that completed before this hook subscribed, and
+ *   2. listening for the live `update-available` / `update-downloaded`
+ *      events so long-running sessions surface new releases without a reload.
+ */
+export function useAppUpdate(): AppUpdateState | null {
+  const [update, setUpdate] = useState<AppUpdateState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Point-in-time check. `available` is electron-updater's own verdict — it
+    // accounts for pre-release channels, staged rollouts, downgrades and
+    // minimum-system-version gates — so we trust it instead of diffing version
+    // strings here (see the rationale in src/main/updater.ts).
+    void window.updater
+      .checkForUpdates()
+      .then((result) => {
+        if (cancelled || !result.ok || !result.available) return;
+        // Don't clobber a download-complete state if the event raced ahead.
+        setUpdate((prev) => prev ?? { version: result.latestVersion, downloaded: false });
+      })
+      .catch(() => {
+        // A failed check just means "nothing to show" for now; the periodic
+        // background check and the listeners below will correct this later.
+      });
+
+    const offAvailable = window.updater.onUpdateAvailable((info) => {
+      // Same version → keep whatever download state we already have. A genuinely
+      // newer version → reset to "not downloaded yet".
+      setUpdate((prev) =>
+        prev && prev.version === info.version
+          ? prev
+          : { version: info.version, downloaded: false },
+      );
+    });
+    const offDownloaded = window.updater.onUpdateDownloaded((info) => {
+      setUpdate({ version: info.version, downloaded: true });
+    });
+
+    return () => {
+      cancelled = true;
+      offAvailable();
+      offDownloaded();
+    };
+  }, []);
+
+  return update;
+}


### PR DESCRIPTION
## What

The desktop top-bar update button is now gated on the background auto-update check: it stays hidden while the app is up to date and appears only when a newer version is actually available.

Requested behavior:
1. ✅ Auto-update check runs in the background automatically — already implemented in `apps/desktop/src/main/updater.ts` (silent `autoDownload`, a check 5s after boot, and an hourly poll). This PR makes the renderer reflect that result.
2. ✅ When already up to date, the update button is hidden (renders nothing).
3. ✅ The button appears only when a new version is available.

## How

- **`hooks/use-app-update.ts`** — `useAppUpdate()` mirrors the main-process background check into the renderer. On mount it asks `window.updater.checkForUpdates()` for the authoritative current verdict (covers a check that finished before the component subscribed), then listens to the live `update-available` / `update-downloaded` IPC events so long-running sessions pick up releases without a reload. Returns `null` when up to date. It trusts electron-updater's own `available` verdict rather than diffing version strings (matches the rationale already documented in `updater.ts`).
- **`components/update-button.tsx`** — `UpdateButton` renders nothing when up to date; shows the circular refresh icon in the window toolbar when an update is available. Clicking installs once the package has downloaded, otherwise opens Settings → Updates (live progress).
- **`components/desktop-layout.tsx`** — wires `<UpdateButton />` into the `WindowToolbar` nav group, beside back/forward.

Note: the repo previously had no always-visible top-bar update button — the only update UI was the post-download bottom-right `UpdateNotification` toast, plus an unused `onUpdateAvailable` preload bridge. This PR adds the properly-gated top-bar button (consuming that bridge) to reach the requested end state.

## Tests

- New `update-button.test.tsx`: hidden when up to date; shown on on-mount check; shown on background `update-available`; offers restart after `update-downloaded`.
- Full desktop suite green (28 files / 243 tests), `typecheck` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)