### PR TITLE
feat(inbox): add paginated inbox list

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -62,6 +62,8 @@ import type {
   RuntimeLocalSkillListRequest,
   CreateRuntimeLocalSkillImportRequest,
   RuntimeLocalSkillImportRequest,
+  InboxCursor,
+  InboxPage,
   TimelineEntry,
   AssigneeFrequencyEntry,
   TaskMessagePayload,
@@ -218,6 +220,10 @@ import {
   EMPTY_CANCEL_TASK_RESPONSE,
   CreateFeedbackResponseSchema,
   EMPTY_CREATE_FEEDBACK_RESPONSE,
+  InboxPageSchema,
+  EMPTY_INBOX_PAGE,
+  InboxUnreadCountSchema,
+  EMPTY_INBOX_UNREAD_COUNT,
   InboxUnreadSummarySchema,
   EMPTY_INBOX_UNREAD_SUMMARY,
 } from "./schemas";
@@ -1480,7 +1486,26 @@ export class ApiClient {
 
   // Inbox
   async listInbox(): Promise<InboxItem[]> {
-    return this.fetch("/api/inbox");
+    const page = await this.listInboxPage();
+    return page.items;
+  }
+
+  async listInboxPage(params?: {
+    limit?: number;
+    before?: InboxCursor | null;
+  }): Promise<InboxPage> {
+    const search = new URLSearchParams();
+    if (params?.limit) search.set("limit", String(params.limit));
+    if (params?.before) {
+      search.set("before_created_at", params.before.created_at);
+      search.set("before_id", params.before.id);
+    }
+    const query = search.toString();
+    const path = `/api/inbox${query ? `?${query}` : ""}`;
+    const raw = await this.fetch<unknown>(path);
+    return parseWithFallback(raw, InboxPageSchema, EMPTY_INBOX_PAGE, {
+      endpoint: "GET /api/inbox",
+    });
   }
 
   async markInboxRead(id: string): Promise<InboxItem> {
@@ -1492,7 +1517,10 @@ export class ApiClient {
   }
 
   async getUnreadInboxCount(): Promise<{ count: number }> {
-    return this.fetch("/api/inbox/unread-count");
+    const raw = await this.fetch<unknown>("/api/inbox/unread-count");
+    return parseWithFallback(raw, InboxUnreadCountSchema, EMPTY_INBOX_UNREAD_COUNT, {
+      endpoint: "GET /api/inbox/unread-count",
+    });
   }
 
   // Cross-workspace unread summary: one entry per workspace the user belongs

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -7,8 +7,12 @@ import {
   CreateFeedbackResponseSchema,
   DuplicateIssueErrorBodySchema,
   EMPTY_CREATE_FEEDBACK_RESPONSE,
+  EMPTY_INBOX_PAGE,
+  EMPTY_INBOX_UNREAD_COUNT,
   EMPTY_INBOX_UNREAD_SUMMARY,
   EMPTY_USER,
+  InboxPageSchema,
+  InboxUnreadCountSchema,
   InboxUnreadSummarySchema,
   IssueTriggerPreviewSchema,
   ListIssuesResponseSchema,
@@ -467,6 +471,91 @@ describe("AppConfigSchema cdn_signed drift", () => {
   it("defaults malformed feature_flags to an empty object", () => {
     const parsed = AppConfigSchema.parse({ feature_flags: ["not", "an", "object"] });
     expect(parsed.feature_flags).toEqual({});
+  });
+});
+
+describe("InboxPageSchema", () => {
+  const ENDPOINT = { endpoint: "GET /api/inbox" };
+  const inboxItem = {
+    id: "inbox-1",
+    workspace_id: "ws-1",
+    recipient_type: "member",
+    recipient_id: "user-1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: "issue-1",
+    title: "New comment",
+    body: null,
+    issue_status: "todo",
+    read: false,
+    archived: false,
+    created_at: "2026-07-07T00:00:00Z",
+    details: { comment_id: "comment-1" },
+  };
+
+  it("parses a paginated inbox response", () => {
+    const parsed = parseWithFallback(
+      {
+        items: [inboxItem],
+        limit: 50,
+        has_more: true,
+        next_cursor: {
+          created_at: "2026-07-07T00:00:00Z",
+          id: "inbox-1",
+        },
+        future_field: "kept",
+      },
+      InboxPageSchema,
+      EMPTY_INBOX_PAGE,
+      ENDPOINT,
+    );
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_cursor).toEqual({
+      created_at: "2026-07-07T00:00:00Z",
+      id: "inbox-1",
+    });
+  });
+
+  it("normalizes the legacy array response into a page", () => {
+    const parsed = parseWithFallback(
+      [inboxItem],
+      InboxPageSchema,
+      EMPTY_INBOX_PAGE,
+      ENDPOINT,
+    );
+
+    expect(parsed).toMatchObject({
+      items: [inboxItem],
+      limit: 1,
+      has_more: false,
+      next_cursor: null,
+    });
+  });
+
+  it("returns the empty fallback for malformed inbox bodies", () => {
+    expect(
+      parseWithFallback({ items: "not an array" }, InboxPageSchema, EMPTY_INBOX_PAGE, ENDPOINT),
+    ).toBe(EMPTY_INBOX_PAGE);
+  });
+});
+
+describe("InboxUnreadCountSchema", () => {
+  const ENDPOINT = { endpoint: "GET /api/inbox/unread-count" };
+
+  it("parses the unread count response", () => {
+    expect(
+      parseWithFallback({ count: 3 }, InboxUnreadCountSchema, EMPTY_INBOX_UNREAD_COUNT, ENDPOINT),
+    ).toEqual({ count: 3 });
+  });
+
+  it("returns the zero fallback for malformed counts", () => {
+    expect(
+      parseWithFallback({ count: "3" }, InboxUnreadCountSchema, EMPTY_INBOX_UNREAD_COUNT, ENDPOINT),
+    ).toBe(EMPTY_INBOX_UNREAD_COUNT);
   });
 });
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -15,6 +15,8 @@ import type {
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
   GroupedIssuesResponse,
+  InboxItem,
+  InboxPage,
   InboxWorkspaceUnread,
   ListIssuesResponse,
   ListWebhookDeliveriesResponse,
@@ -972,6 +974,69 @@ export const EMPTY_USER: User = {
   created_at: "",
   updated_at: "",
 };
+
+// ---------------------------------------------------------------------------
+// Inbox list schemas (`/api/inbox` GET).
+//
+// New servers return a paginated envelope. Older servers returned a raw array,
+// so accept both at the API boundary and normalize to the paginated shape.
+// ---------------------------------------------------------------------------
+
+const InboxItemSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  recipient_type: z.string(),
+  recipient_id: z.string(),
+  actor_type: z.string().nullable().default(null),
+  actor_id: z.string().nullable().default(null),
+  type: z.string(),
+  severity: z.string(),
+  issue_id: z.string().nullable().default(null),
+  title: z.string().default(""),
+  body: z.string().nullable().default(null),
+  issue_status: z.string().nullable().default(null),
+  read: z.boolean().default(false),
+  archived: z.boolean().default(false),
+  created_at: z.string().default(""),
+  details: z.record(z.string(), z.unknown()).nullable().default(null),
+}).loose();
+
+const InboxCursorSchema = z.object({
+  created_at: z.string(),
+  id: z.string(),
+}).loose();
+
+const InboxPageEnvelopeSchema = z.object({
+  items: z.array(InboxItemSchema).default([]),
+  limit: z.number().default(50),
+  has_more: z.boolean().default(false),
+  next_cursor: InboxCursorSchema.nullable().default(null),
+}).loose();
+
+export const InboxPageSchema = z.union([
+  InboxPageEnvelopeSchema,
+  z.array(InboxItemSchema).transform((items) => ({
+    items,
+    limit: items.length,
+    has_more: false,
+    next_cursor: null,
+  })),
+]);
+
+export const EMPTY_INBOX_PAGE: InboxPage = {
+  items: [],
+  limit: 50,
+  has_more: false,
+  next_cursor: null,
+};
+
+export const EMPTY_INBOX_ITEMS: InboxItem[] = [];
+
+export const InboxUnreadCountSchema = z.object({
+  count: z.number().default(0),
+}).loose();
+
+export const EMPTY_INBOX_UNREAD_COUNT = { count: 0 };
 
 // ---------------------------------------------------------------------------
 // Cross-workspace unread inbox summary (`/api/inbox/unread-summary` GET).

--- a/packages/core/inbox/mutations.ts
+++ b/packages/core/inbox/mutations.ts
@@ -4,6 +4,14 @@ import { inboxKeys } from "./queries";
 import { useWorkspaceId } from "../hooks";
 import type { InboxItem } from "../types";
 
+function invalidateInboxCaches(
+  qc: ReturnType<typeof useQueryClient>,
+  wsId: string,
+) {
+  qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadSummary() });
+}
+
 export function useMarkInboxRead() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
