### PR TITLE
feat(agents): align create-agent visibility with MUL-3963 access model (MUL-4010)

### DIFF
--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -17,7 +17,7 @@ export type {
 export { FeatureFlagService } from "./service";
 export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
-export { COMPOSIO_MCP_APPS_FLAG } from "./keys";
+export { COMPOSIO_MCP_APPS_FLAG, AGENT_ACCESS_PICKER_FLAG } from "./keys";
 export {
   FeatureFlagsProvider,
   useFeatureFlagService,

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,1 +1,11 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
+
+/**
+ * AGENT_ACCESS_PICKER_FLAG gates the MUL-3963-aligned access UI in the
+ * agent create/duplicate flow. When ON, the visibility section switches from
+ * the legacy Workspace/Personal toggle to the new Private / Public-to model
+ * (`permission_mode` + `invocation_targets`) that matches AccessPicker on
+ * the agent detail page. Defaults to OFF so production stays on the legacy
+ * toggle until the rollout is greenlit.
+ */
+export const AGENT_ACCESS_PICKER_FLAG = "agent_access_picker";

--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -6,6 +6,8 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import type { Agent, MemberWithUser, RuntimeDevice } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { WorkspaceSlugProvider } from "@multica/core/paths";
+import { configStore } from "@multica/core/config";
+import { AGENT_ACCESS_PICKER_FLAG } from "@multica/core/feature-flags";
 import { NavigationProvider, type NavigationAdapter } from "../../navigation";
 import enCommon from "../../locales/en/common.json";
 import enAgents from "../../locales/en/agents.json";
@@ -285,5 +287,138 @@ describe("CreateAgentDialog runtime visibility gate", () => {
       .find((b) => b.textContent === "Create");
     expect(createBtn).toBeDefined();
     expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The dialog's default (workspace) still needs to be usable by ME:
+    // reset flags before every test so a stray "on" state in one test
+    // can't bleed into the next.
+    configStore.getState().setFeatureFlags({});
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    configStore.getState().setFeatureFlags({});
+  });
+
+  it("keeps the legacy Workspace/Personal toggle when the flag is OFF", async () => {
+    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: false });
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
+    const { onCreate } = renderDialog([mine]);
+
+    // Legacy copy is rendered — matches VISIBILITY_DESCRIPTION.
+    expect(screen.getByText(/All members can assign/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Deep Research Agent"), {
+      target: { value: "Legacy Agent" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    // Legacy path submits visibility, NOT permission_mode/invocation_targets.
+    expect(payload.visibility).toBe("workspace");
+    expect(payload.permission_mode).toBeUndefined();
+    expect(payload.invocation_targets).toBeUndefined();
+  });
+
+  it("submits permission_mode=public_to + workspace target when the flag is ON (default)", async () => {
+    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
+    const { onCreate } = renderDialog([mine]);
+
+    // New copy replaces the old one.
+    expect(screen.getByText("Only you can run this agent")).toBeInTheDocument();
+    expect(screen.getByText("Choose who can run this agent")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Deep Research Agent"), {
+      target: { value: "Access Agent" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    // MUL-3963 payload shape.
+    expect(payload.visibility).toBeUndefined();
+    expect(payload.permission_mode).toBe("public_to");
+    expect(payload.invocation_targets).toEqual([
+      { target_type: "workspace" },
+    ]);
+  });
+
+  it("submits permission_mode=private with empty targets when Private is chosen", async () => {
+    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
+    const { onCreate } = renderDialog([mine]);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Deep Research Agent"), {
+      target: { value: "Private Agent" },
+    });
+    // Click the Private card. The Private description doubles as a stable
+    // click target inside the button.
+    fireEvent.click(screen.getByText("Only you can run this agent"));
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    expect(payload.permission_mode).toBe("private");
+    expect(payload.invocation_targets).toEqual([]);
+  });
+
+  it("collapses an empty public_to (no workspace, no members) back to private on submit", async () => {
+    // MUL-3963 normalisation: a public_to with zero grants is a no-op share.
+    // The AccessPicker emits it as private; the create dialog does the same
+    // so the backend never sees a bogus "public with nothing" request.
+    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
+    const { onCreate } = renderDialog([mine]);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Deep Research Agent"), {
+      target: { value: "Empty Public Agent" },
+    });
+    // Uncheck the workspace target — no members are ticked either.
+    // Checkbox order inside AccessSection when Public is selected:
+    // [0] "Everyone in workspace", [1..] member allow-list (ME excluded).
+    const boxes = screen.getAllByRole("checkbox");
+    fireEvent.click(boxes[0]!);
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    expect(payload.permission_mode).toBe("private");
+    expect(payload.invocation_targets).toEqual([]);
+  });
+
+  it("includes ticked members in the invocation_targets payload", async () => {
+    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
+    const { onCreate } = renderDialog([mine]);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Deep Research Agent"), {
+      target: { value: "Shared Agent" },
+    });
+    // Only "Other" (excluding the current user Me) appears in the member
+    // list, so it's always the second checkbox after the workspace toggle.
+    const boxes = screen.getAllByRole("checkbox");
+    fireEvent.click(boxes[1]!);
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    expect(payload.permission_mode).toBe("public_to");
+    // Order: workspace target first (still on by default), member target after.
+    expect(payload.invocation_targets).toEqual([
+      { target_type: "workspace" },
+      { target_type: "member", target_id: OTHER },
+    ]);
   });
 });

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -10,9 +10,13 @@ import { SkillMultiSelect } from "./skill-multi-select";
 import { AvatarPicker } from "./avatar-picker";
 import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { useFeatureEnabled } from "@multica/core/config";
