### PR TITLE
fix(agents): defend AccessPicker against undefined invocation_targets (GH #4915)

### DIFF
--- a/packages/core/permissions/rules.test.ts
+++ b/packages/core/permissions/rules.test.ts
@@ -259,6 +259,30 @@ describe("canAssignAgentToIssue", () => {
     expect(d.allowed).toBe(false);
     expect(d.reason).toBe("not_authenticated");
   });
+
+  // Regression: GH #4915. Legacy self-host backends / stale caches may
+  // return an agent without `invocation_targets` even though the modern
+  // type says required-array. The gate must degrade to "no grants" instead
+  // of throwing on `.some()` of undefined.
+  it("does not throw when invocation_targets is undefined", () => {
+    const a = makeAgent({
+      permission_mode: "public_to",
+      invocation_targets:
+        undefined as unknown as Agent["invocation_targets"],
+      owner_id: ALICE,
+    });
+    // Non-owner: no grants means denied.
+    expect(() =>
+      canAssignAgentToIssue(a, { userId: BOB, role: "member" }),
+    ).not.toThrow();
+    const d = canAssignAgentToIssue(a, { userId: BOB, role: "member" });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toBe("private_visibility");
+    // Owner path still allows.
+    expect(
+      canAssignAgentToIssue(a, { userId: ALICE, role: "member" }).allowed,
+    ).toBe(true);
+  });
 });
 
 describe("canEditSkill / canDeleteSkill", () => {

--- a/packages/core/permissions/rules.ts
+++ b/packages/core/permissions/rules.ts
@@ -75,8 +75,10 @@ export function canAssignAgentToIssue(
   }
 
   // permission_mode === "public_to": resolve the invocation grants. A
-  // workspace grant opens invocation to any workspace member.
-  const targets = agent.invocation_targets;
+  // workspace grant opens invocation to any workspace member. The `?? []`
+  // guards against legacy self-host backends / stale caches that omit the
+  // field even though the type says required-array (GH #4915).
+  const targets = agent.invocation_targets ?? [];
   if (targets.some((t) => t.target_type === "workspace")) {
     if (ctx.role === null) {
       return deny("not_member", "Join this workspace to assign agents.");

--- a/packages/views/agents/components/inspector/access-picker.test.tsx
+++ b/packages/views/agents/components/inspector/access-picker.test.tsx
@@ -116,4 +116,34 @@ describe("AccessPicker owner-only editing (MUL-3963)", () => {
       ],
     });
   });
+
+  // Regression: GH #4915. Older self-host backends / stale caches may return
+  // an agent without `invocation_targets` even though the modern type says
+  // required-array. The picker must degrade gracefully to the "Private" /
+  // empty-allowlist summary instead of crashing the whole agent detail
+  // route with "Cannot read properties of undefined (reading 'some')".
+  it("renders without crashing when invocationTargets is undefined", () => {
+    expect(() =>
+      renderPicker({
+        // Force the runtime shape produced by a legacy backend response.
+        invocationTargets: undefined as unknown as AgentInvocationTarget[],
+      }),
+    ).not.toThrow();
+    // Private is the fallback summary when there are no grants.
+    expect(screen.getAllByText("Only me").length).toBeGreaterThan(0);
+  });
+
+  it("read-only mode: undefined invocationTargets does not crash for non-owners", () => {
+    expect(() =>
+      renderPicker({
+        canEdit: false,
+        permissionMode: "public_to",
+        invocationTargets: undefined as unknown as AgentInvocationTarget[],
+        visibility: "workspace",
+      }),
+    ).not.toThrow();
+    // No workspace target in the (empty) list ⇒ shows the "no members" state
+    // rather than the workspace one, which is the safe degradation.
+    expect(screen.getByTestId("access-readonly")).toBeInTheDocument();
+  });
 });

--- a/packages/views/agents/components/inspector/access-picker.tsx
+++ b/packages/views/agents/components/inspector/access-picker.tsx
@@ -52,18 +52,32 @@ export type AccessChange = {
   invocation_targets: AgentInvocationTargetInput[];
 };
 
