### PR TITLE
fix(autopilot): clean runs before delete (MUL-4180)

### DIFF
--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -971,10 +971,9 @@ func (h *Handler) DeleteAutopilot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// autopilot_subscriber carries no DB-level foreign key/cascade (repo rule:
-	// referential cleanup lives in the application layer), so delete the
-	// subscriber template alongside the autopilot in one transaction. Without
-	// this, deleting an autopilot would orphan its subscriber rows.
+	// Referential cleanup lives in the application layer. Keep all dependent
+	// autopilot rows in the same transaction so deleting the parent row does not
+	// rely on DB-level cascades for the hot path.
 	tx, err := h.TxStarter.Begin(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
@@ -990,6 +989,25 @@ func (h *Handler) DeleteAutopilot(w http.ResponseWriter, r *http.Request) {
 	if err := qtx.DeleteAutopilotCollaboratorsForAutopilot(r.Context(), idUUID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
 		return
+	}
+	runIDs, err := qtx.ListAutopilotRunIDsForAutopilot(r.Context(), idUUID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+		return
+	}
+	if len(runIDs) > 0 {
+		if err := qtx.ClearAgentTasksAutopilotRunIDs(r.Context(), runIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+			return
+		}
+		if err := qtx.ClearWebhookDeliveriesAutopilotRunIDs(r.Context(), runIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+			return
+		}
+		if err := qtx.DeleteAutopilotRunsByIDs(r.Context(), runIDs); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
+			return
+		}
 	}
 	if err := qtx.DeleteAutopilot(r.Context(), idUUID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")

--- a/server/internal/handler/autopilot_subscriber_test.go
+++ b/server/internal/handler/autopilot_subscriber_test.go
@@ -597,22 +597,33 @@ func TestAutopilotDispatchSkipsInboxWhenNoSubscribers(t *testing.T) {
 	}
 }
 
-// TestDeleteAutopilotRemovesSubscribers guards the app-layer cleanup that
-// replaced the dropped autopilot_subscriber → autopilot ON DELETE CASCADE:
-// deleting an autopilot must also delete its subscriber template rows in the
-// same transaction, leaving no orphans behind.
+// TestDeleteAutopilotRemovesSubscribers guards the app-layer cleanup used by
+// DELETE /api/autopilots/{id}: deleting an autopilot must clear its dependent
+// rows in the same transaction instead of relying on database cascades.
 func TestDeleteAutopilotRemovesSubscribers(t *testing.T) {
 	ctx := context.Background()
 	var autopilotID string
+	var taskID string
+	var deliveryID string
 	defer func() {
+		if taskID != "" {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		}
+		if deliveryID != "" {
+			testPool.Exec(ctx, `DELETE FROM webhook_delivery WHERE id = $1`, deliveryID)
+		}
 		if autopilotID != "" {
 			testPool.Exec(ctx, `DELETE FROM autopilot_subscriber WHERE autopilot_id = $1`, autopilotID)
 			testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
 		}
 	}()
 
-	var agentID string
-	if err := testPool.QueryRow(ctx, `SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id, runtime_id FROM agent
+		WHERE workspace_id = $1 AND runtime_id IS NOT NULL
+		LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
 		t.Fatalf("load test agent: %v", err)
 	}
 
@@ -643,6 +654,48 @@ func TestDeleteAutopilotRemovesSubscribers(t *testing.T) {
 		t.Fatalf("subscriber rows before delete = %d, want 1", before)
 	}
 
+	var triggerID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_trigger (autopilot_id, kind, webhook_token)
+		VALUES ($1, 'webhook', 'delete-app-layer-test')
+		RETURNING id
+	`, autopilotID).Scan(&triggerID); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	var runID1, runID2 string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status)
+		VALUES ($1, $2, 'webhook', 'completed')
+		RETURNING id
+	`, autopilotID, triggerID).Scan(&runID1); err != nil {
+		t.Fatalf("create first run: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status)
+		VALUES ($1, $2, 'webhook', 'failed')
+		RETURNING id
+	`, autopilotID, triggerID).Scan(&runID2); err != nil {
+		t.Fatalf("create second run: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, priority, autopilot_run_id
+		)
+		VALUES ($1, $2, 'completed', 0, $3)
+		RETURNING id
+	`, agentID, runtimeID, runID1).Scan(&taskID); err != nil {
+		t.Fatalf("create linked task: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO webhook_delivery (
+			workspace_id, autopilot_id, trigger_id, provider, status, autopilot_run_id
+		)
+		VALUES ($1, $2, $3, 'generic', 'dispatched', $4)
+		RETURNING id
+	`, testWorkspaceID, autopilotID, triggerID, runID2).Scan(&deliveryID); err != nil {
+		t.Fatalf("create linked delivery: %v", err)
+	}
+
 	w = httptest.NewRecorder()
 	req = newRequest("DELETE", "/api/autopilots/"+autopilotID+"?workspace_id="+testWorkspaceID, nil)
 	req = withURLParam(req, "id", autopilotID)
