### PR TITLE
ZIC-10: Fix GitHub close-intent PR linking

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -562,6 +563,7 @@ func (h *Handler) ListPullRequestsForIssue(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
+	h.reconcileIssuePullRequestMetadata(r.Context(), issue)
 	rows, err := h.Queries.ListPullRequestsByIssue(r.Context(), issue.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list pull requests")
@@ -572,6 +574,92 @@ func (h *Handler) ListPullRequestsForIssue(w http.ResponseWriter, r *http.Reques
 		out = append(out, issuePullRequestRowToResponse(row))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"pull_requests": out})
+}
+
+func (h *Handler) reconcileIssuePullRequestMetadata(ctx context.Context, issue db.Issue) {
+	metadata := parseIssueMetadata(issue.Metadata)
+	rawURL, ok := metadata["pr_url"].(string)
+	if !ok {
+		return
+	}
+	owner, repo, number, ok := parseGitHubPullRequestURL(rawURL)
+	if !ok {
+		return
+	}
+	if metaNumber, ok := metadataPRNumber(metadata["pr_number"]); ok && metaNumber != number {
+		return
+	}
+	pr, err := h.Queries.GetGitHubPullRequest(ctx, db.GetGitHubPullRequestParams{
+		WorkspaceID: issue.WorkspaceID,
+		RepoOwner:   owner,
+		RepoName:    repo,
+		PrNumber:    number,
+	})
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn("github: reconcile issue pr metadata lookup failed", "err", err, "issue_id", uuidToString(issue.ID))
+		}
+		return
+	}
+	if err := h.Queries.LinkIssueToPullRequest(ctx, db.LinkIssueToPullRequestParams{
+		IssueID:             issue.ID,
+		PullRequestID:       pr.ID,
+		CloseIntent:         false,
+		PreserveCloseIntent: false,
+		LinkedByType:        strToText("system"),
+		LinkedByID:          pgtype.UUID{},
+	}); err != nil {
+		slog.Warn("github: reconcile issue pr metadata link failed", "err", err, "issue_id", uuidToString(issue.ID), "pr_id", uuidToString(pr.ID))
+	}
+}
+
+func metadataPRNumber(v any) (int32, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n <= 0 || n > math.MaxInt32 || n != math.Trunc(n) {
+			return 0, false
+		}
+		return int32(n), true
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(n), 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		return int32(parsed), true
+	default:
+		return 0, false
+	}
+}
+
+func parseGitHubPullRequestURL(raw string) (owner, repo string, number int32, ok bool) {
+	s := strings.TrimSpace(raw)
+	if i := strings.Index(s, "]("); i >= 0 {
+		rest := s[i+2:]
+		if j := strings.Index(rest, ")"); j >= 0 {
+			s = rest[:j]
+		}
+	}
+	s = strings.Trim(strings.TrimSpace(s), "<>")
+	if strings.HasPrefix(strings.ToLower(s), "github.com/") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", "", 0, false
+	}
+	host := strings.TrimPrefix(strings.ToLower(u.Host), "www.")
+	if host != "github.com" {
+		return "", "", 0, false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || !strings.EqualFold(parts[2], "pull") {
+		return "", "", 0, false
+	}
+	n, err := strconv.ParseInt(parts[3], 10, 32)
+	if err != nil || n <= 0 {
+		return "", "", 0, false
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), int32(n), true
 }
 
 // ── Webhook ─────────────────────────────────────────────────────────────────
