### PR TITLE
fix(views): enable multi-file selection on all attachment upload buttons

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -398,6 +398,7 @@ export function ChatInput({
           {uploadEnabled && (
             <FileUploadButton
               size="sm"
+              multiple
               onSelect={(file) => editorRef.current?.uploadFile(file)}
             />
           )}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1985,6 +1985,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               />
               <FileUploadButton
                 size="sm"
+                multiple
                 onSelect={(file) => descEditorRef.current?.uploadFile(file)}
               />
             </div>

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -864,6 +864,7 @@ export function ManualCreatePanel({
             <div className="flex flex-col gap-2 border-t px-4 py-3 shrink-0 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex min-h-7 items-center gap-2">
                 <FileUploadButton
+                  multiple
                   onSelect={(file) => descEditorRef.current?.uploadFile(file)}
                 />
               </div>

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -164,6 +164,7 @@ export function FeedbackModal({
         <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
           <FileUploadButton
             size="sm"
+            multiple
             onSelect={(file) => editorRef.current?.uploadFile(file)}
           />
           <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -539,6 +539,7 @@ export function AgentCreatePanel({
           <div className="flex min-h-7 items-center gap-2">
             <FileUploadButton
               size="sm"
+              multiple
               disabled={uploading}
               onSelect={(file) => editorRef.current?.uploadFile(file)}
             />


### PR DESCRIPTION
## Summary

Fixes MUL-4074 (批量上传文件 / batch file upload) for web and desktop.

`FileUploadButton` already supports batch selection — its native input honors a `multiple` prop and it invokes `onSelect` once per picked file — and every composer surface already fans out N uploads (drag-drop and clipboard paste were multi-file everywhere). The only gap was five call sites that never passed `multiple`, so the OS file picker capped selection at one file:

- Chat composer (`packages/views/chat/components/chat-input.tsx`)
- Create-issue modal (`packages/views/modals/create-issue.tsx`)
- Quick-create issue modal (`packages/views/modals/quick-create-issue.tsx`)
- Issue detail description (`packages/views/issues/components/issue-detail.tsx`)
- Feedback modal (`packages/views/modals/feedback.tsx`)

This PR adds `multiple` at those five call sites — same pattern the comment/reply composers already use. No backend, CLI, or daemon changes needed: `POST /api/upload-file` stays one-file-per-request and clients fan out, and issue/comment/chat linking already accepts `attachment_ids` arrays.

Out of scope per issue owner: mobile (single-pick pickers), avatar/logo uploads (intentionally single).

## Verification

- `pnpm --filter @multica/views typecheck` and `--filter @multica/ui typecheck` pass
- Vitest on all five touched surfaces passes (76 tests: chat-input, create-issue, quick-create-issue, issue-detail, feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)