### PR TITLE
MUL-4107: make running task timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ MULTICA_APP_URL=${FRONTEND_ORIGIN}
 # avoid Host / X-Forwarded-Host spoofing when a self-hosted reverse proxy
 # is not hardened.
 MULTICA_PUBLIC_URL=
+# Optional server-side backstop for tasks stuck in "running". Defaults to
+# 2h30m; raise this for self-hosted deployments that intentionally run
+# multi-hour research, training, or other compute-heavy agent tasks.
+# MULTICA_TASK_RUNNING_TIMEOUT=2h30m
 # Comma-separated CIDR list of reverse proxies whose X-Forwarded-For /
 # X-Real-IP headers the per-IP webhook rate limiter is allowed to trust.
 # Empty (the default) means "trust no headers" — the limiter uses

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -170,6 +170,16 @@ When a request is over the limit, the server replies with `429 Too Many Requests
 
 This separate `RATE_LIMIT_TRUSTED_PROXIES` is **not** the same as `MULTICA_TRUSTED_PROXIES`, which controls the autopilot-webhook limiter (`/api/webhooks/autopilots/{token}`). Each limiter parses its own list, so a deployment behind a proxy should set both.
 
+## Task lifecycle tuning
+
+The server sweeps task rows that appear stuck so orphaned work does not stay visible forever after a daemon crash or failed callback.
+
+| Variable | Default | Description |
+|---|---|---|
+| `MULTICA_TASK_RUNNING_TIMEOUT` | `2h30m` | Server-side backstop for tasks stuck in `running`. Accepts Go duration strings such as `6h` or `12h30m`. Raise this for self-hosted deployments that intentionally run multi-hour research, training, or compute-heavy agent tasks |
+
+Invalid, zero, or negative values are ignored with a warning and the default is used.
+
 ## Daemon tuning parameters
 
 The daemon runs on the user's local machine, and its config is read from local environment variables too. The common ones:

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -36,13 +36,15 @@ const (
 	// The dispatched→running transition should be near-instant, so 5 minutes
 	// means something went wrong (e.g. StartTask API call failed silently).
 	dispatchTimeoutSeconds = 300.0
-	// runningTimeoutSeconds fails tasks stuck in 'running' beyond this. It is a
+	// defaultRunningTimeout fails tasks stuck in 'running' beyond this. It is a
 	// coarse server-side backstop keyed on started_at (it does NOT look at task
 	// activity) — mainly for runs whose daemon died without reporting. The
 	// daemon itself decides stuck-vs-long-running by activity (idle/tool
-	// watchdog), so this only needs to sit generously above any realistic single
-	// run rather than track a per-run wall-clock cap (MUL-3064).
-	runningTimeoutSeconds = 9000.0
+	// watchdog), so this only needs to sit generously above ordinary runs
+	// rather than track a per-run wall-clock cap (MUL-3064). Self-hosted
+	// deployments that intentionally run multi-hour compute can raise this with
+	// MULTICA_TASK_RUNNING_TIMEOUT.
+	defaultRunningTimeout = 150 * time.Minute
 	// queuedTTLSeconds expires tasks that have been sitting in 'queued'
 	// for longer than this without ever being claimed. This is the cleanup
 	// arm of the MUL-1899 backlog fix: even with the dispatch-time
@@ -246,7 +248,7 @@ func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 func sweepStaleTasks(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus) {
 	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
 		DispatchTimeoutSecs: dispatchTimeoutSeconds,
-		RunningTimeoutSecs:  runningTimeoutSeconds,
+		RunningTimeoutSecs:  runningTimeoutSeconds(),
 	})
 	if err != nil {
 		slog.Warn("task sweeper: failed to clean up stale tasks", "error", err)
@@ -259,6 +261,10 @@ func sweepStaleTasks(ctx context.Context, queries *db.Queries, taskSvc *service.
 	slog.Info("task sweeper: failed stale tasks", "count", len(failedTasks))
 	taskSvc.CaptureLeaseExpiredTasks(ctx, failedTasks)
 	taskSvc.HandleFailedTasks(ctx, failedTasks)
+}
+
+func runningTimeoutSeconds() float64 {
+	return envDurationPositive("MULTICA_TASK_RUNNING_TIMEOUT", defaultRunningTimeout).Seconds()
 }
 
 // sweepExpiredQueuedTasks fails tasks that have been sitting in 'queued' for

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -5,10 +5,53 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/multica-ai/multica/server/internal/events"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
+
+func TestRunningTimeoutSecondsUsesDefault(t *testing.T) {
+	t.Setenv("MULTICA_TASK_RUNNING_TIMEOUT", "")
+
+	got := runningTimeoutSeconds()
+	want := defaultRunningTimeout.Seconds()
+	if got != want {
+		t.Fatalf("runningTimeoutSeconds() = %v, want %v", got, want)
+	}
+}
+
+func TestRunningTimeoutSecondsUsesEnvOverride(t *testing.T) {
+	t.Setenv("MULTICA_TASK_RUNNING_TIMEOUT", "6h30m")
+
+	got := runningTimeoutSeconds()
+	want := (6*time.Hour + 30*time.Minute).Seconds()
+	if got != want {
+		t.Fatalf("runningTimeoutSeconds() = %v, want %v", got, want)
+	}
+}
+
+func TestRunningTimeoutSecondsRejectsInvalidEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"invalid_duration", "forever"},
+		{"zero_duration", "0s"},
+		{"negative_duration", "-1h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MULTICA_TASK_RUNNING_TIMEOUT", tt.value)
+
+			got := runningTimeoutSeconds()
+			want := defaultRunningTimeout.Seconds()
+			if got != want {
+				t.Fatalf("runningTimeoutSeconds() = %v, want fallback %v", got, want)
+			}
+		})
+	}
+}
 
 // setupSweeperTestFixture creates an issue and a task in the given status with
 // timestamps old enough to trigger the sweeper. Returns (issueID, agentID, taskID).


### PR DESCRIPTION
## Summary

- Add `MULTICA_TASK_RUNNING_TIMEOUT` as a self-host server override for the running-task sweeper backstop.
- Keep the existing `2h30m` default and fall back to it when the env value is invalid, zero, or negative.
- Document the new variable in the self-host env docs and `.env.example`.

Closes #4958
Multica issue: MUL-4107

## Testing

- `go test ./cmd/server -run 'TestRunningTimeoutSeconds'` from `server/`
