### PR TITLE
Add NanoClaw issue bridge

### DIFF
--- a/integrations/nanoclaw/README.md
+++ b/integrations/nanoclaw/README.md
@@ -1,0 +1,16 @@
+# NanoClaw integration
+
+This integration lets a NanoClaw agent create Multica issues for an agent or
+squad by display name and read an issue's current status.
+
+The Multica PAT stays in the host-side `multica` CLI configuration. NanoClaw
+receives a separate bridge token whose authority is limited to two bridge
+operations:
+
+- `POST /v1/issues`
+- `GET /v1/issues/{id}`
+
+Install the NanoClaw side by copying `add-multica` into the target NanoClaw
+checkout as `.claude/skills/add-multica`, then run `/add-multica` there.
+
+See [`add-multica/SKILL.md`](add-multica/SKILL.md) for setup and verification.

--- a/integrations/nanoclaw/add-multica/REMOVE.md
+++ b/integrations/nanoclaw/add-multica/REMOVE.md
@@ -1,0 +1,21 @@
+# Remove Multica from NanoClaw
+
+Run from the NanoClaw project root for every configured group:
+
+```bash
+ncl groups config remove-mcp-server --id <group-id> --name multica
+ncl groups restart --id <group-id>
+```
+
+Remove the copied MCP client:
+
+```bash
+rm container/agent-runner/src/multica-mcp-stdio.ts
+```
+
+Stop the host `multica nanoclaw serve` process or service. After every group is
+unregistered, remove the limited bridge token:
+
+```bash
+rm ~/.config/multica-nanoclaw/bridge-token
+```

