### PR TITLE
PUR-137: add manual PR rescan path

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -111,6 +111,16 @@ var issuePullRequestsCmd = &cobra.Command{
 	RunE:    runIssuePullRequests,
 }
 
+var issueRescanPullRequestCmd = &cobra.Command{
+	Use:     "rescan-pr <issue-id> <pull-request>",
+	Aliases: []string{"relink-pr"},
+	Short:   "Re-scan an existing GitHub pull request and rebuild issue links",
+	Long: "Fetch the current GitHub PR payload and rerun the same issue-key scanner " +
+		"used by webhook delivery. Accepted PR refs: owner/repo#123 or https://github.com/owner/repo/pull/123.",
+	Args: exactArgs(2),
+	RunE: runIssueRescanPullRequest,
+}
+
 var issueChildrenCmd = &cobra.Command{
 	Use:     "children <id>",
 	Aliases: []string{"subissues"},
@@ -294,6 +304,7 @@ func init() {
 	issueCmd.AddCommand(issueListCmd)
 	issueCmd.AddCommand(issueGetCmd)
 	issueCmd.AddCommand(issuePullRequestsCmd)
+	issueCmd.AddCommand(issueRescanPullRequestCmd)
 	issueCmd.AddCommand(issueChildrenCmd)
 	issueCmd.AddCommand(issueCreateCmd)
 	issueCmd.AddCommand(issueUpdateCmd)
@@ -335,6 +346,8 @@ func init() {
 
 	// issue pull-requests
 	issuePullRequestsCmd.Flags().String("output", "table", "Output format: table or json")
+	issueRescanPullRequestCmd.Flags().String("output", "table", "Output format: table or json")
+	issueRescanPullRequestCmd.Flags().Int64("installation-id", 0, "Optional GitHub installation ID to force for the rescan")
 
 	issueChildrenCmd.Flags().String("output", "table", "Output format: table or json")
 	issueChildrenCmd.Flags().Bool("full-id", false, "Show full UUIDs in table output")
@@ -601,6 +614,90 @@ func runIssuePullRequests(cmd *cobra.Command, args []string) error {
 	prs, _ := result["pull_requests"].([]any)
 	printIssuePullRequestsTable(normalizePullRequestList(prs))
 	return nil
+}
+
+func runIssueRescanPullRequest(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	issueRef, err := resolveIssueRef(ctx, client, args[0])
+	if err != nil {
+		return fmt.Errorf("resolve issue: %w", err)
+	}
+	repoOwner, repoName, number, err := parsePullRequestRef(args[1])
+	if err != nil {
+		return err
+	}
+
+	body := map[string]any{
+		"repo_owner": repoOwner,
+		"repo_name":  repoName,
+		"number":     number,
+	}
+	if installationID, _ := cmd.Flags().GetInt64("installation-id"); installationID > 0 {
+		body["installation_id"] = installationID
+	}
+
+	var result map[string]any
+	path := "/api/issues/" + url.PathEscape(issueRef.ID) + "/pull-requests/rescan"
+	if err := client.PostJSON(ctx, path, body, &result); err != nil {
+		return fmt.Errorf("rescan pull request: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	if pr, ok := result["pull_request"].(map[string]any); ok {
+		printIssuePullRequestsTable([]map[string]any{pr})
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+func parsePullRequestRef(input string) (repoOwner, repoName string, number int, err error) {
+	raw := strings.TrimSpace(input)
+	if raw == "" {
+		return "", "", 0, fmt.Errorf("pull request ref is required")
+	}
+
+	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
+		u, parseErr := url.Parse(raw)
+		if parseErr != nil {
+			return "", "", 0, fmt.Errorf("parse pull request ref: %w", parseErr)
+		}
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if !strings.EqualFold(u.Host, "github.com") || len(parts) < 4 || parts[2] != "pull" {
+			return "", "", 0, fmt.Errorf("pull request ref %q is not a recognized GitHub pull request URL", input)
+		}
+		n, ok := parsePositiveInt(parts[3])
+		if !ok {
+			return "", "", 0, fmt.Errorf("pull request ref %q has an invalid pull request number", input)
+		}
+		return parts[0], parts[1], n, nil
+	}
+
+	hash := strings.LastIndex(raw, "#")
+	if hash <= 0 || hash >= len(raw)-1 {
+		return "", "", 0, fmt.Errorf("pull request ref %q is not recognized; use owner/repo#123 or a GitHub pull request URL", input)
+	}
+	repo := raw[:hash]
+	numberPart := raw[hash+1:]
+	slash := strings.Index(repo, "/")
+	if slash <= 0 || slash >= len(repo)-1 || strings.Contains(repo[slash+1:], "/") {
+		return "", "", 0, fmt.Errorf("pull request ref %q is not recognized; use owner/repo#123 or a GitHub pull request URL", input)
+	}
+	n, ok := parsePositiveInt(numberPart)
+	if !ok {
+		return "", "", 0, fmt.Errorf("pull request ref %q has an invalid pull request number", input)
+	}
+	return repo[:slash], repo[slash+1:], n, nil
 }
 
 func normalizePullRequestList(raw []any) []map[string]any {

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -373,6 +373,13 @@ func newIssuePullRequestsTestCmd() *cobra.Command {
 	return cmd
 }
 
+func newIssueRescanPullRequestTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "rescan-pr"}
+	cmd.Flags().String("output", "table", "")
+	cmd.Flags().Int64("installation-id", 0, "")
+	return cmd
+}
+
 func TestRunIssuePullRequestsListsLinkedPRsAsJSON(t *testing.T) {
 	var gotPaths []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -517,6 +524,129 @@ func TestRunIssuePullRequestsTableIncludesCoreFields(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("table output missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestParsePullRequestRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantNum   int
+		wantErr   string
+	}{
+		{
+			name:      "owner repo hash syntax",
+			input:     "Wilson-G/multi-loop#44",
+			wantOwner: "Wilson-G",
+			wantRepo:  "multi-loop",
+			wantNum:   44,
+		},
+		{
+			name:      "github url syntax",
+			input:     "https://github.com/Wilson-G/multi-loop/pull/44",
+			wantOwner: "Wilson-G",
+			wantRepo:  "multi-loop",
+			wantNum:   44,
+		},
+		{
+			name:    "reject malformed ref",
+			input:   "Wilson-G/multi-loop",
+			wantErr: "not recognized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, num, err := parsePullRequestRef(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parsePullRequestRef(%q) error = %v, want substring %q", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePullRequestRef(%q): %v", tt.input, err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo || num != tt.wantNum {
+				t.Fatalf("parsePullRequestRef(%q) = (%q, %q, %d), want (%q, %q, %d)", tt.input, owner, repo, num, tt.wantOwner, tt.wantRepo, tt.wantNum)
+			}
+		})
+	}
+}
+
+func TestRunIssueRescanPullRequestPostsBodyAsJSON(t *testing.T) {
+	var gotMethod string
+	var gotPaths []string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPaths = append(gotPaths, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/issues/MUL-2818":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         "issue-uuid",
+				"identifier": "MUL-2818",
+				"title":      "CLI PR rescan",
+			})
+		case "/api/issues/issue-uuid/pull-requests/rescan":
+			if r.Method != http.MethodPost {
+				t.Fatalf("rescan method = %s, want POST", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"pull_request": map[string]any{
+					"html_url": "https://github.com/Wilson-G/multi-loop/pull/44",
+					"number":   float64(44),
+					"state":    "merged",
+					"title":    "PUR-133: tighten mention routing",
+				},
+				"linked_issue_ids": []string{"issue-uuid"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := newIssueRescanPullRequestTestCmd()
+	_ = cmd.Flags().Set("output", "json")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := runIssueRescanPullRequest(cmd, []string{"MUL-2818", "Wilson-G/multi-loop#44"})
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("runIssueRescanPullRequest: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %s, want POST", gotMethod)
+	}
+	if want := []string{"/api/issues/MUL-2818", "/api/issues/issue-uuid/pull-requests/rescan"}; fmt.Sprint(gotPaths) != fmt.Sprint(want) {
+		t.Fatalf("paths = %v, want %v", gotPaths, want)
+	}
+	if gotBody["repo_owner"] != "Wilson-G" || gotBody["repo_name"] != "multi-loop" || gotBody["number"] != float64(44) {
+		t.Fatalf("unexpected body: %#v", gotBody)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, string(out))
+	}
+	pr, _ := payload["pull_request"].(map[string]any)
+	if pr["number"] != float64(44) || pr["state"] != "merged" {
+		t.Fatalf("unexpected pull_request payload: %#v", pr)
 	}
 }
 

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -918,6 +918,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Put("/metadata/{key}", h.SetIssueMetadataKey)
 					r.Delete("/metadata/{key}", h.DeleteIssueMetadataKey)
 					r.Get("/pull-requests", h.ListPullRequestsForIssue)
+					r.Post("/pull-requests/rescan", h.RescanPullRequestForIssue)
 				})
 			})
 

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -93,6 +93,57 @@ type GitHubPullRequestResponse struct {
 	ChangedFiles int32 `json:"changed_files"`
 }
 
