### PR TITLE
fix(web): redirect legacy squads and usage routes (MUL-3965)

### DIFF
--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "./proxy";
+
+function makeRequest(path: string, cookies: Record<string, string> = {}) {
+  const cookieHeader = Object.entries(cookies)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("; ");
+
+  return new NextRequest(`https://app.multica.test${path}`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+  });
+}
+
+function redirectLocation(path: string, cookies: Record<string, string> = {}) {
+  return proxy(makeRequest(path, cookies)).headers.get("location");
+}
+
+describe("proxy legacy workspace route redirects", () => {
+  const sessionCookies = {
+    multica_logged_in: "1",
+    last_workspace_slug: "acme",
+  };
+
+  it.each([
+    ["issues", "/acme/issues"],
+    ["projects", "/acme/projects"],
+    ["agents", "/acme/agents"],
+    ["squads", "/acme/squads"],
+    ["inbox", "/acme/inbox"],
+    ["my-issues", "/acme/my-issues"],
+    ["autopilots", "/acme/autopilots"],
+    ["runtimes", "/acme/runtimes"],
+    ["skills", "/acme/skills"],
+    ["settings", "/acme/settings"],
+    ["usage", "/acme/usage"],
+  ])("redirects legacy /%s URLs through the last workspace slug", (segment, expectedPath) => {
+    expect(redirectLocation(`/${segment}?tab=all`, sessionCookies)).toBe(
+      `https://app.multica.test${expectedPath}?tab=all`,
+    );
+  });
+
+  it("preserves nested legacy paths and query strings", () => {
+    expect(
+      redirectLocation("/squads/squad-123?view=members", sessionCookies),
+    ).toBe("https://app.multica.test/acme/squads/squad-123?view=members");
+  });
+
+  it("sends logged-out legacy URLs to login", () => {
+    expect(redirectLocation("/usage?tab=billing")).toBe(
+      "https://app.multica.test/login?tab=billing",
+    );
+  });
+
+  it("sends logged-in legacy URLs without a last workspace cookie to root", () => {
+    expect(
+      redirectLocation("/squads", { multica_logged_in: "1" }),
+    ).toBe("https://app.multica.test/");
+  });
+
+  it("does not redirect workspace-scoped URLs whose first segment is already a slug", () => {
+    expect(redirectLocation("/acme/squads", sessionCookies)).toBeNull();
+  });
+});

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -13,12 +13,14 @@ const LEGACY_ROUTE_SEGMENTS = new Set([
   "issues",
   "projects",
   "agents",
+  "squads",
   "inbox",
   "my-issues",
   "autopilots",
   "runtimes",
   "skills",
   "settings",
+  "usage",
 ]);
 
 function resolveLocale(req: NextRequest): string {


### PR DESCRIPTION
## What does this PR do?

This PR fixes a legacy URL redirect gap in the web proxy.

Workspace-scoped routes moved under `/{workspaceSlug}/...`, and `apps/web/proxy.ts` preserves old links by redirecting legacy root-level routes such as `/issues` to `/{last_workspace_slug}/issues`. However, `squads` and `usage` were missing from that legacy route segment list even though they are valid workspace routes.

Without this fix, old links like `/squads`, `/squads/team-123`, or `/usage?tab=billing` could fall through as root-level routes and 404 instead of redirecting into the user's last workspace.

The fix keeps the existing proxy behavior and simply extends the legacy segment allowlist, plus adds focused tests to prevent future drift.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `apps/web/proxy.ts` to include `squads` and `usage` in `LEGACY_ROUTE_SEGMENTS`.
- Added `apps/web/proxy.test.ts` covering:
  - legacy route redirects through `last_workspace_slug`
  - preservation of nested paths and query strings
  - logged-out legacy URL redirect to `/login`
  - logged-in users without a workspace cookie redirecting to `/`
  - already workspace-scoped URLs not being redirected

## How to Test

1. Run the focused proxy test:

   ```bash
   pnpm -C apps/web exec vitest run proxy.test.ts
   ```

2. Verify the test passes:

   ```text
   Test Files  1 passed (1)
   Tests       15 passed (15)
   ```

3. Optional manual checks with a logged-in browser session that has `last_workspace_slug=acme`:

   - `/squads` redirects to `/acme/squads`
   - `/squads/squad-123?view=members` redirects to `/acme/squads/squad-123?view=members`
   - `/usage?tab=billing` redirects to `/acme/usage?tab=billing`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
I used Cursor to inspect the route definitions and web proxy behavior, identify workspace routes missing from the legacy redirect allowlist, implement the small proxy fix, and add focused Vitest coverage around the redirect behavior.

## Screenshots (optional)

Not applicable. This change affects proxy redirects only and does not change visible UI.