### PR TITLE
fix(views): preserve character before opening backtick in inline-code shortcut

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -53,6 +53,7 @@ import { ImageView } from "./image-view";
 import { BlockMathExtension, InlineMathExtension } from "./math";
 import { HighlightExtension } from "./highlight";
 import { AutolinkEmailRepairExtension } from "./autolink-email-repair";
+import { InlineCodeFixedExtension } from "./inline-code-input";
 
 const lowlight = createLowlight(common);
 
@@ -162,8 +163,14 @@ export function createEditorExtensions(
       // list item (see list-item.ts). PatchedListItem below restores the
       // standard split → lift fallback chain.
       listItem: false,
+      // Disable StarterKit's stock Code mark so InlineCodeFixedExtension
+      // below replaces it without duplicate-mark / duplicate-input-rule
+      // collisions. See `./inline-code-input.ts` for the upstream bug being
+      // worked around (issue #4728).
+      code: false,
     }),
     PatchedListItem,
+    InlineCodeFixedExtension,
     // Checkbox task lists: `- [ ]` / `- [x]`. TaskList + TaskItem ship their own
     // markdown tokenizer / renderMarkdown, an input rule (typing `[] ` / `[x] `),
     // and a checkbox NodeView. The taskList tokenizer is consulted before

--- a/packages/views/editor/extensions/inline-code-input.test.ts
+++ b/packages/views/editor/extensions/inline-code-input.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Regression tests for the inline-code Markdown shortcut.
+ *
+ * Bug #4728: typing `` `code` `` while the cursor sits anywhere after a non-
+ * backtick character would swallow the character immediately preceding the
+ * opening backtick. Repro: type `abcd\`123\`` — the final string is
+ * `abc\`123\``, with the `d` eaten.
+ *
+ * Root cause: the upstream `markInputRule` helper in `@tiptap/core@3.22.1`
+ * computes the start of the deletion range using `fullMatch.search(/\S/)`,
+ * which assumes the regex's leading capture group is whitespace. The
+ * `@tiptap/extension-code` regex `/(^|[^\`])\`([^\`]+)\`(?!\`)$/` uses a
+ * NON-whitespace capture (`[^\`]`) as a guard against nested backticks, so
+ * the search returns 0 and `markInputRule` deletes from the start of the
+ * full match — eating the guard character along with the opening backtick.
+ *
+ * These tests pin both the bug shape and the contract the fix must satisfy.
+ *
+ * Test driver: ProseMirror's input rules fire from `handleTextInput`, which
+ * is invoked by EditorView during real DOM input — not by `insertContent` /
+ * `setContent` commands. We seed the document with the pre-trigger text via
+ * commands and then drive the final backtick through `view.someProp(
+ * "handleTextInput", ...)` to exercise the exact code path a real keystroke
+ * would take. This is the lowest-level public API that the inputRules
+ * plugin listens on.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Editor } from "@tiptap/core";
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import { Code } from "@tiptap/extension-code";
+import { BulletList, ListItem } from "@tiptap/extension-list";
+import { Markdown } from "@tiptap/markdown";
+import { InlineCodeFixedExtension } from "./inline-code-input";
+
+import type { AnyExtension } from "@tiptap/core";
+
+function makeEditor(extensions: AnyExtension[]) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  const editor = new Editor({
+    element,
+    extensions: [Document, Paragraph, Text, ...extensions],
+    content: "",
+  });
+  return { editor, element };
+}
+
+/**
+ * Seed the editor with `prefix`, then drive each character of `suffix`
+ * through `handleTextInput` so input rules fire. The split mirrors what a
+ * real user does: they type the lead-in, then the final trigger character.
+ */
+function typeWithRules(editor: Editor, prefix: string, suffix: string) {
+  if (prefix) {
+    editor.commands.insertContent(prefix);
+  }
+  // Move the selection to the end of the document so handleTextInput inserts
+  // at the right position.
+  editor.commands.focus("end");
+  const view = editor.view;
+  type TextInputHandler = (
+    view: typeof editor.view,
+    from: number,
+    to: number,
+    text: string,
+  ) => boolean;
+  for (const ch of suffix) {
+    const { from, to } = view.state.selection;
+    // handleTextInput is what prosemirror-inputrules subscribes to. Returns
+    // true if a rule handled it; otherwise we insert the text ourselves so
+    // the document stays in sync. The someProp generic is too narrow for
+    // jsdom's prosemirror types — we know the runtime contract.
+    const handled = (
+      view.someProp as (
+        prop: "handleTextInput",
+        f: (handler: TextInputHandler) => boolean,
+      ) => boolean | undefined
+    )("handleTextInput", (f) => f(view, from, to, ch));
+    if (!handled) {
+      view.dispatch(view.state.tr.insertText(ch, from, to));
+    }
+  }
+}
+
+describe("inline-code input rule", () => {
+  describe("upstream @tiptap/extension-code (broken in 3.22.1)", () => {
+    let editor: Editor;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      const made = makeEditor([Code]);
+      editor = made.editor;
+      element = made.element;
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+    });
+
+    // This test pins the BUG. When the fix is applied via overlay, we still
+    // expect the unpatched extension to misbehave — it documents WHY the
+    // overlay exists. If TipTap upstream ever fixes markInputRule and we
+    // bump versions, this test will start failing and tell us we can drop
+    // the overlay.
+    it("[REGRESSION DOC] swallows the character preceding the opening backtick", () => {
+      // Type `abcd` first, then the rule trigger sequence `\`123\``.
+      typeWithRules(editor, "abcd", "`123`");
+      const html = editor.getHTML();
+      expect(html).toContain("<code>123</code>");
+      // The bug: `d` was eaten. If this assertion ever fails (i.e. `d` shows
+      // up adjacent to the <code>), the upstream bug has been fixed and the
+      // overlay can be removed.
+      expect(html).not.toMatch(/d<code>/);
+    });
+  });
+
+  describe("overlay fix InlineCodeFixedExtension", () => {
+    let editor: Editor;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      const made = makeEditor([InlineCodeFixedExtension]);
+      editor = made.editor;
+      element = made.element;
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+    });
+
+    it("preserves the character before the opening backtick (the reported bug)", () => {
+      typeWithRules(editor, "abcd", "`123`");
+      const html = editor.getHTML();
+      // Expected: the `d` survives, only the surrounding backticks are
+      // consumed, and `123` is wrapped in a <code> mark.
+      expect(html).toContain("d<code>123</code>");
+      expect(html).not.toContain("`");
+    });
+
+    it("still applies the code mark when the opening backtick is at the start of the line", () => {
+      typeWithRules(editor, "", "`hello`");
+      expect(editor.getHTML()).toContain("<code>hello</code>");
+      expect(editor.getHTML()).not.toContain("`");
+    });
+
+    it("still applies the code mark when the opening backtick is preceded by a space", () => {
+      typeWithRules(editor, "see ", "`here`");
+      const html = editor.getHTML();
+      expect(html).toContain("see <code>here</code>");
+      expect(html).not.toContain("`");
+    });
+
+    it("preserves a Chinese character before the opening backtick", () => {
+      // Multi-byte characters are the original repro target's domain — issue
+      // author's screenshots include CJK text. This pin guards against a
+      // naive fix that uses byte offsets instead of code-unit offsets.
+      typeWithRules(editor, "代码", "`abc`");
+      const html = editor.getHTML();
+      expect(html).toContain("代码<code>abc</code>");
+      expect(html).not.toContain("`");
+    });
+
+    it("does NOT fire on triple backticks (preserves fenced-code-block syntax)", () => {
+      // The upstream regex uses `(?!\`)` to skip if a third backtick follows.
+      // The overlay must preserve that guard so it doesn't grab content that
+      // a fenced-code-block input rule should handle.
+      typeWithRules(editor, "a", "```code```");
+      const html = editor.getHTML();
+      // No <code> mark should appear; the literal backticks stay as text.
+      expect(html).not.toContain("<code>");
+    });
+
+    it("does NOT fire when the user is mid-content and there is no closing backtick yet", () => {
+      typeWithRules(editor, "abcd", "`123");
+      const html = editor.getHTML();
+      expect(html).not.toContain("<code>");
+      // All four leading chars must survive.
+      expect(html).toContain("abcd");
+    });
+
+    it("handles empty content between backticks gracefully (no crash, no empty code mark)", () => {
+      typeWithRules(editor, "a", "``");
+      const html = editor.getHTML();
+      // The upstream regex requires `[^\`]+` inside, so an empty pair should
+      // NOT trigger the rule. Verify nothing crashed and no <code>.
+      expect(html).not.toContain("<code>");
+    });
+
+    it("handles consecutive code spans on the same line", () => {
+      typeWithRules(editor, "a", "`x` b`y`");
+      const html = editor.getHTML();
+      expect(html).toContain("<code>x</code>");
+      expect(html).toContain("<code>y</code>");
+      // No raw backticks left.
+      expect(html).not.toContain("`");
+    });
+
+    it("preserves the boundary inside a non-empty paragraph (mid-sentence)", () => {
+      // Seed a longer pre-existing paragraph so the input rule fires while
+      // the cursor is well past the start of a textblock — the rule's
+      // `range.from` is no longer the start of the document. This is the
+      // shape closest to a real user typing into an existing comment.
+      typeWithRules(editor, "I prefer abcd", "`123`");
+      const html = editor.getHTML();
+      expect(html).toContain("I prefer abcd<code>123</code>");
+      expect(html).not.toContain("`");
+    });
+  });
+
+  describe("overlay fix InlineCodeFixedExtension — inside non-paragraph blocks", () => {
+    let editor: Editor;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      const made = makeEditor([
+        BulletList,
+        ListItem,
+        InlineCodeFixedExtension,
+      ]);
+      editor = made.editor;
+      element = made.element;
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+    });
+
+    it("preserves the boundary character inside a list item", () => {
+      // Start a bullet list, then type into the item.
+      editor.commands.toggleBulletList();
+      editor.commands.focus("end");
+      typeWithRules(editor, "abcd", "`123`");
+      const html = editor.getHTML();
+      // The list-item content must show `abcd<code>123</code>` — boundary
+      // preserved even inside a non-paragraph textblock.
+      expect(html).toContain("abcd<code>123</code>");
+      expect(html).not.toContain("`");
+    });
+  });
+
+  describe("overlay fix InlineCodeFixedExtension — markdown round-trip", () => {
+    let editor: Editor;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      // Markdown extension provides `renderMarkdown` + `parseMarkdown`
+      // wired to the Code mark's serializer. Lets us check the output
+      // format the rest of the product reads/writes.
+      const made = makeEditor([InlineCodeFixedExtension, Markdown]);
+      editor = made.editor;
+      element = made.element;
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+    });
+
+    it("emits standard Markdown backticks for an inline code span", () => {
+      typeWithRules(editor, "abcd", "`123`");
+      // The Markdown extension installs `getMarkdown` directly on the
+      // Editor instance; cast through unknown so we don't leak the
+      // extension's augmentation typing into this file.
+      const md = (
+        editor as unknown as { getMarkdown: () => string }
+      ).getMarkdown();
+      expect(md).toContain("abcd`123`");
+    });
+  });
+
+  describe("overlay fix InlineCodeFixedExtension — paste path (#4728 paste twin)", () => {
+    let editor: Editor;
+    let element: HTMLElement;
+    let removeClipboardPolyfill: (() => void) | null = null;
+
+    beforeEach(() => {
+      // jsdom does not implement ClipboardEvent or DataTransfer at all.
+      // TipTap's PasteRule plugin constructs `new ClipboardEvent("paste")`
+      // internally even when paste is *simulated* via `applyPasteRules`.
+      // Polyfill just enough surface to let the plugin run; the handlers
+      // under test never read the event payload (only the meta flag).
+      if (typeof globalThis.ClipboardEvent === "undefined") {
+        const g = globalThis as unknown as {
+          ClipboardEvent?: unknown;
+          DataTransfer?: unknown;
+        };
+        g.ClipboardEvent = class ClipboardEvent extends Event {
+          clipboardData: unknown;
+          constructor(type: string, init?: { clipboardData?: unknown }) {
+            super(type, init as EventInit);
+            this.clipboardData = init?.clipboardData ?? null;
+          }
+        };
+        g.DataTransfer = class DataTransfer {
+          private store = new Map<string, string>();
+          setData(format: string, data: string) {
+            this.store.set(format, data);
+          }
+          getData(format: string) {
+            return this.store.get(format) ?? "";
+          }
+        };
+        removeClipboardPolyfill = () => {
+          delete g.ClipboardEvent;
+          delete g.DataTransfer;
+        };
+      }
+
+      const made = makeEditor([InlineCodeFixedExtension]);
+      editor = made.editor;
+      element = made.element;
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+      if (removeClipboardPolyfill) {
+        removeClipboardPolyfill();
+        removeClipboardPolyfill = null;
+      }
+    });
+
+    it("preserves the boundary character when the markdown text is pasted, not typed", () => {
+      // TipTap's PasteRule plugin treats `insertContent(..., {
+      // applyPasteRules: true })` exactly like a real DOM paste event,
+      // including the offset arithmetic — see
+      // `transaction.getMeta("applyPasteRules")` in PasteRule.ts. With
+      // the ClipboardEvent / DataTransfer polyfill above, the plugin can
+      // run in jsdom without touching the real DOM clipboard API.
+      editor.commands.insertContent("abcd");
+      editor.commands.focus("end");
+      editor
+        .chain()
+        .insertContent("`123`", { applyPasteRules: true })
+        .run();
+
+      const html = editor.getHTML();
+      // The paste-twin of #4728: pasting `\`123\`` must NOT eat `d`.
+      expect(html).toContain("abcd<code>123</code>");
+      expect(html).not.toContain("`");
+    });
+  });
+
+  describe("overlay fix InlineCodeFixedExtension — full product extension stack", () => {
+    // End-to-end sanity: load the SAME extension array the product uses
+    // (StarterKit + PatchedListItem + InlineCodeFixedExtension + everything
+    // else) and verify the bug is fixed in that exact configuration. This
+    // catches any conflict introduced by a sibling extension's input or
+    // paste rule.
+    let editor: Editor;
+    let element: HTMLElement;
+
+    beforeEach(async () => {
+      const { createEditorExtensions } = await import("./index");
+      const extensions = createEditorExtensions({});
+      element = document.createElement("div");
+      document.body.appendChild(element);
+      editor = new Editor({
+        element,
+        extensions,
+        content: "",
+      });
+    });
+
+    afterEach(() => {
+      editor.destroy();
+      element.remove();
+    });
+
+    it("preserves the boundary character with the full product extension stack", () => {
+      typeWithRules(editor, "abcd", "`123`");
+      const html = editor.getHTML();
+      expect(html).toContain("abcd<code>123</code>");
+      expect(html).not.toContain("`");
+    });
+
+    it("preserves a Chinese boundary character with the full product extension stack", () => {
+      typeWithRules(editor, "代码", "`abc`");
+      const html = editor.getHTML();
+      expect(html).toContain("代码<code>abc</code>");
+      expect(html).not.toContain("`");
+    });
+  });
+});

