### PR TITLE
feat(chat): pin a chat to the top of the Chat list (MUL-4240)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1777,6 +1777,13 @@ export class ApiClient {
     });
   }
 
+  async setChatSessionPinned(id: string, pinned: boolean): Promise<ChatSession> {
+    return this.fetch(`/api/chat/sessions/${id}/pin`, {
+      method: "PATCH",
+      body: JSON.stringify({ pinned }),
+    });
+  }
+
   // Quick-agent bar: per-user pinned agents.
   async listChatPinnedAgents(): Promise<ChatPinnedAgent[]> {
     return this.fetch("/api/chat/pinned-agents");

--- a/packages/core/chat/mutations.ts
+++ b/packages/core/chat/mutations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { useWorkspaceId } from "../hooks";
-import { chatKeys } from "./queries";
+import { chatKeys, sortChatSessions } from "./queries";
 import { createLogger } from "../logger";
 import type { ChatSession, ChatPinnedAgent } from "../types";
 
@@ -147,6 +147,43 @@ export function useUpdateChatSession() {
     },
     onError: (err, vars, ctx) => {
       logger.error("updateChatSession.error.rollback", { sessionId: vars.sessionId, err });
+      if (ctx?.prevSessions) qc.setQueryData(chatKeys.sessions(wsId), ctx.prevSessions);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: chatKeys.sessions(wsId) });
+    },
+  });
+}
+
+/**
+ * Pins or unpins a chat. Optimistically flips `pinned` and re-sorts the cached
+ * list (pinned first, then by activity) so the row jumps to / from the top
+ * instantly; rolls back on error. The matching `chat:session_updated` WS event
+ * carries the new pin state to other tabs/devices — see use-realtime-sync.ts.
+ */
+export function useSetChatSessionPinned() {
+  const qc = useQueryClient();
+  const wsId = useWorkspaceId();
+
+  return useMutation({
+    mutationFn: (data: { sessionId: string; pinned: boolean }) => {
+      logger.info("setChatSessionPinned.start", data);
+      return api.setChatSessionPinned(data.sessionId, data.pinned);
+    },
+    onMutate: async ({ sessionId, pinned }) => {
+      await qc.cancelQueries({ queryKey: chatKeys.sessions(wsId) });
+
+      const prevSessions = qc.getQueryData<ChatSession[]>(chatKeys.sessions(wsId));
+
+      const patch = (old?: ChatSession[]) =>
+        old &&
+        sortChatSessions(old.map((s) => (s.id === sessionId ? { ...s, pinned } : s)));
+      qc.setQueryData<ChatSession[]>(chatKeys.sessions(wsId), patch);
+
+      return { prevSessions };
+    },
+    onError: (err, vars, ctx) => {
+      logger.error("setChatSessionPinned.error.rollback", { sessionId: vars.sessionId, err });
       if (ctx?.prevSessions) qc.setQueryData(chatKeys.sessions(wsId), ctx.prevSessions);
     },
     onSettled: () => {

--- a/packages/core/chat/queries.test.ts
+++ b/packages/core/chat/queries.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { TaskMessagePayload } from "../types/events";
+import type { ChatSession } from "../types/chat";
 import {
   isTaskMessageTaskId,
   mergeTaskMessagesBySeq,
+  sortChatSessions,
   taskMessagesOptions,
 } from "./queries";
 
@@ -57,5 +59,47 @@ describe("mergeTaskMessagesBySeq", () => {
     // Query observers don't re-render on replayed events.
     expect(mergeTaskMessagesBySeq(existing, [])).toBe(existing);
     expect(mergeTaskMessagesBySeq(existing, [msg(1), msg(2)])).toBe(existing);
+  });
+});
+
+describe("sortChatSessions", () => {
+  const session = (over: Partial<ChatSession>): ChatSession => ({
+    id: "s",
+    workspace_id: "w",
+    agent_id: "a",
+    creator_id: "c",
+    title: "t",
+    status: "active",
+    has_unread: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...over,
+  });
+
+  it("puts pinned sessions before unpinned ones regardless of activity", () => {
+    const pinnedOld = session({ id: "pinned-old", pinned: true, updated_at: "2026-01-01T00:00:00Z" });
+    const unpinnedNew = session({ id: "unpinned-new", pinned: false, updated_at: "2026-06-01T00:00:00Z" });
+
+    const sorted = sortChatSessions([unpinnedNew, pinnedOld]);
+    expect(sorted.map((s) => s.id)).toEqual(["pinned-old", "unpinned-new"]);
+  });
+
+  it("orders within each group by most-recent activity (last message wins over updated_at)", () => {
+    const a = session({
+      id: "a",
+      updated_at: "2026-01-01T00:00:00Z",
+      last_message: { content: "x", role: "assistant", created_at: "2026-06-02T00:00:00Z" },
+    });
+    const b = session({ id: "b", updated_at: "2026-06-01T00:00:00Z" });
+
+    const sorted = sortChatSessions([b, a]);
+    expect(sorted.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [session({ id: "1" }), session({ id: "2", pinned: true })];
+    const snapshot = input.map((s) => s.id);
+    sortChatSessions(input);
+    expect(input.map((s) => s.id)).toEqual(snapshot);
   });
 });

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -1,6 +1,7 @@
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
 import type { TaskMessagePayload } from "../types/events";
+import type { ChatSession } from "../types/chat";
 
 // NOTE on workspace scoping:
 // `wsId` is used only as part of queryKey for cache isolation per workspace.
@@ -47,6 +48,28 @@ export function chatSessionsOptions(wsId: string) {
     queryKey: chatKeys.sessions(wsId),
     queryFn: () => api.listChatSessions({ status: "all" }),
     staleTime: Infinity,
+  });
+}
+
+/** Last-activity timestamp used to rank the IM list (newest first). */
+function sessionActivityTime(s: ChatSession): number {
+  return new Date(s.last_message?.created_at ?? s.updated_at).getTime();
+}
+
+/**
+ * Orders the chat list the same way the server does: pinned chats first, then
+ * everyone else by most-recent activity. Used both to render the list and to
+ * re-sort the cache after an optimistic pin/unpin or a WS patch, so a mutated
+ * flat cache never renders out of order. Returns a new array; stable for equal
+ * keys (Array.prototype.sort is stable), so pinned rows keep their server
+ * order when pin timestamps aren't carried in the list payload.
+ */
+export function sortChatSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((a, b) => {
+    const ap = a.pinned ? 1 : 0;
+    const bp = b.pinned ? 1 : 0;
+    if (ap !== bp) return bp - ap;
+    return sessionActivityTime(b) - sessionActivityTime(a);
   });
 }
 

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -44,7 +44,7 @@ import {
   type SystemNotificationPayload,
 } from "../platform/system-notification";
 import type { Workspace } from "../types/workspace";
