### PR TITLE
fix(agent): harden Windows browser MCP defaults

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -183,6 +183,10 @@ Daemon behavior is configured via flags or environment variables:
 | GC orphan TTL (no `.gc_meta.json`) | — | `MULTICA_GC_ORPHAN_TTL` | `72h` |
 | GC artifact TTL (open issues) | — | `MULTICA_GC_ARTIFACT_TTL` | `12h` (set `0` to disable) |
 | GC artifact patterns | — | `MULTICA_GC_ARTIFACT_PATTERNS` | `node_modules,.next,.turbo` |
+| Browser MCP Chrome DevTools executable | — | `MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH` | Auto-detect on Windows |
+| Browser MCP Chrome DevTools channel | — | `MULTICA_CHROME_DEVTOOLS_CHANNEL` | unset |
+
+On Windows, daemon-managed browser MCP configs add a Playwright launch config that disables GPU compositing for headless runs, and `chrome-devtools` is pinned to an installed Chromium-family browser when Chrome stable is not the right target. Set `MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH` for an explicit browser executable, or `MULTICA_CHROME_DEVTOOLS_CHANNEL` to pass a `chrome-devtools-mcp` channel instead.
 
 #### Workspace garbage collection
 

--- a/server/pkg/agent/browser_mcp_config.go
+++ b/server/pkg/agent/browser_mcp_config.go
@@ -59,8 +59,8 @@ func hardenWindowsBrowserMcpConfig(raw json.RawMessage, tempDir string) ([]byte,
 				servers[name], changed = mustMarshalRaw(entry), true
 			}
 		case lowerName == "chrome-devtools" || argsContain(args, "chrome-devtools-mcp"):
-			if path, ok := windowsChromiumFallbackExecutable(); ok && shouldPinChromeDevToolsExecutable(args) {
-				entry["args"] = append(args, "--executablePath="+path)
+			if flag, ok := windowsChromeDevToolsBrowserFlag(); ok && shouldPinChromeDevToolsExecutable(args) {
+				entry["args"] = append(args, flag)
 				servers[name], changed = mustMarshalRaw(entry), true
 			}
 		}
@@ -99,24 +99,58 @@ func hardenWindowsPlaywrightMcpArgs(args []string, tempDir string) ([]string, er
 	return append(args, "--config", configPath), nil
 }
 
+func windowsChromeDevToolsBrowserFlag() (string, bool) {
+	if channel := strings.TrimSpace(browserMcpEnv("MULTICA_CHROME_DEVTOOLS_CHANNEL")); channel != "" {
+		return "--channel=" + channel, true
+	}
+	if path, ok := windowsChromiumFallbackExecutable(); ok {
+		return "--executablePath=" + path, true
+	}
+	return "", false
+}
+
 func windowsChromiumFallbackExecutable() (string, bool) {
 	if path := strings.TrimSpace(browserMcpEnv("MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH")); path != "" {
 		return path, true
 	}
-	for _, root := range []string{
-		browserMcpEnv("ProgramFiles(x86)"),
-		browserMcpEnv("ProgramFiles"),
-		browserMcpEnv("LocalAppData"),
-	} {
-		if strings.TrimSpace(root) == "" {
-			continue
-		}
-		path := windowsPathJoin(root, "Microsoft", "Edge", "Application", "msedge.exe")
-		if _, err := browserMcpStat(path); err == nil {
-			return path, true
+	for _, candidate := range windowsChromiumExecutableCandidates() {
+		if _, err := browserMcpStat(candidate); err == nil {
+			return candidate, true
 		}
 	}
 	return "", false
+}
+
+func windowsChromiumExecutableCandidates() []string {
+	installRoots := []string{
+		browserMcpEnv("ProgramFiles(x86)"),
+		browserMcpEnv("ProgramFiles"),
+	}
+	localRoot := browserMcpEnv("LocalAppData")
+
+	var candidates []string
+	for _, root := range installRoots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		candidates = append(candidates,
+			windowsPathJoin(root, "Microsoft", "Edge", "Application", "msedge.exe"),
+			windowsPathJoin(root, "Google", "Chrome Beta", "Application", "chrome.exe"),
+			windowsPathJoin(root, "Google", "Chrome SxS", "Application", "chrome.exe"),
+			windowsPathJoin(root, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+			windowsPathJoin(root, "Chromium", "Application", "chrome.exe"),
+		)
+	}
+	if strings.TrimSpace(localRoot) != "" {
+		candidates = append(candidates,
+			windowsPathJoin(localRoot, "Microsoft", "Edge", "Application", "msedge.exe"),
+			windowsPathJoin(localRoot, "Google", "Chrome Beta", "Application", "chrome.exe"),
+			windowsPathJoin(localRoot, "Google", "Chrome SxS", "Application", "chrome.exe"),
+			windowsPathJoin(localRoot, "BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+			windowsPathJoin(localRoot, "Chromium", "Application", "chrome.exe"),
+		)
+	}
+	return candidates
 }
 
 func windowsPathJoin(root string, elems ...string) string {

--- a/server/pkg/agent/browser_mcp_config_test.go
+++ b/server/pkg/agent/browser_mcp_config_test.go
@@ -108,6 +108,25 @@ func TestHardenWindowsBrowserMcpConfigRespectsExplicitBrowserArgs(t *testing.T) 
 	}
 }
 
+func TestHardenWindowsBrowserMcpConfigAppliesChromeDevToolsChannelOverride(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"MULTICA_CHROME_DEVTOOLS_CHANNEL": "chrome-beta",
+	}, nil)
+
+	raw := json.RawMessage(`{"mcpServers":{
+		"chrome-devtools":{"command":"npx","args":["chrome-devtools-mcp@latest","--headless","--isolated"]}
+	}}`)
+
+	got, err := hardenBrowserMcpConfig(raw, t.TempDir())
+	if err != nil {
+		t.Fatalf("hardenBrowserMcpConfig: %v", err)
+	}
+	chromeArgs := decodeArgs(t, decodeMcpServers(t, got)["chrome-devtools"])
+	if !contains(chromeArgs, "--channel=chrome-beta") {
+		t.Fatalf("chrome-devtools args missing channel override:\n%v", chromeArgs)
+	}
+}
+
 func TestHardenWindowsBrowserMcpConfigKeepsRawOnMalformedInput(t *testing.T) {
 	withBrowserMcpTestHost(t, "windows", nil, nil)
 
@@ -168,6 +187,47 @@ func TestWindowsChromiumFallbackExecutableSkipsMissingInstallDirs(t *testing.T) 
 	}
 }
 
