### PR TITLE
fix(execenv): constrain comment body files to the workdir, never shared /tmp

### DIFF
--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -167,9 +167,10 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 				"do NOT reuse --parent values from previous turns in this session.\n\n"+
 				"On Windows, write the reply body to a UTF-8 file with your file-write tool, then post it with `--content-file`. "+
 				"Do NOT pipe via `--content-stdin` — Windows PowerShell 5.1's `$OutputEncoding` defaults to ASCIIEncoding when piping to native commands and silently drops non-ASCII (Chinese, Japanese, Cyrillic, accents, emoji) as `?` before the bytes reach `multica.exe`. "+
-				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
+				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line. "+
+				"The file must live inside your current working directory — never a shared system temp directory; posting a path you did not just successfully write publishes stale content (GitHub #4913). If the file write fails, do NOT run the post command.\n\n"+
 				"Use this form, preserving the same issue ID and --parent value:\n\n"+
-				"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
+				"    # 1. Write the reply body to a UTF-8 file in your working directory (e.g. reply.md) with your file-write tool.\n"+
 				"    # 2. Post the comment:\n"+
 				"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
 				"    # 3. Remove the temp file so a later run does not pick up stale content:\n"+
@@ -193,9 +194,10 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 			"Write the reply body to a UTF-8 file with your file-write tool first, then post it with `--content-file`. "+
 			"Do NOT use inline `--content`; the shell rewrites unescaped backticks, `$()`, `$VAR`, or quotes in the body before the CLI receives them. "+
 			"Do NOT use `--content-stdin` with a HEREDOC either — when extra flags (e.g. `--assignee`, `--project` on `multica issue create`) accompany the command, the bash heredoc/flag boundary is fragile and flags can be silently swallowed into the stdin stream while the command still exits 0 (see GitHub #4182, OXY-78 / OXY-76). "+
-			"It is also easy to lose formatting or compress a structured reply into one line with inline forms.\n\n"+
+			"It is also easy to lose formatting or compress a structured reply into one line with inline forms. "+
+			"The file must live inside your current working directory — NEVER under `/tmp`: on multi-daemon hosts `/tmp` is shared across unix users, a fixed name like `/tmp/reply.md` can collide with another user's leftover file, your write fails with `Permission denied`, and a separately-run post then publishes that user's stale content (GitHub #4913). If you write via shell redirection, chain the write and the post with `&&` so a failed write aborts the post.\n\n"+
 			"Use this form, preserving the same issue ID and --parent value:\n\n"+
-			"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
+			"    # 1. Write the reply body to a UTF-8 file in your working directory (e.g. reply.md — never /tmp) with your file-write tool.\n"+
 			"    # 2. Post the comment:\n"+
 			"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
 			"    # 3. Remove the temp file so a later run does not pick up stale content:\n"+

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -33,6 +33,8 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 		"Write the reply body to a UTF-8 file",
 		"`--content-file`",
 		"#4182",
+		"NEVER under `/tmp`",
+		"#4913",
 		"rm ./reply.md",
 		"Do NOT write literal `\\n` escapes to simulate line breaks",
 		"do NOT reuse --parent values from previous turns",
@@ -89,6 +91,8 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					"Write the reply body to a UTF-8 file",
 					"`--content-file`",
 					"#4182",
+					"NEVER under `/tmp`",
+					"#4913",
 					"rm ./reply.md",
 					"do NOT reuse --parent values from previous turns",
 					"If you decide to reply",
@@ -142,6 +146,8 @@ func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
 				"Do NOT pipe via `--content-stdin`",
 				"silently drops non-ASCII",
 				"$OutputEncoding",
+				"never a shared system temp directory",
+				"#4913",
 			} {
 				if !strings.Contains(got, want) {
 					t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, got)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -556,16 +556,28 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	// line, the body never reaches the shell, no heredoc boundary exists for
 	// flags to leak across. This is identical to the long-standing Windows
 	// path, so the cross-platform guidance is now one shape.
+	//
+	// The body file itself must live inside the run's working directory —
+	// never a shared system temp dir. On multi-daemon hosts, /tmp is shared
+	// across the daemons' unix users: a fixed name like /tmp/reply.md can
+	// collide with another user's leftover file, the agent's write fails with
+	// `Permission denied` (sticky /tmp), and a follow-up post that runs as a
+	// separate statement publishes the OTHER workspace's stale content
+	// (GitHub #4913 — observed cross-workspace disclosure in production).
+	// Same reason the write and the post must be one fail-fast unit: a failed
+	// write must abort the post, never ship whatever the path already held.
 	b.WriteString("## Comment Formatting\n\n")
 	if runtimeGOOS == "windows" {
 		b.WriteString("On Windows, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`** — do NOT pipe via `--content-stdin`. PowerShell 5.1's `$OutputEncoding` defaults to ASCIIEncoding when piping to a native command, silently dropping non-ASCII characters as `?` before they reach `multica.exe`. Never use inline `--content` for agent-authored comments. ")
+		b.WriteString("The body file MUST live inside your current working directory (e.g. `./reply.md`) — never a shared system temp directory: leftover files there can belong to other users or earlier runs, and posting a path you did not just successfully write publishes stale content (GitHub #4913). If the file write fails for any reason, do NOT run the post command — fix the write first. ")
 		b.WriteString("Keep the same `--parent` value from the trigger comment when replying. ")
-		b.WriteString("After posting, remove the temp file with `Remove-Item ./reply.md` (or your chosen path) so a later run does not pick up stale content. ")
+		b.WriteString("After posting, remove the temp file with `Remove-Item ./reply.md` (or your chosen workdir-relative path) so a later run does not pick up stale content. ")
 		b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
 	} else {
 		b.WriteString("For issue comments, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`**. Never use inline `--content` for agent-authored comments — the shell rewrites backticks, `$()`, `$VAR`, or quotes in the body before the CLI receives them (MUL-2904). Do NOT use `--content-stdin` with a HEREDOC either: when extra flags accompany the command (e.g. `--assignee`, `--project` on `multica issue create`), the bash heredoc/flag boundary is fragile and flags can be silently swallowed into the stdin stream while the command still exits 0 (GitHub #4182). ")
+		b.WriteString("The body file MUST live inside your current working directory (e.g. `./reply.md`) — NEVER under `/tmp`: on multi-daemon hosts `/tmp` is shared across unix users, a fixed name like `/tmp/reply.md` can collide with another user's leftover file, your write fails with `Permission denied`, and a separately-run post then publishes that user's stale content (GitHub #4913). If you write the file via shell redirection, chain the write and the post with `&&` in one invocation so a failed write aborts the post; if the write fails for any reason, do NOT run the post command. ")
 		b.WriteString("Keep the same `--parent` value from the trigger comment when replying. ")
-		b.WriteString("After posting, remove the temp file with `rm ./reply.md` (or your chosen path) so a later run does not pick up stale content. ")
+		b.WriteString("After posting, remove the temp file with `rm ./reply.md` (or your chosen workdir-relative path) so a later run does not pick up stale content. ")
 		b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
 	}
 

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -201,6 +201,47 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 	}
 }
 
