### PR TITLE
fix(slack): preserve configured state after secret updates

### DIFF
--- a/server/internal/handler/slack.go
+++ b/server/internal/handler/slack.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -49,24 +51,17 @@ func slackInstallationToResponse(row db.ChannelInstallation) SlackInstallationRe
 
 // ListSlackInstallations (GET /api/workspaces/{id}/slack/installations) is
 // member-visible so the Integrations tab renders for non-admins. Response
-// flags mirror Lark:
-//   - configured: at-rest encryption key is set (SlackInstall != nil).
-//   - install_supported: kept for the management UI; true whenever configured,
-//     since a BYO install needs only the at-rest key (no hosted OAuth creds).
+// flags mirror Lark for fresh installs, with one Slack-specific recovery case:
+// existing installations are still public-listable when the install service is
+// unavailable, because listing does not decrypt stored tokens. That keeps the
+// settings page from incorrectly presenting an already-connected workspace as
+// "not enabled"; token-writing actions remain disabled behind SlackInstall.
 func (h *Handler) ListSlackInstallations(w http.ResponseWriter, r *http.Request) {
-	if h.SlackInstall == nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"installations":     []SlackInstallationResponse{},
-			"configured":        false,
-			"install_supported": false,
-		})
-		return
-	}
 	wsUUID, ok := parseUUIDOrBadRequest(w, chi.URLParam(r, "id"), "workspace id")
 	if !ok {
 		return
 	}
-	rows, err := h.SlackInstall.ListByWorkspace(r.Context(), wsUUID)
+	rows, installSupported, err := h.listSlackInstallations(r.Context(), wsUUID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list slack installations")
 		return
@@ -77,9 +72,24 @@ func (h *Handler) ListSlackInstallations(w http.ResponseWriter, r *http.Request)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"installations":     out,
-		"configured":        true,
-		"install_supported": true,
+		"configured":        installSupported || len(out) > 0,
+		"install_supported": installSupported,
 	})
+}
+
+func (h *Handler) listSlackInstallations(ctx context.Context, wsUUID pgtype.UUID) ([]db.ChannelInstallation, bool, error) {
+	if h.SlackInstall != nil {
+		rows, err := h.SlackInstall.ListByWorkspace(ctx, wsUUID)
+		return rows, true, err
+	}
+	if h.Queries == nil {
+		return nil, false, nil
+	}
+	rows, err := h.Queries.ListChannelInstallationsByWorkspace(ctx, db.ListChannelInstallationsByWorkspaceParams{
+		WorkspaceID: wsUUID,
+		ChannelType: string(slack.TypeSlack),
+	})
+	return rows, false, err
 }
 
 // RegisterSlackBYORequest is the body for a bring-your-own-app install: the two

--- a/server/internal/handler/slack_test.go
+++ b/server/internal/handler/slack_test.go
@@ -1,6 +1,10 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/events"
@@ -42,5 +46,72 @@ func TestPublishSlackInstallationCreated(t *testing.T) {
 	payload, ok := got.Payload.(map[string]any)
 	if !ok || payload["id"] != instID {
 		t.Errorf("payload = %v, want installation id %s", got.Payload, instID)
+	}
+}
+
+func TestListSlackInstallationsShowsExistingRowsWhenInstallServiceUnavailable(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `DELETE FROM channel_installation WHERE workspace_id = $1 AND channel_type = 'slack'`, testWorkspaceID); err != nil {
+		t.Fatalf("clear slack installations: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE workspace_id = $1 AND channel_type = 'slack'`, testWorkspaceID)
+	})
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent
+		WHERE workspace_id = $1
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("load test agent: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO channel_installation (
+			workspace_id, agent_id, channel_type, config, installer_user_id
+		)
+		VALUES (
+			$1, $2, 'slack',
+			'{"app_id":"A-fallback","team_id":"T-fallback","bot_user_id":"U-bot"}'::jsonb,
+			$3
+		)
+	`, testWorkspaceID, agentID, testUserID); err != nil {
+		t.Fatalf("insert slack installation: %v", err)
+	}
+
+	orig := testHandler.SlackInstall
+	testHandler.SlackInstall = nil
+	t.Cleanup(func() { testHandler.SlackInstall = orig })
+
+	req := withURLParam(newRequest(http.MethodGet, "/api/workspaces/"+testWorkspaceID+"/slack/installations", nil), "id", testWorkspaceID)
+	w := httptest.NewRecorder()
+	testHandler.ListSlackInstallations(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got struct {
+		Installations    []SlackInstallationResponse `json:"installations"`
+		Configured       bool                        `json:"configured"`
+		InstallSupported bool                        `json:"install_supported"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.Configured {
+		t.Fatal("configured should stay true when Slack installation rows already exist")
+	}
+	if got.InstallSupported {
+		t.Fatal("install_supported should remain false without the Slack install service")
+	}
+	if len(got.Installations) != 1 {
+		t.Fatalf("installations length = %d, want 1", len(got.Installations))
+	}
+	if got.Installations[0].TeamID != "T-fallback" || got.Installations[0].BotUserID != "U-bot" {
+		t.Fatalf("unexpected installation response: %+v", got.Installations[0])
 	}
 }

