### PR TITLE
fix(comments): stamp source_task_id on agent HTTP comments (MUL-4019)

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1209,39 +1209,59 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Determine author identity: agent (via X-Agent-ID header) or member.
 	authorType, authorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
 
-	// Defense against resumed-session drift: when an agent posts from inside a
-	// comment-triggered task AND the comment is being posted on that same
-	// issue, the parent_id must exactly match the task's trigger comment.
-	// Resumed Claude sessions otherwise carry forward a previous turn's
-	// --parent UUID and silently misplace the reply.
+	// For agent-authored comments the CLI stamps X-Task-ID on every request.
+	// We use it (when it resolves to an existing task) for three purposes:
 	//
-	// The task.IssueID scope is important: the CLI stamps X-Task-ID on every
-	// request, so an agent legitimately commenting on a different issue must
-	// not be blocked by its current task's trigger. Assignment-triggered
-	// tasks (no TriggerCommentID) are also unaffected.
+	//  1. Defense against resumed-session drift: when the task is a
+	//     comment-triggered task on THIS same issue, parent_id must exactly
+	//     match the task's trigger comment. Resumed Claude sessions otherwise
+	//     carry forward a previous turn's --parent UUID and silently misplace
+	//     the reply.
+	//  2. Reject writes on tasks the squad leader has already evaluated as
+	//     no_action.
+	//  3. Persist source_task_id on the created comment so downstream flows
+	//     can walk from an agent-authored comment back to the task that
+	//     produced it. This is load-bearing for multi-hop A→L→B chains
+	//     (MUL-4019): resolveOriginatorFromTriggerComment reads
+	//     comment.source_task_id → task.originator_user_id when the comment
+	//     author is an agent, and canInvokeAgent judges A2A permission by
+	//     that originator. Without the stamp the chain loses the human
+	//     originator at the first agent hop and a private / member-scoped
+	//     @agent mentioned by a squad leader is silently dropped.
+	//
+	// The (1)/(2) checks stay scoped to the current issue: the CLI stamps
+	// X-Task-ID on every request, so an agent legitimately commenting on a
+	// different issue must not be blocked by its current task's trigger.
+	// The (3) source_task_id stamp is unconditional (matching the internal
+	// TaskService.createAgentComment path in service/task.go) — the comment
+	// is produced by that task regardless of which issue it lands on.
+	var sourceTaskID pgtype.UUID
 	if authorType == "agent" {
 		if taskIDHeader := r.Header.Get("X-Task-ID"); taskIDHeader != "" {
 			taskUUID, parseErr := util.ParseUUID(taskIDHeader)
 			if parseErr == nil {
 				task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
-				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
-					if task.TriggerCommentID.Valid {
-						if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
-							writeError(w, http.StatusConflict,
-								"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
+				if err == nil {
+					sourceTaskID = taskUUID
+					if task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
+						if task.TriggerCommentID.Valid {
+							if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
+								writeError(w, http.StatusConflict,
+									"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
+								return
+							}
+						}
+						noAction, checkErr := service.HasSquadLeaderNoActionEvaluationForTask(r.Context(), h.Queries, task)
+						if checkErr != nil {
+							slog.Warn("checking squad leader no_action evaluation failed", append(logger.RequestAttrs(r),
+								"error", checkErr,
+								"task_id", taskIDHeader,
+								"issue_id", issueID,
+							)...)
+						} else if noAction {
+							writeError(w, http.StatusConflict, "squad leader recorded no_action; comments are not allowed for this task")
 							return
 						}
-					}
-					noAction, checkErr := service.HasSquadLeaderNoActionEvaluationForTask(r.Context(), h.Queries, task)
-					if checkErr != nil {
-						slog.Warn("checking squad leader no_action evaluation failed", append(logger.RequestAttrs(r),
-							"error", checkErr,
-							"task_id", taskIDHeader,
-							"issue_id", issueID,
-						)...)
-					} else if noAction {
-						writeError(w, http.StatusConflict, "squad leader recorded no_action; comments are not allowed for this task")
-						return
 					}
 				}
 			}
@@ -1269,13 +1289,14 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
-		IssueID:     issue.ID,
-		WorkspaceID: issue.WorkspaceID,
-		AuthorType:  authorType,
-		AuthorID:    parseUUID(authorID),
-		Content:     req.Content,
-		Type:        req.Type,
-		ParentID:    parentID,
+		IssueID:      issue.ID,
+		WorkspaceID:  issue.WorkspaceID,
+		AuthorType:   authorType,
+		AuthorID:     parseUUID(authorID),
+		Content:      req.Content,
+		Type:         req.Type,
+		ParentID:     parentID,
+		SourceTaskID: sourceTaskID,
 	})
 	if err != nil {
 		slog.Warn("create comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)

--- a/server/internal/handler/comment_source_task_id_test.go
+++ b/server/internal/handler/comment_source_task_id_test.go
@@ -1,0 +1,320 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCreateComment_AgentAuthored_StampsSourceTaskIDFromXTaskID pins the
+// invariant that MUL-4019 depends on: every agent-authored comment written
+// through the HTTP CreateComment path carries source_task_id pointing at the
+// task that produced it. Without this stamp,
+// resolveOriginatorFromTriggerComment cannot walk agent → parent-task →
+// originator, so the human originator is lost at the first agent hop and
+// canInvokeAgent silently denies downstream private / member-scoped @agent
+// triggers.
+func TestCreateComment_AgentAuthored_StampsSourceTaskIDFromXTaskID(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "source-task-id-stamp-agent", nil)
+
+	// Create an issue the agent is running on.
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, 'source-task-id stamp test')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	// Simulate the agent's active task; the CLI stamps this task ID on every
+	// outbound HTTP request as X-Task-ID.
+	taskID := createHandlerTestTaskForAgentOnIssue(t, agentID, issueID)
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "worker result posted from inside the agent's task",
+	})
+	r.Header.Set("X-Agent-ID", agentID)
+	r.Header.Set("X-Task-ID", taskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.SourceTaskID == nil {
+		t.Fatalf("expected source_task_id on the response, got nil")
+	}
+	if *resp.SourceTaskID != taskID {
+		t.Fatalf("source_task_id mismatch: got %q, want %q", *resp.SourceTaskID, taskID)
+	}
+
+	// Verify the underlying row too — response omission can hide a NULL
+	// column if the JSON marshalling changes independently of the handler.
+	var stored *string
+	if err := testPool.QueryRow(ctx,
+		`SELECT source_task_id::text FROM comment WHERE id = $1`, resp.ID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("select stored comment: %v", err)
+	}
+	if stored == nil {
+		t.Fatalf("comment.source_task_id is NULL in the database; expected %s", taskID)
+	}
+	if *stored != taskID {
+		t.Fatalf("comment.source_task_id in db = %q, want %q", *stored, taskID)
+	}
+}
+
+// TestCreateComment_MemberAuthored_LeavesSourceTaskIDNull pins the other half
+// of the contract: a member-authored comment has no source task by
+// definition, so source_task_id must stay NULL even if a stray X-Task-ID
+// header were forwarded. Member comments are the top of the originator
+// chain, not a fanout hop.
+func TestCreateComment_MemberAuthored_LeavesSourceTaskIDNull(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, 'source-task-id member test')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "human comment",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.SourceTaskID != nil {
+		t.Fatalf("member comment should have no source_task_id, got %v", *resp.SourceTaskID)
+	}
+
+	var stored *string
+	if err := testPool.QueryRow(ctx,
+		`SELECT source_task_id::text FROM comment WHERE id = $1`, resp.ID,
+	).Scan(&stored); err != nil {
+		t.Fatalf("select stored comment: %v", err)
+	}
+	if stored != nil {
+		t.Fatalf("member comment.source_task_id in db = %q, want NULL", *stored)
+	}
+}
+
+// TestCreateComment_MUL4019_SquadLeaderMentionOfPrivateAgentChain reproduces
+// the full MUL-4019 failure chain end-to-end at the HTTP handler level and
+// asserts the fixed behavior:
+//
+//	human U (private agent B's owner) → issue assigned to squad S →
+//	worker agent A runs a task on that issue and posts a result comment →
+//	squad leader L is auto-triggered by A's comment (originator inherited
+//	from A's task = U via comment.source_task_id) →
+//	L runs and posts a comment @-mentioning private agent B →
+//	B is enqueued because canInvokeAgent judges A2A by the ORIGINATOR (U),
+//	who IS B's owner.
+//
+// Before the fix the HTTP CreateComment path did not stamp source_task_id on
+// agent-authored comments, which nulled the originator at the A→L hop and
+// silently blocked L's private-B trigger. This test would fail on that
+// pre-fix code path with "expected private B to be enqueued, got 0".
+func TestCreateComment_MUL4019_SquadLeaderMentionOfPrivateAgentChain(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Private agent B, owned by ownerID.
+	privateAgentB, ownerID, _ := privateAgentTestFixture(t)
+
+	// Workspace-invocable worker agent A and leader L (both public_to workspace).
+	workerA := createHandlerTestAgent(t, "mul4019-worker-A", nil)
+	leaderL := createHandlerTestAgent(t, "mul4019-leader-L", nil)
+
+	// Squad S with L as its leader.
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, 'MUL-4019 squad', '', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, leaderL, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+
+	// Issue assigned to squad S. Creator = ownerID so any assignment gate
+	// passes; ownerID is a workspace member seeded by privateAgentTestFixture.
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title, assignee_type, assignee_id)
+		VALUES ($1, 'member', $2, 'MUL-4019 chain', 'squad', $3)
+		RETURNING id
+	`, testWorkspaceID, ownerID, squadID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	// A's task is running on this issue with the human originator stamped.
+	var workerTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, issue_id, originator_user_id)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), 'running', 0, $2, $3)
+		RETURNING id
+	`, workerA, issueID, ownerID).Scan(&workerTaskID); err != nil {
+		t.Fatalf("seed worker task: %v", err)
+	}
+	// t.Cleanup delete-by-issue above sweeps this too.
+
+	countQueuedFor := func(agentID string) int {
+		t.Helper()
+		var n int
+		if err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
+			issueID, agentID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count queued tasks for %s: %v", agentID, err)
+		}
+		return n
+	}
+
+	// Step 1: A finishes and posts a result comment. No @-mention — the squad
+	// leader routes via routeAssignedSquadLeaderFallback.
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "worker A done, please coordinate the next step",
+	})
+	r.Header.Set("X-Agent-ID", workerA)
+	r.Header.Set("X-Task-ID", workerTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("A CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var workerComment CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&workerComment); err != nil {
+		t.Fatalf("decode worker comment: %v", err)
+	}
+	if workerComment.SourceTaskID == nil || *workerComment.SourceTaskID != workerTaskID {
+		got := "<nil>"
+		if workerComment.SourceTaskID != nil {
+			got = *workerComment.SourceTaskID
+		}
+		t.Fatalf("A's comment should carry source_task_id=%s, got %s (this is the MUL-4019 bug)",
+			workerTaskID, got)
+	}
+
+	// The squad leader L must be queued with the human U's originator
+	// inherited from A's task via the comment.source_task_id trail.
+	if got := countQueuedFor(leaderL); got != 1 {
+		t.Fatalf("expected exactly 1 queued task for squad leader L after A's comment, got %d", got)
+	}
+	var leaderTaskID, leaderOriginator string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text, coalesce(originator_user_id::text, '') FROM agent_task_queue
+		 WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		 ORDER BY created_at DESC LIMIT 1`,
+		issueID, leaderL,
+	).Scan(&leaderTaskID, &leaderOriginator); err != nil {
+		t.Fatalf("load leader task: %v", err)
+	}
+	if leaderOriginator != ownerID {
+		t.Fatalf("squad leader task originator_user_id = %q, want %q (originator must inherit from A's task via source_task_id)",
+			leaderOriginator, ownerID)
+	}
+
+	// Step 2: promote L's task to running so it can act as the task actor
+	// on its subsequent HTTP write.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'running', started_at = now() WHERE id = $1`,
+		leaderTaskID,
+	); err != nil {
+		t.Fatalf("promote leader task: %v", err)
+	}
+
+	// Step 3: L posts a comment @-mentioning private agent B.
+	// Note: keep parent_id matching L's trigger comment (A's comment ID) to
+	// pass the resumed-session parent-drift guard.
+	w = httptest.NewRecorder()
+	r = newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content":   "delegating deep work to [@B](mention://agent/" + privateAgentB + ")",
+		"parent_id": workerComment.ID,
+	})
+	r.Header.Set("X-Agent-ID", leaderL)
+	r.Header.Set("X-Task-ID", leaderTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("L CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var leaderComment CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&leaderComment); err != nil {
+		t.Fatalf("decode leader comment: %v", err)
+	}
+	if leaderComment.SourceTaskID == nil || *leaderComment.SourceTaskID != leaderTaskID {
+		got := "<nil>"
+		if leaderComment.SourceTaskID != nil {
+			got = *leaderComment.SourceTaskID
+		}
+		t.Fatalf("L's comment should carry source_task_id=%s, got %s",
+			leaderTaskID, got)
+	}
+
+	// Final assertion: private agent B must be queued. Before the fix
+	// canInvokeAgent saw an empty originator (L's task had NULL
+	// originator_user_id because A's comment lacked source_task_id) and
+	// silently dropped the trigger.
+	if got := countQueuedFor(privateAgentB); got != 1 {
+		t.Fatalf("expected private agent B to be enqueued by squad leader @mention, got %d queued tasks (this is the MUL-4019 symptom)",
+			got)
+	}
+	var privateBOriginator string
+	if err := testPool.QueryRow(ctx,
+		`SELECT coalesce(originator_user_id::text, '') FROM agent_task_queue
+		 WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		 ORDER BY created_at DESC LIMIT 1`,
+		issueID, privateAgentB,
+	).Scan(&privateBOriginator); err != nil {
+		t.Fatalf("load private B task: %v", err)
+	}
+	if privateBOriginator != ownerID {
+		t.Fatalf("private B task originator_user_id = %q, want %q (must inherit from L's task via source_task_id)",
+			privateBOriginator, ownerID)
+	}
+}


