### PR TITLE
Fix private agent A2A access gate

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -589,9 +589,10 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 	}
 	alwaysRedact := workspaceAlwaysRedactSecrets(ws.Settings)
 
-	// Resolve the request actor once. Agents bypass the private-agent gate
-	// to preserve A2A collaboration; members must be in allowed_principals
-	// (agent owner or workspace owner/admin) to see private agents.
+	// Resolve the request actor once. Members must be in allowed_principals
+	// (agent owner or workspace owner/admin) to see private agents. Agent
+	// actors keep workspace-wide list visibility for A2A discovery; actual
+	// task-producing and chat surfaces still call canAccessPrivateAgent.
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 	visible := make([]AgentResponse, 0, len(agents))
 	for _, a := range agents {

--- a/server/internal/handler/agent_access.go
+++ b/server/internal/handler/agent_access.go
@@ -14,9 +14,12 @@ import (
 //
 // Public agents are unrestricted — the predicate returns true unconditionally.
 //
-// Agent-to-agent traffic is always allowed (actorType == "agent"); this is
-// what preserves A2A collaboration even with private agents. The trust
-// boundary is at member↔agent, not agent↔agent.
+// Agent-to-agent traffic is checked through the calling agent's owner. This
+// preserves A2A collaboration for the same allowed principals while keeping
+// another user's agent from dispatching work into a private agent.
+//
+// Platform-owned system triggers are allowed. They are not acting on behalf of
+// another workspace member or agent.
 //
 // For members, the implicit allowed_principals set is computed inline as:
 // {agent.owner_id} ∪ workspace owner/admin members. Manual configuration of
@@ -26,13 +29,43 @@ func (h *Handler) canAccessPrivateAgent(ctx context.Context, agent db.Agent, act
 	if agent.Visibility != "private" {
 		return true
 	}
+	if actorType == "system" {
+		return true
+	}
 	if actorType == "agent" {
+		return h.canAgentActorAccessPrivateAgent(ctx, agent, actorID, workspaceID)
+	}
+	return h.canMemberAccessPrivateAgent(ctx, agent, actorID, workspaceID)
+}
+
+func (h *Handler) canMemberAccessPrivateAgent(ctx context.Context, agent db.Agent, userID, workspaceID string) bool {
+	if uuidToString(agent.OwnerID) == userID {
 		return true
 	}
-	if uuidToString(agent.OwnerID) == actorID {
+	member, err := h.getWorkspaceMember(ctx, userID, workspaceID)
+	if err != nil {
+		return false
+	}
+	return roleAllowed(member.Role, "owner", "admin")
+}
+
+func (h *Handler) canAgentActorAccessPrivateAgent(ctx context.Context, target db.Agent, actorID, workspaceID string) bool {
+	if h == nil || h.Queries == nil {
+		return false
+	}
+	actorUUID, err := util.ParseUUID(actorID)
+	if err != nil {
+		return false
+	}
+	actor, err := h.Queries.GetAgent(ctx, actorUUID)
+	if err != nil || uuidToString(actor.WorkspaceID) != workspaceID {
+		return false
+	}
+	ownerID := uuidToString(actor.OwnerID)
+	if uuidToString(target.OwnerID) == ownerID {
 		return true
 	}
-	member, err := h.getWorkspaceMember(ctx, actorID, workspaceID)
+	member, err := h.getWorkspaceMember(ctx, ownerID, workspaceID)
 	if err != nil {
 		return false
 	}
@@ -73,17 +106,16 @@ func (h *Handler) accessibleAgentIDs(ctx context.Context, workspaceID, actorType
 	}
 	return allowed, true
 }
+
 // canEnqueueSquadLeader returns true when the given actor is allowed to
 // trigger the squad's private leader. It loads the leader agent and delegates
 // to canAccessPrivateAgent. Non-private leaders always pass. System-initiated
-// triggers (e.g. github webhooks) pass by treating "system" like "agent".
+// triggers (e.g. github webhooks) pass through the platform-owned "system"
+// actor type.
 func (h *Handler) canEnqueueSquadLeader(ctx context.Context, leaderID pgtype.UUID, actorType, actorID, workspaceID string) bool {
 	agent, err := h.Queries.GetAgent(ctx, leaderID)
 	if err != nil {
 		return false
-	}
-	if actorType == "system" {
-		actorType = "agent"
 	}
 	return h.canAccessPrivateAgent(ctx, agent, actorType, actorID, workspaceID)
 }

--- a/server/internal/handler/agent_access_test.go
+++ b/server/internal/handler/agent_access_test.go
@@ -50,6 +50,24 @@ func TestMemberAllowedForPrivateAgent_Pure(t *testing.T) {
 	}
 }
 
+func TestCanAccessPrivateAgent_AgentActorFailsClosedWithoutOwnershipEvidence(t *testing.T) {
+	target := db.Agent{
+		Visibility: "private",
+		OwnerID:    util.MustParseUUID("11111111-1111-1111-1111-111111111111"),
+	}
+
+	got := (&Handler{}).canAccessPrivateAgent(
+		context.Background(),
+		target,
+		"agent",
+		"22222222-2222-2222-2222-222222222222",
+		"33333333-3333-3333-3333-333333333333",
+	)
+	if got {
+		t.Fatal("private agent access by an unverifiable agent actor must fail closed")
+	}
+}
+
 // privateAgentTestFixture sets up a private agent owned by a freshly created
 // user, plus a second non-admin member in the workspace. Returns the agent
 // id, the owner's user id, and the unrelated member's user id. The caller's
@@ -267,6 +285,115 @@ func TestCreateIssue_AssignToPrivateAgentForbidsPlainMember(t *testing.T) {
 	testHandler.CreateIssue(w, newRequestAs(memberID, "POST", "/api/issues?workspace_id="+testWorkspaceID, body(memberID)))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("CreateIssue as plain member: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateIssue_AgentActorCannotAssignOtherUsersPrivateAgent verifies that a
+// legitimate running agent cannot use the issue-assignment surface to route
+// work into another user's private agent. Private agent visibility protects the
+// target agent's dispatch boundary, regardless of whether the caller is human
+// or agent-authored.
+func TestCreateIssue_AgentActorCannotAssignOtherUsersPrivateAgent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	targetAgentID, _, memberID := privateAgentTestFixture(t)
+
+	var sourceAgentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args
+		)
+		VALUES ($1, 'private-access-source-agent', '', 'cloud', '{}'::jsonb,
+		        $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, handlerTestRuntimeID(t), memberID).Scan(&sourceAgentID); err != nil {
+		t.Fatalf("create source agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, sourceAgentID)
+	})
+	sourceTaskID := createHandlerTestTaskForAgent(t, sourceAgentID)
+
+	title := "agent actor cannot assign other private agent " + memberID
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `
+			DELETE FROM agent_task_queue
+			WHERE issue_id IN (SELECT id FROM issue WHERE title = $1)
+		`, title)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE title = $1`, title)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequestAs(memberID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         title,
+		"status":        "todo",
+		"priority":      "medium",
+		"assignee_type": "agent",
+		"assignee_id":   targetAgentID,
+	})
+	req.Header.Set("X-Agent-ID", sourceAgentID)
+	req.Header.Set("X-Task-ID", sourceTaskID)
+
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateIssue from other user's agent: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateIssue_AgentActorCanAssignOwnPrivateAgent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	targetAgentID, ownerID, _ := privateAgentTestFixture(t)
+
+	var sourceAgentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args
+		)
+		VALUES ($1, 'private-access-owned-source-agent', '', 'cloud', '{}'::jsonb,
+		        $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, handlerTestRuntimeID(t), ownerID).Scan(&sourceAgentID); err != nil {
+		t.Fatalf("create source agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, sourceAgentID)
+	})
+	sourceTaskID := createHandlerTestTaskForAgent(t, sourceAgentID)
+
+	title := "agent actor can assign own private agent " + ownerID
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `
+			DELETE FROM agent_task_queue
+			WHERE issue_id IN (SELECT id FROM issue WHERE title = $1)
+		`, title)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE title = $1`, title)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequestAs(ownerID, "POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         title,
+		"status":        "todo",
+		"priority":      "medium",
+		"assignee_type": "agent",
+		"assignee_id":   targetAgentID,
+	})
+	req.Header.Set("X-Agent-ID", sourceAgentID)
+	req.Header.Set("X-Task-ID", sourceTaskID)
+
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue from same owner's agent: expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -513,7 +640,7 @@ func TestMentionAgent_RejectsCrossWorkspaceAgentUUID(t *testing.T) {
 //   - reject plain workspace members (not owner, not admin, not agent owner)
 //   - allow the agent owner
 //   - allow workspace owners/admins
