### PR TITLE
Fix API token create button interaction

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -106,6 +106,13 @@
     },
     "create": "Create",
     "creating": "Creating...",
+    "create_dialog": {
+      "title": "Create API Token",
+      "description": "Name the token and choose how long it should stay active.",
+      "name_label": "Name",
+      "expiry_label": "Expiration",
+      "cancel": "Cancel"
+    },
     "toast_load_failed": "Failed to load tokens",
     "toast_create_failed": "Failed to create token",
     "toast_revoked": "Token revoked",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -106,6 +106,13 @@
     },
     "create": "作成",
     "creating": "作成中...",
+    "create_dialog": {
+      "title": "API トークンを作成",
+      "description": "トークン名を入力し、有効期間を選択してください。",
+      "name_label": "名前",
+      "expiry_label": "有効期限",
+      "cancel": "キャンセル"
+    },
     "toast_load_failed": "トークンを読み込めませんでした",
     "toast_create_failed": "トークンを作成できませんでした",
     "toast_revoked": "トークンを失効しました",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -106,6 +106,13 @@
     },
     "create": "만들기",
     "creating": "만드는 중...",
+    "create_dialog": {
+      "title": "API 토큰 만들기",
+      "description": "토큰 이름을 입력하고 활성 상태로 둘 기간을 선택하세요.",
+      "name_label": "이름",
+      "expiry_label": "만료",
+      "cancel": "취소"
+    },
     "toast_load_failed": "토큰을 불러오지 못했습니다",
     "toast_create_failed": "토큰을 만들지 못했습니다",
     "toast_revoked": "토큰을 폐기했습니다",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -106,6 +106,13 @@
     },
     "create": "创建",
     "creating": "创建中...",
+    "create_dialog": {
+      "title": "创建 API Token",
+      "description": "为 token 命名，并选择它的有效时长。",
+      "name_label": "名称",
+      "expiry_label": "过期时间",
+      "cancel": "取消"
+    },
     "toast_load_failed": "加载 token 失败",
     "toast_create_failed": "创建 token 失败",
     "toast_revoked": "已吊销 token",

