### PR TITLE
Fix manual issue create switch lag (ZIC-16)

### DIFF
--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -756,6 +756,21 @@ describe("CreateIssueModal", () => {
     );
   });
 
+  it("keeps the Switch to Agent control free of continuous border animation", () => {
+    renderModal(
+      <ManualCreatePanel
+        onClose={vi.fn()}
+        onSwitchMode={vi.fn()}
+        isExpanded={false}
+        setIsExpanded={vi.fn()}
+      />,
+    );
+
+    const switchButton = screen.getByRole("button", { name: /Switch to Agent/i });
+    expect(switchButton).not.toHaveClass("border-beam");
+    expect(switchButton).toHaveClass("ring-brand/20");
+  });
+
   // Manual → agent must forward parent_issue_id when the modal was opened
   // from "Add sub issue". Before this, the agent panel received no parent
   // context and the new issue was filed as a standalone — silently dropping

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -815,7 +815,7 @@ export function ManualCreatePanel({
                   type="button"
                   onClick={switchToAgent}
                   title={t(($) => $.create_issue.switch_to_agent_tooltip)}
-                  className="border-beam group flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground bg-brand/5 hover:bg-brand/10 hover:text-foreground transition-colors cursor-pointer"
+                  className="group flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground bg-brand/5 ring-1 ring-brand/20 hover:bg-brand/10 hover:text-foreground transition-colors cursor-pointer"
                 >
                   <ArrowLeftRight className="size-3.5 text-brand/80 transition-transform duration-300 group-hover:rotate-180" />
                   {t(($) => $.create_issue.switch_to_agent)}


### PR DESCRIPTION
## What does this PR do?

Removes the continuously animated `border-beam` treatment from the manual create-issue dialog's Switch to Agent control. The button stays available and keeps a static brand ring, but no longer runs a conic-gradient border animation next to the rich text editor while the user types.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #3845

Multica issue: ZIC-16

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/modals/create-issue.tsx`: replaced the animated Switch to Agent border beam with a static brand ring.
- `packages/views/modals/create-issue.test.tsx`: added regression coverage that prevents reintroducing the continuous border animation on that control.

## How to Test

1. Open the create-issue dialog in Manual mode.
2. Type in the title/description fields and interact with inputs.
3. Confirm the Switch to Agent button is still present, but the manual form remains responsive because it no longer runs the border-beam animation.

Validation run locally:

- `pnpm --filter @multica/views test -- create-issue.test.tsx` - passed. Vitest ran the full `@multica/views` suite: 148 files, 1543 tests.
- `pnpm --filter @multica/views typecheck` - passed.
- `pnpm --filter @multica/views lint` - passed with existing warnings only.
- `make check-worktree` - blocked by local Docker daemon availability while checking PostgreSQL (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`). The target printed a success line despite the Docker error, so I did not count it as a valid full check.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Screenshot note: no screenshot captured because the local full app check was blocked by Docker/Postgres. This is a styling-only change to remove an animation class from an existing button.

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Followed the Multica contribution workflow for GitHub #3845. Traced the manual create-issue dialog, identified the Switch to Agent control's continuous `border-beam` animation as the performance risk, replaced it with a static ring, and added regression coverage.

## Screenshots (optional)

Not captured; see screenshot note above.
