### PR TITLE
fix(desktop): prevent duplicate tabs when clicking sidebar navigation

### DIFF
--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -145,6 +145,28 @@ function tryRouteToPinnedNewTab(path: string): boolean {
 }
 
 /**
+ * Before navigating the active tab to a path, check whether another tab
+ * in the active workspace already has that path open. If so, activate it
+ * instead — this is the sidebar dedupe behaviour that prevents duplicate
+ * tabs (e.g. clicking Inbox twice shouldn't create two Inbox tabs).
+ *
+ * Returns `true` if an existing tab was activated (caller should NOT
+ * proceed with navigation). Returns `false` if no tab matches the path
+ * (caller should navigate the active tab as usual).
+ */
+function tryActivateExistingTab(path: string): boolean {
+  const store = useTabStore.getState();
+  const { activeWorkspaceSlug, byWorkspace } = store;
+  if (!activeWorkspaceSlug) return false;
+  const group = byWorkspace[activeWorkspaceSlug];
+  if (!group) return false;
+  const existing = group.tabs.find((t) => t.path === path);
+  if (!existing || existing.id === group.activeTabId) return false;
+  store.setActiveTab(existing.id);
+  return true;
+}
+
+/**
  * Root-level navigation provider for components outside the per-tab
  * RouterProviders (sidebar, search dialog, modals, WindowOverlay contents).
  *
@@ -203,6 +225,7 @@ export function DesktopNavigationProvider({
         if (active && routerLocationPath(active.router) === path) return;
         if (tryRouteToOtherWorkspace(path)) return;
         if (tryRouteToPinnedNewTab(path)) return;
+        if (tryActivateExistingTab(path)) return;
         active?.router.navigate(path);
       },
       replace: (path: string) => {
@@ -280,6 +303,7 @@ export function TabNavigationProvider({
         if (routerLocationPath(router) === path) return;
         if (tryRouteToOtherWorkspace(path)) return;
         if (tryRouteToPinnedNewTab(path)) return;
+        if (tryActivateExistingTab(path)) return;
         router.navigate(path);
       },
       replace: (path: string) => {


### PR DESCRIPTION
## Summary

Fixes #4284 — clicking sidebar navigation items (Inbox, Issues, Projects, etc.) was creating duplicate tabs instead of activating the already-open tab.

## Root Cause

In `DesktopNavigationProvider.push()` and `TabNavigationProvider.push()`, when a sidebar link was clicked, the code would navigate the **active** tab to the target path via `router.navigate(path)`, even if another tab already had that exact path open. The `openTab()` method in the tab store already had deduplication logic (it finds existing tabs by path), but `push()` wasn't using it.

## Fix

Added `tryActivateExistingTab(path)` helper that checks whether any tab in the active workspace already has the target path:
- If found → activate that tab (no duplicate created)
- If not found → fall through to existing navigation behavior

Called in both providers' `push()` methods, after pinned-tab handling but before the final `router.navigate()` fallback.

## Test Plan

- ✅ All 249 desktop tests pass (28 test files)
- ✅ TypeScript compiles cleanly
- Manual verification: clicking Inbox twice → only one tab; clicking Inbox from Issues → activates existing Inbox tab

Closes #4284