### PR TITLE
feat(lark): serve `multica chat` history via the unified pull path (MUL-4166)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -234,6 +234,12 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		engine.Config{},
 	)
 
+	// Per-platform readers behind the unified `multica chat history` / `thread`
+	// commands (MUL-3871, MUL-4166). Each integration block below registers its
+	// reader by channel type; after both, h.ChatHistory is a channel-type
+	// dispatcher over whatever is configured (nil when neither is).
+	chatHistoryReaders := map[string]handler.ChatChannelHistoryReader{}
+
 	// Lark integration. Only wired when MULTICA_LARK_SECRET_KEY is set:
 	// the InstallationService refuses to fall back to plaintext storage
 	// for app_secret, and the BindingTokenService cannot mint usable
@@ -286,6 +292,14 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				cs := lark.NewChannelStore(queries)
 				patcher := lark.NewPatcher(cs, installSvc, larkClient, lark.PatcherConfig{})
 				patcher.Register(bus)
+
+				// On-demand history reader behind the unified `multica chat`
+				// commands (MUL-4166): pull the session's Feishu conversation when
+				// the agent asks, the same pull model Slack uses — replacing the
+				// enricher's force-assembled <recent_context> block (disabled
+				// below). Reuses the channel store's binding/installation lookups
+				// and the shared APIClient.
+				chatHistoryReaders[string(channel.TypeFeishu)] = lark.NewHistory(cs, installSvc, larkClient, slog.Default())
 
 				// Typing indicator: shows a "processing" reaction on the user's
 				// message while the agent is working, then removes it before the
@@ -473,7 +487,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			// On-demand history reader behind the unified `multica chat history`
 			// command (MUL-3871): pull the session's Slack conversation when the
 			// agent asks, instead of force-assembling it on every inbound.
-			h.SlackHistory = slack.NewHistory(queries, box.Open, slog.Default())
+			chatHistoryReaders[string(slack.TypeSlack)] = slack.NewHistory(queries, box.Open, slog.Default())
 
 			// `/issue` slash command (MUL-3908): a real Slack slash command,
 			// delivered over the same Socket Mode connection. It is a quick-create
@@ -510,6 +524,11 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	} else {
 		slog.Info("slack integration disabled (MULTICA_SLACK_SECRET_KEY not set)")
 	}
+
+	// Dispatch `multica chat history` / `thread` to the reader for the session's
+	// channel type. NewChatHistoryRouter returns nil when no reader is
+	// configured, so GetChatChannelHistory reports "no channel integration".
+	h.ChatHistory = handler.NewChatHistoryRouter(queries, chatHistoryReaders)
 
 	// Composio integration (MUL-3720). Gated by COMPOSIO_API_KEY plus the
 	// composio_mcp_apps feature flag. The env var is the project-scoped key the
@@ -1328,13 +1347,19 @@ func buildLarkConnector(installSvc *lark.InstallationService, apiClient lark.API
 		}
 		return creds, nil
 	})
