### PR TITLE
fix: preflight Claude root/sudo launches with an actionable error

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -64,6 +64,10 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cmd.Dir = opts.Cwd
 	}
 	cmd.Env = buildEnv(b.cfg.Env)
+	if err := claudeRootSudoPreflight(args, cmd.Env); err != nil {
+		cancel()
+		return nil, err
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -646,6 +650,44 @@ func resolveSessionID(requestedResume, emitted string, failed bool) string {
 
 func buildEnv(extra map[string]string) []string {
 	return mergeEnv(os.Environ(), extra)
+}
+
+func claudeRootSudoPreflight(args, env []string) error {
+	if !argsRequestBypassPermissions(args) || os.Geteuid() != 0 || envHasSandbox(env) {
+		return nil
+	}
+	return fmt.Errorf("Claude Code refuses bypassPermissions under root/sudo privileges. Run the Multica daemon as a non-root user, or set IS_SANDBOX=1 if running in a genuine container/sandbox")
+}
+
+func argsRequestBypassPermissions(args []string) bool {
+	for i, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			return true
+		}
+		if arg == "--permission-mode" && i+1 < len(args) && args[i+1] == "bypassPermissions" {
+			return true
+		}
+	}
+	return false
+}
+
+func envHasSandbox(env []string) bool {
+	for i := len(env) - 1; i >= 0; i-- {
+		key, value, ok := strings.Cut(env[i], "=")
+		if key != "IS_SANDBOX" {
+			continue
+		}
+		if !ok {
+			return false
+		}
+		switch strings.ToLower(value) {
+		case "1", "true", "yes", "on":
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func mergeEnv(base []string, extra map[string]string) []string {

--- a/server/pkg/agent/claude_deadlock_test.go
+++ b/server/pkg/agent/claude_deadlock_test.go
@@ -167,7 +167,7 @@ func TestClaudeExecuteDoesNotDeadlockOnStartupStdoutBurst(t *testing.T) {
 
 	backend, err := New("claude", Config{
 		ExecutablePath: self,
-		Env:            map[string]string{"CLAUDE_FAKE_MODE": "startup_stdout_burst"},
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "startup_stdout_burst", "IS_SANDBOX": "1"},
 		Logger:         slog.Default(),
 	})
 	if err != nil {
@@ -214,7 +214,7 @@ func TestClaudeExecuteRespondsToControlRequest(t *testing.T) {
 
 	backend, err := New("claude", Config{
 		ExecutablePath: self,
-		Env:            map[string]string{"CLAUDE_FAKE_MODE": "control_request"},
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "control_request", "IS_SANDBOX": "1"},
 		Logger:         slog.Default(),
 	})
 	if err != nil {
@@ -262,7 +262,7 @@ func TestClaudeExecuteForcesBackgroundControlRequestForeground(t *testing.T) {
 
 	backend, err := New("claude", Config{
 		ExecutablePath: self,
-		Env:            map[string]string{"CLAUDE_FAKE_MODE": "background_control_request"},
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "background_control_request", "IS_SANDBOX": "1"},
 		Logger:         slog.Default(),
 	})
 	if err != nil {
@@ -310,7 +310,7 @@ func TestClaudeExecuteFailsLoudlyOnAsyncLaunchedToolResult(t *testing.T) {
 
 	backend, err := New("claude", Config{
 		ExecutablePath: self,
-		Env:            map[string]string{"CLAUDE_FAKE_MODE": "async_launched_tool_result"},
+		Env:            map[string]string{"CLAUDE_FAKE_MODE": "async_launched_tool_result", "IS_SANDBOX": "1"},
 		Logger:         slog.Default(),
 	})
 	if err != nil {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -331,6 +331,48 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 	}
 }
 
+func TestArgsRequestBypassPermissions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "permission mode bypass",
+			args: []string{"--permission-mode", "bypassPermissions"},
+			want: true,
+		},
+		{
+			name: "dangerous skip permissions",
+			args: []string{"--dangerously-skip-permissions"},
+			want: true,
+		},
+		{
+			name: "neither",
+			args: []string{"--model", "sonnet"},
+			want: false,
+		},
+		{
+			name: "permission mode default",
+			args: []string{"--permission-mode", "default"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := argsRequestBypassPermissions(tc.args); got != tc.want {
+				t.Fatalf("argsRequestBypassPermissions(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFilterCustomArgsBlocksProtocolFlags(t *testing.T) {
 	t.Parallel()
 
@@ -604,6 +646,82 @@ func TestBuildEnvNilExtras(t *testing.T) {
 	}
 }
 
+func TestEnvHasSandbox(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		env  []string
+		want bool
+	}{
+		{name: "one", env: []string{"IS_SANDBOX=1"}, want: true},
+		{name: "true", env: []string{"IS_SANDBOX=true"}, want: true},
+		{name: "yes", env: []string{"IS_SANDBOX=yes"}, want: true},
+		{name: "on", env: []string{"IS_SANDBOX=on"}, want: true},
+		{name: "zero", env: []string{"IS_SANDBOX=0"}, want: false},
+		{name: "false", env: []string{"IS_SANDBOX=false"}, want: false},
+		{name: "empty", env: []string{"IS_SANDBOX="}, want: false},
+		{name: "absent", env: []string{"PATH=/usr/bin"}, want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := envHasSandbox(tc.env); got != tc.want {
+				t.Fatalf("envHasSandbox(%v) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeRootSudoPreflight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sandbox bypass allowed", func(t *testing.T) {
+		t.Parallel()
+
+		err := claudeRootSudoPreflight(
+			[]string{"--permission-mode", "bypassPermissions"},
+			[]string{"IS_SANDBOX=1"},
+		)
+		if err != nil {
+			t.Fatalf("expected sandboxed bypass to pass preflight, got %v", err)
+		}
+	})
+
+	t.Run("non bypass allowed", func(t *testing.T) {
+		t.Parallel()
+
+		err := claudeRootSudoPreflight(
+			[]string{"--permission-mode", "default"},
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("expected non-bypass args to pass preflight, got %v", err)
+		}
+	})
+
+	t.Run("root bypass without sandbox errors", func(t *testing.T) {
+		t.Parallel()
+		if os.Geteuid() != 0 {
+			t.Skip("root-only preflight assertion")
+		}
+
+		err := claudeRootSudoPreflight(
+			[]string{"--permission-mode", "bypassPermissions"},
+			nil,
+		)
+		if err == nil {
+			t.Fatal("expected root bypass without sandbox to fail preflight")
+		}
+		if !strings.Contains(err.Error(), "IS_SANDBOX") || !strings.Contains(err.Error(), "non-root") {
+			t.Fatalf("expected actionable root guidance, got %q", err.Error())
+		}
+	})
+}
+
 func TestBuildClaudeArgsBlocksMcpConfig(t *testing.T) {
 	t.Parallel()
 
@@ -746,7 +864,11 @@ func TestClaudeExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
 		"exit 3\n"
 	writeTestExecutable(t, fakePath, []byte(script))
 
-	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	backend, err := New("claude", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"IS_SANDBOX": "1"},
+		Logger:         slog.Default(),
+	})
 	if err != nil {
 		t.Fatalf("new claude backend: %v", err)
 	}
@@ -798,7 +920,11 @@ func TestClaudeExecuteRecordsResultModelUsage(t *testing.T) {
 		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"session_id\":\"sess-result-usage\",\"result\":\"done\",\"modelUsage\":{\"zhipu/coding-plan\":{\"inputTokens\":123,\"outputTokens\":45,\"cacheReadInputTokens\":7,\"cacheCreationInputTokens\":11,\"costUSD\":0.01}}}'\n"
 	writeTestExecutable(t, fakePath, []byte(script))
 
-	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	backend, err := New("claude", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"IS_SANDBOX": "1"},
+		Logger:         slog.Default(),
+	})
 	if err != nil {
 		t.Fatalf("new claude backend: %v", err)
 	}


### PR DESCRIPTION
## What does this PR do?

When Multica launches the Claude Code CLI from a root or sudo context, the run fails only after the daemon spawns the provider process. Claude Code refuses `--permission-mode bypassPermissions` (and `--dangerously-skip-permissions`) when the effective UID is 0, printing `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons` to stderr and exiting. Because `buildClaudeArgs` in `server/pkg/agent/claude.go` hardcodes `--permission-mode bypassPermissions` for autonomous local runs, the user only sees a raw exit-status-1 with an opaque CLI stderr and no guidance about what to do next (issue #3278).

This PR adds a Claude-specific preflight in `claudeBackend.Execute`. It runs after the launch args and child environment are resolved but before the process starts, and converts that late, opaque failure into an early, self-explanatory daemon error. It follows the direction the maintainers already endorsed on the issue: surface guidance, never silently auto-bypass Claude Code's safety check. It also honors the `IS_SANDBOX=1` escape hatch that a commenter found for genuine container runs.

The preflight returns an actionable error only when all three conditions hold:

1. The final args request bypass or skip permissions (`--permission-mode bypassPermissions` or `--dangerously-skip-permissions`).
2. The process is running as root (`os.Geteuid() == 0`). On Windows `Geteuid` returns -1, so the check is false there, matching that Claude Code's refusal is a Unix behavior.
3. `IS_SANDBOX` is not set to a truthy value in the resolved child environment.

If a user strips the permission flag through `custom_args`, runs as a non-root user, or sets `IS_SANDBOX=1`, the preflight stays out of the way.

## Related Issue

Closes #3278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/claude.go`: added `claudeRootSudoPreflight(args, env []string) error`, invoked in `claudeBackend.Execute` right after `cmd.Env = buildEnv(...)` and before the process is started. Added two small, testable detection helpers: `argsRequestBypassPermissions(args []string) bool` and `envHasSandbox(env []string) bool` (treats `1`, `true`, `yes`, `on` as truthy, case-insensitive; empty, `0`, `false`, and absent as not truthy). The error names both supported remedies: run the Multica daemon as a non-root user, or set `IS_SANDBOX=1` for a genuine container or sandbox.
- `server/pkg/agent/claude_test.go`: added unit tests for `argsRequestBypassPermissions`, `envHasSandbox`, and `claudeRootSudoPreflight`. The root-fires assertion is gated on `os.Geteuid() == 0` so it only runs when the test process is actually root; the sandbox-allowed and non-bypass paths are asserted unconditionally. Also set `IS_SANDBOX=1` on the two existing fake-CLI execute tests so they keep exercising stderr and model-usage behavior when the suite runs as root.
- `server/pkg/agent/claude_deadlock_test.go`: set `IS_SANDBOX=1` on the four fake-Claude execute configs so the new preflight does not fire when the suite runs as UID 0 in a container.

## How to Test

Reproduction: on a Debian or Docker host, run the Multica daemon as root and start a Claude task. Before this change the task fails with a bare `exit status 1` and the CLI stderr `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`, with no guidance. After this change the daemon returns an early error that names the two fixes (run as non-root, or set `IS_SANDBOX=1`), and setting `IS_SANDBOX=1` restores the previous working behavior.

Automated verification, run from `server/`:

1. `gofmt -l pkg/agent/claude.go pkg/agent/claude_test.go pkg/agent/claude_deadlock_test.go` prints nothing.
2. `go vet ./pkg/agent/...` passes.
3. `go build ./...` passes.
4. `go test ./pkg/agent/...` passes, including the new preflight, arg-detection, and env-truthiness tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A: backend-only change, no UI)
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs, CLI flags, or API fields changed; this adds an internal daemon preflight error, so no docs needed updating)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (N/A: none added)
- [ ] If this PR touches Chinese product copy, I checked it against the conventions doc (N/A: no product copy touched)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** AI coding assistant

**Prompt / approach:** I started from the issue thread, including the maintainer's stated preference to surface guidance rather than auto-bypass Claude Code's root check, and the commenter's `IS_SANDBOX=1` workaround. I asked an AI coding assistant to add a localized preflight in `claudeBackend.Execute` that detects the exact three-part condition (bypass args, root euid, no truthy `IS_SANDBOX`) and returns an actionable error, with the detection logic split into small helpers so it can be unit-tested without a real root process. I reviewed the result, kept the change to the agent package, gated the root-only assertion on `os.Geteuid() == 0`, and made sure the existing fake-CLI tests still pass when the suite runs as root by marking them as sandboxed. I verified locally with gofmt, go vet, go build, and go test.
