### PR TITLE
[ZIC-15] Fix comment attachment URL resolution

### DIFF
--- a/packages/core/types/attachment-url.test.ts
+++ b/packages/core/types/attachment-url.test.ts
@@ -67,7 +67,12 @@ describe("attachmentIdFromDownloadURL", () => {
 });
 
 describe("contentReferencesAttachment", () => {
-  const att = { id: ID, url: "/uploads/workspaces/ws/legacy.png" };
+  const att = {
+    id: ID,
+    url: "/uploads/workspaces/ws/legacy.png",
+    download_url: "https://cdn.example.com/workspaces/ws/file.png?Signature=fresh",
+    markdown_url: `https://multica-api.copilothub.ai/api/attachments/${ID}/download`,
+  };
 
   it("matches when the markdown uses the stable download path", () => {
     const md = `body\n\n![file](${attachmentDownloadPath(ID)})\n`;
@@ -76,6 +81,22 @@ describe("contentReferencesAttachment", () => {
 
   it("matches when the markdown uses the legacy storage URL", () => {
     const md = `body\n\n![file](${att.url})\n`;
+    expect(contentReferencesAttachment(md, att)).toBe(true);
+  });
+
+  it("matches when the markdown uses the response download_url", () => {
+    const md = `body\n\n![file](${att.download_url})\n`;
+    expect(contentReferencesAttachment(md, att)).toBe(true);
+  });
+
+  it("matches when the markdown uses an older signed download_url for the same object", () => {
+    const stale = "https://cdn.example.com/workspaces/ws/file.png?Signature=stale";
+    const md = `body\n\n![file](${stale})\n`;
+    expect(contentReferencesAttachment(md, att)).toBe(true);
+  });
+
+  it("matches when the markdown uses the server-provided markdown_url", () => {
+    const md = `body\n\n![file](${att.markdown_url})\n`;
     expect(contentReferencesAttachment(md, att)).toBe(true);
   });
 
@@ -111,8 +132,7 @@ describe("contentReferencesAttachment", () => {
   // absolute-host download URL via its stable-path substring, so the
   // attachment now binds the same way comments do.
   it("matches the absolute-host markdown_url the editor actually persists", () => {
-    const markdownUrl = `https://multica-api.copilothub.ai/api/attachments/${ID}/download`;
-    const md = `body\n\n![pasted](${markdownUrl})\n`;
+    const md = `body\n\n![pasted](${att.markdown_url})\n`;
     // The raw storage url is NOT present in the body — the old
     // `md.includes(a.url)` check would have returned false here.
     expect(md.includes(att.url)).toBe(false);

--- a/packages/core/types/attachment-url.ts
+++ b/packages/core/types/attachment-url.ts
@@ -92,6 +92,17 @@ export function attachmentIdFromDownloadURL(rawURL: string): string | undefined 
   return id;
 }
 
+function stripQueryAndFragment(url: string): string {
+  return url.split(/[?#]/, 1)[0] ?? "";
+}
+
+function contentReferencesURL(content: string, url?: string): boolean {
+  if (!url) return false;
+  if (content.includes(url)) return true;
+  const stable = stripQueryAndFragment(url);
+  return stable !== "" && content.includes(stable);
+}
+
 /**
  * True when `content` contains a markdown reference to `attachment` —
  * either the new stable `/api/attachments/<id>/download` shape OR the
@@ -109,10 +120,17 @@ export function attachmentIdFromDownloadURL(rawURL: string): string | undefined 
  */
 export function contentReferencesAttachment(
   content: string,
-  attachment: { id: string; url: string },
+  attachment: {
+    id: string;
+    url: string;
+    download_url?: string;
+    markdown_url?: string;
+  },
 ): boolean {
   if (!content) return false;
   if (content.includes(attachmentDownloadPath(attachment.id))) return true;
-  if (attachment.url && content.includes(attachment.url)) return true;
+  if (contentReferencesURL(content, attachment.url)) return true;
+  if (contentReferencesURL(content, attachment.download_url)) return true;
+  if (contentReferencesURL(content, attachment.markdown_url)) return true;
   return false;
 }

--- a/packages/views/editor/attachment-download-context.tsx
+++ b/packages/views/editor/attachment-download-context.tsx
@@ -28,6 +28,18 @@ interface ProviderProps {
   children: ReactNode;
 }
 
+function stripQueryAndFragment(url: string): string {
+  return url.split(/[?#]/, 1)[0] ?? "";
+}
+
+function matchesAttachmentURL(embeddedURL: string, attachmentURL?: string): boolean {
+  if (!embeddedURL || !attachmentURL) return false;
+  if (embeddedURL === attachmentURL) return true;
+  const embeddedStable = stripQueryAndFragment(embeddedURL);
+  const attachmentStable = stripQueryAndFragment(attachmentURL);
+  return embeddedStable !== "" && embeddedStable === attachmentStable;
+}
+
 /**
  * Provides a click-time download handler to Tiptap NodeViews mounted inside
  * `ContentEditor`. Without a provider the consumer falls back to opening the
@@ -60,7 +72,12 @@ export function AttachmentDownloadProvider({ attachments, children }: ProviderPr
         // straight at the CDN, and anything else where
         // `attachments[i].url` was the literal value embedded in
         // markdown.
-        return attachments.find((a) => a.url === url);
+        return attachments.find(
+          (a) =>
+            matchesAttachmentURL(url, a.url) ||
+            matchesAttachmentURL(url, a.download_url) ||
+            matchesAttachmentURL(url, a.markdown_url),
+        );
       };
       return {
         resolveAttachmentId: (url) => lookup(url)?.id,

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -535,6 +535,31 @@ describe("ReadonlyContent file-card → AttachmentBlock HTML routing", () => {
     expect(container.querySelector("iframe")).toBeNull();
     expect(container.querySelector("img")).toBeNull();
   });
+
+  it("resolves a markdown image whose src is the response download_url", () => {
+    const href = "https://cdn.example.test/shot.png?Signature=stale";
+    const fresh = "https://cdn.example.test/shot.png?Signature=fresh";
+    const attachment = {
+      id: "11111111-2222-3333-4444-555555555555",
+      url: "https://cdn.example.test/shot.png",
+      download_url: fresh,
+      markdown_url: "/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      filename: "shot.png",
+      content_type: "image/png",
+      size_bytes: 1024,
+    } as any;
+
+    const { container } = renderWithQuery(
+      <ReadonlyContent
+        content={`![](${href})`}
+        attachments={[attachment]}
+      />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe(fresh);
+    expect(img?.getAttribute("alt")).toBe("shot.png");
+  });
 });
 
 describe("ReadonlyContent slash command rendering", () => {

--- a/packages/views/issues/components/comment-card.test.tsx
+++ b/packages/views/issues/components/comment-card.test.tsx
@@ -109,4 +109,26 @@ describe("AttachmentList — inline attachment filtering", () => {
     expect(screen.queryByText("report.pdf")).toBeNull();
     expect(container.firstChild).toBeNull();
   });
+
+  it("does not render a bottom attachment row when the body already has the response download_url", () => {
+    const href = "https://cdn.example.test/report.pdf?Signature=stale";
+    const attachment = {
+      id: "11111111-2222-3333-4444-555555555555",
+      url: "/uploads/report.pdf",
+      download_url: "https://cdn.example.test/report.pdf?Signature=fresh",
+      filename: "report.pdf",
+      content_type: "application/pdf",
+      size_bytes: 1024,
+    } as any;
+
+    const { container } = renderWithQuery(
+      <AttachmentList
+        attachments={[attachment]}
+        content={`!file[report.pdf](${href})`}
+      />,
+    );
+
+    expect(screen.queryByText("report.pdf")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes issue comment attachment rendering when markdown references an attachment by `download_url` instead of the raw storage `url` or stable `/api/attachments/<id>/download` path.

The attachment resolver now matches inline markdown URLs against `url`, `download_url`, and `markdown_url`, including stale signed URLs whose query string differs from the fresh attachment metadata. The standalone comment attachment list uses the same URL shapes when deciding whether an attachment is already rendered inline, so comment uploads do not disappear or duplicate below the body.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #3855

Multica issue: ZIC-15

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `AttachmentDownloadProvider` to resolve embedded URLs by `url`, `download_url`, and `markdown_url`, with query/fragment-insensitive matching for signed URLs.
- Updated `contentReferencesAttachment` so comment attachment filtering recognizes `download_url` and `markdown_url` embeds.
- Added regression tests for `download_url` inline image resolution and comment standalone attachment filtering.

## How to Test

1. Post an issue comment with an uploaded image attachment.
2. Embed the attachment using a `/api/attachments/<id>/download` URL or a signed `download_url`.
3. Confirm the image renders inline, the attachment remains downloadable, and no duplicate bottom attachment row appears when the body already references it.

Local validation:

- `git diff --check` passed.
- `make check-worktree` exited 0, but its output reported Docker was unreachable while checking PostgreSQL, so DB-backed verification was not meaningfully exercised.
- Focused Vitest commands were attempted but blocked because this fresh worktree had no `node_modules`; `pnpm install --frozen-lockfile` failed with `ERR_PNPM_ENOSPC` before `vitest` became available.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced issue comment rendering through `CommentCard`, `ReadonlyContent`, and the shared attachment renderer. The smallest shared fix was to teach the URL resolver and inline-reference helper about every attachment URL shape returned by the server, including signed URL query drift.

## Screenshots (optional)

Not captured locally because dependency installation failed with `ERR_PNPM_ENOSPC` and Docker was unavailable.