+// TestCommentFormattingForbidsSharedTmp pins the shared-/tmp guardrail
+// (GitHub #4913): the always-injected `## Comment Formatting` section must
+// constrain the body file to the run's working directory, forbid `/tmp` on
+// Linux/macOS (shared across daemon unix users — a Permission-denied write
+// followed by a separately-run post published another workspace's stale
+// file), and demand fail-fast write→post chaining.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestCommentFormattingForbidsSharedTmp(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	ctx := TaskContextForEnv{IssueID: "i-1", TriggerCommentID: "tc-1",
+		AgentName: "Eve", AgentID: "eve-1"}
+
+	runtimeGOOS = "linux"
+	out := buildMetaSkillContent("claude", ctx)
+	for _, want := range []string{
+		"MUST live inside your current working directory",
+		"NEVER under `/tmp`",
+		"chain the write and the post with `&&`",
+		"#4913",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("linux Comment Formatting missing %q", want)
+		}
+	}
+
+	runtimeGOOS = "windows"
+	out = buildMetaSkillContent("claude", ctx)
+	for _, want := range []string{
+		"MUST live inside your current working directory",
+		"never a shared system temp directory",
+		"#4913",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("windows Comment Formatting missing %q", want)
+		}
+	}
+}
+
 // TestSlimQuickCreateAvailableCommands locks the minimal-variant content
 // for quick-create's Available Commands: `issue create` present, every
 // other Core command absent (the hard guardrails forbid the call).


### PR DESCRIPTION
Addresses the **instruction-level fix (#2)** proposed in #4913 (multi-user self-host: shared `/tmp` lets agents post stale content across workspaces). The daemon-level per-run `TMPDIR` (fix #1) and the self-host docs recommendation (fix #3) are intentionally left out — #1 deserves its own design discussion, so this PR does not close the issue.

## What changed

The always-injected `## Comment Formatting` guidance (and the full reply template) already told agents to write the body to a file, post with `--content-file`, and `rm` it afterwards — but the path was unconstrained (*"or your chosen path"*), and models habitually pick fixed names under `/tmp`. On multi-daemon hosts `/tmp` is shared across the daemons' unix users: a write onto another user's leftover file fails with `Permission denied` (sticky `/tmp`), a separately-run post still exits 0, and the **other workspace's** stale content gets published. See #4913 for the observed production incident (7 issues in one workspace received another workspace's comment verbatim).

This PR tightens the guidance from advisory to constrained, in `buildMetaSkillContent` (both OS branches) and `BuildCommentReplyInstructions` (both OS branches):

- the body file MUST live inside the run's working directory — never a shared system temp dir; `/tmp` is called out explicitly on Linux/macOS with the failure chain, so the model knows *why*
- shell-redirect writes must chain write and post with `&&` in one invocation, so a failed write aborts the post instead of shipping whatever the path already held
- `(or your chosen path)` → `(or your chosen workdir-relative path)` in the `rm` example, so it no longer licenses arbitrary locations
- the reply-template step 1 example now reads "in your working directory (e.g. reply.md — never /tmp)"

The slim reply variant is untouched — it already defers to `## Comment Formatting` for the full rule, so it inherits the constraint.

## Tests

- new `TestCommentFormattingForbidsSharedTmp` pins both OS branches of the section (workdir constraint, `/tmp` ban, `&&` chaining, #4913 reference), using the package's existing `runtimeGOOS`-mutation pattern
- existing reply-instruction tests (`CodexLinux`, `NonCodexLinux`, `WindowsUsesContentFile`) extended with the new substrings
- `go test ./internal/daemon/execenv/` and the prompt/instruction-related `./internal/daemon/` tests pass; `go vet` and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
