### PR TITLE
feat(agents): add DevEco Code (deveco) runtime agent

### DIFF
--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -87,6 +87,16 @@ Open-source CLI agent. Dynamically discovers available models from its own confi
 | Install | Follow the official guide at [opencode.ai](https://opencode.ai/) or the GitHub repo at [github.com/sst/opencode](https://github.com/sst/opencode). The typical route is the install script or the npm package. |
 | Authentication | Configure your model provider(s) per OpenCode's docs (Anthropic, OpenAI, etc.). |
 
+### DevEco Code (Huawei)
+
+Huawei's HarmonyOS coding-agent CLI (`deveco`), an OpenCode fork. Driven over the same `run --format json` event stream as OpenCode, with models discovered dynamically from `deveco models` (built-in `deveco/GLM-5.1`). MCP is not wired up yet — configure tools through DevEco's own config for now.
+
+| | |
+|---|---|
+| Daemon looks for | `deveco` |
+| Install | See the project at [gitcode.com/openharmony-sig/deveco-code](https://gitcode.com/openharmony-sig/deveco-code). Typically installed via the npm package `@deveco/deveco-code`. |
+| Authentication | Run `deveco auth login` once to complete the Huawei-account OAuth flow (token persists under `~/.config/deveco/`). |
+
 ### Kiro CLI (Amazon)
 
 ACP-over-stdio transport. Session resumption works through ACP `session/load`; MCP config is passed through ACP `mcpServers`; skills are copied into `.kiro/skills/`.

--- a/apps/docs/content/docs/providers.mdx
+++ b/apps/docs/content/docs/providers.mdx
@@ -1,11 +1,11 @@
 ---
 title: AI coding tools matrix
-description: Multica supports 14 AI coding tools; they implement the same interface, but the capability details diverge significantly.
+description: Multica supports 15 AI coding tools; they implement the same interface, but the capability details diverge significantly.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Multica ships with built-in support for **14 AI coding tools**. They all implement the same interface — queue, dispatch, execute, return results — so you can drive any of them from the same Multica board. **But the capability details diverge significantly**: whether session resumption actually works, whether MCP is supported, where skill files live, how models are selected. This page is the full matrix.
+Multica ships with built-in support for **15 AI coding tools**. They all implement the same interface — queue, dispatch, execute, return results — so you can drive any of them from the same Multica board. **But the capability details diverge significantly**: whether session resumption actually works, whether MCP is supported, where skill files live, how models are selected. This page is the full matrix.
 
 For guidance on picking a tool when creating an agent, see [Creating and configuring agents](/agents-create).
 
@@ -19,6 +19,7 @@ For guidance on picking a tool when creating an agent, see [Creating and configu
 | **Codex** | OpenAI | ✅ | ✅ | `$CODEX_HOME/skills/` | Static |
 | **Copilot** | GitHub | ✅ | ❌ | `.github/skills/` | Static (determined by account entitlement) |
 | **Cursor** | Anysphere | ✅ | ✅ | `.cursor/skills/` | Dynamic discovery |
+| **DevEco Code** | Huawei | ✅ | ❌ | `.deveco/skills/` | Dynamic discovery (`deveco models`) |
 | **Hermes** | Nous Research | ✅ | ✅ | `.agent_context/skills/` (fallback) | Dynamic discovery |
 | **Kimi** | Moonshot | ✅ | ✅ | `.kimi/skills/` | Dynamic discovery |
 | **Kiro CLI** | Amazon | ✅ | ✅ | `.kiro/skills/` | Dynamic discovery |
@@ -53,6 +54,10 @@ From GitHub. Model routing goes through your GitHub account entitlement — the 
 ### Cursor
 
 From Anysphere, the CLI counterpart to the Cursor editor. **Session resumption works** with current Cursor Agent releases: the stream-json event includes a `session_id`, and Multica passes it back with `--resume <id>` on the next run. MCP config is materialized into the task workspace's `.cursor/mcp.json`, with Cursor's project approval file written under a per-task `CURSOR_DATA_DIR` so managed MCP servers do not depend on the user's global Cursor approvals.
+
+### DevEco Code
+
+From Huawei — their HarmonyOS coding-agent CLI (`deveco`, [gitcode.com/openharmony-sig/deveco-code](https://gitcode.com/openharmony-sig/deveco-code)). Multica drives it the same way as OpenCode: `deveco run --format json` emits an NDJSON event stream that Multica parses. **Session resumption works** through `--session <id>`, and models are discovered dynamically from `deveco models` (the built-in provider ships `deveco/GLM-5.1`). System context is delivered through the per-task `AGENTS.md` the daemon writes (DevEco's `run` subcommand has no `--prompt` flag). **MCP is not wired up yet** — DevEco reads inline config from `DEVECO_CONFIG_CONTENT`, but plumbing `mcp_config` through it is planned; for now the MCP tab is hidden for DevEco agents. Authenticate with `deveco auth login` (Huawei account).
 
 ### Hermes
 
@@ -109,7 +114,7 @@ The session resumption mechanism is covered in [Tasks](/tasks#can-a-task-continu
 
 ## MCP configuration: provider-specific support
 
-**Of the 14 tools, eleven consume `mcp_config`: Claude Code, CodeBuddy, Codex, Cursor, Hermes, Kimi, Kiro CLI, OpenCode, OpenClaw, Qoder, and Trae**. The other three (Antigravity, Copilot, Pi) accept the field but **ignore it** — no error, no warning, the config just has no effect.
+**Of the 15 tools, eleven consume `mcp_config`: Claude Code, CodeBuddy, Codex, Cursor, Hermes, Kimi, Kiro CLI, OpenCode, OpenClaw, Qoder, and Trae**. The other four (Antigravity, Copilot, DevEco Code, Pi) accept the field but **ignore it** — no error, no warning, the config just has no effect.
 
 The runtime paths are provider-specific: Claude Code and CodeBuddy receive it through `--mcp-config` paired with `--strict-mcp-config`; Codex writes a daemon-managed `mcp_servers` block into the per-task `$CODEX_HOME/config.toml`; Cursor writes `.cursor/mcp.json` plus per-task project approvals under `CURSOR_DATA_DIR`; Hermes, Kimi, Kiro CLI, Qoder, and Trae receive ACP `mcpServers`; OpenCode receives inline config through `OPENCODE_CONFIG_CONTENT`; OpenClaw receives `mcp.servers` through Multica's per-task config wrapper. OpenCode's path does **not** rewrite the project's `opencode.json`.
 
@@ -131,6 +136,7 @@ Each tool uses **its own** skill discovery path. Before a task runs, the Multica
 | Kimi | `.kimi/skills/` | ✅ Native |
 | Kiro CLI | `.kiro/skills/` | ✅ Native |
 | OpenCode | `.opencode/skills/` | ✅ Native |
+| DevEco Code | `.deveco/skills/` | ✅ Native |
 | Pi | `.pi/skills/` | ✅ Native |
 | Qoder | `.qoder/skills/` | ✅ Native |
 | Antigravity | `.agents/skills/` | ✅ Native (inherits Gemini CLI's workspace layout — see [Antigravity docs](https://antigravity.google/docs/gcli-migration)) |

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -102,6 +102,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "codex",
   "copilot",
   "opencode",
+  "deveco",
   "openclaw",
   "hermes",
   "pi",

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -75,6 +75,20 @@ function OpenCodeLogo({ className }: { className: string }) {
   );
 }
 
+// DevEco Code — placeholder "D" monogram. No official Huawei DevEco Code mark
+// is bundled yet; swap this for the official asset when available.
+function DevecoLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-label="DevEco Code">
+      <rect x="2" y="2" width="20" height="20" rx="5" fill="currentColor" />
+      <path
+        d="M9 7h3.6c2.8 0 4.6 1.9 4.6 5s-1.8 5-4.6 5H9V7Zm2.2 2v6h1.3c1.5 0 2.4-1.1 2.4-3s-.9-3-2.4-3h-1.3Z"
+        fill="#fff"
+      />
+    </svg>
+  );
+}
+
 // OpenClaw — lobster mascot, vector version based on official branding
 function OpenClawLogo({ className }: { className: string }) {
   return (
@@ -274,6 +288,8 @@ export function ProviderLogo({
       return <CodexLogo className={className} />;
     case "opencode":
       return <OpenCodeLogo className={className} />;
+    case "deveco":
+      return <DevecoLogo className={className} />;
     case "openclaw":
       return <OpenClawLogo className={className} />;
     case "hermes":

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -266,6 +266,9 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if e, ok := probe("MULTICA_OPENCODE_PATH", "opencode", "MULTICA_OPENCODE_MODEL"); ok {
 		agents["opencode"] = e
 	}
+	if e, ok := probe("MULTICA_DEVECO_PATH", "deveco", "MULTICA_DEVECO_MODEL"); ok {
+		agents["deveco"] = e
+	}
 	if e, ok := probe("MULTICA_OPENCLAW_PATH", "openclaw", "MULTICA_OPENCLAW_MODEL"); ok {
 		agents["openclaw"] = e
 	}
@@ -312,7 +315,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		agents["traecli"] = e
 	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor-agent, kimi, kiro-cli, agy, qodercli, or traecli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codebuddy, codex, copilot, opencode, deveco, openclaw, hermes, pi, cursor-agent, kimi, kiro-cli, agy, qodercli, or traecli and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -254,6 +254,13 @@ func skillsDirPath(workDir, provider string) string {
 		// without those, OpenCode walks from the daemon's inherited PWD and
 		// misses .opencode/skills + AGENTS.md entirely (MUL-2416).
 		return filepath.Join(workDir, ".opencode", "skills")
+	case "deveco":
+		// DevEco Code (Huawei's OpenCode fork) natively discovers project
+		// skills from .deveco/skills/ in the workdir, mirroring OpenCode's
+		// .opencode/skills layout under its DEVECO_-prefixed brand. Discovery
+		// is anchored at the task workdir via `deveco run --dir <workDir>` +
+		// the PWD override in devecoBackend, same anchor OpenCode uses.
+		return filepath.Join(workDir, ".deveco", "skills")
 	case "openclaw":
 		// OpenClaw's native skill scanner reads <workspaceDir>/skills/. The
 		// daemon pairs this with a per-task synthesized openclaw-config.json

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -160,6 +160,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For Copilot:  writes {workDir}/AGENTS.md  (skills discovered natively from .github/skills/)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .opencode/skills/)
+// For DevEco Code: writes {workDir}/AGENTS.md  (skills discovered natively from .deveco/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from {workDir}/skills/ via per-task openclaw-config.json that pins agents.defaults.workspace)
 // For Hermes:   writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; AGENTS.md points there)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from .pi/skills/)
@@ -188,7 +189,7 @@ func runtimeConfigPath(workDir, provider string) string {
 	switch provider {
 	case "claude", "codebuddy":
 		return filepath.Join(workDir, "CLAUDE.md")
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder", "traecli":
+	case "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder", "traecli":
 		return filepath.Join(workDir, "AGENTS.md")
 	default:
 		return ""
@@ -752,7 +753,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude", "codebuddy":
 			// Claude/CodeBuddy discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro", "qoder", "antigravity", "traecli":
+		case "codex", "copilot", "opencode", "deveco", "openclaw", "pi", "cursor", "kimi", "kiro", "qoder", "antigravity", "traecli":
 			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, Kiro, Qoder,
 			// and Antigravity discover skills natively from their respective paths.
 			// For OpenClaw, the daemon also writes a per-task openclaw-config.json

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -420,7 +420,7 @@ func writeSkills(b *strings.Builder, provider string, ctx TaskContextForEnv) {
 	switch provider {
 	case "claude", "codebuddy":
 		b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro", "qoder", "antigravity":
+	case "codex", "copilot", "opencode", "deveco", "openclaw", "pi", "cursor", "kimi", "kiro", "qoder", "antigravity":
 		b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 	case "hermes":
 		b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")

--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -124,6 +124,8 @@ func localSkillRootsForProvider(provider string) ([]localSkillRoot, bool, error)
 		providerRoot = filepath.Join(home, ".copilot", "skills")
 	case "opencode":
 		providerRoot = filepath.Join(home, ".config", "opencode", "skills")
+	case "deveco":
+		providerRoot = filepath.Join(home, ".config", "deveco", "skills")
 	case "openclaw":
 		providerRoot = filepath.Join(home, ".openclaw", "skills")
 	case "pi":

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -51,7 +51,7 @@ func gitEnv() []string {
 	)
 }
 
-var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode"}
+var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode", ".deveco"}
 
 const repoCacheGitTimeout = 10 * time.Minute
 

--- a/server/internal/metrics/labels.go
+++ b/server/internal/metrics/labels.go
@@ -125,6 +125,7 @@ var (
 		"multica_agent": "multica_agent",
 		"openclaw":      "openclaw",
 		"opencode":      "opencode",
+		"deveco":        "deveco",
 		"pi":            "pi",
 		"other":         "other",
 	}

--- a/server/migrations/134_runtime_profile_add_deveco.down.sql
+++ b/server/migrations/134_runtime_profile_add_deveco.down.sql
@@ -1,0 +1,19 @@
+-- Reverse migration 134: remove 'deveco' from the runtime_profile
+-- protocol_family whitelist, restoring the post-126 set.
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity'
+    )) NOT VALID;

--- a/server/migrations/134_runtime_profile_add_deveco.up.sql
+++ b/server/migrations/134_runtime_profile_add_deveco.up.sql
@@ -1,0 +1,22 @@
+-- Add 'deveco' (DevEco Code, Huawei's OpenCode fork) to the runtime_profile
+-- protocol_family whitelist. Mirrors the drop/re-add NOT VALID pattern from
+-- migration 126 so historical rows are not revalidated. Kept in lockstep with
+-- agent.SupportedTypes and agent.New() (see server/pkg/agent/agent.go).
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'deveco',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
-// coding agents (Claude Code, CodeBuddy, Codex, Copilot, OpenCode, OpenClaw,
-// Hermes, Pi, Cursor, Kimi, Kiro, Antigravity, Qoder). It mirrors the
+// coding agents (Claude Code, CodeBuddy, Codex, Copilot, OpenCode, DevEco Code,
+// OpenClaw, Hermes, Pi, Cursor, Kimi, Kiro, Antigravity, Qoder). It mirrors the
 // happy-cli AgentBackend pattern, translated to idiomatic Go.
 package agent
 
@@ -133,7 +133,7 @@ type Config struct {
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder", "traecli".
+// Supported types: "claude", "codebuddy", "codex", "copilot", "opencode", "deveco", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "antigravity", "qoder", "traecli".
 //
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
@@ -147,6 +147,7 @@ var SupportedTypes = []string{
 	"codex",
 	"copilot",
 	"opencode",
+	"deveco",
 	"openclaw",
 	"hermes",
 	"pi",
@@ -184,6 +185,8 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &copilotBackend{cfg: cfg}, nil
 	case "opencode":
 		return &opencodeBackend{cfg: cfg}, nil
+	case "deveco":
+		return &devecoBackend{cfg: cfg}, nil
 	case "openclaw":
 		return &openclawBackend{cfg: cfg}, nil
 	case "hermes":
@@ -203,7 +206,7 @@ func New(agentType string, cfg Config) (Backend, error) {
 	case "traecli":
 		return &traecliBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, kiro, antigravity, qoder, traecli)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codebuddy, codex, copilot, opencode, deveco, openclaw, hermes, pi, cursor, kimi, kiro, antigravity, qoder, traecli)", agentType)
 	}
 }
 
@@ -225,6 +228,7 @@ var launchHeaders = map[string]string{
 	"codex":       "codex app-server",
 	"copilot":     "copilot (json)",
 	"cursor":      "cursor-agent (stream-json)",
+	"deveco":      "deveco run (json)",
 	"hermes":      "hermes acp",
 	"kimi":        "kimi acp",
 	"kiro":        "kiro-cli acp",

--- a/server/pkg/agent/agent_supported_types_test.go
+++ b/server/pkg/agent/agent_supported_types_test.go
@@ -38,7 +38,7 @@ func TestSupportedTypesLockstepWithNew(t *testing.T) {
 func TestSupportedTypesMatchesMigrationWhitelist(t *testing.T) {
 	want := map[string]bool{
 		"claude": true, "codebuddy": true, "codex": true, "copilot": true,
-		"opencode": true, "openclaw": true, "hermes": true,
+		"opencode": true, "deveco": true, "openclaw": true, "hermes": true,
 		"pi": true, "cursor": true, "kimi": true, "kiro": true, "antigravity": true,
 	}
 	if len(SupportedTypes) != len(want) {

--- a/server/pkg/agent/deveco.go
+++ b/server/pkg/agent/deveco.go
@@ -1,0 +1,455 @@
+package agent
+
+// This file implements the DevEco Code backend as a fully self-contained,
+// independent agent. DevEco Code (the `deveco` CLI, Huawei's HarmonyOS
+// coding-agent CLI at https://gitcode.com/openharmony-sig/deveco-code) is a
+// separate product maintained by a different company. It is intentionally kept
+// decoupled from the OpenCode backend: it owns its own backend struct, event
+// types, blocked-args table, and process lifecycle, so a change to either agent
+// can never affect the other. The two share only the package-wide generic
+// process helpers (configureProcessGroup, filterCustomArgs, trySend, …) that
+// every backend in this package reuses.
+//
+// DevEco speaks the same `run --format json` protocol and emits the same NDJSON
+// event stream as upstream OpenCode (it is forked from it), so the event schema
+// below mirrors that shape. Two deliberate differences from the OpenCode
+// integration:
+//
+//  1. No `--prompt` flag — DevEco's `run` subcommand does not expose it
+//     (verified via `deveco run --help`). System context therefore reaches the
+//     CLI through the per-task AGENTS.md the daemon writes, the same file-based
+//     channel the daemon relies on for OpenCode in production.
+//
+//  2. No inline MCP injection yet — DevEco reads MCP from DEVECO_CONFIG_CONTENT
+//     (its DEVECO_-prefixed mirror of OPENCODE_CONFIG_CONTENT), but plumbing
+//     agent.mcp_config through it is deferred to a follow-up so this backend
+//     stays self-contained. The UI hides the MCP tab for deveco in the meantime
+//     (see packages/core/agents/mcp-support.ts).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// devecoTerminateGraceNanos optionally overrides, in nanoseconds, how long a
+// cancelled deveco process is given to exit after SIGTERM before it (and its
+// whole process group) is SIGKILLed. Zero means use the default. It is atomic
+// so tests can shorten the grace without racing the cancellation goroutine that
+// reads it.
+var devecoTerminateGraceNanos atomic.Int64
+
+func devecoTerminateGrace() time.Duration {
+	if n := devecoTerminateGraceNanos.Load(); n > 0 {
+		return time.Duration(n)
+	}
+	return 5 * time.Second
+}
+
+// devecoBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. DevEco's `run` subcommand exposes
+// the same daemon-managed flags as OpenCode's.
+var devecoBlockedArgs = map[string]blockedArgMode{
+	"--format":                       blockedWithValue,  // json output format for daemon communication
+	"--dir":                          blockedWithValue,  // task workdir anchor for skill / AGENTS.md discovery
+	"--variant":                      blockedWithValue,  // owned by agent.thinking_level
+	"--dangerously-skip-permissions": blockedStandalone, // daemon manages non-interactive permission prompts
+}
+
+// devecoBackend implements Backend by spawning `deveco run --format json` and
+// reading streaming JSON events from stdout.
+type devecoBackend struct {
+	cfg Config
+}
+
+func (b *devecoBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "deveco"
+	}
+	resolved, err := exec.LookPath(execPath)
+	if err != nil {
+		return nil, fmt.Errorf("deveco executable not found at %q: %w", execPath, err)
+	}
+	execPath = resolved
+
+	timeout := opts.Timeout
+	runCtx, cancel := runContext(ctx, timeout)
+
+	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
+	// Anchor DevEco's project discovery (AGENTS.md walk-up + .deveco/skills/
+	// project config scan) at the task workdir, mirroring the OpenCode anchor:
+	// without --dir, DevEco falls back to PWD (inherited from the daemon) or
+	// process.cwd(), which in self-host deployments can resolve to the user's
+	// shell working directory and silently bypass the per-task workdir. PWD is
+	// also overridden below for the same reason.
+	if opts.Cwd != "" {
+		args = append(args, "--dir", opts.Cwd)
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	if opts.ThinkingLevel != "" {
+		args = append(args, "--variant", opts.ThinkingLevel)
+	}
+	// DevEco's `run` subcommand has no --prompt flag, so SystemPrompt is
+	// intentionally not forwarded; system context is delivered via the
+	// per-task AGENTS.md the daemon writes for deveco.
+	if opts.MaxTurns > 0 {
+		b.cfg.Logger.Warn("deveco does not support --max-turns; ignoring", "maxTurns", opts.MaxTurns)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--session", opts.ResumeSessionID)
+	}
+	args = append(args, filterCustomArgs(opts.CustomArgs, devecoBlockedArgs, b.cfg.Logger)...)
+	args = append(args, prompt)
+
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
+	// Run deveco in its own process group so cancellation can reach the whole
+	// tree (deveco plus any tool subprocess it spawns), not just the direct
+	// child — otherwise a cancelled or restarted run can orphan a descendant.
+	configureProcessGroup(cmd)
+	// Take over context cancellation: drive a graceful, group-wide
+	// SIGTERM→SIGKILL from the cancellation goroutine below and close the
+	// stdout read end only after the tree has been signalled. Returning nil
+	// here keeps os/exec from racing us with its own kill; WaitDelay is the
+	// hard backstop.
+	cmd.Cancel = func() error { return nil }
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
+	cmd.WaitDelay = 10 * time.Second
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+
+	env := buildEnv(b.cfg.Env)
+	// Override PWD so the child DevEco process resolves its discovery root to
+	// the task workdir. cmd.Dir alone is not enough: DevEco reads PWD
+	// (inherited from the parent daemon) before falling back to process.cwd()
+	// when computing the directory it walks for AGENTS.md / .deveco/skills.
+	if opts.Cwd != "" {
+		env = append(env, "PWD="+opts.Cwd)
+	}
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("deveco stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[deveco:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start deveco: %w", err)
+	}
+
+	b.cfg.Logger.Info("deveco started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	// procDone closes once cmd.Wait() returns, letting the cancellation handler
+	// skip a process that already exited and avoid signalling a dead pid.
+	procDone := make(chan struct{})
+
+	// On cancellation / timeout, terminate deveco (and the tool subprocesses it
+	// spawned) BEFORE unblocking the scanner. Closing the stdout read end
+	// immediately would leave deveco writing into a closed pipe (EPIPE), which
+	// can spin the orphaned process at 100% CPU. Instead SIGTERM the whole
+	// process group, give it a grace period to exit cleanly, then SIGKILL it.
+	// Only then is it safe to close the stdout read end as a last-resort
+	// unblock for a scanner that a wedged descendant still keeps open.
+	go func() {
+		select {
+		case <-procDone:
+			return // finished on its own; nothing to terminate
+		case <-runCtx.Done():
+		}
+		if cmd.Process != nil {
+			signalProcessGroup(cmd.Process, syscall.SIGTERM)
+			select {
+			case <-procDone: // exited within the grace window
+			case <-time.After(devecoTerminateGrace()):
+				signalProcessGroup(cmd.Process, syscall.SIGKILL)
+			}
+		}
+		_ = stdout.Close()
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		scanResult := b.processEvents(stdout, msgCh)
+
+		exitErr := cmd.Wait()
+		close(procDone)
+		duration := time.Since(startTime)
+
+		if runCtx.Err() == context.DeadlineExceeded {
+			scanResult.status = "timeout"
+			scanResult.errMsg = fmt.Sprintf("deveco timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			scanResult.status = "aborted"
+			scanResult.errMsg = "execution cancelled"
+		} else if exitErr != nil && scanResult.status == "completed" {
+			scanResult.status = "failed"
+			scanResult.errMsg = fmt.Sprintf("deveco exited with error: %v", exitErr)
+		}
+
+		b.cfg.Logger.Info("deveco finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())
+
+		// Build usage map. DevEco doesn't report model per-step, so attribute
+		// all usage to the configured model (or "unknown").
+		var usage map[string]TokenUsage
+		u := scanResult.usage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usage = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     scanResult.status,
+			Output:     scanResult.output,
+			Error:      scanResult.errMsg,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  scanResult.sessionID,
+			Usage:      usage,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// ── Event handlers ──
+
+// devecoEventResult holds the accumulated state from processing the event stream.
+type devecoEventResult struct {
+	status    string
+	errMsg    string
+	output    string
+	sessionID string
+	usage     TokenUsage // accumulated token usage across all steps
+}
+
+// processEvents reads JSON lines from r, dispatches events to ch, and returns
+// the accumulated result. This is the core scanner loop, extracted for testability.
+func (b *devecoBackend) processEvents(r io.Reader, ch chan<- Message) devecoEventResult {
+	var output strings.Builder
+	var sessionID string
+	var usage TokenUsage
+	finalStatus := "completed"
+	var finalError string
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var event devecoEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+
+		if event.SessionID != "" {
+			sessionID = event.SessionID
+		}
+
+		switch event.Type {
+		case "text":
+			b.handleTextEvent(event, ch, &output)
+		case "tool_use":
+			b.handleToolUseEvent(event, ch)
+		case "error":
+			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
+		case "step_start":
+			trySend(ch, Message{Type: MessageStatus, Status: "running"})
+		case "step_finish":
+			// Accumulate token usage from step_finish events.
+			if t := event.Part.Tokens; t != nil {
+				usage.InputTokens += t.Input
+				usage.OutputTokens += t.Output
+				if t.Cache != nil {
+					usage.CacheReadTokens += t.Cache.Read
+					usage.CacheWriteTokens += t.Cache.Write
+				}
+			}
+		}
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		b.cfg.Logger.Warn("deveco stdout scanner error", "error", scanErr)
+		if finalStatus == "completed" {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("stdout read error: %v", scanErr)
+		}
+	}
+
+	return devecoEventResult{
+		status:    finalStatus,
+		errMsg:    finalError,
+		output:    output.String(),
+		sessionID: sessionID,
+		usage:     usage,
+	}
+}
+
+func (b *devecoBackend) handleTextEvent(event devecoEvent, ch chan<- Message, output *strings.Builder) {
+	text := event.Part.Text
+	if text != "" {
+		output.WriteString(text)
+		trySend(ch, Message{Type: MessageText, Content: text})
+	}
+}
+
+// handleToolUseEvent processes "tool_use" events. A single tool_use event
+// contains both the call and result in part.state when the tool has completed
+// (state.status == "completed").
+func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message) {
+	var input map[string]any
+	if event.Part.State != nil && event.Part.State.Input != nil {
+		_ = json.Unmarshal(event.Part.State.Input, &input)
+	}
+
+	trySend(ch, Message{
+		Type:   MessageToolUse,
+		Tool:   event.Part.Tool,
+		CallID: event.Part.CallID,
+		Input:  input,
+	})
+
+	if event.Part.State != nil && event.Part.State.Status == "completed" {
+		outputStr := extractDevecoToolOutput(event.Part.State.Output)
+		trySend(ch, Message{
+			Type:   MessageToolResult,
+			Tool:   event.Part.Tool,
+			CallID: event.Part.CallID,
+			Output: outputStr,
+		})
+	}
+}
+
+// handleErrorEvent processes "error" events. DevEco can exit with RC=0 even on
+// errors (e.g. invalid model), so error events are the reliable failure signal.
+func (b *devecoBackend) handleErrorEvent(event devecoEvent, ch chan<- Message, finalStatus, finalError *string) {
+	errMsg := ""
+	if event.Error != nil {
+		errMsg = event.Error.Message()
+	}
+	if errMsg == "" {
+		errMsg = "unknown deveco error"
+	}
+
+	b.cfg.Logger.Warn("deveco error event", "error", errMsg)
+	trySend(ch, Message{Type: MessageError, Content: errMsg})
+
+	*finalStatus = "failed"
+	*finalError = errMsg
+}
+
+// extractDevecoToolOutput converts the tool state output (which may be a string
+// or a structured object) into a string.
+func extractDevecoToolOutput(output any) string {
+	if output == nil {
+		return ""
+	}
+	if s, ok := output.(string); ok {
+		return s
+	}
+	data, _ := json.Marshal(output)
+	return string(data)
+}
+
+// ── JSON types for `deveco run --format json` stdout events ──
+//
+// DevEco emits the same NDJSON event schema as upstream OpenCode. Event types
+// observed in real output:
+//
+//	"step_start"  — agent step begins
+//	"text"        — text output from agent (part.text)
+//	"tool_use"    — tool invocation with call and result (part.tool, part.callID, part.state)
+//	"error"       — error from deveco (error.name, error.data.message)
+//	"step_finish" — agent step completes (includes token usage)
+type devecoEvent struct {
+	Type      string          `json:"type"`
+	Timestamp int64           `json:"timestamp,omitempty"`
+	SessionID string          `json:"sessionID,omitempty"`
+	Part      devecoEventPart `json:"part"`
+	Error     *devecoError    `json:"error,omitempty"`
+}
+
+// devecoEventPart represents the part field in a deveco event.
+type devecoEventPart struct {
+	ID        string `json:"id,omitempty"`
+	MessageID string `json:"messageID,omitempty"`
+	SessionID string `json:"sessionID,omitempty"`
+	Type      string `json:"type,omitempty"`
+
+	// Text events
+	Text string `json:"text,omitempty"`
+
+	// Tool use events
+	Tool   string           `json:"tool,omitempty"`
+	CallID string           `json:"callID,omitempty"`
+	State  *devecoToolState `json:"state,omitempty"`
+
+	// step_finish token usage
+	Tokens *devecoTokens `json:"tokens,omitempty"`
+}
+
+// devecoTokens represents token usage in a step_finish event.
+type devecoTokens struct {
+	Input  int64              `json:"input"`
+	Output int64              `json:"output"`
+	Cache  *devecoCacheTokens `json:"cache,omitempty"`
+}
+
+type devecoCacheTokens struct {
+	Read  int64 `json:"read"`
+	Write int64 `json:"write"`
+}
+
+// devecoToolState represents the state of a tool invocation.
+type devecoToolState struct {
+	Status string          `json:"status,omitempty"`
+	Input  json.RawMessage `json:"input,omitempty"`
+	Output any             `json:"output,omitempty"`
+}
+
+// devecoError represents an error event from deveco.
+type devecoError struct {
+	Name string         `json:"name,omitempty"`
+	Data *devecoErrData `json:"data,omitempty"`
+}
+
+// Message returns the human-readable error message.
+func (e *devecoError) Message() string {
+	if e.Data != nil && e.Data.Message != "" {
+		return e.Data.Message
+	}
+	if e.Name != "" {
+		return e.Name
+	}
+	return ""
+}
+
+type devecoErrData struct {
+	Message string `json:"message,omitempty"`
+}

--- a/server/pkg/agent/deveco_models.go
+++ b/server/pkg/agent/deveco_models.go
@@ -1,0 +1,82 @@
+package agent
+
+// DevEco Code model discovery. Self-contained and independent of the OpenCode
+// model parser: DevEco maintains its own catalog and CLI, so its discovery code
+// lives here rather than reusing parseOpenCodeModels. A missing CLI or empty
+// catalog returns an empty list so the caller (the runtime model picker) falls
+// back to manual model entry instead of erroring.
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// discoverDevecoModels enumerates the `deveco models` catalog. It shells out to
+// the DevEco Code CLI and parses `provider/model` rows. Discovery failures
+// (binary missing, non-zero exit, unparseable output) silently yield an empty
+// list so model selection degrades to manual entry rather than blocking.
+func discoverDevecoModels(ctx context.Context, executablePath string) ([]Model, error) {
+	if executablePath == "" {
+		executablePath = "deveco"
+	}
+	if _, err := exec.LookPath(executablePath); err != nil {
+		return []Model{}, nil
+	}
+	// `deveco models` may sync its hosted catalog over the network on first
+	// run; allow a generous timeout so the picker isn't empty on a cold start.
+	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, executablePath, "models")
+	hideAgentWindow(cmd)
+	out, _ := cmd.Output()
+	models := parseDevecoModels(string(out))
+	if len(models) == 0 {
+		return []Model{}, nil
+	}
+	return models, nil
+}
+
+// parseDevecoModels extracts `provider/model` IDs from `deveco models` output.
+// Each non-empty line's first whitespace-delimited token is treated as a model
+// id when it contains a `/` and does not look like a header row or JSON. Output
+// is de-duplicated, preserving first-seen order. Per-model variant/thinking
+// annotation is not parsed here; the thinking-level picker is not offered for
+// DevEco in this revision (see thinking.go).
+func parseDevecoModels(output string) []Model {
+	var models []Model
+	seen := map[string]bool{}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		id := fields[0]
+		// Skip JSON objects/arrays, quoted strings, and header rows such as
+		// "PROVIDER/MODEL".
+		if strings.HasPrefix(id, "{") || strings.HasPrefix(id, "[") || strings.HasPrefix(id, "\"") {
+			continue
+		}
+		if !strings.Contains(id, "/") {
+			continue
+		}
+		if id == strings.ToUpper(id) {
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		provider := ""
+		if slash := strings.Index(id, "/"); slash > 0 {
+			provider = id[:slash]
+		}
+		models = append(models, Model{ID: id, Label: id, Provider: provider})
+	}
+	return models
+}

--- a/server/pkg/agent/deveco_test.go
+++ b/server/pkg/agent/deveco_test.go
@@ -1,0 +1,248 @@
+package agent
+
+// Tests for the DevEco Code backend. Self-contained: they use a deveco-specific
+// fake script and devecoEvent fixtures, and reuse only the package-wide generic
+// test helpers (writeTestExecutable, containsString, …) that every backend's
+// tests share. They do not depend on the OpenCode backend or its test fixtures.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"log/slog"
+)
+
+func TestNewReturnsDevecoBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("deveco", Config{ExecutablePath: "/nonexistent/deveco"})
+	if err != nil {
+		t.Fatalf("New(deveco) error: %v", err)
+	}
+	if _, ok := b.(*devecoBackend); !ok {
+		t.Fatalf("expected *devecoBackend, got %T", b)
+	}
+}
+
+// fakeDevecoScript impersonates the `deveco` CLI: it records argv to
+// $DEVECO_ARGS_FILE, then emits a minimal completed step on stdout so the
+// backend's event loop terminates, and exits 0.
+func fakeDevecoScript() string {
+	return `#!/bin/sh
+if [ -n "$DEVECO_ARGS_FILE" ]; then
+  for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$DEVECO_ARGS_FILE"
+  done
+fi
+printf '{"type":"step_start","timestamp":1,"sessionID":"ses_fake","part":{"type":"step-start"}}\n'
+printf '{"type":"text","timestamp":2,"sessionID":"ses_fake","part":{"type":"text","text":"ok"}}\n'
+printf '{"type":"step_finish","timestamp":3,"sessionID":"ses_fake","part":{"type":"step-finish","tokens":{"total":10,"input":7,"output":3,"cache":{"read":0,"write":0}}}}\n'
+`
+}
+
+// TestDevecoBackendArgvShapeAndNoPrompt pins the two DevEco differences from
+// the OpenCode backend: argv is `run --format json --dangerously-skip-permissions
+// --dir <wd> [--model …] [--variant …] [--session …] <prompt>`, and — crucially
+// — there is never a `--prompt` flag, because DevEco's `run` subcommand does not
+// accept one (it would reject the invocation).
+func TestDevecoBackendArgvShapeAndNoPrompt(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePath := filepath.Join(tempDir, "deveco")
+	writeTestExecutable(t, fakePath, []byte(fakeDevecoScript()))
+
+	workDir := t.TempDir()
+
+	backend, err := New("deveco", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"DEVECO_ARGS_FILE": argsFile},
+	})
+	if err != nil {
+		t.Fatalf("new deveco backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// SystemPrompt is set deliberately; the backend must NOT forward it as
+	// --prompt (DevEco has no such flag).
+	session, err := backend.Execute(ctx, "do the thing", ExecOptions{
+		Cwd:          workDir,
+		Model:        "deveco/GLM-5.1",
+		SystemPrompt: "you are a helpful agent",
+		Timeout:      5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	res := <-session.Result
+	if res.Status != "completed" {
+		t.Fatalf("result status = %q, error = %q; want completed", res.Status, res.Error)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	args := splitNonEmptyLines(string(raw))
+
+	if len(args) < 2 || args[0] != "run" {
+		t.Fatalf("expected first arg 'run', got %q", args)
+	}
+	if !containsAdjacent(args, "--format", "json") {
+		t.Errorf("expected --format json in argv: %v", args)
+	}
+	if !containsString(args, "--dangerously-skip-permissions") {
+		t.Errorf("expected --dangerously-skip-permissions in argv: %v", args)
+	}
+	if !containsAdjacent(args, "--dir", workDir) {
+		t.Errorf("expected --dir %q in argv: %v", workDir, args)
+	}
+	if !containsAdjacent(args, "--model", "deveco/GLM-5.1") {
+		t.Errorf("expected --model deveco/GLM-5.1 in argv: %v", args)
+	}
+	if containsString(args, "--prompt") {
+		t.Errorf("argv must NOT contain --prompt (DevEco has no such flag): %v", args)
+	}
+	// The prompt is the final positional arg.
+	if len(args) == 0 || args[len(args)-1] != "do the thing" {
+		t.Errorf("expected prompt as final positional arg, got %v", args)
+	}
+}
+
+// ── Event parsing tests with a real `deveco run --format json` fixture ──
+
+func TestDevecoEventParsingTextFixture(t *testing.T) {
+	t.Parallel()
+
+	// Real output captured from `deveco run "..." --format json`.
+	line := `{"type":"text","timestamp":1783090764802,"sessionID":"ses_0d78241f1ffeAi4CgaYW5ygSLt","part":{"id":"prt_x","messageID":"msg_x","sessionID":"ses_0d78241f1ffeAi4CgaYW5ygSLt","type":"text","text":"pong","time":{"start":1783090764733,"end":1783090764791}}}`
+
+	var event devecoEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if event.Type != "text" {
+		t.Errorf("type: got %q, want %q", event.Type, "text")
+	}
+	if event.SessionID != "ses_0d78241f1ffeAi4CgaYW5ygSLt" {
+		t.Errorf("sessionID: got %q", event.SessionID)
+	}
+	if event.Part.Text != "pong" {
+		t.Errorf("part.text: got %q, want %q", event.Part.Text, "pong")
+	}
+}
+
+func TestDevecoEventParsingStepFinishTokensFixture(t *testing.T) {
+	t.Parallel()
+
+	line := `{"type":"step_finish","timestamp":1783090764802,"sessionID":"ses_x","part":{"id":"prt_x","reason":"stop","messageID":"msg_x","type":"step-finish","tokens":{"total":11640,"input":11637,"output":3,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0}}`
+
+	var event devecoEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if event.Type != "step_finish" {
+		t.Fatalf("type: got %q, want %q", event.Type, "step_finish")
+	}
+	if event.Part.Tokens == nil {
+		t.Fatal("expected tokens")
+	}
+	if event.Part.Tokens.Input != 11637 || event.Part.Tokens.Output != 3 {
+		t.Errorf("tokens: input=%d output=%d, want 11637/3", event.Part.Tokens.Input, event.Part.Tokens.Output)
+	}
+	if event.Part.Tokens.Cache == nil || event.Part.Tokens.Cache.Read != 0 {
+		t.Errorf("cache tokens: %+v", event.Part.Tokens.Cache)
+	}
+}
+
+// ── processEvents integration test ──
+
+func TestDevecoProcessEventsHappyPath(t *testing.T) {
+	t.Parallel()
+
+	b := &devecoBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_happy","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1001,"sessionID":"ses_happy","part":{"type":"text","text":"working"}}`,
+		`{"type":"tool_use","timestamp":1002,"sessionID":"ses_happy","part":{"tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"ls"},"output":"a.go\n"}}}`,
+		`{"type":"step_finish","timestamp":1003,"sessionID":"ses_happy","part":{"type":"step-finish","tokens":{"total":10,"input":7,"output":3,"cache":{"read":0,"write":0}}}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
+	}
+	if result.sessionID != "ses_happy" {
+		t.Errorf("sessionID: got %q, want %q", result.sessionID, "ses_happy")
+	}
+	if result.output != "working" {
+		t.Errorf("output: got %q, want %q", result.output, "working")
+	}
+	if result.usage.InputTokens != 7 || result.usage.OutputTokens != 3 {
+		t.Errorf("usage: got %+v", result.usage)
+	}
+
+	close(ch)
+	var msgs []Message
+	for m := range ch {
+		msgs = append(msgs, m)
+	}
+	// status(running), text, tool-use, tool-result = 4 messages.
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d: %+v", len(msgs), msgs)
+	}
+}
+
+func TestDevecoProcessEventsErrorCausesFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	b := &devecoBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_err","part":{"type":"step-start"}}`,
+		`{"type":"error","timestamp":1001,"sessionID":"ses_err","error":{"name":"UnknownError","data":{"message":"Model not found: bad/model"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_err","part":{"type":"step-finish"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "failed" {
+		t.Errorf("status: got %q, want %q", result.status, "failed")
+	}
+	if result.errMsg != "Model not found: bad/model" {
+		t.Errorf("errMsg: got %q", result.errMsg)
+	}
+
+	close(ch)
+}
+
+func TestDevecoHandleErrorEventNilError(t *testing.T) {
+	t.Parallel()
+
+	b := &devecoBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 10)
+	status := "completed"
+	errMsg := ""
+
+	b.handleErrorEvent(devecoEvent{Type: "error"}, ch, &status, &errMsg)
+
+	if errMsg != "unknown deveco error" {
+		t.Errorf("error: got %q, want %q", errMsg, "unknown deveco error")
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -143,6 +143,10 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)
 		})
+	case "deveco":
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
+			return discoverDevecoModels(ctx, executablePath)
+		})
 	case "pi":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverPiModels(ctx, executablePath)


### PR DESCRIPTION
## Summary

Adds **DevEco Code** — Huawei's HarmonyOS coding-agent CLI (the `deveco` binary, an OpenCode fork: https://gitcode.com/openharmony-sig/deveco-code) — as a first-class runtime agent, selectable alongside OpenCode and the others.

DevEco speaks the same `run --format json` protocol and emits the same NDJSON event schema as upstream OpenCode, so the integration shape is familiar — but it is implemented as a **fully independent backend**.

## Independence from OpenCode (by design)

DevEco Code is a different company's product. Its backend is fully self-contained:

- New `server/pkg/agent/deveco.go` — own `devecoBackend`, own event types, own blocked-args table, own process lifecycle.
- New `server/pkg/agent/deveco_models.go` — own model discovery/parser (not a reuse of the OpenCode variant parser).
- **`opencode.go` is not modified.** A change to either backend can never affect the other; they share only the package-wide generic process helpers every backend already uses.

## Two verified behavioral differences from OpenCode

Confirmed against `deveco run --help` and a live run:

1. **No `--prompt` flag.** DevEco's `run` rejects unknown flags, so the backend never appends it. System context reaches the CLI through the per-task `AGENTS.md` (the same file-based channel OpenCode relies on in production).
2. **`DEVECO_` env prefix** (config under `~/.config/deveco/`, skills under `.deveco/skills/`).

## Deferred: MCP

DevEco reads MCP from `DEVECO_CONFIG_CONTENT`, but plumbing `agent.mcp_config` through it is **not** in this PR — doing it while keeping the two backends independent means DevEco owns its own translator rather than reusing OpenCode's. Until then the MCP tab is hidden for DevEco agents (no silent-ignore). DevEco works fully via its built-in tools.

## Changes
- **Backend**: `deveco.go`, `deveco_models.go`, registered in `agent.New`/`SupportedTypes`/`launchHeaders`/`ListModels`.
- **Daemon**: binary probe, AGENTS.md + `.deveco/skills` + `~/.config/deveco/skills` resolution, `.deveco` git-exclude, `deveco` metrics label.
- **Migration 134**: adds `deveco` to `runtime_profile.protocol_family` CHECK (drop/re-add `NOT VALID`, mirroring 126), in lockstep with `SupportedTypes`.
- **UI**: `deveco` in `RUNTIME_PROFILE_PROTOCOL_FAMILIES` + a placeholder `DevecoLogo` lettermark (swap for the official Huawei asset when available).
- **Docs**: providers matrix + install-agent-runtime section (English).

## Verification
- `go build ./...` clean; `go vet ./pkg/agent/` clean.
- `go test ./pkg/agent/ ./internal/daemon/... ./internal/metrics/...` — all pass, including new deveco tests and the lockstep whitelist test.
- **End-to-end with the real `deveco` binary**: `agent.New("deveco")` → `Execute("Reply with: pong")` → `status=completed`, `output="pong"`, session id captured.
- `pnpm typecheck` clean for `@multica/core` + `@multica/views`; unit tests green (752 + 1624).
- Migration not applied to a live DB here (no Postgres container), but the SQL mirrors production migration 126 and the whitelist is pinned by `TestSupportedTypesMatchesMigrationWhitelist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)