@@ -1235,15 +1323,15 @@ func parseGHTimeRequired(s string) pgtype.Timestamptz {
 
 const githubWebhookHost = "github.com"
 
-// resolveWorkspaceForRepo routes a delivery to the workspace whose repos
-// registry owns github.com/owner/name, so one installation can serve repos in
-// several workspaces; falls back to the caller-supplied workspace when
-// unmatched (callers pass the installation's oldest binding, since an
-// installation may now be bound to several workspaces). The registry is
-// admin-editable, so it overrides the verified installation binding only when
-// owner == the delivering account (accountLogin) and the host matches — no
+// resolveWorkspaceForRepo routes a delivery to the workspace whose project or
+// workspace repo registry owns github.com/owner/name, so one installation can
+// serve repos in several workspaces. Project-level github_repo resources take
+// precedence because they are the task/issue-specific repo source used by
+// agents; the legacy workspace.repos list is the fallback registry. The
+// registries are admin-editable, so either override is honored only when owner
+// == the delivering account (accountLogin) and the host matches — no
 // cross-account capture. On ties the fallback workspace wins if it is among the
-// matches, else the lowest id (query is ORDER BY id).
+// matches, else the lowest id from the query ordering wins.
 func (h *Handler) resolveWorkspaceForRepo(ctx context.Context, fallback pgtype.UUID, accountLogin, owner, name string) pgtype.UUID {
 	owner = strings.TrimSpace(owner)
 	name = strings.TrimSpace(name)
@@ -1255,6 +1343,10 @@ func (h *Handler) resolveWorkspaceForRepo(ctx context.Context, fallback pgtype.U
 		return fallback
 	}
 	target := githubWebhookHost + "/" + strings.ToLower(owner) + "/" + strings.ToLower(name)
+	if matches := h.matchProjectRepoWorkspaces(ctx, target); len(matches) > 0 {
+		return chooseRepoWorkspace(fallback, matches)
+	}
+
 	rows, err := h.Queries.ListWorkspacesWithRepos(ctx)
 	if err != nil {
 		slog.Warn("github: list workspaces with repos failed", "err", err)
@@ -1275,19 +1367,49 @@ func (h *Handler) resolveWorkspaceForRepo(ctx context.Context, fallback pgtype.U
 			}
 		}
 	}
+	return chooseRepoWorkspace(fallback, matches)
+}
+
+func (h *Handler) matchProjectRepoWorkspaces(ctx context.Context, target string) []pgtype.UUID {
+	rows, err := h.Queries.ListGitHubRepoProjectResources(ctx)
+	if err != nil {
+		slog.Warn("github: list project github_repo resources failed", "err", err)
+		return nil
+	}
+	matches := make([]pgtype.UUID, 0, 1)
+	seen := map[pgtype.UUID]struct{}{}
+	for _, row := range rows {
+		var ref struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(row.ResourceRef, &ref); err != nil {
+			continue
+		}
+		if repoIdentityFromURL(ref.URL) != target {
+			continue
+		}
+		if _, dup := seen[row.WorkspaceID]; dup {
+			continue
+		}
+		seen[row.WorkspaceID] = struct{}{}
+		matches = append(matches, row.WorkspaceID)
+	}
+	return matches
+}
+
+func chooseRepoWorkspace(fallback pgtype.UUID, matches []pgtype.UUID) pgtype.UUID {
 	switch len(matches) {
 	case 0:
 		return fallback
 	case 1:
 		return matches[0]
-	default:
-		for _, m := range matches {
-			if m == fallback {
-				return m
-			}
-		}
-		return matches[0]
 	}
+	for _, m := range matches {
+		if m == fallback {
+			return m
+		}
+	}
+	return matches[0]
 }
 
 // repoIdentityFromURL returns lowercased "host/owner/name" from an https, scp

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -2699,6 +2700,120 @@ func TestRepoIdentityFromURL(t *testing.T) {
 	}
 }
 
