### PR TITLE
Fix macOS Desktop proxy env for Antigravity auth

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -30,6 +30,7 @@ import {
   isAuthStatusError,
   type AuthProbeResult,
 } from "./daemon-auth-probe";
+import { desktopSpawnEnv } from "./daemon-proxy-env";
 
 const DEFAULT_HEALTH_PORT = 19514;
 const POLL_INTERVAL_MS = 5_000;
@@ -808,15 +809,6 @@ async function withGuard<T>(fn: () => Promise<T>): Promise<T | { success: false;
 
 function profileArgs(active: ActiveProfile): string[] {
   return active.name ? ["--profile", active.name] : [];
-}
-
-// Env passed to every CLI child so the daemon process knows it was spawned
-// by the Desktop app. The server uses this to mark runtimes as managed and
-// hide CLI self-update UI. Computed lazily so it picks up the PATH fix
-// applied by fix-path in main/index.ts — as a top-level const it would
-// snapshot process.env at import time, before that block runs.
-function desktopSpawnEnv(): NodeJS.ProcessEnv {
-  return { ...process.env, MULTICA_LAUNCHED_BY: "desktop" };
 }
 
 async function startDaemon(): Promise<{ success: boolean; error?: string }> {

--- a/apps/desktop/src/main/daemon-proxy-env.test.ts
+++ b/apps/desktop/src/main/daemon-proxy-env.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { desktopSpawnEnv } from "./daemon-proxy-env";
+
+const macProxyOutput = `
+<dictionary> {
+  HTTPEnable : 1
+  HTTPPort : 7897
+  HTTPProxy : 127.0.0.1
+  HTTPSEnable : 1
+  HTTPSPort : 7898
+  HTTPSProxy : proxy.local
+  ExceptionsList : <array> {
+    0 : 127.0.0.1
+    1 : *.local
+  }
+  ExcludeSimpleHostnames : 1
+}
+`;
+
+describe("desktopSpawnEnv", () => {
+  it("marks Desktop-launched daemon processes", () => {
+    expect(desktopSpawnEnv({}, "linux").MULTICA_LAUNCHED_BY).toBe("desktop");
+  });
+
+  it("fills missing macOS proxy env from system settings", () => {
+    const env = desktopSpawnEnv({ PATH: "/usr/bin" }, "darwin", () => macProxyOutput);
+
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7897");
+    expect(env.http_proxy).toBe("http://127.0.0.1:7897");
+    expect(env.HTTPS_PROXY).toBe("http://proxy.local:7898");
+    expect(env.https_proxy).toBe("http://proxy.local:7898");
+    expect(env.NO_PROXY).toBe("127.0.0.1,*.local,localhost");
+    expect(env.no_proxy).toBe("127.0.0.1,*.local,localhost");
+  });
+
+  it("does not override explicit proxy env", () => {
+    const env = desktopSpawnEnv(
+      {
+        HTTP_PROXY: "http://shell-proxy:8888",
+        HTTPS_PROXY: "http://shell-secure-proxy:8889",
+        NO_PROXY: "localhost,internal",
+      },
+      "darwin",
+      () => macProxyOutput,
+    );
+
+    expect(env.HTTP_PROXY).toBe("http://shell-proxy:8888");
+    expect(env.http_proxy).toBe("http://shell-proxy:8888");
+    expect(env.HTTPS_PROXY).toBe("http://shell-secure-proxy:8889");
+    expect(env.https_proxy).toBe("http://shell-secure-proxy:8889");
+    expect(env.NO_PROXY).toBe("localhost,internal");
+    expect(env.no_proxy).toBe("localhost,internal");
+  });
+
+  it("does not read macOS proxy settings on other platforms", () => {
+    const readProxy = vi.fn(() => macProxyOutput);
+    const env = desktopSpawnEnv({}, "linux", readProxy);
+
+    expect(readProxy).not.toHaveBeenCalled();
+    expect(env.HTTP_PROXY).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+  });
+
+  it("leaves proxy env unset when macOS proxy settings are disabled", () => {
+    const env = desktopSpawnEnv(
+      {},
+      "darwin",
+      () => `
+<dictionary> {
+  HTTPEnable : 0
+  HTTPSEnable : 0
+}
+`,
+    );
+
+    expect(env.HTTP_PROXY).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.NO_PROXY).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/daemon-proxy-env.ts
+++ b/apps/desktop/src/main/daemon-proxy-env.ts
@@ -1,0 +1,151 @@
+import { execFileSync } from "child_process";
+
+const PROXY_READ_TIMEOUT_MS = 2_000;
+const PROXY_READ_MAX_BUFFER = 64 * 1024;
+
+interface ParsedMacProxySettings {
+  httpProxy?: string;
+  httpsProxy?: string;
+  noProxy?: string;
+}
+
+function envValue(env: NodeJS.ProcessEnv, key: string): string {
+  return typeof env[key] === "string" ? env[key].trim() : "";
+}
+
+function proxyURL(host: string | undefined, port: string | undefined): string {
+  const cleanHost = (host ?? "").trim();
+  const cleanPort = (port ?? "").trim();
+  if (!cleanHost || !cleanPort) return "";
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(cleanHost)) return cleanHost;
+  const formattedHost =
+    cleanHost.includes(":") && !cleanHost.startsWith("[")
+      ? `[${cleanHost}]`
+      : cleanHost;
+  return `http://${formattedHost}:${cleanPort}`;
+}
+
+function readMacSystemProxy(): string {
+  try {
+    return execFileSync("/usr/sbin/scutil", ["--proxy"], {
+      encoding: "utf8",
+      timeout: PROXY_READ_TIMEOUT_MS,
+      maxBuffer: PROXY_READ_MAX_BUFFER,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return "";
+  }
+}
+
+function parseMacSystemProxy(raw: string): ParsedMacProxySettings {
+  const values: Record<string, string> = {};
+  const exceptions: string[] = [];
+  let inExceptions = false;
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    if (/^ExceptionsList\s*:\s*<array>/.test(trimmed)) {
+      inExceptions = true;
+      continue;
+    }
+
+    if (inExceptions) {
+      if (trimmed === "}") {
+        inExceptions = false;
+        continue;
+      }
+      const exception = trimmed.match(/^\d+\s*:\s*(.+)$/);
+      if (exception?.[1]) exceptions.push(exception[1].trim());
+      continue;
+    }
+
+    const pair = trimmed.match(/^([A-Za-z0-9]+)\s*:\s*(.*)$/);
+    if (pair?.[1]) values[pair[1]] = (pair[2] ?? "").trim();
+  }
+
+  const noProxy = exceptions.slice();
+  if (values.ExcludeSimpleHostnames === "1") noProxy.push("localhost");
+
+  return {
+    httpProxy:
+      values.HTTPEnable === "1"
+        ? proxyURL(values.HTTPProxy, values.HTTPPort)
+        : undefined,
+    httpsProxy:
+      values.HTTPSEnable === "1"
+        ? proxyURL(values.HTTPSProxy, values.HTTPSPort)
+        : undefined,
+    noProxy: noProxy.length > 0 ? Array.from(new Set(noProxy)).join(",") : undefined,
+  };
+}
+
+function setProxyPair(
+  env: NodeJS.ProcessEnv,
+  upperKey: string,
+  lowerKey: string,
+  fallbackValue: string | undefined,
+): boolean {
+  const upper = envValue(env, upperKey);
+  const lower = envValue(env, lowerKey);
+
+  if (upper && !lower) {
+    env[lowerKey] = upper;
+    return true;
+  }
+  if (!upper && lower) {
+    env[upperKey] = lower;
+    return true;
+  }
+  if (!upper && !lower && fallbackValue) {
+    env[upperKey] = fallbackValue;
+    env[lowerKey] = fallbackValue;
+    return true;
+  }
+  return false;
+}
+
+function addMacSystemProxyEnv(
+  env: NodeJS.ProcessEnv,
+  readProxy: () => string,
+): string[] {
+  const settings = parseMacSystemProxy(readProxy());
+  const applied: string[] = [];
+
+  if (setProxyPair(env, "HTTP_PROXY", "http_proxy", settings.httpProxy)) {
+    applied.push("HTTP_PROXY");
+  }
+  if (setProxyPair(env, "HTTPS_PROXY", "https_proxy", settings.httpsProxy)) {
+    applied.push("HTTPS_PROXY");
+  }
+  if (setProxyPair(env, "NO_PROXY", "no_proxy", settings.noProxy)) {
+    applied.push("NO_PROXY");
+  }
+
+  return applied;
+}
+
+// Env passed to every CLI child so the daemon process knows it was spawned
+// by the Desktop app. On macOS, GUI-launched apps may not inherit the shell's
+// proxy variables, so fill missing proxy env from System Settings at spawn time.
+// Computed lazily so it picks up the PATH fix applied by fix-path in main/index.ts.
+export function desktopSpawnEnv(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  readProxy: () => string = readMacSystemProxy,
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv, MULTICA_LAUNCHED_BY: "desktop" };
+
+  if (platform === "darwin") {
+    const applied = addMacSystemProxyEnv(env, readProxy);
+    if (applied.length > 0) {
+      console.log(
+        `[daemon] inherited macOS system proxy env for daemon (${applied.join(", ")})`,
+      );
+    }
+  }
+
+  return env;
+}

--- a/apps/docs/content/docs/troubleshooting.mdx
+++ b/apps/docs/content/docs/troubleshooting.mdx
@@ -61,6 +61,31 @@ On the server side (self-host), grep for `"no_tasks"` / `"no_capacity"` to see t
 - Agent archived → `multica agent restore <id>`
 - Runtime not registered → `multica daemon restart`, and the daemon will re-register
 
+## Antigravity opens browser login then times out on macOS Desktop
+
+**Symptom**: Antigravity (`agy`) works from a terminal, but a task launched by the macOS Desktop app opens a Google login page and then fails with `authentication failed or timed out`.
+
+**Likely cause**: the Desktop app was launched from Finder / Dock and did not inherit proxy variables from your shell. If `agy` needs a local proxy to reach Google services, the Desktop-launched daemon may miss `HTTP_PROXY` / `HTTPS_PROXY` even though your terminal has them.
+
+**How to diagnose**:
+
+```bash
+env | grep -Ei '^(http|https|no)_proxy='
+/usr/sbin/scutil --proxy
+multica daemon logs --lines 100
+```
+
+**How to fix**: on current Desktop builds, macOS system proxy settings are inherited automatically when those env vars are absent. If you need a temporary workaround, set the variables in the GUI launch session and reopen Multica Desktop:
+
+```bash
+launchctl setenv HTTP_PROXY http://127.0.0.1:7897
+launchctl setenv HTTPS_PROXY http://127.0.0.1:7897
+launchctl setenv http_proxy http://127.0.0.1:7897
+launchctl setenv https_proxy http://127.0.0.1:7897
+launchctl setenv NO_PROXY '127.0.0.1,localhost,*.local'
+launchctl setenv no_proxy '127.0.0.1,localhost,*.local'
+```
+
 ## WebSocket can't connect
 
 **Symptom**: the browser console logs `WebSocket is closed`; the page doesn't show real-time updates (task progress, comments, inbox), and a refresh is needed to see them; backend tasks still execute.


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes macOS Desktop daemon startup so GUI-launched Multica can inherit System Settings proxy configuration when shell proxy environment variables are absent. This keeps Desktop-launched Antigravity (`agy`) tasks aligned with terminal behavior on proxy-dependent networks while preserving any explicit proxy env the user already set.

## Related Issue

Closes #4882

Multica issue: ZIC-54

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added a Desktop main-process proxy env helper that reads `/usr/sbin/scutil --proxy` on macOS and fills missing `HTTP_PROXY`, `HTTPS_PROXY`, lowercase variants, and `NO_PROXY`.
- Wired daemon startup through that helper while keeping `MULTICA_LAUNCHED_BY=desktop`.
- Added unit coverage for macOS proxy inheritance, explicit-env precedence, non-macOS no-op behavior, and disabled proxy settings.
- Documented the Antigravity macOS Desktop auth-timeout symptom and `launchctl setenv` workaround.

## How to Test

1. `pnpm --filter @multica/desktop test -- daemon-proxy-env.test.ts`
2. `pnpm --filter @multica/desktop typecheck:node`
3. `pnpm --filter @multica/desktop lint`
4. `pnpm --filter @multica/docs typecheck`
5. `git diff --check`
6. `make check-worktree`

`make check-worktree` exited 0 in this worktree, but Docker was not running and printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`, so Docker-backed database checks did not actually run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the Desktop daemon spawn environment, added a focused macOS proxy-env merge helper with unit tests, documented the workaround, and ran focused validation plus the preferred worktree check.

## Screenshots (optional)

N/A