-	// Inbound enricher: expands quoted replies / forwarded bundles AND
-	// prefetches a window of surrounding group history (MUL-3084) into the
-	// agent's body via the IM API before dispatch. It shares the
-	// connector's resolved credentials and runs under the connector's
-	// EnrichTimeout so it cannot overrun the Lark long-conn ACK budget.
+	// Inbound enricher: expands quoted replies / forwarded bundles the user
+	// EXPLICITLY attached to the trigger message (not recoverable from channel
+	// history), before dispatch. It shares the connector's resolved credentials
+	// and runs under the connector's EnrichTimeout so it cannot overrun the Lark
+	// long-conn ACK budget.
+	//
+	// RecentContextSize is 0 (recent-history prefetch disabled): surrounding
+	// group context is now PULLED on demand via `multica chat history`
+	// (MUL-4166), the same model Slack uses, instead of force-assembling a
+	// <recent_context> block into every inbound. Quote/forward expansion stays —
+	// it is trigger-specific content the history pull cannot reconstruct.
 	enricher := lark.NewInboundEnricher(apiClient, lark.InboundEnricherConfig{
-		RecentContextSize: lark.DefaultRecentContextSize,
+		RecentContextSize: 0,
 		Logger:            slog.Default(),
 	})
 	conn, err := lark.NewWSLongConnConnector(lark.WSConnectorConfig{

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -270,6 +270,8 @@ func channelDisplayName(channelType string) string {
 	switch channelType {
 	case "slack":
 		return "Slack"
+	case "feishu":
+		return "Lark"
 	default:
 		return channelType
 	}

--- a/server/internal/handler/chat_history.go
+++ b/server/internal/handler/chat_history.go
@@ -136,6 +136,19 @@ func (h *Handler) respondChatHistory(w http.ResponseWriter, r *http.Request, ses
 			})
 			return
 		}
+		// The channel IS bound but its history can't be read for a known,
+		// non-transient reason (e.g. the app is missing a required scope). Answer
+		// with the actionable reason as a note + 200 — never a retryable 5xx,
+		// which the agent would misreport as a transient platform outage and keep
+		// retrying against a permanent failure.
+		var unavailable *channel.HistoryUnavailableError
+		if errors.As(err, &unavailable) {
+			writeJSON(w, http.StatusOK, ChatChannelHistoryResponse{
+				Messages: []channel.HistoryMessage{},
+				Note:     unavailable.Reason,
+			})
+			return
+		}
 		slog.Error("chat channel history read failed", append(logger.RequestAttrs(r),
 			"error", err, "chat_session_id", uuidToString(sessionID))...)
 		writeError(w, http.StatusBadGateway, "failed to read channel history")

--- a/server/internal/handler/chat_history.go
+++ b/server/internal/handler/chat_history.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // ChatChannelHistoryReader reads a chat session's bound IM-channel history. The
@@ -48,11 +50,11 @@ func (h *Handler) GetChatChannelHistory(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
-	if h.SlackHistory == nil {
+	if h.ChatHistory == nil {
 		h.writeNoChannelIntegration(w)
 		return
 	}
-	page, err := h.SlackHistory.ChannelOverview(r.Context(), sessionID, historyOptionsFrom(r))
+	page, err := h.ChatHistory.ChannelOverview(r.Context(), sessionID, historyOptionsFrom(r))
 	h.respondChatHistory(w, r, sessionID, page, err)
 }
 
@@ -65,12 +67,12 @@ func (h *Handler) GetChatThread(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if h.SlackHistory == nil {
+	if h.ChatHistory == nil {
 		h.writeNoChannelIntegration(w)
 		return
 	}
 	threadID := r.URL.Query().Get("id")
-	page, err := h.SlackHistory.Thread(r.Context(), sessionID, threadID, historyOptionsFrom(r))
+	page, err := h.ChatHistory.Thread(r.Context(), sessionID, threadID, historyOptionsFrom(r))
 	h.respondChatHistory(w, r, sessionID, page, err)
 }
 
@@ -123,7 +125,11 @@ func (h *Handler) chatHistorySession(w http.ResponseWriter, r *http.Request) (pg
 // is not channel-backed, a 502 on a real read failure, the page otherwise.
 func (h *Handler) respondChatHistory(w http.ResponseWriter, r *http.Request, sessionID pgtype.UUID, page channel.HistoryPage, err error) {
 	if err != nil {
-		if errors.Is(err, slack.ErrNoSlackSession) {
+		// The session is not backed by a channel this server can read — a
+		// web-only session (slack.ErrNoSlackSession) or one with no reader for
+		// its channel type (channel.ErrNoChannelSession, from the dispatcher).
+		// Both answer as an empty read with a note, not a failure.
+		if errors.Is(err, slack.ErrNoSlackSession) || errors.Is(err, channel.ErrNoChannelSession) {
 			writeJSON(w, http.StatusOK, ChatChannelHistoryResponse{
 				Messages: []channel.HistoryMessage{},
 				Note:     "This conversation is not connected to a chat channel, so there is no channel history to read.",
@@ -173,4 +179,64 @@ func parseHistoryLimit(raw string) int {
 		return 0
 	}
 	return n
+}
+
+// chatHistoryBindingQuerier is the one query the dispatcher needs: the session's
+// channel binding, by session id alone, to learn which channel type it is bound
+// to. *db.Queries satisfies it.
+type chatHistoryBindingQuerier interface {
+	GetChannelChatSessionBindingBySessionAny(ctx context.Context, chatSessionID pgtype.UUID) (db.ChannelChatSessionBinding, error)
+}
+
+// chatHistoryRouter dispatches an agent's history read to the reader for the
+// session's channel type. It is the one seam that lets the unified `multica chat`
+// commands serve every platform: it looks up the session's binding (by session
+// alone), then delegates to that channel type's registered reader. A session
+// with no binding, or one bound to a channel with no reader wired, resolves to
+// channel.ErrNoChannelSession, which the handler answers as an empty read + note.
+type chatHistoryRouter struct {
+	q       chatHistoryBindingQuerier
+	readers map[string]ChatChannelHistoryReader
+}
+
+// NewChatHistoryRouter builds the channel-type dispatcher over the per-platform
+// readers (keyed by channel_type: "slack", "feishu"). Returns nil when no reader
+// is registered, so callers can leave Handler.ChatHistory nil ("no channel
+// integration configured") instead of wiring an empty router.
+func NewChatHistoryRouter(q chatHistoryBindingQuerier, readers map[string]ChatChannelHistoryReader) ChatChannelHistoryReader {
+	if len(readers) == 0 {
+		return nil
+	}
+	return &chatHistoryRouter{q: q, readers: readers}
+}
+
+func (rt *chatHistoryRouter) readerFor(ctx context.Context, chatSessionID pgtype.UUID) (ChatChannelHistoryReader, error) {
+	binding, err := rt.q.GetChannelChatSessionBindingBySessionAny(ctx, chatSessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, channel.ErrNoChannelSession
+		}
+		return nil, err
+	}
+	reader, ok := rt.readers[binding.ChannelType]
+	if !ok {
+		return nil, channel.ErrNoChannelSession
+	}
+	return reader, nil
+}
+
+func (rt *chatHistoryRouter) ChannelOverview(ctx context.Context, chatSessionID pgtype.UUID, opts channel.HistoryOptions) (channel.HistoryPage, error) {
+	reader, err := rt.readerFor(ctx, chatSessionID)
+	if err != nil {
+		return channel.HistoryPage{}, err
+	}
+	return reader.ChannelOverview(ctx, chatSessionID, opts)
+}
+
+func (rt *chatHistoryRouter) Thread(ctx context.Context, chatSessionID pgtype.UUID, threadID string, opts channel.HistoryOptions) (channel.HistoryPage, error) {
+	reader, err := rt.readerFor(ctx, chatSessionID)
+	if err != nil {
+		return channel.HistoryPage{}, err
+	}
+	return reader.Thread(ctx, chatSessionID, threadID, opts)
 }

--- a/server/internal/handler/chat_history_test.go
+++ b/server/internal/handler/chat_history_test.go
@@ -176,6 +176,31 @@ func TestGetChatHistory_NoBindingReturnsNote(t *testing.T) {
 	}
 }
 
+// A HistoryUnavailableError (bound channel, but history unreadable for a known
+// reason like a missing scope) becomes a 200 + the actionable reason as a note,
+// NOT a 502 — so the agent proceeds and reports the fixable cause instead of
+// retrying a "transient" failure forever.
+func TestGetChatHistory_UnavailableReturnsActionableNote(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("requires test database")
+	}
+	taskID := newChatHistoryTask(t, true)
+	reason := "Lark channel history is unavailable: the connected Feishu app is missing a required permission (need scope: im:message.group_msg)."
+	withChatHistory(t, &fakeChatHistoryReader{err: &channel.HistoryUnavailableError{Reason: reason}})
+
+	w := httptest.NewRecorder()
+	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (not a retryable 5xx): %s", w.Code, w.Body.String())
+	}
+	var resp ChatChannelHistoryResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Note != reason || len(resp.Messages) != 0 {
+		t.Fatalf("expected the actionable reason as the note, got %+v", resp)
+	}
+}
+
 func TestGetChatHistory_NilReaderReturnsNote(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("requires test database")

--- a/server/internal/handler/chat_history_test.go
+++ b/server/internal/handler/chat_history_test.go
@@ -72,11 +72,11 @@ func taskActorReq(target, taskID string) *http.Request {
 	return req
 }
 
-func withSlackHistory(t *testing.T, r ChatChannelHistoryReader) {
+func withChatHistory(t *testing.T, r ChatChannelHistoryReader) {
 	t.Helper()
-	orig := testHandler.SlackHistory
-	testHandler.SlackHistory = r
-	t.Cleanup(func() { testHandler.SlackHistory = orig })
+	orig := testHandler.ChatHistory
+	testHandler.ChatHistory = r
+	t.Cleanup(func() { testHandler.ChatHistory = orig })
 }
 
 func TestGetChatChannelHistory_Success(t *testing.T) {
@@ -92,7 +92,7 @@ func TestGetChatChannelHistory_Success(t *testing.T) {
 		},
 		NextCursor: "100",
 	}}
-	withSlackHistory(t, fake)
+	withChatHistory(t, fake)
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history?limit=10", taskID))
@@ -121,7 +121,7 @@ func TestGetChatThread_CurrentThread(t *testing.T) {
 	}
 	taskID := newChatHistoryTask(t, true)
 	fake := &fakeChatHistoryReader{page: channel.HistoryPage{ChannelType: "slack", ThreadID: "50.0", Messages: []channel.HistoryMessage{{ID: "50.0", TS: "50.0", Text: "root"}}}}
-	withSlackHistory(t, fake)
+	withChatHistory(t, fake)
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatThread(w, taskActorReq("/api/chat/thread", taskID))
@@ -143,7 +143,7 @@ func TestGetChatThread_ByID(t *testing.T) {
 	}
 	taskID := newChatHistoryTask(t, true)
 	fake := &fakeChatHistoryReader{page: channel.HistoryPage{ChannelType: "slack", ThreadID: "70.0"}}
-	withSlackHistory(t, fake)
+	withChatHistory(t, fake)
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatThread(w, taskActorReq("/api/chat/thread?id=70.0", taskID))
@@ -161,7 +161,7 @@ func TestGetChatHistory_NoBindingReturnsNote(t *testing.T) {
 		t.Skip("requires test database")
 	}
 	taskID := newChatHistoryTask(t, true)
-	withSlackHistory(t, &fakeChatHistoryReader{err: slack.ErrNoSlackSession})
+	withChatHistory(t, &fakeChatHistoryReader{err: slack.ErrNoSlackSession})
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
@@ -181,7 +181,7 @@ func TestGetChatHistory_NilReaderReturnsNote(t *testing.T) {
 		t.Skip("requires test database")
 	}
 	taskID := newChatHistoryTask(t, true)
-	withSlackHistory(t, nil)
+	withChatHistory(t, nil)
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))
@@ -206,7 +206,7 @@ func TestGetChatHistory_RejectsForgedTaskID(t *testing.T) {
 	}
 	taskID := newChatHistoryTask(t, true)
 	fake := &fakeChatHistoryReader{page: channel.HistoryPage{ChannelType: "slack"}}
-	withSlackHistory(t, fake)
+	withChatHistory(t, fake)
 
 	req := newRequest("GET", "/api/chat/history", nil)
 	req.Header.Set("X-Task-ID", taskID) // forged: no X-Actor-Source=task_token
@@ -240,7 +240,7 @@ func TestGetChatHistory_NonChatTask(t *testing.T) {
 		t.Skip("requires test database")
 	}
 	taskID := newChatHistoryTask(t, false) // task with no chat_session_id
-	withSlackHistory(t, &fakeChatHistoryReader{})
+	withChatHistory(t, &fakeChatHistoryReader{})
 
 	w := httptest.NewRecorder()
 	testHandler.GetChatChannelHistory(w, taskActorReq("/api/chat/history", taskID))

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -20,7 +20,6 @@ import (
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
-	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
@@ -1630,18 +1629,18 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			resp.ChatSessionID = uuidToString(cs.ID)
 			resp.ThreadName = cs.Title
 			// Flag a channel-backed session so the daemon makes the agent aware
-			// it is operating inside Slack — read this conversation's history
-			// from the channel via `multica chat history` / `multica chat thread`,
-			// not from Multica (MUL-3871). Empty for a web-only chat session.
-			// ChatInThread tells the agent which command to start with: the
-			// latest trigger was a thread reply iff its reply-target thread
-			// (last_thread_id) differs from its own message id (a top-level
-			// @mention records its own ts as both).
-			if binding, berr := h.Queries.GetChannelChatSessionBindingBySession(r.Context(), db.GetChannelChatSessionBindingBySessionParams{
-				ChatSessionID: cs.ID,
-				ChannelType:   string(slack.TypeSlack),
-			}); berr == nil {
-				resp.ChatChannelType = string(slack.TypeSlack)
+			// it is operating inside its IM channel (Slack, Lark) — read this
+			// conversation's history from the channel via `multica chat history` /
+			// `multica chat thread`, not from Multica (MUL-3871, MUL-4166). Empty
+			// for a web-only chat session. The binding is looked up by session
+			// alone (chat_session_id is UNIQUE) so any wired channel type lights
+			// up the pull path, not just Slack. ChatInThread tells the agent which
+			// command to start with: the latest trigger was a thread reply iff its
+			// reply-target thread (last_thread_id) differs from its own message id
+			// — for Slack a top-level @mention records its own ts as both; for Lark
+			// last_thread_id is set only inside a topic (话题).
+			if binding, berr := h.Queries.GetChannelChatSessionBindingBySessionAny(r.Context(), cs.ID); berr == nil {
+				resp.ChatChannelType = binding.ChannelType
 				resp.ChatInThread = binding.LastThreadID.Valid && binding.LastThreadID.String != "" &&
 					binding.LastThreadID.String != binding.LastMessageID.String
 			}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -192,12 +192,14 @@ type Handler struct {
 	// "link your Slack account" prompt (MUL-3666). Nil unless Slack is
 	// configured (MULTICA_SLACK_SECRET_KEY set).
 	SlackBindingTokens *slack.BindingTokenService
-	// SlackHistory backs the agent-facing `multica chat history` command: it
-	// reads a chat session's bound Slack conversation on demand (MUL-3871). Nil
-	// unless Slack is configured; GetChatChannelHistory then reports "no channel
-	// integration". A future platform satisfies the same reader interface.
-	SlackHistory ChatChannelHistoryReader
-	cfg          Config
+	// ChatHistory backs the agent-facing `multica chat history` / `multica chat
+	// thread` commands: it reads a chat session's bound IM conversation on
+	// demand (MUL-3871, MUL-4166). In production it is a channel-type dispatcher
+	// (NewChatHistoryRouter) over the per-platform readers (Slack, Feishu). Nil
+	// when no channel integration is configured; GetChatChannelHistory then
+	// reports "no channel integration".
+	ChatHistory ChatChannelHistoryReader
+	cfg         Config
 }
 
 func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *events.Bus, emailService *service.EmailService, store storage.Storage, cfSigner *auth.CloudFrontSigner, analyticsClient analytics.Client, cfg Config, daemonHubs ...*daemonws.Hub) *Handler {

--- a/server/internal/integrations/channel/history.go
+++ b/server/internal/integrations/channel/history.go
@@ -1,5 +1,14 @@
 package channel
 
+import "errors"
+
+// ErrNoChannelSession reports that a chat session has no channel binding a
+// history reader can serve — a web-only session, or one bound to a platform
+// with no reader wired. Readers and the channel-type dispatcher return it so
+// the unified `multica chat history` / `multica chat thread` commands answer
+// gracefully (an empty read with an explanatory note) rather than failing.
+var ErrNoChannelSession = errors.New("channel: session has no channel binding")
+
 // This file defines the channel-agnostic vocabulary for ON-DEMAND history
 // reads. History is PULLED by the agent through two unified CLI commands —
 // `multica chat history` (the channel OVERVIEW: top-level messages + thread

--- a/server/internal/integrations/channel/history.go
+++ b/server/internal/integrations/channel/history.go
@@ -9,6 +9,20 @@ import "errors"
 // gracefully (an empty read with an explanatory note) rather than failing.
 var ErrNoChannelSession = errors.New("channel: session has no channel binding")
 
+// HistoryUnavailableError marks a bound channel whose history cannot be read
+// for a known, NON-transient reason — most importantly a missing platform
+// permission (e.g. the connected Feishu app lacks the scope to read group
+// messages). The unified commands surface Reason as an actionable note with a
+// 200, NOT a retryable 5xx: retrying a permission failure just fails again, and
+// a generic 5xx makes the agent misreport it as a transient platform outage.
+type HistoryUnavailableError struct {
+	// Reason is the agent-facing, actionable explanation (what is missing and
+	// how to fix it). It is returned verbatim as the response note.
+	Reason string
+}
+
+func (e *HistoryUnavailableError) Error() string { return e.Reason }
+
 // This file defines the channel-agnostic vocabulary for ON-DEMAND history
 // reads. History is PULLED by the agent through two unified CLI commands —
 // `multica chat history` (the channel OVERVIEW: top-level messages + thread

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -96,6 +96,17 @@ type APIClient interface {
 	// adapter: flattening and block assembly are the enricher's job.
 	ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error)
 
+	// ListContainerMessages lists one page of messages in a chat
+	// (container_id_type=chat, the whole conversation) or a topic
+	// (container_id_type=thread, one 话题) via GET /open-apis/im/v1/messages,
+	// newest-first (sort_type=ByCreateTimeDesc). Where ListChatMessages fetches
+	// a single time-anchored page for the inbound enricher, this exposes
+	// page_token cursoring so the on-demand `multica chat` history reader can
+	// page to OLDER messages (MUL-4166). body.content is forwarded verbatim for
+	// the reader's flattener; the result carries Lark's next page_token (empty
+	// when no older page remains).
+	ListContainerMessages(ctx context.Context, creds InstallationCredentials, p ListContainerParams) (ListContainerResult, error)
+
 	// BatchGetUsers resolves a set of user open_ids to their display names
 	// via GET /open-apis/contact/v3/users/batch. The enricher uses it to
 	// label recent-context / quoted / forwarded speakers (and the sender
@@ -136,6 +147,40 @@ type ListMessagesParams struct {
 	EndTime int64
 }
 
+// ListContainerParams selects one page of messages in a Lark chat or topic
+// for the on-demand history reader. ContainerType is "chat" (the whole
+// conversation) or "thread" (one 话题).
+type ListContainerParams struct {
+	// ContainerType is the container_id_type: "chat" or "thread".
+	ContainerType string
+	// ContainerID is the chat_id (ContainerType "chat") or thread_id
+	// (ContainerType "thread") to read.
+	ContainerID string
+	// PageSize is how many messages to return; clamped to Lark's 1..50 range.
+	PageSize int
+	// PageToken is an opaque cursor from a prior ListContainerResult; empty
+	// reads the newest page. Lark pages backward in time from here under
+	// sort_type=ByCreateTimeDesc.
+	PageToken string
+}
+
+// larkContainerTypeChat / larkContainerTypeThread are the container_id_type
+// values the history reader passes.
+const (
+	larkContainerTypeChat   = "chat"
+	larkContainerTypeThread = "thread"
+)
+
+// ListContainerResult is one page of messages plus the cursor to the next
+// (older) page. Messages are in Lark's returned order (newest-first under
+// ByCreateTimeDesc); the reader sorts them oldest-first.
+type ListContainerResult struct {
+	Messages []LarkMessage
+	// PageToken is the cursor for the next (older) page, or empty when Lark
+	// reports no more messages (has_more=false).
+	PageToken string
+}
+
 // LarkMessage is the normalized slice of an IM v1 message item the
 // enricher needs. Body.content is passed through raw (still the
 // JSON-encoded, msg_type-specific string Lark double-encodes) so the
@@ -150,8 +195,12 @@ type LarkMessage struct {
 	ParentID       string
 	RootID         string
 	UpperMessageID string // the merge_forward parent a child hangs under
-	Deleted        bool
-	Mentions       []LarkMessageMention
+	// ThreadID is the Lark topic (话题) this message belongs to. Empty when the
+	// message is not part of a topic. The history reader surfaces it so the
+	// agent can drill into a topic with `multica chat thread <thread_id>`.
+	ThreadID string
+	Deleted  bool
+	Mentions []LarkMessageMention
 }
 
 // LarkMessageMention mirrors a mentions[] entry on the IM REST item
@@ -381,6 +430,11 @@ func (s *stubAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 func (s *stubAPIClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
 	s.log.Warn("lark stub client: ListChatMessages called", "chat_id", string(p.ChatID))
 	return nil, ErrAPIClientNotConfigured
+}
+
+func (s *stubAPIClient) ListContainerMessages(ctx context.Context, creds InstallationCredentials, p ListContainerParams) (ListContainerResult, error) {
+	s.log.Warn("lark stub client: ListContainerMessages called", "container_type", p.ContainerType, "container_id", p.ContainerID)
+	return ListContainerResult{}, ErrAPIClientNotConfigured
 }
 
 func (s *stubAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCredentials, openIDs []string) (map[string]string, error) {

--- a/server/internal/integrations/lark/history.go
+++ b/server/internal/integrations/lark/history.go
@@ -1,0 +1,259 @@
+package lark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+const (
+	// defaultHistoryLimit is the page size used when the caller asks for none.
+	defaultHistoryLimit = 20
+	// maxHistoryLimit caps a single page (Lark's own im/v1/messages cap is 50)
+	// so a pull can't dump an unbounded transcript into the agent's context.
+	maxHistoryLimit = 50
+)
+
+// historyQueries is the slice of the channel store the reader needs. *ChannelStore
+// satisfies it; tests inject a fake.
+type historyQueries interface {
+	GetLarkChatSessionBindingBySession(ctx context.Context, chatSessionID pgtype.UUID) (ChatSessionBinding, error)
+	GetLarkInstallation(ctx context.Context, id pgtype.UUID) (Installation, error)
+}
+
+// History reads a Lark (Feishu) conversation on demand — the pull side of the
+// unified `multica chat history` (chat overview) and `multica chat thread [id]`
+// (one 话题/topic) commands (MUL-4166), the same contract Slack's reader serves.
+// A Lark session spans the whole chat (channel_chat_id is the real chat_id), so
+// the overview is the chat's recent messages and a thread read drills into one
+// topic. The chat is resolved server-side from the binding and never taken from
+// the agent, so a thread id is only a within-chat locator. Sessions with no
+// Feishu binding (web-only, or a different channel) return
+// channel.ErrNoChannelSession.
+type History struct {
+	q      historyQueries
+	creds  CredentialsResolver
+	client APIClient
+	logger *slog.Logger
+}
+
+// NewHistory builds the reader over the channel store, the app-secret decrypter
+// (*InstallationService at wiring time), and the Lark HTTP client.
+func NewHistory(q historyQueries, creds CredentialsResolver, client APIClient, logger *slog.Logger) *History {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &History{q: q, creds: creds, client: client, logger: logger}
+}
+
+// larkTarget is the resolved per-session read context: the installation's
+// transport credentials plus the session's pinned chat, its own topic root, and
+// the bot's identity (used to mark the bot's own turns as assistant).
+type larkTarget struct {
+	creds        InstallationCredentials
+	chatID       string
+	threadRoot   string // the session's current topic (empty when not in one)
+	ownAppID     string
+	ownBotOpenID string
+}
+
+// resolve maps a chat_session to its Lark chat + transport credentials. The chat
+// is server-derived here and never accepted from the caller — that is the
+// security boundary for `multica chat thread <id>` (the agent supplies only a
+// within-chat topic locator).
+func (h *History) resolve(ctx context.Context, chatSessionID pgtype.UUID) (larkTarget, error) {
+	binding, err := h.q.GetLarkChatSessionBindingBySession(ctx, chatSessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return larkTarget{}, channel.ErrNoChannelSession
+		}
+		return larkTarget{}, fmt.Errorf("lookup feishu chat binding: %w", err)
+	}
+	inst, err := h.q.GetLarkInstallation(ctx, binding.InstallationID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return larkTarget{}, channel.ErrNoChannelSession
+		}
+		return larkTarget{}, fmt.Errorf("load feishu installation: %w", err)
+	}
+	if inst.Status != string(InstallationActive) {
+		return larkTarget{}, channel.ErrNoChannelSession // revoked install: nothing to read
+	}
+	if h.creds == nil {
+		return larkTarget{}, errors.New("lark history: credentials resolver missing")
+	}
+	secret, err := h.creds.DecryptAppSecret(inst)
+	if err != nil {
+		return larkTarget{}, fmt.Errorf("decrypt app_secret: %w", err)
+	}
+	creds := InstallationCredentials{
+		AppID:     inst.AppID,
+		AppSecret: secret,
+		Region:    RegionOrDefault(inst.Region),
+	}
+	if inst.TenantKey.Valid {
+		creds.TenantKey = inst.TenantKey.String
+	}
+	t := larkTarget{
+		creds:        creds,
+		chatID:       binding.ChannelChatID,
+		ownAppID:     inst.AppID,
+		ownBotOpenID: inst.BotOpenID,
+	}
+	if binding.LastThreadID.Valid {
+		t.threadRoot = binding.LastThreadID.String
+	}
+	return t, nil
+}
+
+// ChannelOverview returns the chat's recent messages (oldest-first). A message
+// that belongs to a topic is tagged with its thread_id so the agent can drill
+// in with `multica chat thread <thread_id>`. Lark's list endpoint carries no
+// per-topic reply count, so ReplyCount is left unset. Backs `multica chat
+// history`.
+func (h *History) ChannelOverview(ctx context.Context, chatSessionID pgtype.UUID, opts channel.HistoryOptions) (channel.HistoryPage, error) {
+	t, err := h.resolve(ctx, chatSessionID)
+	if err != nil {
+		return channel.HistoryPage{}, err
+	}
+	res, err := h.client.ListContainerMessages(ctx, t.creds, ListContainerParams{
+		ContainerType: larkContainerTypeChat,
+		ContainerID:   t.chatID,
+		PageSize:      clampHistoryLimit(opts.Limit),
+		PageToken:     opts.Before,
+	})
+	if err != nil {
+		return channel.HistoryPage{}, fmt.Errorf("read feishu chat: %w", err)
+	}
+	page := h.normalizePage(ctx, t, res.Messages, true)
+	page.ChannelType = string(channel.TypeFeishu)
+	page.NextCursor = res.PageToken
+	return page, nil
+}
+
+// Thread returns one topic's messages (oldest-first). threadID empty reads the
+// topic the session is in (the agent's own topic); a non-empty id reads that
+// specific topic — but always within the session's pinned chat. A chat with no
+// topic (or an unrecoverable root) falls back to the chat's linear recent
+// messages. Backs `multica chat thread [id]`.
+func (h *History) Thread(ctx context.Context, chatSessionID pgtype.UUID, threadID string, opts channel.HistoryOptions) (channel.HistoryPage, error) {
+	t, err := h.resolve(ctx, chatSessionID)
+	if err != nil {
+		return channel.HistoryPage{}, err
+	}
+	limit := clampHistoryLimit(opts.Limit)
+	ts := threadID
+	if ts == "" {
+		ts = t.threadRoot // the session's own topic
+	}
+
+	params := ListContainerParams{PageSize: limit, PageToken: opts.Before}
+	if ts == "" {
+		// No topic to read (a chat without topics, or a root we could not
+		// recover): fall back to the chat's linear conversation.
+		params.ContainerType = larkContainerTypeChat
+		params.ContainerID = t.chatID
+	} else {
+		params.ContainerType = larkContainerTypeThread
+		params.ContainerID = ts
+	}
+	res, err := h.client.ListContainerMessages(ctx, t.creds, params)
+	if err != nil {
+		return channel.HistoryPage{}, fmt.Errorf("read feishu thread: %w", err)
+	}
+	page := h.normalizePage(ctx, t, res.Messages, false)
+	page.ChannelType = string(channel.TypeFeishu)
+	page.ThreadID = ts
+	page.NextCursor = res.PageToken
+	return page, nil
+}
+
+func clampHistoryLimit(n int) int {
+	if n <= 0 {
+		return defaultHistoryLimit
+	}
+	if n > maxHistoryLimit {
+		return maxHistoryLimit
+	}
+	return n
+}
+
+// normalizePage turns raw Lark messages into a normalized, oldest-first page: it
+// sorts by create time, batch-resolves display names, labels senders, maps
+// roles (the bot's own app messages are assistant turns), and flattens bodies.
+// When overview is true, a message that belongs to a topic is tagged with its
+// thread_id so the agent can drill in with `multica chat thread <id>`. The page
+// cursor is set by the caller from Lark's page_token, not derived here.
+func (h *History) normalizePage(ctx context.Context, t larkTarget, raw []LarkMessage, overview bool) channel.HistoryPage {
+	sorted := make([]LarkMessage, len(raw))
+	copy(sorted, raw)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return parseLarkMillis(sorted[i].CreateTime) < parseLarkMillis(sorted[j].CreateTime)
+	})
+
+	names := h.resolveNames(ctx, t.creds, sorted)
+	labeler := newSpeakerLabeler(names)
+
+	out := make([]channel.HistoryMessage, 0, len(sorted))
+	for i := range sorted {
+		m := sorted[i]
+		text := flattenLarkMessage(m)
+		if text == "" {
+			continue // unrenderable / unknown-type marker: no readable body
+		}
+		own := isOwnBotMessage(m, t.ownAppID, t.ownBotOpenID)
+		role := channel.HistoryRoleUser
+		if own {
+			role = channel.HistoryRoleAssistant
+		}
+		hm := channel.HistoryMessage{
+			ID:       m.MessageID,
+			Author:   labeler.label(m),
+			AuthorID: m.SenderID,
+			Role:     role,
+			Text:     text,
+			TS:       m.CreateTime,
+		}
+		// The chat overview tags topic messages so the agent can open them.
+		// Lark's list carries no reply count, so ReplyCount stays unset.
+		if overview && m.ThreadID != "" {
+			hm.ThreadID = m.ThreadID
+		}
+		out = append(out, hm)
+	}
+	return channel.HistoryPage{Messages: out}
+}
+
+// isOwnBotMessage reports whether a message was sent by THIS installation's bot
+// (an assistant turn). Lark records a bot send as an app sender whose id is the
+// app_id; some paths surface the bot's open_id instead, so both are accepted.
+func isOwnBotMessage(m LarkMessage, ownAppID, ownBotOpenID string) bool {
+	if m.SenderType != "app" || m.SenderID == "" {
+		return false
+	}
+	return (ownAppID != "" && m.SenderID == ownAppID) ||
+		(ownBotOpenID != "" && m.SenderID == ownBotOpenID)
+}
+
+// resolveNames batch-resolves human senders' display names, best-effort. A
+// failure (restricted contact scope, transport error) yields a nil map so the
+// labeler falls back to positional "User N" rather than blocking the read.
+func (h *History) resolveNames(ctx context.Context, creds InstallationCredentials, msgs []LarkMessage) map[string]string {
+	ids := senderOpenIDs(msgs)
+	if len(ids) == 0 {
+		return nil
+	}
+	names, err := h.client.BatchGetUsers(ctx, creds, ids)
+	if err != nil {
+		h.logger.WarnContext(ctx, "lark history: user name resolution failed", "ids", len(ids), "error", err)
+		return nil
+	}
+	return names
+}

--- a/server/internal/integrations/lark/history.go
+++ b/server/internal/integrations/lark/history.go
@@ -130,7 +130,7 @@ func (h *History) ChannelOverview(ctx context.Context, chatSessionID pgtype.UUID
 		PageToken:     opts.Before,
 	})
 	if err != nil {
-		return channel.HistoryPage{}, fmt.Errorf("read feishu chat: %w", err)
+		return channel.HistoryPage{}, readError("read feishu chat", err)
 	}
 	page := h.normalizePage(ctx, t, res.Messages, true)
 	page.ChannelType = string(channel.TypeFeishu)
@@ -166,13 +166,34 @@ func (h *History) Thread(ctx context.Context, chatSessionID pgtype.UUID, threadI
 	}
 	res, err := h.client.ListContainerMessages(ctx, t.creds, params)
 	if err != nil {
-		return channel.HistoryPage{}, fmt.Errorf("read feishu thread: %w", err)
+		return channel.HistoryPage{}, readError("read feishu thread", err)
 	}
 	page := h.normalizePage(ctx, t, res.Messages, false)
 	page.ChannelType = string(channel.TypeFeishu)
 	page.ThreadID = ts
 	page.NextCursor = res.PageToken
 	return page, nil
+}
+
+// readError classifies a Lark list-messages failure. A missing-scope error
+// (e.g. im:message.group_msg for group history) is permanent and actionable, so
+// it becomes a channel.HistoryUnavailableError — the handler answers it as a
+// 200 + note so the agent proceeds without history and reports the real,
+// fixable cause instead of retrying a "transient" 5xx forever (MUL-4166). Every
+// other failure (transport, 5xx, unexpected code) stays a plain error → 502.
+func readError(op string, err error) error {
+	if IsMissingPermission(err) {
+		hint := "read this chat's messages"
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.Msg != "" {
+			hint = apiErr.Msg // Lark's message names the exact scope, e.g. "need scope: im:message.group_msg"
+		}
+		return &channel.HistoryUnavailableError{Reason: fmt.Sprintf(
+			"Lark channel history is unavailable: the connected Feishu app is missing a required permission (%s). "+
+				"Grant that scope in the Feishu app's permissions, then re-publish and re-authorize the app. "+
+				"For now, answer using the current message without channel history.", hint)}
+	}
+	return fmt.Errorf("%s: %w", op, err)
 }
 
 func clampHistoryLimit(n int) int {

--- a/server/internal/integrations/lark/history_test.go
+++ b/server/internal/integrations/lark/history_test.go
@@ -3,6 +3,7 @@ package lark
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -217,5 +218,44 @@ func TestHistoryInactiveInstall(t *testing.T) {
 	h := newTestHistory(historyFakeQueries{binding: ChatSessionBinding{ChannelChatID: "oc_chat"}, inst: inst}, newHistoryFakeClient())
 	if _, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{}); !errors.Is(err, channel.ErrNoChannelSession) {
 		t.Fatalf("revoked install should read as no-session, got %v", err)
+	}
+}
+
+// A missing-scope read (Lark code 230027, e.g. group history without
+// im:message.group_msg) is permanent, so it degrades to an actionable
+// HistoryUnavailableError (→ 200 + note), NOT a retryable error.
+func TestHistoryMissingPermissionDegrades(t *testing.T) {
+	client := newHistoryFakeClient()
+	client.listErr = &APIError{Op: "http 400", Code: 230027, Msg: "Lack of necessary permissions, ext=need scope: im:message.group_msg"}
+	h := newTestHistory(historyFakeQueries{binding: ChatSessionBinding{ChannelChatID: "oc_chat"}, inst: activeInstall()}, client)
+
+	_, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{})
+	var un *channel.HistoryUnavailableError
+	if !errors.As(err, &un) {
+		t.Fatalf("missing scope should yield HistoryUnavailableError, got %v", err)
+	}
+	if !strings.Contains(un.Reason, "im:message.group_msg") {
+		t.Errorf("note should surface the missing scope, got %q", un.Reason)
+	}
+	// The Thread path degrades the same way.
+	if _, terr := h.Thread(context.Background(), pgtype.UUID{}, "", channel.HistoryOptions{}); !errors.As(terr, &un) {
+		t.Fatalf("Thread should also degrade on missing scope, got %v", terr)
+	}
+}
+
+// A transient / unclassified read failure stays a plain error (→ 502), never a
+// note — the agent should not silently proceed on an ambiguous outage.
+func TestHistoryTransientErrorStaysError(t *testing.T) {
+	client := newHistoryFakeClient()
+	client.listErr = errors.New("http 500: boom")
+	h := newTestHistory(historyFakeQueries{binding: ChatSessionBinding{ChannelChatID: "oc_chat"}, inst: activeInstall()}, client)
+
+	_, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{})
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	var un *channel.HistoryUnavailableError
+	if errors.As(err, &un) {
+		t.Fatalf("a transient error must NOT degrade to a note: %v", err)
 	}
 }