+func TestParseGitHubPullRequestURL(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantOwner  string
+		wantRepo   string
+		wantNumber int32
+		wantOK     bool
+	}{
+		{"https://github.com/acme/widget/pull/42", "acme", "widget", 42, true},
+		{"[https://github.com/acme/widget/pull/42](https://github.com/acme/widget/pull/42)", "acme", "widget", 42, true},
+		{"github.com/acme/widget/pull/42", "acme", "widget", 42, true},
+		{"https://gitlab.com/acme/widget/-/merge_requests/42", "", "", 0, false},
+		{"https://github.com/acme/widget/issues/42", "", "", 0, false},
+	}
+	for _, tc := range cases {
+		owner, repo, number, ok := parseGitHubPullRequestURL(tc.in)
+		if owner != tc.wantOwner || repo != tc.wantRepo || number != tc.wantNumber || ok != tc.wantOK {
+			t.Errorf("parseGitHubPullRequestURL(%q) = %q %q %d %v, want %q %q %d %v",
+				tc.in, owner, repo, number, ok, tc.wantOwner, tc.wantRepo, tc.wantNumber, tc.wantOK)
+		}
+	}
+}
+
+func TestListPullRequestsForIssueReconcilesMetadataLink(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "metadata pr link",
+		"status": "done",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	const repoOwner, repoName = "metadata-acme", "metadata-widget"
+	const installationID int64 = 778899004
+	const prNumber int32 = 4545
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   repoOwner,
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+	pr, err := testHandler.Queries.UpsertGitHubPullRequest(ctx, db.UpsertGitHubPullRequestParams{
+		WorkspaceID:         parseUUID(testWorkspaceID),
+		InstallationID:      installationID,
+		RepoOwner:           repoOwner,
+		RepoName:            repoName,
+		PrNumber:            prNumber,
+		Title:               "Metadata-only PR",
+		State:               "merged",
+		HtmlUrl:             "https://github.com/metadata-acme/metadata-widget/pull/4545",
+		Branch:              pgtype.Text{String: "feat/metadata", Valid: true},
+		MergedAt:            parseGHTime("2026-04-29T00:00:00Z"),
+		ClosedAt:            parseGHTime("2026-04-29T00:00:00Z"),
+		PrCreatedAt:         parseGHTimeRequired("2026-04-28T00:00:00Z"),
+		PrUpdatedAt:         parseGHTimeRequired("2026-04-29T00:00:00Z"),
+		HeadSha:             "metadata-head",
+		ClearMergeableState: pgtype.Bool{Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("UpsertGitHubPullRequest: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE issue SET metadata = $1 WHERE id = $2`,
+		[]byte(`{"pr_url":"[https://github.com/metadata-acme/metadata-widget/pull/4545](https://github.com/metadata-acme/metadata-widget/pull/4545)","pr_number":4545}`),
+		created.ID,
+	); err != nil {
+		t.Fatalf("set issue metadata: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE id = $1`, pr.ID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	rec := httptest.NewRecorder()
+	listReq := withURLParam(newRequest("GET", "/api/issues/"+created.ID+"/pull-requests", nil), "id", created.ID)
+	testHandler.ListPullRequestsForIssue(rec, listReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ListPullRequestsForIssue: expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		PullRequests []GitHubPullRequestResponse `json:"pull_requests"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.PullRequests) != 1 {
+		t.Fatalf("pull_requests length = %d, want 1", len(payload.PullRequests))
+	}
+	if payload.PullRequests[0].Number != prNumber || payload.PullRequests[0].State != "merged" {
+		t.Fatalf("pull request = #%d state %q, want #%d merged", payload.PullRequests[0].Number, payload.PullRequests[0].State, prNumber)
+	}
+
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("metadata reconciliation should persist the missing link row, got %d links", len(linked))
+	}
+}
+
 // TestWebhook_RoutesToRepoOwningWorkspace is the regression test for the bug
 // where one GitHub App installation serving repos in several workspaces filed
 // every PR under the installation's single workspace — so a PR's identifier
@@ -2834,6 +2949,166 @@ func TestWebhook_RoutesToRepoOwningWorkspace(t *testing.T) {
 	}
 	if len(linked) != 1 {
 		t.Fatalf("expected 1 linked PR on the repo-owning workspace issue, got %d", len(linked))
+	}
+}
+
+// TestWebhook_RoutesToProjectGitHubRepoWorkspace covers the project-resource
+// variant of the repo routing path: agents receive github_repo resources from
+// the issue's project, not only the legacy workspace.repos list. A merged PR
+// from that repo must be mirrored in the issue workspace, linked by its
+// title/body identifier scan, and returned by the issue pull-requests query.
+func TestWebhook_RoutesToProjectGitHubRepoWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "project-resource-route-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	const repoOwner, repoName = "project-route-acme", "project-route-widget"
+	repoURL := "https://github.com/" + repoOwner + "/" + repoName
+
+	project, err := testHandler.Queries.CreateProject(ctx, db.CreateProjectParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		Title:       "project route",
+		Status:      "in_progress",
+		Priority:    "none",
+	})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	resource, err := testHandler.Queries.CreateProjectResource(ctx, db.CreateProjectResourceParams{
+		ProjectID:    project.ID,
+		WorkspaceID:  parseUUID(testWorkspaceID),
+		ResourceType: "github_repo",
+		ResourceRef:  []byte(`{"url":"` + repoURL + `"}`),
+		Label:        pgtype.Text{String: "project repo", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateProjectResource: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":      "project resource route test",
+		"status":     "in_progress",
+		"project_id": uuidToString(project.ID),
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, "project-route-install-ws")
+	wsA, err := testHandler.Queries.CreateWorkspace(ctx, db.CreateWorkspaceParams{
+		Name:        "project-route-install-ws",
+		Slug:        "project-route-install-ws",
+		IssuePrefix: "PRW",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	const installationID int64 = 778899003
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    wsA.ID,
+		InstallationID: installationID,
+		AccountLogin:   repoOwner,
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE repo_owner = $1 AND repo_name = $2`, repoOwner, repoName)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE installation_id = $1`, installationID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM project_resource WHERE id = $1`, resource.ID)
+		testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, project.ID)
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsA.ID)
+	})
+
+	const prNumber = 4343
+	body := map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"number":        prNumber,
+			"html_url":      repoURL + "/pull/4343",
+			"title":         "Ship project fix " + created.Identifier,
+			"body":          "Closes " + created.Identifier,
+			"state":         "closed",
+			"draft":         false,
+			"merged":        true,
+			"merged_at":     "2026-04-29T00:00:00Z",
+			"closed_at":     "2026-04-29T00:00:00Z",
+			"created_at":    "2026-04-28T00:00:00Z",
+			"updated_at":    "2026-04-29T00:00:00Z",
+			"head":          map[string]any{"ref": "feat/project-route"},
+			"user":          map[string]any{"login": "octocat", "avatar_url": ""},
+			"additions":     3,
+			"deletions":     1,
+			"changed_files": 2,
+		},
+		"repository": map[string]any{
+			"name":  repoName,
+			"owner": map[string]any{"login": repoOwner},
+		},
+		"installation": map[string]any{"id": installationID},
+	}
+	raw, _ := json.Marshal(body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(raw)
+
+	rec := httptest.NewRecorder()
+	hookReq := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(raw))
+	hookReq.Header.Set("X-GitHub-Event", "pull_request")
+	hookReq.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	testHandler.HandleGitHubWebhook(rec, hookReq)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook: expected 202, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	pr, err := testHandler.Queries.GetGitHubPullRequest(ctx, db.GetGitHubPullRequestParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		RepoOwner:   repoOwner,
+		RepoName:    repoName,
+		PrNumber:    prNumber,
+	})
+	if err != nil {
+		t.Fatalf("expected PR filed under the project resource workspace: %v", err)
+	}
+	if pr.State != "merged" {
+		t.Fatalf("pr state = %q, want merged", pr.State)
+	}
+	if _, err := testHandler.Queries.GetGitHubPullRequest(ctx, db.GetGitHubPullRequestParams{
+		WorkspaceID: wsA.ID,
+		RepoOwner:   repoOwner,
+		RepoName:    repoName,
+		PrNumber:    prNumber,
+	}); err == nil {
+		t.Fatalf("PR should NOT be filed under the installation workspace")
+	}
+
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked PR on the project issue, got %d", len(linked))
+	}
+	if linked[0].PrNumber != prNumber || linked[0].State != "merged" {
+		t.Fatalf("linked PR = #%d state %q, want #%d merged", linked[0].PrNumber, linked[0].State, prNumber)
+	}
+
+	updated, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if updated.Status != "done" {
+		t.Fatalf("issue status = %q, want done", updated.Status)
 	}
 }
 

