### PR TITLE
fix(makefile): inject version ldflags into make daemon/multica/cli targets (MUL-4207)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ cli: ## Run the multica CLI with ARGS or MULTICA_ARGS from source
 	@$(MAKE) multica MULTICA_ARGS="$(MULTICA_ARGS)"
 
 multica: ## Run the multica CLI entrypoint directly from the Go source tree
-	cd server && go run ./cmd/multica $(MULTICA_ARGS)
+	cd server && go run -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" ./cmd/multica $(MULTICA_ARGS)
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)


### PR DESCRIPTION
## Repro

1. Open Multica Desktop, in a workspace.
2. Click **New Issue**.
3. Switch to the **Create with agent** tab and pick an agent whose runtime is a locally dev-run daemon (`make daemon`).
4. Modal shows: *"This agent's daemon doesn't report a CLI version. Create with agent needs multica CLI ≥ 0.2.21. Upgrade the daemon and reconnect, or switch to manual create."*

## Summary

- The `multica` Makefile target (used by `make daemon`, `make multica`, `make cli`) ran `go run ./cmd/multica` with no `-ldflags`, unlike the `build` target. `main.version` stays at its hardcoded `"dev"` default for any daemon started this way.
- The quick-create CLI version gate (`packages/core/runtimes/cli-version.ts`, `server/pkg/agent/version.go`) treats `"dev"` as unparsable — it fails both the semver check and the git-describe dev-build exemption (`^v?\d+\.\d+\.\d+-\d+-g[0-9a-fA-F]+`) that's specifically meant to keep `make daemon` unblocked. So any locally dev-run daemon reports `cli_version: "dev"`, and "Create with agent" fails closed with *"This agent's daemon doesn't report a CLI version."*
- Fix: give `multica` the same `-ldflags "-X main.version=$(VERSION) ..."` the `build` target already uses, so `go run` reports the real `git describe` version (e.g. `v0.3.39-3-g774e77dad-dirty`), which the gate is designed to accept.

Confirmed on `origin/main` before this PR:
```
$ go run ./cmd/multica version --output json
{"version": "dev", ...}   # fails the gate

$ go run -ldflags "-X main.version=$(git describe --tags --always --dirty) ..." ./cmd/multica version --output json
{"version": "v0.3.39-3-g774e77dad-dirty", ...}   # passes
```

## Test plan

- [x] `go run ./cmd/multica version --output json` before the fix reports `"dev"`
- [x] `go run -ldflags "-X main.version=$(git describe ...) ..." ./cmd/multica version --output json` after the fix reports the git-describe version
- [ ] `make daemon` reconnects and "Create with agent" no longer shows the version-missing warning (verify in a full local stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)