### PR TITLE
Fix long issue detail first-open description cost

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -545,14 +545,24 @@ describe("IssueDetail (shared)", () => {
     ).toBe(true);
   });
 
-  it("renders issue title and description after loading", async () => {
+  it("renders issue title and readonly description after loading", async () => {
     renderIssueDetail();
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("Implement authentication")).toBeInTheDocument();
     });
 
-    expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+    expect(screen.getByText("Add JWT auth to the backend")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Add JWT auth to the backend")).not.toBeInTheDocument();
+  });
+
+  it("mounts the description editor only after user intent", async () => {
+    renderIssueDetail();
+
+    const readonlyDescription = await screen.findByText("Add JWT auth to the backend");
+    fireEvent.click(readonlyDescription);
+
+    expect(await screen.findByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
   });
 
   it("opts the description editor into the unmount flush", async () => {
@@ -563,6 +573,8 @@ describe("IssueDetail (shared)", () => {
     // markdown and its attachment_ids bind (MUL-3254). The flush behavior
     // itself is covered in content-editor.test.tsx; this pins the wiring.
     renderIssueDetail();
+
+    fireEvent.click(await screen.findByText("Add JWT auth to the backend"));
 
     const description = await screen.findByDisplayValue("Add JWT auth to the backend");
     expect(description).toHaveAttribute("data-flush-on-unmount", "true");
@@ -1275,11 +1287,9 @@ describe("IssueDetail (shared)", () => {
   it("sends empty description when editor is cleared", async () => {
     renderIssueDetail();
 
-    await waitFor(() => {
-      expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
-    });
+    fireEvent.click(await screen.findByText("Add JWT auth to the backend"));
 
-    const editor = screen.getByPlaceholderText("Add description...");
+    const editor = await screen.findByPlaceholderText("Add description...");
     fireEvent.change(editor, { target: { value: "" } });
 
     await waitFor(() => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -30,7 +30,7 @@ import { Button } from "@multica/ui/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
-import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
+import { ContentEditor, type ContentEditorRef, ReadonlyContent, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import {
   Tooltip,
@@ -1236,8 +1236,26 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [highlightCommentId, items, targetIdx, scrollContainerEl, replyToRoot, expandedResolved, timelineView, toggleResolvedExpand]);
 
   const descEditorRef = useRef<ContentEditorRef>(null);
+  const [descEditing, setDescEditing] = useState(false);
+  const descFocusPendingRef = useRef(false);
+  const descQueuedUploadsRef = useRef<File[]>([]);
+  const openDescriptionEditor = useCallback((focus = false) => {
+    descFocusPendingRef.current = descFocusPendingRef.current || focus;
+    setDescEditing(true);
+  }, []);
+  const uploadDescriptionFile = useCallback(
+    (file: File) => {
+      if (descEditorRef.current) {
+        descEditorRef.current.uploadFile(file);
+        return;
+      }
+      descQueuedUploadsRef.current = [...descQueuedUploadsRef.current, file];
+      openDescriptionEditor(true);
+    },
+    [openDescriptionEditor],
+  );
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
-    onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
+    onDrop: (files) => files.forEach(uploadDescriptionFile),
   });
   // Pending uploads in the description editor. We don't pass `issueId` on
   // upload (to avoid orphaning attachments when the user deletes the file
@@ -1266,8 +1284,23 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
   useEffect(() => {
     descPendingAttachmentsRef.current = [];
+    descQueuedUploadsRef.current = [];
+    descFocusPendingRef.current = false;
     setDescPendingAttachments([]);
+    setDescEditing(false);
   }, [id]);
+
+  useEffect(() => {
+    if (!descEditing || !descEditorRef.current) return;
+    if (descFocusPendingRef.current) {
+      descFocusPendingRef.current = false;
+      descEditorRef.current.focus();
+    }
+    const queued = descQueuedUploadsRef.current;
+    if (queued.length === 0) return;
+    descQueuedUploadsRef.current = [];
+    queued.forEach((file) => descEditorRef.current?.uploadFile(file));
+  }, [descEditing]);
 
   // Shared issue actions (mutations, pin, copy-link, modal dispatch, etc.).
   // Called before the `if (!issue)` early return so hook order stays stable.
@@ -1941,43 +1974,76 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           )}
 
           <div {...descDropZoneProps} className="relative mt-5 rounded-lg">
-            <ContentEditor
-              ref={descEditorRef}
-              key={id}
-              defaultValue={issue.description || ""}
-              placeholder={t(($) => $.detail.desc_placeholder)}
-              onUpdate={(md) => {
-                // Bind any pending uploads still referenced in the markdown
-                // so they appear in `issueAttachments` after refresh and the
-                // editor's text/code preview keeps working past reload.
-                //
-                // Match with `contentReferencesAttachment`, NOT `md.includes(a.url)`:
-                // the editor persists the durable `markdownLink`
-                // (`/api/attachments/<id>/download` / `markdown_url`) into the
-                // body, never the raw storage `a.url`. A bare `md.includes(a.url)`
-                // therefore never matches, so the upload is never linked via
-                // `attachment_ids`. After reload it's absent from
-                // `issueAttachments`, the renderer can't resolve it to a
-                // freshly-signed `download_url`, and the persisted auth-gated
-                // download endpoint fails to load as a native <img> on clients
-                // whose origin isn't the API host (Desktop/Electron, mobile
-                // webview) — while still working on web via the cookie/proxy.
-                // This mirrors the comment/reply/chat composers, which already
-                // bind via `contentReferencesAttachment` (MUL-3130 / MUL-3192).
-                const ids = descPendingAttachmentsRef.current
-                  .filter((a) => contentReferencesAttachment(md, a))
-                  .map((a) => a.id);
-                handleUpdateField({ description: md, attachment_ids: ids.length > 0 ? ids : undefined });
-              }}
-              onUploadFile={handleDescriptionUpload}
-              debounceMs={1500}
-              // Closing the issue modal must save what the user last saw —
-              // without the flush, a paste followed by a quick close loses
-              // the image markdown and its attachment_ids bind (MUL-3254).
-              flushPendingOnUnmount
-              currentIssueId={id}
-              attachments={descEditorAttachments}
-            />
+            {descEditing ? (
+              <ContentEditor
+                ref={descEditorRef}
+                key={id}
+                defaultValue={issue.description || ""}
+                placeholder={t(($) => $.detail.desc_placeholder)}
+                onUpdate={(md) => {
+                  // Bind any pending uploads still referenced in the markdown
+                  // so they appear in `issueAttachments` after refresh and the
+                  // editor's text/code preview keeps working past reload.
+                  //
+                  // Match with `contentReferencesAttachment`, NOT `md.includes(a.url)`:
+                  // the editor persists the durable `markdownLink`
+                  // (`/api/attachments/<id>/download` / `markdown_url`) into the
+                  // body, never the raw storage `a.url`. A bare `md.includes(a.url)`
+                  // therefore never matches, so the upload is never linked via
+                  // `attachment_ids`. After reload it's absent from
+                  // `issueAttachments`, the renderer can't resolve it to a
+                  // freshly-signed `download_url`, and the persisted auth-gated
+                  // download endpoint fails to load as a native <img> on clients
+                  // whose origin isn't the API host (Desktop/Electron, mobile
+                  // webview) — while still working on web via the cookie/proxy.
+                  // This mirrors the comment/reply/chat composers, which already
+                  // bind via `contentReferencesAttachment` (MUL-3130 / MUL-3192).
+                  const ids = descPendingAttachmentsRef.current
+                    .filter((a) => contentReferencesAttachment(md, a))
+                    .map((a) => a.id);
+                  handleUpdateField({ description: md, attachment_ids: ids.length > 0 ? ids : undefined });
+                }}
+                onUploadFile={handleDescriptionUpload}
+                debounceMs={1500}
+                // Closing the issue modal must save what the user last saw —
+                // without the flush, a paste followed by a quick close loses
+                // the image markdown and its attachment_ids bind (MUL-3254).
+                flushPendingOnUnmount
+                currentIssueId={id}
+                attachments={descEditorAttachments}
+              />
+            ) : (
+              <div
+                role="button"
+                tabIndex={0}
+                className={cn(
+                  "min-h-10 rounded-md px-3 py-2 outline-none transition-colors hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring",
+                  !issue.description && "text-sm text-muted-foreground",
+                )}
+                onClick={(event) => {
+                  const target = event.target;
+                  if (
+                    target instanceof HTMLElement &&
+                    target.closest("a,button,input,textarea,select")
+                  ) {
+                    return;
+                  }
+                  openDescriptionEditor(true);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    openDescriptionEditor(true);
+                  }
+                }}
+              >
+                {issue.description ? (
+                  <ReadonlyContent content={issue.description} attachments={descEditorAttachments} />
+                ) : (
+                  t(($) => $.detail.desc_placeholder)
+                )}
+              </div>
+            )}
 
             <div className="flex items-center gap-1 mt-3">
               <ReactionBar
@@ -1989,7 +2055,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               <FileUploadButton
                 size="sm"
                 multiple
-                onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+                onSelect={uploadDescriptionFile}
               />
             </div>
             {descDragOver && <FileDropOverlay />}


### PR DESCRIPTION
## What does this PR do?

<!-- multica-auto-bugfix -->

Defers the heavy issue description editor on issue detail first open. The page now renders the description with the lightweight readonly markdown renderer, then mounts the full `ContentEditor` only when the user clicks/focuses the description or uploads/drops a file.

This reduces first-open work on long issue pages while preserving access to the full description, attachments, and inline editing behavior.

## Related Issue

Closes #4930

Multica issue: ZIC-53

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx`
  - Render issue descriptions as readonly markdown on first open.
  - Lazily mount the editable description editor on click, keyboard activation, file upload, or file drop.
  - Preserve queued uploads and existing flush-on-unmount save behavior once editing starts.
- `packages/views/issues/components/issue-detail.test.tsx`
  - Updated coverage for readonly first paint, lazy editor mounting, flush wiring, and clearing the description.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views lint`

Attempted `make check-worktree`, but the local Docker daemon was unavailable (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`). The target exited 0 after printing that Docker error, so I do not count it as full-stack validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Investigated the issue detail timeline/description render path, identified eager Tiptap description editor mounting as avoidable first-open work, implemented lazy mounting with focused regression coverage, then ran focused tests, typecheck, and lint.

## Screenshots (optional)

Not included; this is a performance-focused behavior change with the same visual output until editing starts.
