### PR TITLE
feat(issues): add board-hidden `archived` status

### DIFF
--- a/apps/mobile/components/inbox/detail-label.tsx
+++ b/apps/mobile/components/inbox/detail-label.tsx
@@ -33,6 +33,7 @@ const STATUS_LABEL: Record<IssueStatus, string> = {
   done: "Done",
   blocked: "Blocked",
   cancelled: "Cancelled",
+  archived: "Archived",
 };
 
 // Mirrors PRIORITY_CONFIG.label in packages/core/issues/config/priority.ts

--- a/apps/mobile/components/issue/mention-suggestion-bar.tsx
+++ b/apps/mobile/components/issue/mention-suggestion-bar.tsx
@@ -331,7 +331,8 @@ export function MentionSuggestionBar({
           // issue
           const closed =
             item.issue.status === "done" ||
-            item.issue.status === "cancelled";
+            item.issue.status === "cancelled" ||
+            item.issue.status === "archived";
           return (
             <Pressable
               onPress={() =>

--- a/apps/mobile/components/ui/status-icon.tsx
+++ b/apps/mobile/components/ui/status-icon.tsx
@@ -30,6 +30,7 @@ const STATUS_COLOR: Record<IssueStatus, string> = {
   done: "#3b82f6", // info
   blocked: "#dc2626", // destructive
   cancelled: "#71717a",
+  archived: "#71717a",
 };
 
 function piePath(progress: number): string {

--- a/apps/mobile/lib/format-activity.ts
+++ b/apps/mobile/lib/format-activity.ts
@@ -25,6 +25,7 @@ const STATUS_LABEL: Record<IssueStatus, string> = {
   done: "Done",
   blocked: "Blocked",
   cancelled: "Cancelled",
+  archived: "Archived",
 };
 
 const PRIORITY_LABEL: Record<IssuePriority, string> = {

--- a/apps/mobile/lib/issue-status.ts
+++ b/apps/mobile/lib/issue-status.ts
@@ -30,6 +30,7 @@ export const STATUS_LABEL: Record<IssueStatus, string> = {
   done: "Done",
   blocked: "Blocked",
   cancelled: "Cancelled",
+  archived: "Archived",
 };
 
 export const PRIORITY_LABEL: Record<IssuePriority, string> = {

--- a/docs/rfcs/hidden-board-status.md
+++ b/docs/rfcs/hidden-board-status.md
@@ -1,0 +1,70 @@
+# RFC: Hidden / archivable board statuses
+
+- Status: Draft
+- Tracking issues: JON-115 (epic), JON-116 (this RFC), JON-117..JON-120
+
+## Motivation
+
+Users want to move completed issues out of the active board view without sending
+them back to `backlog` or losing them. A concrete case: on a "Manejo Facturas"
+board, issues that have been in `done` for more than 2h should disappear from the
+board while remaining tracked and recoverable.
+
+## Current state (as-is)
+
+Issue status is a **fixed enum hardcoded across four layers**:
+
+| Layer | File | Reference |
+|-------|------|-----------|
+| DB | `server/migrations/001_init.up.sql` | `CHECK (status IN (...))` (lines 57-58) |
+| Backend (Go) | `server/internal/handler/issue.go` | `validIssueStatuses` (line 74), sort `CASE` (line ~512) |
+| Core (TS) | `packages/core/types/issue.ts` (`IssueStatus`), `packages/core/issues/config/status.ts` (`STATUS_ORDER`, `ALL_STATUSES`, `BOARD_STATUSES`, `STATUS_CONFIG`) | — |
+| Mobile | `apps/mobile/lib/issue-status.ts` | mirror of the enum |
+
+Key finding: `BOARD_STATUSES` in `packages/core/issues/config/status.ts` **already
+excludes `cancelled`**, so `cancelled` issues are already hidden from board columns.
+This means the "hide from board" behavior already exists — it is just semantically
+wrong to reuse `cancelled` for "completed and archived".
+
+## Options
+
+### Option A — Add a built-in `archived` terminal status (recommended first PR)
+
+Introduce one new status, `archived`, that is a terminal state excluded from
+`BOARD_STATUSES` (same treatment as `cancelled`). Semantically correct for
+"done and hidden".
+
+Changes (small, reviewable, single PR):
+1. DB: add `archived` to the `CHECK` constraint (new migration `NNN_add_archived_status`).
+2. Go: add `"archived"` to `validIssueStatuses`; give it a sort weight.
+3. Core TS: add `"archived"` to `IssueStatus`, `STATUS_ORDER`, `ALL_STATUSES`, and
+   `STATUS_CONFIG`; leave it OUT of `BOARD_STATUSES`.
+4. Mobile: mirror in `apps/mobile/lib/issue-status.ts`.
+5. i18n: add the label to `packages/views/locales/*/issues.json`.
+
+Pros: ships quickly, low risk, immediately usable by the auto-transition rule.
+Cons: still a fixed enum; not user-defined.
+
+### Option B — User-defined custom statuses with a `hidden` flag (the JON-115 epic)
+
+Model statuses as data (per workspace, optional per-project override) with fields:
+`key`, `label`, `category` (todo/in_progress/done/terminal), `order`, `hidden`.
+
+Changes (multi-PR): new `issue_status` table + migration off the enum, API contract,
+list/board endpoints honoring `hidden` + order, CLI (`multica status ...`), board UI
+for custom/hidden columns, mobile parity.
+
+Pros: fully flexible. Cons: large surface, data migration off the enum, higher risk.
+
+## Related: time-based auto-transition (JON-120)
+
+A native rule "if an issue has been in status X for more than N hours, move it to
+status Y" would replace the current autopilot workaround and measure time from the
+actual status change (not the generic `updated_at`). Pairs naturally with an
+`archived`/hidden status as the destination.
+
+## Recommendation
+
+Ship **Option A** first (`archived` status) as the immediate, low-risk PR that solves
+the user's need with correct semantics, then pursue Option B (JON-115) and the
+auto-transition rule (JON-120) as follow-ups.

--- a/packages/core/issues/config/status.ts
+++ b/packages/core/issues/config/status.ts
@@ -8,6 +8,7 @@ export const STATUS_ORDER: IssueStatus[] = [
   "done",
   "blocked",
   "cancelled",
+  "archived",
 ];
 
 export const ALL_STATUSES: IssueStatus[] = [
@@ -18,9 +19,10 @@ export const ALL_STATUSES: IssueStatus[] = [
   "done",
   "blocked",
   "cancelled",
+  "archived",
 ];
 
-/** Statuses shown as board columns (excludes cancelled). */
+/** Statuses shown as board columns (excludes cancelled and archived). */
 export const BOARD_STATUSES: IssueStatus[] = [
   "backlog",
   "todo",
@@ -47,4 +49,5 @@ export const STATUS_CONFIG: Record<
   done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10", dividerColor: "bg-info", columnBg: "bg-info/5" },
   blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10", dividerColor: "bg-destructive", columnBg: "bg-destructive/5" },
   cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", columnBg: "bg-muted/40" },
+  archived: { label: "Archived", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", columnBg: "bg-muted/40" },
 };

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -7,7 +7,8 @@ export type IssueStatus =
   | "in_review"
   | "done"
   | "blocked"
-  | "cancelled";
+  | "cancelled"
+  | "archived";
 
 export type IssuePriority = "urgent" | "high" | "medium" | "low" | "none";
 

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -387,9 +387,12 @@ function MentionRow({
 }) {
   const { t } = useT("editor");
   if (item.type === "issue") {
-    // Visually dim closed issues (done/cancelled) so they're distinguishable
-    // from active ones in the suggestion list — they're still selectable.
-    const isClosed = item.status === "done" || item.status === "cancelled";
+    // Visually dim closed issues (done/cancelled/archived) so they're
+    // distinguishable from active ones in the suggestion list — still selectable.
+    const isClosed =
+      item.status === "done" ||
+      item.status === "cancelled" ||
+      item.status === "archived";
     return (
       <button
         type="button"

--- a/packages/views/issues/components/gantt-view.tsx
+++ b/packages/views/issues/components/gantt-view.tsx
@@ -298,6 +298,7 @@ const STATUS_BAR_BG: Record<IssueStatus, string> = {
   done: "bg-info",
   blocked: "bg-destructive",
   cancelled: "bg-muted-foreground/40",
+  archived: "bg-muted-foreground/40",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -577,7 +577,10 @@ function SubIssueRow({ child }: { child: Issue }) {
   const updateIssue = useUpdateIssue();
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(child.id));
   const toggleSelected = useIssueSelectionStore((s) => s.toggle);
-  const isDone = child.status === "done" || child.status === "cancelled";
+  const isDone =
+    child.status === "done" ||
+    child.status === "cancelled" ||
+    child.status === "archived";
 
   const handleUpdate = useCallback(
     (updates: Partial<UpdateIssueRequest>) => {

--- a/packages/views/issues/components/status-icon.tsx
+++ b/packages/views/issues/components/status-icon.tsx
@@ -139,6 +139,22 @@ function CancelledIcon() {
   );
 }
 
+/** Filled ring with an archive-box glyph (lid + tray + handle slot) */
+function ArchivedIcon() {
+  return (
+    <ProgressCircle progress={0}>
+      <path
+        d="M4 5 H10 M4.5 5 V9 A0.5 0.5 0 0 0 5 9.5 H9 A0.5 0.5 0 0 0 9.5 9 V5 M6 6.75 H8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.1}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </ProgressCircle>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Renderer map
 // ---------------------------------------------------------------------------
@@ -151,6 +167,7 @@ const STATUS_RENDERERS: Record<IssueStatus, () => React.ReactNode> = {
   done: DoneIcon,
   blocked: BlockedIcon,
   cancelled: CancelledIcon,
+  archived: ArchivedIcon,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -13,7 +13,8 @@
     "in_review": "In Review",
     "done": "Done",
     "blocked": "Blocked",
-    "cancelled": "Cancelled"
+    "cancelled": "Cancelled",
+    "archived": "Archived"
   },
   "priority": {
     "urgent": "Urgent",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -13,7 +13,8 @@
     "in_review": "レビュー中",
     "done": "完了",
     "blocked": "ブロック中",
-    "cancelled": "キャンセル済み"
+    "cancelled": "キャンセル済み",
+    "archived": "アーカイブ済み"
   },
   "priority": {
     "urgent": "緊急",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -13,7 +13,8 @@
     "in_review": "리뷰 중",
     "done": "완료",
     "blocked": "막힘",
-    "cancelled": "취소됨"
+    "cancelled": "취소됨",
+    "archived": "보관됨"
   },
   "priority": {
     "urgent": "긴급",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -13,7 +13,8 @@
     "in_review": "审核中",
     "done": "已完成",
     "blocked": "已阻塞",
-    "cancelled": "已取消"
+    "cancelled": "已取消",
+    "archived": "已归档"
   },
   "priority": {
     "urgent": "紧急",

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -143,7 +143,7 @@ var issueStatusCmd = &cobra.Command{
 	Use:   "status <id> <status>",
 	Short: "Change issue status",
 	Long: "Change an issue's status. Valid statuses: " +
-		"backlog, todo, in_progress, in_review, done, blocked, cancelled.",
+		"backlog, todo, in_progress, in_review, done, blocked, cancelled, archived.",
 	Args: exactArgs(2),
 	RunE: runIssueStatus,
 }
@@ -266,7 +266,7 @@ var issueSearchCmd = &cobra.Command{
 }
 
 var validIssueStatuses = []string{
-	"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled",
+	"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled", "archived",
 }
 
 var validIssuePriorities = []string{
@@ -788,7 +788,7 @@ func runIssueChildren(cmd *cobra.Command, args []string) error {
 		}
 		stages[gi].Issues = append(stages[gi].Issues, c)
 		stages[gi].Total++
-		if st := strVal(c, "status"); st == "done" || st == "cancelled" {
+		if st := strVal(c, "status"); st == "done" || st == "cancelled" || st == "archived" {
 			stages[gi].Done++
 		}
 	}

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2372,6 +2372,7 @@ func TestValidIssueStatuses(t *testing.T) {
 		"done":        true,
 		"blocked":     true,
 		"cancelled":   true,
+		"archived":    true,
 	}
 	for _, s := range validIssueStatuses {
 		if !expected[s] {

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -269,7 +269,7 @@ func (d *Daemon) gcDecisionIssue(ctx context.Context, taskDir string, meta *exec
 		return gcActionSkip
 	}
 
-	if (status.Status == "done" || status.Status == "cancelled") &&
+	if (status.Status == "done" || status.Status == "cancelled" || status.Status == "archived") &&
 		time.Since(status.UpdatedAt) > d.cfg.GCTTL {
 		d.logger.Info("gc: eligible for cleanup",
 			"dir", filepath.Base(taskDir),

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -945,7 +945,7 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 		// intent was ever delivered, the user should decide manually.
 		if state == "merged" || state == "closed" {
 			for _, issue := range reevalIssues {
-				if issue.Status == "done" || issue.Status == "cancelled" {
+				if issue.Status == "done" || issue.Status == "cancelled" || issue.Status == "archived" {
 					continue
 				}
 				counts, err := h.Queries.GetIssuePullRequestCloseAggregate(ctx, issue.ID)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -450,7 +450,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	whereClause := "(" + strings.Join(whereParts, " OR ") + ")"
 
 	if !includeClosed {
-		whereClause += " AND i.status NOT IN ('done', 'cancelled')"
+		whereClause += " AND i.status NOT IN ('done', 'cancelled', 'archived')"
 	}
 
 	// --- ORDER BY clause ---

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -71,7 +71,7 @@ type IssueResponse struct {
 // the issue table. Write handlers pre-validate these so callers get a clean
 // 400 with the allowed values instead of a database CHECK violation bubbling
 // up as a 500.
-var validIssueStatuses = []string{"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"}
+var validIssueStatuses = []string{"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled", "archived"}
 var validIssuePriorities = []string{"urgent", "high", "medium", "low", "none"}
 
 func validateIssueEnum(w http.ResponseWriter, field, value string, allowed []string) bool {
@@ -515,7 +515,8 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 		WHEN 'backlog' THEN 4
 		WHEN 'done' THEN 5
 		WHEN 'cancelled' THEN 6
-		ELSE 7
+		WHEN 'archived' THEN 7
+		ELSE 8
 	END`
 
 	// --- match_source expression ---

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -202,10 +202,11 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 }
 
 // isTerminalChildStatus reports whether a child issue status counts as
-// "finished" for stage-barrier purposes. Cancelled counts as terminal: a
-// cancelled sibling will never complete, so it must not hold a stage open.
+// "finished" for stage-barrier purposes. Cancelled and archived count as
+// terminal: such a sibling will never complete, so it must not hold a stage
+// open.
 func isTerminalChildStatus(status string) bool {
-	return status == "done" || status == "cancelled"
+	return status == "done" || status == "cancelled" || status == "archived"
 }
 
 // siblingsAreStaged reports whether any child in the set carries an explicit

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -36,8 +36,8 @@ func TestBuildSearchQuery_SingleTerm(t *testing.T) {
 	}
 
 	// Should exclude closed issues by default.
-	if !strings.Contains(query, "NOT IN ('done', 'cancelled')") {
-		t.Error("query should exclude done/cancelled when includeClosed=false")
+	if !strings.Contains(query, "NOT IN ('done', 'cancelled', 'archived')") {
+		t.Error("query should exclude done/cancelled/archived when includeClosed=false")
 	}
 }
 
@@ -79,8 +79,8 @@ func TestBuildSearchQuery_WithNumber(t *testing.T) {
 func TestBuildSearchQuery_IncludeClosed(t *testing.T) {
 	query, _ := buildSearchQuery("test", []string{"test"}, 0, false, true)
 
-	if strings.Contains(query, "NOT IN ('done', 'cancelled')") {
-		t.Error("query should not exclude done/cancelled when includeClosed=true")
+	if strings.Contains(query, "NOT IN ('done', 'cancelled', 'archived')") {
+		t.Error("query should not exclude done/cancelled/archived when includeClosed=true")
 	}
 }
 

--- a/server/migrations/134_issue_archived_status.down.sql
+++ b/server/migrations/134_issue_archived_status.down.sql
@@ -1,0 +1,7 @@
+-- Revert the 'archived' status. Any issues currently in 'archived' must be moved
+-- to a status that survives the tightened CHECK; 'cancelled' is the closest
+-- terminal, board-hidden state.
+UPDATE issue SET status = 'cancelled' WHERE status = 'archived';
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_status_check;
+ALTER TABLE issue ADD CONSTRAINT issue_status_check
+    CHECK (status IN ('backlog', 'todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'));

--- a/server/migrations/134_issue_archived_status.up.sql
+++ b/server/migrations/134_issue_archived_status.up.sql
@@ -1,0 +1,11 @@
+-- Add 'archived' as a terminal issue status. Like 'cancelled', it is excluded
+-- from the board columns (BOARD_STATUSES in packages/core/issues/config/status.ts),
+-- so archived issues stay tracked and recoverable but drop out of the active
+-- board view. Gives "completed and hidden" a correct semantic home instead of
+-- overloading 'cancelled'. See docs/rfcs/hidden-board-status.md (JON-115/JON-117).
+--
+-- The original constraint is the inline CHECK from 001_init, auto-named
+-- issue_status_check by Postgres.
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_status_check;
+ALTER TABLE issue ADD CONSTRAINT issue_status_check
+    CHECK (status IN ('backlog', 'todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled', 'archived'));


### PR DESCRIPTION
## Summary

Adds a terminal `archived` issue status that is **excluded from the board columns** (like `cancelled`), so completed issues can be hidden from the active board while staying tracked and recoverable.

Motivation: teams want to move finished issues out of the active board view without sending them back to `backlog` or overloading `cancelled` (which is semantically "cancelled", not "completed and archived"). `BOARD_STATUSES` already excludes `cancelled`, so this follows the exact same, well-established pattern — just with correct semantics for completed work.

See `docs/rfcs/hidden-board-status.md` for the full design (this is "Option A"; user-defined custom statuses and a native time-based auto-transition rule are proposed as follow-ups).

## Changes

Wires `archived` through **every layer that enumerates issue status**:

- **DB** — migration `134_issue_archived_status` extends the `issue_status` CHECK constraint (down-migration moves `archived → cancelled` before tightening).
- **Go** — `validIssueStatuses` (handler + CLI), search status rank, and `issue status` CLI help text.
- **Core TS** — `IssueStatus` union, `STATUS_ORDER`, `ALL_STATUSES`, `STATUS_CONFIG` (kept **out** of `BOARD_STATUSES`).
- **Web / Mobile** — status icon / label / color maps (added an archive-box icon on web).
- **i18n** — `en`, `ja`, `ko`, `zh-Hans`.

`archived` is treated as **terminal, with the same semantics as `cancelled`** in closed-issue predicates:

- daemon GC eligibility, GitHub PR-driven auto-close skip, stage-barrier child rollup (`isTerminalChildStatus`), CLI children "done" count, mention-suggestion dimming, child "done" styling;
- **default search excludes `archived`** alongside `done`/`cancelled` (`includeClosed=false`).

It is intentionally **not** counted as a `done` completion (same as `cancelled`), so progress bars are unaffected.

## Verification

- `go build ./...` — ✅
- `go vet` on touched packages — ✅
- Affected Go unit tests (`TestValidIssueStatuses`, `TestValidateIssueStatus`, `BuildSearchQuery*`, children rollup) — ✅
- `pnpm typecheck` (core, ui, views, docs, web, desktop) — ✅ 6/6
- `pnpm --filter @multica/mobile typecheck` — ✅

## Notes for reviewers

- Two pre-existing Windows-only test failures in `cmd/multica` (`TestRunRuntimeProfileSetAndUnsetPath`, `...PreservesExistingConfig`) are unrelated to this change — they assert `/opt/bin/...` is an absolute path, which is false on Windows.
- Test snapshots that assert an exact status set were updated; a broader sweep for snapshot fixtures may be worth a CI run.