--- a/server/pkg/db/generated/project_resource.sql.go
+++ b/server/pkg/db/generated/project_resource.sql.go
@@ -74,6 +74,41 @@ func (q *Queries) DeleteProjectResource(ctx context.Context, id pgtype.UUID) err
 	return err
 }
 
+const listGitHubRepoProjectResources = `-- name: ListGitHubRepoProjectResources :many
+SELECT workspace_id, resource_ref
+FROM project_resource
+WHERE resource_type = 'github_repo'
+ORDER BY workspace_id, project_id, position ASC, created_at ASC
+`
+
+type ListGitHubRepoProjectResourcesRow struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	ResourceRef []byte      `json:"resource_ref"`
+}
+
+// GitHub webhook routing needs to find the workspace that owns a repo even
+// when the repo is attached at the project level rather than the legacy
+// workspace.repos list.
+func (q *Queries) ListGitHubRepoProjectResources(ctx context.Context) ([]ListGitHubRepoProjectResourcesRow, error) {
+	rows, err := q.db.Query(ctx, listGitHubRepoProjectResources)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListGitHubRepoProjectResourcesRow{}
+	for rows.Next() {
+		var i ListGitHubRepoProjectResourcesRow
+		if err := rows.Scan(&i.WorkspaceID, &i.ResourceRef); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getProjectResource = `-- name: GetProjectResource :one
 SELECT id, project_id, workspace_id, resource_type, resource_ref, label, position, created_at, created_by FROM project_resource
 WHERE id = $1

--- a/server/pkg/db/queries/project_resource.sql
+++ b/server/pkg/db/queries/project_resource.sql
@@ -8,6 +8,15 @@ SELECT * FROM project_resource
 WHERE project_id = ANY(sqlc.arg('project_ids')::uuid[])
 ORDER BY project_id, position ASC, created_at ASC;
 
+-- name: ListGitHubRepoProjectResources :many
+-- GitHub webhook routing needs to find the workspace that owns a repo even
+-- when the repo is attached at the project level rather than the legacy
+-- workspace.repos list.
+SELECT workspace_id, resource_ref
+FROM project_resource
+WHERE resource_type = 'github_repo'
+ORDER BY workspace_id, project_id, position ASC, created_at ASC;
+
 -- name: GetProjectResource :one
 SELECT * FROM project_resource
 WHERE id = $1;


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub PR-to-issue linking when the repo is attached through a project-level `github_repo` resource instead of the legacy workspace repo list.

The webhook resolver now checks project repo resources first, then falls back to `workspace.repos`. The issue pull-requests endpoint also reconciles `pr_url` / `pr_number` metadata to an already-mirrored PR row in the same workspace, so metadata-only rows can repair a missing link without fabricating PR state or close intent.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4788

Multica issue: ZIC-10

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/github.go`: route PR webhooks through project-level GitHub repo resources before the workspace repo registry.
- `server/internal/handler/github.go`: reconcile `pr_url` / `pr_number` metadata to an existing mirrored PR row when listing issue pull requests.
- `server/pkg/db/queries/project_resource.sql`: add a query for project `github_repo` resources.
- `server/internal/handler/github_test.go`: add regression coverage for merged close-intent webhooks, project repo routing, and metadata-only link reconciliation.

## How to Test

1. `cd server && go test ./internal/handler`
2. `make check-worktree`

`make check-worktree` exited 0 locally, but printed that Docker was unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the GitHub pull_request webhook linking path from the reported issue, found that repo routing only considered the workspace repo registry, added project `github_repo` routing plus metadata reconciliation for already-mirrored PR rows, and covered the bug with focused handler tests.

## Screenshots (optional)

N/A
