### PR TITLE
fix(daemon): harden background-task-safety brief against background-and-yield (MUL-4140)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -858,6 +858,15 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				"Do NOT end your turn while background tasks",
 				"wait for a future notification/reminder",
 				"run the work synchronously instead",
+				// Hardened pins (MUL-4140): the mechanism that slipped
+				// through in MUL-4091 was a turn ending cleanly with a
+				// "standing by, I'll report when CI finishes" message and
+				// no follow-up wakeup. These pins forbid that shape.
+				"Never background-and-yield",
+				"foreground tool call that blocks",
+				"gh run watch",
+				"running in the background so you can keep working",
+				"standing by",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -840,10 +840,11 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 func writeBackgroundTaskSafetyInstructions(b *strings.Builder) {
 	b.WriteString("## Background Task Safety\n\n")
-	b.WriteString("Multica marks this task terminal when your top-level agent process/turn exits. Any background work you started but did not collect before exiting can be orphaned: its result may be lost, and the user may see a completed/failed task even though the delegated work was never synthesized.\n\n")
-	b.WriteString("- Do NOT end your turn while background tasks, async subagents, background shell commands, or detached tool calls are still running.\n")
-	b.WriteString("- If a tool or runtime offers a background mode, use it only when you can explicitly wait for completion and collect the result before your final response.\n")
-	b.WriteString("- If a tool response says to wait for a future notification/reminder instead of collecting now, do not rely on that in Multica-managed runs. Block on the appropriate wait/output/collect operation before exiting.\n")
+	b.WriteString("Multica marks this task terminal the moment your top-level agent process/turn exits. A Multica-managed run has NO \"background work finishes later and wakes you up\" step: whatever you leave running in the background is orphaned, its result is lost, and the final comment you meant to post once it finished never sends. The user sees a task that ended with no conclusion and has to re-trigger you.\n\n")
+	b.WriteString("- Do NOT end your turn while background tasks, async subagents, background shell commands, or detached tool calls are still running. Never background-and-yield: never end a turn expecting a future notification, reminder, or wakeup to let you resume — that wakeup does not exist here.\n")
+	b.WriteString("- Do every wait synchronously inside a single foreground tool call that blocks until the work is done — e.g. `gh run watch <run-id>` for CI, or a blocking test/build command. Never split \"start the wait\" into this turn and \"collect the result\" into a later turn.\n")
+	b.WriteString("- If a tool response says to wait for a future notification/reminder, or tells you it is now running in the background so you can keep working, do NOT rely on that in Multica-managed runs — that hint comes from the standalone harness and does not apply here. Block on the appropriate wait/output/collect operation before exiting.\n")
 	b.WriteString("- If you cannot observe or collect a background task's result, do not spawn it in the background; run the work synchronously instead.\n")
+	b.WriteString("- Never end a turn with a \"standing by\" / \"I'll report back once X finishes\" / \"waiting for CI\" message. That message becomes your final output and the task ends immediately — either finish the wait synchronously now and report the real outcome, or post the result you already have.\n")
 	b.WriteString("- Before posting your final result or exiting silently, account for every background task you started and incorporate its output or failure into your response.\n\n")
 }

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -281,3 +281,35 @@ func TestSlimBriefIsSubstantiallyShorter(t *testing.T) {
 	}
 	t.Logf("slim brief reduction: %.1f%% (legacy=%d, slim=%d, Δ=%d)", ratio*100, len(legacy), len(slim), len(legacy)-len(slim))
 }
