### PR TITLE
feat(chat): rename ChatWindow header to 快速任务

### DIFF
--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -75,7 +75,7 @@
     "running": "Running",
     "unread": "Unread",
     "no_previous": "No previous chats",
-    "untitled": "New chat",
+    "untitled": "Quick Task",
     "my_agents": "My agents",
     "others": "Others",
     "no_agents": "No agents",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -72,7 +72,7 @@
     "running": "実行中",
     "unread": "未読",
     "no_previous": "以前のチャットはありません",
-    "untitled": "新規チャット",
+    "untitled": "クイックタスク",
     "my_agents": "マイエージェント",
     "others": "その他",
     "no_agents": "エージェントなし",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -72,7 +72,7 @@
     "running": "실행 중",
     "unread": "읽지 않음",
     "no_previous": "이전 채팅 없음",
-    "untitled": "새 채팅",
+    "untitled": "빠른 작업",
     "my_agents": "내 에이전트",
     "others": "기타",
     "no_agents": "에이전트 없음",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -72,7 +72,7 @@
     "running": "运行中",
     "unread": "未读",
     "no_previous": "暂无历史对话",
-    "untitled": "新对话",
+    "untitled": "快速任务",
     "my_agents": "我的智能体",
     "others": "其他",
     "no_agents": "暂无智能体",


### PR DESCRIPTION
## Summary
- Change the default (untitled) ChatWindow header title across all locales
  - en: "New chat" → "Quick Task"
  - zh-Hans: "新对话" → "快速任务"
  - ja: "新規チャット" → "クイックタスク"
  - ko: "새 채팅" → "빠른 작업"

## Test plan
- [ ] Verify ChatWindow header shows "快速任务" in Chinese locale
- [ ] Verify ChatWindow header shows "Quick Task" in English locale
- [ ] Verify locale parity test still passes

Closes WS-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)