### PR TITLE
fix(runtime): add traecli to custom runtime profile whitelist

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -110,6 +110,7 @@ export const RUNTIME_PROFILE_PROTOCOL_FAMILIES = [
   "kiro",
   "antigravity",
   "qoder",
+  "traecli",
 ] as const;
 
 export type RuntimeProtocolFamily =

--- a/server/migrations/136_runtime_profile_add_traecli.down.sql
+++ b/server/migrations/136_runtime_profile_add_traecli.down.sql
@@ -1,0 +1,20 @@
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+-- Restore the pre-136 whitelist (migration 134 shape, without traecli). NOT VALID
+-- keeps the historical Gemini tolerance so the rollback cannot fail on old rows.
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity',
+        'qoder'
+    )) NOT VALID;

--- a/server/migrations/136_runtime_profile_add_traecli.up.sql
+++ b/server/migrations/136_runtime_profile_add_traecli.up.sql
@@ -1,0 +1,25 @@
+ALTER TABLE runtime_profile DROP CONSTRAINT IF EXISTS runtime_profile_protocol_family_check;
+
+-- Widen the whitelist to include Trae (`traecli`). Trae already has a New()
+-- backend, launch header (`traecli acp serve`) and provider branding, but was
+-- missing from the protocol_family whitelist, so custom runtime profiles based
+-- on Trae were rejected and it never appeared in the family picker (#4945).
+-- NOT VALID mirrors migrations 126/134 so a historical Gemini row they
+-- intentionally tolerated does not block the upgrade.
+ALTER TABLE runtime_profile ADD CONSTRAINT runtime_profile_protocol_family_check
+    CHECK (protocol_family IN (
+        'claude',
+        'codebuddy',
+        'codex',
+        'copilot',
+        'opencode',
+        'openclaw',
+        'hermes',
+        'pi',
+        'cursor',
+        'kimi',
+        'kiro',
+        'antigravity',
+        'qoder',
+        'traecli'
+    )) NOT VALID;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -138,10 +138,13 @@ type Config struct {
 // SupportedTypes is the canonical whitelist of agent types eligible to back a
 // custom runtime profile. It MUST stay in lockstep with the
 // runtime_profile.protocol_family CHECK constraint (migration 120, widened by
-// migration 134 to add qoder): a custom runtime profile may only be based on a
-// backend Multica officially supports. qoder is exposed here so Qoder CN
-// (`qoderclicn`) users can point the Qoder backend at a non-default binary
-// instead of misrouting through Kiro/ACP with incompatible arguments (#4883).
+// migration 134 to add qoder and migration 136 to add traecli): a custom
+// runtime profile may only be based on a backend Multica officially supports.
+// qoder is exposed here so Qoder CN (`qoderclicn`) users can point the Qoder
+// backend at a non-default binary instead of misrouting through Kiro/ACP with
+// incompatible arguments (#4883). traecli (Trae) has a New backend, launch
+// header and provider branding but was previously missing from this whitelist,
+// so the family picker rejected it (#4945).
 var SupportedTypes = []string{
 	"claude",
 	"codebuddy",
@@ -156,6 +159,7 @@ var SupportedTypes = []string{
 	"kiro",
 	"antigravity",
 	"qoder",
+	"traecli",
 }
 
 // IsSupportedType reports whether agentType is in the SupportedTypes whitelist.

--- a/server/pkg/agent/agent_supported_types_test.go
+++ b/server/pkg/agent/agent_supported_types_test.go
@@ -40,7 +40,7 @@ func TestSupportedTypesMatchesMigrationWhitelist(t *testing.T) {
 		"claude": true, "codebuddy": true, "codex": true, "copilot": true,
 		"opencode": true, "openclaw": true, "hermes": true,
 		"pi": true, "cursor": true, "kimi": true, "kiro": true, "antigravity": true,
-		"qoder": true,
+		"qoder": true, "traecli": true,
 	}
 	if len(SupportedTypes) != len(want) {
 		t.Fatalf("SupportedTypes has %d entries, migration whitelist has %d; keep them in lockstep", len(SupportedTypes), len(want))


### PR DESCRIPTION
## Summary

Trae (`traecli`) is a fully wired agent backend — it has a `New()` constructor, a launch header (`traecli acp serve`), provider branding/logo, and an entry in the MCP-support list — but it was **missing from every `protocol_family` whitelist**. As a result, a custom runtime profile based on Trae was rejected server-side and Trae never appeared in the runtime family picker.

This is the same class of drift that triggered #4945 (which was actually about Qoder — Qoder turned out to be fully wired; the only genuinely missing provider was Trae).

## Changes

- `server/pkg/agent/agent.go` — add `"traecli"` to `SupportedTypes` (the canonical whitelist `IsSupportedType` / the handler validate against).
- `server/pkg/agent/agent_supported_types_test.go` — add `"traecli"` to the lockstep `want` map so the count/drift guard stays green.
- `packages/core/types/agent.ts` — add `"traecli"` to `RUNTIME_PROFILE_PROTOCOL_FAMILIES`, the single source of truth the family picker + `buildRuntimeCatalog` render from. `provider-logo.tsx` already has a `case "traecli"`.
- `server/migrations/136_runtime_profile_add_traecli.{up,down}.sql` — new migration widening the `runtime_profile_protocol_family_check` CHECK to include `'traecli'`, mirroring migration 134's shape (`NOT VALID` to tolerate the historical Gemini row).

This also reconciles a docs/code mismatch: `apps/docs/content/docs/daemon-runtimes.mdx` already advertises **14** built-in providers, but the whitelist only had 13 (through `qoder`). This change brings it to 14.

## Verification

- `go test ./server/pkg/agent/ -run TestSupportedTypes` — both `TestSupportedTypesLockstepWithNew` and `TestSupportedTypesMatchesMigrationWhitelist` pass.
- `gofmt` clean, `go vet ./server/pkg/agent/` clean.
- TS change is a single additive entry to an `as const` tuple (the union type derives from it, and `traecli` is already handled downstream); CI typecheck will confirm.

MUL-4094
