### PR TITLE
fix(agents): gate create-agent access picker on composio_mcp_apps flag (MUL-4010)

### DIFF
--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -17,7 +17,7 @@ export type {
 export { FeatureFlagService } from "./service";
 export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
-export { COMPOSIO_MCP_APPS_FLAG, AGENT_ACCESS_PICKER_FLAG } from "./keys";
+export { COMPOSIO_MCP_APPS_FLAG } from "./keys";
 export {
   FeatureFlagsProvider,
   useFeatureFlagService,

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,11 +1,1 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
-
-/**
- * AGENT_ACCESS_PICKER_FLAG gates the MUL-3963-aligned access UI in the
- * agent create/duplicate flow. When ON, the visibility section switches from
- * the legacy Workspace/Personal toggle to the new Private / Public-to model
- * (`permission_mode` + `invocation_targets`) that matches AccessPicker on
- * the agent detail page. Defaults to OFF so production stays on the legacy
- * toggle until the rollout is greenlit.
- */
-export const AGENT_ACCESS_PICKER_FLAG = "agent_access_picker";

--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -7,7 +7,7 @@ import type { Agent, MemberWithUser, RuntimeDevice } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { WorkspaceSlugProvider } from "@multica/core/paths";
 import { configStore } from "@multica/core/config";
-import { AGENT_ACCESS_PICKER_FLAG } from "@multica/core/feature-flags";
+import { COMPOSIO_MCP_APPS_FLAG } from "@multica/core/feature-flags";
 import { NavigationProvider, type NavigationAdapter } from "../../navigation";
 import enCommon from "../../locales/en/common.json";
 import enAgents from "../../locales/en/agents.json";
@@ -306,7 +306,7 @@ describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () =>
   });
 
   it("keeps the legacy Workspace/Personal toggle when the flag is OFF", async () => {
-    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: false });
+    configStore.getState().setFeatureFlags({ [COMPOSIO_MCP_APPS_FLAG]: false });
     const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
     const { onCreate } = renderDialog([mine]);
 
