### PR TITLE
Fix Mermaid syntax error rendering (MUL-3900)

### DIFF
--- a/packages/views/editor/mermaid-diagram.tsx
+++ b/packages/views/editor/mermaid-diagram.tsx
@@ -281,6 +281,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
           theme: "base",
           themeVariables: getMermaidThemeVariables(containerRef.current),
         });
+        await mermaid.parse(chart);
         const { svg: renderedSvg } = await mermaid.render(diagramId, chart);
         if (!cancelled) {
           const measured = getMermaidLayout(renderedSvg);

--- a/packages/views/editor/mermaid-diagram.tsx
+++ b/packages/views/editor/mermaid-diagram.tsx
@@ -280,8 +280,12 @@ export function MermaidDiagram({ chart }: { chart: string }) {
           securityLevel: "strict",
           theme: "base",
           themeVariables: getMermaidThemeVariables(containerRef.current),
+          // On invalid syntax, make render() throw instead of drawing Mermaid's
+          // built-in error graphic into the DOM. The catch below then shows our
+          // own compact error state — no orphaned error SVG, and no extra parse
+          // pass over valid charts.
+          suppressErrorRendering: true,
         });
-        await mermaid.parse(chart);
         const { svg: renderedSvg } = await mermaid.render(diagramId, chart);
         if (!cancelled) {
           const measured = getMermaidLayout(renderedSvg);

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -48,7 +48,6 @@ vi.mock("./utils/link-handler", () => ({
 vi.mock("mermaid", () => ({
   default: {
     initialize: vi.fn(),
-    parse: vi.fn().mockResolvedValue(true),
     render: vi.fn().mockResolvedValue({
       svg: '<svg viewBox="0 0 123 45"><g><text>mock diagram</text></g></svg>',
     }),
@@ -397,8 +396,10 @@ describe("ReadonlyContent Mermaid rendering", () => {
   });
 
   it("shows the compact error state instead of embedding Mermaid's parser error SVG", async () => {
-    vi.mocked(mermaid.parse).mockRejectedValueOnce(
-      new Error("Syntax error in text"),
+    // With suppressErrorRendering enabled, invalid syntax makes render() reject
+    // instead of emitting Mermaid's built-in error graphic.
+    vi.mocked(mermaid.render).mockRejectedValueOnce(
+      new Error("Parse error on line 3"),
     );
 
     const chart = "graph LR\n  A -->";
@@ -414,7 +415,6 @@ describe("ReadonlyContent Mermaid rendering", () => {
     expect(container.querySelector(".mermaid-diagram-error code")?.textContent).toBe(
       chart,
     );
-    expect(mermaid.render).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -48,6 +48,7 @@ vi.mock("./utils/link-handler", () => ({
 vi.mock("mermaid", () => ({
   default: {
     initialize: vi.fn(),
+    parse: vi.fn().mockResolvedValue(true),
     render: vi.fn().mockResolvedValue({
       svg: '<svg viewBox="0 0 123 45"><g><text>mock diagram</text></g></svg>',
     }),
@@ -393,6 +394,27 @@ describe("ReadonlyContent Mermaid rendering", () => {
     await waitFor(() => {
       expect(document.querySelector(".mermaid-diagram-lightbox")).toBeNull();
     });
+  });
+
+  it("shows the compact error state instead of embedding Mermaid's parser error SVG", async () => {
+    vi.mocked(mermaid.parse).mockRejectedValueOnce(
+      new Error("Syntax error in text"),
+    );
+
+    const chart = "graph LR\n  A -->";
+    const { container } = render(
+      <ReadonlyContent content={["```mermaid", chart, "```"].join("\n")} />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".mermaid-diagram-error")).not.toBeNull();
+    });
+
+    expect(container.querySelector(".mermaid-diagram-frame")).toBeNull();
+    expect(container.querySelector(".mermaid-diagram-error code")?.textContent).toBe(
+      chart,
+    );
+    expect(mermaid.render).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Preflights Mermaid diagrams with `mermaid.parse(chart)` before rendering them. Invalid Mermaid syntax now falls into the existing compact error state instead of embedding Mermaid's parser-error SVG in issue markdown surfaces.

## Related Issue

Closes #3653

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/mermaid-diagram.tsx`: validate Mermaid source with `mermaid.parse(chart)` before `mermaid.render(...)`.
- `packages/views/editor/readonly-content.test.tsx`: add a regression test that invalid Mermaid syntax renders the compact error UI and does not call `render`.

## How to Test

1. Open an issue/comment containing a malformed Mermaid fenced code block.
2. Confirm the compact Mermaid error state appears and the original chart text remains readable.
3. Confirm valid Mermaid diagrams still render in the sandboxed iframe.

Validation run locally:

- `corepack pnpm --filter @multica/views exec vitest run editor/readonly-content.test.tsx` — 27 tests passed.
- `corepack pnpm --filter @multica/views typecheck` — passed.
- `git diff --check` — passed.

Full validation note: `make check-worktree` could not complete meaningful full validation because Docker daemon was not reachable in this environment, although the Makefile exited 0. `corepack pnpm --filter @multica/views lint` was blocked because the worktree dependency install did not generate an `eslint` bin.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Daily automated bugfix maintenance. I inspected the bug report, checked visible linked PRs/development state, traced Mermaid rendering in the editor package, made the smallest local fix, and added a regression test.

## Screenshots (optional)

Not included. The change affects malformed Mermaid error handling and is covered by a regression test.