--- a/server/internal/integrations/lark/history_test.go
+++ b/server/internal/integrations/lark/history_test.go
@@ -1,0 +1,221 @@
+package lark
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+// --- fakes ---
+
+type historyFakeQueries struct {
+	binding    ChatSessionBinding
+	bindingErr error
+	inst       Installation
+	instErr    error
+}
+
+func (f historyFakeQueries) GetLarkChatSessionBindingBySession(_ context.Context, _ pgtype.UUID) (ChatSessionBinding, error) {
+	return f.binding, f.bindingErr
+}
+
+func (f historyFakeQueries) GetLarkInstallation(_ context.Context, _ pgtype.UUID) (Installation, error) {
+	return f.inst, f.instErr
+}
+
+type historyFakeCreds struct{ err error }
+
+func (f historyFakeCreds) DecryptAppSecret(_ Installation) (string, error) {
+	return "plaintext-secret", f.err
+}
+
+// historyFakeClient implements APIClient: it records ListContainerMessages
+// calls and returns canned pages, and resolves names from a fixed map.
+type historyFakeClient struct {
+	APIClient // embedded stub for the unused methods
+	calls     []ListContainerParams
+	result    ListContainerResult
+	listErr   error
+	names     map[string]string
+}
+
+func newHistoryFakeClient() *historyFakeClient {
+	return &historyFakeClient{APIClient: NewStubAPIClient(nil)}
+}
+
+func (f *historyFakeClient) ListContainerMessages(_ context.Context, _ InstallationCredentials, p ListContainerParams) (ListContainerResult, error) {
+	f.calls = append(f.calls, p)
+	if f.listErr != nil {
+		return ListContainerResult{}, f.listErr
+	}
+	return f.result, nil
+}
+
+func (f *historyFakeClient) BatchGetUsers(_ context.Context, _ InstallationCredentials, ids []string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, id := range ids {
+		if n := f.names[id]; n != "" {
+			out[id] = n
+		}
+	}
+	return out, nil
+}
+
+func historyMsg(id, sender, senderType, createTime, threadID, body string) LarkMessage {
+	return LarkMessage{
+		MessageID:   id,
+		MessageType: "text",
+		Content:     `{"text":"` + body + `"}`,
+		SenderID:    sender,
+		SenderType:  senderType,
+		CreateTime:  createTime,
+		ThreadID:    threadID,
+	}
+}
+
+func activeInstall() Installation {
+	return Installation{
+		Status:    string(InstallationActive),
+		AppID:     "cli_app",
+		BotOpenID: "ou_bot",
+		Region:    "feishu",
+	}
+}
+
+func newTestHistory(q historyFakeQueries, c *historyFakeClient) *History {
+	return NewHistory(q, historyFakeCreds{}, c, nil)
+}
+
+// --- tests ---
+
+func TestHistoryChannelOverview(t *testing.T) {
+	client := newHistoryFakeClient()
+	// Lark returns newest-first; the reader must sort oldest-first.
+	client.result = ListContainerResult{
+		Messages: []LarkMessage{
+			historyMsg("m2", "cli_app", "app", "2000", "", "on it"),       // bot reply
+			historyMsg("m1", "ou_alice", "user", "1000", "th9", "deploy"), // a topic message
+		},
+		PageToken: "next-tok",
+	}
+	client.names = map[string]string{"ou_alice": "Alice"}
+
+	h := newTestHistory(historyFakeQueries{
+		binding: ChatSessionBinding{ChannelChatID: "oc_chat"},
+		inst:    activeInstall(),
+	}, client)
+
+	page, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{Limit: 5, Before: "cur"})
+	if err != nil {
+		t.Fatalf("ChannelOverview: %v", err)
+	}
+	if page.ChannelType != "feishu" {
+		t.Errorf("ChannelType = %q, want feishu", page.ChannelType)
+	}
+	if page.NextCursor != "next-tok" {
+		t.Errorf("NextCursor = %q, want next-tok (Lark page_token)", page.NextCursor)
+	}
+	if len(client.calls) != 1 || client.calls[0].ContainerType != "chat" ||
+		client.calls[0].ContainerID != "oc_chat" || client.calls[0].PageToken != "cur" || client.calls[0].PageSize != 5 {
+		t.Fatalf("unexpected list call: %+v", client.calls)
+	}
+	if len(page.Messages) != 2 {
+		t.Fatalf("want 2 messages, got %d: %+v", len(page.Messages), page.Messages)
+	}
+	// Oldest-first: the topic message (ts 1000) before the bot reply (ts 2000).
+	first, second := page.Messages[0], page.Messages[1]
+	if first.ID != "m1" || first.Role != channel.HistoryRoleUser || first.Author != "Alice" {
+		t.Errorf("first message wrong: %+v", first)
+	}
+	if first.Text != "deploy" || first.ThreadID != "th9" {
+		t.Errorf("overview did not carry topic tag / text: %+v", first)
+	}
+	if second.ID != "m2" || second.Role != channel.HistoryRoleAssistant || second.Author != "Bot" {
+		t.Errorf("bot reply not tagged as assistant: %+v", second)
+	}
+}
+
+func TestHistoryThreadCurrentTopic(t *testing.T) {
+	client := newHistoryFakeClient()
+	client.result = ListContainerResult{Messages: []LarkMessage{historyMsg("m1", "ou_a", "user", "1", "th1", "hi")}}
+
+	h := newTestHistory(historyFakeQueries{
+		binding: ChatSessionBinding{ChannelChatID: "oc_chat", LastThreadID: pgtype.Text{String: "th1", Valid: true}},
+		inst:    activeInstall(),
+	}, client)
+
+	page, err := h.Thread(context.Background(), pgtype.UUID{}, "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	if len(client.calls) != 1 || client.calls[0].ContainerType != "thread" || client.calls[0].ContainerID != "th1" {
+		t.Fatalf("expected thread read of th1, got: %+v", client.calls)
+	}
+	if page.ThreadID != "th1" {
+		t.Errorf("page.ThreadID = %q, want th1", page.ThreadID)
+	}
+	// A thread read must not tag rows with ThreadID (that is overview-only).
+	if len(page.Messages) != 1 || page.Messages[0].ThreadID != "" {
+		t.Errorf("thread-read row should not carry ThreadID: %+v", page.Messages)
+	}
+}
+
+func TestHistoryThreadFallsBackToChat(t *testing.T) {
+	client := newHistoryFakeClient()
+	client.result = ListContainerResult{Messages: []LarkMessage{historyMsg("m1", "ou_a", "user", "1", "", "hi")}}
+
+	// No last_thread_id and no explicit id: fall back to the linear chat read.
+	h := newTestHistory(historyFakeQueries{
+		binding: ChatSessionBinding{ChannelChatID: "oc_chat"},
+		inst:    activeInstall(),
+	}, client)
+
+	page, err := h.Thread(context.Background(), pgtype.UUID{}, "", channel.HistoryOptions{})
+	if err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	if len(client.calls) != 1 || client.calls[0].ContainerType != "chat" || client.calls[0].ContainerID != "oc_chat" {
+		t.Fatalf("expected chat fallback, got: %+v", client.calls)
+	}
+	if page.ThreadID != "" {
+		t.Errorf("fallback page.ThreadID = %q, want empty", page.ThreadID)
+	}
+}
+
+func TestHistoryThreadByID(t *testing.T) {
+	client := newHistoryFakeClient()
+	client.result = ListContainerResult{Messages: []LarkMessage{historyMsg("m1", "ou_a", "user", "1", "tX", "hi")}}
+	h := newTestHistory(historyFakeQueries{
+		binding: ChatSessionBinding{ChannelChatID: "oc_chat", LastThreadID: pgtype.Text{String: "th1", Valid: true}},
+		inst:    activeInstall(),
+	}, client)
+
+	if _, err := h.Thread(context.Background(), pgtype.UUID{}, "tX", channel.HistoryOptions{}); err != nil {
+		t.Fatalf("Thread: %v", err)
+	}
+	// An explicit id overrides the session's own topic.
+	if len(client.calls) != 1 || client.calls[0].ContainerType != "thread" || client.calls[0].ContainerID != "tX" {
+		t.Fatalf("expected thread read of tX, got: %+v", client.calls)
+	}
+}
+
+func TestHistoryNoBinding(t *testing.T) {
+	h := newTestHistory(historyFakeQueries{bindingErr: pgx.ErrNoRows}, newHistoryFakeClient())
+	if _, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{}); !errors.Is(err, channel.ErrNoChannelSession) {
+		t.Fatalf("want ErrNoChannelSession, got %v", err)
+	}
+}
+
+func TestHistoryInactiveInstall(t *testing.T) {
+	inst := activeInstall()
+	inst.Status = string(InstallationRevoked)
+	h := newTestHistory(historyFakeQueries{binding: ChatSessionBinding{ChannelChatID: "oc_chat"}, inst: inst}, newHistoryFakeClient())
+	if _, err := h.ChannelOverview(context.Background(), pgtype.UUID{}, channel.HistoryOptions{}); !errors.Is(err, channel.ErrNoChannelSession) {
+		t.Fatalf("revoked install should read as no-session, got %v", err)
+	}
+}

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -60,7 +60,22 @@ const (
 	// open.feishu.cn/document/server-docs/api-call-guide/server-error-codes.
 	codeTokenExpired = 99991663
 	codeTokenInvalid = 99991664
+	// codeMissingPermission is Lark's "Lack of necessary permissions" code
+	// (returned as HTTP 400) when the app is missing a required scope — e.g.
+	// im:message.group_msg to read group chat history. The history reader
+	// classifies it as a non-transient, actionable failure rather than a
+	// retryable transport error. See MUL-4166.
+	codeMissingPermission = 230027
 )