--- a/server/internal/util/secretbox/secretbox.go
+++ b/server/internal/util/secretbox/secretbox.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // KeySize is the required master-key length in bytes (AES-256).
@@ -92,11 +93,11 @@ func (b *Box) Open(sealed []byte) ([]byte, error) {
 // env values are treated as "not configured" and surface as a clear
 // error rather than silently using a zero key.
 func LoadKey(envVar string) ([]byte, error) {
-	raw := os.Getenv(envVar)
+	raw := strings.TrimSpace(os.Getenv(envVar))
 	if raw == "" {
 		return nil, fmt.Errorf("secretbox: %s is not set", envVar)
 	}
-	key, err := base64.StdEncoding.DecodeString(raw)
+	key, err := decodeKeyBase64(raw)
 	if err != nil {
 		return nil, fmt.Errorf("secretbox: %s is not valid base64: %w", envVar, err)
 	}
@@ -104,4 +105,22 @@ func LoadKey(envVar string) ([]byte, error) {
 		return nil, fmt.Errorf("secretbox: %s decodes to %d bytes, expected %d", envVar, len(key), KeySize)
 	}
 	return key, nil
+}
+
+func decodeKeyBase64(raw string) ([]byte, error) {
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	}
+	var lastErr error
+	for _, enc := range encodings {
+		key, err := enc.DecodeString(raw)
+		if err == nil {
+			return key, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("secretbox: key is not valid base64: %w", lastErr)
 }

--- a/server/internal/util/secretbox/secretbox_test.go
+++ b/server/internal/util/secretbox/secretbox_test.go
@@ -105,4 +105,28 @@ func TestLoadKey(t *testing.T) {
 			t.Fatalf("LoadKey returned wrong bytes")
 		}
 	})
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		key := make([]byte, KeySize)
+		_, _ = rand.Read(key)
+		t.Setenv(envVar, " \n"+base64.StdEncoding.EncodeToString(key)+"\n ")
+		got, err := LoadKey(envVar)
+		if err != nil {
+			t.Fatalf("LoadKey: %v", err)
+		}
+		if !bytes.Equal(got, key) {
+			t.Fatalf("LoadKey returned wrong bytes")
+		}
+	})
+	t.Run("accepts url safe unpadded base64", func(t *testing.T) {
+		key := make([]byte, KeySize)
+		_, _ = rand.Read(key)
+		t.Setenv(envVar, base64.RawURLEncoding.EncodeToString(key))
+		got, err := LoadKey(envVar)
+		if err != nil {
+			t.Fatalf("LoadKey: %v", err)
+		}
+		if !bytes.Equal(got, key) {
+			t.Fatalf("LoadKey returned wrong bytes")
+		}
+	})
 }


### PR DESCRIPTION
## What does this PR do?

Fixes Slack settings configured-state detection when a deployment already has Slack installation rows but the runtime install service is unavailable after a secret update/reload. The settings endpoint now still lists public installation metadata without decrypting tokens, so existing connected bots do not collapse into a false "Slack integration not enabled" state. It also makes `MULTICA_*_SECRET_KEY` loading tolerate surrounding whitespace and URL-safe base64 formats commonly produced by secret managers.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4904

Multica issue: ZIC-26

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/slack.go`: list existing Slack installation rows even when `SlackInstall` is nil; keep `install_supported=false` so new token-writing actions remain disabled.
- `server/internal/util/secretbox/secretbox.go`: trim secret-key env values and accept standard/raw URL-safe base64 encodings.
- Added regression coverage for the Slack settings fallback and secret-key loader formats.

## How to Test

1. `go test ./internal/util/secretbox -run TestLoadKey -v`
2. `go test ./internal/util/secretbox ./internal/handler -run 'TestLoadKey|TestListSlackInstallationsShowsExistingRowsWhenInstallServiceUnavailable|TestPublishSlackInstallationCreated' -v`
3. `make check-worktree` attempted; Docker daemon is unavailable locally, so Postgres-backed checks could not run (`Cannot connect to the Docker daemon`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Notes: UI screenshots, docs, landing copy, and Chinese product copy are not applicable; this is backend/API behavior only. Full worktree verification is blocked by Docker daemon availability in this environment.

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Traced GitHub #4904 from the Slack settings endpoint to backend Slack install-service wiring and secret-key loading. Implemented the smallest backend fix that preserves existing installation visibility without enabling token-writing actions when runtime Slack install support is unavailable.

## Screenshots (optional)

N/A