### PR TITLE
fix(slack): recover attachment/blocks text for empty-Text chat messages (MUL-3931)

### DIFF
--- a/server/internal/integrations/slack/history.go
+++ b/server/internal/integrations/slack/history.go
@@ -238,8 +238,9 @@ func normalizePage(ctx context.Context, client historyClient, logger *slog.Logge
 	out := make([]channel.HistoryMessage, 0, len(raw))
 	for i := range raw {
 		m := raw[i]
-		if m.Text == "" {
-			continue // join/system/edit markers carry no readable body
+		text := flattenSlackText(m)
+		if text == "" {
+			continue // genuine join/system/edit marker: no readable body
 		}
 		own := m.User != "" && m.User == botUserID
 		role := channel.HistoryRoleUser
@@ -251,7 +252,7 @@ func normalizePage(ctx context.Context, client historyClient, logger *slog.Logge
 			Author:   labeler.label(m, own),
 			AuthorID: m.User,
 			Role:     role,
-			Text:     m.Text,
+			Text:     text,
 			TS:       m.Timestamp,
 		}
 		if overview && m.ReplyCount > 0 {
@@ -269,6 +270,108 @@ func normalizePage(ctx context.Context, client historyClient, logger *slog.Logge
 		page.NextCursor = out[0].TS
 	}
 	return page
+}
+
+// maxDerivedTextLen caps text recovered from attachments/blocks so a verbose
+// alert card cannot flood the agent's context. It applies only to the fallback
+// path; a normal top-level message body is passed through untouched.
+const maxDerivedTextLen = 4000
+
+// flattenSlackText renders a Slack message to the plain-text body the history
+// contract promises (channel.HistoryMessage.Text). Alerting/webhook bots
+// (Grafana cards, incoming webhooks) carry their whole body in attachments or
+// Block Kit blocks and leave the top-level Text empty; without this fallback
+// such a message is indistinguishable from a join/system marker and gets
+// dropped (MUL-3931 / #4803). Order: top-level text, then each attachment's
+// built-in Fallback / title+text/fields, then a best-effort blocks flatten.
+// Returns "" only when nothing renderable exists — a real system marker.
+func flattenSlackText(m slack.Message) string {
+	if t := strings.TrimSpace(m.Text); t != "" {
+		return t
+	}
+	parts := make([]string, 0, len(m.Attachments)+1)
+	for i := range m.Attachments {
+		if t := attachmentText(m.Attachments[i]); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	if len(parts) == 0 {
+		if t := flattenBlocks(m.Blocks); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return truncateRunes(strings.TrimSpace(strings.Join(parts, "\n")), maxDerivedTextLen)
+}
+
+// attachmentText summarizes one attachment, preferring Slack's built-in
+// Fallback (the plain-text rendering Slack ships for exactly this purpose),
+// then a pretext/title/text/fields composite, then the attachment's own blocks.
+func attachmentText(a slack.Attachment) string {
+	if t := strings.TrimSpace(a.Fallback); t != "" {
+		return t
+	}
+	parts := make([]string, 0, 3+len(a.Fields))
+	for _, s := range []string{a.Pretext, a.Title, a.Text} {
+		if s = strings.TrimSpace(s); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	for _, f := range a.Fields {
+		if s := strings.TrimSpace(f.Title + " " + f.Value); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "\n")
+	}
+	return flattenBlocks(a.Blocks)
+}
+
+// flattenBlocks renders Block Kit blocks to plain text, best-effort: it walks
+// the common text-bearing blocks (section, header, context, markdown) and skips
+// interactive/media blocks. Deeply nested rich_text is not expanded.
+func flattenBlocks(blocks slack.Blocks) string {
+	parts := make([]string, 0, len(blocks.BlockSet))
+	add := func(s string) {
+		if s = strings.TrimSpace(s); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	for _, b := range blocks.BlockSet {
+		switch v := b.(type) {
+		case *slack.SectionBlock:
+			if v.Text != nil {
+				add(v.Text.Text)
+			}
+			for _, f := range v.Fields {
+				if f != nil {
+					add(f.Text)
+				}
+			}
+		case *slack.HeaderBlock:
+			if v.Text != nil {
+				add(v.Text.Text)
+			}
+		case *slack.MarkdownBlock:
+			add(v.Text)
+		case *slack.ContextBlock:
+			for _, el := range v.ContextElements.Elements {
+				if tb, ok := el.(*slack.TextBlockObject); ok {
+					add(tb.Text)
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// truncateRunes trims s to at most max runes, appending an ellipsis when cut.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }
 
 // resolveUserNames batch-resolves human senders' display names, best-effort. A

--- a/server/internal/integrations/slack/history.go
+++ b/server/internal/integrations/slack/history.go
@@ -328,8 +328,8 @@ func attachmentText(a slack.Attachment) string {
 }
 
 // flattenBlocks renders Block Kit blocks to plain text, best-effort: it walks
-// the common text-bearing blocks (section, header, context, markdown) and skips
-// interactive/media blocks. Deeply nested rich_text is not expanded.
+// the common text-bearing blocks (section, header, context, markdown, and
+// rich_text) and skips interactive/media blocks.
 func flattenBlocks(blocks slack.Blocks) string {
 	parts := make([]string, 0, len(blocks.BlockSet))
 	add := func(s string) {
@@ -360,9 +360,59 @@ func flattenBlocks(blocks slack.Blocks) string {
 					add(tb.Text)
 				}
 			}
+		case *slack.RichTextBlock:
+			add(richTextBlockText(v))
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+// richTextBlockText flattens a rich_text block to plain text, best-effort: it
+// walks sections, lists, quotes, and preformatted runs and concatenates their
+// text and link runs (one line per section). Mentions, emoji, and other inline
+// decorations are skipped — this is the plain body an agent needs, not a
+// faithful re-render. A rich_text-only body is the standard shape for messages
+// composed in Slack's own rich text input, so a bot that posts one with an
+// empty top-level Text would otherwise be dropped.
+func richTextBlockText(b *slack.RichTextBlock) string {
+	var lines []string
+	var writeElement func(el slack.RichTextElement)
+	writeSection := func(els []slack.RichTextSectionElement) {
+		var sb strings.Builder
+		for _, e := range els {
+			switch v := e.(type) {
+			case *slack.RichTextSectionTextElement:
+				sb.WriteString(v.Text)
+			case *slack.RichTextSectionLinkElement:
+				if v.Text != "" {
+					sb.WriteString(v.Text)
+				} else {
+					sb.WriteString(v.URL)
+				}
+			}
+		}
+		if s := strings.TrimSpace(sb.String()); s != "" {
+			lines = append(lines, s)
+		}
+	}
+	writeElement = func(el slack.RichTextElement) {
+		switch v := el.(type) {
+		case *slack.RichTextSection:
+			writeSection(v.Elements)
+		case *slack.RichTextQuote:
+			writeSection(v.Elements)
+		case *slack.RichTextPreformatted:
+			writeSection(v.Elements)
+		case *slack.RichTextList:
+			for _, item := range v.Elements {
+				writeElement(item)
+			}
+		}
+	}
+	for _, el := range b.Elements {
+		writeElement(el)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // truncateRunes trims s to at most max runes, appending an ellipsis when cut.

--- a/server/internal/integrations/slack/history_test.go
+++ b/server/internal/integrations/slack/history_test.go
@@ -247,6 +247,95 @@ func TestChannelOverviewLimitClamp(t *testing.T) {
 	}
 }
 
+// TestThreadRecoversBotAttachmentText covers alerting/webhook bots (Grafana
+// cards, incoming webhooks): the body lives in attachments with an empty
+// top-level Text. The root must be recovered, not dropped (MUL-3931 / #4803).
+func TestThreadRecoversBotAttachmentText(t *testing.T) {
+	q := &fakeHistoryQueries{binding: groupBinding("50.000000"), inst: activeSlackInstall()}
+	root := slack.Message{Msg: slack.Msg{
+		Username:  "Grafana",
+		BotID:     "B1",
+		Timestamp: "50.000000",
+		Attachments: []slack.Attachment{{
+			Fallback: "[FIRING:1] HighLatency prod",
+			Title:    "HighLatency",
+			Text:     "p99 over threshold",
+		}},
+	}}
+	fc := &fakeHistoryClient{repliesMsgs: []slack.Message{
+		msg("U1", "@bot what's this alert?", "51.000000"),
+		root,
+	}}
+	h := newTestHistory(q, fc)
+
+	page, err := h.Thread(context.Background(), uid(9), "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	if len(page.Messages) != 2 {
+		t.Fatalf("expected root + reply, got %d: %+v", len(page.Messages), page.Messages)
+	}
+	got := findByTS(page.Messages, "50.000000")
+	if got == nil {
+		t.Fatalf("bot root message was dropped: %+v", page.Messages)
+	}
+	if got.Text != "[FIRING:1] HighLatency prod" {
+		t.Errorf("root text = %q, want the attachment fallback", got.Text)
+	}
+	if got.Author != "Grafana" {
+		t.Errorf("root author = %q, want Grafana", got.Author)
+	}
+}
+
+// TestThreadRecoversBlocksText: a message with no Text and no attachment
+// fallback is flattened from its Block Kit blocks.
+func TestThreadRecoversBlocksText(t *testing.T) {
+	q := &fakeHistoryQueries{binding: groupBinding("50.000000"), inst: activeSlackInstall()}
+	root := slack.Message{Msg: slack.Msg{
+		Username:  "Webhook",
+		BotID:     "B2",
+		Timestamp: "50.000000",
+		Blocks: slack.Blocks{BlockSet: []slack.Block{
+			slack.NewHeaderBlock(slack.NewTextBlockObject(slack.PlainTextType, "Deploy failed", false, false)),
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "service *api* rolled back", false, false), nil, nil),
+		}},
+	}}
+	fc := &fakeHistoryClient{repliesMsgs: []slack.Message{root}}
+	h := newTestHistory(q, fc)
+
+	page, err := h.Thread(context.Background(), uid(9), "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	got := findByTS(page.Messages, "50.000000")
+	if got == nil {
+		t.Fatalf("blocks-only message was dropped: %+v", page.Messages)
+	}
+	if got.Text != "Deploy failed\nservice *api* rolled back" {
+		t.Errorf("root text = %q, want the flattened blocks", got.Text)
+	}
+}
+
+// TestThreadDropsEmptySystemMarker: a message with no readable body anywhere
+// (a join/leave/system marker) is still dropped — the fallback must not
+// resurrect content-less markers.
+func TestThreadDropsEmptySystemMarker(t *testing.T) {
+	q := &fakeHistoryQueries{binding: groupBinding("50.000000"), inst: activeSlackInstall()}
+	fc := &fakeHistoryClient{repliesMsgs: []slack.Message{
+		{Msg: slack.Msg{SubType: "channel_join", User: "U1", Timestamp: "50.000000"}},
+		msg("U2", "real reply", "51.000000"),
+	}}
+	h := newTestHistory(q, fc)
+
+	page, err := h.Thread(context.Background(), uid(9), "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	if len(page.Messages) != 1 || page.Messages[0].TS != "51.000000" {
+		t.Fatalf("expected only the real reply, got %+v", page.Messages)
+	}
+}
+
 // TestHistoryTargetDerivesRoot pins channel + thread-root recovery from a binding.
 func TestHistoryTargetDerivesRoot(t *testing.T) {
 	if ch, root := historyTarget(groupBinding("50.0")); ch != "C1" || root != "50.0" {

--- a/server/internal/integrations/slack/history_test.go
+++ b/server/internal/integrations/slack/history_test.go
@@ -316,6 +316,39 @@ func TestThreadRecoversBlocksText(t *testing.T) {
 	}
 }
 
+// TestThreadRecoversRichTextBlock: a message whose only body is a Block Kit
+// rich_text block (the shape Slack's rich text input produces) is flattened.
+func TestThreadRecoversRichTextBlock(t *testing.T) {
+	q := &fakeHistoryQueries{binding: groupBinding("50.000000"), inst: activeSlackInstall()}
+	root := slack.Message{Msg: slack.Msg{
+		Username:  "Webhook",
+		BotID:     "B3",
+		Timestamp: "50.000000",
+		Blocks: slack.Blocks{BlockSet: []slack.Block{
+			slack.NewRichTextBlock("blk",
+				slack.NewRichTextSection(
+					slack.NewRichTextSectionTextElement("incident opened: ", nil),
+					slack.NewRichTextSectionLinkElement("https://ex.co/i/1", "INC-1", nil),
+				),
+			),
+		}},
+	}}
+	fc := &fakeHistoryClient{repliesMsgs: []slack.Message{root}}
+	h := newTestHistory(q, fc)
+
+	page, err := h.Thread(context.Background(), uid(9), "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	got := findByTS(page.Messages, "50.000000")
+	if got == nil {
+		t.Fatalf("rich_text-only message was dropped: %+v", page.Messages)
+	}
+	if got.Text != "incident opened: INC-1" {
+		t.Errorf("root text = %q, want the flattened rich_text", got.Text)
+	}
+}
+
 // TestThreadDropsEmptySystemMarker: a message with no readable body anywhere
 // (a join/leave/system marker) is still dropped — the fallback must not
 // resurrect content-less markers.


### PR DESCRIPTION
## Summary

`multica chat thread` / `multica chat history` dropped any message whose top-level `Text` was empty. The skip in `normalizePage()` was meant to filter join/system markers, but it also discarded **alerting/webhook bot roots** (Grafana cards, incoming webhooks) whose body lives entirely in `Attachments`/`Blocks`.

Net effect: when an agent is @mentioned under an alert card, `thread_id` resolves correctly but the **root message content is missing** — exactly the failure #4717 was meant to fix, for its most common trigger.

Fixes #4803 · MUL-3931

## Root cause

`server/internal/integrations/slack/history.go`, `normalizePage()`:

```go
if m.Text == "" {
    continue // join/system/edit markers carry no readable body
}
```

This contradicts the documented contract in `channel/history.go` (`Text is the message body, flattened to plain text by the adapter`) — no flattening was ever implemented for attachment/blocks-only messages.

## Change

Add `flattenSlackText()` and use it before the empty-text `continue`. Fallback order:

1. Top-level `Text` (unchanged path for normal messages).
2. Each attachment: Slack's built-in `Fallback` → `Pretext`/`Title`/`Text`/`Fields` → the attachment's own blocks.
3. Best-effort Block Kit flatten of message-level blocks (`section`, `header`, `context`, `markdown`).

Only when nothing renderable is found is the message discarded, so genuine content-less markers (`channel_join`, etc.) are still dropped. Derived text is capped (`maxDerivedTextLen`) so a verbose card can't flood the agent's context; the normal top-level body is passed through untouched.

Both `ChannelOverview` and `Thread` share `normalizePage`, so this single change fixes both `chat history` and `chat thread`. As a bonus, bot-authored thread roots now also get their `thread_id`/`reply_count` metadata tagged in the overview.

## Testing

`go test ./internal/integrations/slack/` — all pass (11 tests). New cases:

- `TestThreadRecoversBotAttachmentText` — Grafana-style attachment (empty `Text`, body in `Fallback`/`Title`) is recovered.
- `TestThreadRecoversBlocksText` — a blocks-only message is flattened (header + section).
- `TestThreadDropsEmptySystemMarker` — a `channel_join` marker with no body is still dropped (no regression).

Also ran `gofmt -l` (clean) and `go vet ./internal/integrations/slack/` (clean).