+
+// IsMissingPermission reports whether err is a Lark APIError signalling the app
+// lacks a required scope (codeMissingPermission). The on-demand history reader
+// uses it to turn a permanent permission failure into an actionable note
+// instead of a retryable 5xx.
+func IsMissingPermission(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.Code == codeMissingPermission
+}
 
 // HTTPClientConfig configures the production Lark HTTP APIClient.
 type HTTPClientConfig struct {
@@ -974,6 +989,19 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 		return fmt.Errorf("read body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Lark returns its business envelope {code,msg} even on non-2xx (e.g. a
+		// 400 with code 230027 when the app is missing a required scope). Surface
+		// it as a structured *APIError so callers can classify the failure
+		// (permission vs transient) instead of string-matching; fall back to an
+		// opaque transport error when the body is not a Lark envelope (e.g. a bare
+		// 5xx from a gateway).
+		var env struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+		}
+		if json.Unmarshal(rawBody, &env) == nil && env.Code != 0 {
+			return &APIError{Op: fmt.Sprintf("http %d", resp.StatusCode), Code: env.Code, Msg: env.Msg}
+		}
 		return fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
 	}
 	if out != nil && len(rawBody) > 0 {

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -654,6 +654,73 @@ func (c *httpAPIClient) ListChatMessages(ctx context.Context, creds Installation
 	return out, nil
 }
 
+// ListContainerMessages lists one page of messages in a chat or a topic via
+// GET /open-apis/im/v1/messages, newest-first, with page_token cursoring. It
+// backs the on-demand `multica chat` history reader (MUL-4166): unlike
+// ListChatMessages (a single time-anchored page for the inbound enricher),
+// this pages to older messages via Lark's page_token and reports whether an
+// older page exists. Note Lark rejects start_time/end_time for
+// container_id_type=thread, so this method never sends them — page_token is
+// the sole cursor, valid for both container types.
+func (c *httpAPIClient) ListContainerMessages(ctx context.Context, creds InstallationCredentials, p ListContainerParams) (ListContainerResult, error) {
+	if p.ContainerType != larkContainerTypeChat && p.ContainerType != larkContainerTypeThread {
+		return ListContainerResult{}, fmt.Errorf("lark http client: invalid container_id_type %q", p.ContainerType)
+	}
+	if p.ContainerID == "" {
+		return ListContainerResult{}, errors.New("lark http client: missing container_id")
+	}
+	size := p.PageSize
+	if size <= 0 {
+		size = 1
+	} else if size > larkListMessagesMaxPageSize {
+		size = larkListMessagesMaxPageSize
+	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return ListContainerResult{}, err
+	}
+	q := url.Values{}
+	q.Set("container_id_type", p.ContainerType)
+	q.Set("container_id", p.ContainerID)
+	q.Set("sort_type", "ByCreateTimeDesc")
+	q.Set("page_size", strconv.Itoa(size))
+	q.Set("user_id_type", "open_id")
+	if p.PageToken != "" {
+		q.Set("page_token", p.PageToken)
+	}
+	path := "/open-apis/im/v1/messages?" + q.Encode()
+
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			HasMore   bool                  `json:"has_more"`
+			PageToken string                `json:"page_token"`
+			Items     []larkRESTMessageItem `json:"items"`
+		} `json:"data"`
+	}
+	if err := c.doJSON(ctx, c.resolveBaseURL(creds), http.MethodGet, path, token, nil, &resp); err != nil {
+		return ListContainerResult{}, fmt.Errorf("lark http client: list container messages: %w", err)
+	}
+	if resp.Code != 0 {
+		if isTokenError(resp.Code) {
+			c.invalidateToken(creds.AppID)
+		}
+		return ListContainerResult{}, fmt.Errorf("lark http client: list container messages: code=%d msg=%q", resp.Code, resp.Msg)
+	}
+
+	out := ListContainerResult{Messages: make([]LarkMessage, 0, len(resp.Data.Items))}
+	for _, it := range resp.Data.Items {
+		out.Messages = append(out.Messages, it.normalize())
+	}
+	// Only advertise a cursor when Lark says an older page exists; a page_token
+	// with has_more=false points at nothing.
+	if resp.Data.HasMore {
+		out.PageToken = resp.Data.PageToken
+	}
+	return out, nil
+}
+
 // larkBatchGetUsersMaxIDs is Lark's hard cap on user_ids per
 // contact/v3/users/batch call. We drop the overflow rather than error so
 // a caller asking for more still gets the first 50 resolved.
