### PR TITLE
MUL-4138: add agent list search

### DIFF
--- a/packages/views/agents/components/agent-list-toolbar.tsx
+++ b/packages/views/agents/components/agent-list-toolbar.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUp,
   ChevronDown,
   Filter,
+  Search,
   X,
 } from "lucide-react";
 import type { AgentAvailability } from "@multica/core/agents";
@@ -19,6 +20,7 @@ import {
   type AgentSortField,
 } from "@multica/core/agents/stores";
 import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -85,6 +87,8 @@ export function AgentListToolbar({
   scope,
   onScopeChange,
   scopeCounts,
+  search,
+  onSearchChange,
   filters,
   onToggleFilter,
   onClearFilters,
@@ -102,6 +106,8 @@ export function AgentListToolbar({
   onScopeChange: (scope: AgentsScope) => void;
   /** Per-scope totals from the FULL set — scope counts ignore filters. */
   scopeCounts: Record<AgentsScope, number>;
+  search: string;
+  onSearchChange: (value: string) => void;
   filters: AgentListFilters;
   onToggleFilter: (key: keyof AgentListFilters, value: string) => void;
   onClearFilters: () => void;
@@ -122,6 +128,7 @@ export function AgentListToolbar({
 
   const activeCount = countActiveFilterDimensions(filters);
   const hasActiveFilters = activeCount > 0;
+  const hasSearch = search.trim().length > 0;
 
   // Option lists with counts, derived from the scope's unfiltered rows so
   // toggling one dimension doesn't make the others' options vanish.
@@ -184,11 +191,21 @@ export function AgentListToolbar({
   return (
     <div className="h-12 shrink-0 overflow-x-auto px-5 [-webkit-overflow-scrolling:touch]">
       <div className="flex h-full w-max min-w-full items-center justify-between gap-2">
-        {/* Left: scope buttons + result count. Scope mixes the ownership lens
-          (mine/all) with the archived lifecycle stage; no search box (scope
-          partitions the small set). Button styling and the <md dropdown
-          collapse follow the issues header's scope buttons. */}
+        {/* Left: local search + scope buttons + result count. Scope mixes the
+          ownership lens (mine/all) with the archived lifecycle stage. Button
+          styling and the <md dropdown collapse follow the issues header's
+          scope buttons. */}
       <div className="flex min-w-0 items-center gap-2">
+        <div className="relative hidden shrink-0 md:block">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={t(($) => $.page.search_placeholder)}
+            className="h-8 w-56 pl-8 text-sm"
+          />
+        </div>
+
         <div className="hidden shrink-0 items-center gap-1 md:flex">
           {AGENT_SCOPES.map((s) => (
             <Button
@@ -240,7 +257,7 @@ export function AgentListToolbar({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {hasActiveFilters && (
+        {(hasActiveFilters || hasSearch) && (
           <span
             title={t(($) => $.toolbar.result_count_title)}
             className="hidden shrink-0 text-xs tabular-nums text-muted-foreground md:inline"

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -78,8 +78,12 @@ import { PageHeader } from "../../layout/page-header";
 import { availabilityConfig } from "../presence";
 import { CreateAgentDialog } from "./create-agent-dialog";
 import { AgentRowActions } from "./agent-row-actions";
-import { AgentListToolbar } from "./agent-list-toolbar";
+import {
+  AgentListToolbar,
+  countActiveFilterDimensions,
+} from "./agent-list-toolbar";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 // Column template — single source of truth for header, rows, and skeletons.
 // Same conventions as the skills/autopilots lists (see list-grid.tsx):
@@ -163,6 +167,17 @@ function lastActiveDaysAgo(activity: AgentActivity | null): number | null {
     if (bucket && bucket.total > 0) return activity.buckets.length - 1 - i;
   }
   return null;
+}
+
+function matchesAgentSearch(row: AgentListRow, query: string): boolean {
+  if (!query) return true;
+  const { agent } = row;
+  return (
+    agent.name.toLowerCase().includes(query) ||
+    matchesPinyin(agent.name, query) ||
+    (agent.description?.toLowerCase().includes(query) ?? false) ||
+    (agent.description ? matchesPinyin(agent.description, query) : false)
+  );
 }
 
 export interface AgentsPageProps {
@@ -820,6 +835,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(
     new Set(),
   );
+  const [search, setSearch] = useState("");
 
   const rawScope = useAgentsViewStore((s) => s.scope);
   const scope = AGENT_SCOPES.includes(rawScope) ? rawScope : "mine";
@@ -926,9 +942,11 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
     isWorkspaceAdmin,
   ]);
 
-  // Visible rows: filters, then sort.
+  // Visible rows: local search + filters, then sort.
   const rows = useMemo<AgentListRow[]>(() => {
+    const q = search.trim().toLowerCase();
     const filtered = scopeRows.filter((row) => {
+      if (!matchesAgentSearch(row, q)) return false;
       if (
         filters.availability.length > 0 &&
         (!row.presence ||
@@ -984,7 +1002,25 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
       );
     });
     return filtered;
-  }, [scopeRows, filters, sortField, sortDirection]);
+  }, [scopeRows, search, filters, sortField, sortDirection]);
+
+  const noMatchText = useMemo(() => {
+    const query = search.trim();
+    if (query) {
+      if (scope === "archived") {
+        return t(($) => $.no_matches.search_archived, { query });
+      }
+      if (countActiveFilterDimensions(filters) > 0) {
+        return t(($) => $.no_matches.search_active_filtered, { query });
+      }
+      return t(($) => $.no_matches.search_active, { query });
+    }
+    if (scope === "archived") return t(($) => $.no_matches.no_archived);
+    if (countActiveFilterDimensions(filters) > 0) {
+      return t(($) => $.no_matches.no_filter_match);
+    }
+    return t(($) => $.no_matches.title);
+  }, [filters, scope, search, t]);
 
   // Row virtualization — headless math, offsets as padding on the rows
   // wrapper, fixed-height rows. The scroll element is the SINGLE outer
@@ -1077,6 +1113,8 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
             scope={scope}
             onScopeChange={setScope}
             scopeCounts={scopeCounts}
+            search={search}
+            onSearchChange={setSearch}
             filters={filters}
             onToggleFilter={toggleFilter}
             onClearFilters={clearFilters}
@@ -1116,7 +1154,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
               >
                 {rows.length === 0 && (
                   <div className="col-span-full py-16 text-center text-sm text-muted-foreground">
-                    {t(($) => $.no_matches.title)}
+                    {noMatchText}
                   </div>
                 )}
                 {virtualItems.map((vi) => {


### PR DESCRIPTION
Summary:
- Add a local search box to the Agents list toolbar.
- Filter agents by name, pinyin, and description before existing filters and sorting.
- Show contextual empty-state text when search returns no matches.

Verification:
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views exec eslint agents/components/agents-page.tsx agents/components/agent-list-toolbar.tsx