### PR TITLE
MUL-3982: WS-1325: keep daily create-issue autopilots visible when runtime is offline

### DIFF
--- a/apps/docs/content/docs/autopilots.ja.mdx
+++ b/apps/docs/content/docs/autopilots.ja.mdx
@@ -192,7 +192,7 @@ curl -X POST "$MULTICA_WEBHOOK_URL" \
 Multica は正常な no-op の結果に対して `status` フィールド付きで `200 OK` を返すため、プロバイダーの webhook 再試行メカニズムが URL を叩き続けることはありません。
 
 - `{"status":"accepted","run_id":"…","autopilot_id":"…","trigger_id":"…"}` — 実行がディスパッチされました。
-- `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}` — 割り当て先のランタイムがオフラインで、`skipped` の実行として記録されます。
+- `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}` — `run_only` オートパイロットでは、割り当て先のランタイムがオフラインのためタスクはキューに入りません。`create_issue` オートパイロットは追跡可能な issue を作成し、ランタイム復帰後に引き継げるようにします。
 - `{"status":"ignored","reason":"trigger_disabled"}` — トリガーが無効になっています。
 - `{"status":"ignored","reason":"autopilot_paused"}` — オートパイロットが一時停止しています。
 - `{"status":"ignored","reason":"autopilot_archived"}` — オートパイロットがアーカイブされています。

--- a/apps/docs/content/docs/autopilots.ko.mdx
+++ b/apps/docs/content/docs/autopilots.ko.mdx
@@ -192,7 +192,7 @@ curl -X POST "$MULTICA_WEBHOOK_URL" \
 Multica는 정상적인 no-op 결과에 대해 `status` 필드와 함께 `200 OK`를 반환하므로, 제공자의 webhook 재시도 메커니즘이 URL을 계속 두드리지 않습니다.
 
 - `{"status":"accepted","run_id":"…","autopilot_id":"…","trigger_id":"…"}` — 실행이 디스패치되었습니다.
-- `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}` — 수신 대상의 런타임이 오프라인이며, `skipped` 실행으로 기록됩니다.
+- `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}` — `run_only` 오토파일럿에서는 수신 대상의 런타임이 오프라인이어서 작업을 큐에 넣지 않습니다. `create_issue` 오토파일럿은 추적 가능한 이슈를 계속 생성하므로 런타임이 돌아오면 작업을 이어받을 수 있습니다.
 - `{"status":"ignored","reason":"trigger_disabled"}` — 트리거가 비활성화되어 있습니다.
 - `{"status":"ignored","reason":"autopilot_paused"}` — 오토파일럿이 일시 정지되어 있습니다.
 - `{"status":"ignored","reason":"autopilot_archived"}` — 오토파일럿이 보관되어 있습니다.

--- a/apps/docs/content/docs/autopilots.mdx
+++ b/apps/docs/content/docs/autopilots.mdx
@@ -241,7 +241,9 @@ your provider's webhook-retry machinery doesn't keep hammering the URL:
 - `{"status":"accepted","run_id":"…","autopilot_id":"…","trigger_id":"…"}`
   — a run was dispatched.
 - `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}`
-  — the assignee's runtime is offline; recorded as a `skipped` run.
+  — for `run_only` autopilots, the assignee's runtime is offline and no task
+  was queued. `create_issue` autopilots still create the tracked issue so the
+  work stays visible and can be claimed when the runtime returns.
 - `{"status":"ignored","reason":"trigger_disabled"}` — the trigger is disabled.
 - `{"status":"ignored","reason":"autopilot_paused"}` — the autopilot is paused.
 - `{"status":"ignored","reason":"autopilot_archived"}` — the autopilot is archived.

--- a/apps/docs/content/docs/autopilots.zh.mdx
+++ b/apps/docs/content/docs/autopilots.zh.mdx
@@ -229,7 +229,8 @@ curl -X POST "$MULTICA_WEBHOOK_URL" \
 - `{"status":"accepted","run_id":"…","autopilot_id":"…","trigger_id":"…"}`
   —— 已派发一次 run。
 - `{"status":"skipped","run_id":"…","reason":"agent runtime is offline at dispatch time"}`
-  —— 受派智能体的 runtime 离线，记为 `skipped` run。
+  —— 对 `run_only` Autopilot，受派智能体的 runtime 离线且不会入队；
+  `create_issue` Autopilot 仍会创建可追踪 issue，等 runtime 回来后继续认领。
 - `{"status":"ignored","reason":"trigger_disabled"}` —— 触发器已禁用。
 - `{"status":"ignored","reason":"autopilot_paused"}` —— Autopilot 已暂停。
 - `{"status":"ignored","reason":"autopilot_archived"}` —— Autopilot 已归档。

--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -399,6 +399,102 @@ func TestAutopilotDispatchSkipsWhenRuntimeOffline(t *testing.T) {
 	}
 }
 