+type githubPullRequestRescanRequest struct {
+	RepoOwner      string `json:"repo_owner"`
+	RepoName       string `json:"repo_name"`
+	Number         int32  `json:"number"`
+	InstallationID *int64 `json:"installation_id,omitempty"`
+}
+
+type githubPullRequestSyncSnapshot struct {
+	Action         string
+	BaseRefChanged bool
+	RepoOwner      string
+	RepoName       string
+	Number         int32
+	HTMLURL        string
+	Title          string
+	Body           string
+	State          string
+	Draft          bool
+	Merged         bool
+	MergedAt       string
+	ClosedAt       string
+	CreatedAt      string
+	UpdatedAt      string
+	MergeableState string
+	Additions      int32
+	Deletions      int32
+	ChangedFiles   int32
+	HeadRef        string
+	HeadSHA        string
+	AuthorLogin    string
+	AuthorAvatar   string
+}
+
+type githubAPIHTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *githubAPIHTTPError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("github api returned %d", e.StatusCode)
+	}
+	return fmt.Sprintf("github api returned %d: %s", e.StatusCode, e.Body)
+}
+
+var (
+	errGitHubAppAuthNotConfigured = errors.New("github app auth not configured")
+	errGitHubNoInstallation       = errors.New("github installation not found")
+	errGitHubPullRequestNotFound  = errors.New("github pull request not found")
+)
+
 type GitHubConnectResponse struct {
 	URL        string `json:"url"`
 	Configured bool   `json:"configured"`
@@ -177,6 +228,34 @@ func issuePullRequestRowToResponse(p db.ListPullRequestsByIssueRow) GitHubPullRe
 		Additions:        p.Additions,
 		Deletions:        p.Deletions,
 		ChangedFiles:     p.ChangedFiles,
+	}
+}
+
+func pullRequestSnapshotFromWebhookPayload(p ghPullRequestPayload) githubPullRequestSyncSnapshot {
+	return githubPullRequestSyncSnapshot{
+		Action:         p.Action,
+		BaseRefChanged: baseRefChanged(p.Changes),
+		RepoOwner:      p.Repository.Owner.Login,
+		RepoName:       p.Repository.Name,
+		Number:         p.PullRequest.Number,
+		HTMLURL:        p.PullRequest.HTMLURL,
+		Title:          p.PullRequest.Title,
+		Body:           p.PullRequest.Body,
+		State:          p.PullRequest.State,
+		Draft:          p.PullRequest.Draft,
+		Merged:         p.PullRequest.Merged,
+		MergedAt:       p.PullRequest.MergedAt,
+		ClosedAt:       p.PullRequest.ClosedAt,
+		CreatedAt:      p.PullRequest.CreatedAt,
+		UpdatedAt:      p.PullRequest.UpdatedAt,
+		MergeableState: p.PullRequest.MergeableState,
+		Additions:      p.PullRequest.Additions,
+		Deletions:      p.PullRequest.Deletions,
+		ChangedFiles:   p.PullRequest.ChangedFiles,
+		HeadRef:        p.PullRequest.Head.Ref,
+		HeadSHA:        p.PullRequest.Head.SHA,
+		AuthorLogin:    p.PullRequest.User.Login,
+		AuthorAvatar:   p.PullRequest.User.AvatarURL,
 	}
 }
 
