### PR TITLE
fix(slack): stop the chat agent narrating its history reads (MUL-3871)

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -203,10 +203,14 @@ func buildChatPrompt(task Task) string {
 		b.WriteString("- `multica chat history --output json` — the channel overview: recent top-level messages, each thread tagged with a `thread_id` and `reply_count`. It does NOT expand thread contents.\n")
 		b.WriteString("- `multica chat thread [<thread_id>] --output json` — read one thread's messages; omit the id to read the thread you are in, or pass a `thread_id` from the overview to read a specific thread.\n")
 		if task.ChatInThread {
-			b.WriteString("You were @mentioned inside a thread: start with `multica chat thread` to read it; if you need the wider channel, run `multica chat history` and open a specific thread with `multica chat thread <thread_id>`.\n\n")
+			b.WriteString("You were @mentioned inside a thread: start with `multica chat thread` to read it; if you need the wider channel, run `multica chat history` and open a specific thread with `multica chat thread <thread_id>`.\n")
 		} else {
-			b.WriteString("You were @mentioned at the channel top level: start with `multica chat history` to see the channel, then read a specific thread's contents with `multica chat thread <thread_id>`.\n\n")
+			b.WriteString("You were @mentioned at the channel top level: start with `multica chat history` to see the channel, then read a specific thread's contents with `multica chat thread <thread_id>`.\n")
 		}
+		// These reads are the agent's private context-gathering; narrating them
+		// into a chat reply reads as noise (the user reported every reply being
+		// prefixed with "我先读取…"). Tell the agent to keep them out of its answer.
+		b.WriteString("Do these reads SILENTLY as an internal step — they are how you gather context, not part of your answer. Do NOT narrate them: your reply must not begin with what you are about to read or just read (no \"我先读取…\" / \"let me read the history / open the thread\"). Reply to the user with your answer only.\n\n")
 	}
 	if task.Agent != nil && len(task.Agent.Skills) > 0 {
 		refs := ExtractSlashSkills(task.ChatMessage)

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -277,7 +277,7 @@ func TestBuildChatPromptChannelAwareness(t *testing.T) {
 			ChatChannelType: "slack",
 			ChatMessage:     "你刚刚和 xxx 聊了什么",
 		})
-		for _, want := range []string{"Slack", "NOT in Multica", "multica chat history", "multica chat thread"} {
+		for _, want := range []string{"Slack", "NOT in Multica", "multica chat history", "multica chat thread", "Do NOT narrate"} {
 			if !strings.Contains(out, want) {
 				t.Fatalf("slack-backed prompt missing %q\n--- output ---\n%s", want, out)
 			}


### PR DESCRIPTION
## Summary

Follow-up UX fix on the Slack chat flow (MUL-3871, after #4762). Testing on dev showed every agent reply is prefixed with process narration — e.g.:

> 我先读取 Slack 频道概览，再打开相关线程看 Viktor 前面具体说了什么…我把那个线程和 Viktor 后面发的自我介绍线程都打开核对一下。

…before the actual answer. That is the model announcing the `multica chat history` / `multica chat thread` reads that the channel-awareness prompt instructs it to do. Those reads are internal context-gathering, not part of the reply.

## Fix

Add one instruction to the channel-awareness prompt block: do the reads **silently** as an internal step and reply with the answer only — no preamble about what it is about to read or just read (no "我先读取…" / "let me read the history / open the thread").

Prompt-only change (the block is built daemon-side). No API, schema, or CLI changes.

## Testing

- `TestBuildChatPromptChannelAwareness` asserts the channel block now carries the "Do NOT narrate" instruction alongside the two read commands.
- `go build`, `go vet`, `gofmt` clean; `internal/daemon` prompt tests pass.

Relates to MUL-3871. Follow-up to #4762.
