### PR TITLE
MUL-4117: feat(cli): add workspace member invite command

### DIFF
--- a/apps/docs/content/docs/cli/reference.zh.mdx
+++ b/apps/docs/content/docs/cli/reference.zh.mdx
@@ -225,6 +225,18 @@ multica workspace get <workspace-id> --output json
 multica workspace member list <workspace-id>
 ```
 
+### Invite Member
+
+按邮箱邀请成员加入 workspace。被邀请人会收到一条待接受（pending）的邀请，接受后才真正加入——不是即时添加。workspace 参数可选，接受完整 UUID、slug 或短 UUID 前缀（≥4 位十六进制），省略时用当前默认 workspace（`--workspace-id` / `MULTICA_WORKSPACE_ID` / profile 默认）。
+
+```bash
+multica workspace member invite alice@example.com
+multica workspace member invite alice@example.com <workspace-id> --role admin
+multica workspace member invite alice@example.com --output json
+```
+
+`--role` 默认 `member`，可传 `admin`；不允许邀请 `owner`。目前只支持邮箱标识（不做用户名/工号解析）。若该邮箱已是成员或已有待接受邀请，服务端返回 409 并给出对应提示。
+
 ### Update Workspace
 
 需要 admin 或 owner 权限。所有字段都是部分更新（PATCH 语义）：未传的字段保持不变。

--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -46,6 +46,21 @@ var workspaceMemberListCmd = &cobra.Command{
 	RunE:  runWorkspaceMembers,
 }
 
+var workspaceMemberInviteCmd = &cobra.Command{
+	Use:   "invite <email> [workspace-id|slug|prefix]",
+	Short: "Invite a member to a workspace by email",
+	Long: "Sends a workspace invitation to an email address. The invitee gets a " +
+		"pending invitation they must accept before they join — this does not " +
+		"add them instantly. The optional workspace argument accepts a full " +
+		"UUID, a slug, or a short UUID prefix (≥4 hex chars) as shown in " +
+		"'workspace list'; if omitted the current default workspace is used " +
+		"(--workspace-id / MULTICA_WORKSPACE_ID / profile default).\n\n" +
+		"Role defaults to 'member'; pass '--role admin' to invite an admin. " +
+		"Owners cannot be invited.",
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runWorkspaceMemberInvite,
+}
+
 var workspaceUpdateCmd = &cobra.Command{
 	Use:   "update [workspace-id|slug|prefix]",
 	Short: "Update workspace metadata (admin/owner only)",
@@ -74,6 +89,7 @@ func init() {
 	workspaceCmd.AddCommand(workspaceGetCmd)
 	workspaceCmd.AddCommand(workspaceMemberCmd)
 	workspaceMemberCmd.AddCommand(workspaceMemberListCmd)
+	workspaceMemberCmd.AddCommand(workspaceMemberInviteCmd)
 	workspaceCmd.AddCommand(workspaceUpdateCmd)
 	workspaceCmd.AddCommand(workspaceSwitchCmd)
 
@@ -81,6 +97,8 @@ func init() {
 	workspaceListCmd.Flags().Bool("full-id", false, "Show full UUIDs in table output")
 	workspaceGetCmd.Flags().String("output", "json", "Output format: table or json")
 	workspaceMemberListCmd.Flags().String("output", "table", "Output format: table or json")
+	workspaceMemberInviteCmd.Flags().String("role", "member", "Member role to grant: member or admin (owner is not allowed)")
+	workspaceMemberInviteCmd.Flags().String("output", "table", "Output format: table or json")
 
 	workspaceUpdateCmd.Flags().String("name", "", "New workspace name")
 	workspaceUpdateCmd.Flags().String("description", "", "New description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
@@ -468,5 +486,59 @@ func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
 		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+func runWorkspaceMemberInvite(cmd *cobra.Command, args []string) error {
+	email := strings.ToLower(strings.TrimSpace(args[0]))
+	if email == "" {
+		return fmt.Errorf("email is required")
+	}
+
+	// Validate the role client-side to fail fast with a clear message; the
+	// server enforces the same rule (normalizeMemberRole rejects unknown roles
+	// and CreateInvitation refuses owner). Keep the accepted set in sync.
+	role, _ := cmd.Flags().GetString("role")
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		role = "member"
+	}
+	switch role {
+	case "member", "admin":
+	case "owner":
+		return fmt.Errorf("cannot invite as owner; use --role member or --role admin")
+	default:
+		return fmt.Errorf("invalid --role %q; expected member or admin", role)
+	}
+
+	wsID, err := resolveWorkspaceArg(cmd, args[1:])
+	if err != nil {
+		return err
+	}
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass an id/slug/prefix as argument or set MULTICA_WORKSPACE_ID")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body := map[string]any{"email": email, "role": role}
+	var inv map[string]any
+	if err := client.PostJSON(ctx, "/api/workspaces/"+wsID+"/members", body, &inv); err != nil {
+		return fmt.Errorf("invite member: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, inv)
+	}
+
+	fmt.Fprintf(os.Stdout, "Invitation sent to %s (role: %s, status: %s)\n",
+		strVal(inv, "invitee_email"), strVal(inv, "role"), strVal(inv, "status"))
 	return nil
 }

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -402,3 +402,139 @@ func TestBuildWorkspaceUpdateBody(t *testing.T) {
 		}
 	})
 }
+
+func newWorkspaceMemberInviteTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "invite"}
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("role", "member", "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func TestWorkspaceMemberInviteCommandIsRegistered(t *testing.T) {
+	cmd, _, err := workspaceMemberCmd.Find([]string{"invite", "alice@example.com"})
+	if err != nil {
+		t.Fatalf("find invite command: %v", err)
+	}
+	if cmd == nil || cmd.Name() != "invite" {
+		t.Fatalf("invite command not registered; got %#v", cmd)
+	}
+	for _, flag := range []string{"role", "output"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("invite command missing --%s flag", flag)
+		}
+	}
+}
+
+func TestRunWorkspaceMemberInvitePostsInvitation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
+
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if r.Header.Get("X-Workspace-ID") != "workspace-123" {
+			t.Fatalf("X-Workspace-ID = %q, want workspace-123", r.Header.Get("X-Workspace-ID"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"invitee_email": "alice@example.com",
+			"role":          "member",
+			"status":        "pending",
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := newWorkspaceMemberInviteTestCmd()
+	// A mixed-case email should be lowercased before it is sent.
+	if err := runWorkspaceMemberInvite(cmd, []string{"Alice@Example.com"}); err != nil {
+		t.Fatalf("runWorkspaceMemberInvite: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/workspaces/workspace-123/members" {
+		t.Fatalf("path = %q, want /api/workspaces/workspace-123/members", gotPath)
+	}
+	if gotBody["email"] != "alice@example.com" {
+		t.Fatalf("body email = %v, want alice@example.com", gotBody["email"])
+	}
+	if gotBody["role"] != "member" {
+		t.Fatalf("body role = %v, want member (default)", gotBody["role"])
+	}
+}
+
+func TestRunWorkspaceMemberInviteUsesWorkspaceArgAndRoleFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	const wsUUID = "11111111-1111-1111-1111-111111111111"
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"invitee_email": "bob@example.com", "role": "admin", "status": "pending"})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := newWorkspaceMemberInviteTestCmd()
+	_ = cmd.Flags().Set("role", "admin")
+	// A full UUID positional is forwarded as-is, without a /api/workspaces lookup.
+	if err := runWorkspaceMemberInvite(cmd, []string{"bob@example.com", wsUUID}); err != nil {
+		t.Fatalf("runWorkspaceMemberInvite: %v", err)
+	}
+	if gotPath != "/api/workspaces/"+wsUUID+"/members" {
+		t.Fatalf("path = %q, want /api/workspaces/%s/members", gotPath, wsUUID)
+	}
+	if gotBody["role"] != "admin" {
+		t.Fatalf("body role = %v, want admin", gotBody["role"])
+	}
+}
+
+func TestRunWorkspaceMemberInviteRejectsOwnerRole(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := newWorkspaceMemberInviteTestCmd()
+	_ = cmd.Flags().Set("role", "owner")
+	if err := runWorkspaceMemberInvite(cmd, []string{"alice@example.com"}); err == nil {
+		t.Fatal("expected error for --role owner, got nil")
+	}
+	if called {
+		t.Fatal("owner role should be rejected client-side without an HTTP call")
+	}
+}
+
+func TestRunWorkspaceMemberInviteRejectsUnknownRole(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "workspace-123")
+
+	cmd := newWorkspaceMemberInviteTestCmd()
+	_ = cmd.Flags().Set("role", "superuser")
+	if err := runWorkspaceMemberInvite(cmd, []string{"alice@example.com"}); err == nil {
+		t.Fatal("expected error for unknown --role, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a CLI command to invite workspace members, closing the gap where `multica workspace member` only had `list`.

Closes #4967

```bash
multica workspace member invite alice@example.com
multica workspace member invite alice@example.com <workspace-id|slug|prefix> --role admin
multica workspace member invite alice@example.com --output json
```

This is a thin wrapper over the existing `POST /api/workspaces/{id}/members` invitation endpoint (`server/internal/handler/invitation.go`) — no backend changes.

### Behavior

- **Email is the only identity input.** No username / employee-id resolution (the backend API doesn't support it), matching the scope agreed on the issue.
- **`--role`** defaults to `member`, also accepts `admin`. `owner` is rejected client-side with a clear message, mirroring the server (`normalizeMemberRole` + `CreateInvitation`).
- **Workspace targeting** matches `workspace member list`: an optional positional (`UUID` / slug / short prefix), otherwise the standard `--workspace-id` / `MULTICA_WORKSPACE_ID` / profile default chain.
- **Invitation semantics** are surfaced honestly: the invitee gets a *pending* invitation to accept — it is not an instant add. Server conflict responses (already a member / already-pending → 409) propagate as errors.
- `--output` defaults to `table` (prints a one-line confirmation); `json` prints the raw invitation object.

### Testing

- `go build ./cmd/multica/`, `go vet`, `gofmt` — clean.
- New tests in `cmd_workspace_test.go` (all passing): command registration + flags, POST path/body with default role and email lowercasing, workspace positional arg + `--role admin`, and client-side rejection of `owner` / unknown roles (no HTTP call).
- Verified `--help` output for `workspace member` and `workspace member invite`.

Docs: updated `apps/docs/content/docs/cli/reference.zh.mdx` with an "Invite Member" section.

MUL-4117
