### PR TITLE
fix(daemon): add zero-output watchdog for stuck resume sessions

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -50,7 +50,18 @@ const (
 	// matching tool_result would otherwise run forever. This is the backstop for
 	// that stuck-tool case (MUL-3064). Set MULTICA_AGENT_TOOL_WATCHDOG=0 to
 	// disable, in which case an in-flight tool never force-stops the run.
-	DefaultAgentToolWatchdog       = 2 * time.Hour
+	DefaultAgentToolWatchdog = 2 * time.Hour
+	// DefaultAgentZeroOutputWatchdog force-stops a run that has produced zero
+	// user-visible timeline items (text, thinking, tool_use, tool_result, error)
+	// for this long. Unlike the idle watchdog — which resets on every backend
+	// message including internal frames — this watchdog only resets on messages
+	// that produce user-visible output. A stuck --resume session that emits
+	// system/init frames but no content will trip this watchdog while the idle
+	// watchdog stays silent (#4407). 5 minutes is short enough for fast UX
+	// recovery but long enough that a legitimately slow cold-start (model
+	// loading, MCP handshake) won't be killed prematurely.
+	// Set MULTICA_AGENT_ZERO_OUTPUT_WATCHDOG=0 to disable.
+	DefaultAgentZeroOutputWatchdog = 5 * time.Minute
 	DefaultRuntimeName             = "Local Agent"
 	DefaultWorkspaceSyncInterval   = 30 * time.Second
 	DefaultHealthPort              = 19514
@@ -99,6 +110,7 @@ type Config struct {
 	CodexSemanticInactivityTimeout time.Duration
 	AgentIdleWatchdog              time.Duration // force-stop a run when the backend goes silent this long with an empty queue (0 = disabled)
 	AgentToolWatchdog              time.Duration // force-stop a run when a single tool call stays in flight (silent) this long (0 = disabled); backstop for hung tools now that there is no wall-clock cap
+	AgentZeroOutputWatchdog        time.Duration // force-stop a run when it has produced zero user-visible timeline items (text, thinking, tool_use, tool_result, error) for this long (0 = disabled); catches stuck --resume sessions that emit internal frames but no user-visible output (#4407)
 	ClaudeArgs                     []string
 	CodexArgs                      []string
 	CodebuddyArgs                  []string
@@ -382,6 +394,13 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
+	// MULTICA_AGENT_ZERO_OUTPUT_WATCHDOG=0 disables the zero-output watchdog;
+	// any positive duration overrides DefaultAgentZeroOutputWatchdog.
+	agentZeroOutputWatchdog, err := durationFromEnv("MULTICA_AGENT_ZERO_OUTPUT_WATCHDOG", DefaultAgentZeroOutputWatchdog)
+	if err != nil {
+		return Config{}, err
+	}
+
 	maxConcurrentTasks, err := intFromEnv("MULTICA_DAEMON_MAX_CONCURRENT_TASKS", DefaultMaxConcurrentTasks)
 	if err != nil {
 		return Config{}, err
@@ -531,6 +550,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		CodexSemanticInactivityTimeout: codexSemanticInactivityTimeout,
 		AgentIdleWatchdog:              agentIdleWatchdog,
 		AgentToolWatchdog:              agentToolWatchdog,
+		AgentZeroOutputWatchdog:        agentZeroOutputWatchdog,
 		ClaudeArgs:                     claudeArgs,
 		CodexArgs:                      codexArgs,
 		CodebuddyArgs:                  codebuddyArgs,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4248,11 +4248,16 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				// slow downstream call (mu.Lock contention, batch resize)
 				// can't be misattributed to backend silence.
 				lastActivityAt.Store(time.Now().UnixNano())
-				// Stamp user-visible activity for all types except
-				// MessageStatus (session init, pin). The zero-output
-				// watchdog uses this to detect runs that emit internal
-				// frames but no content the user can see (#4407).
-				if msg.Type != agent.MessageStatus {
+				// Stamp user-visible activity only for message types
+				// that produce timeline items the user can see. The
+				// zero-output watchdog uses this to detect stuck
+				// --resume sessions that emit internal frames
+				// (MessageStatus for session init, MessageLog for
+				// debug output) but no real content (#4407).
+				switch msg.Type {
+				case agent.MessageText, agent.MessageThinking,
+					agent.MessageToolUse, agent.MessageToolResult,
+					agent.MessageError:
 					lastUserVisibleActivityAt.Store(time.Now().UnixNano())
 				}
 				switch msg.Type {
@@ -4368,7 +4373,12 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 			// generic "agent_error" bucket the aborted path falls into.
 			result.Status = "idle_watchdog"
 			if result.Error == "" {
-				result.Error = idleWatchdogReason(time.Duration(idleWatchdogThreshold.Load()))
+				tripped := time.Duration(idleWatchdogThreshold.Load())
+				if d.cfg.AgentZeroOutputWatchdog > 0 && tripped == d.cfg.AgentZeroOutputWatchdog {
+					result.Error = zeroOutputWatchdogReason(tripped)
+				} else {
+					result.Error = idleWatchdogReason(tripped)
+				}
 			}
 		}
 		return result, toolCount.Load(), nil
@@ -4378,9 +4388,14 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		// classifiers so a watchdog-induced stop isn't misreported as
 		// "task cancelled by server".
 		if idleWatchdogFired.Load() {
+			tripped := time.Duration(idleWatchdogThreshold.Load())
+			reason := idleWatchdogReason(tripped)
+			if d.cfg.AgentZeroOutputWatchdog > 0 && tripped == d.cfg.AgentZeroOutputWatchdog {
+				reason = zeroOutputWatchdogReason(tripped)
+			}
 			return agent.Result{
 				Status: "idle_watchdog",
-				Error:  idleWatchdogReason(time.Duration(idleWatchdogThreshold.Load())),
+				Error:  reason,
 			}, toolCount.Load(), nil
 		}
 		// Distinguish external cancellation (e.g. server-initiated cancel
@@ -4406,6 +4421,14 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 // drain-timeout branch in executeAndDrain emit identical wording.
 func idleWatchdogReason(window time.Duration) string {
 	return fmt.Sprintf("agent produced no new messages for %s and message queue was empty; force-stopped by idle watchdog", window)
+}
+
+// zeroOutputWatchdogReason formats the explanation for zero-output watchdog
+// dispositions. Unlike the idle watchdog (which fires on total backend
+// silence), the zero-output watchdog fires when the backend is emitting
+// internal frames but no user-visible timeline items.
+func zeroOutputWatchdogReason(window time.Duration) string {
+	return fmt.Sprintf("agent produced no user-visible output for %s despite emitting internal frames; force-stopped by zero-output watchdog", window)
 }
 
 // runIdleWatchdog ticks until either agentCtx is cancelled or the backend has
@@ -4467,12 +4490,17 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow, z
 				continue
 			}
 
+			toolInFlight := inFlightTools.Load() > 0
+
 			// Check 1: Zero-output watchdog. If no user-visible timeline
 			// items have been produced for zeroOutputWindow, fire. This
-			// is independent of the idle watchdog — a backend emitting
-			// internal frames keeps lastActivityAt fresh but does NOT
-			// reset lastUserVisibleActivityAt.
-			if zeroOutputWindow > 0 {
+			// catches stuck --resume sessions that emit internal frames
+			// (keeps lastActivityAt fresh) but no user-visible content.
+			// Skipped when a tool is in flight: a legitimate long-running
+			// tool (npm install, docker build) may run silently for hours
+			// after tool_use, and the tool watchdog (2h) is the correct
+			// budget for that case.
+			if zeroOutputWindow > 0 && !toolInFlight {
 				lastVisible := time.Unix(0, lastUserVisibleActivityAt.Load())
 				silentFor := time.Since(lastVisible)
 				if silentFor >= zeroOutputWindow {
@@ -4494,7 +4522,6 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow, z
 				continue
 			}
 			threshold := window
-			toolInFlight := inFlightTools.Load() > 0
 			if toolInFlight {
 				if toolWindow <= 0 {
 					continue

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4155,12 +4155,15 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	// message also trips the watchdog.
 	var lastActivityAt atomic.Int64
 	lastActivityAt.Store(time.Now().UnixNano())
-	// inFlightTools counts tool_use messages that haven't yet been paired
-	// with a matching tool_result. A non-zero count means the agent is
-	// legitimately waiting on a tool (e.g. `npm install`, `docker build`)
-	// that may run far longer than the idle window without emitting any
-	// message — so while a tool is in flight the watchdog applies the larger
-	// AgentToolWatchdog budget instead of treating that silence as a hang.
+	// lastUserVisibleActivityAt records when the drain loop most recently
+	// received a user-visible message (text, thinking, tool_use, tool_result,
+	// or error). The idle watchdog uses this to distinguish a backend that is
+	// emitting internal frames (status/init) from one that is producing real
+	// output the user can see. Without this, a stuck --resume that emits
+	// system frames keeps resetting lastActivityAt and the idle watchdog
+	// never fires (#4407).
+	var lastUserVisibleActivityAt atomic.Int64
+	lastUserVisibleActivityAt.Store(time.Now().UnixNano())
 	var inFlightTools atomic.Int32
 	var idleWatchdogFired atomic.Bool
 	// idleWatchdogThreshold records (as nanos) which silence budget actually
@@ -4169,8 +4172,9 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	var idleWatchdogThreshold atomic.Int64
 	idleWatchdogThreshold.Store(int64(d.cfg.AgentIdleWatchdog))
 	idleWindow := d.cfg.AgentIdleWatchdog
-	if idleWindow > 0 {
-		go d.runIdleWatchdog(agentCtx, idleWindow, d.cfg.AgentToolWatchdog, &lastActivityAt, &inFlightTools, &idleWatchdogFired, &idleWatchdogThreshold, agentCancel, session.Messages, taskLog, taskID)
+	zeroOutputWindow := d.cfg.AgentZeroOutputWatchdog
+	if idleWindow > 0 || zeroOutputWindow > 0 {
+		go d.runIdleWatchdog(agentCtx, idleWindow, d.cfg.AgentToolWatchdog, zeroOutputWindow, &lastActivityAt, &lastUserVisibleActivityAt, &inFlightTools, &idleWatchdogFired, &idleWatchdogThreshold, agentCancel, session.Messages, taskLog, taskID)
 	}
 
 	go func() {
@@ -4244,6 +4248,13 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				// slow downstream call (mu.Lock contention, batch resize)
 				// can't be misattributed to backend silence.
 				lastActivityAt.Store(time.Now().UnixNano())
+				// Stamp user-visible activity for all types except
+				// MessageStatus (session init, pin). The zero-output
+				// watchdog uses this to detect runs that emit internal
+				// frames but no content the user can see (#4407).
+				if msg.Type != agent.MessageStatus {
+					lastUserVisibleActivityAt.Store(time.Now().UnixNano())
+				}
 				switch msg.Type {
 				case agent.MessageStatus:
 					// Persist the session/work_dir as soon as the backend
@@ -4400,32 +4411,47 @@ func idleWatchdogReason(window time.Duration) string {
 // runIdleWatchdog ticks until either agentCtx is cancelled or the backend has
 // been silent past the applicable budget. On firing, it records the tripped
 // threshold, sets fired, and calls cancel, which propagates to the agent
-// subprocess (via the ctx passed to backend.Execute) and to drainCtx. The
-// silence budget depends on whether a tool call is in flight:
+// subprocess (via the ctx passed to backend.Execute) and to drainCtx.
 //
-//  1. No tool in flight — a silent backend is a hang after `window`.
-//  2. A tool in flight (tool_use with no matching tool_result yet) — a real
-//     tool (e.g. `npm install`, `docker build`) legitimately runs silently for
-//     many minutes, so the larger `toolWindow` applies instead. toolWindow <= 0
-//     keeps the historical behavior of never force-stopping while a tool is in
-//     flight. Without this in-flight budget a backend that emits tool_use and
-//     never the matching tool_result would run forever now that there is no
-//     wall-clock cap (MUL-3064).
+// Three silence budgets operate in parallel:
 //
-// In both cases the watchdog also requires the session.Messages buffer to be
-// empty — a buffered-but-undrained message means the drain loop is behind, not
-// the backend.
+//  1. Zero-output window — if the run has produced zero user-visible timeline
+//     items (text, thinking, tool_use, tool_result, error) for this long, fire
+//     immediately. This catches stuck --resume sessions that emit internal
+//     frames (status/init) but no content (#4407). zeroOutputWindow <= 0
+//     disables this check.
 //
-// Tick interval is window/2 (floored at 30 s in production, but the floor only
-// kicks in for windows >= 1 min so tests can pass tiny windows like 50 ms and
-// see the watchdog fire within a few ticks).
-func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow time.Duration, lastActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, firedThreshold *atomic.Int64, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger, taskID string) {
+//  2. Idle window (no tool in flight) — a silent backend is a hang after
+//     `window`.
+//
+//  3. Tool window (tool in flight) — a real tool (e.g. `npm install`,
+//     `docker build`) legitimately runs silently for many minutes, so the
+//     larger `toolWindow` applies instead. toolWindow <= 0 keeps the
+//     historical behavior of never force-stopping while a tool is in flight.
+//
+// In all cases the watchdog also requires the session.Messages buffer to be
+// empty — a buffered-but-undrained message means the drain loop is behind,
+// not the backend.
+//
+// Tick interval is the smallest applicable window/2 (floored at 30 s in
+// production, but the floor only kicks in for windows >= 1 min so tests can
+// pass tiny windows like 50 ms and see the watchdog fire within a few ticks).
+func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow, zeroOutputWindow time.Duration, lastActivityAt, lastUserVisibleActivityAt *atomic.Int64, inFlightTools *atomic.Int32, fired *atomic.Bool, firedThreshold *atomic.Int64, cancel context.CancelFunc, messages <-chan agent.Message, taskLog *slog.Logger, taskID string) {
+	// Compute tick interval: the smallest applicable window / 2.
 	interval := window / 2
+	if interval <= 0 {
+		interval = zeroOutputWindow / 2
+	}
+	if zeroOutputWindow > 0 && zeroOutputWindow/2 > 0 && zeroOutputWindow/2 < interval {
+		interval = zeroOutputWindow / 2
+	}
 	if window >= time.Minute && interval < 30*time.Second {
 		interval = 30 * time.Second
 	}
 	if interval <= 0 {
-		interval = window
+		// Both windows are 0 or negative — should never reach here because
+		// the caller guards with `if idleWindow > 0 || zeroOutputWindow > 0`.
+		return
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -4434,10 +4460,39 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow ti
 		case <-agentCtx.Done():
 			return
 		case <-ticker.C:
-			// Pick the silence budget. A tool in flight is expected to be
-			// silent (a long build/install/test emits nothing between
-			// tool_use and tool_result), so it gets the larger toolWindow;
-			// toolWindow <= 0 disables the in-flight bound entirely.
+			// A buffered-but-undrained message means the drain loop is
+			// behind, not the backend. Wait one more tick rather than
+			// killing a backend that is still producing output.
+			if len(messages) > 0 {
+				continue
+			}
+
+			// Check 1: Zero-output watchdog. If no user-visible timeline
+			// items have been produced for zeroOutputWindow, fire. This
+			// is independent of the idle watchdog — a backend emitting
+			// internal frames keeps lastActivityAt fresh but does NOT
+			// reset lastUserVisibleActivityAt.
+			if zeroOutputWindow > 0 {
+				lastVisible := time.Unix(0, lastUserVisibleActivityAt.Load())
+				silentFor := time.Since(lastVisible)
+				if silentFor >= zeroOutputWindow {
+					taskLog.Warn("zero-output watchdog firing: no user-visible output, force-stopping run",
+						"task", shortID(taskID),
+						"silent_for", silentFor.Round(time.Second).String(),
+						"threshold", zeroOutputWindow.String(),
+					)
+					firedThreshold.Store(int64(zeroOutputWindow))
+					fired.Store(true)
+					cancel()
+					return
+				}
+			}
+
+			// Check 2: Idle watchdog. Pick the silence budget based on
+			// whether a tool is in flight.
+			if window <= 0 {
+				continue
+			}
 			threshold := window
 			toolInFlight := inFlightTools.Load() > 0
 			if toolInFlight {
@@ -4449,12 +4504,6 @@ func (d *Daemon) runIdleWatchdog(agentCtx context.Context, window, toolWindow ti
 			last := time.Unix(0, lastActivityAt.Load())
 			idleFor := time.Since(last)
 			if idleFor < threshold {
-				continue
-			}
-			// A buffered-but-undrained message means the drain loop is
-			// behind, not the backend. Wait one more tick rather than
-			// killing a backend that is still producing output.
-			if len(messages) > 0 {
 				continue
 			}
 			taskLog.Warn("idle watchdog firing: no agent activity, force-stopping run",

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1509,6 +1509,121 @@ func TestExecuteAndDrain_IdleWatchdog_FiresAfterToolResultIfBackendStaysSilent(t
 	}
 }
 
+// statusOnlyBackend simulates a stuck --resume session that emits internal
+// MessageStatus frames (session init, pin) but never produces user-visible
+// output. The idle watchdog stays quiet because lastActivityAt keeps resetting,
+// but the zero-output watchdog should fire (#4407).
+type statusOnlyBackend struct {
+	interval time.Duration // how often to emit a status frame
+}
+
+func (b statusOnlyBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	msgCh := make(chan agent.Message, 8)
+	resCh := make(chan agent.Result)
+	go func() {
+		// Emit a burst of status frames, then go silent. Each frame resets
+		// lastActivityAt but NOT lastUserVisibleActivityAt.
+		for i := 0; i < 5; i++ {
+			msgCh <- agent.Message{Type: agent.MessageStatus, Status: "init", SessionID: "sess-123"}
+			if b.interval > 0 {
+				time.Sleep(b.interval)
+			}
+		}
+		// Never close msgCh, never send to resCh — hung backend.
+	}()
+	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func TestExecuteAndDrain_ZeroOutputWatchdog_FiresWhenOnlyStatusFrames(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	// Disable the idle watchdog so only the zero-output watchdog is active.
+	d.cfg.AgentIdleWatchdog = 0
+	d.cfg.AgentZeroOutputWatchdog = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	result, _, err := d.executeAndDrain(ctx, statusOnlyBackend{interval: 5 * time.Millisecond}, "p", agent.ExecOptions{}, slog.Default(), "t-zero-out")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "idle_watchdog" {
+		t.Fatalf("expected status=idle_watchdog (zero-output trip), got %q (err=%q)", result.Status, result.Error)
+	}
+	if elapsed := time.Since(start); elapsed > 10*d.cfg.AgentZeroOutputWatchdog {
+		t.Fatalf("zero-output watchdog took too long to fire: %s (window=%s)", elapsed, d.cfg.AgentZeroOutputWatchdog)
+	}
+}
+
+func TestExecuteAndDrain_ZeroOutputWatchdog_DoesNotFireWhenUserVisibleOutputExists(t *testing.T) {
+	t.Parallel()
+
+	// Test runIdleWatchdog directly to avoid scheduling races with the drain
+	// goroutine. Pre-stamp lastUserVisibleActivityAt to a recent time (as the
+	// drain loop would after processing a MessageText). The zero-output
+	// watchdog should NOT fire because user-visible output was "produced".
+	var lastActivityAt atomic.Int64
+	lastActivityAt.Store(time.Now().UnixNano())
+	var lastUserVisibleActivityAt atomic.Int64
+	lastUserVisibleActivityAt.Store(time.Now().UnixNano()) // stamped by drain after processing MessageText
+	var inFlightTools atomic.Int32
+	var fired atomic.Bool
+	var firedThreshold atomic.Int64
+
+	agentCtx, agentCancel := context.WithCancel(context.Background())
+	defer agentCancel()
+
+	cancelled := make(chan struct{})
+	go func() {
+		agentCancel()
+		close(cancelled)
+	}()
+
+	// Run the watchdog with a 100ms zero-output window. Since
+	// lastUserVisibleActivityAt was just stamped, the watchdog should NOT
+	// fire for 100ms. We cancel the context after 50ms.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		agentCancel()
+	}()
+
+	messages := make(chan agent.Message) // empty, unbuffered
+	d := newTestDaemon(t)
+	d.runIdleWatchdog(agentCtx, 0, 0, 100*time.Millisecond, &lastActivityAt, &lastUserVisibleActivityAt, &inFlightTools, &fired, &firedThreshold, agentCancel, messages, slog.Default(), "t-zero-no-fire")
+
+	if fired.Load() {
+		t.Fatalf("zero-output watchdog should not fire when lastUserVisibleActivityAt was recently stamped, but it did (threshold=%s)", time.Duration(firedThreshold.Load()))
+	}
+}
+
+func TestExecuteAndDrain_ZeroOutputWatchdog_DisabledWhenZero(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	d.cfg.AgentIdleWatchdog = 0
+	d.cfg.AgentZeroOutputWatchdog = 0 // disabled
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Cancel after 100ms — neither watchdog should fire.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	result, _, err := d.executeAndDrain(ctx, statusOnlyBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-zero-disabled")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status == "idle_watchdog" {
+		t.Fatalf("watchdog should not fire when both AgentIdleWatchdog=0 and AgentZeroOutputWatchdog=0, got status=%q", result.Status)
+	}
+}
+
 // ensureRepoReady must refresh `workspaceState.settings` on every checkout —
 // even when the repo cache already holds the URL. The /repo/checkout handler
 // reads `workspaceCoAuthoredByEnabled` right after, and the 30s workspace

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1576,23 +1576,19 @@ func TestExecuteAndDrain_ZeroOutputWatchdog_DoesNotFireWhenUserVisibleOutputExis
 	agentCtx, agentCancel := context.WithCancel(context.Background())
 	defer agentCancel()
 
-	cancelled := make(chan struct{})
+	// Run the watchdog with a 200ms zero-output window (tick at ~50ms).
+	// Since lastUserVisibleActivityAt was just stamped, the watchdog should
+	// NOT fire for 200ms. We cancel the context after 150ms — after
+	// multiple ticks but before the threshold — to confirm the watchdog
+	// stays quiet when user-visible activity is recent.
 	go func() {
-		agentCancel()
-		close(cancelled)
-	}()
-
-	// Run the watchdog with a 100ms zero-output window. Since
-	// lastUserVisibleActivityAt was just stamped, the watchdog should NOT
-	// fire for 100ms. We cancel the context after 50ms.
-	go func() {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 		agentCancel()
 	}()
 
 	messages := make(chan agent.Message) // empty, unbuffered
 	d := newTestDaemon(t)
-	d.runIdleWatchdog(agentCtx, 0, 0, 100*time.Millisecond, &lastActivityAt, &lastUserVisibleActivityAt, &inFlightTools, &fired, &firedThreshold, agentCancel, messages, slog.Default(), "t-zero-no-fire")
+	d.runIdleWatchdog(agentCtx, 0, 0, 200*time.Millisecond, &lastActivityAt, &lastUserVisibleActivityAt, &inFlightTools, &fired, &firedThreshold, agentCancel, messages, slog.Default(), "t-zero-no-fire")
 
 	if fired.Load() {
 		t.Fatalf("zero-output watchdog should not fire when lastUserVisibleActivityAt was recently stamped, but it did (threshold=%s)", time.Duration(firedThreshold.Load()))


### PR DESCRIPTION
## Summary

When a  session emits internal frames ( for session init/pin) but no user-visible output (text, thinking, tool calls, errors), the existing idle watchdog never fires because  keeps resetting on **every** backend message regardless of type. The task stays  for up to 2.5 hours until the server-side sweeper backstop kicks in. During this time,  serialization on  blocks all subsequent reply tasks from being claimed.

This PR adds a **zero-output watchdog** that tracks  separately from , firing after 5 minutes (configurable) when no user-visible timeline items have been produced.

Closes #4407.

## Root Cause

In  (daemon.go:4246), the drain loop stamps  on **every** message from the backend channel �� including  (session init, pin) frames that don't produce user-visible timeline items. The idle watchdog reads  to decide if the backend has gone silent, so a stuck  that emits internal frames keeps resetting the watchdog indefinitely.

The  test () only covers the case where the backend emits **zero messages at all** �� it doesn't cover the more common case where the backend emits internal frames but no user-visible content.

## Changes

| File | Change |
|------|--------|
|  | Add  field (default 5m),  env var |
|  | Add  atomic in drain loop; stamp only for user-visible types (not ); extend  with zero-output check |
|  | 3 new tests: fires on status-only frames, does not fire with visible output, disabled when zero |

## How It Works

The existing  now checks three silence budgets in parallel:

1. **Zero-output window** (new, default 5m) �� fires when  is older than the window. Independent of . Catches stuck  sessions.
2. **Idle window** (existing, default 30m) �� fires when  is older than the window and no tool is in flight.
3. **Tool window** (existing, default 2h) �� fires when  is older than the window and a tool IS in flight.

The tick interval is the smallest applicable window / 2, so the zero-output watchdog gets checked frequently enough to fire promptly.

## Tests



## AI Disclosure

This PR was authored with AI assistance (QoderWork). The contributor reviewed all code changes and verified test results before submission.