-function hasWorkspaceTarget(targets: AgentInvocationTarget[]): boolean {
-  return targets.some((t) => t.target_type === "workspace");
+// The helpers below defensively coerce a missing (`undefined` / `null`) list
+// to an empty array. `Agent.invocation_targets` is TYPED as a required array,
+// and the modern backend always serialises `[]` when there are no grants,
+// but older self-host servers / stale query caches / template create
+// responses (see `MinimalAgentSchema` in api/schemas.ts) can still surface an
+// undefined value at runtime. Without the fallback, opening an agent detail
+// page against a legacy backend crashes the whole route with
+// "Cannot read properties of undefined (reading 'some')" (GH #4915).
+function hasWorkspaceTarget(
+  targets: AgentInvocationTarget[] | undefined | null,
+): boolean {
+  return (targets ?? []).some((t) => t.target_type === "workspace");
 }
 
-function selectedMemberIds(targets: AgentInvocationTarget[]): string[] {
-  return targets
+function selectedMemberIds(
+  targets: AgentInvocationTarget[] | undefined | null,
+): string[] {
+  return (targets ?? [])
     .filter((t) => t.target_type === "member" && t.target_id !== null)
     .map((t) => t.target_id as string);
 }
 
-function selectedTeamIds(targets: AgentInvocationTarget[]): string[] {
-  return targets
+function selectedTeamIds(
+  targets: AgentInvocationTarget[] | undefined | null,
+): string[] {
+  return (targets ?? [])
     .filter((t) => t.target_type === "team" && t.target_id !== null)
     .map((t) => t.target_id as string);
 }
@@ -78,7 +92,13 @@ export function AccessPicker({
   onChange,
 }: {
   permissionMode: AgentPermissionMode;
-  invocationTargets: AgentInvocationTarget[];
+  /**
+   * The agent's invocation grants. Typed loose (may be `undefined`) because
+   * the schema is `optional()` and older self-host backends / template create
+   * responses can omit the field even though the modern shape is a
+   * required-array. The internal helpers `?? []` this before reading.
+   */
+  invocationTargets: AgentInvocationTarget[] | undefined;
   /**
    * Legacy derived visibility. No longer rendered directly (the read-only and
    * editable states both summarise permission_mode + targets), but kept in the

--- a/packages/views/agents/components/tabs/agent-mcp-tab.test.tsx
+++ b/packages/views/agents/components/tabs/agent-mcp-tab.test.tsx
@@ -234,4 +234,25 @@ describe("AgentMcpTab", () => {
       screen.queryByText(/any workspace member may use these Composio apps/i),
     ).toBeNull();
   });
+
+  // Regression: GH #4915. Legacy self-host backends / stale caches may
+  // return an agent without `invocation_targets` even though the modern
+  // type declares a required array. The tab must degrade to the "not
+  // workspace-public" copy instead of crashing the whole detail route
+  // with "Cannot read properties of undefined (reading 'some')".
+  it("does not crash when invocation_targets is undefined", () => {
+    expect(() =>
+      renderTab({
+        permission_mode: "public_to",
+        invocation_targets:
+          undefined as unknown as Agent["invocation_targets"],
+        composio_toolkit_allowlist: ["notion"],
+      }),
+    ).not.toThrow();
+    // Falls back to the generic shared warning (no workspace target
+    // resolves to `false`), not the workspace-wide one.
+    expect(
+      screen.queryByText(/any workspace member may use these Composio apps/i),
+    ).toBeNull();
+  });
 });

--- a/packages/views/agents/components/tabs/agent-mcp-tab.tsx
+++ b/packages/views/agents/components/tabs/agent-mcp-tab.tsx
@@ -90,7 +90,9 @@ export function AgentMcpTab({ agent }: { agent: Agent }) {
   const isPrivate = agent.permission_mode === "private";
   const isWorkspacePublic =
     agent.permission_mode === "public_to" &&
-    agent.invocation_targets.some((target) => target.target_type === "workspace");
+    (agent.invocation_targets ?? []).some(
+      (target) => target.target_type === "workspace",
+    );
   const showSharedWarning =
     !isPrivate && (allowlist.length > 0 || activeSlugs.length > 0);
 


### PR DESCRIPTION
## Background

Fixes GH [#4915](https://github.com/multica-ai/multica/issues/4915) — on v0.3.37 (self-host, Windows desktop) opening the agent detail page crashes the whole route with:

```
TypeError: Cannot read properties of undefined (reading 'some')
    at hasWorkspaceTarget
    at AccessPicker
```

## Root cause

`AccessPicker` (introduced by MUL-3963) has three module-local helpers — `hasWorkspaceTarget`, `selectedMemberIds`, `selectedTeamIds` — that call `.some()` / `.filter()` directly on the `invocationTargets` prop with no null defense. The prop is typed `AgentInvocationTarget[]` and the field is likewise declared required on `Agent`, so TypeScript is satisfied, **but at runtime the value can be `undefined`**:

- `packages/core/api/schemas.ts` declares `invocation_targets: AgentInvocationTargetsSchema.optional()`, and `MinimalAgentSchema` (create-from-template response) is optional too.
- `api.listAgents` / `api.getAgent` return raw JSON without going through the schema — so an older self-host backend that predates MUL-3963 (the exact GH #4915 setup) yields an `Agent` with the field missing, and `.some()` on `undefined` blows up.

Two more sites had the same unguarded pattern:
- `AgentMcpTab` (composio warning branch)
- `canAssignAgentToIssue` in `packages/core/permissions/rules.ts`

## Fix

Add a `?? []` defence at every read site, matching the already-established pattern in `create-agent-dialog.tsx`:

- **`access-picker.tsx`** — coerce inside the three helpers and widen `invocationTargets` prop to `AgentInvocationTarget[] | undefined` so the accepted runtime shape is documented.
- **`agent-mcp-tab.tsx`** — `(agent.invocation_targets ?? []).some(...)`.
- **`permissions/rules.ts`** — `agent.invocation_targets ?? []` before the workspace/member membership checks.

## Tests

- `access-picker.test.tsx`: two new tests verify the owner-editable and non-owner read-only paths do not throw when `invocationTargets` is `undefined`, and render the "Private" / "empty allowlist" summary.
- `agent-mcp-tab.test.tsx`: new test verifies the composio warning branch degrades to the generic shared-warning copy (not workspace-wide) when `invocation_targets` is undefined.
- `rules.test.ts`: new test verifies `canAssignAgentToIssue` denies non-owners with `private_visibility` and still allows the owner when `invocation_targets` is undefined.

`pnpm --filter @multica/core --filter @multica/views typecheck` and `lint` pass with 0 errors; the three affected test files pass locally (`vitest run permissions/rules.test.ts` — 39/39; `vitest run agents/components/inspector/access-picker.test.tsx agents/components/tabs/agent-mcp-tab.test.tsx` — 17/17). The one pre-existing `projects/mutations.test.tsx` failure on `main` (localStorage/zustand middleware) is unrelated to this change.

## Test focus for reviewer

1. Simulate a legacy self-host server response by patching `api.listAgents` to strip `invocation_targets` — the agent detail route now renders the AccessPicker in the "Private" read-only state instead of crashing.
2. AccessPicker interactions on a modern (well-formed) agent are unchanged (the existing tests still pass, no behavior regression on the happy path).
