### PR TITLE
Fix mention tokenizer freeze on Java stack traces

### DIFF
--- a/packages/views/editor/extensions/mention-extension.test.ts
+++ b/packages/views/editor/extensions/mention-extension.test.ts
@@ -14,6 +14,17 @@ const renderMarkdown = BaseMentionExtension.config.renderMarkdown as (
   node: { attrs: Record<string, string> },
 ) => string;
 
+const JAVA_STACK_TRACE = [
+  "Caused by: java.lang.OutOfMemoryError: Java heap space",
+  "        at org.apache.commons.fileupload.disk.DiskFileItem.get(DiskFileItem.java:308) ~[commons-fileupload-1.5.jar!/:1.5]",
+  "        at org.springframework.web.multipart.commons.CommonsMultipartFile.getBytes(CommonsMultipartFile.java:143) ~[spring-web-5.3.39.jar!/:5.3.39]",
+  "        at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_342]",
+  "        at org.springframework.web.servlet.HandlerExecutionChain.applyPreHandle(HandlerExecutionChain.java:148) ~[spring-webmvc-5.3.39.jar!/:5.3.39]",
+  "        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067) ~[spring-webmvc-5.3.39.jar!/:5.3.39]",
+  "        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965) ~[spring-webmvc-5.3.39.jar!/:5.3.39]",
+  "        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.39.jar!/:5.3.39]",
+].join("\n");
+
 function tokenize(src: string) {
   const start = startFn(src);
   if (start === -1) return undefined;
@@ -88,5 +99,26 @@ describe("mention tokenizer", () => {
     expect(token!.attributes.label).toBe("MUL-123");
     expect(token!.attributes.type).toBe("issue");
     expect(token!.attributes.id).toBe("aaa-bbb");
+  });
+
+  it("does not treat Java jar source markers as mention candidates", () => {
+    const stackTrace = `${JAVA_STACK_TRACE}\n`.repeat(250);
+
+    expect(startFn(stackTrace)).toBe(-1);
+    expect(tokenize(stackTrace)).toBeUndefined();
+  });
+
+  it("still finds a mention after Java jar source markers", () => {
+    const src = [
+      JAVA_STACK_TRACE,
+      "Assigned to [@Worker](mention://agent/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)",
+    ].join("\n\n");
+
+    const token = tokenize(src);
+
+    expect(token).toBeDefined();
+    expect(token!.attributes.label).toBe("Worker");
+    expect(token!.attributes.type).toBe("agent");
+    expect(token!.attributes.id).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
   });
 });

