### PR TITLE
docs(slack): drop reinstall callout from Slack integration docs (MUL-3874)

### DIFF
--- a/apps/docs/content/docs/slack-bot-integration.ja.mdx
+++ b/apps/docs/content/docs/slack-bot-integration.ja.mdx
@@ -77,10 +77,6 @@ settings:
 
 **OAuth リダイレクト URL はありません**。BYO は OAuth を使わないからです。
 
-<Callout type="warning">
-以前のマニフェストでアプリを作成済みですか？**OAuth & Permissions → Bot Token Scopes** で **`reactions:write`** スコープを追加し、新しいスコープを反映させるために**アプリをワークスペースに再インストール**してください。それまではエージェントは通常どおり返信します——👀「処理中」リアクションがスキップされるだけです。
-</Callout>
-
 <Callout type="info">
 Slack で特定の名前を表示したいですか？ 作成前に `display_information.name` と `features.bot_user.display_name`（たとえばエージェントの名前に）を変更するか、あとで **App Home** で編集してください。Slack は Bot をその **bot display name** で表示しますが、これはアプリ名と異なる場合があります。
 </Callout>

--- a/apps/docs/content/docs/slack-bot-integration.ko.mdx
+++ b/apps/docs/content/docs/slack-bot-integration.ko.mdx
@@ -77,10 +77,6 @@ settings:
 
 **OAuth redirect URL은 없습니다.** BYO는 OAuth를 사용하지 않기 때문입니다.
 
-<Callout type="warning">
-이전 매니페스트로 이미 앱을 만들었나요? **OAuth & Permissions → Bot Token Scopes**에서 **`reactions:write`** 스코프를 추가한 뒤, 새 스코프가 적용되도록 **앱을 워크스페이스에 다시 설치**하세요. 그 전까지 에이전트는 정상적으로 답변하며 — 👀 "처리 중" 반응만 건너뜁니다.
-</Callout>
-
 <Callout type="info">
 Slack에서 특정 이름을 쓰고 싶나요? 생성하기 전에 `display_information.name`과 `features.bot_user.display_name`을 (예: 에이전트 이름으로) 변경하거나, 나중에 **App Home**에서 편집하세요. Slack은 봇을 **bot display name**으로 표시하며, 이는 앱 이름과 다를 수 있습니다.
 </Callout>

--- a/apps/docs/content/docs/slack-bot-integration.mdx
+++ b/apps/docs/content/docs/slack-bot-integration.mdx
@@ -77,10 +77,6 @@ This manifest configures everything Multica needs, so you don't set anything by 
 
 There is **no OAuth redirect URL**, because BYO doesn't use OAuth.
 
-<Callout type="warning">
-Already created your app with an earlier manifest? Add the **`reactions:write`** scope under **OAuth & Permissions → Bot Token Scopes**, then **reinstall the app to your workspace** so the new scope takes effect. Until you do, the agent still replies normally — only the 👀 "processing" reaction is skipped.
-</Callout>
-
 <Callout type="info">
 Want a specific name in Slack? Change `display_information.name` and `features.bot_user.display_name` (e.g. to your agent's name) before creating, or edit it later under **App Home**. Slack shows the bot by its **bot display name**, which can differ from the app name.
 </Callout>

--- a/apps/docs/content/docs/slack-bot-integration.zh.mdx
+++ b/apps/docs/content/docs/slack-bot-integration.zh.mdx
@@ -77,10 +77,6 @@ settings:
 
 这里**没有 OAuth 重定向 URL**，因为 BYO 不使用 OAuth。
 
-<Callout type="warning">
-已经用旧版 manifest 创建过 app？在 **OAuth & Permissions → Bot Token Scopes** 里加上 **`reactions:write`** 权限，然后**把 app 重新安装到工作区**让新权限生效。在此之前智能体仍然正常回复——只是会跳过 👀「处理中」表情。
-</Callout>
-
 <Callout type="info">
 想在 Slack 里用一个特定的名字？在创建之前改 `display_information.name` 和 `features.bot_user.display_name`（比如改成你智能体的名字），或者之后在 **App Home** 里编辑。Slack 是按 Bot 的**显示名（bot display name）**来展示它的，这个名字可以和 app 名不一样。
 </Callout>


### PR DESCRIPTION
## Summary

Removes the "already created your app with an older manifest → add `reactions:write` and reinstall" warning callout from the Slack integration docs, in all four locales (en/zh/ja/ko).

Slack isn't officially launched yet, so there are no pre-launch installs running an older manifest — the reinstall guidance is unnecessary noise. New installs follow the current manifest, which already includes `reactions:write`.

## What stays

The `reactions:write` scope **remains** in both the app manifest and the scope table — the typing indicator (👀 reaction) added in #4737 still requires it. Only the reinstall callout is removed.

## Scope

Docs-only, 4 files, 16 deletions. Follow-up to the merged #4737 (MUL-3874).
