### PR TITLE
MUL-4247: align frontend state guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,10 @@ Go backend + monorepo frontend (pnpm workspaces + Turborepo) with shared package
 ### State Management (critical)
 
 - **React Query** owns all server state (issues, members, agents, inbox, workspace list)
-- **Zustand** owns all client state (current workspace selection, view filters, drafts, modals)
+- **Route/platform context** owns current workspace identity; any store/singleton copy is only a sync mirror for headers, persistence, or legacy consumers
+- **Zustand** owns client view state (filters, drafts, modals, tab layout, UI pointers)
 - All Zustand stores live in `packages/core/` - never in `packages/views/` or app directories
-- WS events invalidate React Query - never write directly to stores
+- WS events and mutation successes use the same cache-apply path. Do not mirror server-data payloads into stores; pointer cleanup is allowed only as the designated responder with self-initiated guards
 
 ### Package Boundaries (hard rules)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,15 +31,16 @@ Shared packages export raw `.ts` / `.tsx` and are compiled by consuming apps. De
 Keep server state and client state separate.
 
 - TanStack Query owns server state: issues, users, workspaces, inbox, agents, members, and anything fetched from the API.
-- Zustand owns client state: selected workspace, filters, drafts, modals, tab layout, and navigation history.
+- Route/platform context owns the active workspace identity. URL slug + platform resolver determine `wsId`; `setCurrentWorkspace` / workspace storage are synchronization mirrors for request headers, persistence, and legacy consumers, not the source of selection truth.
+- Zustand owns client view state: filters, drafts, modals, tab layout, navigation history, and other user-controlled UI pointers.
 - Shared Zustand stores live in `packages/core/`, never in `packages/views/` or app directories.
 - React Context is for platform plumbing only, such as `WorkspaceIdProvider` and `NavigationProvider`.
 - Only auth/workspace stores may call `api.*` directly. Other server interaction belongs in queries/mutations.
 - Workspace-scoped query keys must include `wsId`.
 - Optimistic updates only when ALL hold: outcome locally predictable, user stays on the same screen (no navigation), failure is rare, rollback is trivial. Canonical: status/assignee/toggle field patches — patch determinate caches, roll back on failure, invalidate uncertain projections on settle.
 - Flows that navigate or confirm (create, delete, leave) must await the server before navigating or cleaning up; never optimistically remove an entity from cache.
-- Chat/message send uses the pending-message pattern: render immediately with a visible pending state and retry on failure, not silent optimism.
-- WebSocket events invalidate or patch Query cache; they never write directly to Zustand stores.
+- Chat/message send follows the product's turn model: turn-based agent/AI flows await send and clear drafts only on success; free-form concurrent chat may render a visible pending item with retry. Never silently pretend delivery succeeded.
+- WebSocket events and mutation success handlers must converge on the same cache-apply path. Realtime handlers must not mirror server-data payloads into Zustand; clearing client-owned pointers is allowed only as the designated responder and must distinguish self-initiated events.
 - Persist durable preferences/drafts/layout. Do not persist server data or ephemeral UI state.
 - Zustand selectors must return stable references. Do not return freshly allocated objects/arrays from selectors without shallow comparison.
 - Hooks that need workspace context should accept `wsId`; do not call `useWorkspaceId()` internally unless the hook is guaranteed to run under the provider.
@@ -155,9 +156,9 @@ Desktop routing has three categories:
 More desktop constraints:
 
 - New pre-workspace desktop flows register a `WindowOverlay` type in `stores/window-overlay-store.ts`; do not add them to `routes.tsx`.
-- `setCurrentWorkspace(slug, uuid)` from `@multica/core/platform` is the active workspace source of truth.
-- Code that leaves workspace context must call `setCurrentWorkspace(null, null)` explicitly.
-- Leave/delete workspace flow order: read cached destination, clear current workspace, navigate, then run the mutation.
+- The desktop `/:workspaceSlug/...` route is the active workspace source of truth. `WorkspaceRouteLayout` resolves slug to `wsId` and calls `setCurrentWorkspace(slug, uuid)` only to sync the platform mirror.
+- Code that leaves workspace context must clear that mirror with `setCurrentWorkspace(null, null)` when its route no longer supplies a workspace.
+- Workspace flows that navigate or confirm must await the server, keep loading/error UI in place, then navigate and clean up. Current leave-workspace code is a narrow exception: it clears/navigates before the mutation only to avoid the existing `member:removed` self-event race until leave gets the same self-initiated guard as delete. Do not copy that order to new flows; delete already uses await-then-navigate.
 - Cross-workspace navigation must go through the navigation adapter so it can call `switchWorkspace(slug, targetPath)`.
 - Full-window desktop views outside the dashboard shell must mount `<DragStrip />` from `@multica/views/platform` as the first flex child. Interactive controls in the top 48px need `WebkitAppRegion: "no-drag"`.
 

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -216,6 +216,12 @@ When the same logic needs to exist on both sides, copy the design — not the im
 
 ### Event-always-wins (optimistic conflict policy)
 