+// TestAutopilotCreateIssueDispatchCreatesIssueWhenRuntimeOffline locks in the
+// audit-trail contract for tracked autopilots: create_issue mode must still
+// create a visible issue when the assignee runtime is offline, leaving the
+// issue/task to be claimed when the runtime comes back instead of silently
+// recording an unrecoverable skipped run.
+func TestAutopilotCreateIssueDispatchCreatesIssueWhenRuntimeOffline(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var runtimeID, agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, 'Offline create-issue runtime', 'local', 'ws1325_offline_runtime', 'offline', '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID)).Scan(&runtimeID); err != nil {
+		t.Fatalf("create offline runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id
+		)
+		VALUES ($1, 'ws1325-offline-create-issue-agent', '', 'local', '{}'::jsonb, $2, 'workspace', 1, $3)
+		RETURNING id::text
+	`, parseUUID(testWorkspaceID), runtimeID, parseUUID(testUserID)).Scan(&agentID); err != nil {
+		t.Fatalf("create offline agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Offline create-issue autopilot",
+		Description:        pgtype.Text{String: "WS-1325 regression test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "create_issue",
+		IssueTitleTemplate: pgtype.Text{String: "Tracked issue", Valid: true},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+
+	run, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected a run, got nil")
+	}
+	if run.Status != "issue_created" {
+		t.Fatalf("expected run status 'issue_created', got %q", run.Status)
+	}
+	if !run.IssueID.Valid {
+		t.Fatal("create_issue dispatch did not link an issue")
+	}
+	if run.FailureReason.Valid {
+		t.Fatalf("expected no failure reason, got %q", run.FailureReason.String)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, run.IssueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, run.IssueID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, run.IssueID)
+	})
+
+	tasks, err := queries.ListTasksByIssue(ctx, run.IssueID)
+	if err != nil {
+		t.Fatalf("ListTasksByIssue: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected one queued issue task, got %d", len(tasks))
+	}
+	if tasks[0].AgentID != parseUUID(agentID) {
+		t.Fatalf("task agent mismatch: got %v want %v", tasks[0].AgentID, parseUUID(agentID))
+	}
+	if tasks[0].RuntimeID != parseUUID(runtimeID) {
+		t.Fatalf("task runtime mismatch: got %v want %v", tasks[0].RuntimeID, parseUUID(runtimeID))
+	}
+}
+
 // TestManualTriggerDoesNotErrorOnPostAdmissionSkip locks in PR #2888 review
 // fix #2: if the dispatcher decides to skip after the admission gate has
 // already passed (e.g. the leader's runtime went offline between admission

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -47,15 +47,20 @@ func NewAutopilotService(q *db.Queries, tx TxStarter, bus *events.Bus, taskSvc *
 // It creates a run and either creates an issue or enqueues a direct agent task
 // depending on execution_mode.
 //
-// Before any work is queued we run an admission check against the assignee
+// Before run_only work is queued we run an admission check against the assignee
 // agent's runtime: if it is not online, we record a `skipped` run with a
 // failure_reason and return without enqueueing. This is the "触发时准入" gate
 // from MUL-1899 — without it a paused laptop / offline daemon causes scheduled
 // autopilots to pile thousands of doomed tasks onto agent_task_queue.
 //
+// create_issue mode is different: its primary contract is a durable audit
+// trail. If the assignee has a runtime but that runtime is merely offline,
+// dispatch still creates the issue and issue task so the work is visible and
+// can be claimed when the runtime returns.
+//
 // When assignee_type='squad' the gate runs against the squad leader (Path A
-// from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), so an offline or
-// archived leader produces the same skip behaviour as an offline solo agent.
+// from MUL-2429: Autopilot-on-squad ≈ Autopilot-on-leader), with the same
+// create_issue audit-trail exception for a merely offline leader runtime.
 func (s *AutopilotService) DispatchAutopilot(
 	ctx context.Context,
 	autopilot db.Autopilot,
@@ -161,11 +166,11 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 //   - It is in-flight in a state whose downstream side effect is
 //     observable:
 //
-//     * issue_created with a valid issue_id — the issue exists and
-//       the issue-event listener owns task creation from here.
+//   - issue_created with a valid issue_id — the issue exists and
+//     the issue-event listener owns task creation from here.
 //
-//     * running with a valid task_id — the task is queued, the
-//       listener will close the run when the task terminates.
+//   - running with a valid task_id — the task is queued, the
+//     listener will close the run when the task terminates.
 //
 // Anything else — most importantly issue_created/running with NULL
 // issue_id/task_id, or the brief 'pending' state — is a partial run:
@@ -868,7 +873,15 @@ func (s *AutopilotService) shouldSkipDispatch(ctx context.Context, ap db.Autopil
 		return "", false
 	}
 	if !ready {
-		return formatAdmissionReason(ap, reason), true
+		if ap.ExecutionMode == "create_issue" && strings.HasPrefix(reason, "agent runtime is ") {
+			slog.Info("autopilot admission: allowing create_issue dispatch for offline runtime",
+				"autopilot_id", util.UUIDToString(ap.ID),
+				"runtime_id", util.UUIDToString(agent.RuntimeID),
+				"reason", reason,
+			)
+		} else {
+			return formatAdmissionReason(ap, reason), true
+		}
 	}
 	// Private-agent gate at the autopilot layer. Caller identity = the
 	// autopilot's creator: if the creator no longer has access to the


### PR DESCRIPTION
Summary:
- Let create_issue autopilots create the tracked issue when the assignee runtime is offline, while run_only still records a skipped run and avoids queueing.
- Add integration regression coverage for the create_issue offline-runtime path.
- Update autopilot docs for the mode-specific offline behavior.

Test Plan:
- go test ./cmd/server -run Autopilot -count=1
- go test ./internal/service -run Autopilot -count=1

Issue: WS-1325