--- a/integrations/nanoclaw/add-multica/SKILL.md
+++ b/integrations/nanoclaw/add-multica/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: add-multica
+description: Add Multica issue creation and status lookup tools to a NanoClaw agent group without putting a Multica PAT in the agent container.
+---
+
+# Add Multica to NanoClaw
+
+This capability has two parts:
+
+1. `multica nanoclaw serve` runs on the host and uses the host's authenticated
+   Multica CLI configuration.
+2. A small stdio MCP server runs in the NanoClaw container and calls that
+   bridge with a separate, revocable bridge token.
+
+The MCP tools are:
+
+- `multica_create_issue`: create an issue for an agent or squad by name;
+- `multica_get_issue`: fetch an issue and its current `status`.
+
+## Phase 1: Host bridge
+
+Verify the Multica CLI is authenticated and has a workspace selected:
+
+```bash
+multica auth status
+multica config show
+```
+
+Use a dedicated random bridge token. This is not a Multica PAT; it only grants
+the two bridge operations above.
+
+```bash
+mkdir -p ~/.config/multica-nanoclaw
+openssl rand -hex 32 > ~/.config/multica-nanoclaw/bridge-token
+chmod 600 ~/.config/multica-nanoclaw/bridge-token
+```
+
+Start the bridge so NanoClaw's containers can reach it through the Docker host
+gateway:
+
+```bash
+MULTICA_NANOCLAW_BRIDGE_TOKEN="$(cat ~/.config/multica-nanoclaw/bridge-token)" \
+  multica nanoclaw serve --listen 0.0.0.0:8099
+```
+
+Run the bridge under the same user as the authenticated Multica CLI. For a
+persistent install, put that command in the host service manager and load the
+token from the mode-0600 file; do not paste the Multica PAT into NanoClaw.
+
+## Phase 2: Install the MCP client
+
+Run from the NanoClaw project root. Re-running this copy is safe.
+
+```bash
+cp "${CLAUDE_SKILL_DIR}/multica-mcp-stdio.ts" \
+  container/agent-runner/src/multica-mcp-stdio.ts
+```
+
+The file is pure-add and `/app/src` is mounted read-only from the host runner
+tree, so no NanoClaw core source edit is required.
+
+## Phase 3: Register for an agent group
+
+List groups and choose the group that should receive the tools:
+
+```bash
+ncl groups list
+```
+
+Build the MCP environment without putting the token literal in shell history:
+
+```bash
+BRIDGE_TOKEN="$(cat ~/.config/multica-nanoclaw/bridge-token)"
+MCP_ENV="$(jq -cn \
+  --arg url 'http://host.docker.internal:8099' \
+  --arg token "$BRIDGE_TOKEN" \
+  '{MULTICA_BRIDGE_URL:$url,MULTICA_BRIDGE_TOKEN:$token}')"
+
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name multica \
+  --command bun \
+  --args '["run","/app/src/multica-mcp-stdio.ts"]' \
+  --env "$MCP_ENV"
+unset BRIDGE_TOKEN MCP_ENV
+
+ncl groups restart --id <group-id>
+```
+
+The bridge token is intentionally present in the selected container. It cannot
+act as a general Multica credential: the bridge only implements create/get.
+Rotate it by replacing the host token file and re-registering the MCP env.
+
+## Phase 4: Verify
+
+Check the bridge from the host:
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $(cat ~/.config/multica-nanoclaw/bridge-token)" \
+  http://127.0.0.1:8099/health
+```
+
+Then tell NanoClaw:
+
+> Create a Multica task called "Check subscription retries" for the
+> "AWG Service" team, but leave it in backlog.
+
+The response must contain the created issue ID and `status: backlog`. Then ask:
+
+> What is the current status of that Multica task?
+
+If an agent or squad name is missing or ambiguous, the tool returns the
+matching error and NanoClaw must ask the user to clarify instead of guessing.
+
+## Removal
+
+See [`REMOVE.md`](REMOVE.md).

--- a/integrations/nanoclaw/add-multica/multica-mcp-stdio.ts
+++ b/integrations/nanoclaw/add-multica/multica-mcp-stdio.ts
@@ -1,0 +1,221 @@
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { createInterface } from 'node:readline';
+
+type JsonRpcRequest = {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+};
+
+const bridgeUrl = new URL(process.env.MULTICA_BRIDGE_URL ?? 'http://host.docker.internal:8099');
+const bridgeToken = process.env.MULTICA_BRIDGE_TOKEN?.trim();
+
+if (!bridgeToken) {
+  throw new Error('MULTICA_BRIDGE_TOKEN is required');
+}
+
+const tools = [
+  {
+    name: 'multica_create_issue',
+    description:
+      'Create a Multica issue assigned to an agent or squad by its spoken/display name. Use assignee_kind when the user explicitly says agent or team. If the name is ambiguous, return the error and ask the user to clarify.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['title', 'assignee'],
+      properties: {
+        title: { type: 'string', description: 'Issue title.' },
+        description: { type: 'string', description: 'Optional issue description.' },
+        assignee: { type: 'string', description: 'Agent or squad display name.' },
+        assignee_kind: {
+          type: 'string',
+          enum: ['agent', 'squad'],
+          description: 'Use squad when the user says team/command; use agent for a specific agent.',
+        },
+        start_immediately: {
+          type: 'boolean',
+          description: 'true creates todo and starts the assignee; false creates backlog. Defaults to true.',
+        },
+      },
+    },
+  },
+  {
+    name: 'multica_get_issue',
+    description: 'Get a Multica issue, including its current status, by UUID or routable key such as A-26.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['issue_id'],
+      properties: {
+        issue_id: { type: 'string', description: 'Multica issue UUID or routable key.' },
+      },
+    },
+  },
+] as const;
+
+function bridgeRequest(method: 'GET' | 'POST', pathname: string, body?: unknown): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const payload = body === undefined ? undefined : JSON.stringify(body);
+    const transport = bridgeUrl.protocol === 'https:' ? https : http;
+    const request = transport.request(
+      new URL(pathname, bridgeUrl),
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${bridgeToken}`,
+          Accept: 'application/json',
+          ...(payload
+            ? {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(payload).toString(),
+              }
+            : {}),
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk: Buffer | string) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        response.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          let value: unknown;
+          try {
+            value = text ? JSON.parse(text) : {};
+          } catch {
+            reject(new Error(`Multica bridge returned invalid JSON (${response.statusCode ?? 0})`));
+            return;
+          }
+          if ((response.statusCode ?? 500) >= 400) {
+            const message =
+              typeof value === 'object' && value !== null && 'error' in value
+                ? String((value as { error: unknown }).error)
+                : `Multica bridge request failed (${response.statusCode ?? 0})`;
+            reject(new Error(message));
+            return;
+          }
+          resolve(value);
+        });
+      },
+    );
+    request.setTimeout(40_000, () => request.destroy(new Error('Multica bridge request timed out')));
+    request.on('error', reject);
+    if (payload) request.write(payload);
+    request.end();
+  });
+}
+
+function stringArg(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+  switch (name) {
+    case 'multica_create_issue': {
+      const assigneeKind = args.assignee_kind;
+      if (assigneeKind !== undefined && assigneeKind !== 'agent' && assigneeKind !== 'squad') {
+        throw new Error('assignee_kind must be agent or squad');
+      }
+      return bridgeRequest('POST', '/v1/issues', {
+        title: stringArg(args, 'title'),
+        ...(typeof args.description === 'string' && args.description.trim()
+          ? { description: args.description.trim() }
+          : {}),
+        assignee: stringArg(args, 'assignee'),
+        ...(assigneeKind ? { assignee_kind: assigneeKind } : {}),
+        status: args.start_immediately === false ? 'backlog' : 'todo',
+      });
+    }
+    case 'multica_get_issue':
+      return bridgeRequest('GET', `/v1/issues/${encodeURIComponent(stringArg(args, 'issue_id'))}`);
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+function send(response: JsonRpcResponse): void {
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+}
+
+async function handle(request: JsonRpcRequest): Promise<void> {
+  if (request.id === undefined) return;
+  const id = request.id ?? null;
+  try {
+    switch (request.method) {
+      case 'initialize':
+        send({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion: '2024-11-05',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'multica-nanoclaw', version: '1.0.0' },
+          },
+        });
+        return;
+      case 'ping':
+        send({ jsonrpc: '2.0', id, result: {} });
+        return;
+      case 'tools/list':
+        send({ jsonrpc: '2.0', id, result: { tools } });
+        return;
+      case 'tools/call': {
+        const name = request.params?.name;
+        const args = request.params?.arguments;
+        if (typeof name !== 'string') throw new Error('tool name is required');
+        if (args !== undefined && (typeof args !== 'object' || args === null || Array.isArray(args))) {
+          throw new Error('tool arguments must be an object');
+        }
+        try {
+          const result = await callTool(name, (args ?? {}) as Record<string, unknown>);
+          send({
+            jsonrpc: '2.0',
+            id,
+            result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
+          });
+        } catch (error) {
+          send({
+            jsonrpc: '2.0',
+            id,
+            result: {
+              isError: true,
+              content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+            },
+          });
+        }
+        return;
+      }
+      default:
+        send({ jsonrpc: '2.0', id, error: { code: -32601, message: `Method not found: ${request.method}` } });
+    }
+  } catch (error) {
+    send({
+      jsonrpc: '2.0',
+      id,
+      error: { code: -32602, message: error instanceof Error ? error.message : String(error) },
+    });
+  }
+}
+
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+for await (const line of lines) {
+  if (!line.trim()) continue;
+  try {
+    await handle(JSON.parse(line) as JsonRpcRequest);
+  } catch (error) {
+    console.error(`[multica-mcp] ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/server/cmd/multica/cmd_nanoclaw.go
+++ b/server/cmd/multica/cmd_nanoclaw.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+const (
+	defaultNanoClawListen = "127.0.0.1:8099"
+	maxNanoClawBodyBytes  = 64 << 10
+)
+
+var nanoclawCmd = &cobra.Command{
+	Use:   "nanoclaw",
+	Short: "Expose limited Multica issue tools to NanoClaw",
+}
+
+var nanoclawServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Run the authenticated NanoClaw issue bridge",
+	Long: "Run a local HTTP bridge that lets NanoClaw create issues and read issue status without receiving the Multica PAT. " +
+		"Set MULTICA_NANOCLAW_BRIDGE_TOKEN to a random value of at least 32 characters.",
+	RunE: runNanoClawServe,
+}
+
+func init() {
+	nanoclawCmd.AddCommand(nanoclawServeCmd)
+	nanoclawServeCmd.Flags().String("listen", defaultNanoClawListen, "Listen address; use 0.0.0.0:8099 only when a container must reach the host")
+}
+
+type nanoclawBridge struct {
+	client *cli.APIClient
+	token  string
+}
+
+type nanoclawCreateIssueRequest struct {
+	Title        string `json:"title"`
+	Description  string `json:"description,omitempty"`
+	Assignee     string `json:"assignee"`
+	AssigneeKind string `json:"assignee_kind,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+func runNanoClawServe(cmd *cobra.Command, _ []string) error {
+	token := strings.TrimSpace(os.Getenv("MULTICA_NANOCLAW_BRIDGE_TOKEN"))
+	if len(token) < 32 {
+		return fmt.Errorf("MULTICA_NANOCLAW_BRIDGE_TOKEN must contain at least 32 characters")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	if client.WorkspaceID == "" {
+		return fmt.Errorf("workspace ID not set: use --workspace-id, MULTICA_WORKSPACE_ID, or 'multica config set workspace_id <id>'")
+	}
+
+	listen, _ := cmd.Flags().GetString("listen")
+	listener, err := net.Listen("tcp", listen)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", listen, err)
+	}
+
+	bridge := &nanoclawBridge{client: client, token: token}
+	server := &http.Server{
+		Handler:           bridge.handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      cli.APITimeout() + 5*time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer stop()
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "NanoClaw bridge listening on http://%s\n", listener.Addr())
+
+	select {
+	case err := <-serveErr:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shut down NanoClaw bridge: %w", err)
+		}
+		return nil
+	}
+}
+
+func (b *nanoclawBridge) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		writeNanoClawJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("POST /v1/issues", b.createIssue)
+	mux.HandleFunc("GET /v1/issues/{id}", b.getIssue)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !validNanoClawBearer(r.Header.Get("Authorization"), b.token) {
+			writeNanoClawError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		mux.ServeHTTP(w, r)
+	})
+}
+
+func validNanoClawBearer(header, token string) bool {
+	expected := "Bearer " + token
+	if len(header) != len(expected) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(header), []byte(expected)) == 1
+}
+
+func (b *nanoclawBridge) createIssue(w http.ResponseWriter, r *http.Request) {
+	var input nanoclawCreateIssueRequest
+	body := http.MaxBytesReader(w, r.Body, maxNanoClawBodyBytes)
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		writeNanoClawError(w, http.StatusBadRequest, "invalid JSON request")
+		return
+	}
+	if err := ensureNanoClawJSONEOF(decoder); err != nil {
+		writeNanoClawError(w, http.StatusBadRequest, "request must contain one JSON object")
+		return
+	}
+
+	input.Title = strings.TrimSpace(input.Title)
+	input.Assignee = strings.TrimSpace(input.Assignee)
+	input.AssigneeKind = strings.ToLower(strings.TrimSpace(input.AssigneeKind))
+	input.Status = strings.ToLower(strings.TrimSpace(input.Status))
+	if input.Title == "" {
+		writeNanoClawError(w, http.StatusBadRequest, "title is required")
+		return
+	}
+	if input.Assignee == "" {
+		writeNanoClawError(w, http.StatusBadRequest, "assignee is required")
+		return
+	}
+	if input.Status == "" {
+		input.Status = "todo"
+	}
+	if input.Status != "todo" && input.Status != "backlog" {
+		writeNanoClawError(w, http.StatusBadRequest, "status must be todo or backlog")
+		return
+	}
+
+	kinds := assigneeKinds{agent: true, squad: true}
+	switch input.AssigneeKind {
+	case "":
+	case "agent":
+		kinds.squad = false
+	case "squad", "team":
+		kinds.agent = false
+	default:
+		writeNanoClawError(w, http.StatusBadRequest, "assignee_kind must be agent, squad, or omitted")
+		return
+	}
+
+	ctx, cancel := cli.APIContext(r.Context())
+	defer cancel()
+	assigneeType, assigneeID, err := resolveAssignee(ctx, b.client, input.Assignee, kinds)
+	if err != nil {
+		writeNanoClawError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	request := map[string]any{
+		"title":         input.Title,
+		"status":        input.Status,
+		"assignee_type": assigneeType,
+		"assignee_id":   assigneeID,
+	}
+	if description := strings.TrimSpace(input.Description); description != "" {
+		request["description"] = description
+	}
+
+	var issue map[string]any
+	if err := b.client.PostJSON(ctx, "/api/issues", request, &issue); err != nil {
+		writeNanoClawAPIError(w, err)
+		return
+	}
+	writeNanoClawJSON(w, http.StatusCreated, issue)
+}
+
+func (b *nanoclawBridge) getIssue(w http.ResponseWriter, r *http.Request) {
+	ref, err := url.PathUnescape(r.PathValue("id"))
+	if err != nil || strings.TrimSpace(ref) == "" {
+		writeNanoClawError(w, http.StatusBadRequest, "issue id is required")
+		return
+	}
+
+	ctx, cancel := cli.APIContext(r.Context())
+	defer cancel()
+	resolved, err := resolveIssueRef(ctx, b.client, ref)
+	if err != nil {
+		writeNanoClawAPIError(w, err)
+		return
+	}
+
+	var issue map[string]any
+	if err := b.client.GetJSON(ctx, "/api/issues/"+url.PathEscape(resolved.ID), &issue); err != nil {
+		writeNanoClawAPIError(w, err)
+		return
+	}
+	writeNanoClawJSON(w, http.StatusOK, issue)
+}
+
+func ensureNanoClawJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("extra JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func writeNanoClawAPIError(w http.ResponseWriter, err error) {
+	var httpErr *cli.HTTPError
+	if errors.As(err, &httpErr) {
+		status := httpErr.StatusCode
+		if status < 400 || status > 599 {
+			status = http.StatusBadGateway
+		}
+		writeNanoClawError(w, status, cli.FormatError(err, false))
+		return
+	}
+	writeNanoClawError(w, http.StatusBadGateway, cli.FormatError(err, false))
+}
+
+func writeNanoClawError(w http.ResponseWriter, status int, message string) {
+	writeNanoClawJSON(w, status, map[string]string{"error": message})
+}
+
+func writeNanoClawJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/server/cmd/multica/cmd_nanoclaw_test.go
+++ b/server/cmd/multica/cmd_nanoclaw_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+const testNanoClawToken = "0123456789abcdef0123456789abcdef"
+
+func TestNanoClawBridgeRequiresBearerToken(t *testing.T) {
+	bridge := &nanoclawBridge{token: testNanoClawToken}
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	bridge.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestNanoClawBridgeCreatesIssueForNamedSquad(t *testing.T) {
+	var created map[string]any
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode([]map[string]any{{"id": "agent-1", "name": "Backend"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/squads":
+			json.NewEncoder(w).Encode([]map[string]any{{"id": "squad-1", "name": "AWG Service"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues":
+			if err := json.NewDecoder(r.Body).Decode(&created); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": "issue-1", "status": "todo"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	bridge := &nanoclawBridge{
+		client: cli.NewAPIClient(api.URL, "workspace-1", "multica-token"),
+		token:  testNanoClawToken,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/issues", strings.NewReader(`{
+		"title":"Fix billing",
+		"description":"Handle retries",
+		"assignee":"AWG Service",
+		"assignee_kind":"squad",
+		"status":"todo"
+	}`))
+	req.Header.Set("Authorization", "Bearer "+testNanoClawToken)
+	rec := httptest.NewRecorder()
+
+	bridge.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if got := created["assignee_type"]; got != "squad" {
+		t.Fatalf("assignee_type = %#v, want squad", got)
+	}
+	if got := created["assignee_id"]; got != "squad-1" {
+		t.Fatalf("assignee_id = %#v, want squad-1", got)
+	}
+	if got := created["status"]; got != "todo" {
+		t.Fatalf("status = %#v, want todo", got)
+	}
+}
+
+func TestNanoClawBridgeRejectsAmbiguousAssignee(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/agents":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "agent-1", "name": "Backend One"},
+				{"id": "agent-2", "name": "Backend Two"},
+			})
+		case "/api/squads":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	bridge := &nanoclawBridge{
+		client: cli.NewAPIClient(api.URL, "workspace-1", "multica-token"),
+		token:  testNanoClawToken,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/issues", strings.NewReader(`{
+		"title":"Fix API",
+		"assignee":"Backend",
+		"assignee_kind":"agent"
+	}`))
+	req.Header.Set("Authorization", "Bearer "+testNanoClawToken)
+	rec := httptest.NewRecorder()
+
+	bridge.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "ambiguous assignee") {
+		t.Fatalf("body = %q, want ambiguity detail", rec.Body.String())
+	}
+}
+
+func TestNanoClawBridgeGetsIssueStatus(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || (r.URL.Path != "/api/issues/A-26" && r.URL.Path != "/api/issues/issue-26") {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "issue-26",
+			"identifier": "A-26",
+			"status":     "in_progress",
+		})
+	}))
+	defer api.Close()
+
+	bridge := &nanoclawBridge{
+		client: cli.NewAPIClient(api.URL, "workspace-1", "multica-token"),
+		token:  testNanoClawToken,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/issues/A-26", nil)
+	req.Header.Set("Authorization", "Bearer "+testNanoClawToken)
+	rec := httptest.NewRecorder()
+
+	bridge.handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"in_progress"`) {
+		t.Fatalf("body = %q, want issue status", rec.Body.String())
+	}
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -66,6 +66,7 @@ func init() {
 	configCmd.GroupID = groupAdditional
 	updateCmd.GroupID = groupAdditional
 	versionCmd.GroupID = groupAdditional
+	nanoclawCmd.GroupID = groupAdditional
 
 	rootCmd.AddCommand(issueCmd)
 	rootCmd.AddCommand(projectCmd)
@@ -86,6 +87,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(nanoclawCmd)
 
 	initHelp(rootCmd)
 }


### PR DESCRIPTION
## What

- add `multica nanoclaw serve`, an authenticated host bridge limited to issue creation and lookup
- resolve spoken agent/squad names with the existing ambiguity-safe assignee resolver
- ship an additive NanoClaw skill and stdio MCP client
- keep the Multica PAT on the host; NanoClaw receives only a revocable bridge capability token

## Verification

- `go test ./cmd/multica -count=1`
- `go vet ./cmd/multica`
- standalone TypeScript typecheck for `multica-mcp-stdio.ts`
- Docker/Bun MCP smoke test against a real local Multica workspace
- live backlog creation through NanoClaw bridge followed by immediate cancellation (`A-27`)

`go test ./...` passes all packages except three pre-existing timing-sensitive Codex inactivity tests in `server/pkg/agent`; those also fail when rerun independently and are unrelated to this change.

Closes A-26
