### PR TITLE
fix(workspace): await delete before navigating; suppress self-initiated realtime relocate (MUL-4129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ Keep server state and client state separate.
 - React Context is for platform plumbing only, such as `WorkspaceIdProvider` and `NavigationProvider`.
 - Only auth/workspace stores may call `api.*` directly. Other server interaction belongs in queries/mutations.
 - Workspace-scoped query keys must include `wsId`.
-- Mutations should be optimistic by default: patch locally, send request, roll back on failure, invalidate on settle.
+- Optimistic updates only when ALL hold: outcome locally predictable, user stays on the same screen (no navigation), failure is rare, rollback is trivial. Canonical: status/assignee/toggle field patches — patch determinate caches, roll back on failure, invalidate uncertain projections on settle.
+- Flows that navigate or confirm (create, delete, leave) must await the server before navigating or cleaning up; never optimistically remove an entity from cache.
+- Chat/message send uses the pending-message pattern: render immediately with a visible pending state and retry on failure, not silent optimism.
 - WebSocket events invalidate or patch Query cache; they never write directly to Zustand stores.
 - Persist durable preferences/drafts/layout. Do not persist server data or ephemeral UI state.
 - Zustand selectors must return stable references. Do not return freshly allocated objects/arrays from selectors without shallow comparison.

--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -4,8 +4,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { WSClient } from "../api/ws-client";
+import { defaultStorage } from "../platform/storage";
+import { workspaceKeys } from "../workspace/queries";
+import {
+  markWorkspaceDeletePending,
+  unmarkWorkspaceDeletePending,
+} from "../workspace/pending-delete";
 import { useRealtimeSync, type RealtimeSyncStores } from "./use-realtime-sync";
 
 vi.mock("../platform/workspace-storage", () => ({
@@ -185,5 +191,61 @@ describe("useRealtimeSync — ws instance change", () => {
     expect(calls).toContainEqual(["chat", "messages-page"]);
     expect(calls).toContainEqual(["chat", "pending-task"]);
     expect(calls).toContainEqual(["task-messages"]);
+  });
+});
+
+describe("useRealtimeSync — workspace:deleted self-initiated suppression", () => {
+  let qc: QueryClient;
+  let stores: RealtimeSyncStores;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    stores = createStores();
+  });
+
+  afterEach(() => {
+    unmarkWorkspaceDeletePending("ws-2");
+    localStorage.clear();
+  });
+
+  // getCurrentWsId is mocked to "ws-1" at module level, so deleting "ws-2"
+  // never enters the relocate branch — these tests only exercise the
+  // storage-cleanup path, which is the observable difference between a
+  // handled and a suppressed event.
+  const dispatchWorkspaceDeleted = (ws: WSClient, workspaceId: string) => {
+    const call = vi
+      .mocked(ws.on)
+      .mock.calls.find(([event]) => event === "workspace:deleted");
+    expect(call).toBeDefined();
+    (call![1] as (p: unknown) => void)({ workspace_id: workspaceId });
+  };
+
+  it("ignores the event for a delete this client initiated", () => {
+    const ws = createMockWs();
+    renderHook(() => useRealtimeSync(ws, stores), {
+      wrapper: createWrapper(qc),
+    });
+    qc.setQueryData(workspaceKeys.list(), [{ id: "ws-2", slug: "delete-me" }]);
+    defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
+
+    markWorkspaceDeletePending("ws-2");
+    dispatchWorkspaceDeleted(ws, "ws-2");
+
+    // useDeleteWorkspace.onSuccess owns cleanup for self-initiated deletes;
+    // the handler must not have touched storage.
+    expect(defaultStorage.getItem("multica_issue_draft:delete-me")).toBe("draft");
+  });
+
+  it("still cleans up for a delete initiated elsewhere", () => {
+    const ws = createMockWs();
+    renderHook(() => useRealtimeSync(ws, stores), {
+      wrapper: createWrapper(qc),
+    });
+    qc.setQueryData(workspaceKeys.list(), [{ id: "ws-2", slug: "delete-me" }]);
+    defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
+
+    dispatchWorkspaceDeleted(ws, "ws-2");
+
+    expect(defaultStorage.getItem("multica_issue_draft:delete-me")).toBeNull();
   });
 });

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -38,6 +38,7 @@ import {
   notificationPreferenceKeys,
 } from "../notification-preferences/queries";
 import { workspaceKeys, workspaceListOptions } from "../workspace/queries";
