### PR TITLE
feat(service): schedule runtime restore after rate-limit fallback (PAN-210)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -372,6 +372,7 @@ func main() {
 	go runRuntimeSweeper(sweepCtx, queries, liveness, taskSvc, bus)
 	go heartbeatScheduler.Run(sweepCtx)
 	go runAutopilotFailureMonitor(autopilotCtx, queries, bus, envFailureMonitorConfig())
+	go runRuntimeProviderFailureMonitor(autopilotCtx, queries, bus, envRuntimeProviderFailureMonitorConfig())
 	go runDBStatsLogger(sweepCtx, pool)
 
 	// Channel inbound supervisor (MUL-3620): holds the §4.4 WS lease per

--- a/server/cmd/server/rerun_session_test.go
+++ b/server/cmd/server/rerun_session_test.go
@@ -235,7 +235,9 @@ func TestCreateRetryTaskFreshensCodexSemanticInactivity(t *testing.T) {
 	}
 
 	queries := db.New(testPool)
-	child, err := queries.CreateRetryTask(ctx, pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true})
+	child, err := queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{
+		ID: pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true},
+	})
 	if err != nil {
 		t.Fatalf("CreateRetryTask failed: %v", err)
 	}
@@ -278,7 +280,9 @@ func TestCreateRetryTaskKeepsOrdinaryTimeoutSession(t *testing.T) {
 	}
 
 	queries := db.New(testPool)
-	child, err := queries.CreateRetryTask(ctx, pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true})
+	child, err := queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{
+		ID: pgtype.UUID{Bytes: parseUUIDBytes(parentID), Valid: true},
+	})
 	if err != nil {
 		t.Fatalf("CreateRetryTask failed: %v", err)
 	}

--- a/server/cmd/server/runtime_provider_failure_monitor.go
+++ b/server/cmd/server/runtime_provider_failure_monitor.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// runtimeProviderFailureMonitorConfig controls runtime-wide provider
+// capacity/session-limit alerting. It deliberately alerts without pausing
+// anything: retries and fallback handle individual tasks, while the alert
+// tells workspace operators that upstream capacity is repeatedly degrading.
+type runtimeProviderFailureMonitorConfig struct {
+	Interval     time.Duration
+	Lookback     time.Duration
+	Threshold    int64
+	StartupDelay time.Duration
+}
+
+func defaultRuntimeProviderFailureMonitorConfig() runtimeProviderFailureMonitorConfig {
+	return runtimeProviderFailureMonitorConfig{
+		Interval:     time.Hour,
+		Lookback:     24 * time.Hour,
+		Threshold:    3,
+		StartupDelay: time.Minute,
+	}
+}
+
+func envRuntimeProviderFailureMonitorConfig() runtimeProviderFailureMonitorConfig {
+	cfg := defaultRuntimeProviderFailureMonitorConfig()
+	cfg.Interval = envDurationOrZero("RUNTIME_PROVIDER_FAILURE_MONITOR_INTERVAL", cfg.Interval)
+	cfg.Lookback = envDurationPositive("RUNTIME_PROVIDER_FAILURE_MONITOR_LOOKBACK", cfg.Lookback)
+	cfg.StartupDelay = envDurationNonNegative("RUNTIME_PROVIDER_FAILURE_MONITOR_STARTUP_DELAY", cfg.StartupDelay)
+	if v, ok := envInt64Positive("RUNTIME_PROVIDER_FAILURE_MONITOR_THRESHOLD"); ok {
+		cfg.Threshold = v
+	}
+	return cfg
+}
+
+func runRuntimeProviderFailureMonitor(ctx context.Context, queries *db.Queries, bus *events.Bus, cfg runtimeProviderFailureMonitorConfig) {
+	if cfg.Interval <= 0 {
+		slog.Info("runtime provider failure monitor: disabled (interval <= 0)")
+		return
+	}
+
+	slog.Info(
+		"runtime provider failure monitor: starting",
+		"interval", cfg.Interval.String(),
+		"lookback", cfg.Lookback.String(),
+		"threshold", cfg.Threshold,
+	)
+
+	if cfg.StartupDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(cfg.StartupDelay):
+		}
+	}
+
+	tickRuntimeProviderFailureMonitor(ctx, queries, bus, cfg)
+
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tickRuntimeProviderFailureMonitor(ctx, queries, bus, cfg)
+		}
+	}
+}
+
+func tickRuntimeProviderFailureMonitor(ctx context.Context, queries *db.Queries, bus *events.Bus, cfg runtimeProviderFailureMonitorConfig) {
+	if cfg.Threshold <= 0 || cfg.Lookback <= 0 {
+		return
+	}
+
+	since := time.Now().Add(-cfg.Lookback)
+	candidates, err := queries.SelectWorkspacesExceedingProviderFailureThreshold(
+		ctx,
+		db.SelectWorkspacesExceedingProviderFailureThresholdParams{
+			Since:     pgtype.Timestamptz{Time: since, Valid: true},
+			Threshold: cfg.Threshold,
+		},
+	)
+	if err != nil {
+		slog.Warn("runtime provider failure monitor: failed to query candidates", "error", err)
+		return
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	slog.Info("runtime provider failure monitor: candidates", "count", len(candidates))
+	for _, c := range candidates {
+		emitRuntimeProviderFailureAlert(ctx, queries, bus, c, cfg)
+	}
+}
+
+type runtimeProviderFailureRecipient struct {
+	Type string
+	ID   pgtype.UUID
+}
+
+func runtimeProviderFailureRecipients(
+	ctx context.Context,
+	queries *db.Queries,
+	workspaceID pgtype.UUID,
+) []runtimeProviderFailureRecipient {
+	members, err := queries.ListMembers(ctx, workspaceID)
+	if err != nil {
+		slog.Warn("runtime provider failure monitor: failed to list members",
+			"workspace_id", util.UUIDToString(workspaceID),
+			"error", err,
+		)
+		return nil
+	}
+
+	recipients := make([]runtimeProviderFailureRecipient, 0, len(members))
+	for _, m := range members {
+		if m.Role == "owner" || m.Role == "admin" {
+			recipients = append(recipients, runtimeProviderFailureRecipient{
+				Type: "member",
+				ID:   m.UserID,
+			})
+		}
+	}
+	return recipients
+}
+
+func emitRuntimeProviderFailureAlert(
+	ctx context.Context,
+	queries *db.Queries,
+	bus *events.Bus,
+	c db.SelectWorkspacesExceedingProviderFailureThresholdRow,
+	cfg runtimeProviderFailureMonitorConfig,
+) {
+	recipients := runtimeProviderFailureRecipients(ctx, queries, c.WorkspaceID)
+	if len(recipients) == 0 {
+		return
+	}
+
+	sampleError := ""
+	if c.SampleError.Valid {
+		sampleError = c.SampleError.String
+	}
+
+	title := "Runtime provider capacity alert"
+	body := fmt.Sprintf(
+		"%d capacity/session-limit task failures were recorded in the last %s. Runtime retries and model fallback will continue, but inspect provider capacity or account limits if this repeats.",
+		c.FailedTasks, formatLookback(cfg.Lookback),
+	)
+	details, _ := json.Marshal(map[string]any{
+		"reason":            "provider_capacity_or_session_limit",
+		"failure_reason":    "agent_provider_capacity_or_rate_limit",
+		"failed_tasks":      c.FailedTasks,
+		"threshold":         cfg.Threshold,
+		"lookback_seconds":  int64(cfg.Lookback.Seconds()),
+		"first_failed_at":   util.TimestampToString(c.FirstFailedAt),
+		"last_failed_at":    util.TimestampToString(c.LastFailedAt),
+		"sample_task_id":    util.UUIDToString(c.SampleTaskID),
+		"sample_task_error": sampleError,
+	})
+
+	workspaceID := util.UUIDToString(c.WorkspaceID)
+	emitted := make(map[string]bool, len(recipients))
+	for _, r := range recipients {
+		key := r.Type + ":" + util.UUIDToString(r.ID)
+		if emitted[key] {
+			continue
+		}
+		emitted[key] = true
+
+		item, err := queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+			WorkspaceID:   c.WorkspaceID,
+			RecipientType: r.Type,
+			RecipientID:   r.ID,
+			Type:          "runtime_provider_capacity_alert",
+			Severity:      "attention",
+			IssueID:       pgtype.UUID{},
+			Title:         title,
+			Body:          util.StrToText(body),
+			ActorType:     util.StrToText("system"),
+			ActorID:       pgtype.UUID{},
+			Details:       details,
+		})
+		if err != nil {
+			slog.Warn("runtime provider failure monitor: inbox write failed",
+				"workspace_id", workspaceID,
+				"recipient_type", r.Type,
+				"recipient_id", util.UUIDToString(r.ID),
+				"error", err,
+			)
+			continue
+		}
+
+		bus.Publish(events.Event{
+			Type:        protocol.EventInboxNew,
+			WorkspaceID: workspaceID,
+			ActorType:   "system",
+			ActorID:     "",
+			Payload:     map[string]any{"item": inboxItemToResponse(item)},
+		})
+	}
+}

--- a/server/cmd/server/runtime_provider_failure_monitor.go
+++ b/server/cmd/server/runtime_provider_failure_monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
 // runtimeProviderFailureMonitorConfig controls runtime-wide provider
