### PR TITLE
Fix recovered Antigravity transcript messages

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -186,9 +186,13 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 			// produced) without writing anything to stdout, leaving a blank but
 			// "completed" run none of the guards above catch (MUL-3726). Recover
 			// the assistant text agy persisted to its conversation transcript so
-			// the user sees the actual answer instead of an empty result.
+			// the user sees the actual answer instead of an empty result. Also
+			// emit it as a MessageText event so the task transcript catches up;
+			// otherwise Result.Output becomes visible only in the synthesized
+			// final comment while the execution transcript remains blank.
 			if recovered := readAntigravityTranscriptOutput(logPath, sessionID); recovered != "" {
 				finalOutput = recovered
+				trySend(msgCh, Message{Type: MessageText, Content: recovered})
 				b.cfg.Logger.Info("agy recovered empty stdout from transcript", "bytes", len(recovered))
 			}
 		}

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -665,10 +665,6 @@ func TestAntigravityBackendRecoversEmptyStdoutFromTranscript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	go func() {
-		for range session.Messages {
-		}
-	}()
 
 	select {
 	case result, ok := <-session.Result:
@@ -690,5 +686,20 @@ func TestAntigravityBackendRecoversEmptyStdoutFromTranscript(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
+	}
+
+	var messages []Message
+	for msg := range session.Messages {
+		messages = append(messages, msg)
+	}
+	var recoveredMessage bool
+	for _, msg := range messages {
+		if msg.Type == MessageText && strings.Contains(msg.Content, "created result.txt with VERIFIED=yes") {
+			recoveredMessage = true
+			break
+		}
+	}
+	if !recoveredMessage {
+		t.Fatalf("expected recovered transcript reply to be emitted as MessageText, got %#v", messages)
 	}
 }


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Antigravity already recovers assistant text from the CLI transcript when `agy` completes with empty stdout, but that recovered text only became `Result.Output`. The daemon can synthesize a final issue comment from that output, while the task execution transcript can still remain blank because no `MessageText` event was emitted.

This PR emits the recovered transcript reply as a normal text message before returning the completed result, so the live/persisted task transcript catches up with the final output.

Thinking path: #4779 was split from the broader runtime transcript report after Cursor/Kiro fixes. The Antigravity backend already has an empty-stdout transcript recovery path, so the smallest remaining gap is to route recovered text through the same message stream used by stdout-backed Antigravity output.

## Related Issue

Closes #4779

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/antigravity.go`: emit recovered transcript text as `MessageText` when empty stdout is recovered from `transcript.jsonl`.
- `server/pkg/agent/antigravity_test.go`: assert that the empty-stdout recovery path populates both `Result.Output` and the message stream.

## How to Test

1. Run `go test ./pkg/agent` from `server/`.
2. Confirm `TestAntigravityBackendRecoversEmptyStdoutFromTranscript` passes and verifies recovered text is emitted as `MessageText`.
3. Attempt `make check-worktree`; this environment hit a Docker daemon connection error while starting PostgreSQL, so full worktree verification is blocked here.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: the recovered text may arrive at the end of the run instead of live while Antigravity is silent, but it uses the existing text-message pipeline and only runs when stdout is otherwise empty.

Validation:

- `go test ./pkg/agent` passed
- `git diff --check` passed
- `make check-worktree` blocked: Docker daemon was unavailable while checking PostgreSQL; the Makefile printed the Docker error and exited 0, so this is not counted as a clean full verification

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Daily automated bugfix maintenance. I checked for existing PR coverage for #4779, inspected the Antigravity empty-stdout recovery path, made the smallest backend change, and added a regression assertion around recovered task messages.

## Screenshots (optional)

N/A