### PR TITLE
fix(diagnostics): make client-freeze telemetry survive repeat hangs (MUL-4120)

### DIFF
--- a/apps/desktop/src/main/freeze-breadcrumb.test.ts
+++ b/apps/desktop/src/main/freeze-breadcrumb.test.ts
@@ -5,8 +5,10 @@ import { join } from "node:path";
 
 import {
   writeFreezeBreadcrumb,
-  readAndClearFreezeBreadcrumb,
+  readFreezeBreadcrumb,
+  ackFreezeBreadcrumb,
   clearFreezeBreadcrumb,
+  FREEZE_BREADCRUMB_TTL_MS,
   type FreezeBreadcrumb,
 } from "./freeze-breadcrumb";
 
@@ -29,59 +31,133 @@ const sample: FreezeBreadcrumb = {
   version: "0.3.1",
 };
 
-describe("freeze breadcrumb round-trip", () => {
+// A `now` safely inside the TTL window relative to sample.ts.
+const NOW = sample.ts + 60_000;
+
+describe("freeze breadcrumb read/ack split", () => {
   it("writes then reads back the breadcrumb", () => {
     const file = tempFile();
     writeFreezeBreadcrumb(file, sample);
-    expect(readAndClearFreezeBreadcrumb(file)).toEqual(sample);
+    expect(readFreezeBreadcrumb(file, NOW)).toEqual(sample);
   });
 
-  it("read clears the file so a failure reports exactly once", () => {
+  it("read does NOT clear the file — a re-hang before reporting keeps the retry alive", () => {
     const file = tempFile();
     writeFreezeBreadcrumb(file, sample);
-    expect(readAndClearFreezeBreadcrumb(file)).toEqual(sample);
+    expect(readFreezeBreadcrumb(file, NOW)).toEqual(sample);
+    expect(existsSync(file)).toBe(true);
+    // A second boot (this one hung before acking) reads it again.
+    expect(readFreezeBreadcrumb(file, NOW)).toEqual(sample);
+  });
+
+  it("ack with the matching ts deletes the file", () => {
+    const file = tempFile();
+    writeFreezeBreadcrumb(file, sample);
+    ackFreezeBreadcrumb(file, sample.ts);
     expect(existsSync(file)).toBe(false);
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+  });
+
+  it("ack with a mismatched ts keeps the file — a late ack can't delete a newer breadcrumb", () => {
+    const file = tempFile();
+    const newer: FreezeBreadcrumb = { ...sample, ts: sample.ts + 1 };
+    writeFreezeBreadcrumb(file, newer);
+    // Renderer acks the ts it read BEFORE the newer breadcrumb was written.
+    ackFreezeBreadcrumb(file, sample.ts);
+    expect(readFreezeBreadcrumb(file, NOW)).toEqual(newer);
+  });
+
+  it("ack on a missing file is a no-op, never throws", () => {
+    expect(() => ackFreezeBreadcrumb(tempFile(), sample.ts)).not.toThrow();
   });
 
   it("clearFreezeBreadcrumb removes a pending breadcrumb (hang recovered)", () => {
     const file = tempFile();
     writeFreezeBreadcrumb(file, sample);
     clearFreezeBreadcrumb(file);
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+  });
+});
+
+describe("freeze breadcrumb TTL", () => {
+  it("an expired breadcrumb is dropped AND deleted — no unbounded retry on analytics-disabled builds", () => {
+    const file = tempFile();
+    writeFreezeBreadcrumb(file, sample);
+    const afterTtl = sample.ts + FREEZE_BREADCRUMB_TTL_MS + 1;
+    expect(readFreezeBreadcrumb(file, afterTtl)).toBeNull();
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("a breadcrumb exactly at the TTL boundary is still reported", () => {
+    const file = tempFile();
+    writeFreezeBreadcrumb(file, sample);
+    const atTtl = sample.ts + FREEZE_BREADCRUMB_TTL_MS;
+    expect(readFreezeBreadcrumb(file, atTtl)).toEqual(sample);
+    expect(existsSync(file)).toBe(true);
   });
 });
 
 // The breadcrumb crosses a process boundary (main writes, renderer flushes via
 // IPC) and lives across app versions — a future write shape or a corrupt file
-// must never throw into boot. CLAUDE.md "API Response Compatibility".
+// must never throw into boot. And now that a valid read no longer deletes,
+// every invalid payload MUST be deleted on read, or it becomes permanent
+// boot noise re-parsed on every launch.
 describe("freeze breadcrumb defends against malformed input", () => {
   it("returns null when no file exists", () => {
-    expect(readAndClearFreezeBreadcrumb(tempFile())).toBeNull();
+    expect(readFreezeBreadcrumb(tempFile(), NOW)).toBeNull();
   });
 
-  it("returns null on corrupt JSON", () => {
+  it("drops and deletes corrupt JSON", () => {
     const file = tempFile();
     writeFileSync(file, "{ not valid json", "utf8");
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
   });
 
-  it("returns null when `kind` is missing", () => {
+  it("drops and deletes a payload missing `kind`", () => {
     const file = tempFile();
-    writeFileSync(file, JSON.stringify({ ts: 1, version: "x" }), "utf8");
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    writeFileSync(file, JSON.stringify({ ts: NOW, version: "x" }), "utf8");
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
   });
 
-  it("returns null when `kind` is the wrong type", () => {
+  it("drops and deletes a payload with a wrong-typed `kind`", () => {
     const file = tempFile();
-    writeFileSync(file, JSON.stringify({ kind: 42, context: {} }), "utf8");
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    writeFileSync(file, JSON.stringify({ kind: 42, ts: NOW, context: {} }), "utf8");
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
   });
 
-  it("returns null on a JSON null payload", () => {
+  it("drops and deletes a payload missing a numeric `ts` — TTL and ack need it", () => {
+    const file = tempFile();
+    writeFileSync(file, JSON.stringify({ kind: "unresponsive", context: {} }), "utf8");
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("drops and deletes a payload with a non-finite `ts`", () => {
+    const file = tempFile();
+    writeFileSync(
+      file,
+      JSON.stringify({ kind: "unresponsive", ts: "yesterday", context: {} }),
+      "utf8",
+    );
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("drops and deletes a JSON null payload", () => {
     const file = tempFile();
     writeFileSync(file, "null", "utf8");
-    expect(readAndClearFreezeBreadcrumb(file)).toBeNull();
+    expect(readFreezeBreadcrumb(file, NOW)).toBeNull();
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("ack deletes a malformed file too — it could never be reported anyway", () => {
+    const file = tempFile();
+    writeFileSync(file, "{ not valid json", "utf8");
+    ackFreezeBreadcrumb(file, 123);
+    expect(existsSync(file)).toBe(false);
   });
 
   it("clearing a non-existent file is a no-op, never throws", () => {

--- a/apps/desktop/src/main/freeze-breadcrumb.ts
+++ b/apps/desktop/src/main/freeze-breadcrumb.ts
@@ -5,10 +5,25 @@ import type { FreezeBreadcrumb } from "../shared/freeze-breadcrumb";
 // itself — the thread is blocked or gone. The main process (always alive) is
 // the only watcher that can react, but during the hang it can't reach the
 // renderer's posthog-js either. So it writes a breadcrumb to disk; the next
-// time a renderer boots, it reads + clears the file and reports the event.
+// time a renderer boots, it reads the file and reports the event.
 // This survives even a force-quit, which is the whole point.
+//
+// Read and delete are deliberately SPLIT (MUL-4120): the renderer reads the
+// breadcrumb, sends the event with posthog's send_instantly, and only then
+// acks the timestamp back so the file is deleted. If the renderer hangs again
+// (or is killed) before the event could leave the process, the file survives
+// and the next boot retries — the signal is eventually delivered instead of
+// being lost on the first attempt. Occasional duplicate reports are the
+// accepted cost; events carry `breadcrumb_ts` for query-side dedupe.
 
 export type { FreezeBreadcrumb };
+
+// A breadcrumb the renderer never manages to ack (analytics disabled on
+// self-hosted builds, or a persistently crashing boot path) must not be
+// re-read on every launch forever. One week comfortably covers "user killed
+// the app and reopened it days later" while bounding both the retry loop and
+// the duplicate-report window.
+export const FREEZE_BREADCRUMB_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Best-effort write. A breadcrumb we can't persist is lost, never fatal.
@@ -44,33 +59,76 @@ export function clearFreezeBreadcrumb(filePath: string): void {
 }
 
 /**
- * Read the breadcrumb and delete it in the same call, so a failure is reported
- * exactly once. Returns null when there's no breadcrumb (the normal case) or
- * when the file is unreadable / corrupt.
+ * Read the breadcrumb WITHOUT deleting it. Deletion happens via
+ * `ackFreezeBreadcrumb` once the renderer confirms the event was handed to
+ * posthog-js — see the module comment for why.
+ *
+ * The file is still deleted eagerly in two cases, so an unreportable
+ * breadcrumb can never become permanent boot noise:
+ *   - malformed payload (corrupt JSON, missing `kind`, missing/invalid `ts`);
+ *   - expired payload (`ts` older than FREEZE_BREADCRUMB_TTL_MS).
+ *
+ * Returns null when there's no breadcrumb (the normal case) or when the file
+ * was dropped for one of the reasons above.
  */
-export function readAndClearFreezeBreadcrumb(filePath: string): FreezeBreadcrumb | null {
+export function readFreezeBreadcrumb(
+  filePath: string,
+  nowMs: number = Date.now(),
+): FreezeBreadcrumb | null {
   let raw: string;
   try {
     raw = readFileSync(filePath, "utf8");
   } catch {
     return null;
   }
-  try {
-    rmSync(filePath, { force: true });
-  } catch {
-    // If we can't delete it we'd re-report next launch; acceptable over throwing.
+  const breadcrumb = parseBreadcrumb(raw);
+  if (!breadcrumb || nowMs - breadcrumb.ts > FREEZE_BREADCRUMB_TTL_MS) {
+    clearFreezeBreadcrumb(filePath);
+    return null;
   }
+  return breadcrumb;
+}
+
+/**
+ * Acknowledge a reported breadcrumb: delete the file only if the on-disk
+ * breadcrumb still carries the acked `ts`. The guard makes a late ack from a
+ * previous read harmless — if a NEW failure wrote a fresh breadcrumb in the
+ * meantime, its `ts` differs and the file is kept for the next boot.
+ */
+export function ackFreezeBreadcrumb(filePath: string, ts: number): void {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch {
+    return;
+  }
+  const breadcrumb = parseBreadcrumb(raw);
+  if (breadcrumb && breadcrumb.ts !== ts) return;
+  // Matching ts — reported, safe to delete. A malformed file is also deleted
+  // here rather than kept: it could never be reported anyway.
+  clearFreezeBreadcrumb(filePath);
+}
+
+/**
+ * The breadcrumb crosses a process boundary and lives across app versions —
+ * a future write shape or a corrupt file must never throw into boot. `kind`
+ * and a finite `ts` are required: without `kind` the event can't be labeled,
+ * and without `ts` neither the TTL nor the ack guard can work.
+ */
+function parseBreadcrumb(raw: string): FreezeBreadcrumb | null {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (
       parsed &&
       typeof parsed === "object" &&
-      typeof (parsed as FreezeBreadcrumb).kind === "string"
+      typeof (parsed as FreezeBreadcrumb).kind === "string" &&
+      typeof (parsed as FreezeBreadcrumb).ts === "number" &&
+      Number.isFinite((parsed as FreezeBreadcrumb).ts)
     ) {
       return parsed as FreezeBreadcrumb;
     }
   } catch {
-    // Corrupt JSON — drop.
+    // Corrupt JSON — caller drops the file.
   }
   return null;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -25,7 +25,8 @@ import {
 } from "./renderer-recovery";
 import {
   writeFreezeBreadcrumb,
-  readAndClearFreezeBreadcrumb,
+  readFreezeBreadcrumb,
+  ackFreezeBreadcrumb,
   clearFreezeBreadcrumb,
 } from "./freeze-breadcrumb";
 
@@ -458,12 +459,23 @@ if (!gotTheLock) {
       event.returnValue = { version: getAppVersion(), os };
     });
 
-    // Sync IPC: read + clear any freeze/crash breadcrumb left by a previous
-    // session. The renderer flushes it to telemetry on boot (it couldn't be
-    // reported when it happened — the renderer was hung or gone). Read-and-
-    // clear so a failure reports exactly once.
+    // Sync IPC: read any freeze/crash breadcrumb left by a previous session.
+    // The renderer flushes it to telemetry on boot (it couldn't be reported
+    // when it happened — the renderer was hung or gone). Read does NOT clear:
+    // the renderer acks the breadcrumb's ts via `freeze:ack` after handing
+    // the event to posthog, so a boot that hangs again before the event
+    // leaves the process keeps the file and the next boot retries (MUL-4120).
     ipcMain.on("freeze:get-last", (event) => {
-      event.returnValue = readAndClearFreezeBreadcrumb(freezeBreadcrumbPath());
+      event.returnValue = readFreezeBreadcrumb(freezeBreadcrumbPath());
+    });
+
+    // Delete the breadcrumb the renderer just reported. Guarded by ts so a
+    // late ack can never delete a NEWER breadcrumb written after the read.
+    // Sender check mirrors the route-context handler below.
+    ipcMain.on("freeze:ack", (event, ts: unknown) => {
+      if (!mainWindow || event.sender !== mainWindow.webContents) return;
+      if (typeof ts !== "number" || !Number.isFinite(ts)) return;
+      ackFreezeBreadcrumb(freezeBreadcrumbPath(), ts);
     });
 
     // Sync IPC: preload exposes the validated runtime config before renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -16,9 +16,12 @@ interface DesktopAPI {
   onSystemLocaleChanged: (callback: (locale: string) => void) => () => void;
   /** Validated runtime endpoint config, or a blocking config error. */
   runtimeConfig: RuntimeConfigResult;
-  /** Read + clear any freeze/crash breadcrumb from a previous session, so the
-   *  renderer can flush it to telemetry on boot. Null when nothing's pending. */
+  /** Read any freeze/crash breadcrumb from a previous session, so the
+   *  renderer can flush it to telemetry on boot. Null when nothing's pending.
+   *  Does NOT delete — pair with `ackFreeze(ts)` after reporting. */
   getLastFreeze: () => FreezeBreadcrumb | null;
+  /** Delete a reported breadcrumb; main only deletes on an exact `ts` match. */
+  ackFreeze: (ts: number) => void;
   /** Listen for auth token delivered via deep link. Returns an unsubscribe function. */
   onAuthToken: (callback: (token: string) => void) => () => void;
   /** Listen for invitation IDs delivered via deep link. Returns an unsubscribe function. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -79,9 +79,11 @@ const desktopAPI = {
   },
   /** Validated runtime endpoint config, or a blocking config error. */
   runtimeConfig,
-  /** Read + clear any freeze/crash breadcrumb left by a previous session, so
-   *  the renderer can flush it to telemetry on boot. Returns null when there's
-   *  nothing pending (the normal case). */
+  /** Read any freeze/crash breadcrumb left by a previous session, so the
+   *  renderer can flush it to telemetry on boot. Returns null when there's
+   *  nothing pending (the normal case). Reading does NOT delete the file —
+   *  call `ackFreeze(ts)` once the event was handed to posthog, so a boot
+   *  that hangs again before reporting keeps the breadcrumb for retry. */
   getLastFreeze: (): FreezeBreadcrumb | null => {
     try {
       return ipcRenderer.sendSync("freeze:get-last") as FreezeBreadcrumb | null;
@@ -89,6 +91,9 @@ const desktopAPI = {
       return null;
     }
   },
+  /** Acknowledge a reported breadcrumb by its `ts`; the main process deletes
+   *  the file only if the on-disk breadcrumb still carries that exact ts. */
+  ackFreeze: (ts: number) => ipcRenderer.send("freeze:ack", ts),
   /** Listen for auth token delivered via deep link */
   onAuthToken: (callback: (token: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, token: string) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -19,6 +19,7 @@ import { useTabStore } from "./stores/tab-store";
 import { useWindowOverlayStore } from "./stores/window-overlay-store";
 import { useDaemonIPCBridge } from "./platform/daemon-ipc-bridge";
 import { createDesktopLocaleAdapter } from "./platform/i18n-adapter";
+import { getDiagnosticRoutePath } from "./diagnostics/diagnostic-route";
 import { captureEvent } from "@multica/core/analytics";
 import { RESOURCES } from "@multica/views/locales";
 
@@ -33,6 +34,19 @@ const HTML_LANG: Record<SupportedLocale, string> = {
   ko: "ko-KR",
   ja: "ja-JP",
 };
+
+// Grace window between handing the breadcrumb event to posthog-js and acking
+// the file for deletion — posthog exposes no per-event delivery callback, so
+// this buys the `send_instantly` request its network round-trip. If the
+// renderer hangs or dies inside the window, the timer never fires, the file
+// survives, and the next boot retries.
+const FREEZE_ACK_DELAY_MS = 5_000;
+
+// Now that reading the breadcrumb no longer clears it, a re-mount of App
+// (HMR, remount) would re-capture the same failure within one session —
+// guard at module level so a breadcrumb is flushed at most once per renderer
+// lifetime.
+let freezeBreadcrumbFlushed = false;
 
 
 /**
@@ -338,19 +352,43 @@ export default function App() {
   // (the renderer is blocked or gone), so the main process persists it and we
   // emit it here on the next boot. The in-thread, recoverable freeze tier is
   // handled separately by the shared watchdog in CoreProvider.
+  //
+  // The read no longer deletes the file (MUL-4120): the event goes out with
+  // `sendInstantly` (bypassing posthog's batch timer, which a re-hang would
+  // kill), and only after the hand-off — plus a grace window for the network
+  // request — do we ack the breadcrumb's ts back so main deletes it. If this
+  // boot hangs or dies first, the file survives and the next boot retries.
+  // A rare duplicate report is dedupable by `breadcrumb_ts`.
   useEffect(() => {
+    if (freezeBreadcrumbFlushed) return;
     const last = window.desktopAPI.getLastFreeze();
     if (!last) return;
+    freezeBreadcrumbFlushed = true;
     const crashed = last.kind === "render-process-gone";
-    captureEvent(crashed ? "client_crash" : "client_unresponsive", {
-      // Spread context FIRST so our explicit fields below always win — a
-      // future context key (e.g. its own `source`) must not silently override.
-      ...last.context,
-      source: crashed ? "render-process-gone" : "main-unresponsive",
-      recovered: false,
-      breadcrumb_ts: last.ts,
-      crashed_version: last.version,
-    });
+    captureEvent(
+      crashed ? "client_crash" : "client_unresponsive",
+      {
+        // Spread context FIRST so our explicit fields below always win — a
+        // future context key (e.g. its own `source`) must not silently override.
+        ...last.context,
+        source: crashed ? "render-process-gone" : "main-unresponsive",
+        recovered: false,
+        breadcrumb_ts: last.ts,
+        crashed_version: last.version,
+      },
+      {
+        sendInstantly: true,
+        // Fires when the event was handed to posthog.capture — never on
+        // analytics-disabled builds, where the 7d TTL in main is what
+        // eventually drops the file.
+        onCaptured: () => {
+          setTimeout(
+            () => window.desktopAPI.ackFreeze(last.ts),
+            FREEZE_ACK_DELAY_MS,
+          );
+        },
+      },
+    );
   }, []);
 
   // Stable identity reference so downstream effects (WS reconnect) don't
@@ -409,6 +447,7 @@ export default function App() {
           locale={locale}
           resources={resources}
           localeAdapter={localeAdapter}
+          diagnosticsPathProvider={getDiagnosticRoutePath}
         >
           <AppContent />
         </CoreProvider>

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
@@ -9,7 +9,7 @@ const state = vi.hoisted(() => ({
   activeWorkspaceSlug: null as string | null,
   byWorkspace: {} as Record<
     string,
-    { activeTabId: string; tabs: { id: string; path: string }[] }
+    { activeTabId: string; tabs: { id: string; path: string; search?: string }[] }
   >,
   capturePageview: vi.fn<(path?: string) => void>(),
 }));
@@ -58,6 +58,10 @@ vi.mock("@/stores/tab-store", () => {
 });
 
 import { PageviewTracker } from "./pageview-tracker";
+import { getDiagnosticRoutePath } from "@/diagnostics/diagnostic-route";
+import type { RendererRouteContextInput } from "../../../shared/renderer-route-context";
+
+const setRendererRouteContext = vi.fn<(context: RendererRouteContextInput) => void>();
 
 function reset() {
   state.user = { id: "u1" };
@@ -65,6 +69,10 @@ function reset() {
   state.activeWorkspaceSlug = null;
   state.byWorkspace = {};
   state.capturePageview.mockClear();
+  setRendererRouteContext.mockClear();
+  (window as unknown as { desktopAPI: unknown }).desktopAPI = {
+    setRendererRouteContext,
+  };
 }
 
 beforeEach(() => {
@@ -242,6 +250,77 @@ describe("PageviewTracker", () => {
     render(<PageviewTracker />);
     // Restored tab — seeded, treated as a re-activation.
     expect(state.capturePageview).not.toHaveBeenCalled();
+  });
+
+  // MUL-4120: the diagnostic route context must carry the query string and
+  // stay current on query-only navigation, while the $pageview surface is
+  // strictly unchanged (pathname-based, unchanged early return).
+  describe("diagnostic route context", () => {
+    it("reports the tab's search alongside path, slug and tabId", () => {
+      state.byWorkspace = {
+        acme: {
+          activeTabId: "tA",
+          tabs: [{ id: "tA", path: "/acme/inbox", search: "?issue=a1" }],
+        },
+      };
+      state.activeWorkspaceSlug = "acme";
+
+      render(<PageviewTracker />);
+
+      expect(setRendererRouteContext).toHaveBeenLastCalledWith({
+        surface: "tab",
+        path: "/acme/inbox",
+        search: "?issue=a1",
+        workspaceSlug: "acme",
+        tabId: "tA",
+      });
+      expect(getDiagnosticRoutePath()).toBe("/acme/inbox");
+    });
+
+    it("query-only navigation re-reports route context but never fires a $pageview", () => {
+      state.byWorkspace = {
+        acme: {
+          activeTabId: "tA",
+          tabs: [{ id: "tA", path: "/acme/inbox", search: "?issue=a1" }],
+        },
+      };
+      state.activeWorkspaceSlug = "acme";
+
+      const { rerender } = render(<PageviewTracker />);
+      state.capturePageview.mockClear();
+      setRendererRouteContext.mockClear();
+
+      // User clicks the next issue in the inbox: same pathname, new query.
+      state.byWorkspace = {
+        acme: {
+          activeTabId: "tA",
+          tabs: [{ id: "tA", path: "/acme/inbox", search: "?issue=b2" }],
+        },
+      };
+      rerender(<PageviewTracker />);
+
+      expect(setRendererRouteContext).toHaveBeenCalledTimes(1);
+      expect(setRendererRouteContext).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/acme/inbox", search: "?issue=b2" }),
+      );
+      expect(state.capturePageview).not.toHaveBeenCalled();
+    });
+
+    it("omits search when the tab has none", () => {
+      state.byWorkspace = {
+        acme: {
+          activeTabId: "tA",
+          tabs: [{ id: "tA", path: "/acme/issues", search: "" }],
+        },
+      };
+      state.activeWorkspaceSlug = "acme";
+
+      render(<PageviewTracker />);
+
+      expect(setRendererRouteContext).toHaveBeenLastCalledWith(
+        expect.objectContaining({ surface: "tab", search: undefined }),
+      );
+    });
   });
 });
 

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
@@ -7,6 +7,7 @@ import {
   useTabStore,
 } from "@/stores/tab-store";
 import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overlay-store";
+import { setDiagnosticRoute } from "@/diagnostics/diagnostic-route";
 import type { RendererRouteContextInput } from "../../../shared/renderer-route-context";
 
 /**
@@ -46,6 +47,12 @@ export function PageviewTracker() {
   const overlay = useWindowOverlayStore((s) => s.overlay);
   const { slug: activeWorkspaceSlug, tabId: activeTabId } = useActiveTabIdentity();
   const activeTabPath = useTabStore((s) => getActiveTab(s)?.path ?? null);
+  // Query string of the active tab, in the deps below so a query-only
+  // navigation (/x/inbox?issue=A → ?issue=B) re-reports the diagnostic route
+  // context. It must NOT influence the pageview logic — that stays
+  // pathname-based, so those navigations exit via the `unchanged` early
+  // return without a new $pageview (MUL-4120).
+  const activeTabSearch = useTabStore((s) => getActiveTab(s)?.search ?? "");
 
   // (slug:tabId) → last path observed while that tab was visible. Lets us
   // tell "re-activating a tab on a path we already saw" (suppress) apart
@@ -96,6 +103,7 @@ export function PageviewTracker() {
       path,
     };
     if (kind === "tab") {
+      routeContext.search = activeTabSearch || undefined;
       routeContext.workspaceSlug = activeWorkspaceSlug ?? undefined;
       routeContext.tabId = activeTabId ?? undefined;
     }
@@ -118,12 +126,16 @@ export function PageviewTracker() {
 
     capturePageview(path);
     lastSurfaceRef.current = next;
-  }, [user, overlay, activeWorkspaceSlug, activeTabId, activeTabPath]);
+  }, [user, overlay, activeWorkspaceSlug, activeTabId, activeTabPath, activeTabSearch]);
 
   return null;
 }
 
 function reportRendererRouteContext(context: RendererRouteContextInput) {
+  // Mirror for the renderer-side freeze watchdog before the IPC hop, so
+  // longtask events and main-process freeze breadcrumbs attribute a freeze
+  // to the same route.
+  setDiagnosticRoute(context);
   const desktopAPI = window.desktopAPI as
     | { setRendererRouteContext?: (context: RendererRouteContextInput) => void }
     | undefined;

--- a/apps/desktop/src/renderer/src/diagnostics/diagnostic-route.ts
+++ b/apps/desktop/src/renderer/src/diagnostics/diagnostic-route.ts
@@ -1,0 +1,26 @@
+import type { RendererRouteContextInput } from "../../../shared/renderer-route-context";
+
+// Renderer-side mirror of the last route context reported to the main
+// process (PageviewTracker → setRendererRouteContext IPC). Keeping it here
+// gives the shared freeze watchdog a lazy path provider from the SAME source
+// the main process uses for freeze breadcrumbs, so a longtask event and a
+// main-unresponsive breadcrumb for the same freeze attribute to the same
+// route (MUL-4120). Module-level state matches the watchdog's page-lifetime
+// singleton scope.
+
+let current: RendererRouteContextInput | null = null;
+
+/** Record the route context that was just reported to the main process. */
+export function setDiagnosticRoute(context: RendererRouteContextInput): void {
+  current = context;
+}
+
+/**
+ * Current surface path for freeze-watchdog attribution: the active tab's
+ * memory-router pathname, or the `/login` / overlay synthetic path. Undefined
+ * until the first report (the watchdog then falls back to
+ * `location.pathname`).
+ */
+export function getDiagnosticRoutePath(): string | undefined {
+  return current?.path;
+}

--- a/apps/desktop/src/renderer/src/hooks/use-tab-router-sync.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-router-sync.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { DataRouter } from "react-router-dom";
+
+// createTabRouter transitively pulls in route modules that expect a browser
+// router context. For store-driven hook tests we stub it to a minimal
+// disposable, same as tab-store.test.ts.
+const createTabRouterMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    dispose: vi.fn(),
+    state: { location: { pathname: "/" } },
+    navigate: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  })),
+);
+vi.mock("../routes", () => ({
+  createTabRouter: createTabRouterMock,
+}));
+
+import { useTabStore } from "@/stores/tab-store";
+import { useTabRouterSync } from "./use-tab-router-sync";
+
+type FakeRouterState = {
+  location: { pathname: string; search: string };
+  historyAction: "PUSH" | "POP" | "REPLACE";
+};
+
+// A controllable stand-in for the tab's memory router: the hook reads
+// `state.location` on mount and re-syncs on every subscribe callback.
+function makeFakeRouter(pathname: string, search: string) {
+  let listener: ((state: FakeRouterState) => void) | null = null;
+  const router = {
+    state: { location: { pathname, search } },
+    subscribe: (cb: (state: FakeRouterState) => void) => {
+      listener = cb;
+      return () => {
+        listener = null;
+      };
+    },
+  };
+  return {
+    router: router as unknown as DataRouter,
+    navigate(state: FakeRouterState) {
+      router.state.location = state.location;
+      listener?.(state);
+    },
+  };
+}
+
+function activeTab() {
+  const s = useTabStore.getState();
+  return s.byWorkspace[s.activeWorkspaceSlug!].tabs[0];
+}
+
+beforeEach(() => {
+  useTabStore.getState().reset();
+  useTabStore.getState().switchWorkspace("acme");
+});
+
+describe("useTabRouterSync", () => {
+  it("syncs initial pathname AND search into the tab store", () => {
+    const { router } = makeFakeRouter("/acme/inbox", "?issue=a1");
+    renderHook(() => useTabRouterSync(activeTab().id, router));
+
+    const tab = activeTab();
+    expect(tab.path).toBe("/acme/inbox");
+    expect(tab.search).toBe("?issue=a1");
+  });
+
+  it("a query-only navigation updates the stored search (MUL-4120)", () => {
+    const { router, navigate } = makeFakeRouter("/acme/inbox", "?issue=a1");
+    renderHook(() => useTabRouterSync(activeTab().id, router));
+
+    navigate({
+      location: { pathname: "/acme/inbox", search: "?issue=b2" },
+      historyAction: "REPLACE",
+    });
+
+    const tab = activeTab();
+    expect(tab.path).toBe("/acme/inbox");
+    expect(tab.search).toBe("?issue=b2");
+  });
+
+  it("navigating to a path without a query clears the stored search", () => {
+    const { router, navigate } = makeFakeRouter("/acme/inbox", "?issue=a1");
+    renderHook(() => useTabRouterSync(activeTab().id, router));
+
+    navigate({
+      location: { pathname: "/acme/issues", search: "" },
+      historyAction: "PUSH",
+    });
+
+    const tab = activeTab();
+    expect(tab.path).toBe("/acme/issues");
+    expect(tab.search).toBe("");
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/use-tab-router-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-tab-router-sync.ts
@@ -14,13 +14,18 @@ export function useTabRouterSync(tabId: string, router: DataRouter) {
   const lengthRef = useRef(1);
 
   useEffect(() => {
-    // Sync initial state
+    // Sync initial state. `search` rides along for the diagnostic route
+    // context (MUL-4120) — see the Tab.search doc for its runtime-only scope.
     const initialPath = router.state.location.pathname;
     const store = useTabStore.getState();
-    store.updateTab(tabId, { path: initialPath, icon: resolveRouteIcon(initialPath) });
+    store.updateTab(tabId, {
+      path: initialPath,
+      search: router.state.location.search,
+      icon: resolveRouteIcon(initialPath),
+    });
 
     const unsubscribe = router.subscribe((state) => {
-      const { pathname } = state.location;
+      const { pathname, search } = state.location;
       const action = state.historyAction;
 
       if (action === "PUSH") {
@@ -40,7 +45,7 @@ export function useTabRouterSync(tabId: string, router: DataRouter) {
       // REPLACE: index and length stay the same
 
       const store = useTabStore.getState();
-      store.updateTab(tabId, { path: pathname, icon: resolveRouteIcon(pathname) });
+      store.updateTab(tabId, { path: pathname, search, icon: resolveRouteIcon(pathname) });
       store.updateTabHistory(tabId, indexRef.current, lengthRef.current);
     });
 

--- a/apps/desktop/src/renderer/src/stores/tab-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.test.ts
@@ -230,10 +230,36 @@ describe("useTabStore actions", () => {
     const tab = useTabStore.getState().byWorkspace.acme.tabs[0];
     const before = useTabStore.getState().byWorkspace.acme;
 
-    store.updateTab(tab.id, { path: tab.path, icon: tab.icon, title: tab.title });
+    store.updateTab(tab.id, {
+      path: tab.path,
+      search: tab.search,
+      icon: tab.icon,
+      title: tab.title,
+    });
     store.updateTabHistory(tab.id, tab.historyIndex, tab.historyLength);
 
     expect(useTabStore.getState().byWorkspace.acme).toBe(before);
+  });
+
+  // MUL-4120: `search` is runtime-only diagnostic state — reactive for
+  // query-only navigation, but never persisted.
+  it("a query-only updateTab (same path, new search) still notifies subscribers", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const tab = useTabStore.getState().byWorkspace.acme.tabs[0];
+
+    store.updateTab(tab.id, { path: tab.path, search: "?issue=a1", icon: tab.icon });
+    const afterFirst = useTabStore.getState().byWorkspace.acme;
+    expect(afterFirst.tabs[0].search).toBe("?issue=a1");
+
+    store.updateTab(tab.id, { path: tab.path, search: "?issue=b2", icon: tab.icon });
+    const afterSecond = useTabStore.getState().byWorkspace.acme;
+    expect(afterSecond).not.toBe(afterFirst);
+    expect(afterSecond.tabs[0].search).toBe("?issue=b2");
+
+    // Identical path AND search — a true no-op, group reference preserved.
+    store.updateTab(tab.id, { path: tab.path, search: "?issue=b2", icon: tab.icon });
+    expect(useTabStore.getState().byWorkspace.acme).toBe(afterSecond);
   });
 
   it("validateWorkspaceSlugs drops groups for slugs not in the valid set and repoints active", () => {
@@ -469,5 +495,53 @@ describe("migrateV2ToV3", () => {
     const v3 = migrateV2ToV3({ activeWorkspaceSlug: null } as Parameters<typeof migrateV2ToV3>[0]);
     expect(v3.byWorkspace).toEqual({});
     expect(v3.activeWorkspaceSlug).toBeNull();
+  });
+});
+
+// MUL-4120: `search` must never reach localStorage (persist boundary) and
+// must come back as "" after rehydration.
+describe("search persistence boundary", () => {
+  it("partialize strips search (and the other runtime-only fields) from the persisted shape", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const tab = useTabStore.getState().byWorkspace.acme.tabs[0];
+    store.updateTab(tab.id, { search: "?issue=a1" });
+
+    const partialize = useTabStore.persist.getOptions().partialize!;
+    const persisted = partialize(useTabStore.getState()) as {
+      byWorkspace: Record<string, { tabs: Record<string, unknown>[] }>;
+    };
+
+    const persistedTab = persisted.byWorkspace.acme.tabs[0];
+    expect(persistedTab.path).toBe(tab.path);
+    expect("search" in persistedTab).toBe(false);
+    expect("router" in persistedTab).toBe(false);
+    expect("historyIndex" in persistedTab).toBe(false);
+  });
+
+  it("rehydrated tabs default search to empty", () => {
+    const merge = useTabStore.persist.getOptions().merge!;
+    const merged = merge(
+      {
+        activeWorkspaceSlug: "acme",
+        byWorkspace: {
+          acme: {
+            activeTabId: "t1",
+            tabs: [
+              {
+                id: "t1",
+                path: "/acme/issues",
+                title: "Issues",
+                icon: "ListTodo",
+                pinned: false,
+              },
+            ],
+          },
+        },
+      },
+      useTabStore.getState(),
+    ) as ReturnType<typeof useTabStore.getState>;
+
+    expect(merged.byWorkspace.acme.tabs[0].search).toBe("");
   });
 });

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -15,6 +15,13 @@ export interface Tab {
   id: string;
   /** Every tab path is workspace-scoped: `/{workspaceSlug}/{route}/...`. */
   path: string;
+  /**
+   * The tab's current query string (`?issue=<id>` etc.), synced from its
+   * router alongside `path`. Runtime-only diagnostic state for the freeze
+   * route context (MUL-4120): persist's `partialize` strips it, rehydration
+   * resets it to "", and tab dedupe stays `path`-only.
+   */
+  search: string;
   title: string;
   icon: string;
   router: DataRouter;
@@ -83,7 +90,10 @@ interface TabStore {
    */
   setActiveTab: (tabId: string) => void;
   /** Patch metadata of a tab (router-sync, title-sync). Finds across groups. */
-  updateTab: (tabId: string, patch: Partial<Pick<Tab, "path" | "title" | "icon">>) => void;
+  updateTab: (
+    tabId: string,
+    patch: Partial<Pick<Tab, "path" | "search" | "title" | "icon">>,
+  ) => void;
   /** Patch history tracking of a tab. Finds across groups. */
   updateTabHistory: (tabId: string, historyIndex: number, historyLength: number) => void;
   /** Recreate the active tab's router at the same path after a route-level crash. */
@@ -215,6 +225,7 @@ function makeTab(path: string, title: string, icon: string): Tab {
   return {
     id: createId(),
     path,
+    search: "",
     title,
     icon,
     router: createTabRouter(path),
@@ -445,8 +456,12 @@ export const useTabStore = create<TabStore>()(
         const { slug, group, index } = hit;
         const current = group.tabs[index];
         const next: Tab = { ...current, ...patch };
+        // `search` participates in the no-op check: a query-only navigation
+        // (same pathname, new ?issue=) must still notify subscribers so the
+        // diagnostic route context stays current (MUL-4120).
         if (
           next.path === current.path &&
+          next.search === current.search &&
           next.title === current.title &&
           next.icon === current.icon
         ) {
@@ -659,6 +674,7 @@ export const useTabStore = create<TabStore>()(
               tabs: group.tabs.map(
                 ({
                   router: _router,
+                  search: _search,
                   historyIndex: _hi,
                   historyLength: _hl,
                   ...rest
@@ -691,6 +707,7 @@ export const useTabStore = create<TabStore>()(
             tabs.push({
               id: pTab.id,
               path: clean,
+              search: "",
               title: pTab.title,
               icon: pTab.icon,
               router: createTabRouter(clean),

--- a/apps/desktop/src/shared/renderer-route-context.ts
+++ b/apps/desktop/src/shared/renderer-route-context.ts
@@ -5,6 +5,12 @@ export type RendererRouteSurface = "login" | "overlay" | "tab";
 export type RendererRouteContextInput = {
   surface: RendererRouteSurface;
   path: string;
+  /**
+   * Current query string (`?issue=<id>` etc.) so a freeze breadcrumb can be
+   * attributed to the specific resource, not just the page (MUL-4120). Only
+   * internal UUIDs / route state — never user-typed content.
+   */
+  search?: string;
   workspaceSlug?: string;
   tabId?: string;
 };
@@ -27,12 +33,14 @@ export function sanitizeRendererRouteContext(
   const path = sanitizeString(input.path);
   if (!path) return null;
 
+  const search = sanitizeString(input.search);
   const workspaceSlug = sanitizeString(input.workspaceSlug);
   const tabId = sanitizeString(input.tabId);
 
   return {
     surface: input.surface,
     path,
+    ...(search ? { search } : {}),
     ...(workspaceSlug ? { workspaceSlug } : {}),
     ...(tabId ? { tabId } : {}),
     reportedAt: reportedAt.toISOString(),

--- a/packages/core/analytics/index.test.ts
+++ b/packages/core/analytics/index.test.ts
@@ -187,6 +187,100 @@ describe("capturePageview", () => {
   });
 });
 
+describe("captureEvent options", () => {
+  function captureMock(posthog: unknown) {
+    return (posthog as { capture: ReturnType<typeof vi.fn> }).capture;
+  }
+
+  it("passes send_instantly to posthog.capture when sendInstantly is set (post-init)", async () => {
+    const { analytics, posthog } = await loadModule();
+    analytics.initAnalytics({ key: "k", host: "" });
+    const capture = captureMock(posthog);
+    capture.mockClear();
+
+    analytics.captureEvent("client_unresponsive", { source: "main-unresponsive" }, {
+      sendInstantly: true,
+    });
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(
+      "client_unresponsive",
+      expect.objectContaining({ source: "main-unresponsive" }),
+      { send_instantly: true },
+    );
+  });
+
+  it("keeps the batched default (no capture options) when sendInstantly is absent", async () => {
+    const { analytics, posthog } = await loadModule();
+    analytics.initAnalytics({ key: "k", host: "" });
+    const capture = captureMock(posthog);
+    capture.mockClear();
+
+    analytics.captureEvent("step_completed", { step: 3 });
+
+    expect(capture).toHaveBeenCalledWith(
+      "step_completed",
+      expect.objectContaining({ step: 3 }),
+      undefined,
+    );
+  });
+
+  it("fires onCaptured synchronously when already initialized", async () => {
+    const { analytics } = await loadModule();
+    analytics.initAnalytics({ key: "k", host: "" });
+
+    const onCaptured = vi.fn();
+    analytics.captureEvent("client_unresponsive", undefined, { onCaptured });
+
+    expect(onCaptured).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a pre-init event with its options intact and fires onCaptured at replay time", async () => {
+    const { analytics, posthog } = await loadModule();
+    const capture = captureMock(posthog);
+    capture.mockClear();
+
+    const onCaptured = vi.fn();
+    analytics.captureEvent(
+      "client_unresponsive",
+      { breadcrumb_ts: 1700 },
+      { sendInstantly: true, onCaptured },
+    );
+
+    // Pre-init: buffered, no hand-off yet.
+    expect(capture).not.toHaveBeenCalled();
+    expect(onCaptured).not.toHaveBeenCalled();
+
+    analytics.initAnalytics({ key: "k", host: "" });
+
+    expect(capture).toHaveBeenCalledWith(
+      "client_unresponsive",
+      expect.objectContaining({ breadcrumb_ts: 1700 }),
+      { send_instantly: true },
+    );
+    expect(onCaptured).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires onCaptured when analytics stays disabled (no key) — callers converge via TTL", async () => {
+    const { analytics, posthog } = await loadModule();
+    const capture = captureMock(posthog);
+    capture.mockClear();
+
+    const onCaptured = vi.fn();
+    analytics.captureEvent("client_unresponsive", undefined, {
+      sendInstantly: true,
+      onCaptured,
+    });
+
+    // Self-hosted / no-key config: init reports disabled and must not replay.
+    expect(analytics.initAnalytics({ key: "", host: "" })).toBe(false);
+    expect(analytics.initAnalytics(null)).toBe(false);
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(onCaptured).not.toHaveBeenCalled();
+  });
+});
+
 describe("captureException", () => {
   it("buffers a pre-init exception and flushes it on init", async () => {
     const { analytics, posthog } = await loadModule();

--- a/packages/core/analytics/index.ts
+++ b/packages/core/analytics/index.ts
@@ -58,7 +58,12 @@ let lastCapturedPath: string | null = null;
 // only ever carry user-triggered signals on identified users, so the
 // buffer stays small (~one step-transition worth).
 type PendingOp =
-  | { kind: "event"; name: string; props?: Record<string, unknown> }
+  | {
+      kind: "event";
+      name: string;
+      props?: Record<string, unknown>;
+      options?: CaptureEventOptions;
+    }
   | { kind: "set"; props: Record<string, unknown> }
   | { kind: "exception"; error: unknown; props?: Record<string, unknown> };
 const pendingOps: PendingOp[] = [];
@@ -217,7 +222,7 @@ export function initAnalytics(config: AnalyticsConfig | null | undefined): boole
   while (pendingOps.length > 0) {
     const op = pendingOps.shift()!;
     if (op.kind === "event") {
-      posthog.capture(op.name, withClientEventProperties(op.props));
+      captureNow(op.name, op.props, op.options);
     } else if (op.kind === "exception") {
       posthog.captureException(op.error, withClientEventProperties(op.props));
     } else {
@@ -265,6 +270,25 @@ export function resetAnalytics(): void {
   }
 }
 
+export interface CaptureEventOptions {
+  /**
+   * Bypass posthog-js's batching queue (`send_instantly`) so the event's
+   * network request fires immediately. For failure-tier signals (freeze
+   * breadcrumb flush) whose sender may hang or die before a batch timer
+   * ever runs — regular product events should stay on the batched default.
+   */
+  sendInstantly?: boolean;
+  /**
+   * Called when the event was actually handed to `posthog.capture` —
+   * synchronously when analytics is initialized, or during the pending-ops
+   * replay inside initAnalytics otherwise. This is NOT a network-delivery
+   * ack (posthog-js exposes none); it only marks the hand-off. Never fires
+   * when analytics stays disabled (no key / SSR) — callers relying on it
+   * for cleanup need their own convergence path (e.g. the breadcrumb TTL).
+   */
+  onCaptured?: () => void;
+}
+
 /**
  * Capture a frontend-emitted event. Most funnel events fire server-side
  * (see `server/internal/analytics`); this wrapper is reserved for the
@@ -273,17 +297,32 @@ export function resetAnalytics(): void {
  * to a handler.
  *
  * Calls before initAnalytics() buffer in order so a late-arriving config
- * doesn't silently swallow a step transition.
+ * doesn't silently swallow a step transition. Buffered events keep their
+ * options, so `sendInstantly` / `onCaptured` semantics survive the replay.
  */
 export function captureEvent(
   name: string,
   props?: Record<string, unknown>,
+  options?: CaptureEventOptions,
 ): void {
   if (!initialized) {
-    pendingOps.push({ kind: "event", name, props });
+    pendingOps.push({ kind: "event", name, props, options });
     return;
   }
-  posthog.capture(name, withClientEventProperties(props));
+  captureNow(name, props, options);
+}
+
+function captureNow(
+  name: string,
+  props?: Record<string, unknown>,
+  options?: CaptureEventOptions,
+): void {
+  posthog.capture(
+    name,
+    withClientEventProperties(props),
+    options?.sendInstantly ? { send_instantly: true } : undefined,
+  );
+  options?.onCaptured?.();
 }
 
 /**

--- a/packages/core/diagnostics/freeze-watchdog.test.ts
+++ b/packages/core/diagnostics/freeze-watchdog.test.ts
@@ -131,4 +131,104 @@ describe("installFreezeWatchdog", () => {
     fireLongTask(2500);
     expect(captureEvent).toHaveBeenCalledTimes(2);
   });
+
+  // Desktop injects its memory-router tab path (location.pathname there is
+  // the loaded index.html file path — MUL-4120). Web passes no provider and
+  // must keep the location.pathname behavior byte-for-byte.
+  describe("path provider", () => {
+    it("prefers the injected provider over location.pathname", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog({ getPath: () => "/acme/inbox" });
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledWith("client_unresponsive", {
+        source: "longtask",
+        duration_ms: 2300,
+        path: "/acme/inbox",
+      });
+    });
+
+    it("is called lazily at emit time, not at install time", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      let route = "/acme/issues";
+      installFreezeWatchdog({ getPath: () => route });
+      route = "/acme/inbox";
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledWith(
+        "client_unresponsive",
+        expect.objectContaining({ path: "/acme/inbox" }),
+      );
+    });
+
+    it("falls back to location.pathname when the provider returns undefined", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog({ getPath: () => undefined });
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledWith(
+        "client_unresponsive",
+        expect.objectContaining({ path: "/acme/issues" }),
+      );
+    });
+
+    it("falls back to location.pathname when the provider returns an empty string", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog({ getPath: () => "" });
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledWith(
+        "client_unresponsive",
+        expect.objectContaining({ path: "/acme/issues" }),
+      );
+    });
+
+    it("falls back to location.pathname when the provider throws", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog({
+        getPath: () => {
+          throw new Error("store not ready");
+        },
+      });
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledWith(
+        "client_unresponsive",
+        expect.objectContaining({ path: "/acme/issues" }),
+      );
+    });
+
+    it("no provider (web) keeps the location.pathname default", async () => {
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog();
+
+      fireLongTask(2300);
+
+      expect(captureEvent).toHaveBeenCalledWith(
+        "client_unresponsive",
+        expect.objectContaining({ path: "/acme/issues" }),
+      );
+    });
+
+    it("cooldown still applies with a provider", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const { installFreezeWatchdog, captureEvent } = await load();
+      installFreezeWatchdog({ getPath: () => "/acme/inbox" });
+
+      fireLongTask(2500);
+      fireLongTask(2500);
+      expect(captureEvent).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_000);
+      fireLongTask(2500);
+      expect(captureEvent).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/core/diagnostics/freeze-watchdog.ts
+++ b/packages/core/diagnostics/freeze-watchdog.ts
@@ -36,16 +36,41 @@ let lastEmitMs = 0;
 
 let installed = false;
 
+export interface FreezeWatchdogOptions {
+  /**
+   * Resolve the route to attach to the event, called lazily at emit time.
+   * Desktop injects its memory-router tab path here — `location.pathname`
+   * in an Electron renderer is the loaded `index.html` file path, useless
+   * for attribution (MUL-4120). When the provider is absent, returns a
+   * falsy value, or throws, the event falls back to `location.pathname`,
+   * so web behavior is unchanged.
+   */
+  getPath?: () => string | undefined;
+}
+
 /**
  * Install the long-task observer. Safe to call multiple times (idempotent) and
  * safe on the server (no-op when `window` / `PerformanceObserver` is absent).
  * Call once from a client-only effect.
  */
-export function installFreezeWatchdog(): void {
+export function installFreezeWatchdog(options?: FreezeWatchdogOptions): void {
   if (installed) return;
   if (typeof window === "undefined") return;
   if (typeof PerformanceObserver === "undefined") return;
   installed = true;
+
+  const getPath = options?.getPath;
+  const resolvePath = (): string | undefined => {
+    if (getPath) {
+      try {
+        const path = getPath();
+        if (path) return path;
+      } catch {
+        // Provider failure must never take the watchdog down with it.
+      }
+    }
+    return typeof location !== "undefined" ? location.pathname : undefined;
+  };
 
   try {
     const observer = new PerformanceObserver((list) => {
@@ -59,7 +84,7 @@ export function installFreezeWatchdog(): void {
         captureEvent("client_unresponsive", {
           source: "longtask",
           duration_ms: Math.round(entry.duration),
-          path: typeof location !== "undefined" ? location.pathname : undefined,
+          path: resolvePath(),
         });
       }
     });

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -75,6 +75,7 @@ export function CoreProvider({
   locale,
   resources,
   localeAdapter,
+  diagnosticsPathProvider,
 }: CoreProviderProps) {
   // Initialize singletons on first render only. Dependencies are read-once:
   // apiBaseUrl, storage, and callbacks are set at app boot and never change at runtime.
@@ -82,10 +83,14 @@ export function CoreProvider({
   useMemo(() => initCore(apiBaseUrl, storage, onLogin, onLogout, cookieAuth, identity), []);
 
   // Client-only freeze watchdog — shared by web and desktop. No-op on the
-  // server and idempotent, so mounting it here covers both apps in one place.
+  // server and idempotent (first install wins), so mounting it here covers
+  // both apps in one place. Desktop threads its tab-route provider through;
+  // web passes nothing and keeps the location.pathname default.
   useEffect(() => {
-    installFreezeWatchdog();
-  }, []);
+    installFreezeWatchdog(
+      diagnosticsPathProvider ? { getPath: diagnosticsPathProvider } : undefined,
+    );
+  }, [diagnosticsPathProvider]);
 
   // I18nProvider wraps everything else: server and client must use the same
   // (locale, resources) to avoid hydration mismatch. Language switching goes

--- a/packages/core/platform/types.ts
+++ b/packages/core/platform/types.ts
@@ -40,4 +40,9 @@ export interface CoreProviderProps {
   /** Locale adapter for persisting user choice (used by Settings switcher).
    *  Optional because some shells (e.g. CLI auth pages) don't need switching. */
   localeAdapter?: LocaleAdapter;
+  /** Route provider for freeze-watchdog diagnostics, called lazily at emit
+   *  time. Desktop passes its memory-router tab path (`location.pathname`
+   *  there is the loaded index.html file path); web omits it and keeps the
+   *  `location.pathname` default. */
+  diagnosticsPathProvider?: () => string | undefined;
 }


### PR DESCRIPTION
## Summary

Fixes the three client-freeze observability gaps from MUL-4120 (exposed by the MUL-4115 incident, where a deterministic renderer freeze produced **zero** `client_unresponsive` events across three user retries):

1. **Freeze breadcrumb read/ack split.** `freeze:get-last` no longer deletes on read. The renderer flushes the event with posthog-js `send_instantly` (bypassing the batch timer that a re-hang kills) and acks the breadcrumb `ts` back via a new `freeze:ack` IPC after a 5s grace window; main deletes only on an exact `ts` match, so a late ack can never drop a newer breadcrumb. If the renderer hangs or dies before acking, the file survives and the next boot retries — the signal is eventually delivered. Expired (7-day TTL) and malformed payloads (corrupt JSON, missing `kind`, missing finite `ts`) are deleted on read so nothing becomes permanent boot noise on analytics-disabled builds.
2. **Longtask route attribution on desktop.** `installFreezeWatchdog` accepts an optional lazy path provider. Desktop injects its memory-router tab path (in the Electron renderer, `location.pathname` is the loaded `index.html` file path — useless). Provider missing / empty / throwing falls back to `location.pathname`; web passes nothing and is byte-for-byte unchanged. The 2s threshold and 60s cooldown (MUL-3331) are untouched.
3. **Resource id in the diagnostic route context.** The tab store gains a runtime-only `search` field (synced from the tab router, stripped by persist `partialize`, `""` after rehydration; tab dedupe stays `path`-only). The route context now carries it, and query-only navigation (`?issue=A → ?issue=B`) re-reports the context — previously the context both stripped the id **and** went stale on same-page issue switches.

**`$pageview` boundary:** `capturePageview` and `normalizePageviewPath` are untouched; query-only navigation exits through the existing `unchanged` early return, so pageview volume and shape are identical.

`captureEvent` gains an optional third parameter (`{ sendInstantly, onCaptured }`) — additive, zero behavior change for existing callers; pre-init `pendingOps` replay preserves the options. `onCaptured` only marks the hand-off to `posthog.capture` (posthog-js exposes no per-event delivery ack) and never fires when analytics stays disabled — the TTL is the convergence path there. `CaptureOptions.send_instantly` verified as a public contract in the locked `@posthog/types@1.369.3`.

## Verification

- `apps/desktop`: 29 test files / 266 tests pass (includes rewritten `freeze-breadcrumb.test.ts`: read-does-not-delete, ack ts match/mismatch, TTL expiry, malformed-payload deletion; new `use-tab-router-sync.test.ts`; new pageview-tracker route-context cases; tab-store persistence-boundary cases).
- `packages/core`: 72 test files / 765 tests pass (new `captureEvent` options cases incl. no-key/no-ack; new watchdog provider cases incl. lazy call, empty/throw fallback, cooldown with provider).
- `pnpm typecheck`: 6/6 tasks pass. `turbo lint` for both packages: 0 errors (3 pre-existing warnings, identical on the base branch).

## Residual risk

- `send_instantly` still has no delivery guarantee — the loss window shrinks from "batch timer + seconds" to one network round-trip, and an unacked file retries next boot (eventual delivery).
- The delayed ack is a heuristic, not a delivery confirmation; occasional duplicate `main-unresponsive` events are possible and dedupable by `breadcrumb_ts`, bounded by the 7d TTL.
- A breadcrumb that never reports within 7 days (app not reopened, analytics unreachable throughout) is dropped by design.

Closes MUL-4120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
