### PR TITLE
fix(chat): default chat window to closed on workspace open

### DIFF
--- a/packages/core/chat/store.test.ts
+++ b/packages/core/chat/store.test.ts
@@ -43,6 +43,30 @@ describe("newSessionDraftKey", () => {
   });
 });
 
+describe("chat store — open/closed default", () => {
+  it("starts closed when no preference is stored", () => {
+    const store = createChatStore({ storage: memStorage() });
+    expect(store.getState().isOpen).toBe(false);
+  });
+
+  it("honours an explicit stored 'open' preference", () => {
+    const storage = memStorage();
+    storage.setItem("multica:chat:isOpen", "true");
+    const store = createChatStore({ storage });
+    expect(store.getState().isOpen).toBe(true);
+  });
+
+  it("persists a toggle so the choice survives reload", () => {
+    const storage = memStorage();
+    const store = createChatStore({ storage });
+    store.getState().setOpen(true);
+    expect(storage.getItem("multica:chat:isOpen")).toBe("true");
+
+    const reloaded = createChatStore({ storage });
+    expect(reloaded.getState().isOpen).toBe(true);
+  });
+});
+
 describe("chat store — draft attachments", () => {
   let store: ReturnType<typeof createChatStore>;
 

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -30,7 +30,8 @@ const CHAT_EXPANDED_KEY = "multica:chat:expanded";
 /**
  * Open/closed preference, persisted globally (not per-workspace) — most users
  * have one habitual chat-panel preference across workspaces. Missing key =
- * new user (or cleared storage); default to OPEN so the chat is discoverable.
+ * new user (or cleared storage); default to CLOSED so opening a workspace
+ * never pops the chat window uninvited (the FAB keeps it discoverable).
  * Once the user toggles even once, their explicit choice is respected on
  * every subsequent reload.
  */
@@ -162,10 +163,10 @@ export function createChatStore(options: ChatStoreOptions) {
   };
 
   // Resolve initial isOpen from storage. The three-state read (null /
-  // "true" / "false") is what enables the "new user → open" default while
-  // still honouring an explicit "I closed it" choice on every reload.
+  // "true" / "false") keeps the "new user → closed" default while still
+  // honouring an explicit "I opened it" choice on every reload.
   const storedOpen = storage.getItem(OPEN_KEY);
-  const initialIsOpen = storedOpen === null ? true : storedOpen === "true";
+  const initialIsOpen = storedOpen === "true";
 
   const store = create<ChatState>((set, get) => ({
     isOpen: initialIsOpen,


### PR DESCRIPTION
## Summary

Opening a workspace no longer opens the chat window by default (MUL-4149).

- `packages/core/chat/store.ts`: when no `multica:chat:isOpen` preference is stored (new user / cleared storage), `isOpen` now initializes to `false` instead of `true`. The chat FAB keeps chat discoverable.
- An explicit stored preference (user opened or closed chat before) is still honoured on every reload — no change for users who deliberately keep chat open.
- Added unit tests for the closed default, the stored-open override, and toggle persistence.

## Verification

- `pnpm vitest run chat/store.test.ts` in `packages/core` — 6 passed.
- `pnpm --filter @multica/core typecheck` — clean.
- Verified in the local web app with Playwright: fresh storage → workspace opens with chat closed (FAB only); stored `"true"` → chat window still opens.
- E2E helpers already pin `multica:chat:isOpen=false`, so existing specs are unaffected.
