### PR TITLE
fix(markdown): render inline data-URI images (MUL-3961)

### DIFF
--- a/packages/ui/markdown/Markdown.tsx
+++ b/packages/ui/markdown/Markdown.tsx
@@ -84,6 +84,10 @@ const sanitizeSchema = {
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), 'mention', 'slash'],
+    // Permit inline data-URI images (QR codes, charts, base64 screenshots).
+    // The scheme gate only allows `data:` through here; attributes.img below
+    // narrows it to image/* so non-image data URIs are still rejected.
+    src: [...(defaultSchema.protocols?.src ?? []), 'data'],
   },
   attributes: {
     ...defaultSchema.attributes,
@@ -100,8 +104,17 @@ const sanitizeSchema = {
       ['className', /^hljs/],
     ],
     img: [
-      ...(defaultSchema.attributes?.img ?? []),
+      // Drop the default plain `src` entry so the value allow-list below is the
+      // one findDefinition resolves — it returns the first match by name, so a
+      // bare `src` string would otherwise shadow (and disable) the allow-list.
+      ...(defaultSchema.attributes?.img ?? []).filter(
+        (attr) => (typeof attr === 'string' ? attr : attr[0]) !== 'src',
+      ),
       'alt',
+      // Allow inline data:image/* URIs while leaving every other src form
+      // (http/https/site-relative) exactly as before: the negative lookahead
+      // keeps all non-data values, and data: is narrowed to images only.
+      ['src', /^data:image\//i, /^(?!data:)/i],
     ],
   },
 }
