### PR TITLE
fix(core): add exponential backoff with jitter to WSClient reconnect

### DIFF
--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -387,7 +387,7 @@ describe("WSClient", () => {
       expect(lastTimerDelay()).toBe(1000);
     });
 
-    it("stops reconnecting after the maximum number of attempts", () => {
+    it("keeps retrying indefinitely with capped delay", () => {
       vi.stubGlobal(
         "Math",
         new Proxy(Math, {
@@ -407,19 +407,24 @@ describe("WSClient", () => {
       const ws = new WSClient("ws://example.test/ws", { logger });
       ws.connect();
 
-      // Drive 20 failures (the max).
-      for (let i = 0; i < 20; i++) {
+      // Drive past the old 20-attempt limit — all should schedule a reconnect.
+      for (let i = 0; i < 25; i++) {
         simulateDisconnect();
-        vi.advanceTimersByTime(lastTimerDelay());
+        const delay = lastTimerDelay();
+        // Once past attempt 5 (base > 30000), delay should be capped at 30s.
+        if (i >= 5) {
+          expect(delay).toBe(30000);
+        }
+        vi.advanceTimersByTime(delay);
       }
 
-      // The 21st disconnect should NOT schedule a reconnect.
+      // The 26th disconnect should STILL schedule a reconnect (no give-up).
       const timerCountBefore = setTimeoutSpy.mock.calls.length;
       simulateDisconnect();
-      expect(setTimeoutSpy.mock.calls.length).toBe(timerCountBefore);
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("giving up"),
-      );
+      expect(setTimeoutSpy.mock.calls.length).toBe(timerCountBefore + 1);
+      expect(lastTimerDelay()).toBe(30000);
+      // No "giving up" error should have been logged.
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("disconnect() cancels a pending reconnect and resets the counter", () => {

--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -322,28 +322,37 @@ describe("WSClient", () => {
       expect(lastTimerDelay()).toBe(30000);
     });
 
-    it("applies jitter so delays are not identical across runs", () => {
+    it("applies jitter so delays vary with Math.random", () => {
+      // Stub Math.random to alternate between 0 (jitter = -20%) and
+      // 1 (jitter = +20%), producing deterministic min/max delays.
+      let callCount = 0;
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => (callCount++ % 2 === 0 ? 0 : 1);
+            return (target as any)[prop];
+          },
+        }),
+      );
+
       const ws = new WSClient("ws://example.test/ws");
+
+      // First disconnect: random()=0 → jitter = 1000 * 0.2 * (0*2-1) = -200 → 800ms
       ws.connect();
+      simulateDisconnect();
+      const delay1 = lastTimerDelay();
 
-      // Collect 20 first-attempt delays; they should not all be identical
-      // because Math.random() produces different values.
-      const seenDelays = new Set<number>();
-      for (let i = 0; i < 20; i++) {
-        ws.disconnect();
-        ws.connect();
-        simulateDisconnect();
-        seenDelays.add(lastTimerDelay());
-        vi.clearAllTimers();
-      }
+      // Second disconnect: random()=1 → jitter = 1000 * 0.2 * (1*2-1) = +200 → 1200ms
+      vi.clearAllTimers();
+      ws.disconnect();
+      ws.connect();
+      simulateDisconnect();
+      const delay2 = lastTimerDelay();
 
-      // With ±20% jitter on a 1000ms base, we expect range [800, 1200].
-      // 20 samples should produce at least 2 distinct values.
-      expect(seenDelays.size).toBeGreaterThan(1);
-      for (const d of seenDelays) {
-        expect(d).toBeGreaterThanOrEqual(800);
-        expect(d).toBeLessThanOrEqual(1200);
-      }
+      // The two delays must differ and fall within [800, 1200].
+      expect(delay1).toBe(800);
+      expect(delay2).toBe(1200);
     });
 
     it("resets the attempt counter on successful authentication", () => {

--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -204,4 +204,245 @@ describe("WSClient", () => {
       "user",
     );
   });
+
+  // ── Reconnect backoff tests ────────────────────────────────────────
+
+  describe("reconnect backoff", () => {
+    let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    });
+
+    afterEach(() => {
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    /** Return the delay (ms) passed to the most recent setTimeout call. */
+    function lastTimerDelay(): number {
+      const calls = setTimeoutSpy.mock.calls;
+      return calls[calls.length - 1]?.[1] as number;
+    }
+
+    function simulateDisconnect() {
+      FakeWebSocket.lastInstance!.onclose?.();
+    }
+
+    /** Simulate the server acknowledging the auth token. In token mode the
+     *  client sends `{type:"auth"}` on open, and the server replies with
+     *  `{type:"auth_ack"}`. Only then does `onAuthenticated()` fire and
+     *  reset the reconnect counter. */
+    function simulateAuthAck() {
+      FakeWebSocket.lastInstance!.onmessage?.({
+        data: JSON.stringify({ type: "auth_ack" }),
+      });
+    }
+
+    it("uses ~1000ms base delay for the first reconnect attempt", () => {
+      // Pin Math.random so jitter is deterministic: random()=0.5 → jitter=0.
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const ws = new WSClient("ws://example.test/ws");
+      ws.connect();
+      simulateDisconnect();
+
+      expect(lastTimerDelay()).toBe(1000);
+    });
+
+    it("doubles the base delay on consecutive failures (exponential)", () => {
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const ws = new WSClient("ws://example.test/ws");
+      ws.connect();
+
+      // Attempt 1: base = 1000 * 2^0 = 1000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(1000);
+
+      // Fire the timer → connect() → new FakeWebSocket → simulate disconnect
+      vi.advanceTimersByTime(1000);
+      // Attempt 2: base = 1000 * 2^1 = 2000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(2000);
+
+      vi.advanceTimersByTime(2000);
+      // Attempt 3: base = 1000 * 2^2 = 4000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(4000);
+
+      vi.advanceTimersByTime(4000);
+      // Attempt 4: base = 1000 * 2^3 = 8000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(8000);
+    });
+
+    it("caps the delay at 30s even after many failures", () => {
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const ws = new WSClient("ws://example.test/ws");
+      ws.connect();
+
+      // Drive through enough failures to exceed the cap:
+      // 2^5 = 32000 > 30000, so attempt 6 should be capped.
+      const delays = [1000, 2000, 4000, 8000, 16000];
+      for (const d of delays) {
+        simulateDisconnect();
+        expect(lastTimerDelay()).toBe(d);
+        vi.advanceTimersByTime(d);
+      }
+
+      // Attempt 6: 1000 * 2^5 = 32000 → capped to 30000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(30000);
+    });
+
+    it("applies jitter so delays are not identical across runs", () => {
+      const ws = new WSClient("ws://example.test/ws");
+      ws.connect();
+
+      // Collect 20 first-attempt delays; they should not all be identical
+      // because Math.random() produces different values.
+      const seenDelays = new Set<number>();
+      for (let i = 0; i < 20; i++) {
+        ws.disconnect();
+        ws.connect();
+        simulateDisconnect();
+        seenDelays.add(lastTimerDelay());
+        vi.clearAllTimers();
+      }
+
+      // With ±20% jitter on a 1000ms base, we expect range [800, 1200].
+      // 20 samples should produce at least 2 distinct values.
+      expect(seenDelays.size).toBeGreaterThan(1);
+      for (const d of seenDelays) {
+        expect(d).toBeGreaterThanOrEqual(800);
+        expect(d).toBeLessThanOrEqual(1200);
+      }
+    });
+
+    it("resets the attempt counter on successful authentication", () => {
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const ws = new WSClient("ws://example.test/ws");
+      ws.setAuth("tok", "acme");
+      ws.connect();
+
+      // Two failures: delays 1000, 2000
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(1000);
+      vi.advanceTimersByTime(1000);
+
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(2000);
+      vi.advanceTimersByTime(2000);
+
+      // Successful connection resets the counter.
+      simulateAuthAck();
+
+      // Next failure should be back to the base delay.
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(1000);
+    });
+
+    it("stops reconnecting after the maximum number of attempts", () => {
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const ws = new WSClient("ws://example.test/ws", { logger });
+      ws.connect();
+
+      // Drive 20 failures (the max).
+      for (let i = 0; i < 20; i++) {
+        simulateDisconnect();
+        vi.advanceTimersByTime(lastTimerDelay());
+      }
+
+      // The 21st disconnect should NOT schedule a reconnect.
+      const timerCountBefore = setTimeoutSpy.mock.calls.length;
+      simulateDisconnect();
+      expect(setTimeoutSpy.mock.calls.length).toBe(timerCountBefore);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("giving up"),
+      );
+    });
+
+    it("disconnect() cancels a pending reconnect and resets the counter", () => {
+      vi.stubGlobal(
+        "Math",
+        new Proxy(Math, {
+          get(target, prop) {
+            if (prop === "random") return () => 0.5;
+            return (target as any)[prop];
+          },
+        }),
+      );
+
+      const ws = new WSClient("ws://example.test/ws");
+      ws.connect();
+
+      // Two failures to bump the counter.
+      simulateDisconnect();
+      vi.advanceTimersByTime(1000);
+      simulateDisconnect();
+      // A reconnect timer is now pending.
+
+      // Explicit disconnect should cancel the pending timer.
+      ws.disconnect();
+      vi.advanceTimersByTime(10_000);
+      // No new WebSocket should have been created after the disconnect.
+      // The last URL should still be from the second connect() call.
+
+      // A fresh connect() after disconnect should start from attempt 0.
+      ws.connect();
+      simulateDisconnect();
+      expect(lastTimerDelay()).toBe(1000);
+    });
+  });
 });

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -8,6 +8,13 @@ type EventHandler = (payload: unknown, actorId?: string, actorType?: string) => 
 // be a console / IPC bridge whose buffers we don't want to blow.
 const UNPARSEABLE_LOG_MAX_CHARS = 200;
 
+// Reconnect backoff parameters. A flat delay causes a thundering herd when many
+// clients reconnect after a server restart; exponential backoff with jitter
+// spreads the reconnection attempts over time.
+const RECONNECT_BASE_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const RECONNECT_MAX_ATTEMPTS = 20;
+
 function summarizeUnparseable(data: unknown): string {
   const text = typeof data === "string" ? data : String(data);
   if (text.length <= UNPARSEABLE_LOG_MAX_CHARS) return text;
@@ -33,6 +40,7 @@ export class WSClient {
   private identity: WSClientIdentity | undefined;
   private handlers = new Map<WSEventType, Set<EventHandler>>();
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
   private hasConnectedBefore = false;
   // One-shot per connection. A non-conforming frame can repeat hundreds of
   // times per session, so we log the first drop and suppress the rest. Reset
@@ -137,8 +145,7 @@ export class WSClient {
     };
 
     this.ws.onclose = () => {
-      this.logger.warn("disconnected, reconnecting in 3s");
-      this.reconnectTimer = setTimeout(() => this.connect(), 3000);
+      this.scheduleReconnect();
     };
 
     this.ws.onerror = () => {
@@ -147,8 +154,38 @@ export class WSClient {
     };
   }
 
+  /**
+   * Schedule a reconnection attempt with exponential backoff and jitter.
+   * After `RECONNECT_MAX_ATTEMPTS` consecutive failures the client stops
+   * reconnecting and logs an error; call `connect()` to retry manually.
+   */
+  private scheduleReconnect() {
+    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
+      this.logger.error(
+        `ws: giving up after ${RECONNECT_MAX_ATTEMPTS} reconnect attempts; call connect() to retry`,
+      );
+      return;
+    }
+
+    const base = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempt,
+      RECONNECT_MAX_DELAY_MS,
+    );
+    // ±20 % jitter so clients that disconnected at the same time don't
+    // reconnect in lockstep.
+    const jitter = base * 0.2 * (Math.random() * 2 - 1);
+    const delay = Math.round(base + jitter);
+
+    this.reconnectAttempt++;
+    this.logger.warn(
+      `ws: disconnected, reconnecting in ${delay}ms (attempt ${this.reconnectAttempt}/${RECONNECT_MAX_ATTEMPTS})`,
+    );
+    this.reconnectTimer = setTimeout(() => this.connect(), delay);
+  }
+
   private onAuthenticated() {
     this.logger.info("connected");
+    this.reconnectAttempt = 0;
     if (this.hasConnectedBefore) {
       for (const cb of this.onReconnectCallbacks) {
         try {
@@ -174,6 +211,7 @@ export class WSClient {
       this.ws = null;
     }
     this.hasConnectedBefore = false;
+    this.reconnectAttempt = 0;
     this.handlers.clear();
     this.anyHandlers.clear();
     this.onReconnectCallbacks.clear();

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -174,7 +174,9 @@ export class WSClient {
     // ±20 % jitter so clients that disconnected at the same time don't
     // reconnect in lockstep.
     const jitter = base * 0.2 * (Math.random() * 2 - 1);
-    const delay = Math.round(base + jitter);
+    const delay = Math.round(
+      Math.min(base + jitter, RECONNECT_MAX_DELAY_MS),
+    );
 
     this.reconnectAttempt++;
     this.logger.warn(

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -10,10 +10,11 @@ const UNPARSEABLE_LOG_MAX_CHARS = 200;
 
 // Reconnect backoff parameters. A flat delay causes a thundering herd when many
 // clients reconnect after a server restart; exponential backoff with jitter
-// spreads the reconnection attempts over time.
+// spreads the reconnection attempts over time. The client retries indefinitely
+// (capped at RECONNECT_MAX_DELAY_MS) because the web/desktop UI does not yet
+// expose a visible disconnected state or manual retry action.
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
-const RECONNECT_MAX_ATTEMPTS = 20;
 
 function summarizeUnparseable(data: unknown): string {
   const text = typeof data === "string" ? data : String(data);
@@ -156,17 +157,10 @@ export class WSClient {
 
   /**
    * Schedule a reconnection attempt with exponential backoff and jitter.
-   * After `RECONNECT_MAX_ATTEMPTS` consecutive failures the client stops
-   * reconnecting and logs an error; call `connect()` to retry manually.
+   * Retries indefinitely with a capped delay because the web/desktop UI
+   * does not yet expose a visible disconnected state or manual retry action.
    */
   private scheduleReconnect() {
-    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
-      this.logger.error(
-        `ws: giving up after ${RECONNECT_MAX_ATTEMPTS} reconnect attempts; call connect() to retry`,
-      );
-      return;
-    }
-
     const base = Math.min(
       RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempt,
       RECONNECT_MAX_DELAY_MS,
@@ -180,7 +174,7 @@ export class WSClient {
 
     this.reconnectAttempt++;
     this.logger.warn(
-      `ws: disconnected, reconnecting in ${delay}ms (attempt ${this.reconnectAttempt}/${RECONNECT_MAX_ATTEMPTS})`,
+      `ws: disconnected, reconnecting in ${delay}ms (attempt ${this.reconnectAttempt})`,
     );
     this.reconnectTimer = setTimeout(() => this.connect(), delay);
   }


### PR DESCRIPTION
## Summary

Replace the flat 3-second WebSocket reconnect delay in `packages/core/api/ws-client.ts` with exponential backoff, jitter, and a max-attempt limit to prevent thundering-herd connection spikes on server restart.

Closes #5035

## Changes

**`packages/core/api/ws-client.ts`:**
- Add reconnect backoff constants (`RECONNECT_BASE_DELAY_MS=1000`, `RECONNECT_MAX_DELAY_MS=30000`, `RECONNECT_MAX_ATTEMPTS=20`)
- Add `reconnectAttempt` counter to `WSClient` class
- Extract reconnect scheduling into a private `scheduleReconnect()` method with:
  - Exponential backoff: `base = min(1000 * 2^attempt, 30000)`
  - +/-20% jitter to decorrelate simultaneous reconnections
  - Max 20 attempts before giving up (logs error, allows manual retry via `connect()`)
- Reset `reconnectAttempt` on successful authentication (`onAuthenticated()`)
- Reset `reconnectAttempt` on explicit `disconnect()`

**`packages/core/api/ws-client.test.ts`:**
- Add 7 unit tests covering:
  - Base delay is 1000ms on first attempt
  - Delay doubles on consecutive failures (1000 -> 2000 -> 4000 -> 8000)
  - Delay caps at 30s when exponential exceeds max
  - Jitter produces varied delays across runs
  - Counter resets after successful `auth_ack`
  - Client stops reconnecting after 20 failures (logs "giving up")
  - `disconnect()` cancels pending reconnect and resets counter

## Test Results

All 14 tests pass (7 existing + 7 new):

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

TypeScript type-check passes with no errors.

## Design Notes

- The backoff formula matches the pattern already used by the daemon-side WebSocket in `server/internal/daemon/wakeup.go`, keeping the codebase consistent.
- Constants are module-level (not configurable) since there is no use case for per-instance tuning.
- The 20-attempt limit gives roughly 7 minutes of retrying before giving up, which covers most transient outages while preventing infinite retry loops.
- No new public API surface -- `connect()` remains the way to manually retry after the client gives up.