@@ -21,7 +29,7 @@ export function useMarkInboxRead() {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }
@@ -50,7 +58,7 @@ export function useArchiveInbox() {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }
@@ -74,7 +82,7 @@ export function useMarkAllInboxRead() {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }
@@ -85,7 +93,7 @@ export function useArchiveAllInbox() {
   return useMutation({
     mutationFn: () => api.archiveAllInbox(),
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }
@@ -96,7 +104,7 @@ export function useArchiveAllReadInbox() {
   return useMutation({
     mutationFn: () => api.archiveAllReadInbox(),
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }
@@ -107,7 +115,7 @@ export function useArchiveCompletedInbox() {
   return useMutation({
     mutationFn: () => api.archiveCompletedInbox(),
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateInboxCaches(qc, wsId);
     },
   });
 }

--- a/packages/core/inbox/queries.test.ts
+++ b/packages/core/inbox/queries.test.ts
@@ -148,6 +148,17 @@ describe("unreadWorkspaceIds", () => {
 });
 
 describe("inboxKeys.unreadSummary", () => {
+  it("keeps workspace-scoped inbox caches under the same prefix", () => {
+    expect(inboxKeys.all("ws-1")).toEqual(["inbox", "ws-1"]);
+    expect(inboxKeys.list("ws-1")).toEqual(["inbox", "ws-1", "list"]);
+    expect(inboxKeys.pages("ws-1")).toEqual(["inbox", "ws-1", "pages"]);
+    expect(inboxKeys.unreadCount("ws-1")).toEqual([
+      "inbox",
+      "ws-1",
+      "unread-count",
+    ]);
+  });
+
   it("is a stable account-level key independent of any workspace", () => {
     expect(inboxKeys.unreadSummary()).toEqual(["inbox", "unread-summary"]);
   });

--- a/packages/core/inbox/queries.ts
+++ b/packages/core/inbox/queries.ts
@@ -1,10 +1,12 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions, useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import type { InboxItem, InboxWorkspaceUnread } from "../types";
 
 export const inboxKeys = {
   all: (wsId: string) => ["inbox", wsId] as const,
   list: (wsId: string) => [...inboxKeys.all(wsId), "list"] as const,
+  pages: (wsId: string) => [...inboxKeys.all(wsId), "pages"] as const,
+  unreadCount: (wsId: string) => [...inboxKeys.all(wsId), "unread-count"] as const,
   // Account-level (not workspace-scoped): a single shared cache entry that
   // holds unread counts for every workspace the user belongs to.
   unreadSummary: () => ["inbox", "unread-summary"] as const,
@@ -14,6 +16,26 @@ export function inboxListOptions(wsId: string) {
   return queryOptions({
     queryKey: inboxKeys.list(wsId),
     queryFn: () => api.listInbox(),
+  });
+}
+
+export function inboxPageOptions(wsId: string, limit = 50) {
+  return infiniteQueryOptions({
+    queryKey: inboxKeys.pages(wsId),
+    queryFn: ({ pageParam }) =>
+      api.listInboxPage({ before: pageParam, limit }),
+    initialPageParam: null as { created_at: string; id: string } | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.next_cursor ?? undefined : undefined,
+    enabled: !!wsId,
+  });
+}
+
+export function inboxUnreadCountOptions(wsId: string) {
+  return queryOptions({
+    queryKey: inboxKeys.unreadCount(wsId),
+    queryFn: () => api.getUnreadInboxCount(),
+    enabled: !!wsId,
   });
 }
 
@@ -59,11 +81,9 @@ export function unreadWorkspaceIds(summary: InboxWorkspaceUnread[]): Set<string>
  */
 export function useInboxUnreadCount(wsId: string | null | undefined): number {
   const { data } = useQuery({
-    queryKey: inboxKeys.list(wsId ?? ""),
-    queryFn: () => api.listInbox(),
+    ...inboxUnreadCountOptions(wsId ?? ""),
     enabled: !!wsId,
-    select: (items: InboxItem[]) =>
-      deduplicateInboxItems(items).filter((i) => !i.read).length,
+    select: (value) => value.count,
   });
   return data ?? 0;
 }

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -8,8 +8,8 @@ export function onInboxNew(
   _item: InboxItem,
 ) {
   // Use invalidateQueries instead of setQueryData — triggers a refetch that
-  // reliably notifies all observers. The inbox list is small so this is cheap.
-  qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+  // reliably notifies all observers.
+  qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
 }
 
 export function patchInboxIssueStatus(
@@ -32,6 +32,7 @@ export function onInboxIssueStatusChanged(
   status: IssueStatus,
 ) {
   patchInboxIssueStatus(qc, wsId, issueId, status);
+  qc.invalidateQueries({ queryKey: inboxKeys.pages(wsId) });
 }
 
 // Mirrors the DB-level ON DELETE CASCADE on inbox_item.issue_id: when an issue
@@ -45,10 +46,11 @@ export function onInboxIssueDeleted(
   qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
     old?.filter((i) => i.issue_id !== issueId),
   );
+  qc.invalidateQueries({ queryKey: inboxKeys.pages(wsId) });
 }
 
 export function onInboxInvalidate(qc: QueryClient, wsId: string) {
-  qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+  qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
 }
 
 // Refresh the cross-workspace unread summary (workspace-switcher dot). The

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -438,7 +438,7 @@ describe("handleInboxNew", () => {
     await handleInboxNew(qc, inboxItem());
 
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: inboxKeys.list("ws-a"),
+      queryKey: inboxKeys.all("ws-a"),
     });
     expect(showNotification).toHaveBeenCalledWith(
       expect.objectContaining({ slug: "workspace-a" }),

--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -33,6 +33,18 @@ export interface InboxWorkspaceUnread {
   count: number;
 }
 
+export interface InboxCursor {
+  created_at: string;
+  id: string;
+}
+
+export interface InboxPage {
+  items: InboxItem[];
+  limit: number;
+  has_more: boolean;
+  next_cursor: InboxCursor | null;
+}
+
 export interface InboxItem {
   id: string;
   workspace_id: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -64,7 +64,7 @@ export type {
 } from "./agent";
 export { RUNTIME_PROFILE_PROTOCOL_FAMILIES } from "./agent";
 export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
-export type { InboxItem, InboxSeverity, InboxItemType, InboxWorkspaceUnread } from "./inbox";
+export type { InboxCursor, InboxItem, InboxPage, InboxSeverity, InboxItemType, InboxWorkspaceUnread } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";
 export type { Comment, CommentType, CommentAuthorType, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, Reaction } from "./comment";
 export type { Label, CreateLabelRequest, UpdateLabelRequest, ListLabelsResponse, IssueLabelsResponse } from "./label";

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useDefaultLayout } from "react-resizable-panels";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import {
-  inboxListOptions,
+  inboxPageOptions,
   deduplicateInboxItems,
   useInboxUnreadCount,
 } from "@multica/core/inbox/queries";
@@ -70,7 +70,17 @@ export function InboxPage() {
   }, [urlIssue]);
 
   const wsId = useWorkspaceId();
-  const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
+  const {
+    data: inboxPages,
+    isLoading: loading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery(inboxPageOptions(wsId));
+  const rawItems = useMemo(
+    () => inboxPages?.pages.flatMap((page) => page.items) ?? [],
+    [inboxPages],
+  );
   const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
 
   const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
@@ -101,12 +111,27 @@ export function InboxPage() {
     if (loading) return;
     if (!selectedKey) return;
     if (selected) return;
+    if (isFetchingNextPage) return;
+    if (hasNextPage) {
+      fetchNextPage();
+      return;
+    }
     if (lastResolvedKeyRef.current === selectedKey) {
       setSelectedKey("");
       return;
     }
     replace(wsPaths.issueDetail(selectedKey));
-  }, [loading, selectedKey, selected, replace, wsPaths, setSelectedKey]);
+  }, [
+    loading,
+    selectedKey,
+    selected,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    replace,
+    wsPaths,
+    setSelectedKey,
+  ]);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_inbox_layout",
@@ -283,6 +308,21 @@ export function InboxPage() {
           onArchive={() => handleArchive(item.id)}
         />
       ))}
+      {hasNextPage && (
+        <div className="p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full text-muted-foreground"
+            disabled={isFetchingNextPage}
+            onClick={() => fetchNextPage()}
+          >
+            {isFetchingNextPage
+              ? t(($) => $.list.loading_more)
+              : t(($) => $.list.load_more)}
+          </Button>
+        </div>
+      )}
     </div>
   );
 

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -127,8 +127,7 @@ vi.mock("@multica/core/api", async (importOriginal) => {
   };
 });
 vi.mock("@multica/core/inbox/queries", () => ({
-  deduplicateInboxItems: (items: unknown[]) => items,
-  inboxKeys: { list: () => ["inbox"], unreadSummary: () => ["inbox", "unread-summary"] },
+  inboxUnreadCountOptions: () => ({ queryKey: ["inbox", "ws-1", "unread-count"] }),
   inboxUnreadSummaryOptions: () => ({ queryKey: ["inbox", "unread-summary"] }),
   hasOtherWorkspaceUnread: (
     entries: { workspace_id: string; count: number }[],
@@ -159,6 +158,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
   useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
     if (queryKey[0] === "pins") return { data: pins.current };
     if (queryKey[0] === "issue") return detail.current;
+    if (queryKey[0] === "inbox" && queryKey[2] === "unread-count") return { data: { count: 0 } };
     if (queryKey[0] === "inbox" && queryKey[1] === "unread-summary") return { data: summary.current };
     if (queryKey[0] === "workspaces") return { data: workspaces.current };
     return { data: [] };

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -70,7 +70,7 @@ import { useCurrentWorkspace, useWorkspacePaths, paths } from "@multica/core/pat
 import { workspaceListOptions, myInvitationListOptions, workspaceKeys } from "@multica/core/workspace/queries";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { inboxKeys, deduplicateInboxItems, inboxUnreadSummaryOptions, hasOtherWorkspaceUnread, unreadWorkspaceIds } from "@multica/core/inbox/queries";
+import { inboxUnreadCountOptions, inboxUnreadSummaryOptions, hasOtherWorkspaceUnread, unreadWorkspaceIds } from "@multica/core/inbox/queries";
 import { api, ApiError } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { useConfigStore } from "@multica/core/config";
@@ -100,7 +100,6 @@ function isNavActive(pathname: string, href: string): boolean {
 const EMPTY_PINS: PinnedItem[] = [];
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
 const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
-const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
 const EMPTY_INBOX_SUMMARY: Awaited<ReturnType<typeof api.getInboxUnreadSummary>> = [];
 
 // Nav items reference WorkspacePaths method names so they can be resolved
@@ -356,15 +355,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const workspaceCreationDisabled = useConfigStore((s) => s.workspaceCreationDisabled);
 
   const wsId = workspace?.id;
-  const { data: inboxItems = EMPTY_INBOX } = useQuery({
-    queryKey: wsId ? inboxKeys.list(wsId) : ["inbox", "disabled"],
-    queryFn: () => api.listInbox(),
+  const { data: unreadCountResponse } = useQuery({
+    ...inboxUnreadCountOptions(wsId ?? ""),
     enabled: !!wsId,
   });
-  const unreadCount = React.useMemo(
-    () => deduplicateInboxItems(inboxItems).filter((i) => !i.read).length,
-    [inboxItems],
-  );
+  const unreadCount = unreadCountResponse?.count ?? 0;
   // Cross-workspace unread summary backs the workspace-switcher dot. One
   // shared cache entry across workspaces; gated on an active workspace since
   // the endpoint resolves through the workspace-member middleware.

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -11,6 +11,8 @@
   },
   "list": {
     "empty": "No notifications",
+    "load_more": "Load more",
+    "loading_more": "Loading...",
     "mark_done_tooltip": "Mark as done",
     "archive_tooltip": "Archive",
     "time": {

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -11,6 +11,8 @@
   },
   "list": {
     "empty": "通知はありません",
+    "load_more": "さらに読み込む",
+    "loading_more": "読み込み中...",
     "mark_done_tooltip": "完了にする",
     "archive_tooltip": "アーカイブ",
     "time": {

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -11,6 +11,8 @@
   },
   "list": {
     "empty": "알림이 없습니다",
+    "load_more": "더 보기",
+    "loading_more": "불러오는 중...",
     "mark_done_tooltip": "완료로 표시",
     "archive_tooltip": "보관",
     "time": {

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -11,6 +11,8 @@
   },
   "list": {
     "empty": "暂无通知",
+    "load_more": "加载更多",
+    "loading_more": "加载中...",
     "mark_done_tooltip": "标为已完成",
     "archive_tooltip": "归档",
     "time": {

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -785,11 +786,82 @@ func TestInboxThroughRouter(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("ListInbox: expected 200, got %d", resp.StatusCode)
 	}
-	var items []map[string]any
-	readJSON(t, resp, &items)
-	// Inbox may be empty, just verify it returns valid JSON array
-	if items == nil {
+	var page struct {
+		Items      []map[string]any `json:"items"`
+		Limit      int              `json:"limit"`
+		HasMore    bool             `json:"has_more"`
+		NextCursor *struct {
+			CreatedAt string `json:"created_at"`
+			ID        string `json:"id"`
+		} `json:"next_cursor"`
+	}
+	readJSON(t, resp, &page)
+	if page.Items == nil {
 		t.Fatal("expected non-nil inbox items array")
+	}
+	if page.Limit <= 0 {
+		t.Fatalf("expected positive page limit, got %d", page.Limit)
+	}
+}
+
+func TestInboxPaginationThroughRouter(t *testing.T) {
+	ctx := context.Background()
+	const titlePrefix = "Pagination fixture "
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO inbox_item (workspace_id, recipient_type, recipient_id, type, title, created_at)
+		VALUES
+			($1, 'member', $2, 'issue_assigned', $3 || 'newest', now() + interval '3 hours'),
+			($1, 'member', $2, 'issue_assigned', $3 || 'middle', now() + interval '2 hours'),
+			($1, 'member', $2, 'issue_assigned', $3 || 'oldest', now() + interval '1 hour')
+	`, testWorkspaceID, testUserID, titlePrefix); err != nil {
+		t.Fatalf("failed to seed inbox pagination fixtures: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM inbox_item WHERE workspace_id = $1 AND title LIKE $2`, testWorkspaceID, titlePrefix+"%")
+	})
+
+	resp := authRequest(t, "GET", "/api/inbox?limit=2", nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("ListInbox page 1: expected 200, got %d", resp.StatusCode)
+	}
+	var firstPage struct {
+		Items      []map[string]any `json:"items"`
+		HasMore    bool             `json:"has_more"`
+		NextCursor *struct {
+			CreatedAt string `json:"created_at"`
+			ID        string `json:"id"`
+		} `json:"next_cursor"`
+	}
+	readJSON(t, resp, &firstPage)
+	if len(firstPage.Items) != 2 {
+		t.Fatalf("expected first page length 2, got %d", len(firstPage.Items))
+	}
+	if !firstPage.HasMore || firstPage.NextCursor == nil {
+		t.Fatalf("expected first page to have a next cursor, got %+v", firstPage)
+	}
+	if firstPage.Items[0]["title"] != titlePrefix+"newest" || firstPage.Items[1]["title"] != titlePrefix+"middle" {
+		t.Fatalf("unexpected first page ordering: %+v", firstPage.Items)
+	}
+
+	cursor := url.Values{}
+	cursor.Set("limit", "2")
+	cursor.Set("before_created_at", firstPage.NextCursor.CreatedAt)
+	cursor.Set("before_id", firstPage.NextCursor.ID)
+	resp = authRequest(t, "GET", "/api/inbox?"+cursor.Encode(), nil)
+	if resp.StatusCode != 200 {
+		t.Fatalf("ListInbox page 2: expected 200, got %d", resp.StatusCode)
+	}
+	var secondPage struct {
+		Items   []map[string]any `json:"items"`
+		HasMore bool             `json:"has_more"`
+	}
+	readJSON(t, resp, &secondPage)
+	if len(secondPage.Items) == 0 || secondPage.Items[0]["title"] != titlePrefix+"oldest" {
+		t.Fatalf("expected second page to start with oldest fixture, got %+v", secondPage.Items)
+	}
+	if secondPage.HasMore {
+		t.Fatal("expected final page to have has_more=false")
 	}
 }
 

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -5,12 +5,19 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/logger"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	defaultInboxPageLimit = 50
+	maxInboxPageLimit     = 100
 )
 
 type InboxItemResponse struct {
@@ -30,6 +37,18 @@ type InboxItemResponse struct {
 	ActorType     *string         `json:"actor_type"`
 	ActorID       *string         `json:"actor_id"`
 	Details       json.RawMessage `json:"details"`
+}
+
+type InboxCursorResponse struct {
+	CreatedAt string `json:"created_at"`
+	ID        string `json:"id"`
+}
+
+type InboxPageResponse struct {
+	Items      []InboxItemResponse  `json:"items"`
+	Limit      int32                `json:"limit"`
+	HasMore    bool                 `json:"has_more"`
+	NextCursor *InboxCursorResponse `json:"next_cursor"`
 }
 
 func inboxToResponse(i db.InboxItem) InboxItemResponse {
@@ -73,6 +92,41 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 	}
 }
 
+func inboxPageRowToResponse(r db.ListInboxItemsPageRow) InboxItemResponse {
+	return InboxItemResponse{
+		ID:            uuidToString(r.ID),
+		WorkspaceID:   uuidToString(r.WorkspaceID),
+		RecipientType: r.RecipientType,
+		RecipientID:   uuidToString(r.RecipientID),
+		Type:          r.Type,
+		Severity:      r.Severity,
+		IssueID:       uuidToPtr(r.IssueID),
+		Title:         r.Title,
+		Body:          textToPtr(r.Body),
+		Read:          r.Read,
+		Archived:      r.Archived,
+		CreatedAt:     timestampToString(r.CreatedAt),
+		IssueStatus:   textToPtr(r.IssueStatus),
+		ActorType:     textToPtr(r.ActorType),
+		ActorID:       uuidToPtr(r.ActorID),
+		Details:       json.RawMessage(r.Details),
+	}
+}
+
+func parseInboxPageLimit(raw string) int32 {
+	if raw == "" {
+		return defaultInboxPageLimit
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit <= 0 {
+		return defaultInboxPageLimit
+	}
+	if limit > maxInboxPageLimit {
+		return maxInboxPageLimit
+	}
+	return int32(limit)
+}
+
 func (h *Handler) enrichInboxResponse(ctx context.Context, resp InboxItemResponse, issueID pgtype.UUID) InboxItemResponse {
 	if !issueID.Valid {
 		return resp
@@ -96,22 +150,68 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	items, err := h.Queries.ListInboxItems(r.Context(), db.ListInboxItemsParams{
-		WorkspaceID:   wsUUID,
-		RecipientType: "member",
-		RecipientID:   parseUUID(userID),
+	limit := parseInboxPageLimit(r.URL.Query().Get("limit"))
+	beforeCreatedAtRaw := r.URL.Query().Get("before_created_at")
+	beforeIDRaw := r.URL.Query().Get("before_id")
+	if (beforeCreatedAtRaw == "") != (beforeIDRaw == "") {
+		writeError(w, http.StatusBadRequest, "before_created_at and before_id must be provided together")
+		return
+	}
+
+	var beforeCreatedAt pgtype.Timestamptz
+	var beforeID pgtype.UUID
+	if beforeCreatedAtRaw != "" {
+		t, err := time.Parse(time.RFC3339Nano, beforeCreatedAtRaw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid before_created_at")
+			return
+		}
+		beforeCreatedAt = pgtype.Timestamptz{Time: t, Valid: true}
+		var ok bool
+		beforeID, ok = parseUUIDOrBadRequest(w, beforeIDRaw, "before_id")
+		if !ok {
+			return
+		}
+	}
+
+	rows, err := h.Queries.ListInboxItemsPage(r.Context(), db.ListInboxItemsPageParams{
+		WorkspaceID:     wsUUID,
+		RecipientType:   "member",
+		RecipientID:     parseUUID(userID),
+		BeforeCreatedAt: beforeCreatedAt,
+		BeforeID:        beforeID,
+		RowLimit:        limit + 1,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list inbox")
 		return
 	}
 
-	resp := make([]InboxItemResponse, len(items))
-	for i, item := range items {
-		resp[i] = inboxRowToResponse(item)
+	hasMore := int32(len(rows)) > limit
+	if hasMore {
+		rows = rows[:limit]
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	items := make([]InboxItemResponse, len(rows))
+	for i, item := range rows {
+		items[i] = inboxPageRowToResponse(item)
+	}
+
+	var nextCursor *InboxCursorResponse
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		nextCursor = &InboxCursorResponse{
+			CreatedAt: timestampToString(last.CreatedAt),
+			ID:        uuidToString(last.ID),
+		}
+	}
+
+	writeJSON(w, http.StatusOK, InboxPageResponse{
+		Items:      items,
+		Limit:      limit,
+		HasMore:    hasMore,
+		NextCursor: nextCursor,
+	})
 }
 
 func (h *Handler) MarkInboxRead(w http.ResponseWriter, r *http.Request) {

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -158,8 +158,17 @@ func (q *Queries) ArchiveInboxItem(ctx context.Context, id pgtype.UUID) (InboxIt
 }
 
 const countUnreadInbox = `-- name: CountUnreadInbox :one
-SELECT count(*) FROM inbox_item
-WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false
+SELECT count(*) FROM (
+    SELECT DISTINCT ON (COALESCE(i.issue_id, i.id))
+        i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = $2
+      AND i.recipient_id = $3
+      AND i.archived = false
+    ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) newest
+WHERE newest.read = false
 `
 
 type CountUnreadInboxParams struct {
@@ -185,7 +194,7 @@ FROM (
     WHERE i.recipient_type = 'member'
       AND i.recipient_id = $1
       AND i.archived = false
-    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC
+    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
 ) newest
 WHERE newest.read = false
 GROUP BY newest.workspace_id
@@ -351,7 +360,7 @@ SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severit
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC
+ORDER BY i.created_at DESC, i.id DESC
 `
 
 type ListInboxItemsParams struct {
@@ -388,6 +397,95 @@ func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) 
 	items := []ListInboxItemsRow{}
 	for rows.Next() {
 		var i ListInboxItemsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.RecipientType,
+			&i.RecipientID,
+			&i.Type,
+			&i.Severity,
+			&i.IssueID,
+			&i.Title,
+			&i.Body,
+			&i.Read,
+			&i.Archived,
+			&i.CreatedAt,
+			&i.ActorType,
+			&i.ActorID,
+			&i.Details,
+			&i.IssueStatus,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInboxItemsPage = `-- name: ListInboxItemsPage :many
+SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
+       iss.status as issue_status
+FROM inbox_item i
+LEFT JOIN issue iss ON iss.id = i.issue_id
+WHERE i.workspace_id = $1
+  AND i.recipient_type = $2
+  AND i.recipient_id = $3
+  AND i.archived = false
+  AND (
+    $4::timestamptz IS NULL
+    OR (i.created_at, i.id) < ($4::timestamptz, $5::uuid)
+  )
+ORDER BY i.created_at DESC, i.id DESC
+LIMIT $6::int
+`
+
+type ListInboxItemsPageParams struct {
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	RecipientType   string             `json:"recipient_type"`
+	RecipientID     pgtype.UUID        `json:"recipient_id"`
+	BeforeCreatedAt pgtype.Timestamptz `json:"before_created_at"`
+	BeforeID        pgtype.UUID        `json:"before_id"`
+	RowLimit        int32              `json:"row_limit"`
+}
+
+type ListInboxItemsPageRow struct {
+	ID            pgtype.UUID        `json:"id"`
+	WorkspaceID   pgtype.UUID        `json:"workspace_id"`
+	RecipientType string             `json:"recipient_type"`
+	RecipientID   pgtype.UUID        `json:"recipient_id"`
+	Type          string             `json:"type"`
+	Severity      string             `json:"severity"`
+	IssueID       pgtype.UUID        `json:"issue_id"`
+	Title         string             `json:"title"`
+	Body          pgtype.Text        `json:"body"`
+	Read          bool               `json:"read"`
+	Archived      bool               `json:"archived"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ActorType     pgtype.Text        `json:"actor_type"`
+	ActorID       pgtype.UUID        `json:"actor_id"`
+	Details       []byte             `json:"details"`
+	IssueStatus   pgtype.Text        `json:"issue_status"`
+}
+
+func (q *Queries) ListInboxItemsPage(ctx context.Context, arg ListInboxItemsPageParams) ([]ListInboxItemsPageRow, error) {
+	rows, err := q.db.Query(ctx, listInboxItemsPage,
+		arg.WorkspaceID,
+		arg.RecipientType,
+		arg.RecipientID,
+		arg.BeforeCreatedAt,
+		arg.BeforeID,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListInboxItemsPageRow{}
+	for rows.Next() {
+		var i ListInboxItemsPageRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WorkspaceID,

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -4,7 +4,23 @@ SELECT i.*,
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC;
+ORDER BY i.created_at DESC, i.id DESC;
+
+-- name: ListInboxItemsPage :many
+SELECT i.*,
+       iss.status as issue_status
+FROM inbox_item i
+LEFT JOIN issue iss ON iss.id = i.issue_id
+WHERE i.workspace_id = sqlc.arg(workspace_id)
+  AND i.recipient_type = sqlc.arg(recipient_type)
+  AND i.recipient_id = sqlc.arg(recipient_id)
+  AND i.archived = false
+  AND (
+    sqlc.narg('before_created_at')::timestamptz IS NULL
+    OR (i.created_at, i.id) < (sqlc.narg('before_created_at')::timestamptz, sqlc.narg('before_id')::uuid)
+  )
+ORDER BY i.created_at DESC, i.id DESC
+LIMIT sqlc.arg(row_limit)::int;
 
 -- name: GetInboxItem :one
 SELECT * FROM inbox_item
@@ -42,8 +58,17 @@ WHERE workspace_id = $1 AND issue_id = $2 AND type = $3 AND archived = false
 RETURNING recipient_type, recipient_id;
 
 -- name: CountUnreadInbox :one
-SELECT count(*) FROM inbox_item
-WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;
+SELECT count(*) FROM (
+    SELECT DISTINCT ON (COALESCE(i.issue_id, i.id))
+        i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = $2
+      AND i.recipient_id = $3
+      AND i.archived = false
+    ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) newest
+WHERE newest.read = false;
 
 -- name: CountUnreadInboxByWorkspace :many
 -- Per-workspace unread inbox counts for a recipient member, matching the
@@ -65,7 +90,7 @@ FROM (
     WHERE i.recipient_type = 'member'
       AND i.recipient_id = $1
       AND i.archived = false
-    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC
+    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
 ) newest
 WHERE newest.read = false
 GROUP BY newest.workspace_id;


### PR DESCRIPTION
## Summary
- add keyset pagination for GET /api/inbox with a stable created_at/id cursor
- normalize the API client around a paginated inbox page while accepting legacy array responses
- switch inbox UI to infinite loading and move sidebar/badge unread counts to the count endpoint

## Tests
- pnpm --filter @multica/core exec vitest run api/schemas.test.ts inbox/queries.test.ts inbox/ws-updaters.test.ts
- pnpm --filter @multica/views exec vitest run layout/app-sidebar.test.tsx
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- go test ./cmd/server -run 'TestInbox'