### PR TITLE
MUL-4016: fix mention tokenizer stacktrace backtracking

### DIFF
--- a/packages/ui/markdown/file-cards.ts
+++ b/packages/ui/markdown/file-cards.ts
@@ -47,9 +47,14 @@ export function isAllowedFileCardHref(href: string): boolean {
   )
 }
 
-/** New syntax: !file[name](url) — unambiguous, no hostname matching needed. */
+/**
+ * New syntax: !file[name](url) — unambiguous, no hostname matching needed.
+ * Backslash is excluded from the label char class so "\x" runs can only be
+ * consumed by \\. — overlapping alternatives backtrack in 2^n ways (ReDoS,
+ * GitHub #4881). This runs on every comment/description render.
+ */
 const NEW_FILE_CARD_RE = new RegExp(
-  `^!file\\[((?:\\\\.|[^\\]])*)\\]\\((${FILE_CARD_URL_PATTERN.source})\\)$`,
+  `^!file\\[((?:\\\\.|[^\\]\\\\])*)\\]\\((${FILE_CARD_URL_PATTERN.source})\\)$`,
 )
 
 /** Legacy syntax: [name](cdnUrl) on its own line — matched by CDN hostname. */

--- a/packages/views/editor/extensions/file-card-markdown.test.ts
+++ b/packages/views/editor/extensions/file-card-markdown.test.ts
@@ -61,6 +61,20 @@ describe("file-card tokenizer", () => {
     expect(token).toBeDefined();
     expect(token!.attributes.filename).toBe("readme.md");
   });
+
+  it("rejects an unterminated file card with escape-pair runs in linear time", () => {
+    // Each "\a" pair is ambiguous under (?:\\.|[^\]]) — the pre-fix regex
+    // enumerates 2^28 backtrack paths (~10s) before failing. The disjoint
+    // char class must fail fast instead.
+    const src = `!file[${"\\a".repeat(28)}](/uploads/x`;
+
+    const t0 = performance.now();
+    const token = tokenize(src);
+    const elapsed = performance.now() - t0;
+
+    expect(token).toBeUndefined();
+    expect(elapsed).toBeLessThan(100);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -80,5 +94,18 @@ describe("preprocessFileCards", () => {
     const result = preprocessFileCards(input, "cdn.example.com");
     expect(result).toContain('data-type="fileCard"');
     expect(result).toContain('data-filename="readme.md"');
+  });
+
+  it("rejects an unterminated file card with escape-pair runs in linear time", () => {
+    // This path runs on every read-only comment/description render, so a
+    // backtracking label regex here is reachable without opening the editor.
+    const input = `!file[${"\\a".repeat(28)}](/uploads/x`;
+
+    const t0 = performance.now();
+    const result = preprocessFileCards(input, "cdn.example.com");
+    const elapsed = performance.now() - t0;
+
+    expect(result).toBe(input);
+    expect(elapsed).toBeLessThan(100);
   });
 });

--- a/packages/views/editor/extensions/file-card.tsx
+++ b/packages/views/editor/extensions/file-card.tsx
@@ -21,8 +21,11 @@ import { FILE_CARD_URL_PATTERN } from "@multica/ui/markdown";
 import { escapeMarkdownLabel } from "../utils/escape-markdown-label";
 import { Attachment } from "../attachment";
 
+// Backslash is excluded from the label char class so "\x" runs can only be
+// consumed by \\. — overlapping alternatives backtrack in 2^n ways (ReDoS,
+// GitHub #4881).
 const FILE_CARD_MARKDOWN_RE = new RegExp(
-  `^!file\\[((?:\\\\.|[^\\]])*)\\]\\((${FILE_CARD_URL_PATTERN.source})\\)`,
+  `^!file\\[((?:\\\\.|[^\\]\\\\])*)\\]\\((${FILE_CARD_URL_PATTERN.source})\\)`,
 );
 
 

--- a/packages/views/editor/extensions/mention-extension.test.ts
+++ b/packages/views/editor/extensions/mention-extension.test.ts
@@ -14,6 +14,9 @@ const renderMarkdown = BaseMentionExtension.config.renderMarkdown as (
   node: { attrs: Record<string, string> },
 ) => string;
 