-import { chatKeys, mergeTaskMessagesBySeq } from "../chat/queries";
+import { chatKeys, mergeTaskMessagesBySeq, sortChatSessions } from "../chat/queries";
 import { useChatStore } from "../chat";
 import { resolvePostAuthDestination, useHasOnboarded } from "../paths";
 import type {
@@ -84,6 +84,7 @@ import type {
   ChatMessage,
   ChatPendingTask,
   ChatMessagesPage,
+  ChatSession,
   InvitationCreatedPayload,
 } from "../types";
 
@@ -1117,24 +1118,29 @@ export function useRealtimeSync(
       const payload = p as {
         chat_session_id: string;
         title?: string;
+        pinned?: boolean;
         updated_at?: string;
       };
       chatWsLogger.info("chat:session_updated (global)", payload);
       const id = getCurrentWsId();
       if (!id) return;
-      const patch = (
-        old?: { id: string; title: string; updated_at: string }[],
-      ) =>
-        old?.map((s) =>
+      // `pinned` is present only on pin/unpin events; a plain rename omits it,
+      // so leave the existing pin state untouched then. When it changes we
+      // re-sort so the row jumps to / from the top like the server order.
+      qc.setQueryData<ChatSession[]>(chatKeys.sessions(id), (old) => {
+        if (!old) return old;
+        const next = old.map((s) =>
           s.id === payload.chat_session_id
             ? {
                 ...s,
                 title: payload.title ?? s.title,
+                pinned: payload.pinned ?? s.pinned,
                 updated_at: payload.updated_at ?? s.updated_at,
               }
             : s,
         );
-      qc.setQueryData(chatKeys.sessions(id), patch);
+        return payload.pinned === undefined ? next : sortChatSessions(next);
+      });
     });
 
     // chat:session_deleted fires after a hard delete. The originating tab has

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -30,6 +30,9 @@ export interface ChatSession {
   unread_count?: number;
   /** Latest message in the session, or null when empty. List-only. */
   last_message?: ChatLastMessage | null;
+  /** True when the user has pinned this chat to the top of the list.
+   *  Optional so older clients / non-list payloads stay valid. */
+  pinned?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/packages/views/chat/components/chat-thread-list.tsx
+++ b/packages/views/chat/components/chat-thread-list.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Clock, Loader2, Square, Trash2 } from "lucide-react";
+import { Clock, Loader2, Pin, PinOff, Square, Trash2 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePresenceMap } from "@multica/core/agents";
 import { api } from "@multica/core/api";
-import { pendingChatTasksOptions, chatKeys } from "@multica/core/chat/queries";
-import { useDeleteChatSession } from "@multica/core/chat/mutations";
+import { pendingChatTasksOptions, chatKeys, sortChatSessions } from "@multica/core/chat/queries";
+import { useDeleteChatSession, useSetChatSessionPinned } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
 import type { Agent, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -63,9 +63,11 @@ export function ChatThreadList({
   const wsId = useWorkspaceId();
   const agentById = useMemo(() => new Map(agents.map((a) => [a.id, a])), [agents]);
 
-  // Legacy soft-archived rows are dead data — excluded from history.
+  // Legacy soft-archived rows are dead data — excluded from history. Sorted
+  // pinned-first (then by activity) so the list stays ordered even after an
+  // optimistic pin/unpin or a WS patch mutates the flat cache in place.
   const historySessions = useMemo(
-    () => sessions.filter((s) => s.status !== "archived"),
+    () => sortChatSessions(sessions.filter((s) => s.status !== "archived")),
     [sessions],
   );
 
@@ -73,6 +75,7 @@ export function ChatThreadList({
   const [confirmingStopId, setConfirmingStopId] = useState<string | null>(null);
   const [stoppingTaskId, setStoppingTaskId] = useState<string | null>(null);
   const deleteSession = useDeleteChatSession();
+  const setPinned = useSetChatSessionPinned();
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const queryClient = useQueryClient();
 
@@ -222,7 +225,13 @@ export function ChatThreadList({
 
         <div className="min-w-0 flex-1">
           {/* Line 1: name + time (time stays put; hover actions overlay below) */}
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            {session.pinned && (
+              <Pin
+                aria-label={t(($) => $.list.pinned)}
+                className="size-3 shrink-0 -rotate-45 fill-current text-muted-foreground"
+              />
+            )}
             <span className={cn("min-w-0 flex-1 truncate text-sm", unread > 0 ? "font-semibold text-foreground" : "font-medium")}>
               {titleText}
             </span>
@@ -279,6 +288,11 @@ export function ChatThreadList({
             changes the row height (which was making the list jump). */}
         {!isConfirmingAction && (
           <div className="absolute inset-y-0 right-1 hidden items-center gap-0.5 rounded-md bg-gradient-to-l from-accent from-40% to-transparent pl-10 pr-1 group-hover/row:flex">
+            <RowAction
+              icon={session.pinned ? <PinOff className="size-3.5" /> : <Pin className="size-3.5 -rotate-45" />}
+              label={session.pinned ? t(($) => $.list.unpin) : t(($) => $.list.pin)}
+              onClick={() => setPinned.mutate({ sessionId: session.id, pinned: !session.pinned })}
+            />
             {isRunning ? (
               <RowAction
                 icon={<Square className="size-3 fill-current" />}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -136,7 +136,10 @@
     "add": "Add",
     "add_agent": "Add a frequent agent",
     "unpin_agent": "Remove from frequent",
-    "waiting": "Waiting for reply"
+    "waiting": "Waiting for reply",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "pinned": "Pinned"
   },
   "header": {
     "view_profile": "View agent profile",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -133,7 +133,10 @@
     "add": "追加",
     "add_agent": "よく使う Agent を追加",
     "unpin_agent": "よく使うから外す",
-    "waiting": "返信待ち"
+    "waiting": "返信待ち",
+    "pin": "ピン留め",
+    "unpin": "ピン留めを解除",
+    "pinned": "ピン留め済み"
   },
   "header": {
     "view_profile": "Agent のプロフィール",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -133,7 +133,10 @@
     "add": "추가",
     "add_agent": "자주 쓰는 Agent 추가",
     "unpin_agent": "자주 쓰기에서 제거",
-    "waiting": "답장 대기 중"
+    "waiting": "답장 대기 중",
+    "pin": "고정",
+    "unpin": "고정 해제",
+    "pinned": "고정됨"
   },
   "header": {
     "view_profile": "Agent 프로필 보기",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -133,7 +133,10 @@
     "add": "添加",
     "add_agent": "添加常用 Agent",
     "unpin_agent": "移出常用",
-    "waiting": "等待回复"
+    "waiting": "等待回复",
+    "pin": "置顶",
+    "unpin": "取消置顶",
+    "pinned": "已置顶"
   },
   "header": {
     "view_profile": "查看 Agent 资料",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1238,6 +1238,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				r.Route("/{sessionId}", func(r chi.Router) {
 					r.Get("/", h.GetChatSession)
 					r.Patch("/", h.UpdateChatSession)
+					r.Patch("/pin", h.SetChatSessionPinned)
 					r.Delete("/", h.DeleteChatSession)
 					r.Post("/messages", h.SendChatMessage)
 					r.Get("/messages", h.ListChatMessages)

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -147,6 +147,7 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 				HasUnread:   s.UnreadCount > 0,
 				UnreadCount: int(s.UnreadCount),
 				LastMessage: buildChatLastMessage(s.LastMessageAt, s.LastMessageContent, s.LastMessageRole, s.LastMessageFailureReason),
+				Pinned:      s.PinnedAt.Valid,
 				CreatedAt:   timestampToString(s.CreatedAt),
 				UpdatedAt:   timestampToString(s.UpdatedAt),
 			})
@@ -175,6 +176,7 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 				HasUnread:   s.UnreadCount > 0,
 				UnreadCount: int(s.UnreadCount),
 				LastMessage: buildChatLastMessage(s.LastMessageAt, s.LastMessageContent, s.LastMessageRole, s.LastMessageFailureReason),
+				Pinned:      s.PinnedAt.Valid,
 				CreatedAt:   timestampToString(s.CreatedAt),
 				UpdatedAt:   timestampToString(s.UpdatedAt),
 			})
@@ -300,6 +302,54 @@ func (h *Handler) UpdateChatSession(w http.ResponseWriter, r *http.Request) {
 	h.publishChat(protocol.EventChatSessionUpdated, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionUpdatedPayload{
 		ChatSessionID: resolvedSessionID,
 		Title:         updated.Title,
+		UpdatedAt:     timestampToString(updated.UpdatedAt),
+	})
+
+	writeJSON(w, http.StatusOK, chatSessionToResponse(updated))
+}
+
+type SetChatSessionPinnedRequest struct {
+	Pinned bool `json:"pinned"`
+}
+
+// SetChatSessionPinned pins or unpins a chat so it sticks to the top of the
+// caller's conversation list. Pin state is per-session and, since sessions are
+// per-creator, inherently per-user. It never bumps updated_at (see the SQL) so
+// an unpinned chat does not jump the activity-sorted list.
+func (h *Handler) SetChatSessionPinned(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	sessionID := chi.URLParam(r, "sessionId")
+
+	var req SetChatSessionPinnedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	session, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
+		return
+	}
+
+	updated, err := h.Queries.SetChatSessionPinned(r.Context(), db.SetChatSessionPinnedParams{
+		ID:     session.ID,
+		Pinned: req.Pinned,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update chat session")
+		return
+	}
+
+	resolvedSessionID := uuidToString(updated.ID)
+	pinned := updated.PinnedAt.Valid
+	h.publishChat(protocol.EventChatSessionUpdated, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionUpdatedPayload{
+		ChatSessionID: resolvedSessionID,
+		Title:         updated.Title,
+		Pinned:        &pinned,
 		UpdatedAt:     timestampToString(updated.UpdatedAt),
 	})
 
@@ -1032,8 +1082,11 @@ type ChatSessionResponse struct {
 	HasUnread   bool             `json:"has_unread"`
 	UnreadCount int              `json:"unread_count"`
 	LastMessage *ChatLastMessage `json:"last_message"`
-	CreatedAt   string           `json:"created_at"`
-	UpdatedAt   string           `json:"updated_at"`
+	// Pinned marks a chat the user has stuck to the top of the list. Populated
+	// by list endpoints and by the pin/unpin + single-session responses.
+	Pinned    bool   `json:"pinned"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // ChatLastMessage is a preview of a session's most recent message, used to
@@ -1089,6 +1142,7 @@ func chatSessionToResponse(s db.ChatSession) ChatSessionResponse {
 		CreatorID:   uuidToString(s.CreatorID),
 		Title:       s.Title,
 		Status:      s.Status,
+		Pinned:      s.PinnedAt.Valid,
 		CreatedAt:   timestampToString(s.CreatedAt),
 		UpdatedAt:   timestampToString(s.UpdatedAt),
 	}

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -233,6 +234,76 @@ func TestUpdateChatSession_RenamesTitle(t *testing.T) {
 	}
 	if dbTitle != "Renamed Session" {
 		t.Fatalf("db title: want %q, got %q", "Renamed Session", dbTitle)
+	}
+}
+
+// TestSetChatSessionPinned_TogglesPin confirms PATCH /pin stamps pinned_at on
+// pin and clears it on unpin, returns the new state, and does not bump
+// updated_at (pinning is a list-ordering preference, not activity).
+func TestSetChatSessionPinned_TogglesPin(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ChatPinAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+
+	var updatedBefore time.Time
+	if err := testPool.QueryRow(
+		context.Background(),
+		`SELECT updated_at FROM chat_session WHERE id = $1`,
+		sessionID,
+	).Scan(&updatedBefore); err != nil {
+		t.Fatalf("query updated_at: %v", err)
+	}
+
+	pin := func(pinned bool) ChatSessionResponse {
+		req := newRequest("PATCH", "/api/chat/sessions/"+sessionID+"/pin", map[string]any{
+			"pinned": pinned,
+		})
+		req = withURLParam(req, "sessionId", sessionID)
+		req = withChatTestWorkspaceCtx(t, req)
+		w := httptest.NewRecorder()
+		testHandler.SetChatSessionPinned(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("SetChatSessionPinned(%v): expected 200, got %d: %s", pinned, w.Code, w.Body.String())
+		}
+		var resp ChatSessionResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode pin: %v", err)
+		}
+		return resp
+	}
+
+	// Pin.
+	if resp := pin(true); !resp.Pinned {
+		t.Fatalf("pin=true response Pinned: want true, got false")
+	}
+	var pinnedAt *time.Time
+	var updatedAfter time.Time
+	if err := testPool.QueryRow(
+		context.Background(),
+		`SELECT pinned_at, updated_at FROM chat_session WHERE id = $1`,
+		sessionID,
+	).Scan(&pinnedAt, &updatedAfter); err != nil {
+		t.Fatalf("query pinned_at: %v", err)
+	}
+	if pinnedAt == nil {
+		t.Fatalf("pinned_at: want non-null after pin, got null")
+	}
+	if !updatedAfter.Equal(updatedBefore) {
+		t.Fatalf("updated_at must not change on pin: before %v, after %v", updatedBefore, updatedAfter)
+	}
+
+	// Unpin.
+	if resp := pin(false); resp.Pinned {
+		t.Fatalf("pin=false response Pinned: want false, got true")
+	}
+	if err := testPool.QueryRow(
+		context.Background(),
+		`SELECT pinned_at FROM chat_session WHERE id = $1`,
+		sessionID,
+	).Scan(&pinnedAt); err != nil {
+		t.Fatalf("query pinned_at after unpin: %v", err)
+	}
+	if pinnedAt != nil {
+		t.Fatalf("pinned_at: want null after unpin, got %v", *pinnedAt)
 	}
 }
 

--- a/server/migrations/148_chat_session_pinned.down.sql
+++ b/server/migrations/148_chat_session_pinned.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_chat_session_pinned;
+ALTER TABLE chat_session DROP COLUMN IF EXISTS pinned_at;

--- a/server/migrations/148_chat_session_pinned.up.sql
+++ b/server/migrations/148_chat_session_pinned.up.sql
@@ -1,0 +1,12 @@
+-- Per-conversation pin for the Chat list: a user can pin a chat so it stays
+-- at the top of their conversation list, above the activity-sorted rest.
+-- `pinned_at` doubles as the sort key within the pinned group (most-recently
+-- pinned first) and as the boolean flag (NULL = not pinned). Sessions are
+-- already per-creator, so no extra user dimension is needed.
+ALTER TABLE chat_session ADD COLUMN pinned_at TIMESTAMPTZ;
+
+-- Partial index over pinned rows only — the pinned group is small, and the
+-- list query orders by pinned_at within a single (workspace, creator) scan.
+CREATE INDEX idx_chat_session_pinned
+    ON chat_session (creator_id, workspace_id, pinned_at DESC)
+    WHERE pinned_at IS NOT NULL;

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -52,7 +52,7 @@ func (q *Queries) CreateChatMessage(ctx context.Context, arg CreateChatMessagePa
 const createChatSession = `-- name: CreateChatSession :one
 INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, runtime_id, is_agent_intro)
 VALUES ($1, $2, $3, $4, (SELECT runtime_id FROM agent WHERE id = $2), $5)
-RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro
+RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro, pinned_at
 `
 
 type CreateChatSessionParams struct {
@@ -86,6 +86,7 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 		&i.RuntimeID,
 		&i.LastReadAt,
 		&i.IsAgentIntro,
+		&i.PinnedAt,
 	)
 	return i, err
 }
@@ -237,7 +238,7 @@ func (q *Queries) GetChatMessage(ctx context.Context, id pgtype.UUID) (ChatMessa
 }
 
 const getChatSession = `-- name: GetChatSession :one
-SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro FROM chat_session
+SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro, pinned_at FROM chat_session
 WHERE id = $1
 `
 
@@ -258,12 +259,13 @@ func (q *Queries) GetChatSession(ctx context.Context, id pgtype.UUID) (ChatSessi
 		&i.RuntimeID,
 		&i.LastReadAt,
 		&i.IsAgentIntro,
+		&i.PinnedAt,
 	)
 	return i, err
 }
 
 const getChatSessionInWorkspace = `-- name: GetChatSessionInWorkspace :one
-SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro FROM chat_session
+SELECT id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro, pinned_at FROM chat_session
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -289,6 +291,7 @@ func (q *Queries) GetChatSessionInWorkspace(ctx context.Context, arg GetChatSess
 		&i.RuntimeID,
 		&i.LastReadAt,
 		&i.IsAgentIntro,
+		&i.PinnedAt,
 	)
 	return i, err
 }
@@ -434,7 +437,7 @@ func (q *Queries) LinkChatMessageToTask(ctx context.Context, arg LinkChatMessage
 }
 
 const listAllChatSessionsByCreator = `-- name: ListAllChatSessionsByCreator :many
-SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.runtime_id, cs.last_read_at, cs.is_agent_intro,
+SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.runtime_id, cs.last_read_at, cs.is_agent_intro, cs.pinned_at,
        (SELECT count(*) FROM chat_message m
           WHERE m.chat_session_id = cs.id
             AND m.role = 'assistant'
@@ -452,7 +455,7 @@ LEFT JOIN LATERAL (
    LIMIT 1
 ) lm ON true
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2
-ORDER BY COALESCE(lm.created_at, cs.updated_at) DESC
+ORDER BY (cs.pinned_at IS NOT NULL) DESC, cs.pinned_at DESC, COALESCE(lm.created_at, cs.updated_at) DESC
 `
 
 type ListAllChatSessionsByCreatorParams struct {
@@ -474,6 +477,7 @@ type ListAllChatSessionsByCreatorRow struct {
 	RuntimeID                pgtype.UUID        `json:"runtime_id"`
 	LastReadAt               pgtype.Timestamptz `json:"last_read_at"`
 	IsAgentIntro             bool               `json:"is_agent_intro"`
+	PinnedAt                 pgtype.Timestamptz `json:"pinned_at"`
 	UnreadCount              int32              `json:"unread_count"`
 	LastMessageContent       string             `json:"last_message_content"`
 	LastMessageRole          string             `json:"last_message_role"`
@@ -504,6 +508,7 @@ func (q *Queries) ListAllChatSessionsByCreator(ctx context.Context, arg ListAllC
 			&i.RuntimeID,
 			&i.LastReadAt,
 			&i.IsAgentIntro,
+			&i.PinnedAt,
 			&i.UnreadCount,
 			&i.LastMessageContent,
 			&i.LastMessageRole,
@@ -608,7 +613,7 @@ func (q *Queries) ListChatMessagesPage(ctx context.Context, arg ListChatMessages
 }
 
 const listChatSessionsByCreator = `-- name: ListChatSessionsByCreator :many
-SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.runtime_id, cs.last_read_at, cs.is_agent_intro,
+SELECT cs.id, cs.workspace_id, cs.agent_id, cs.creator_id, cs.title, cs.session_id, cs.work_dir, cs.status, cs.created_at, cs.updated_at, cs.runtime_id, cs.last_read_at, cs.is_agent_intro, cs.pinned_at,
        (SELECT count(*) FROM chat_message m
           WHERE m.chat_session_id = cs.id
             AND m.role = 'assistant'
@@ -626,7 +631,7 @@ LEFT JOIN LATERAL (
    LIMIT 1
 ) lm ON true
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2 AND cs.status = 'active'
-ORDER BY COALESCE(lm.created_at, cs.updated_at) DESC
+ORDER BY (cs.pinned_at IS NOT NULL) DESC, cs.pinned_at DESC, COALESCE(lm.created_at, cs.updated_at) DESC
 `
 
 type ListChatSessionsByCreatorParams struct {
@@ -648,6 +653,7 @@ type ListChatSessionsByCreatorRow struct {
 	RuntimeID                pgtype.UUID        `json:"runtime_id"`
 	LastReadAt               pgtype.Timestamptz `json:"last_read_at"`
 	IsAgentIntro             bool               `json:"is_agent_intro"`
+	PinnedAt                 pgtype.Timestamptz `json:"pinned_at"`
 	UnreadCount              int32              `json:"unread_count"`
 	LastMessageContent       string             `json:"last_message_content"`
 	LastMessageRole          string             `json:"last_message_role"`
@@ -681,6 +687,7 @@ func (q *Queries) ListChatSessionsByCreator(ctx context.Context, arg ListChatSes
 			&i.RuntimeID,
 			&i.LastReadAt,
 			&i.IsAgentIntro,
+			&i.PinnedAt,
 			&i.UnreadCount,
 			&i.LastMessageContent,
 			&i.LastMessageRole,
@@ -787,6 +794,45 @@ func (q *Queries) MarkChatSessionRead(ctx context.Context, id pgtype.UUID) error
 	return err
 }
 
+const setChatSessionPinned = `-- name: SetChatSessionPinned :one
+UPDATE chat_session
+SET pinned_at = CASE WHEN $2::bool THEN COALESCE(pinned_at, now()) ELSE NULL END
+WHERE id = $1
+RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro, pinned_at
+`
+
+type SetChatSessionPinnedParams struct {
+	ID     pgtype.UUID `json:"id"`
+	Pinned bool        `json:"pinned"`
+}
+
+// Pin/unpin a chat. Deliberately does NOT touch updated_at: pinning is a
+// list-ordering preference, not activity, so it must not bump the session's
+// last-activity sort key (which would make an unpinned chat jump the list).
+// pinned = true stamps pinned_at only when it was NULL, so re-pinning keeps
+// the original pin order; pinned = false clears it.
+func (q *Queries) SetChatSessionPinned(ctx context.Context, arg SetChatSessionPinnedParams) (ChatSession, error) {
+	row := q.db.QueryRow(ctx, setChatSessionPinned, arg.ID, arg.Pinned)
+	var i ChatSession
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.AgentID,
+		&i.CreatorID,
+		&i.Title,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.RuntimeID,
+		&i.LastReadAt,
+		&i.IsAgentIntro,
+		&i.PinnedAt,
+	)
+	return i, err
+}
+
 const touchChatSession = `-- name: TouchChatSession :exec
 UPDATE chat_session SET updated_at = now()
 WHERE id = $1
@@ -831,7 +877,7 @@ func (q *Queries) UpdateChatSessionSession(ctx context.Context, arg UpdateChatSe
 const updateChatSessionTitle = `-- name: UpdateChatSessionTitle :one
 UPDATE chat_session SET title = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro
+RETURNING id, workspace_id, agent_id, creator_id, title, session_id, work_dir, status, created_at, updated_at, runtime_id, last_read_at, is_agent_intro, pinned_at
 `
 
 type UpdateChatSessionTitleParams struct {
@@ -856,6 +902,7 @@ func (q *Queries) UpdateChatSessionTitle(ctx context.Context, arg UpdateChatSess
 		&i.RuntimeID,
 		&i.LastReadAt,
 		&i.IsAgentIntro,
+		&i.PinnedAt,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -327,6 +327,7 @@ type ChatSession struct {
 	RuntimeID    pgtype.UUID        `json:"runtime_id"`
 	LastReadAt   pgtype.Timestamptz `json:"last_read_at"`
 	IsAgentIntro bool               `json:"is_agent_intro"`
+	PinnedAt     pgtype.Timestamptz `json:"pinned_at"`
 }
 
 type Comment struct {

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -33,7 +33,7 @@ LEFT JOIN LATERAL (
    LIMIT 1
 ) lm ON true
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2 AND cs.status = 'active'
-ORDER BY COALESCE(lm.created_at, cs.updated_at) DESC;
+ORDER BY (cs.pinned_at IS NOT NULL) DESC, cs.pinned_at DESC, COALESCE(lm.created_at, cs.updated_at) DESC;
 
 -- name: ListAllChatSessionsByCreator :many
 SELECT cs.*,
@@ -54,10 +54,21 @@ LEFT JOIN LATERAL (
    LIMIT 1
 ) lm ON true
 WHERE cs.workspace_id = $1 AND cs.creator_id = $2
-ORDER BY COALESCE(lm.created_at, cs.updated_at) DESC;
+ORDER BY (cs.pinned_at IS NOT NULL) DESC, cs.pinned_at DESC, COALESCE(lm.created_at, cs.updated_at) DESC;
 
 -- name: UpdateChatSessionTitle :one
 UPDATE chat_session SET title = $2, updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: SetChatSessionPinned :one
+-- Pin/unpin a chat. Deliberately does NOT touch updated_at: pinning is a
+-- list-ordering preference, not activity, so it must not bump the session's
+-- last-activity sort key (which would make an unpinned chat jump the list).
+-- pinned = true stamps pinned_at only when it was NULL, so re-pinning keeps
+-- the original pin order; pinned = false clears it.
+UPDATE chat_session
+SET pinned_at = CASE WHEN @pinned::bool THEN COALESCE(pinned_at, now()) ELSE NULL END
 WHERE id = $1
 RETURNING *;
 

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -122,7 +122,10 @@ type ChatSessionDeletedPayload struct {
 type ChatSessionUpdatedPayload struct {
 	ChatSessionID string `json:"chat_session_id"`
 	Title         string `json:"title"`
-	UpdatedAt     string `json:"updated_at"`
+	// Pinned is set only by the pin/unpin path; nil on a plain rename so a
+	// receiver leaves the existing pin state untouched.
+	Pinned    *bool  `json:"pinned,omitempty"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // DaemonHeartbeatRequestPayload is sent from daemon to server over WebSocket


### PR DESCRIPTION
## Pin a chat to the top of the Chat list (MUL-4240)

Stacked on **#5076 (Chat V2)** — base branch is `agent/lambda/e5a4c3a5`, so this diff shows only the pin feature. Merge after #5076.

Adds a per-conversation **pin** so a user can keep important chats at the top of the IM-style thread list, above the activity-sorted rest.

### Backend
- **Migration 148** (`chat_session.pinned_at`, nullable + partial index). The timestamp doubles as the pinned-group sort key (most-recently-pinned first) and the boolean flag (NULL = not pinned). Sessions are already per-creator, so no extra user dimension is needed.
- List queries order **pinned-first, then by most-recent activity**: `ORDER BY (pinned_at IS NOT NULL) DESC, pinned_at DESC, COALESCE(lm.created_at, cs.updated_at) DESC`.
- `SetChatSessionPinned` query + `PATCH /api/chat/sessions/{id}/pin` handler. Pinning **never bumps `updated_at`** (it's a list-ordering preference, not activity), so an unpinned chat won't jump the activity list. Re-pinning keeps the original pin order via `COALESCE(pinned_at, now())`.
- `ChatSessionResponse.pinned`; `chat:session_updated` carries the new pin state (`pinned` pointer, omitted on a plain rename).

### Frontend (shared core + views → web + desktop)
- `ChatSession.pinned`; `setChatSessionPinned` API + `useSetChatSessionPinned` mutation with **optimistic re-sort** (row jumps to/from top instantly, rolls back on error).
- Shared `sortChatSessions` comparator (pinned-first, then activity) used by the list render, the optimistic patch, and the WS handler — so a mutated flat cache never renders out of order.
- Thread list: a **pin glyph** on pinned rows + a **pin/unpin hover action** next to delete.
- Realtime `chat:session_updated` re-sorts on pin change; `pin`/`unpin`/`pinned` strings in en/ja/ko/zh-Hans.

### Verification
- `go build ./...`, `go vet ./internal/handler/ ./pkg/protocol/` — clean
- All 148 migrations apply cleanly to a fresh DB; `pinned_at` column + partial index confirmed
- `TestSetChatSessionPinned_TogglesPin` (pin stamps / unpin clears / `updated_at` unchanged) + full `Chat` handler suite — pass
- `pnpm typecheck` — 6/6 packages green
- `sortChatSessions` unit tests + core (21) / views (39) chat tests — pass

Closes MUL-4240.
