### PR TITLE
Add Devin runtime support via ACP adapter

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -68,6 +68,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "kimi",
   "kiro",
   "antigravity",
+  "devin",
 ] as const;
 
 export type RuntimeProtocolFamily =

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -24,6 +24,7 @@ import (
 // Cursor:      skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:        skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
 // Kiro:        skills → {workDir}/.kiro/skills/{name}/SKILL.md  (native discovery)
+// Devin:       skills → {workDir}/.devin/skills/{name}/SKILL.md  (native discovery)
 // Qoder:       skills → {workDir}/.qoder/skills/{name}/SKILL.md  (project-level; see docs.qoder.com/cli/Skills.md)
 // Antigravity: skills → {workDir}/.agents/skills/{name}/SKILL.md  (native discovery — see https://antigravity.google/docs/gcli-migration "Workspace skills")
 // Default:     skills → {workDir}/.agent_context/skills/{name}/SKILL.md
@@ -215,6 +216,10 @@ func skillsDirPath(workDir, provider string) string {
 		// Kiro CLI auto-discovers project-level skills from .kiro/skills/
 		// in the workdir.
 		return filepath.Join(workDir, ".kiro", "skills")
+	case "devin":
+		// Devin CLI auto-discovers project-level skills from .devin/skills/
+		// in the workdir.
+		return filepath.Join(workDir, ".devin", "skills")
 	case "qoder":
 		// Qoder CLI discovers project-level skills under .qoder/skills/.
 		// See https://docs.qoder.com/cli/Skills.md

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -166,6 +166,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
 // For Kimi:        writes {workDir}/AGENTS.md  (Kimi Code CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
 // For Kiro:        writes {workDir}/AGENTS.md  (Kiro CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
+// For Devin:       writes {workDir}/AGENTS.md  (Devin CLI reads AGENTS.md natively; skills auto-discovered from .devin/skills/)
 // For Qoder:       writes {workDir}/AGENTS.md  (skills discovered from .qoder/skills/, user-level ~/.qoder/skills is unaffected)
 // For Antigravity: writes {workDir}/AGENTS.md  (agy CLI reads AGENTS.md natively; skills discovered natively from .agents/skills/ — see https://antigravity.google/docs/gcli-migration)
 // For Traecli:     writes {workDir}/AGENTS.md  (traecli reads .trae/rules/ not AGENTS.md, so the brief is delivered inline via providerNeedsInlineSystemPrompt; the file is written for parity/visibility only)
@@ -188,7 +189,7 @@ func runtimeConfigPath(workDir, provider string) string {
 	switch provider {
 	case "claude", "codebuddy":
 		return filepath.Join(workDir, "CLAUDE.md")
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder", "traecli":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "devin", "antigravity", "qoder", "traecli":
 		return filepath.Join(workDir, "AGENTS.md")
 	default:
 		return ""

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -154,6 +154,7 @@ var SupportedTypes = []string{
 	"kimi",
 	"kiro",
 	"antigravity",
+	"devin",
 }
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.
@@ -198,12 +199,14 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kiroBackend{cfg: cfg}, nil
 	case "antigravity":
 		return &antigravityBackend{cfg: cfg}, nil
+	case "devin":
+		return &devinBackend{cfg: cfg}, nil
 	case "qoder":
 		return &qoderBackend{cfg: cfg}, nil
 	case "traecli":
 		return &traecliBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, kiro, antigravity, qoder, traecli)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, kiro, antigravity, devin, qoder, traecli)", agentType)
 	}
 }
 
