### PR TITLE
ZIC-22: Fix Codex DeepSeek model catalog launch

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Directories to symlink from the shared ~/.codex/ into the per-task CODEX_HOME.
@@ -105,6 +108,10 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		logger.Warn("execenv: codex-home sanitize config failed", "error", err)
 	}
 
+	if err := syncCodexModelCatalog(codexHome, sharedHome); err != nil {
+		return fmt.Errorf("sync codex model_catalog_json: %w", err)
+	}
+
 	if err := exposeSharedCodexPluginCache(codexHome, sharedHome); err != nil {
 		logger.Warn("execenv: codex-home plugin cache exposure failed", "error", err)
 	}
@@ -150,6 +157,76 @@ func resolveSharedCodexHome() string {
 		return filepath.Join(os.TempDir(), ".codex") // last resort fallback
 	}
 	return filepath.Join(home, ".codex")
+}
+
+func syncCodexModelCatalog(codexHome, sharedHome string) error {
+	configPath := filepath.Join(codexHome, "config.toml")
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", configPath, err)
+	}
+
+	var cfg struct {
+		ModelCatalogJSON string `toml:"model_catalog_json"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	catalogPath := strings.TrimSpace(cfg.ModelCatalogJSON)
+	if catalogPath == "" {
+		return nil
+	}
+
+	src, err := resolveCodexConfigPath(catalogPath, sharedHome)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("model_catalog_json %q resolved to missing file %s: %w", catalogPath, src, err)
+	}
+
+	if filepath.IsAbs(catalogPath) || strings.HasPrefix(catalogPath, "~") {
+		return nil
+	}
+	cleanCatalogPath := filepath.Clean(catalogPath)
+	if !filepath.IsLocal(cleanCatalogPath) {
+		return fmt.Errorf("model_catalog_json %q must be a local relative path or an absolute path", catalogPath)
+	}
+	dst := filepath.Join(codexHome, cleanCatalogPath)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create model catalog directory %s: %w", filepath.Dir(dst), err)
+	}
+	if _, err := os.Lstat(dst); err == nil {
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove stale model catalog %s: %w", dst, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat model catalog %s: %w", dst, err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		return fmt.Errorf("copy model_catalog_json %s to %s: %w", src, dst, err)
+	}
+	return nil
+}
+
+func resolveCodexConfigPath(configPath, sharedHome string) (string, error) {
+	if filepath.IsAbs(configPath) {
+		return filepath.Clean(configPath), nil
+	}
+	if strings.HasPrefix(configPath, "~/") || strings.HasPrefix(configPath, `~\`) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve model_catalog_json %q: user home: %w", configPath, err)
+		}
+		return filepath.Join(home, configPath[2:]), nil
+	}
+	if strings.HasPrefix(configPath, "~") {
+		return "", fmt.Errorf("model_catalog_json %q uses unsupported ~user expansion", configPath)
+	}
+	return filepath.Join(sharedHome, filepath.Clean(configPath)), nil
 }
 
 func exposeSharedCodexPluginCache(codexHome, sharedHome string) error {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2005,6 +2005,53 @@ func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexHomeCopiesRelativeModelCatalog(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_catalog_json = "cc-switch-model-catalog.json"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "cc-switch-model-catalog.json"), []byte(`{"models":[{"model":"deepseek-v4-flash"}]}`), 0o644); err != nil {
+		t.Fatalf("write shared model catalog: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "cc-switch-model-catalog.json"))
+	if err != nil {
+		t.Fatalf("read per-task model catalog: %v", err)
+	}
+	if string(data) != `{"models":[{"model":"deepseek-v4-flash"}]}` {
+		t.Errorf("per-task model catalog = %q", data)
+	}
+}
+
+func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_catalog_json = "missing-catalog.json"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	err := prepareCodexHome(codexHome, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHome to fail for missing model catalog")
+	}
+	for _, want := range []string{"model_catalog_json", "missing-catalog.json", filepath.Join(sharedHome, "missing-catalog.json")} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
 // Regression test for #1753 — Codex Desktop writes plugin-backed
 // `[[skills.config]]` entries without a `path` field, and the CLI's TOML
 // parser rejects them with `missing field path`. prepareCodexHome must drop


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes Codex launch when the user's shared Codex config points `model_catalog_json` at a relative catalog file, which is how CC Switch commonly wires DeepSeek/local-routing model lists. Multica already copied `config.toml` into the per-task `CODEX_HOME`, but left the referenced catalog behind in the shared Codex home, so Codex failed configuration loading with a generic missing-file error.

The daemon now parses the copied Codex config during per-task home preparation, resolves `model_catalog_json`, mirrors local relative catalogs into the isolated `CODEX_HOME`, and fails early with the resolved missing path if the catalog is absent.

## Related Issue

Closes #4825

Multica issue: ZIC-22

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/execenv/codex_home.go`: syncs `model_catalog_json` from the shared Codex home into the per-task Codex home for local relative catalog paths, while preserving existing absolute and `~/` paths.
- `server/internal/daemon/execenv/execenv_test.go`: adds regression coverage for a CC Switch-style relative model catalog and for clear missing-catalog error output.

## How to Test

1. `cd server && go test ./internal/daemon/execenv`
2. `cd server && go test ./internal/daemon/...`
3. `make check-worktree`

`make check-worktree` returned exit code 0 locally, but printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock` during its PostgreSQL check, so the focused Go tests above are the clean validation for this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Worked from GitHub issue #4825 and Multica issue ZIC-22. Traced Codex daemon launch configuration, identified that isolated per-task `CODEX_HOME` copied `config.toml` without relative `model_catalog_json` sidecar files, implemented the narrow sync path, and added focused regression tests.

## Screenshots (optional)

N/A
