### PR TITLE
MUL-4173: expose MCP config tab for supported providers

### DIFF
--- a/packages/core/agents/mcp-support.test.ts
+++ b/packages/core/agents/mcp-support.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { providerSupportsMcpConfig } from "./mcp-support";
+
+describe("providerSupportsMcpConfig", () => {
+  it("matches providers whose runtime consumes mcp_config", () => {
+    expect(providerSupportsMcpConfig("claude")).toBe(true);
+    expect(providerSupportsMcpConfig("codebuddy")).toBe(true);
+    expect(providerSupportsMcpConfig("codex")).toBe(true);
+    expect(providerSupportsMcpConfig("cursor")).toBe(true);
+    expect(providerSupportsMcpConfig("hermes")).toBe(true);
+    expect(providerSupportsMcpConfig("kimi")).toBe(true);
+    expect(providerSupportsMcpConfig("kiro")).toBe(true);
+    expect(providerSupportsMcpConfig("opencode")).toBe(true);
+    expect(providerSupportsMcpConfig("openclaw")).toBe(true);
+    expect(providerSupportsMcpConfig("qoder")).toBe(true);
+    expect(providerSupportsMcpConfig("traecli")).toBe(true);
+  });
+
+  it("rejects providers whose runtime ignores mcp_config", () => {
+    expect(providerSupportsMcpConfig("antigravity")).toBe(false);
+    expect(providerSupportsMcpConfig("copilot")).toBe(false);
+    expect(providerSupportsMcpConfig("pi")).toBe(false);
+    expect(providerSupportsMcpConfig(undefined)).toBe(false);
+    expect(providerSupportsMcpConfig(null)).toBe(false);
+  });
+});

--- a/packages/core/agents/mcp-support.ts
+++ b/packages/core/agents/mcp-support.ts
@@ -7,6 +7,7 @@
 // config for CLIs that do not receive it through ExecOptions.
 const MCP_SUPPORTED_PROVIDERS = new Set([
   "claude",
+  "codebuddy",
   "codex",
   "cursor",
   "hermes",
@@ -14,6 +15,7 @@ const MCP_SUPPORTED_PROVIDERS = new Set([
   "kiro",
   "opencode",
   "openclaw",
+  "qoder",
   "traecli",
 ]);
 


### PR DESCRIPTION
Summary
- Add CodeBuddy and Qoder to the MCP-capable provider gate so the Agents UI shows the MCP config tab for runtimes whose backends consume mcp_config.
- Add a regression test for supported and unsupported providers.

Testing
- pnpm --filter @multica/core exec vitest run agents/mcp-support.test.ts
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/core exec eslint agents/mcp-support.ts agents/mcp-support.test.ts

Note
- pnpm --filter @multica/core test -- mcp-support.test.ts unexpectedly ran the whole core suite; unrelated localStorage environment tests failed. The direct Vitest file run passed.