### PR TITLE
WS-1261: add gated skill invocation trace (MUL-3939)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ MULTICA_DAEMON_ID=
 MULTICA_DAEMON_DEVICE_NAME=
 MULTICA_DAEMON_POLL_INTERVAL=3s
 MULTICA_DAEMON_HEARTBEAT_INTERVAL=15s
+# Opt-in daemon-local JSONL trace of mounted skill behavior. Empty/false keeps
+# the trace disabled. When enabled without an explicit path, the daemon writes
+# to <workspaces_root>/skill-invocations.jsonl.
+MULTICA_SKILL_TRACE_ENABLED=
+MULTICA_SKILL_TRACE_PATH=
 MULTICA_CODEX_PATH=codex
 MULTICA_CODEX_MODEL=
 MULTICA_CODEX_WORKDIR=

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -183,6 +183,8 @@ Daemon behavior is configured via flags or environment variables:
 | GC orphan TTL (no `.gc_meta.json`) | — | `MULTICA_GC_ORPHAN_TTL` | `72h` |
 | GC artifact TTL (open issues) | — | `MULTICA_GC_ARTIFACT_TTL` | `12h` (set `0` to disable) |
 | GC artifact patterns | — | `MULTICA_GC_ARTIFACT_PATTERNS` | `node_modules,.next,.turbo` |
+| Skill trace enabled | — | `MULTICA_SKILL_TRACE_ENABLED` | disabled (set `true`/`1`/`yes`/`on` to enable) |
+| Skill trace path | — | `MULTICA_SKILL_TRACE_PATH` | `<workspaces_root>/skill-invocations.jsonl` |
 
 #### Workspace garbage collection
 
@@ -193,6 +195,12 @@ The daemon periodically scans `MULTICA_WORKSPACES_ROOT` and reclaims disk space 
 - **Artifact-only cleanup** — when a task has been completed for at least `MULTICA_GC_ARTIFACT_TTL` but the issue is still open, regenerable build outputs whose directory basename matches `MULTICA_GC_ARTIFACT_PATTERNS` are removed; the rest of the workdir (source, `.git`, `output/`, `logs/`, `.gc_meta.json`) is preserved so the agent can resume the same workdir on the next task.
 
 Patterns are basename-only — entries containing `/` or `\` are silently dropped — and `.git` subtrees are never descended into. The default list (`node_modules`, `.next`, `.turbo`) is intentionally narrow; extend it per deployment if your repos consistently produce other regenerable directories (for example, `MULTICA_GC_ARTIFACT_PATTERNS=node_modules,.next,.turbo,target,__pycache__`). To disable artifact cleanup entirely, set `MULTICA_GC_ARTIFACT_TTL=0`.
+
+#### Skill behavior trace
+
+`MULTICA_SKILL_TRACE_ENABLED=true` turns on a daemon-local append-only JSONL stream for skill adoption analysis. It is disabled by default and is not shipped to PostHog. Each line includes task/workspace/agent/runtime/machine metadata plus the skill id/name/source/hash.
+
+The daemon emits `skill_loaded` when an agent's mounted skill is materialized for a task. It emits `skill_invoked` only for explicit chat slash-skill links (`slash://skill/<id>`) that match one of the mounted skills. Provider-internal model choices are not inferred, because agent CLIs do not expose a portable "model used this skill" event.
 
 Agent-specific overrides:
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	GCOrphanTTL                    time.Duration         // clean orphan dirs with no meta, or dirs whose issue gc-check returns 404, once they exceed this age (default: 72h). The 404 path uses the same TTL — a scoped-down token can't instantly wipe live workspaces.
 	GCArtifactTTL                  time.Duration         // when a task has been completed for at least this long but its issue is still open, drop regenerable artifacts (default: 12h, set 0 to disable)
 	GCArtifactPatterns             []string              // basename patterns whose subtrees are removed during artifact cleanup (default: node_modules, .next, .turbo)
