### PR TITLE
fix(slack): allow slack_chat issue origin so /issue can create issues (MUL-3908)

### DIFF
--- a/server/migrations/131_issue_origin_slack_chat.down.sql
+++ b/server/migrations/131_issue_origin_slack_chat.down.sql
@@ -1,0 +1,8 @@
+-- Revert to the pre-slack_chat issue_origin_type_check list. Any existing rows
+-- with origin_type='slack_chat' would violate the rolled-back constraint; the
+-- down migration assumes the operator has already deleted or relabeled those
+-- rows. Kept strict (no DROP NOT VALID dance) to preserve the schema invariant
+-- downstream code relies on. Mirrors 111.
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_origin_type_check;
+ALTER TABLE issue ADD CONSTRAINT issue_origin_type_check
+    CHECK (origin_type IN ('autopilot', 'quick_create', 'lark_chat'));

--- a/server/migrations/131_issue_origin_slack_chat.up.sql
+++ b/server/migrations/131_issue_origin_slack_chat.up.sql
@@ -1,0 +1,10 @@
+-- Extend issue.origin_type to allow the Slack `/issue` command paths (both the
+-- message-prefix form and the slash command) to stamp issues with
+-- origin_type='slack_chat'. The Slack integration shipped this origin label
+-- (originSlackChat) but no migration ever added it to the CHECK list, so every
+-- Slack /issue create tripped SQLSTATE 23514 and IssueService.Create failed —
+-- surfaced end-to-end by the /issue slash command (MUL-3908). Mirrors 111
+-- (lark_chat), which fixed the identical gap for Lark.
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_origin_type_check;
+ALTER TABLE issue ADD CONSTRAINT issue_origin_type_check
+    CHECK (origin_type IN ('autopilot', 'quick_create', 'lark_chat', 'slack_chat'));


### PR DESCRIPTION
## Summary

Follow-up fix for the Slack `/issue` slash command (MUL-3908, #4780).

#4780 (merged) added the slash-command code, docs, and the `commands` scope. But the required DB migration was pushed to that branch **after** it had already been squash-merged, so it never landed on `main` — and without it `/issue` still fails at issue creation with **"Something went wrong creating the issue."**

## Root cause

The `issue.origin_type` CHECK constraint (migration 111) only allows `autopilot / quick_create / lark_chat`. The Slack integration stamps `origin_type='slack_chat'` (`originSlackChat`) on every `/issue` create, so the INSERT trips **SQLSTATE 23514** and `IssueService.Create` fails. This also silently broke the pre-existing **message-based** Slack `/issue` — nobody had exercised it end-to-end.

## Fix

Migration `131_issue_origin_slack_chat` extends the constraint to include `'slack_chat'`, mirroring 111 (which fixed the identical gap for Lark). Numbered **131** because 129/130 were taken on `main` (`self_host_source_*`) since #4780 branched.

## Testing

Verified against a real Postgres:
- The full migration chain up to **131 applies cleanly** on top of current `main`.
- An `issue` insert with `origin_type='slack_chat'` **passes** the CHECK after 131 and **fails with `violates check constraint "issue_origin_type_check"` (23514)** under the pre-131 constraint — matching the reported error.

## Rollout

Ships a DB migration only; it runs on backend deploy. Once merged and deployed, `/issue` creates issues with no further Slack-side changes.

MUL-3908
