### PR TITLE
feat(usage): log per-run prompt-cache hit ratio (MUL-3887)

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2342,6 +2342,24 @@ func (h *Handler) ReportTaskUsage(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		h.TaskService.CaptureTaskUsage(r.Context(), task, provider, u.Model, u.InputTokens, u.OutputTokens, u.CacheReadTokens, u.CacheWriteTokens)
+
+		// Surface prompt-cache effectiveness per run so cache hit rates are
+		// observable in logs, not just queryable from runtime_usage. The ratio
+		// is cached input over total input-side tokens; a persistently low
+		// value flags a prompt prefix that is not being reused across runs
+		// (e.g. volatile values poisoning the cacheable prefix). MUL-3887.
+		if totalInput := u.InputTokens + u.CacheReadTokens + u.CacheWriteTokens; totalInput > 0 {
+			slog.Info("task prompt-cache usage",
+				"task_id", taskID,
+				"provider", provider,
+				"model", u.Model,
+				"input_tokens", u.InputTokens,
+				"output_tokens", u.OutputTokens,
+				"cache_read_tokens", u.CacheReadTokens,
+				"cache_write_tokens", u.CacheWriteTokens,
+				"cache_read_ratio", float64(u.CacheReadTokens)/float64(totalInput),
+			)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})


### PR DESCRIPTION
## What

Adds a structured per-run **prompt-cache effectiveness** log line at the usage-capture chokepoint (`ReportTaskUsage` in `server/internal/handler/daemon.go`):

```
task prompt-cache usage  task_id=… provider=… model=…
  input_tokens=… output_tokens=…
  cache_read_tokens=… cache_write_tokens=…
  cache_read_ratio=0.xx
```

`cache_read_ratio = cache_read / (input + cache_read + cache_write)` — the fraction of input-side tokens served from cache. A persistently low value flags a prompt prefix that isn't being reused across runs.

Relates to MUL-3887 (comment-resume token cost) and #4754.

## Why

We're investigating why Multica's token consumption runs noticeably higher than using a CLI agent directly. The cache token counts (`CacheReadTokens` / `CacheWriteTokens`) are already parsed from the CLI backends and persisted to `runtime_usage`, but there's **no computed hit ratio and no per-run log** — so today you can't quickly tell whether prompt caching is actually working for a given run, or spot a regression.

This is deliberately the **measure-first** step. Before changing prompt assembly, we want per-run cache-hit visibility to quantify the opportunity and confirm any later fix actually moves the number.

## Architecture finding (context for reviewers)

Multica delegates all LLM calls to CLI wrappers (`claude`, `codex`, …) and does **not** call the Anthropic SDK directly, so it cannot set `cache_control` breakpoints itself — the CLI owns caching. The only lever Multica controls is the **byte-stability of what it injects** (the runtime brief, passed to Claude Code via `--append-system-prompt`). Anthropic caches the system block as one unit keyed on its exact bytes, so any volatile value in the brief misses the cache on the next run.

While here I noticed a concrete instance worth a separate, scoped change: the runtime brief's `### Workflow` section (`runtime_config_sections.go` → `writeWorkflowComment` / `writeWorkflowAssignment`, system block) re-embeds `ctx.IssueID` and `ctx.TriggerCommentID`. Those same volatile IDs are already delivered **authoritatively** by `buildCommentPrompt` in the **user** prompt (after the cache breakpoint, re-emitted every turn — see the comment at `prompt.go:143`). So they're both (a) duplicated and (b) poisoning the cacheable system prefix on every new comment / resume.

I intentionally did **not** touch that here — it's behavior-sensitive (spans the slim + legacy brief paths, has golden tests, and is documented agent behavior), so it deserves its own task validated against the data this PR surfaces, rather than an unvalidated change on a triage-stage issue.

## Verification

- `gofmt -l` clean, `go vet ./internal/handler/` clean, package builds.
- Behavior-only addition: no CLI/API/schema/product-behavior change, so no SKILL.md updates required. Uses the `slog` logger already imported and used in this handler.
