### PR TITLE
fix(realtime): WS heartbeat for half-open sockets + create no longer relies on WS for scoped lists (MUL-4076)

### DIFF
--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WSClient } from "./ws-client";
+import {
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_TIMEOUT_MS,
+  WSClient,
+} from "./ws-client";
 import type { WSMessage } from "../types/events";
 
 // Capture URL passed to WebSocket so we can assert the connect-time
 // query string.  We don't simulate the full WS lifecycle here — only the
-// upgrade URL construction, which is what carries client identity.
+// upgrade URL construction, which is what carries client identity, plus
+// enough of the message surface for the heartbeat tests.
 class FakeWebSocket {
+  static OPEN = 1;
   static lastUrl: string | null = null;
   static lastInstance: FakeWebSocket | null = null;
   // Fields read by WSClient.connect()/disconnect(), all no-op here.
@@ -13,13 +19,16 @@ class FakeWebSocket {
   onmessage: ((ev: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
-  readyState = 0;
+  readyState = FakeWebSocket.OPEN;
+  sent: string[] = [];
+  close = vi.fn();
   constructor(url: string) {
     FakeWebSocket.lastUrl = url;
     FakeWebSocket.lastInstance = this;
   }
-  close() {}
-  send() {}
+  send(data: string) {
+    this.sent.push(data);
+  }
 }
 
 describe("WSClient", () => {
@@ -203,5 +212,82 @@ describe("WSClient", () => {
       "user-123",
       "user",
     );
+  });
+
+  describe("heartbeat", () => {
+    // Connect in token mode and complete auth so the heartbeat arms —
+    // returns the fake socket for frame injection.
+    const connectAndAuth = (ws: WSClient) => {
+      ws.setAuth("tok", "acme");
+      ws.connect();
+      const fakeWs = FakeWebSocket.lastInstance!;
+      fakeWs.onopen?.();
+      fakeWs.onmessage?.({ data: JSON.stringify({ type: "auth_ack" }) });
+      fakeWs.sent = []; // drop the auth frame
+      return fakeWs;
+    };
+    const pings = (fakeWs: FakeWebSocket) =>
+      fakeWs.sent.filter((f) => JSON.parse(f).type === "ping").length;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("pings an idle connection and closes the socket when nothing answers", () => {
+      const ws = new WSClient("ws://example.test/ws");
+      const fakeWs = connectAndAuth(ws);
+
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(pings(fakeWs)).toBe(1);
+      expect(fakeWs.close).not.toHaveBeenCalled();
+
+      // Half-open socket: no frame of any kind comes back.
+      vi.advanceTimersByTime(HEARTBEAT_TIMEOUT_MS);
+      expect(fakeWs.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the socket open when any frame arrives after the ping", () => {
+      const ws = new WSClient("ws://example.test/ws");
+      const fakeWs = connectAndAuth(ws);
+
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(pings(fakeWs)).toBe(1);
+      fakeWs.onmessage?.({ data: JSON.stringify({ type: "pong" }) });
+
+      vi.advanceTimersByTime(HEARTBEAT_TIMEOUT_MS * 2);
+      expect(fakeWs.close).not.toHaveBeenCalled();
+    });
+
+    it("does not ping while organic traffic proves liveness", () => {
+      const ws = new WSClient("ws://example.test/ws");
+      const fakeWs = connectAndAuth(ws);
+
+      // A frame lands mid-interval, so at every tick the connection has
+      // been idle for less than a full interval.
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS / 2);
+      fakeWs.onmessage?.({
+        data: JSON.stringify({ type: "issue:updated", payload: {} }),
+      });
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS / 2);
+      expect(pings(fakeWs)).toBe(0);
+
+      // Once truly idle for a full interval, the ping fires.
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(pings(fakeWs)).toBe(1);
+    });
+
+    it("stops the heartbeat on disconnect", () => {
+      const ws = new WSClient("ws://example.test/ws");
+      const fakeWs = connectAndAuth(ws);
+      ws.disconnect();
+
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
+      expect(pings(fakeWs)).toBe(0);
+      expect(fakeWs.close).toHaveBeenCalledTimes(1); // the disconnect() close only
+    });
   });
 });

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -24,6 +24,20 @@ export interface WSClientIdentity {
   os?: string;
 }
 
+// Application-level heartbeat cadence. A socket can die without the client
+// ever receiving a close frame — macOS sleep/wake, a network-path change, or
+// a middlebox dropping the idle connection leaves a half-open WebSocket that
+// looks OPEN but receives nothing. Since every cache in the app trusts WS
+// events for freshness (staleTime: Infinity), such a socket silently freezes
+// Inbox / project / sub-issue views until a manual reload (MUL-4076). The
+// heartbeat turns that silent death into a normal close: ping every
+// HEARTBEAT_INTERVAL_MS when the connection is otherwise idle (the server
+// answers `{"type":"pong"}`), and if no frame of any kind arrives within
+// HEARTBEAT_TIMEOUT_MS, force-close so the standard onclose → reconnect →
+// onReconnect resync chain recovers the missed events.
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_TIMEOUT_MS = 10_000;
+
 export class WSClient {
   private ws: WebSocket | null = null;
   private baseUrl: string;
@@ -41,6 +55,9 @@ export class WSClient {
   private onReconnectCallbacks = new Set<() => void>();
   private anyHandlers = new Set<(msg: WSMessage) => void>();
   private logger: Logger;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastFrameAt = 0;
 
   constructor(
     url: string,
@@ -91,6 +108,10 @@ export class WSClient {
     };
 
     this.ws.onmessage = (event) => {
+      // Any inbound data proves the connection is alive — even a frame we
+      // fail to parse below. Feed the heartbeat before validation.
+      this.lastFrameAt = Date.now();
+      this.clearHeartbeatTimeout();
       let msg: WSMessage;
       try {
         msg = JSON.parse(event.data as string) as WSMessage;
@@ -137,6 +158,7 @@ export class WSClient {
     };
 
     this.ws.onclose = () => {
+      this.stopHeartbeat();
       this.logger.warn("disconnected, reconnecting in 3s");
       this.reconnectTimer = setTimeout(() => this.connect(), 3000);
     };
@@ -149,6 +171,7 @@ export class WSClient {
 
   private onAuthenticated() {
     this.logger.info("connected");
+    this.startHeartbeat();
     if (this.hasConnectedBefore) {
       for (const cb of this.onReconnectCallbacks) {
         try {
@@ -161,7 +184,45 @@ export class WSClient {
     this.hasConnectedBefore = true;
   }
 
+  // Heartbeat starts after auth (pre-auth frames would race the server's
+  // auth reader) and stops with the socket. Each tick pings only when the
+  // connection has been idle for a full interval — organic traffic already
+  // proves liveness — then expects SOME frame back within the timeout.
+  private startHeartbeat() {
+    this.stopHeartbeat();
+    this.lastFrameAt = Date.now();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.ws?.readyState !== WebSocket.OPEN) return;
+      if (Date.now() - this.lastFrameAt < HEARTBEAT_INTERVAL_MS) return;
+      if (this.heartbeatTimeoutTimer) return; // ping already in flight
+      this.ws.send(JSON.stringify({ type: "ping" }));
+      this.heartbeatTimeoutTimer = setTimeout(() => {
+        this.heartbeatTimeoutTimer = null;
+        this.logger.warn("ws: heartbeat timed out — closing dead socket");
+        // close() on a half-open socket still fires onclose locally, which
+        // funnels into the normal reconnect + resync path.
+        this.ws?.close();
+      }, HEARTBEAT_TIMEOUT_MS);
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private clearHeartbeatTimeout() {
+    if (this.heartbeatTimeoutTimer) {
+      clearTimeout(this.heartbeatTimeoutTimer);
+      this.heartbeatTimeoutTimer = null;
+    }
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.clearHeartbeatTimeout();
+  }
+
   disconnect() {
+    this.stopHeartbeat();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -10,6 +10,7 @@ import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import {
   useBatchUpdateIssues,
+  useCreateIssue,
   useLoadMoreByAssigneeGroup,
   useLoadMoreByStatus,
   useResolveComment,
@@ -34,6 +35,19 @@ import type {
 vi.mock("../hooks", () => ({
   useWorkspaceId: () => "ws-1",
 }));
+
+// useCreateIssue records the new issue in the persisted recent-issues store;
+// persistence is irrelevant here and jsdom's localStorage is not available
+// through the zustand persist wrapper in this suite.
+vi.mock("./stores", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./stores")>();
+  return {
+    ...original,
+    useRecentIssuesStore: {
+      getState: () => ({ recordVisit: vi.fn() }),
+    },
+  };
+});
 
 const WS_ID = "ws-1";
 
@@ -384,6 +398,41 @@ describe("useLoadMoreByAssigneeGroup", () => {
       "issue-1",
       "issue-2",
     ]);
+  });
+});
+
+describe("useCreateIssue", () => {
+  let qc: QueryClient;
+  let createIssue: ReturnType<typeof vi.fn<(d: unknown) => Promise<Issue>>>;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    createIssue = vi.fn();
+    setApiInstance({ createIssue } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("invalidates scoped `my` lists on settle so the project view does not depend on the WS event (MUL-4076)", async () => {
+    createIssue.mockResolvedValue(makeIssue(1, { project_id: "project-9" }));
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        title: "New issue",
+        project_id: "project-9",
+      });
+    });
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidatedKeys).toContainEqual(issueKeys.myAll(WS_ID));
   });
 });
 

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -206,6 +206,14 @@ export function useCreateIssue() {
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      // Scoped lists (project / My Issues / actor panels) live under the
+      // `my` prefix and were previously refreshed only by the WS
+      // issue:created event — one missed event (half-open socket, relay
+      // gap) left the new issue permanently absent from the project view
+      // while the locally-patched workspace list looked fine (MUL-4076).
+      // Invalidate on settle so our own creations never depend on WS
+      // delivery.
+      qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });


### PR DESCRIPTION
Fixes the "created issues don't auto-appear in the project view / Inbox / sub-issue lists" class of staleness reported in MUL-4076.

## Root cause

A WebSocket can die without the client ever receiving a close frame — macOS sleep/wake, a network-path change, or a middlebox dropping the idle connection leaves a half-open socket that looks OPEN but receives nothing. Every query cache uses `staleTime: Infinity` and trusts WS events for freshness, so a dead socket silently freezes all realtime-driven views until a manual reload. The project view is where users notice first, because scoped (`my`-prefix) lists are refreshed **only** by the WS `issue:created` echo — the workspace Issues list masks the same loss with its local optimistic patch.

## Changes

1. **`ws-client.ts` — application-level heartbeat.** After 30s of inbound silence, send `{"type":"ping"}` (the server already replies `{"type":"pong"}` in `hub.handleFrame`). If no frame of any kind arrives within 10s, force-close the socket, which funnels into the existing `onclose → reconnect → onReconnect` resync chain (`invalidateWorkspaceScopedQueries`) and recovers everything missed. Organic traffic suppresses pings; heartbeat starts on auth and stops with the socket.
2. **`useCreateIssue.onSettled` — invalidate `issueKeys.myAll`.** Self-created issues no longer depend on the WS echo to appear in project / My Issues / actor views.

## Verification

- Unit: 4 new heartbeat tests (fake timers) + a create-invalidation regression test; `pnpm typecheck` and the core suite pass (the one pre-existing `projects/mutations.test.tsx` failure reproduces on a clean tree under Node 25 and is unrelated).
- E2E (local stack + Playwright):
  - With a WS proxy **dropping** the `issue:created` frame, a dialog-created issue with a project still appears in the project view (change 2).
  - With the backend frozen via `SIGSTOP` (silent-but-open socket), the client pinged at +26s, logged `heartbeat timed out — closing dead socket` at +36s, reconnected 3s after `SIGCONT`, and an externally created issue appeared in the project view immediately after recovery (change 1).

Closes MUL-4076.