@@ -665,5 +718,27 @@ func TestDeleteAutopilotRemovesSubscribers(t *testing.T) {
 	}
 	if autopilotRows != 0 {
 		t.Fatalf("autopilot rows after delete = %d, want 0", autopilotRows)
+	}
+
+	var runRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_run WHERE autopilot_id = $1`, autopilotID).Scan(&runRows); err != nil {
+		t.Fatalf("count runs after delete: %v", err)
+	}
+	if runRows != 0 {
+		t.Fatalf("autopilot_run rows after delete = %d, want 0 (app-layer cleanup)", runRows)
+	}
+	var taskRunValid bool
+	if err := testPool.QueryRow(ctx, `SELECT autopilot_run_id IS NOT NULL FROM agent_task_queue WHERE id = $1`, taskID).Scan(&taskRunValid); err != nil {
+		t.Fatalf("load task run link after delete: %v", err)
+	}
+	if taskRunValid {
+		t.Fatal("agent_task_queue.autopilot_run_id after delete is still set, want NULL")
+	}
+	var deliveryRows int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM webhook_delivery WHERE id = $1`, deliveryID).Scan(&deliveryRows); err != nil {
+		t.Fatalf("count delivery after delete: %v", err)
+	}
+	if deliveryRows != 0 {
+		t.Fatalf("webhook_delivery rows after delete = %d, want 0", deliveryRows)
 	}
 }

--- a/server/migrations/145_agent_task_queue_autopilot_run_id_index.down.sql
+++ b/server/migrations/145_agent_task_queue_autopilot_run_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_autopilot_run_id;

--- a/server/migrations/145_agent_task_queue_autopilot_run_id_index.up.sql
+++ b/server/migrations/145_agent_task_queue_autopilot_run_id_index.up.sql
@@ -1,0 +1,33 @@
+-- Index the FK column agent_task_queue.autopilot_run_id (MUL-4180).
+--
+-- Migration 042 added `agent_task_queue.autopilot_run_id` with
+-- `REFERENCES autopilot_run(id) ON DELETE SET NULL` but never created an
+-- index on the referencing column. Postgres does NOT auto-index FK
+-- columns, so the referential-action trigger that fires when an
+-- autopilot_run row is deleted —
+--   UPDATE agent_task_queue SET autopilot_run_id = NULL
+--   WHERE autopilot_run_id = <deleted run id>
+-- — has no index to use and degrades to a full sequential scan of
+-- agent_task_queue, the hottest/largest table in the schema.
+--
+-- Deleting an autopilot cascades (ON DELETE CASCADE) into every one of its
+-- autopilot_run rows, and each deleted run fires that trigger once. So
+-- `DELETE FROM autopilot` costs one full agent_task_queue seq scan PER run.
+-- For an autopilot with real run history this is O(runs × queue-size) and
+-- the DELETE request hangs for seconds-to-minutes — the client sits on the
+-- "删除中..." confirm dialog and the UI appears frozen (MUL-4180).
+--
+-- Partial `WHERE autopilot_run_id IS NOT NULL` keeps the index tiny: only
+-- autopilot-originated tasks set the column, the vast majority of queue
+-- rows leave it NULL. The trigger's `autopilot_run_id = $1` predicate
+-- implies IS NOT NULL, so the planner can still use the partial index.
+-- Mirrors idx_webhook_delivery_run (migration 093), which indexes the same
+-- ON DELETE SET NULL FK on webhook_delivery.
+--
+-- CONCURRENTLY because agent_task_queue is on the hot dispatch path — a
+-- plain CREATE INDEX takes ACCESS EXCLUSIVE and would block claims during
+-- the build. Single-statement file: the migration runner cannot mix
+-- CONCURRENTLY with other statements (see migration 080/143).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_autopilot_run_id
+    ON agent_task_queue (autopilot_run_id)
+    WHERE autopilot_run_id IS NOT NULL;

