### PR TITLE
feat(github): decouple auto-done from auto-link PRs (MUL-4013)

### DIFF
--- a/packages/core/github/settings.test.ts
+++ b/packages/core/github/settings.test.ts
@@ -13,6 +13,7 @@ describe("deriveGitHubSettings", () => {
       prSidebar: true,
       coAuthor: true,
       autoLinkPRs: true,
+      autoCloseIssueOnPRMerge: true,
     });
   });
 
@@ -22,6 +23,7 @@ describe("deriveGitHubSettings", () => {
       prSidebar: true,
       coAuthor: true,
       autoLinkPRs: true,
+      autoCloseIssueOnPRMerge: true,
     });
   });
 
@@ -32,6 +34,7 @@ describe("deriveGitHubSettings", () => {
         github_pr_sidebar_enabled: true,
         co_authored_by_enabled: true,
         github_auto_link_prs_enabled: true,
+        github_auto_close_issue_on_pr_merge_enabled: true,
       }),
     );
     expect(got).toEqual({
@@ -39,21 +42,57 @@ describe("deriveGitHubSettings", () => {
       prSidebar: false,
       coAuthor: false,
       autoLinkPRs: false,
+      autoCloseIssueOnPRMerge: false,
     });
   });
 
   it("each sub-flag can be flipped independently when master is on", () => {
     expect(
       deriveGitHubSettings(ws({ github_pr_sidebar_enabled: false })),
-    ).toMatchObject({ enabled: true, prSidebar: false, coAuthor: true, autoLinkPRs: true });
+    ).toMatchObject({
+      enabled: true,
+      prSidebar: false,
+      coAuthor: true,
+      autoLinkPRs: true,
+      autoCloseIssueOnPRMerge: true,
+    });
 
     expect(
       deriveGitHubSettings(ws({ co_authored_by_enabled: false })),
-    ).toMatchObject({ enabled: true, prSidebar: true, coAuthor: false, autoLinkPRs: true });
+    ).toMatchObject({
+      enabled: true,
+      prSidebar: true,
+      coAuthor: false,
+      autoLinkPRs: true,
+      autoCloseIssueOnPRMerge: true,
+    });
 
     expect(
       deriveGitHubSettings(ws({ github_auto_link_prs_enabled: false })),
-    ).toMatchObject({ enabled: true, prSidebar: true, coAuthor: true, autoLinkPRs: false });
+    ).toMatchObject({
+      enabled: true,
+      prSidebar: true,
+      coAuthor: true,
+      autoLinkPRs: false,
+      // autoCloseIssueOnPRMerge is decoupled from auto-link at the derivation
+      // layer — the UI is responsible for disabling the switch when
+      // autoLinkPRs is off (since a link that never happens can never trigger
+      // auto-done anyway). Keeping them independent here means re-enabling
+      // auto-link doesn't silently flip the auto-done flag.
+      autoCloseIssueOnPRMerge: true,
+    });
+
+    expect(
+      deriveGitHubSettings(
+        ws({ github_auto_close_issue_on_pr_merge_enabled: false }),
+      ),
+    ).toMatchObject({
+      enabled: true,
+      prSidebar: true,
+      coAuthor: true,
+      autoLinkPRs: true,
+      autoCloseIssueOnPRMerge: false,
+    });
   });
 
   it("treats non-false values (true, null, missing) as enabled", () => {
@@ -62,5 +101,10 @@ describe("deriveGitHubSettings", () => {
         ws({ github_enabled: true, github_pr_sidebar_enabled: null }),
       ),
     ).toMatchObject({ enabled: true, prSidebar: true });
+    expect(
+      deriveGitHubSettings(
+        ws({ github_auto_close_issue_on_pr_merge_enabled: null }),
+      ),
+    ).toMatchObject({ autoCloseIssueOnPRMerge: true });
   });
 });

