### PR TITLE
Fix local-directory lock for squad leader wrap-up (ZIC-37)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2977,7 +2977,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 			// sibling workdir (which is the user's path) or the envRoot
 			// itself (we want output/ and logs/ to linger for forensic
 			// access).
-			if assignment, _ := findLocalDirectoryAssignment(task.ProjectResources, d.cfg.DaemonID); assignment != nil {
+			if assignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID); assignment != nil {
 				meta.LocalDirectory = true
 			}
 			if err := execenv.WriteGCMeta(result.EnvRoot, meta, taskLog); err != nil {
@@ -3008,7 +3008,7 @@ func (d *Daemon) acquireLocalDirectoryLockIfNeeded(ctx context.Context, task Tas
 	if len(task.ProjectResources) == 0 || d.cfg.DaemonID == "" {
 		return nil, false
 	}
-	assignment, err := findLocalDirectoryAssignment(task.ProjectResources, d.cfg.DaemonID)
+	assignment, err := localDirectoryAssignmentForTask(task, d.cfg.DaemonID)
 	if err != nil {
 		taskLog.Error("local_directory: resolve resource failed", "error", err)
 		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "local_directory_error"); failErr != nil {
@@ -3570,12 +3570,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	}
 	// Resolve any local_directory assignment again here so runTask can plumb
 	// LocalWorkDir into execenv. handleTask already validated + locked the
-	// path; this call is a pure JSON parse over the same task payload.
-	localAssignment, _ := findLocalDirectoryAssignment(task.ProjectResources, d.cfg.DaemonID)
+	// path for worker tasks; leader tasks intentionally skip the assignment.
+	localAssignment, _ := localDirectoryAssignmentForTask(task, d.cfg.DaemonID)
 	// Reuse intentionally skipped for local_directory tasks: the prior
 	// WorkDir is the user's own path (always present) but the reuse path
 	// loses the envRoot association the GC loop needs, and re-running
 	// Prepare against a stable user path is cheap (no clone, no copy).
+	// Squad-leader tasks also skip reuse so a pre-fix leader session recorded
+	// against the user's local_directory cannot be re-entered without a lock.
 	var agentMcpConfig json.RawMessage
 	if task.Agent != nil {
 		agentMcpConfig = task.Agent.McpConfig
@@ -3589,7 +3591,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.Agent != nil && provider == "openclaw" {
 		openclawMode, openclawGateway = decodeOpenclawRuntimeConfig(task.Agent.RuntimeConfig, d.logger)
 	}
-	if task.PriorWorkDir != "" && localAssignment == nil {
+	if task.PriorWorkDir != "" && localAssignment == nil && !task.IsLeaderTask {
 		env = execenv.Reuse(execenv.ReuseParams{
 			WorkDir:         task.PriorWorkDir,
 			Provider:        provider,

--- a/server/internal/daemon/local_directory.go
+++ b/server/internal/daemon/local_directory.go
@@ -40,6 +40,17 @@ type localDirectoryAssignment struct {
 	RealPath string // canonical key for the path mutex
 }
 
+// localDirectoryAssignmentForTask returns the local_directory assignment a task
+// should execute inside. Squad-leader tasks are coordinators: they may create
+// child issues or comments, but should not bind to the user's repo worktree or
+// hold the path mutex while downstream workers are ready to write.
+func localDirectoryAssignmentForTask(task Task, daemonID string) (*localDirectoryAssignment, error) {
+	if task.IsLeaderTask {
+		return nil, nil
+	}
+	return findLocalDirectoryAssignment(task.ProjectResources, daemonID)
+}
+
 // findLocalDirectoryAssignment scans the task's project resources for one of
 // type local_directory whose daemon_id matches this daemon. Returns nil
 // (without error) when no such resource exists — the task takes the regular

--- a/server/internal/daemon/local_directory_test.go
+++ b/server/internal/daemon/local_directory_test.go
@@ -138,6 +138,83 @@ func TestFindLocalDirectoryAssignment(t *testing.T) {
 	})
 }
 
+func TestAcquireLocalDirectoryLockSkipsSquadLeaderTasks(t *testing.T) {
+	t.Parallel()
+
+	const daemonID = "d-mine"
+	tmp := t.TempDir()
+	raw, err := json.Marshal(localDirectoryRef{LocalPath: tmp, DaemonID: daemonID})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resources := []ProjectResourceData{
+		{ID: "r1", ResourceType: localDirectoryResourceType, ResourceRef: raw},
+	}
+
+	worker := Task{
+		ID:               "worker-task",
+		ProjectResources: resources,
+	}
+	assignment, err := localDirectoryAssignmentForTask(worker, daemonID)
+	if err != nil {
+		t.Fatalf("worker assignment: %v", err)
+	}
+	if assignment == nil {
+		t.Fatal("worker assignment is nil")
+	}
+
+	d := &Daemon{
+		cfg:            Config{DaemonID: daemonID},
+		localPathLocks: NewLocalPathLocker(),
+		logger:         slog.Default(),
+	}
+	leader := Task{
+		ID:               "leader-task",
+		IsLeaderTask:     true,
+		ProjectResources: resources,
+	}
+	leaderAssignment, err := localDirectoryAssignmentForTask(leader, daemonID)
+	if err != nil {
+		t.Fatalf("leader assignment: %v", err)
+	}
+	if leaderAssignment != nil {
+		t.Fatalf("leader assignment = %+v, want nil", leaderAssignment)
+	}
+	leaderRelease, abort := d.acquireLocalDirectoryLockIfNeeded(context.Background(), leader, slog.Default())
+	if abort {
+		t.Fatal("leader lock acquisition aborted")
+	}
+	if leaderRelease != nil {
+		t.Fatal("leader lock acquisition returned a release callback")
+	}
+	if got := d.localPathLocks.Holder(assignment.RealPath); got != "" {
+		t.Fatalf("holder after leader skip = %q, want empty", got)
+	}
+
+	release, abort := d.acquireLocalDirectoryLockIfNeeded(context.Background(), worker, slog.Default())
+	if abort {
+		t.Fatal("worker lock acquisition aborted")
+	}
+	if release == nil {
+		t.Fatal("worker lock acquisition returned nil release")
+	}
+	defer release()
+	if got := d.localPathLocks.Holder(assignment.RealPath); got != worker.ID {
+		t.Fatalf("holder = %q, want %q", got, worker.ID)
+	}
+
+	leaderRelease, abort = d.acquireLocalDirectoryLockIfNeeded(context.Background(), leader, slog.Default())
+	if abort {
+		t.Fatal("leader lock acquisition aborted")
+	}
+	if leaderRelease != nil {
+		t.Fatal("leader lock acquisition returned a release callback")
+	}
+	if got := d.localPathLocks.Holder(assignment.RealPath); got != worker.ID {
+		t.Fatalf("holder after leader skip = %q, want %q", got, worker.ID)
+	}
+}
+
 func TestValidateLocalPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("blacklist constants are POSIX-only in this test")

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -67,6 +67,7 @@ type Task struct {
 	ProjectTitle             string                `json:"project_title,omitempty"`               // human-readable project title for context injection
 	ProjectDescription       string                `json:"project_description,omitempty"`         // durable project-level context injected into the brief
 	ProjectResources         []ProjectResourceData `json:"project_resources,omitempty"`           // project-scoped resources to expose to the agent
+	IsLeaderTask             bool                  `json:"is_leader_task,omitempty"`              // true when executing in the squad-leader coordinator role
 	PriorSessionID           string                `json:"prior_session_id,omitempty"`            // Claude session ID from a previous task on this issue
 	PriorWorkDir             string                `json:"prior_work_dir,omitempty"`              // work_dir from a previous task on this issue
 	TriggerCommentID         string                `json:"trigger_comment_id,omitempty"`          // comment that triggered this task

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -286,6 +286,7 @@ type AgentTaskResponse struct {
 	Attempt            int32                 `json:"attempt"`
 	MaxAttempts        int32                 `json:"max_attempts"`
 	ParentTaskID       *string               `json:"parent_task_id,omitempty"`
+	IsLeaderTask       bool                  `json:"is_leader_task,omitempty"`
 	Agent              *TaskAgentData        `json:"agent,omitempty"`
 	ConnectedApps      []ConnectedAppData    `json:"connected_apps,omitempty"` // daemon-claim only: per-run app capabilities mounted through runtime MCP overlays
 	Repos              []RepoData            `json:"repos,omitempty"`
@@ -444,6 +445,7 @@ func taskToResponse(t db.AgentTaskQueue, workspaceID string) AgentTaskResponse {
 		Attempt:          t.Attempt,
 		MaxAttempts:      t.MaxAttempts,
 		ParentTaskID:     uuidToPtr(t.ParentTaskID),
+		IsLeaderTask:     t.IsLeaderTask,
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
 		TriggerSummary:   textToPtr(t.TriggerSummary),


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub #4926 / ZIC-37 by keeping squad-leader coordinator runs out of `local_directory` worktrees. The claim response now exposes `is_leader_task` to the daemon, and the daemon uses that role to skip local-directory assignment, path locking, prior workdir reuse, and local-directory GC metadata for leader tasks. Worker and direct agent tasks still use the existing local-directory mutex.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4926

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/agent.go`: include `is_leader_task` in daemon claim responses.
- `server/internal/daemon/types.go`: decode `is_leader_task` on claimed tasks.
- `server/internal/daemon/local_directory.go`: centralize local-directory assignment eligibility and skip it for squad-leader coordinator tasks.
- `server/internal/daemon/daemon.go`: use the shared eligibility rule for path locking, execution environment selection, prior workdir reuse, and GC metadata.
- `server/internal/daemon/local_directory_test.go`: cover leader wrap-up followed by worker lock acquisition, plus leader skip while a worker holds the lock.

## How to Test

1. `go test ./internal/daemon -run 'TestAcquireLocalDirectoryLockSkipsSquadLeaderTasks|TestFindLocalDirectoryAssignment|TestValidateLocalPath|TestLocalPathLocker'`
2. `go test ./internal/handler -run '^$'`
3. `go test ./internal/daemon`
4. `make check-worktree` returned exit 0, but Docker was unavailable while it attempted to ensure PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the reported local-directory mutex behavior from daemon task handling to project resource assignment. The smallest safe fix is to treat squad-leader tasks as coordinators: they should not enter the user's repo worktree or hold the path mutex, while worker/direct tasks keep the existing serialization.

## Screenshots (optional)

N/A
