### PR TITLE
fix(daemon): sync active task status after WS reconnect

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -192,6 +192,12 @@ type Daemon struct {
 	activeTasks   atomic.Int64       // number of tasks currently in handleTask; exposed via /health
 	ready         atomic.Bool        // false until preflight completes; gates /health status (starting -> running)
 
+	// activeTaskCancels tracks running task IDs and their cancel functions so
+	// syncActiveTasks can immediately check status after a WS reconnect instead
+	// of waiting for the next watchTaskCancellation poll tick.
+	activeTaskCancelsMu sync.Mutex
+	activeTaskCancels   map[string]context.CancelFunc
+
 	// claimMu guards pauseClaims and claimsInFlight. It is held only for the
 	// microseconds it takes to make a decision; ClaimTask itself runs without
 	// the lock so a slow per-runtime claim cannot stall auto-update or any
@@ -259,6 +265,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		agentVersions:             make(map[string]string),
 		wsHBLastAck:               make(map[string]time.Time),
 		activeEnvRoots:            make(map[string]int),
+		activeTaskCancels:         make(map[string]context.CancelFunc),
 		localPathLocks:            NewLocalPathLocker(),
 		runtimeGoneInflight:       make(map[string]struct{}),
 		reregisterNextAttempt:     make(map[string]time.Time),
@@ -2763,6 +2770,37 @@ func (d *Daemon) watchTaskCancellation(ctx context.Context, taskID string, pollI
 	return cancelled
 }
 
+// syncActiveTasks checks the server-side status of every running task and
+// cancels the local agent for any that have reached a terminal state. This
+// closes the gap after a WebSocket reconnect where watchTaskCancellation's
+// periodic poll may not yet have detected a cancellation that happened
+// during the disconnect window.
+func (d *Daemon) syncActiveTasks(ctx context.Context) {
+	d.activeTaskCancelsMu.Lock()
+	tasks := make(map[string]context.CancelFunc, len(d.activeTaskCancels))
+	for k, v := range d.activeTaskCancels {
+		tasks[k] = v
+	}
+	d.activeTaskCancelsMu.Unlock()
+
+	if len(tasks) == 0 {
+		return
+	}
+
+	d.logger.Info("syncing active tasks after reconnect", "count", len(tasks))
+	for taskID, cancel := range tasks {
+		status, err := d.client.GetTaskStatus(ctx, taskID)
+		if shouldInterruptAgent(status, err) {
+			if err != nil {
+				d.logger.Info("sync: task gone server-side, cancelling agent", "task", shortID(taskID), "error", err)
+			} else {
+				d.logger.Info("sync: task reached terminal state, cancelling agent", "task", shortID(taskID), "status", status)
+			}
+			cancel()
+		}
+	}
+}
+
 func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	d.mu.Lock()
 	rt := d.runtimeIndex[task.RuntimeID]
@@ -2838,6 +2876,20 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	// deleted (404).
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
+
+	// Register so syncActiveTasks (called on WS reconnect) can cancel this
+	// task immediately if the server reports a terminal state.
+	d.activeTaskCancelsMu.Lock()
+	if d.activeTaskCancels == nil {
+		d.activeTaskCancels = make(map[string]context.CancelFunc)
+	}
+	d.activeTaskCancels[task.ID] = runCancel
+	d.activeTaskCancelsMu.Unlock()
+	defer func() {
+		d.activeTaskCancelsMu.Lock()
+		delete(d.activeTaskCancels, task.ID)
+		d.activeTaskCancelsMu.Unlock()
+	}()
 
 	// Poll interval is d.cancelPollInterval (5s in production, reduced in tests
 	// via direct field override). Guard against zero so a misconfigured daemon

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -896,6 +896,65 @@ func TestWatchTaskCancellation_RunningTaskNotInterrupted(t *testing.T) {
 	}
 }
 
