### PR TITLE
fix(server): do not cancel issue tasks on assignee change (MUL-4113, #4963)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2613,11 +2613,17 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// Reconcile the task queue. Whether this write starts an agent run — and
 	// for whom (agent assignee or squad leader) — is decided by the single
 	// WillEnqueueRun predicate, shared verbatim with the preview endpoint so
-	// the two never drift (MUL-3375). Cancellation on reassignment is a
-	// separate side effect and always runs, independent of the run decision.
-	if assigneeChanged {
-		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
-	}
+	// the two never drift (MUL-3375).
+	//
+	// A reassignment intentionally does NOT cancel existing tasks on the issue
+	// (#4963 / MUL-4113). The previous "cancel every active task on the issue"
+	// was too coarse: it silently dropped unrelated in-flight work (a
+	// mention-triggered run for another agent, a squad task) with no requeue,
+	// and it self-cancelled a run that reassigned the issue from inside itself.
+	// Ownership handoff no longer implies interruption; the new assignee's run,
+	// if any, is enqueued by WillEnqueueRun below and runs alongside whatever
+	// was already in flight. Explicit terminal actions — issue → cancelled and
+	// delete — still cancel active tasks (see below / DeleteIssue).
 	if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
 		service.IssueTriggerInput{
 			Issue:           issue,
@@ -3113,9 +3119,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			"project_changed":  projectChanged,
 		})
 
-		if assigneeChanged {
-			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
-		}
+		// Reassignment does not cancel existing tasks (#4963 / MUL-4113) —
+		// mirrors UpdateIssue. See that handler for the rationale.
+		//
 		// Same single predicate as UpdateIssue — batch must not grow its own
 		// copy of the enqueue rule (the historical source of four-entry-point
 		// drift, MUL-3375). suppress_run applies batch-wide.

--- a/server/internal/handler/issue_reassign_no_cancel_test.go
+++ b/server/internal/handler/issue_reassign_no_cancel_test.go
@@ -111,3 +111,52 @@ func TestBatchUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
 		t.Fatalf("unrelated agent's task must survive batch reassignment, got status %q", got)
 	}
 }
