### PR TITLE
MUL-4169 feat(api): emit Content-Length header on JSON responses

### DIFF
--- a/server/cmd/server/health.go
+++ b/server/cmd/server/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -163,7 +164,17 @@ func (h *serverHealth) computeReadiness(parent context.Context) (readinessRespon
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
+	// Buffer the payload so we can emit an accurate Content-Length; encoding
+	// straight into the ResponseWriter after WriteHeader would force chunked
+	// transfer encoding and drop the header.
+	body, err := json.Marshal(v)
+	if err != nil {
+		body = []byte(`{"error":"failed to encode response"}`)
+		status = http.StatusInternalServerError
+	}
+	body = append(body, '\n')
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	_, _ = w.Write(body)
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/netip"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -262,9 +263,23 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
+	// Marshal the body up front so we can advertise an accurate Content-Length
+	// header. Streaming straight into the ResponseWriter after WriteHeader forces
+	// net/http into chunked transfer encoding, which omits Content-Length; buffering
+	// first lets clients (and proxies) see the exact body size.
+	body, err := json.Marshal(v)
+	if err != nil {
+		// Fall back to a minimal, self-describing error payload rather than leaving
+		// the client with a half-written response.
+		body = []byte(`{"error":"failed to encode response"}`)
+		status = http.StatusInternalServerError
+	}
+	// Match the trailing newline that json.Encoder.Encode historically appended.
+	body = append(body, '\n')
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	_, _ = w.Write(body)
 }
 
 // writeMeasuredJSON behaves like writeJSON but returns the encoded body size so
@@ -278,6 +293,7 @@ func writeMeasuredJSON(w http.ResponseWriter, status int, v any) (int, error) {
 	}
 	body = append(body, '\n')
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(status)
 	if _, err := w.Write(body); err != nil {
 		return len(body), err

--- a/server/internal/handler/handler_writejson_test.go
+++ b/server/internal/handler/handler_writejson_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
@@ -95,5 +96,60 @@ func TestWriteMeasuredJSONByteIdenticalToWriteJSON(t *testing.T) {
 	writeJSON(rec, http.StatusOK, map[string]string{"x": "<&>"})
 	if bytes.ContainsRune(rec.Body.Bytes(), '<') {
 		t.Fatalf("expected '<' to be HTML-escaped out of the body, got %q", rec.Body.String())
+	}
+}
+
+// TestWriteJSONSetsContentLength verifies that the JSON response writers advertise
+// an accurate Content-Length header. Encoding straight into the ResponseWriter after
+// WriteHeader forces net/http into chunked transfer encoding (no Content-Length), so
+// both writeJSON and writeMeasuredJSON buffer the body first and set the header
+// explicitly. The value must equal the exact number of bytes written on the wire.
+func TestWriteJSONSetsContentLength(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"empty_map", map[string]any{}},
+		{"simple", map[string]string{"hello": "world"}},
+		{"html_escapable", map[string]any{"s": `a<b> & "c" <script>`}},
+		{"unicode", map[string]any{"s": "héllo 世界 🚀"}},
+		{"nested", map[string]any{"a": []any{1, "two", true, nil}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeJSON(rec, http.StatusOK, tc.v)
+
+			got := rec.Header().Get("Content-Length")
+			if got == "" {
+				t.Fatalf("writeJSON did not set Content-Length header")
+			}
+			cl, err := strconv.Atoi(got)
+			if err != nil {
+				t.Fatalf("Content-Length %q is not an integer: %v", got, err)
+			}
+			if cl != rec.Body.Len() {
+				t.Fatalf("Content-Length = %d, want %d (actual body length)", cl, rec.Body.Len())
+			}
+
+			// writeMeasuredJSON must set the same, accurate Content-Length.
+			recMeasured := httptest.NewRecorder()
+			n, err := writeMeasuredJSON(recMeasured, http.StatusOK, tc.v)
+			if err != nil {
+				t.Fatalf("writeMeasuredJSON returned error: %v", err)
+			}
+			gotMeasured := recMeasured.Header().Get("Content-Length")
+			clMeasured, err := strconv.Atoi(gotMeasured)
+			if err != nil {
+				t.Fatalf("writeMeasuredJSON Content-Length %q is not an integer: %v", gotMeasured, err)
+			}
+			if clMeasured != recMeasured.Body.Len() || clMeasured != n {
+				t.Fatalf("writeMeasuredJSON Content-Length = %d, body = %d, reported = %d; all must match", clMeasured, recMeasured.Body.Len(), n)
+			}
+			if got != gotMeasured {
+				t.Fatalf("Content-Length differs: writeJSON=%q writeMeasuredJSON=%q", got, gotMeasured)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Background

The backend API did not return a `Content-Length` response header on JSON responses. The shared `writeJSON` helpers streamed the body via `json.NewEncoder(w).Encode(v)` **after** calling `w.WriteHeader(status)`. Once the status is flushed, Go's `net/http` can no longer back-fill `Content-Length` and falls back to `Transfer-Encoding: chunked`, so clients and proxies never see the exact body size.

## Change

Buffer the marshaled JSON body first, then set an accurate `Content-Length` before `WriteHeader`:

- `server/internal/handler/handler.go` — `writeJSON` (the helper behind almost every API handler and `writeError`) now marshals to a buffer, sets `Content-Length`, and writes. Malformed values fall back to a self-describing `500` error payload instead of a half-written response.
- `server/internal/handler/handler.go` — `writeMeasuredJSON` already buffered; it now also sets `Content-Length`.
- `server/cmd/server/health.go` — the health/readiness `writeJSON` gets the same treatment.

The trailing newline that `json.Encoder.Encode` historically appended is preserved, so the on-wire bytes are unchanged apart from the added header. The existing byte-identity invariant test between `writeJSON` and `writeMeasuredJSON` still passes.

## Testing

- New `TestWriteJSONSetsContentLength` asserts the header is present and equals the exact on-wire body length for empty, simple, HTML-escapable, unicode, and nested payloads — for both writers.
- Existing `TestWriteMeasuredJSONByteIdenticalToWriteJSON` still passes (no wire regression).
- Full `./internal/handler/` and `./cmd/server/` packages pass against a live Postgres; `go vet` and `go build ./...` clean.

No compression middleware wraps responses in the router, so an explicit `Content-Length` is correct and safe.
