### PR TITLE
fix(lark): allow rebinding a revoked Feishu bot to a different agent

### DIFF
--- a/server/internal/integrations/lark/channel_store.go
+++ b/server/internal/integrations/lark/channel_store.go
@@ -142,6 +142,20 @@ func (s *ChannelStore) UpsertLarkInstallation(ctx context.Context, arg UpsertIns
 	return installationFromRow(row)
 }
 
+// RemoveRevokedInstallationByAppID hard-deletes a revoked installation keyed by its
+// platform app identity. This clears the (channel_type, config->>'app_id') unique
+// slot so the caller can re-install the same Lark/Feishu app against a different
+// agent without tripping the functional unique index. The delete is fenced to one
+// workspace and only matches status='revoked' — an active installation is never
+// removed through this path.
+func (s *ChannelStore) RemoveRevokedInstallationByAppID(ctx context.Context, workspaceID pgtype.UUID, appID string) error {
+	return s.Queries.DeleteChannelInstallationByAppID(ctx, db.DeleteChannelInstallationByAppIDParams{
+		ChannelType: channelTypeFeishu,
+		AppID:       appID,
+		WorkspaceID: workspaceID,
+	})
+}
+
 func (s *ChannelStore) SetLarkInstallationStatus(ctx context.Context, arg SetInstallationStatusParams) error {
 	return s.Queries.SetChannelInstallationStatus(ctx, db.SetChannelInstallationStatusParams{
 		ID:     arg.ID,

--- a/server/internal/integrations/lark/registration_service.go
+++ b/server/internal/integrations/lark/registration_service.go
@@ -563,6 +563,19 @@ func (s *RegistrationService) finishSuccess(ctx context.Context, sess *registrat
 	defer tx.Rollback(ctx)
 	qtx := s.queries.WithTx(tx)
 
+	// If the same Feishu app (app_id) was previously bound to a different
+	// agent in this workspace and later revoked, the revoked row still
+	// holds the (channel_type, config->>'app_id') unique index slot and
+	// blocks the UpsertChannelInstallation INSERT below. Remove the
+	// revoked placeholder first — the transaction wraps both the delete
+	// and the upsert so a failure between them rolls back cleanly.
+	if err := qtx.RemoveRevokedInstallationByAppID(ctx, sess.workspaceID, res.ClientID); err != nil {
+		s.cfg.Logger.Warn("lark registration: cleanup revoked installation",
+			"session_id", sess.id, "err", err)
+		sess.markError(RegistrationReasonInternalError, err.Error(), s.gcDeadline())
+		return
+	}
+
 	inst, err := qtx.UpsertLarkInstallation(ctx, UpsertInstallationParams{
 		WorkspaceID:        sess.workspaceID,
 		AgentID:            sess.agentID,

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -589,6 +589,25 @@ func (q *Queries) GetChannelInstallationByAppID(ctx context.Context, arg GetChan
 	return i, err
 }
 
+const deleteChannelInstallationByAppID = `-- name: DeleteChannelInstallationByAppID :exec
+DELETE FROM channel_installation
+WHERE channel_type = $1
+  AND config ->> 'app_id' = $2::text
+  AND workspace_id = $3
+  AND status = 'revoked'
+`
+
+type DeleteChannelInstallationByAppIDParams struct {
+	ChannelType string      `json:"channel_type"`
+	AppID       string      `json:"app_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+func (q *Queries) DeleteChannelInstallationByAppID(ctx context.Context, arg DeleteChannelInstallationByAppIDParams) error {
+	_, err := q.db.Exec(ctx, deleteChannelInstallationByAppID, arg.ChannelType, arg.AppID, arg.WorkspaceID)
+	return err
+}
+
 const getChannelInstallationInWorkspace = `-- name: GetChannelInstallationInWorkspace :one
 SELECT id, workspace_id, agent_id, channel_type, config, status, ws_lease_token, ws_lease_expires_at, installer_user_id, installed_at, created_at, updated_at FROM channel_installation
 WHERE id = $1

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -98,6 +98,21 @@ SELECT * FROM channel_installation
 WHERE channel_type = sqlc.arg('channel_type')
   AND config ->> 'app_id' = sqlc.arg('app_id')::text;
 
+-- name: DeleteChannelInstallationByAppID :exec
+-- Hard-delete a REVOKED installation keyed by its platform app identity.
+-- When a Feishu/Lark Bot is disconnected from agent A (status → 'revoked')
+-- and the same Bot (same app_id) is later bound to agent B, the revoked
+-- row still occupies the (channel_type, config->>'app_id') unique slot
+-- and blocks the UpsertChannelInstallation INSERT. Removing the revoked
+-- placeholder first lets the upsert create a fresh row for the new agent.
+-- Fenced to one workspace AND status='revoked' so an active installation
+-- can never be silently deleted through this path.
+DELETE FROM channel_installation
+WHERE channel_type = sqlc.arg('channel_type')
+  AND config ->> 'app_id' = sqlc.arg('app_id')::text
+  AND workspace_id = sqlc.arg('workspace_id')
+  AND status = 'revoked';
+
 -- name: ListChannelInstallationsByWorkspace :many
 -- Scoped by channel_type so a per-channel management surface (e.g. the Lark
 -- installation list) only ever sees its own platform's installations.


### PR DESCRIPTION
## Problem

When a Feishu/Lark Bot is disconnected from Agent A (status → `revoked`) and the same Bot (same `app_id`) is later bound to Agent B, the install fails with:

```
ERROR: duplicate key value violates unique constraint "idx_channel_installation_type_appid" (SQLSTATE 23505)
```

The frontend shows: *"Could not save the installation. Another bot may already be bound to this agent."*

## Root Cause

The "Disconnect" action uses a **soft delete** — it sets `status = revoked` but preserves the row for audit. The revoked row still holds the `(channel_type, config->>app_id)` unique index slot.

When binding the same Bot to Agent B, `UpsertChannelInstallation` conflicts on `(workspace_id, agent_id, channel_type)`. Since Agent B has no installation yet, there is no conflict match, so it tries INSERT — which immediately hits the `app_id` unique index because Agent A's revoked row occupies that slot.

## Fix

Before the upsert (inside the same transaction), hard-delete any **revoked** installation with the same `app_id` in the same workspace. The delete is fenced to `status = 'revoked'` so an active installation can never be silently removed through this path.

If no revoked row exists, the `DELETE` is a no-op (deletes zero rows, returns nil error) and the upsert proceeds normally.

### Files changed

| File | Change |
|------|--------|
| `server/pkg/db/queries/channel.sql` | Add `DeleteChannelInstallationByAppID :exec` query |
| `server/pkg/db/generated/channel.sql.go` | Generated code for the new query |
| `server/internal/integrations/lark/channel_store.go` | Add `RemoveRevokedInstallationByAppID` method |
| `server/internal/integrations/lark/registration_service.go` | Call cleanup before upsert in the install transaction |

## Edge Cases

- **No revoked row exists**: DELETE is a no-op, upsert proceeds normally ✅
- **Active installation exists** (same app_id, different agent): DELETE doesn't match (`status = 'revoked'` guard), upsert still fails with unique violation → caught by existing error handling ✅
- **Revoked installation in different workspace**: DELETE scoped by `workspace_id`, doesn't match → correct cross-workspace isolation ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)