### PR TITLE
MUL-3922: expose local skills for ACP providers

### DIFF
--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -89,7 +89,11 @@ const (
 //   - Pi: https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md
 //   - Cursor: official forum guidance referencing the built-in /create-skill flow
 //     (https://forum.cursor.com/t/cursor-doesnt-know-new-skills-arens-saved/158507)
+//   - Hermes: ~/.hermes/skills is Hermes Agent's primary skill directory
+//     (https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)
+//   - Kimi: ~/.kimi/skills mirrors Kimi CLI's project-level .kimi/skills layout
 //   - Kiro: project and user-level .kiro/skills directories discovered by Kiro CLI
+//   - Qoder: ~/.qoder/skills mirrors Qoder CLI's project-level .qoder/skills layout
 //   - Antigravity: ~/.gemini/antigravity-cli/skills user-level skill root
 //     (https://antigravity.google/docs/gcli-migration "Global skills")
 //
@@ -126,8 +130,14 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		providerRoot = filepath.Join(home, ".pi", "agent", "skills")
 	case "cursor":
 		providerRoot = filepath.Join(home, ".cursor", "skills")
+	case "hermes":
+		providerRoot = filepath.Join(home, ".hermes", "skills")
+	case "kimi":
+		providerRoot = filepath.Join(home, ".kimi", "skills")
 	case "kiro":
 		providerRoot = filepath.Join(home, ".kiro", "skills")
+	case "qoder":
+		providerRoot = filepath.Join(home, ".qoder", "skills")
 	case "traecli":
 		// Official TRAE CLI global skills live in ~/.traecli/skills.
 		// See https://docs.trae.cn/cli_skills

--- a/server/internal/daemon/local_skills_test.go
+++ b/server/internal/daemon/local_skills_test.go
@@ -99,6 +99,86 @@ func TestListRuntimeLocalSkills_Kiro(t *testing.T) {
 	}
 }
 
+func TestLocalSkills_DiscoversACPProviderRoots(t *testing.T) {
+	tests := []struct {
+		provider string
+		root     string
+		wantPath string
+		wantName string
+	}{
+		{
+			provider: "hermes",
+			root:     filepath.Join(".hermes", "skills"),
+			wantPath: "~/.hermes/skills/review-helper",
+			wantName: "Hermes Review",
+		},
+		{
+			provider: "kimi",
+			root:     filepath.Join(".kimi", "skills"),
+			wantPath: "~/.kimi/skills/review-helper",
+			wantName: "Kimi Review",
+		},
+		{
+			provider: "qoder",
+			root:     filepath.Join(".qoder", "skills"),
+			wantPath: "~/.qoder/skills/review-helper",
+			wantName: "Qoder Review",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
+			writeTestLocalSkill(t, filepath.Join(home, tc.root), "review-helper", map[string]string{
+				"SKILL.md": "---\nname: " + tc.wantName + "\ndescription: Review code\n---\n# Review\n",
+				"notes.md": "notes",
+			})
+
+			skills, supported, err := listRuntimeLocalSkills(tc.provider)
+			if err != nil {
+				t.Fatalf("listRuntimeLocalSkills: %v", err)
+			}
+			if !supported {
+				t.Fatalf("%s should be supported", tc.provider)
+			}
+			if len(skills) != 1 {
+				t.Fatalf("expected 1 skill, got %d (%v)", len(skills), skills)
+			}
+			if skills[0].Key != "review-helper" {
+				t.Fatalf("key = %q, want review-helper", skills[0].Key)
+			}
+			if skills[0].Name != tc.wantName {
+				t.Fatalf("name = %q, want %q", skills[0].Name, tc.wantName)
+			}
+			if skills[0].Root != localSkillRootProvider {
+				t.Fatalf("root = %q, want %q", skills[0].Root, localSkillRootProvider)
+			}
+			if skills[0].SourcePath != tc.wantPath {
+				t.Fatalf("source_path = %q, want %q", skills[0].SourcePath, tc.wantPath)
+			}
+
+			bundle, supported, err := loadRuntimeLocalSkillBundle(tc.provider, "review-helper")
+			if err != nil {
+				t.Fatalf("loadRuntimeLocalSkillBundle: %v", err)
+			}
+			if !supported {
+				t.Fatalf("%s should be supported for import", tc.provider)
+			}
+			if bundle.Name != tc.wantName {
+				t.Fatalf("bundle name = %q, want %q", bundle.Name, tc.wantName)
+			}
+			if bundle.SourcePath != tc.wantPath {
+				t.Fatalf("bundle source_path = %q, want %q", bundle.SourcePath, tc.wantPath)
+			}
+			if len(bundle.Files) != 1 {
+				t.Fatalf("expected 1 supporting file, got %d", len(bundle.Files))
+			}
+		})
+	}
+}
+
 // Skill installers (for example lark-cli) place every skill at a shared
 // location like ~/.agents/skills/<name> and symlink each one into the
 // runtime root (~/.claude/skills/<name>). The previous filepath.WalkDir


### PR DESCRIPTION
## Summary
- add local-skill roots for Hermes, Kimi, and Qoder runtimes so the daemon can list/import their local skills
- keep provider-specific roots ahead of the universal ~/.agents/skills fallback
- add regression coverage for list/import behavior across the ACP providers

## Testing
- go test ./internal/daemon -run 'Test(LocalSkills_DiscoversACPProviderRoots|ListRuntimeLocalSkills|LoadRuntimeLocalSkillBundle)'
- go test ./internal/daemon