### PR TITLE
fix(cli): reject issue list --direction on position/default sort [MUL-4222]

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -342,7 +342,7 @@ multica issue list --sort created_at --direction desc  # newest first
 
 Table output shows a routable issue `KEY` such as `MUL-123`; copy that key into follow-up commands like `issue get`, `issue comment list`, `issue status`, or `--parent`. Add `--full-id` when you need canonical UUIDs. Available filters: `--status`, `--priority`, `--assignee` / `--assignee-id`, `--project`, `--metadata`, `--limit`. Use `--assignee-id <uuid>` for unambiguous filtering when names overlap.
 
-Results come back in board order (`position`, ascending) by default. Pass `--sort` to change the column (`position`, `title`, `created_at`, `start_date`, `due_date`, `priority`) and `--direction asc|desc` to flip the order. `position` is always ascending (it is the manual drag order), so `--direction` only affects the other columns.
+Results come back in board order (`position`, ascending) by default. Pass `--sort` to change the column (`position`, `title`, `created_at`, `start_date`, `due_date`, `priority`) and `--direction asc|desc` to flip the order. `position` is always ascending (it is the manual drag order), so `--direction` is rejected when `--sort` is `position` or omitted — use it only with `title`, `created_at`, `start_date`, `due_date`, or `priority`.
 
 Use `--metadata key=value` (repeatable; combined with AND) to filter by per-issue metadata. The value is JSON-parsed: `true`/`false` become bool, numbers become numbers, anything else is a string. Wrap as `'"42"'` to force a string when the value would otherwise sniff as a number:
 

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -297,6 +297,19 @@ var validIssueSortColumns = []string{
 	"position", "title", "created_at", "start_date", "due_date", "priority",
 }
 
+// directionalIssueSortColumns are the sort keys for which --direction is
+// meaningful: every valid column except "position". Derived from
+// validIssueSortColumns so the two stay in sync.
+var directionalIssueSortColumns = func() []string {
+	cols := make([]string, 0, len(validIssueSortColumns)-1)
+	for _, c := range validIssueSortColumns {
+		if c != "position" {
+			cols = append(cols, c)
+		}
+	}
+	return cols
+}()
+
 func validateIssueStatus(status string) error {
 	return validateIssueEnum("status", status, validIssueStatuses)
 }
@@ -355,7 +368,7 @@ func init() {
 	issueListCmd.Flags().Int("limit", 50, "Maximum number of issues to return")
 	issueListCmd.Flags().Int("offset", 0, "Number of issues to skip (for pagination)")
 	issueListCmd.Flags().String("sort", "", "Sort column: position (default, manual board order), title, created_at, start_date, due_date, priority")
-	issueListCmd.Flags().String("direction", "", "Sort direction (asc or desc) for non-position sorts; ignored for position")
+	issueListCmd.Flags().String("direction", "", "Sort direction (asc or desc); requires --sort to be a non-position column (position is always ascending)")
 
 	// issue get
 	issueGetCmd.Flags().String("output", "json", "Output format: table or json")
@@ -532,23 +545,31 @@ func runIssueList(cmd *cobra.Command, _ []string) error {
 		}
 		params.Set("metadata", filter)
 	}
