### PR TITLE
fix(skills): preserve runtime import files MUL-4215

### DIFF
--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -121,7 +121,7 @@ type LocalSkillImportStore interface {
 	// transitions them to running. Used by the heartbeat handler to deliver
 	// multiple imports per heartbeat cycle.
 	PopPendingBatch(ctx context.Context, runtimeID string, limit int) ([]*RuntimeLocalSkillImportRequest, error)
-	Complete(ctx context.Context, id string, skill SkillResponse) error
+	Complete(ctx context.Context, id string, skill SkillWithFilesResponse) error
 	// Conflict transitions a request to the terminal RuntimeLocalSkillConflict
 	// state, attaching structured conflict metadata for the caller to act on.
 	Conflict(ctx context.Context, id string, info LocalSkillImportConflict) error
@@ -211,7 +211,7 @@ type RuntimeLocalSkillImportRequest struct {
 	// the new `conflict` status and the legacy `failed` behavior.
 	SupportsConflict bool                           `json:"supports_conflict,omitempty"`
 	Status           RuntimeLocalSkillRequestStatus `json:"status"`
-	Skill            *SkillResponse                 `json:"skill,omitempty"`
+	Skill            *SkillWithFilesResponse        `json:"skill,omitempty"`
 	Conflict         *LocalSkillImportConflict      `json:"conflict,omitempty"`
 	Error            string                         `json:"error,omitempty"`
 	CreatedAt        time.Time                      `json:"created_at"`
@@ -450,7 +450,7 @@ func (s *InMemoryLocalSkillImportStore) PopPendingBatch(_ context.Context, runti
 	return result, nil
 }
 
-func (s *InMemoryLocalSkillImportStore) Complete(_ context.Context, id string, skill SkillResponse) error {
+func (s *InMemoryLocalSkillImportStore) Complete(_ context.Context, id string, skill SkillWithFilesResponse) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -861,7 +861,7 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 			h.failLocalSkillImport(w, r, requestID, failMsg)
 			return
 		}
-		if err := h.LocalSkillImportStore.Complete(r.Context(), requestID, resp.SkillResponse); err != nil {
+		if err := h.LocalSkillImportStore.Complete(r.Context(), requestID, resp); err != nil {
 			// The overwrite already committed; unlike the create path we must
 			// NOT delete the skill to "roll back" (that would destroy a
 			// pre-existing skill and its agent bindings). Surface 5xx so the
@@ -915,7 +915,7 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := h.LocalSkillImportStore.Complete(r.Context(), requestID, resp.SkillResponse); err != nil {
+	if err := h.LocalSkillImportStore.Complete(r.Context(), requestID, resp); err != nil {
 		// We already wrote the Skill to Postgres. If the store-side Complete
 		// fails we can't leave that Skill orphaned: the daemon will retry on
 		// 5xx and re-create it, which blows up on the unique-name constraint

--- a/server/internal/handler/runtime_local_skills_redis_store.go
+++ b/server/internal/handler/runtime_local_skills_redis_store.go
@@ -485,7 +485,7 @@ func (s *RedisLocalSkillImportStore) PopPendingBatch(ctx context.Context, runtim
 	return result, nil
 }
 
-func (s *RedisLocalSkillImportStore) Complete(ctx context.Context, id string, skill SkillResponse) error {
+func (s *RedisLocalSkillImportStore) Complete(ctx context.Context, id string, skill SkillWithFilesResponse) error {
 	req, err := s.loadImportRequest(ctx, id)
 	if err != nil {
 		return err

--- a/server/internal/handler/runtime_local_skills_redis_store_test.go
+++ b/server/internal/handler/runtime_local_skills_redis_store_test.go
@@ -270,6 +270,64 @@ func TestRedisLocalSkillImportStore_PreservesCreatorID(t *testing.T) {
 	}
 }
 
+func TestRedisLocalSkillImportStore_CompletePreservesFiles(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+	store := NewRedisLocalSkillImportStore(rdb)
+
+	req, err := store.Create(ctx, LocalSkillImportRequestInput{
+		RuntimeID: "runtime-1",
+		CreatorID: "user-1",
+		SkillKey:  "review-helper",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	completedAt := time.Now().UTC().Format(time.RFC3339)
+	skill := SkillWithFilesResponse{
+		SkillResponse: SkillResponse{
+			ID:          "skill-1",
+			WorkspaceID: testWorkspaceID,
+			Name:        "Review Helper",
+			Description: "Review PRs",
+			Content:     "# Review Helper",
+			CreatedAt:   completedAt,
+			UpdatedAt:   completedAt,
+		},
+		Files: []SkillFileResponse{
+			{
+				ID:        "file-1",
+				SkillID:   "skill-1",
+				Path:      "rules.md",
+				Content:   "Use the review checklist.",
+				CreatedAt: completedAt,
+				UpdatedAt: completedAt,
+			},
+		},
+	}
+	if err := store.Complete(ctx, req.ID, skill); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != RuntimeLocalSkillCompleted {
+		t.Fatalf("status = %s, want completed", got.Status)
+	}
+	if got.Skill == nil {
+		t.Fatal("completed skill lost round trip")
+	}
+	if len(got.Skill.Files) != 1 {
+		t.Fatalf("files lost round trip: %+v", got.Skill.Files)
+	}
+	if got.Skill.Files[0].Path != "rules.md" || got.Skill.Files[0].Content != "Use the review checklist." {
+		t.Fatalf("file corrupted round trip: %+v", got.Skill.Files[0])
+	}
+}
+
 func TestRedisLocalSkillImportStore_PreservesConflict(t *testing.T) {
 	rdb := newRedisTestClient(t)
 	ctx := context.Background()

--- a/server/internal/handler/runtime_local_skills_test.go
+++ b/server/internal/handler/runtime_local_skills_test.go
@@ -372,6 +372,12 @@ func TestRuntimeLocalSkillImportFlow_EndToEnd(t *testing.T) {
 	if completed.Skill.Description != "Imported description" {
 		t.Fatalf("imported description = %q", completed.Skill.Description)
 	}
+	if len(completed.Skill.Files) != 1 {
+		t.Fatalf("expected poll response to include 1 imported file, got %d", len(completed.Skill.Files))
+	}
+	if completed.Skill.Files[0].Path != "templates/check.md" || completed.Skill.Files[0].Content != "body" {
+		t.Fatalf("unexpected imported file in poll response: %+v", completed.Skill.Files[0])
+	}
 	if got := countSkillFiles(t, completed.Skill.ID); got != 1 {
 		t.Fatalf("expected 1 imported file, got %d", got)
 	}


### PR DESCRIPTION
## Summary
- Preserve the full SkillWithFilesResponse when completing runtime local skill imports.
- Return supporting files in the poll result so the skill detail cache is seeded with imported files immediately.
- Add regression coverage for the handler flow and Redis import store files round trip.

## Root Cause
Runtime local import previously completed the request with only SkillResponse, which stripped the Files payload after the database write. The desktop UI then cached that incomplete poll result with an infinite stale time, so supporting files such as rules.md or references/* did not appear until a refresh/refetch.

## Validation
- go test ./internal/handler -run 'TestRuntimeLocalSkillImportFlow_EndToEnd|TestBatchImportViaHeartbeat|TestRedisLocalSkillImportStore_(CompletePreservesFiles|PreservesCreatorID|PreservesConflict)'
- go test ./internal/daemon -run 'TestLoadRuntimeLocalSkillBundle|TestListRuntimeLocalSkills'
- go build ./...
- go vet ./...