### PR DESCRIPTION
Fixes [MUL-4019](https://github.com/multica-ai/multica/issues/50c99423-bdf8-4b7e-8a56-ed368443ae23) — after the agent public/private permission model landed, a squad leader's `@agent` mention silently dropped when the mentioned agent was private (or member-scoped `public_to`).

## Summary

The HTTP `CreateComment` handler in `server/internal/handler/comment.go` never stamped `source_task_id` on the comment row it inserted. Only the internal `TaskService.createAgentComment` path did. As a result, every agent-authored comment posted through the `multica` CLI landed with `source_task_id = NULL`.

That broke the multi-hop originator chain. `resolveOriginatorFromTriggerComment` walks:

```
agent-authored comment  →  comment.source_task_id  →  parent task.originator_user_id
```

to surface the top-of-chain human. With the stamp missing, an agent hop returned an invalid originator, so a squad leader that was auto-triggered by a worker agent's result comment inherited `originator_user_id = NULL`. Its own downstream `@mention` of a private (or member-scoped) agent then hit `canInvokeAgent` with an empty effective user, matched no owner and no allow-list, and was silently dropped.

## Reproduction chain from the issue

- User assigns issue to a squad, then `@`-mentions worker agent A.
- A finishes, posts a result comment. Squad leader L is auto-triggered.
- L `@`-mentions private agent B → **B never runs.** ← the bug.

## Fix

Capture the resolved task id as `sourceTaskID` whenever the `X-Task-ID` header points at an existing task, and pass it through `CreateCommentParams.SourceTaskID`. The stamp is unconditional (matching the internal `createAgentComment` path in `service/task.go`), while the existing issue-scoped `parent_id` / `no_action` checks stay scoped to the current issue.

## Verification

- `go test ./internal/handler/...` — full package green (~12.7s).
- `go test ./internal/service/... ./internal/util/...` — green.
- Added three regression tests in `server/internal/handler/comment_source_task_id_test.go`:
  1. `TestCreateComment_AgentAuthored_StampsSourceTaskIDFromXTaskID` — agent comment via HTTP has `source_task_id` set in the response AND in the DB.
  2. `TestCreateComment_MemberAuthored_LeavesSourceTaskIDNull` — member comment stays `NULL`.
  3. `TestCreateComment_MUL4019_SquadLeaderMentionOfPrivateAgentChain` — full user→A→L→@private-B chain enqueues B with the human originator propagated end to end.
- Sanity-checked that all three regression tests **fail** on the pre-fix code path (stash-pop against `HEAD` before the patch was applied), so they truly guard the invariant.

## Scope

Backend-only. No migration, no API contract change (`source_task_id` was already exposed on `CommentResponse`), no frontend touched.
