### PR TITLE
docs: document Trae CLI runtime and align provider tool counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ See the [CLI and Daemon Guide](CLI_AND_DAEMON.md) for the full command reference
                      ┌──────┴───────┐
                      │ Agent Daemon │  runs on your machine
                      └──────────────┘  (Claude Code, Codex, GitHub Copilot CLI,
-                                        OpenCode, OpenClaw, Hermes, Gemini,
-                                        Pi, Cursor Agent, Kimi, Kiro CLI, Qoder CLI)
+                                        OpenCode, OpenClaw, Hermes, Gemini, Pi,
+                                        Cursor Agent, Kimi, Kiro CLI, Qoder CLI, Trae CLI)
 ```
 
 | Layer | Stack |
@@ -174,7 +174,7 @@ See the [CLI and Daemon Guide](CLI_AND_DAEMON.md) for the full command reference
 | Frontend | Next.js 16 (App Router) |
 | Backend | Go (Chi router, sqlc, gorilla/websocket) |
 | Database | PostgreSQL 17 with pgvector |
-| Agent Runtime | Local daemon executing Claude Code, Codex, GitHub Copilot CLI, OpenClaw, OpenCode, Hermes, Gemini, Pi, Cursor Agent, Kimi, Kiro CLI, or Qoder CLI |
+| Agent Runtime | Local daemon executing Claude Code, Codex, GitHub Copilot CLI, OpenClaw, OpenCode, Hermes, Gemini, Pi, Cursor Agent, Kimi, Kiro CLI, Qoder CLI, or Trae CLI |
 
 ## Development
 

--- a/apps/docs/content/docs/agents-create.mdx
+++ b/apps/docs/content/docs/agents-create.mdx
@@ -21,7 +21,7 @@ The form has only two required fields: **name** (unique within the workspace) an
 
 ## Pick an AI coding tool
 
-Each runtime is backed by a specific AI coding tool. Multica supports 12 of them. The most common choices:
+Each runtime is backed by a specific AI coding tool. Multica supports 14 of them. The most common choices:
 
 | Tool | Good for |
 |---|---|
@@ -123,5 +123,5 @@ Archived agents can't be assigned new tasks.
 ## Next steps
 
 - [Skills](/skills) — attach knowledge packs to an agent
-- [AI coding tools comparison](/providers) — full capability matrix across all 12 tools
+- [AI coding tools comparison](/providers) — full capability matrix across all 14 tools
 - [Assigning issues to agents](/assigning-issues) — put your new agent to work

--- a/apps/docs/content/docs/cloud-quickstart.mdx
+++ b/apps/docs/content/docs/cloud-quickstart.mdx
@@ -114,6 +114,6 @@ The web UI updates in **real time** (via WebSocket) — no refresh needed.
 
 - [Daemon and runtimes](/daemon-runtimes) — how the daemon operates and what runtimes mean
 - [Tasks](/tasks) — task lifecycle and retry rules
-- [AI coding tools compared](/providers) — capability differences across the 12 tools
+- [AI coding tools compared](/providers) — capability differences across the 14 tools
 - [Desktop app](/desktop-app) — if you'd rather not run the daemon yourself
 - [Self-host quickstart](/self-host-quickstart) — run your own backend

--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -21,7 +21,7 @@ multica daemon start
 On startup it does four things:
 
 1. Reads the credentials saved when you logged in
-2. Detects AI coding tools installed on your `PATH` (12 built-in: [Antigravity](/providers#antigravity), [Claude Code](/providers#claude-code), [CodeBuddy](/providers#codebuddy), [Codex](/providers#codex), [Cursor](/providers#cursor), [Copilot](/providers#copilot), [Hermes](/providers#hermes), [Kimi](/providers#kimi), [Kiro CLI](/providers#kiro-cli), [OpenCode](/providers#opencode), [OpenClaw](/providers#openclaw), [Pi](/providers#pi))
+2. Detects AI coding tools installed on your `PATH` (14 built-in: [Antigravity](/providers#antigravity), [Claude Code](/providers#claude-code), [CodeBuddy](/providers#codebuddy), [Codex](/providers#codex), [Cursor](/providers#cursor), [Copilot](/providers#copilot), [Hermes](/providers#hermes), [Kimi](/providers#kimi), [Kiro CLI](/providers#kiro-cli), [OpenCode](/providers#opencode), [OpenClaw](/providers#openclaw), [Pi](/providers#pi), [Qoder](/providers#qoder), [Trae CLI](/providers#trae))
 3. Registers itself with the server, along with a runtime for each detected tool
 4. Keeps **polling every 3 seconds** for tasks to pick up, and **sends a heartbeat every 15 seconds**
 
@@ -146,4 +146,4 @@ More scenarios in [Troubleshooting](/troubleshooting).
 ## Next
 
 - [Tasks](/tasks) — the full lifecycle of a task once the daemon picks it up
-- [Providers Matrix](/providers) — capability differences across the 12 AI coding tools
+- [Providers Matrix](/providers) — capability differences across the 14 AI coding tools

--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -1,11 +1,11 @@
 ---
 title: Install an agent runtime
-description: Multica drives whichever AI coding tools you have on your machine. This page shows you how to install each of the 13 supported tools so the daemon can detect them.
+description: Multica drives whichever AI coding tools you have on your machine. This page shows you how to install each of the 14 supported tools so the daemon can detect them.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-A **runtime** in Multica is the daemon on your machine paired with one AI coding tool the daemon found on your `PATH`. If the onboarding "Connect a runtime" step shows **No supported tools detected**, it means the daemon scanned `PATH` and didn't find any of the 13 tools it knows how to drive. Install one (or several) of the tools below, then come back to the step and re-scan — the runtime will show up within a few seconds.
+A **runtime** in Multica is the daemon on your machine paired with one AI coding tool the daemon found on your `PATH`. If the onboarding "Connect a runtime" step shows **No supported tools detected**, it means the daemon scanned `PATH` and didn't find any of the 14 tools it knows how to drive. Install one (or several) of the tools below, then come back to the step and re-scan — the runtime will show up within a few seconds.
 
 This page is the install-side companion to:
 
@@ -31,9 +31,9 @@ multica daemon restart
 
 Or, in the desktop app, just relaunch the app. The daemon re-scans `PATH` on every start.
 
-## The 13 supported tools
+## The 14 supported tools
 
-Listed roughly from most to least common. Pick whichever ones you already have credentials for — you don't need all 13.
+Listed roughly from most to least common. Pick whichever ones you already have credentials for — you don't need all 14.
 
 ### Claude Code (Anthropic)
 
@@ -156,6 +156,17 @@ Agentic coding CLI using the ACP protocol over stdio (shares the transport with 
 | Daemon looks for | `qodercli` |
 | Install | See the official CLI docs at [qoder.com/cli](https://qoder.com/cli). |
 | Authentication | Per the vendor's docs. |
+
+### Trae CLI (ByteDance)
+
+ByteDance's official TRAE CLI (`traecli`, paired with the Trae IDE — **not** the open-source `bytedance/trae-agent`). It is ACP-native, so Multica drives it over stdio via `traecli acp serve --yolo`, sharing the transport with Hermes, Kimi, Kiro CLI, and Qoder. Session resumption works through ACP `session/load`, MCP config is passed through ACP `mcpServers`, model selection is discovered dynamically (switched per task via `session/set_model`), and skills are copied into `.traecli/skills/`.
+
+| | |
+|---|---|
+| Daemon looks for | `traecli` |
+| Install | See the official CLI docs at [docs.trae.cn/cli](https://docs.trae.cn/cli). |
+| Authentication | Run `traecli` once interactively to complete the browser-based enterprise login (the token persists in `~/.trae` plus the OS keyring). Logging into the Trae **IDE** does not log in the CLI — they are separate. |
+| Notes | traecli reads project rules from `.trae/rules/` and has no `--system-prompt` flag, so Multica delivers its runtime brief inline in the prompt. Set a daemon-wide default model with `MULTICA_TRAECLI_MODEL`. |
 
 ### Antigravity (Google)
 

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -111,7 +111,7 @@ The session resumption mechanism is covered in [Tasks](/tasks#can-a-task-continu
 
 **Of the 14 tools, eleven consume `mcp_config`: Claude Code, CodeBuddy, Codex, Cursor, Hermes, Kimi, Kiro CLI, OpenCode, OpenClaw, Qoder, and Trae**. The other three (Antigravity, Copilot, Pi) accept the field but **ignore it** — no error, no warning, the config just has no effect.
 
-The runtime paths are provider-specific: Claude Code and CodeBuddy receive it through `--mcp-config` paired with `--strict-mcp-config`; Codex writes a daemon-managed `mcp_servers` block into the per-task `$CODEX_HOME/config.toml`; Cursor writes `.cursor/mcp.json` plus per-task project approvals under `CURSOR_DATA_DIR`; Hermes, Kimi, Kiro CLI, and Qoder receive ACP `mcpServers`; OpenCode receives inline config through `OPENCODE_CONFIG_CONTENT`; OpenClaw receives `mcp.servers` through Multica's per-task config wrapper. OpenCode's path does **not** rewrite the project's `opencode.json`.
+The runtime paths are provider-specific: Claude Code and CodeBuddy receive it through `--mcp-config` paired with `--strict-mcp-config`; Codex writes a daemon-managed `mcp_servers` block into the per-task `$CODEX_HOME/config.toml`; Cursor writes `.cursor/mcp.json` plus per-task project approvals under `CURSOR_DATA_DIR`; Hermes, Kimi, Kiro CLI, Qoder, and Trae receive ACP `mcpServers`; OpenCode receives inline config through `OPENCODE_CONFIG_CONTENT`; OpenClaw receives `mcp.servers` through Multica's per-task config wrapper. OpenCode's path does **not** rewrite the project's `opencode.json`.
 
 <Callout type="warning">
 If you set `mcp_config` in an agent configuration but pick a tool not marked ✅ in the MCP column, your MCP servers have **no effect** on that agent. MCP integration is provider-specific.
@@ -148,4 +148,4 @@ For creating and using skills, see [Skills](/skills).
 - [Creating and configuring agents](/agents-create) — pick a tool for your agent
 - [Tasks](/tasks) — task lifecycle and session-resumption mechanics
 - [Daemon and runtimes](/daemon-runtimes) — where the tools run and how they connect to Multica
-- [Install an agent runtime](/install-agent-runtime) — installation and authentication for each of the 13 supported tools
+- [Install an agent runtime](/install-agent-runtime) — installation and authentication for each of the 14 supported tools

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -70,4 +70,4 @@ By now you know what an agent is, how to create one, and how to attach skills. T
 
 - [Daemon and runtimes](/daemon-runtimes) — where agents actually run, and how to tell online from offline
 - [Executing tasks](/tasks) — the full lifecycle of one "agent work session"
-- [AI coding tools comparison](/providers) — full comparison of all 12 tools (including each one's skill injection path)
+- [AI coding tools comparison](/providers) — full comparison of all 14 tools (including each one's skill injection path)

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -112,5 +112,5 @@ See [Providers Matrix → Session resumption](/providers#session-resumption-who-
 
 ## Next
 
-- [Providers Matrix](/providers) — capability differences across the 12 AI coding tools (including the exact session-resumption status)
+- [Providers Matrix](/providers) — capability differences across the 14 AI coding tools (including the exact session-resumption status)
 - [Assigning issues to agents](/assigning-issues) / [@-mentioning agents in comments](/mentioning-agents) / [Chat](/chat) / [Autopilots](/autopilots) — the four ways to trigger a task


### PR DESCRIPTION
## Summary

Docs follow-up to #4724, which added the ByteDance **Trae CLI** (`traecli`) ACP backend but left the surrounding documentation behind. This makes the docs Trae-complete and internally consistent.

The second-round review of #4724 flagged that the install page and provider matrix were inconsistent with the new provider; #4724 was merged (its own docs edits were already in), and this PR catches up the rest.

## Changes (English docs only)

- **`install-agent-runtime.mdx`** — add a **Trae CLI (ByteDance)** section (install link, ACP transport `traecli acp serve --yolo`, enterprise/browser login vs. IDE login, inline runtime brief because traecli reads `.trae/rules/` and has no `--system-prompt`, `MULTICA_TRAECLI_MODEL`). Bump count 13 → 14.
- **`providers.mdx`** — fix a self-contradiction: the MCP paragraph listed the ACP `mcpServers` receivers as only Hermes/Kimi/Kiro CLI/Qoder even though the same page already says Trae consumes `mcp_config`. Trae now included. Count reference 13 → 14.
- **`daemon-runtimes.mdx`** — the "built-in" detection list was still at 12 and missing **both Qoder and Trae**; add both → 14.
- **`README.md`** — add Trae CLI to the architecture diagram and the Agent Runtime table row.
- **Count cross-references** (`agents-create`, `cloud-quickstart`, `skills`, `tasks`) — bump stale "12/13 tools" → 14. The "12" numbers were already drifting (they predate Qoder); this aligns them to the authoritative 14-row provider matrix.

## Out of scope

The `*.ja.mdx` / `*.zh.mdx` localizations are separately behind (they predate Qoder too) and need their own translation-sync pass — intentionally not touched here to keep this PR focused and avoid half-baked translations.

## Verification

Docs-only (MDX/markdown). No code changed, so no build/test run. Manually verified: anchors (`/providers#trae`, `/providers#qoder`) resolve to existing headings, new tables match the existing provider-section format, and no stale "12/13" tool-count references remain in the English docs.

Related: MUL-3860