+import { isWorkspaceDeletePending } from "../workspace/pending-delete";
 import {
   showWebNotification,
   type SystemNotificationPayload,
@@ -773,6 +774,12 @@ export function useRealtimeSync(
 
     const unsubWsDeleted = ws.on("workspace:deleted", (p) => {
       const { workspace_id } = p as WorkspaceDeletedPayload;
+      // Self-initiated delete: useDeleteWorkspace owns storage cleanup and
+      // navigation (both run after the DELETE resolves). Reacting here too
+      // would race that flow's navigation with a full-page relocate — the
+      // CancelledError + reload combo this guard exists to prevent. This
+      // handler only serves deletes initiated elsewhere (other user/device).
+      if (isWorkspaceDeletePending(workspace_id)) return;
       // Event payload has UUID; look up slug from cached workspace list
       // since clearWorkspaceStorage keys are namespaced by slug.
       const wsList = qc.getQueryData<{ id: string; slug: string }[]>(workspaceKeys.list()) ?? [];

--- a/packages/core/workspace/mutations.test.tsx
+++ b/packages/core/workspace/mutations.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import type { Workspace } from "../types";
+import { useDeleteWorkspace } from "./mutations";
+import { workspaceKeys } from "./queries";
+
+function createWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const makeWorkspace = (id: string, slug: string): Workspace => ({
+  id,
+  name: slug,
+  slug,
+  description: null,
+  context: null,
+  settings: {},
+  repos: [],
+  issue_prefix: "MUL",
+  avatar_url: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+});
+
+describe("useDeleteWorkspace", () => {
+  let qc: QueryClient;
+  let deleteWorkspace: ReturnType<typeof vi.fn<(id: string) => Promise<void>>>;
+
+  const seedList = () => {
+    qc.setQueryData<Workspace[]>(workspaceKeys.list(), [
+      makeWorkspace("ws-1", "keep-me"),
+      makeWorkspace("ws-2", "delete-me"),
+    ]);
+  };
+
+  const cachedList = () =>
+    qc.getQueryData<Workspace[]>(workspaceKeys.list()) ?? [];
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    deleteWorkspace = vi.fn().mockResolvedValue(undefined);
+    setApiInstance({ deleteWorkspace } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("removes the workspace from the list cache while the DELETE is pending", async () => {
+    seedList();
+    // Hold the DELETE open so we can observe the pending window — the bug
+    // was that during this window the list cache still contained the
+    // workspace, so any consumer re-presented it as selectable/current.
+    let resolveDelete!: () => void;
+    deleteWorkspace.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    let mutationDone: Promise<void>;
+    await act(async () => {
+      mutationDone = result.current.mutateAsync("ws-2");
+      // Let onMutate (cancelQueries + optimistic removal) run.
+      await Promise.resolve();
+    });
+
+    expect(deleteWorkspace).toHaveBeenCalledWith("ws-2");
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+
+    await act(async () => {
+      resolveDelete();
+      await mutationDone;
+    });
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+  });
+
+  it("invalidates the workspace list after a successful delete", async () => {
+    seedList();
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("ws-2");
+    });
+
+    expect(qc.getQueryState(workspaceKeys.list())?.isInvalidated).toBe(true);
+  });
+
+  it("rolls the list back when the DELETE fails", async () => {
+    seedList();
+    deleteWorkspace.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
+    });
+
+    await waitFor(() => {
+      expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
+    });
+  });
+});

--- a/packages/core/workspace/mutations.test.tsx
+++ b/packages/core/workspace/mutations.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { setApiInstance } from "../api";
@@ -10,8 +10,11 @@ import type { ApiClient } from "../api/client";
 import { defaultStorage } from "../platform/storage";
 import type { Workspace } from "../types";
 import { useDeleteWorkspace } from "./mutations";
-import { workspaceKeys, workspaceListOptions } from "./queries";
-import { unmarkWorkspaceDeletePending } from "./pending-delete";
+import { workspaceKeys } from "./queries";
+import {
+  isWorkspaceDeletePending,
+  unmarkWorkspaceDeletePending,
+} from "./pending-delete";
 
 function createWrapper(qc: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -38,13 +41,13 @@ describe("useDeleteWorkspace", () => {
   let deleteWorkspace: ReturnType<typeof vi.fn<(id: string) => Promise<void>>>;
   let listWorkspaces: ReturnType<typeof vi.fn<() => Promise<Workspace[]>>>;
 
-  const staleServerList = () => [
+  const serverList = () => [
     makeWorkspace("ws-1", "keep-me"),
     makeWorkspace("ws-2", "delete-me"),
   ];
 
   const seedList = () => {
-    qc.setQueryData<Workspace[]>(workspaceKeys.list(), staleServerList());
+    qc.setQueryData<Workspace[]>(workspaceKeys.list(), serverList());
   };
 
   const cachedList = () =>
@@ -53,25 +56,25 @@ describe("useDeleteWorkspace", () => {
   beforeEach(() => {
     qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     deleteWorkspace = vi.fn().mockResolvedValue(undefined);
-    listWorkspaces = vi.fn().mockResolvedValue(staleServerList());
+    listWorkspaces = vi.fn().mockResolvedValue(serverList());
     setApiInstance({ deleteWorkspace, listWorkspaces } as unknown as ApiClient);
   });
 
   afterEach(() => {
     qc.clear();
-    // The tombstone registry is module state; onSettled unmarks it in every
-    // test flow, but keep a belt-and-braces reset so one failing test can't
-    // poison the others.
+    // The self-initiated marker is module state and is intentionally KEPT
+    // after a successful delete (it suppresses the WS echo); reset it so
+    // tests stay independent.
     unmarkWorkspaceDeletePending("ws-2");
     localStorage.clear();
     vi.restoreAllMocks();
   });
 
-  it("removes the workspace from the list cache while the DELETE is pending", async () => {
+  it("leaves the list cache untouched while the DELETE is pending (no optimistic removal)", async () => {
     seedList();
-    // Hold the DELETE open so we can observe the pending window — the bug
-    // was that during this window the list cache still contained the
-    // workspace, so any consumer re-presented it as selectable/current.
+    // Hold the DELETE open to observe the pending window. The flow awaits
+    // the mutation with the dialog in a loading state, so the cache must
+    // keep reflecting server truth: the workspace still exists.
     let resolveDelete!: () => void;
     deleteWorkspace.mockReturnValue(
       new Promise<void>((resolve) => {
@@ -86,18 +89,16 @@ describe("useDeleteWorkspace", () => {
     let mutationDone: Promise<void>;
     await act(async () => {
       mutationDone = result.current.mutateAsync("ws-2");
-      // Let onMutate (cancelQueries + optimistic removal) run.
       await Promise.resolve();
     });
 
     expect(deleteWorkspace).toHaveBeenCalledWith("ws-2");
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
 
     await act(async () => {
       resolveDelete();
       await mutationDone;
     });
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
   });
 
   it("invalidates the workspace list after a successful delete", async () => {
@@ -113,28 +114,11 @@ describe("useDeleteWorkspace", () => {
     expect(qc.getQueryState(workspaceKeys.list())?.isInvalidated).toBe(true);
   });
 
-  it("rolls the list back when the DELETE fails", async () => {
+  it("clears the deleted slug's workspace-scoped storage on success", async () => {
     seedList();
-    deleteWorkspace.mockRejectedValue(new Error("boom"));
-
-    const { result } = renderHook(() => useDeleteWorkspace(), {
-      wrapper: createWrapper(qc),
-    });
-
-    await act(async () => {
-      await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
-    });
-
-    await waitFor(() => {
-      expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
-    });
-  });
-
-  it("clears the deleted slug's workspace-scoped storage on success, using the pre-removal slug", async () => {
-    seedList();
-    // The realtime `workspace:deleted` handler reverse-looks-up the slug from
-    // the list cache — which the optimistic removal has already emptied on
-    // the initiating client — so the mutation itself must own this cleanup.
+    // The realtime `workspace:deleted` handler skips self-initiated deletes,
+    // so the mutation owns this cleanup; the slug is captured from the list
+    // cache before the mutation fires.
     defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
     defaultStorage.setItem("multica_issue_draft:keep-me", "draft");
 
@@ -150,7 +134,7 @@ describe("useDeleteWorkspace", () => {
     expect(defaultStorage.getItem("multica_issue_draft:keep-me")).toBe("draft");
   });
 
-  it("does not clear workspace-scoped storage when the DELETE fails", async () => {
+  it("leaves storage and cache untouched when the DELETE fails", async () => {
     seedList();
     deleteWorkspace.mockRejectedValue(new Error("boom"));
     defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
@@ -163,60 +147,31 @@ describe("useDeleteWorkspace", () => {
       await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
     });
 
+    // No optimistic write happened, so there is nothing to roll back.
     expect(defaultStorage.getItem("multica_issue_draft:delete-me")).toBe("draft");
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
   });
 
-  it("keeps the workspace out of the cache when a list refetch lands mid-pending", async () => {
+  it("keeps the self-initiated marker after success and lifts it after failure", async () => {
     seedList();
-    let resolveDelete!: () => void;
-    deleteWorkspace.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveDelete = resolve;
-      }),
-    );
-
     const { result } = renderHook(() => useDeleteWorkspace(), {
       wrapper: createWrapper(qc),
     });
 
-    let mutationDone: Promise<void>;
+    // Success: the id is gone for good; the kept marker suppresses the WS
+    // echo of our own delete whenever it arrives.
     await act(async () => {
-      mutationDone = result.current.mutateAsync("ws-2");
-      await Promise.resolve();
+      await result.current.mutateAsync("ws-2");
     });
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+    expect(isWorkspaceDeletePending("ws-2")).toBe(true);
 
-    // Simulate a refetch during the pending window (realtime invalidation /
-    // reconnect recovery / explicit fetchQuery) where the server has not
-    // committed the delete yet and still returns the old row.
-    await act(async () => {
-      await qc.fetchQuery({ ...workspaceListOptions(), staleTime: 0 });
-    });
-    expect(listWorkspaces).toHaveBeenCalled();
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
-
-    await act(async () => {
-      resolveDelete();
-      await mutationDone;
-    });
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
-  });
-
-  it("lifts the tombstone after a failed DELETE settles, so refetches show the restored row", async () => {
-    seedList();
+    // Failure: the workspace still exists, so a later external delete of
+    // the same id must be handled by the realtime handler again.
+    unmarkWorkspaceDeletePending("ws-2");
     deleteWorkspace.mockRejectedValue(new Error("boom"));
-
-    const { result } = renderHook(() => useDeleteWorkspace(), {
-      wrapper: createWrapper(qc),
-    });
-
     await act(async () => {
       await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
     });
-
-    await act(async () => {
-      await qc.fetchQuery({ ...workspaceListOptions(), staleTime: 0 });
-    });
-    expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
+    expect(isWorkspaceDeletePending("ws-2")).toBe(false);
   });
 });

--- a/packages/core/workspace/mutations.test.tsx
+++ b/packages/core/workspace/mutations.test.tsx
@@ -7,9 +7,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
+import { defaultStorage } from "../platform/storage";
 import type { Workspace } from "../types";
 import { useDeleteWorkspace } from "./mutations";
-import { workspaceKeys } from "./queries";
+import { workspaceKeys, workspaceListOptions } from "./queries";
+import { unmarkWorkspaceDeletePending } from "./pending-delete";
 
 function createWrapper(qc: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -34,12 +36,15 @@ const makeWorkspace = (id: string, slug: string): Workspace => ({
 describe("useDeleteWorkspace", () => {
   let qc: QueryClient;
   let deleteWorkspace: ReturnType<typeof vi.fn<(id: string) => Promise<void>>>;
+  let listWorkspaces: ReturnType<typeof vi.fn<() => Promise<Workspace[]>>>;
+
+  const staleServerList = () => [
+    makeWorkspace("ws-1", "keep-me"),
+    makeWorkspace("ws-2", "delete-me"),
+  ];
 
   const seedList = () => {
-    qc.setQueryData<Workspace[]>(workspaceKeys.list(), [
-      makeWorkspace("ws-1", "keep-me"),
-      makeWorkspace("ws-2", "delete-me"),
-    ]);
+    qc.setQueryData<Workspace[]>(workspaceKeys.list(), staleServerList());
   };
 
   const cachedList = () =>
@@ -48,11 +53,17 @@ describe("useDeleteWorkspace", () => {
   beforeEach(() => {
     qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     deleteWorkspace = vi.fn().mockResolvedValue(undefined);
-    setApiInstance({ deleteWorkspace } as unknown as ApiClient);
+    listWorkspaces = vi.fn().mockResolvedValue(staleServerList());
+    setApiInstance({ deleteWorkspace, listWorkspaces } as unknown as ApiClient);
   });
 
   afterEach(() => {
     qc.clear();
+    // The tombstone registry is module state; onSettled unmarks it in every
+    // test flow, but keep a belt-and-braces reset so one failing test can't
+    // poison the others.
+    unmarkWorkspaceDeletePending("ws-2");
+    localStorage.clear();
     vi.restoreAllMocks();
   });
 
@@ -117,5 +128,95 @@ describe("useDeleteWorkspace", () => {
     await waitFor(() => {
       expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
     });
+  });
+
+  it("clears the deleted slug's workspace-scoped storage on success, using the pre-removal slug", async () => {
+    seedList();
+    // The realtime `workspace:deleted` handler reverse-looks-up the slug from
+    // the list cache — which the optimistic removal has already emptied on
+    // the initiating client — so the mutation itself must own this cleanup.
+    defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
+    defaultStorage.setItem("multica_issue_draft:keep-me", "draft");
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("ws-2");
+    });
+
+    expect(defaultStorage.getItem("multica_issue_draft:delete-me")).toBeNull();
+    expect(defaultStorage.getItem("multica_issue_draft:keep-me")).toBe("draft");
+  });
+
+  it("does not clear workspace-scoped storage when the DELETE fails", async () => {
+    seedList();
+    deleteWorkspace.mockRejectedValue(new Error("boom"));
+    defaultStorage.setItem("multica_issue_draft:delete-me", "draft");
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
+    });
+
+    expect(defaultStorage.getItem("multica_issue_draft:delete-me")).toBe("draft");
+  });
+
+  it("keeps the workspace out of the cache when a list refetch lands mid-pending", async () => {
+    seedList();
+    let resolveDelete!: () => void;
+    deleteWorkspace.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    let mutationDone: Promise<void>;
+    await act(async () => {
+      mutationDone = result.current.mutateAsync("ws-2");
+      await Promise.resolve();
+    });
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+
+    // Simulate a refetch during the pending window (realtime invalidation /
+    // reconnect recovery / explicit fetchQuery) where the server has not
+    // committed the delete yet and still returns the old row.
+    await act(async () => {
+      await qc.fetchQuery({ ...workspaceListOptions(), staleTime: 0 });
+    });
+    expect(listWorkspaces).toHaveBeenCalled();
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+
+    await act(async () => {
+      resolveDelete();
+      await mutationDone;
+    });
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1"]);
+  });
+
+  it("lifts the tombstone after a failed DELETE settles, so refetches show the restored row", async () => {
+    seedList();
+    deleteWorkspace.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useDeleteWorkspace(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("ws-2")).rejects.toThrow("boom");
+    });
+
+    await act(async () => {
+      await qc.fetchQuery({ ...workspaceListOptions(), staleTime: 0 });
+    });
+    expect(cachedList().map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
   });
 });

--- a/packages/core/workspace/mutations.ts
+++ b/packages/core/workspace/mutations.ts
@@ -39,6 +39,30 @@ export function useDeleteWorkspace() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (workspaceId: string) => api.deleteWorkspace(workspaceId),
+    // Optimistically drop the workspace from the list cache while the
+    // DELETE is in flight. The delete flow navigates away BEFORE awaiting
+    // the mutation (see workspace-tab.tsx's navigateAwayFromCurrentWorkspace
+    // for the CancelledError race that forces that ordering), so during the
+    // pending window every list consumer — sidebar switcher, by-slug route
+    // resolution, post-auth destination — must already see the workspace as
+    // gone, or a concurrent list refetch re-presents it as selectable and
+    // it can be re-entered mid-delete.
+    onMutate: async (workspaceId) => {
+      // Cancel in-flight list fetches so a response that started before the
+      // delete can't land after the optimistic update and resurrect the row.
+      await qc.cancelQueries({ queryKey: workspaceKeys.list() });
+      const previous = qc.getQueryData<Workspace[]>(workspaceKeys.list());
+      qc.setQueryData<Workspace[]>(workspaceKeys.list(), (old) =>
+        old?.filter((w) => w.id !== workspaceId),
+      );
+      return { previous };
+    },
+    // Rollback: the server still has the workspace, so put it back in the
+    // list (the caller surfaces the error toast). onSettled's invalidate
+    // then reconciles against server truth either way.
+    onError: (_err, _workspaceId, ctx) => {
+      if (ctx?.previous) qc.setQueryData(workspaceKeys.list(), ctx.previous);
+    },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: workspaceKeys.list() });
     },

--- a/packages/core/workspace/mutations.ts
+++ b/packages/core/workspace/mutations.ts
@@ -45,49 +45,35 @@ export function useDeleteWorkspace() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (workspaceId: string) => api.deleteWorkspace(workspaceId),
-    // Optimistically drop the workspace from the list cache while the
-    // DELETE is in flight. The delete flow navigates away BEFORE awaiting
-    // the mutation (see workspace-tab.tsx's navigateAwayFromCurrentWorkspace
-    // for the CancelledError race that forces that ordering), so during the
-    // pending window every list consumer — sidebar switcher, by-slug route
-    // resolution, post-auth destination — must already see the workspace as
-    // gone, or a concurrent list refetch re-presents it as selectable and
-    // it can be re-entered mid-delete.
-    onMutate: async (workspaceId) => {
-      // Tombstone until settled: refetches that land while the DELETE is
-      // pending go through workspaceListOptions' queryFn, which filters
-      // against this registry — without it, an invalidation/reconnect
-      // refetch would write the not-yet-committed row straight back.
+    // No optimistic removal: the delete flow awaits this mutation with the
+    // confirm dialog in a loading state and only navigates on success, so
+    // the cache staying truthful (server still has the row until commit)
+    // is correct, and a failed DELETE needs no rollback.
+    onMutate: (workspaceId) => {
+      // Mark the delete as self-initiated so the realtime `workspace:deleted`
+      // handler no-ops instead of racing this flow's navigation with its own
+      // full-page relocate. See pending-delete.ts for lifetime rules.
       markWorkspaceDeletePending(workspaceId);
-      // Cancel in-flight list fetches so a response that started before the
-      // delete can't land after the optimistic update and resurrect the row.
-      await qc.cancelQueries({ queryKey: workspaceKeys.list() });
-      const previous = qc.getQueryData<Workspace[]>(workspaceKeys.list());
-      qc.setQueryData<Workspace[]>(workspaceKeys.list(), (old) =>
-        old?.filter((w) => w.id !== workspaceId),
-      );
-      // Capture the slug BEFORE the optimistic removal erases the row: the
-      // realtime `workspace:deleted` handler reverse-looks-up the slug from
-      // this same cache to clear `${key}:${slug}` storage, so on the
-      // initiating client that lookup misses and cleanup falls to onSuccess.
-      return { previous, slug: previous?.find((w) => w.id === workspaceId)?.slug };
+      // Capture the slug for onSuccess's storage cleanup — cheap here, and
+      // the row is guaranteed to still be in the list pre-mutation.
+      const slug = qc
+        .getQueryData<Workspace[]>(workspaceKeys.list())
+        ?.find((w) => w.id === workspaceId)?.slug;
+      return { slug };
     },
     // Success is the only path that clears the deleted workspace's persisted
     // `${key}:${slug}` namespace — a failed DELETE means the workspace still
-    // exists and its drafts/view state must survive.
+    // exists and its drafts/view state must survive. The realtime handler
+    // skips self-initiated deletes, so cleanup has to happen here.
     onSuccess: (_data, _workspaceId, ctx) => {
       if (ctx?.slug) clearWorkspaceStorage(defaultStorage, ctx.slug);
     },
-    // Rollback: the server still has the workspace, so put it back in the
-    // list (the caller surfaces the error toast). onSettled's invalidate
-    // then reconciles against server truth either way.
-    onError: (_err, _workspaceId, ctx) => {
-      if (ctx?.previous) qc.setQueryData(workspaceKeys.list(), ctx.previous);
-    },
-    onSettled: (_data, _err, workspaceId) => {
-      // Lift the tombstone before invalidating so the reconcile refetch
-      // reflects server truth: gone on success, restored on failure.
+    // The workspace still exists after a failed DELETE, so a later external
+    // delete of the same ID must be handled by the realtime handler again.
+    onError: (_err, workspaceId) => {
       unmarkWorkspaceDeletePending(workspaceId);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: workspaceKeys.list() });
     },
   });

--- a/packages/core/workspace/mutations.ts
+++ b/packages/core/workspace/mutations.ts
@@ -1,7 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Workspace } from "../types";
 import { api } from "../api";
+import { defaultStorage } from "../platform/storage";
+import { clearWorkspaceStorage } from "../platform/storage-cleanup";
 import { workspaceKeys } from "./queries";
+import {
+  markWorkspaceDeletePending,
+  unmarkWorkspaceDeletePending,
+} from "./pending-delete";
 
 export function useCreateWorkspace() {
   const qc = useQueryClient();
@@ -48,6 +54,11 @@ export function useDeleteWorkspace() {
     // gone, or a concurrent list refetch re-presents it as selectable and
     // it can be re-entered mid-delete.
     onMutate: async (workspaceId) => {
+      // Tombstone until settled: refetches that land while the DELETE is
+      // pending go through workspaceListOptions' queryFn, which filters
+      // against this registry — without it, an invalidation/reconnect
+      // refetch would write the not-yet-committed row straight back.
+      markWorkspaceDeletePending(workspaceId);
       // Cancel in-flight list fetches so a response that started before the
       // delete can't land after the optimistic update and resurrect the row.
       await qc.cancelQueries({ queryKey: workspaceKeys.list() });
@@ -55,7 +66,17 @@ export function useDeleteWorkspace() {
       qc.setQueryData<Workspace[]>(workspaceKeys.list(), (old) =>
         old?.filter((w) => w.id !== workspaceId),
       );
-      return { previous };
+      // Capture the slug BEFORE the optimistic removal erases the row: the
+      // realtime `workspace:deleted` handler reverse-looks-up the slug from
+      // this same cache to clear `${key}:${slug}` storage, so on the
+      // initiating client that lookup misses and cleanup falls to onSuccess.
+      return { previous, slug: previous?.find((w) => w.id === workspaceId)?.slug };
+    },
+    // Success is the only path that clears the deleted workspace's persisted
+    // `${key}:${slug}` namespace — a failed DELETE means the workspace still
+    // exists and its drafts/view state must survive.
+    onSuccess: (_data, _workspaceId, ctx) => {
+      if (ctx?.slug) clearWorkspaceStorage(defaultStorage, ctx.slug);
     },
     // Rollback: the server still has the workspace, so put it back in the
     // list (the caller surfaces the error toast). onSettled's invalidate
@@ -63,7 +84,10 @@ export function useDeleteWorkspace() {
     onError: (_err, _workspaceId, ctx) => {
       if (ctx?.previous) qc.setQueryData(workspaceKeys.list(), ctx.previous);
     },
-    onSettled: () => {
+    onSettled: (_data, _err, workspaceId) => {
+      // Lift the tombstone before invalidating so the reconcile refetch
+      // reflects server truth: gone on success, restored on failure.
+      unmarkWorkspaceDeletePending(workspaceId);
       qc.invalidateQueries({ queryKey: workspaceKeys.list() });
     },
   });

--- a/packages/core/workspace/pending-delete.ts
+++ b/packages/core/workspace/pending-delete.ts
@@ -1,15 +1,20 @@
 /**
- * Registry of workspace IDs with a DELETE in flight.
+ * Registry of workspace IDs whose DELETE was initiated by THIS client.
  *
- * Marked in useDeleteWorkspace.onMutate, cleared in onSettled. The workspace
- * list queryFn filters against it so a refetch that lands during the pending
- * window (realtime invalidation, reconnect recovery, explicit fetchQuery)
- * cannot write the not-yet-committed row back into the visible cache after
- * the optimistic removal.
+ * Marked in useDeleteWorkspace.onMutate. The realtime `workspace:deleted`
+ * handler checks it and no-ops for self-initiated deletes: the mutation flow
+ * owns storage cleanup and navigation (both run after the DELETE resolves),
+ * and letting the handler react too would race that flow's navigation with
+ * its own full-page relocate.
  *
- * Module scope rather than React state because the queryFn runs outside the
- * component tree. A hard reload drops the registry, which matches server
- * truth: an uncommitted delete's workspace legitimately still exists.
+ * Lifted only when the DELETE fails — the workspace still exists, so a later
+ * external delete of the same ID must be handled normally. On success the ID
+ * is gone for good, and keeping the mark suppresses the WS echo of our own
+ * delete no matter when it arrives.
+ *
+ * Module scope rather than React state because the realtime handler runs
+ * outside the component tree. Per-tab by construction: other tabs/devices
+ * have an empty registry, so their handlers process the event normally.
  */
 const pendingDeletes = new Set<string>();
 
@@ -21,8 +26,7 @@ export function unmarkWorkspaceDeletePending(workspaceId: string) {
   pendingDeletes.delete(workspaceId);
 }
 
-/** Drop rows whose delete is still in flight from a fetched workspace list. */
-export function omitPendingDeletes<T extends { id: string }>(list: T[]): T[] {
-  if (pendingDeletes.size === 0) return list;
-  return list.filter((w) => !pendingDeletes.has(w.id));
+/** True if this client initiated a DELETE for the workspace. */
+export function isWorkspaceDeletePending(workspaceId: string): boolean {
+  return pendingDeletes.has(workspaceId);
 }

--- a/packages/core/workspace/pending-delete.ts
+++ b/packages/core/workspace/pending-delete.ts
@@ -1,0 +1,28 @@
+/**
+ * Registry of workspace IDs with a DELETE in flight.
+ *
+ * Marked in useDeleteWorkspace.onMutate, cleared in onSettled. The workspace
+ * list queryFn filters against it so a refetch that lands during the pending
+ * window (realtime invalidation, reconnect recovery, explicit fetchQuery)
+ * cannot write the not-yet-committed row back into the visible cache after
+ * the optimistic removal.
+ *
+ * Module scope rather than React state because the queryFn runs outside the
+ * component tree. A hard reload drops the registry, which matches server
+ * truth: an uncommitted delete's workspace legitimately still exists.
+ */
+const pendingDeletes = new Set<string>();
+
+export function markWorkspaceDeletePending(workspaceId: string) {
+  pendingDeletes.add(workspaceId);
+}
+
+export function unmarkWorkspaceDeletePending(workspaceId: string) {
+  pendingDeletes.delete(workspaceId);
+}
+
+/** Drop rows whose delete is still in flight from a fetched workspace list. */
+export function omitPendingDeletes<T extends { id: string }>(list: T[]): T[] {
+  if (pendingDeletes.size === 0) return list;
+  return list.filter((w) => !pendingDeletes.has(w.id));
+}

--- a/packages/core/workspace/queries.ts
+++ b/packages/core/workspace/queries.ts
@@ -1,7 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
 import type { Agent, Squad, Workspace } from "../types";
-import { omitPendingDeletes } from "./pending-delete";
 
 export const workspaceKeys = {
   all: (wsId: string) => ["workspaces", wsId] as const,
@@ -23,11 +22,7 @@ export const workspaceKeys = {
 export function workspaceListOptions() {
   return queryOptions({
     queryKey: workspaceKeys.list(),
-    // A workspace with a DELETE in flight must not re-enter the cache via a
-    // concurrent refetch (realtime invalidation, reconnect recovery, explicit
-    // fetchQuery) — the server hasn't committed yet and would still return
-    // the row, undoing useDeleteWorkspace's optimistic removal.
-    queryFn: async () => omitPendingDeletes(await api.listWorkspaces()),
+    queryFn: () => api.listWorkspaces(),
   });
 }
 

--- a/packages/core/workspace/queries.ts
+++ b/packages/core/workspace/queries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
 import type { Agent, Squad, Workspace } from "../types";
+import { omitPendingDeletes } from "./pending-delete";
 
 export const workspaceKeys = {
   all: (wsId: string) => ["workspaces", wsId] as const,
@@ -22,7 +23,11 @@ export const workspaceKeys = {
 export function workspaceListOptions() {
   return queryOptions({
     queryKey: workspaceKeys.list(),
-    queryFn: () => api.listWorkspaces(),
+    // A workspace with a DELETE in flight must not re-enter the cache via a
+    // concurrent refetch (realtime invalidation, reconnect recovery, explicit
+    // fetchQuery) — the server hasn't committed yet and would still return
+    // the row, undoing useDeleteWorkspace's optimistic removal.
+    queryFn: async () => omitPendingDeletes(await api.listWorkspaces()),
   });
 }
 

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -21,7 +21,6 @@ import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import { useLeaveWorkspace, useDeleteWorkspace } from "@multica/core/workspace/mutations";
-import { useWorkspaceId } from "@multica/core/hooks";
 import {
   memberListOptions,
   workspaceKeys,
@@ -46,8 +45,17 @@ export function WorkspaceTab() {
   const { t } = useT("settings");
   const user = useAuthStore((s) => s.user);
   const workspace = useCurrentWorkspace();
-  const wsId = useWorkspaceId();
-  const { data: members = [], isFetched: membersFetched } = useQuery(memberListOptions(wsId));
+  // Derive the id from useCurrentWorkspace instead of the throwing
+  // useWorkspaceId: this component can legitimately render while the
+  // workspace is gone from the list cache but the URL slug hasn't changed
+  // yet (post-delete invalidation before navigation completes, or an
+  // external delete of the workspace we're on). The `!workspace` guard
+  // below renders null for that window; a throwing hook would crash first.
+  const wsId = workspace?.id;
+  const { data: members = [], isFetched: membersFetched } = useQuery({
+    ...memberListOptions(wsId ?? ""),
+    enabled: !!wsId,
+  });
   const qc = useQueryClient();
   const leaveWorkspace = useLeaveWorkspace();
   const deleteWorkspace = useDeleteWorkspace();
@@ -55,36 +63,34 @@ export function WorkspaceTab() {
   const hasOnboarded = useHasOnboarded();
 
   /**
-   * Send the user to a safe URL BEFORE the leave/delete mutation fires.
-   * The destination is computed from the current cached workspace list,
-   * minus the workspace that's about to go away.
+   * Send the user to a safe URL, computed from the current cached workspace
+   * list minus the workspace that's going away.
    *
-   * Why navigate first, not after:
-   *   1. The backend broadcasts `workspace:deleted` / `member:removed` the
-   *      moment the mutation lands. If the user is still on the soon-to-
-   *      be-deleted workspace's URL when that event arrives, the realtime
-   *      handler in `use-realtime-sync.ts` also triggers a relocation —
-   *      and both code paths race with the mutation's own
-   *      `invalidateQueries` refetch. The loser's in-flight fetch gets
-   *      cancelled, surfacing as an unhandled `CancelledError`.
-   *   2. Navigating first means by the time the WS event fires, the
-   *      active workspace is already something else; the realtime
-   *      handler's "current === deleted" check fails and its relocate
-   *      branch no-ops.
-   *   3. UX: the destructive flow feels instant (dialog closes → new
-   *      workspace appears) even though the API hasn't responded yet.
+   * Call ordering differs per flow:
+   *   - Delete calls this AFTER the mutation succeeds. The realtime
+   *     `workspace:deleted` handler skips self-initiated deletes (see
+   *     pending-delete.ts), so nothing races this navigation.
+   *   - Leave still calls this BEFORE the mutation fires: `member:removed`
+   *     has no self-initiated marker yet, so if the user were still on the
+   *     workspace's URL when that event arrives, the realtime handler in
+   *     `use-realtime-sync.ts` would trigger a parallel full-page relocate
+   *     that races the mutation's `invalidateQueries` refetch — the loser's
+   *     in-flight fetch gets cancelled, surfacing as an unhandled
+   *     `CancelledError`. Navigating first makes the handler's
+   *     "current === lost workspace" check fail and its relocate no-op.
+   *     Known debt: give leave the same await-then-navigate shape as delete.
    */
   const navigateAwayFromCurrentWorkspace = () => {
     const cachedList =
       qc.getQueryData<Workspace[]>(workspaceListOptions().queryKey) ?? [];
     const remaining = cachedList.filter((w) => w.id !== workspace?.id);
-    // Clear the workspace-context singleton BEFORE navigating and BEFORE
-    // the mutation fires. Three downstream consumers read it:
-    //  1. Realtime `workspace:deleted` handler's "current === deleted"
-    //     check — if the singleton still points at the deleting workspace
-    //     when the WS event arrives, it fires a parallel relocate that
-    //     races the mutation's invalidate and the settings page's own
-    //     navigate, surfacing a CancelledError and a full-page reload.
+    // Clear the workspace-context singleton BEFORE navigating. Three
+    // downstream consumers read it:
+    //  1. Realtime relocate handlers' "current === lost workspace" check
+    //     (`member:removed` for leave; also a second line of defense for
+    //     delete) — if the singleton still points at the lost workspace
+    //     when the WS event arrives, they fire a parallel full-page
+    //     relocate that races this navigation.
     //  2. Chrome gating (`{slug && <AppSidebar />}` on desktop) — if the
     //     singleton lingers, the sidebar stays mounted while the deleted
     //     workspace is no longer in the list, and `useWorkspaceId` throws.
@@ -237,14 +243,17 @@ export function WorkspaceTab() {
   const handleConfirmDelete = async () => {
     if (!workspace) return;
     setActionId("delete-workspace");
-    // Close the dialog and navigate away FIRST. See navigateAwayFromCurrentWorkspace
-    // comment for why: keeps the realtime `workspace:deleted` handler out
-    // of the race so we don't end up with concurrent refetches cancelling
-    // each other and surfacing CancelledError.
-    setDeleteDialogOpen(false);
-    navigateAwayFromCurrentWorkspace();
+    // Await the DELETE with the dialog in its loading state, and only
+    // navigate on success (CLAUDE.md: flows that navigate must await the
+    // server; no optimistic removal). The realtime `workspace:deleted`
+    // handler skips self-initiated deletes via the pending-delete registry,
+    // so it can't race this navigation with its own full-page relocate.
+    // On failure the dialog stays open, the cache was never touched, and
+    // the user is exactly where they started.
     try {
       await deleteWorkspace.mutateAsync(workspace.id);
+      setDeleteDialogOpen(false);
+      navigateAwayFromCurrentWorkspace();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : t(($) => $.workspace.toast_delete_failed));
     } finally {


### PR DESCRIPTION
## Context

Fix for MUL-4129, third iteration on this branch. History:

- #4980 — optimistic-removal half only; merged early, reverted in #4982 after a BLOCKED review.
- This branch's first approach — optimistic removal + pending-delete tombstone + storage-cleanup ownership transfer. **Superseded by the commits below**: local testing surfaced a crash it introduced (details next section).
- Current approach — no optimistic update at all; await the DELETE, then navigate.

## Problems addressed

**1. Original bug (MUL-4129):** deleting a workspace navigated away before awaiting the DELETE, so during the pending window the workspace stayed in the list cache — still selectable in the sidebar switcher, and a concurrent list refetch could "resurrect" it.

**2. Crash introduced by the optimistic approach:**

```
Uncaught Error: useWorkspaceId: no workspace selected — ensure component renders inside a workspace route
    at useWorkspaceId (hooks.tsx:15)
    at WorkspaceTab (workspace-tab.tsx:49)
```

`useWorkspaceId` derives the current workspace from URL slug + list cache and throws on a miss. Optimistic removal emptied the list at click time while the settings page was still mounted on the old slug (navigation isn't synchronous unmount), so the still-mounted `WorkspaceTab` re-rendered into a guaranteed throw.

**3. Root cause of the whole patch stack:** the navigate-first ordering existed only because the realtime `workspace:deleted` handler couldn't distinguish a self-initiated delete from an external one, and would race the local flow with its own full-page relocate (the documented `CancelledError` + reload). Every subsequent patch (optimistic removal, tombstone queryFn filter, storage-cleanup transfer) was scaffolding around that workaround.

## Fix

Give the initiating client a self-initiated marker and make the mutation flow the single owner of delete handling:

- **`workspace-tab.tsx`** — confirm dialog stays open in its loading state, `await mutateAsync`, navigate only on success. Failure: error toast, dialog stays, cache never touched, nothing to roll back. Also replaces the throwing `useWorkspaceId` with `workspace?.id` + `enabled` gating — an independent latent crash (an external delete of the workspace you're viewing hits the same throw).
- **`pending-delete.ts`** — repurposed from tombstone filter to "this client initiated the delete" registry. Kept on success (suppresses the WS echo of our own delete whenever it arrives — the id never comes back), lifted on failure (a later external delete of the same id must be handled normally).
- **`use-realtime-sync.ts`** — `workspace:deleted` returns early for self-initiated deletes; it now only serves deletes initiated elsewhere (other user/device), where its slug reverse-lookup still works because the initiating cache was never modified.
- **`mutations.ts`** — no optimistic removal, no snapshot, no rollback. `onMutate` marks + captures slug; `onSuccess` owns `${key}:${slug}` storage cleanup; `onSettled` invalidates.
- **`queries.ts`** — restored to main (tombstone filter removed).
- **`CLAUDE.md`** — the "mutations optimistic by default" state rule (which steered the original approach) is replaced with scoped rules: optimistic only for predictable same-screen field patches; navigating/confirming flows await the server first; chat send uses the pending-message pattern. Grounded in TanStack Query maintainer guidance ("optimistic updates are over-used"; dialog-close/redirect before settle is "hard to undo") and React Router's pending-UI criteria (optimistic UI requires the action not change the URL).

Side benefit: the previous approach's documented gap (hard refresh during the pending window showing the workspace) no longer exists — there is no pretend-window at all.

## Known debt

`useLeaveWorkspace` still navigates before awaiting (`member:removed` has no self-initiated marker yet). Annotated in `navigateAwayFromCurrentWorkspace`'s comment; follow-up candidate.

## Verification

- `packages/core/workspace/mutations.test.tsx` (5): cache untouched while pending; invalidate on success; storage cleared on success using the pre-mutation slug; failure leaves storage + cache untouched; marker kept on success / lifted on failure.
- `packages/core/realtime/use-realtime-sync-ws-instance.test.tsx` (+2): self-initiated `workspace:deleted` ignored; external delete still cleans up.
- `pnpm typecheck` green across the monorepo; manual delete flow verified (loading → success → navigate; failure path leaves the dialog in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