@@ -574,6 +653,60 @@ func (h *Handler) ListPullRequestsForIssue(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]any{"pull_requests": out})
 }
 
+// RescanPullRequestForIssue fetches the current GitHub PR payload and reruns
+// the same PR mirror + issue-key scanner used by webhook delivery. It is the
+// manual repair path for "PR exists but issue ↔ PR link rows are missing".
+func (h *Handler) RescanPullRequestForIssue(w http.ResponseWriter, r *http.Request) {
+	issue, ok := h.loadIssueForUser(w, r, chi.URLParam(r, "id"))
+	if !ok {
+		return
+	}
+
+	var req githubPullRequestRescanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	req.RepoOwner = strings.TrimSpace(req.RepoOwner)
+	req.RepoName = strings.TrimSpace(req.RepoName)
+	if req.RepoOwner == "" || req.RepoName == "" || req.Number <= 0 {
+		writeError(w, http.StatusBadRequest, "repo_owner, repo_name, and number are required")
+		return
+	}
+
+	inst, pr, err := h.fetchPullRequestForRescan(r.Context(), issue.WorkspaceID, req)
+	if err != nil {
+		switch {
+		case errors.Is(err, errGitHubNoInstallation):
+			writeError(w, http.StatusConflict, "no github installation connected for this workspace")
+		case errors.Is(err, errGitHubAppAuthNotConfigured):
+			writeError(w, http.StatusServiceUnavailable, "github app auth not configured for manual rescan")
+		case errors.Is(err, errGitHubPullRequestNotFound):
+			writeError(w, http.StatusNotFound, "pull request not found")
+		default:
+			slog.Warn("github: manual rescan fetch failed", "err", err, "repo_owner", req.RepoOwner, "repo_name", req.RepoName, "pr_number", req.Number)
+			writeError(w, http.StatusBadGateway, "failed to fetch pull request from github")
+		}
+		return
+	}
+
+	resp, linkedIssueIDs, err := h.syncGitHubPullRequest(r.Context(), issue.WorkspaceID, inst, pr, false)
+	if err != nil {
+		slog.Warn("github: manual rescan sync failed", "err", err, "repo_owner", req.RepoOwner, "repo_name", req.RepoName, "pr_number", req.Number)
+		writeError(w, http.StatusInternalServerError, "failed to rescan pull request")
+		return
+	}
+
+	h.publish(protocol.EventPullRequestUpdated, uuidToString(issue.WorkspaceID), "system", "", map[string]any{
+		"pull_request":     resp,
+		"linked_issue_ids": linkedIssueIDs,
+	})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pull_request":     resp,
+		"linked_issue_ids": linkedIssueIDs,
+	})
+}
+
 // ── Webhook ─────────────────────────────────────────────────────────────────
 
 // identifierRe extracts identifiers like "MUL-1510" from text. Case-insensitive