@@ -90,8 +91,9 @@ func tickRuntimeProviderFailureMonitor(ctx context.Context, queries *db.Queries,
 	candidates, err := queries.SelectWorkspacesExceedingProviderFailureThreshold(
 		ctx,
 		db.SelectWorkspacesExceedingProviderFailureThresholdParams{
-			Since:     pgtype.Timestamptz{Time: since, Valid: true},
-			Threshold: cfg.Threshold,
+			Since:         pgtype.Timestamptz{Time: since, Valid: true},
+			FailureReason: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+			Threshold:     cfg.Threshold,
 		},
 	)
 	if err != nil {
@@ -151,11 +153,6 @@ func emitRuntimeProviderFailureAlert(
 		return
 	}
 
-	sampleError := ""
-	if c.SampleError.Valid {
-		sampleError = c.SampleError.String
-	}
-
 	title := "Runtime provider capacity alert"
 	body := fmt.Sprintf(
 		"%d capacity/session-limit task failures were recorded in the last %s. Runtime retries and model fallback will continue, but inspect provider capacity or account limits if this repeats.",
@@ -163,14 +160,14 @@ func emitRuntimeProviderFailureAlert(
 	)
 	details, _ := json.Marshal(map[string]any{
 		"reason":            "provider_capacity_or_session_limit",
-		"failure_reason":    "agent_provider_capacity_or_rate_limit",
+		"failure_reason":    taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
 		"failed_tasks":      c.FailedTasks,
 		"threshold":         cfg.Threshold,
 		"lookback_seconds":  int64(cfg.Lookback.Seconds()),
 		"first_failed_at":   util.TimestampToString(c.FirstFailedAt),
 		"last_failed_at":    util.TimestampToString(c.LastFailedAt),
 		"sample_task_id":    util.UUIDToString(c.SampleTaskID),
-		"sample_task_error": sampleError,
+		"sample_task_error": c.SampleError,
 	})
 
 	workspaceID := util.UUIDToString(c.WorkspaceID)

--- a/server/cmd/server/runtime_provider_failure_monitor_test.go
+++ b/server/cmd/server/runtime_provider_failure_monitor_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+func TestRuntimeProviderFailureMonitor_AlertsOwnerOncePerLookback(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no database connection")
+	}
+
+	issueID, agentID, runtimeID := setupRerunTestFixture(t)
+	t.Cleanup(func() { cleanupRerunFixture(t, issueID) })
+
+	ctx := context.Background()
+	startedAt := time.Now().Add(-1 * time.Second)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `
+			DELETE FROM inbox_item
+			WHERE workspace_id = $1
+			  AND type = 'runtime_provider_capacity_alert'
+			  AND created_at >= $2
+		`, testWorkspaceID, startedAt)
+	})
+
+	for i := 0; i < 4; i++ {
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, issue_id, status, priority,
+				started_at, completed_at, created_at, failure_reason, error
+			)
+			VALUES ($1, $2, $3, 'failed', 0, now(), now(), now(), $4, $5)
+		`, agentID, runtimeID, issueID,
+			taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+			fmt.Sprintf("provider capacity monitor fixture %d", i),
+		); err != nil {
+			t.Fatalf("seed provider-capacity task: %v", err)
+		}
+	}
+
+	queries := db.New(testPool)
+	bus := events.New()
+	cfg := runtimeProviderFailureMonitorConfig{
+		Interval:     time.Hour,
+		Lookback:     24 * time.Hour,
+		Threshold:    3,
+		StartupDelay: 0,
+	}
+
+	var inboxEvents []events.Event
+	bus.Subscribe(protocol.EventInboxNew, func(e events.Event) {
+		inboxEvents = append(inboxEvents, e)
+	})
+
+	tickRuntimeProviderFailureMonitor(ctx, queries, bus, cfg)
+
+	if len(inboxEvents) != 1 {
+		t.Fatalf("expected 1 inbox:new event, got %d", len(inboxEvents))
+	}
+	item := inboxEvents[0].Payload.(map[string]any)["item"].(map[string]any)
+	if got := item["type"]; got != "runtime_provider_capacity_alert" {
+		t.Fatalf("expected inbox type runtime_provider_capacity_alert, got %v", got)
+	}
+	if got := item["severity"]; got != "attention" {
+		t.Fatalf("expected severity attention, got %v", got)
+	}
+	if got := item["recipient_id"]; got != testUserID {
+		t.Fatalf("expected recipient %s, got %v", testUserID, got)
+	}
+
+	tickRuntimeProviderFailureMonitor(ctx, queries, bus, cfg)
+
+	if len(inboxEvents) != 1 {
+		t.Fatalf("duplicate tick should not re-alert inside lookback, got %d events", len(inboxEvents))
+	}
+}

--- a/server/cmd/server/runtime_provider_failure_monitor_test.go
+++ b/server/cmd/server/runtime_provider_failure_monitor_test.go
@@ -18,20 +18,9 @@ func TestRuntimeProviderFailureMonitor_AlertsOwnerOncePerLookback(t *testing.T) 
 		t.Skip("no database connection")
 	}
 
-	issueID, agentID, runtimeID := setupRerunTestFixture(t)
-	t.Cleanup(func() { cleanupRerunFixture(t, issueID) })
+	workspaceID, ownerID, issueID, agentID, runtimeID := setupRuntimeProviderFailureMonitorFixture(t)
 
 	ctx := context.Background()
-	startedAt := time.Now().Add(-1 * time.Second)
-	t.Cleanup(func() {
-		testPool.Exec(context.Background(), `
-			DELETE FROM inbox_item
-			WHERE workspace_id = $1
-			  AND type = 'runtime_provider_capacity_alert'
-			  AND created_at >= $2
-		`, testWorkspaceID, startedAt)
-	})
-
 	for i := 0; i < 4; i++ {
 		if _, err := testPool.Exec(ctx, `
 			INSERT INTO agent_task_queue (
@@ -73,8 +62,11 @@ func TestRuntimeProviderFailureMonitor_AlertsOwnerOncePerLookback(t *testing.T) 
 	if got := item["severity"]; got != "attention" {
 		t.Fatalf("expected severity attention, got %v", got)
 	}
-	if got := item["recipient_id"]; got != testUserID {
-		t.Fatalf("expected recipient %s, got %v", testUserID, got)
+	if got := item["recipient_id"]; got != ownerID {
+		t.Fatalf("expected recipient %s, got %v", ownerID, got)
+	}
+	if got := item["workspace_id"]; got != workspaceID {
+		t.Fatalf("expected workspace %s, got %v", workspaceID, got)
 	}
 
 	tickRuntimeProviderFailureMonitor(ctx, queries, bus, cfg)
@@ -82,4 +74,78 @@ func TestRuntimeProviderFailureMonitor_AlertsOwnerOncePerLookback(t *testing.T) 
 	if len(inboxEvents) != 1 {
 		t.Fatalf("duplicate tick should not re-alert inside lookback, got %d events", len(inboxEvents))
 	}
+}
+
+func setupRuntimeProviderFailureMonitorFixture(t *testing.T) (workspaceID, ownerID, issueID, agentID, runtimeID string) {
+	t.Helper()
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	email := fmt.Sprintf("runtime-provider-monitor-%d@multica.test", suffix)
+	slug := fmt.Sprintf("runtime-provider-monitor-%d", suffix)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		testPool.Exec(cleanupCtx, `DELETE FROM workspace WHERE slug = $1`, slug)
+		testPool.Exec(cleanupCtx, `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('Runtime Provider Monitor Owner', $1)
+		RETURNING id::text
+	`, email).Scan(&ownerID); err != nil {
+		t.Fatalf("create monitor owner: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description)
+		VALUES ('Runtime Provider Monitor Test', $1, 'isolated runtime provider failure monitor fixture')
+		RETURNING id::text
+	`, slug).Scan(&workspaceID); err != nil {
+		t.Fatalf("create monitor workspace: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'owner')
+	`, workspaceID, ownerID); err != nil {
+		t.Fatalf("create monitor member: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider,
+			status, device_info, metadata, last_seen_at, visibility, owner_id
+		)
+		VALUES ($1, NULL, 'Runtime Provider Monitor Runtime', 'cloud',
+			'runtime_provider_monitor_test', 'online', 'test runtime', '{}'::jsonb, now(), 'private', $2)
+		RETURNING id::text
+	`, workspaceID, ownerID).Scan(&runtimeID); err != nil {
+		t.Fatalf("create monitor runtime: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, 'Runtime Provider Monitor Agent', '', 'cloud', '{}'::jsonb, $2, 'private', 1, $3)
+		RETURNING id::text
+	`, workspaceID, runtimeID, ownerID).Scan(&agentID); err != nil {
+		t.Fatalf("create monitor agent: %v", err)
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority,
+			creator_type, creator_id, assignee_type, assignee_id, number
+		)
+		VALUES ($1, 'Runtime provider monitor issue', 'todo', 'none',
+			'member', $2, 'agent', $3, 1)
+		RETURNING id::text
+	`, workspaceID, ownerID, agentID).Scan(&issueID); err != nil {
+		t.Fatalf("create monitor issue: %v", err)
+	}
+
+	return workspaceID, ownerID, issueID, agentID, runtimeID
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3890,7 +3890,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"timeout", execOpts.Timeout,
 	)
 
-	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
+	result, tools, err := d.executeWithCapacityFallback(ctx, backend, prompt, execOpts, taskLog, task.ID, provider)
 	if err != nil {
 		return TaskResult{}, err
 	}
@@ -4091,6 +4091,90 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			FailureReason: failureReason,
 		}, nil
 	}
+}
+
+func (d *Daemon) executeWithCapacityFallback(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID, provider string) (agent.Result, int32, error) {
+	result, tools, err := d.executeAndDrain(ctx, backend, prompt, opts, taskLog, taskID)
+	if err != nil {
+		return result, tools, err
+	}
+
+	usage := result.Usage
+	for _, fallbackModel := range capacityFallbackModels(provider, opts.Model) {
+		if !shouldTryCapacityModelFallback(result) {
+			break
+		}
+		retryOpts := opts
+		retryOpts.Model = fallbackModel
+		retryOpts.ResumeSessionID = ""
+		taskLog.Warn("provider model capacity failure, retrying with fallback model",
+			"provider", provider,
+			"from_model", opts.Model,
+			"fallback_model", fallbackModel,
+			"error", result.Error,
+		)
+		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, prompt, retryOpts, taskLog, taskID)
+		if retryErr != nil {
+			taskLog.Error("fallback model retry failed to start", "provider", provider, "model", fallbackModel, "error", retryErr)
+			break
+		}
+		result = retryResult
+		result.Usage = mergeUsage(usage, result.Usage)
+		usage = result.Usage
+		tools += retryTools
+	}
+	return result, tools, nil
+}
+
+func shouldTryCapacityModelFallback(result agent.Result) bool {
+	if result.Status != "failed" {
+		return false
+	}
+	errText := strings.ToLower(strings.TrimSpace(result.Error))
+	if errText == "" || strings.Contains(errText, "session limit") {
+		return false
+	}
+	if taskfailure.Classify(errText) != taskfailure.ReasonAgentProviderCapacityOrRateLimit {
+		return false
+	}
+	return strings.Contains(errText, "capacity") && strings.Contains(errText, "model")
+}
+
+func capacityFallbackModels(provider, currentModel string) []string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	current := strings.ToLower(strings.TrimSpace(currentModel))
+	switch provider {
+	case "claude":
+		switch {
+		case current == "":
+			return []string{"claude-haiku-4-5-20251001"}
+		case strings.Contains(current, "opus"):
+			return []string{"claude-sonnet-4-6", "claude-haiku-4-5-20251001"}
+		case strings.Contains(current, "sonnet"):
+			return []string{"claude-haiku-4-5-20251001"}
+		}
+	case "codebuddy":
+		switch {
+		case strings.Contains(current, "opus"):
+			return []string{"claude-sonnet-4.6", "claude-haiku-4.5"}
+		case strings.Contains(current, "sonnet"):
+			return []string{"claude-haiku-4.5"}
+		}
+	case "codex":
+		switch {
+		case current == "":
+			return []string{"gpt-5.5-mini"}
+		case strings.Contains(current, "mini"):
+			return nil
+		case strings.HasPrefix(current, "gpt-5.5"):
+			return []string{"gpt-5.5-mini"}
+		case strings.HasPrefix(current, "gpt-5.4"):
+			return []string{"gpt-5.4-mini"}
+		case current == "gpt-5":
+			return []string{"gpt-5.4-mini"}
+		}
+	}
+	return nil
 }
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -924,6 +924,48 @@ func TestMergeUsage(t *testing.T) {
 	}
 }
 
+func TestExecuteWithCapacityFallbackRetriesLowerClaudeModel(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	backend := &fakeBackend{
+		results: []agent.Result{
+			{Status: "failed", Error: "Selected model is at capacity. Please try a different model."},
+			{Status: "completed", Output: "done", Usage: map[string]agent.TokenUsage{
+				"claude-sonnet-4-6": {InputTokens: 10, OutputTokens: 2},
+			}},
+		},
+	}
+
+	got, _, err := d.executeWithCapacityFallback(
+		context.Background(),
+		backend,
+		"prompt",
+		agent.ExecOptions{Model: "claude-opus-4-6"},
+		slog.Default(),
+		"task-capacity",
+		"claude",
+	)
+	if err != nil {
+		t.Fatalf("executeWithCapacityFallback returned error: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Fatalf("status = %q, want completed", got.Status)
+	}
+	if len(backend.calls) != 2 {
+		t.Fatalf("backend calls = %d, want 2", len(backend.calls))
+	}
+	if backend.calls[0].Model != "claude-opus-4-6" {
+		t.Fatalf("first model = %q, want claude-opus-4-6", backend.calls[0].Model)
+	}
+	if backend.calls[1].Model != "claude-sonnet-4-6" {
+		t.Fatalf("fallback model = %q, want claude-sonnet-4-6", backend.calls[1].Model)
+	}
+	if backend.calls[1].ResumeSessionID != "" {
+		t.Fatalf("fallback retry must start fresh, got ResumeSessionID=%q", backend.calls[1].ResumeSessionID)
+	}
+}
+
 // fakeBackend is a test double for agent.Backend that returns preconfigured
 // results. Each call to Execute pops the next entry from the results slice.
 type fakeBackend struct {

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -479,7 +479,9 @@ func TestCreateRetryTask_InheritsIsLeaderTask(t *testing.T) {
 				testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1 OR parent_task_id = $1`, parentID)
 			})
 