+
+// TestBackgroundTaskSafetySlimHardPins asserts the slim brief carries the
+// same hardened Background Task Safety pins as the legacy brief (MUL-4140).
+// The verbose path is covered by
+// TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic; this locks
+// the compressed slim path so a future slim-brief trim can't quietly drop
+// the no-background-and-yield / no-"standing by" guardrails that address
+// the MUL-4091 mechanism.
+func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
+	withSlimBrief(t)
+
+	out := buildMetaSkillContent("claude", TaskContextForEnv{
+		IssueID: "i-1", TriggerCommentID: "tc-1",
+		AgentName: "Eve", AgentID: "eve-1",
+	})
+
+	for _, want := range []string{
+		"## Background Task Safety",
+		"Do NOT end your turn while background tasks",
+		"wait for a future notification/reminder",
+		"run the work synchronously instead",
+		"Never background-and-yield",
+		"foreground tool call that blocks",
+		"gh run watch",
+		"running in the background so you can keep working",
+		"standing by",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out)
+		}
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -44,16 +44,18 @@ func writeHeader(b *strings.Builder) {
 
 // writeBackgroundTaskSafetySlim is the slim analogue of
 // writeBackgroundTaskSafetyInstructions (legacy). Drops the verbose
-// preamble and keeps the three behaviour pins (the same ones tests
-// assert): "Do NOT end your turn while background tasks",
-// "wait for a future notification/reminder", "run the work synchronously
-// instead".
+// preamble but keeps the same hard behaviour pins the tests assert:
+// "Do NOT end your turn while background tasks", "wait for a future
+// notification/reminder", "run the work synchronously instead", the
+// no-background-and-yield rule, and the no-"standing by" sign-off rule.
 func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("## Background Task Safety\n\n")
-	b.WriteString("Multica marks the task terminal when your top-level turn exits — any background work still running may be orphaned and its result lost.\n\n")
-	b.WriteString("- Do NOT end your turn while background tasks, async subagents, background shell commands, or detached tool calls are still running.\n")
-	b.WriteString("- If a tool response says to wait for a future notification/reminder, do not rely on that in Multica-managed runs — block on the appropriate wait / output / collect operation before exiting.\n")
-	b.WriteString("- If you can't observe a background task's result, run the work synchronously instead.\n\n")
+	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any background work still running is orphaned, its result lost, and the final comment you meant to post after it never sends. There is no background-completion wakeup here.\n\n")
+	b.WriteString("- Do NOT end your turn while background tasks, async subagents, background shell commands, or detached tool calls are still running. Never background-and-yield: never end a turn expecting a future notification or wakeup to resume — it will not arrive.\n")
+	b.WriteString("- Do every wait synchronously inside one foreground tool call that blocks to completion (e.g. `gh run watch`, a blocking test command); never split \"start the wait\" and \"collect the result\" across turns.\n")
+	b.WriteString("- If a tool response says to wait for a future notification/reminder, or that it is running in the background so you can keep working, do not rely on that in Multica-managed runs — block on the appropriate wait / output / collect operation before exiting.\n")
+	b.WriteString("- If you can't observe a background task's result, run the work synchronously instead.\n")
+	b.WriteString("- Never end a turn with a \"standing by\" / \"I'll report back when X finishes\" message — that becomes your final output and the task ends.\n\n")
 }
 
 // writeAgentIdentity emits the Agent Identity heading and (optionally) the


### PR DESCRIPTION
## Summary

A Multica-managed run goes **terminal the moment the top-level turn exits** — there is no "background work finishes later and wakes you up" step. When an agent starts background work (a `run_in_background` shell, a `Monitor`, an async subagent) and then ends its turn to "wait for a completion notification", the work is orphaned, the result comment it meant to post is never sent, and the user sees a task that ended with no conclusion (the MUL-4091 / #4970 incident, where CI polling was pushed into a background shell + `Monitor` and the turn ended with a "Standing by" message).

This PR hardens the **Background Task Safety** runtime brief so the agent is told, in hard terms, never to background-and-yield.

## Why the brief, and not (only) a runtime hard-fail

Framed against the three-layer plan discussed on MUL-4140 (runtime hard constraint › harness-copy de-misleading › prompt constraint):

- **A partial runtime/protocol guard already exists — for Claude only** (`server/pkg/agent/claude.go`): it rewrites `run_in_background: true → false` on tool control requests (`forceClaudeToolInputForeground`) and fails the run loud if an `async_launched` tool result slips through. That guard is real and stays.
- **It cannot catch the actual MUL-4091 mechanism.** The incident wasn't a caught `run_in_background` input — it was a turn that *ended cleanly* with a "Standing by, I'll report when CI finishes" message. A clean turn-exit is indistinguishable from a legitimate one at the protocol layer, so no presence-check can flag it. That shape is only addressable **behaviorally**, and behavioral guidance is **harness-agnostic** (covers claude, codex, openclaw, everything) — whereas the protocol guard is claude-only.

So this PR ships the layer that actually closes the observed hole. Deliberately **out of scope** here (tracked as follow-ups): a harness-agnostic runtime "bounded-drain / re-wakeup with timeout, then fail loud" constraint (needs new background-handle tracking machinery that doesn't exist yet), and porting the claude protocol guard to the codex/openclaw backends.

## Changes

Hardened `writeBackgroundTaskSafetyInstructions` (legacy/verbose — the **production** path) and `writeBackgroundTaskSafetySlim` (slim — the staging path) in `server/internal/daemon/execenv/` with explicit pins:

- **Never background-and-yield** — never end a turn expecting a future notification/reminder/wakeup to resume; that wakeup does not exist in a Multica-managed run.
- **Do every wait synchronously in one foreground call** that blocks to completion (e.g. `gh run watch <run-id>`, a blocking test/build command); never split "start the wait" and "collect the result" across turns.
- The standalone-harness hint *"it's running in the background, you can keep working"* **does not apply here** — ignore it.
- **Never end a turn with a "standing by" / "I'll report back once X finishes" sign-off** — that message becomes your final output and the task ends immediately.

Both the pre-existing asserted substrings and the new pins are covered by tests, so a future brief trim can't quietly drop the guardrails.

## Testing

- `go vet ./internal/daemon/execenv/` — clean.
- `go test ./internal/daemon/execenv/ -count=1` — full package passes, including:
  - `TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic` — extended to assert the new verbose-path pins across claude/codex/opencode/hermes.
  - `TestBackgroundTaskSafetySlimHardPins` — new slim-path coverage for the same pins.
  - `TestSlimBriefIsSubstantiallyShorter` / `TestBuildMetaSkillContentSlimKindMatrix` — unaffected.
- `gofmt` clean; no built-in `SKILL.md` documents this brief (nothing to sync).

Relates to MUL-4140. Incident: MUL-4091 / #4970.
