### PR TITLE
MUL-4103: harden Windows browser MCP config

### DIFF
--- a/server/pkg/agent/browser_mcp_config.go
+++ b/server/pkg/agent/browser_mcp_config.go
@@ -176,11 +176,8 @@ func argsContain(args []string, needle string) bool {
 }
 
 func hasFlag(args []string, flag string) bool {
-	for i, arg := range args {
+	for _, arg := range args {
 		if arg == flag || strings.HasPrefix(arg, flag+"=") {
-			return true
-		}
-		if len(flag) == 2 && strings.HasPrefix(flag, "-") && !strings.HasPrefix(flag, "--") && arg == flag && i+1 < len(args) {
 			return true
 		}
 	}

--- a/server/pkg/agent/browser_mcp_config.go
+++ b/server/pkg/agent/browser_mcp_config.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	browserMcpGOOS = runtime.GOOS
+	browserMcpStat = os.Stat
+	browserMcpEnv  = os.Getenv
+)
+
+func hardenBrowserMcpConfig(raw json.RawMessage, tempDir string) ([]byte, error) {
+	if browserMcpGOOS != "windows" {
+		return raw, nil
+	}
+	return hardenWindowsBrowserMcpConfig(raw, tempDir)
+}
+
+func hardenWindowsBrowserMcpConfig(raw json.RawMessage, tempDir string) ([]byte, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return raw, nil
+	}
+	serversRaw, ok := top["mcpServers"]
+	if !ok {
+		return raw, nil
+	}
+	var servers map[string]json.RawMessage
+	if err := json.Unmarshal(serversRaw, &servers); err != nil {
+		return raw, nil
+	}
+
+	changed := false
+	for name, serverRaw := range servers {
+		var entry map[string]any
+		if err := json.Unmarshal(serverRaw, &entry); err != nil {
+			continue
+		}
+		args, ok := stringSlice(entry["args"])
+		if !ok {
+			continue
+		}
+
+		lowerName := strings.ToLower(name)
+		switch {
+		case lowerName == "playwright" || argsContain(args, "@playwright/mcp") || argsContain(args, `@playwright\mcp`):
+			nextArgs, err := hardenWindowsPlaywrightMcpArgs(args, tempDir)
+			if err != nil {
+				return nil, err
+			}
+			if !sameStringSlice(args, nextArgs) {
+				entry["args"] = nextArgs
+				servers[name], changed = mustMarshalRaw(entry), true
+			}
+		case lowerName == "chrome-devtools" || argsContain(args, "chrome-devtools-mcp"):
+			if path, ok := windowsChromiumFallbackExecutable(); ok && shouldPinChromeDevToolsExecutable(args) {
+				entry["args"] = append(args, "--executablePath="+path)
+				servers[name], changed = mustMarshalRaw(entry), true
+			}
+		}
+	}
+	if !changed {
+		return raw, nil
+	}
+
+	top["mcpServers"] = mustMarshalRaw(servers)
+	data, err := json.Marshal(top)
+	if err != nil {
+		return nil, fmt.Errorf("marshal hardened mcp config: %w", err)
+	}
+	return data, nil
+}
+
+func hardenWindowsPlaywrightMcpArgs(args []string, tempDir string) ([]string, error) {
+	if hasFlag(args, "--config") || hasFlag(args, "--cdp-endpoint") || hasFlag(args, "--extension") {
+		return args, nil
+	}
+	configPath := filepath.Join(tempDir, "playwright-windows-browser.json")
+	config := map[string]any{
+		"browser": map[string]any{
+			"launchOptions": map[string]any{
+				"args": []string{"--disable-gpu"},
+			},
+		},
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal playwright mcp browser config: %w", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		return nil, fmt.Errorf("write playwright mcp browser config: %w", err)
+	}
+	return append(args, "--config", configPath), nil
+}
+
+func windowsChromiumFallbackExecutable() (string, bool) {
+	if path := strings.TrimSpace(browserMcpEnv("MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH")); path != "" {
+		return path, true
+	}
+	for _, root := range []string{
+		browserMcpEnv("ProgramFiles(x86)"),
+		browserMcpEnv("ProgramFiles"),
+		browserMcpEnv("LocalAppData"),
+	} {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		path := windowsPathJoin(root, "Microsoft", "Edge", "Application", "msedge.exe")
+		if _, err := browserMcpStat(path); err == nil {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func windowsPathJoin(root string, elems ...string) string {
+	root = strings.TrimRight(root, `\/`)
+	if root == "" {
+		return ""
+	}
+	return root + `\` + strings.Join(elems, `\`)
+}
+
+func shouldPinChromeDevToolsExecutable(args []string) bool {
+	for _, flag := range []string{
+		"--executablePath",
+		"--executable-path",
+		"-e",
+		"--channel",
+		"--browserUrl",
+		"--browser-url",
+		"-u",
+		"--wsEndpoint",
+		"--ws-endpoint",
+		"-w",
+		"--autoConnect",
+		"--auto-connect",
+	} {
+		if hasFlag(args, flag) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSlice(v any) ([]string, bool) {
+	raw, ok := v.([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, s)
+	}
+	return out, true
+}
+
+func argsContain(args []string, needle string) bool {
+	needle = strings.ToLower(needle)
+	for _, arg := range args {
+		if strings.Contains(strings.ToLower(arg), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlag(args []string, flag string) bool {
+	for i, arg := range args {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+		if len(flag) == 2 && strings.HasPrefix(flag, "-") && !strings.HasPrefix(flag, "--") && arg == flag && i+1 < len(args) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func mustMarshalRaw(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/server/pkg/agent/browser_mcp_config_test.go
+++ b/server/pkg/agent/browser_mcp_config_test.go
@@ -90,8 +90,8 @@ func TestHardenWindowsBrowserMcpConfigRespectsExplicitBrowserArgs(t *testing.T) 
 
 	tempDir := t.TempDir()
 	raw := json.RawMessage(`{"mcpServers":{
-		"playwright":{"command":"npx","args":["@playwright/mcp@latest","--config","custom.json"]},
-		"chrome-devtools":{"command":"npx","args":["chrome-devtools-mcp@latest","--channel=beta"]}
+		"playwright":{"command":"npx","args":["@playwright/mcp@latest","--config=custom.json"]},
+		"chrome-devtools":{"command":"npx","args":["chrome-devtools-mcp@latest","-e","D:\\Browsers\\Chrome\\chrome.exe"]}
 	}}`)
 
 	got, err := hardenBrowserMcpConfig(raw, tempDir)

--- a/server/pkg/agent/browser_mcp_config_test.go
+++ b/server/pkg/agent/browser_mcp_config_test.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func withBrowserMcpTestHost(t *testing.T, goos string, env map[string]string, existing map[string]bool) {
+	t.Helper()
+	oldGOOS := browserMcpGOOS
+	oldEnv := browserMcpEnv
+	oldStat := browserMcpStat
+	browserMcpGOOS = goos
+	browserMcpEnv = func(key string) string { return env[key] }
+	browserMcpStat = func(path string) (os.FileInfo, error) {
+		if existing[path] {
+			return nil, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	t.Cleanup(func() {
+		browserMcpGOOS = oldGOOS
+		browserMcpEnv = oldEnv
+		browserMcpStat = oldStat
+	})
+}
+
+func TestHardenBrowserMcpConfigNoopOffWindows(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"mcpServers":{"playwright":{"command":"node","args":["@playwright/mcp","--headless"]}}}`)
+	got, err := hardenBrowserMcpConfig(raw, t.TempDir())
+	if err != nil {
+		t.Fatalf("hardenBrowserMcpConfig: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("non-Windows config changed:\n got %s\nwant %s", got, raw)
+	}
+}
+
+func TestHardenWindowsBrowserMcpConfigAddsPlaywrightLaunchConfigAndEdgeFallback(t *testing.T) {
+	edgePath := `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"ProgramFiles(x86)": `C:\Program Files (x86)`,
+	}, map[string]bool{edgePath: true})
+
+	tempDir := t.TempDir()
+	raw := json.RawMessage(`{"mcpServers":{
+		"playwright":{"command":"node","args":["C:\\npm\\node_modules\\@playwright\\mcp\\cli.js","--headless","--isolated"]},
+		"chrome-devtools":{"command":"node","args":["C:\\npm\\node_modules\\chrome-devtools-mcp\\dist\\index.js","--headless","--isolated"]}
+	}}`)
+
+	got, err := hardenBrowserMcpConfig(raw, tempDir)
+	if err != nil {
+		t.Fatalf("hardenBrowserMcpConfig: %v", err)
+	}
+
+	servers := decodeMcpServers(t, got)
+	playwrightArgs := decodeArgs(t, servers["playwright"])
+	configIndex := indexOfString(playwrightArgs, "--config")
+	if configIndex < 0 || configIndex+1 >= len(playwrightArgs) {
+		t.Fatalf("playwright args missing --config path: %v", playwrightArgs)
+	}
+	configPath := playwrightArgs[configIndex+1]
+	if !strings.HasPrefix(configPath, tempDir) {
+		t.Fatalf("playwright config path %q is not under temp dir %q", configPath, tempDir)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read playwright config: %v", err)
+	}
+	if !strings.Contains(string(configData), "--disable-gpu") {
+		t.Fatalf("playwright config missing --disable-gpu: %s", configData)
+	}
+
+	chromeArgs := decodeArgs(t, servers["chrome-devtools"])
+	if !contains(chromeArgs, "--executablePath="+edgePath) {
+		t.Fatalf("chrome-devtools args missing Edge executable fallback:\n%v", chromeArgs)
+	}
+}
+
+func TestHardenWindowsBrowserMcpConfigRespectsExplicitBrowserArgs(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH": `D:\Browsers\Chrome\chrome.exe`,
+	}, nil)
+
+	tempDir := t.TempDir()
+	raw := json.RawMessage(`{"mcpServers":{
+		"playwright":{"command":"npx","args":["@playwright/mcp@latest","--config","custom.json"]},
+		"chrome-devtools":{"command":"npx","args":["chrome-devtools-mcp@latest","--channel=beta"]}
+	}}`)
+
+	got, err := hardenBrowserMcpConfig(raw, tempDir)
+	if err != nil {
+		t.Fatalf("hardenBrowserMcpConfig: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("explicit browser args should not be changed:\n got %s\nwant %s", got, raw)
+	}
+	if entries, err := os.ReadDir(tempDir); err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("explicit config should not create sidecar files: %v", entries)
+	}
+}
+
+func TestHardenWindowsBrowserMcpConfigKeepsRawOnMalformedInput(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", nil, nil)
+
+	raw := json.RawMessage(`not json`)
+	got, err := hardenBrowserMcpConfig(raw, t.TempDir())
+	if err != nil {
+		t.Fatalf("hardenBrowserMcpConfig: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("malformed config changed: got %s want %s", got, raw)
+	}
+}
+
+func decodeMcpServers(t *testing.T, raw []byte) map[string]json.RawMessage {
+	t.Helper()
+	var top struct {
+		McpServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &top); err != nil {
+		t.Fatalf("unmarshal mcp config: %v\n%s", err, raw)
+	}
+	return top.McpServers
+}
+
+func decodeArgs(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	var entry struct {
+		Args []string `json:"args"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal mcp server: %v\n%s", err, raw)
+	}
+	return entry.Args
+}
+
+func indexOfString(items []string, item string) int {
+	for i, candidate := range items {
+		if candidate == item {
+			return i
+		}
+	}
+	return -1
+}
+
+func contains(items []string, item string) bool {
+	return indexOfString(items, item) >= 0
+}
+
+func TestWindowsChromiumFallbackExecutableSkipsMissingInstallDirs(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"ProgramFiles(x86)": "",
+		"ProgramFiles":      "",
+		"LocalAppData":      "",
+	}, nil)
+
+	if got, ok := windowsChromiumFallbackExecutable(); ok {
+		t.Fatalf("fallback executable = %q, want none", got)
+	}
+}
+
+func TestWindowsChromiumFallbackExecutablePropagatesOverride(t *testing.T) {
+	override := filepath.Clean(`D:\Browsers\Chromium\chrome.exe`)
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH": override,
+	}, map[string]bool{})
+
+	got, ok := windowsChromiumFallbackExecutable()
+	if !ok || got != override {
+		t.Fatalf("fallback executable = %q, %v; want %q, true", got, ok, override)
+	}
+}
+
+func TestWithBrowserMcpTestHostUsesMissingStat(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", nil, nil)
+	_, err := browserMcpStat("missing")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("browserMcpStat missing error = %v, want os.ErrNotExist", err)
+	}
+}

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -46,7 +47,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			return nil, err
 		}
 		mcpConfigPath = path
