### PR TITLE
docs(agent): align state guidance with frontend-state-sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ Go backend + monorepo frontend (pnpm workspaces + Turborepo) with shared package
 ### State Management (critical)
 
 - **React Query** owns all server state (issues, members, agents, inbox, workspace list)
-- **Zustand** owns all client state (current workspace selection, view filters, drafts, modals)
+- **Zustand** owns client/view state (view filters, drafts, modals, desktop tab state); current workspace identity is route-driven and only mirrored for platform plumbing
 - All Zustand stores live in `packages/core/` - never in `packages/views/` or app directories
-- WS events invalidate React Query - never write directly to stores
+- WS events update React Query for server data; store writes are only for clearing client-owned pointers with a single responder/self-event guard
 
 ### Package Boundaries (hard rules)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Shared packages export raw `.ts` / `.tsx` and are compiled by consuming apps. De
 Keep server state and client state separate.
 
 - TanStack Query owns server state: issues, users, workspaces, inbox, agents, members, and anything fetched from the API.
-- Zustand owns client state: selected workspace, filters, drafts, modals, tab layout, and navigation history.
+- Zustand owns client/view state: filters, drafts, modals, tab layout, and navigation history. Current workspace identity is route-driven; platform stores/singletons may mirror slug/id only for headers, persistence namespaces, and reconnects.
 - Shared Zustand stores live in `packages/core/`, never in `packages/views/` or app directories.
 - React Context is for platform plumbing only, such as `WorkspaceIdProvider` and `NavigationProvider`.
 - Only auth/workspace stores may call `api.*` directly. Other server interaction belongs in queries/mutations.
@@ -39,7 +39,7 @@ Keep server state and client state separate.
 - Optimistic updates only when ALL hold: outcome locally predictable, user stays on the same screen (no navigation), failure is rare, rollback is trivial. Canonical: status/assignee/toggle field patches — patch determinate caches, roll back on failure, invalidate uncertain projections on settle.
 - Flows that navigate or confirm (create, delete, leave) must await the server before navigating or cleaning up; never optimistically remove an entity from cache.
 - Chat/message send uses the pending-message pattern: render immediately with a visible pending state and retry on failure, not silent optimism.
-- WebSocket events invalidate or patch Query cache; they never write directly to Zustand stores.
+- WebSocket events invalidate or patch Query cache for server data. They must never mirror server payload data into Zustand; clearing client-owned pointers (active session, selection, current workspace) is allowed only with a single responder and a self-initiated guard when this client can cause the event.
 - Persist durable preferences/drafts/layout. Do not persist server data or ephemeral UI state.
 - Zustand selectors must return stable references. Do not return freshly allocated objects/arrays from selectors without shallow comparison.
 - Hooks that need workspace context should accept `wsId`; do not call `useWorkspaceId()` internally unless the hook is guaranteed to run under the provider.
@@ -155,9 +155,9 @@ Desktop routing has three categories:
 More desktop constraints:
 
 - New pre-workspace desktop flows register a `WindowOverlay` type in `stores/window-overlay-store.ts`; do not add them to `routes.tsx`.
-- `setCurrentWorkspace(slug, uuid)` from `@multica/core/platform` is the active workspace source of truth.
+- `setCurrentWorkspace(slug, uuid)` from `@multica/core/platform` mirrors the active route for headers, storage namespaces, and reconnects; workspace route layouts own setting it.
 - Code that leaves workspace context must call `setCurrentWorkspace(null, null)` explicitly.
-- Leave/delete workspace flow order: read cached destination, clear current workspace, navigate, then run the mutation.
+- Workspace delete must await the server before navigation/cleanup. Workspace leave currently clears/navigates before mutation only to avoid the `member:removed` realtime race; treat that as known debt, not a reusable pattern.
 - Cross-workspace navigation must go through the navigation adapter so it can call `switchWorkspace(slug, targetPath)`.
 - Full-window desktop views outside the dashboard shell must mount `<DragStrip />` from `@multica/views/platform` as the first flex child. Interactive controls in the top 48px need `WebkitAppRegion: "no-drag"`.
 

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -394,8 +394,11 @@ Before opening a PR for a new screen / mutation / realtime hook:
 2. API methods → `fetchValidated` / `fetchValidatedWith` (or raw
    `this.fetch` only for writes with no consumed response).
 3. Query key → factory in `data/queries/<feature>.ts`, 3-segment shape.
-4. Mutations → optimistic three-step (snapshot → patch → rollback) +
-   settle invalidate, all keys via factory.
+4. Mutations → optimistic only when the post-state is locally predictable,
+   the user stays on the same screen, failure is rare, and rollback is
+   trivial. When that gate passes, use snapshot → patch → rollback +
+   settle invalidate, all keys via factory. Create/delete/navigate/confirm
+   flows await the server instead.
 5. Realtime → `useWSSubscriptions(setup, deps)`, typed `ws.on<E>()`,
    per-event patching (no global invalidate) when payload carries the
    full object.


### PR DESCRIPTION
## Summary

- Tighten root agent guidance so current workspace identity is route-driven, with platform stores/singletons only mirroring it for headers, persistence namespaces, and reconnects.
- Replace the absolute “WS never writes stores” guidance with the `frontend-state-sweep` distinction: server payload data belongs in Query cache, while client-owned pointers may be cleared with single-responder/self-event guards.
- Clarify desktop workspace delete/leave guidance and mobile mutation guidance so optimistic updates are gated rather than treated as the default.

## Why

`frontend-state-sweep` treats URL ownership, realtime responders, and optimistic mutation gates as correctness contracts. The existing docs had a few overly broad shortcuts that could teach future agents to introduce a second source of truth, mirror server data into stores, or copy a navigate-before-mutation exception into new destructive flows.

Fixes MUL-4247.

## Validation

- `git diff --check`
- Docs-only change; no runtime tests run.
