### PR TITLE
fix(self-host): restore official source report endpoint

### DIFF
--- a/server/internal/sourcechannel/sender.go
+++ b/server/internal/sourcechannel/sender.go
@@ -18,11 +18,9 @@ import (
 )
 
 const (
-	ReportPath = "/api/acquisition/self-host-source"
-	// Temporary validation target for the dev/staging rollout of #4741.
-	sourceChannelReportAPIURL = "https://multica-api.copilothub.ai"
-	systemSaltKey             = "self_host_source_channel_salt"
-	defaultTimeout            = 3 * time.Second
+	ReportPath     = "/api/acquisition/self-host-source"
+	systemSaltKey  = "self_host_source_channel_salt"
+	defaultTimeout = 3 * time.Second
 )
 
 type settingStore interface {
@@ -65,7 +63,7 @@ func NewSender(settings settingStore, cfg SenderConfig) (*Sender, error) {
 	return &Sender{
 		settings: settings,
 		client:   client,
-		endpoint: sourceChannelReportAPIURL + ReportPath,
+		endpoint: OfficialMulticaAPIURL + ReportPath,
 		timeout:  timeout,
 		logger:   logger,
 	}, nil

--- a/server/internal/sourcechannel/sender_test.go
+++ b/server/internal/sourcechannel/sender_test.go
@@ -33,8 +33,8 @@ func recordingClient(t *testing.T, got chan<- Report) *http.Client {
 			if req.Method != http.MethodPost {
 				t.Errorf("method: want POST, got %s", req.Method)
 			}
-			if req.URL.String() != sourceChannelReportAPIURL+ReportPath {
-				t.Errorf("url: want %s, got %s", sourceChannelReportAPIURL+ReportPath, req.URL.String())
+			if req.URL.String() != OfficialMulticaAPIURL+ReportPath {
+				t.Errorf("url: want %s, got %s", OfficialMulticaAPIURL+ReportPath, req.URL.String())
 			}
 			var payload Report
 			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {


### PR DESCRIPTION
## Summary
- restore self-host source-channel reports to the official Multica API endpoint
- remove the temporary staging endpoint constant from the sender
- update sender tests to assert the official endpoint

## Validation
- go test ./internal/sourcechannel
- git diff --check origin/main...HEAD