+func TestWindowsChromiumFallbackExecutableDetectsChromiumFamilyBrowsers(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		existing string
+	}{
+		{
+			name: "chrome beta in program files",
+			env: map[string]string{
+				"ProgramFiles": `C:\Program Files`,
+			},
+			existing: `C:\Program Files\Google\Chrome Beta\Application\chrome.exe`,
+		},
+		{
+			name: "brave in local app data",
+			env: map[string]string{
+				"LocalAppData": `C:\Users\alice\AppData\Local`,
+			},
+			existing: `C:\Users\alice\AppData\Local\BraveSoftware\Brave-Browser\Application\brave.exe`,
+		},
+		{
+			name: "chromium in program files x86",
+			env: map[string]string{
+				"ProgramFiles(x86)": `C:\Program Files (x86)`,
+			},
+			existing: `C:\Program Files (x86)\Chromium\Application\chrome.exe`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withBrowserMcpTestHost(t, "windows", tc.env, map[string]bool{tc.existing: true})
+
+			got, ok := windowsChromiumFallbackExecutable()
+			if !ok || got != tc.existing {
+				t.Fatalf("fallback executable = %q, %v; want %q, true", got, ok, tc.existing)
+			}
+		})
+	}
+}
+
 func TestWindowsChromiumFallbackExecutablePropagatesOverride(t *testing.T) {
 	override := filepath.Clean(`D:\Browsers\Chromium\chrome.exe`)
 	withBrowserMcpTestHost(t, "windows", map[string]string{
@@ -177,6 +237,18 @@ func TestWindowsChromiumFallbackExecutablePropagatesOverride(t *testing.T) {
 	got, ok := windowsChromiumFallbackExecutable()
 	if !ok || got != override {
 		t.Fatalf("fallback executable = %q, %v; want %q, true", got, ok, override)
+	}
+}
+
+func TestWindowsChromeDevToolsBrowserFlagPrefersChannelOverride(t *testing.T) {
+	withBrowserMcpTestHost(t, "windows", map[string]string{
+		"MULTICA_CHROME_DEVTOOLS_CHANNEL":         "chrome-beta",
+		"MULTICA_CHROME_DEVTOOLS_EXECUTABLE_PATH": `D:\Browsers\Chrome\chrome.exe`,
+	}, map[string]bool{})
+
+	got, ok := windowsChromeDevToolsBrowserFlag()
+	if !ok || got != "--channel=chrome-beta" {
+		t.Fatalf("browser flag = %q, %v; want --channel=chrome-beta, true", got, ok)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Hardens Windows browser MCP config generation so daemon-injected browser MCP servers run headlessly without leaking Playwright's phantom Chrome for Testing window, and so `chrome-devtools-mcp` can target an available Chromium-family browser instead of assuming Chrome stable.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #4955

Multica issue: ZIC-48

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Extend Windows `chrome-devtools-mcp` hardening to support `MULTICA_CHROME_DEVTOOLS_CHANNEL`.
- Expand Windows browser executable detection beyond Edge to Chrome Beta, Chrome Canary, Brave, and Chromium in common machine and per-user install locations.
- Document the browser MCP override environment variables in `CLI_AND_DAEMON.md`.
- Add structured unit coverage for channel overrides and Chromium-family fallback detection.

## How to Test

1. `cd server && go test ./pkg/agent`
2. `make check-worktree` (exited 0, but emitted a local Docker daemon unavailable warning while checking PostgreSQL)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the daemon-generated browser MCP config path, kept the existing Windows Playwright GPU hardening, extended `chrome-devtools-mcp` browser selection to configurable channel/executable and broader Chromium-family auto-detection, then covered the generated arguments with focused Go tests.

## Screenshots (optional)

N/A
