### PR TITLE
WS-1274: contain Windows agent process trees

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.35.0
 	google.golang.org/protobuf v1.36.8
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -63,6 +64,5 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.43.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -571,8 +571,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	// this, killing the leader leaves grandchildren as orphans that
 	// keep consuming memory until the OS reaps them; see #4520, where a
 	// scanner overflow during thread/resume otherwise leaked Codex
-	// processes indefinitely. configureProcessGroup is a no-op on
-	// Windows.
+	// processes indefinitely. On Windows, startProcessGroup creates a
+	// kill-on-close Job Object for the same tree-cleanup contract.
 	configureProcessGroup(cmd)
 	// Override the default exec.CommandContext cancel behaviour. The
 	// default sends SIGKILL only to cmd.Process (the leader); we instead
@@ -608,7 +608,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[codex:stderr] "), codexStderrTailBytes)
 	cmd.Stderr = stderrBuf
 
-	if err := cmd.Start(); err != nil {
+	if err := startProcessGroup(cmd); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start codex: %w", err)
 	}
@@ -748,6 +748,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			waitCh := make(chan struct{})
 			go func() {
 				_ = cmd.Wait()
+				releaseProcessGroup(cmd.Process)
 				close(waitCh)
 			}()
 			select {

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -164,7 +164,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
 
-	if err := cmd.Start(); err != nil {
+	if err := startProcessGroup(cmd); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
@@ -215,6 +215,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
+		releaseProcessGroup(cmd.Process)
 		close(procDone)
 		duration := time.Since(startTime)
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -182,12 +182,13 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	// it spawned) BEFORE unblocking the scanner. The previous implementation
 	// closed the stdout read end immediately, which left opencode writing into
 	// a closed pipe: every write returns EPIPE and, per anomalyco/opencode#33653,
-	// can spin the orphaned process at 100% CPU. Instead we SIGTERM the whole
+	// can spin the orphaned process at 100% CPU. On Unix we SIGTERM the whole
 	// process group, give it a grace period to exit cleanly, then SIGKILL it.
-	// SIGKILL is uncatchable, so once it is delivered no group member can run
-	// (or write) again — only then is it safe to close the stdout read end as a
-	// last-resort unblock for a scanner that a wedged descendant still keeps
-	// open. WaitDelay is the final backstop (#4533).
+	// On Windows, signalProcessGroup closes the kill-on-close Job Object on
+	// the first call, so cancellation immediately terminates the process tree;
+	// the grace window is a no-op there. Only after tree termination do we close
+	// the stdout read end as a last-resort unblock for a scanner that a wedged
+	// descendant still keeps open. WaitDelay is the final backstop (#4533).
 	go func() {
 		select {
 		case <-procDone:

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -24,6 +24,12 @@ func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+func startProcessGroup(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
+func releaseProcessGroup(_ *os.Process) {}
+
 // signalProcessGroup sends sig to the whole process group led by p (when the
 // command was started with configureProcessGroup), falling back to the single
 // process if the group send fails. Targeting the group (negative pid) reaches

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -3,9 +3,15 @@
 package agent
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // createNewConsole allocates a fresh console for the child process. Combined
@@ -18,7 +24,12 @@ import (
 // which forces Windows to allocate a new visible console per grandchild
 // when the grandchild is a console-subsystem program that doesn't itself
 // pass CREATE_NO_WINDOW — the exact popup storm reported in #1521.
-const createNewConsole = 0x00000010
+const (
+	createNewConsole = 0x00000010
+	createSuspended  = 0x00000004
+)
+
+var processGroupJobs sync.Map // map[int]windows.Handle
 
 // hideAgentWindow configures cmd to suppress the console window on Windows
 // while still giving descendant processes a hidden console to inherit.
@@ -33,16 +44,134 @@ func hideAgentWindow(cmd *exec.Cmd) {
 }
 
 // configureProcessGroup is a no-op on Windows: there is no Setpgid/process-group
-// signalling. Descendant cleanup relies on the hidden console group set up by
-// hideAgentWindow plus exec.CommandContext / WaitDelay terminating the child.
+// signalling. Callers that need descendant cleanup must start with
+// startProcessGroup, which assigns the child to a kill-on-close Job Object.
 func configureProcessGroup(cmd *exec.Cmd) {}
 
-// signalProcessGroup terminates the process on Windows. Windows has no
+func prepareProcessGroup(cmd *exec.Cmd) (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create job object: %w", err)
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, fmt.Errorf("set job object kill-on-close: %w", err)
+	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createSuspended
+	return job, nil
+}
+
+func startProcessGroup(cmd *exec.Cmd) error {
+	job, err := prepareProcessGroup(cmd)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = windows.CloseHandle(job)
+		return err
+	}
+
+	var assignErr error
+	if err := cmd.Process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(job, windows.Handle(handle))
+	}); err != nil {
+		assignErr = err
+	}
+	if assignErr != nil {
+		_ = windows.CloseHandle(job)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("assign process to job object: %w", assignErr)
+	}
+
+	processGroupJobs.Store(cmd.Process.Pid, job)
+	if err := resumeProcess(cmd.Process.Pid); err != nil {
+		releaseProcessGroup(cmd.Process)
+		_ = cmd.Wait()
+		return fmt.Errorf("resume suspended process: %w", err)
+	}
+	return nil
+}
+
+func resumeProcess(pid int) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("create thread snapshot: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("read first thread: %w", err)
+	}
+
+	found := false
+	for {
+		if entry.OwnerProcessID == uint32(pid) {
+			found = true
+			if err := resumeThread(entry.ThreadID); err != nil {
+				return err
+			}
+		}
+
+		err := windows.Thread32Next(snapshot, &entry)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			break
+		}
+		return fmt.Errorf("read next thread: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("no threads found for pid %d", pid)
+	}
+	return nil
+}
+
+func resumeThread(threadID uint32) error {
+	thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, threadID)
+	if err != nil {
+		return fmt.Errorf("open thread %d: %w", threadID, err)
+	}
+	defer windows.CloseHandle(thread)
+	if _, err := windows.ResumeThread(thread); err != nil {
+		return fmt.Errorf("resume thread %d: %w", threadID, err)
+	}
+	return nil
+}
+
+func releaseProcessGroup(p *os.Process) {
+	if p == nil {
+		return
+	}
+	if job, ok := processGroupJobs.LoadAndDelete(p.Pid); ok {
+		_ = windows.CloseHandle(job.(windows.Handle))
+	}
+}
+
+// signalProcessGroup terminates the process tree on Windows by closing the
+// kill-on-close Job Object created by startProcessGroup. Windows has no
 // SIGTERM/SIGKILL distinction or process-group signalling, so the signal is
-// ignored and the process is killed directly (TerminateProcess via Kill). The
-// caller's grace window still applies before this is invoked with SIGKILL.
+// ignored. If the process was not started through startProcessGroup, fall back
+// to killing the direct child.
 func signalProcessGroup(p *os.Process, _ syscall.Signal) {
 	if p == nil {
+		return
+	}
+	if _, ok := processGroupJobs.Load(p.Pid); ok {
+		releaseProcessGroup(p)
 		return
 	}
 	_ = p.Kill()

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -6,6 +6,9 @@ import (
 	"os/exec"
 	"syscall"
 	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // TestHideAgentWindowSetsCreateNewConsole guards against a regression where
@@ -61,5 +64,35 @@ func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
 	}
 	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
 		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")
+	}
+}
+
+func TestPrepareProcessGroupCreatesKillOnCloseSuspendedJob(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	hideAgentWindow(cmd)
+
+	job, err := prepareProcessGroup(cmd)
+	if err != nil {
+		t.Fatalf("prepareProcessGroup failed: %v", err)
+	}
+	defer windows.CloseHandle(job)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be initialized")
+	}
+	if cmd.SysProcAttr.CreationFlags&createSuspended == 0 {
+		t.Errorf("CreationFlags should include CREATE_SUSPENDED (0x%x), got 0x%x",
+			createSuspended, cmd.SysProcAttr.CreationFlags)
+	}
+
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	err = windows.QueryInformationJobObject(job, windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)), nil)
+	if err != nil {
+		t.Fatalf("QueryInformationJobObject failed: %v", err)
+	}
+	if info.BasicLimitInformation.LimitFlags&windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE == 0 {
+		t.Errorf("job LimitFlags should include KILL_ON_JOB_CLOSE (0x%x), got 0x%x",
+			windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, info.BasicLimitInformation.LimitFlags)
 	}
 }

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -3,13 +3,22 @@
 package agent
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
+
+const windowsProcessGroupHostJobHelperEnv = "MULTICA_WINDOWS_PROCESS_GROUP_HOST_JOB_HELPER"
 
 // TestHideAgentWindowSetsCreateNewConsole guards against a regression where
 // hideAgentWindow reverts to CREATE_NO_WINDOW. CREATE_NO_WINDOW strips the
