### PR TITLE
Add project-level issue prefixes

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -196,6 +196,7 @@ export const EMPTY_PROJECT: Project = {
   priority: "none",
   lead_type: null,
   lead_id: null,
+  issue_prefix: "",
   created_at: "",
   updated_at: "",
   issue_count: 0,

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -325,6 +325,7 @@ const ProjectSchema = z.object({
   icon: z.string().nullable(),
   status: z.string(),
   priority: z.string(),
+  issue_prefix: z.string().nullable().default(null),
   lead_type: z.string().nullable(),
   lead_id: z.string().nullable(),
   created_at: z.string(),

--- a/packages/core/types/project.ts
+++ b/packages/core/types/project.ts
@@ -10,6 +10,7 @@ export interface Project {
   icon: string | null;
   status: ProjectStatus;
   priority: ProjectPriority;
+  issue_prefix: string | null;
   lead_type: "member" | "agent" | null;
   lead_id: string | null;
   created_at: string;
@@ -25,6 +26,7 @@ export interface CreateProjectRequest {
   icon?: string;
   status?: ProjectStatus;
   priority?: ProjectPriority;
+  issue_prefix?: string;
   lead_type?: "member" | "agent";
   lead_id?: string;
   // Resources to attach in the same transaction as the project. Server returns
@@ -38,6 +40,7 @@ export interface UpdateProjectRequest {
   icon?: string | null;
   status?: ProjectStatus;
   priority?: ProjectPriority;
+  issue_prefix?: string | null;
   lead_type?: "member" | "agent" | null;
   lead_id?: string | null;
 }

--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -186,6 +186,7 @@ const PROJECT: Project = {
   priority: "high",
   lead_type: null,
   lead_id: null,
+  issue_prefix: null,
   created_at: "2026-06-01T00:00:00Z",
   updated_at: "2026-06-01T00:00:00Z",
   issue_count: 3,

--- a/server/cmd/multica/cmd_project.go
+++ b/server/cmd/multica/cmd_project.go
@@ -134,6 +134,7 @@ func init() {
 	projectCreateCmd.Flags().String("description", "", "Project description")
 	projectCreateCmd.Flags().String("status", "", "Project status")
 	projectCreateCmd.Flags().String("icon", "", "Project icon (emoji)")
+	projectCreateCmd.Flags().String("issue-prefix", "", "Project issue prefix; empty means inherit workspace prefix")
 	projectCreateCmd.Flags().String("lead", "", "Lead name (member or agent)")
 	projectCreateCmd.Flags().StringArray("repo", nil, "Attach a github_repo resource by URL (may be repeated)")
 	projectCreateCmd.Flags().String("output", "json", "Output format: table or json")
@@ -177,6 +178,7 @@ func init() {
 	projectUpdateCmd.Flags().String("description", "", "New description")
 	projectUpdateCmd.Flags().String("status", "", "New status")
 	projectUpdateCmd.Flags().String("icon", "", "New icon (emoji)")
+	projectUpdateCmd.Flags().String("issue-prefix", "", "New project issue prefix; pass empty string to inherit workspace prefix")
 	projectUpdateCmd.Flags().String("lead", "", "New lead name (member or agent)")
 	projectUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -297,40 +299,23 @@ func runProjectGet(cmd *cobra.Command, args []string) error {
 	return cli.PrintJSON(os.Stdout, project)
 }
 
-func runProjectCreate(cmd *cobra.Command, _ []string) error {
-	title, _ := cmd.Flags().GetString("title")
-	if title == "" {
-		return fmt.Errorf("--title is required")
-	}
-
-	client, err := newAPIClient(cmd)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := cli.APIContext(context.Background())
-	defer cancel()
-
+func buildProjectCreateBody(cmd *cobra.Command, title string) (map[string]any, error) {
 	body := map[string]any{"title": title}
 	if v, _ := cmd.Flags().GetString("description"); v != "" {
 		body["description"] = v
 	}
 	if v, _ := cmd.Flags().GetString("status"); v != "" {
 		if err := validateProjectStatus(v); err != nil {
-			return err
+			return nil, err
 		}
 		body["status"] = v
 	}
 	if v, _ := cmd.Flags().GetString("icon"); v != "" {
 		body["icon"] = v
 	}
-	if v, _ := cmd.Flags().GetString("lead"); v != "" {
-		aType, aID, resolveErr := resolveAssignee(ctx, client, v, memberOrAgentKinds)
-		if resolveErr != nil {
-			return fmt.Errorf("resolve lead: %w", resolveErr)
-		}
-		body["lead_type"] = aType
-		body["lead_id"] = aID
+	if cmd.Flags().Changed("issue-prefix") {
+		v, _ := cmd.Flags().GetString("issue-prefix")
+		body["issue_prefix"] = v
 	}
 
 	// Bundle resources into the create payload so the server attaches them in
@@ -354,6 +339,36 @@ func runProjectCreate(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	return body, nil
+}
+
+func runProjectCreate(cmd *cobra.Command, _ []string) error {
+	title, _ := cmd.Flags().GetString("title")
+	if title == "" {
+		return fmt.Errorf("--title is required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body, err := buildProjectCreateBody(cmd, title)
+	if err != nil {
+		return err
+	}
+	if v, _ := cmd.Flags().GetString("lead"); v != "" {
+		aType, aID, resolveErr := resolveAssignee(ctx, client, v, memberOrAgentKinds)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve lead: %w", resolveErr)
+		}
+		body["lead_type"] = aType
+		body["lead_id"] = aID
+	}
+
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/projects", body, &result); err != nil {
 		return fmt.Errorf("create project: %w", err)
@@ -374,6 +389,34 @@ func runProjectCreate(cmd *cobra.Command, _ []string) error {
 	return cli.PrintJSON(os.Stdout, result)
 }
 
+func buildProjectUpdateBody(cmd *cobra.Command) (map[string]any, error) {
+	body := map[string]any{}
+	if cmd.Flags().Changed("title") {
+		v, _ := cmd.Flags().GetString("title")
+		body["title"] = v
+	}
+	if cmd.Flags().Changed("description") {
+		v, _ := cmd.Flags().GetString("description")
+		body["description"] = v
+	}
+	if cmd.Flags().Changed("status") {
+		v, _ := cmd.Flags().GetString("status")
+		if err := validateProjectStatus(v); err != nil {
+			return nil, err
+		}
+		body["status"] = v
+	}
+	if cmd.Flags().Changed("icon") {
+		v, _ := cmd.Flags().GetString("icon")
+		body["icon"] = v
+	}
+	if cmd.Flags().Changed("issue-prefix") {
+		v, _ := cmd.Flags().GetString("issue-prefix")
+		body["issue_prefix"] = v
+	}
+	return body, nil
+}
+
 func runProjectUpdate(cmd *cobra.Command, args []string) error {
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -388,25 +431,9 @@ func runProjectUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve project: %w", err)
 	}
 
-	body := map[string]any{}
-	if cmd.Flags().Changed("title") {
-		v, _ := cmd.Flags().GetString("title")
-		body["title"] = v
-	}
-	if cmd.Flags().Changed("description") {
-		v, _ := cmd.Flags().GetString("description")
-		body["description"] = v
-	}
-	if cmd.Flags().Changed("status") {
-		v, _ := cmd.Flags().GetString("status")
-		if err := validateProjectStatus(v); err != nil {
-			return err
-		}
-		body["status"] = v
-	}
-	if cmd.Flags().Changed("icon") {
-		v, _ := cmd.Flags().GetString("icon")
-		body["icon"] = v
+	body, err := buildProjectUpdateBody(cmd)
+	if err != nil {
+		return err
 	}
 	if cmd.Flags().Changed("lead") {
 		v, _ := cmd.Flags().GetString("lead")
@@ -419,7 +446,7 @@ func runProjectUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use flags like --title, --status, --description, --icon, --lead")
+		return fmt.Errorf("no fields to update; use flags like --title, --status, --description, --icon, --issue-prefix, --lead")
 	}
 
 	var result map[string]any

--- a/server/cmd/multica/cmd_project_test.go
+++ b/server/cmd/multica/cmd_project_test.go
@@ -26,6 +26,46 @@ func TestValidateProjectStatus(t *testing.T) {
 	}
 }
 
+func TestBuildProjectCreateBodyIncludesIssuePrefix(t *testing.T) {
+	cmd := &cobra.Command{Use: "create"}
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("icon", "", "")
+	cmd.Flags().String("issue-prefix", "", "")
+	cmd.Flags().StringArray("repo", nil, "")
+	_ = cmd.Flags().Set("issue-prefix", "LOL")
+
+	body, err := buildProjectCreateBody(cmd, "Project")
+	if err != nil {
+		t.Fatalf("buildProjectCreateBody: %v", err)
+	}
+	if body["issue_prefix"] != "LOL" {
+		t.Fatalf("issue_prefix = %v, want LOL", body["issue_prefix"])
+	}
+}
+
+func TestBuildProjectUpdateBodyIncludesEmptyIssuePrefix(t *testing.T) {
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("title", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().String("icon", "", "")
+	cmd.Flags().String("issue-prefix", "", "")
+	_ = cmd.Flags().Set("issue-prefix", "")
+
+	body, err := buildProjectUpdateBody(cmd)
+	if err != nil {
+		t.Fatalf("buildProjectUpdateBody: %v", err)
+	}
+	value, ok := body["issue_prefix"]
+	if !ok {
+		t.Fatal("issue_prefix missing from update body")
+	}
+	if value != "" {
+		t.Fatalf("issue_prefix = %v, want empty string", value)
+	}
+}
+
 // newProjectResourceUpdateTestCmd mirrors the flag surface of
 // projectResourceUpdateCmd so unit tests can exercise the shortcut-flag plumbing
 // without spinning up a server.

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1380,8 +1380,6 @@ func extractClosingIdentifiers(parts ...string) []string {
 	return out
 }
 
-// lookupIssueByIdentifier looks up an issue in the given workspace by its
-// "PREFIX-NUMBER" identifier. Returns the row + true if the prefix matches
 // workspaceAutoLinkPRsEnabled reports whether the workspace allows the
 // GitHub webhook to create issue ↔ PR link rows. Defaults to true so that
 // workspaces predating RFC MUL-2414 keep the historical "auto-link on"
@@ -1408,14 +1406,17 @@ func (h *Handler) workspaceAutoLinkPRsEnabled(ctx context.Context, workspaceID p
 	return *s.GitHubAutoLinkPRsEnabled
 }
 
-// the workspace's configured prefix and the number resolves to a real issue.
-func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtype.UUID, prefix, identifier string) (db.Issue, bool) {
+// lookupIssueByIdentifier looks up an issue in the given workspace by its
+// "PREFIX-NUMBER" identifier. The number remains workspace-global, but the
+// prefix must match the issue's current display prefix (project override when
+// set, otherwise workspace prefix).
+func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtype.UUID, _ string, identifier string) (db.Issue, bool) {
 	idx := strings.LastIndex(identifier, "-")
 	if idx < 0 {
 		return db.Issue{}, false
 	}
 	gotPrefix, numStr := identifier[:idx], identifier[idx+1:]
-	if !strings.EqualFold(gotPrefix, prefix) {
+	if gotPrefix == "" || numStr == "" {
 		return db.Issue{}, false
 	}
 	n, err := strconv.Atoi(numStr)
@@ -1427,6 +1428,9 @@ func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtyp
 		Number:      int32(n),
 	})
 	if err != nil {
+		return db.Issue{}, false
+	}
+	if !strings.EqualFold(gotPrefix, h.getIssueDisplayPrefix(ctx, issue)) {
 		return db.Issue{}, false
 	}
 	return issue, true
@@ -1451,7 +1455,7 @@ func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, worksp
 	// exists, parent not terminal), so calling it unconditionally is safe.
 	h.notifyParentOfChildDone(ctx, issue, updated)
 
-	prefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
+	prefix := h.getIssueDisplayPrefix(ctx, updated)
 	resp := issueToResponse(updated, prefix)
 	h.publish(protocol.EventIssueUpdated, workspaceID, "system", "", map[string]any{
 		"issue":          resp,

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/netip"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -679,6 +680,9 @@ func (h *Handler) resolveIssueByIdentifier(ctx context.Context, id, workspaceID 
 	if err != nil {
 		return db.Issue{}, false
 	}
+	if !strings.EqualFold(parts.prefix, h.getIssueDisplayPrefix(ctx, issue)) {
+		return db.Issue{}, false
+	}
 	return issue, true
 }
 
@@ -724,6 +728,36 @@ func (h *Handler) getIssuePrefix(ctx context.Context, workspaceID pgtype.UUID) s
 		return ws.IssuePrefix
 	}
 	return generateIssuePrefix(ws.Name)
+}
+
+func (h *Handler) getProjectIssuePrefixes(ctx context.Context, workspaceID pgtype.UUID, projectIDs []pgtype.UUID) map[string]string {
+	if len(projectIDs) == 0 {
+		return map[string]string{}
+	}
+	rows, err := h.Queries.ListProjectIssuePrefixes(ctx, db.ListProjectIssuePrefixesParams{
+		WorkspaceID: workspaceID,
+		ProjectIds:  projectIDs,
+	})
+	if err != nil {
+		slog.Warn("ListProjectIssuePrefixes failed", "error", err)
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if row.IssuePrefix.Valid && row.IssuePrefix.String != "" {
+			out[uuidToString(row.ID)] = row.IssuePrefix.String
+		}
+	}
+	return out
+}
+
+func (h *Handler) getIssueDisplayPrefix(ctx context.Context, issue db.Issue) string {
+	workspacePrefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
+	if !issue.ProjectID.Valid {
+		return workspacePrefix
+	}
+	projectPrefixes := h.getProjectIssuePrefixes(ctx, issue.WorkspaceID, []pgtype.UUID{issue.ProjectID})
+	return issueDisplayPrefix(issue, workspacePrefix, projectPrefixes)
 }
 
 func (h *Handler) loadAgentForUser(w http.ResponseWriter, r *http.Request, agentID string) (db.Agent, bool) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -112,6 +112,118 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 	}
 }
 
+func issueDisplayPrefix(i db.Issue, workspacePrefix string, projectPrefixes map[string]string) string {
+	if i.ProjectID.Valid {
+		if prefix := projectPrefixes[uuidToString(i.ProjectID)]; prefix != "" {
+			return prefix
+		}
+	}
+	return workspacePrefix
+}
+
+func issueListDisplayPrefix(i db.ListIssuesRow, workspacePrefix string, projectPrefixes map[string]string) string {
+	if i.ProjectID.Valid {
+		if prefix := projectPrefixes[uuidToString(i.ProjectID)]; prefix != "" {
+			return prefix
+		}
+	}
+	return workspacePrefix
+}
+
+func openIssueDisplayPrefix(i db.ListOpenIssuesRow, workspacePrefix string, projectPrefixes map[string]string) string {
+	if i.ProjectID.Valid {
+		if prefix := projectPrefixes[uuidToString(i.ProjectID)]; prefix != "" {
+			return prefix
+		}
+	}
+	return workspacePrefix
+}
+
+func issueProjectIDs(issues []db.Issue) []pgtype.UUID {
+	seen := map[string]bool{}
+	ids := []pgtype.UUID{}
+	for _, issue := range issues {
+		if !issue.ProjectID.Valid {
+			continue
+		}
+		id := uuidToString(issue.ProjectID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, issue.ProjectID)
+	}
+	return ids
+}
+
+func searchIssueProjectIDs(results []searchResult) []pgtype.UUID {
+	seen := map[string]bool{}
+	ids := []pgtype.UUID{}
+	for _, result := range results {
+		if !result.issue.ProjectID.Valid {
+			continue
+		}
+		id := uuidToString(result.issue.ProjectID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, result.issue.ProjectID)
+	}
+	return ids
+}
+
+func listIssueProjectIDs(issues []db.ListIssuesRow) []pgtype.UUID {
+	seen := map[string]bool{}
+	ids := []pgtype.UUID{}
+	for _, issue := range issues {
+		if !issue.ProjectID.Valid {
+			continue
+		}
+		id := uuidToString(issue.ProjectID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, issue.ProjectID)
+	}
+	return ids
+}
+
+func groupedIssueProjectIDs(issues []groupedIssueRow) []pgtype.UUID {
+	seen := map[string]bool{}
+	ids := []pgtype.UUID{}
+	for _, issue := range issues {
+		if !issue.ProjectID.Valid {
+			continue
+		}
+		id := uuidToString(issue.ProjectID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, issue.ProjectID)
+	}
+	return ids
+}
+
+func openIssueProjectIDs(issues []db.ListOpenIssuesRow) []pgtype.UUID {
+	seen := map[string]bool{}
+	ids := []pgtype.UUID{}
+	for _, issue := range issues {
+		if !issue.ProjectID.Valid {
+			continue
+		}
+		id := uuidToString(issue.ProjectID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, issue.ProjectID)
+	}
+	return ids
+}
+
 // issueListRowToResponse converts a list-query row (no description) to an IssueResponse.
 func issueListRowToResponse(i db.ListIssuesRow, issuePrefix string) IssueResponse {
 	identifier := issuePrefix + "-" + strconv.Itoa(int(i.Number))
@@ -714,9 +826,11 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		total = results[0].totalCount
 	}
 
-	prefix := h.getIssuePrefix(ctx, wsUUID)
+	workspacePrefix := h.getIssuePrefix(ctx, wsUUID)
+	projectPrefixes := h.getProjectIssuePrefixes(ctx, wsUUID, searchIssueProjectIDs(results))
 	resp := make([]SearchIssueResponse, len(results))
 	for i, sr := range results {
+		prefix := issueDisplayPrefix(sr.issue, workspacePrefix, projectPrefixes)
 		sir := SearchIssueResponse{
 			IssueResponse: issueToResponse(sr.issue, prefix),
 			MatchSource:   sr.matchSource,
@@ -839,7 +953,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		prefix := h.getIssuePrefix(ctx, wsUUID)
+		workspacePrefix := h.getIssuePrefix(ctx, wsUUID)
+		projectPrefixes := h.getProjectIssuePrefixes(ctx, wsUUID, openIssueProjectIDs(issues))
 		ids := make([]pgtype.UUID, len(issues))
 		for i, issue := range issues {
 			ids[i] = issue.ID
@@ -847,6 +962,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
 		resp := make([]IssueResponse, len(issues))
 		for i, issue := range issues {
+			prefix := openIssueDisplayPrefix(issue, workspacePrefix, projectPrefixes)
 			resp[i] = openIssueRowToResponse(issue, prefix)
 			labels := labelsMap[resp[i].ID]
 			if labels == nil {
@@ -1082,7 +1198,8 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 		total = int64(len(issues))
 	}
 
-	prefix := h.getIssuePrefix(ctx, wsUUID)
+	workspacePrefix := h.getIssuePrefix(ctx, wsUUID)
+	projectPrefixes := h.getProjectIssuePrefixes(ctx, wsUUID, listIssueProjectIDs(issues))
 	ids := make([]pgtype.UUID, len(issues))
 	for i, issue := range issues {
 		ids[i] = issue.ID
@@ -1090,6 +1207,7 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
 	resp := make([]IssueResponse, len(issues))
 	for i, issue := range issues {
+		prefix := issueListDisplayPrefix(issue, workspacePrefix, projectPrefixes)
 		resp[i] = issueListRowToResponse(issue, prefix)
 		labels := labelsMap[resp[i].ID]
 		if labels == nil {
@@ -1596,7 +1714,8 @@ ORDER BY
 		ids[i] = row.ID
 	}
 	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
-	prefix := h.getIssuePrefix(ctx, wsUUID)
+	workspacePrefix := h.getIssuePrefix(ctx, wsUUID)
+	projectPrefixes := h.getProjectIssuePrefixes(ctx, wsUUID, groupedIssueProjectIDs(groupedRows))
 
 	groups := []IssueAssigneeGroupResponse{}
 	groupIndex := map[string]int{}
@@ -1615,6 +1734,7 @@ ORDER BY
 			})
 		}
 
+		prefix := issueListDisplayPrefix(row.ListIssuesRow, workspacePrefix, projectPrefixes)
 		issue := issueListRowToResponse(row.ListIssuesRow, prefix)
 		labels := labelsMap[issue.ID]
 		if labels == nil {
@@ -1633,7 +1753,7 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+	prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 	resp := issueToResponse(issue, prefix)
 	detailLabels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]
 	if detailLabels == nil {
@@ -1676,9 +1796,11 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to list child issues")
 		return
 	}
-	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+	workspacePrefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+	projectPrefixes := h.getProjectIssuePrefixes(r.Context(), issue.WorkspaceID, issueProjectIDs(children))
 	resp := make([]IssueResponse, len(children))
 	for i, child := range children {
+		prefix := issueDisplayPrefix(child, workspacePrefix, projectPrefixes)
 		resp[i] = issueToResponse(child, prefix)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -1745,9 +1867,11 @@ func (h *Handler) ListChildrenByParents(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "failed to list child issues")
 		return
 	}
-	prefix := h.getIssuePrefix(r.Context(), wsUUID)
+	workspacePrefix := h.getIssuePrefix(r.Context(), wsUUID)
+	projectPrefixes := h.getProjectIssuePrefixes(r.Context(), wsUUID, issueProjectIDs(children))
 	resp := make([]IssueResponse, len(children))
 	for i, child := range children {
+		prefix := issueDisplayPrefix(child, workspacePrefix, projectPrefixes)
 		resp[i] = issueToResponse(child, prefix)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -2251,10 +2375,6 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		originID = oid
 	}
 
-	// Prefix is workspace-level; pre-compute once so both the broadcast
-	// payload builder and the HTTP response share the same value.
-	prefix := h.getIssuePrefix(r.Context(), wsUUID)
-
 	// Analytics agent ID: assignee agent when the issue is being assigned
 	// to an agent, otherwise the creator agent for agent-authored issues.
 	// Resolved here (not in the service) because creator identity is HTTP-side.
@@ -2301,6 +2421,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		AnalyticsAgentID: analyticsAgentID,
 		Platform:         func() string { p, _, _ := middleware.ClientMetadataFromContext(r.Context()); return p }(),
 		BroadcastPayload: func(issue db.Issue, atts []db.Attachment) map[string]any {
+			prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 			payload := issueToResponse(issue, prefix)
 			payload.Attachments = buildAttachmentResponses(atts)
 			return map[string]any{"issue": payload}
@@ -2309,7 +2430,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 
 	if errors.Is(err, service.ErrActiveDuplicate) {
 		dup := *res.DuplicateIssue
-		existing := issueToResponse(dup, h.getIssuePrefix(r.Context(), dup.WorkspaceID))
+		existing := issueToResponse(dup, h.getIssueDisplayPrefix(r.Context(), dup))
 		writeJSON(w, http.StatusConflict, map[string]any{
 			"code":  "active_duplicate_issue",
 			"error": duplicateIssueMessage(existing),
@@ -2334,6 +2455,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	issue := res.Issue
 	slog.Info("issue created", append(logger.RequestAttrs(r), "issue_id", uuidToString(issue.ID), "title", issue.Title, "status", issue.Status, "workspace_id", workspaceID)...)
 
+	prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 	resp := issueToResponse(issue, prefix)
 	resp.Attachments = buildAttachmentResponses(res.Attachments)
 	writeJSON(w, http.StatusCreated, resp)
@@ -2563,7 +2685,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		h.linkAttachmentsByIssueIDs(r.Context(), issue.ID, issue.WorkspaceID, attachmentIDs)
 	}
 
-	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+	prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 	resp := issueToResponse(issue, prefix)
 	slog.Info("issue updated", append(logger.RequestAttrs(r), "issue_id", id, "workspace_id", workspaceID)...)
 
@@ -3101,7 +3223,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+		prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 		resp := issueToResponse(issue, prefix)
 		actorType, actorID := h.resolveActor(r, userID, workspaceID)
 

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -126,7 +126,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	}
 	staged := siblingsAreStaged(children)
 
-	prefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
+	prefix := h.getIssueDisplayPrefix(ctx, issue)
 	identifier := prefix + "-" + strconv.Itoa(int(issue.Number))
 	childID := uuidToString(issue.ID)
 	title := sanitizeChildTitleForSystemComment(issue.Title)

--- a/server/internal/handler/onboarding_shim.go
+++ b/server/internal/handler/onboarding_shim.go
@@ -316,7 +316,7 @@ func (h *Handler) BootstrapOnboardingRuntime(w http.ResponseWriter, r *http.Requ
 		))
 	}
 	if issueCreated {
-		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+		prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 		resp := issueToResponse(issue, prefix)
 		h.publish(protocol.EventIssueCreated, req.WorkspaceID, "member", userID, map[string]any{"issue": resp})
 		platform, _, _ := middleware.ClientMetadataFromContext(r.Context())
@@ -456,7 +456,7 @@ func (h *Handler) BootstrapOnboardingNoRuntime(w http.ResponseWriter, r *http.Re
 	}
 
 	if issueCreated {
-		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+		prefix := h.getIssueDisplayPrefix(r.Context(), issue)
 		resp := issueToResponse(issue, prefix)
 		h.publish(protocol.EventIssueCreated, req.WorkspaceID, "member", userID, map[string]any{"issue": resp})
 		platform2, _, _ := middleware.ClientMetadataFromContext(r.Context())

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,7 @@ type ProjectResponse struct {
 	Icon        *string `json:"icon"`
 	Status      string  `json:"status"`
 	Priority    string  `json:"priority"`
+	IssuePrefix *string `json:"issue_prefix"`
 	LeadType    *string `json:"lead_type"`
 	LeadID      *string `json:"lead_id"`
 	CreatedAt   string  `json:"created_at"`
@@ -48,6 +50,7 @@ func projectToResponse(p db.Project) ProjectResponse {
 		Icon:        textToPtr(p.Icon),
 		Status:      p.Status,
 		Priority:    p.Priority,
+		IssuePrefix: textToPtr(p.IssuePrefix),
 		LeadType:    textToPtr(p.LeadType),
 		LeadID:      uuidToPtr(p.LeadID),
 		CreatedAt:   timestampToString(p.CreatedAt),
@@ -77,6 +80,7 @@ type CreateProjectRequest struct {
 	Icon        *string                               `json:"icon"`
 	Status      string                                `json:"status"`
 	Priority    string                                `json:"priority"`
+	IssuePrefix *string                               `json:"issue_prefix"`
 	LeadType    *string                               `json:"lead_type"`
 	LeadID      *string                               `json:"lead_id"`
 	Resources   []CreateProjectResourceRequestPayload `json:"resources,omitempty"`
@@ -98,6 +102,7 @@ type UpdateProjectRequest struct {
 	Icon        *string `json:"icon"`
 	Status      *string `json:"status"`
 	Priority    *string `json:"priority"`
+	IssuePrefix *string `json:"issue_prefix"`
 	LeadType    *string `json:"lead_type"`
 	LeadID      *string `json:"lead_id"`
 }
@@ -191,6 +196,7 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 // exact mismatch reported in #3925 (`--status active`).
 var validProjectStatuses = []string{"planned", "in_progress", "paused", "completed", "cancelled"}
 var validProjectPriorities = []string{"urgent", "high", "medium", "low", "none"}
+var projectIssuePrefixPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]{1,9}$`)
 
 // validateProjectEnum writes a 400 and returns false when value is not in
 // allowed; the caller returns immediately on false.
@@ -201,6 +207,28 @@ func validateProjectEnum(w http.ResponseWriter, field, value string, allowed []s
 		}
 	}
 	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid %s %q; valid values: %s", field, value, strings.Join(allowed, ", ")))
+	return false
+}
+
+func normalizeProjectIssuePrefix(raw *string) pgtype.Text {
+	if raw == nil {
+		return pgtype.Text{}
+	}
+	prefix := strings.ToUpper(strings.TrimSpace(*raw))
+	if prefix == "" {
+		return pgtype.Text{String: "", Valid: true}
+	}
+	return pgtype.Text{String: prefix, Valid: true}
+}
+
+func validateProjectIssuePrefix(w http.ResponseWriter, prefix pgtype.Text) bool {
+	if !prefix.Valid || prefix.String == "" {
+		return true
+	}
+	if projectIssuePrefixPattern.MatchString(prefix.String) {
+		return true
+	}
+	writeError(w, http.StatusBadRequest, "invalid issue_prefix; use 2-10 uppercase letters or digits, starting with a letter")
 	return false
 }
 
@@ -246,6 +274,10 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		priority = "none"
 	}
 	if !validateProjectEnum(w, "priority", priority, validProjectPriorities) {
+		return
+	}
+	issuePrefix := normalizeProjectIssuePrefix(req.IssuePrefix)
+	if !validateProjectIssuePrefix(w, issuePrefix) {
 		return
 	}
 	var leadType pgtype.Text
@@ -310,6 +342,7 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		LeadType:    leadType,
 		LeadID:      leadID,
 		Priority:    priority,
+		IssuePrefix: issuePrefix,
 	}
 
 	// Without resources, keep the simple non-tx path.
@@ -441,6 +474,7 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		Icon:        prevProject.Icon,
 		LeadType:    prevProject.LeadType,
 		LeadID:      prevProject.LeadID,
+		IssuePrefix: prevProject.IssuePrefix,
 	}
 	if req.Title != nil {
 		params.Title = pgtype.Text{String: *req.Title, Valid: true}
@@ -456,6 +490,12 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		params.Priority = pgtype.Text{String: *req.Priority, Valid: true}
+	}
+	if _, ok := rawFields["issue_prefix"]; ok {
+		params.IssuePrefix = normalizeProjectIssuePrefix(req.IssuePrefix)
+		if !validateProjectIssuePrefix(w, params.IssuePrefix) {
+			return
+		}
 	}
 	if _, ok := rawFields["description"]; ok {
 		if req.Description != nil {

--- a/server/internal/handler/project_validation_test.go
+++ b/server/internal/handler/project_validation_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,6 +61,125 @@ func TestCreateProjectValidStatusReturns201(t *testing.T) {
 	})
 	if project.Status != "in_progress" {
 		t.Errorf("expected status in_progress, got %q", project.Status)
+	}
+}
+
+func TestProjectIssuePrefixOverridesIssueIdentifierDisplay(t *testing.T) {
+	setWorkspaceIssuePrefixForTest(t, "CAL")
+
+	projectW := httptest.NewRecorder()
+	projectReq := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title":        "project prefix project",
+		"issue_prefix": "LOL",
+	})
+	testHandler.CreateProject(projectW, projectReq)
+	if projectW.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", projectW.Code, projectW.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(projectW.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	t.Cleanup(func() {
+		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
+		req = withURLParam(req, "id", project.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), req)
+	})
+	if project.IssuePrefix == nil || *project.IssuePrefix != "LOL" {
+		t.Fatalf("CreateProject issue_prefix = %v, want LOL", project.IssuePrefix)
+	}
+
+	issueW := httptest.NewRecorder()
+	issueReq := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":      "issue with project prefix",
+		"project_id": project.ID,
+	})
+	testHandler.CreateIssue(issueW, issueReq)
+	if issueW.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", issueW.Code, issueW.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(issueW.Body).Decode(&created); err != nil {
+		t.Fatalf("decode CreateIssue: %v", err)
+	}
+	wantProjectIdentifier := fmt.Sprintf("LOL-%d", created.Number)
+	if created.Identifier != wantProjectIdentifier {
+		t.Fatalf("CreateIssue identifier = %q, want %q", created.Identifier, wantProjectIdentifier)
+	}
+
+	listW := httptest.NewRecorder()
+	listReq := newRequest("GET", "/api/issues?workspace_id="+testWorkspaceID+"&project_id="+project.ID, nil)
+	testHandler.ListIssues(listW, listReq)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("ListIssues: expected 200, got %d: %s", listW.Code, listW.Body.String())
+	}
+	var listed struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.NewDecoder(listW.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode ListIssues: %v", err)
+	}
+	if len(listed.Issues) != 1 {
+		t.Fatalf("ListIssues returned %d issues, want 1", len(listed.Issues))
+	}
+	if listed.Issues[0].Identifier != wantProjectIdentifier {
+		t.Fatalf("ListIssues identifier = %q, want %q", listed.Issues[0].Identifier, wantProjectIdentifier)
+	}
+
+	getW := httptest.NewRecorder()
+	getReq := newRequest("GET", "/api/issues/"+created.ID, nil)
+	getReq = withURLParam(getReq, "id", created.ID)
+	testHandler.GetIssue(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetIssue: expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+	var fetched IssueResponse
+	if err := json.NewDecoder(getW.Body).Decode(&fetched); err != nil {
+		t.Fatalf("decode GetIssue: %v", err)
+	}
+	if fetched.Identifier != wantProjectIdentifier {
+		t.Fatalf("GetIssue identifier = %q, want %q", fetched.Identifier, wantProjectIdentifier)
+	}
+
+	byIdentifierW := httptest.NewRecorder()
+	byIdentifierReq := newRequest("GET", "/api/issues/"+wantProjectIdentifier, nil)
+	byIdentifierReq = withURLParam(byIdentifierReq, "id", wantProjectIdentifier)
+	testHandler.GetIssue(byIdentifierW, byIdentifierReq)
+	if byIdentifierW.Code != http.StatusOK {
+		t.Fatalf("GetIssue by project identifier: expected 200, got %d: %s", byIdentifierW.Code, byIdentifierW.Body.String())
+	}
+
+	clearW := httptest.NewRecorder()
+	clearReq := newRequest("PUT", "/api/projects/"+project.ID, map[string]any{
+		"issue_prefix": "",
+	})
+	clearReq = withURLParam(clearReq, "id", project.ID)
+	testHandler.UpdateProject(clearW, clearReq)
+	if clearW.Code != http.StatusOK {
+		t.Fatalf("UpdateProject clear issue_prefix: expected 200, got %d: %s", clearW.Code, clearW.Body.String())
+	}
+	var cleared ProjectResponse
+	if err := json.NewDecoder(clearW.Body).Decode(&cleared); err != nil {
+		t.Fatalf("decode UpdateProject clear: %v", err)
+	}
+	if cleared.IssuePrefix != nil {
+		t.Fatalf("cleared project issue_prefix = %v, want nil", *cleared.IssuePrefix)
+	}
+
+	fallbackW := httptest.NewRecorder()
+	fallbackReq := newRequest("GET", "/api/issues/"+created.ID, nil)
+	fallbackReq = withURLParam(fallbackReq, "id", created.ID)
+	testHandler.GetIssue(fallbackW, fallbackReq)
+	if fallbackW.Code != http.StatusOK {
+		t.Fatalf("GetIssue after clear: expected 200, got %d: %s", fallbackW.Code, fallbackW.Body.String())
+	}
+	var fallback IssueResponse
+	if err := json.NewDecoder(fallbackW.Body).Decode(&fallback); err != nil {
+		t.Fatalf("decode GetIssue after clear: %v", err)
+	}
+	wantWorkspaceIdentifier := fmt.Sprintf("CAL-%d", created.Number)
+	if fallback.Identifier != wantWorkspaceIdentifier {
+		t.Fatalf("identifier after clear = %q, want %q", fallback.Identifier, wantWorkspaceIdentifier)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-projects-and-resources/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-projects-and-resources/SKILL.md
@@ -37,7 +37,10 @@ Common resource types:
 multica project list --output json
 multica project get <project-id> --output json
 multica project create --title "<title>" --repo <github-url> --output json
+multica project create --title "<title>" --issue-prefix LOL --output json
 multica project update <project-id> --title "<title>" --output json
+multica project update <project-id> --issue-prefix LOL --output json
+multica project update <project-id> --issue-prefix "" --output json  # inherit workspace prefix
 multica project status <project-id> in_progress --output json
 multica project resource list <project-id> --output json
 multica project resource add <project-id> --type github_repo --url <github-url> --output json
@@ -56,6 +59,15 @@ Add/update a project resource when the user asks for durable project context: "æ
 
 Project resources are durable and affect future tasks. `multica repo checkout`
 is task-local checkout state.
+
+## Project issue prefixes
+
+A project can override the workspace issue prefix with `issue_prefix`. Issues still
+use workspace-global numbers, but display identifiers prefer the project prefix
+when the issue is assigned to a project. For example, a workspace with `CAL` can
+have a PM-LOL project whose issues display as `LOL-123`. Pass an empty
+`--issue-prefix ""` on `project update` to clear the override and inherit the
+workspace prefix again.
 
 ## Debugging wrong context
 

--- a/server/internal/service/builtin_skills/multica-projects-and-resources/references/projects-and-resources-source-map.md
+++ b/server/internal/service/builtin_skills/multica-projects-and-resources/references/projects-and-resources-source-map.md
@@ -3,6 +3,7 @@
 - `server/cmd/multica/cmd_project.go` registers project `list`, `get`, `create`, `update`, `delete`, and `status`.
 - The same file registers `project resource list/add/update/remove`.
 - `project create --repo` attaches `github_repo` resources during project creation.
+- `project create/update --issue-prefix` maps to `project.issue_prefix`; issue response identifiers prefer this project prefix and fall back to `workspace.issue_prefix`.
 - `project resource add` supports shortcuts for `github_repo` (`--url`, non-JSON `--ref` for checkout ref, `--default-branch-hint`) and `local_directory` (`--local-path`, `--daemon-id`, `--ref-label`), or generic JSON `--ref '<json>'`.
 - `project resource update` merges shortcut edits with existing `resource_ref` so a partial edit does not clobber required fields; non-JSON `--ref` updates `github_repo.resource_ref.ref`.
 - `server/cmd/server/router.go` exposes `/api/projects` plus `/api/projects/{projectId}/resources` routes.

--- a/server/migrations/145_project_issue_prefix.down.sql
+++ b/server/migrations/145_project_issue_prefix.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE project
+    DROP CONSTRAINT IF EXISTS project_issue_prefix_format,
+    DROP COLUMN IF EXISTS issue_prefix;

--- a/server/migrations/145_project_issue_prefix.up.sql
+++ b/server/migrations/145_project_issue_prefix.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE project
+    ADD COLUMN issue_prefix TEXT,
+    ADD CONSTRAINT project_issue_prefix_format
+        CHECK (
+            issue_prefix IS NULL
+            OR issue_prefix = upper(issue_prefix)
+            AND issue_prefix ~ '^[A-Z][A-Z0-9]{1,9}$'
+        );

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -689,6 +689,7 @@ type Project struct {
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 	Priority    string             `json:"priority"`
+	IssuePrefix pgtype.Text        `json:"issue_prefix"`
 }
 
 type ProjectResource struct {

--- a/server/pkg/db/generated/project.sql.go
+++ b/server/pkg/db/generated/project.sql.go
@@ -26,10 +26,10 @@ func (q *Queries) CountIssuesByProject(ctx context.Context, projectID pgtype.UUI
 const createProject = `-- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, issue_prefix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
-) RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+    $1, $2, $3, $4, $5, $6, $7, $8, NULLIF($9, '')
+) RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, issue_prefix
 `
 
 type CreateProjectParams struct {
@@ -41,6 +41,7 @@ type CreateProjectParams struct {
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
 	Priority    string      `json:"priority"`
+	IssuePrefix pgtype.Text `json:"issue_prefix"`
 }
 
 func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error) {
@@ -53,6 +54,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		arg.LeadType,
 		arg.LeadID,
 		arg.Priority,
+		arg.IssuePrefix,
 	)
 	var i Project
 	err := row.Scan(
@@ -67,6 +69,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.IssuePrefix,
 	)
 	return i, err
 }
@@ -87,7 +90,7 @@ func (q *Queries) DeleteProject(ctx context.Context, arg DeleteProjectParams) er
 }
 
 const getProject = `-- name: GetProject :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, issue_prefix FROM project
 WHERE id = $1
 `
 
@@ -106,12 +109,13 @@ func (q *Queries) GetProject(ctx context.Context, id pgtype.UUID) (Project, erro
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.IssuePrefix,
 	)
 	return i, err
 }
 
 const getProjectInWorkspace = `-- name: GetProjectInWorkspace :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, issue_prefix FROM project
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -135,6 +139,7 @@ func (q *Queries) GetProjectInWorkspace(ctx context.Context, arg GetProjectInWor
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.IssuePrefix,
 	)
 	return i, err
 }
@@ -174,8 +179,46 @@ func (q *Queries) GetProjectIssueStats(ctx context.Context, projectIds []pgtype.
 	return items, nil
 }
 
+const listProjectIssuePrefixes = `-- name: ListProjectIssuePrefixes :many
+SELECT id, issue_prefix FROM project
+WHERE workspace_id = $1
+  AND id = ANY($2::uuid[])
+  AND issue_prefix IS NOT NULL
+  AND issue_prefix <> ''
+`
+
+type ListProjectIssuePrefixesParams struct {
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	ProjectIds  []pgtype.UUID `json:"project_ids"`
+}
+
+type ListProjectIssuePrefixesRow struct {
+	ID          pgtype.UUID `json:"id"`
+	IssuePrefix pgtype.Text `json:"issue_prefix"`
+}
+
+func (q *Queries) ListProjectIssuePrefixes(ctx context.Context, arg ListProjectIssuePrefixesParams) ([]ListProjectIssuePrefixesRow, error) {
+	rows, err := q.db.Query(ctx, listProjectIssuePrefixes, arg.WorkspaceID, arg.ProjectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListProjectIssuePrefixesRow{}
+	for rows.Next() {
+		var i ListProjectIssuePrefixesRow
+		if err := rows.Scan(&i.ID, &i.IssuePrefix); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProjects = `-- name: ListProjects :many
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, issue_prefix FROM project
 WHERE workspace_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR priority = $3)
@@ -209,6 +252,7 @@ func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]P
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Priority,
+			&i.IssuePrefix,
 		); err != nil {
 			return nil, err
 		}
@@ -227,11 +271,12 @@ UPDATE project SET
     icon = $4,
     status = COALESCE($5, status),
     priority = COALESCE($6, priority),
-    lead_type = $7,
-    lead_id = $8,
+    issue_prefix = NULLIF($7, ''),
+    lead_type = $8,
+    lead_id = $9,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, issue_prefix
 `
 
 type UpdateProjectParams struct {
@@ -241,6 +286,7 @@ type UpdateProjectParams struct {
 	Icon        pgtype.Text `json:"icon"`
 	Status      pgtype.Text `json:"status"`
 	Priority    pgtype.Text `json:"priority"`
+	IssuePrefix pgtype.Text `json:"issue_prefix"`
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
 }
@@ -253,6 +299,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		arg.Icon,
 		arg.Status,
 		arg.Priority,
+		arg.IssuePrefix,
 		arg.LeadType,
 		arg.LeadID,
 	)
@@ -269,6 +316,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.IssuePrefix,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/project.sql
+++ b/server/pkg/db/queries/project.sql
@@ -16,9 +16,9 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, issue_prefix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, NULLIF(sqlc.narg('issue_prefix'), '')
 ) RETURNING *;
 
 -- name: UpdateProject :one
@@ -28,11 +28,19 @@ UPDATE project SET
     icon = sqlc.narg('icon'),
     status = COALESCE(sqlc.narg('status'), status),
     priority = COALESCE(sqlc.narg('priority'), priority),
+    issue_prefix = NULLIF(sqlc.narg('issue_prefix'), ''),
     lead_type = sqlc.narg('lead_type'),
     lead_id = sqlc.narg('lead_id'),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
+
+-- name: ListProjectIssuePrefixes :many
+SELECT id, issue_prefix FROM project
+WHERE workspace_id = $1
+  AND id = ANY(sqlc.arg('project_ids')::uuid[])
+  AND issue_prefix IS NOT NULL
+  AND issue_prefix <> '';
 
 -- name: DeleteProject :exec
 -- Defense-in-depth: workspace_id is a SQL-layer tenant guard. See DeleteIssue.


### PR DESCRIPTION
## Summary
- add optional project-level `issue_prefix` storage and validation
- use project prefix for issue identifiers when an issue belongs to a project, falling back to workspace `issue_prefix`
- expose `--issue-prefix` on `multica project create` / `multica project update`
- update core Project types/schemas and Multica projects built-in skill docs

## Motivation
Workspaces can currently only set a global issue prefix via `multica workspace update --issue-prefix`. That makes it impossible for a workspace with multiple distinct projects to show project-specific issue keys, e.g. keeping the workspace prefix as `CAL` while a PM-LOL project displays issues as `LOL-123`.

## Testing
- `docker run --rm -e IS_SANDBOX=1 -v /home/calvin/multica:/repo -w /repo/server golang:1.26.1 sh -lc 'export PATH=/usr/local/go/bin:$PATH; go test ./cmd/multica ./internal/handler -count=1'`
- `docker run --rm --user $(id -u):$(id -g) -e IS_SANDBOX=1 -e HOME=/tmp/home -v /home/calvin/multica:/repo -w /repo/server golang:1.26.1 sh -lc 'export PATH=/usr/local/go/bin:$PATH; mkdir -p /tmp/home; go test ./... -count=1'`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/core test -- --runInBand`

Note: one earlier root-container full-suite run without matching user/HOME hit environment-sensitive daemon/redaction failures; rerunning with non-root docker user and sandbox env passed.
