### PR TITLE
feat(views): add CommandPage with title 任务控制台

### DIFF
--- a/packages/views/src/command/CommandPage.tsx
+++ b/packages/views/src/command/CommandPage.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export function CommandPage() {
+  return (
+    <div>
+      <h2>任务控制台</h2>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `packages/views/src/command/CommandPage.tsx` with h2 title "任务控制台"
- Resolves WS-154

## Test plan
- [ ] Verify `CommandPage` renders with h2 showing "任务控制台"
- [ ] Confirm no TypeScript errors in the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)