### PR TITLE
[ZIC-28] Fix squad leader member wakeup mentions

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1042,6 +1043,7 @@ type commentAgentTrigger struct {
 
 type commentTriggerComputeOptions struct {
 	ExcludeTriggerCommentID pgtype.UUID
+	SourceTaskID            pgtype.UUID
 	// OriginatorUserID is the top-of-chain human user id for this trigger
 	// (MUL-3963). Only consulted for AGENT actors — canInvokeAgent judges A2A
 	// by the originator, not the immediate agent principal. Members are their
@@ -1356,6 +1358,7 @@ func (h *Handler) triggerTasksForComment(ctx context.Context, issue db.Issue, co
 	}
 	triggers := h.computeCommentAgentTriggers(ctx, issue, comment.Content, parentComment, actorType, actorID, commentTriggerComputeOptions{
 		ExcludeTriggerCommentID: comment.ID,
+		SourceTaskID:            comment.SourceTaskID,
 		OriginatorUserID:        originatorUserID,
 	})
 	triggers = filterSuppressedCommentAgentTriggers(triggers, suppressAgentIDs)
@@ -1472,6 +1475,10 @@ func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issu
 		return nil
 	}
 
+	if !hasRoutingMention(mentions) {
+		mentions = h.resolvePlainSquadLeaderAgentMentions(ctx, issue, content, actorType, actorID, opts)
+	}
+
 	if hasAgentOrSquadMention(mentions) {
 		return h.resolveMentionedAgentCommentTriggers(ctx, issue, mentions, actorType, actorID, opts)
 	}
@@ -1554,6 +1561,95 @@ func hasMemberMention(mentions []util.Mention) bool {
 		}
 	}
 	return false
+}
+
+func hasRoutingMention(mentions []util.Mention) bool {
+	for _, m := range mentions {
+		if m.Type == "agent" || m.Type == "squad" || m.Type == "member" || m.Type == "all" {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) resolvePlainSquadLeaderAgentMentions(ctx context.Context, issue db.Issue, content, authorType, authorID string, opts commentTriggerComputeOptions) []util.Mention {
+	if authorType != "agent" || !opts.SourceTaskID.Valid {
+		return nil
+	}
+
+	task, err := h.Queries.GetAgentTask(ctx, opts.SourceTaskID)
+	if err != nil ||
+		!task.IssueID.Valid ||
+		uuidToString(task.IssueID) != uuidToString(issue.ID) ||
+		!task.AgentID.Valid ||
+		uuidToString(task.AgentID) != authorID ||
+		!task.IsLeaderTask ||
+		!task.SquadID.Valid {
+		return nil
+	}
+
+	squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+		ID:          task.SquadID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil || uuidToString(squad.LeaderID) != authorID {
+		return nil
+	}
+
+	members, err := h.Queries.ListSquadMembers(ctx, squad.ID)
+	if err != nil {
+		return nil
+	}
+
+	type plainMentionCandidate struct {
+		name string
+		id   string
+	}
+	candidates := make([]plainMentionCandidate, 0)
+	ambiguousNames := make(map[string]bool)
+	matchedByName := make(map[string]string)
+	for _, member := range members {
+		if member.MemberType != "agent" || uuidToString(member.MemberID) == authorID {
+			continue
+		}
+		agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          member.MemberID,
+			WorkspaceID: issue.WorkspaceID,
+		})
+		if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+			continue
+		}
+		name := strings.TrimSpace(agent.Name)
+		if name == "" || !containsPlainAtName(content, name) {
+			continue
+		}
+		nameKey := strings.ToLower(name)
+		if prevID, ok := matchedByName[nameKey]; ok && prevID != uuidToString(agent.ID) {
+			ambiguousNames[nameKey] = true
+			continue
+		}
+		matchedByName[nameKey] = uuidToString(agent.ID)
+		candidates = append(candidates, plainMentionCandidate{name: nameKey, id: uuidToString(agent.ID)})
+	}
+
+	mentions := make([]util.Mention, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if ambiguousNames[candidate.name] {
+			continue
+		}
+		if _, ok := seen[candidate.id]; ok {
+			continue
+		}
+		seen[candidate.id] = struct{}{}
+		mentions = append(mentions, util.Mention{Type: "agent", ID: candidate.id})
+	}
+	return mentions
+}
+
+func containsPlainAtName(content, name string) bool {
+	pattern := `(?i)(^|[^\pL\pN_])@` + regexp.QuoteMeta(name) + `($|[^\pL\pN_])`
+	return regexp.MustCompile(pattern).FindStringIndex(content) != nil
 }
 
 func (h *Handler) routeReplyToParentAuthor(ctx context.Context, issue db.Issue, parent *db.Comment, authorType, authorID string, opts commentTriggerComputeOptions) (commentAgentTrigger, bool) {

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -455,6 +455,142 @@ func TestCreateComment_DualRoleAgentWorkerCommentWakesLeader(t *testing.T) {
 	}
 }
 