+func TestSyncActiveTasks_CancelsTerminalTasks(t *testing.T) {
+	t.Parallel()
+
+	// Mock server: task-cancelled returns "cancelled", task-running returns "running",
+	// task-deleted returns 404.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "task-cancelled/status"):
+			_, _ = w.Write([]byte(`{"status":"cancelled"}`))
+		case strings.HasSuffix(r.URL.Path, "task-running/status"):
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		case strings.HasSuffix(r.URL.Path, "task-deleted/status"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"task not found"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	cancelled1, cancelled2, notCancelled := false, false, false
+
+	d := &Daemon{
+		client:            NewClient(srv.URL),
+		logger:            slog.Default(),
+		activeTaskCancels: make(map[string]context.CancelFunc),
+	}
+	d.activeTaskCancels["task-cancelled"] = func() { cancelled1 = true }
+	d.activeTaskCancels["task-running"] = func() { notCancelled = true }
+	d.activeTaskCancels["task-deleted"] = func() { cancelled2 = true }
+
+	d.syncActiveTasks(ctx)
+
+	if !cancelled1 {
+		t.Error("expected task-cancelled to be cancelled")
+	}
+	if !cancelled2 {
+		t.Error("expected task-deleted to be cancelled")
+	}
+	if notCancelled {
+		t.Error("expected task-running to NOT be cancelled")
+	}
+}
+
+func TestSyncActiveTasks_NoActiveTasks(t *testing.T) {
+	t.Parallel()
+
+	d := &Daemon{
+		client:            NewClient("http://localhost:0"),
+		logger:            slog.Default(),
+		activeTaskCancels: make(map[string]context.CancelFunc),
+	}
+
+	// Should not panic or make any HTTP calls when there are no active tasks.
+	d.syncActiveTasks(context.Background())
+}
+
 func TestMergeUsage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -105,6 +105,14 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	d.logger.Info("task wakeup websocket connected", "runtimes", len(runtimeIDs))
 	signalTaskWakeup(taskWakeups, "")
 
+	// Immediately re-validate any tasks the daemon was running when the WS
+	// dropped. During the disconnect window the server may have moved them to
+	// a terminal state (cancelled/completed/failed); without this sync the
+	// daemon would keep the agent running until watchTaskCancellation's next
+	// poll tick (up to 5s). Runs in a goroutine so the HTTP calls don't
+	// block the WS read-pump startup below.
+	go d.syncActiveTasks(ctx)
+
 	// Serialize all writes through a single channel: the gorilla/websocket
 	// Conn does not allow concurrent WriteMessage calls, and the heartbeat
 	// sender now coexists with future server-initiated writes. The buffer


### PR DESCRIPTION
## What does this PR do?

When the daemon's task-wakeup WebSocket drops and reconnects, the only catch-up mechanism is  which claims **new** tasks but never validates tasks the daemon was **already running**.  polls every 5 seconds, so if a task was cancelled/completed/failed during the disconnect window, the agent keeps running for up to 5 seconds on a dead task.

This PR adds an active task cancel registry and a post-reconnect sync that immediately checks all running tasks' status via  and cancels any that have reached a terminal state server-side.

## Related Issue

Closes #4614

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Tests
- [ ] CI / Infrastructure

## Changes Made

- ****:
  - Added  +  to the  struct for tracking running tasks' cancel functions.
  - Initialized the map in  constructor.
  -  registers  in the map on entry (with nil-safe lazy init for test fixtures) and deregisters via deferred cleanup.
  - New  method: snapshots the registry, calls  for each task, and invokes the cancel function for any that  returns true.

- ****:
  - After  on WS connect, fires  in a goroutine so HTTP calls don't block the WS read-pump startup.

- ****:
  - : mock server returns cancelled/running/404 for 3 tasks; verifies only terminal ones are cancelled.
  - : empty registry doesn't panic or make HTTP calls.

## How to Test

1. Run the new tests: 
2. Verify existing tests still pass: 

## Checklist

- [x] I have traced my reasoning and the thinking path is clear
- [x] I have run local tests and they pass (, , , 7/7 targeted tests)
- [x] I have updated relevant tests
- [ ] I have updated relevant documentation
- [x] I have checked Chinese copy conventions where applicable
- [x] I have documented any risks or migration notes
- [x] I will respond to reviewer comments

## AI Disclosure

- **AI tool used**: QoderWork
- **Prompt / approach**: Deep-analyzed the daemon's WS reconnection architecture (taskWakeupLoop, pollLoop, watchTaskCancellation, handleTask pipeline). Identified that no centralized task registry exists and the only post-reconnect catch-up was  for new claims. Designed a minimal registry + sync approach that reuses the existing  decision function and runs in a goroutine to avoid blocking WS startup.

## Screenshots

N/A — daemon-side change, no UI impact.
