### PR TITLE
Fix Codex MCP config rendering for generic discovery allowlists

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -379,15 +379,26 @@ func renderCodexMcpServersBlock(raw json.RawMessage) (string, bool, error) {
 }
 
 func normalizeCodexMcpServerConfig(server map[string]any) map[string]any {
+	normalized := make(map[string]any, len(server)+1)
 	if !isCodexRemoteMcpServer(server) {
-		return server
+		for k, v := range server {
+			if shouldDropGenericMcpDiscoveryConfig(k, v) {
+				continue
+			}
+			normalized[k] = v
+		}
+		return normalized
 	}
 
-	normalized := make(map[string]any, len(server)+1)
 	for k, v := range server {
 		switch k {
 		case "type":
 			continue
+		case "tools":
+			if shouldDropGenericMcpDiscoveryConfig(k, v) {
+				continue
+			}
+			normalized[k] = v
 		case "headers":
 			if _, ok := server["http_headers"]; !ok {
 				normalized["http_headers"] = v
@@ -398,6 +409,24 @@ func normalizeCodexMcpServerConfig(server map[string]any) map[string]any {
 	}
 	normalized["experimental_use_rmcp_client"] = true
 	return normalized
+}
+
+func shouldDropGenericMcpDiscoveryConfig(key string, value any) bool {
+	switch key {
+	case "prompts", "resources":
+		return true
+	case "tools":
+		tools, ok := value.(map[string]any)
+		if !ok {
+			return false
+		}
+		_, hasInclude := tools["include"]
+		_, hasPrompts := tools["prompts"]
+		_, hasResources := tools["resources"]
+		return hasInclude || hasPrompts || hasResources
+	default:
+		return false
+	}
 }
 
 func isCodexRemoteMcpServer(server map[string]any) bool {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2365,6 +2365,70 @@ func TestEnsureCodexMcpConfigTranslatesRemoteHTTPServer(t *testing.T) {
 	}
 }
 
+func TestEnsureCodexMcpConfigDropsGenericDiscoveryAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"gxg-kb":{"type":"http","url":"https://kb.example.test/mcp","headers":{"Authorization":"Bearer test-token"},"tools":{"include":["kb_get","kb_search"],"prompts":false,"resources":false}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		`[mcp_servers.gxg-kb]`,
+		`url = "https://kb.example.test/mcp"`,
+		`http_headers = { Authorization = "Bearer test-token" }`,
+		`experimental_use_rmcp_client = true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+	for _, unexpected := range []string{
+		`tools = `,
+		`include`,
+		`kb_get`,
+		`prompts`,
+		`resources`,
+	} {
+		if strings.Contains(got, unexpected) {
+			t.Fatalf("generic discovery key %q should not be written to Codex config.toml, got:\n%s", unexpected, got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigPreservesCodexToolApprovals(t *testing.T) {
+	t.Parallel()
+
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(tmp, []byte("sandbox_mode = \"workspace-write\"\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	raw := json.RawMessage(`{"mcpServers":{"local":{"command":"uvx","tools":{"read":"prompt","write":"approve"}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, `tools = { read = "prompt", write = "approve" }`) {
+		t.Fatalf("expected Codex-native tool approvals to be preserved, got:\n%s", got)
+	}
+}
+
 func TestRenderCodexMcpServersBlockTreatsURLOnlyServerAsRemote(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Strip generic MCP discovery keys (`tools.include`, `prompts`, `resources`) before rendering per-task Codex `config.toml`
- Preserve Codex-native per-tool approval maps such as `tools = { read = "prompt" }`
- Add regression coverage for the `kb_get` allowlist crash reported in #4901

## Test
- `go test ./pkg/agent -run 'TestEnsureCodexMcpConfig(DropsGenericDiscoveryAllowlist|PreservesCodexToolApprovals|TranslatesRemoteHTTPServer|WritesManagedBlock)|TestRenderCodexMcpServersBlockTreatsURLOnlyServerAsRemote'`\n\nFixes #4901