### PR TITLE
fix(editor): keep Mermaid zoom icon pinned during horizontal scroll

### DIFF
--- a/packages/views/editor/mermaid-diagram.tsx
+++ b/packages/views/editor/mermaid-diagram.tsx
@@ -340,16 +340,22 @@ export function MermaidDiagram({ chart }: { chart: string }) {
     >
       {sandboxedDocument ? (
         <>
-          <iframe
-            className="mermaid-diagram-frame"
-            sandbox=""
-            srcDoc={sandboxedDocument}
-            style={{
-              height: layout.height ? `${layout.height}px` : undefined,
-              width: layout.width ? `${layout.width}px` : undefined,
-            }}
-            title="Mermaid diagram"
-          />
+          {/* Only this wrapper scrolls horizontally. The toolbar below stays a
+              child of the non-scrolling .mermaid-diagram so its absolute
+              position stays pinned to the visible top-right corner instead of
+              scrolling away with a wide diagram. */}
+          <div className="mermaid-diagram-scroll">
+            <iframe
+              className="mermaid-diagram-frame"
+              sandbox=""
+              srcDoc={sandboxedDocument}
+              style={{
+                height: layout.height ? `${layout.height}px` : undefined,
+                width: layout.width ? `${layout.width}px` : undefined,
+              }}
+              title="Mermaid diagram"
+            />
+          </div>
           <div className="mermaid-diagram-toolbar">
             <button
               type="button"

--- a/packages/views/editor/styles/mermaid.css
+++ b/packages/views/editor/styles/mermaid.css
@@ -4,9 +4,16 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   margin: 0.75rem 0;
-  overflow-x: auto;
   padding: 1rem;
   position: relative;
+}
+
+/* Horizontal scroll lives on this inner wrapper, not on .mermaid-diagram.
+   Keeping the scroll container separate from the positioning context means
+   the absolutely-positioned toolbar (anchored to .mermaid-diagram) no longer
+   scrolls away when a wide diagram is scrolled sideways. */
+.rich-text-editor .mermaid-diagram-scroll {
+  overflow-x: auto;
 }
 
 .rich-text-editor .mermaid-diagram-frame {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the Mermaid diagram **zoom (expand) icon** does not stay pinned to the visible top-right corner when a wide diagram is scrolled horizontally in its non-zoomed state.

**Symptom:** When a rendered Mermaid diagram is wider than its container, the diagram becomes horizontally scrollable. The zoom toolbar is supposed to float fixed at the top-right corner of the visible area, but when the user scrolls sideways to see the right part of the diagram, the icon scrolls away with the content instead of staying put.

**Root cause:** `.mermaid-diagram` was simultaneously the positioning context (`position: relative`) **and** the horizontal scroll container (`overflow-x: auto`). An absolutely-positioned descendant of a scroll container is part of that container's *scrollable content*, so the toolbar translated together with the diagram during horizontal scroll.

**Fix:** Split the two responsibilities. The horizontal scroll is moved onto a new inner wrapper `.mermaid-diagram-scroll` that only wraps the iframe. The toolbar stays an absolutely-positioned child of the **non-scrolling** outer `.mermaid-diagram` (which keeps `position: relative`), so it remains pinned to the visible top-right corner regardless of horizontal scroll position.

## Related Issue

No existing upstream tracking issue was found for this bug (searched open/merged PRs and issues touching the Mermaid zoom toolbar; none address horizontal-scroll pinning).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/mermaid-diagram.tsx` — wrap the `<iframe>` in a new `<div className="mermaid-diagram-scroll">`; the toolbar `<div>` stays a direct child of `.mermaid-diagram`.
- `packages/views/editor/styles/mermaid.css` — move `overflow-x: auto` off `.mermaid-diagram` onto the new `.mermaid-diagram-scroll`; `.mermaid-diagram` keeps `position: relative` as the toolbar's positioning context.

No component logic, props, or public API changed — purely a DOM-nesting + CSS scope adjustment.

## How to Test

1. Open an Issue/answer that renders a Mermaid diagram wide enough to overflow its container horizontally (so the horizontal scrollbar appears in the non-zoomed state).
2. Scroll the diagram sideways to view its right edge.
3. **Before:** the top-right zoom icon scrolls out of view together with the diagram content.
   **After:** the zoom icon stays pinned to the visible top-right corner throughout the horizontal scroll.

**Manual verification:** Manually verified by the maintainer on a local MC instance (self-hosted docker-compose stack on `:3200`, with the fix built into the frontend image): with a horizontally-overflowing Mermaid diagram, the zoom icon stays pinned to the top-right corner while scrolling. Confirmed working.

## Code Review

Adversarial code review performed with Codex (read-only): **PASS** — no high/medium issues. The only low-severity note was a missing layout-regression test for the pinned toolbar after horizontal scroll, which Codex itself judged a coverage gap (needs a real layout engine / Playwright), not a defect; it does not block this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx (N/A — no product copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Testing notes:**
- `packages/views` vitest: `readonly-content.test.tsx` 30/30 and `code-block-view.test.tsx` 3/3 pass.
- `pnpm typecheck` passes; ESLint clean, no warnings.
- No regression observed for short diagrams, the lightbox zoomed state, dark theme, or the load-error state.
- **Known test boundary:** the visual assertion "icon stays pinned after horizontal scroll" cannot be covered by the current jsdom-based unit tests (jsdom has no real layout engine, so scroll offsets and absolute positioning are not computed). This behavior was confirmed in a real browser (see Manual verification above); a meaningful automated regression test would require Playwright / a real layout engine, which is outside this PR's scope.

## AI Disclosure

**AI tool used:** Multica Agent (Claude)

**Prompt / approach:** Reproduced and diagnosed the reported bug (zoom icon scrolling away on wide Mermaid diagrams), traced the root cause to the shared positioning-context / scroll-container element in `.mermaid-diagram`, and applied a minimal DOM+CSS separation so the scroll container and the toolbar's positioning context are distinct elements. The change was cross-reviewed for correctness with Codex before opening this PR.

## Screenshots

Real product screenshots cropped to the Mermaid block (the hover-only zoom control was forced visible for these stills). Left→right/top→bottom: Normal, Bug (scrolled ~50%), Fixed (scrolled ~50%).

![Mermaid zoom icon — Normal vs Bug vs Fixed](https://raw.githubusercontent.com/n374/multica/assets/pr-4937-screenshots/crop-comparison.png)

_Screenshots are hosted on an orphan asset branch (`assets/pr-4937-screenshots`) of the fork; they are not part of this PR's code diff, so no binaries land in `main`._


