### PR TITLE
fix(autopilot): preserve creator originator for initial tasks

### DIFF
--- a/server/internal/handler/squad_worker_comment_wakes_leader_test.go
+++ b/server/internal/handler/squad_worker_comment_wakes_leader_test.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -355,5 +357,125 @@ func TestCreateComment_WorkerAgentCommentWakesPrivateSquadLeader_MUL4015(t *test
 	if leaderTasksQueued != 1 {
 		t.Fatalf("after worker done: expected 1 queued leader task for private L, got %d — leader→worker→leader loop broken for private leader (MUL-4015)",
 			leaderTasksQueued)
+	}
+}
+
+func TestAutopilotSquadLeaderTaskCarriesOriginatorForPrivateWorkerMention(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	privateAgent := func(name string) string {
+		var agentID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent (
+				workspace_id, name, description, runtime_mode, runtime_config,
+				runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
+				instructions, custom_env, custom_args, mcp_config
+			)
+			VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+			RETURNING id
+		`, testWorkspaceID, name, handlerTestRuntimeID(t), testUserID).Scan(&agentID); err != nil {
+			t.Fatalf("create private agent %q: %v", name, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+		})
+		return agentID
+	}
+
+	leaderID := privateAgent(fmt.Sprintf("autopilot-originator-leader-%d", suffix))
+	workerID := privateAgent(fmt.Sprintf("autopilot-originator-worker-%d", suffix))
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("autopilot-originator-squad-%d", suffix), leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+
+	var autopilotID string
+	autopilotTitle := fmt.Sprintf("autopilot-originator-%d", suffix)
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot (
+			workspace_id, title, assignee_type, assignee_id, execution_mode,
+			issue_title_template, created_by_type, created_by_id
+		)
+		VALUES ($1, $2, 'squad', $3, 'create_issue', $4, 'member', $5)
+		RETURNING id
+	`, testWorkspaceID, autopilotTitle, squadID, autopilotTitle, testUserID).Scan(&autopilotID); err != nil {
+		t.Fatalf("create autopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM autopilot_run WHERE autopilot_id = $1`, autopilotID)
+		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+	})
+
+	ap, err := testHandler.Queries.GetAutopilot(ctx, parseUUID(autopilotID))
+	if err != nil {
+		t.Fatalf("load autopilot: %v", err)
+	}
+	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "manual", nil)
+	if err != nil {
+		t.Fatalf("dispatch autopilot: %v", err)
+	}
+	if run == nil || !run.IssueID.Valid {
+		t.Fatalf("dispatch run = %+v, want linked issue", run)
+	}
+	issueID := uuidToString(run.IssueID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	var leaderTaskID string
+	var leaderOriginator pgtype.UUID
+	if err := testPool.QueryRow(ctx, `
+		SELECT id, originator_user_id
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND is_leader_task = TRUE
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, issueID, leaderID).Scan(&leaderTaskID, &leaderOriginator); err != nil {
+		t.Fatalf("load leader task: %v", err)
+	}
+	if !leaderOriginator.Valid || uuidToString(leaderOriginator) != testUserID {
+		t.Fatalf("leader task originator = %v (valid=%v), want autopilot creator %s",
+			uuidToString(leaderOriginator), leaderOriginator.Valid, testUserID)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET status = 'running', started_at = now() WHERE id = $1`, leaderTaskID); err != nil {
+		t.Fatalf("mark leader task running: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "please handle [@Worker](mention://agent/" + workerID + ")",
+	})
+	r.Header.Set("X-Agent-ID", leaderID)
+	r.Header.Set("X-Task-ID", leaderTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("leader worker mention CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var workerTasks int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+	`, issueID, workerID).Scan(&workerTasks); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if workerTasks != 1 {
+		t.Fatalf("expected private worker task after autopilot leader mention, got %d", workerTasks)
 	}
 }

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -415,6 +415,7 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 	// route to the resolved leader as the executing agent (Path A from
 	// MUL-2429); agent-assigned autopilots go through the standard issue
 	// path. Both code paths land in agent_task_queue with agent_id = leader.
+	originatorUserID := autopilotOriginator(ap)
 	if ap.AssigneeType == "squad" {
 		// Fail-closed invocation gate: verify the autopilot creator may still
 		// invoke the leader under the permission model. Catches configs that
@@ -423,11 +424,11 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 		if !s.canCreatorInvokeAgent(ctx, ap, leader) {
 			return fmt.Errorf("autopilot creator cannot access private squad leader")
 		}
-		if _, err := s.TaskSvc.EnqueueTaskForSquadLeader(ctx, issue, leader.ID, ap.AssigneeID, pgtype.UUID{}); err != nil {
+		if _, err := s.TaskSvc.EnqueueTaskForSquadLeaderWithOriginator(ctx, issue, leader.ID, ap.AssigneeID, originatorUserID); err != nil {
 			return fmt.Errorf("enqueue squad leader task: %w", err)
 		}
 	} else {
-		if _, err := s.TaskSvc.EnqueueTaskForIssue(ctx, issue); err != nil {
+		if _, err := s.TaskSvc.EnqueueTaskForIssueWithOriginator(ctx, issue, originatorUserID); err != nil {
 			return fmt.Errorf("enqueue task for issue: %w", err)
 		}
 	}
@@ -569,11 +570,16 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 		return &errDispatchSkipped{reason: formatAdmissionReason(ap, "creator cannot access private squad leader")}
 	}
 
+	originatorUserID := autopilotOriginator(ap)
+	runtimeMCPOverlay := s.TaskSvc.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	task, err := s.Queries.CreateAutopilotTask(ctx, db.CreateAutopilotTaskParams{
-		AgentID:        agent.ID,
-		RuntimeID:      agent.RuntimeID,
-		Priority:       0,
-		AutopilotRunID: run.ID,
+		AgentID:              agent.ID,
+		RuntimeID:            agent.RuntimeID,
+		Priority:             0,
+		AutopilotRunID:       run.ID,
+		OriginatorUserID:     originatorUserID,
+		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
+		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
 		// Snapshot the autopilot title so task rows self-describe later
 		// without joining back to autopilot. Truncated for the same
 		// transmission-cost reason as comment-driven summaries.
@@ -990,6 +996,13 @@ func (s *AutopilotService) resolveAutopilotLeader(ctx context.Context, ap db.Aut
 func autopilotSquadAttribution(ap db.Autopilot) pgtype.UUID {
 	if ap.AssigneeType == "squad" && ap.AssigneeID.Valid {
 		return ap.AssigneeID
+	}
+	return pgtype.UUID{}
+}
+
+func autopilotOriginator(ap db.Autopilot) pgtype.UUID {
+	if ap.CreatedByType == "member" && ap.CreatedByID.Valid {
+		return ap.CreatedByID
 	}
 	return pgtype.UUID{}
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -280,7 +280,9 @@ func (s *TaskService) resolveOriginatorFromTriggerComment(ctx context.Context, c
 // direct issue assignment/creation falls back to the issue's member creator.
 // Agent-created quick-create issues have an explicit origin link back to the
 // quick-create task, so they can inherit that task's originator safely. Other
-// agent/system origins, including autopilot, deliberately remain unattributed.
+// agent/system origins deliberately remain unattributed. Autopilot initial
+// dispatch knows the member creator and passes that originator explicitly
+// instead of asking this fallback to infer it from an agent-created issue.
 func (s *TaskService) resolveOriginatorForIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID) pgtype.UUID {
 	if triggerCommentID.Valid {
 		return s.resolveOriginatorFromTriggerComment(ctx, triggerCommentID)
@@ -301,6 +303,13 @@ func (s *TaskService) resolveOriginatorForIssueTask(ctx context.Context, issue d
 	default:
 		return pgtype.UUID{}
 	}
+}
+
+func (s *TaskService) effectiveOriginatorForIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, originatorOverride pgtype.UUID) pgtype.UUID {
+	if originatorOverride.Valid {
+		return originatorOverride
+	}
+	return s.resolveOriginatorForIssueTask(ctx, issue, triggerCommentID)
 }
 
 func (s *TaskService) captureTaskDispatched(ctx context.Context, task db.AgentTaskQueue) {
@@ -599,6 +608,13 @@ func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, t
 	return s.enqueueIssueTask(ctx, issue, commentID, false, "")
 }
 
+// EnqueueTaskForIssueWithOriginator creates the initial issue task when the
+// caller already knows the trusted human originator. Invalid originator falls
+// back to the normal issue/comment-chain resolution.
+func (s *TaskService) EnqueueTaskForIssueWithOriginator(ctx context.Context, issue db.Issue, originatorUserID pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueIssueTaskWithOriginator(ctx, issue, pgtype.UUID{}, false, "", originatorUserID)
+}
+
 // EnqueueTaskForIssueWithHandoff is the assign/promote variant that carries a
 // handoff note into the run's opening context (MUL-3375). The note rides a
 // dedicated task column; the daemon renders it via the assignment-handoff
@@ -653,6 +669,10 @@ func (s *TaskService) ResolveIssueReviewSHAParam(ctx context.Context, issueID pg
 }
 
 func (s *TaskService) enqueueIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, forceFreshSession bool, handoffNote string) (db.AgentTaskQueue, error) {
+	return s.enqueueIssueTaskWithOriginator(ctx, issue, triggerCommentID, forceFreshSession, handoffNote, pgtype.UUID{})
+}
+
+func (s *TaskService) enqueueIssueTaskWithOriginator(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, forceFreshSession bool, handoffNote string, originatorOverride pgtype.UUID) (db.AgentTaskQueue, error) {
 	if !issue.AssigneeID.Valid {
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", "issue has no assignee")
 		return db.AgentTaskQueue{}, fmt.Errorf("issue has no assignee")
@@ -672,7 +692,7 @@ func (s *TaskService) enqueueIssueTask(ctx context.Context, issue db.Issue, trig
 		return db.AgentTaskQueue{}, fmt.Errorf("agent has no runtime")
 	}
 
-	originatorUserID := s.resolveOriginatorForIssueTask(ctx, issue, triggerCommentID)
+	originatorUserID := s.effectiveOriginatorForIssueTask(ctx, issue, triggerCommentID, originatorOverride)
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
 		AgentID:              issue.AssigneeID,
@@ -740,6 +760,13 @@ func (s *TaskService) EnqueueTaskForSquadLeader(ctx context.Context, issue db.Is
 	return s.enqueueMentionTask(ctx, issue, leaderID, triggerCommentID, true, squadID, false, "")
 }
 
+// EnqueueTaskForSquadLeaderWithOriginator is the initial leader dispatch for
+// callers that already know the trusted human originator. Invalid originator
+// falls back to the normal issue/comment-chain resolution.
+func (s *TaskService) EnqueueTaskForSquadLeaderWithOriginator(ctx context.Context, issue db.Issue, leaderID pgtype.UUID, squadID pgtype.UUID, originatorUserID pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueMentionTaskWithOriginator(ctx, issue, leaderID, pgtype.UUID{}, true, squadID, false, "", originatorUserID)
+}
+
 // EnqueueTaskForSquadLeaderWithHandoff is the assign/promote variant carrying a
 // handoff note into the leader run's opening context (MUL-3375). Empty note
 // behaves exactly like EnqueueTaskForSquadLeader.
@@ -748,6 +775,10 @@ func (s *TaskService) EnqueueTaskForSquadLeaderWithHandoff(ctx context.Context, 
 }
 
 func (s *TaskService) enqueueMentionTask(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string) (db.AgentTaskQueue, error) {
+	return s.enqueueMentionTaskWithOriginator(ctx, issue, agentID, triggerCommentID, isLeader, squadID, forceFreshSession, handoffNote, pgtype.UUID{})
+}
+
+func (s *TaskService) enqueueMentionTaskWithOriginator(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, isLeader bool, squadID pgtype.UUID, forceFreshSession bool, handoffNote string, originatorOverride pgtype.UUID) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
 		slog.Error("mention task enqueue failed: agent not found", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID), "error", err)
@@ -762,7 +793,7 @@ func (s *TaskService) enqueueMentionTask(ctx context.Context, issue db.Issue, ag
 		return db.AgentTaskQueue{}, fmt.Errorf("agent has no runtime")
 	}
 
-	originatorUserID := s.resolveOriginatorForIssueTask(ctx, issue, triggerCommentID)
+	originatorUserID := s.effectiveOriginatorForIssueTask(ctx, issue, triggerCommentID, originatorOverride)
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
 		AgentID:              agentID,

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -209,17 +209,29 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 
 const createAutopilotTask = `-- name: CreateAutopilotTask :one
 
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id, trigger_summary)
-VALUES ($1, $2, NULL, 'queued', $3, $4, $5)
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, autopilot_run_id,
+    trigger_summary, originator_user_id, runtime_mcp_overlay, runtime_connected_apps
+)
+VALUES (
+    $1, $2, NULL, 'queued', $3, $4,
+    $5,
+    $6::uuid,
+    $7::jsonb,
+    $8::jsonb
+)
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps
 `
 
 type CreateAutopilotTaskParams struct {
-	AgentID        pgtype.UUID `json:"agent_id"`
-	RuntimeID      pgtype.UUID `json:"runtime_id"`
-	Priority       int32       `json:"priority"`
-	AutopilotRunID pgtype.UUID `json:"autopilot_run_id"`
-	TriggerSummary pgtype.Text `json:"trigger_summary"`
+	AgentID              pgtype.UUID `json:"agent_id"`
+	RuntimeID            pgtype.UUID `json:"runtime_id"`
+	Priority             int32       `json:"priority"`
+	AutopilotRunID       pgtype.UUID `json:"autopilot_run_id"`
+	TriggerSummary       pgtype.Text `json:"trigger_summary"`
+	OriginatorUserID     pgtype.UUID `json:"originator_user_id"`
+	RuntimeMcpOverlay    []byte      `json:"runtime_mcp_overlay"`
+	RuntimeConnectedApps []byte      `json:"runtime_connected_apps"`
 }
 
 // =====================
@@ -232,6 +244,9 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		arg.Priority,
 		arg.AutopilotRunID,
 		arg.TriggerSummary,
+		arg.OriginatorUserID,
+		arg.RuntimeMcpOverlay,
+		arg.RuntimeConnectedApps,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -327,8 +327,17 @@ ORDER BY t.id;
 -- =====================
 
 -- name: CreateAutopilotTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id, trigger_summary)
-VALUES ($1, $2, NULL, 'queued', $3, $4, sqlc.narg(trigger_summary))
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, autopilot_run_id,
+    trigger_summary, originator_user_id, runtime_mcp_overlay, runtime_connected_apps
+)
+VALUES (
+    $1, $2, NULL, 'queued', $3, $4,
+    sqlc.narg(trigger_summary),
+    sqlc.narg(originator_user_id)::uuid,
+    sqlc.narg(runtime_mcp_overlay)::jsonb,
+    sqlc.narg(runtime_connected_apps)::jsonb
+)
 RETURNING *;
 
 -- =====================
@@ -451,4 +460,3 @@ SELECT EXISTS (
 -- Powers the per-row can_write flag on the list endpoint without an N+1.
 SELECT autopilot_id FROM autopilot_collaborator
 WHERE user_type = 'member' AND user_id = $1;
-


### PR DESCRIPTION
Fixes #5031.

## Product verdict

This fixes a task-routing bug for private agents. Autopilot-created squad issues enqueue an initial leader task, but that task previously lost the human creator. If the leader later mentioned a private worker agent, the private invocation gate could not prove the originating human was allowed to invoke that worker, so no worker task was queued.

## Root cause

Autopilot-created issues intentionally use the executing agent as the issue creator. The task originator fallback deliberately does not infer humans from agent/system origins such as autopilot, so the initial autopilot task needs to receive the autopilot member creator explicitly.

## Changes

- Pass the autopilot member creator as the explicit originator for create_issue initial agent/leader tasks.
- Store the same originator on run_only autopilot tasks and build their runtime MCP overlay with it.
- Keep the existing issue/comment-chain originator fallback unchanged for normal assignment and mention paths.
- Add a DB-backed regression test for private squad leader -> private worker mention after autopilot dispatch.

## Verification

- `go test ./internal/handler -run TestAutopilotSquadLeaderTaskCarriesOriginatorForPrivateWorkerMention`
- `go test ./cmd/server -run TestReadinessEndpoints -count=1 -v`
- `go test ./internal/handler ./internal/service ./cmd/server`
- `git diff --cached --check`

Note: the first package test run failed only because the local test DB was behind the newly fetched upstream migrations; after applying migrations `135` through `144` locally, the same checks passed.