@@ -328,7 +328,7 @@ describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () =>
   });
 
   it("submits permission_mode=public_to + workspace target when the flag is ON (default)", async () => {
-    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    configStore.getState().setFeatureFlags({ [COMPOSIO_MCP_APPS_FLAG]: true });
     const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
     const { onCreate } = renderDialog([mine]);
 
@@ -353,7 +353,7 @@ describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () =>
   });
 
   it("submits permission_mode=private with empty targets when Private is chosen", async () => {
-    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    configStore.getState().setFeatureFlags({ [COMPOSIO_MCP_APPS_FLAG]: true });
     const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
     const { onCreate } = renderDialog([mine]);
 
@@ -376,7 +376,7 @@ describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () =>
     // MUL-3963 normalisation: a public_to with zero grants is a no-op share.
     // The AccessPicker emits it as private; the create dialog does the same
     // so the backend never sees a bogus "public with nothing" request.
-    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    configStore.getState().setFeatureFlags({ [COMPOSIO_MCP_APPS_FLAG]: true });
     const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
     const { onCreate } = renderDialog([mine]);
 
@@ -398,7 +398,7 @@ describe("CreateAgentDialog access picker (MUL-4010, feature-flag gated)", () =>
   });
 
   it("includes ticked members in the invocation_targets payload", async () => {
-    configStore.getState().setFeatureFlags({ [AGENT_ACCESS_PICKER_FLAG]: true });
+    configStore.getState().setFeatureFlags({ [COMPOSIO_MCP_APPS_FLAG]: true });
     const mine = makeRuntime({ id: "rt-mine", name: "My Runtime", owner_id: ME });
     const { onCreate } = renderDialog([mine]);
 

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -11,7 +11,7 @@ import { AvatarPicker } from "./avatar-picker";
 import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useFeatureEnabled } from "@multica/core/config";
-import { AGENT_ACCESS_PICKER_FLAG } from "@multica/core/feature-flags";
+import { COMPOSIO_MCP_APPS_FLAG } from "@multica/core/feature-flags";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type {
   Agent,
@@ -84,10 +84,12 @@ export function CreateAgentDialog({
   const queryClient = useQueryClient();
   const wsId = useWorkspaceId();
   // MUL-4010: rolls out the private / public_to access model in the create
-  // flow to match the AccessPicker on the agent detail page. Defaults OFF so
-  // production stays on the legacy Workspace / Personal toggle until the flag
-  // is flipped.
-  const accessPickerEnabled = useFeatureEnabled(AGENT_ACCESS_PICKER_FLAG, false);
+  // flow to match the AccessPicker on the agent detail page. Shares the
+  // `composio_mcp_apps` switch with the Composio rollout — the MUL-3963
+  // permission model exists to gate Composio sharing, so both surfaces flip
+  // together. Defaults OFF so production stays on the legacy Workspace /
+  // Personal toggle until Composio is greenlit.
+  const accessPickerEnabled = useFeatureEnabled(COMPOSIO_MCP_APPS_FLAG, false);
 
   // Name defaults: duplicate uses "<original> copy". Manual-create starts blank.
   const [name, setName] = useState(
@@ -484,7 +486,7 @@ export function CreateAgentDialog({
 
 /**
  * AccessSection — inline access editor for the create/duplicate flow, gated
- * on `AGENT_ACCESS_PICKER_FLAG`. Mirrors the semantics of
+ * on `COMPOSIO_MCP_APPS_FLAG`. Mirrors the semantics of
  * `AccessPicker` on the agent detail page: the underlying model is
  * `permission_mode` + `invocation_targets` (MUL-3963), not the legacy
  * `visibility`.

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -7,19 +7,16 @@ import (
 )
 
 const (
-	// ComposioMCPApps gates the Composio app management UI and runtime MCP
-	// overlay injection.
+	// ComposioMCPApps gates the Composio app management UI and — together with
+	// the MUL-3963 permission_mode / invocation_targets access model it depends
+	// on — the aligned Private / Public-to picker in the agent create flow.
+	// The access model exists to gate Composio sharing, so the two ship on the
+	// same switch.
 	ComposioMCPApps = "composio_mcp_apps"
-	// AgentAccessPicker gates the MUL-3963 permission_mode + invocation_targets
-	// picker in the agent create/duplicate flow. When OFF the create dialog
-	// keeps the legacy Workspace/Personal toggle; when ON it switches to the
-	// same private / public_to model used on the agent detail page.
-	AgentAccessPicker = "agent_access_picker"
 )
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
-	AgentAccessPicker,
 }
 
 func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) bool {


### PR DESCRIPTION
## Background

Follow-up to #4879. Yushen pointed out the MUL-3963 access model was built as part of the Composio rollout and should ride the same feature flag, not a new one. This PR removes the standalone `agent_access_picker` flag and gates the create-flow access picker on the existing `composio_mcp_apps` switch.

## Core logic

- `packages/core/feature-flags/keys.ts` — drop `AGENT_ACCESS_PICKER_FLAG`.
- `packages/core/feature-flags/index.ts` — drop the re-export.
- `server/internal/featureflags/keys.go` — drop `AgentAccessPicker` from `frontendPublicFlags`.
- `packages/views/agents/components/create-agent-dialog.tsx` — read `COMPOSIO_MCP_APPS_FLAG` instead.
- Tests updated to set/clear the Composio flag.

## Effect

Environments that already have `FF_COMPOSIO_MCP_APPS=true` (Yushen's test env included) now see the aligned Private / Public-to picker in Create Agent + Duplicate — no extra env var, no restart beyond the deploy of this PR.

## Verification

- `pnpm --filter @multica/views typecheck` + `pnpm --filter @multica/core typecheck` clean.
- `go build ./...` clean.
- `agents/components/create-agent-dialog.test.tsx` — 10/10 pass.
- `agent-mcp-tab.test.tsx`, `integrations-tab.test.tsx`, `agent-overview-pane.test.tsx` — 26/26 pass (confirms the shared flag doesn't cross-wire other Composio surfaces).

Closes the follow-up on MUL-4010.
