### PR TITLE
feat(slack): make the chat agent explicitly channel-aware (MUL-3871)

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -190,13 +190,16 @@ func buildChatPrompt(task Task) string {
 	var b strings.Builder
 	b.WriteString("You are running as a chat assistant for a Multica workspace.\n")
 	b.WriteString("A user is chatting with you directly. Respond to their message.\n\n")
-	// Discoverability nudge for the on-demand channel-history pull (MUL-3871).
-	// When this conversation came from an IM channel (e.g. Slack) the message
-	// below may be only the line that triggered the agent, not the surrounding
-	// thread/channel discussion. The agent has no other signal that earlier
-	// context exists, so point it at the unified command; it returns an empty
-	// list (with a note) for web-only sessions, so an always-on hint is safe.
-	b.WriteString("If this conversation came from a chat channel (e.g. a Slack thread, channel, or DM), the message below may be only what triggered you — not what was said earlier. Run `multica chat history --output json` before replying to read the prior conversation. It auto-selects the right scope — the surrounding channel on your first reply (where earlier context lives), your own thread on follow-ups — and you can add `--scope channel` to pull the wider channel when a follow-up needs more. It returns an empty list if there is no connected channel.\n\n")
+	// Channel awareness (MUL-3871). When the session is backed by an IM channel,
+	// the agent must KNOW it is operating inside that channel — otherwise an ask
+	// like "what did you just talk about" sends it to read Multica instead of the
+	// Slack conversation. State it explicitly and point history reads at the
+	// channel, not Multica. A web-only chat session gets no such line — its
+	// history is the Multica chat_session the agent already resumes.
+	if task.ChatChannelType != "" {
+		platform := channelDisplayName(task.ChatChannelType)
+		fmt.Fprintf(&b, "You are operating inside a %s conversation (a channel, thread, or DM) — not the Multica web app. This conversation and its history live in %s, NOT in Multica. When the user asks about earlier messages, what was discussed, or who said what here, read it with `multica chat history --output json`; do NOT look in Multica issues or comments for this conversation's history. The message below may be only what triggered you — `multica chat history` auto-selects the right scope (the surrounding channel on your first reply, your own thread on follow-ups; add `--scope channel` to pull the wider channel when needed).\n\n", platform, platform)
+	}
 	if task.Agent != nil && len(task.Agent.Skills) > 0 {
 		refs := ExtractSlashSkills(task.ChatMessage)
 		if len(refs) > 0 {
@@ -248,6 +251,16 @@ func buildChatPrompt(task Task) string {
 		b.WriteString("When creating an issue that should preserve one of these attachments, pass `--attachment-id <id>` to `multica issue create` in addition to keeping the attachment markdown inline.\n")
 	}
 	return b.String()
+}
+
+// channelDisplayName renders a chat_channel_type for prompt copy.
+func channelDisplayName(channelType string) string {
+	switch channelType {
+	case "slack":
+		return "Slack"
+	default:
+		return channelType
+	}
 }
 
 // buildAutopilotPrompt constructs a prompt for run_only autopilot tasks.

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -270,6 +270,31 @@ func TestBuildChatPromptAttachmentIDsCanBeBoundToCreatedIssues(t *testing.T) {
 	}
 }
 
+func TestBuildChatPromptChannelAwareness(t *testing.T) {
+	t.Run("slack-backed session tells the agent it is in slack", func(t *testing.T) {
+		out := buildChatPrompt(Task{
+			ChatSessionID:   "sess-1",
+			ChatChannelType: "slack",
+			ChatMessage:     "你刚刚和 xxx 聊了什么",
+		})
+		for _, want := range []string{"Slack", "multica chat history", "NOT in Multica"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("slack-backed prompt missing %q\n--- output ---\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("web-only session has no channel block", func(t *testing.T) {
+		out := buildChatPrompt(Task{
+			ChatSessionID: "sess-1",
+			ChatMessage:   "hi",
+		})
+		if strings.Contains(out, "multica chat history") {
+			t.Fatalf("web-only chat prompt should not mention channel history, got:\n%s", out)
+		}
+	})
+}
+
 func TestBuildChatPromptSlashSkills(t *testing.T) {
 	t.Run("injects selected skills block", func(t *testing.T) {
 		task := Task{
@@ -285,11 +310,6 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 		}
 		if !strings.Contains(out, "User message:\nplease [/deploy](slash://skill/abc-123) this") {
 			t.Fatalf("expected raw user message preserved, got:\n%s", out)
-		}
-		// Every chat prompt points the agent at the on-demand channel-history
-		// pull so it can recover Slack thread/channel context (MUL-3871).
-		if !strings.Contains(out, "multica chat history") {
-			t.Fatalf("expected channel-history nudge, got:\n%s", out)
 		}
 	})
 

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -68,6 +68,7 @@ type Task struct {
 	NewCommentCount          int                   `json:"new_comment_count,omitempty"`           // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
 	NewCommentsSince         string                `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	ChatSessionID            string                `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatChannelType          string                `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
 	ChatMessage              string                `json:"chat_message,omitempty"`                // user message content for chat tasks
 	ChatMessageAttachments   []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
 	AutopilotRunID           string                `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -277,6 +277,7 @@ type AgentTaskResponse struct {
 	NewCommentCount          int                  `json:"new_comment_count,omitempty"`           // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
 	NewCommentsSince         string               `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
 	ChatSessionID            string               `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatChannelType          string               `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
 	ChatMessage              string               `json:"chat_message,omitempty"`                // user message for chat tasks
 	ChatMessageAttachments   []ChatAttachmentMeta `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
 	AutopilotRunID           string               `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -1594,6 +1595,16 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			resp.WorkspaceID = uuidToString(cs.WorkspaceID)
 			resp.ChatSessionID = uuidToString(cs.ID)
 			resp.ThreadName = cs.Title
+			// Flag a channel-backed session so the daemon makes the agent aware
+			// it is operating inside Slack — read this conversation's history
+			// from the channel via `multica chat history`, not from Multica
+			// (MUL-3871). Empty for a web-only chat session.
+			if _, berr := h.Queries.GetChannelChatSessionBindingBySession(r.Context(), db.GetChannelChatSessionBindingBySessionParams{
+				ChatSessionID: cs.ID,
+				ChannelType:   string(slack.TypeSlack),
+			}); berr == nil {
+				resp.ChatChannelType = string(slack.TypeSlack)
+			}
 			if ws, err := h.Queries.GetWorkspace(r.Context(), cs.WorkspaceID); err == nil && ws.Repos != nil {
 				var repos []RepoData
 				if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {


### PR DESCRIPTION
## Summary

Follow-up to #4747 (the unified `multica chat history` pull, now merged).

#4747 gave the agent a way to *read* a Slack conversation's history, but the agent was never told, explicitly, that it **is** operating inside Slack. The chat prompt only carried a generic, always-on hint ("*if* this came from a chat channel…") and the task carried no channel signal. So for an ambiguous ask like **"what did you just talk about with X"**, the agent could go read **Multica** instead of the **Slack** conversation.

This makes the agent explicitly channel-aware — but only when the session genuinely is channel-backed.

## What's in it

- **Server tags channel-backed chat tasks.** In `taskToResponse`, when the chat session has a Slack binding (`GetChannelChatSessionBindingBySession`), the task response now carries `chat_channel_type = "slack"`. A web-only chat session leaves it empty.
- **Daemon emits an explicit channel block** in `buildChatPrompt` **only when** `chat_channel_type` is set:

  > You are operating inside a **Slack** conversation (a channel, thread, or DM) — not the Multica web app. This conversation and its history live in **Slack, NOT in Multica**. When the user asks about earlier messages, what was discussed, or who said what here, read it with `multica chat history` — do **NOT** look in Multica issues or comments for this conversation's history.

- **Web-only chat sessions get no such block** — their history is the Multica `chat_session` the agent already resumes, so the old generic always-on hint is removed.

Net effect on the reported case: in Slack, "what did you just chat about" → the agent knows it's in Slack → runs `multica chat history` (auto scope: channel on the first turn, thread on follow-ups) → reads the Slack conversation, not Multica. ✅

No DB migration; no new query (reuses `GetChannelChatSessionBindingBySession`).

## Testing

- `daemon`: new `TestBuildChatPromptChannelAwareness` — a slack-backed prompt asserts the explicit "Slack / NOT in Multica / `multica chat history`" copy; a web-only prompt asserts the block is absent.
- `go build ./...`, `go vet`, `gofmt` clean; full `internal/daemon` + `internal/handler` suites pass against current `main`.

## Deploy note

The block is rendered daemon-side, so it needs **both** the backend deploy (to send `chat_channel_type`) **and** the new daemon build (to render the block). The daemon auto-updates from the CLI release, so no manual restart.

Relates to MUL-3871. Follow-up to #4747.
