### PR TITLE
test(onboarding): cover official source reporting controls

### DIFF
--- a/packages/views/onboarding/source-backfill-modal.test.tsx
+++ b/packages/views/onboarding/source-backfill-modal.test.tsx
@@ -162,6 +162,26 @@ describe("SourceBackfillModal", () => {
     ).toBeChecked();
   });
 
+  it("does not show reporting controls on the official API URL", async () => {
+    setUser({
+      id: "u1",
+      onboarded_at: "2026-01-01T00:00:00Z",
+      onboarding_questionnaire: { source: [] },
+    });
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(await screen.findByText("Friends or colleagues"));
+
+    expect(
+      screen.queryByText(
+        "Help us understand how you heard about Multica. No extra information is sent.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /allow sending domain/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("Submit PATCHes the merged questionnaire preserving role / use_case", async () => {
     setUser({
       id: "u1",

--- a/packages/views/onboarding/steps/step-source.test.tsx
+++ b/packages/views/onboarding/steps/step-source.test.tsx
@@ -83,6 +83,22 @@ describe("StepSource (single-select primary source)", () => {
     ).toBeChecked();
   });
 
+  it("does not show reporting controls on the official API URL", () => {
+    renderStep({
+      ...EMPTY,
+      source: ["social_linkedin"],
+    });
+
+    expect(
+      screen.queryByText(
+        "Help us understand how you heard about Multica. No extra information is sent.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /allow sending domain/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("lets the user disable plaintext domain reporting", async () => {
     setApiInstance(new ApiClient("https://api.customer.example"));
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- add onboarding source-step coverage that official API users do not see the domain-reporting controls
- add source-backfill modal coverage for the same official API behavior

## Validation
- pnpm --filter @multica/views test -- --run onboarding/steps/step-source.test.tsx onboarding/source-backfill-modal.test.tsx
- git diff --check origin/main...HEAD
