### PR TITLE
refactor(chat): remove starter prompts from chat empty state (MUL-4237)

### DIFF
--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -136,7 +136,7 @@ export function ChatPage() {
 
   // The conversation pane: message list / skeleton / empty above a persistent
   // banner + input. Identical composition to the floating window's body, so a
-  // brand-new chat (no active session) still shows the starter prompts + input.
+  // brand-new chat (no active session) shows the agent-aware empty state + input.
   // No compose-box agent selector — the agent is fixed when the chat starts.
   const conversation = (
     <div className="flex flex-1 flex-col min-h-0">
@@ -157,10 +157,7 @@ export function ChatPage() {
           onLoadOlderMessages={() => void c.fetchOlderMessages()}
         />
       ) : (
-        <EmptyState
-          agent={c.activeAgent}
-          onPickPrompt={(text) => c.handleSend(text)}
-        />
+        <EmptyState agent={c.activeAgent} />
       )}
 
       {c.noAgent ? (

--- a/packages/views/chat/components/chat-empty-state.tsx
+++ b/packages/views/chat/components/chat-empty-state.tsx
@@ -4,32 +4,13 @@ import type { Agent } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useT } from "../../i18n";
 
-// Three starter prompts shown on the empty compose. Each is keyed into the
-// chat namespace so labels translate per locale; the icon stays raw since
-// emojis are locale-neutral.
-const STARTER_KEYS: ("list_open" | "summarize_today" | "plan_next")[] = [
-  "list_open",
-  "summarize_today",
-  "plan_next",
-];
-const STARTER_ICONS: Record<(typeof STARTER_KEYS)[number], string> = {
-  list_open: "📋",
-  summarize_today: "📝",
-  plan_next: "💡",
-};
-
 /**
  * Empty compose placeholder shown when a chat has no messages yet. Agent-aware:
  * it leads with the chosen agent's avatar + name + description so the user knows
- * exactly who they're about to talk to, then offers starter prompts.
+ * exactly who they're about to talk to. The composer below is the entry point —
+ * no starter prompts, they read as filler more than help.
  */
-export function EmptyState({
-  agent,
-  onPickPrompt,
-}: {
-  agent: Agent | null;
-  onPickPrompt: (text: string) => void;
-}) {
+export function EmptyState({ agent }: { agent: Agent | null }) {
   const { t } = useT("chat");
   const description = agent?.description?.trim();
   return (
@@ -48,25 +29,9 @@ export function EmptyState({
             ? t(($) => $.empty_state.chat_with_named, { name: agent.name })
             : t(($) => $.empty_state.first_time_title)}
         </h3>
-        <p className="text-sm text-muted-foreground">
-          {description || t(($) => $.empty_state.returning_subtitle)}
-        </p>
-      </div>
-      <div className="w-full max-w-xs space-y-2">
-        {STARTER_KEYS.map((key) => {
-          const text = t(($) => $.starter_prompts[key]);
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => onPickPrompt(text)}
-              className="w-full rounded-lg border border-border bg-card px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent hover:border-brand/40"
-            >
-              <span className="mr-2">{STARTER_ICONS[key]}</span>
-              {text}
-            </button>
-          );
-        })}
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
       </div>
     </div>
   );

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -94,13 +94,7 @@
     "first_time_actions": "Ask for a summary, plan your day, or hand off a quick task.",
     "returning_title_named": "Hi, I'm {{name}}",
     "returning_title_default": "Welcome to Multica",
-    "returning_subtitle": "Try asking",
     "chat_with_named": "Chat with {{name}}"
-  },
-  "starter_prompts": {
-    "list_open": "List my open tasks by priority",
-    "summarize_today": "Summarize what I did today",
-    "plan_next": "Plan what to work on next"
   },
   "no_agent_banner": "You need an agent to start chatting.",
   "offline_banner": {

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -91,13 +91,7 @@
     "first_time_actions": "要約を頼んだり、今日の予定を立てたり、簡単なタスクを任せたりしてみましょう。",
     "returning_title_named": "こんにちは、{{name}} です",
     "returning_title_default": "Multica へようこそ",
-    "returning_subtitle": "こう聞いてみましょう",
     "chat_with_named": "{{name}} とチャット"
-  },
-  "starter_prompts": {
-    "list_open": "オープンなタスクを優先度順にまとめて",
-    "summarize_today": "今日やったことを要約して",
-    "plan_next": "次に取り組むことを計画して"
   },
   "no_agent_banner": "チャットを始めるにはエージェントが必要です。",
   "offline_banner": {

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -91,13 +91,7 @@
     "first_time_actions": "요약을 요청하거나, 오늘 할 일을 계획하거나, 간단한 작업을 맡겨보세요.",
     "returning_title_named": "안녕하세요, 저는 {{name}}입니다",
     "returning_title_default": "Multica에 오신 것을 환영합니다",
-    "returning_subtitle": "이렇게 요청해 보세요",
     "chat_with_named": "{{name}}와 채팅"
-  },
-  "starter_prompts": {
-    "list_open": "열린 작업을 우선순위별로 정리해 줘",
-    "summarize_today": "오늘 내가 한 일을 요약해 줘",
-    "plan_next": "다음에 할 일을 계획해 줘"
   },
   "no_agent_banner": "채팅을 시작하려면 에이전트가 필요합니다.",
   "offline_banner": {

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -91,13 +91,7 @@
     "first_time_actions": "让它做一份总结、规划你的一天，或交给它一个小任务。",
     "returning_title_named": "你好，我是 {{name}}",
     "returning_title_default": "欢迎使用 Multica",
-    "returning_subtitle": "试试问",
     "chat_with_named": "与 {{name}} 对话"
-  },
-  "starter_prompts": {
-    "list_open": "按优先级列出我未完成的任务",
-    "summarize_today": "总结一下我今天做了什么",
-    "plan_next": "规划接下来该做什么"
   },
   "no_agent_banner": "需要先有一个智能体才能开始对话。",
   "offline_banner": {


### PR DESCRIPTION
## What

Removes the three starter prompts from the chat empty state (the "Chat with {name} → Try asking" surface):

- 📋 List my open tasks by priority
- 📝 Summarize what I did today
- 💡 Plan what to work on next

On web/desktop, clicking a prompt sends it immediately. In practice these three read as filler — "list by priority" duplicates the issues view, "what I did today" asks the agent for data it doesn't reliably have, and "plan next" is too vague. Per the issue owner they add no value, so they're removed.

## What stays

The empty state keeps its agent-aware header — avatar + **Chat with {name}** + the agent's description (when set). The composer stays the entry point.

## Changes

- `packages/views/chat/components/chat-empty-state.tsx` — drop `STARTER_KEYS`/`STARTER_ICONS`, the prompt buttons, and the `onPickPrompt` prop; render the description only when present.
- `packages/views/chat/chat-page.tsx` — drop the `onPickPrompt` wiring.
- `packages/views/locales/{en,zh-Hans,ja,ko}/chat.json` — remove the `starter_prompts` block and the now-unused `empty_state.returning_subtitle` (locale key parity preserved).

## Base

Targets the **Chat V2** branch (`agent/lambda/e5a4c3a5`, #5076 / MUL-4171), not `main` — the empty state this touches only exists on Chat V2.

Closes MUL-4237.

> Note: I couldn't run `pnpm typecheck` in this environment (deps not installed). The change is a self-contained prop/const/JSON removal with all call sites updated; the locale key sets stay parity-consistent.