-//   - allow agent-to-agent traffic regardless of agent visibility
+//   - allow agent-to-agent traffic when the calling agent owner is allowed
 func TestShouldEnqueueOnComment_PrivateAgentGate(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
@@ -574,17 +701,17 @@ func TestShouldEnqueueOnComment_PrivateAgentGate(t *testing.T) {
 			reason:    "workspace owners/admins are in the allowed_principals set",
 		},
 		{
-			name:      "agent-to-agent — allowed",
+			name:      "same-owner agent-to-agent — allowed",
 			actorType: "agent",
 			actorID:   agentID,
 			want:      true,
-			reason:    "A2A traffic bypasses the visibility gate by design",
+			reason:    "A2A traffic is checked through the calling agent's owner",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-				got := testHandler.shouldEnqueueAssigneeFallback(ctx, issue, tc.actorType, tc.actorID, commentTriggerComputeOptions{})
+			got := testHandler.shouldEnqueueAssigneeFallback(ctx, issue, tc.actorType, tc.actorID, commentTriggerComputeOptions{})
 			if got != tc.want {
 				t.Fatalf("%s\n  actor=%s/%s got=%v want=%v",
 					tc.reason, tc.actorType, tc.actorID, got, tc.want)

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -72,8 +72,8 @@ func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Private-agent gate: members must be in allowed_principals to start
-	// a chat with a private agent. Agent-to-agent chat sessions bypass
-	// the gate so A2A collaboration still works.
+	// a chat with a private agent. Agent-to-agent chat sessions are checked
+	// through the calling agent's owner.
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
 	if !h.canAccessPrivateAgent(r.Context(), agent, actorType, actorID, workspaceID) {
 		writeError(w, http.StatusForbidden, "you do not have access to this agent")
@@ -442,7 +442,7 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	// The session's creator passed the gate at create time, but their
 	// workspace role (or the agent's owner) may have changed since — keep
 	// stale sessions from being a back-door into a private agent the user
-	// can no longer reach. Agent senders bypass to preserve A2A collaboration.
+	// can no longer reach. Agent senders are checked through their owner.
 	session, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID)
 	if !ok {
 		return

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1820,7 +1820,7 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 			continue
 		}
 		// Private-agent gate (member→private requires allowed_principals;
-		// agent→agent always passes).
+		// agent→agent is checked through the calling agent's owner).
 		if !h.canAccessPrivateAgent(ctx, agent, authorType, authorID, wsID) {
 			continue
 		}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2628,8 +2628,9 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 // to an existing entity in the workspace. For agent assignees it also rejects
 // archived agents and runs the private-agent gate via canAccessPrivateAgent
 // — assigning an issue is a task-producing surface, so it must use the same
-// predicate as chat / @-mention / history. Agent callers (X-Agent-ID) bypass
-// the gate so A2A flows can still hand work off to private agents.
+// predicate as chat / @-mention / history. Agent callers (X-Agent-ID) are
+// checked through their owner, so A2A handoffs cannot cross another user's
+// private-agent boundary unless that owner would be allowed directly.
 //
 // Returns (statusCode, errorMessage). statusCode == 0 means the pair is valid;
 // callers should treat any non-zero status as a rejection and surface it back

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -192,22 +192,22 @@ Contracts:
 Source:
 
 ```text
-server/internal/handler/agent_access.go           # canAccessPrivateAgent ~25-40, canEnqueueSquadLeader ~82-91
+server/internal/handler/agent_access.go           # canAccessPrivateAgent ~28-72, canEnqueueSquadLeader ~115-120
 server/internal/handler/squad.go                   # enqueueSquadLeaderTask gate ~1037
 ```
 
 Contracts:
 
 - public leaders pass — `canAccessPrivateAgent` returns true when
-  `agent.Visibility != "private"` (agent_access.go:26-28);
-- agent-to-agent traffic is allowed — `actorType == "agent"` short-circuits
-  (agent_access.go:29-31);
+  `agent.Visibility != "private"` (agent_access.go:29-31);
+- agent-to-agent traffic is checked through the calling agent's owner; another
+  user's agent cannot route work into a private leader unless that owner is
+  allowed directly (agent_access.go:35-72);
 - private leader access for members is limited to owner/admin or agent owner
-  (agent_access.go:32-39);
-- system triggers are treated like agent triggers for squad leader enqueue:
-  `canEnqueueSquadLeader` remaps `actorType == "system"` to `"agent"` before
-  delegating to `canAccessPrivateAgent` (agent_access.go:87-90). This is wired
-  into `enqueueSquadLeaderTask`, which denies the enqueue when the actor cannot
+  (agent_access.go:41-49);
+- system triggers use the platform-owned `"system"` actor type and pass inside
+  `canAccessPrivateAgent` (agent_access.go:32-34). This is wired into
+  `enqueueSquadLeaderTask`, which denies the enqueue when the actor cannot
   access the leader (squad.go:1037).
 
 ## Tests


### PR DESCRIPTION
## Summary
- Gate `actorType == "agent"` private-agent access through the calling agent's owner instead of allowing all A2A traffic.
- Preserve same-owner and workspace owner/admin A2A handoffs, while denying another user's agent from assigning or dispatching work into a private agent.
- Keep platform-owned `system` triggers explicitly allowed, and update nearby handler comments plus squad source-map docs so the access boundary stays clear.

## Issue
Fixes #4841.

## Verification
- `DATABASE_URL='postgres://multica:multica@localhost:55432/multica_e2e_codex?sslmode=disable' go test ./internal/handler -count=1`
- `DATABASE_URL='postgres://multica:multica@localhost:55432/multica_e2e_codex?sslmode=disable' go test ./...` from `server/`
- Full Playwright E2E with temporary local Postgres and app ports: `pnpm exec playwright test` -> 21 passed
- `git diff --check`

## Notes
- `ENV_FILE=.env.worktree bash scripts/check.sh` currently stops at the repo's desktop typecheck before reaching E2E. The blocking errors are unrelated to this backend change: `apps/desktop/src/renderer/src/main.tsx` cannot see `ImportMeta.env`, and `packages/views/runtimes/components/provider-logo.tsx` references missing `./antigravity-logo.png`.
- The local E2E run also needed Playwright Chromium installed and a local `node_modules/dotenv` symlink because `e2e/env.ts` imports `dotenv` from the root workspace while the root package does not declare it. Those are local test-environment fixes only and are not included in this PR.
