### PR TITLE
MUL-3897: fix(selfhost): pass MULTICA_SLACK_SECRET_KEY through to backend container

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -111,6 +111,12 @@ services:
       MULTICA_LARK_SECRET_KEY: ${MULTICA_LARK_SECRET_KEY:-}
       MULTICA_LARK_HTTP_BASE_URL: ${MULTICA_LARK_HTTP_BASE_URL:-}
       MULTICA_LARK_CALLBACK_BASE_URL: ${MULTICA_LARK_CALLBACK_BASE_URL:-}
+      # Slack bot integration. MULTICA_SLACK_SECRET_KEY is the opt-in: unset =
+      # integration disabled. It decrypts the per-installation bot/app tokens,
+      # which are brought by each workspace via OAuth/BYO and stored encrypted
+      # in the database, so this single deployment-wide key is all the operator
+      # needs to set here.
+      MULTICA_SLACK_SECRET_KEY: ${MULTICA_SLACK_SECRET_KEY:-}
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Problem

On self-host deployments using `docker-compose.selfhost.yml`, setting `MULTICA_SLACK_SECRET_KEY` in `.env` had no effect — the backend container never received the variable, so Slack integration stayed disabled:

```
slack integration disabled (MULTICA_SLACK_SECRET_KEY not set)
```

## Root cause

The `backend` service `environment:` block forwarded `MULTICA_LARK_SECRET_KEY` but omitted `MULTICA_SLACK_SECRET_KEY`. The server reads it via `secretbox.LoadKey("MULTICA_SLACK_SECRET_KEY")` (`server/cmd/server/router.go`), so without the passthrough it always read as unset.

## Fix

Add the missing passthrough line to the `backend` environment block:

```yaml
MULTICA_SLACK_SECRET_KEY: ${MULTICA_SLACK_SECRET_KEY:-}
```

`MULTICA_SLACK_SECRET_KEY` is the only deployment-level env var needed: it decrypts the per-installation bot/app tokens, which workspaces bring via OAuth/BYO and which are stored encrypted in the database (`app_token_encrypted` / bot token on the `channel_installation` row) — they are not env vars. No change to `docker-compose.selfhost.build.yml` is needed; it is a build-only overlay that inherits the environment block from this base file.

## Verification

```bash
# default (unset) — present with empty default
docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml config | grep MULTICA_SLACK_SECRET_KEY
# => MULTICA_SLACK_SECRET_KEY: ""

# with a value set — passed through
MULTICA_SLACK_SECRET_KEY=test-value-123 docker compose -f docker-compose.selfhost.yml config | grep MULTICA_SLACK_SECRET_KEY
# => MULTICA_SLACK_SECRET_KEY: test-value-123
```

Reported by a self-host community user, who confirmed this exact root cause by manually patching their compose file.

MUL-3897