@@ -113,6 +126,11 @@ const sanitizeSchema = {
 function urlTransform(url: string): string {
   if (url.startsWith('mention://')) return url
   if (url.startsWith('slash://skill/')) return url
+  // Allow inline data:image/* URIs — defaultUrlTransform strips every data: URL
+  // to '', which would blank the src even after rehype-sanitize keeps it. Kept
+  // in sync with the image/* narrowing in sanitizeSchema (protocols.src +
+  // attributes.img) so both gates agree on what a valid inline image is.
+  if (/^data:image\//i.test(url)) return url
   return defaultUrlTransform(url)
 }
 

--- a/packages/views/common/markdown.test.tsx
+++ b/packages/views/common/markdown.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { Markdown as MarkdownBase } from "@multica/ui/markdown";
 import { Markdown } from "./markdown";
 
 vi.mock("@multica/core/config", () => ({
@@ -88,5 +89,40 @@ describe("Markdown", () => {
 
     expect(screen.getByTestId("project-chip")).toHaveTextContent("project-123");
     expect(screen.getByRole("link")).toHaveAttribute("href", "/projects/project-123");
+  });
+});
+
+// The base renderer uses a plain <img>; exercising it here (instead of the
+// views wrapper, which swaps in <Attachment>) lets us assert the sanitized
+// `src` directly. Covers the two gates that used to blank data-URI images:
+// rehype-sanitize's protocols.src and react-markdown's urlTransform.
+describe("Markdown inline data-URI images", () => {
+  const PNG_1X1 =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  it("preserves the src of an inline data:image/png image", () => {
+    render(<MarkdownBase>{`![demo](${PNG_1X1})`}</MarkdownBase>);
+
+    const img = screen.getByAltText("demo");
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", PNG_1X1);
+  });
+
+  it("keeps regular http(s) images working", () => {
+    render(<MarkdownBase>{"![cat](https://cdn.example.com/cat.png)"}</MarkdownBase>);
+
+    expect(screen.getByAltText("cat")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/cat.png",
+    );
+  });
+
+  it("strips non-image data URIs (data:text/html)", () => {
+    render(
+      <MarkdownBase>{"![x](data:text/html,<script>alert(1)</script>)"}</MarkdownBase>,
+    );
+
+    const img = screen.getByAltText("x");
+    expect(img.getAttribute("src") ?? "").toBe("");
   });
 });

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -562,6 +562,40 @@ describe("ReadonlyContent file-card → AttachmentBlock HTML routing", () => {
   });
 });
 
+describe("ReadonlyContent inline data-URI images", () => {
+  // Issue comments render through ReadonlyContent, which has its own sanitize
+  // schema + urlTransform separate from the base Markdown component. Agents
+  // inline auth QR codes as `![](data:image/png;base64,...)`; both gates used
+  // to strip the src and surface a broken image (MUL-3961).
+  const PNG_1X1 =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  function renderWithQuery(ui: ReactElement) {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  }
+
+  it("preserves the src of an inline data:image/png image", () => {
+    const { container } = renderWithQuery(
+      <ReadonlyContent content={`![QR Code](${PNG_1X1})`} />,
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(PNG_1X1);
+  });
+
+  it("strips non-image data URIs (data:text/html)", () => {
+    const { container } = renderWithQuery(
+      <ReadonlyContent content={"![x](data:text/html,<script>alert(1)</script>)"} />,
+    );
+
+    // The value allow-list rejects non-image data URIs, so no usable src reaches
+    // the <img>. AttachmentRenderer still mounts an <img>, but with an empty src.
+    expect(container.querySelector("img")?.getAttribute("src") ?? "").toBe("");
+  });
+});
+
 describe("ReadonlyContent slash command rendering", () => {
   it("renders slash skill links as slash command pills", () => {
     const { container } = render(

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -76,6 +76,10 @@ const sanitizeSchema = {
   protocols: {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "mention", "slash"],
+    // Permit inline data-URI images (QR codes, charts, base64 screenshots).
+    // The scheme gate only allows `data:` through here; attributes.img below
+    // narrows it to image/* so non-image data URIs are still rejected.
+    src: [...(defaultSchema.protocols?.src ?? []), "data"],
   },
   attributes: {
     ...defaultSchema.attributes,
@@ -92,8 +96,17 @@ const sanitizeSchema = {
       ["className", /^hljs/],
     ],
     img: [
-      ...(defaultSchema.attributes?.img ?? []),
+      // Drop the default plain `src` entry so the value allow-list below is the
+      // one findDefinition resolves — it returns the first match by name, so a
+      // bare `src` string would otherwise shadow (and disable) the allow-list.
+      ...(defaultSchema.attributes?.img ?? []).filter(
+        (attr) => (typeof attr === "string" ? attr : attr[0]) !== "src",
+      ),
       "alt",
+      // Allow inline data:image/* URIs while leaving every other src form
+      // (http/https/site-relative) exactly as before: the negative lookahead
+      // keeps all non-data values, and data: is narrowed to images only.
+      ["src", /^data:image\//i, /^(?!data:)/i],
     ],
   },
 };
@@ -105,6 +118,11 @@ const sanitizeSchema = {
 function urlTransform(url: string): string {
   if (url.startsWith("mention://")) return url;
   if (url.startsWith("slash://skill/")) return url;
+  // Allow inline data:image/* URIs — defaultUrlTransform strips every data: URL
+  // to '', which would blank the src even after rehype-sanitize keeps it. Kept
+  // in sync with the image/* narrowing in sanitizeSchema (protocols.src +
+  // attributes.img) so both gates agree on what a valid inline image is.
+  if (/^data:image\//i.test(url)) return url;
   return defaultUrlTransform(url);
 }
 


### PR DESCRIPTION
## Summary

Inline data-URI images (`![alt](data:image/png;base64,…)`) in chat / comment markdown were stripped and rendered as broken-image placeholders. The most visible case is agent auth flows that inline a QR code. Fixes MUL-3961 (community GH #4827).

## Root cause

Two independent gates dropped the image `src` before render:

1. **`rehype-sanitize`** — `sanitizeSchema.protocols.src` inherited the default `['http','https']`, so any `data:` src was removed by the scheme check.
2. **`react-markdown`** — `defaultUrlTransform` (applied to `src` *after* the rehype plugins) blanks any `data:` URL to `''`. So even after fixing the sanitize schema, the src would still be wiped.

The original issue only diagnosed gate #1; #2 was found while verifying and is fixed here too — otherwise the image stays broken.

## Changes (`packages/ui/markdown/Markdown.tsx`)

- `protocols.src`: add `'data'` so the scheme gate lets data URIs through.
- `attributes.img`: replace the default plain `src` entry with a value allow-list `['src', /^data:image\//i, /^(?!data:)/i]`. This narrows `data:` to **image subtypes only** (a `data:text/html` blob is still rejected) while the negative lookahead keeps every non-data src (http/https/site-relative) working exactly as before. Dropping the default `src` entry is required because `hast-util-sanitize`'s `findDefinition` returns the *first* match by name, so a bare `src` would shadow and disable the allow-list.
- `urlTransform`: allow `data:image/*` before falling back to `defaultUrlTransform`, kept in sync with the schema narrowing.

`packages/ui/markdown/file-cards.ts` deliberately rejects `data:` for security and is **left untouched**.

## Testing

Added `packages/views/common/markdown.test.tsx` cases against the base renderer (plain `<img>`, so the sanitized `src` can be asserted directly):

- inline `data:image/png` src is preserved
- regular `https://` images keep working
- non-image `data:text/html` is stripped

Verified:
- The `data:image` test **fails without the fix** and passes with it (genuine regression test).
- `pnpm test` (views markdown suite) — 8/8 pass.
- `pnpm typecheck` — clean for `@multica/ui` and `@multica/views`.
- `eslint` — clean on both changed files.

MUL-3961