@@ -790,6 +857,7 @@ type larkRESTMessageItem struct {
 	MessageID      string `json:"message_id"`
 	RootID         string `json:"root_id"`
 	ParentID       string `json:"parent_id"`
+	ThreadID       string `json:"thread_id"`
 	UpperMessageID string `json:"upper_message_id"`
 	MsgType        string `json:"msg_type"`
 	CreateTime     string `json:"create_time"`
@@ -819,6 +887,7 @@ func (it larkRESTMessageItem) normalize() LarkMessage {
 		CreateTime:     it.CreateTime,
 		ParentID:       it.ParentID,
 		RootID:         it.RootID,
+		ThreadID:       it.ThreadID,
 		UpperMessageID: it.UpperMessageID,
 		Deleted:        it.Deleted,
 	}

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -1109,8 +1109,8 @@ func TestHTTPClient_GetBotInfo_HappyPath(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"bot": map[string]any{
-				"open_id":   "ou_bot_42",
-				"app_name":  "PersonalAgent",
+				"open_id":    "ou_bot_42",
+				"app_name":   "PersonalAgent",
 				"avatar_url": "https://example/avatar.png",
 			},
 		})
@@ -1231,6 +1231,31 @@ func TestHTTPClient_BadHTTPStatus(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "http 500") {
 		t.Errorf("want http 500 surfaced, got %v", err)
+	}
+}
+
+// A Lark envelope on a non-2xx response (e.g. 400 + code 230027 for a missing
+// scope) must surface as a structured *APIError so callers can classify it —
+// here IsMissingPermission — instead of an opaque "http 400" string.
+func TestHTTPClient_MissingScopeIsStructured(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		_, _ = io.WriteString(w, `{"code":230027,"msg":"Lack of necessary permissions, ext=need scope: im:message.group_msg"}`)
+	})
+	c := newTestClient(fake, time.Now)
+	_, err := c.ListContainerMessages(context.Background(), testCreds(), ListContainerParams{
+		ContainerType: larkContainerTypeChat,
+		ContainerID:   "oc",
+		PageSize:      10,
+	})
+	if !IsMissingPermission(err) {
+		t.Fatalf("want IsMissingPermission true, got %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != 230027 {
+		t.Fatalf("want *APIError code 230027, got %v", err)
 	}
 }
 

