### PR TITLE
MUL-4141: fix(desktop): resolve electron-vite bin via PATH in dev script

### DIFF
--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -13,6 +13,7 @@ import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { envWithLocalBins } from "./package.mjs";
 import {
   applyWorktreeDevEnv,
   repoRootFromScriptDir,
@@ -25,10 +26,10 @@ applyWorktreeDevEnv(process.env, {
   log: true,
 });
 
-function run(command, args, { shell = false } = {}) {
+function run(command, args, { shell = false, env = process.env } = {}) {
   const result = spawnSync(command, args, {
     stdio: "inherit",
-    env: process.env,
+    env,
     shell,
   });
   if (result.error) {
@@ -43,11 +44,10 @@ run(node, [join(here, "bundle-cli.mjs")]);
 run(node, [join(here, "brand-dev-electron.mjs")]);
 
 const isWin = process.platform === "win32";
-const electronVite = join(
-  here,
-  "..",
-  "node_modules",
-  ".bin",
-  isWin ? "electron-vite.cmd" : "electron-vite",
-);
-run(electronVite, ["dev", ...process.argv.slice(2)], { shell: isWin });
+// electron-vite's bin lands in apps/desktop/node_modules/.bin under the
+// isolated linker but only in the repo-root .bin under the hoisted linker
+// (.npmrc node-linker=hoisted); envWithLocalBins puts both on PATH.
+run("electron-vite", ["dev", ...process.argv.slice(2)], {
+  shell: isWin,
+  env: envWithLocalBins(process.env),
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `pnpm dev:desktop` failing with ENOENT when the repo is installed with `node-linker=hoisted`. The dev script hardcoded the electron-vite binary path as `apps/desktop/node_modules/.bin/electron-vite`, but under the hoisted linker pnpm only creates bin shims in the repo-root `node_modules/.bin`. Instead of guessing the path, the script now invokes `electron-vite` by name with `envWithLocalBins(process.env)`, which prepends both the package-local and repo-root `.bin` directories to `PATH` — the same approach the sibling scripts in `apps/desktop/scripts` already use, so it works under both linkers.

Thinking path: `pnpm dev:desktop` → `apps/desktop/scripts/dev.mjs` spawns electron-vite by hardcoded path → path only exists under the default isolated linker → reuse the existing `envWithLocalBins` helper from `package.mjs` rather than adding a second path-probing mechanism.

## Related Issue

Closes #4991

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `apps/desktop/scripts/dev.mjs`: import `envWithLocalBins` from `./package.mjs`; let `run()` accept an `env` option; replace the hardcoded `node_modules/.bin/electron-vite` path with a plain `electron-vite` invocation using the augmented PATH.

## How to Test

1. With the default isolated linker: `pnpm install && pnpm dev:desktop` — the desktop dev server starts as before.
2. Add `node-linker=hoisted` to `.npmrc`, reinstall with `pnpm install`.
3. Run `pnpm dev:desktop` — previously this exited with ENOENT for `apps/desktop/node_modules/.bin/electron-vite`; now electron-vite is resolved from the repo-root `.bin` and the dev server starts.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass (dev-script-only change; no unit tests cover it — verified manually by running `pnpm dev:desktop` under the hoisted linker)
- [ ] I have added or updated tests where applicable (not applicable for the dev launcher script)
- [ ] If this change affects the UI, I have included before/after screenshots (no UI change)
- [ ] I have updated relevant documentation to reflect my changes (no docs describe this internal script)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**
Described the ENOENT failure under the hoisted linker and asked Claude Code to fix the dev script; it reused the existing `envWithLocalBins` helper instead of adding new path-resolution logic, then created this issue/PR from the repo templates.

## Screenshots (optional)

Not applicable — dev tooling change only.