+Mutation success handlers and realtime handlers for the same server change
+must share the same updater shape: patch the same cache keys, invalidate the
+same uncertain projections, and never mirror server-data payloads into
+Zustand. Clearing mobile-owned pointers is allowed only when the hook is the
+single designated responder for that transition.
+
 Mutations like `useUpdateIssue` apply an optimistic patch to the detail cache, then the server processes the request and broadcasts `issue:updated`. If a separate WS event (from another client / another user / an agent) arrives between the optimistic patch and the mutation response, the WS handler overwrites the optimistic state with the server's authoritative state. Brief UI flicker is acceptable; correctness wins.
 
 **Do not** add timestamp-comparison logic to "protect" the optimistic state — the server is the truth and the user benefits from seeing real changes immediately. If a specific event proves problematic in practice, add the gate at that point, not by default.
@@ -373,17 +379,19 @@ Adding a new event type? Extend `packages/core/types/events.ts`:
 Forgetting step 3 means callers get `unknown` (loud — they have to
 narrow), not `any` (silent unsafe access). That's the safety net.
 
-### Synchronous setQueryData before `await cancelQueries`
+### Narrow exception: synchronous mark-read patch before navigation snapshots
 
-Optimistic mutations that flip state read by a UI element that's about
-to be in a navigation snapshot (the classic case: marking an inbox row
-read, then `router.push` to the issue) MUST call `setQueryData` in
-`onMutate` **before** `await qc.cancelQueries(...)`. The await yields
-one microtask; iOS captures the source-view snapshot during that gap and
-freezes the row in its unread style inside the slide-in transition.
+`useMarkInboxRead` is a documented exception to the usual "no optimistic
+patch when the URL changes" rule. It flips one deterministic `read=true`
+bit before `router.push` only so iOS does not freeze the source inbox row
+in its unread style during the native slide transition. The mutation still
+owns the patch, snapshots for rollback, and invalidates on settle.
 
-Lives inside the mutation, not the caller. See `useMarkInboxRead.onMutate`
-in `apps/mobile/data/mutations/inbox.ts` for the canonical example.
+Do not generalize this to create/delete/submit/navigation flows; those
+await the server with loading/error UI and only then navigate or close.
+If a similar snapshot exception is proposed, document why the optimistic
+state is deterministic, failure is rare, rollback is trivial, and the sync
+patch must happen before `await qc.cancelQueries(...)`.
 
 ### Checklist for a new feature
 
@@ -394,8 +402,12 @@ Before opening a PR for a new screen / mutation / realtime hook:
 2. API methods → `fetchValidated` / `fetchValidatedWith` (or raw
    `this.fetch` only for writes with no consumed response).
 3. Query key → factory in `data/queries/<feature>.ts`, 3-segment shape.
-4. Mutations → optimistic three-step (snapshot → patch → rollback) +
-   settle invalidate, all keys via factory.
+4. Mutations → choose by the optimistic gate first. Same-screen,
+   deterministic, rare-failure, trivial-rollback changes may use the
+   variables pattern for one display site or snapshot → patch → rollback
+   + settle invalidate for multiple display sites, all keys via factory.
+   Navigating, destructive, confirmed, or server-computed mutations await
+   the server with loading/error UI and then navigate/close/invalidate.
 5. Realtime → `useWSSubscriptions(setup, deps)`, typed `ws.on<E>()`,
    per-event patching (no global invalidate) when payload carries the
    full object.


### PR DESCRIPTION
Summary:
- Align root workspace ownership docs with route/platform context as source of truth.
- Rewrite realtime/store guidance around shared cache apply paths and pointer-cleanup exceptions.
- Gate mobile optimistic mutation guidance and mark the inbox snapshot patch as a narrow exception.

Verification:
- git diff --check
- rg old conflict phrases in CLAUDE.md, AGENTS.md, apps/mobile/CLAUDE.md

Closes MUL-4247