--- a/server/internal/integrations/lark/inbound_enricher.go
+++ b/server/internal/integrations/lark/inbound_enricher.go
@@ -22,14 +22,15 @@ const larkMsgTypeMergeForward = "merge_forward"
 // visible "... (N more truncated)" marker.
 const defaultMaxForwardChildren = 100
 
-// DefaultRecentContextSize is the window the production wiring uses for
-// the group-context prefetch: the page_size of the single list call made
-// when a user @-mentions the Bot in a group. It is a FETCH budget, not a
-// guaranteed rendered count — the trigger message itself and any quoted
-// parent are filtered out of the result, so the <recent_context> block
-// usually renders one or two fewer lines. 10 keeps the agent's prompt
-// meaningfully contextual without bloating it or straining the inbound
-// ACK budget (one list call, page_size 10).
+// DefaultRecentContextSize is the historical window for the group-context
+// prefetch: the page_size of the single list call made when a user @-mentions
+// the Bot in a group. As of MUL-4166 the production wiring sets
+// RecentContextSize to 0 (prefetch disabled) — surrounding context is now
+// PULLED on demand via `multica chat history`, matching Slack. This constant is
+// retained for tests and for any deployment that opts the force-assembled
+// <recent_context> block back in. It is a FETCH budget, not a guaranteed
+// rendered count — the trigger message itself and any quoted parent are
+// filtered out of the result.
 const DefaultRecentContextSize = 10
 
 // Enricher expands an inbound message's body with context the user