+const JAVA_STACKTRACE_SOURCE_MARKER =
+  "        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) \\~\\[spring-webmvc-5.3.39.jar!/:5.3.39\\]\n";
+
 function tokenize(src: string) {
   const start = startFn(src);
   if (start === -1) return undefined;
@@ -88,5 +91,30 @@ describe("mention tokenizer", () => {
     expect(token!.attributes.label).toBe("MUL-123");
     expect(token!.attributes.type).toBe("issue");
     expect(token!.attributes.id).toBe("aaa-bbb");
+  });
+
+  it("does not start at escaped Java stacktrace source markers before a real mention", () => {
+    const prefix = JAVA_STACKTRACE_SOURCE_MARKER.repeat(3);
+    const src = `${prefix}[@Alice](mention://member/aaa-bbb)`;
+
+    const start = startFn(src);
+    expect(start).toBe(prefix.length);
+
+    const token = tokenizeFn(src.slice(start));
+    expect(token).toBeDefined();
+    expect(token!.attributes.label).toBe("Alice");
+    expect(token!.attributes.type).toBe("member");
+    expect(token!.attributes.id).toBe("aaa-bbb");
+  });
+
+  it("keeps escaped Java stacktrace source marker detection fast when no mention exists", () => {
+    const src = JAVA_STACKTRACE_SOURCE_MARKER.repeat(11);
+
+    const t0 = performance.now();
+    const start = startFn(src);
+    const elapsed = performance.now() - t0;
+
+    expect(start).toBe(-1);
+    expect(elapsed).toBeLessThan(50);
   });
 });

--- a/packages/views/editor/extensions/mention-extension.test.ts
+++ b/packages/views/editor/extensions/mention-extension.test.ts
@@ -45,6 +45,23 @@ describe("mention tokenizer", () => {
     expect(token!.attributes.type).toBe("agent");
   });
 
+  it.each(["A\\", "ends\\", "a\\]b", "f(x)", "back\\slash"])(
+    "round-trips a label containing backslash/parens: %j",
+    (label) => {
+      // The linear tokenizer treats "\" as an escape lead, so renderMarkdown
+      // must escape "\" too — otherwise a trailing "\" swallows the closing "]"
+      // and the mention fails to parse back (regression guard for the
+      // de-ambiguation fix).
+      const md = renderMarkdown({
+        attrs: { id: "aaa-bbb", label, type: "member" },
+      });
+      const token = tokenize(md);
+      expect(token).toBeDefined();
+      expect(token!.attributes.label).toBe(label);
+      expect(token!.attributes.id).toBe("aaa-bbb");
+    },
+  );
+
   it("does not match an ordinary Markdown link before a mention", () => {
     const src =
       "Check [docs](https://example.com) - [@User](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)";

--- a/packages/views/editor/extensions/mention-extension.test.ts
+++ b/packages/views/editor/extensions/mention-extension.test.ts
@@ -117,4 +117,18 @@ describe("mention tokenizer", () => {
     expect(start).toBe(-1);
     expect(elapsed).toBeLessThan(50);
   });
+
+  it("rejects an unterminated mention with escape-pair runs in linear time", () => {
+    // Each "\a" pair is ambiguous under (?:\\.|[^\]]) — the pre-fix regex
+    // enumerates 2^28 backtrack paths (~10s) before failing. The disjoint
+    // char class must fail fast instead.
+    const src = `[@${"\\a".repeat(28)}](mention://member/abc`;
+
+    const t0 = performance.now();
+    const token = tokenizeFn(src);
+    const elapsed = performance.now() - t0;
+
+    expect(token).toBeUndefined();
+    expect(elapsed).toBeLessThan(100);
+  });
 });

