### PR TITLE
MUL-4018: feat(runtime): allow qoder as a custom runtime profile base (#4883)

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -109,6 +109,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "kimi",
   "kiro",
   "antigravity",
+  "qoder",
 ] as const;
 
 export type RuntimeProtocolFamily =

--- a/server/migrations/134_runtime_profile_add_qoder.down.sql
+++ b/server/migrations/134_runtime_profile_add_qoder.down.sql
@@ -1,0 +1,19 @@
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+-- Restore the pre-134 whitelist (migration 126 shape, without qoder). NOT VALID
+-- keeps the historical Gemini tolerance so the rollback cannot fail on old rows.
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity'
+    )) NOT VALID;

--- a/server/migrations/134_runtime_profile_add_qoder.up.sql
+++ b/server/migrations/134_runtime_profile_add_qoder.up.sql
@@ -1,0 +1,23 @@
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+-- Widen the whitelist to include Qoder so Qoder CN (`qoderclicn`) users can base
+-- a custom runtime profile on the existing Qoder backend (launches
+-- `<command> --yolo --acp`) instead of misrouting through Kiro/ACP with
+-- incompatible arguments (#4883). NOT VALID mirrors migration 126 so a
+-- historical Gemini row it intentionally tolerated does not block the upgrade.
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity',
+        'qoder'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -137,10 +137,11 @@ type Config struct {
 //
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
-// runtime_profile.protocol_family CHECK constraint (migration 120): a custom
-// runtime profile may only be based on a backend Multica officially supports.
-// (qoder is a built-in provider New can construct, but it is not offered as a
-// custom-profile base, so it is intentionally absent from this list.)
+// runtime_profile.protocol_family CHECK constraint (migration 120, widened by
+// migration 134 to add qoder): a custom runtime profile may only be based on a
+// backend Multica officially supports. qoder is exposed here so Qoder CN
+// (`qoderclicn`) users can point the Qoder backend at a non-default binary
+// instead of misrouting through Kiro/ACP with incompatible arguments (#4883).
 var SupportedTypes = []string{
 	"claude",
 	"codebuddy",
@@ -154,6 +155,7 @@ var SupportedTypes = []string{
 	"kimi",
 	"kiro",
 	"antigravity",
+	"qoder",
 }
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.

--- a/server/pkg/agent/agent_supported_types_test.go
+++ b/server/pkg/agent/agent_supported_types_test.go
@@ -40,6 +40,7 @@ func TestSupportedTypesMatchesMigrationWhitelist(t *testing.T) {
 		"claude": true, "codebuddy": true, "codex": true, "copilot": true,
 		"opencode": true, "openclaw": true, "hermes": true,
 		"pi": true, "cursor": true, "kimi": true, "kiro": true, "antigravity": true,
+		"qoder": true,
 	}
 	if len(SupportedTypes) != len(want) {
 		t.Fatalf("SupportedTypes has %d entries, migration whitelist has %d; keep them in lockstep", len(SupportedTypes), len(want))


### PR DESCRIPTION
## Summary

Qoder CN (`qoderclicn`) could only be wired up as a Multica custom runtime by picking the **Kiro/ACP** protocol family, because `qoder` was intentionally excluded from the custom-profile whitelist. The Kiro backend launches:

```sh
<command> acp --trust-all-tools
```

which is incompatible with Qoder's argv — Qoder enters ACP mode via the global flag `--acp` (not an `acp` subcommand) and bypasses permissions via `--yolo`. The result was a runtime that looked online but failed every task in ~1s with `kiro initialize failed: kiro process exited` and no run messages.

This PR exposes the **existing** `qoderBackend` as a selectable custom-profile base. That backend already honors an `ExecutablePath` override and launches `<command> --yolo --acp`, so a profile with `protocol_family=qoder` + `command_name=qoderclicn` now launches with the correct shape instead of the Kiro one — no new Qoder-specific branching in the Kiro path.

## Changes

`qoder` added to the custom-profile `protocol_family` whitelist across every lockstep layer:

- `server/pkg/agent/agent.go` — `SupportedTypes` (+ updated the "intentionally absent" comment).
- `server/pkg/agent/agent_supported_types_test.go` — whitelist pin (`want` map).
- `server/migrations/134_runtime_profile_add_qoder.{up,down}.sql` — widens the `runtime_profile.protocol_family` CHECK. `NOT VALID` mirrors migration 126 so a historical Gemini row it tolerated cannot block the upgrade.
- `packages/core/types/agent.ts` — `RUNTIME_PROFILE_PROTOCOL_FAMILIES` (drives the family picker + built-in catalog row).

No new UI/branding was needed: Qoder already ships a provider logo and the catalog/label derive from the const. The handler and daemon already validate via `agent.IsSupportedType`, so both pick up `qoder` automatically.

## Verification

- `go build ./...` — clean.
- `go test ./pkg/agent/ -run 'TestSupportedTypes|TestQoder'` — pass. The whitelist lockstep tests now pin `qoder`, and `TestQoderBackendInvokesACPFlagAndFiltersBlockedArgs` already exercises the exact custom-runtime scenario: a custom `ExecutablePath` launched as `--yolo --acp` with blocked-arg filtering.
- `gofmt` / `go vet ./pkg/agent/` — clean.
- Frontend: the change is a one-line addition to a const tuple with no exhaustive consumers (`Record<RuntimeProtocolFamily>` is unused; the provider-logo switch has a `default`). Full FE typecheck/tests run in CI (deps not installed in this environment).

## Validation note for maintainer

The reporter's local shim mapped Kiro's `--trust-all-tools` → `--dangerously-skip-permissions`. The built-in Qoder backend instead hardcodes `--yolo` (the documented upstream Qoder bypass flag, already shipping for `qodercli`). This should be fine if Qoder CN shares the upstream flag set, but it's worth confirming that `qoderclicn --yolo --acp` is accepted by Qoder CN. If Qoder CN diverges on the bypass flag, a follow-up (CN-specific mapping/alias) would be needed on top of this whitelist change.

Addresses #4883 · MUL-4018