@@ -822,147 +955,21 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 	// per-repo, so the binding only supplies the delivering account and the
 	// fallback workspace. The oldest binding is a deterministic fallback.
 	inst := insts[0]
-
 	// Route to the workspace that owns this repo, not the installation's single
 	// workspace — one installation can serve repos across several workspaces.
 	wsID := h.resolveWorkspaceForRepo(ctx, inst.WorkspaceID, inst.AccountLogin, p.Repository.Owner.Login, p.Repository.Name)
-
-	state := derivePRState(p.PullRequest.State, p.PullRequest.Draft, p.PullRequest.Merged)
-	mergeable, clearMergeable := derivePRMergeableState(p.Action, p.PullRequest.MergeableState, baseRefChanged(p.Changes))
-	pr, err := h.Queries.UpsertGitHubPullRequest(ctx, db.UpsertGitHubPullRequestParams{
-		WorkspaceID:         wsID,
-		InstallationID:      inst.InstallationID,
-		RepoOwner:           p.Repository.Owner.Login,
-		RepoName:            p.Repository.Name,
-		PrNumber:            p.PullRequest.Number,
-		Title:               p.PullRequest.Title,
-		State:               state,
-		HtmlUrl:             p.PullRequest.HTMLURL,
-		Branch:              ptrToText(strPtrOrNil(p.PullRequest.Head.Ref)),
-		AuthorLogin:         ptrToText(strPtrOrNil(p.PullRequest.User.Login)),
-		AuthorAvatarUrl:     ptrToText(strPtrOrNil(p.PullRequest.User.AvatarURL)),
-		MergedAt:            parseGHTime(p.PullRequest.MergedAt),
-		ClosedAt:            parseGHTime(p.PullRequest.ClosedAt),
-		PrCreatedAt:         parseGHTimeRequired(p.PullRequest.CreatedAt),
-		PrUpdatedAt:         parseGHTimeRequired(p.PullRequest.UpdatedAt),
-		HeadSha:             p.PullRequest.Head.SHA,
-		MergeableState:      mergeable,
-		ClearMergeableState: pgtype.Bool{Bool: clearMergeable, Valid: true},
-		Additions:           p.PullRequest.Additions,
-		Deletions:           p.PullRequest.Deletions,
-		ChangedFiles:        p.PullRequest.ChangedFiles,
-	})
+	snapshot := pullRequestSnapshotFromWebhookPayload(p)
+	state := derivePRState(snapshot.State, snapshot.Draft, snapshot.Merged)
+	preserveCloseIntent := p.Action != "closed" && (state == "merged" || state == "closed")
+	resp, linkedIssueIDs, err := h.syncGitHubPullRequest(ctx, wsID, inst, snapshot, preserveCloseIntent)
 	if err != nil {
-		slog.Warn("github: upsert pr failed", "err", err)
+		slog.Warn("github: sync pr failed", "err", err)
 		return
-	}
-
-	// Drain any check_suite events that arrived before this PR row was
-	// mirrored (out-of-order webhook delivery). Each drained row is
-	// replayed through the same upsert path used by live check_suite
-	// events; the DrainPending… query removes them atomically so a
-	// concurrent PR upsert can't double-apply.
-	h.replayPendingCheckSuitesForPR(ctx, pr, wsID)
-
-	workspaceID := uuidToString(wsID)
-	resp := githubPullRequestToResponse(pr)
-
-	// Auto-link: scan title/body/branch for issue identifiers, look them
-	// up in this workspace, attach the link rows. Idempotent (ON CONFLICT
-	// upserts the close_intent flag — see LinkIssueToPullRequest) so
-	// re-firing the webhook doesn't duplicate.
-	//
-	// RFC MUL-2414 §4.8: the PR mirror upsert above always runs (so re-enabling
-	// GitHub features restores history without backfill), but the link rows
-	// are a "new side-effect" and must be gated by the workspace's auto-link
-	// flag (which itself short-circuits when the master `github_enabled`
-	// switch is off).
-	linkedIssueIDs := make([]string, 0)
-	if h.workspaceAutoLinkPRsEnabled(ctx, wsID) {
-		idents := extractIdentifiers(p.PullRequest.Title, p.PullRequest.Body, p.PullRequest.Head.Ref)
-		// closingIdents is the subset of identifiers that this PR explicitly
-		// declared via a closing keyword ("Closes/Fixes/Resolves MUL-X").
-		// Linking still happens for every mention (idents above), but the
-		// link row's close_intent column — and therefore whether the
-		// auto-advance gate eventually fires — is only set for keyword-
-		// declared identifiers. Bare title prefixes and branch-name
-		// references are link-only.
-		closingIdents := map[string]struct{}{}
-		for _, c := range extractClosingIdentifiers(p.PullRequest.Title, p.PullRequest.Body) {
-			closingIdents[c] = struct{}{}
-		}
-		// close_intent should follow the PR title/body while the PR is still
-		// editable before its terminal close event. Once GitHub has delivered
-		// a terminal event, later edit/synchronize webhooks must not rewrite
-		// the merge-time close decision.
-		preserveCloseIntent := p.Action != "closed" && (state == "merged" || state == "closed")
-		prefix := h.getIssuePrefix(ctx, wsID)
-		// reevalIssues collects each issue whose link row we just touched so
-		// we can re-run the auto-advance gate against the persisted aggregate
-		// after every link upsert in this event. Driving the gate off
-		// persisted state (instead of "did *this* webhook declare closing
-		// intent?") is what fixes the multi-PR sibling case: a PR with
-		// `Closes MUL-1` merges first while a link-only sibling is still
-		// open, then the sibling closes later — its webhook has no closing
-		// keyword, but the earlier link row carries close_intent=true, so
-		// MUL-1 still advances.
-		reevalIssues := make([]db.Issue, 0, len(idents))
-		for _, id := range idents {
-			issue, ok := h.lookupIssueByIdentifier(ctx, wsID, prefix, id)
-			if !ok {
-				continue
-			}
-			_, declared := closingIdents[id]
-			closeIntent := declared && !preserveCloseIntent
-			if err := h.Queries.LinkIssueToPullRequest(ctx, db.LinkIssueToPullRequestParams{
-				IssueID:             issue.ID,
-				PullRequestID:       pr.ID,
-				CloseIntent:         closeIntent,
-				PreserveCloseIntent: preserveCloseIntent,
-				LinkedByType:        strToText("system"),
-				LinkedByID:          pgtype.UUID{},
-			}); err != nil {
-				slog.Warn("github: link failed", "err", err)
-				continue
-			}
-			linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))
-			reevalIssues = append(reevalIssues, issue)
-		}
-
-		// A terminal PR event (`merged` or `closed`) may be the moment the
-		// last in-flight sibling resolves. We re-evaluate every issue we
-		// just linked once both the PR row and the link row are persisted,
-		// so the aggregate query sees the freshest state. We advance the
-		// issue to done when:
-		//   1. the issue isn't already terminal (`done` / `cancelled`);
-		//   2. no linked PR is still `open` / `draft`;
-		//   3. at least one merged linked PR declared close_intent (a
-		//      "Closes/Fixes/Resolves" keyword on its link row).
-		// Rule (3) is what prevents "Follow up in MUL-2" / "Unblocks MUL-3"
-		// references from being treated the same as "Closes MUL-1", and
-		// also prevents an "all closed-without-merge" sequence from
-		// silently auto-closing the issue — if nothing carrying closing
-		// intent was ever delivered, the user should decide manually.
-		if state == "merged" || state == "closed" {
-			for _, issue := range reevalIssues {
-				if issue.Status == "done" || issue.Status == "cancelled" {
-					continue
-				}
-				counts, err := h.Queries.GetIssuePullRequestCloseAggregate(ctx, issue.ID)
-				if err != nil {
-					slog.Warn("github: count linked pr states failed", "err", err, "issue_id", uuidToString(issue.ID))
-					continue
-				}
-				if counts.OpenCount == 0 && counts.MergedWithCloseIntentCount > 0 {
-					h.advanceIssueToDone(ctx, issue, workspaceID)
-				}
-			}
-		}
 	}
 
 	// Broadcast PR change to the workspace so any open issue detail page
 	// re-queries its PR list.
