### PR TITLE
fix(agent): pi agent final output excludes intermediate steps

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -282,14 +282,15 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			case "agent_start":
 				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 
+			case "turn_start":
+				output.Reset()
+				textBuffer.Reset()
+
 			case "message_update":
 				if evt.AssistantMessageEvent == nil {
 					continue
 				}
 				switch evt.AssistantMessageEvent.Type {
-				case "text_start":
-					output.Reset()
-					textBuffer.Reset()
 				case "text_delta":
 					if d := drainPiTextBuffer(&textBuffer, evt.AssistantMessageEvent.Delta); d != "" {
 						output.WriteString(d)

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -287,6 +287,9 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 					continue
 				}
 				switch evt.AssistantMessageEvent.Type {
+				case "text_start":
+					output.Reset()
+					textBuffer.Reset()
 				case "text_delta":
 					if d := drainPiTextBuffer(&textBuffer, evt.AssistantMessageEvent.Delta); d != "" {
 						output.WriteString(d)

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -119,6 +119,72 @@ func TestPiExecuteAttachesStdinPipe(t *testing.T) {
 	}
 }
 
+// piEventStreamScript builds a sh script that prints each JSON event on
+// its own stdout line. Fixtures must not contain single quotes.
+func piEventStreamScript(events []string) string {
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	for _, e := range events {
+		b.WriteString("printf '%s\\n' '")
+		b.WriteString(e)
+		b.WriteString("'\n")
+	}
+	return b.String()
+}
+
+// TestPiExecuteRetainsOnlyLastTurnOutput verifies turn_start resets the
+// output buffer so Result.Output keeps only the final turn's text.
+func TestPiExecuteRetainsOnlyLastTurnOutput(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	events := []string{
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"intermediate"}}`,
+		`{"type":"tool_execution_start","toolCallId":"call_1","toolName":"bash","args":{"command":"echo hi"}}`,
+		`{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{"content":[{"type":"text","text":"hi"}]},"isError":false}`,
+		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"final"}}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":" "}}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"answer"}}`,
+		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":2,"output":2}}}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "final answer" {
+			t.Fatalf("Output: got %q, want %q", result.Output, "final answer")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func TestStripPiToolCallMarkup(t *testing.T) {
 	tests := map[string]string{
 		`before call:bash{command:<|"|>cd repo/path && ls -F<|"|>}<tool_call|> after`:                           "before  after",


### PR DESCRIPTION
Updated PI agent to only retain the final result in JSON output.

Previously, `text_delta` included both intermediate steps and final content.

Now, output is reset on each `text_start` to concatenate only the final text.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- server/pkg/agent/pi.go  +2loc

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. chat with an agent using pi runtime, give it some task that will execute 10 more steps
2. For long enough steps, it's very likely to have intermediate text output, which is more like thinking content
3. In the chat view(`/api/task/ID/messages`), it rendered OK
4. **BUT** `/api/sessions/ID/messages` returns intermediate texts.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** N/A

