### PR TITLE
feat(help): surface the running server version in the Help popover

### DIFF
--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -468,6 +468,11 @@ describe("AppConfigSchema cdn_signed drift", () => {
     const parsed = AppConfigSchema.parse({ feature_flags: ["not", "an", "object"] });
     expect(parsed.feature_flags).toEqual({});
   });
+
+  it("parses server_version and leaves it undefined when the server omits it", () => {
+    expect(AppConfigSchema.parse({ server_version: "1.2.3" }).server_version).toBe("1.2.3");
+    expect(AppConfigSchema.parse({}).server_version).toBeUndefined();
+  });
 });
 
 describe("InboxUnreadSummarySchema", () => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -44,6 +44,7 @@ export interface AppConfigResponse {
   daemon_app_url?: string;
   workspace_creation_disabled?: boolean;
   feature_flags?: Record<string, boolean>;
+  server_version?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +194,7 @@ export const AppConfigSchema = z.object({
   daemon_app_url: OptionalStringSchema,
   workspace_creation_disabled: BooleanWithDefaultSchema(false).optional(),
   feature_flags: FeatureFlagsSchema,
+  server_version: OptionalStringSchema,
 }).loose();
 
 export const EMPTY_APP_CONFIG: AppConfigResponse = {

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -16,6 +16,10 @@ interface ConfigState {
   // the managed-cloud case.
   workspaceCreationDisabled: boolean;
   featureFlags: Record<string, boolean>;
+  // The running API build version, surfaced in the Help popover so
+  // self-hosted operators can confirm what's deployed. Empty for dev builds
+  // or servers older than this feature.
+  serverVersion: string;
   setCdnConfig: (config: { cdnDomain: string; cdnSigned?: boolean }) => void;
   setAuthConfig: (config: {
     allowSignup: boolean;
@@ -27,6 +31,7 @@ interface ConfigState {
     daemonAppUrl?: string;
   }) => void;
   setFeatureFlags: (flags?: Record<string, boolean>) => void;
+  setServerVersion: (version?: string) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
@@ -38,12 +43,14 @@ export const configStore = createStore<ConfigState>((set) => ({
   daemonAppUrl: "",
   workspaceCreationDisabled: false,
   featureFlags: {},
+  serverVersion: "",
   setCdnConfig: ({ cdnDomain, cdnSigned = false }) => set({ cdnDomain, cdnSigned }),
   setAuthConfig: ({ allowSignup, googleClientId = "", workspaceCreationDisabled = false }) =>
     set({ allowSignup, googleClientId, workspaceCreationDisabled }),
   setDaemonConfig: ({ daemonServerUrl = "", daemonAppUrl = "" }) =>
     set({ daemonServerUrl, daemonAppUrl }),
   setFeatureFlags: (flags = {}) => set({ featureFlags: { ...flags } }),
+  setServerVersion: (version = "") => set({ serverVersion: version }),
 }));
 
 export function useConfigStore(): ConfigState;

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -68,6 +68,7 @@ export function AuthInitializer({
           daemonAppUrl: cfg.daemon_app_url,
         });
         configStore.getState().setFeatureFlags(cfg.feature_flags);
+        configStore.getState().setServerVersion(cfg.server_version);
         if (cfg.posthog_key) {
           initAnalytics({
             key: cfg.posthog_key,

--- a/packages/views/layout/help-launcher.test.tsx
+++ b/packages/views/layout/help-launcher.test.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configStore } from "@multica/core/config";
+import { HelpLauncher } from "./help-launcher";
+
+// react-i18next isn't initialised in the views test env, so resolve the
+// selector against the real en/layout.json to assert on actual copy.
+vi.mock("../i18n", () => ({
+  useT: () => ({
+    t: (
+      sel: (r: { help: Record<string, string> }) => string,
+      vars?: Record<string, string>,
+    ) => {
+      const template = sel({
+        help: {
+          trigger: "Help",
+          docs: "Docs",
+          changelog: "Change log",
+          discord: "Discord",
+          feedback: "Feedback",
+          server_version: "Server version {{version}}",
+        },
+      });
+      return vars
+        ? template.replace(/\{\{(\w+)\}\}/g, (_, key) => String(vars[key] ?? ""))
+        : template;
+    },
+  }),
+}));
+
+// Follows the app-sidebar.test.tsx convention of flattening the Base UI
+// dropdown primitives to plain children so the menu content is always in
+// the DOM, instead of exercising the real portal/open-state interaction.
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => null,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+afterEach(() => {
+  configStore.getState().setServerVersion("");
+});
+
+describe("HelpLauncher", () => {
+  it("does not show a version row when the server omits it", () => {
+    render(<HelpLauncher />);
+    expect(screen.queryByText(/Server version/)).not.toBeInTheDocument();
+  });
+
+  it("shows the server version once /api/config resolves it", () => {
+    configStore.getState().setServerVersion("1.2.3");
+    render(<HelpLauncher />);
+    expect(screen.getByText("Server version 1.2.3")).toBeInTheDocument();
+  });
+});

--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -5,9 +5,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useModalStore } from "@multica/core/modals";
+import { useConfigStore } from "@multica/core/config";
 import { DISCORD_URL, DiscordIcon } from "./discord";
 import { useT } from "../i18n";
 
@@ -16,6 +19,7 @@ const CHANGELOG_URL = "https://multica.ai/changelog";
 
 export function HelpLauncher() {
   const { t } = useT("layout");
+  const serverVersion = useConfigStore((state) => state.serverVersion);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -68,6 +72,14 @@ export function HelpLauncher() {
           <MessageCircle className="h-3.5 w-3.5" />
           {t(($) => $.help.feedback)}
         </DropdownMenuItem>
+        {serverVersion && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="font-normal">
+              {t(($) => $.help.server_version, { version: serverVersion })}
+            </DropdownMenuLabel>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -17,7 +17,8 @@
     "docs": "Docs",
     "changelog": "Change log",
     "discord": "Discord",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "server_version": "Server version {{version}}"
   },
   "workspace_loader": {
     "loading_workspace": "Loading workspace…",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -17,7 +17,8 @@
     "docs": "ドキュメント",
     "changelog": "変更ログ",
     "discord": "Discord",
-    "feedback": "フィードバック"
+    "feedback": "フィードバック",
+    "server_version": "サーバーバージョン {{version}}"
   },
   "workspace_loader": {
     "loading_workspace": "ワークスペースを読み込み中…",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -17,7 +17,8 @@
     "docs": "문서",
     "changelog": "변경 로그",
     "discord": "Discord",
-    "feedback": "피드백"
+    "feedback": "피드백",
+    "server_version": "서버 버전 {{version}}"
   },
   "workspace_loader": {
     "loading_workspace": "워크스페이스 로딩 중...",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -17,7 +17,8 @@
     "docs": "文档",
     "changelog": "更新日志",
     "discord": "Discord",
-    "feedback": "反馈"
+    "feedback": "反馈",
+    "server_version": "服务器版本 {{version}}"
   },
   "workspace_loader": {
     "loading_workspace": "正在加载工作区...",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -176,6 +176,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		AttachmentDownloadMode:   os.Getenv("ATTACHMENT_DOWNLOAD_MODE"),
 		AttachmentDownloadURLTTL: envDuration("ATTACHMENT_DOWNLOAD_URL_TTL", 30*time.Minute),
 		AttachmentFrameAncestors: origins,
+		ServerVersion:            version,
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	h.Metrics = opts.BusinessMetrics

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -49,6 +49,11 @@ type AppConfig struct {
 	// FeatureFlags exposes only frontend-safe boolean decisions. Do not dump
 	// raw rules here: /api/config is public and may be called anonymously.
 	FeatureFlags map[string]bool `json:"feature_flags,omitempty"`
+
+	// ServerVersion is the running API build version, so self-hosted
+	// operators can confirm what's deployed and include it in bug reports.
+	// Empty (and omitted) for dev builds that aren't stamped via -X main.version.
+	ServerVersion string `json:"server_version,omitempty"`
 }
 
 // GetConfig is mounted on the public (unauthenticated) route group because
@@ -67,6 +72,7 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config.CdnSigned = h.CFSigner != nil
 	config.DaemonServerURL, config.DaemonAppURL = daemonSetupURLsFromEnv()
 	config.FeatureFlags = featureflags.EvaluateFrontendPublicFlags(r.Context(), h.FeatureFlags)
+	config.ServerVersion = h.cfg.ServerVersion
 
 	// Re-read from env on every request so operators can rotate keys via
 	// secret refresh without a server restart.

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -287,6 +287,39 @@ func TestGetConfigExposesWorkspaceCreationDisabled(t *testing.T) {
 	}
 }
 
+// TestGetConfigExposesServerVersion verifies /api/config reports the build
+// version main.go stamps into handler.Config via -X main.version, so
+// self-hosted operators can confirm what's deployed from the Help popover.
+func TestGetConfigExposesServerVersion(t *testing.T) {
+	origCfg := testHandler.cfg
+	defer func() { testHandler.cfg = origCfg }()
+
+	testHandler.cfg.ServerVersion = ""
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var cfg AppConfig
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.ServerVersion != "" {
+		t.Fatalf("server_version: want empty for dev build, got %q", cfg.ServerVersion)
+	}
+
+	testHandler.cfg.ServerVersion = "1.2.3"
+	w = httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.ServerVersion != "1.2.3" {
+		t.Fatalf("server_version: want 1.2.3, got %q", cfg.ServerVersion)
+	}
+}
+
 func TestGetConfigExposesFrontendFeatureFlags(t *testing.T) {
 	h := &Handler{}
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -94,6 +94,11 @@ type Config struct {
 	// frontend/CORS origin allowlist so split app/api self-hosted deployments
 	// can frame API-hosted PDFs without allowing arbitrary third-party frames.
 	AttachmentFrameAncestors []string
+	// ServerVersion is the build version of the running API binary (the same
+	// value main.go stamps via -X main.version and reports on /metrics).
+	// Surfaced through /api/config so self-hosted operators can confirm which
+	// server build is deployed. Empty in dev builds.
+	ServerVersion string
 }
 
 type cloudRuntimeProxy interface {


### PR DESCRIPTION
## Problem

Self-hosted operators have no way to see which server build is deployed from the app UI — the Help popover (`packages/views/layout/help-launcher.tsx`) only links to Docs/Change log/Discord/Feedback, and the server build version (`main.version`, stamped via `-X main.version` at build time) was previously only reported on the internal `/metrics` endpoint. This makes it hard to confirm a deploy, or include the right version in a bug report.

## Solution

Extended the existing `/api/config` → `configStore` → `HelpLauncher` pipeline (already used for CDN domain, PostHog keys, daemon setup URLs, and feature flags) instead of adding a new endpoint or store:

- **Backend**: added `ServerVersion` to `handler.Config`, wired from the `version` build var already declared in `cmd/server/main.go` (read directly in `router.go`, same package). `GetConfig` now sets `AppConfig.ServerVersion`, serialized as `server_version,omitempty` so older/dev builds that don't stamp a version simply omit the field.
- **Frontend**: added `server_version` to `AppConfigResponse` / `AppConfigSchema` (optional, following the same lenient pattern as the other config fields), a `serverVersion` field + `setServerVersion` action on the shared `configStore`, and wired it from `AuthInitializer` alongside the existing config setters.
- **UI**: `HelpLauncher` reads `serverVersion` from the store and renders a muted `DropdownMenuSeparator` + `DropdownMenuLabel` footer row ("Server version x.y.z") only when the value is non-empty, so servers that omit the field (pre-upgrade self-hosted instances) don't show a blank row. Added the `help.server_version` i18n key to all four locales (en/ja/ko/zh-Hans).

## Files changed

- `server/internal/handler/handler.go` — `Config.ServerVersion` field
- `server/cmd/server/router.go` — wires the existing `version` build var into `Config.ServerVersion`
- `server/internal/handler/config.go` — `AppConfig.ServerVersion` (`server_version`, omitempty), set in `GetConfig`
- `server/internal/handler/config_test.go` — `TestGetConfigExposesServerVersion`
- `packages/core/api/schemas.ts` (+ `schemas.test.ts`) — `server_version` on `AppConfigResponse`/`AppConfigSchema`
- `packages/core/config/index.ts` — `serverVersion` state + `setServerVersion` action
- `packages/core/platform/auth-initializer.tsx` — calls `setServerVersion` from the `/api/config` response
- `packages/views/layout/help-launcher.tsx` (+ new `help-launcher.test.tsx`) — renders the version row
- `packages/views/locales/{en,ja,ko,zh-Hans}/layout.json` — `help.server_version` copy

## Trade-offs considered

- **Public vs authenticated endpoint**: went through the existing public `/api/config` rather than adding an authenticated one — consistent with how CDN/daemon/feature-flag info is already exposed there, and a build version string isn't sensitive.
- **Scope**: the ticket's premise mentioned the popover "already exposes daemon and runtime versions" — that's not accurate today (it currently shows none), and daemon/CLI version (`cli_version`) is per-runtime info that already lives on the Runtimes page. Kept this change scoped to the server-level version only, rather than pulling runtime-scoped data into a global popover.
- **Omit vs empty string**: used `omitempty` end-to-end (Go JSON tag, zod optional, empty-string store default) so the UI cleanly hides the row instead of rendering "Server version " for older servers or unstamped dev builds.

## Testing performed

- `pnpm vitest run` in `packages/views` — 162 files / 1629 tests passing (includes the new `help-launcher.test.tsx`).
- `pnpm vitest run` in `packages/core` — schema and config tests passing (includes the new `server_version` schema test).
- `pnpm typecheck` for `@multica/core` and `@multica/views` — clean.
- `go build ./...` and `go vet ./...` in `server/` — clean.
- Added `TestGetConfigExposesServerVersion` in `server/internal/handler/config_test.go` following the existing `config_test.go` pattern; DB-backed Go tests could not be executed end-to-end in the sandbox used to prepare this PR (no local Postgres/Docker daemon available), but the new test requires no schema changes and mirrors the existing `TestGetConfigExposesWorkspaceCreationDisabled`/`TestGetConfigExposesFrontendFeatureFlags` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