+	SkillTraceEnabled              bool                  // opt-in local JSONL skill behavior trace (default: false)
+	SkillTracePath                 string                // append-only JSONL target for skill trace events
 	AutoUpdateEnabled              bool                  // periodically check for a newer CLI release and self-update when idle (default: true on Multica Cloud, false on self-host)
 	AutoUpdateCheckInterval        time.Duration         // how often the auto-update loop polls for a new release (default: 6h)
 	PollInterval                   time.Duration
@@ -453,6 +455,12 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// Keep env after task: env > default (false)
 	keepEnv := os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "true" || os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "1"
 
+	skillTraceEnabled := envBool("MULTICA_SKILL_TRACE_ENABLED")
+	skillTracePath := strings.TrimSpace(os.Getenv("MULTICA_SKILL_TRACE_PATH"))
+	if skillTracePath == "" {
+		skillTracePath = filepath.Join(workspacesRoot, "skill-invocations.jsonl")
+	}
+
 	// GC config: env > defaults
 	gcEnabled := true
 	if v := os.Getenv("MULTICA_GC_ENABLED"); v == "false" || v == "0" {
@@ -521,6 +529,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		GCOrphanTTL:                    gcOrphanTTL,
 		GCArtifactTTL:                  gcArtifactTTL,
 		GCArtifactPatterns:             gcArtifactPatterns,
+		SkillTraceEnabled:              skillTraceEnabled,
+		SkillTracePath:                 skillTracePath,
 		AutoUpdateEnabled:              autoUpdateEnabled,
 		AutoUpdateCheckInterval:        autoUpdateInterval,
 		HealthPort:                     healthPort,
@@ -617,6 +627,15 @@ func ResolveWorkspacesRoot(profile, override string) (string, error) {
 // matches what the GC would actually reclaim.
 func ArtifactPatternsFromEnv() []string {
 	return patternsFromEnv("MULTICA_GC_ARTIFACT_PATTERNS", DefaultGCArtifactPatterns)
+}
+
+func envBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // patternsFromEnv reads a comma-separated list from env. Patterns containing

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -37,6 +37,45 @@ func TestPatternsFromEnv_DropsSeparatorBearingEntries(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_SkillTraceDisabledByDefault(t *testing.T) {
+	stageFakeAgent(t)
+	root := t.TempDir()
+	cfg, err := LoadConfig(Overrides{
+		ServerURL:      "http://localhost:8080",
+		WorkspacesRoot: root,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.SkillTraceEnabled {
+		t.Fatal("SkillTraceEnabled = true by default, want false")
+	}
+	if cfg.SkillTracePath != filepath.Join(root, "skill-invocations.jsonl") {
+		t.Fatalf("SkillTracePath = %q, want default under workspaces root", cfg.SkillTracePath)
+	}
+}
+
+func TestLoadConfig_SkillTraceEnabledFromEnv(t *testing.T) {
+	stageFakeAgent(t)
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	t.Setenv("MULTICA_SKILL_TRACE_ENABLED", "true")
+	t.Setenv("MULTICA_SKILL_TRACE_PATH", path)
+
+	cfg, err := LoadConfig(Overrides{
+		ServerURL:      "http://localhost:8080",
+		WorkspacesRoot: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.SkillTraceEnabled {
+		t.Fatal("SkillTraceEnabled = false, want true from env")
+	}
+	if cfg.SkillTracePath != path {
+		t.Fatalf("SkillTracePath = %q, want env path %q", cfg.SkillTracePath, path)
+	}
+}
+
 func TestIsSafeAgentName(t *testing.T) {
 	for _, tc := range []struct {
 		in   string

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -155,6 +155,7 @@ type Daemon struct {
 	client     *Client
 	repoCache  repoCacheBackend
 	skillCache *SkillBundleCache
+	skillTrace *SkillTraceRecorder
 	logger     *slog.Logger
 
 	mu           sync.Mutex
@@ -257,6 +258,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		client:                    client,
 		repoCache:                 repocache.New(cacheRoot, logger),
 		skillCache:                NewSkillBundleCache(skillCacheRoot),
+		skillTrace:                NewSkillTraceRecorder(cfg),
 		logger:                    logger,
 		workspaces:                make(map[string]*workspaceState),
 		runtimeIndex:              make(map[string]Runtime),
@@ -871,6 +873,31 @@ func (d *Daemon) findRuntime(id string) *Runtime {
 		return &rt
 	}
 	return nil
+}
+
+func (d *Daemon) skillTraceMetaForTask(task Task, provider string) skillTraceMeta {
+	meta := skillTraceMeta{
+		Provider:      provider,
+		MachineID:     d.cfg.DaemonID,
+		DeviceName:    d.cfg.DeviceName,
+		DaemonProfile: d.cfg.Profile,
+	}
+	if rt := d.findRuntime(task.RuntimeID); rt != nil {
+		meta.RuntimeProfileID = rt.ProfileID
+	}
+	return meta
+}
+
+func (d *Daemon) recordSkillTrace(task Task, skills []SkillData, provider string, taskLog *slog.Logger) {
+	if d.skillTrace == nil || !d.skillTrace.Enabled() {
+		return
+	}
+	events := buildSkillTraceEvents(task, skills, d.skillTraceMetaForTask(task, provider))
+	if err := d.skillTrace.Record(events); err != nil {
+		if taskLog != nil {
+			taskLog.Warn("skill trace write failed (non-fatal)", "error", err)
+		}
+	}
 }
 
 // recordProfileLaunch remembers the absolute executable path and fixed launch
@@ -3644,6 +3671,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, fmt.Errorf("start task failed: %w", err)
 	}
 	stopPrepareLease()
+	d.recordSkillTrace(task, skills, provider, taskLog)
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
 	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, taskLog)

--- a/server/internal/daemon/skill_trace.go
+++ b/server/internal/daemon/skill_trace.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	SkillTraceEventLoaded  = "skill_loaded"
+	SkillTraceEventInvoked = "skill_invoked"
+
+	SkillTraceTriggerImplicit = "implicit"
+	SkillTraceTriggerExplicit = "explicit"
+)
+
+type skillTraceMeta struct {
+	Provider         string
+	MachineID        string
+	DeviceName       string
+	DaemonProfile    string
+	RuntimeProfileID string
+}
+
+// SkillTraceEvent is one append-only skill behavior record. The stream is
+// intentionally local and gated; external curator jobs can consume the JSONL
+// without coupling skill adoption measurement to token billing.
+type SkillTraceEvent struct {
+	EventType        string    `json:"event_type"`
+	TS               time.Time `json:"ts"`
+	WorkspaceID      string    `json:"workspace_id,omitempty"`
+	TaskID           string    `json:"task_id,omitempty"`
+	IssueID          string    `json:"issue_id,omitempty"`
+	ChatSessionID    string    `json:"chat_session_id,omitempty"`
+	AutopilotRunID   string    `json:"autopilot_run_id,omitempty"`
+	AgentID          string    `json:"agent_id,omitempty"`
+	AgentName        string    `json:"agent_name,omitempty"`
+	RuntimeID        string    `json:"runtime_id,omitempty"`
+	Provider         string    `json:"provider,omitempty"`
+	RuntimeProfileID string    `json:"runtime_profile_id,omitempty"`
+	DaemonProfile    string    `json:"daemon_profile,omitempty"`
+	MachineID        string    `json:"machine_id,omitempty"`
+	DeviceName       string    `json:"device_name,omitempty"`
+	EmployeeID       string    `json:"employee_id,omitempty"`
+	EmployeeName     string    `json:"employee_name,omitempty"`
+	EmployeeType     string    `json:"employee_type,omitempty"`
+	SkillID          string    `json:"skill_id,omitempty"`
+	SkillName        string    `json:"skill_name,omitempty"`
+	SkillSource      string    `json:"skill_source,omitempty"`
+	SkillHash        string    `json:"skill_hash,omitempty"`
+	Trigger          string    `json:"trigger"`
+}
+
+type SkillTraceRecorder struct {
+	enabled bool
+	path    string
+	mu      sync.Mutex
+}
+
+func NewSkillTraceRecorder(cfg Config) *SkillTraceRecorder {
+	return &SkillTraceRecorder{
+		enabled: cfg.SkillTraceEnabled,
+		path:    cfg.SkillTracePath,
+	}
+}
+
+func (r *SkillTraceRecorder) Enabled() bool {
+	return r != nil && r.enabled
+}
+
+func (r *SkillTraceRecorder) Record(events []SkillTraceEvent) error {
+	if !r.Enabled() || len(events) == 0 {
+		return nil
+	}
+	if r.path == "" {
+		return fmt.Errorf("skill trace path is empty")
+	}
+
+	now := time.Now().UTC()
+	for i := range events {
+		if events[i].TS.IsZero() {
+			events[i].TS = now
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return fmt.Errorf("create skill trace directory: %w", err)
+	}
+	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open skill trace file: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			return fmt.Errorf("write skill trace event: %w", err)
+		}
+	}
+	return nil
+}
+
+func buildSkillTraceEvents(task Task, skills []SkillData, meta skillTraceMeta) []SkillTraceEvent {
+	if len(skills) == 0 {
+		return nil
+	}
+
+	base := SkillTraceEvent{
+		WorkspaceID:      task.WorkspaceID,
+		TaskID:           task.ID,
+		IssueID:          task.IssueID,
+		ChatSessionID:    task.ChatSessionID,
+		AutopilotRunID:   task.AutopilotRunID,
+		RuntimeID:        task.RuntimeID,
+		Provider:         meta.Provider,
+		RuntimeProfileID: meta.RuntimeProfileID,
+		DaemonProfile:    meta.DaemonProfile,
+		MachineID:        meta.MachineID,
+		DeviceName:       meta.DeviceName,
+	}
+	if task.Agent != nil {
+		base.AgentID = task.Agent.ID
+		base.AgentName = task.Agent.Name
+	}
+	populateSkillTraceEmployee(&base, task)
+
+	events := make([]SkillTraceEvent, 0, len(skills))
+	byID := make(map[string]SkillData, len(skills))
+	for _, skill := range skills {
+		byID[skill.ID] = skill
+		events = append(events, skillTraceEventForSkill(base, skill, SkillTraceEventLoaded, SkillTraceTriggerImplicit))
+	}
+
+	for _, ref := range ExtractSlashSkills(task.ChatMessage) {
+		skill, ok := byID[ref.ID]
+		if !ok {
+			continue
+		}
+		events = append(events, skillTraceEventForSkill(base, skill, SkillTraceEventInvoked, SkillTraceTriggerExplicit))
+	}
+
+	return events
+}
+
+func skillTraceEventForSkill(base SkillTraceEvent, skill SkillData, eventType, trigger string) SkillTraceEvent {
+	ev := base
+	ev.EventType = eventType
+	ev.SkillID = skill.ID
+	ev.SkillName = skill.Name
+	ev.SkillSource = skill.Source
+	ev.SkillHash = skill.Hash
+	ev.Trigger = trigger
+	return ev
+}
+
+func populateSkillTraceEmployee(ev *SkillTraceEvent, task Task) {
+	if task.InitiatorName != "" || task.InitiatorID != "" || task.InitiatorType != "" {
+		ev.EmployeeID = task.InitiatorID
+		ev.EmployeeName = task.InitiatorName
+		ev.EmployeeType = task.InitiatorType
+		return
+	}
+	if task.RequestingUserName != "" {
+		ev.EmployeeName = task.RequestingUserName
+		ev.EmployeeType = "runtime_owner"
+	}
+}

--- a/server/internal/daemon/skill_trace_test.go
+++ b/server/internal/daemon/skill_trace_test.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillTraceRecorderDisabledDoesNotCreateFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	rec := NewSkillTraceRecorder(Config{SkillTracePath: path})
+
+	if rec.Enabled() {
+		t.Fatal("recorder should be disabled unless SkillTraceEnabled is true")
+	}
+	if err := rec.Record([]SkillTraceEvent{{EventType: SkillTraceEventLoaded, SkillID: "skill-1"}}); err != nil {
+		t.Fatalf("Record on disabled recorder should be a no-op, got %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("disabled recorder should not create %s, stat err=%v", path, err)
+	}
+}
+
+func TestSkillTraceRecorderAppendsJSONLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "traces", "skill-invocations.jsonl")
+	rec := NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path})
+
+	events := []SkillTraceEvent{
+		{EventType: SkillTraceEventLoaded, WorkspaceID: "ws-1", TaskID: "task-1", SkillID: "skill-1", SkillName: "deploy", SkillSource: "workspace", Trigger: SkillTraceTriggerImplicit},
+		{EventType: SkillTraceEventInvoked, WorkspaceID: "ws-1", TaskID: "task-1", SkillID: "skill-1", SkillName: "deploy", SkillSource: "workspace", Trigger: SkillTraceTriggerExplicit},
+	}
+	if err := rec.Record(events); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	got := readSkillTraceEvents(t, path)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].TS.IsZero() || got[1].TS.IsZero() {
+		t.Fatalf("events should be timestamped: %+v", got)
+	}
+	if got[0].EventType != SkillTraceEventLoaded || got[0].Trigger != SkillTraceTriggerImplicit {
+		t.Fatalf("first event = %+v, want implicit loaded event", got[0])
+	}
+	if got[1].EventType != SkillTraceEventInvoked || got[1].Trigger != SkillTraceTriggerExplicit {
+		t.Fatalf("second event = %+v, want explicit invocation event", got[1])
+	}
+}
+
+func TestBuildSkillTraceEventsSeparatesLoadedAndExplicitInvocations(t *testing.T) {
+	task := Task{
+		ID:            "task-1",
+		WorkspaceID:   "ws-1",
+		IssueID:       "issue-1",
+		RuntimeID:     "rt-1",
+		ChatSessionID: "chat-1",
+		ChatMessage:   "[/Deploy](slash://skill/skill-1) and again [/Deploy](slash://skill/skill-1) plus [/Unknown](slash://skill/missing)",
+		InitiatorType: "member",
+		InitiatorID:   "member-1",
+		InitiatorName: "Jane Doe",
+		Agent: &AgentData{
+			ID:   "agent-1",
+			Name: "Builder",
+		},
+	}
+	skills := []SkillData{
+		{ID: "skill-1", Source: "workspace", Name: "deploy", Hash: "sha256:one"},
+		{ID: "skill-2", Source: "builtin", Name: "multica-working-on-issues", Hash: "sha256:two"},
+	}
+	meta := skillTraceMeta{
+		Provider:         "codex",
+		MachineID:        "daemon-1",
+		DeviceName:       "laptop",
+		DaemonProfile:    "default",
+		RuntimeProfileID: "profile-1",
+	}
+
+	events := buildSkillTraceEvents(task, skills, meta)
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want two loaded events and one explicit invocation: %+v", len(events), events)
+	}
+
+	if events[0].EventType != SkillTraceEventLoaded || events[0].SkillID != "skill-1" || events[0].Trigger != SkillTraceTriggerImplicit {
+		t.Fatalf("event[0] = %+v, want implicit loaded skill-1", events[0])
+	}
+	if events[1].EventType != SkillTraceEventLoaded || events[1].SkillID != "skill-2" || events[1].Trigger != SkillTraceTriggerImplicit {
+		t.Fatalf("event[1] = %+v, want implicit loaded skill-2", events[1])
+	}
+	if events[2].EventType != SkillTraceEventInvoked || events[2].SkillID != "skill-1" || events[2].Trigger != SkillTraceTriggerExplicit {
+		t.Fatalf("event[2] = %+v, want explicit invocation for skill-1", events[2])
+	}
+	if events[2].EmployeeID != "member-1" || events[2].EmployeeName != "Jane Doe" || events[2].EmployeeType != "member" {
+		t.Fatalf("employee fields = (%q,%q,%q), want member initiator", events[2].EmployeeID, events[2].EmployeeName, events[2].EmployeeType)
+	}
+	if events[2].AgentID != "agent-1" || events[2].AgentName != "Builder" || events[2].RuntimeProfileID != "profile-1" {
+		t.Fatalf("agent/runtime fields not propagated: %+v", events[2])
+	}
+}
+
+func TestDaemonRecordSkillTraceWritesRuntimeMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "skill-invocations.jsonl")
+	d := &Daemon{
+		cfg: Config{
+			DaemonID:   "daemon-1",
+			DeviceName: "laptop",
+			Profile:    "default",
+		},
+		skillTrace: NewSkillTraceRecorder(Config{SkillTraceEnabled: true, SkillTracePath: path}),
+		runtimeIndex: map[string]Runtime{
+			"rt-1": {ID: "rt-1", Provider: "codex", ProfileID: "profile-1"},
+		},
+	}
+	task := Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		RuntimeID:   "rt-1",
+		ChatMessage: "[/Deploy](slash://skill/skill-1)",
+		Agent: &AgentData{
+			ID:   "agent-1",
+			Name: "Builder",
+		},
+	}
+	skills := []SkillData{{ID: "skill-1", Source: "workspace", Name: "deploy", Hash: "sha256:one"}}
+
+	d.recordSkillTrace(task, skills, "codex", slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	got := readSkillTraceEvents(t, path)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want loaded and explicit invocation events: %+v", len(got), got)
+	}
+	for _, ev := range got {
+		if ev.Provider != "codex" || ev.MachineID != "daemon-1" || ev.DeviceName != "laptop" || ev.DaemonProfile != "default" {
+			t.Fatalf("daemon metadata not propagated: %+v", ev)
+		}
+		if ev.RuntimeProfileID != "profile-1" {
+			t.Fatalf("runtime profile id = %q, want profile-1 in %+v", ev.RuntimeProfileID, ev)
+		}
+	}
+}
+
+func readSkillTraceEvents(t *testing.T, path string) []SkillTraceEvent {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open trace file: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var got []SkillTraceEvent
+	for scanner.Scan() {
+		var ev SkillTraceEvent
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			t.Fatalf("decode line %q: %v", scanner.Text(), err)
+		}
+		got = append(got, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan trace file: %v", err)
+	}
+	return got
+}


### PR DESCRIPTION
Refs WS-1261

Summary:
- Add a gated daemon-local append-only JSONL skill behavior trace controlled by MULTICA_SKILL_TRACE_ENABLED and MULTICA_SKILL_TRACE_PATH.
- Emit skill_loaded for mounted skills after the task is accepted as running, and skill_invoked for explicit slash-skill chat links that match mounted skills.
- Include workspace, task, agent, runtime, machine, employee, and skill metadata for curator-style adoption analysis.
- Document the env vars and semantics in the daemon guide and env example.

Tests:
- go test ./internal/daemon -run "TestSkillTrace|TestDaemonRecordSkillTrace|TestLoadConfig_SkillTrace" -count=1
- go test ./internal/daemon -count=1

Note:
- This intentionally does not close WS-1261 on merge. CSO L4验收 requires a post-merge daemon upgrade/demo event and a curator follow-up before the parent is done.
