### PR TITLE
ZIC-29: Preserve configured Git identity for agent checkouts

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -503,19 +503,8 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			_ = excludeFromGit(worktreePath, pattern)
 		}
 
-		// Install or remove the Co-authored-by hook based on the workspace
-		// setting. The hook lives in the bare repo's shared hooks dir, so we
-		// must actively remove it when disabled — otherwise a previously
-		// installed hook keeps appending the trailer to every commit even
-		// after the user toggles the setting off.
-		if params.CoAuthoredByEnabled {
-			if err := installCoAuthoredByHook(worktreePath); err != nil {
-				c.logger.Warn("repo checkout: install co-authored-by hook failed (non-fatal)", "error", err)
-			}
-		} else {
-			if err := removeCoAuthoredByHook(worktreePath); err != nil {
-				c.logger.Warn("repo checkout: remove co-authored-by hook failed (non-fatal)", "error", err)
-			}
+		if action, err := reconcileCoAuthoredByHook(worktreePath, params.CoAuthoredByEnabled); err != nil {
+			c.logger.Warn("repo checkout: "+action+" co-authored-by hook failed (non-fatal)", "error", err)
 		}
 
 		c.logger.Info("repo checkout: existing worktree updated",
@@ -543,17 +532,8 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		_ = excludeFromGit(worktreePath, pattern)
 	}
 
-	// Install or remove the Co-authored-by hook based on the workspace
-	// setting. See the existing-worktree branch above for why removal is
-	// required when the setting is disabled.
-	if params.CoAuthoredByEnabled {
-		if err := installCoAuthoredByHook(worktreePath); err != nil {
-			c.logger.Warn("repo checkout: install co-authored-by hook failed (non-fatal)", "error", err)
-		}
-	} else {
-		if err := removeCoAuthoredByHook(worktreePath); err != nil {
-			c.logger.Warn("repo checkout: remove co-authored-by hook failed (non-fatal)", "error", err)
-		}
+	if action, err := reconcileCoAuthoredByHook(worktreePath, params.CoAuthoredByEnabled); err != nil {
+		c.logger.Warn("repo checkout: "+action+" co-authored-by hook failed (non-fatal)", "error", err)
 	}
 
 	c.logger.Info("repo checkout: worktree created",
@@ -869,6 +849,26 @@ func installCoAuthoredByHook(worktreePath string) error {
 		return fmt.Errorf("write prepare-commit-msg hook: %w", err)
 	}
 	return nil
+}
+
+func reconcileCoAuthoredByHook(worktreePath string, enabled bool) (string, error) {
+	if enabled && !gitIdentityConfigured(worktreePath) {
+		return "install", installCoAuthoredByHook(worktreePath)
+	}
+	return "remove", removeCoAuthoredByHook(worktreePath)
+}
+
+func gitIdentityConfigured(worktreePath string) bool {
+	return gitConfigValue(worktreePath, "user.name") != "" &&
+		gitConfigValue(worktreePath, "user.email") != ""
+}
+
+func gitConfigValue(worktreePath, key string) string {
+	out, err := runGitOutput("-C", worktreePath, "config", "--get", key)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // isDaemonInstalledHook reports whether a prepare-commit-msg hook on disk was

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -15,6 +15,17 @@ func testLogger() *slog.Logger {
 	return slog.Default()
 }
 
+func isolateGitGlobalConfig(t *testing.T, contents string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write isolated gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", path)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_COUNT", "0")
+}
+
 func TestGitEnv(t *testing.T) {
 	t.Parallel()
 	env := gitEnv()
@@ -1129,10 +1140,11 @@ func TestGetRemoteDefaultBranchUsesBareHeadHintForCustomDefault(t *testing.T) {
 }
 
 // TestCreateWorktreeInstallsCoAuthoredByHook verifies that CreateWorktree
-// installs a prepare-commit-msg hook that appends a Co-authored-by trailer
-// for the Multica Agent to every commit made in the worktree.
+// installs a prepare-commit-msg hook only when Git cannot already resolve a
+// configured user identity.
 func TestCreateWorktreeInstallsCoAuthoredByHook(t *testing.T) {
-	t.Parallel()
+	isolateGitGlobalConfig(t, "")
+
 	sourceRepo := createTestRepo(t)
 	cacheRoot := t.TempDir()
 
@@ -1173,10 +1185,55 @@ func TestCreateWorktreeInstallsCoAuthoredByHook(t *testing.T) {
 	}
 }
 
+func TestCreateWorktreeSkipsCoAuthoredByHookWhenGitIdentityConfigured(t *testing.T) {
+	isolateGitGlobalConfig(t, "[user]\n\tname = Ada Lovelace\n\temail = ada@example.com\n")
+
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID:         "ws-1",
+		RepoURL:             sourceRepo,
+		WorkDir:             workDir,
+		AgentName:           "Test Agent",
+		TaskID:              "c3d4e5f6-0000-0000-0000-000000000000",
+		CoAuthoredByEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	hookPath := filepath.Join(cache.Lookup("ws-1", sourceRepo), "hooks", "prepare-commit-msg")
+	if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no Multica hook when git identity is configured, stat err=%v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(result.Path, "test.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	runGitAuthored(t, result.Path, "add", ".")
+	runGitAuthored(t, result.Path, "commit", "-m", "test commit")
+
+	out, err := exec.Command("git", "-C", result.Path, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	if commitMsg := string(out); strings.Contains(commitMsg, "Co-authored-by: multica-agent") {
+		t.Errorf("commit unexpectedly carries fallback trailer despite configured identity.\ngot:\n%s", commitMsg)
+	}
+}
+
 // TestCoAuthoredByHookIdempotent verifies that the hook does not add a
 // duplicate Co-authored-by trailer if one is already present in the message.
 func TestCoAuthoredByHookIdempotent(t *testing.T) {
-	t.Parallel()
+	isolateGitGlobalConfig(t, "")
+
 	sourceRepo := createTestRepo(t)
 	cacheRoot := t.TempDir()
 
@@ -1226,7 +1283,8 @@ func TestCoAuthoredByHookIdempotent(t *testing.T) {
 // Otherwise commits keep getting the trailer even after the user disables the
 // workspace setting.
 func TestCreateWorktreeRemovesCoAuthoredByHookWhenDisabled(t *testing.T) {
-	t.Parallel()
+	isolateGitGlobalConfig(t, "")
+
 	sourceRepo := createTestRepo(t)
 	cacheRoot := t.TempDir()
 
@@ -1288,6 +1346,69 @@ func TestCreateWorktreeRemovesCoAuthoredByHookWhenDisabled(t *testing.T) {
 	commitMsg := string(out)
 	if strings.Contains(commitMsg, "Co-authored-by: multica-agent") {
 		t.Errorf("commit unexpectedly carries the Co-authored-by trailer with setting disabled.\ngot:\n%s", commitMsg)
+	}
+}
+
+func TestCreateWorktreeRemovesLegacyAgentLocalHookWhenGitIdentityConfigured(t *testing.T) {
+	isolateGitGlobalConfig(t, "[user]\n\tname = Ada Lovelace\n\temail = ada@example.com\n")
+
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	const legacyAgentLocalHook = `#!/bin/sh
+# Multica: add Co-authored-by trailer for the Multica Agent.
+# Installed by the Multica daemon. Do not edit — it will be overwritten.
+
+COMMIT_MSG_FILE="$1"
+TRAILER="Co-authored-by: Test Agent <test-agent@multica.local>"
+git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
+`
+
+	barePath := cache.Lookup("ws-1", sourceRepo)
+	hooksDir := filepath.Join(barePath, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	hookPath := filepath.Join(hooksDir, "prepare-commit-msg")
+	if err := os.WriteFile(hookPath, []byte(legacyAgentLocalHook), 0o755); err != nil {
+		t.Fatalf("seed legacy hook: %v", err)
+	}
+
+	workDir := t.TempDir()
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID:         "ws-1",
+		RepoURL:             sourceRepo,
+		WorkDir:             workDir,
+		AgentName:           "Test Agent",
+		TaskID:              "55555555-0000-0000-0000-000000000000",
+		CoAuthoredByEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy agent-local hook to be removed, stat err=%v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(result.Path, "test.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	runGitAuthored(t, result.Path, "add", ".")
+	runGitAuthored(t, result.Path, "commit", "-m", "test commit")
+
+	out, err := exec.Command("git", "-C", result.Path, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	commitMsg := string(out)
+	if strings.Contains(commitMsg, "multica.local") || strings.Contains(commitMsg, "Co-authored-by: Test Agent") {
+		t.Errorf("commit unexpectedly carries stale agent-local trailer.\ngot:\n%s", commitMsg)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Preserves configured Git identity for daemon-created agent worktrees. The repo cache now installs Multica's fallback Co-authored-by hook only when Git cannot resolve both `user.name` and `user.email`; when identity is already configured, checkout removes any daemon-owned hook, including stale legacy hooks that could append `@multica.local` attribution.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4620

Multica issue: ZIC-29

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/repocache/cache.go`: reconcile the daemon-owned prepare-commit-msg hook against resolved Git identity instead of only the workspace setting.
- `server/internal/daemon/repocache/cache_test.go`: add regression coverage for configured global identity and stale `agent@multica.local` legacy hooks.

## How to Test

1. `cd server && go test ./internal/daemon/repocache`
2. `cd server && go test ./internal/daemon/...`
3. `make check-worktree` (returned success, but local Docker was unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the daemon repo checkout path for Git attribution, identified the daemon-owned prepare-commit-msg hook as the fallback attribution source, then made hook installation conditional on Git identity resolution while preserving cleanup of daemon-owned legacy hooks.

## Screenshots (optional)

N/A
