### PR TITLE
test(server): cap pkg/agent test concurrency under -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,9 @@ test: ## Run Go tests after ensuring the target DB exists and migrations are app
 	# parent event loops so they miss the deadline. Run the rest of the suite at
 	# full concurrency and cap only pkg/agent's package- and within-package
 	# parallelism, keeping those tests within budget without slowing the whole suite.
-	cd server && go test -race $$(go list ./... | grep -vE '/pkg/agent(/|$$)')
+	# Build the package list via explicit assignments so a go list failure
+	# fails this target instead of being swallowed by command substitution.
+	cd server && pkgs="$$(go list ./...)" && pkgs="$$(printf '%s\n' "$$pkgs" | grep -vE '/pkg/agent(/|$$)')" && go test -race $$pkgs
 	cd server && go test -race -p 2 -parallel 2 ./pkg/agent/...
 
 # Database

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,13 @@ test: ## Run Go tests after ensuring the target DB exists and migrations are app
 	$(REQUIRE_ENV)
 	@bash scripts/ensure-postgres.sh "$(ENV_FILE)"
 	cd server && go run ./cmd/migrate up
-	cd server && go test -race ./...
+	# pkg/agent spawns many subprocess-backed tests with hard 5s deadlines; under
+	# -race on high-core machines the default GOMAXPROCS fan-out starves their
+	# parent event loops so they miss the deadline. Run the rest of the suite at
+	# full concurrency and cap only pkg/agent's package- and within-package
+	# parallelism, keeping those tests within budget without slowing the whole suite.
+	cd server && go test -race $$(go list ./... | grep -vE '/pkg/agent(/|$$)')
+	cd server && go test -race -p 2 -parallel 2 ./pkg/agent/...
 
 # Database
 ##@ Database


### PR DESCRIPTION
## What does this PR do?

Split out from #5057 at reviewer request, so the version-derivation fix stays focused and this CI change can be reviewed and reverted independently.

`pkg/agent` spawns many subprocess-backed tests with hard 5s deadlines. Under `-race` on high-core machines, the default `GOMAXPROCS` fan-out — across packages via `-p` and within a package via `-parallel` — starves the parent event loops so they miss the deadline and flake.

Rather than throttle the entire Go suite (as the first draft in #5057 did with a blanket `-p 2 -parallel 2 ./...`), this runs the rest of the suite at full concurrency and caps only `pkg/agent`:

```make
cd server && go test -race $(go list ./... | grep -vE '/pkg/agent(/|$)')
cd server && go test -race -p 2 -parallel 2 ./pkg/agent/...
```

This keeps the deadline-sensitive package within budget while leaving the other 46 packages' CI wall-clock unaffected.

## Related Issue

Follow-up to #5057 (reviewer requested the concurrency change be split out).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- `Makefile`: `make test` now runs the suite in two invocations — all packages except `pkg/agent` at full concurrency, then `pkg/agent` alone with `-p 2 -parallel 2`.

## How to Test

Run `make test`. The whole suite runs under `-race`; `pkg/agent`'s subprocess-backed, deadline-sensitive tests run with capped concurrency and stay within their 5s budget on high-core machines, while the rest of the suite is unthrottled.

## Checklist

- [x] I have run tests locally and they pass
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Split the CI-hardening change out of #5057 per review, and scoped the concurrency cap to only the deadline-sensitive `pkg/agent` package instead of the whole suite.
