### PR TITLE
Fix chat widget context after third turn (ZIC-44)

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -243,6 +243,10 @@ func buildChatPrompt(task Task) string {
 			}
 		}
 	}
+	if strings.TrimSpace(task.ChatHistory) != "" && task.ChatChannelType == "" {
+		b.WriteString("Recent conversation context in this chat session:\n")
+		fmt.Fprintf(&b, "%s\n\n", task.ChatHistory)
+	}
 	fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
 	// List attachments by id + filename so the agent can fetch them via
 	// the CLI. We deliberately do NOT inline the URL: chat attachments

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -309,6 +309,37 @@ func TestBuildChatPromptChannelAwareness(t *testing.T) {
 	})
 }
 
+func TestBuildChatPromptIncludesWebChatHistory(t *testing.T) {
+	out := buildChatPrompt(Task{
+		ChatSessionID: "sess-1",
+		ChatHistory:   "user: remember the project is Apollo\n\nassistant: Got it.",
+		ChatMessage:   "what project did I mention?",
+	})
+
+	for _, want := range []string{
+		"Recent conversation context in this chat session:",
+		"user: remember the project is Apollo",
+		"assistant: Got it.",
+		"User message:\nwhat project did I mention?",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("web chat prompt missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildChatPromptOmitsHistoryForChannelChat(t *testing.T) {
+	out := buildChatPrompt(Task{
+		ChatSessionID:   "sess-1",
+		ChatChannelType: "slack",
+		ChatHistory:     "user: stale Multica transcript",
+		ChatMessage:     "hi",
+	})
+	if strings.Contains(out, "stale Multica transcript") {
+		t.Fatalf("channel chat prompt must not inline Multica chat history, got:\n%s", out)
+	}
+}
+
 func TestBuildChatPromptSlashSkills(t *testing.T) {
 	t.Run("injects selected skills block", func(t *testing.T) {
 		task := Task{

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -81,6 +81,7 @@ type Task struct {
 	ChatChannelType          string                `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
 	ChatInThread             bool                  `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; selects which read command the prompt tells the agent to start with
 	ChatMessage              string                `json:"chat_message,omitempty"`                // user message content for chat tasks
+	ChatHistory              string                `json:"chat_history,omitempty"`                // bounded recent web-chat transcript before the current unanswered user message(s)
 	ChatMessageAttachments   []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
 	AutopilotRunID           string                `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks
 	AutopilotID              string                `json:"autopilot_id,omitempty"`                // autopilot that spawned this run

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -321,6 +321,7 @@ type AgentTaskResponse struct {
 	ChatChannelType          string               `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
 	ChatInThread             bool                 `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; tells the agent to start with `multica chat thread` vs `multica chat history`
 	ChatMessage              string               `json:"chat_message,omitempty"`                // user message for chat tasks
+	ChatHistory              string               `json:"chat_history,omitempty"`                // bounded recent web-chat transcript before the current unanswered user message(s)
 	ChatMessageAttachments   []ChatAttachmentMeta `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
 	AutopilotRunID           string               `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks
 	AutopilotID              string               `json:"autopilot_id,omitempty"`                // autopilot that spawned this task

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1690,6 +1690,9 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			// URL alone is signed and 30-min expiring on the private CDN.
 			if msgs, err := h.Queries.ListChatMessages(r.Context(), cs.ID); err == nil && len(msgs) > 0 {
 				unanswered := trailingUserMessages(msgs)
+				if resp.ChatChannelType == "" {
+					resp.ChatHistory = chatHistoryBeforeUnanswered(msgs, unanswered)
+				}
 				parts := make([]string, 0, len(unanswered))
 				for _, m := range unanswered {
 					if strings.TrimSpace(m.Content) != "" {
@@ -2078,6 +2081,52 @@ func trailingUserMessages(msgs []db.ChatMessage) []db.ChatMessage {
 		}
 	}
 	return msgs[start:]
+}
+
+const (
+	chatHistoryContextMaxMessages = 12
+	chatHistoryContextMaxChars    = 8000
+)
+
+// chatHistoryBeforeUnanswered returns a bounded transcript of the current
+// web-chat session before the unanswered user-message run. Provider-native
+// session resume remains the primary memory path, but this explicit context
+// keeps later widget turns coherent when a runtime cannot resume or reports a
+// stale session id.
+func chatHistoryBeforeUnanswered(msgs []db.ChatMessage, unanswered []db.ChatMessage) string {
+	if len(msgs) == 0 {
+		return ""
+	}
+	cutoff := len(msgs) - len(unanswered)
+	if cutoff <= 0 {
+		return ""
+	}
+	start := cutoff - chatHistoryContextMaxMessages
+	if start < 0 {
+		start = 0
+	}
+
+	var b strings.Builder
+	for _, m := range msgs[start:cutoff] {
+		content := strings.TrimSpace(m.Content)
+		if content == "" {
+			continue
+		}
+		role := m.Role
+		if role != "assistant" {
+			role = "user"
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "%s: %s", role, content)
+	}
+
+	out := b.String()
+	if len(out) <= chatHistoryContextMaxChars {
+		return out
+	}
+	return out[len(out)-chatHistoryContextMaxChars:]
 }
 
 // ListPendingTasksByRuntime returns queued/dispatched tasks for a runtime.

--- a/server/internal/handler/daemon_chat_prompt_test.go
+++ b/server/internal/handler/daemon_chat_prompt_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"strings"
 	"testing"
 
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -84,5 +85,30 @@ func TestTrailingUserMessages(t *testing.T) {
 				t.Fatalf("trailingUserMessages = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestChatHistoryBeforeUnansweredIncludesPriorTurns(t *testing.T) {
+	msgs := []db.ChatMessage{
+		msg("user", "remember Apollo"),
+		msg("assistant", "I will remember Apollo."),
+		msg("user", "also remember launch is Friday"),
+		msg("assistant", "Got it."),
+		msg("user", "what did I ask you to remember?"),
+	}
+
+	history := chatHistoryBeforeUnanswered(msgs, trailingUserMessages(msgs))
+	for _, want := range []string{
+		"user: remember Apollo",
+		"assistant: I will remember Apollo.",
+		"user: also remember launch is Friday",
+		"assistant: Got it.",
+	} {
+		if !strings.Contains(history, want) {
+			t.Fatalf("history missing %q\n--- history ---\n%s", want, history)
+		}
+	}
+	if strings.Contains(history, "what did I ask you to remember?") {
+		t.Fatalf("history must exclude current unanswered message, got:\n%s", history)
 	}
 }

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2929,6 +2929,7 @@ type claimRuntimeGuardTask struct {
 	PriorSessionID           string   `json:"prior_session_id"`
 	PriorWorkDir             string   `json:"prior_work_dir"`
 	ChatMessage              string   `json:"chat_message"`
+	ChatHistory              string   `json:"chat_history"`
 	ThreadName               string   `json:"thread_name"`
 	QuickCreateAttachmentIDs []string `json:"quick_create_attachment_ids"`
 	ProjectID                string   `json:"project_id"`
@@ -3492,6 +3493,18 @@ func TestClaimTask_ChatDeliversAllUnansweredUserMessages(t *testing.T) {
 	task = claimTaskForRuntimeGuard(t, runtimeID, daemonID)
 	if task.ChatMessage != "深圳呢" {
 		t.Fatalf("after a reply, only the new user message must be delivered; got %q", task.ChatMessage)
+	}
+	for _, want := range []string{
+		"user: 看上海天气",
+		"user: 还有青岛",
+		"assistant: 上海与青岛天气如下…",
+	} {
+		if !strings.Contains(task.ChatHistory, want) {
+			t.Fatalf("follow-up chat history missing %q\n--- history ---\n%s", want, task.ChatHistory)
+		}
+	}
+	if strings.Contains(task.ChatHistory, "深圳呢") {
+		t.Fatalf("follow-up chat history must exclude current unanswered message, got %q", task.ChatHistory)
 	}
 }
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Preserves bottom-right chat context on later turns by including a bounded recent web-chat transcript in daemon chat prompts. The active chat session still sends only the current unanswered user message(s), but the claim payload now carries prior turns explicitly so follow-up replies remain coherent even when provider-native session resume is unavailable or stale.

## Related Issue

Closes #5013

Multica issue: ZIC-44

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added `chat_history` to chat task claim payloads for web-only chat sessions.
- Added bounded prior-turn transcript formatting that excludes the current unanswered user message(s).
- Included the transcript in daemon chat prompts, while keeping channel-backed Slack chat on its channel-history path.
- Added unit and claim-path regression coverage for multi-turn chat history.

## How to Test

1. `cd server && go test ./internal/daemon ./internal/handler`
2. `git diff --check`
3. `make check-worktree` exits 0 locally, but Docker is not reachable in this environment (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`), so the PostgreSQL-backed full check could not be trusted as complete.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Investigated GitHub #5013 and the chat widget send/claim path. The bug was traced to web chat relying on provider-native prior-session resume while sending only the latest unanswered user input to the daemon prompt. I added explicit bounded prior-turn context to the claim payload and daemon prompt, with tests covering web-chat history inclusion and channel-chat exclusion.

## Screenshots (optional)

Not applicable; this is a prompt/context construction fix rather than a visual UI change.
