### PR TITLE
WS-1494: harden Codex skill loading and usage attribution

### DIFF
--- a/server/internal/daemon/execenv/codex_user_skills.go
+++ b/server/internal/daemon/execenv/codex_user_skills.go
@@ -79,6 +79,32 @@ func seedUserCodexSkills(codexHome string, workspaceSkills []SkillContextForEnv,
 			logger.Warn("execenv: codex user-skill copy failed", "name", name, "error", err)
 			continue
 		}
+		if err := normalizeCopiedCodexUserSkill(dst, name); err != nil {
+			_ = os.RemoveAll(dst)
+			logger.Warn("execenv: codex user-skill frontmatter normalization failed", "name", name, "error", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// normalizeCopiedCodexUserSkill is the cold-start guard for user-installed
+// Codex skills. Unlike workspace skills, user skills arrive from ~/.codex/skills
+// and used to be copied byte-for-byte into the per-task CODEX_HOME. A missing
+// or malformed frontmatter block makes Codex reject that SKILL.md during startup,
+// which can stall unrelated task prompts before they produce a fallback answer.
+func normalizeCopiedCodexUserSkill(skillDir, name string) error {
+	path := filepath.Join(skillDir, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read SKILL.md: %w", err)
+	}
+	normalized := ensureSkillFrontmatter(string(data), sanitizeSkillName(name), "")
+	if normalized == string(data) {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(normalized), 0o644); err != nil {
+		return fmt.Errorf("write SKILL.md: %w", err)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2940,8 +2940,15 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "summarize", "SKILL.md")); err != nil {
 		t.Fatalf("user skill SKILL.md not seeded: %v", err)
-	} else if string(data) != "summarize" {
-		t.Errorf("summarize SKILL.md = %q, want %q", data, "summarize")
+	} else {
+		got := string(data)
+		fm := parseFrontmatter(t, got)
+		if name, _ := fm["name"].(string); name != "summarize" {
+			t.Errorf("frontmatter name = %#v, want %q", fm["name"], "summarize")
+		}
+		if !strings.Contains(got, "summarize") {
+			t.Errorf("summarize body was dropped:\n%s", got)
+		}
 	}
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "summarize", "examples", "ex.md")); err != nil {
 		t.Fatalf("user skill support file not seeded: %v", err)
@@ -2950,11 +2957,65 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 	}
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "translate", "SKILL.md")); err != nil {
 		t.Fatalf("second user skill not seeded: %v", err)
-	} else if string(data) != "translate" {
-		t.Errorf("translate SKILL.md = %q, want %q", data, "translate")
+	} else {
+		fm := parseFrontmatter(t, string(data))
+		if name, _ := fm["name"].(string); name != "translate" {
+			t.Errorf("frontmatter name = %#v, want %q", fm["name"], "translate")
+		}
 	}
 	if _, err := os.Stat(filepath.Join(env.CodexHome, "skills", ".DS_Store")); !os.IsNotExist(err) {
 		t.Errorf("ignored dotfile leaked into codex-home/skills: err=%v", err)
+	}
+}
+
+// TestPrepareCodexNormalizesUserSkillFrontmatter covers the WS-1494 failure
+// mode: user-installed Codex skills are copied into the per-task CODEX_HOME.
+// If their SKILL.md lacks YAML frontmatter, Codex logs "missing YAML
+// frontmatter delimited by ---" while loading skills and the task can stall
+// before the daily-report prompt produces any fallback text.
+func TestPrepareCodexNormalizesUserSkillFrontmatter(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	for _, name := range []string{"koc-publish-registration", "koc-sample-registration"} {
+		dir := filepath.Join(sharedHome, "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("seed user skill dir: %v", err)
+		}
+		body := "# " + name + "\n\nPlain-text guidance without frontmatter.\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("seed user SKILL.md: %v", err)
+		}
+	}
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-koc-user-skills",
+		TaskID:         "0f1e2d3c-4b5a-6978-90ab-cdef12345678",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "koc-frontmatter-test"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	for _, name := range []string{"koc-publish-registration", "koc-sample-registration"} {
+		data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("seeded %s missing: %v", name, err)
+		}
+		got := string(data)
+		fm := parseFrontmatter(t, got)
+		if fmName, _ := fm["name"].(string); fmName != name {
+			t.Errorf("%s frontmatter name = %#v, want %q", name, fm["name"], name)
+		}
+		if !strings.Contains(got, "Plain-text guidance without frontmatter.") {
+			t.Errorf("%s body was dropped during normalization:\n%s", name, got)
+		}
 	}
 }
 
@@ -3091,8 +3152,13 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeded SKILL.md missing: %v", err)
 	}
-	if string(data) != "lark" {
-		t.Errorf("seeded SKILL.md = %q, want %q", data, "lark")
+	got := string(data)
+	fm := parseFrontmatter(t, got)
+	if name, _ := fm["name"].(string); name != "lark-mail" {
+		t.Errorf("frontmatter name = %#v, want %q", fm["name"], "lark-mail")
+	}
+	if !strings.Contains(got, "lark") {
+		t.Errorf("seeded SKILL.md body was dropped:\n%s", got)
 	}
 }
 
