### PR TITLE
feat(helm): expand self-host env configuration --issue=#4941

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -180,19 +180,25 @@ kubectl create namespace multica
 
 ### Step 3 — Create the `multica-secrets` Secret
 
-The chart references this Secret by name. Create it once with random values:
+The chart references this Secret by name and imports the whole Secret into the backend via `envFrom`. Create it once with random values, then keep optional integration secrets there as you enable them:
 
 ```bash
 kubectl -n multica create secret generic multica-secrets \
   --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
   --from-literal=POSTGRES_PASSWORD="$(openssl rand -hex 16)" \
   --from-literal=RESEND_API_KEY="" \
+  --from-literal=SMTP_PASSWORD="" \
   --from-literal=GOOGLE_CLIENT_SECRET="" \
+  --from-literal=AWS_ACCESS_KEY_ID="" \
+  --from-literal=AWS_SECRET_ACCESS_KEY="" \
   --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+  --from-literal=GITHUB_WEBHOOK_SECRET="" \
+  --from-literal=MULTICA_LARK_SECRET_KEY="" \
+  --from-literal=MULTICA_SLACK_SECRET_KEY="" \
   --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 ```
 
-Leave optional values empty for now — you can fill them in later (see [Step 5 — Log In](#step-5--log-in)).
+Leave optional values empty for now — you can patch them later as needed. For an external PostgreSQL cluster, set `postgres.external.enabled=true` and put `DATABASE_URL` in this Secret instead of `POSTGRES_PASSWORD`.
 
 ### Step 4 — Install the chart
 
@@ -269,7 +275,31 @@ The chart defaults to `APP_ENV=production` (set in `values.yaml` under `backend.
   kubectl -n multica rollout restart deploy/multica-backend
   ```
 
-`ALLOW_SIGNUP`, `DISABLE_WORKSPACE_CREATION`, and `GOOGLE_CLIENT_ID` likewise live under `backend.config.*` in `values.yaml` (as `allowSignup`, `disableWorkspaceCreation`, and `googleClientId`). After `helm upgrade`, the backend pod will roll automatically because the ConfigMap hash changes; the web UI reads all three from `/api/config` at runtime, so no web rebuild is needed.
+Docker self-host backend env has Helm equivalents in two places:
+
+- Non-secret values live under `backend.config.*` in `values.yaml`, including signup gates, Google client ID / redirect URI, SMTP host/port, S3/AWS endpoint switches, attachment download mode, GitHub app slug, public API URL, trusted proxies, metrics, log level, and Lark callback URLs.
+- Sensitive values live in `existingSecret` and are imported via `envFrom`, including `JWT_SECRET`, database credentials or external `DATABASE_URL`, email provider secrets, OAuth secrets, AWS credentials, CloudFront private key, GitHub webhook secret, and Lark/Slack secrets.
+
+For less-common or provider-specific env vars that do not have a dedicated `backend.config.*` key, use `backend.extraEnv`. It renders directly into the backend Deployment's Kubernetes `env` list and supports both plain `value` and `valueFrom` references:
+
+```yaml
+backend:
+  config:
+    smtpHost: smtp.internal.example.com
+    smtpPort: "587"
+    publicUrl: https://api.example.com
+    trustedProxies: "10.0.0.0/8"
+  extraEnv:
+    - name: REDIS_URL
+      valueFrom:
+        secretKeyRef:
+          name: multica-redis
+          key: url
+    - name: CLOUDFRONT_PRIVATE_KEY_SECRET
+      value: multica/cloudfront-signing-key
+```
+
+After `helm upgrade`, the backend pod rolls automatically when the rendered ConfigMap changes; values that only change in the out-of-band Secret still require a backend rollout restart. The web UI reads signup and auth config from `/api/config` at runtime, so those backend config changes do not require a web rebuild. `frontend.extraEnv` is available for runtime-only frontend env; build-time web variables such as `REMOTE_API_URL`, `NEXT_PUBLIC_WS_URL`, and `NEXT_PUBLIC_APP_VERSION` still require a custom web image built with those values.
 
 > **Warning:** do **not** set `MULTICA_DEV_VERIFICATION_CODE` on a publicly reachable instance — anyone who knows an email address can then log in with that fixed code.
 

--- a/deploy/helm/multica/templates/_helpers.tpl
+++ b/deploy/helm/multica/templates/_helpers.tpl
@@ -33,3 +33,23 @@ on the same container (see envFrom on the backend Deployment).
 {{- define "multica.databaseUrl" -}}
 postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "multica.postgres.fullname" . }}:5432/$(POSTGRES_DB)?sslmode=disable
 {{- end -}}
+
+{{/*
+Render additional container env entries.
+Each item supports Kubernetes EnvVar fields. String `value` fields are passed
+through tpl so operators can reference chart values in custom environment.
+*/}}
+{{- define "multica.extraEnv" -}}
+{{- $root := .root -}}
+{{- range .env }}
+- name: {{ required "extraEnv entries require a name" .name | quote }}
+  {{- if hasKey . "valueFrom" }}
+  valueFrom:
+    {{- tpl (toYaml .valueFrom) $root | nindent 4 }}
+  {{- else if hasKey . "value" }}
+  value: {{ tpl (toString .value) $root | quote }}
+  {{- else }}
+  value: ""
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/multica/templates/backend.yaml
+++ b/deploy/helm/multica/templates/backend.yaml
@@ -68,10 +68,15 @@ spec:
                 name: {{ .Release.Name }}-config
             - secretRef:
                 name: {{ .Values.existingSecret }}
-          {{- if not .Values.postgres.external.enabled }}
+          {{- if or (not .Values.postgres.external.enabled) .Values.backend.extraEnv }}
           env:
+            {{- if not .Values.postgres.external.enabled }}
             - name: DATABASE_URL
               value: {{ include "multica.databaseUrl" . | quote }}
+            {{- end }}
+            {{- with .Values.backend.extraEnv }}
+            {{- include "multica.extraEnv" (dict "root" $ "env" .) | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.backend.uploads.persistence.enabled }}
           volumeMounts:

--- a/deploy/helm/multica/templates/configmap.yaml
+++ b/deploy/helm/multica/templates/configmap.yaml
@@ -8,22 +8,43 @@ data:
   # --- Backend ---
   PORT: "8080"
   APP_ENV: {{ .Values.backend.config.appEnv | quote }}
+  LOG_LEVEL: {{ .Values.backend.config.logLevel | quote }}
+  METRICS_ADDR: {{ .Values.backend.config.metricsAddr | quote }}
   MULTICA_APP_URL: {{ .Values.backend.config.appUrl | quote }}
+  MULTICA_PUBLIC_URL: {{ .Values.backend.config.publicUrl | quote }}
   FRONTEND_ORIGIN: {{ .Values.backend.config.frontendOrigin | quote }}
   CORS_ALLOWED_ORIGINS: {{ .Values.backend.config.corsAllowedOrigins | quote }}
+  ALLOWED_ORIGINS: {{ .Values.backend.config.allowedOrigins | quote }}
   COOKIE_DOMAIN: {{ .Values.backend.config.cookieDomain | quote }}
+  DATABASE_MAX_CONNS: {{ .Values.backend.config.databaseMaxConns | quote }}
+  DATABASE_MIN_CONNS: {{ .Values.backend.config.databaseMinConns | quote }}
   RESEND_FROM_EMAIL: {{ .Values.backend.config.resendFromEmail | quote }}
+  SMTP_HOST: {{ .Values.backend.config.smtpHost | quote }}
+  SMTP_PORT: {{ .Values.backend.config.smtpPort | quote }}
+  SMTP_USERNAME: {{ .Values.backend.config.smtpUsername | quote }}
+  SMTP_TLS: {{ .Values.backend.config.smtpTls | quote }}
+  SMTP_TLS_INSECURE: {{ .Values.backend.config.smtpTlsInsecure | quote }}
+  SMTP_EHLO_NAME: {{ .Values.backend.config.smtpEhloName | quote }}
   ALLOW_SIGNUP: {{ .Values.backend.config.allowSignup | quote }}
   ALLOWED_EMAILS: {{ .Values.backend.config.allowedEmails | quote }}
   ALLOWED_EMAIL_DOMAINS: {{ .Values.backend.config.allowedEmailDomains | quote }}
   DISABLE_WORKSPACE_CREATION: {{ .Values.backend.config.disableWorkspaceCreation | quote }}
   GOOGLE_CLIENT_ID: {{ .Values.backend.config.googleClientId | quote }}
   GOOGLE_REDIRECT_URI: {{ .Values.backend.config.googleRedirectUri | quote }}
+  GITHUB_APP_SLUG: {{ .Values.backend.config.githubAppSlug | quote }}
   S3_BUCKET: {{ .Values.backend.config.s3Bucket | quote }}
   S3_REGION: {{ .Values.backend.config.s3Region | quote }}
+  AWS_ENDPOINT_URL: {{ .Values.backend.config.awsEndpointUrl | quote }}
+  S3_USE_PATH_STYLE: {{ .Values.backend.config.s3UsePathStyle | quote }}
+  ATTACHMENT_DOWNLOAD_MODE: {{ .Values.backend.config.attachmentDownloadMode | quote }}
+  ATTACHMENT_DOWNLOAD_URL_TTL: {{ .Values.backend.config.attachmentDownloadUrlTtl | quote }}
   CLOUDFRONT_DOMAIN: {{ .Values.backend.config.cloudfrontDomain | quote }}
   CLOUDFRONT_KEY_PAIR_ID: {{ .Values.backend.config.cloudfrontKeyPairId | quote }}
   LOCAL_UPLOAD_BASE_URL: {{ .Values.backend.config.localUploadBaseUrl | quote }}
+  RATE_LIMIT_TRUSTED_PROXIES: {{ .Values.backend.config.rateLimitTrustedProxies | quote }}
+  MULTICA_TRUSTED_PROXIES: {{ .Values.backend.config.trustedProxies | quote }}
+  MULTICA_LARK_HTTP_BASE_URL: {{ .Values.backend.config.larkHttpBaseUrl | quote }}
+  MULTICA_LARK_CALLBACK_BASE_URL: {{ .Values.backend.config.larkCallbackBaseUrl | quote }}
 
   {{- if not .Values.postgres.external.enabled }}
   # --- PostgreSQL (consumed by the backend to build DATABASE_URL) ---

--- a/deploy/helm/multica/templates/frontend.yaml
+++ b/deploy/helm/multica/templates/frontend.yaml
@@ -31,6 +31,9 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: "3000"
+            {{- with .Values.frontend.extraEnv }}
+            {{- include "multica.extraEnv" (dict "root" $ "env" .) | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
 ---

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -19,15 +19,23 @@ images:
     pullPolicy: IfNotPresent
 
 # -----------------------------------------------------------------------------
-# Pre-created Secret with sensitive values. Create it before `helm install`:
+# Pre-created Secret with sensitive values. Create it before `helm install`.
+# The backend imports the whole Secret via envFrom, so you can add any optional
+# secret env var without changing this chart. Keep real values out of git.
 #
 # Built-in postgres (default):
 #   kubectl -n <namespace> create secret generic multica-secrets \
 #     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
 #     --from-literal=POSTGRES_PASSWORD="$(openssl rand -hex 16)" \
 #     --from-literal=RESEND_API_KEY="" \
+#     --from-literal=SMTP_PASSWORD="" \
 #     --from-literal=GOOGLE_CLIENT_SECRET="" \
+#     --from-literal=AWS_ACCESS_KEY_ID="" \
+#     --from-literal=AWS_SECRET_ACCESS_KEY="" \
 #     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+#     --from-literal=GITHUB_WEBHOOK_SECRET="" \
+#     --from-literal=MULTICA_LARK_SECRET_KEY="" \
+#     --from-literal=MULTICA_SLACK_SECRET_KEY="" \
 #     --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
 #
 # External postgres (postgres.external.enabled=true):
@@ -36,12 +44,15 @@ images:
 #     --from-literal=JWT_SECRET="$(openssl rand -hex 32)" \
 #     --from-literal=DATABASE_URL="postgres://user:pass@host:5432/multica?sslmode=require" \
 #     --from-literal=RESEND_API_KEY="" \
+#     --from-literal=SMTP_PASSWORD="" \
 #     --from-literal=GOOGLE_CLIENT_SECRET="" \
+#     --from-literal=AWS_ACCESS_KEY_ID="" \
+#     --from-literal=AWS_SECRET_ACCESS_KEY="" \
 #     --from-literal=CLOUDFRONT_PRIVATE_KEY="" \
+#     --from-literal=GITHUB_WEBHOOK_SECRET="" \
+#     --from-literal=MULTICA_LARK_SECRET_KEY="" \
+#     --from-literal=MULTICA_SLACK_SECRET_KEY="" \
 #     --from-literal=MULTICA_DEV_VERIFICATION_CODE=""
-#
-# The chart references this Secret by name; it does not template it, so real
-# values never need to land in git.
 # -----------------------------------------------------------------------------
 existingSecret: multica-secrets
 
@@ -110,10 +121,22 @@ backend:
   config:
     appEnv: production
     appUrl: http://multica.dev.lan
+    publicUrl: http://api.multica.dev.lan
     frontendOrigin: http://multica.dev.lan
     corsAllowedOrigins: ""
+    allowedOrigins: ""
     cookieDomain: ""
+    logLevel: info
+    metricsAddr: ""
+    databaseMaxConns: ""
+    databaseMinConns: ""
     resendFromEmail: noreply@multica.ai
+    smtpHost: ""
+    smtpPort: "25"
+    smtpUsername: ""
+    smtpTls: ""
+    smtpTlsInsecure: false
+    smtpEhloName: ""
     allowSignup: true
     allowedEmails: ""
     allowedEmailDomains: ""
@@ -123,11 +146,31 @@ backend:
     disableWorkspaceCreation: false
     googleClientId: ""
     googleRedirectUri: http://multica.dev.lan/auth/callback
+    githubAppSlug: ""
     s3Bucket: ""
     s3Region: us-west-2
+    awsEndpointUrl: ""
+    s3UsePathStyle: ""
+    attachmentDownloadMode: auto
+    attachmentDownloadUrlTtl: 30m
     cloudfrontDomain: ""
     cloudfrontKeyPairId: ""
     localUploadBaseUrl: http://api.multica.dev.lan
+    rateLimitTrustedProxies: ""
+    trustedProxies: ""
+    larkHttpBaseUrl: ""
+    larkCallbackBaseUrl: ""
+  # Additional backend env entries rendered into the Deployment's `env` list.
+  # Use this for less common knobs or valueFrom references, for example:
+  # extraEnv:
+  #   - name: CLOUDFRONT_PRIVATE_KEY_SECRET
+  #     value: my/aws/secret
+  #   - name: REDIS_URL
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: multica-redis
+  #         key: url
+  extraEnv: []
   resources:
     requests:
       cpu: 100m
@@ -145,6 +188,8 @@ backend:
 # -----------------------------------------------------------------------------
 frontend:
   replicas: 1
+  # Additional frontend env entries rendered into the Deployment's `env` list.
+  extraEnv: []
   # Compatibility shim for the prebuilt multica-web image.
   compatibility:
     # When true (default) the chart creates an ExternalName Service literally


### PR DESCRIPTION
## What does this PR do?

Expands the Helm self-host chart so backend runtime configuration is closer to the Docker self-host environment surface. The change maps additional non-secret backend env vars through `backend.config.*`, keeps secret values in the existing Secret, and adds `backend.extraEnv` / `frontend.extraEnv` for less-common runtime env entries without requiring chart template edits.

## Related Issue

Related: #4941

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- `deploy/helm/multica/templates/_helpers.tpl`: add shared extra env rendering for `value` and `valueFrom` entries.
- `deploy/helm/multica/templates/backend.yaml`: render `backend.extraEnv` alongside the built-in `DATABASE_URL` when needed.
- `deploy/helm/multica/templates/frontend.yaml`: render `frontend.extraEnv` for runtime frontend env injection.
- `deploy/helm/multica/templates/configmap.yaml`: expose additional non-secret backend config env vars.
- `deploy/helm/multica/values.yaml`: document new Secret keys, backend config values, and extra env fields.
- `SELF_HOSTING.md`: document Helm equivalents for Docker self-host backend env and Secret-only rollout behavior.

## How to Test

1. `git diff --check $(git merge-base HEAD upsteam/main)..HEAD`
2. `helm lint deploy/helm/multica`
3. `helm template multica deploy/helm/multica --set 'backend.extraEnv[0].name=REDIS_URL' --set 'backend.extraEnv[0].valueFrom.secretKeyRef.name=multica-redis' --set 'backend.extraEnv[0].valueFrom.secretKeyRef.key=url' --set 'frontend.extraEnv[0].name=NEXT_RUNTIME_FLAG' --set 'frontend.extraEnv[0].value=enabled'`
4. `helm template multica deploy/helm/multica --set 'postgres.external.enabled=true' --set 'backend.extraEnv[0].name=DATABASE_MAX_IDLE_TIME' --set 'backend.extraEnv[0].value=30m'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenCode / Hephaestus

**Prompt / approach:** Created from a branch that extends Helm self-host configuration. I inspected the branch against `upsteam/main`, checked repository PR/issue conventions, verified Helm rendering through `helm lint` and `helm template`, then drafted this PR against the required issue.

## Screenshots (optional)

Not applicable; Helm chart and documentation changes only.

Predicted auto-labels / suggested labels: enhancement (could not apply to issue due upstream label permission).