-		mcpFileCleanup = func() { os.Remove(mcpConfigPath) }
+		mcpFileCleanup = func() { cleanupMcpConfigTemp(mcpConfigPath) }
 		args = append(args, "--mcp-config", mcpConfigPath)
 	}
 	// Clean up the temp file if we return before the goroutine takes ownership.
@@ -127,7 +128,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer close(msgCh)
 		defer close(resCh)
 		if mcpConfigPath != "" {
-			defer os.Remove(mcpConfigPath)
+			defer cleanupMcpConfigTemp(mcpConfigPath)
 		}
 
 		startTime := time.Now()
@@ -785,23 +786,36 @@ func stripSurroundingQuotes(s string) (string, bool) {
 	return s, false
 }
 
-// writeMcpConfigToTemp writes raw MCP config JSON to a temporary file and returns
-// its path. The caller is responsible for removing the file when done.
+// writeMcpConfigToTemp writes MCP config JSON to a temporary file and returns
+// its path. The caller is responsible for removing it via cleanupMcpConfigTemp.
 func writeMcpConfigToTemp(raw json.RawMessage) (string, error) {
-	f, err := os.CreateTemp("", "multica-mcp-*.json")
+	dir, err := os.MkdirTemp("", "multica-mcp-*")
 	if err != nil {
-		return "", fmt.Errorf("create mcp config temp file: %w", err)
+		return "", fmt.Errorf("create mcp config temp dir: %w", err)
 	}
-	if _, err := f.Write(raw); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+	data, err := hardenBrowserMcpConfig(raw, dir)
+	if err != nil {
+		cleanupMcpConfigTemp(filepath.Join(dir, "mcp-config.json"))
+		return "", err
+	}
+	path := filepath.Join(dir, "mcp-config.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		cleanupMcpConfigTemp(path)
 		return "", fmt.Errorf("write mcp config temp file: %w", err)
 	}
-	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
-		return "", fmt.Errorf("close mcp config temp file: %w", err)
+	return path, nil
+}
+
+func cleanupMcpConfigTemp(path string) {
+	if path == "" {
+		return
 	}
-	return f.Name(), nil
+	dir := filepath.Dir(path)
+	if strings.HasPrefix(filepath.Base(dir), "multica-mcp-") {
+		_ = os.RemoveAll(dir)
+		return
+	}
+	_ = os.Remove(path)
 }
 
 // detectVersionTimeout bounds a single `<cli> --version` probe. Version

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -651,10 +651,8 @@ func TestWriteMcpConfigToTemp(t *testing.T) {
 		t.Fatalf("expected %s, got %s", raw, data)
 	}
 