@@ -3140,8 +3206,13 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("user skill not refreshed on reuse: %v", err)
 	}
-	if string(data) != "v2" {
-		t.Errorf("after Reuse, user skill content = %q, want %q", data, "v2")
+	got := string(data)
+	fm := parseFrontmatter(t, got)
+	if name, _ := fm["name"].(string); name != "summarize" {
+		t.Errorf("frontmatter name = %#v, want %q", fm["name"], "summarize")
+	}
+	if !strings.Contains(got, "v2") {
+		t.Errorf("after Reuse, user skill body was not refreshed:\n%s", got)
 	}
 }
 

--- a/server/internal/handler/dashboard_test.go
+++ b/server/internal/handler/dashboard_test.go
@@ -1316,6 +1316,146 @@ func TestDashboardUsageDailyCrossMidnightFullPipeline(t *testing.T) {
 	}
 }
 
+// TestDashboardUsageExcludesStaleRuntimeBuckets covers the WS-1494 attribution
+// canary: a runtime whose last heartbeat is older than the activity bucket by
+// more than 24h must not make an employee look active "today" just because a
+// stray usage row was attached to that runtime.
+func TestDashboardUsageExcludesStaleRuntimeBuckets(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	insertRuntime := func(name string, lastSeen time.Time) string {
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_runtime (
+				workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+			)
+			VALUES ($1, NULL, $2, 'cloud', 'claude', 'online', '{}'::jsonb, '{}'::jsonb, $3)
+			RETURNING id
+		`, testWorkspaceID, name, lastSeen).Scan(&id); err != nil {
+			t.Fatalf("create runtime %s: %v", name, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, id) })
+		return id
+	}
+	now := time.Now().UTC()
+	staleRuntimeID := insertRuntime("stale-window-runtime", now.Add(-48*time.Hour))
+	freshRuntimeID := insertRuntime("fresh-window-runtime", now)
+
+	insertAgent := func(name, runtimeID string) string {
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent (
+				workspace_id, name, description, runtime_mode, runtime_config,
+				runtime_id, visibility, max_concurrent_tasks, owner_id,
+				instructions, custom_env, custom_args, mcp_config
+			)
+			VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+			RETURNING id
+		`, testWorkspaceID, name, runtimeID, testUserID).Scan(&id); err != nil {
+			t.Fatalf("create agent %s: %v", name, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, id) })
+		return id
+	}
+	staleAgentID := insertAgent("stale-window-agent", staleRuntimeID)
+	freshAgentID := insertAgent("fresh-window-agent", freshRuntimeID)
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, creator_id, creator_type, number)
+		VALUES ($1, 'stale runtime attribution test', $2, 'member',
+		        (SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1))
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	insertUsage := func(agentID, runtimeID, model string, tokens int) {
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, created_at)
+			VALUES ($1, $2, $3, 'completed', now()) RETURNING id
+		`, agentID, issueID, runtimeID).Scan(&taskID); err != nil {
+			t.Fatalf("insert task %s: %v", model, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at, updated_at)
+			VALUES ($1, 'claude', $2, $3, 0, now(), now())
+		`, taskID, model, tokens); err != nil {
+			t.Fatalf("insert usage %s: %v", model, err)
+		}
+	}
+	insertUsage(staleAgentID, staleRuntimeID, "m-stale-runtime-window", 111)
+	insertUsage(freshAgentID, freshRuntimeID, "m-fresh-runtime-window", 222)
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM task_usage_hourly WHERE model IN ('m-stale-runtime-window', 'm-fresh-runtime-window')`)
+		testPool.Exec(ctx, `DELETE FROM task_usage_hourly_dirty WHERE model IN ('m-stale-runtime-window', 'm-fresh-runtime-window')`)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		SELECT rollup_task_usage_hourly_window('1970-01-01'::timestamptz, now() + interval '1 hour')
+	`); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=1&tz=UTC", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("daily: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var dailyRows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&dailyRows); err != nil {
+		t.Fatalf("decode daily: %v", err)
+	}
+	assertModelPresence := func(label string, rows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}) {
+		t.Helper()
+		var fresh, stale bool
+		for _, row := range rows {
+			if row.Model == "m-fresh-runtime-window" {
+				fresh = true
+				if row.InputTokens != 222 {
+					t.Errorf("%s: fresh tokens = %d, want 222", label, row.InputTokens)
+				}
+			}
+			if row.Model == "m-stale-runtime-window" {
+				stale = true
+			}
+		}
+		if !fresh {
+			t.Errorf("%s: fresh runtime usage row missing in %v", label, rows)
+		}
+		if stale {
+			t.Errorf("%s: stale runtime usage row should be excluded: %v", label, rows)
+		}
+	}
+	assertModelPresence("daily", dailyRows)
+
+	w = httptest.NewRecorder()
+	testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&tz=UTC", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("by-agent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var byAgentRows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&byAgentRows); err != nil {
+		t.Fatalf("decode by-agent: %v", err)
+	}
+	assertModelPresence("by-agent", byAgentRows)
+}
+
 // TestRollupTaskUsageHourlyConvergesOnTaskUsageDelete covers the
 // `trg_tu_dirty_hourly` trigger — a BEFORE DELETE trigger on task_usage.
 // Migration 102 notes it has no production callers today and exists purely