-	h.publish(protocol.EventPullRequestUpdated, workspaceID, "system", "", map[string]any{
+	h.publish(protocol.EventPullRequestUpdated, uuidToString(wsID), "system", "", map[string]any{
 		"pull_request":     resp,
 		"linked_issue_ids": linkedIssueIDs,
 	})
@@ -1212,6 +1219,276 @@ func derivePRState(state string, draft, merged bool) string {
 		return "draft"
 	}
 	return "open"
+}
+
+func (h *Handler) syncGitHubPullRequest(ctx context.Context, workspaceID pgtype.UUID, inst db.GithubInstallation, snapshot githubPullRequestSyncSnapshot, preserveCloseIntent bool) (GitHubPullRequestResponse, []string, error) {
+	state := derivePRState(snapshot.State, snapshot.Draft, snapshot.Merged)
+	mergeable, clearMergeable := derivePRMergeableState(snapshot.Action, snapshot.MergeableState, snapshot.BaseRefChanged)
+	pr, err := h.Queries.UpsertGitHubPullRequest(ctx, db.UpsertGitHubPullRequestParams{
+		WorkspaceID:         workspaceID,
+		InstallationID:      inst.InstallationID,
+		RepoOwner:           snapshot.RepoOwner,
+		RepoName:            snapshot.RepoName,
+		PrNumber:            snapshot.Number,
+		Title:               snapshot.Title,
+		State:               state,
+		HtmlUrl:             snapshot.HTMLURL,
+		Branch:              ptrToText(strPtrOrNil(snapshot.HeadRef)),
+		AuthorLogin:         ptrToText(strPtrOrNil(snapshot.AuthorLogin)),
+		AuthorAvatarUrl:     ptrToText(strPtrOrNil(snapshot.AuthorAvatar)),
+		MergedAt:            parseGHTime(snapshot.MergedAt),
+		ClosedAt:            parseGHTime(snapshot.ClosedAt),
+		PrCreatedAt:         parseGHTimeRequired(snapshot.CreatedAt),
+		PrUpdatedAt:         parseGHTimeRequired(snapshot.UpdatedAt),
+		HeadSha:             snapshot.HeadSHA,
+		MergeableState:      mergeable,
+		ClearMergeableState: pgtype.Bool{Bool: clearMergeable, Valid: true},
+		Additions:           snapshot.Additions,
+		Deletions:           snapshot.Deletions,
+		ChangedFiles:        snapshot.ChangedFiles,
+	})
+	if err != nil {
+		return GitHubPullRequestResponse{}, nil, err
+	}
+
+	h.replayPendingCheckSuitesForPR(ctx, pr, workspaceID)
+
+	resp := githubPullRequestToResponse(pr)
+	linkedIssueIDs := make([]string, 0)
+	if h.workspaceAutoLinkPRsEnabled(ctx, workspaceID) {
+		idents := extractIdentifiers(snapshot.Title, snapshot.Body, snapshot.HeadRef)
+		closingIdents := map[string]struct{}{}
+		for _, c := range extractClosingIdentifiers(snapshot.Title, snapshot.Body) {
+			closingIdents[c] = struct{}{}
+		}
+		prefix := h.getIssuePrefix(ctx, workspaceID)
+		reevalIssues := make([]db.Issue, 0, len(idents))
+		for _, id := range idents {
+			issue, ok := h.lookupIssueByIdentifier(ctx, workspaceID, prefix, id)
+			if !ok {
+				continue
+			}
+			_, declared := closingIdents[id]
+			closeIntent := declared && !preserveCloseIntent
+			if err := h.Queries.LinkIssueToPullRequest(ctx, db.LinkIssueToPullRequestParams{
+				IssueID:             issue.ID,
+				PullRequestID:       pr.ID,
+				CloseIntent:         closeIntent,
+				PreserveCloseIntent: preserveCloseIntent,
+				LinkedByType:        strToText("system"),
+				LinkedByID:          pgtype.UUID{},
+			}); err != nil {
+				slog.Warn("github: link failed", "err", err)
+				continue
+			}
+			linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))
+			reevalIssues = append(reevalIssues, issue)
+		}
+
+		if state == "merged" || state == "closed" {
+			workspaceIDStr := uuidToString(workspaceID)
+			for _, issue := range reevalIssues {
+				if issue.Status == "done" || issue.Status == "cancelled" {
+					continue
+				}
+				counts, err := h.Queries.GetIssuePullRequestCloseAggregate(ctx, issue.ID)
+				if err != nil {
+					slog.Warn("github: count linked pr states failed", "err", err, "issue_id", uuidToString(issue.ID))
+					continue
+				}
+				if counts.OpenCount == 0 && counts.MergedWithCloseIntentCount > 0 {
+					h.advanceIssueToDone(ctx, issue, workspaceIDStr)
+				}
+			}
+		}
+	}
+	return resp, linkedIssueIDs, nil
+}
+
+func (h *Handler) fetchPullRequestForRescan(ctx context.Context, workspaceID pgtype.UUID, req githubPullRequestRescanRequest) (db.GithubInstallation, githubPullRequestSyncSnapshot, error) {
+	insts, err := h.Queries.ListGitHubInstallationsByWorkspace(ctx, workspaceID)
+	if err != nil {
+		return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, err
+	}
+	if len(insts) == 0 {
+		return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, errGitHubNoInstallation
+	}
+
+	candidates := make([]db.GithubInstallation, 0, len(insts))
+	if req.InstallationID != nil {
+		for _, inst := range insts {
+			if inst.InstallationID == *req.InstallationID {
+				candidates = append(candidates, inst)
+				break
+			}
+		}
+		if len(candidates) == 0 {
+			return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, errGitHubNoInstallation
+		}
+	} else {
+		for _, inst := range insts {
+			if strings.EqualFold(strings.TrimSpace(inst.AccountLogin), req.RepoOwner) {
+				candidates = append(candidates, inst)
+			}
+		}
+		for _, inst := range insts {
+			if strings.EqualFold(strings.TrimSpace(inst.AccountLogin), req.RepoOwner) {
+				continue
+			}
+			candidates = append(candidates, inst)
+		}
+	}
+
+	var lastErr error
+	for _, inst := range candidates {
+		pr, err := fetchGitHubPullRequest(ctx, inst.InstallationID, req.RepoOwner, req.RepoName, req.Number)
+		if err == nil {
+			return inst, pr, nil
+		}
+		if errors.Is(err, errGitHubAppAuthNotConfigured) {
+			return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, err
+		}
+		var httpErr *githubAPIHTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusForbidden) {
+			lastErr = err
+			continue
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errGitHubPullRequestNotFound
+	}
+	var httpErr *githubAPIHTTPError
+	if errors.As(lastErr, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusForbidden) {
+		return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, errGitHubPullRequestNotFound
+	}
+	return db.GithubInstallation{}, githubPullRequestSyncSnapshot{}, lastErr
+}
+
+func fetchGitHubInstallationToken(ctx context.Context, installationID int64) (string, error) {
+	appJWT, err := signGitHubAppJWT(time.Now())
+	if err != nil {
+		return "", err
+	}
+	if appJWT == "" {
+		return "", errGitHubAppAuthNotConfigured
+	}
+	endpoint := fmt.Sprintf("%s/app/installations/%d/access_tokens", strings.TrimRight(githubAPIBase, "/"), installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader("{}"))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", &githubAPIHTTPError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(data))}
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(body.Token) == "" {
+		return "", errors.New("github installation token response was empty")
+	}
+	return body.Token, nil
+}
+
+func fetchGitHubPullRequest(ctx context.Context, installationID int64, repoOwner, repoName string, number int32) (githubPullRequestSyncSnapshot, error) {
+	token, err := fetchGitHubInstallationToken(ctx, installationID)
+	if err != nil {
+		return githubPullRequestSyncSnapshot{}, err
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/pulls/%d",
+		strings.TrimRight(githubAPIBase, "/"),
+		url.PathEscape(repoOwner),
+		url.PathEscape(repoName),
+		number,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return githubPullRequestSyncSnapshot{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return githubPullRequestSyncSnapshot{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return githubPullRequestSyncSnapshot{}, &githubAPIHTTPError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(data))}
+	}
+	var body struct {
+		Number         int32   `json:"number"`
+		HTMLURL        string  `json:"html_url"`
+		Title          string  `json:"title"`
+		Body           string  `json:"body"`
+		State          string  `json:"state"`
+		Draft          bool    `json:"draft"`
+		Merged         bool    `json:"merged"`
+		MergedAt       *string `json:"merged_at"`
+		ClosedAt       *string `json:"closed_at"`
+		CreatedAt      string  `json:"created_at"`
+		UpdatedAt      string  `json:"updated_at"`
+		MergeableState string  `json:"mergeable_state"`
+		Additions      int32   `json:"additions"`
+		Deletions      int32   `json:"deletions"`
+		ChangedFiles   int32   `json:"changed_files"`
+		Head           struct {
+			Ref string `json:"ref"`
+			SHA string `json:"sha"`
+		} `json:"head"`
+		User struct {
+			Login     string `json:"login"`
+			AvatarURL string `json:"avatar_url"`
+		} `json:"user"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return githubPullRequestSyncSnapshot{}, err
+	}
+	mergedAt := ""
+	if body.MergedAt != nil {
+		mergedAt = *body.MergedAt
+	}
+	closedAt := ""
+	if body.ClosedAt != nil {
+		closedAt = *body.ClosedAt
+	}
+	merged := body.Merged || body.MergedAt != nil
+	return githubPullRequestSyncSnapshot{
+		Action:         "edited",
+		RepoOwner:      repoOwner,
+		RepoName:       repoName,
+		Number:         body.Number,
+		HTMLURL:        body.HTMLURL,
+		Title:          body.Title,
+		Body:           body.Body,
+		State:          body.State,
+		Draft:          body.Draft,
+		Merged:         merged,
+		MergedAt:       mergedAt,
+		ClosedAt:       closedAt,
+		CreatedAt:      body.CreatedAt,
+		UpdatedAt:      body.UpdatedAt,
+		MergeableState: body.MergeableState,
+		Additions:      body.Additions,
+		Deletions:      body.Deletions,
+		ChangedFiles:   body.ChangedFiles,
+		HeadRef:        body.Head.Ref,
+		HeadSHA:        body.Head.SHA,
+		AuthorLogin:    body.User.Login,
+		AuthorAvatar:   body.User.AvatarURL,
+	}, nil
 }
 
 func parseGHTime(s string) pgtype.Timestamptz {

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -2214,6 +2214,138 @@ func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
 	}
 }
 
+func TestRescanPullRequestForIssue_IdempotentLinkOnlyRepair(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	pemBytes, _ := generateTestRSAKeyPEM(t)
+	t.Setenv("GITHUB_APP_ID", "424242")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", string(pemBytes))
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "manual rescan repair",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	const installationID int64 = 40440444
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO github_installation (workspace_id, installation_id, account_login, account_type)
+		VALUES ($1, $2, $3, $4)
+	`, testWorkspaceID, installationID, "Wilson-G", "User"); err != nil {
+		t.Fatalf("insert github_installation: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	oldBase := githubAPIBase
+	t.Cleanup(func() { githubAPIBase = oldBase })
+
+	var tokenPosts, pullGets int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/app/installations/%d/access_tokens", installationID):
+			tokenPosts++
+			if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+				t.Fatalf("installation token auth header = %q, want Bearer", auth)
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"token": "installation-token"})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/Wilson-G/multi-loop/pulls/44":
+			pullGets++
+			if auth := r.Header.Get("Authorization"); auth != "Bearer installation-token" {
+				t.Fatalf("pull fetch auth header = %q, want installation token", auth)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"number":          44,
+				"html_url":        "https://github.com/Wilson-G/multi-loop/pull/44",
+				"title":           created.Identifier + ": tighten mention routing",
+				"body":            "Refs " + created.Identifier,
+				"state":           "closed",
+				"draft":           false,
+				"merged":          true,
+				"merged_at":       "2026-07-02T15:00:00Z",
+				"closed_at":       "2026-07-02T15:00:00Z",
+				"created_at":      "2026-07-02T14:00:00Z",
+				"updated_at":      "2026-07-02T15:00:00Z",
+				"mergeable_state": "clean",
+				"additions":       12,
+				"deletions":       3,
+				"changed_files":   2,
+				"head":            map[string]any{"ref": "agent/loop-builder/pur-133-fixture", "sha": "abc123"},
+				"user":            map[string]any{"login": "octocat", "avatar_url": ""},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	githubAPIBase = srv.URL
+
+	body := map[string]any{
+		"repo_owner": "Wilson-G",
+		"repo_name":  "multi-loop",
+		"number":     44,
+	}
+	for i := 0; i < 2; i++ {
+		w = httptest.NewRecorder()
+		req = withURLParam(newRequest("POST", "/api/issues/"+created.ID+"/pull-requests/rescan", body), "id", created.ID)
+		testHandler.RescanPullRequestForIssue(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("rescan attempt %d: expected 200, got %d (%s)", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	if tokenPosts != 2 || pullGets != 2 {
+		t.Fatalf("expected 2 token fetches and 2 pull fetches, got token=%d pull=%d", tokenPosts, pullGets)
+	}
+
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected exactly 1 linked PR after repeated rescan, got %d", len(linked))
+	}
+
+	var linkCount int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM issue_pull_request WHERE issue_id = $1`, created.ID).Scan(&linkCount); err != nil {
+		t.Fatalf("count issue_pull_request rows: %v", err)
+	}
+	if linkCount != 1 {
+		t.Fatalf("issue_pull_request row count = %d, want 1", linkCount)
+	}
+
+	counts, err := testHandler.Queries.GetIssuePullRequestCloseAggregate(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssuePullRequestCloseAggregate: %v", err)
+	}
+	if counts.MergedWithCloseIntentCount != 0 {
+		t.Fatalf("merged_with_close_intent_count = %d, want 0", counts.MergedWithCloseIntentCount)
+	}
+
+	updated, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if updated.Status != "in_progress" {
+		t.Fatalf("issue status = %q, want in_progress", updated.Status)
+	}
+}
+
 // generateTestRSAKeyPEM mints an RSA-2048 key, returns its PKCS#1 PEM
 // encoding (the format GitHub hands operators when they create the App)
 // and the parsed *rsa.PrivateKey for verification.


### PR DESCRIPTION
## Summary
- add a manual `POST /api/issues/{id}/pull-requests/rescan` repair path that fetches an existing GitHub PR and reruns the same issue-key scanner used by webhook delivery
- add `multica issue rescan-pr <issue-id> <owner/repo#number>` as the operator-facing CLI entrypoint
- cover the minimal repair contract with tests: repeated rescans stay idempotent and `Refs <ISSUE-KEY>` does not auto-mark the issue done

## Testing
- `go test ./cmd/multica -run 'Test(ParsePullRequestRef|RunIssuePullRequests|RunIssueRescanPullRequest)'`
- `go test ./internal/handler -run 'TestRescanPullRequestForIssue_IdempotentLinkOnlyRepair'`
- `go test ./cmd/server -run '^$'`

Refs PUR-137