--- a/packages/views/editor/extensions/mention-extension.ts
+++ b/packages/views/editor/extensions/mention-extension.ts
@@ -3,6 +3,43 @@ import { mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { MentionView } from "./mention-view";
 
+const MENTION_LINK_MARKER = "](mention://";
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+function findUnescapedMentionMarker(src: string, from = 0): number {
+  let marker = src.indexOf(MENTION_LINK_MARKER, from);
+
+  while (marker !== -1) {
+    if (!isEscaped(src, marker)) return marker;
+    marker = src.indexOf(MENTION_LINK_MARKER, marker + MENTION_LINK_MARKER.length);
+  }
+
+  return -1;
+}
+
+function findMentionStart(src: string): number {
+  let marker = findUnescapedMentionMarker(src);
+
+  while (marker !== -1) {
+    for (let i = marker - 1; i >= 0; i--) {
+      const char = src[i];
+      if (char === "\n" || char === "\r") break;
+      if (char === "[" && !isEscaped(src, i)) return i;
+    }
+
+    marker = findUnescapedMentionMarker(src, marker + MENTION_LINK_MARKER.length);
+  }
+
+  return -1;
+}
+
 export const BaseMentionExtension = Mention.extend({
   addNodeView() {
     return ReactNodeViewRenderer(MentionView);
@@ -39,10 +76,9 @@ export const BaseMentionExtension = Mention.extend({
     name: "mention",
     level: "inline" as const,
     start(src: string) {
-      // Accept escaped brackets (\\[ \\]) and non-] chars in the label.
-      // This prevents matching ordinary Markdown links like [docs](url)
-      // that appear before a mention on the same line.
-      return src.search(/\[@?(?:\\.|[^\]])+\]\(mention:\/\//);
+      // Anchor on Multica's mention href first. Scanning forward from every
+      // "[" backtracks badly on escaped stacktrace markers like \~\[...\].
+      return findMentionStart(src);
     },
     tokenize(src: string) {
       // Label accepts escaped chars (\\[ \\]) or any non-] character.

--- a/packages/views/editor/extensions/mention-extension.ts
+++ b/packages/views/editor/extensions/mention-extension.ts
@@ -2,6 +2,7 @@ import Mention from "@tiptap/extension-mention";
 import { mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { MentionView } from "./mention-view";
+import { escapeMarkdownLabel } from "../utils/escape-markdown-label";
 
 const MENTION_LINK_MARKER = "](mention://";
 
@@ -90,8 +91,10 @@ export const BaseMentionExtension = Mention.extend({
         /^\[@?((?:\\.|[^\]\\])+)\]\(mention:\/\/(\w+)\/([^)]+)\)/,
       );
       if (!match) return undefined;
-      // Unescape backslash-escaped brackets that renderMarkdown may produce.
-      const rawLabel = match[1]?.replace(/\\\[/g, "[").replace(/\\\]/g, "]");
+      // Reverse escapeMarkdownLabel: unescape \[ \] \\ \( \) that
+      // renderMarkdown produced. Must mirror the escaped set exactly, or a
+      // label containing "\" fails to round-trip through the linear tokenizer.
+      const rawLabel = match[1]?.replace(/\\([[\]\\()])/g, "$1");
       return {
         type: "mention",
         raw: match[0],
@@ -105,9 +108,11 @@ export const BaseMentionExtension = Mention.extend({
   renderMarkdown: (node: any) => {
     const { id, label, type = "member" } = node.attrs || {};
     const prefix = type === "issue" || type === "project" ? "" : "@";
-    // Escape square brackets in the label so the markdown link syntax
-    // is not broken when the name contains [ or ] (e.g. "David[TF]").
-    const safeLabel = (label ?? id).replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+    // Escape [ ] \ ( ) in the label so the markdown link syntax is not broken
+    // and the label survives the linear tokenizer (which now treats "\" as an
+    // escape lead, not an ordinary char). Must stay in sync with the unescape
+    // in tokenize() above. Shared with file-card/slash via escapeMarkdownLabel.
+    const safeLabel = escapeMarkdownLabel(label ?? id);
     return `[${prefix}${safeLabel}](mention://${type}/${id})`;
   },
 });

--- a/packages/views/editor/extensions/mention-extension.ts
+++ b/packages/views/editor/extensions/mention-extension.ts
@@ -81,11 +81,13 @@ export const BaseMentionExtension = Mention.extend({
       return findMentionStart(src);
     },
     tokenize(src: string) {
-      // Label accepts escaped chars (\\[ \\]) or any non-] character.
-      // This prevents the label from crossing a ]( Markdown link boundary
-      // while still supporting bracket-containing names like "David\[TF\]".
+      // Label accepts escaped chars (\\[ \\]) or any non-] non-backslash
+      // character. Excluding backslash from the char class keeps the two
+      // alternatives disjoint — otherwise "\x" runs backtrack in 2^n ways
+      // (ReDoS, GitHub #4881) — while still supporting bracket-containing
+      // names like "David\[TF\]".
       const match = src.match(
-        /^\[@?((?:\\.|[^\]])+)\]\(mention:\/\/(\w+)\/([^)]+)\)/,
+        /^\[@?((?:\\.|[^\]\\])+)\]\(mention:\/\/(\w+)\/([^)]+)\)/,
       );
       if (!match) return undefined;
       // Unescape backslash-escaped brackets that renderMarkdown may produce.

--- a/packages/views/editor/extensions/slash-command-extension.test.ts
+++ b/packages/views/editor/extensions/slash-command-extension.test.ts
@@ -79,6 +79,16 @@ describe("slash command tokenizer", () => {
     expect(tokenize(md)?.attributes.label).toBe("deploy[prod]");
   });
 
+  it.each(["A\\", "ends\\", "a\\]b", "f(x)", "back\\slash"])(
+    "round-trips a label containing backslash/parens: %j",
+    (label) => {
+      // renderMarkdown must escape "\" so a trailing "\" does not swallow the
+      // closing "]" under the linear tokenizer (regression guard).
+      const md = renderMarkdown({ attrs: { id: "skill-1", label } });
+      expect(tokenize(md)?.attributes.label).toBe(label);
+    },
+  );
+
   it("does not match ordinary markdown links", () => {
     expect(tokenize("[docs](https://example.com)")).toBeUndefined();
   });

--- a/packages/views/editor/extensions/slash-command-extension.test.ts
+++ b/packages/views/editor/extensions/slash-command-extension.test.ts
@@ -86,4 +86,29 @@ describe("slash command tokenizer", () => {
   it("does not match slash action links", () => {
     expect(tokenize("[/deploy](slash://action/deploy)")).toBeUndefined();
   });
+
+  it("rejects an unterminated slash link with escape-pair runs in linear time", () => {
+    // Each "\a" pair is ambiguous under (?:\\.|[^\]]) — the pre-fix regex
+    // enumerates 2^28 backtrack paths (~10s) before failing. The disjoint
+    // char class must fail fast instead.
+    const src = `[/${"\\a".repeat(28)}](slash://skill/abc`;
+
+    const t0 = performance.now();
+    const token = tokenizeFn(src);
+    const elapsed = performance.now() - t0;
+
+    expect(token).toBeUndefined();
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("returns -1 fast from start() when escape-pair runs precede no slash link", () => {
+    const src = `[/${"\\a".repeat(28)}] plain text, no slash link`;
+
+    const t0 = performance.now();
+    const start = startFn(src);
+    const elapsed = performance.now() - t0;
+
+    expect(start).toBe(-1);
+    expect(elapsed).toBeLessThan(100);
+  });
 });

--- a/packages/views/editor/extensions/slash-command-extension.ts
+++ b/packages/views/editor/extensions/slash-command-extension.ts
@@ -3,6 +3,7 @@ import { mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { SlashCommandView } from "./slash-command-view";
 import { formatSlashCommandLabel } from "./slash-command-utils";
+import { escapeMarkdownLabel } from "../utils/escape-markdown-label";
 
 export const SlashCommandExtension = Mention.extend({
   name: "slashCommand",
@@ -45,7 +46,10 @@ export const SlashCommandExtension = Mention.extend({
         /^\[\/((?:\\.|[^\]\\])+)\]\(slash:\/\/skill\/([^)]+)\)/,
       );
       if (!match) return undefined;
-      const rawLabel = match[1]?.replace(/\\\[/g, "[").replace(/\\\]/g, "]");
+      // Reverse escapeMarkdownLabel: unescape \[ \] \\ \( \). Must mirror the
+      // escaped set exactly, or a label containing "\" fails to round-trip
+      // through the linear tokenizer.
+      const rawLabel = match[1]?.replace(/\\([[\]\\()])/g, "$1");
       return {
         type: "slashCommand",
         raw: match[0],
@@ -60,9 +64,9 @@ export const SlashCommandExtension = Mention.extend({
 
   renderMarkdown: (node: any) => {
     const { id, label } = node.attrs || {};
-    const safeLabel = formatSlashCommandLabel(label)
-      .replace(/\[/g, "\\[")
-      .replace(/\]/g, "\\]");
+    // Escape [ ] \ ( ) so the label survives the linear tokenizer; must stay in
+    // sync with the unescape in tokenize() above.
+    const safeLabel = escapeMarkdownLabel(formatSlashCommandLabel(label));
     return `[/${safeLabel}](slash://skill/${id})`;
   },
 });

--- a/packages/views/editor/extensions/slash-command-extension.ts
+++ b/packages/views/editor/extensions/slash-command-extension.ts
@@ -35,11 +35,14 @@ export const SlashCommandExtension = Mention.extend({
     name: "slashCommand",
     level: "inline" as const,
     start(src: string) {
-      return src.search(/\[\/(?:\\.|[^\]])+\]\(slash:\/\/skill\//);
+      // Backslash is excluded from the char class so "\x" runs can only be
+      // consumed by \\. — overlapping alternatives backtrack in 2^n ways
+      // (ReDoS, GitHub #4881).
+      return src.search(/\[\/(?:\\.|[^\]\\])+\]\(slash:\/\/skill\//);
     },
     tokenize(src: string) {
       const match = src.match(
-        /^\[\/((?:\\.|[^\]])+)\]\(slash:\/\/skill\/([^)]+)\)/,
+        /^\[\/((?:\\.|[^\]\\])+)\]\(slash:\/\/skill\/([^)]+)\)/,
       );
       if (!match) return undefined;
       const rawLabel = match[1]?.replace(/\\\[/g, "[").replace(/\\\]/g, "]");


### PR DESCRIPTION
## Summary

- Replace mention tokenizer start detection with marker-first scanning on `](mention://`.
- Avoid backtracking through escaped Java stacktrace source markers such as `\~\[...\]`.
- Add regression coverage for both correct mention positioning and fast no-mention scanning.

## Validation

- `pnpm --filter @multica/views exec vitest run editor/extensions/mention-extension.test.ts`
- `pnpm --filter @multica/views test`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` (passes with existing warnings)
