### PR TITLE
fix(web): stop login arrival effect from racing fresh form logins (#5009)

### DIFF
--- a/apps/web/app/(auth)/login/page.test.tsx
+++ b/apps/web/app/(auth)/login/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -25,26 +25,35 @@ const {
   mockSendCode,
   mockVerifyCode,
   mockIssueCliToken,
+  mockListWorkspaces,
+  mockListMyInvitations,
+  mockPush,
+  mockReplace,
   searchParamsState,
   authStateRef,
 } = vi.hoisted(() => ({
   mockSendCode: vi.fn(),
   mockVerifyCode: vi.fn(),
   mockIssueCliToken: vi.fn(),
+  mockListWorkspaces: vi.fn(),
+  mockListMyInvitations: vi.fn(),
+  mockPush: vi.fn(),
+  mockReplace: vi.fn(),
   searchParamsState: { params: new URLSearchParams() },
   authStateRef: {
     state: {
       sendCode: vi.fn(),
       verifyCode: vi.fn(),
-      user: null as null | { id: string; email: string },
+      user: null as null | { id: string; email: string; onboarded_at?: string | null },
       isLoading: false,
     },
   },
 }));
 
-// Mock next/navigation
+// Mock next/navigation — router spies are hoisted so tests can assert
+// which navigation (if any) the page issued.
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
   usePathname: () => "/login",
   useSearchParams: () => searchParamsState.params,
 }));