+// TestCreateComment_SquadLeaderAgentMentionWakesMember pins GitHub #4601:
+// a squad leader running in leader mode must be able to delegate to an agent
+// squad member by posting the valid mention markdown from the squad briefing.
+// The mention should enqueue the member exactly once and must not also create
+// a leader self-trigger loop.
+func TestCreateComment_SquadLeaderAgentMentionWakesMember(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	fx := newSquadCommentTriggerFixture(t)
+	issueID := uuidToString(fx.Issue.ID)
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+	})
+
+	var leaderRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent WHERE id = $1`, fx.LeaderID).Scan(&leaderRuntimeID); err != nil {
+		t.Fatalf("load leader runtime: %v", err)
+	}
+	var leaderTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, is_leader_task, squad_id)
+		VALUES ($1, $2, $3, 'running', TRUE, $4)
+		RETURNING id
+	`, fx.LeaderID, leaderRuntimeID, issueID, fx.SquadID).Scan(&leaderTaskID); err != nil {
+		t.Fatalf("seed leader task: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "[@Other](mention://agent/" + fx.OtherID + ") please take this because it matches your role.",
+	})
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", leaderTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var workerTasks int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = FALSE
+	`, issueID, fx.OtherID).Scan(&workerTasks); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if workerTasks != 1 {
+		t.Fatalf("leader @agent delegation queued %d worker tasks, want 1", workerTasks)
+	}
+
+	var leaderTasks int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = TRUE
+	`, issueID, fx.LeaderID).Scan(&leaderTasks); err != nil {
+		t.Fatalf("count leader tasks: %v", err)
+	}
+	if leaderTasks != 0 {
+		t.Fatalf("leader @agent delegation queued %d leader tasks, want 0", leaderTasks)
+	}
+}
+
+// TestCreateComment_SquadLeaderPlainNameMentionWakesMember is the bounded
+// compatibility path for GitHub #4601: if a leader posts plain @AgentName
+// from an active leader task, resolve it only against agent members of the
+// same squad. This keeps ordinary plain @text inert while preventing squad
+// handoffs from stalling when an agent emits a natural-language mention.
+func TestCreateComment_SquadLeaderPlainNameMentionWakesMember(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	fx := newSquadCommentTriggerFixture(t)
+	issueID := uuidToString(fx.Issue.ID)
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+	})
+
+	var otherName string
+	if err := testPool.QueryRow(ctx, `SELECT name FROM agent WHERE id = $1`, fx.OtherID).Scan(&otherName); err != nil {
+		t.Fatalf("load other agent name: %v", err)
+	}
+	var leaderRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent WHERE id = $1`, fx.LeaderID).Scan(&leaderRuntimeID); err != nil {
+		t.Fatalf("load leader runtime: %v", err)
+	}
+	var leaderTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, is_leader_task, squad_id)
+		VALUES ($1, $2, $3, 'running', TRUE, $4)
+		RETURNING id
+	`, fx.LeaderID, leaderRuntimeID, issueID, fx.SquadID).Scan(&leaderTaskID); err != nil {
+		t.Fatalf("seed leader task: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "@" + otherName + " please take this because it matches your role.",
+	})
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", leaderTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var workerTasks int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = FALSE
+	`, issueID, fx.OtherID).Scan(&workerTasks); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if workerTasks != 1 {
+		t.Fatalf("leader plain @name delegation queued %d worker tasks, want 1", workerTasks)
+	}
+
+	var leaderTasks int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = TRUE
+	`, issueID, fx.LeaderID).Scan(&leaderTasks); err != nil {
+		t.Fatalf("count leader tasks: %v", err)
+	}
+	if leaderTasks != 0 {
+		t.Fatalf("leader plain @name delegation queued %d leader tasks, want 0", leaderTasks)
+	}
+}
+
 // TestCreateComment_SquadLeaderMentionTaskDoesNotSelfTriggerAssignedFallback
 // pins MUL-4024's direct-mention gap:
 //


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes squad leader delegation so an agent member can be woken from a leader-authored comment even when the leader emits a plain `@AgentName` instead of the full mention markdown. The fallback is intentionally narrow: it only runs for comments posted from an active squad leader task, only resolves agent members of that same squad, and still gives canonical `mention://agent/<uuid>` links precedence.

This preserves the existing protection that arbitrary plain `@text` in normal comments does not create agent runs.

## Related Issue

Closes #4601

Multica issue: ZIC-28

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/comment.go`: carry comment source task provenance into trigger routing and add a bounded squad-leader plain-name resolver.
- `server/internal/handler/squad_comment_trigger_test.go`: add regressions for canonical `mention://agent` delegation and leader plain `@AgentName` delegation.

## How to Test

1. `cd server && go test ./internal/handler -run 'TestCreateComment_SquadLeader(AgentMentionWakesMember|PlainNameMentionWakesMember|MentionTaskDoesNotSelfTriggerAssignedFallback|ThreadParentTaskDoesNotSelfTriggerAssignedFallback)$|TestShouldEnqueueSquadLeaderOnComment_AgentAuthoredWorkerCommentsWakeLeader' -count=1`
2. `cd server && go test ./internal/handler -count=1`
3. `make check-worktree` was attempted from the repo root. It exited 0, but local Docker was unavailable while checking pgvector, so the handler package tests above are the meaningful validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced issue-comment mention dispatch, verified canonical `mention://agent` delegation already worked, then added a narrowly scoped backend fallback for leader-task plain-name delegation plus regression coverage.

## Screenshots (optional)

N/A
