### PR TITLE
MUL-3922: add Add to agent action on skill detail page

### DIFF
--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -58,6 +58,8 @@
     "my_agents": "My agents",
     "other_agents": "Other agents",
     "no_agents": "No agents available",
+    "search_placeholder": "Search agents…",
+    "no_agents_match": "No agents match your search.",
     "has_partial": "{{owned}}/{{total}} added",
     "added_toast": "Added to {{name}}",
     "add_failed_toast": "Failed to add skill",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -58,6 +58,8 @@
     "my_agents": "自分のエージェント",
     "other_agents": "その他のエージェント",
     "no_agents": "利用可能なエージェントがありません",
+    "search_placeholder": "エージェントを検索…",
+    "no_agents_match": "一致するエージェントがありません。",
     "has_partial": "{{owned}}/{{total}} 追加済み",
     "added_toast": "{{name}} に追加しました",
     "add_failed_toast": "スキルの追加に失敗しました",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -58,6 +58,8 @@
     "my_agents": "내 에이전트",
     "other_agents": "다른 에이전트",
     "no_agents": "사용 가능한 에이전트가 없습니다",
+    "search_placeholder": "에이전트 검색…",
+    "no_agents_match": "검색과 일치하는 에이전트가 없습니다.",
     "has_partial": "{{owned}}/{{total}} 보유",
     "added_toast": "{{name}}에 추가했습니다",
     "add_failed_toast": "스킬 추가에 실패했습니다",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -70,6 +70,8 @@
     "my_agents": "我的智能体",
     "other_agents": "其他智能体",
     "no_agents": "暂无可用智能体",
+    "search_placeholder": "搜索智能体…",
+    "no_agents_match": "没有匹配的智能体。",
     "has_partial": "已有 {{owned}}/{{total}}",
     "added_toast": "已添加到 {{name}}",
     "add_failed_toast": "添加 skill 失败",

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -13,6 +13,7 @@ import {
   Save,
   Sparkles,
   Trash2,
+  UserPlus,
 } from "lucide-react";
 import type {
   Agent,
@@ -25,6 +26,7 @@ import type {
 import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
+import { useAuthStore } from "@multica/core/auth";
 import { useTimeAgo } from "../../i18n";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
@@ -64,6 +66,10 @@ import { CapabilityBanner } from "@multica/ui/components/common/capability-banne
 import { readOrigin, totalFileCount, type OriginInfo } from "../lib/origin";
 import { FileTree } from "./file-tree";
 import { FileViewer } from "./file-viewer";
+import {
+  AddToAgentDialog,
+  type SkillActionsContext,
+} from "./skill-list-actions";
 import { useT } from "../../i18n";
 
 const SKILL_MD = "SKILL.md";
@@ -249,6 +255,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   const qc = useQueryClient();
   const paths = useWorkspacePaths();
   const navigation = useNavigation();
+  const currentUserId = useAuthStore((s) => s.user?.id ?? null);
 
   const {
     data: skill,
@@ -273,6 +280,19 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   const canEdit = useCanEditSkill(skill, wsId);
   const skillPermissions = useSkillPermissions(skill ?? null, wsId);
 
+  // Context for the shared "Add to agent" dialog (also used by the skills
+  // list). Members see their own agents; workspace owners/admins see all.
+  const myRole = useMemo(
+    () => members.find((m) => m.user_id === currentUserId)?.role ?? null,
+    [members, currentUserId],
+  );
+  const actionsCtx: SkillActionsContext = {
+    wsId,
+    agents,
+    currentUserId,
+    isAdmin: myRole === "owner" || myRole === "admin",
+  };
+
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
@@ -281,6 +301,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [showAddToAgents, setShowAddToAgents] = useState(false);
   const [addingFile, setAddingFile] = useState(false);
   const [conflictPending, setConflictPending] = useState(false);
 
@@ -867,9 +888,20 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
           )}
 
           <div>
-            <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              {t(($) => $.detail.sidebar.used_by, { count: skillAgents.length })}
-            </h3>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h3 className="min-w-0 truncate text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                {t(($) => $.detail.sidebar.used_by, { count: skillAgents.length })}
+              </h3>
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() => setShowAddToAgents(true)}
+                className="h-6 shrink-0 gap-1"
+              >
+                <UserPlus className="h-3 w-3" />
+                {t(($) => $.actions.add_to_agent)}
+              </Button>
+            </div>
             <UsedBySection agents={skillAgents} />
           </div>
 
@@ -942,6 +974,13 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AddToAgentDialog
+        skills={[skill]}
+        ctx={actionsCtx}
+        open={showAddToAgents}
+        onOpenChange={setShowAddToAgents}
+      />
     </div>
   );
 }

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   MoreHorizontal,
   Plus,
+  Search,
   Trash2,
   X,
 } from "lucide-react";