@@ -55,9 +56,10 @@ type InboundEnricherConfig struct {
 	// RecentContextSize caps how many surrounding group messages the
 	// enricher prefetches and inlines as a <recent_context> block when a
 	// user @-mentions the Bot in a group. <=0 DISABLES the prefetch
-	// entirely (only explicitly-attached quote/forward context is used);
-	// the production wiring sets DefaultRecentContextSize. Values above
-	// Lark's 50-per-page cap are clamped by the client.
+	// entirely (only explicitly-attached quote/forward context is used).
+	// The production wiring sets 0 as of MUL-4166 — recent context is pulled
+	// on demand via `multica chat history` instead. Values above Lark's
+	// 50-per-page cap are clamped by the client.
 	RecentContextSize int
 	// Logger receives best-effort warnings about fetch failures. Nil
 	// uses slog.Default().
@@ -439,6 +441,16 @@ func (e *inboundEnricher) renderForwardedItems(items []LarkMessage, forwardID st
 // context, not a fresh trigger, so passing empty bot identifiers leaves
 // every @-mention rendered as a readable @name.
 func (e *inboundEnricher) flattenMessage(m LarkMessage) string {
+	return flattenLarkMessage(m)
+}
+
+// flattenLarkMessage turns one fetched IM message into plain text: a deleted
+// marker, else structural flatten by msg_type followed by @_user_N placeholder
+// resolution against the message's own mentions. Empty bot identifiers leave
+// every @-mention rendered as a readable @name — a quoted / forwarded /
+// historical message is context, not a fresh trigger, so nothing is stripped.
+// Shared by the inbound enricher and the on-demand history reader.
+func flattenLarkMessage(m LarkMessage) string {
 	if m.Deleted {
 		return "[deleted message]"
 	}

--- a/server/internal/integrations/lark/inbound_enricher_test.go
+++ b/server/internal/integrations/lark/inbound_enricher_test.go
@@ -73,6 +73,9 @@ func (f *enricherFakeClient) BatchGetUsers(ctx context.Context, creds Installati
 }
 
 // Unused-by-enricher methods — present only to satisfy APIClient.
+func (f *enricherFakeClient) ListContainerMessages(context.Context, InstallationCredentials, ListContainerParams) (ListContainerResult, error) {
+	return ListContainerResult{}, nil
+}
 func (f *enricherFakeClient) SendInteractiveCard(context.Context, SendCardParams) (string, error) {
 	return "", nil
 }

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -149,6 +149,9 @@ func (f *fakeAPIClient) GetMessage(ctx context.Context, creds InstallationCreden
 func (f *fakeAPIClient) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
 	return nil, nil
 }
+func (f *fakeAPIClient) ListContainerMessages(ctx context.Context, creds InstallationCredentials, p ListContainerParams) (ListContainerResult, error) {
+	return ListContainerResult{}, nil
+}
 func (f *fakeAPIClient) BatchGetUsers(ctx context.Context, creds InstallationCredentials, openIDs []string) (map[string]string, error) {
 	return nil, nil
 }

--- a/server/internal/integrations/lark/outcome_replier_test.go
+++ b/server/internal/integrations/lark/outcome_replier_test.go
@@ -90,6 +90,9 @@ func (s *stubAPIClientWithRecorder) GetMessage(ctx context.Context, creds Instal
 func (s *stubAPIClientWithRecorder) ListChatMessages(ctx context.Context, creds InstallationCredentials, p ListMessagesParams) ([]LarkMessage, error) {
 	return nil, nil
 }
+func (s *stubAPIClientWithRecorder) ListContainerMessages(ctx context.Context, creds InstallationCredentials, p ListContainerParams) (ListContainerResult, error) {
+	return ListContainerResult{}, nil
+}
 func (s *stubAPIClientWithRecorder) BatchGetUsers(ctx context.Context, creds InstallationCredentials, openIDs []string) (map[string]string, error) {
 	return nil, nil
 }

--- a/server/internal/integrations/lark/typing_indicator_test.go
+++ b/server/internal/integrations/lark/typing_indicator_test.go
@@ -56,6 +56,9 @@ func (f *fakeTypingAPIClient) GetMessage(context.Context, InstallationCredential
 func (f *fakeTypingAPIClient) ListChatMessages(context.Context, InstallationCredentials, ListMessagesParams) ([]LarkMessage, error) {
 	return nil, nil
 }
+func (f *fakeTypingAPIClient) ListContainerMessages(context.Context, InstallationCredentials, ListContainerParams) (ListContainerResult, error) {
+	return ListContainerResult{}, nil
+}
 func (f *fakeTypingAPIClient) BatchGetUsers(context.Context, InstallationCredentials, []string) (map[string]string, error) {
 	return nil, nil
 }

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -518,6 +518,33 @@ func (q *Queries) GetChannelChatSessionBindingBySession(ctx context.Context, arg
 	return i, err
 }
 
+const getChannelChatSessionBindingBySessionAny = `-- name: GetChannelChatSessionBindingBySessionAny :one
+SELECT id, chat_session_id, installation_id, channel_type, channel_chat_id, chat_type, last_message_id, last_thread_id, config, created_at FROM channel_chat_session_binding
+WHERE chat_session_id = $1
+`
+
+// Reverse lookup by session alone. chat_session_id is UNIQUE, so this returns
+// the one binding regardless of channel type — used where the caller must
+// DISCOVER which channel a session is bound to (unified `multica chat` history
+// dispatch, prompt channel awareness) rather than assert a specific platform.
+func (q *Queries) GetChannelChatSessionBindingBySessionAny(ctx context.Context, chatSessionID pgtype.UUID) (ChannelChatSessionBinding, error) {
+	row := q.db.QueryRow(ctx, getChannelChatSessionBindingBySessionAny, chatSessionID)
+	var i ChannelChatSessionBinding
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.InstallationID,
+		&i.ChannelType,
+		&i.ChannelChatID,
+		&i.ChatType,
+		&i.LastMessageID,
+		&i.LastThreadID,
+		&i.Config,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getChannelInstallation = `-- name: GetChannelInstallation :one
 SELECT id, workspace_id, agent_id, channel_type, config, status, ws_lease_token, ws_lease_expires_at, installer_user_id, installed_at, created_at, updated_at FROM channel_installation
 WHERE id = $1 AND channel_type = $2

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -291,6 +291,14 @@ SELECT * FROM channel_chat_session_binding
 WHERE chat_session_id = sqlc.arg('chat_session_id')
   AND channel_type = sqlc.arg('channel_type');
 
+-- name: GetChannelChatSessionBindingBySessionAny :one
+-- Reverse lookup by session alone. chat_session_id is UNIQUE, so this returns
+-- the one binding regardless of channel type — used where the caller must
+-- DISCOVER which channel a session is bound to (unified `multica chat` history
+-- dispatch, prompt channel awareness) rather than assert a specific platform.
+SELECT * FROM channel_chat_session_binding
+WHERE chat_session_id = $1;
+
 -- name: UpdateChannelChatSessionBindingReplyTarget :exec
 -- Records the most recent inbound trigger message + thread so the decoupled
 -- outbound patcher can thread its reply back into the originating topic.


### PR DESCRIPTION
## What & why

Slack has a unified, on-demand context-fetching CLI — `multica chat history` (channel overview) and `multica chat thread [id]` (one thread) — introduced in MUL-3871. The agent *pulls* the conversation when it needs it, through a platform-neutral `ChatChannelHistoryReader`.

Lark (Feishu) was never wired into that pull path. It fed context the old way: the inbound **enricher force-assembled a `<recent_context>` block into every inbound message** and persisted it into `chat_message.content`. This PR migrates Lark onto the same unified pull model Slack uses (MUL-4166).

## Changes

- **`lark.History` reader** (`server/internal/integrations/lark/history.go`) — satisfies `ChatChannelHistoryReader`. A Lark session spans the whole chat (`channel_chat_id` is the real `chat_id`), so:
  - `ChannelOverview` lists the chat's recent messages (oldest-first); messages that belong to a topic (话题) are tagged with their `thread_id` so the agent can drill in. Lark's list carries no per-topic reply count, so `reply_count` is honestly omitted.
  - `Thread` reads one topic (`container_id_type=thread`); with no id it reads the session's current topic (`last_thread_id`), falling back to the linear chat when the session isn't in a topic (mirrors Slack's DM fallback).
  - The chat is resolved server-side from the binding and never taken from the agent — the thread id is only a within-chat locator (same security boundary as Slack).
- **`APIClient.ListContainerMessages`** (`client.go` / `http_client.go`) — pages a chat or a topic via `GET /open-apis/im/v1/messages` with `page_token` cursoring (Lark rejects `start_time`/`end_time` for `container_id_type=thread`, so `page_token` is the sole, universal cursor). Parses `thread_id` on IM message items.
- **Channel-type dispatch** — `handler.NewChatHistoryRouter` routes `/api/chat/history|thread` to the reader for the session's channel type (was hard-bound to Slack via `h.SlackHistory`). Adds the session-only lookup `GetChannelChatSessionBindingBySessionAny` and a shared `channel.ErrNoChannelSession` sentinel.
- **Prompt enablement** — the daemon now sets `ChatChannelType` from the session's binding generically (any wired channel, not just Slack), so Feishu sessions get the channel-awareness block; `channelDisplayName("feishu") → "Lark"`.
- **Retire the force-assembly** — the enricher's `<recent_context>` prefetch is disabled in production (`RecentContextSize=0`) now that recent context is pulled on demand. **Quote/forward enrichment stays** — that's trigger-specific content (a quoted parent, a forwarded transcript) the history pull cannot reconstruct.

## Design note

Disabling the `<recent_context>` force-assembly is the one behavioral change worth a close look: it's what makes this a *migration* rather than a second parallel mechanism, and it matches Slack (which was pull-first from the start). It's a one-line, reversible config change (`RecentContextSize`) if the pull model proves insufficient in practice.

## Verification

- `go build ./...` clean; `go vet` clean on the touched packages.
- New unit tests: `lark.History` (overview ordering / role / topic-tagging, thread current-topic / by-id / linear fallback, no-binding, revoked install) and the handler dispatch (existing chat-history tests pass against the new router).
- `go test ./internal/integrations/lark/...`, `./internal/integrations/channel/...`, `./internal/daemon/...` pass; handler chat-history tests pass. (Unrelated pre-existing `handler` failures are test-DB migration drift — `ipr.reference_only` from migration 127 not applied to the local test DB — and email-uniqueness test isolation, both in `github_test.go`/auth.)
- Could not exercise against live Feishu from this environment; the reader is covered by fakes and the two Lark API shapes (`container_id_type=thread`, `thread_id` on message items) were confirmed against the Feishu Open Platform docs.

MUL-4166