-	if v, _ := cmd.Flags().GetString("sort"); v != "" {
+	sortVal, _ := cmd.Flags().GetString("sort")
+	if sortVal != "" {
 		valid := false
 		for _, c := range validIssueSortColumns {
-			if c == v {
+			if c == sortVal {
 				valid = true
 				break
 			}
 		}
 		if !valid {
-			return fmt.Errorf("invalid --sort %q; valid values: %s", v, strings.Join(validIssueSortColumns, ", "))
+			return fmt.Errorf("invalid --sort %q; valid values: %s", sortVal, strings.Join(validIssueSortColumns, ", "))
 		}
-		params.Set("sort", v)
+		params.Set("sort", sortVal)
 	}
 	if v, _ := cmd.Flags().GetString("direction"); v != "" {
 		d := strings.ToLower(v)
 		if d != "asc" && d != "desc" {
 			return fmt.Errorf("invalid --direction %q; valid values: asc, desc", v)
+		}
+		// position (the manual board order) is always ascending, so the server
+		// ignores --direction for it. Reject the combination up front rather
+		// than silently dropping the flag — a passed-but-ignored flag is a
+		// footgun, especially in scripts.
+		if sortVal == "" || sortVal == "position" {
+			return fmt.Errorf("--direction requires --sort to be one of %s; position (the default manual board order) is always ascending", strings.Join(directionalIssueSortColumns, ", "))
 		}
 		params.Set("direction", d)
 	}

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2614,6 +2614,44 @@ func TestRunIssueListRejectsInvalidSortAndDirection(t *testing.T) {
 	}
 }
 
+// TestRunIssueListRejectsDirectionWithoutDirectionalSort guards that passing a
+// valid --direction while the sort is the default/position (which the server
+// always sorts ascending) is rejected up front, rather than silently dropping
+// the flag — a passed-but-ignored flag is a footgun, especially in scripts.
+func TestRunIssueListRejectsDirectionWithoutDirectionalSort(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://127.0.0.1:0")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cases := []struct {
+		name string
+		sort string
+	}{
+		{"direction without sort", ""},
+		{"direction with explicit position sort", "position"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newIssueListTestCmd()
+			if tc.sort != "" {
+				_ = cmd.Flags().Set("sort", tc.sort)
+			}
+			_ = cmd.Flags().Set("direction", "desc")
+			err := runIssueList(cmd, nil)
+			if err == nil {
+				t.Fatal("runIssueList: expected error for --direction on position/default sort")
+			}
+			if !strings.Contains(err.Error(), "--direction requires --sort") {
+				t.Fatalf("error = %q, want it to explain --direction requires a directional --sort", err)
+			}
+			// The message should name a concrete directional column to guide the fix.
+			if !strings.Contains(err.Error(), "created_at") {
+				t.Fatalf("error = %q, want it to list the valid directional sort columns", err)
+			}
+		})
+	}
+}
+
 func TestComputeReorderPosition(t *testing.T) {
 	positions := map[string]float64{"a": 10, "b": 20, "x": 99}
 	tests := []struct {


### PR DESCRIPTION
## What does this PR do?

Follow-up to #4110. That PR added `issue list --sort/--direction`. The server always sorts the default `position` column ascending (it is the manual drag order), so a `--direction` passed together with `position` — or with no `--sort` at all — was accepted and then silently ignored. A flag that the user explicitly passes but the tool quietly drops is a footgun, and especially misleading in scripts that expect a specific order.

This makes the CLI reject that combination up front instead, with a message that names the columns for which `--direction` is meaningful:

```
$ multica issue list --direction desc
error: --direction requires --sort to be one of title, created_at, start_date, due_date, priority; position (the default manual board order) is always ascending
```

Valid combinations (`--sort created_at --direction desc`, etc.) are unchanged. No server change.

## Related Issue

Follow-up to #4110 (CLI issue ordering). Tracks Multica MUL-4222.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_issue.go`: `runIssueList` now rejects `--direction` when `--sort` is `position` or omitted; added `directionalIssueSortColumns` (derived from `validIssueSortColumns` so the two never drift) for the error message; updated the `--direction` flag help.
- `server/cmd/multica/cmd_issue_test.go`: added `TestRunIssueListRejectsDirectionWithoutDirectionalSort` (rejects `--direction` with no sort and with explicit `position`, and asserts the error lists the directional columns). Existing valid-combo and invalid-value tests unchanged.
- `CLI_AND_DAEMON.md`: documents that `--direction` is rejected for `position`/default and only applies to the other columns.

## How to Test

1. `cd server && go test ./cmd/multica/ -run 'TestRunIssueList'`
2. Against a running workspace:
   - `multica issue list --direction desc` → errors, naming the valid `--sort` columns.
   - `multica issue list --sort position --direction desc` → same error.
   - `multica issue list --sort created_at --direction desc` → still works (newest first).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (CLI only, n/a)
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy + docs (n/a)
- [ ] If this PR touches Chinese product copy (n/a)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code)

**Prompt / approach:** Raised during the review of #4110 as a CLI-design nit — `--direction` was silently ignored on the default `position` sort. A second-round review recommended rejecting the combination outright rather than warning, so this PR implements that: reject up front, name the directional columns in the error, and derive that list from the existing sort-column list to avoid drift.

**Risks:** Minimal. This tightens input validation on a flag that previously no-op'd, so the only user-visible change is that a `--direction` which used to be silently ignored now returns a clear error. No behavior change for valid `--sort` + `--direction` combinations, and no server change.