@@ -95,4 +104,150 @@ func TestPrepareProcessGroupCreatesKillOnCloseSuspendedJob(t *testing.T) {
 		t.Errorf("job LimitFlags should include KILL_ON_JOB_CLOSE (0x%x), got 0x%x",
 			windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, info.BasicLimitInformation.LimitFlags)
 	}
+}
+
+func TestStartProcessGroupKillsGrandchildWhenLeaderExits(t *testing.T) {
+	runProcessGroupGrandchildCleanup(t)
+}
+
+func TestStartProcessGroupWorksWhenHostAlreadyInJob(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable failed: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestStartProcessGroupHostJobHelper$", "-test.v")
+	cmd.Env = append(os.Environ(), windowsProcessGroupHostJobHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("host-job helper failed: %v\n%s", err, output)
+	}
+}
+
+func TestStartProcessGroupHostJobHelper(t *testing.T) {
+	if os.Getenv(windowsProcessGroupHostJobHelperEnv) != "1" {
+		t.Skip("helper process only")
+	}
+
+	parentJob, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		t.Fatalf("CreateJobObject parent failed: %v", err)
+	}
+	defer windows.CloseHandle(parentJob)
+
+	if err := windows.AssignProcessToJobObject(parentJob, windows.CurrentProcess()); err != nil {
+		t.Fatalf("assign helper process to parent job: %v", err)
+	}
+
+	runProcessGroupGrandchildCleanup(t)
+}
+
+func runProcessGroupGrandchildCleanup(t *testing.T) {
+	t.Helper()
+
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	leaderScript := strings.Join([]string{
+		"$ErrorActionPreference = 'Stop'",
+		"$child = Start-Process -FilePath powershell.exe -WindowStyle Hidden -PassThru -ArgumentList @(",
+		"  '-NoProfile',",
+		"  '-ExecutionPolicy', 'Bypass',",
+		"  '-Command', 'Start-Sleep -Seconds 60'",
+		")",
+		"$child.Id | Set-Content -Path $env:MULTICA_TEST_GRANDCHILD_PID_FILE -NoNewline -Encoding ascii",
+	}, "\n")
+
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", leaderScript)
+	cmd.Env = append(os.Environ(), "MULTICA_TEST_GRANDCHILD_PID_FILE="+pidFile)
+	hideAgentWindow(cmd)
+	configureProcessGroup(cmd)
+
+	var waited bool
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned || cmd.Process == nil {
+			return
+		}
+		signalProcessGroup(cmd.Process, syscall.SIGKILL)
+		releaseProcessGroup(cmd.Process)
+		if !waited {
+			_ = cmd.Wait()
+		}
+	})
+
+	if err := startProcessGroup(cmd); err != nil {
+		t.Fatalf("startProcessGroup failed: %v", err)
+	}
+
+	grandchildPID := waitForPIDFile(t, pidFile)
+	if running, err := windowsProcessRunning(grandchildPID); err != nil {
+		t.Fatalf("checking grandchild before release: %v", err)
+	} else if !running {
+		t.Fatalf("grandchild process %d exited before job release", grandchildPID)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("leader process failed: %v", err)
+	}
+	waited = true
+
+	releaseProcessGroup(cmd.Process)
+	cleaned = true
+	waitForProcessExit(t, grandchildPID)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				t.Fatalf("parse pid file %s: %v", path, err)
+			}
+			if pid <= 0 {
+				t.Fatalf("pid file %s contained invalid pid %d", path, pid)
+			}
+			return pid
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for pid file %s", path)
+	return 0
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		running, err := windowsProcessRunning(pid)
+		if err != nil {
+			t.Fatalf("checking process %d: %v", pid, err)
+		}
+		if !running {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("process %d still running after job release", pid)
+}
+
+func windowsProcessRunning(pid int) (bool, error) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false, nil
+		}
+		return false, fmt.Errorf("open process: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	const stillActive = 259
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false, fmt.Errorf("get exit code: %w", err)
+	}
+	return exitCode == stillActive, nil
 }


### PR DESCRIPTION
## Summary
- Adds Windows Job Object containment for Codex/opencode process-tree cleanup paths.
- Starts opted-in Windows agent processes suspended, assigns them to a kill-on-close Job Object, then resumes the process so descendants inherit containment before the agent can spawn app-server/tool subprocesses.
- Releases the Job Object after `Wait()` so orphaned descendants are killed when the direct child exits, and uses Job Object close for cancellation/tree-kill.

## Verification
- `git diff --check`
- `GOOS=windows GOARCH=amd64 go test -c ./pkg/agent`
- `go test ./pkg/agent -run 'TestOpencodeCancellationTerminatesProcessGroupGraceful|TestOpencodeCancellationEscalatesToSIGKILL|TestCodexExecuteCleansUpWhenScannerOverflowsOnResume' -count=1`

## Known gap
- Machine-side verification on `DESKTOP-ORSLCSS` remains blocked: UU cannot find that device in the current account, and SSH to `NINGMEI@desktop-orslcss` closes the connection before auth.
- Full `go test ./pkg/agent` currently fails in existing Codex timing tests with 72-120ms first-progress windows; a single rerun of `TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress` reproduced the same timing failure, separate from this Windows process containment path.
