### PR TITLE
fix(core): mark list stale after off-window status count move (MUL-4182)

### DIFF
--- a/packages/core/issues/cache-coordinator.test.ts
+++ b/packages/core/issues/cache-coordinator.test.ts
@@ -116,7 +116,8 @@ describe("applyIssueChange", () => {
     qc.setQueryData<ListIssuesCache>(wsKey, bucketed([issue()]));
     // p1 list loaded but the card is beyond its loaded window — the change
     // is certain (old + new status known, membership definite), so the two
-    // bucket totals shift arithmetically with zero requests.
+    // bucket totals shift arithmetically right away; the list is then marked
+    // stale so the server can place the row in the target bucket's window.
     qc.setQueryData<ListIssuesCache>(projectP1Key, bucketed([], 3));
     // p2 list loaded; the issue was never a member — untouched.
     qc.setQueryData<ListIssuesCache>(projectP2Key, bucketed([]));
@@ -154,13 +155,18 @@ describe("applyIssueChange", () => {
     ).toBe("in_progress");
 
     // Off-window count arithmetic: todo 3 → 2, in_progress 0 → 1, loaded
-    // arrays untouched, and no refetch needed.
+    // arrays untouched (never hard-insert).
     expect(total(qc, projectP1Key, "todo")).toBe(2);
     expect(total(qc, projectP1Key, "in_progress")).toBe(1);
     expect(ids(qc, projectP1Key, "todo")).toEqual([]);
 
     const staleHashes = result.staleKeys.map(hashKey);
-    expect(staleHashes).not.toContain(hashKey(projectP1Key));
+    // The moved list IS flagged stale: the row now counted in in_progress
+    // can only be placed into that bucket's loaded window by the server,
+    // and with staleTime: Infinity no other channel triggers that reconcile.
+    expect(staleHashes).toContain(hashKey(projectP1Key));
+    // Never-a-member p2 and the surgically-rebucketed workspace list have
+    // nothing to reconcile — no stale keys.
     expect(staleHashes).not.toContain(hashKey(projectP2Key));
     expect(staleHashes).not.toContain(hashKey(wsKey));
   });

--- a/packages/core/issues/cache-coordinator.ts
+++ b/packages/core/issues/cache-coordinator.ts
@@ -39,8 +39,10 @@ import type { InboxItem, Issue, ListIssuesCache } from "../types";
  *     patch + mark the key stale
  *   card absent, change can't affect this list → skip
  *   card absent, stayed a member + status changed → move one unit of the
- *     server total between the two buckets (count-only arithmetic, arrays
- *     untouched, zero requests)
+ *     server total between the two buckets immediately, then mark the key
+ *     stale: the row's slot in the destination bucket's loaded window is
+ *     server knowledge, and under staleTime: Infinity an explicit
+ *     invalidation is the only channel that ever fills it in
  *   card absent, left the list (reassigned / re-projected) → old status
  *     bucket total -1
  *   card absent, may have ENTERED, or anything undecidable (no base entity,
@@ -181,6 +183,11 @@ export function applyIssueChange(
         if (next !== data) {
           prevLists.push([key, data]);
           qc.setQueryData<ListIssuesCache>(key, next);
+          // The count moved but the row can't be inserted client-side (its
+          // page/slot under the list's sort is server knowledge). Leave the
+          // reconcile trigger: with staleTime: Infinity nothing else ever
+          // brings the destination bucket's window in line with its total.
+          staleKeys.push(key);
         }
         continue;
       }

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -462,6 +462,36 @@ describe("onIssueUpdated — off-screen status change reconciles column counts",
     expectInvalidated(qc, issueKeys.myAll(WS_ID));
   });
 
+  it("moves the bucket counts AND refetches when the off-screen issue's base entity is known", () => {
+    // The detail cache knows the pre-change entity, so the coordinator moves
+    // one unit of total between the buckets instantly — but the row itself
+    // can only be placed into done's loaded window by the server, and with
+    // staleTime: Infinity this invalidation is the only reconcile channel.
+    // (Before the fix this branch moved counts with no stale key: an open
+    // board showed "done 61" with 60 visible rows until something else
+    // happened to invalidate the list.)
+    const offScreen: Issue = { ...baseIssue, id: "off-screen", status: "in_review" };
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, "off-screen"), offScreen);
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {
+      byStatus: {
+        in_review: { issues: [], total: 1 },
+        done: { issues: [], total: 60 },
+      },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { ...offScreen, status: "done" },
+      { statusChanged: true },
+    );
+
+    const list = qc.getQueryData<ListIssuesCache>(issueKeys.list(WS_ID));
+    expect(list?.byStatus.in_review?.total).toBe(0);
+    expect(list?.byStatus.done?.total).toBe(61);
+    expectInvalidated(qc, issueKeys.list(WS_ID));
+  });
+
   it("does NOT refetch when the status-changed issue is loaded (surgical patch suffices)", () => {
     const loaded: Issue = { ...baseIssue, id: "loaded", status: "in_review" };
     qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {


### PR DESCRIPTION
Closes MUL-4182

## Problem

`applyIssueChange`'s absent-card status-move branch (card beyond the loaded window, still a member, status changed) moved one unit of server total between the two status buckets and stopped — no stale key.

The app runs `staleTime: Infinity` + `refetchOnWindowFocus: false` (`packages/core/query-client.ts`), so explicit invalidation is the only channel that ever reconciles a loaded list. An open board would therefore show the moved count with the row permanently missing from the destination bucket's visible window — e.g. a column header reading "done 61" above 60 visible rows — until some unrelated event happened to invalidate that list. Quiet workspaces never self-heal (MUL-4182).

## Fix

One rule change in the coordinator: after a successful `moveBucketTotal`, push the list key onto `staleKeys`. The count still moves instantly (optimistic UX unchanged); the refetch only fills the row into the destination bucket's window, since its page/slot under the list's sort is server knowledge.

- No mutation/WS fork — both paths flow through the same rules table; flush timing follows the existing contract (mutations on `onSettled`, WS immediately).
- No pre-installed rate limiting. If WS-driven refetch pressure ever shows up in metrics, the pressure valves live outside the coordinator (invalidation debounce at the WS entry, or batched server broadcasts).
- No backend/API/DB/daemon changes.

## Tests

- Flipped the assertion in `cache-coordinator.test.ts` that locked in the old behavior: the off-window move's list key must now be in `staleKeys`; never-a-member and surgically-patched lists still must not be.
- Kept existing coverage: off-window leave (total −1, no stale), member→member reassignment (untouched, no stale), rollback of the count arithmetic.
- Added a narrow WS chain test in `ws-updaters.test.ts`: known base entity + off-screen status change → bucket totals move AND the list is invalidated (previously the silent-drift case).

Verified: `packages/core` full suite 762 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

