### PR TITLE
MUL-3985: guard large paste and code highlighting

### DIFF
--- a/packages/core/issues/stores/comment-draft-store.test.ts
+++ b/packages/core/issues/stores/comment-draft-store.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Attachment } from "../../types";
+import { useCommentDraftStore, type CommentDraftKey } from "./comment-draft-store";
+
+function makeAttachment(id: string, overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    id,
+    workspace_id: "ws-1",
+    issue_id: "issue-1",
+    comment_id: null,
+    chat_session_id: null,
+    chat_message_id: null,
+    uploader_type: "member",
+    uploader_id: "user-1",
+    filename: `${id}.txt`,
+    url: `/uploads/${id}.txt`,
+    download_url: `/api/attachments/${id}/download`,
+    markdown_url: `/api/attachments/${id}/download`,
+    content_type: "text/plain",
+    size_bytes: 12,
+    created_at: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("comment draft store — attachments", () => {
+  const draftKey = "new:issue-1" as CommentDraftKey;
+
+  beforeEach(() => {
+    useCommentDraftStore.setState({ drafts: {} });
+  });
+
+  it("deduplicates attachment drafts by id", () => {
+    useCommentDraftStore
+      .getState()
+      .addDraftAttachment(draftKey, makeAttachment("att-1"));
+    useCommentDraftStore.getState().addDraftAttachment(
+      draftKey,
+      makeAttachment("att-1", { filename: "updated.txt" }),
+    );
+
+    const attachments = useCommentDraftStore
+      .getState()
+      .getDraftAttachments(draftKey);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.filename).toBe("updated.txt");
+  });
+
+  it("keeps attachment records when the draft content changes", () => {
+    useCommentDraftStore
+      .getState()
+      .addDraftAttachment(draftKey, makeAttachment("att-1"));
+
+    useCommentDraftStore.getState().setDraft(draftKey, "updated markdown");
+
+    expect(useCommentDraftStore.getState().getDraft(draftKey)).toBe(
+      "updated markdown",
+    );
+    expect(
+      useCommentDraftStore.getState().getDraftAttachments(draftKey),
+    ).toHaveLength(1);
+  });
+
+  it("clearDraft clears both content and attachment records", () => {
+    useCommentDraftStore.getState().setDraft(draftKey, "hello");
+    useCommentDraftStore
+      .getState()
+      .addDraftAttachment(draftKey, makeAttachment("att-1"));
+
+    useCommentDraftStore.getState().clearDraft(draftKey);
+
+    expect(useCommentDraftStore.getState().getDraft(draftKey)).toBeUndefined();
+    expect(useCommentDraftStore.getState().getDraftAttachments(draftKey)).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/core/issues/stores/comment-draft-store.ts
+++ b/packages/core/issues/stores/comment-draft-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import type { Attachment } from "../../types/attachment";
 import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
@@ -22,13 +23,17 @@ export type CommentDraftKey =
 
 interface CommentDraft {
   content: string;
+  attachments?: Attachment[];
   updatedAt: number;
 }
 
 interface CommentDraftStore {
   drafts: Record<string, CommentDraft>;
   getDraft: (key: CommentDraftKey) => string | undefined;
+  getDraftAttachments: (key: CommentDraftKey) => Attachment[];
   setDraft: (key: CommentDraftKey, content: string) => void;
+  setDraftAttachments: (key: CommentDraftKey, attachments: Attachment[]) => void;
+  addDraftAttachment: (key: CommentDraftKey, attachment: Attachment) => void;
   clearDraft: (key: CommentDraftKey) => void;
 }
 
@@ -37,12 +42,45 @@ interface CommentDraftStore {
 // slowly leak localStorage quota.
 const TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
-function pruneStaleDrafts(drafts: Record<string, CommentDraft>): Record<string, CommentDraft> {
+function isAttachmentDraft(value: unknown): value is Attachment {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    typeof (value as { filename?: unknown }).filename === "string"
+  );
+}
+
+function sanitizeDraft(value: unknown): CommentDraft {
+  const draft =
+    typeof value === "object" && value !== null
+      ? (value as Partial<CommentDraft>)
+      : {};
+  const attachments = Array.isArray(draft.attachments)
+    ? draft.attachments.filter(isAttachmentDraft)
+    : [];
+  return {
+    content: typeof draft.content === "string" ? draft.content : "",
+    updatedAt:
+      typeof draft.updatedAt === "number" && Number.isFinite(draft.updatedAt)
+        ? draft.updatedAt
+        : 0,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  };
+}
+
+function pruneStaleDrafts(
+  drafts: Record<string, unknown> | undefined,
+): Record<string, CommentDraft> {
   const cutoff = Date.now() - TTL_MS;
   const out: Record<string, CommentDraft> = {};
-  for (const [k, v] of Object.entries(drafts)) {
-    if (v.updatedAt >= cutoff && v.content.trim().length > 0) {
-      out[k] = v;
+  for (const [k, raw] of Object.entries(drafts ?? {})) {
+    const draft = sanitizeDraft(raw);
+    if (
+      draft.updatedAt >= cutoff &&
+      (draft.content.trim().length > 0 || (draft.attachments?.length ?? 0) > 0)
+    ) {
+      out[k] = draft;
     }
   }
   return out;
@@ -53,10 +91,59 @@ export const useCommentDraftStore = create<CommentDraftStore>()(
     (set, get) => ({
       drafts: {},
       getDraft: (key) => get().drafts[key]?.content,
+      getDraftAttachments: (key) => get().drafts[key]?.attachments ?? [],
       setDraft: (key, content) =>
-        set((s) => ({
-          drafts: { ...s.drafts, [key]: { content, updatedAt: Date.now() } },
-        })),
+        set((s) => {
+          const existing = s.drafts[key];
+          const attachments = existing?.attachments;
+          return {
+            drafts: {
+              ...s.drafts,
+              [key]: {
+                content,
+                updatedAt: Date.now(),
+                ...(attachments && attachments.length > 0 ? { attachments } : {}),
+              },
+            },
+          };
+        }),
+      setDraftAttachments: (key, attachments) =>
+        set((s) => {
+          const existing = s.drafts[key];
+          const sanitized = attachments.filter(isAttachmentDraft);
+          const content = existing?.content ?? "";
+          if (!content.trim() && sanitized.length === 0 && !existing) return s;
+          const next = { ...s.drafts };
+          if (!content.trim() && sanitized.length === 0) {
+            delete next[key];
+            return { drafts: next };
+          }
+          next[key] = {
+            content,
+            updatedAt: Date.now(),
+            ...(sanitized.length > 0 ? { attachments: sanitized } : {}),
+          };
+          return { drafts: next };
+        }),
+      addDraftAttachment: (key, attachment) =>
+        set((s) => {
+          if (!attachment.id) return s;
+          const existing = s.drafts[key];
+          const attachments = existing?.attachments ?? [];
+          const nextAttachments = attachments.some((a) => a.id === attachment.id)
+            ? attachments.map((a) => (a.id === attachment.id ? attachment : a))
+            : [...attachments, attachment];
+          return {
+            drafts: {
+              ...s.drafts,
+              [key]: {
+                content: existing?.content ?? "",
+                updatedAt: Date.now(),
+                attachments: nextAttachments,
+              },
+            },
+          };
+        }),
       clearDraft: (key) =>
         set((s) => {
           if (!(key in s.drafts)) return s;

--- a/packages/ui/markdown/CodeBlock.tsx
+++ b/packages/ui/markdown/CodeBlock.tsx
@@ -10,6 +10,7 @@ import {
   CODE_LIGATURE_CLASS,
   CODE_LIGATURE_DESCENDANT_CLASS,
 } from '@multica/ui/lib/code-style'
+import { shouldHighlightCode } from './code-thresholds'
 
 export interface CodeBlockProps {
   code: string
@@ -75,12 +76,20 @@ export function CodeBlock({
   // Resolve language alias - keep as string to allow 'text' fallback
   const langLower = language.toLowerCase()
   const resolvedLang: string = LANGUAGE_ALIASES[langLower] || langLower
+  const highlightLang = isValidLanguage(resolvedLang) ? resolvedLang : null
 
   React.useEffect(() => {
     let cancelled = false
 
     async function highlight(): Promise<void> {
-      const cacheKey = getCacheKey(code, resolvedLang)
+      const lang = highlightLang
+      if (!shouldHighlightCode(code, lang)) {
+        setHighlighted(null)
+        setIsLoading(false)
+        return
+      }
+
+      const cacheKey = getCacheKey(code, lang)
 
       const cached = highlightCache.get(cacheKey)
       if (cached) {
@@ -92,9 +101,6 @@ export function CodeBlock({
       }
 
       try {
-        // Use valid language or fallback to plaintext
-        const lang = isValidLanguage(resolvedLang) ? resolvedLang : 'text'
-
         // Dual themes: Shiki outputs CSS variables for both themes in one pass.
         // CSS handles switching via .dark selector (see globals.css).
         const html = await codeToHtml(code, {
@@ -132,7 +138,7 @@ export function CodeBlock({
     return () => {
       cancelled = true
     }
-  }, [code, resolvedLang])
+  }, [code, highlightLang, resolvedLang])
 
   const handleCopy = React.useCallback(async () => {
     if (await copyText(code)) {

--- a/packages/ui/markdown/code-thresholds.ts
+++ b/packages/ui/markdown/code-thresholds.ts
@@ -1,0 +1,8 @@
+export const LARGE_TEXT_THRESHOLD = 4_000;
+
+export function shouldHighlightCode(
+  code: string,
+  language: string | null | undefined,
+): language is string {
+  return Boolean(language) && code.length <= LARGE_TEXT_THRESHOLD;
+}

--- a/packages/ui/markdown/index.ts
+++ b/packages/ui/markdown/index.ts
@@ -1,5 +1,6 @@
 export { Markdown, MemoizedMarkdown, type MarkdownProps, type RenderMode } from './Markdown'
 export { CodeBlock, InlineCode, type CodeBlockProps } from './CodeBlock'
+export { LARGE_TEXT_THRESHOLD, shouldHighlightCode } from './code-thresholds'
 export { StreamingMarkdown, type StreamingMarkdownProps } from './StreamingMarkdown'
 export { preprocessLinks, detectLinks, hasLinks } from './linkify'
 export { preprocessMentionShortcodes } from './mentions'

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -374,6 +374,7 @@ export function ChatInput({
             }}
             onSubmit={handleSend}
             onUploadFile={uploadEnabled ? handleUpload : undefined}
+            largePasteMode="file"
             attachments={draftAttachments}
             debounceMs={100}
             mentionMode={contextItems ? "context" : "default"}

--- a/packages/views/editor/code-block-static.test.tsx
+++ b/packages/views/editor/code-block-static.test.tsx
@@ -22,4 +22,27 @@ describe("CodeBlockStatic", () => {
     expect(codeCss).toContain("pre.rich-text-editor");
     expect(codeCss).toContain("pre.rich-text-editor code");
   });
+
+  it("renders no-language blocks as plain text instead of auto-detecting", () => {
+    const { container } = render(
+      <CodeBlockStatic language={undefined} body="const answer = 42;" />,
+    );
+
+    const code = container.querySelector("pre.rich-text-editor code");
+    expect(code?.textContent).toBe("const answer = 42;");
+    expect(code?.querySelector("span")).toBeNull();
+  });
+
+  it("renders code over the large-text threshold as plain text even with a language", () => {
+    const body = "echo payload\n".repeat(400);
+    expect(body.length).toBeGreaterThan(4_000);
+
+    const { container } = render(
+      <CodeBlockStatic language="bash" body={body} />,
+    );
+
+    const code = container.querySelector("pre.rich-text-editor code");
+    expect(code?.textContent).toBe(body.replace(/\n$/, ""));
+    expect(code?.querySelector("span")).toBeNull();
+  });
 });

--- a/packages/views/editor/code-block-static.tsx
+++ b/packages/views/editor/code-block-static.tsx
@@ -17,6 +17,7 @@ import { useMemo } from "react";
 import { createLowlight, common } from "lowlight";
 import { toHtml } from "hast-util-to-html";
 import { cn } from "@multica/ui/lib/utils";
+import { shouldHighlightCode } from "@multica/ui/markdown";
 import "./styles/code.css";
 
 const lowlight = createLowlight(common);
@@ -30,10 +31,9 @@ interface CodeBlockStaticProps {
 export function CodeBlockStatic({ language, body, className }: CodeBlockStaticProps) {
   const html = useMemo(() => {
     const code = body.replace(/\n$/, "");
+    if (!shouldHighlightCode(code, language)) return escapeHtml(code);
     try {
-      const tree = language
-        ? lowlight.highlight(language, code)
-        : lowlight.highlightAuto(code);
+      const tree = lowlight.highlight(language, code);
       return toHtml(tree) as string;
     } catch {
       // Unknown language tag — fall back to escaped plain text so we don't

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -62,7 +62,11 @@ vi.mock("./attachment-download-context", () => ({
 const editorRef = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
 const onCreateFired = vi.hoisted(() => ({ value: false }));
 const latestEditorOptions = vi.hoisted<{
-  current?: { onUpdate?: (args: { editor: unknown }) => void };
+  current?: {
+    content?: unknown;
+    contentType?: string;
+    onUpdate?: (args: { editor: unknown }) => void;
+  };
 }>(() => ({}));
 
 vi.mock("@tiptap/react", () => ({
@@ -164,6 +168,49 @@ describe("ContentEditor", () => {
     expect(mockSetContent).toHaveBeenCalledWith(
       "new content from server",
       expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+  });
+
+  it("mounts a large defaultValue as a plain code block doc instead of markdown-parsing the whole string", () => {
+    const large = "large draft\n" + "payload\n".repeat(700);
+    expect(large.length).toBeGreaterThan(4_000);
+
+    render(<ContentEditor defaultValue={large} />);
+
+    expect(latestEditorOptions.current?.content).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          content: [{ type: "text", text: large }],
+        },
+      ],
+    });
+    expect(latestEditorOptions.current?.contentType).toBeUndefined();
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("syncs a large external defaultValue as a plain code block doc instead of markdown-parsing the whole string", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+    const large = "large draft\n" + "payload\n".repeat(700);
+    expect(large.length).toBeGreaterThan(4_000);
+
+    editorState.markdown = "old content";
+    rerender(<ContentEditor defaultValue={large} />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      {
+        type: "doc",
+        content: [
+          {
+            type: "codeBlock",
+            content: [{ type: "text", text: large }],
+          },
+        ],
+      },
+      { emitUpdate: false },
     );
   });
 

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -130,6 +130,12 @@ interface ContentEditorProps {
   onSubmit?: () => void;
   onBlur?: () => void;
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
+  /**
+   * Large text paste handling. Defaults to a plain no-language code block.
+   * Set to "file" only on surfaces whose draft flow persists attachment
+   * records, so reload can still submit the generated file card correctly.
+   */
+  largePasteMode?: "codeBlock" | "file";
   /** Show the floating formatting toolbar on text selection. Defaults true. */
   showBubbleMenu?: boolean;
   /** When true, bare Enter submits (chat-style). Mod-Enter always submits. */
@@ -209,6 +215,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       onSubmit,
       onBlur,
       onUploadFile,
+      largePasteMode = "codeBlock",
       showBubbleMenu = true,
       submitOnEnter = false,
       currentIssueId,
@@ -364,6 +371,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         queryClient,
         onSubmitRef,
         onUploadFileRef,
+        largePasteMode,
         submitOnEnter,
         disableMentions,
         mentionMode,

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -41,6 +41,7 @@ import {
 } from "react";
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import { cn } from "@multica/ui/lib/utils";
+import { LARGE_TEXT_THRESHOLD } from "@multica/ui/markdown";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import { useWorkspaceSlug } from "@multica/core/paths";
 import { useQueryClient } from "@tanstack/react-query";
@@ -85,6 +86,22 @@ function normalizeMarkdown(md: string): string {
 /** `normalizeMarkdown` applied to the live editor's serialized content. */
 function normalizeEditorMarkdown(editor: Editor): string {
   return normalizeMarkdown(editor.getMarkdown());
+}
+
+function plainCodeBlockDoc(text: string) {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "codeBlock",
+        content: [{ type: "text", text }],
+      },
+    ],
+  };
+}
+
+function shouldBypassMarkdownParse(markdown: string): boolean {
+  return markdown.length > LARGE_TEXT_THRESHOLD;
 }
 
 /** True when any node in the document is mid-upload (`attrs.uploading`). The
@@ -219,6 +236,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     >(undefined);
     const mentionContextItemsRef = useRef<MentionItem[]>(mentionContextItems ?? []);
     const lastEmittedRef = useRef<string | null>(null);
+    const bypassedMarkdownRef = useRef<string | null>(null);
 
     // In-session record of attachments freshly uploaded through this editor.
     // Surfaces (like the quick-create modal) that don't have a server-supplied
@@ -298,9 +316,12 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     const queryClient = useQueryClient();
 
     const initialContent = defaultValue ? preprocessMarkdown(defaultValue) : "";
-    // Large markdown is parsed in chunks to dodge marked's O(n²) tokenizer (see
-    // parseMarkdownChunked). Small docs stay on the single-parse fast path.
-    const mountChunked = initialContent.length > MARKDOWN_CHUNK_THRESHOLD;
+    const mountPlainCodeBlock = shouldBypassMarkdownParse(initialContent);
+    // Very large markdown bypasses the parser entirely and mounts as a plain
+    // code block. The chunked path is kept as a bounded fallback if this guard
+    // is ever raised while still staying below the unsafe whole-parse size.
+    const mountChunked =
+      !mountPlainCodeBlock && initialContent.length > MARKDOWN_CHUNK_THRESHOLD;
 
     const editor = useEditor({
       immediatelyRender: false,
@@ -325,10 +346,15 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
             });
           }
         }
+        bypassedMarkdownRef.current = mountPlainCodeBlock ? initialContent : null;
         lastEmittedRef.current = normalizeEditorMarkdown(ed);
       },
-      content: mountChunked ? "" : initialContent,
-      contentType: mountChunked
+      content: mountPlainCodeBlock
+        ? plainCodeBlockDoc(initialContent)
+        : mountChunked
+          ? ""
+          : initialContent,
+      contentType: mountPlainCodeBlock || mountChunked
         ? undefined
         : defaultValue
           ? "markdown"
@@ -441,6 +467,8 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       if (isDirty) return;
 
       const incoming = defaultValue ? preprocessMarkdown(defaultValue) : "";
+      const bypassIncoming = shouldBypassMarkdownParse(incoming);
+      if (bypassIncoming && bypassedMarkdownRef.current === incoming) return;
       const incomingNormalized = normalizeMarkdown(incoming);
       // Guard 3: normalized-equal short-circuit. Avoids a no-op transaction
       // when the cache reflects a write this same editor just emitted.
@@ -452,19 +480,26 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       const { from, to } = editor.state.selection;
       // Same chunked path on WS-driven re-parse of a large description.
       const manager =
-        incoming.length > MARKDOWN_CHUNK_THRESHOLD
+        !bypassIncoming && incoming.length > MARKDOWN_CHUNK_THRESHOLD
           ? (editor.storage as { markdown?: { manager?: MarkdownManagerLike } })
               .markdown?.manager
           : undefined;
-      if (manager) {
+      if (bypassIncoming) {
+        editor.commands.setContent(plainCodeBlockDoc(incoming), {
+          emitUpdate: false,
+        });
+        bypassedMarkdownRef.current = incoming;
+      } else if (manager) {
         editor.commands.setContent(parseMarkdownChunked(manager, incoming), {
           emitUpdate: false,
         });
+        bypassedMarkdownRef.current = null;
       } else {
         editor.commands.setContent(incoming, {
           emitUpdate: false,
           contentType: "markdown",
         });
+        bypassedMarkdownRef.current = null;
       }
 
       // Clamp prior selection to the new doc size so the caret doesn't snap

--- a/packages/views/editor/extensions/code.test.ts
+++ b/packages/views/editor/extensions/code.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "@tiptap/markdown";
@@ -7,6 +7,8 @@ import { createEditorExtensions } from ".";
 let editor: Editor | null = null;
 
 interface JsonNode {
+  type?: string;
+  text?: string;
   marks?: Array<{ type: string }>;
   content?: JsonNode[];
 }
@@ -17,7 +19,9 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function makeProductionEditor(): Editor {
+function makeProductionEditor(
+  options: Partial<Parameters<typeof createEditorExtensions>[0]> = {},
+): Editor {
   const element = document.createElement("div");
   document.body.appendChild(element);
 
@@ -28,6 +32,7 @@ function makeProductionEditor(): Editor {
       disableMentions: true,
       enableSlashCommands: false,
       onUploadFileRef: { current: undefined },
+      ...options,
     }),
   });
 }
@@ -60,6 +65,38 @@ function typeText(ed: Editor, text: string) {
 function hasCodeMark(node: JsonNode): boolean {
   if (node.marks?.some((mark) => mark.type === "code")) return true;
   return (node.content ?? []).some(hasCodeMark);
+}
+
+function fakePasteEvent(text: string) {
+  return {
+    clipboardData: {
+      files: [],
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+    },
+  } as unknown as ClipboardEvent;
+}
+
+function paste(editor: Editor, text: string): boolean {
+  const event = fakePasteEvent(text);
+  return (
+    editor.view.someProp("handlePaste", (handler) =>
+      handler(editor.view, event, editor.view.state.selection.content()),
+    ) === true
+  );
+}
+
+function findFirst(json: JsonNode, type: string): JsonNode | undefined {
+  if (json.type === type) return json;
+  for (const child of json.content ?? []) {
+    const hit = findFirst(child, type);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+function nodeText(node: JsonNode): string {
+  if (node.text !== undefined) return node.text;
+  return (node.content ?? []).map(nodeText).join("");
 }
 
 describe("inline code input rule", () => {
@@ -101,5 +138,40 @@ describe("inline code paste rule", () => {
 
     expect(editor.getText()).toBe("abcd123");
     expect(editor.getMarkdown().trim()).toBe("abcd`123`");
+  });
+});
+
+describe("large text paste file mode", () => {
+  it("defaults to a plain code block even when an upload handler exists", () => {
+    const upload = vi.fn(async (_file: File) => null);
+    editor = makeProductionEditor({
+      onUploadFileRef: { current: upload },
+    });
+    const text = "large paste\n" + "payload\n".repeat(700);
+
+    const handled = paste(editor, text);
+
+    expect(handled).toBe(true);
+    expect(upload).not.toHaveBeenCalled();
+    const codeBlock = findFirst(editor.getJSON() as JsonNode, "codeBlock");
+    expect(codeBlock).toBeDefined();
+    expect(nodeText(codeBlock!)).toBe(text);
+  });
+
+  it("creates pasted-text.txt only when largePasteMode is file", () => {
+    const upload = vi.fn(async (_file: File) => null);
+    editor = makeProductionEditor({
+      largePasteMode: "file",
+      onUploadFileRef: { current: upload },
+    });
+    const text = "large paste\n" + "payload\n".repeat(700);
+
+    const handled = paste(editor, text);
+
+    expect(handled).toBe(true);
+    expect(upload).toHaveBeenCalledTimes(1);
+    const file = upload.mock.calls[0]?.[0] as File;
+    expect(file.name).toBe("pasted-text.txt");
+    expect(file.type).toBe("text/plain");
   });
 });

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -148,6 +148,8 @@ export interface EditorExtensionsOptions {
   onUploadFileRef?: RefObject<
     ((file: File) => Promise<UploadResult | null>) | undefined
   >;
+  /** Large text paste behavior. Defaults to plain code block insertion. */
+  largePasteMode?: "codeBlock" | "file";
   /** When true, bare Enter also submits (chat-style). Default false. */
   submitOnEnter?: boolean;
   /**
@@ -247,6 +249,7 @@ export function createEditorExtensions(
     Placeholder.configure({ placeholder: placeholderText }),
     createMarkdownPasteExtension({
       handleLargeTextPaste: (text, editor) => {
+        if (options.largePasteMode !== "file") return false;
         const handler = options.onUploadFileRef?.current;
         const file = handler ? makePastedTextFile(text) : null;
         if (!handler || !file) return false;

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -36,6 +36,7 @@ import { Markdown } from "@tiptap/markdown";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import type { AnyExtension } from "@tiptap/core";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import { shouldHighlightCode } from "@multica/ui/markdown";
 import { escapeMarkdownLabel } from "../utils/escape-markdown-label";
 import { BaseMentionExtension } from "./mention-extension";
 import { createMentionSuggestion, type MentionItem } from "./mention-suggestion";
@@ -47,7 +48,7 @@ import { createMarkdownPasteExtension } from "./markdown-paste";
 import { createMarkdownCopyExtension } from "./markdown-copy";
 import { createSubmitExtension } from "./submit-shortcut";
 import { createBlurShortcutExtension } from "./blur-shortcut";
-import { createFileUploadExtension } from "./file-upload";
+import { createFileUploadExtension, uploadAndInsertFile } from "./file-upload";
 import { FileCardExtension } from "./file-card";
 import { ImageView } from "./image-view";
 import { BlockMathExtension, InlineMathExtension } from "./math";
@@ -55,6 +56,30 @@ import { HighlightExtension } from "./highlight";
 import { AutolinkEmailRepairExtension } from "./autolink-email-repair";
 
 const lowlight = createLowlight(common);
+
+function plainLowlightRoot(code: string, language?: string) {
+  return {
+    type: "root",
+    children: [{ type: "text", value: code }],
+    data: language ? { language } : undefined,
+  } as ReturnType<typeof lowlight.highlight>;
+}
+
+const rawHighlight = lowlight.highlight.bind(lowlight);
+lowlight.highlight = ((language: string, code: string, options?: unknown) => {
+  if (!shouldHighlightCode(code, language)) {
+    return plainLowlightRoot(code, language);
+  }
+  return rawHighlight(language, code, options as never);
+}) as typeof lowlight.highlight;
+
+lowlight.highlightAuto = ((code: string) =>
+  plainLowlightRoot(code)) as typeof lowlight.highlightAuto;
+
+function makePastedTextFile(text: string): File | null {
+  if (typeof File === "undefined") return null;
+  return new File([text], "pasted-text.txt", { type: "text/plain" });
+}
 
 const LinkExtension = Link.extend({ inclusive: false }).configure({
   openOnClick: false,
@@ -220,7 +245,15 @@ export function createEditorExtensions(
     }),
     Typography,
     Placeholder.configure({ placeholder: placeholderText }),
-    createMarkdownPasteExtension(),
+    createMarkdownPasteExtension({
+      handleLargeTextPaste: (text, editor) => {
+        const handler = options.onUploadFileRef?.current;
+        const file = handler ? makePastedTextFile(text) : null;
+        if (!handler || !file) return false;
+        void uploadAndInsertFile(editor, file, handler);
+        return true;
+      },
+    }),
     createSubmitExtension(
       () => {
         const fn = options.onSubmitRef?.current;

--- a/packages/views/editor/extensions/markdown-paste.test.ts
+++ b/packages/views/editor/extensions/markdown-paste.test.ts
@@ -24,12 +24,14 @@ function fakePasteEvent(text: string, html?: string) {
   } as unknown as ClipboardEvent;
 }
 
-function makeEditor(content: object) {
+type MarkdownPasteOptions = Parameters<typeof createMarkdownPasteExtension>[0];
+
+function makeEditor(content: object, options?: MarkdownPasteOptions) {
   const element = document.createElement("div");
   document.body.appendChild(element);
   return new Editor({
     element,
-    extensions: [StarterKit, Markdown, createMarkdownPasteExtension()],
+    extensions: [StarterKit, Markdown, createMarkdownPasteExtension(options)],
     content,
   });
 }
@@ -263,13 +265,42 @@ describe("markdownPaste — code block context", () => {
       content: [{ type: "paragraph" }],
     });
 
-    const text = Array.from(
-      { length: 1600 },
-      (_, index) => `log ${index}: ${"payload".repeat(6)}`,
-    ).join("\n");
-    expect(text.length).toBeGreaterThan(50_000);
+    const text = "large paste\n" + "payload\n".repeat(700);
+    expect(text.length).toBeGreaterThan(4_000);
 
-    expectLiteralPaste(editor, text);
+    editor.commands.setTextSelection(1);
+    const parseSpy = vi.spyOn(editor.markdown!, "parse");
+
+    const handled = paste(editor, text);
+
+    expect(handled).toBe(true);
+    expect(parseSpy).not.toHaveBeenCalled();
+    const codeBlock = findFirst(editor.getJSON() as JsonNode, "codeBlock");
+    expect(codeBlock).toBeDefined();
+    expect(nodeText(codeBlock!)).toBe(text);
+  });
+
+  it("turns large pasted text into a file when the editor has a fileification handler", () => {
+    const handleLargeTextPaste = vi.fn(() => true);
+    editor = makeEditor(
+      {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+      { handleLargeTextPaste },
+    );
+    const text = "large paste\n" + "payload\n".repeat(700);
+    expect(text.length).toBeGreaterThan(4_000);
+
+    editor.commands.setTextSelection(1);
+    const parseSpy = vi.spyOn(editor.markdown!, "parse");
+
+    const handled = paste(editor, text);
+
+    expect(handled).toBe(true);
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(handleLargeTextPaste).toHaveBeenCalledWith(text, editor);
+    expect(findFirst(editor.getJSON() as JsonNode, "codeBlock")).toBeUndefined();
   });
 
   it("preserves single unknown HTML-like tag (e.g. <T>)", () => {
@@ -356,11 +387,15 @@ describe("markdownPaste — code block context", () => {
     });
 
     const parseJsonSpy = vi.spyOn(JSON, "parse");
-    const text = `{${"not-json".repeat(7_000)}}`;
-    expect(text.length).toBeGreaterThan(50_000);
+    const text = `{${"not-json".repeat(600)}}`;
+    expect(text.length).toBeGreaterThan(4_000);
 
-    expectLiteralPaste(editor, text);
+    const handled = paste(editor, text);
+    expect(handled).toBe(true);
     expect(parseJsonSpy).not.toHaveBeenCalled();
+    const codeBlock = findFirst(editor.getJSON() as JsonNode, "codeBlock");
+    expect(codeBlock).toBeDefined();
+    expect(nodeText(codeBlock!)).toBe(text);
   });
 });
 

--- a/packages/views/editor/extensions/markdown-paste.ts
+++ b/packages/views/editor/extensions/markdown-paste.ts
@@ -12,9 +12,10 @@
  * `data-pm-slice` in the HTML — this attribute is added by ProseMirror's
  * own clipboard serializer. If present, the source is another ProseMirror
  * editor and its HTML is structurally correct — let ProseMirror handle it.
- * Otherwise, classify text/plain into one of three paths:
+ * Otherwise, classify text/plain into one of four paths:
  * - native: let ProseMirror or another extension handle it
  * - literal: insert exact text without Markdown parsing
+ * - large-text: hand text to fileification, or insert a plain code block
  * - markdown: parse text/plain as Markdown
  *
  * Why not clipboardTextParser? It only runs when there's NO text/html on
@@ -25,11 +26,12 @@
  * Syntax-highlight wrappers from editors (<pre>/<code>/<span>/<div>) are not
  * enough by themselves, because those should still paste as Markdown source.
  */
-import { Extension } from "@tiptap/core";
+import { Extension, type Editor } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Slice } from "@tiptap/pm/model";
+import type { EditorView } from "@tiptap/pm/view";
+import { LARGE_TEXT_THRESHOLD } from "@multica/ui/markdown";
 
-const LARGE_PASTE_TEXT_THRESHOLD = 50_000;
 const SEMANTIC_RICH_HTML_SELECTOR = [
   "a[href]",
   "b",
@@ -236,7 +238,11 @@ function findRawHtmlTagsOutsideCode(text: string): string[] {
   return tags;
 }
 
-type PasteMode = "native" | "literal" | "markdown";
+type PasteMode = "native" | "literal" | "large-text" | "markdown";
+
+interface MarkdownPasteOptions {
+  handleLargeTextPaste?: (text: string, editor: Editor) => boolean;
+}
 
 interface PasteClassificationInput {
   text: string;
@@ -340,14 +346,28 @@ function classifyPaste({
   if (hasFiles) return "native";
   if (!text) return "native";
   if (isInsideCodeBlock) return "literal";
+  if (text.length > LARGE_TEXT_THRESHOLD) return "large-text";
   if (html && html.includes("data-pm-slice")) return "native";
   if (html && hasSemanticRichHtml(html, text)) return "native";
-  if (text.length > LARGE_PASTE_TEXT_THRESHOLD) return "literal";
   if (isStructuredPlainText(text)) return "literal";
   return "markdown";
 }
 
-export function createMarkdownPasteExtension() {
+function insertPlainCodeBlock(view: EditorView, text: string) {
+  const codeBlock = view.state.schema.nodes.codeBlock;
+  if (!codeBlock) {
+    view.dispatch(view.state.tr.insertText(text));
+    return;
+  }
+
+  const node = codeBlock.create(
+    null,
+    text ? view.state.schema.text(text) : undefined,
+  );
+  view.dispatch(view.state.tr.replaceSelectionWith(node, false));
+}
+
+export function createMarkdownPasteExtension(options: MarkdownPasteOptions = {}) {
   return Extension.create({
     name: "markdownPaste",
     addProseMirrorPlugins() {
@@ -375,6 +395,12 @@ export function createMarkdownPasteExtension() {
 
               if (mode === "literal") {
                 view.dispatch(view.state.tr.insertText(text));
+                return true;
+              }
+
+              if (mode === "large-text") {
+                if (options.handleLargeTextPaste?.(text, editor)) return true;
+                insertPlainCodeBlock(view, text);
                 return true;
               }
 

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -267,13 +267,27 @@ describe("ReadonlyContent code styling", () => {
     expect(blockCode?.textContent).toBe(literalCode);
   });
 
-  it("renders code blocks without a language tag (lowlight highlightAuto fallback)", () => {
+  it("renders code blocks without a language tag as plain text instead of auto-detecting", () => {
     const token = "mul_407ec1e4464b580304362ed749f821901fd7d310";
     const { container } = render(
       <ReadonlyContent content={["```", token, "```"].join("\n")} />,
     );
     const blockCode = container.querySelector("pre code");
     expect(blockCode?.textContent?.trim()).toBe(token);
+    expect(blockCode?.querySelector("span")).toBeNull();
+  });
+
+  it("renders code blocks over the large-text threshold as plain text even with a language tag", () => {
+    const source = "echo payload\n".repeat(400);
+    expect(source.length).toBeGreaterThan(4_000);
+
+    const { container } = render(
+      <ReadonlyContent content={["```bash", source, "```"].join("\n")} />,
+    );
+
+    const blockCode = container.querySelector("pre code");
+    expect(blockCode?.textContent).toBe(source);
+    expect(blockCode?.querySelector("span")).toBeNull();
   });
 
   it("copies the whole fenced code block from the readonly toolbar", async () => {

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -32,6 +32,7 @@ import { createLowlight, common } from "lowlight";
 import { toHtml } from "hast-util-to-html";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { shouldHighlightCode } from "@multica/ui/markdown";
 import { copyText } from "@multica/ui/lib/clipboard";
 import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
 import type { Attachment } from "@multica/core/types";
@@ -353,25 +354,25 @@ function buildComponents(): Partial<Components> {
 
       // Block code — highlight with lowlight, output hljs classes
       const code = String(children).replace(/\n$/, "");
-      try {
-        const tree = lang
-          ? lowlight.highlight(lang, code)
-          : lowlight.highlightAuto(code);
-        const html = toHtml(tree);
-        if (html) {
-          return (
-            <code
-              className={cn("hljs", lang && `language-${lang}`)}
-              dangerouslySetInnerHTML={{ __html: html }}
-            />
-          );
+      if (shouldHighlightCode(code, lang)) {
+        try {
+          const tree = lowlight.highlight(lang, code);
+          const html = toHtml(tree);
+          if (html) {
+            return (
+              <code
+                className={cn("hljs", lang && `language-${lang}`)}
+                dangerouslySetInnerHTML={{ __html: html }}
+              />
+            );
+          }
+        } catch {
+          // fall through to plain render
         }
-      } catch {
-        // fall through to plain render
       }
       return (
         <code className={cn("hljs", className)} {...props}>
-          {children}
+          {code}
         </code>
       );
     },

--- a/packages/views/editor/utils/parse-markdown-chunked.ts
+++ b/packages/views/editor/utils/parse-markdown-chunked.ts
@@ -1,13 +1,12 @@
 import type { JSONContent } from "@tiptap/core";
+import { LARGE_TEXT_THRESHOLD } from "@multica/ui/markdown";
 
 /**
- * Above this source size, ContentEditor parses markdown in chunks instead of in
- * one shot. `@tiptap/markdown` parses via `marked`, whose tokenizer is O(n²) in
- * document length (measured: 533KB plain text → 61.8s parse, while the following
- * ProseMirror setContent is only 40ms). Whole-document parse is the bottleneck;
- * below this threshold the single-parse path is fast enough and stays in use.
+ * Shared cutoff for avoiding unsafe whole-document markdown parsing. Current
+ * ContentEditor behavior bypasses parsing above this size; this chunker remains
+ * as the bounded parser fallback if the bypass threshold is ever raised.
  */
-export const MARKDOWN_CHUNK_THRESHOLD = 50_000;
+export const MARKDOWN_CHUNK_THRESHOLD = LARGE_TEXT_THRESHOLD;
 
 export interface MarkdownManagerLike {
   parse(markdown: string): JSONContent;

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -332,15 +332,46 @@ function useEditAttachmentState(
     content: editing ? content : "",
   });
 
+  const draftKey = `edit:${issueId}:${entry.id}` as const;
+  const getDraft = useCommentDraftStore.getState().getDraft;
+  const getDraftAttachments = useCommentDraftStore.getState().getDraftAttachments;
+  const setDraft = useCommentDraftStore((s) => s.setDraft);
+  const setDraftAttachments = useCommentDraftStore((s) => s.setDraftAttachments);
+  const addDraftAttachment = useCommentDraftStore((s) => s.addDraftAttachment);
+  const clearDraft = useCommentDraftStore((s) => s.clearDraft);
+
   const editorAttachments = pendingAttachments.length > 0
     ? [...(entry.attachments ?? []), ...pendingAttachments]
     : entry.attachments;
 
+  const pruneDraftAttachments = useCallback(
+    (md: string, attachments: Attachment[]) => {
+      if (attachments.length === 0) return;
+      const referenced = attachments.filter((attachment) =>
+        contentReferencesAttachment(md, attachment),
+      );
+      if (referenced.length !== attachments.length) {
+        setPendingAttachments(referenced);
+      }
+      setDraftAttachments(draftKey, referenced);
+    },
+    [draftKey, setDraftAttachments],
+  );
+
   const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
-    if (result) setPendingAttachments((prev) => [...prev, result]);
+    if (result) {
+      setPendingAttachments((prev) =>
+        prev.some((attachment) => attachment.id === result.id)
+          ? prev.map((attachment) =>
+              attachment.id === result.id ? result : attachment,
+            )
+          : [...prev, result],
+      );
+      addDraftAttachment(draftKey, result);
+    }
     return result;
-  }, [uploadWithToast, issueId]);
+  }, [addDraftAttachment, draftKey, uploadWithToast, issueId]);
 
   useEffect(() => {
     setSuppressedAgentIds(new Set());
@@ -351,14 +382,29 @@ function useEditAttachmentState(
     enabled: editing,
   });
 
-  const draftKey = `edit:${issueId}:${entry.id}` as const;
-  const getDraft = useCommentDraftStore.getState().getDraft;
-  const setDraft = useCommentDraftStore((s) => s.setDraft);
-  const clearDraft = useCommentDraftStore((s) => s.clearDraft);
-
   const initialValue = editing
     ? (getDraft(draftKey) ?? entry.content ?? "")
     : (entry.content ?? "");
+
+  const updateDraftContent = useCallback(
+    (md: string) => {
+      setContent(md);
+      if (md.trim().length > 0) {
+        setDraft(draftKey, md);
+        pruneDraftAttachments(md, pendingAttachments);
+      } else {
+        setPendingAttachments([]);
+        clearDraft(draftKey);
+      }
+    },
+    [
+      clearDraft,
+      draftKey,
+      pendingAttachments,
+      pruneDraftAttachments,
+      setDraft,
+    ],
+  );
 
   useEffect(() => {
     const visible = new Set(triggerPreview.agents.map((agent) => agent.id));
@@ -392,6 +438,7 @@ function useEditAttachmentState(
 
   const startEdit = () => {
     cancelledRef.current = false;
+    setPendingAttachments(getDraftAttachments(draftKey));
     setContent(getDraft(draftKey) ?? entry.content ?? "");
     setRetainedStandaloneIds(initialStandaloneAttachmentIds(entry));
     setEditing(true);
@@ -456,9 +503,7 @@ function useEditAttachmentState(
     suppressedAgentIds,
     toggleSuppressedAgent,
     draftKey,
-    setDraft,
-    setContent,
-    clearDraft,
+    updateDraftContent,
     initialValue,
     standaloneEditAttachments,
     retainedStandaloneIds,
@@ -618,13 +663,10 @@ function CommentRow({
               ref={edit.editorRef}
               defaultValue={edit.initialValue}
               placeholder={t(($) => $.comment.edit_placeholder)}
-              onUpdate={(md) => {
-                edit.setContent(md);
-                if (md.trim().length > 0) edit.setDraft(edit.draftKey, md);
-                else edit.clearDraft(edit.draftKey);
-              }}
+              onUpdate={edit.updateDraftContent}
               onSubmit={edit.saveEdit}
               onUploadFile={edit.handleUpload}
+              largePasteMode="file"
               debounceMs={100}
               currentIssueId={issueId}
               attachments={edit.editorAttachments}
@@ -908,13 +950,10 @@ function CommentCardImpl({
                     ref={edit.editorRef}
                     defaultValue={edit.initialValue}
                     placeholder={t(($) => $.comment.edit_placeholder)}
-                    onUpdate={(md) => {
-                      edit.setContent(md);
-                      if (md.trim().length > 0) edit.setDraft(edit.draftKey, md);
-                      else edit.clearDraft(edit.draftKey);
-                    }}
+                    onUpdate={edit.updateDraftContent}
                     onSubmit={edit.saveEdit}
                     onUploadFile={edit.handleUpload}
+                    largePasteMode="file"
                     debounceMs={100}
                     currentIssueId={issueId}
                     attachments={edit.editorAttachments}

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -3,6 +3,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import type { Attachment } from "@multica/core/types";
+import {
+  useCommentDraftStore,
+  type CommentDraftKey,
+} from "@multica/core/issues/stores";
 import { renderWithI18n } from "../../test/i18n";
 import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
@@ -37,11 +42,15 @@ vi.mock("../../editor", () => ({
       onUpdate,
       placeholder,
       onUploadFile,
+      largePasteMode,
+      attachments,
     }: {
       defaultValue?: string;
       onUpdate?: (markdown: string) => void;
       placeholder?: string;
       onUploadFile?: (file: File) => Promise<UploadResult | null>;
+      largePasteMode?: "codeBlock" | "file";
+      attachments?: Attachment[];
     },
     ref: Ref<unknown>,
   ) {
@@ -66,6 +75,8 @@ vi.mock("../../editor", () => ({
     return (
       <textarea
         data-testid="editor"
+        data-large-paste-mode={largePasteMode ?? ""}
+        data-attachment-count={attachments?.length ?? 0}
         defaultValue={defaultValue}
         placeholder={placeholder}
         onChange={(event) => {
@@ -96,9 +107,11 @@ function renderCommentInput(onSubmit = vi.fn().mockResolvedValue(true)) {
 function renderReplyInput({
   onSubmit = vi.fn().mockResolvedValue(true),
   size = "sm",
+  draftKey = "reply:issue-1:comment-1" as CommentDraftKey,
 }: {
   onSubmit?: (content: string, attachmentIds?: string[], suppressAgentIds?: string[]) => Promise<boolean>;
   size?: "sm" | "default";
+  draftKey?: CommentDraftKey;
 } = {}) {
   const view = renderWithProviders(
     <ReplyInput
@@ -108,6 +121,7 @@ function renderReplyInput({
       avatarId="user-1"
       onSubmit={onSubmit}
       size={size}
+      draftKey={draftKey}
     />,
   );
   return { ...view, onSubmit };
@@ -119,9 +133,38 @@ function getSubmitButton(container: HTMLElement): HTMLButtonElement {
   return button;
 }
 
+function getFileInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) throw new Error("Expected file input to render");
+  return input;
+}
+
+function makeUploadResult(id: string): UploadResult {
+  return {
+    id,
+    workspace_id: "ws-1",
+    issue_id: "issue-1",
+    comment_id: null,
+    chat_session_id: null,
+    chat_message_id: null,
+    uploader_type: "member",
+    uploader_id: "user-1",
+    filename: `${id}.txt`,
+    url: `/api/attachments/${id}/download`,
+    download_url: `/api/attachments/${id}/download`,
+    markdown_url: `/api/attachments/${id}/download`,
+    content_type: "text/plain",
+    size_bytes: 12,
+    created_at: new Date(0).toISOString(),
+    link: `/api/attachments/${id}/download`,
+    markdownLink: `/api/attachments/${id}/download`,
+  };
+}
+
 beforeEach(() => {
   uploadWithToast.mockReset();
   localStorage.clear();
+  useCommentDraftStore.setState({ drafts: {} });
 });
 
 describe("comment composers", () => {
@@ -149,6 +192,21 @@ describe("comment composers", () => {
     expect(shell.className).not.toContain("h-[60vh]");
   });
 
+  it("enables large paste file mode for main comments and replies", () => {
+    const comment = renderCommentInput();
+    expect(screen.getByTestId("editor")).toHaveAttribute(
+      "data-large-paste-mode",
+      "file",
+    );
+    comment.unmount();
+
+    renderReplyInput();
+    expect(screen.getByTestId("editor")).toHaveAttribute(
+      "data-large-paste-mode",
+      "file",
+    );
+  });
+
   it("lets default-size replies grow without a height cap", () => {
     const { container } = renderReplyInput({ size: "default" });
 
@@ -169,6 +227,49 @@ describe("comment composers", () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith("hello from composer", undefined, undefined);
+    });
+  });
+
+  it("persists uploaded main comment attachment drafts and submits active ids", async () => {
+    const uploadResult = makeUploadResult("att-1");
+    uploadWithToast.mockResolvedValue(uploadResult);
+    const { container, onSubmit } = renderCommentInput();
+
+    fireEvent.change(getFileInput(container), {
+      target: {
+        files: [
+          new File(["payload"], "pasted-text.txt", { type: "text/plain" }),
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(uploadWithToast).toHaveBeenCalledWith(expect.any(File), {
+        issueId: "issue-1",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        useCommentDraftStore
+          .getState()
+          .getDraftAttachments("new:issue-1"),
+      ).toHaveLength(1),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("editor")).toHaveAttribute(
+        "data-attachment-count",
+        "1",
+      ),
+    );
+
+    fireEvent.click(getSubmitButton(container));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        "/api/attachments/att-1/download",
+        ["att-1"],
+        undefined,
+      );
     });
   });
 

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -32,6 +32,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   // button would be disabled even though the editor visibly contains text.
   const draftKey = `new:${issueId}` as const;
   const initialDraft = useCommentDraftStore.getState().getDraft(draftKey);
+  const initialDraftAttachments = useCommentDraftStore
+    .getState()
+    .getDraftAttachments(draftKey);
   const [content, setContent] = useState(initialDraft ?? "");
   const [isEmpty, setIsEmpty] = useState(() => !initialDraft?.trim());
   const [submitting, setSubmitting] = useState(false);
@@ -41,7 +44,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   //  - submit-time `attachment_ids` payload (filtered to URLs still in markdown)
   //  - the editor's AttachmentDownloadProvider, so file-card Eye buttons can
   //    resolve text/code/markdown previews that require the attachment id.
-  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
+  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>(
+    initialDraftAttachments,
+  );
   const { uploadWithToast } = useFileUpload(api);
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
@@ -52,11 +57,29 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   // Flush on every onUpdate (debounced upstream) + visibilitychange/pagehide
   // so tab close / mobile background doesn't lose work. Cleared on submit.
   const setDraft = useCommentDraftStore((s) => s.setDraft);
+  const setDraftAttachments = useCommentDraftStore((s) => s.setDraftAttachments);
+  const addDraftAttachment = useCommentDraftStore((s) => s.addDraftAttachment);
   const clearDraft = useCommentDraftStore((s) => s.clearDraft);
+  const pruneDraftAttachments = useCallback(
+    (md: string, attachments: Attachment[]) => {
+      if (attachments.length === 0) return;
+      const referenced = attachments.filter((attachment) =>
+        contentReferencesAttachment(md, attachment),
+      );
+      if (referenced.length !== attachments.length) {
+        setPendingAttachments(referenced);
+      }
+      setDraftAttachments(draftKey, referenced);
+    },
+    [draftKey, setDraftAttachments],
+  );
   useEffect(() => {
     const flush = () => {
       const md = editorRef.current?.getMarkdown();
-      if (md && md.trim().length > 0) setDraft(draftKey, md);
+      if (md && md.trim().length > 0) {
+        setDraft(draftKey, md);
+        pruneDraftAttachments(md, pendingAttachments);
+      }
     };
     const onVis = () => { if (document.visibilityState === "hidden") flush(); };
     document.addEventListener("visibilitychange", onVis);
@@ -65,15 +88,22 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
       document.removeEventListener("visibilitychange", onVis);
       window.removeEventListener("pagehide", flush);
     };
-  }, [draftKey, setDraft]);
+  }, [draftKey, pendingAttachments, pruneDraftAttachments, setDraft]);
 
   const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
     if (result) {
-      setPendingAttachments((prev) => [...prev, result]);
+      setPendingAttachments((prev) =>
+        prev.some((attachment) => attachment.id === result.id)
+          ? prev.map((attachment) =>
+              attachment.id === result.id ? result : attachment,
+            )
+          : [...prev, result],
+      );
+      addDraftAttachment(draftKey, result);
     }
     return result;
-  }, [uploadWithToast, issueId]);
+  }, [addDraftAttachment, draftKey, uploadWithToast, issueId]);
 
   useEffect(() => {
     setSuppressedAgentIds(new Set());
@@ -159,11 +189,17 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
             setIsEmpty(!md.trim());
             // Debounced upstream (debounceMs=100). Persist on every tick so a
             // reload or scroll-out-of-viewport restores work to the keystroke.
-            if (md.trim().length > 0) setDraft(draftKey, md);
-            else clearDraft(draftKey);
+            if (md.trim().length > 0) {
+              setDraft(draftKey, md);
+              pruneDraftAttachments(md, pendingAttachments);
+            } else {
+              setPendingAttachments([]);
+              clearDraft(draftKey);
+            }
           }}
           onSubmit={handleSubmit}
           onUploadFile={handleUpload}
+          largePasteMode="file"
           debounceMs={100}
           currentIssueId={issueId}
           attachments={pendingAttachments}

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -285,7 +285,10 @@ vi.mock("@multica/core/issues/stores", () => ({
       const state = {
         drafts: {} as Record<string, { content: string; updatedAt: number }>,
         getDraft: () => undefined,
+        getDraftAttachments: () => [],
         setDraft: () => {},
+        setDraftAttachments: () => {},
+        addDraftAttachment: () => {},
         clearDraft: () => {},
       };
       return selector ? selector(state) : state;
@@ -294,7 +297,10 @@ vi.mock("@multica/core/issues/stores", () => ({
       getState: () => ({
         drafts: {} as Record<string, { content: string; updatedAt: number }>,
         getDraft: () => undefined,
+        getDraftAttachments: () => [],
         setDraft: () => {},
+        setDraftAttachments: () => {},
+        addDraftAttachment: () => {},
         clearDraft: () => {},
       }),
     },

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -58,8 +58,13 @@ function ReplyInput({
   const initialDraft = draftKey
     ? useCommentDraftStore.getState().getDraft(draftKey)
     : undefined;
+  const initialDraftAttachments = draftKey
+    ? useCommentDraftStore.getState().getDraftAttachments(draftKey)
+    : [];
   const [content, setContent] = useState(initialDraft ?? "");
   const setDraft = useCommentDraftStore((s) => s.setDraft);
+  const setDraftAttachments = useCommentDraftStore((s) => s.setDraftAttachments);
+  const addDraftAttachment = useCommentDraftStore((s) => s.addDraftAttachment);
   const clearDraft = useCommentDraftStore((s) => s.clearDraft);
   const [isEmpty, setIsEmpty] = useState(!initialDraft?.trim());
   const [submitting, setSubmitting] = useState(false);
@@ -67,18 +72,37 @@ function ReplyInput({
   const triggerPreview = useCommentTriggerPreview({ issueId, parentId, content });
   // Attachments uploaded in this composer session — see CommentInput for the
   // rationale (drives both submit-time attachment_ids and editor previews).
-  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
+  const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>(
+    initialDraftAttachments,
+  );
   const { uploadWithToast } = useFileUpload(api);
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
   });
 
   // Flush on tab close / mobile background — same rationale as CommentInput.
+  const pruneDraftAttachments = useCallback(
+    (md: string, attachments: Attachment[]) => {
+      if (!draftKey || attachments.length === 0) return;
+      const referenced = attachments.filter((attachment) =>
+        contentReferencesAttachment(md, attachment),
+      );
+      if (referenced.length !== attachments.length) {
+        setPendingAttachments(referenced);
+      }
+      setDraftAttachments(draftKey, referenced);
+    },
+    [draftKey, setDraftAttachments],
+  );
+
   useEffect(() => {
     if (!draftKey) return;
     const flush = () => {
       const md = editorRef.current?.getMarkdown();
-      if (md && md.trim().length > 0) setDraft(draftKey, md);
+      if (md && md.trim().length > 0) {
+        setDraft(draftKey, md);
+        pruneDraftAttachments(md, pendingAttachments);
+      }
     };
     const onVis = () => { if (document.visibilityState === "hidden") flush(); };
     document.addEventListener("visibilitychange", onVis);
@@ -87,15 +111,22 @@ function ReplyInput({
       document.removeEventListener("visibilitychange", onVis);
       window.removeEventListener("pagehide", flush);
     };
-  }, [draftKey, setDraft]);
+  }, [draftKey, pendingAttachments, pruneDraftAttachments, setDraft]);
 
   const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
     if (result) {
-      setPendingAttachments((prev) => [...prev, result]);
+      setPendingAttachments((prev) =>
+        prev.some((attachment) => attachment.id === result.id)
+          ? prev.map((attachment) =>
+              attachment.id === result.id ? result : attachment,
+            )
+          : [...prev, result],
+      );
+      if (draftKey) addDraftAttachment(draftKey, result);
     }
     return result;
-  }, [uploadWithToast, issueId]);
+  }, [addDraftAttachment, draftKey, uploadWithToast, issueId]);
 
   useEffect(() => {
     setSuppressedAgentIds(new Set());
@@ -185,12 +216,18 @@ function ReplyInput({
               setContent(md);
               setIsEmpty(!md.trim());
               if (draftKey) {
-                if (md.trim().length > 0) setDraft(draftKey, md);
-                else clearDraft(draftKey);
+                if (md.trim().length > 0) {
+                  setDraft(draftKey, md);
+                  pruneDraftAttachments(md, pendingAttachments);
+                } else {
+                  setPendingAttachments([]);
+                  clearDraft(draftKey);
+                }
               }
             }}
             onSubmit={handleSubmit}
             onUploadFile={handleUpload}
+            largePasteMode={draftKey ? "file" : "codeBlock"}
             debounceMs={100}
             currentIssueId={issueId}
             attachments={pendingAttachments}


### PR DESCRIPTION
## Summary
- add an explicit `largePasteMode` on `ContentEditor`; default large paste still falls back to a plain no-language code block, while fileification is enabled only for chat and comment draft flows
- persist pending attachment records in `multica_comment_drafts` so comment/reply/edit drafts can reload generated file cards and still submit the correct `attachment_ids`
- keep the shared 4k threshold and code highlighting guards across paste, editor rehydrate, editable/readonly code blocks, and chat markdown
- disable no-language auto-detect and over-threshold highlighting across editable, readonly, and chat markdown code paths

## Verification
- `pnpm -C packages/core test issues/stores/comment-draft-store.test.ts`
- `pnpm -C packages/views test editor/extensions/code.test.ts editor/extensions/markdown-paste.test.ts editor/content-editor.test.tsx issues/components/comment-composers.test.tsx`
- `pnpm -C packages/core typecheck`
- `pnpm -C packages/views typecheck`
- `pnpm -C packages/core lint`
- `pnpm -C packages/views lint` (passes with existing warnings)

Closes MUL-3985