@@ -225,6 +228,7 @@ var launchHeaders = map[string]string{
 	"codex":       "codex app-server",
 	"copilot":     "copilot (json)",
 	"cursor":      "cursor-agent (stream-json)",
+	"devin":       "devin acp",
 	"hermes":      "hermes acp",
 	"kimi":        "kimi acp",
 	"kiro":        "kiro-cli acp",

--- a/server/pkg/agent/devin.go
+++ b/server/pkg/agent/devin.go
@@ -1,0 +1,482 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// devinBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. `acp` is the protocol subcommand,
+// and --permission-mode=dangerous ensures autonomous operation (auto-approve
+// every tool) since there is no human in the loop for Multica agent runs.
+var devinBlockedArgs = map[string]blockedArgMode{
+	"acp":                blockedStandalone,
+	"--permission-mode":  blockedWithValue,
+	"--config":           blockedWithValue,
+	"--agent-config":     blockedWithValue,
+}
+
+// devinBackend implements Backend by spawning `devin acp` and communicating
+// via the standard ACP JSON-RPC 2.0 transport over stdin/stdout.
+//
+// Devin CLI (v2026.5.26+) advertises loadSession, returns models from
+// session/new, and supports session/set_model, so the existing Hermes/Kimi ACP
+// client can drive it with only provider-specific launch and tool-name
+// normalization.
+type devinBackend struct {
+	cfg Config
+}
+
+func (b *devinBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "devin"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("devin executable not found at %q: %w", execPath, err)
+	}
+
+	// Translate the agent's mcp_config (Claude-style object of objects)
+	// into the array shape ACP `session/new` and `session/load` expect.
+	// Fail closed on malformed JSON so the launch surfaces the real error
+	// instead of silently dropping all MCP servers.
+	mcpServers, err := buildACPMcpServers(opts.McpConfig, b.cfg.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("devin: invalid mcp_config: %w", err)
+	}
+
+	timeout := opts.Timeout
+	runCtx, cancel := runContext(ctx, timeout)
+
+	devinArgs := append([]string{"acp", "--permission-mode=dangerous"}, filterCustomArgs(opts.CustomArgs, devinBlockedArgs, b.cfg.Logger)...)
+	cmd := exec.CommandContext(runCtx, execPath, devinArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", devinArgs)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("devin stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("devin stdin pipe: %w", err)
+	}
+	// StderrPipe + an explicit copier give us a join point
+	// (`stderrDone`) that fires before the failure-promotion
+	// decision; see the matching comment in hermes.go for why the
+	// io.MultiWriter form races with stopReason=end_turn under load.
+	providerErr := newACPProviderErrorSniffer("devin")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("devin stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start devin: %w", err)
+	}
+
+	stderrSink := io.MultiWriter(newLogWriter(b.cfg.Logger, "[devin:stderr] "), providerErr)
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(stderrSink, stderr)
+	}()
+
+	b.cfg.Logger.Info("devin acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var outputMu sync.Mutex
+	var output strings.Builder
+	var streamingCurrentTurn atomic.Bool
+	var sawCompletedGoalComplete atomic.Bool
+	var sawCompletedIssueComment atomic.Bool
+	var goalCompleteCallIDs sync.Map
+	var issueCommentCallIDs sync.Map
+
+	promptDone := make(chan hermesPromptResult, 1)
+
+	c := &hermesClient{
+		cfg:          b.cfg,
+		stdin:        stdin,
+		pending:      make(map[int]*pendingRPC),
+		pendingTools: make(map[string]*pendingToolCall),
+		acceptNotification: func(string) bool {
+			return streamingCurrentTurn.Load()
+		},
+		onMessage: func(msg Message) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			if msg.Type == MessageToolUse {
+				msg.Tool = devinToolNameFromTitle(msg.Tool)
+				if msg.Tool == "goal_complete" && msg.CallID != "" {
+					goalCompleteCallIDs.Store(msg.CallID, struct{}{})
+				}
+				if msg.CallID != "" && isDevinIssueCommentAddTool(msg) {
+					issueCommentCallIDs.Store(msg.CallID, struct{}{})
+				}
+			}
+			if msg.Type == MessageToolResult {
+				if _, ok := goalCompleteCallIDs.LoadAndDelete(msg.CallID); ok {
+					sawCompletedGoalComplete.Store(msg.Status == "completed")
+				}
+				if _, ok := issueCommentCallIDs.LoadAndDelete(msg.CallID); ok {
+					sawCompletedIssueComment.Store(msg.Status == "completed")
+				}
+			}
+			if msg.Type == MessageText {
+				outputMu.Lock()
+				output.WriteString(msg.Content)
+				outputMu.Unlock()
+			}
+			trySend(msgCh, msg)
+		},
+		onPromptDone: func(result hermesPromptResult) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			select {
+			case promptDone <- result:
+			default:
+			}
+		},
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("devin process exited"))
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+		var sessionID string
+
+		initResult, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("devin initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// Drop MCP entries whose remote transport the runtime didn't
+		// advertise. See the matching comment in hermes.go for why
+		// unconditionally sending http/sse to a stdio-only ACP runtime
+		// tanks the whole session/new.
+		mcpServers = filterACPMcpServersByCapability(mcpServers, extractACPMcpCapabilities(initResult), "devin", b.cfg.Logger)
+
+		cwd := opts.Cwd
+		if cwd == "" {
+			cwd = "."
+		}
+
+		if opts.ResumeSessionID != "" {
+			result, err := c.request(runCtx, "session/load", map[string]any{
+				"cwd":        cwd,
+				"sessionId":  opts.ResumeSessionID,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("devin session/load failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			// Apply the same defensive resolution kimi/hermes use: if
+			// devin echoes a sessionId in the session/load response, prefer
+			// it (the canonical id the backend is committed to). When the
+			// response is empty or doesn't include sessionId — devin's
+			// current observed shape — the helper falls back to the
+			// requested id, preserving today's behavior. Fixing this here
+			// too means a future devin that DOES return a different id on
+			// silent state reset is handled the same way as hermes/kimi.
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "devin",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
+		} else {
+			result, err := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": mcpServers,
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("devin session/new failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			sessionID = extractACPSessionID(result)
+			if sessionID == "" {
+				finalStatus = "failed"
+				finalError = "devin session/new returned no session ID"
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+		}
+
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("devin session created", "session_id", sessionID)
+
+		if opts.Model != "" {
+			if _, err := c.request(runCtx, "session/set_model", map[string]any{
+				"sessionId": sessionID,
+				"modelId":   opts.Model,
+			}); err != nil {
+				b.cfg.Logger.Warn("devin set_session_model failed", "error", err, "requested_model", opts.Model)
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("devin could not switch to model %q: %v", opts.Model, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// On a resumed session with a model override, the dead
+					// session surfaces here instead of at session/prompt.
+					// Same fix as the prompt path below: clear the id so
+					// the daemon's resume-failure fallback retries fresh.
+					b.cfg.Logger.Warn("resumed session not found at set_model time; clearing session id so the daemon retries fresh",
+						"backend", "devin",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
+				resCh <- Result{
+					Status:     finalStatus,
+					Error:      finalError,
+					DurationMs: time.Since(startTime).Milliseconds(),
+					SessionID:  sessionID,
+				}
+				return
+			}
+			b.cfg.Logger.Info("devin session model set", "model", opts.Model)
+		}
+
+		userText := prompt
+		if opts.SystemPrompt != "" {
+			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
+		}
+
+		promptBlocks := []map[string]any{
+			{"type": "text", "text": userText},
+		}
+		// Send prompt field per standard ACP shape.
+		streamingCurrentTurn.Store(true)
+		_, err = c.request(runCtx, "session/prompt", map[string]any{
+			"sessionId": sessionID,
+			"prompt":    promptBlocks,
+		})
+		if err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("devin timed out after %s", timeout)
+			} else if runCtx.Err() == context.Canceled {
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			} else {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("devin session/prompt failed: %v", err)
+				if (sawCompletedGoalComplete.Load() || sawCompletedIssueComment.Load()) && isDevinGoalCompleteCloseError(err) {
+					b.cfg.Logger.Warn("devin session/prompt failed after completed task result; preserving completed task status", "error", err)
+					finalStatus = "completed"
+					finalError = ""
+				} else if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					// See the hermes backend: the runtime echoes the
+					// requested id back from session/resume even when
+					// the session is gone, so the stale id only fails
+					// here, at prompt time. Empty SessionID lets the
+					// daemon's resume-failure fallback retry fresh and
+					// store the replacement id.
+					b.cfg.Logger.Warn("resumed session not found at prompt time; clearing session id so the daemon retries fresh",
+						"backend", "devin",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
+			}
+		} else {
+			select {
+			case pr := <-promptDone:
+				if pr.stopReason == "cancelled" {
+					finalStatus = "aborted"
+					finalError = "devin cancelled the prompt"
+				}
+				c.usageMu.Lock()
+				c.usage.InputTokens += pr.usage.InputTokens
+				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usageMu.Unlock()
+			default:
+			}
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("devin finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		stdin.Close()
+		cancel()
+
+		<-readerDone
+		// Ensure the stderr copier has drained before consulting the
+		// provider-error sniffer; see hermes.go for the failure mode.
+		<-stderrDone
+
+		outputMu.Lock()
+		finalOutput := output.String()
+		outputMu.Unlock()
+
+		// Promote completed→failed when stderr or the agent text
+		// stream show a terminal upstream-LLM failure (HTTP 4xx /
+		// rate-limit / expired token). See the helper docs for the
+		// full signal set; the key safety property is that transient
+		// per-attempt warnings followed by a successful retry stay
+		// "completed".
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		var usageMap map[string]TokenUsage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     finalOutput,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      usageMap,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func isDevinGoalCompleteCloseError(err error) bool {
+	var rpcErr *acpRPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	if rpcErr.Method != "session/prompt" || rpcErr.Code != -32603 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(rpcErr.Message), "Internal error") {
+		return false
+	}
+	return strings.Contains(strings.ToLower(rpcErr.Data), "failed to generate a response")
+}
+
+func isDevinIssueCommentAddTool(msg Message) bool {
+	if msg.Tool != "terminal" {
+		return false
+	}
+	command, _ := msg.Input["command"].(string)
+	return isDevinIssueCommentAddCommand(command)
+}
+
+func isDevinIssueCommentAddCommand(command string) bool {
+	parts := trimLeadingEnvAssignments(strings.Fields(command))
+	// Some runtimes route terminal calls through a shell wrapper such as
+	// `sh -c "multica issue comment add ..."`; unwrap a single such layer so
+	// the real invocation is still recognized.
+	if len(parts) >= 3 && isPOSIXShellName(parts[0]) && parts[1] == "-c" {
+		inner := strings.Trim(strings.Join(parts[2:], " "), "\"'")
+		parts = trimLeadingEnvAssignments(strings.Fields(inner))
+	}
+	if len(parts) < 4 {
+		return false
+	}
+	executable := strings.TrimPrefix(parts[0], "./")
+	if executable != "multica" && !strings.HasSuffix(executable, "/multica") {
+		return false
+	}
+	return parts[1] == "issue" && parts[2] == "comment" && parts[3] == "add"
+}
+
+func devinToolNameFromTitle(title string) string {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return ""
+	}
+
+	if idx := strings.Index(t, ":"); idx > 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
+
+	lower := strings.ToLower(t)
+	switch lower {
+	case "read", "read file":
+		return "read_file"
+	case "write", "write file":
+		return "write_file"
+	case "edit", "patch":
+		return "edit_file"
+	case "shell", "bash", "terminal", "run command", "run shell command":
+		return "terminal"
+	case "grep", "search", "find":
+		return "search_files"
+	case "glob":
+		return "glob"
+	case "code":
+		return "code"
+	case "web search":
+		return "web_search"
+	case "fetch", "web fetch":
+		return "web_fetch"
+	case "todo", "todo write", "todo list", "todo_list":
+		return "todo_write"
+	}
+
+	return strings.ReplaceAll(lower, " ", "_")
+}

--- a/server/pkg/agent/devin_test.go
+++ b/server/pkg/agent/devin_test.go
@@ -1,0 +1,236 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewReturnsDevinBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("devin", Config{ExecutablePath: "/nonexistent/devin"})
+	if err != nil {
+		t.Fatalf("New(devin) error: %v", err)
+	}
+	if _, ok := b.(*devinBackend); !ok {
+		t.Fatalf("expected *devinBackend, got %T", b)
+	}
+}
+
+func TestDevinToolNameFromTitle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Read file: /tmp/foo.go", "read_file"},
+		{"Write: /tmp/bar.go", "write_file"},
+		{"Patch: /tmp/x", "edit_file"},
+		{"Shell: ls -la", "terminal"},
+		{"Run command: pwd", "terminal"},
+		{"grep", "search_files"},
+		{"Glob: *.go", "glob"},
+		{"Code", "code"},
+		{"Todo List", "todo_write"},
+		{"Custom Thing", "custom_thing"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := devinToolNameFromTitle(tt.title)
+		if got != tt.want {
+			t.Errorf("devinToolNameFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
+		}
+	}
+}
+
+func fakeDevinACPScript() string {
+	return `#!/bin/sh
+if [ -n "$DEVIN_ARGS_FILE" ]; then
+  for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$DEVIN_ARGS_FILE"
+  done
+fi
+while IFS= read -r line; do
+  if [ -n "$DEVIN_REQUESTS_FILE" ]; then
+    printf '%s\n' "$line" >> "$DEVIN_REQUESTS_FILE"
+  fi
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_new","models":{"currentModelId":"opus","availableModels":[{"modelId":"opus","name":"opus"}]}}}\n' "$id"
+      ;;
+    *'"method":"session/load"'*)
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"history should be ignored"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"UsageUpdate","usage":{"inputTokens":1000,"outputTokens":1000,"cachedReadTokens":100}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"ToolCall","toolCallId":"tc-current","name":"Shell","status":"pending","parameters":{"command":"echo replay"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+    *'"method":"session/set_model"'*)
+      case "$line" in
+        *bogus-model*)
+          printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"model not available: bogus-model"}}\n' "$id"
+          exit 0
+          ;;
+        *)
+          printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+          ;;
+      esac
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"ToolCallUpdate","toolCallId":"tc-current","status":"completed","name":"Shell","parameters":{"command":"echo current"},"output":"current tool output\\n"}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"loaded"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":2,"outputTokens":1}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestDevinBackendSetModelFailureFailsTask(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "devin")
+	writeTestExecutable(t, fakePath, []byte(fakeDevinACPScript()))
+
+	backend, err := New("devin", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new devin backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Model:   "bogus-model",
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, `could not switch to model "bogus-model"`) {
+			t.Errorf("expected error to name the requested model, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "model not available") {
+			t.Errorf("expected error to surface upstream message, got %q", result.Error)
+		}
+		if result.SessionID != "ses_new" {
+			t.Errorf("expected session id to be preserved on failure, got %q", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func fakeDevinACPGoalCompleteCloseErrorScript(goalStatus string) string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_goal_done"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCall","toolCallId":"tc-goal","name":"goal_complete","status":"pending","parameters":{}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_goal_done","update":{"type":"ToolCallUpdate","toolCallId":"tc-goal","status":"` + goalStatus + `","name":"goal_complete","output":"ok"}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"Internal error","data":"Devin failed to generate a response"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestDevinBackendTreatsGoalCompleteCloseErrorAsCompleted(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "devin")
+	writeTestExecutable(t, fakePath, []byte(fakeDevinACPGoalCompleteCloseErrorScript("completed")))
+
+	backend, err := New("devin", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new devin backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed after goal_complete close error, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Error != "" {
+			t.Fatalf("expected close-handshake error to be suppressed, got %q", result.Error)
+		}
+		if result.SessionID != "ses_goal_done" {
+			t.Fatalf("session id = %q, want ses_goal_done", result.SessionID)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
+func TestDevinIssueCommentAddCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{"multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"./multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"/usr/local/bin/multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"MULTICA_TOKEN=x multica issue comment add issue-1 --content-file ./reply.md", true},
+		{"FOO=1 BAR=2 ./multica issue comment add issue-1", true},
+		{`sh -c "multica issue comment add issue-1 --content-file ./reply.md"`, true},
+		{`bash -c 'multica issue comment add issue-1'`, true},
+		{`/bin/sh -c "multica issue comment add issue-1"`, true},
+		{"multica issue get issue-1", false},
+		{"echo multica issue comment add issue-1", false},
+		{`sh -c "echo multica issue comment add issue-1"`, false},
+		{"FOO=bar", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isDevinIssueCommentAddCommand(tt.command); got != tt.want {
+			t.Errorf("isDevinIssueCommentAddCommand(%q) = %v, want %v", tt.command, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds first-class Devin CLI runtime support via ACP (Agent Communication Protocol) adapter, mirroring the existing hermes/kimi/kiro pattern.

## Changes

### Backend (`server/pkg/agent/`)
- **`devin.go`** — New ACP adapter spawning `devin acp --permission-mode=dangerous`
  - JSON-RPC 2.0 over stdio transport
  - Session lifecycle: `initialize` → `session/new`/`session/load` → `session/set_model` → `session/prompt`
  - Tool-call normalization (`devinToolNameFromTitle`)
  - Goal-complete & issue-comment-add close-error handling
  - Provider error detection & result promotion
- **`devin_test.go`** — Comprehensive test coverage
  - Backend instantiation
  - Tool name normalization
  - Model override failures
  - Goal-complete close-error handling
  - Issue comment detection
  - All tests passing ✓
- **`agent.go`** — Registration
  - Added "devin" to `SupportedTypes` whitelist
  - Registered `devinBackend` in `New()` switch
  - Added `launchHeaders["devin"] = "devin acp"`

### ExecEnv (`server/internal/daemon/execenv/`)
- **`context.go`** — Skills path mapping: `.devin/skills/` (native Devin CLI discovery)
- **`runtime_config.go`** — Config file mapping: `AGENTS.md` (read natively by Devin CLI)

### Frontend (`packages/core/types/`)
- **`agent.ts`** — Added "devin" to `RUNTIME_PROFILE_PROTOCOL_FAMILIES` (enables custom runtime profiles based on Devin)

## Protocol Details

- **Adapter type:** ACP (JSON-RPC 2.0 over stdio)
- **Command:** `devin acp --permission-mode=dangerous`
- **Permission mode:** `dangerous` for autonomous runs (auto-approve all tools, no human in loop) — matches codex/gemini `--yolo` posture
- **Models:** Static list (`opus`, `sonnet`, `swe`, `gpt`) — Devin CLI has no `--list-models` command
- **Auth:** User-managed via `devin auth` (must run once per host) — Multica cannot inject API keys
- **Pricing:** Devin-side (billed to Devin user accounts, not Multica)

## Testing

```bash
cd server
go test -v ./pkg/agent -run "TestDevin"
```

All tests passing ✓

## Upstream Context

- Implements support requested in [multica-ai/multica#4071](https://github.com/multica-ai/multica/issues/4071)
- Uses ACP (recommended path per upstream issue)
- Devin CLI ≥v2026.5.26 required

## Breaking Changes

None. This is a new backend type, not a modification of existing ones.

## Migration Required

None. No schema changes.

## Related Issues

Closes WIN-76