--- a/server/migrations/145_agent_task_queue_autopilot_run_id_index.up.sql
+++ b/server/migrations/145_agent_task_queue_autopilot_run_id_index.up.sql
@@ -10,12 +10,16 @@
 -- — has no index to use and degrades to a full sequential scan of
 -- agent_task_queue, the hottest/largest table in the schema.
 --
--- Deleting an autopilot cascades (ON DELETE CASCADE) into every one of its
--- autopilot_run rows, and each deleted run fires that trigger once. So
--- `DELETE FROM autopilot` costs one full agent_task_queue seq scan PER run.
--- For an autopilot with real run history this is O(runs × queue-size) and
--- the DELETE request hangs for seconds-to-minutes — the client sits on the
--- "删除中..." confirm dialog and the UI appears frozen (MUL-4180).
+-- Autopilot deletion now performs this cleanup in the application layer with
+-- one set-based UPDATE before deleting the runs, but that UPDATE still needs
+-- the same lookup to be indexed:
+--   UPDATE agent_task_queue SET autopilot_run_id = NULL
+--   WHERE autopilot_run_id = ANY(<run ids>)
+-- Without an index, an autopilot with real run history can still hang the
+-- DELETE request for seconds-to-minutes while the client sits on the
+-- "删除中..." confirm dialog (MUL-4180). The index also protects any remaining
+-- database-level ON DELETE SET NULL trigger path until the historical FK is
+-- removed in a future cleanup.
 --
 -- Partial `WHERE autopilot_run_id IS NOT NULL` keeps the index tiny: only
 -- autopilot-originated tasks set the column, the vast majority of queue

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -81,6 +81,28 @@ func (q *Queries) AdvanceTriggerNextRun(ctx context.Context, arg AdvanceTriggerN
 	return err
 }
 
+const clearAgentTasksAutopilotRunIDs = `-- name: ClearAgentTasksAutopilotRunIDs :exec
+UPDATE agent_task_queue
+SET autopilot_run_id = NULL
+WHERE autopilot_run_id = ANY($1::uuid[])
+`
+
+func (q *Queries) ClearAgentTasksAutopilotRunIDs(ctx context.Context, runIds []pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, clearAgentTasksAutopilotRunIDs, runIds)
+	return err
+}
+
+const clearWebhookDeliveriesAutopilotRunIDs = `-- name: ClearWebhookDeliveriesAutopilotRunIDs :exec
+UPDATE webhook_delivery
+SET autopilot_run_id = NULL
+WHERE autopilot_run_id = ANY($1::uuid[])
+`
+
+func (q *Queries) ClearWebhookDeliveriesAutopilotRunIDs(ctx context.Context, runIds []pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, clearWebhookDeliveriesAutopilotRunIDs, runIds)
+	return err
+}
+
 const createAutopilot = `-- name: CreateAutopilot :one
 INSERT INTO autopilot (
     workspace_id, title, description, assignee_type, assignee_id,
@@ -366,6 +388,16 @@ WHERE autopilot_id = $1
 // Application-layer cleanup run inside the autopilot delete transaction.
 func (q *Queries) DeleteAutopilotCollaboratorsForAutopilot(ctx context.Context, autopilotID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, deleteAutopilotCollaboratorsForAutopilot, autopilotID)
+	return err
+}
+
+const deleteAutopilotRunsByIDs = `-- name: DeleteAutopilotRunsByIDs :exec
+DELETE FROM autopilot_run
+WHERE id = ANY($1::uuid[])
+`
+
+func (q *Queries) DeleteAutopilotRunsByIDs(ctx context.Context, runIds []pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAutopilotRunsByIDs, runIds)
 	return err
 }
 
@@ -727,6 +759,33 @@ func (q *Queries) ListAutopilotIDsForCollaborator(ctx context.Context, userID pg
 			return nil, err
 		}
 		items = append(items, autopilot_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAutopilotRunIDsForAutopilot = `-- name: ListAutopilotRunIDsForAutopilot :many