-	// Cleanup should remove the file.
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("remove temp file: %v", err)
-	}
+	// Cleanup should remove the temp directory and every related sidecar file.
+	cleanupMcpConfigTemp(path)
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected temp file to be removed, but it still exists")
 	}

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -92,7 +91,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 			return nil, err
 		}
 		mcpConfigPath = path
-		mcpFileCleanup = func() { os.Remove(mcpConfigPath) }
+		mcpFileCleanup = func() { cleanupMcpConfigTemp(mcpConfigPath) }
 		args = append(args, "--mcp-config", mcpConfigPath)
 	}
 	// Clean up the temp file if we return before the goroutine takes ownership.
@@ -160,7 +159,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 		defer close(msgCh)
 		defer close(resCh)
 		if mcpConfigPath != "" {
-			defer os.Remove(mcpConfigPath)
+			defer cleanupMcpConfigTemp(mcpConfigPath)
 		}
 
 		startTime := time.Now()
@@ -419,7 +418,7 @@ type codebuddySDKMessage struct {
 
 	// result fields
 	ResultText string                               `json:"result,omitempty"`
-	IsError    bool                                  `json:"is_error,omitempty"`
+	IsError    bool                                 `json:"is_error,omitempty"`
 	DurationMs float64                              `json:"duration_ms,omitempty"`
 	NumTurns   int                                  `json:"num_turns,omitempty"`
 	Usage      *codebuddyUsage                      `json:"usage,omitempty"`

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -418,7 +418,7 @@ type codebuddySDKMessage struct {
 
 	// result fields
 	ResultText string                               `json:"result,omitempty"`
-	IsError    bool                                 `json:"is_error,omitempty"`
+	IsError    bool                                  `json:"is_error,omitempty"`
 	DurationMs float64                              `json:"duration_ms,omitempty"`
 	NumTurns   int                                  `json:"num_turns,omitempty"`
 	Usage      *codebuddyUsage                      `json:"usage,omitempty"`


### PR DESCRIPTION
Summary:
- Harden Windows browser MCP temp configs for Claude and CodeBuddy.
- Add a Playwright MCP sidecar config with Chromium --disable-gpu launch args when no explicit --config is present.
- Point chrome-devtools MCP at installed Edge on Windows when no browser, channel, or connection override exists.

Testing:
- go test ./pkg/agent

Refs MUL-4103