### PR TITLE
Fix Codex MCP allowlist config rendering (MUL-4099, ZIC-38)

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -380,15 +380,24 @@ func renderCodexMcpServersBlock(raw json.RawMessage) (string, bool, error) {
 
 func normalizeCodexMcpServerConfig(server map[string]any) map[string]any {
 	if !isCodexRemoteMcpServer(server) {
-		return server
+		normalized := make(map[string]any, len(server))
+		for k, v := range server {
+			if isMulticaMcpSelectorKey(k) {
+				continue
+			}
+			normalized[k] = v
+		}
+		return normalized
 	}
 
 	normalized := make(map[string]any, len(server)+1)
 	for k, v := range server {
-		switch k {
-		case "type":
+		switch {
+		case isMulticaMcpSelectorKey(k):
 			continue
-		case "headers":
+		case k == "type":
+			continue
+		case k == "headers":
 			if _, ok := server["http_headers"]; !ok {
 				normalized["http_headers"] = v
 			}
@@ -398,6 +407,15 @@ func normalizeCodexMcpServerConfig(server map[string]any) map[string]any {
 	}
 	normalized["experimental_use_rmcp_client"] = true
 	return normalized
+}
+
+func isMulticaMcpSelectorKey(k string) bool {
+	switch k {
+	case "tools", "prompts", "resources":
+		return true
+	default:
+		return false
+	}
 }
 
 func isCodexRemoteMcpServer(server map[string]any) bool {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2365,6 +2365,86 @@ func TestEnsureCodexMcpConfigTranslatesRemoteHTTPServer(t *testing.T) {
 	}
 }
 
+func TestEnsureCodexMcpConfigDropsInternalSelectors(t *testing.T) {
+	t.Parallel()
+
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch"],"env":{"API_KEY":"secret"},"timeout":30,"tools":{"include":["kb_get"]},"prompts":{"include":["daily"]},"resources":{"include":["docs"]}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		`[mcp_servers.fetch]`,
+		`command = "uvx"`,
+		`args = ["mcp-server-fetch"]`,
+		`env = { API_KEY = "secret" }`,
+		`timeout = 30`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+	for _, unexpected := range []string{
+		"\ntools = ",
+		"\nprompts = ",
+		"\nresources = ",
+		"kb_get",
+		"daily",
+		"docs",
+	} {
+		if strings.Contains(got, unexpected) {
+			t.Fatalf("internal MCP selector %q must not render into Codex config.toml:\n%s", unexpected, got)
+		}
+	}
+}
+
+func TestEnsureCodexMcpConfigDropsInternalSelectorsFromRemoteHTTPServer(t *testing.T) {
+	t.Parallel()
+
+	tmp := filepath.Join(t.TempDir(), "config.toml")
+	raw := json.RawMessage(`{"mcpServers":{"remote":{"type":"http","url":"https://mcp.example.test/session","headers":{"Authorization":"Bearer test-token"},"timeout":45,"tools":{"include":["kb_get"]},"prompts":{"include":["daily"]},"resources":{"include":["docs"]}}}}`)
+	if err := ensureCodexMcpConfig(tmp, raw, slog.Default()); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		`[mcp_servers.remote]`,
+		`url = "https://mcp.example.test/session"`,
+		`http_headers = { Authorization = "Bearer test-token" }`,
+		`timeout = 45`,
+		`experimental_use_rmcp_client = true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in:\n%s", want, got)
+		}
+	}
+	for _, unexpected := range []string{
+		"\ntools = ",
+		"\nprompts = ",
+		"\nresources = ",
+		"kb_get",
+		"daily",
+		"docs",
+		`type = "http"`,
+		"\nheaders = ",
+	} {
+		if strings.Contains(got, unexpected) {
+			t.Fatalf("internal or provider-incompatible key %q must not render into Codex config.toml:\n%s", unexpected, got)
+		}
+	}
+}
+
 func TestRenderCodexMcpServersBlockTreatsURLOnlyServerAsRemote(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Codex-backed agents can receive Multica's internal MCP selector shape (`tools.include`, `prompts`, and `resources`) in an agent `mcp_config`. The Codex config renderer copied those keys into `$CODEX_HOME/config.toml`, where Codex interprets `tools` as its own approval-policy map and rejects selector names such as `kb_get`.

This PR keeps the provider-neutral saved MCP config unchanged, but strips Multica selector keys at the Codex adapter boundary before rendering `[mcp_servers.*]` TOML. Valid server fields such as stdio command/args/env/timeout and remote URL/headers/timeout are still preserved.

Thinking path: traced issue #4901 to `ensureCodexMcpConfig` / `renderCodexMcpServersBlock`, verified the renderer already owns the Codex `mcp_servers` config path, and made the smallest adapter-level normalization change so other runtimes and stored config semantics are unaffected.

## Related Issue

Closes #4901

Multica workspace issue: ZIC-38

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/codex.go`: drop Multica internal MCP selector keys (`tools`, `prompts`, `resources`) before rendering Codex MCP server TOML.
- `server/pkg/agent/codex_test.go`: add regression coverage for stdio and remote HTTP MCP servers with selector allowlists, asserting selectors are omitted while valid fields remain.

## How to Test

1. `cd server && go test ./pkg/agent`
2. `make check-worktree` exited 0 locally, but the environment printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock` while checking PostgreSQL, so the focused Go package test above is the reliable local validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Worked from Multica issue ZIC-38 / GitHub issue #4901, followed the contribution workflow, traced Codex MCP config generation, implemented an adapter-level sanitizer, and added focused regression tests.

## Screenshots (optional)

N/A