@@ -18,6 +19,7 @@ import { workspaceKeys } from "@multica/core/workspace/queries";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { Button } from "@multica/ui/components/ui/button";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
+import { Input } from "@multica/ui/components/ui/input";
 import {
   Collapsible,
   CollapsibleContent,
@@ -234,14 +236,31 @@ export function AddToAgentDialog({
     new Set(),
   );
   const [saving, setSaving] = useState(false);
+  const [query, setQuery] = useState("");
 
   const skillIds = skills.map((s) => s.id);
   const { mine, others } = partitionAgents(ctx);
   const count = selectedIds.size;
 
+  // Search across both groups by agent name. Filtering is applied per group
+  // so the "My agents" / "Other agents" split is preserved; when a query is
+  // active both groups are force-expanded (via the remount key below) so
+  // matches in the normally-collapsed "Other agents" group stay visible.
+  const trimmedQuery = query.trim().toLowerCase();
+  const searching = trimmedQuery.length > 0;
+  const matchesQuery = (a: Agent) =>
+    !searching || a.name.toLowerCase().includes(trimmedQuery);
+  const filteredMine = mine.filter(matchesQuery);
+  const filteredOthers = others.filter(matchesQuery);
+  const hasAnyAgent = mine.length + others.length > 0;
+  const hasMatch = filteredMine.length + filteredOthers.length > 0;
+
   const handleOpenChange = (v: boolean) => {
     if (saving) return;
-    if (!v) setSelectedIds(new Set());
+    if (!v) {
+      setSelectedIds(new Set());
+      setQuery("");
+    }
     onOpenChange(v);
   };
 
@@ -303,25 +322,43 @@ export function AddToAgentDialog({
 
         <SkillChips skills={skills} />
 
+        {hasAnyAgent && (
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t(($) => $.actions.search_placeholder)}
+              className="h-8 pl-7 text-xs"
+            />
+          </div>
+        )}
+
         <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border bg-card p-1.5">
-          {mine.length === 0 && others.length === 0 ? (
+          {!hasAnyAgent ? (
             <div className="py-6 text-center text-xs text-muted-foreground">
               {t(($) => $.actions.no_agents)}
+            </div>
+          ) : !hasMatch ? (
+            <div className="py-6 text-center text-xs text-muted-foreground">
+              {t(($) => $.actions.no_agents_match)}
             </div>
           ) : (
             <>
               <AgentGroup
+                key={`mine-${searching}`}
                 label={t(($) => $.actions.my_agents)}
-                agents={mine}
+                agents={filteredMine}
                 defaultOpen
                 skillIds={skillIds}
                 selectedIds={selectedIds}
                 onToggle={handleToggle}
               />
               <AgentGroup
+                key={`others-${searching}`}
                 label={t(($) => $.actions.other_agents)}
-                agents={others}
-                defaultOpen={false}
+                agents={filteredOthers}
+                defaultOpen={searching}
                 skillIds={skillIds}
                 selectedIds={selectedIds}
                 onToggle={handleToggle}


### PR DESCRIPTION
## Summary

Adds an **"Add to agent"** action to each skill's own detail page, so a single skill can be attached to multiple agents in one step — without opening each agent's Skills tab individually.

The trigger lives on the **"Used by N agents"** sidebar panel header (right-aligned) — the section that already lists which agents have the skill — so adding more agents happens right where you see the current coverage.

## Changes

- **`skill-detail-page.tsx`**: new "Add to agent" button on the "Used by N agents" panel header; wires up the shared dialog with a `SkillActionsContext` built from the current user's role (members see their own agents; workspace owners/admins see all).
- **`skill-list-actions.tsx`**: reuse the existing `AddToAgentDialog` (previously only reachable from the skills-list row menu / batch toolbar) instead of adding a parallel component, and add an **agent search box** to it. Groups auto-expand while a search query is active. This also improves the list-page dialog.
- **i18n**: added `search_placeholder` and `no_agents_match` keys for en / zh-Hans / ja / ko.

## Behavior notes

- Binding is **additive** (`addAgentSkills`) — it never clobbers an agent's other skills, and re-adding is a no-op.
- Agents that **already have the skill render checked + disabled** (non-selectable) in the dialog, so they can't be double-added; the confirm count excludes them.
- Permission model is inherited from the existing dialog: members only see/act on their own agents, admins on all.

## Testing

- `pnpm --filter @multica/views typecheck` — passes.
- `pnpm --filter @multica/views lint` — 0 errors.
- `pnpm --filter @multica/views test` — full suite passes (1534 tests), including the locale-parity guard for the new i18n keys.
- Manually verified on a local dev stack: button placement, multi-select + count, search filtering, and the already-added/disabled state (bound the skill to one agent and confirmed it renders locked).

MUL-3922