--- a/packages/views/editor/extensions/inline-code-input.ts
+++ b/packages/views/editor/extensions/inline-code-input.ts
@@ -1,0 +1,162 @@
+/**
+ * InlineCodeFixedExtension — overlay the upstream @tiptap/extension-code
+ * input and paste rules so the character before the opening backtick is
+ * preserved.
+ *
+ * Why this exists
+ * ===============
+ *
+ * The upstream Code mark in @tiptap/extension-code@3.22.1 wires both an
+ * inputRule and a pasteRule through `markInputRule` / `markPasteRule`.
+ * Both helpers compute the deletion start with `fullMatch.search(/\S/)`,
+ * which assumes the regex's leading group is whitespace. Code's regex
+ * uses a NON-whitespace guard group `(^|[^`])`, so `search(/\S/)` returns
+ * 0 and the helper deletes from the start of the full match — eating the
+ * guard character along with the opening backtick.
+ *
+ * Concrete repro (issue #4728): typing or pasting `abcd\`123\`` produces
+ * `abc<code>123</code>` instead of `abcd<code>123</code>`.
+ *
+ * Fix: extend Code, replace `addInputRules` AND `addPasteRules` with
+ * handlers that use the regex's first capture group as an explicit
+ * boundary instead of delegating to the broken upstream helpers. The
+ * two-capture-group regex is unchanged so existing behaviour
+ * (no triple-backtick collision, no nested backticks, no IME-composition
+ * trigger) is preserved.
+ *
+ * IME / composition note
+ * ----------------------
+ * ProseMirror's inputRules plugin returns false while
+ * `EditorView.composing` is true, which means CJK / dead-key composition
+ * itself never fires inline-code formatting. This is correct behaviour
+ * inherited unchanged from upstream; the fix only changes the offset
+ * arithmetic.
+ *
+ * How to remove this overlay
+ * ==========================
+ *
+ * If upstream `markInputRule` / `markPasteRule` ever land a fix — e.g.
+ * by replacing `search(/\S/)` with `match[1]?.length ?? 0`, or by passing
+ * the boundary length explicitly — the `[REGRESSION DOC]` tests in
+ * inline-code-input.test.ts will start failing. To remove the overlay:
+ *
+ *   1) Delete this file and inline-code-input.test.ts.
+ *   2) Drop the `code: false` line from StarterKit.configure in
+ *      extensions/index.ts, restoring StarterKit's stock Code mark.
+ *   3) Drop the `@tiptap/extension-code` direct dependency from
+ *      packages/views/package.json if no other code references it.
+ *   4) Re-run vitest to confirm no other test pinned the overlay name.
+ */
+import { InputRule, PasteRule } from "@tiptap/core";
+import { Code } from "@tiptap/extension-code";
+
+/**
+ * Mirrors the upstream regex shape. Kept inline (not re-exported from
+ * `@tiptap/extension-code`) so the fix is self-contained — a future upstream
+ * regex change won't silently alter this overlay's behaviour.
+ *
+ * - `(^|[^`])` — the boundary group: either start-of-block or a single
+ *   non-backtick character. NOT consumed by the resulting code mark.
+ * - `([^`]+)` — the code content, one or more non-backtick characters.
+ * - `(?!`)` — must not be followed by a third backtick, so a fenced code
+ *   block opener doesn't trigger the inline rule.
+ */
+const INLINE_CODE_INPUT_REGEX = /(^|[^`])`([^`]+)`(?!`)$/;
+
+/**
+ * Same shape as INLINE_CODE_INPUT_REGEX but global and without the `$`
+ * anchor — pasteRules scan the whole pasted slice and need to match every
+ * occurrence rather than only the suffix.
+ */
+const INLINE_CODE_PASTE_REGEX = /(^|[^`])`([^`]+)`(?!`)/g;
+
+/**
+ * Shared offset-correct mutation: take the `(boundary, codeText)` capture
+ * shape and apply (delete close `, delete open `, addMark) to `tr` against
+ * the original document `range.from`. Returns nothing — callers don't
+ * need to know whether the rule fired.
+ */
+function applyInlineCodeMark(
+  tr: import("@tiptap/pm/state").Transaction,
+  rangeFrom: number,
+  rangeTo: number,
+  boundary: string,
+  codeTextLength: number,
+  markType: import("@tiptap/pm/model").MarkType,
+) {
+  // All four anchors are computed against the ORIGINAL document. We mutate
+  // from the tail forward so earlier positions stay valid for later
+  // operations.
+  const openBacktick = rangeFrom + boundary.length;
+  const codeFrom = openBacktick + 1;
+  const codeTo = codeFrom + codeTextLength;
+  const closeBacktickEnd = codeTo + 1;
+
+  if (codeTo < rangeTo) {
+    tr.delete(codeTo, Math.max(rangeTo, closeBacktickEnd));
+  }
+  tr.delete(openBacktick, codeFrom);
+
+  const markFrom = openBacktick;
+  const markTo = markFrom + codeTextLength;
+  tr.addMark(markFrom, markTo, markType.create());
+}
+
+export const InlineCodeFixedExtension = Code.extend({
+  addInputRules() {
+    return [
+      new InputRule({
+        find: INLINE_CODE_INPUT_REGEX,
+        handler: ({ state, range, match }) => {
+          const boundary = match[1] ?? "";
+          const codeText = match[2];
+          if (!codeText) {
+            return null;
+          }
+          applyInlineCodeMark(
+            state.tr,
+            range.from,
+            range.to,
+            boundary,
+            codeText.length,
+            this.type,
+          );
+          // Stop stored marks so the next character the user types isn't
+          // also formatted as code.
+          state.tr.removeStoredMark(this.type);
+          return;
+        },
+      }),
+    ];
+  },
+
+  addPasteRules() {
+    return [
+      new PasteRule({
+        find: INLINE_CODE_PASTE_REGEX,
+        handler: ({ state, range, match }) => {
+          const boundary = match[1] ?? "";
+          const codeText = match[2];
+          if (!codeText) {
+            return null;
+          }
+          // PasteRule scans the entire pasted slice. `range.from` is the
+          // document position of THIS match's start, so the same offset
+          // arithmetic the input rule uses applies unchanged.
+          // `removeStoredMark` is intentionally NOT called here: a paste
+          // does not leave a typing cursor at the end of the code span,
+          // so storedMarks is irrelevant on the paste path.
+          applyInlineCodeMark(
+            state.tr,
+            range.from,
+            range.to,
+            boundary,
+            codeText.length,
+            this.type,
+          );
+          return;
+        },
+      }),
+    ];
+  },
+});

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -65,6 +65,7 @@
     "@multica/ui": "workspace:*",
     "@tanstack/react-virtual": "catalog:",
     "@tiptap/core": "^3.22.1",