--- a/packages/core/github/settings.ts
+++ b/packages/core/github/settings.ts
@@ -9,6 +9,13 @@ export interface GitHubSettings {
   coAuthor: boolean;
   /** Auto-link issues ↔ PRs from webhook payloads. Implies `enabled`. */
   autoLinkPRs: boolean;
+  /**
+   * When a linked PR with a "Closes/Fixes/Resolves MUL-X" keyword merges,
+   * advance the linked issue to `done`. Implies `enabled`. Strict sub-flag
+   * of `autoLinkPRs`: the sidebar / link row keeps working when this is
+   * off, only the auto-done side effect is suppressed.
+   */
+  autoCloseIssueOnPRMerge: boolean;
 }
 
 /**
@@ -25,5 +32,7 @@ export function deriveGitHubSettings(
     prSidebar: enabled && s.github_pr_sidebar_enabled !== false,
     coAuthor: enabled && s.co_authored_by_enabled !== false,
     autoLinkPRs: enabled && s.github_auto_link_prs_enabled !== false,
+    autoCloseIssueOnPRMerge:
+      enabled && s.github_auto_close_issue_on_pr_merge_enabled !== false,
   };
 }

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -220,6 +220,8 @@
     "feature_co_author_description_suffix": "to commits authored by agents.",
     "feature_auto_link_label": "Auto-link issues and PRs",
     "feature_auto_link_description": "Match PR titles, bodies, and branch names against issue identifiers and create the link automatically.",
+    "feature_auto_close_label": "Merged PR closes the issue",
+    "feature_auto_close_description": "When a linked PR that declared \"Closes/Fixes/Resolves MUL-X\" is merged, move the issue to Done. Turn this off to keep the auto-link sidebar but manage issue status manually.",
     "section_repositories": "Repositories",
     "repositories_shortcut_label": "Repository URLs live in the Repositories tab",
     "repositories_shortcut_link": "Manage repositories →",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -220,6 +220,8 @@
     "feature_co_author_description_suffix": "を追加します。",
     "feature_auto_link_label": "イシューと PR を自動リンク",
     "feature_auto_link_description": "PR のタイトル、本文、ブランチ名をイシュー識別子と照合し、自動でリンクを作成します。",
+    "feature_auto_close_label": "PR マージでイシューを完了",
+    "feature_auto_close_description": "「Closes/Fixes/Resolves MUL-X」キーワードを含むリンク済み PR がマージされたとき、イシューを Done に移動します。オフにすると、自動リンクのサイドバーは維持したまま、イシューのステータス変更を手動で管理できます。",
     "section_repositories": "リポジトリ",
     "repositories_shortcut_label": "リポジトリ URL はリポジトリタブにあります",
     "repositories_shortcut_link": "リポジトリを管理 →",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -220,6 +220,8 @@
     "feature_co_author_description_suffix": "을(를) 추가합니다.",
     "feature_auto_link_label": "이슈와 PR 자동 연결",
     "feature_auto_link_description": "PR 제목, 본문, 브랜치 이름을 이슈 식별자와 대조해 자동으로 연결합니다.",
+    "feature_auto_close_label": "PR 병합 시 이슈 자동 완료",
+    "feature_auto_close_description": "\"Closes/Fixes/Resolves MUL-X\" 키워드가 포함된 연결된 PR이 병합되면 이슈를 Done으로 이동합니다. 이 옵션을 끄면 자동 연결 사이드바는 유지하면서 이슈 상태를 수동으로 관리할 수 있습니다.",
     "section_repositories": "저장소",
     "repositories_shortcut_label": "저장소 URL은 저장소 탭에 있습니다",
     "repositories_shortcut_link": "저장소 관리 →",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -220,6 +220,8 @@
     "feature_co_author_description_suffix": "。",
     "feature_auto_link_label": "Issue ↔ PR 自动关联",
     "feature_auto_link_description": "根据 PR 标题、正文和分支名匹配 issue 编号并自动建立链接。",
+    "feature_auto_close_label": "PR 合并后自动关闭 Issue",
+    "feature_auto_close_description": "当带有 “Closes/Fixes/Resolves MUL-X” 关键字的已关联 PR 被合并时，将 Issue 推进为 Done。关闭此项可以保留自动关联的侧栏，但让 Issue 状态由人工管理。",
     "section_repositories": "代码仓库",
     "repositories_shortcut_label": "仓库 URL 仍在「代码仓库」标签页中管理",
     "repositories_shortcut_link": "前往管理 →",

--- a/packages/views/settings/components/github-tab.test.tsx
+++ b/packages/views/settings/components/github-tab.test.tsx
@@ -277,4 +277,51 @@ describe("GitHubTab", () => {
     await user.click(screen.getByRole("button", { name: /Manage repositories/ }));
     expect(mockNavPush).toHaveBeenCalledWith("/acme/settings?tab=repositories");
   });
+
+  it("auto-close-on-merge switch defaults to on and persists to github_auto_close_issue_on_pr_merge_enabled=false", async () => {
+    const user = userEvent.setup();
+    mockUpdateWorkspace.mockResolvedValue({
+      ...workspaceRef.current,
+      settings: { github_auto_close_issue_on_pr_merge_enabled: false },
+    });
+
+    render(<GitHubTab />, { wrapper: I18nWrapper });
+
+    const autoClose = screen.getByRole("switch", {
+      name: /Merged PR closes the issue/i,
+    });
+    expect(autoClose.getAttribute("aria-checked")).toBe("true");
+
+    await user.click(autoClose);
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith("workspace-1", {
+        settings: { github_auto_close_issue_on_pr_merge_enabled: false },
+      });
+    });
+  });
+
+  it("auto-close-on-merge switch is disabled when auto-link is off (no link → no auto-done)", () => {
+    workspaceRef.current.settings = { github_auto_link_prs_enabled: false };
+    render(<GitHubTab />, { wrapper: I18nWrapper });
+
+    const autoClose = screen.getByRole("switch", {
+      name: /Merged PR closes the issue/i,
+    });
+    const ariaDisabled = autoClose.getAttribute("aria-disabled");
+    const disabled = autoClose.hasAttribute("disabled");
+    expect(ariaDisabled === "true" || disabled).toBe(true);
+  });
+
+  it("auto-close-on-merge reflects a persisted `false` from workspace settings", () => {
+    workspaceRef.current.settings = {
+      github_auto_close_issue_on_pr_merge_enabled: false,
+    };
+    render(<GitHubTab />, { wrapper: I18nWrapper });
+
+    const autoClose = screen.getByRole("switch", {
+      name: /Merged PR closes the issue/i,
+    });
+    expect(autoClose.getAttribute("aria-checked")).toBe("false");
+  });
 });

--- a/packages/views/settings/components/github-tab.tsx
+++ b/packages/views/settings/components/github-tab.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { ExternalLink, GitCommitHorizontal, Link2, PanelRight } from "lucide-react";
+import { ExternalLink, GitCommitHorizontal, GitMerge, Link2, PanelRight } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { Label } from "@multica/ui/components/ui/label";
@@ -36,7 +36,8 @@ type SettingsKey =
   | "github_enabled"
   | "github_pr_sidebar_enabled"
   | "co_authored_by_enabled"
-  | "github_auto_link_prs_enabled";
+  | "github_auto_link_prs_enabled"
+  | "github_auto_close_issue_on_pr_merge_enabled";
 
 export function GitHubTab() {
   const { t } = useT("settings");
@@ -301,6 +302,29 @@ export function GitHubTab() {
               checked={flags.autoLinkPRs}
               disabled={!canManage || !flags.enabled || savingKey === "github_auto_link_prs_enabled"}
               onCheckedChange={(v) => persistSetting("github_auto_link_prs_enabled", v)}
+            />
+
+            <FeatureRow
+              id="github-auto-close-on-merge"
+              icon={<GitMerge className="h-4 w-4" />}
+              label={t(($) => $.github.feature_auto_close_label)}
+              description={
+                <p className="text-sm text-muted-foreground">
+                  {t(($) => $.github.feature_auto_close_description)}
+                </p>
+              }
+              checked={flags.autoCloseIssueOnPRMerge}
+              // A closed link that never got created can't trigger auto-done,
+              // so the switch is meaningless while auto-link is off. Gate on
+              // both master and auto-link — flipping either back on re-exposes
+              // this control with the workspace's persisted preference intact.
+              disabled={
+                !canManage ||
+                !flags.enabled ||
+                !flags.autoLinkPRs ||
+                savingKey === "github_auto_close_issue_on_pr_merge_enabled"
+              }
+              onCheckedChange={(v) => persistSetting("github_auto_close_issue_on_pr_merge_enabled", v)}
             />
           </CardContent>
         </Card>

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -934,18 +934,33 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 		// just linked once both the PR row and the link row are persisted,
 		// so the aggregate query sees the freshest state. We advance the
 		// issue to done when:
-		//   1. the issue isn't already terminal (`done` / `cancelled`);
-		//   2. no linked PR is still `open` / `draft`;
-		//   3. at least one merged linked PR declared close_intent (a
+		//   1. the workspace has `github_auto_close_issue_on_pr_merge_enabled`
+		//      on (default true — decouples "auto-link PRs" from
+		//      "PR merge closes issue" so a workspace can keep the link
+		//      sidebar while still managing issue status manually);
+		//   2. the issue isn't already terminal (`done` / `cancelled`);
+		//   3. no linked PR is still `open` / `draft`;
+		//   4. at least one merged linked PR declared close_intent (a
 		//      "Closes/Fixes/Resolves" keyword on its link row).
-		// Rule (3) is what prevents "Follow up in MUL-2" / "Unblocks MUL-3"
+		// Rule (4) is what prevents "Follow up in MUL-2" / "Unblocks MUL-3"
 		// references from being treated the same as "Closes MUL-1", and
 		// also prevents an "all closed-without-merge" sequence from
 		// silently auto-closing the issue — if nothing carrying closing
 		// intent was ever delivered, the user should decide manually.
 		if state == "merged" || state == "closed" {
+			// Read the auto-close flag once per event, not per issue —
+			// the value only depends on the workspace, and reading it
+			// inside the loop would repeat the same GetWorkspace query.
+			autoCloseEnabled := h.workspaceAutoCloseIssueOnPRMergeEnabled(ctx, wsID)
 			for _, issue := range reevalIssues {
 				if issue.Status == "done" || issue.Status == "cancelled" {
+					continue
+				}
+				if !autoCloseEnabled {
+					// Auto-link still recorded the close_intent on the
+					// link row above (so re-enabling the flag later
+					// resumes historical behavior on the next terminal
+					// event), but we stop short of advancing the issue.
 					continue
 				}
 				counts, err := h.Queries.GetIssuePullRequestCloseAggregate(ctx, issue.ID)
@@ -1388,6 +1403,37 @@ func (h *Handler) workspaceAutoLinkPRsEnabled(ctx context.Context, workspaceID p
 		return true
 	}
 	return *s.GitHubAutoLinkPRsEnabled
+}
+
+// workspaceAutoCloseIssueOnPRMergeEnabled decides whether a merged PR that
+// declared `Closes/Fixes/Resolves MUL-X` should auto-advance the linked
+// Multica issue to `done`. This is a strict sub-flag of auto-link: linking
+// still happens (the sidebar still populates, close_intent is still stamped
+// on the link row), but the terminal-event branch in handlePullRequestEvent
+// stops short of calling advanceIssueToDone.
+//
+// Defaults to true so workspaces predating this setting keep the historical
+// "PR merge closes issue" behavior. Master switch (`github_enabled=false`)
+// still forces off, matching workspaceAutoLinkPRsEnabled precedence.
+func (h *Handler) workspaceAutoCloseIssueOnPRMergeEnabled(ctx context.Context, workspaceID pgtype.UUID) bool {
+	ws, err := h.Queries.GetWorkspace(ctx, workspaceID)
+	if err != nil || len(ws.Settings) == 0 {
+		return true
+	}
+	var s struct {
+		GitHubEnabled                        *bool `json:"github_enabled"`
+		GitHubAutoCloseIssueOnPRMergeEnabled *bool `json:"github_auto_close_issue_on_pr_merge_enabled"`
+	}
+	if err := json.Unmarshal(ws.Settings, &s); err != nil {
+		return true
+	}
+	if s.GitHubEnabled != nil && !*s.GitHubEnabled {
+		return false
+	}
+	if s.GitHubAutoCloseIssueOnPRMergeEnabled == nil {
+		return true
+	}
+	return *s.GitHubAutoCloseIssueOnPRMergeEnabled
 }
 
 // the workspace's configured prefix and the number resolves to a real issue.

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -411,6 +411,129 @@ func TestWebhook_MergedPR_PreservesCancelled(t *testing.T) {
 	}
 }
 
+// TestWebhook_MergedPR_AutoCloseDisabled_KeepsLinkOnly guards the workspace
+// setting `github_auto_close_issue_on_pr_merge_enabled=false`. When a
+// closing-keyword PR merges under this flag, the PR must still be mirrored
+// and linked to the issue (the sidebar keeps working, close_intent is still
+// stamped on the link row for later re-runs), but the issue must stay in
+// its pre-merge status — the workspace has opted out of the auto-done side
+// effect while keeping auto-link.
+func TestWebhook_MergedPR_AutoCloseDisabled_KeepsLinkOnly(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "auto-close-disabled-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	// Read prior settings so we can restore them in cleanup — this test
+	// shares the singleton testWorkspaceID with other tests and must not
+	// leak the disabled flag into an unrelated case.
+	var prevSettings []byte
+	testPool.QueryRow(ctx, `SELECT settings FROM workspace WHERE id = $1`, testWorkspaceID).Scan(&prevSettings)
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = $1 WHERE id = $2`,
+		[]byte(`{"github_auto_close_issue_on_pr_merge_enabled":false}`), testWorkspaceID); err != nil {
+		t.Fatalf("set workspace settings: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "Auto-close disabled",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+		if prevSettings == nil {
+			testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID)
+		} else {
+			testPool.Exec(ctx, `UPDATE workspace SET settings = $1 WHERE id = $2`, prevSettings, testWorkspaceID)
+		}
+	})
+
+	const installationID int64 = 40560012
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "auto-close-off-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"action": "closed",
+		"pull_request": map[string]any{
+			"number":     8801,
+			"html_url":   "https://github.com/acme/widget/pull/8801",
+			"title":      "Fix login " + created.Identifier,
+			"body":       "Closes " + created.Identifier,
+			"state":      "closed",
+			"draft":      false,
+			"merged":     true,
+			"merged_at":  "2026-04-29T00:00:00Z",
+			"closed_at":  "2026-04-29T00:00:00Z",
+			"created_at": "2026-04-28T00:00:00Z",
+			"updated_at": "2026-04-29T00:00:00Z",
+			"head":       map[string]any{"ref": "fix/login"},
+			"user":       map[string]any{"login": "octocat", "avatar_url": ""},
+		},
+		"repository":   map[string]any{"name": "widget", "owner": map[string]any{"login": "acme"}},
+		"installation": map[string]any{"id": installationID},
+	})
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	w = httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(body))
+	req2.Header.Set("X-GitHub-Event", "pull_request")
+	req2.Header.Set("X-Hub-Signature-256", sig)
+	testHandler.HandleGitHubWebhook(w, req2)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("webhook: expected 202, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	// PR row still mirrored (auto-link is on).
+	if _, err := testHandler.Queries.GetGitHubPullRequest(ctx, db.GetGitHubPullRequestParams{
+		WorkspaceID: parseUUID(testWorkspaceID),
+		RepoOwner:   "acme",
+		RepoName:    "widget",
+		PrNumber:    8801,
+	}); err != nil {
+		t.Fatalf("expected PR row present under auto-close-disabled: %v", err)
+	}
+
+	// Link row still exists — this is the whole point of the flag: keep
+	// the sidebar link, drop only the auto-done side effect.
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue: %v", err)
+	}
+	if len(linked) != 1 {
+		t.Fatalf("expected 1 linked PR (link path unchanged), got %d", len(linked))
+	}
+
+	// Issue must remain in_progress; auto-done was suppressed.
+	updated, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if updated.Status != "in_progress" {
+		t.Errorf("expected issue status 'in_progress' with auto-close disabled, got %q", updated.Status)
+	}
+}
+
 // TestWebhook_UninstallReturnsWorkspaceForBroadcast guards #4: the uninstall
 // path must look up the workspace_id BEFORE deleting the row so the
 // resulting `github_installation:deleted` event is broadcast scoped to that


### PR DESCRIPTION
## Background

Fixes [MUL-4013](mention://issue/0a5af8da-e916-4d4a-a0b3-17cb67021615).

Before: the only way to stop a merged PR from auto-advancing its linked
Multica issue to `done` was to turn off `github_auto_link_prs_enabled` —
which also killed the PR sidebar and link row. Users who want to keep the
auto-link sidebar but manage issue status manually had no clean toggle.

## What changed

Adds a new workspace setting **`github_auto_close_issue_on_pr_merge_enabled`**
(default `true`, backwards compatible). Strict sub-flag of auto-link:

- Auto-link (title/body/branch scan → link row → `close_intent` stamp) still
  runs when this flag is off. Re-enabling the flag later resumes the
  historical behavior on the next terminal PR event.
- Only the terminal-event branch in `handlePullRequestEvent` stops short of
  calling `advanceIssueToDone`.
- Master switch `github_enabled=false` still forces off, matching
  `workspaceAutoLinkPRsEnabled` precedence.

## Server

- New helper `workspaceAutoCloseIssueOnPRMergeEnabled` in
  `server/internal/handler/github.go`.
- Read the flag once per event (not per issue) and skip the aggregate
  count + advance loop when it is off.

## Core / UI

- Extend `GitHubSettings` with `autoCloseIssueOnPRMerge` and its derivation.
- New Settings → GitHub → Features switch, disabled when either master or
  auto-link is off (a link that never gets created can't trigger auto-done
  anyway; the workspace's persisted preference is preserved across those
  gates).
- i18n copy in `en` / `zh-Hans` / `ja` / `ko`.

## Testing

Backend
- `TestWebhook_MergedPR_AutoCloseDisabled_KeepsLinkOnly` (new): under
  `github_auto_close_issue_on_pr_merge_enabled=false`, a merged closing-
  keyword PR mirrors the PR, links it to the issue, but leaves the issue
  status untouched.
- `go build ./...` clean; existing `TestWebhook_MergedPR_*` still pass.

Frontend
- `github/settings.test.ts` (5 tests): defaults + independent flip +
  master-switch precedence + `null`/`true`/`false` coercion.
- `settings/components/github-tab.test.tsx` (13 tests, 4 new): default on,
  persists `false` on click, disabled when auto-link is off, reflects a
  persisted `false`.
- `pnpm --filter @multica/{core,views} typecheck` clean.

## Notes

The setting name `github_auto_close_issue_on_pr_merge_enabled` is a bit long
but matches the `github_auto_link_prs_enabled` style ("what feature is
gated"). Kept the derivation independent from `autoLinkPRs` at the core
layer — the UI is responsible for gating the switch on auto-link, so
re-enabling auto-link doesn't silently flip the auto-done flag.
