### PR TITLE
[ZIC-47] Preserve Pi text phase for chat folding

### DIFF
--- a/apps/mobile/components/chat/chat-timeline.tsx
+++ b/apps/mobile/components/chat/chat-timeline.tsx
@@ -38,7 +38,9 @@ interface Props {
 }
 
 export function ChatTimeline({ items, isStreaming = false }: Props) {
-  const processSteps = items.filter((i) => i.type !== "text");
+  const processSteps = items.filter(
+    (i) => i.type !== "text" || i.text_phase === "commentary",
+  );
   if (processSteps.length === 0) return null;
 
   return (
@@ -80,6 +82,8 @@ function StepRow({ item }: { item: TaskMessagePayload }) {
   switch (item.type) {
     case "thinking":
       return <ThinkingRow item={item} />;
+    case "text":
+      return <CommentaryRow item={item} />;
     case "tool_use":
       return <ToolCallRow item={item} />;
     case "tool_result":
@@ -89,6 +93,34 @@ function StepRow({ item }: { item: TaskMessagePayload }) {
     default:
       return null;
   }
+}
+
+function CommentaryRow({ item }: { item: TaskMessagePayload }) {
+  const text = item.content ?? "";
+  if (!text) return null;
+  const preview = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  return (
+    <Collapsible>
+      <CollapsibleTrigger asChild>
+        <View className="py-0.5 flex-row items-start gap-1.5 active:opacity-70">
+          <Ionicons
+            name="chatbubble-ellipses-outline"
+            size={12}
+            color="#a1a1aa"
+            style={{ marginTop: 2 }}
+          />
+          <Text className="flex-1 text-xs text-muted-foreground" numberOfLines={1}>
+            {preview}
+          </Text>
+        </View>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Text className="ml-4 mt-0.5 text-xs text-muted-foreground">
+          {text}
+        </Text>
+      </CollapsibleContent>
+    </Collapsible>
+  );
 }
 
 function ThinkingRow({ item }: { item: TaskMessagePayload }) {

--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -305,6 +305,7 @@ export const TaskMessagePayloadSchema: z.ZodType<TaskMessagePayload> = z.object(
   type: z
     .enum(["text", "thinking", "tool_use", "tool_result", "error"])
     .catch("text"),
+  text_phase: z.string().optional(),
   tool: z.string().optional(),
   content: z.string().optional(),
   input: z.record(z.string(), z.unknown()).optional(),

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -117,6 +117,7 @@ export const CHAT_DEFAULT_H = 600;
 export interface ChatTimelineItem {
   seq: number;
   type: "tool_use" | "tool_result" | "thinking" | "text" | "error";
+  text_phase?: string;
   tool?: string;
   content?: string;
   input?: Record<string, unknown>;

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -231,6 +231,7 @@ export interface TaskMessagePayload {
   chat_session_id?: string;
   seq: number;
   type: "text" | "thinking" | "tool_use" | "tool_result" | "error";
+  text_phase?: string;
   tool?: string;
   content?: string;
   input?: Record<string, unknown>;

--- a/packages/views/chat/lib/copy-text.test.ts
+++ b/packages/views/chat/lib/copy-text.test.ts
@@ -9,6 +9,17 @@ const text = (seq: number, content: string): ChatTimelineItem => ({
   content,
 });
 
+const phasedText = (
+  seq: number,
+  content: string,
+  text_phase: string,
+): ChatTimelineItem => ({
+  seq,
+  type: "text",
+  content,
+  text_phase,
+});
+
 const thinking = (seq: number, content = "..."): ChatTimelineItem => ({
   seq,
   type: "thinking",
@@ -79,6 +90,15 @@ describe("splitTimeline", () => {
     expect(out.middle).toEqual([u]);
     expect(out.final).toEqual([f]);
   });
+
+  it("folds explicit commentary text while keeping final_answer text visible", () => {
+    const c = phasedText(1, "checking context", "commentary");
+    const f = phasedText(2, "final answer", "final_answer");
+    const out = splitTimeline([c, f]);
+    expect(out.preface).toEqual([]);
+    expect(out.middle).toEqual([c]);
+    expect(out.final).toEqual([f]);
+  });
 });
 
 describe("extractCopyText", () => {
@@ -130,5 +150,14 @@ describe("extractCopyText", () => {
         text(3, "para 2"),
       ]),
     ).toBe("para 1\n\npara 2");
+  });
+
+  it("copies final_answer text and omits explicit commentary text", () => {
+    expect(
+      extractCopyText(message(""), [
+        phasedText(1, "checking context", "commentary"),
+        phasedText(2, "final answer", "final_answer"),
+      ]),
+    ).toBe("final answer");
   });
 });

--- a/packages/views/chat/lib/copy-text.ts
+++ b/packages/views/chat/lib/copy-text.ts
@@ -3,10 +3,10 @@ import type { ChatTimelineItem } from "@multica/core/chat";
 
 /**
  * Split an assistant timeline into three regions for the conductor-style fold:
- *   preface — text items before the first thinking/tool/error item
- *   middle  — everything from the first to the last non-text item (inclusive),
- *             including any text items sandwiched between them
- *   final   — text items after the last non-text item
+ *   preface — text items before the first process item
+ *   middle  — everything from the first to the last process item (inclusive),
+ *             including thinking/tool/error rows and explicit commentary text
+ *   final   — text items after the last process item
  *
  * UI renders preface above the outer fold, middle inside the fold (with each
  * row keeping its existing inner Collapsible), and final below the fold.
@@ -18,18 +18,21 @@ export function splitTimeline(items: ChatTimelineItem[]): {
   middle: ChatTimelineItem[];
   final: ChatTimelineItem[];
 } {
-  const firstNonTextIdx = items.findIndex((i) => i.type !== "text");
-  if (firstNonTextIdx === -1) {
+  const isProcessItem = (item: ChatTimelineItem) =>
+    item.type !== "text" || item.text_phase === "commentary";
+
+  const firstProcessIdx = items.findIndex(isProcessItem);
+  if (firstProcessIdx === -1) {
     return { preface: [], middle: [], final: items };
   }
-  let lastNonTextIdx = items.length - 1;
-  while (lastNonTextIdx >= 0 && items[lastNonTextIdx]!.type === "text") {
-    lastNonTextIdx--;
+  let lastProcessIdx = items.length - 1;
+  while (lastProcessIdx >= 0 && !isProcessItem(items[lastProcessIdx]!)) {
+    lastProcessIdx--;
   }
   return {
-    preface: items.slice(0, firstNonTextIdx),
-    middle: items.slice(firstNonTextIdx, lastNonTextIdx + 1),
-    final: items.slice(lastNonTextIdx + 1),
+    preface: items.slice(0, firstProcessIdx),
+    middle: items.slice(firstProcessIdx, lastProcessIdx + 1),
+    final: items.slice(lastProcessIdx + 1),
   };
 }
 

--- a/packages/views/common/task-transcript/build-timeline.test.ts
+++ b/packages/views/common/task-transcript/build-timeline.test.ts
@@ -12,6 +12,17 @@ function message(seq: number, type: TaskMessagePayload["type"], content?: string
   };
 }
 
+function textPhase(seq: number, content: string, text_phase: string): TaskMessagePayload {
+  return {
+    task_id: "task-1",
+    issue_id: "issue-1",
+    seq,
+    type: "text",
+    content,
+    text_phase,
+  };
+}
+
 describe("task transcript timeline", () => {
   it("merges adjacent text and thinking fragments split by streaming flushes", () => {
     const items = buildTimeline([
@@ -42,6 +53,18 @@ describe("task transcript timeline", () => {
       "after",
       "failed",
       "done",
+    ]);
+  });
+
+  it("does not merge text chunks with different phases", () => {
+    const items = buildTimeline([
+      textPhase(1, "checking context", "commentary"),
+      textPhase(2, "final answer", "final_answer"),
+    ]);
+
+    expect(items).toEqual([
+      expect.objectContaining({ seq: 1, type: "text", text_phase: "commentary" }),
+      expect.objectContaining({ seq: 2, type: "text", text_phase: "final_answer" }),
     ]);
   });
 

--- a/packages/views/common/task-transcript/build-timeline.ts
+++ b/packages/views/common/task-transcript/build-timeline.ts
@@ -5,6 +5,7 @@ import { redactSecrets } from "./redact";
 export interface TimelineItem {
   seq: number;
   type: "tool_use" | "tool_result" | "thinking" | "text" | "error";
+  text_phase?: string;
   tool?: string;
   content?: string;
   input?: Record<string, unknown>;
@@ -13,7 +14,11 @@ export interface TimelineItem {
 }
 
 function canMergeStreamingText(prev: TimelineItem, next: TimelineItem): boolean {
-  return (prev.type === "thinking" || prev.type === "text") && prev.type === next.type;
+  return (
+    (prev.type === "thinking" || prev.type === "text") &&
+    prev.type === next.type &&
+    prev.text_phase === next.text_phase
+  );
 }
 
 /** Merge adjacent text/thinking fragments that were split only by daemon flush timing. */
@@ -56,6 +61,7 @@ export function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
     items.push({
       seq: msg.seq,
       type: msg.type,
+      text_phase: msg.text_phase,
       tool: msg.tool,
       content: msg.content,
       input: msg.input,

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -245,12 +245,13 @@ func (c *Client) ReportProgress(ctx context.Context, taskID, summary string, ste
 
 // TaskMessageData represents a single agent execution message for batch reporting.
 type TaskMessageData struct {
-	Seq     int            `json:"seq"`
-	Type    string         `json:"type"`
-	Tool    string         `json:"tool,omitempty"`
-	Content string         `json:"content,omitempty"`
-	Input   map[string]any `json:"input,omitempty"`
-	Output  string         `json:"output,omitempty"`
+	Seq       int            `json:"seq"`
+	Type      string         `json:"type"`
+	TextPhase string         `json:"text_phase,omitempty"`
+	Tool      string         `json:"tool,omitempty"`
+	Content   string         `json:"content,omitempty"`
+	Input     map[string]any `json:"input,omitempty"`
+	Output    string         `json:"output,omitempty"`
 }
 
 func (c *Client) ReportTaskMessages(ctx context.Context, taskID string, messages []TaskMessageData) error {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4397,9 +4397,26 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		var seq atomic.Int32
 		var mu sync.Mutex
 		var pendingText strings.Builder
+		var pendingTextPhase string
 		var pendingThinking strings.Builder
 		var batch []TaskMessageData
 		callIDToTool := map[string]string{}
+
+		appendPendingTextLocked := func() {
+			if pendingText.Len() == 0 {
+				pendingTextPhase = ""
+				return
+			}
+			s := seq.Add(1)
+			batch = append(batch, TaskMessageData{
+				Seq:       int(s),
+				Type:      "text",
+				TextPhase: pendingTextPhase,
+				Content:   pendingText.String(),
+			})
+			pendingText.Reset()
+			pendingTextPhase = ""
+		}
 
 		flush := func() {
 			mu.Lock()
@@ -4412,15 +4429,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				})
 				pendingThinking.Reset()
 			}
-			if pendingText.Len() > 0 {
-				s := seq.Add(1)
-				batch = append(batch, TaskMessageData{
-					Seq:     int(s),
-					Type:    "text",
-					Content: pendingText.String(),
-				})
-				pendingText.Reset()
-			}
+			appendPendingTextLocked()
 			toSend := batch
 			batch = nil
 			mu.Unlock()
@@ -4544,6 +4553,10 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 					if msg.Content != "" {
 						taskLog.Debug("agent", "text", truncateLog(msg.Content, 200))
 						mu.Lock()
+						if pendingText.Len() > 0 && pendingTextPhase != msg.TextPhase {
+							appendPendingTextLocked()
+						}
+						pendingTextPhase = msg.TextPhase
 						pendingText.WriteString(msg.Content)
 						mu.Unlock()
 					}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -950,6 +950,80 @@ func (b *fakeBackend) Execute(_ context.Context, _ string, opts agent.ExecOption
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
 }
 
+type messageBackend struct {
+	messages []agent.Message
+	result   agent.Result
+}
+
+func (b messageBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	msgCh := make(chan agent.Message, len(b.messages))
+	resCh := make(chan agent.Result, 1)
+	go func() {
+		for _, msg := range b.messages {
+			msgCh <- msg
+		}
+		close(msgCh)
+		time.Sleep(50 * time.Millisecond)
+		resCh <- b.result
+	}()
+	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func TestExecuteAndDrainPreservesTextPhase(t *testing.T) {
+	reportedCh := make(chan []TaskMessageData, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/tasks/task-phase/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		var body struct {
+			Messages []TaskMessageData `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode task messages: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		reportedCh <- body.Messages
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	backend := messageBackend{
+		messages: []agent.Message{
+			{Type: agent.MessageText, Content: "checking context", TextPhase: "commentary"},
+			{Type: agent.MessageText, Content: "final answer", TextPhase: "final_answer"},
+		},
+		result: agent.Result{Status: "completed", Output: "final answer"},
+	}
+
+	result, _, err := d.executeAndDrain(context.Background(), backend, "prompt", agent.ExecOptions{}, slog.Default(), "task-phase")
+	if err != nil {
+		t.Fatalf("executeAndDrain: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q", result.Status)
+	}
+
+	var reported []TaskMessageData
+	timeout := time.After(5 * time.Second)
+	for len(reported) < 2 {
+		select {
+		case batch := <-reportedCh:
+			reported = append(reported, batch...)
+		case <-timeout:
+			t.Fatalf("timeout waiting for reported messages, got %#v", reported)
+		}
+	}
+	if reported[0].Content != "checking context" || reported[0].TextPhase != "commentary" {
+		t.Fatalf("commentary message = %#v", reported[0])
+	}
+	if reported[1].Content != "final answer" || reported[1].TextPhase != "final_answer" {
+		t.Fatalf("final message = %#v", reported[1])
+	}
+}
+
 func newTestDaemon(t *testing.T) *Daemon {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2466,12 +2466,13 @@ func (h *Handler) FailTask(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 type TaskMessageRequest struct {
-	Seq     int            `json:"seq"`
-	Type    string         `json:"type"`
-	Tool    string         `json:"tool,omitempty"`
-	Content string         `json:"content,omitempty"`
-	Input   map[string]any `json:"input,omitempty"`
-	Output  string         `json:"output,omitempty"`
+	Seq       int            `json:"seq"`
+	Type      string         `json:"type"`
+	TextPhase string         `json:"text_phase,omitempty"`
+	Tool      string         `json:"tool,omitempty"`
+	Content   string         `json:"content,omitempty"`
+	Input     map[string]any `json:"input,omitempty"`
+	Output    string         `json:"output,omitempty"`
 }
 
 type TaskMessageBatchRequest struct {
@@ -2521,13 +2522,14 @@ func (h *Handler) ReportTaskMessages(w http.ResponseWriter, r *http.Request) {
 			inputJSON, _ = json.Marshal(msg.Input)
 		}
 		created, createErr := h.Queries.CreateTaskMessage(r.Context(), db.CreateTaskMessageParams{
-			TaskID:  parseUUID(taskID),
-			Seq:     int32(msg.Seq),
-			Type:    msg.Type,
-			Tool:    pgtype.Text{String: msg.Tool, Valid: msg.Tool != ""},
-			Content: pgtype.Text{String: msg.Content, Valid: msg.Content != ""},
-			Input:   inputJSON,
-			Output:  pgtype.Text{String: msg.Output, Valid: msg.Output != ""},
+			TaskID:    parseUUID(taskID),
+			Seq:       int32(msg.Seq),
+			Type:      msg.Type,
+			TextPhase: pgtype.Text{String: msg.TextPhase, Valid: msg.TextPhase != ""},
+			Tool:      pgtype.Text{String: msg.Tool, Valid: msg.Tool != ""},
+			Content:   pgtype.Text{String: msg.Content, Valid: msg.Content != ""},
+			Input:     inputJSON,
+			Output:    pgtype.Text{String: msg.Output, Valid: msg.Output != ""},
 		})
 		if createErr != nil {
 			slog.Error("failed to create task message", "task_id", taskID, "seq", msg.Seq, "error", createErr)
@@ -2558,6 +2560,7 @@ func taskMessageToPayload(m db.TaskMessage, taskID, issueID string) protocol.Tas
 		IssueID:   issueID,
 		Seq:       int(m.Seq),
 		Type:      m.Type,
+		TextPhase: m.TextPhase.String,
 		Tool:      m.Tool.String,
 		Content:   m.Content.String,
 		Input:     input,

--- a/server/migrations/145_task_message_text_phase.down.sql
+++ b/server/migrations/145_task_message_text_phase.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_message
+DROP COLUMN IF EXISTS text_phase;

--- a/server/migrations/145_task_message_text_phase.up.sql
+++ b/server/migrations/145_task_message_text_phase.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_message
+ADD COLUMN text_phase TEXT;

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -98,6 +98,7 @@ const (
 type Message struct {
 	Type      MessageType
 	Content   string         // text content (Text, Error, Log)
+	TextPhase string         // text phase for MessageText (e.g. commentary, final_answer)
 	Tool      string         // tool name (ToolUse, ToolResult)
 	CallID    string         // tool call ID (ToolUse, ToolResult)
 	Input     map[string]any // tool input (ToolUse)

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -267,6 +267,14 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		// partial on each delta), so give the scanner generous headroom.
 		scanner.Buffer(make([]byte, 0, 1024*1024), 32*1024*1024)
 		var textBuffer strings.Builder
+		var textBufferPhase string
+		flushText := func() {
+			if d := flushPiTextBuffer(&textBuffer); d != "" {
+				output.WriteString(d)
+				trySend(msgCh, Message{Type: MessageText, Content: d, TextPhase: textBufferPhase})
+			}
+			textBufferPhase = ""
+		}
 
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
@@ -285,6 +293,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 			case "turn_start":
 				output.Reset()
 				textBuffer.Reset()
+				textBufferPhase = ""
 
 			case "message_update":
 				if evt.AssistantMessageEvent == nil {
@@ -292,9 +301,14 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				}
 				switch evt.AssistantMessageEvent.Type {
 				case "text_delta":
+					phase := evt.AssistantMessageEvent.textPhase(evt)
+					if textBuffer.Len() > 0 && textBufferPhase != phase {
+						flushText()
+					}
+					textBufferPhase = phase
 					if d := drainPiTextBuffer(&textBuffer, evt.AssistantMessageEvent.Delta); d != "" {
 						output.WriteString(d)
-						trySend(msgCh, Message{Type: MessageText, Content: d})
+						trySend(msgCh, Message{Type: MessageText, Content: d, TextPhase: phase})
 					}
 				case "thinking_delta":
 					if d := evt.AssistantMessageEvent.Delta; d != "" {
@@ -357,10 +371,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 				}
 			}
 		}
-		if d := flushPiTextBuffer(&textBuffer); d != "" {
-			output.WriteString(d)
-			trySend(msgCh, Message{Type: MessageText, Content: d})
-		}
+		flushText()
 
 		waitErr := cmd.Wait()
 		duration := time.Since(startTime)
@@ -402,6 +413,9 @@ type piStreamEvent struct {
 
 	// message_update
 	AssistantMessageEvent *piAssistantMessageEvent `json:"assistantMessageEvent,omitempty"`
+	Phase                 string                   `json:"phase,omitempty"`
+	Kind                  string                   `json:"kind,omitempty"`
+	TextPhase             string                   `json:"textPhase,omitempty"`
 
 	// tool_execution_start / tool_execution_end
 	ToolCallID string          `json:"toolCallId,omitempty"`
@@ -419,8 +433,29 @@ type piStreamEvent struct {
 }
 
 type piAssistantMessageEvent struct {
-	Type  string `json:"type"`
-	Delta string `json:"delta,omitempty"`
+	Type      string `json:"type"`
+	Delta     string `json:"delta,omitempty"`
+	Phase     string `json:"phase,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	TextPhase string `json:"textPhase,omitempty"`
+	TextKind  string `json:"textKind,omitempty"`
+}
+
+func (e *piAssistantMessageEvent) textPhase(parent piStreamEvent) string {
+	for _, phase := range []string{
+		e.Phase,
+		e.TextPhase,
+		e.Kind,
+		e.TextKind,
+		parent.Phase,
+		parent.TextPhase,
+		parent.Kind,
+	} {
+		if strings.TrimSpace(phase) != "" {
+			return strings.TrimSpace(phase)
+		}
+	}
+	return ""
 }
 
 type piMessage struct {

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -185,6 +185,67 @@ func TestPiExecuteRetainsOnlyLastTurnOutput(t *testing.T) {
 	}
 }
 
+func TestPiExecutePreservesTextPhase(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	events := []string{
+		`{"type":"agent_start"}`,
+		`{"type":"turn_start"}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","phase":"commentary","delta":"checking context"}}`,
+		`{"type":"message_update","assistantMessageEvent":{"type":"text_delta","phase":"final_answer","delta":"final answer"}}`,
+		`{"type":"turn_end","message":{"role":"assistant","model":"test","usage":{"input":1,"output":1}}}`,
+	}
+	fakePath := filepath.Join(t.TempDir(), "pi")
+	writeTestExecutable(t, fakePath, []byte(piEventStreamScript(events)))
+
+	backend, err := New("pi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new pi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var messages []Message
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for msg := range session.Messages {
+			if msg.Type == MessageText {
+				messages = append(messages, msg)
+			}
+		}
+	}()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+	<-done
+
+	byPhase := map[string]string{}
+	for _, msg := range messages {
+		byPhase[msg.TextPhase] += msg.Content
+	}
+	if byPhase["commentary"] != "checking context" {
+		t.Fatalf("commentary text = %q (all messages %#v)", byPhase["commentary"], messages)
+	}
+	if byPhase["final_answer"] != "final answer" {
+		t.Fatalf("final text = %q (all messages %#v)", byPhase["final_answer"], messages)
+	}
+}
+
 func TestStripPiToolCallMarkup(t *testing.T) {
 	tests := map[string]string{
 		`before call:bash{command:<|"|>cd repo/path && ls -F<|"|>}<tool_call|> after`:                           "before  after",

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -793,6 +793,7 @@ type TaskMessage struct {
 	TaskID    pgtype.UUID        `json:"task_id"`
 	Seq       int32              `json:"seq"`
 	Type      string             `json:"type"`
+	TextPhase pgtype.Text        `json:"text_phase"`
 	Tool      pgtype.Text        `json:"tool"`
 	Content   pgtype.Text        `json:"content"`
 	Input     []byte             `json:"input"`

--- a/server/pkg/db/generated/task_message.sql.go
+++ b/server/pkg/db/generated/task_message.sql.go
@@ -12,19 +12,20 @@ import (
 )
 
 const createTaskMessage = `-- name: CreateTaskMessage :one
-INSERT INTO task_message (task_id, seq, type, tool, content, input, output)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, task_id, seq, type, tool, content, input, output, created_at
+INSERT INTO task_message (task_id, seq, type, text_phase, tool, content, input, output)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, task_id, seq, type, text_phase, tool, content, input, output, created_at
 `
 
 type CreateTaskMessageParams struct {
-	TaskID  pgtype.UUID `json:"task_id"`
-	Seq     int32       `json:"seq"`
-	Type    string      `json:"type"`
-	Tool    pgtype.Text `json:"tool"`
-	Content pgtype.Text `json:"content"`
-	Input   []byte      `json:"input"`
-	Output  pgtype.Text `json:"output"`
+	TaskID    pgtype.UUID `json:"task_id"`
+	Seq       int32       `json:"seq"`
+	Type      string      `json:"type"`
+	TextPhase pgtype.Text `json:"text_phase"`
+	Tool      pgtype.Text `json:"tool"`
+	Content   pgtype.Text `json:"content"`
+	Input     []byte      `json:"input"`
+	Output    pgtype.Text `json:"output"`
 }
 
 func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessageParams) (TaskMessage, error) {
@@ -32,6 +33,7 @@ func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessagePa
 		arg.TaskID,
 		arg.Seq,
 		arg.Type,
+		arg.TextPhase,
 		arg.Tool,
 		arg.Content,
 		arg.Input,
@@ -43,6 +45,7 @@ func (q *Queries) CreateTaskMessage(ctx context.Context, arg CreateTaskMessagePa
 		&i.TaskID,
 		&i.Seq,
 		&i.Type,
+		&i.TextPhase,
 		&i.Tool,
 		&i.Content,
 		&i.Input,
@@ -63,7 +66,7 @@ func (q *Queries) DeleteTaskMessages(ctx context.Context, taskID pgtype.UUID) er
 }
 
 const listTaskMessages = `-- name: ListTaskMessages :many
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM task_message
+SELECT id, task_id, seq, type, text_phase, tool, content, input, output, created_at FROM task_message
 WHERE task_id = $1
 ORDER BY seq ASC
 `
@@ -82,6 +85,7 @@ func (q *Queries) ListTaskMessages(ctx context.Context, taskID pgtype.UUID) ([]T
 			&i.TaskID,
 			&i.Seq,
 			&i.Type,
+			&i.TextPhase,
 			&i.Tool,
 			&i.Content,
 			&i.Input,
@@ -99,7 +103,7 @@ func (q *Queries) ListTaskMessages(ctx context.Context, taskID pgtype.UUID) ([]T
 }
 
 const listTaskMessagesSince = `-- name: ListTaskMessagesSince :many
-SELECT id, task_id, seq, type, tool, content, input, output, created_at FROM task_message
+SELECT id, task_id, seq, type, text_phase, tool, content, input, output, created_at FROM task_message
 WHERE task_id = $1 AND seq > $2
 ORDER BY seq ASC
 `
@@ -123,6 +127,7 @@ func (q *Queries) ListTaskMessagesSince(ctx context.Context, arg ListTaskMessage
 			&i.TaskID,
 			&i.Seq,
 			&i.Type,
+			&i.TextPhase,
 			&i.Tool,
 			&i.Content,
 			&i.Input,

--- a/server/pkg/db/queries/task_message.sql
+++ b/server/pkg/db/queries/task_message.sql
@@ -1,6 +1,6 @@
 -- name: CreateTaskMessage :one
-INSERT INTO task_message (task_id, seq, type, tool, content, input, output)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO task_message (task_id, seq, type, text_phase, tool, content, input, output)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
 -- name: ListTaskMessages :many

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -56,11 +56,12 @@ type TaskMessagePayload struct {
 	TaskID    string         `json:"task_id"`
 	IssueID   string         `json:"issue_id,omitempty"`
 	Seq       int            `json:"seq"`
-	Type      string         `json:"type"`              // "text", "tool_use", "tool_result", "error"
-	Tool      string         `json:"tool,omitempty"`    // tool name for tool_use/tool_result
-	Content   string         `json:"content,omitempty"` // text content
-	Input     map[string]any `json:"input,omitempty"`   // tool input (tool_use only)
-	Output    string         `json:"output,omitempty"`  // tool output (tool_result only)
+	Type      string         `json:"type"`                 // "text", "tool_use", "tool_result", "error"
+	TextPhase string         `json:"text_phase,omitempty"` // text stream phase for type=text
+	Tool      string         `json:"tool,omitempty"`       // tool name for tool_use/tool_result
+	Content   string         `json:"content,omitempty"`    // text content
+	Input     map[string]any `json:"input,omitempty"`      // tool input (tool_use only)
+	Output    string         `json:"output,omitempty"`     // tool output (tool_result only)
 	CreatedAt string         `json:"created_at,omitempty"`
 }
 


### PR DESCRIPTION
## What does this PR do?

Preserves Pi text stream phase metadata end-to-end so chat clients can distinguish intermediate commentary from final-answer text. The fix adds a nullable `task_message.text_phase` field, carries it through Pi parsing, daemon batching, task-message persistence/websocket payloads, and uses it in chat timeline splitting so commentary stays foldable while final answers remain visible.

<!-- multica-auto-bugfix -->

Thinking path: Pi already exposed text deltas, but the daemon flattened every text delta into generic `type: "text"` rows. Carrying a small optional phase field keeps old messages compatible, avoids changing non-Pi runtimes, and lets clients make folding decisions without inferring from tool/thinking boundaries.

## Related Issue

Closes #4994

Multica issue: ZIC-47

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `task_message.text_phase` migration and updated task-message SQL/generated model code.
- Preserved Pi `phase`/`kind` hints on text deltas and kept daemon text batching from merging different phases.
- Exposed `text_phase` in task-message protocol/types/schemas for web and mobile.
- Updated chat timeline splitting so explicit commentary text folds into process steps while `final_answer` text remains visible/copyable.
- Added Pi parser, daemon pipeline, and timeline regression tests.

## How to Test

1. `go test ./pkg/agent`
2. `go test ./internal/daemon`
3. `go test ./internal/handler`
4. `pnpm --filter @multica/views test -- chat/lib/copy-text.test.ts common/task-transcript/build-timeline.test.ts`
5. `pnpm --filter @multica/views typecheck`
6. `pnpm --filter @multica/mobile typecheck`
7. `make check-worktree` exited 0 locally; it printed a Docker daemon connectivity warning while checking PostgreSQL.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Worked from GitHub issue #4994 and Multica issue ZIC-47. Traced Pi JSON stream parsing through daemon task-message reporting, server persistence/payloads, and chat timeline rendering, then added a minimal optional phase field with focused regression coverage.

## Screenshots (optional)

Not included; this is primarily protocol/data plumbing. The UI behavior is covered by timeline split/copy unit tests.