@@ -76,7 +85,8 @@ vi.mock("@/features/auth/auth-cookie", () => ({
 // Mock api
 vi.mock("@multica/core/api", () => ({
   api: {
-    listWorkspaces: vi.fn().mockResolvedValue([]),
+    listWorkspaces: mockListWorkspaces,
+    listMyInvitations: mockListMyInvitations,
     verifyCode: vi.fn(),
     setToken: vi.fn(),
     getMe: vi.fn(),
@@ -92,6 +102,8 @@ describe("LoginPage", () => {
     searchParamsState.params = new URLSearchParams();
     authStateRef.state.user = null;
     authStateRef.state.isLoading = false;
+    mockListWorkspaces.mockResolvedValue([]);
+    mockListMyInvitations.mockResolvedValue([]);
   });
 
   it("renders login form with email input and continue button", () => {
@@ -203,5 +215,64 @@ describe("LoginPage", () => {
         value: originalLocation,
       });
     }
+  });
+
+  // Regression: #5009 — the "already authenticated on arrival" effect used to
+  // fire for fresh form logins too. verifyCode writes `user` while handleVerify
+  // is still fetching the workspace list, so the effect read an empty cache and
+  // raced handleSuccess with replace("/workspaces/new"); depending on the
+  // interleaving the user could end up stuck on the create-workspace page
+  // despite having workspaces.
+  describe("post-login redirect ownership (#5009)", () => {
+    const onboardedUser = {
+      id: "u1",
+      email: "test@multica.ai",
+      onboarded_at: "2026-01-01T00:00:00Z",
+    };
+
+    it("does not redirect from the arrival effect when the user logs in via the form", async () => {
+      // Auth settles as logged-out first — the page latches "any user from
+      // now on came from the form".
+      const wrapper = createWrapper();
+      const { rerender } = render(<LoginPage />, { wrapper });
+      // verifyCode set the user; the workspace list fetch is still in flight
+      // (cache cold). The arrival effect must stay silent — handleSuccess
+      // owns this navigation.
+      authStateRef.state.user = onboardedUser;
+      rerender(<LoginPage />);
+
+      await act(async () => {});
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockListWorkspaces).not.toHaveBeenCalled();
+    });
+
+    it("fetches the workspace list before redirecting a visitor who arrived authenticated", async () => {
+      // Cold Query cache on a fresh page load: reading it would say "no
+      // workspaces" and misroute to /workspaces/new. The effect must fetch.
+      authStateRef.state.user = onboardedUser;
+      mockListWorkspaces.mockResolvedValue([{ id: "ws-1", slug: "acme" }]);
+
+      render(<LoginPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith("/acme/issues");
+      });
+      expect(mockListWorkspaces).toHaveBeenCalledTimes(1);
+    });
+
+    it("still honors ?next= for a visitor who arrived authenticated", async () => {
+      searchParamsState.params = new URLSearchParams({
+        next: "/invite/abc",
+      });
+      authStateRef.state.user = onboardedUser;
+
+      render(<LoginPage />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith("/invite/abc");
+      });
+      expect(mockListWorkspaces).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { sanitizeNextUrl, useAuthStore } from "@multica/core/auth";
 import { useConfigStore } from "@multica/core/config";
-import { workspaceKeys } from "@multica/core/workspace/queries";
+import {
+  workspaceKeys,
+  workspaceListOptions,
+} from "@multica/core/workspace/queries";
 import {
   paths,
   resolvePostAuthDestination,
@@ -77,11 +80,21 @@ function LoginPageContent() {
   const [desktopError, setDesktopError] = useState("");
   const hasOnboarded = useHasOnboarded();
 
-  // Already authenticated — honor ?next= or fall back to first workspace
-  // (or /onboarding if the user has none). Skip this entire path when
-  // the user arrived to authorize the CLI.
+  // Latched once auth has been observed settled as logged-out on this page.
+  // Any `user` that appears afterwards came from the login form in this
+  // session — not from an existing session found on arrival.
+  const settledLoggedOutRef = useRef(false);
+
+  // Already authenticated ON ARRIVAL — honor ?next= or fall back to first
+  // workspace (or /onboarding if the user has none). Skip this entire path
+  // when the user arrived to authorize the CLI.
   useEffect(() => {
-    if (isLoading || !user || cliCallbackRaw) return;
+    if (isLoading) return;
+    if (!user) {
+      settledLoggedOutRef.current = true;
+      return;
+    }
+    if (cliCallbackRaw) return;
     if (isDesktopHandoff) {
       // Desktop opened the browser for login but the web session is already
       // authenticated — mint a bearer token from the cookie session and hand
@@ -101,14 +114,26 @@ function LoginPageContent() {
         });
       return;
     }
+    // Fresh form login (issue #5009): `user` was written by verifyCode while
+    // handleVerify was still fetching the workspace list, so this effect used
+    // to read the not-yet-seeded list cache and race handleSuccess with a
+    // replace to /workspaces/new. handleSuccess owns post-login navigation;
+    // this effect only serves visitors who arrived already authenticated.
+    if (settledLoggedOutRef.current) return;
     if (nextUrl) {
       router.replace(nextUrl);
       return;
     }
-    const list = qc.getQueryData<Workspace[]>(workspaceKeys.list()) ?? [];
-    void resolveLoggedInDestination(qc, hasOnboarded, list).then((dest) =>
-      router.replace(dest),
-    );
+    // Fetch instead of reading the cache: on a fresh page load the cache is
+    // cold, and `getQueryData() ?? []` would misroute a user who does have
+    // workspaces to /workspaces/new. On fetch failure fall back to [] —
+    // same destination the cold-cache read produced, rather than trapping
+    // the user on the login page.
+    void qc
+      .ensureQueryData(workspaceListOptions())
+      .catch(() => [] as Workspace[])
+      .then((list) => resolveLoggedInDestination(qc, hasOnboarded, list))
+      .then((dest) => router.replace(dest));
   }, [isLoading, user, router, nextUrl, cliCallbackRaw, isDesktopHandoff, hasOnboarded, qc]);
 
   const handleSuccess = async () => {


### PR DESCRIPTION
## Problem (#5009)

After a fresh email-code login, users with existing workspaces could land on `/workspaces/new` instead of their workspace.

Two navigators race after `verifyCode` writes `user` into the auth store:

1. `handleVerify` (`packages/views/auth/login-page.tsx`) — still fetching the workspace list; seeds the cache, then `onSuccess` → `handleSuccess` pushes the correct destination.
2. The `/login` page's "already authenticated" effect (`apps/web/app/(auth)/login/page.tsx:84`) — fires on the `user` change immediately, reads the **not-yet-seeded** list cache (`getQueryData() ?? []`), resolves "zero workspaces", and replaces to `/workspaces/new`.

Which navigation lands last is a coin flip (the effect's un-onboarded leg awaits `listMyInvitations`), so the reporter ended up stuck on the create-workspace page.

Same structural bug as #4983's crash: an explicit flow and a passive watcher both reacting to one state transition, with the watcher firing inside a data-not-yet-consistent window.

## Fix

Both changes in the arrival effect; `handleVerify`/`handleSuccess` untouched:

- **Single ownership** — latch once auth is observed settled as logged-out on this page. Any `user` appearing afterwards came from the login form, and `handleSuccess` owns that navigation; the effect now serves only visitors who **arrived** authenticated. The desktop-handoff branch sits above the latch, so form logins with `platform=desktop` still mint the deep-link token.
- **Correct data for the remaining case** — an arrived-authenticated visitor on a fresh page load has a cold cache; `getQueryData() ?? []` misrouted workspace owners to `/workspaces/new` (second latent bug on the same line). The effect now fetches via `ensureQueryData(workspaceListOptions())`, falling back to `[]` only on fetch failure.

About the issue's proposed options: swapping `verifyCode`/`listWorkspaces` (option A) can't work — the list call needs the token that `verifyCode` obtains (401); `fetchQuery` in `handleSuccess` (option B) doesn't touch the racing effect. Option C (guard) is directionally what this PR does, implemented as a mount-session latch so no cross-component flag plumbing is needed.

Desktop is not affected: its shell resolves the initial destination from a real `useQuery` gated on `isFetched`, and the deep-link path already holds a `bootstrapping` loading screen until the list is seeded (`apps/desktop/src/renderer/src/App.tsx`).

## Verification

- `apps/web/app/(auth)/login/page.test.tsx`: 3 new regression tests — form login does not trigger the arrival effect (no replace/push/list fetch); arrived-authenticated visitor gets the list **fetched** and lands on `/{slug}/issues`; `?next=` still honored. Router mocks upgraded to stable spies so navigation is assertable.
- New tests verified **red against the previous implementation** (2 failed exactly on the race and cold-cache cases), green after the fix.
- Full `apps/web` suite 73/73; `pnpm typecheck` green across the monorepo.

Fixes #5009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