+    "@tiptap/extension-code": "^3.22.1",
     "@tiptap/extension-code-block-lowlight": "^3.22.1",
     "@tiptap/extension-document": "^3.22.1",
     "@tiptap/extension-highlight": "3.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,7 +422,7 @@ importers:
         version: 55.0.15(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+        version: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.24)
@@ -630,10 +630,10 @@ importers:
         version: 5.6.0
       fumadocs-core:
         specifier: ^15.5.2
-        version: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -648,7 +648,7 @@ importers:
         version: 1.0.1(react@19.2.3)
       next:
         specifier: ^16.2.5
-        version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -736,7 +736,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -984,6 +984,9 @@ importers:
       '@tiptap/core':
         specifier: ^3.22.1
         version: 3.22.1(@tiptap/pm@3.22.1)
+      '@tiptap/extension-code':
+        specifier: ^3.22.1
+        version: 3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))
       '@tiptap/extension-code-block-lowlight':
         specifier: ^3.22.1
         version: 3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))(@tiptap/extension-code-block@3.22.1(@tiptap/core@3.22.1(@tiptap/pm@3.22.1))(@tiptap/pm@3.22.1))(@tiptap/pm@3.22.1)(highlight.js@11.11.1)(lowlight@3.3.0)
@@ -11871,7 +11874,7 @@ snapshots:
       ws: 8.20.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12126,7 +12129,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(fb4q2ydjsib3h2ixce2lptexem)
