### PR TITLE
fix(daemon): mark workspaces root as task context

### DIFF
--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +18,10 @@ import (
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 // freshAgentEnvSetCmd returns a standalone cobra.Command with the three
 // --custom-env* flags registered identically to agentEnvSetCmd, so
@@ -252,6 +257,48 @@ func TestResolveToken_AgentContextSkipsConfig(t *testing.T) {
 
 		if got := resolveToken(testCmd()); got != "" {
 			t.Fatalf("resolveToken() = %q, want empty in daemon-managed context without MULTICA_TOKEN", got)
+		}
+	})
+
+	t.Run("workspaces root marker covers cwd at task env root", func(t *testing.T) {
+		env, err := execenv.Prepare(execenv.PrepareParams{
+			WorkspacesRoot: t.TempDir(),
+			WorkspaceID:    "ws-root-marker",
+			TaskID:         "task-root-marker",
+			AgentName:      "Root Marker Agent",
+			Task: execenv.TaskContextForEnv{
+				IssueID: "issue-root-marker",
+				AgentID: "agent-root-marker",
+			},
+		}, discardLogger())
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = env.Cleanup(true)
+		})
+
+		prev, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("get cwd: %v", err)
+		}
+		if err := os.Chdir(env.RootDir); err != nil {
+			t.Fatalf("chdir env root: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chdir(prev); err != nil {
+				t.Fatalf("restore cwd: %v", err)
+			}
+		})
+
+		t.Setenv("MULTICA_AGENT_ID", "")
+		t.Setenv("MULTICA_TASK_ID", "")
+		t.Setenv("MULTICA_DAEMON_PORT", "")
+		t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:8080")
+		t.Setenv("MULTICA_TOKEN", "")
+
+		if got := resolveToken(testCmd()); got != "" {
+			t.Fatalf("resolveToken() = %q, want empty in daemon-managed env root without MULTICA_TOKEN", got)
 		}
 	})
 

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -142,6 +142,40 @@ func writeTaskContextMarker(workDir string, ctx TaskContextForEnv, manifest *sid
 	return nil
 }
 
+// writeWorkspacesRootTaskContextMarker marks the daemon-owned workspaces tree
+// itself as task-managed. The CLI walks upward from its cwd looking for this
+// marker; placing one at WorkspacesRoot keeps subprocesses that cd from
+// envRoot/workdir to envRoot fail-closed even when all MULTICA_* env vars were
+// stripped. It is intentionally not tracked in the per-task sidecar manifest:
+// task cleanup must never delete the root guard.
+func writeWorkspacesRootTaskContextMarker(workspacesRoot string) error {
+	path := filepath.Join(workspacesRoot, TaskContextMarkerRelPath)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create workspaces root .multica dir: %w", err)
+	}
+
+	payload := taskContextMarkerFile{ManagedBy: TaskContextMarkerManagedBy}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal workspaces root task context marker: %w", err)
+	}
+
+	if existing, err := os.ReadFile(path); err == nil {
+		var marker taskContextMarkerFile
+		if json.Unmarshal(existing, &marker) != nil || marker.ManagedBy != TaskContextMarkerManagedBy {
+			return fmt.Errorf("write workspaces root task context marker: %w", errPathPreExists)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read workspaces root task context marker: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write workspaces root task context marker: %w", err)
+	}
+	return nil
+}
+
 // projectResourceFile is the on-disk JSON written into the agent's working
 // directory. Schema is intentionally a thin pass-through of the API response
 // so consumers (skills, future tooling) don't need a separate parser.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -219,6 +219,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 			return nil, fmt.Errorf("execenv: create directory %s: %w", dir, err)
 		}
 	}
+	if err := writeWorkspacesRootTaskContextMarker(params.WorkspacesRoot); err != nil {
+		return nil, fmt.Errorf("execenv: write workspaces root task context marker: %w", err)
+	}
 
 	env := &Environment{
 		RootDir:        envRoot,

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -152,6 +152,20 @@ func TestPrepareDirectoryMode(t *testing.T) {
 		t.Fatalf("marker issue_id = %q, want issue id", marker.IssueID)
 	}
 
+	rootMarkerContent, err := os.ReadFile(filepath.Join(workspacesRoot, TaskContextMarkerRelPath))
+	if err != nil {
+		t.Fatalf("failed to read workspaces root task context marker: %v", err)
+	}
+	var rootMarker struct {
+		ManagedBy string `json:"managed_by"`
+	}
+	if err := json.Unmarshal(rootMarkerContent, &rootMarker); err != nil {
+		t.Fatalf("workspaces root task context marker unmarshal: %v\n%s", err, string(rootMarkerContent))
+	}
+	if rootMarker.ManagedBy != TaskContextMarkerManagedBy {
+		t.Fatalf("root marker managed_by = %q, want %q", rootMarker.ManagedBy, TaskContextMarkerManagedBy)
+	}
+
 	// Verify skill files.
 	skillContent, err := os.ReadFile(filepath.Join(env.WorkDir, ".agent_context", "skills", "code-review", "SKILL.md"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- write a daemon-owned task-context marker at the workspaces root during execenv Prepare
- keep the existing per-workdir marker, but make the root marker persistent and outside the sidecar cleanup manifest
- add CLI regression coverage for cwd at the task env root so stripped-env subprocesses do not fall back to a user PAT

Fixes #5043.

## Verification
- `go test ./internal/daemon/execenv -run TestPrepareDirectoryMode -count=1`
- `go test ./cmd/multica -run 'TestResolveToken_DaemonManagedContextSkipsConfig|TestNewAPIClient_(WorkdirMarker|DaemonPort)RequiresTaskToken' -count=1`\n- `go test ./cmd/multica ./internal/daemon/execenv ./internal/daemon -count=1`\n- `git diff --check upstream/main...HEAD`