### PR TITLE
test(issues): cover pure issue utility helpers

### DIFF
--- a/packages/core/issues/timeline-sort.test.ts
+++ b/packages/core/issues/timeline-sort.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineEntry } from "@multica/core/types";
+
+import { sortTimelineEntriesAsc } from "./timeline-sort";
+
+function entry(id: string, created_at: string): TimelineEntry {
+  return {
+    type: "activity",
+    id,
+    actor_type: "member",
+    actor_id: "member-1",
+    created_at,
+  };
+}
+
+describe("sortTimelineEntriesAsc", () => {
+  it("sorts timeline entries by created_at ascending", () => {
+    const entries = [
+      entry("later", "2026-01-01T00:00:02Z"),
+      entry("earlier", "2026-01-01T00:00:01Z"),
+      entry("latest", "2026-01-01T00:00:03Z"),
+    ];
+
+    expect(sortTimelineEntriesAsc(entries).map((e) => e.id)).toEqual([
+      "earlier",
+      "later",
+      "latest",
+    ]);
+  });
+
+  it("breaks identical created_at ties by id", () => {
+    const entries = [
+      entry("comment-b", "2026-01-01T00:00:01Z"),
+      entry("comment-a", "2026-01-01T00:00:01Z"),
+      entry("comment-c", "2026-01-01T00:00:01Z"),
+    ];
+
+    expect(sortTimelineEntriesAsc(entries).map((e) => e.id)).toEqual([
+      "comment-a",
+      "comment-b",
+      "comment-c",
+    ]);
+  });
+
+  it("returns the same array reference for cache patching callers", () => {
+    const entries = [
+      entry("b", "2026-01-01T00:00:02Z"),
+      entry("a", "2026-01-01T00:00:01Z"),
+    ];
+
+    expect(sortTimelineEntriesAsc(entries)).toBe(entries);
+  });
+});

--- a/packages/views/chat/lib/format.test.ts
+++ b/packages/views/chat/lib/format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { formatElapsedMs, formatElapsedSecs } from "./format";
+
+describe("formatElapsedSecs", () => {
+  it("formats values under one minute as seconds", () => {
+    expect(formatElapsedSecs(0)).toBe("0s");
+    expect(formatElapsedSecs(59)).toBe("59s");
+  });
+
+  it("formats whole minutes without a zero-second suffix", () => {
+    expect(formatElapsedSecs(60)).toBe("1m");
+    expect(formatElapsedSecs(180)).toBe("3m");
+  });
+
+  it("formats mixed minute and second values", () => {
+    expect(formatElapsedSecs(61)).toBe("1m 1s");
+    expect(formatElapsedSecs(125)).toBe("2m 5s");
+  });
+});
+
+describe("formatElapsedMs", () => {
+  it("rounds milliseconds to the nearest second before formatting", () => {
+    expect(formatElapsedMs(1_499)).toBe("1s");
+    expect(formatElapsedMs(1_500)).toBe("2s");
+    expect(formatElapsedMs(60_500)).toBe("1m 1s");
+  });
+
+  it("clamps negative millisecond values to zero", () => {
+    expect(formatElapsedMs(-500)).toBe("0s");
+  });
+});

--- a/packages/views/issues/utils/sort.test.ts
+++ b/packages/views/issues/utils/sort.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@multica/core/types";
+
+import { sortIssues } from "./sort";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Test issue",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("sortIssues", () => {
+  it("sorts by manual position without mutating the input array", () => {
+    const issues = [
+      makeIssue({ id: "second", position: 2 }),
+      makeIssue({ id: "first", position: 1 }),
+    ];
+
+    const sorted = sortIssues(issues, "position", "asc");
+
+    expect(sorted.map((issue) => issue.id)).toEqual(["first", "second"]);
+    expect(issues.map((issue) => issue.id)).toEqual(["second", "first"]);
+  });
+
+  it("sorts priorities by configured rank", () => {
+    const issues = [
+      makeIssue({ id: "low", priority: "low" }),
+      makeIssue({ id: "urgent", priority: "urgent" }),
+      makeIssue({ id: "none", priority: "none" }),
+      makeIssue({ id: "high", priority: "high" }),
+    ];
+
+    expect(sortIssues(issues, "priority", "asc").map((issue) => issue.id)).toEqual([
+      "urgent",
+      "high",
+      "low",
+      "none",
+    ]);
+  });
+
+  it("keeps missing start dates after dated issues in ascending order", () => {
+    const issues = [
+      makeIssue({ id: "no-start", start_date: null }),
+      makeIssue({ id: "later", start_date: "2026-01-03" }),
+      makeIssue({ id: "earlier", start_date: "2026-01-01" }),
+    ];
+
+    expect(sortIssues(issues, "start_date", "asc").map((issue) => issue.id)).toEqual([
+      "earlier",
+      "later",
+      "no-start",
+    ]);
+  });
+
+  it("moves missing due dates to the front when descending reverses the ordered list", () => {
+    const issues = [
+      makeIssue({ id: "earlier", due_date: "2026-01-01" }),
+      makeIssue({ id: "no-due", due_date: null }),
+      makeIssue({ id: "later", due_date: "2026-01-03" }),
+    ];
+
+    expect(sortIssues(issues, "due_date", "desc").map((issue) => issue.id)).toEqual([
+      "no-due",
+      "later",
+      "earlier",
+    ]);
+  });
+
+  it("uses stable ordering when compared values are equal", () => {
+    const issues = [
+      makeIssue({ id: "first", title: "Same title" }),
+      makeIssue({ id: "second", title: "Same title" }),
+    ];
+
+    expect(sortIssues(issues, "title", "asc").map((issue) => issue.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds focused unit coverage for a few pure utility helpers used by issue timelines, issue list sorting, and elapsed-time display. This is a tests-only change that locks in existing behavior around ordering tie-breaks, nullable dates, immutability, and duration formatting boundaries.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `packages/core/issues/timeline-sort.test.ts` for timeline timestamp sorting, id tie-breaks, and same-array cache behavior.
- Added `packages/views/issues/utils/sort.test.ts` for issue priority/date/title/position sorting behavior.
- Added `packages/views/chat/lib/format.test.ts` for elapsed seconds and milliseconds formatting boundaries.

## How to Test

1. `pnpm -C packages/core test issues/timeline-sort.test.ts`
2. `pnpm -C packages/views test issues/utils/sort.test.ts chat/lib/format.test.ts`
3. Confirm both test commands pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Asked Cursor to create a branch from `main` and complete the “pure function tests: timeline / issue sort / elapsed format” candidate from the PR plan. The approach was to inspect the existing helpers and nearby test style, add narrow tests beside each helper, then run focused package-level Vitest commands.

## Screenshots (optional)

N/A