+      expo-router: 55.0.14(28857138dad78e037ca803b5df54c4f8)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -17103,7 +17106,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.14(fb4q2ydjsib3h2ixce2lptexem):
+  expo-router@55.0.14(28857138dad78e037ca803b5df54c4f8):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -17527,7 +17530,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@orama/orama': 3.1.18
@@ -17550,7 +17553,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       lucide-react: 1.0.1(react@19.2.3)
-      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-router: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -17583,14 +17586,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 4.0.3
       esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      fumadocs-core: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       js-yaml: 4.1.1
       lru-cache: 11.2.7
       mdast-util-to-markdown: 2.1.2
@@ -17603,7 +17606,7 @@ snapshots:
       unist-util-visit: 5.1.0
       zod: 4.3.6
     optionalDependencies:
-      next: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
     transitivePeerDependencies:
       - supports-color
@@ -19646,7 +19649,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -19664,7 +19667,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -19673,7 +19676,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -21646,10 +21649,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   styleq@0.1.3: {}
 


### PR DESCRIPTION
## Summary

Fixes #4728 — typing or pasting `` `code` `` in the rich-text editor swallows the character immediately before the opening backtick.

Concrete repro: typing \`abcd\`123\`\` lands as \`abc<code>123</code>\` instead of \`abcd<code>123</code>\` — the **\`d\`** is eaten.

## Root cause (upstream)

\`@tiptap/extension-code@3.22.1\` wires both an inputRule and a pasteRule through \`markInputRule\` / \`markPasteRule\`. Both helpers compute the deletion start with \`fullMatch.search(/\S/)\`, which assumes the regex's leading capture group is whitespace.

But Code's regex \`/(^|[^\`])\`([^\`]+)\`(?!\`)$/\` uses a **non-whitespace** guard group \`(^|[^\`])\` to prevent nested-backtick matches. \`search(/\S/)\` therefore returns \`0\` and the helper deletes from the start of the full match — eating the guard character along with the opening backtick.

Both \`markInputRule\` and \`markPasteRule\` have the same off-by-one, so the bug manifests on **both typing and pasting**.

## Fix

A small overlay in \`packages/views/editor/extensions/inline-code-input.ts\` extends Code and replaces \`addInputRules\` AND \`addPasteRules\` with handlers that use the first capture group's length as an explicit boundary offset:

\`\`\`ts
const openBacktick = range.from + boundary.length;  // not search(/\S/)
\`\`\`

Everything else on Code (\`parseHTML\`, \`renderHTML\`, \`addCommands\`, \`addKeyboardShortcuts\`, markdown serializer, \`excludes: '_'\`) is inherited unchanged via \`Code.extend\`. The two-capture-group regex is unchanged so triple-backtick, nested-backtick, and IME composition behaviour are all preserved.

StarterKit's \`code\` mark is disabled (\`code: false\`) so the overlay doesn't collide with a second Code registration.

## Removing the overlay later

If upstream \`markInputRule\` / \`markPasteRule\` ever land a fix, the \`[REGRESSION DOC]\` test in \`inline-code-input.test.ts\` will start passing on raw upstream Code — that's the signal to remove this overlay. The file's header docstring lists the exact 4 deletion steps.

## Explicitly out of scope

- No change to the regex shape (triple-backtick guard, no-nested-backtick guard, end anchor are preserved).
- No change to any other extension (Markdown, StarterKit's other marks, lists, math, mention, etc.).
- No new metric / log / API surface.
- No server-side changes.
- No bump of TipTap versions.

## Test plan

15 tests in a new \`inline-code-input.test.ts\`:

**Bug pin** (1)
- [x] \`[REGRESSION DOC]\` against raw \`@tiptap/extension-code\` — confirms the upstream bug exists and is the one being fixed (the test will fail once upstream ships a fix, telling future maintainers the overlay can be deleted).

**Core behaviour** (9, against \`InlineCodeFixedExtension\`)
- [x] Preserves character before opening backtick (the reported bug)
- [x] Still fires when opening backtick is at the start of a line
- [x] Still fires when opening backtick is preceded by a space
- [x] Preserves a multi-byte (Chinese) character as the boundary
- [x] Does NOT fire on triple backticks (fenced-code-block guard preserved)
- [x] Does NOT fire on unclosed backtick (no premature trigger)
- [x] Handles empty \`\`\` \`\` \`\`\` pair without crash
- [x] Handles consecutive code spans on the same line
- [x] Preserves the boundary mid-sentence inside a longer paragraph

**Embedding** (1)
- [x] Preserves boundary inside a non-paragraph textblock (bullet list item)

**Markdown round-trip** (1)
- [x] \`editor.getMarkdown()\` emits standard \`\`abcd\`123\`\`\` for the formatted code span

**Paste path** (1)
- [x] Pasting \`abcd\`123\`\` via \`applyPasteRules\` also preserves \`d\` (the same off-by-one in \`markPasteRule\` is fixed)

**Full product extension stack** (2)
- [x] With the real \`createEditorExtensions(...)\` array loaded (StarterKit + PatchedListItem + Markdown + Mention + Math + Link + AutolinkEmailRepair + everything else), typing \`abcd\`123\`\` still preserves \`d\`
- [x] Same with a Chinese boundary character

**Local verification**

- \`pnpm typecheck\` (6 packages) — green
- \`pnpm lint\` — 0 errors (new files: 0/0)
- \`pnpm exec vitest run\` in \`packages/views\` — 148 files / 1536 tests green (pre-existing 1534 plus 2 new product-stack tests; the other 13 belong to a new file)
- 5 sequential vitest runs on \`inline-code-input.test.ts\` — no flakes
- \`gofmt -l\` n/a (no Go changes); \`go build ./...\` not run (no Go changes)

## Compatibility note

The Code mark name stays \`"code"\` (we only \`extend\` it), so HTML/JSON/Markdown serialization is wire-compatible with content written by the previous Code mark. No migration needed.