-			child, err := testHandler.Queries.CreateRetryTask(ctx, util.MustParseUUID(parentID))
+			child, err := testHandler.Queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{
+				ID: util.MustParseUUID(parentID),
+			})
 			if err != nil {
 				t.Fatalf("CreateRetryTask: %v", err)
 			}

--- a/server/internal/handler/squad_id_enqueue_test.go
+++ b/server/internal/handler/squad_id_enqueue_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // TestCreateComment_SquadMentionStampsSquadIDOnLeaderTask locks the enqueue
@@ -116,7 +117,7 @@ func TestCreateRetryTask_InheritsSquadID(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1 OR parent_task_id = $1`, parentID)
 	})
 
-	child, err := testHandler.Queries.CreateRetryTask(ctx, util.MustParseUUID(parentID))
+	child, err := testHandler.Queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: util.MustParseUUID(parentID)})
 	if err != nil {
 		t.Fatalf("CreateRetryTask: %v", err)
 	}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -161,11 +161,11 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 //   - It is in-flight in a state whose downstream side effect is
 //     observable:
 //
-//     * issue_created with a valid issue_id — the issue exists and
-//       the issue-event listener owns task creation from here.
+//   - issue_created with a valid issue_id — the issue exists and
+//     the issue-event listener owns task creation from here.
 //
-//     * running with a valid task_id — the task is queued, the
-//       listener will close the run when the task terminates.
+//   - running with a valid task_id — the task is queued, the
+//     listener will close the run when the task terminates.
 //
 // Anything else — most importantly issue_created/running with NULL
 // issue_id/task_id, or the brief 'pending' state — is a partial run:
@@ -665,6 +665,18 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		s.captureAutopilotRunCompleted(autopilot, updatedRun)
 		s.publishRunDone(wsID, updatedRun, "completed")
 	case "failed", "cancelled":
+		hasActive, err := s.Queries.HasActiveTaskForAutopilotRun(ctx, task.AutopilotRunID)
+		if err != nil {
+			slog.Warn("failed to check active tasks for run_only autopilot failure",
+				"run_id", util.UUIDToString(task.AutopilotRunID),
+				"task_id", util.UUIDToString(task.ID),
+				"error", err,
+			)
+			return
+		}
+		if hasActive {
+			return
+		}
 		reason := "task " + task.Status
 		if task.Error.Valid {
 			reason = task.Error.String

--- a/server/internal/service/runtime_fallback.go
+++ b/server/internal/service/runtime_fallback.go
@@ -1,0 +1,280 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/internal/util"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+const RuntimeRestoreContextType = "runtime_restore"
+
+// RuntimeRestoreContext is stored on deferred agent_task_queue rows whose sole
+// job is to switch an agent back to its preferred runtime after a rate-limit
+// cooldown. PromoteDueDeferredTasksForRuntime applies these inline — they never
+// enter the daemon claim path.
+type RuntimeRestoreContext struct {
+	Type                 string `json:"type"`
+	PreferredRuntimeID   string `json:"preferred_runtime_id"`
+	FallbackRuntimeID    string `json:"fallback_runtime_id,omitempty"`
+	TriggeringTaskID     string `json:"triggering_task_id,omitempty"`
+}
+
+// RuntimeFallbackConfig is read from agent.runtime_config JSONB.
+type RuntimeFallbackConfig struct {
+	FallbackRuntimeID  string `json:"fallback_runtime_id"`
+	PreferredRuntimeID string `json:"preferred_runtime_id"`
+}
+
+func parseRuntimeFallbackConfig(raw []byte) RuntimeFallbackConfig {
+	if len(raw) == 0 {
+		return RuntimeFallbackConfig{}
+	}
+	var cfg RuntimeFallbackConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return RuntimeFallbackConfig{}
+	}
+	return cfg
+}
+
+func parseRuntimeRestoreContext(raw []byte) (RuntimeRestoreContext, bool) {
+	if len(raw) == 0 {
+		return RuntimeRestoreContext{}, false
+	}
+	var payload RuntimeRestoreContext
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return RuntimeRestoreContext{}, false
+	}
+	if payload.Type != RuntimeRestoreContextType || payload.PreferredRuntimeID == "" {
+		return RuntimeRestoreContext{}, false
+	}
+	return payload, true
+}
+
+func mergeRuntimeFallbackConfig(raw []byte, patch RuntimeFallbackConfig) []byte {
+	cfg := parseRuntimeFallbackConfig(raw)
+	if patch.FallbackRuntimeID != "" {
+		cfg.FallbackRuntimeID = patch.FallbackRuntimeID
+	}
+	if patch.PreferredRuntimeID != "" {
+		cfg.PreferredRuntimeID = patch.PreferredRuntimeID
+	}
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// maybeApplyRuntimeRateLimitFallback switches the agent (and its retry child) to
+// a configured fallback runtime when the parent task failed with a provider
+// capacity / rate-limit reason, and schedules a deferred restore on the
+// preferred runtime when the cooldown elapses.
+func (s *TaskService) maybeApplyRuntimeRateLimitFallback(ctx context.Context, parent db.AgentTaskQueue, child *db.AgentTaskQueue) {
+	if child == nil {
+		return
+	}
+	reason := ""
+	if parent.FailureReason.Valid {
+		reason = parent.FailureReason.String
+	}
+	if reason != taskfailure.ReasonAgentProviderCapacityOrRateLimit.String() {
+		return
+	}
+
+	agent, err := s.Queries.GetAgent(ctx, parent.AgentID)
+	if err != nil {
+		slog.Warn("runtime fallback skipped: agent lookup failed",
+			"agent_id", util.UUIDToString(parent.AgentID),
+			"task_id", util.UUIDToString(parent.ID),
+			"error", err,
+		)
+		return
+	}
+	if agent.ArchivedAt.Valid {
+		return
+	}
+
+	cfg := parseRuntimeFallbackConfig(agent.RuntimeConfig)
+	fallbackID, err := util.ParseUUID(cfg.FallbackRuntimeID)
+	if err != nil || !fallbackID.Valid {
+		return
+	}
+
+	preferredID := parent.RuntimeID
+	if cfg.PreferredRuntimeID != "" {
+		if parsed, parseErr := util.ParseUUID(cfg.PreferredRuntimeID); parseErr == nil && parsed.Valid {
+			preferredID = parsed
+		}
+	}
+	if !preferredID.Valid || preferredID == fallbackID {
+		return
+	}
+	// Only switch away from the preferred runtime that rate-limited.
+	if agent.RuntimeID != preferredID {
+		return
+	}
+
+	restoreAt := retryNotBefore(parent, time.Now())
+	if !restoreAt.Valid {
+		restoreAt = pgtype.Timestamptz{Time: time.Now().UTC().Add(2 * time.Minute), Valid: true}
+	}
+
+	updatedConfig := mergeRuntimeFallbackConfig(agent.RuntimeConfig, RuntimeFallbackConfig{
+		FallbackRuntimeID:  util.UUIDToString(fallbackID),
+		PreferredRuntimeID: util.UUIDToString(preferredID),
+	})
+	if _, err := s.Queries.UpdateAgent(ctx, db.UpdateAgentParams{
+		ID:            agent.ID,
+		RuntimeID:     fallbackID,
+		RuntimeConfig: updatedConfig,
+	}); err != nil {
+		slog.Warn("runtime fallback: failed to switch agent runtime",
+			"agent_id", util.UUIDToString(agent.ID),
+			"preferred_runtime_id", util.UUIDToString(preferredID),
+			"fallback_runtime_id", util.UUIDToString(fallbackID),
+			"error", err,
+		)
+		return
+	}
+
+	if err := s.Queries.UpdateAgentTaskRuntime(ctx, db.UpdateAgentTaskRuntimeParams{
+		ID:        child.ID,
+		RuntimeID: fallbackID,
+	}); err != nil {
+		slog.Warn("runtime fallback: failed to retarget retry task runtime",
+			"child_task_id", util.UUIDToString(child.ID),
+			"fallback_runtime_id", util.UUIDToString(fallbackID),
+			"error", err,
+		)
+	}
+
+	if _, err := s.Queries.CancelDeferredRuntimeRestoreForAgent(ctx, agent.ID); err != nil {
+		slog.Warn("runtime fallback: failed to cancel prior restore tasks",
+			"agent_id", util.UUIDToString(agent.ID),
+			"error", err,
+		)
+	}
+
+	payload, err := json.Marshal(RuntimeRestoreContext{
+		Type:               RuntimeRestoreContextType,
+		PreferredRuntimeID: util.UUIDToString(preferredID),
+		FallbackRuntimeID:  util.UUIDToString(fallbackID),
+		TriggeringTaskID:   util.UUIDToString(parent.ID),
+	})
+	if err != nil {
+		return
+	}
+
+	restoreTask, err := s.Queries.CreateDeferredRuntimeRestoreTask(ctx, db.CreateDeferredRuntimeRestoreTaskParams{
+		AgentID:   agent.ID,
+		RuntimeID: preferredID,
+		IssueID:   parent.IssueID,
+		Context:   payload,
+		FireAt:    restoreAt,
+	})
+	if err != nil {
+		slog.Warn("runtime fallback: failed to schedule deferred restore",
+			"agent_id", util.UUIDToString(agent.ID),
+			"preferred_runtime_id", util.UUIDToString(preferredID),
+			"fire_at", restoreAt.Time.UTC().Format(time.RFC3339),
+			"error", err,
+		)
+		return
+	}
+
+	slog.Info("runtime fallback applied",
+		"agent_id", util.UUIDToString(agent.ID),
+		"preferred_runtime_id", util.UUIDToString(preferredID),
+		"fallback_runtime_id", util.UUIDToString(fallbackID),
+		"retry_task_id", util.UUIDToString(child.ID),
+		"restore_task_id", util.UUIDToString(restoreTask.ID),
+		"restore_at", restoreAt.Time.UTC().Format(time.RFC3339),
+	)
+}
+
+func (s *TaskService) promoteDueRuntimeRestoreTasks(ctx context.Context, runtimeID pgtype.UUID) error {
+	tasks, err := s.Queries.ListDueDeferredRuntimeRestoreTasks(ctx, runtimeID)
+	if err != nil {
+		return fmt.Errorf("list due runtime restore tasks: %w", err)
+	}
+	for _, task := range tasks {
+		if err := s.applyRuntimeRestore(ctx, task); err != nil {
+			slog.Warn("runtime restore failed",
+				"task_id", util.UUIDToString(task.ID),
+				"runtime_id", util.UUIDToString(runtimeID),
+				"error", err,
+			)
+		}
+	}
+	return nil
+}
+
+func (s *TaskService) applyRuntimeRestore(ctx context.Context, task db.AgentTaskQueue) error {
+	payload, ok := parseRuntimeRestoreContext(task.Context)
+	if !ok {
+		return fmt.Errorf("invalid runtime_restore context")
+	}
+	preferredID, err := util.ParseUUID(payload.PreferredRuntimeID)
+	if err != nil || !preferredID.Valid {
+		return fmt.Errorf("invalid preferred_runtime_id")
+	}
+
+	agent, err := s.Queries.GetAgent(ctx, task.AgentID)
+	if err != nil {
+		return fmt.Errorf("load agent: %w", err)
+	}
+	if agent.ArchivedAt.Valid {
+		_, _ = s.Queries.CompleteRuntimeRestoreTask(ctx, task.ID)
+		return nil
+	}
+
+	cfg := parseRuntimeFallbackConfig(agent.RuntimeConfig)
+	fallbackID := agent.RuntimeID
+	if cfg.FallbackRuntimeID != "" {
+		if parsed, parseErr := util.ParseUUID(cfg.FallbackRuntimeID); parseErr == nil && parsed.Valid {
+			fallbackID = parsed
+		}
+	}
+	if payload.FallbackRuntimeID != "" {
+		if parsed, parseErr := util.ParseUUID(payload.FallbackRuntimeID); parseErr == nil && parsed.Valid {
+			fallbackID = parsed
+		}
+	}
+
+	// Only restore when the agent is still on the fallback runtime from this
+	// rate-limit episode. Manual runtime changes win.
+	if agent.RuntimeID != fallbackID {
+		_, _ = s.Queries.CompleteRuntimeRestoreTask(ctx, task.ID)
+		return nil
+	}
+
+	updatedConfig := mergeRuntimeFallbackConfig(agent.RuntimeConfig, RuntimeFallbackConfig{
+		PreferredRuntimeID: util.UUIDToString(preferredID),
+		FallbackRuntimeID:  util.UUIDToString(fallbackID),
+	})
+	if _, err := s.Queries.UpdateAgent(ctx, db.UpdateAgentParams{
+		ID:            agent.ID,
+		RuntimeID:     preferredID,
+		RuntimeConfig: updatedConfig,
+	}); err != nil {
+		return fmt.Errorf("restore agent runtime: %w", err)
+	}
+
+	if _, err := s.Queries.CompleteRuntimeRestoreTask(ctx, task.ID); err != nil {
+		return fmt.Errorf("complete restore task: %w", err)
+	}
+
+	slog.Info("runtime restored to preferred runtime",
+		"agent_id", util.UUIDToString(agent.ID),
+		"preferred_runtime_id", util.UUIDToString(preferredID),
+		"restore_task_id", util.UUIDToString(task.ID),
+	)
+	return nil
+}

--- a/server/internal/service/runtime_fallback_test.go
+++ b/server/internal/service/runtime_fallback_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+func TestParseRuntimeFallbackConfig(t *testing.T) {
+	raw := []byte(`{"fallback_runtime_id":"11111111-1111-1111-1111-111111111111","preferred_runtime_id":"22222222-2222-2222-2222-222222222222"}`)
+	cfg := parseRuntimeFallbackConfig(raw)
+	if cfg.FallbackRuntimeID != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("fallback_runtime_id = %q", cfg.FallbackRuntimeID)
+	}
+	if cfg.PreferredRuntimeID != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("preferred_runtime_id = %q", cfg.PreferredRuntimeID)
+	}
+}
+
+func TestParseRuntimeRestoreContext(t *testing.T) {
+	raw, err := json.Marshal(RuntimeRestoreContext{
+		Type:               RuntimeRestoreContextType,
+		PreferredRuntimeID: "22222222-2222-2222-2222-222222222222",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := parseRuntimeRestoreContext(raw)
+	if !ok {
+		t.Fatal("expected valid runtime_restore context")
+	}
+	if got.PreferredRuntimeID != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("preferred = %q", got.PreferredRuntimeID)
+	}
+}
+
+func TestRetryNotBeforeUsesSessionLimitResetForRestoreScheduling(t *testing.T) {
+	now := time.Date(2026, 6, 25, 6, 0, 0, 0, time.UTC)
+	parent := db.AgentTaskQueue{
+		FailureReason: pgtype.Text{
+			String: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+			Valid:  true,
+		},
+		Error:   pgtype.Text{String: "Your limit resets 6:50am (UTC)", Valid: true},
+		Attempt: 1,
+	}
+	got := retryNotBefore(parent, now)
+	if !got.Valid {
+		t.Fatal("expected retryNotBefore for capacity failure")
+	}
+	want := time.Date(2026, 6, 25, 6, 50, 0, 0, time.UTC)
+	if !got.Time.Equal(want) {
+		t.Fatalf("retryNotBefore = %s, want %s", got.Time, want)
+	}
+}
+
+func TestMergeRuntimeFallbackConfigPreservesExistingKeys(t *testing.T) {
+	raw := []byte(`{"fallback_runtime_id":"11111111-1111-1111-1111-111111111111","gateway":{"token":"secret"}}`)
+	merged := mergeRuntimeFallbackConfig(raw, RuntimeFallbackConfig{
+		PreferredRuntimeID: "22222222-2222-2222-2222-222222222222",
+	})
+	var out map[string]any
+	if err := json.Unmarshal(merged, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["preferred_runtime_id"] != "22222222-2222-2222-2222-222222222222" {
+		t.Fatalf("preferred_runtime_id missing after merge: %#v", out)
+	}
+	if out["fallback_runtime_id"] != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("fallback_runtime_id missing after merge: %#v", out)
+	}
+	if _, ok := out["gateway"]; !ok {
+		t.Fatalf("expected unrelated runtime_config keys to survive merge: %#v", out)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1185,6 +1186,15 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 	}
 
 	if len(tasks) == 0 {
+		hasFuture, futureErr := s.Queries.HasFutureQueuedTaskForRuntime(ctx, runtimeID)
+		if futureErr != nil {
+			outcome = "error_future_check"
+			return nil, fmt.Errorf("check future queued tasks: %w", futureErr)
+		}
+		if hasFuture {
+			outcome = "future_db"
+			return nil, nil
+		}
 		s.EmptyClaim.MarkEmpty(ctx, runtimeKey, preSelectVersion)
 		outcome = "empty_db"
 		return nil, nil
@@ -1686,10 +1696,84 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
 var retryableReasons = map[string]bool{
-	"runtime_offline":           true,
-	"runtime_recovery":          true,
-	"timeout":                   true,
-	"codex_semantic_inactivity": true,
+	taskfailure.ReasonRuntimeOffline.String():                   true,
+	taskfailure.ReasonRuntimeRecovery.String():                  true,
+	taskfailure.ReasonTimeout.String():                          true,
+	"codex_semantic_inactivity":                                 true,
+	taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(): true,
+}
+
+var sessionLimitResetRe = regexp.MustCompile(`(?i)\bresets\s+([0-9]{1,2})(?::([0-9]{2}))?\s*([ap]m)?\s*(?:\(([^)]+)\))?`)
+
+func retryNotBefore(parent db.AgentTaskQueue, now time.Time) pgtype.Timestamptz {
+	reason := ""
+	if parent.FailureReason.Valid {
+		reason = parent.FailureReason.String
+	}
+	if reason != taskfailure.ReasonAgentProviderCapacityOrRateLimit.String() {
+		return pgtype.Timestamptz{}
+	}
+
+	retryAt := now.Add(providerCapacityRetryDelay(parent.Attempt))
+	if parent.Error.Valid {
+		if resetAt, ok := parseSessionLimitReset(parent.Error.String, now); ok && resetAt.After(retryAt) {
+			retryAt = resetAt
+		}
+	}
+	return pgtype.Timestamptz{Time: retryAt.UTC(), Valid: true}
+}
+
+func providerCapacityRetryDelay(parentAttempt int32) time.Duration {
+	switch parentAttempt {
+	case 0, 1:
+		return 30 * time.Second
+	case 2:
+		return 2 * time.Minute
+	default:
+		return 10 * time.Minute
+	}
+}
+
+func parseSessionLimitReset(errText string, now time.Time) (time.Time, bool) {
+	m := sessionLimitResetRe.FindStringSubmatch(errText)
+	if m == nil {
+		return time.Time{}, false
+	}
+	hour, err := strconv.Atoi(m[1])
+	if err != nil || hour < 0 || hour > 23 {
+		return time.Time{}, false
+	}
+	minute := 0
+	if m[2] != "" {
+		minute, err = strconv.Atoi(m[2])
+		if err != nil || minute < 0 || minute > 59 {
+			return time.Time{}, false
+		}
+	}
+	switch strings.ToLower(m[3]) {
+	case "am":
+		if hour == 12 {
+			hour = 0
+		}
+	case "pm":
+		if hour < 12 {
+			hour += 12
+		}
+	}
+	loc := time.UTC
+	if tz := strings.TrimSpace(m[4]); tz != "" {
+		loaded, err := time.LoadLocation(tz)
+		if err != nil {
+			return time.Time{}, false
+		}
+		loc = loaded
+	}
+	localNow := now.In(loc)
+	resetAt := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), hour, minute, 0, 0, loc)
+	if !resetAt.After(localNow) {
+		resetAt = resetAt.AddDate(0, 0, 1)
+	}
+	return resetAt.UTC(), true
 }
 
 func resumeUnsafeFailureReason(reason string) bool {
@@ -1710,9 +1794,6 @@ func resumeUnsafeFailureReason(reason string) bool {
 // links and, for resume-safe failures, the parent's session_id/work_dir so
 // the agent can resume the conversation when the backend supports it. Returns
 // the new task, or nil when no retry was created.
-//
-// Autopilot tasks are NOT auto-retried here; the autopilot scheduler owns
-// its own re-run cadence and we don't want to double-fire it.
 func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentTaskQueue) (*db.AgentTaskQueue, error) {
 	if parent.Status != "failed" {
 		return nil, nil
@@ -1732,15 +1813,14 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		)
 		return nil, nil
 	}
-	if parent.AutopilotRunID.Valid {
-		// Autopilot has its own retry semantics; do not double-trigger.
-		return nil, nil
-	}
-	if !parent.IssueID.Valid && !parent.ChatSessionID.Valid {
+	if !parent.IssueID.Valid && !parent.ChatSessionID.Valid && !parent.AutopilotRunID.Valid {
 		return nil, nil
 	}
 
-	child, err := s.Queries.CreateRetryTask(ctx, parent.ID)
+	child, err := s.Queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{
+		ID:        parent.ID,
+		NotBefore: retryNotBefore(parent, time.Now()),
+	})
 	if err != nil {
 		slog.Warn("task auto-retry failed",
 			"parent_task_id", util.UUIDToString(parent.ID),

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1232,6 +1232,9 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 }
 
 func (s *TaskService) PromoteDueDeferredTasksForRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
+	if err := s.promoteDueRuntimeRestoreTasks(ctx, runtimeID); err != nil {
+		return err
+	}
 	tasks, err := s.Queries.PromoteDueDeferredTasksForRuntime(ctx, runtimeID)
 	if err != nil {
 		return fmt.Errorf("promote due deferred tasks: %w", err)
@@ -1829,6 +1832,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		)
 		return nil, err
 	}
+	s.maybeApplyRuntimeRateLimitFallback(ctx, parent, &child)
 	slog.Info("task auto-retry enqueued",
 		"parent_task_id", util.UUIDToString(parent.ID),
 		"child_task_id", util.UUIDToString(child.ID),

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
 // mockRow implements pgx.Row, returning either a scanned task or pgx.ErrNoRows.
@@ -29,6 +31,10 @@ func (r *mockRow) Scan(dest ...any) error {
 		&t.Error, &t.CreatedAt, &t.Context, &t.RuntimeID,
 		&t.SessionID, &t.WorkDir, &t.TriggerCommentID,
 		&t.ChatSessionID, &t.AutopilotRunID,
+		&t.Attempt, &t.MaxAttempts, &t.ParentTaskID,
+		&t.FailureReason, &t.TriggerSummary, &t.ForceFreshSession,
+		&t.IsLeaderTask, &t.WaitReason, &t.InitiatorUserID,
+		&t.HandoffNote, &t.PrepareLeaseExpiresAt, &t.NotBefore,
 	}
 	for i, p := range ptrs {
 		if i >= len(dest) {
@@ -177,6 +183,7 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		{reason: "timeout", wantType: "timeout", wantResumeOK: true, wantRetry: true},
 		{reason: "codex_semantic_inactivity", wantType: "timeout", wantResumeOK: false, wantRetry: true},
 		{reason: "runtime_recovery", wantType: "runtime", wantResumeOK: true, wantRetry: true},
+		{reason: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(), wantType: "agent_error", wantResumeOK: true, wantRetry: true},
 		{reason: "iteration_limit", wantType: "agent_output", wantResumeOK: false, wantRetry: false},
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
 		{reason: "agent_error", wantType: "agent_error", wantResumeOK: true, wantRetry: false},
@@ -194,5 +201,99 @@ func TestTaskFailureClassifiers(t *testing.T) {
 				t.Fatalf("retryableReasons[%q] = %v, want %v", tc.reason, got, tc.wantRetry)
 			}
 		})
+	}
+}
+
+func TestRetryNotBeforeProviderCapacityBackoff(t *testing.T) {
+	now := time.Date(2026, 6, 26, 6, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		attempt int32
+		want    time.Duration
+	}{
+		{name: "first retry", attempt: 1, want: 30 * time.Second},
+		{name: "second retry", attempt: 2, want: 2 * time.Minute},
+		{name: "third retry", attempt: 3, want: 10 * time.Minute},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := retryNotBefore(db.AgentTaskQueue{
+				Attempt: tc.attempt,
+				FailureReason: pgtype.Text{
+					String: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+					Valid:  true,
+				},
+			}, now)
+			if !got.Valid {
+				t.Fatal("retryNotBefore should schedule provider capacity retries")
+			}
+			if want := now.Add(tc.want); !got.Time.Equal(want) {
+				t.Fatalf("retryNotBefore = %s, want %s", got.Time, want)
+			}
+		})
+	}
+}
+
+func TestRetryNotBeforeSessionLimitResetTimeWinsOverBackoff(t *testing.T) {
+	now := time.Date(2026, 6, 25, 6, 32, 32, 0, time.UTC) // 14:32:32 Asia/Shanghai
+	got := retryNotBefore(db.AgentTaskQueue{
+		Attempt: 1,
+		FailureReason: pgtype.Text{
+			String: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+			Valid:  true,
+		},
+		Error: pgtype.Text{
+			String: "You've hit your session limit · resets 2:50pm (Asia/Shanghai)",
+			Valid:  true,
+		},
+	}, now)
+	if !got.Valid {
+		t.Fatal("retryNotBefore should schedule session-limit reset retries")
+	}
+	want := time.Date(2026, 6, 25, 6, 50, 0, 0, time.UTC)
+	if !got.Time.Equal(want) {
+		t.Fatalf("retryNotBefore = %s, want %s", got.Time, want)
+	}
+}
+
+func TestMaybeRetryFailedTask_AllowsRunOnlyAutopilotRetry(t *testing.T) {
+	parentID := testUUID(1)
+	childID := testUUID(2)
+	autopilotRunID := testUUID(3)
+	runtimeID := testUUID(4)
+	child := db.AgentTaskQueue{
+		ID:          childID,
+		Status:      "queued",
+		RuntimeID:   runtimeID,
+		Attempt:     2,
+		MaxAttempts: 4,
+	}
+	mock := &mockDBTX{task: child}
+	svc := &TaskService{
+		Queries: db.New(mock),
+		Bus:     events.New(),
+	}
+
+	got, err := svc.MaybeRetryFailedTask(context.Background(), db.AgentTaskQueue{
+		ID:             parentID,
+		Status:         "failed",
+		RuntimeID:      runtimeID,
+		AutopilotRunID: autopilotRunID,
+		Attempt:        1,
+		MaxAttempts:    4,
+		FailureReason: pgtype.Text{
+			String: taskfailure.ReasonAgentProviderCapacityOrRateLimit.String(),
+			Valid:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("MaybeRetryFailedTask returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("MaybeRetryFailedTask should create a retry child for run_only autopilot tasks")
+	}
+	if got.ID != childID {
+		t.Fatalf("retry child ID = %v, want %v", got.ID, childID)
 	}
 }

--- a/server/migrations/127_agent_task_retry_not_before.down.sql
+++ b/server/migrations/127_agent_task_retry_not_before.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_task_queue
+  ALTER COLUMN max_attempts SET DEFAULT 2,
+  DROP COLUMN IF EXISTS not_before;

--- a/server/migrations/127_agent_task_retry_not_before.up.sql
+++ b/server/migrations/127_agent_task_retry_not_before.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_task_queue
+  ADD COLUMN not_before TIMESTAMPTZ,
+  ALTER COLUMN max_attempts SET DEFAULT 4;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2914,6 +2914,7 @@ SET status = 'queued'
 WHERE runtime_id = $1
   AND status = 'deferred'
   AND fire_at <= now()
+  AND (context IS NULL OR context->>'type' IS DISTINCT FROM 'runtime_restore')
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
@@ -2969,6 +2970,260 @@ func (q *Queries) PromoteDueDeferredTasksForRuntime(ctx context.Context, runtime
 		return nil, err
 	}
 	return items, nil
+}
+
+const listDueDeferredRuntimeRestoreTasks = `-- name: ListDueDeferredRuntimeRestoreTasks :many
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+WHERE runtime_id = $1
+  AND status = 'deferred'
+  AND fire_at <= now()
+  AND context->>'type' = 'runtime_restore'
+`
+
+func (q *Queries) ListDueDeferredRuntimeRestoreTasks(ctx context.Context, runtimeID pgtype.UUID) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, listDueDeferredRuntimeRestoreTasks, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
+			&i.SquadID,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const cancelDeferredRuntimeRestoreForAgent = `-- name: CancelDeferredRuntimeRestoreForAgent :many
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE agent_id = $1
+  AND status = 'deferred'
+  AND context->>'type' = 'runtime_restore'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
+`
+
+func (q *Queries) CancelDeferredRuntimeRestoreForAgent(ctx context.Context, agentID pgtype.UUID) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, cancelDeferredRuntimeRestoreForAgent, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
+			&i.SquadID,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const createDeferredRuntimeRestoreTask = `-- name: CreateDeferredRuntimeRestoreTask :one
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, context, fire_at
+)
+VALUES (
+    $1, $2, $3, 'deferred', 0, $4, $5
+)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
+`
+
+type CreateDeferredRuntimeRestoreTaskParams struct {
+	AgentID   pgtype.UUID        `json:"agent_id"`
+	RuntimeID pgtype.UUID        `json:"runtime_id"`
+	IssueID   pgtype.UUID        `json:"issue_id"`
+	Context   []byte             `json:"context"`
+	FireAt    pgtype.Timestamptz `json:"fire_at"`
+}
+
+func (q *Queries) CreateDeferredRuntimeRestoreTask(ctx context.Context, arg CreateDeferredRuntimeRestoreTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, createDeferredRuntimeRestoreTask,
+		arg.AgentID,
+		arg.RuntimeID,
+		arg.IssueID,
+		arg.Context,
+		arg.FireAt,
+	)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
+		&i.SquadID,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+	)
+	return i, err
+}
+
+const completeRuntimeRestoreTask = `-- name: CompleteRuntimeRestoreTask :one
+UPDATE agent_task_queue
+SET status = 'completed', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE id = $1 AND status IN ('deferred', 'queued')
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
+`
+
+func (q *Queries) CompleteRuntimeRestoreTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, completeRuntimeRestoreTask, id)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
+		&i.SquadID,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+	)
+	return i, err
+}
+
+const updateAgentTaskRuntime = `-- name: UpdateAgentTaskRuntime :exec
+UPDATE agent_task_queue
+SET runtime_id = $2
+WHERE id = $1
+`
+
+type UpdateAgentTaskRuntimeParams struct {
+	ID        pgtype.UUID `json:"id"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+}
+
+func (q *Queries) UpdateAgentTaskRuntime(ctx context.Context, arg UpdateAgentTaskRuntimeParams) error {
+	_, err := q.db.Exec(ctx, updateAgentTaskRuntime, arg.ID, arg.RuntimeID)
+	return err
 }
 
 const reclaimStaleDispatchedTaskForRuntime = `-- name: ReclaimStaleDispatchedTaskForRuntime :one

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -178,7 +178,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -214,6 +214,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -225,7 +226,7 @@ const cancelAgentTasksByAgent = `-- name: CancelAgentTasksByAgent :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE agent_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Bulk-cancel every active (queued/dispatched/running) task for an agent.
@@ -272,6 +273,7 @@ func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UU
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -290,7 +292,7 @@ const cancelAgentTasksByChatSession = `-- name: CancelAgentTasksByChatSession :m
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Cancels active tasks belonging to a chat session. Called from
@@ -337,6 +339,7 @@ func (q *Queries) CancelAgentTasksByChatSession(ctx context.Context, chatSession
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -355,7 +358,7 @@ const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :many
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Cancels every active task on the issue and returns the affected rows so the
@@ -402,6 +405,7 @@ func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UU
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -420,7 +424,7 @@ const cancelAgentTasksByIssueAndAgent = `-- name: CancelAgentTasksByIssueAndAgen
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CancelAgentTasksByIssueAndAgentParams struct {
@@ -471,6 +475,7 @@ func (q *Queries) CancelAgentTasksByIssueAndAgent(ctx context.Context, arg Cance
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -489,7 +494,7 @@ const cancelAgentTasksByTriggerComment = `-- name: CancelAgentTasksByTriggerComm
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE trigger_comment_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Cancels active tasks whose trigger is the given comment. Called when a
@@ -536,6 +541,7 @@ func (q *Queries) CancelAgentTasksByTriggerComment(ctx context.Context, triggerC
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -559,9 +565,9 @@ WITH cancelled AS (
       AND fallback.status IN ('deferred', 'queued', 'dispatched', 'waiting_local_directory')
       AND primary_task.issue_id = $1
       AND primary_task.agent_id = $2
-    RETURNING fallback.id, fallback.agent_id, fallback.issue_id, fallback.status, fallback.priority, fallback.dispatched_at, fallback.started_at, fallback.completed_at, fallback.result, fallback.error, fallback.created_at, fallback.context, fallback.runtime_id, fallback.session_id, fallback.work_dir, fallback.trigger_comment_id, fallback.chat_session_id, fallback.autopilot_run_id, fallback.attempt, fallback.max_attempts, fallback.parent_task_id, fallback.failure_reason, fallback.trigger_summary, fallback.force_fresh_session, fallback.is_leader_task, fallback.wait_reason, fallback.initiator_user_id, fallback.handoff_note, fallback.prepare_lease_expires_at, fallback.squad_id, fallback.escalation_for_task_id, fallback.fire_at
+    RETURNING fallback.id, fallback.agent_id, fallback.issue_id, fallback.status, fallback.priority, fallback.dispatched_at, fallback.started_at, fallback.completed_at, fallback.result, fallback.error, fallback.created_at, fallback.context, fallback.runtime_id, fallback.session_id, fallback.work_dir, fallback.trigger_comment_id, fallback.chat_session_id, fallback.autopilot_run_id, fallback.attempt, fallback.max_attempts, fallback.parent_task_id, fallback.failure_reason, fallback.trigger_summary, fallback.force_fresh_session, fallback.is_leader_task, fallback.wait_reason, fallback.initiator_user_id, fallback.handoff_note, fallback.prepare_lease_expires_at, fallback.not_before, fallback.squad_id, fallback.escalation_for_task_id, fallback.fire_at
 )
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM cancelled
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM cancelled
 `
 
 type CancelDeferredEscalationsForIssueAgentParams struct {
@@ -599,6 +605,7 @@ type CancelDeferredEscalationsForIssueAgentRow struct {
 	InitiatorUserID       pgtype.UUID        `json:"initiator_user_id"`
 	HandoffNote           pgtype.Text        `json:"handoff_note"`
 	PrepareLeaseExpiresAt pgtype.Timestamptz `json:"prepare_lease_expires_at"`
+	NotBefore             pgtype.Timestamptz `json:"not_before"`
 	SquadID               pgtype.UUID        `json:"squad_id"`
 	EscalationForTaskID   pgtype.UUID        `json:"escalation_for_task_id"`
 	FireAt                pgtype.Timestamptz `json:"fire_at"`
@@ -643,6 +650,7 @@ func (q *Queries) CancelDeferredEscalationsForIssueAgent(ctx context.Context, ar
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -662,7 +670,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE escalation_for_task_id = $1
   AND status IN ('deferred', 'queued', 'dispatched', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 func (q *Queries) CancelDeferredEscalationsForTask(ctx context.Context, escalationForTaskID pgtype.UUID) ([]AgentTaskQueue, error) {
@@ -704,6 +712,7 @@ func (q *Queries) CancelDeferredEscalationsForTask(ctx context.Context, escalati
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -726,6 +735,7 @@ SET status = 'dispatched',
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      AND (atq.not_before IS NULL OR atq.not_before <= now())
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -747,7 +757,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type ClaimAgentTaskParams struct {
@@ -797,6 +807,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -883,7 +894,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4, prepare_lease_expires_at = NULL
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CompleteAgentTaskParams struct {
@@ -931,6 +942,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1039,7 +1051,7 @@ VALUES (
     $9,
     $10
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CreateAgentTaskParams struct {
@@ -1099,6 +1111,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1120,7 +1133,7 @@ VALUES (
     $9,
     $10
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CreateDeferredAgentTaskParams struct {
@@ -1183,6 +1196,7 @@ func (q *Queries) CreateDeferredAgentTask(ctx context.Context, arg CreateDeferre
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1193,7 +1207,7 @@ func (q *Queries) CreateDeferredAgentTask(ctx context.Context, arg CreateDeferre
 const createQuickCreateTask = `-- name: CreateQuickCreateTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
 VALUES ($1, $2, NULL, 'queued', $3, $4)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CreateQuickCreateTaskParams struct {
@@ -1244,6 +1258,7 @@ func (q *Queries) CreateQuickCreateTask(ctx context.Context, arg CreateQuickCrea
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1257,7 +1272,7 @@ INSERT INTO agent_task_queue (
     status, priority, trigger_comment_id, trigger_summary, context,
     session_id, work_dir,
     attempt, max_attempts, parent_task_id, force_fresh_session, is_leader_task,
-    squad_id
+    squad_id, not_before
 )
 SELECT
     p.agent_id, p.runtime_id, p.issue_id, p.chat_session_id, p.autopilot_run_id,
@@ -1267,11 +1282,17 @@ SELECT
     p.attempt + 1, p.max_attempts, p.id,
     p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity',
     p.is_leader_task,
-    p.squad_id
+    p.squad_id,
+    $1::timestamptz
 FROM agent_task_queue p
-WHERE p.id = $1
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+WHERE p.id = $2
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
+
+type CreateRetryTaskParams struct {
+	NotBefore pgtype.Timestamptz `json:"not_before"`
+	ID        pgtype.UUID        `json:"id"`
+}
 
 // Clones a parent task into a fresh queued attempt. Carries forward the
 // agent's resume context (session_id/work_dir) so the child can continue
@@ -1284,8 +1305,8 @@ RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, c
 // parent and the self-trigger guard in shouldEnqueueSquadLeaderOnComment
 // continues to recognise it as a leader task. Inheriting squad_id also keeps
 // the squad-leader briefing injection working across retries.
-func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
-	row := q.db.QueryRow(ctx, createRetryTask, id)
+func (q *Queries) CreateRetryTask(ctx context.Context, arg CreateRetryTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, createRetryTask, arg.NotBefore, arg.ID)
 	var i AgentTaskQueue
 	err := row.Scan(
 		&i.ID,
@@ -1317,6 +1338,7 @@ func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1328,8 +1350,8 @@ const expireStaleQueuedTasks = `-- name: ExpireStaleQueuedTasks :many
 WITH victims AS (
     SELECT id FROM agent_task_queue
     WHERE status = 'queued'
-      AND created_at < now() - make_interval(secs => $1::double precision)
-    ORDER BY created_at ASC
+      AND COALESCE(not_before, created_at) < now() - make_interval(secs => $1::double precision)
+    ORDER BY COALESCE(not_before, created_at) ASC
     LIMIT $2::int
     FOR UPDATE SKIP LOCKED
 )
@@ -1343,7 +1365,7 @@ FROM victims v
 WHERE t.id = v.id
   AND t.status = 'queued'
   AND t.created_at < now() - make_interval(secs => $1::double precision)
-RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id, t.escalation_for_task_id, t.fire_at
+RETURNING t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.not_before, t.squad_id, t.escalation_for_task_id, t.fire_at
 `
 
 type ExpireStaleQueuedTasksParams struct {
@@ -1413,6 +1435,7 @@ func (q *Queries) ExpireStaleQueuedTasks(ctx context.Context, arg ExpireStaleQue
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -1434,7 +1457,7 @@ WHERE id = $1
   AND runtime_id = $2
   AND status IN ('dispatched', 'waiting_local_directory')
   AND started_at IS NULL
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type ExtendAgentTaskPrepareLeaseParams struct {
@@ -1480,6 +1503,7 @@ func (q *Queries) ExtendAgentTaskPrepareLease(ctx context.Context, arg ExtendAge
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1497,7 +1521,7 @@ SET status = 'failed',
     work_dir = COALESCE($5, work_dir),
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type FailAgentTaskParams struct {
@@ -1556,6 +1580,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1574,7 +1599,7 @@ WHERE (
     AND (prepare_lease_expires_at IS NULL OR prepare_lease_expires_at < now())
   )
    OR (status = 'running' AND started_at < now() - make_interval(secs => $2::double precision))
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type FailStaleTasksParams struct {
@@ -1632,6 +1657,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -1758,7 +1784,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -1795,6 +1821,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -1803,7 +1830,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 }
 
 const getAgentTaskInWorkspace = `-- name: GetAgentTaskInWorkspace :one
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.escalation_for_task_id, atq.fire_at FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.not_before, atq.squad_id, atq.escalation_for_task_id, atq.fire_at FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE atq.id = $1 AND a.workspace_id = $2
 `
@@ -1853,6 +1880,7 @@ func (q *Queries) GetAgentTaskInWorkspace(ctx context.Context, arg GetAgentTaskI
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -2077,6 +2105,20 @@ func (q *Queries) GetWorkspaceAgentRunCounts(ctx context.Context, workspaceID pg
 	return items, nil
 }
 
+const hasActiveTaskForAutopilotRun = `-- name: HasActiveTaskForAutopilotRun :one
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE autopilot_run_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+`
+
+// Returns true if there is any queued, dispatched, waiting_local_directory,
+// or running task for the run_only autopilot run.
+func (q *Queries) HasActiveTaskForAutopilotRun(ctx context.Context, autopilotRunID pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveTaskForAutopilotRun, autopilotRunID)
+	var has_active bool
+	err := row.Scan(&has_active)
+	return has_active, err
+}
+
 const hasActiveTaskForIssue = `-- name: HasActiveTaskForIssue :one
 SELECT count(*) > 0 AS has_active FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
@@ -2089,6 +2131,21 @@ func (q *Queries) HasActiveTaskForIssue(ctx context.Context, issueID pgtype.UUID
 	var has_active bool
 	err := row.Scan(&has_active)
 	return has_active, err
+}
+
+const hasFutureQueuedTaskForRuntime = `-- name: HasFutureQueuedTaskForRuntime :one
+SELECT count(*) > 0 AS has_future FROM agent_task_queue
+WHERE runtime_id = $1 AND status = 'queued' AND not_before > now()
+`
+
+// Returns true when the runtime has queued work deliberately scheduled for
+// the future. ClaimTaskForRuntime uses this to avoid caching a negative
+// empty-queue verdict that would hide the task after not_before passes.
+func (q *Queries) HasFutureQueuedTaskForRuntime(ctx context.Context, runtimeID pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, hasFutureQueuedTaskForRuntime, runtimeID)
+	var has_future bool
+	err := row.Scan(&has_future)
+	return has_future, err
 }
 
 const hasPendingTaskForIssue = `-- name: HasPendingTaskForIssue :one
@@ -2285,7 +2342,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 ORDER BY created_at DESC
 `
@@ -2334,6 +2391,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2349,7 +2407,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -2393,6 +2451,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2506,7 +2565,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -2550,6 +2609,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2565,8 +2625,9 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE runtime_id = $1 AND status = 'queued'
+  AND (not_before IS NULL OR not_before <= now())
 ORDER BY priority DESC, created_at ASC
 `
 
@@ -2617,6 +2678,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2632,7 +2694,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -2676,6 +2738,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2691,15 +2754,15 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 }
 
 const listWorkspaceAgentTaskSnapshot = `-- name: ListWorkspaceAgentTaskSnapshot :many
-SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.escalation_for_task_id, atq.fire_at FROM agent_task_queue atq
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.not_before, atq.squad_id, atq.escalation_for_task_id, atq.fire_at FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE a.workspace_id = $1
   AND atq.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 
 UNION ALL
 
-SELECT t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id, t.escalation_for_task_id, t.fire_at FROM (
-  SELECT DISTINCT ON (atq.agent_id) atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.squad_id, atq.escalation_for_task_id, atq.fire_at
+SELECT t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.not_before, t.squad_id, t.escalation_for_task_id, t.fire_at FROM (
+  SELECT DISTINCT ON (atq.agent_id) atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.trigger_summary, atq.force_fresh_session, atq.is_leader_task, atq.wait_reason, atq.initiator_user_id, atq.handoff_note, atq.prepare_lease_expires_at, atq.not_before, atq.squad_id, atq.escalation_for_task_id, atq.fire_at
   FROM agent_task_queue atq
   JOIN agent a ON a.id = atq.agent_id
   WHERE a.workspace_id = $1
@@ -2765,6 +2828,7 @@ func (q *Queries) ListWorkspaceAgentTaskSnapshot(ctx context.Context, workspaceI
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2785,7 +2849,7 @@ SET status = 'waiting_local_directory',
     wait_reason = $2,
     prepare_lease_expires_at = now() + make_interval(secs => $3::double precision)
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type MarkAgentTaskWaitingLocalDirectoryParams struct {
@@ -2836,6 +2900,7 @@ func (q *Queries) MarkAgentTaskWaitingLocalDirectory(ctx context.Context, arg Ma
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -2849,7 +2914,7 @@ SET status = 'queued'
 WHERE runtime_id = $1
   AND status = 'deferred'
   AND fire_at <= now()
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 func (q *Queries) PromoteDueDeferredTasksForRuntime(ctx context.Context, runtimeID pgtype.UUID) ([]AgentTaskQueue, error) {
@@ -2891,6 +2956,7 @@ func (q *Queries) PromoteDueDeferredTasksForRuntime(ctx context.Context, runtime
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -2920,7 +2986,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type ReclaimStaleDispatchedTaskForRuntimeParams struct {
@@ -2967,6 +3033,7 @@ func (q *Queries) ReclaimStaleDispatchedTaskForRuntime(ctx context.Context, arg 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,
@@ -2983,7 +3050,7 @@ SET status = 'failed',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE runtime_id = $1 AND status IN ('dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Called by the daemon at startup. Atomically fails any dispatched/running/
@@ -3031,6 +3098,7 @@ func (q *Queries) RecoverOrphanedTasksForRuntime(ctx context.Context, runtimeID 
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -3122,6 +3190,82 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 	return i, err
 }
 
+const selectWorkspacesExceedingProviderFailureThreshold = `-- name: SelectWorkspacesExceedingProviderFailureThreshold :many
+WITH provider_failures AS (
+    SELECT a.workspace_id,
+           atq.id,
+           atq.completed_at,
+           atq.error
+    FROM agent_task_queue atq
+    JOIN agent a ON a.id = atq.agent_id
+    WHERE atq.status = 'failed'
+      AND atq.failure_reason = 'agent_provider_capacity_or_rate_limit'
+      AND atq.completed_at IS NOT NULL
+      AND atq.completed_at >= $1::timestamptz
+)
+SELECT pf.workspace_id,
+       count(*)::bigint AS failed_tasks,
+       min(pf.completed_at)::timestamptz AS first_failed_at,
+       max(pf.completed_at)::timestamptz AS last_failed_at,
+       (array_agg(pf.id ORDER BY pf.completed_at DESC))[1] AS sample_task_id,
+       (array_agg(pf.error ORDER BY pf.completed_at DESC))[1] AS sample_error
+FROM provider_failures pf
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM inbox_item i
+    WHERE i.workspace_id = pf.workspace_id
+      AND i.type = 'runtime_provider_capacity_alert'
+      AND i.created_at >= $1::timestamptz
+)
+GROUP BY pf.workspace_id
+HAVING count(*) > $2::bigint
+ORDER BY failed_tasks DESC, pf.workspace_id ASC
+`
+
+type SelectWorkspacesExceedingProviderFailureThresholdParams struct {
+	Since     pgtype.Timestamptz `json:"since"`
+	Threshold int64              `json:"threshold"`
+}
+
+type SelectWorkspacesExceedingProviderFailureThresholdRow struct {
+	WorkspaceID   pgtype.UUID        `json:"workspace_id"`
+	FailedTasks   int64              `json:"failed_tasks"`
+	FirstFailedAt pgtype.Timestamptz `json:"first_failed_at"`
+	LastFailedAt  pgtype.Timestamptz `json:"last_failed_at"`
+	SampleTaskID  interface{}        `json:"sample_task_id"`
+	SampleError   interface{}        `json:"sample_error"`
+}
+
+// Runtime-wide capacity/session-limit alert candidates. The monitor emits one
+// daily inbox alert per workspace when provider capacity/rate-limit failures
+// exceed the threshold, then suppresses repeats inside the same lookback.
+func (q *Queries) SelectWorkspacesExceedingProviderFailureThreshold(ctx context.Context, arg SelectWorkspacesExceedingProviderFailureThresholdParams) ([]SelectWorkspacesExceedingProviderFailureThresholdRow, error) {
+	rows, err := q.db.Query(ctx, selectWorkspacesExceedingProviderFailureThreshold, arg.Since, arg.Threshold)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SelectWorkspacesExceedingProviderFailureThresholdRow{}
+	for rows.Next() {
+		var i SelectWorkspacesExceedingProviderFailureThresholdRow
+		if err := rows.Scan(
+			&i.WorkspaceID,
+			&i.FailedTasks,
+			&i.FirstFailedAt,
+			&i.LastFailedAt,
+			&i.SampleTaskID,
+			&i.SampleError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running',
@@ -3129,7 +3273,7 @@ SET status = 'running',
     wait_reason = NULL,
     prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('dispatched', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Transitions a task to running. Accepts either 'dispatched' (the normal
@@ -3171,6 +3315,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3199,7 +3199,7 @@ WITH provider_failures AS (
     FROM agent_task_queue atq
     JOIN agent a ON a.id = atq.agent_id
     WHERE atq.status = 'failed'
-      AND atq.failure_reason = 'agent_provider_capacity_or_rate_limit'
+      AND atq.failure_reason = $3::text
       AND atq.completed_at IS NOT NULL
       AND atq.completed_at >= $1::timestamptz
 )
@@ -3207,8 +3207,8 @@ SELECT pf.workspace_id,
        count(*)::bigint AS failed_tasks,
        min(pf.completed_at)::timestamptz AS first_failed_at,
        max(pf.completed_at)::timestamptz AS last_failed_at,
-       (array_agg(pf.id ORDER BY pf.completed_at DESC))[1] AS sample_task_id,
-       (array_agg(pf.error ORDER BY pf.completed_at DESC))[1] AS sample_error
+       ((array_agg(pf.id ORDER BY pf.completed_at DESC))[1])::uuid AS sample_task_id,
+       ((array_agg(pf.error ORDER BY pf.completed_at DESC))[1])::text AS sample_error
 FROM provider_failures pf
 WHERE NOT EXISTS (
     SELECT 1
@@ -3223,8 +3223,9 @@ ORDER BY failed_tasks DESC, pf.workspace_id ASC
 `
 
 type SelectWorkspacesExceedingProviderFailureThresholdParams struct {
-	Since     pgtype.Timestamptz `json:"since"`
-	Threshold int64              `json:"threshold"`
+	Since         pgtype.Timestamptz `json:"since"`
+	Threshold     int64              `json:"threshold"`
+	FailureReason string             `json:"failure_reason"`
 }
 
 type SelectWorkspacesExceedingProviderFailureThresholdRow struct {
@@ -3232,15 +3233,15 @@ type SelectWorkspacesExceedingProviderFailureThresholdRow struct {
 	FailedTasks   int64              `json:"failed_tasks"`
 	FirstFailedAt pgtype.Timestamptz `json:"first_failed_at"`
 	LastFailedAt  pgtype.Timestamptz `json:"last_failed_at"`
-	SampleTaskID  interface{}        `json:"sample_task_id"`
-	SampleError   interface{}        `json:"sample_error"`
+	SampleTaskID  pgtype.UUID        `json:"sample_task_id"`
+	SampleError   string             `json:"sample_error"`
 }
 
 // Runtime-wide capacity/session-limit alert candidates. The monitor emits one
 // daily inbox alert per workspace when provider capacity/rate-limit failures
 // exceed the threshold, then suppresses repeats inside the same lookback.
 func (q *Queries) SelectWorkspacesExceedingProviderFailureThreshold(ctx context.Context, arg SelectWorkspacesExceedingProviderFailureThresholdParams) ([]SelectWorkspacesExceedingProviderFailureThresholdRow, error) {
-	rows, err := q.db.Query(ctx, selectWorkspacesExceedingProviderFailureThreshold, arg.Since, arg.Threshold)
+	rows, err := q.db.Query(ctx, selectWorkspacesExceedingProviderFailureThreshold, arg.Since, arg.Threshold, arg.FailureReason)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -211,7 +211,7 @@ const createAutopilotTask = `-- name: CreateAutopilotTask :one
 
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id, trigger_summary)
 VALUES ($1, $2, NULL, 'queued', $3, $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CreateAutopilotTaskParams struct {
@@ -264,6 +264,7 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -96,7 +96,7 @@ VALUES (
     $1, $2, NULL, 'queued', $3, $4, $5,
     COALESCE($6::boolean, FALSE)
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CreateChatTaskParams struct {
@@ -148,6 +148,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		&i.InitiatorUserID,
 		&i.HandoffNote,
 		&i.PrepareLeaseExpiresAt,
+		&i.NotBefore,
 		&i.SquadID,
 		&i.EscalationForTaskID,
 		&i.FireAt,

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -101,6 +101,7 @@ type AgentTaskQueue struct {
 	InitiatorUserID       pgtype.UUID        `json:"initiator_user_id"`
 	HandoffNote           pgtype.Text        `json:"handoff_note"`
 	PrepareLeaseExpiresAt pgtype.Timestamptz `json:"prepare_lease_expires_at"`
+	NotBefore             pgtype.Timestamptz `json:"not_before"`
 	SquadID               pgtype.UUID        `json:"squad_id"`
 	EscalationForTaskID   pgtype.UUID        `json:"escalation_for_task_id"`
 	FireAt                pgtype.Timestamptz `json:"fire_at"`

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -16,7 +16,7 @@ UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE (runtime_id = ANY($1::uuid[]) OR agent_id = ANY($2::uuid[]))
   AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 type CancelAgentTasksByRuntimeOrAgentParams struct {
@@ -77,6 +77,7 @@ func (q *Queries) CancelAgentTasksByRuntimeOrAgent(ctx context.Context, arg Canc
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,
@@ -199,7 +200,7 @@ WHERE status IN ('dispatched', 'running', 'waiting_local_directory')
   AND runtime_id IN (
     SELECT id FROM agent_runtime WHERE status = 'offline'
   )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, escalation_for_task_id, fire_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, not_before, squad_id, escalation_for_task_id, fire_at
 `
 
 // Marks dispatched/running/waiting_local_directory tasks as failed when
@@ -244,6 +245,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 			&i.InitiatorUserID,
 			&i.HandoffNote,
 			&i.PrepareLeaseExpiresAt,
+			&i.NotBefore,
 			&i.SquadID,
 			&i.EscalationForTaskID,
 			&i.FireAt,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -203,7 +203,7 @@ INSERT INTO agent_task_queue (
     status, priority, trigger_comment_id, trigger_summary, context,
     session_id, work_dir,
     attempt, max_attempts, parent_task_id, force_fresh_session, is_leader_task,
-    squad_id
+    squad_id, not_before
 )
 SELECT
     p.agent_id, p.runtime_id, p.issue_id, p.chat_session_id, p.autopilot_run_id,
@@ -213,9 +213,10 @@ SELECT
     p.attempt + 1, p.max_attempts, p.id,
     p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity',
     p.is_leader_task,
-    p.squad_id
+    p.squad_id,
+    sqlc.narg('not_before')::timestamptz
 FROM agent_task_queue p
-WHERE p.id = $1
+WHERE p.id = sqlc.arg('id')
 RETURNING *;
 
 -- name: CancelAgentTasksByIssue :many
@@ -305,6 +306,7 @@ SET status = 'dispatched',
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      AND (atq.not_before IS NULL OR atq.not_before <= now())
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -558,8 +560,8 @@ RETURNING *;
 WITH victims AS (
     SELECT id FROM agent_task_queue
     WHERE status = 'queued'
-      AND created_at < now() - make_interval(secs => @ttl_secs::double precision)
-    ORDER BY created_at ASC
+      AND COALESCE(not_before, created_at) < now() - make_interval(secs => @ttl_secs::double precision)
+    ORDER BY COALESCE(not_before, created_at) ASC
     LIMIT @max_per_tick::int
     FOR UPDATE SKIP LOCKED
 )
@@ -595,6 +597,12 @@ FOR UPDATE;
 -- or running task for the issue.
 SELECT count(*) > 0 AS has_active FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');
+
+-- name: HasActiveTaskForAutopilotRun :one
+-- Returns true if there is any queued, dispatched, waiting_local_directory,
+-- or running task for the run_only autopilot run.
+SELECT count(*) > 0 AS has_active FROM agent_task_queue
+WHERE autopilot_run_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory');
 
 -- name: HasPendingTaskForIssue :one
 -- Returns true if there is a queued or dispatched (but not yet running) task for the issue.
@@ -648,6 +656,7 @@ ORDER BY priority DESC, created_at ASC;
 -- idx_agent_task_queue_claim_candidates so the warm path is cheap.
 SELECT * FROM agent_task_queue
 WHERE runtime_id = $1 AND status = 'queued'
+  AND (not_before IS NULL OR not_before <= now())
 ORDER BY priority DESC, created_at ASC;
 
 -- name: PromoteDueDeferredTasksForRuntime :many
@@ -677,6 +686,13 @@ WITH cancelled AS (
     RETURNING fallback.*
 )
 SELECT * FROM cancelled;
+
+-- name: HasFutureQueuedTaskForRuntime :one
+-- Returns true when the runtime has queued work deliberately scheduled for
+-- the future. ClaimTaskForRuntime uses this to avoid caching a negative
+-- empty-queue verdict that would hide the task after not_before passes.
+SELECT count(*) > 0 AS has_future FROM agent_task_queue
+WHERE runtime_id = $1 AND status = 'queued' AND not_before > now();
 
 -- name: ListActiveTasksByIssue :many
 -- Backs the issue-detail "agent live" banner. Includes 'queued' so the
@@ -767,6 +783,40 @@ SELECT t.* FROM (
 SELECT * FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC;
+
+-- name: SelectWorkspacesExceedingProviderFailureThreshold :many
+-- Runtime-wide capacity/session-limit alert candidates. The monitor emits one
+-- daily inbox alert per workspace when provider capacity/rate-limit failures
+-- exceed the threshold, then suppresses repeats inside the same lookback.
+WITH provider_failures AS (
+    SELECT a.workspace_id,
+           atq.id,
+           atq.completed_at,
+           atq.error
+    FROM agent_task_queue atq
+    JOIN agent a ON a.id = atq.agent_id
+    WHERE atq.status = 'failed'
+      AND atq.failure_reason = 'agent_provider_capacity_or_rate_limit'
+      AND atq.completed_at IS NOT NULL
+      AND atq.completed_at >= sqlc.arg('since')::timestamptz
+)
+SELECT pf.workspace_id,
+       count(*)::bigint AS failed_tasks,
+       min(pf.completed_at)::timestamptz AS first_failed_at,
+       max(pf.completed_at)::timestamptz AS last_failed_at,
+       (array_agg(pf.id ORDER BY pf.completed_at DESC))[1] AS sample_task_id,
+       (array_agg(pf.error ORDER BY pf.completed_at DESC))[1] AS sample_error
+FROM provider_failures pf
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM inbox_item i
+    WHERE i.workspace_id = pf.workspace_id
+      AND i.type = 'runtime_provider_capacity_alert'
+      AND i.created_at >= sqlc.arg('since')::timestamptz
+)
+GROUP BY pf.workspace_id
+HAVING count(*) > sqlc.arg('threshold')::bigint
+ORDER BY failed_tasks DESC, pf.workspace_id ASC;
 
 -- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -796,7 +796,7 @@ WITH provider_failures AS (
     FROM agent_task_queue atq
     JOIN agent a ON a.id = atq.agent_id
     WHERE atq.status = 'failed'
-      AND atq.failure_reason = 'agent_provider_capacity_or_rate_limit'
+      AND atq.failure_reason = sqlc.arg('failure_reason')::text
       AND atq.completed_at IS NOT NULL
       AND atq.completed_at >= sqlc.arg('since')::timestamptz
 )
@@ -804,8 +804,8 @@ SELECT pf.workspace_id,
        count(*)::bigint AS failed_tasks,
        min(pf.completed_at)::timestamptz AS first_failed_at,
        max(pf.completed_at)::timestamptz AS last_failed_at,
-       (array_agg(pf.id ORDER BY pf.completed_at DESC))[1] AS sample_task_id,
-       (array_agg(pf.error ORDER BY pf.completed_at DESC))[1] AS sample_error
+       ((array_agg(pf.id ORDER BY pf.completed_at DESC))[1])::uuid AS sample_task_id,
+       ((array_agg(pf.error ORDER BY pf.completed_at DESC))[1])::text AS sample_error
 FROM provider_failures pf
 WHERE NOT EXISTS (
     SELECT 1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -665,7 +665,43 @@ SET status = 'queued'
 WHERE runtime_id = @runtime_id
   AND status = 'deferred'
   AND fire_at <= now()
+  AND (context IS NULL OR context->>'type' IS DISTINCT FROM 'runtime_restore')
 RETURNING *;
+
+-- name: ListDueDeferredRuntimeRestoreTasks :many
+SELECT * FROM agent_task_queue
+WHERE runtime_id = @runtime_id
+  AND status = 'deferred'
+  AND fire_at <= now()
+  AND context->>'type' = 'runtime_restore';
+
+-- name: CancelDeferredRuntimeRestoreForAgent :many
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE agent_id = @agent_id
+  AND status = 'deferred'
+  AND context->>'type' = 'runtime_restore'
+RETURNING *;
+
+-- name: CreateDeferredRuntimeRestoreTask :one
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, context, fire_at
+)
+VALUES (
+    @agent_id, @runtime_id, @issue_id, 'deferred', 0, @context, @fire_at
+)
+RETURNING *;
+
+-- name: CompleteRuntimeRestoreTask :one
+UPDATE agent_task_queue
+SET status = 'completed', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE id = $1 AND status IN ('deferred', 'queued')
+RETURNING *;
+
+-- name: UpdateAgentTaskRuntime :exec
+UPDATE agent_task_queue
+SET runtime_id = $2
+WHERE id = $1;
 
 -- name: CancelDeferredEscalationsForTask :many
 UPDATE agent_task_queue

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -125,6 +125,9 @@ func Classify(rawError string) Reason {
 		"overloaded",
 		"529",
 		"no capacity available",
+		"selected model is at capacity",
+		"model is at capacity",
+		"session limit",
 	):
 		return ReasonAgentProviderCapacityOrRateLimit
 

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -79,6 +79,8 @@ func TestClassifyRules(t *testing.T) {
 		{"rate limit", "rate limit exceeded for tier 3", ReasonAgentProviderCapacityOrRateLimit},
 		{"overloaded", "overloaded_error: please retry", ReasonAgentProviderCapacityOrRateLimit},
 		{"no capacity available", "no capacity available; try again later", ReasonAgentProviderCapacityOrRateLimit},
+		{"selected model capacity", "Selected model is at capacity. Please try a different model.", ReasonAgentProviderCapacityOrRateLimit},
+		{"session limit reset", "You've hit your session limit · resets 2:50pm (Asia/Shanghai)", ReasonAgentProviderCapacityOrRateLimit},
 
 		// 6. Provider 5xx / server error.
 		{"server had an error", "the server had an error processing your request", ReasonAgentProviderServerError},


### PR DESCRIPTION
## Summary

Builds on #4589 (WS-1009 provider capacity retry) — includes those commits until #4589 merges.

When an agent configured with `runtime_config.fallback_runtime_id` hits a provider capacity/rate-limit failure and auto-retry creates a child task, this PR:

1. Switches the agent and retry child to the fallback runtime (e.g. OpenCode).
2. Enqueues a deferred `runtime_restore` task on the preferred runtime at the parsed cooldown boundary.
3. Applies restore inline during `PromoteDueDeferredTasksForRuntime` so the agent returns to the preferred runtime without a daemon run.

### Agent config (v1)

```json
{
  "fallback_runtime_id": "<uuid>",
  "preferred_runtime_id": "<uuid>"
}
```

## Related

- Part of multica-ai/multica#1398
- DataAgents: PAN-210

## Test plan

- [ ] `go test ./server/internal/service/... -run RuntimeFallback`
- [ ] E2E rate-limit → fallback → restore after cooldown


Made with [Cursor](https://cursor.com)