+import { AGENT_ACCESS_PICKER_FLAG } from "@multica/core/feature-flags";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type {
   Agent,
+  AgentInvocationTargetInput,
+  AgentPermissionMode,
   AgentVisibility,
   RuntimeDevice,
   MemberWithUser,
@@ -27,6 +31,7 @@ import {
   DialogDescription,
 } from "@multica/ui/components/ui/dialog";
 import { Button } from "@multica/ui/components/ui/button";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { toast } from "sonner";
@@ -35,6 +40,7 @@ import {
   VISIBILITY_DESCRIPTION,
   VISIBILITY_LABEL,
 } from "@multica/core/agents";
+import { ActorAvatar } from "../../common/actor-avatar";
 import { CharCounter } from "./char-counter";
 import { useT } from "../../i18n";
 
@@ -77,15 +83,60 @@ export function CreateAgentDialog({
   const isDuplicate = !!template;
   const queryClient = useQueryClient();
   const wsId = useWorkspaceId();
+  // MUL-4010: rolls out the private / public_to access model in the create
+  // flow to match the AccessPicker on the agent detail page. Defaults OFF so
+  // production stays on the legacy Workspace / Personal toggle until the flag
+  // is flipped.
+  const accessPickerEnabled = useFeatureEnabled(AGENT_ACCESS_PICKER_FLAG, false);
 
   // Name defaults: duplicate uses "<original> copy". Manual-create starts blank.
   const [name, setName] = useState(
     template ? `${template.name}${t(($) => $.create_dialog.duplicate_copy_suffix)}` : "",
   );
   const [description, setDescription] = useState(template?.description ?? "");
+  // Legacy visibility state. Kept as the source of truth when
+  // `accessPickerEnabled` is false; only used to seed the new access state
+  // when the flag flips on for a duplicate.
   const [visibility, setVisibility] = useState<AgentVisibility>(
     template?.visibility ?? "workspace",
   );
+
+  // New access state (MUL-3963 aligned). When duplicating, seed from the
+  // template so the clone lands with the source agent's grants; otherwise
+  // default to public_to + workspace, matching the legacy "Workspace" default
+  // so a plain "click Create" produces the same result as before.
+  const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>(
+    template?.permission_mode ?? "public_to",
+  );
+  const [workspaceTargetOn, setWorkspaceTargetOn] = useState<boolean>(() => {
+    if (template) {
+      return (template.invocation_targets ?? []).some(
+        (tgt) => tgt.target_type === "workspace",
+      );
+    }
+    return true;
+  });
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(
+    () =>
+      new Set(
+        (template?.invocation_targets ?? [])
+          .filter((tgt) => tgt.target_type === "member" && tgt.target_id)
+          .map((tgt) => tgt.target_id as string),
+      ),
+  );
+
+  // Team targets on the template are preserved across the create so we don't
+  // silently drop a grant type the picker doesn't expose yet (mirrors
+  // AccessPicker's `teamIds` pass-through).
+  const templateTeamTargets: AgentInvocationTargetInput[] = (
+    template?.invocation_targets ?? []
+  )
+    .filter((tgt) => tgt.target_type === "team" && tgt.target_id)
+    .map((tgt) => ({
+      target_type: "team" as const,
+      target_id: tgt.target_id as string,
+    }));
+
   const [model, setModel] = useState(template?.model ?? "");
   const [instructions, setInstructions] = useState(template?.instructions ?? "");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(template?.avatar_url ?? null);
@@ -158,11 +209,37 @@ export function CreateAgentDialog({
         name: name.trim(),
         description: description.trim(),
         runtime_id: selectedRuntime.id,
-        visibility,
         model: model.trim() || undefined,
         instructions: trimmedInstructions || undefined,
         avatar_url: avatarUrl ?? undefined,
       };
+      if (accessPickerEnabled) {
+        // New MUL-3963 shape: send the authoritative permission fields and
+        // let the backend derive the legacy `visibility` field. Mirror the
+        // AccessPicker `emit` normalisation — a public_to with zero targets
+        // collapses to private so the backend never sees an "empty public"
+        // request. Team targets pulled from the template are preserved.
+        const invocationTargets: AgentInvocationTargetInput[] = [];
+        if (permissionMode === "public_to") {
+          if (workspaceTargetOn) {
+            invocationTargets.push({ target_type: "workspace" });
+          }
+          for (const id of selectedMemberIds) {
+            invocationTargets.push({ target_type: "member", target_id: id });
+          }
+          for (const tgt of templateTeamTargets) {
+            invocationTargets.push(tgt);
+          }
+        }
+        const collapseToPrivate =
+          permissionMode === "public_to" && invocationTargets.length === 0;
+        data.permission_mode = collapseToPrivate ? "private" : permissionMode;
+        data.invocation_targets = collapseToPrivate ? [] : invocationTargets;
+      } else {
+        // Legacy path: send the visibility toggle unchanged. The backend
+        // maps this to permission_mode + invocation_targets server-side.
+        data.visibility = visibility;
+      }
       if (template) {
         // Duplicate path: forward the hidden config fields the source
         // agent had so the clone is functional out of the box (args /
@@ -285,45 +362,58 @@ export function CreateAgentDialog({
               </div>
             </div>
 
-            <div>
-              <Label className="text-xs text-muted-foreground">{t(($) => $.create_dialog.visibility_label)}</Label>
-              <div className="mt-1.5 flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => setVisibility("workspace")}
-                  className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
-                    visibility === "workspace"
-                      ? "border-primary bg-primary/5"
-                      : "border-border hover:bg-muted"
-                  }`}
-                >
-                  <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <div className="text-left">
-                    <div className="font-medium">{VISIBILITY_LABEL.workspace}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {VISIBILITY_DESCRIPTION.workspace}
+            {accessPickerEnabled ? (
+              <AccessSection
+                permissionMode={permissionMode}
+                onPermissionModeChange={setPermissionMode}
+                workspaceTargetOn={workspaceTargetOn}
+                onWorkspaceTargetChange={setWorkspaceTargetOn}
+                selectedMemberIds={selectedMemberIds}
+                onSelectedMemberIdsChange={setSelectedMemberIds}
+                members={members}
+                currentUserId={currentUserId}
+              />
+            ) : (
+              <div>
+                <Label className="text-xs text-muted-foreground">{t(($) => $.create_dialog.visibility_label)}</Label>
+                <div className="mt-1.5 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setVisibility("workspace")}
+                    className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+                      visibility === "workspace"
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:bg-muted"
+                    }`}
+                  >
+                    <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="text-left">
+                      <div className="font-medium">{VISIBILITY_LABEL.workspace}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {VISIBILITY_DESCRIPTION.workspace}
+                      </div>
                     </div>
-                  </div>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setVisibility("private")}
-                  className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
-                    visibility === "private"
-                      ? "border-primary bg-primary/5"
-                      : "border-border hover:bg-muted"
-                  }`}
-                >
-                  <Lock className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <div className="text-left">
-                    <div className="font-medium">{VISIBILITY_LABEL.private}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {VISIBILITY_DESCRIPTION.private}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setVisibility("private")}
+                    className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+                      visibility === "private"
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:bg-muted"
+                    }`}
+                  >
+                    <Lock className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="text-left">
+                      <div className="font-medium">{VISIBILITY_LABEL.private}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {VISIBILITY_DESCRIPTION.private}
+                      </div>
                     </div>
-                  </div>
-                </button>
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
             <RuntimePicker
               runtimes={runtimes}
@@ -388,5 +478,165 @@ export function CreateAgentDialog({
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+
+/**
+ * AccessSection — inline access editor for the create/duplicate flow, gated
+ * on `AGENT_ACCESS_PICKER_FLAG`. Mirrors the semantics of
+ * `AccessPicker` on the agent detail page: the underlying model is
+ * `permission_mode` + `invocation_targets` (MUL-3963), not the legacy
+ * `visibility`.
+ *
+ * Layout keeps the create-flow's compact 2-button toggle so the visibility
+ * section stays visually stable in the modal. Under "Public" a compact
+ * sub-panel exposes the same choices AccessPicker offers — workspace
+ * toggle + member allow-list — so a caller can share the agent with the
+ * right audience without a second trip to the inspector after create.
+ *
+ * The current viewer is intentionally excluded from the member list: an
+ * owner is always allowed to invoke their own agent, so listing them again
+ * would be misleading.
+ */
+function AccessSection({
+  permissionMode,
+  onPermissionModeChange,
+  workspaceTargetOn,
+  onWorkspaceTargetChange,
+  selectedMemberIds,
+  onSelectedMemberIdsChange,
+  members,
+  currentUserId,
+}: {
+  permissionMode: AgentPermissionMode;
+  onPermissionModeChange: (next: AgentPermissionMode) => void;
+  workspaceTargetOn: boolean;
+  onWorkspaceTargetChange: (next: boolean) => void;
+  selectedMemberIds: Set<string>;
+  onSelectedMemberIdsChange: (next: Set<string>) => void;
+  members: MemberWithUser[];
+  currentUserId: string | null;
+}) {
+  const { t } = useT("agents");
+  const isPrivate = permissionMode === "private";
+
+  const otherMembers = members.filter((m) => m.user_id !== currentUserId);
+  const hasAnyGrant = workspaceTargetOn || selectedMemberIds.size > 0;
+
+  const toggleMember = (userId: string, checked: boolean) => {
+    const next = new Set(selectedMemberIds);
+    if (checked) next.add(userId);
+    else next.delete(userId);
+    onSelectedMemberIdsChange(next);
+  };
+
+  return (
+    <div>
+      <Label className="text-xs text-muted-foreground">
+        {t(($) => $.create_dialog.access.label)}
+      </Label>
+      <div className="mt-1.5 flex gap-2">
+        <button
+          type="button"
+          onClick={() => onPermissionModeChange("private")}
+          className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+            isPrivate
+              ? "border-primary bg-primary/5"
+              : "border-border hover:bg-muted"
+          }`}
+        >
+          <Lock className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="text-left">
+            <div className="font-medium">
+              {t(($) => $.create_dialog.access.private_title)}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t(($) => $.create_dialog.access.private_desc)}
+            </div>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={() => onPermissionModeChange("public_to")}
+          className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+            !isPrivate
+              ? "border-primary bg-primary/5"
+              : "border-border hover:bg-muted"
+          }`}
+        >
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="text-left">
+            <div className="font-medium">
+              {t(($) => $.create_dialog.access.public_title)}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t(($) => $.create_dialog.access.public_desc)}
+            </div>
+          </div>
+        </button>
+      </div>
+
+      {!isPrivate && (
+        <div className="mt-2 rounded-lg border bg-muted/30 px-3 py-2">
+          {/* Everyone in workspace — stackable with any member grants below,
+              exactly like AccessPicker on the detail page. */}
+          <label className="flex cursor-pointer items-center gap-2 rounded-md py-1 text-sm">
+            <Checkbox
+              checked={workspaceTargetOn}
+              onCheckedChange={(v) => onWorkspaceTargetChange(v === true)}
+              aria-label={t(($) => $.create_dialog.access.public_workspace_option)}
+            />
+            <Globe className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              {t(($) => $.create_dialog.access.public_workspace_option)}
+            </span>
+          </label>
+
+          <div className="mt-2 border-t pt-2">
+            <div className="pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {t(($) => $.create_dialog.access.public_members_group)}
+            </div>
+            {otherMembers.length === 0 ? (
+              <div className="py-1 text-xs text-muted-foreground">
+                {t(($) => $.create_dialog.access.public_members_empty)}
+              </div>
+            ) : (
+              <div className="max-h-40 overflow-y-auto">
+                {otherMembers.map((m) => {
+                  const checked = selectedMemberIds.has(m.user_id);
+                  return (
+                    <label
+                      key={m.user_id}
+                      className="flex cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-sm hover:bg-background/60"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(v) =>
+                          toggleMember(m.user_id, v === true)
+                        }
+                        aria-label={m.name}
+                      />
+                      <ActorAvatar
+                        actorType="member"
+                        actorId={m.user_id}
+                        size={18}
+                      />
+                      <span className="min-w-0 flex-1 truncate">{m.name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {!hasAnyGrant && (
+            <div className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+              {t(($) => $.create_dialog.access.public_targets_empty_hint)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -236,6 +236,17 @@
     "description_label": "Description",
     "description_placeholder": "What does this agent do?",
     "visibility_label": "Visibility",
+    "access": {
+      "label": "Access",
+      "private_title": "Private",
+      "private_desc": "Only you can run this agent",
+      "public_title": "Public",
+      "public_desc": "Choose who can run this agent",
+      "public_workspace_option": "Everyone in this workspace",
+      "public_members_group": "Specific people",
+      "public_members_empty": "No workspace members to choose from",
+      "public_targets_empty_hint": "Pick at least one option below — otherwise the agent stays private."
+    },
     "runtime_label": "Runtime",
     "runtime_filter_mine": "Mine",
     "runtime_filter_all": "All",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -220,6 +220,17 @@
     "description_label": "説明",
     "description_placeholder": "このエージェントは何をしますか？",
     "visibility_label": "公開範囲",
+    "access": {
+      "label": "アクセス",
+      "private_title": "プライベート",
+      "private_desc": "このエージェントを実行できるのはあなただけです",
+      "public_title": "公開",
+      "public_desc": "このエージェントを実行できる人を選択します",
+      "public_workspace_option": "ワークスペース全員",
+      "public_members_group": "特定のメンバー",
+      "public_members_empty": "選択できるワークスペースメンバーがいません",
+      "public_targets_empty_hint": "以下から少なくとも1つを選択してください。そうでないとエージェントはプライベートのままになります。"
+    },
     "runtime_label": "ランタイム",
     "runtime_filter_mine": "自分のもの",
     "runtime_filter_all": "すべて",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -228,6 +228,17 @@
     "description_label": "설명",
     "description_placeholder": "이 에이전트는 무엇을 하나요?",
     "visibility_label": "공개 범위",
+    "access": {
+      "label": "액세스",
+      "private_title": "비공개",
+      "private_desc": "본인만 이 에이전트를 실행할 수 있습니다",
+      "public_title": "공개",
+      "public_desc": "이 에이전트를 실행할 수 있는 사람을 선택하세요",
+      "public_workspace_option": "이 워크스페이스의 모든 사람",
+      "public_members_group": "특정 사용자",
+      "public_members_empty": "선택할 수 있는 워크스페이스 멤버가 없습니다",
+      "public_targets_empty_hint": "아래에서 최소 하나 이상을 선택하세요. 그렇지 않으면 에이전트는 비공개로 유지됩니다."
+    },
     "runtime_label": "런타임",
     "runtime_filter_mine": "내 것",
     "runtime_filter_all": "전체",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -228,6 +228,17 @@
     "description_label": "描述",
     "description_placeholder": "这个智能体做什么？",
     "visibility_label": "可见性",
+    "access": {
+      "label": "访问权限",
+      "private_title": "私有",
+      "private_desc": "只有你可以运行该智能体",
+      "public_title": "公开",
+      "public_desc": "选择谁可以运行该智能体",
+      "public_workspace_option": "工作区内所有人",
+      "public_members_group": "指定成员",
+      "public_members_empty": "没有可选择的工作区成员",
+      "public_targets_empty_hint": "至少勾选下方一项 —— 否则该智能体仍为私有。"
+    },
     "runtime_label": "运行时",
     "runtime_filter_mine": "我的",
     "runtime_filter_all": "全部",

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -10,10 +10,16 @@ const (
 	// ComposioMCPApps gates the Composio app management UI and runtime MCP
 	// overlay injection.
 	ComposioMCPApps = "composio_mcp_apps"
+	// AgentAccessPicker gates the MUL-3963 permission_mode + invocation_targets
+	// picker in the agent create/duplicate flow. When OFF the create dialog
+	// keeps the legacy Workspace/Personal toggle; when ON it switches to the
+	// same private / public_to model used on the agent detail page.
+	AgentAccessPicker = "agent_access_picker"
 )
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
+	AgentAccessPicker,
 }
 
 func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) bool {


### PR DESCRIPTION
## Background

The Create Agent (and Duplicate) dialog still shipped the legacy Workspace/Personal visibility toggle even though the agent detail page's `AccessPicker` (MUL-3963) already switched to the authoritative `permission_mode` + `invocation_targets` model. This PR aligns the create flow with the same model, behind a feature flag so nothing changes in production until the flag is flipped.

## Core logic

- **New feature flag `agent_access_picker`** (default OFF). Registered on both:
  - Frontend: `packages/core/feature-flags/keys.ts` — `AGENT_ACCESS_PICKER_FLAG`.
  - Backend: `server/internal/featureflags/keys.go` — `AgentAccessPicker`, added to the frontend-public flag list so it flows to `/api/config`.
- **CreateAgentDialog** now branches on the flag:
  - **Flag OFF** — unchanged. State is `visibility: "workspace" | "private"`, submit body sends `visibility`.
  - **Flag ON** — state becomes `permissionMode` + `workspaceTargetOn` + `selectedMemberIds`. The visibility section is replaced with an inline access editor:
    - Two-button toggle: Private / Public — same visual footprint as before.
    - Under Public, an expanded panel offers "Everyone in workspace" (checkbox) and a member allow-list (checkboxes, current user excluded so we don't list the always-allowed owner).
    - Team targets from the duplicate source are preserved so we don't silently drop a grant type the picker doesn't expose yet.
    - Submit body sends `permission_mode` + `invocation_targets`. An empty `public_to` (no workspace, no members) collapses to `private` — matches AccessPicker's normalisation so the backend never sees a bogus "public with nothing" request.
- i18n strings added for the new access section in en / zh-Hans / ja / ko.

## Testing

- New `create-agent-dialog.test.tsx` cases cover:
  - Flag OFF keeps the legacy Workspace/Personal toggle and submits `visibility`.
  - Flag ON default: submits `permission_mode: "public_to"` + workspace target.
  - Flag ON Private choice: submits `permission_mode: "private"`, empty targets.
  - Flag ON with workspace unchecked and no members: collapses back to `private`.
  - Flag ON with a member ticked: `invocation_targets` includes both the workspace grant and the member grant.
- `pnpm --filter @multica/views test` → 1612/1612 pass.
- `pnpm --filter @multica/views typecheck` + `pnpm --filter @multica/core typecheck` clean.
- `go build ./...` clean.

## Rollout

Flag defaults to OFF everywhere; nothing changes in the shipped UI until it is flipped on for a workspace. The backend already accepts both wire shapes (`visibility` and `permission_mode`/`invocation_targets`), so there is no server-side rollout dependency.

Closes MUL-4010.