+
+// queuedTaskCountFor returns how many queued tasks the agent holds on the issue.
+func queuedTaskCountFor(t *testing.T, issueID, agentID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+	`, issueID, agentID).Scan(&n); err != nil {
+		t.Fatalf("count queued tasks: %v", err)
+	}
+	return n
+}
+
+// TestUpdateIssueReassignToAgentKeepsOldTaskAndEnqueuesNew covers the core
+// handoff path the member-target tests above do not: reassigning from one agent
+// to ANOTHER agent. The previous assignee's in-flight run must survive (the
+// #4963 / MUL-4113 no-cancel guarantee), and the new assignee must still get
+// its run enqueued by WillEnqueueRun — the two effects are independent.
+func TestUpdateIssueReassignToAgentKeepsOldTaskAndEnqueuesNew(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerAgent := createHandlerTestAgent(t, "ReassignAgentToAgentOwner", []byte("[]"))
+	newAgent := createHandlerTestAgent(t, "ReassignAgentToAgentNew", []byte("[]"))
+
+	issueID := insertAgentAssignedIssue(t, ownerAgent, 92112, "reassign-agent-to-agent")
+	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
+
+	// Reassign from ownerAgent to newAgent — an agent→agent ownership handoff.
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"assignee_type": "agent",
+		"assignee_id":   newAgent,
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue reassign: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := taskStatus(t, ownerTask); got != "running" {
+		t.Fatalf("previous agent's own task must survive agent→agent reassignment, got status %q", got)
+	}
+	if got := queuedTaskCountFor(t, issueID, newAgent); got != 1 {
+		t.Fatalf("new assignee must get exactly one run enqueued, got %d queued tasks", got)
+	}
+}

--- a/server/internal/handler/issue_reassign_no_cancel_test.go
+++ b/server/internal/handler/issue_reassign_no_cancel_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// insertRunningIssueTask inserts an in-flight (running) task for the given agent
+// on the given issue and returns its id, registering cleanup.
+func insertRunningIssueTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	var taskID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, issue_id, started_at)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), 'running', 0, $2, now())
+		RETURNING id
+	`, agentID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("insert running task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	return taskID
+}
+
+// insertAgentAssignedIssue inserts an issue assigned to the given agent and
+// returns its id, registering cleanup.
+func insertAgentAssignedIssue(t *testing.T, agentID string, number int, title string) string {
+	t.Helper()
+	var issueID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, $2, 'todo', 'medium', $3, 'member', $4, 0, 'agent', $5)
+		RETURNING id
+	`, testWorkspaceID, title, testUserID, number, agentID).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+	return issueID
+}
+
+// TestUpdateIssueReassignDoesNotCancelActiveTasks locks in the #4963 / MUL-4113
+// decision: changing an issue's assignee cancels nothing. Both the previous
+// assignee's own in-flight run and an unrelated (mention-triggered) run for a
+// different agent must survive the reassignment.
+func TestUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerAgent := createHandlerTestAgent(t, "ReassignNoCancelOwner", []byte("[]"))
+	mentionAgent := createHandlerTestAgent(t, "ReassignNoCancelMention", []byte("[]"))
+
+	issueID := insertAgentAssignedIssue(t, ownerAgent, 92110, "reassign-no-cancel")
+	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
+	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+
+	// Reassign from ownerAgent to a member — a genuine assignee change that
+	// does not itself enqueue a new agent run.
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"assignee_type": "member",
+		"assignee_id":   testUserID,
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue reassign: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := taskStatus(t, ownerTask); got != "running" {
+		t.Fatalf("previous assignee's own task must survive reassignment, got status %q", got)
+	}
+	if got := taskStatus(t, mentionTask); got != "running" {
+		t.Fatalf("unrelated agent's task must survive reassignment (no collateral cancel), got status %q", got)
+	}
+}
+
+// TestBatchUpdateIssueReassignDoesNotCancelActiveTasks is the batch-path mirror
+// of TestUpdateIssueReassignDoesNotCancelActiveTasks — BatchUpdateIssues shares
+// the same no-cancel-on-reassign behavior.
+func TestBatchUpdateIssueReassignDoesNotCancelActiveTasks(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerAgent := createHandlerTestAgent(t, "BatchReassignNoCancelOwner", []byte("[]"))
+	mentionAgent := createHandlerTestAgent(t, "BatchReassignNoCancelMention", []byte("[]"))
+
+	issueID := insertAgentAssignedIssue(t, ownerAgent, 92111, "batch-reassign-no-cancel")
+	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
+	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID},
+		"updates": map[string]any{
+			"assignee_type": "member",
+			"assignee_id":   testUserID,
+		},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues reassign: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := taskStatus(t, ownerTask); got != "running" {
+		t.Fatalf("previous assignee's own task must survive batch reassignment, got status %q", got)
+	}
+	if got := taskStatus(t, mentionTask); got != "running" {
+		t.Fatalf("unrelated agent's task must survive batch reassignment, got status %q", got)
+	}
+}

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -73,12 +73,19 @@ func allowAllAgents(db.Agent) bool { return true }
 // the pending-task dedup), not the top-level decision.
 //
 // The decision must equal the real enqueue conditions so preview never claims
-// a run that the write path then drops. In particular:
-//   - assign source (create / assignee change) cancels existing tasks before
-//     enqueuing, so a pre-existing pending task is moot — not checked here.
-//   - status source (backlog → active) enqueues without cancelling, so a live
-//     pending task would be blocked by the (issue_id, agent_id) unique index;
-//     reflected by the pending check below.
+// a net-new run that the write path then drops. The write enqueues through
+// CreateAgentTask, guarded by the (issue_id, agent_id) partial unique index
+// over pending (queued/dispatched) tasks; the pending check below mirrors that
+// guard, and only the status source needs it:
+//   - status source (backlog → active) can re-fire against an assignee that
+//     already holds a pending task (e.g. one a @mention raised while the issue
+//     sat in backlog); the check keeps preview from promising a run the unique
+//     index would coalesce away.
+//   - assign source (create / assignee change) skips the check: a create
+//     targets a fresh issue with no prior task, and a reassignment no longer
+//     cancels existing tasks (#4963 / MUL-4113) — in the rare case the new
+//     assignee already holds a pending task the insert simply no-ops on the
+//     same unique index, so the assignee still ends up with one pending run.
 func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput, probe IssueTriggerProbe) (IssueRunTrigger, bool) {
 	issue := in.Issue
 	if !issue.AssigneeType.Valid || !issue.AssigneeID.Valid {


### PR DESCRIPTION
## Summary

Changing an issue's assignee no longer cancels any tasks on that issue.

Previously, an assignee change called `CancelTasksForIssue`, which cancels **every** active task on the issue by `issue_id` alone — regardless of which agent owns the task or how it was triggered. In a multi-agent workspace this had two bad consequences (reported in #4963):

- **Collateral drop:** an unrelated in-flight run on the same issue — e.g. a `@mention`-triggered run for another agent, or a squad task — was silently cancelled with no requeue. The comment history showed a handoff happened, but the actual task was dead and nothing signalled the dropped work.
- **Self-cancel on handoff:** when a running agent reassigned the issue from inside its own turn, its own task was cancelled and the daemon interrupted the live run before its post-handoff cleanup could finish.

This PR removes the cancellation on reassignment entirely. Ownership handoff no longer implies interruption:

- The **previous assignee's** run keeps going to completion.
- **Other agents'** independently-triggered runs keep going.
- The **new assignee's** run, if any, is still enqueued by the existing `WillEnqueueRun` path and runs alongside whatever was already in flight.

Explicit terminal actions are unchanged and still cancel active tasks: **issue → `cancelled`** and **delete issue**. Only the assignee-change path changed.

## Changes

- `server/internal/handler/issue.go` — drop the `if assigneeChanged { CancelTasksForIssue(...) }` side effect in both `UpdateIssue` and `BatchUpdateIssues`; keep the cancelled-status and delete cancellations.
- `server/internal/handler/issue_reassign_no_cancel_test.go` — new tests asserting that reassignment leaves both the previous assignee's own running task and an unrelated agent's running task untouched, for the single-update and batch paths.

## Testing

- `go build ./...` — passes.
- New tests pass, and I verified they **fail against the old behavior** (both tasks came back `cancelled`) — so they genuinely lock in the fix rather than passing vacuously.
- Remaining failures in the local `internal/handler` run are pre-existing and unrelated (a `github_test.go` group failing on a missing `issue_pull_request.reference_only` column in the local test DB and some test-isolation collisions); they reproduce identically with this change reverted.

Closes #4963

MUL-4113
