### PR TITLE
MUL-3989: fix(slack): prefer attachment body over fallback

### DIFF
--- a/server/internal/integrations/slack/history.go
+++ b/server/internal/integrations/slack/history.go
@@ -283,8 +283,9 @@ const maxDerivedTextLen = 4000
 // Block Kit blocks and leave the top-level Text empty; without this fallback
 // such a message is indistinguishable from a join/system marker and gets
 // dropped (MUL-3931 / #4803). Order: top-level text, then each attachment's
-// built-in Fallback / title+text/fields, then a best-effort blocks flatten.
-// Returns "" only when nothing renderable exists — a real system marker.
+// rendered text/fields, then last-resort fallback text, then a best-effort
+// blocks flatten. Returns "" only when nothing renderable exists — a real
+// system marker.
 func flattenSlackText(m slack.Message) string {
 	if t := strings.TrimSpace(m.Text); t != "" {
 		return t
@@ -303,13 +304,11 @@ func flattenSlackText(m slack.Message) string {
 	return truncateRunes(strings.TrimSpace(strings.Join(parts, "\n")), maxDerivedTextLen)
 }
 
-// attachmentText summarizes one attachment, preferring Slack's built-in
-// Fallback (the plain-text rendering Slack ships for exactly this purpose),
-// then a pretext/title/text/fields composite, then the attachment's own blocks.
+// attachmentText summarizes one attachment. Attachment fallback is only a
+// last-resort summary for clients that cannot render attachments; Grafana-style
+// alerts often put the useful alert body in Text/Fields while Fallback repeats
+// the short title.
 func attachmentText(a slack.Attachment) string {
-	if t := strings.TrimSpace(a.Fallback); t != "" {
-		return t
-	}
 	parts := make([]string, 0, 3+len(a.Fields))
 	for _, s := range []string{a.Pretext, a.Title, a.Text} {
 		if s = strings.TrimSpace(s); s != "" {
@@ -323,6 +322,9 @@ func attachmentText(a slack.Attachment) string {
 	}
 	if len(parts) > 0 {
 		return strings.Join(parts, "\n")
+	}
+	if t := strings.TrimSpace(a.Fallback); t != "" {
+		return t
 	}
 	return flattenBlocks(a.Blocks)
 }

--- a/server/internal/integrations/slack/history_test.go
+++ b/server/internal/integrations/slack/history_test.go
@@ -279,11 +279,55 @@ func TestThreadRecoversBotAttachmentText(t *testing.T) {
 	if got == nil {
 		t.Fatalf("bot root message was dropped: %+v", page.Messages)
 	}
-	if got.Text != "[FIRING:1] HighLatency prod" {
-		t.Errorf("root text = %q, want the attachment fallback", got.Text)
+	if got.Text != "HighLatency\np99 over threshold" {
+		t.Errorf("root text = %q, want the attachment title and body", got.Text)
 	}
 	if got.Author != "Grafana" {
 		t.Errorf("root author = %q, want Grafana", got.Author)
+	}
+}
+
+func TestAttachmentTextPriority(t *testing.T) {
+	tests := []struct {
+		name string
+		att  slack.Attachment
+		want string
+	}{
+		{
+			name: "fallback only",
+			att: slack.Attachment{
+				Fallback: "short fallback",
+			},
+			want: "short fallback",
+		},
+		{
+			name: "text beats fallback",
+			att: slack.Attachment{
+				Fallback: "[FIRING:1] HighLatency prod",
+				Title:    "HighLatency",
+				Text:     "Summary: p99 over threshold\nDescription: checkout is slow",
+			},
+			want: "HighLatency\nSummary: p99 over threshold\nDescription: checkout is slow",
+		},
+		{
+			name: "fields beat fallback",
+			att: slack.Attachment{
+				Fallback: "short fallback",
+				Fields: []slack.AttachmentField{
+					{Title: "severity", Value: "critical"},
+					{Title: "pod", Value: "checkout-7d8"},
+				},
+			},
+			want: "severity critical\npod checkout-7d8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := attachmentText(tt.att); got != tt.want {
+				t.Fatalf("attachmentText() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes Slack history text recovery for Grafana/Alertmanager-style alert attachments. Attachment fallback text is now treated as a last-resort summary instead of taking priority over the richer attachment body.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4860

Multica issue: ZIC-20

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/integrations/slack/history.go` so attachment `Pretext`/`Title`/`Text`/`Fields` are rendered before `Fallback`.
- Added focused tests in `server/internal/integrations/slack/history_test.go` for fallback-only, text-bearing, and fields-bearing attachment payloads.

## How to Test

1. `cd server && go test ./internal/integrations/slack`
2. `make check-worktree`

Note: `make check-worktree` exited 0 in this worktree but printed a local Docker daemon warning while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:**
Investigated the Slack history attachment text recovery path for GitHub issue #4860, made the smallest ordering change in `attachmentText`, and added regression tests covering fallback-only and richer attachment payloads.

## Screenshots (optional)

N/A
