### PR TITLE
Fix mobile write response validation and move search store

### DIFF
--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -99,6 +99,8 @@ import {
   EMPTY_USER,
   EMPTY_WORKSPACE_LIST,
   InboxListSchema,
+  IssueLabelsResponseSchema,
+  LabelSchema,
   NotificationPreferenceResponseSchema,
   ListLabelsResponseSchema,
   ListProjectResourcesResponseSchema,
@@ -106,6 +108,7 @@ import {
   MemberListSchema,
   PinListSchema,
   PinnedItemSchema,
+  ProjectResourceSchema,
   ProjectSchema,
   RuntimeListSchema,
   SearchIssuesResponseSchema,
@@ -359,6 +362,30 @@ class ApiClient {
     return parseWithFallback(raw, schema, fallback, {
       endpoint: opts?.endpoint ?? `${init.method ?? "GET"} ${path}`,
     });
+  }
+
+  /** Strict write-side validation for responses that immediately seed UI
+   *  caches. A malformed 2xx response must behave like a failed mutation so
+   *  optimistic updates roll back instead of persisting bad cache data. */
+  private async fetchStrictWith<T>(
+    path: string,
+    schema: ZodType,
+    init: RequestInit,
+    opts: { endpoint: string; message: string; signal?: AbortSignal },
+  ): Promise<T> {
+    const raw = await this.fetch<unknown>(path, {
+      ...init,
+      signal: opts.signal ?? init.signal ?? undefined,
+    });
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      console.error(`[api] ← shape mismatch ${opts.endpoint}`, {
+        issues: parsed.error.issues,
+        received: raw,
+      });
+      throw new ApiError(opts.message, 0, raw);
+    }
+    return parsed.data as T;
   }
 
   // --- Auth ---
@@ -615,10 +642,18 @@ class ApiClient {
   // CreateIssue). Mobile sends only the fields the form fills in; backend
   // applies its own defaults for anything omitted.
   async createIssue(body: CreateIssueRequest): Promise<Issue> {
-    return this.fetch<Issue>("/api/issues", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+    return this.fetchStrictWith(
+      "/api/issues",
+      IssueSchema,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+      {
+        endpoint: "POST /api/issues",
+        message: "Create issue response invalid",
+      },
+    );
   }
 
   // Timeline returns the full ASC entry list in one shot — server-side
@@ -804,10 +839,18 @@ class ApiClient {
   // Method is PUT to match backend router (server/cmd/server/router.go:327)
   // and web client (packages/core/api/client.ts:465).
   async updateIssue(id: string, body: UpdateIssueRequest): Promise<Issue> {
-    return this.fetch<Issue>(`/api/issues/${id}`, {
-      method: "PUT",
-      body: JSON.stringify(body),
-    });
+    return this.fetchStrictWith(
+      `/api/issues/${id}`,
+      IssueSchema,
+      {
+        method: "PUT",
+        body: JSON.stringify(body),
+      },
+      {
+        endpoint: "PUT /api/issues/:id",
+        message: "Update issue response invalid",
+      },
+    );
   }
 
   // Backend returns 204 No Content on success
@@ -837,21 +880,34 @@ class ApiClient {
   // used — same convention as createProject (cache rollback on failure is
   // preferable to a parseWithFallback fallback that would mask server errors).
   async createLabel(body: CreateLabelRequest): Promise<Label> {
-    return this.fetch<Label>("/api/labels", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+    return this.fetchStrictWith(
+      "/api/labels",
+      LabelSchema,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+      {
+        endpoint: "POST /api/labels",
+        message: "Create label response invalid",
+      },
+    );
   }
 
   async attachLabel(
     issueId: string,
     labelId: string,
   ): Promise<IssueLabelsResponse> {
-    return this.fetch<IssueLabelsResponse>(
+    return this.fetchStrictWith(
       `/api/issues/${issueId}/labels`,
+      IssueLabelsResponseSchema,
       {
         method: "POST",
         body: JSON.stringify({ label_id: labelId }),
+      },
+      {
+        endpoint: "POST /api/issues/:id/labels",
+        message: "Attach label response invalid",
       },
     );
   }
@@ -860,9 +916,14 @@ class ApiClient {
     issueId: string,
     labelId: string,
   ): Promise<IssueLabelsResponse> {
-    return this.fetch<IssueLabelsResponse>(
+    return this.fetchStrictWith(
       `/api/issues/${issueId}/labels/${labelId}`,
+      IssueLabelsResponseSchema,
       { method: "DELETE" },
+      {
+        endpoint: "DELETE /api/issues/:id/labels/:labelId",
+        message: "Detach label response invalid",
+      },
     );
   }
 
@@ -924,20 +985,36 @@ class ApiClient {
   // patch rolls back; pretending the write succeeded with empty data
   // would silently desync caches.
   async createProject(body: CreateProjectRequest): Promise<Project> {
-    return this.fetch<Project>("/api/projects", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+    return this.fetchStrictWith(
+      "/api/projects",
+      ProjectSchema,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+      {
+        endpoint: "POST /api/projects",
+        message: "Create project response invalid",
+      },
+    );
   }
 
   async updateProject(
     id: string,
     body: UpdateProjectRequest,
   ): Promise<Project> {
-    return this.fetch<Project>(`/api/projects/${id}`, {
-      method: "PUT",
-      body: JSON.stringify(body),
-    });
+    return this.fetchStrictWith(
+      `/api/projects/${id}`,
+      ProjectSchema,
+      {
+        method: "PUT",
+        body: JSON.stringify(body),
+      },
+      {
+        endpoint: "PUT /api/projects/:id",
+        message: "Update project response invalid",
+      },
+    );
   }
 
   async deleteProject(id: string): Promise<void> {
@@ -965,11 +1042,16 @@ class ApiClient {
     projectId: string,
     body: CreateProjectResourceRequest,
   ): Promise<ProjectResource> {
-    return this.fetch<ProjectResource>(
+    return this.fetchStrictWith(
       `/api/projects/${projectId}/resources`,
+      ProjectResourceSchema,
       {
         method: "POST",
         body: JSON.stringify(body),
+      },
+      {
+        endpoint: "POST /api/projects/:id/resources",
+        message: "Create project resource response invalid",
       },
     );
   }

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -126,7 +126,7 @@ export const EMPTY_NOTIFICATION_PREFERENCES = {
   preferences: {},
 } as const;
 
-const LabelSchema = z.object({
+export const LabelSchema = z.object({
   id: z.string(),
   workspace_id: z.string(),
   name: z.string(),
@@ -213,7 +213,7 @@ export const EMPTY_PROJECT: Project = {
 // repos). resource_ref shape varies per resource_type; lenient on both
 // `resource_type` (so a future type doesn't crash the list) and
 // `resource_ref` (passes through unchanged for the renderer to dispatch on).
-const ProjectResourceSchema = z.object({
+export const ProjectResourceSchema = z.object({
   id: z.string(),
   project_id: z.string(),
   workspace_id: z.string(),

--- a/apps/mobile/lib/api-write-validation.test.ts
+++ b/apps/mobile/lib/api-write-validation.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: vi.fn(),
+  setItemAsync: vi.fn(),
+  deleteItemAsync: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("mobile ApiClient write response validation", () => {
+  it("throws when updateIssue receives a malformed 2xx response", async () => {
+    vi.stubEnv("EXPO_PUBLIC_API_URL", "https://api.example.test");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "issue-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    const { api, ApiError } = await import("@/data/api");
+
+    await expect(api.updateIssue("issue-1", { title: "New title" })).rejects.toBeInstanceOf(
+      ApiError,
+    );
+  });
+
+  it("throws when createProject receives a malformed 2xx response", async () => {
+    vi.stubEnv("EXPO_PUBLIC_API_URL", "https://api.example.test");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "project-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    const { api, ApiError } = await import("@/data/api");
+
+    await expect(api.createProject({ title: "Mobile" })).rejects.toBeInstanceOf(
+      ApiError,
+    );
+  });
+});

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -468,6 +468,122 @@ describe("ApiClient", () => {
     ]);
   });
 
+  it("rejects malformed issue write responses", async () => {
+    const malformedIssue = {
+      id: "issue-1",
+      workspace_id: "ws-1",
+      // number must be a number; accepting this would corrupt issue caches.
+      number: "1",
+      identifier: "MUL-1",
+      title: "Bad issue",
+      description: null,
+      status: "todo",
+      priority: "medium",
+      assignee_type: null,
+      assignee_id: null,
+      creator_type: "member",
+      creator_id: "user-1",
+      parent_issue_id: null,
+      project_id: null,
+      position: 0,
+      stage: null,
+      start_date: null,
+      due_date: null,
+      metadata: {},
+      created_at: "2026-07-06T00:00:00Z",
+      updated_at: "2026-07-06T00:00:00Z",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedIssue), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedIssue), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+
+    await expect(client.createIssue({ title: "Bad issue" })).rejects.toMatchObject({
+      message: "invalid issue response",
+      status: 0,
+    });
+    await expect(client.updateIssue("issue-1", { title: "Bad issue" })).rejects.toMatchObject({
+      message: "invalid issue response",
+      status: 0,
+    });
+  });
+
+  it("rejects malformed comment write responses", async () => {
+    const malformedComment = {
+      id: "comment-1",
+      issue_id: "issue-1",
+      author_type: "member",
+      author_id: "user-1",
+      content: "hello",
+      type: "comment",
+      // parent_id must be string or null; accepting this would corrupt timeline caches.
+      parent_id: 123,
+      reactions: [],
+      attachments: [],
+      created_at: "2026-07-06T00:00:00Z",
+      updated_at: "2026-07-06T00:00:00Z",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedComment), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedComment), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedComment), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(malformedComment), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+
+    await expect(client.createComment("issue-1", "hello")).rejects.toMatchObject({
+      message: "invalid comment response",
+      status: 0,
+    });
+    await expect(client.updateComment("comment-1", "hello", [])).rejects.toMatchObject({
+      message: "invalid comment response",
+      status: 0,
+    });
+    await expect(client.resolveComment("comment-1")).rejects.toMatchObject({
+      message: "invalid comment response",
+      status: 0,
+    });
+    await expect(client.unresolveComment("comment-1")).rejects.toMatchObject({
+      message: "invalid comment response",
+      status: 0,
+    });
+  });
+
   it("uses the Cloud Runtime node API contract", async () => {
     const node = {
       id: "node-1",

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -153,6 +153,7 @@ import type {
   CreateCloudRuntimeNodeRequest,
   ListCloudRuntimeNodesParams,
 } from "../runtimes/cloud-runtime";
+import type { ZodType } from "zod";
 import { type Logger, noopLogger } from "../logger";
 import { createRequestId } from "../utils";
 import { getCurrentSlug } from "../platform/workspace-storage";
@@ -165,6 +166,7 @@ import {
   CancelTaskResponseSchema,
   ChatDraftRestoresResponseSchema,
   ChildIssuesResponseSchema,
+  CommentSchema,
   CommentsListSchema,
   CommentTriggerPreviewSchema,
   IssueTriggerPreviewSchema,
@@ -198,6 +200,7 @@ import {
   AppConfigSchema,
   type AppConfigResponse,
   GroupedIssuesResponseSchema,
+  IssueSchema,
   ListAutopilotsResponseSchema,
   EMPTY_LIST_AUTOPILOTS_RESPONSE,
   AutopilotRunSchema,
@@ -468,6 +471,30 @@ export class ApiClient {
     return res.json() as Promise<T>;
   }
 
+  // Strict write-side validation for responses that immediately seed React
+  // Query caches. A malformed 2xx response must behave like a failed mutation
+  // so optimistic updates roll back instead of persisting bad cache data.
+  private async fetchStrictWith<T>(
+    path: string,
+    schema: ZodType,
+    init: RequestInit,
+    opts: { endpoint: string; message: string; signal?: AbortSignal },
+  ): Promise<T> {
+    const raw = await this.fetch<unknown>(path, {
+      ...init,
+      signal: opts.signal ?? init.signal ?? undefined,
+    });
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      this.logger.error(`← shape mismatch ${opts.endpoint}`, {
+        issues: parsed.error.issues,
+        received: raw,
+      });
+      throw new ApiError(opts.message, 0, "Invalid Response", raw);
+    }
+    return parsed.data as T;
+  }
+
   // Auth
   async sendCode(email: string): Promise<void> {
     await this.fetch("/auth/send-code", {
@@ -662,26 +689,18 @@ export class ApiClient {
   }
 
   async createIssue(data: CreateIssueRequest): Promise<Issue> {
-    // Parse through a schema (not a raw cast): the create modal keys its
-    // label-attach compatibility fallback off `labels` being absent vs a
-    // validated Label[], so an unvalidated wrong shape must not slip through.
-    // Unlike list endpoints, a create that returns an unusable body is a
-    // FAILED mutation, not a safe-empty read: fall back to null and reject so
-    // the modal keeps the draft and shows a failure toast instead of a blank
-    // "created" card pointing at an empty issue id. parseWithFallback already
-    // logged the schema issues + raw payload; the empty message lets the modal
-    // render its localized "failed to create" toast.
-    const raw = await this.fetch<unknown>("/api/issues", {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
-    const issue = parseWithFallback<Issue | null>(raw, CreateIssueResponseSchema, null, {
-      endpoint: "POST /api/issues",
-    });
-    if (!issue) {
-      throw new Error();
-    }
-    return issue;
+    return this.fetchStrictWith(
+      "/api/issues",
+      CreateIssueResponseSchema,
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+      {
+        endpoint: "POST /api/issues",
+        message: "invalid issue response",
+      },
+    );
   }
 
   async quickCreateIssue(data: {
@@ -716,9 +735,12 @@ export class ApiClient {
   }
 
   async updateIssue(id: string, data: UpdateIssueRequest): Promise<Issue> {
-    return this.fetch(`/api/issues/${id}`, {
+    return this.fetchStrictWith(`/api/issues/${id}`, IssueSchema, {
       method: "PUT",
       body: JSON.stringify(data),
+    }, {
+      endpoint: "PUT /api/issues/:id",
+      message: "invalid issue response",
     });
   }
 
@@ -780,7 +802,7 @@ export class ApiClient {
     attachmentIds?: string[],
     suppressAgentIds?: string[],
   ): Promise<Comment> {
-    return this.fetch(`/api/issues/${issueId}/comments`, {
+    return this.fetchStrictWith(`/api/issues/${issueId}/comments`, CommentSchema, {
       method: "POST",
       body: JSON.stringify({
         content,
@@ -789,6 +811,9 @@ export class ApiClient {
         ...(attachmentIds?.length ? { attachment_ids: attachmentIds } : {}),
         ...(suppressAgentIds?.length ? { suppress_agent_ids: suppressAgentIds } : {}),
       }),
+    }, {
+      endpoint: "POST /api/issues/:id/comments",
+      message: "invalid comment response",
     });
   }
 
@@ -840,13 +865,16 @@ export class ApiClient {
   }
 
   async updateComment(commentId: string, content: string, attachmentIds?: string[], suppressAgentIds?: string[]): Promise<Comment> {
-    return this.fetch(`/api/comments/${commentId}`, {
+    return this.fetchStrictWith(`/api/comments/${commentId}`, CommentSchema, {
       method: "PUT",
       body: JSON.stringify({
         content,
         attachment_ids: attachmentIds,
         ...(suppressAgentIds?.length ? { suppress_agent_ids: suppressAgentIds } : {}),
       }),
+    }, {
+      endpoint: "PUT /api/comments/:id",
+      message: "invalid comment response",
     });
   }
 
@@ -855,11 +883,17 @@ export class ApiClient {
   }
 
   async resolveComment(commentId: string): Promise<Comment> {
-    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "POST" });
+    return this.fetchStrictWith(`/api/comments/${commentId}/resolve`, CommentSchema, { method: "POST" }, {
+      endpoint: "POST /api/comments/:id/resolve",
+      message: "invalid comment response",
+    });
   }
 
   async unresolveComment(commentId: string): Promise<Comment> {
-    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "DELETE" });
+    return this.fetchStrictWith(`/api/comments/${commentId}/resolve`, CommentSchema, { method: "DELETE" }, {
+      endpoint: "DELETE /api/comments/:id/resolve",
+      message: "invalid comment response",
+    });
   }
 
   async addReaction(commentId: string, emoji: string): Promise<Reaction> {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,7 @@
     "./squads": "./squads/index.ts",
     "./squads/stores": "./squads/stores/index.ts",
     "./permissions": "./permissions/index.ts",
+    "./search": "./search/index.ts",
     "./projects": "./projects/index.ts",
     "./projects/queries": "./projects/queries.ts",
     "./projects/mutations": "./projects/mutations.ts",

--- a/packages/core/search/index.ts
+++ b/packages/core/search/index.ts
@@ -1,0 +1,1 @@
+export { useSearchStore } from "./store";

--- a/packages/core/search/store.test.ts
+++ b/packages/core/search/store.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSearchStore } from "./store";
+
+describe("search store", () => {
+  beforeEach(() => {
+    useSearchStore.setState({ open: false });
+  });
+
+  it("starts closed", () => {
+    expect(useSearchStore.getState().open).toBe(false);
+  });
+
+  it("setOpen updates visibility", () => {
+    useSearchStore.getState().setOpen(true);
+    expect(useSearchStore.getState().open).toBe(true);
+  });
+
+  it("toggle flips visibility", () => {
+    useSearchStore.getState().toggle();
+    expect(useSearchStore.getState().open).toBe(true);
+    useSearchStore.getState().toggle();
+    expect(useSearchStore.getState().open).toBe(false);
+  });
+});

--- a/packages/core/search/store.ts
+++ b/packages/core/search/store.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { create } from "zustand";
 
 interface SearchStore {

--- a/packages/views/layout/global-shortcuts.tsx
+++ b/packages/views/layout/global-shortcuts.tsx
@@ -13,9 +13,9 @@ import {
 import { openCreateIssueWithPreference } from "@multica/core/issues/stores";
 import { useModalStore } from "@multica/core/modals";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useSearchStore } from "@multica/core/search";
 import { isImeComposing } from "@multica/core/utils";
 import { useNavigation } from "../navigation";
-import { useSearchStore } from "../search/search-store";
 
 const GLOBAL_ACTIONS: readonly ShortcutActionId[] = [
   "openSearch",

--- a/packages/views/search/index.ts
+++ b/packages/views/search/index.ts
@@ -1,3 +1,3 @@
 export { SearchCommand } from "./search-command";
 export { SearchTrigger } from "./search-trigger";
-export { useSearchStore } from "./search-store";
+export { useSearchStore } from "@multica/core/search";

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { SearchCommand } from "./search-command";
-import { useSearchStore } from "./search-store";
+import { useSearchStore } from "@multica/core/search";
 import enCommon from "../locales/en/common.json";
 import enAuth from "../locales/en/auth.json";
 import enSettings from "../locales/en/settings.json";

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -70,7 +70,7 @@ import { useNavigation } from "../navigation";
 import { useT } from "../i18n";
 import { matchesPinyin } from "../editor/extensions/pinyin-match";
 import { HighlightText } from "./highlight-text";
-import { useSearchStore } from "./search-store";
+import { useSearchStore } from "@multica/core/search";
 
 // Nav items reference WorkspacePaths method names so they can be resolved
 // against the current workspace slug at render time (see SearchCommand body).

--- a/packages/views/search/search-trigger.tsx
+++ b/packages/views/search/search-trigger.tsx
@@ -2,10 +2,8 @@
 
 import { Search } from "lucide-react";
 import { SidebarMenuButton } from "@multica/ui/components/ui/sidebar";
-import {
-  useShortcut,
-} from "@multica/core/shortcuts";
-import { useSearchStore } from "./search-store";
+import { useShortcut } from "@multica/core/shortcuts";
+import { useSearchStore } from "@multica/core/search";
 import { useT } from "../i18n";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
 


### PR DESCRIPTION
## Summary
- add strict mobile write-response validation for cache-seeding endpoints so malformed 2xx responses throw and trigger mutation rollback
- move the search command Zustand store from packages/views to packages/core/search
- add regression coverage for mobile write validation and the core search store

## Verification
- pnpm --filter @multica/mobile typecheck
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/mobile test
- pnpm --filter @multica/core test
- pnpm --filter @multica/views exec vitest run search/search-command.test.tsx