### PR TITLE
chore: no-op README newline for MUL-4026 manual-merge test

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,4 @@ make dev
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, worktree support, testing, and troubleshooting.
 
 An iOS mobile client lives in [`apps/mobile/`](apps/mobile/) — see its [README](apps/mobile/README.md) for how to build it onto your own iPhone.
+


### PR DESCRIPTION
## Background

Per [MUL-4026](https://multica-app.copilothub.ai/issues/6c564788-e9f3-4eec-a139-1e9b3a3c77d1), submit a no-op PR against `main` so the user can exercise the manual-merge test flow.

## Change

- Append a single trailing newline at the end of `README.md`.
- No functional or visible impact — the file already renders identically.

## Testing

- `git diff` shows a single `+` line at EOF, no other churn.
- No code paths touched, so no build/test surface is affected.