--- a/server/pkg/db/generated/task_usage.sql.go
+++ b/server/pkg/db/generated/task_usage.sql.go
@@ -230,20 +230,27 @@ func (q *Queries) ListDashboardRunTimeDaily(ctx context.Context, arg ListDashboa
 
 const listDashboardUsageByAgent = `-- name: ListDashboardUsageByAgent :many
 SELECT
-    agent_id,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= $2::timestamptz
-  AND ($3::uuid IS NULL OR project_id = $3)
-GROUP BY agent_id, LOWER(provider), model
-ORDER BY agent_id, LOWER(provider), model
+    tuh.agent_id,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= $2::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND ($3::uuid IS NULL OR tuh.project_id = $3)
+GROUP BY tuh.agent_id, LOWER(tuh.provider), tuh.model
+ORDER BY tuh.agent_id, LOWER(tuh.provider), tuh.model
 `
 
 type ListDashboardUsageByAgentParams struct {
@@ -308,20 +315,27 @@ func (q *Queries) ListDashboardUsageByAgent(ctx context.Context, arg ListDashboa
 
 const listDashboardUsageDaily = `-- name: ListDashboardUsageDaily :many
 SELECT
-    DATE(bucket_hour AT TIME ZONE $2::text) AS date,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= $3::timestamptz
-  AND ($4::uuid IS NULL OR project_id = $4)
-GROUP BY DATE(bucket_hour AT TIME ZONE $2::text), LOWER(provider), model
-ORDER BY DATE(bucket_hour AT TIME ZONE $2::text) DESC, LOWER(provider), model
+    DATE(tuh.bucket_hour AT TIME ZONE $2::text) AS date,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= $3::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND ($4::uuid IS NULL OR tuh.project_id = $4)
+GROUP BY DATE(tuh.bucket_hour AT TIME ZONE $2::text), LOWER(tuh.provider), tuh.model
+ORDER BY DATE(tuh.bucket_hour AT TIME ZONE $2::text) DESC, LOWER(tuh.provider), tuh.model
 `
 
 type ListDashboardUsageDailyParams struct {

--- a/server/pkg/db/queries/task_usage.sql
+++ b/server/pkg/db/queries/task_usage.sql
@@ -48,20 +48,27 @@ WHERE atq.issue_id = $1;
 -- before the handler lowercased provider on write) merge with new rows
 -- instead of forming a separate case-variant bucket.
 SELECT
-    DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) AS date,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= sqlc.arg('since')::timestamptz
-  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
-GROUP BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text), LOWER(provider), model
-ORDER BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(provider), model;
+    DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text) AS date,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= sqlc.arg('since')::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND (sqlc.narg('project_id')::uuid IS NULL OR tuh.project_id = sqlc.narg('project_id'))
+GROUP BY DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text), LOWER(tuh.provider), tuh.model
+ORDER BY DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(tuh.provider), tuh.model;
 
 -- name: ListDashboardUsageByAgent :many
 -- Per-(agent, provider, model) token aggregates from `task_usage_hourly`. No
@@ -79,20 +86,27 @@ ORDER BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(provide
 -- provider is LOWER()-normalized so mixed-case historical rows merge with
 -- new rows (see ListDashboardUsageDaily).
 SELECT
-    agent_id,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= @since::timestamptz
-  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
-GROUP BY agent_id, LOWER(provider), model
-ORDER BY agent_id, LOWER(provider), model;
+    tuh.agent_id,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= @since::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND (sqlc.narg('project_id')::uuid IS NULL OR tuh.project_id = sqlc.narg('project_id'))
+GROUP BY tuh.agent_id, LOWER(tuh.provider), tuh.model
+ORDER BY tuh.agent_id, LOWER(tuh.provider), tuh.model;
 
 -- name: ListDashboardRunTimeDaily :many
 -- Daily per-date run time + task counts for the workspace, optionally


### PR DESCRIPTION
Closes WS-1494

Summary:
- Normalize user-installed Codex skills copied from ~/.codex/skills into per-task CODEX_HOME so missing or malformed SKILL.md frontmatter cannot stall unrelated tasks.
- Add regression coverage for the two observed KOC skill names.
- Exclude workspace dashboard usage buckets more than 24h after a runtime's last heartbeat to avoid stale machines being counted as active with current requests.

Verification:
- go test ./internal/daemon/execenv -count=1 -timeout=60s
- go test ./internal/handler -run TestDashboardUsageExcludesStaleRuntimeBuckets -count=1 -timeout=60s
- go test ./internal/handler -run TestDashboardEndpoints -count=1 -timeout=60s
- git diff --check