+SELECT id FROM autopilot_run
+WHERE autopilot_id = $1
+`
+
+// Autopilot deletion intentionally handles run cleanup in the application
+// layer instead of relying on autopilot_run.autopilot_id ON DELETE CASCADE.
+func (q *Queries) ListAutopilotRunIDsForAutopilot(ctx context.Context, autopilotID pgtype.UUID) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listAutopilotRunIDsForAutopilot, autopilotID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -69,6 +69,26 @@ RETURNING *;
 -- name: DeleteAutopilot :exec
 DELETE FROM autopilot WHERE id = $1;
 
+-- name: ListAutopilotRunIDsForAutopilot :many
+-- Autopilot deletion intentionally handles run cleanup in the application
+-- layer instead of relying on autopilot_run.autopilot_id ON DELETE CASCADE.
+SELECT id FROM autopilot_run
+WHERE autopilot_id = $1;
+
+-- name: ClearAgentTasksAutopilotRunIDs :exec
+UPDATE agent_task_queue
+SET autopilot_run_id = NULL
+WHERE autopilot_run_id = ANY(@run_ids::uuid[]);
+
+-- name: ClearWebhookDeliveriesAutopilotRunIDs :exec
+UPDATE webhook_delivery
+SET autopilot_run_id = NULL
+WHERE autopilot_run_id = ANY(@run_ids::uuid[]);
+
+-- name: DeleteAutopilotRunsByIDs :exec
+DELETE FROM autopilot_run
+WHERE id = ANY(@run_ids::uuid[]);
+
 -- name: UpdateAutopilotLastRunAt :exec
 UPDATE autopilot SET last_run_at = now(), updated_at = now()
 WHERE id = $1;
@@ -451,4 +471,3 @@ SELECT EXISTS (
 -- Powers the per-row can_write flag on the list endpoint without an N+1.
 SELECT autopilot_id FROM autopilot_collaborator
 WHERE user_type = 'member' AND user_id = $1;
-


### PR DESCRIPTION
## Summary

Fixes the "delete autopilot freezes the client" bug (MUL-4180). Clicking **删除自动化** on an autopilot with run history can leave the confirm dialog stuck on **删除中...** because the backend delete request blocks.

## Root Cause

`DELETE FROM autopilot` historically relied on `ON DELETE CASCADE` to delete all child `autopilot_run` rows. Each deleted run then fires the existing FK cleanup for:

```sql
agent_task_queue.autopilot_run_id -> autopilot_run(id) ON DELETE SET NULL
```

Migration `042_autopilot` added that FK column but never indexed it. Postgres does not auto-index FK columns, so the cleanup degenerates into repeated scans of `agent_task_queue`, the hottest/largest task table.

## Fix

- Move autopilot run cleanup into the delete handler's transaction:
  - query all `autopilot_run` IDs for the autopilot
  - clear `agent_task_queue.autopilot_run_id` for those run IDs in one set-based update
  - clear `webhook_delivery.autopilot_run_id` for those run IDs in one set-based update
  - batch delete the run rows
  - delete the autopilot row
- Keep migration `145`, adding a partial concurrent index on `agent_task_queue(autopilot_run_id) WHERE autopilot_run_id IS NOT NULL`, because the new set-based cleanup still needs this lookup indexed.
- Update the delete test to cover subscriber cleanup, run cleanup, task run-link nulling, and webhook delivery cleanup.

## Verification

- `go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate`
- `go test ./internal/handler -run Autopilot -count=1`
- `go test ./internal/service -run Autopilot -count=1`
- `git diff --check`

MUL-4180
