### PR TITLE
fix(issues): replace nested "More" action submenu with "Relations" (MUL-3972)

### DIFF
--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -163,9 +163,9 @@ describe("IssueActionsDropdown", () => {
     expect(screen.getByText("Assignee")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
-    expect(screen.getByText("More")).toBeInTheDocument();
+    expect(screen.getByText("Relations")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
-    // Relationship actions are hidden inside the "More" submenu by default.
+    // Relationship actions are hidden inside the "Relations" submenu by default.
     expect(screen.queryByText("Create sub-issue")).not.toBeInTheDocument();
     expect(screen.queryByText("Set parent issue...")).not.toBeInTheDocument();
     expect(screen.queryByText("Add sub-issue...")).not.toBeInTheDocument();
@@ -194,7 +194,7 @@ describe("IssueActionsDropdown", () => {
     expect(await screen.findByText("Test User")).toBeInTheDocument();
   });
 
-  it("shows 'Remove parent issue' in the More submenu only when the issue has a parent", async () => {
+  it("shows 'Remove parent issue' in the Relations submenu only when the issue has a parent", async () => {
     const childIssue = { ...mockIssue, parent_issue_id: "parent-1" } as Issue;
     render(
       wrap(
@@ -206,7 +206,7 @@ describe("IssueActionsDropdown", () => {
     );
 
     fireEvent.click(screen.getByTestId("trigger"));
-    fireEvent.click(await screen.findByText("More"));
+    fireEvent.click(await screen.findByText("Relations"));
 
     expect(await screen.findByText("Remove parent issue")).toBeInTheDocument();
   });
@@ -222,7 +222,7 @@ describe("IssueActionsDropdown", () => {
     );
 
     fireEvent.click(screen.getByTestId("trigger"));
-    fireEvent.click(await screen.findByText("More"));
+    fireEvent.click(await screen.findByText("Relations"));
 
     // The sibling "Set parent issue..." proves the submenu opened.
     expect(await screen.findByText("Set parent issue...")).toBeInTheDocument();

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -10,7 +10,7 @@ import {
   CalendarClock,
   FolderOpen,
   Link2,
-  MoreHorizontal,
+  Network,
   Pin,
   PinOff,
   Plus,
@@ -270,12 +270,14 @@ export function IssueActionsMenuItems({
 
       <P.Separator />
 
-      {/* Relationship actions live under "More" — they're lower-frequency and
-          will grow (blocks, duplicates, related) as we add more relation types. */}
+      {/* Relationship actions live under "Relations" — a semantically explicit
+          label (unlike the old "More") so the first level tells you what the
+          submenu does. Holds parent/sub-issue links today, and will grow
+          (blocks, duplicates, related) as we add more relation types. */}
       <P.Sub>
         <P.SubTrigger>
-          <MoreHorizontal className="h-3.5 w-3.5" />
-          {t(($) => $.actions.more)}
+          <Network className="h-3.5 w-3.5" />
+          {t(($) => $.actions.relations)}
         </P.SubTrigger>
         <P.SubContent>
           <P.Item onClick={openCreateSubIssue}>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -432,7 +432,7 @@
     "unpin_from_sidebar": "Unpin from sidebar",
     "copy_link": "Copy link",
     "copy_workdir_path": "Copy local workdir path",
-    "more": "More",
+    "relations": "Relations",
     "create_sub_issue": "Create sub-issue",
     "set_parent_issue": "Set parent issue...",
     "remove_parent_issue": "Remove parent issue",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -412,7 +412,7 @@
     "unpin_from_sidebar": "サイドバーのピン留めを解除",
     "copy_link": "リンクをコピー",
     "copy_workdir_path": "ローカルの作業ディレクトリのパスをコピー",
-    "more": "その他",
+    "relations": "関係",
     "create_sub_issue": "サブイシューを作成",
     "set_parent_issue": "親イシューを設定...",
     "remove_parent_issue": "親イシューを解除",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -412,7 +412,7 @@
     "unpin_from_sidebar": "사이드바 고정 해제",
     "copy_link": "링크 복사",
     "copy_workdir_path": "로컬 작업 디렉터리 경로 복사",
-    "more": "더 보기",
+    "relations": "관계",
     "create_sub_issue": "하위 이슈 만들기",
     "set_parent_issue": "상위 이슈 설정...",
     "remove_parent_issue": "상위 이슈 제거",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -412,7 +412,7 @@
     "unpin_from_sidebar": "从侧边栏取消固定",
     "copy_link": "复制链接",
     "copy_workdir_path": "复制本地 workdir 路径",
-    "more": "更多",
+    "relations": "关系",
     "create_sub_issue": "创建子 issue",
     "set_parent_issue": "设置父 issue...",
     "remove_parent_issue": "移除父 issue",


### PR DESCRIPTION
## What & why

The issue action menu (the 3-dot dropdown and the right-click context menu) had a
submenu literally labelled **"More"**. Since that menu is itself opened from a
"more actions" affordance, users clicked "More" only to be shown *another* "More" —
and the first-level label told them nothing about what was inside.

Every sibling submenu is a noun that describes its contents (Status, Priority,
Start date, Due date). "More" broke that pattern. The three/four items it hides —
**Create sub-issue**, **Set parent issue…**, **Remove parent issue**, **Add sub-issue…** —
are all operations on the issue's parent/sub-issue relationships.

This PR renames that submenu to the semantically explicit **"Relations"**
(`关系` / `関係` / `관계`) and swaps the `MoreHorizontal` icon for `Network`, so the
first level tells you what the submenu does — consistent with its siblings. The
grouping and the items themselves are unchanged; keeping them under one relations
umbrella also gives future relation types (blocks, duplicates, related) a home,
which was the original intent of the group.

Before: `⋯ More ▸` → Create sub-issue / Set parent issue… / Remove parent issue / Add sub-issue…
After:  `⧉ Relations ▸` → (same items)

## Changes

- Rename i18n key `actions.more` → `actions.relations` across `en` / `zh-Hans` / `ja` / `ko`
  (values: Relations / 关系 / 関係 / 관계).
- Swap the submenu icon from `MoreHorizontal` to `Network` in the shared
  `IssueActionsMenuItems` component (used by both the dropdown and the right-click
  context menu, so detail / list / board / gantt all pick it up).
- Update the shared menu test to assert the new label.

## Verification

- `pnpm --filter @multica/views test` (menu test + locale parity test) — 166 passed.
- `pnpm --filter @multica/views typecheck` — clean.

Refs MUL-3972