--- a/packages/views/settings/components/tokens-tab.test.tsx
+++ b/packages/views/settings/components/tokens-tab.test.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enSettings from "../../locales/en/settings.json";
+
+const mockListPersonalAccessTokens = vi.hoisted(() => vi.fn());
+const mockCreatePersonalAccessToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listPersonalAccessTokens: mockListPersonalAccessTokens,
+    createPersonalAccessToken: mockCreatePersonalAccessToken,
+    revokePersonalAccessToken: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+import { TokensTab } from "./tokens-tab";
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, settings: enSettings },
+};
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+function renderTokensTab() {
+  return render(<TokensTab />, { wrapper: I18nWrapper });
+}
+
+function getDialogCreateButton() {
+  return screen.getAllByRole("button", { name: "Create" }).at(-1)!;
+}
+
+describe("TokensTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListPersonalAccessTokens.mockResolvedValue([]);
+  });
+
+  it("opens the token creation form from an enabled page action", async () => {
+    const user = userEvent.setup();
+    renderTokensTab();
+
+    const createButton = screen.getByRole("button", { name: "Create" });
+    expect(createButton).toBeEnabled();
+
+    await user.click(createButton);
+
+    expect(screen.getByRole("heading", { name: "Create API Token" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(getDialogCreateButton()).toBeDisabled();
+  });
+
+  it("creates a token from the dialog after a name is entered", async () => {
+    mockCreatePersonalAccessToken.mockResolvedValue({
+      id: "tok-1",
+      name: "CLI",
+      token: "pat_secret",
+      token_prefix: "pat",
+      created_at: "2026-07-01T00:00:00Z",
+      last_used_at: null,
+      expires_at: null,
+    });
+
+    const user = userEvent.setup();
+    renderTokensTab();
+
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.type(screen.getByLabelText("Name"), "CLI");
+    await user.click(getDialogCreateButton());
+
+    await waitFor(() => {
+      expect(mockCreatePersonalAccessToken).toHaveBeenCalledWith({
+        name: "CLI",
+        expires_in_days: 90,
+      });
+    });
+    expect(screen.getByRole("heading", { name: "Token created" })).toBeInTheDocument();
+    expect(screen.getByText("pat_secret")).toBeInTheDocument();
+  });
+});

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Key, Trash2, Copy, Check } from "lucide-react";
+import { Key, Trash2, Copy, Check, Plus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import type { PersonalAccessToken } from "@multica/core/types";
 import { Input } from "@multica/ui/components/ui/input";
+import { Label } from "@multica/ui/components/ui/label";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import {
@@ -46,6 +47,7 @@ export function TokensTab() {
   const [tokenName, setTokenName] = useState("");
   const [tokenExpiry, setTokenExpiry] = useState("90");
   const [tokenCreating, setTokenCreating] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newToken, setNewToken] = useState<string | null>(null);
   const [tokenCopied, setTokenCopied] = useState(false);
   const [tokenRevoking, setTokenRevoking] = useState<string | null>(null);
@@ -66,11 +68,14 @@ export function TokensTab() {
   useEffect(() => { loadTokens(); }, [loadTokens]);
 
   const handleCreateToken = async () => {
+    const name = tokenName.trim();
+    if (!name) return;
     setTokenCreating(true);
     try {
       const expiresInDays = tokenExpiry === "never" ? undefined : Number(tokenExpiry);
-      const result = await api.createPersonalAccessToken({ name: tokenName, expires_in_days: expiresInDays });
+      const result = await api.createPersonalAccessToken({ name, expires_in_days: expiresInDays });
       setNewToken(result.token);
+      setCreateDialogOpen(false);
       setTokenName("");
       setTokenExpiry("90");
       await loadTokens();
@@ -112,26 +117,13 @@ export function TokensTab() {
 
         <Card>
           <CardContent className="space-y-3">
-            <p className="text-xs text-muted-foreground">
-              {t(($) => $.tokens.description)}
-            </p>
-            <div className="grid gap-3 sm:grid-cols-[1fr_120px_auto]">
-              <Input
-                type="text"
-                value={tokenName}
-                onChange={(e) => setTokenName(e.target.value)}
-                placeholder={t(($) => $.tokens.name_placeholder)}
-              />
-              <Select value={tokenExpiry} onValueChange={(v) => { if (v) setTokenExpiry(v); }}>
-                <SelectTrigger size="sm"><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {EXPIRY_KEYS.map((key) => (
-                    <SelectItem key={key} value={key}>{t(($) => $.tokens.expiry[key])}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button onClick={handleCreateToken} disabled={tokenCreating || !tokenName.trim()}>
-                {tokenCreating ? t(($) => $.tokens.creating) : t(($) => $.tokens.create)}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-muted-foreground">
+                {t(($) => $.tokens.description)}
+              </p>
+              <Button type="button" onClick={() => setCreateDialogOpen(true)}>
+                <Plus className="h-4 w-4" />
+                {t(($) => $.tokens.create)}
               </Button>
             </div>
           </CardContent>
@@ -195,6 +187,79 @@ export function TokensTab() {
           </div>
         )}
       </section>
+
+      <Dialog
+        open={createDialogOpen}
+        onOpenChange={(v) => {
+          if (!tokenCreating) setCreateDialogOpen(v);
+        }}
+      >
+        <DialogContent>
+          <form
+            className="contents"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreateToken();
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.tokens.create_dialog.title)}</DialogTitle>
+              <DialogDescription>
+                {t(($) => $.tokens.create_dialog.description)}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="token-name" className="text-xs">
+                  {t(($) => $.tokens.create_dialog.name_label)}
+                </Label>
+                <Input
+                  id="token-name"
+                  type="text"
+                  value={tokenName}
+                  onChange={(e) => setTokenName(e.target.value)}
+                  placeholder={t(($) => $.tokens.name_placeholder)}
+                  autoFocus
+                  autoComplete="off"
+                  disabled={tokenCreating}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="token-expiry" className="text-xs">
+                  {t(($) => $.tokens.create_dialog.expiry_label)}
+                </Label>
+                <Select
+                  value={tokenExpiry}
+                  onValueChange={(v) => { if (v) setTokenExpiry(v); }}
+                  disabled={tokenCreating}
+                >
+                  <SelectTrigger id="token-expiry" size="sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {EXPIRY_KEYS.map((key) => (
+                      <SelectItem key={key} value={key}>{t(($) => $.tokens.expiry[key])}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreateDialogOpen(false)}
+                disabled={tokenCreating}
+              >
+                {t(($) => $.tokens.create_dialog.cancel)}
+              </Button>
+              <Button type="submit" disabled={tokenCreating || !tokenName.trim()}>
+                {tokenCreating ? t(($) => $.tokens.creating) : t(($) => $.tokens.create)}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
 
       <AlertDialog open={!!revokeConfirmId} onOpenChange={(v) => { if (!v) setRevokeConfirmId(null); }}>
         <AlertDialogContent>


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes the Personal Access Tokens settings page so the page-level Create button is an enabled action that opens a creation dialog. The required token name validation now lives inside the dialog form, so allowed users can discover and open token creation instead of seeing an inert button.

## Related Issue

Closes #4668

Multica issue: ZIC-13

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Moved API token name and expiry inputs into a controlled creation dialog in `packages/views/settings/components/tokens-tab.tsx`.
- Kept the actual create submit button disabled until a token name is entered, preserving validation while making the page-level Create action clickable.
- Added dialog labels to settings locales.
- Added `tokens-tab.test.tsx` coverage for opening the create form and submitting token creation.

## How to Test

1. `pnpm -C packages/views exec vitest run settings/components/tokens-tab.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views lint`
4. `make check-worktree`

Note: `make check-worktree` exited 0, but the local Docker daemon was unavailable while it checked PostgreSQL (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`). Focused frontend tests, typecheck, and lint were run successfully.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the API Tokens settings tab from issue #4668, moved the disabled inline creation control into an explicit dialog action, preserved form validation in the dialog, and added a focused Vitest regression test for the interaction.

## Screenshots (optional)

Not included; Docker was unavailable for a full local app run, and the behavior is covered by a focused component test.