--- a/packages/views/editor/extensions/mention-extension.ts
+++ b/packages/views/editor/extensions/mention-extension.ts
@@ -3,6 +3,74 @@ import { mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { MentionView } from "./mention-view";
 
+const MENTION_URL_PREFIX = "](mention://";
+const MAX_MENTION_LABEL_SOURCE_LENGTH = 512;
+
+function isEscaped(src: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && src[i] === "\\"; i--) slashCount++;
+  return slashCount % 2 === 1;
+}
+
+function parseMentionMarkdown(src: string) {
+  if (src[0] !== "[") return undefined;
+
+  const labelLimit = Math.min(src.length, 1 + MAX_MENTION_LABEL_SOURCE_LENGTH);
+  let labelEnd = -1;
+  for (let i = 1; i < labelLimit; i++) {
+    if (src[i] === "]" && !isEscaped(src, i) && src.startsWith(MENTION_URL_PREFIX, i)) {
+      labelEnd = i;
+      break;
+    }
+  }
+  if (labelEnd === -1) return undefined;
+
+  const rawLabel = src.slice(1, labelEnd);
+  if (!rawLabel) return undefined;
+
+  const typeStart = labelEnd + MENTION_URL_PREFIX.length;
+  let slashIndex = typeStart;
+  while (slashIndex < src.length && /\w/.test(src[slashIndex] ?? "")) slashIndex++;
+  if (slashIndex === typeStart || src[slashIndex] !== "/") return undefined;
+
+  const idStart = slashIndex + 1;
+  const idEnd = src.indexOf(")", idStart);
+  if (idEnd === -1 || idEnd === idStart) return undefined;
+
+  const labelWithoutPrefix = rawLabel.startsWith("@") ? rawLabel.slice(1) : rawLabel;
+  const label = labelWithoutPrefix.replace(/\\\[/g, "[").replace(/\\\]/g, "]");
+
+  return {
+    raw: src.slice(0, idEnd + 1),
+    label,
+    type: src.slice(typeStart, slashIndex),
+    id: src.slice(idStart, idEnd),
+  };
+}
+
+function findMentionMarkdownStart(src: string): number {
+  let searchFrom = 0;
+
+  while (searchFrom < src.length) {
+    const labelEnd = src.indexOf(MENTION_URL_PREFIX, searchFrom);
+    if (labelEnd === -1) return -1;
+    if (isEscaped(src, labelEnd)) {
+      searchFrom = labelEnd + 1;
+      continue;
+    }
+
+    const minOpen = Math.max(0, labelEnd - MAX_MENTION_LABEL_SOURCE_LENGTH);
+    for (let i = labelEnd - 1; i >= minOpen; i--) {
+      if (src[i] !== "[" || isEscaped(src, i)) continue;
+      if (parseMentionMarkdown(src.slice(i))) return i;
+    }
+
+    searchFrom = labelEnd + MENTION_URL_PREFIX.length;
+  }
+
+  return -1;
+}
+
 export const BaseMentionExtension = Mention.extend({
   addNodeView() {
     return ReactNodeViewRenderer(MentionView);
@@ -39,25 +107,15 @@ export const BaseMentionExtension = Mention.extend({
     name: "mention",
     level: "inline" as const,
     start(src: string) {
-      // Accept escaped brackets (\\[ \\]) and non-] chars in the label.
-      // This prevents matching ordinary Markdown links like [docs](url)
-      // that appear before a mention on the same line.
-      return src.search(/\[@?(?:\\.|[^\]])+\]\(mention:\/\//);
+      return findMentionMarkdownStart(src);
     },
     tokenize(src: string) {
-      // Label accepts escaped chars (\\[ \\]) or any non-] character.
-      // This prevents the label from crossing a ]( Markdown link boundary
-      // while still supporting bracket-containing names like "David\[TF\]".
-      const match = src.match(
-        /^\[@?((?:\\.|[^\]])+)\]\(mention:\/\/(\w+)\/([^)]+)\)/,
-      );
-      if (!match) return undefined;
-      // Unescape backslash-escaped brackets that renderMarkdown may produce.
-      const rawLabel = match[1]?.replace(/\\\[/g, "[").replace(/\\\]/g, "]");
+      const mention = parseMentionMarkdown(src);
+      if (!mention) return undefined;
       return {
         type: "mention",
-        raw: match[0],
-        attributes: { label: rawLabel, type: match[2] ?? "member", id: match[3] },
+        raw: mention.raw,
+        attributes: { label: mention.label, type: mention.type, id: mention.id },
       };
     },
   },


### PR DESCRIPTION
## What does this PR do?

Replaces the mention Markdown tokenizer's broad bracket regex with a literal `](mention://` scanner plus a bounded label parse. Java stack traces with many jar source markers like `~[spring-web-5.3.39.jar!/:5.3.39]` now stay on a cheap no-match path instead of being considered possible mentions.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4881

Multica issue: ZIC-27

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/extensions/mention-extension.ts`: parse mention markdown with a bounded scanner instead of a backtracking regex.
- `packages/views/editor/extensions/mention-extension.test.ts`: add Java stack-trace regression coverage and verify a valid mention after stack-trace text still parses.

## How to Test

1. `pnpm --filter @multica/views test -- editor/extensions/mention-extension.test.ts`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views lint`
4. `make check-worktree`

Validation notes:

- `pnpm --filter @multica/views test -- editor/extensions/mention-extension.test.ts` passed; Vitest ran the full `@multica/views` suite: 161 files, 1,626 tests.
- `pnpm --filter @multica/views typecheck` passed.
- `pnpm --filter @multica/views lint` passed with existing warnings only.
- `make check-worktree` returned exit 0 but printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock` while checking PostgreSQL, so the Docker-backed full-stack portion was not meaningfully exercised locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
I traced the freeze report to issue description loading through `ContentEditor`, where the Tiptap mention tokenizer runs while parsing Markdown. The old tokenizer searched for potential mentions by treating bracketed text broadly; this change first looks for the literal mention URL marker, then parses only a small bounded label window around it. That keeps non-mention stack traces linear while preserving normal mention links and escaped bracket labels.

## Screenshots (optional)

Not applicable; this is parser behavior with unit test coverage.
