### PR TITLE
fix(chat): friendlier failure message when agent runtime errors (MUL-4249)

### DIFF
--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -31,7 +31,6 @@ import type {
   TaskMessagePayload,
 } from "@multica/core/types";
 import type { ChatTimelineItem } from "@multica/core/chat";
-import { failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { buildTimeline } from "../../common/task-transcript";
 import { TaskStatusPill } from "./task-status-pill";
 import { formatElapsedMs } from "../lib/format";
@@ -444,12 +443,23 @@ function FailureBubble({
 }) {
   const { t } = useT("chat");
   const [open, setOpen] = useState(false);
-  // Map the back-end enum to copy via the shared label table; an unknown
-  // reason (e.g. a future enum value the front-end doesn't ship yet)
-  // falls back to a generic translated label.
+  // Chat gets its own friendly, reassuring copy per failure reason — plain
+  // language + a "try again" nudge — instead of the terse developer labels
+  // (`failureReasonLabel`) used on the agent-detail / execution-log surfaces.
+  // An unknown reason (a future enum value this build doesn't ship yet) falls
+  // back to a generic friendly line. The raw error stays tucked under the
+  // collapsible below for anyone who wants the technical detail.
+  const chatFailureCopy: Record<TaskFailureReason, string> = {
+    agent_error: t(($) => $.message_list.failure.agent_error),
+    timeout: t(($) => $.message_list.failure.timeout),
+    codex_semantic_inactivity: t(($) => $.message_list.failure.codex_semantic_inactivity),
+    runtime_offline: t(($) => $.message_list.failure.runtime_offline),
+    runtime_recovery: t(($) => $.message_list.failure.runtime_recovery),
+    manual: t(($) => $.message_list.failure.manual),
+  };
   const label =
-    failureReasonLabel[reason as TaskFailureReason] ??
-    t(($) => $.message_list.task_failed_fallback);
+    chatFailureCopy[reason as TaskFailureReason] ??
+    t(($) => $.message_list.failure.fallback);
 
   return (
     <div className="w-full space-y-1.5">

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -19,7 +19,15 @@
     "show_details": "Show details",
     "replied_in": "Replied in {{elapsed}}",
     "failed_after": "Failed after {{elapsed}}",
-    "task_failed_fallback": "Task failed",
+    "failure": {
+      "agent_error": "The agent ran into an error and couldn't finish replying. Please try again.",
+      "timeout": "The agent took too long and stopped before finishing. Try again, or break your request into smaller steps.",
+      "codex_semantic_inactivity": "The agent went idle and stopped before finishing. Please try again.",
+      "runtime_offline": "The agent is offline right now, so it couldn't reply. Please try again once it's back online.",
+      "runtime_recovery": "The agent restarted before it could finish. Please try again.",
+      "manual": "This reply was cancelled.",
+      "fallback": "Something went wrong and the agent couldn't finish replying. Please try again."
+    },
     "tools_one": "{{count}} tool",
     "tools_other": "{{count}} tools",
     "tool_result_named": "{{tool}} result: ",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -18,7 +18,15 @@
     "show_details": "詳細を表示",
     "replied_in": "{{elapsed}}で返信",
     "failed_after": "{{elapsed}}後に失敗",
-    "task_failed_fallback": "タスクが失敗しました",
+    "failure": {
+      "agent_error": "エージェントでエラーが発生し、返信を完了できませんでした。もう一度お試しください。",
+      "timeout": "処理に時間がかかりすぎたため、完了前に停止しました。もう一度お試しいただくか、リクエストを分けてみてください。",
+      "codex_semantic_inactivity": "エージェントが応答しなくなり、完了前に停止しました。もう一度お試しください。",
+      "runtime_offline": "エージェントは現在オフラインのため、返信できませんでした。オンラインに戻ってから再度お試しください。",
+      "runtime_recovery": "完了する前にエージェントが再起動しました。もう一度お試しください。",
+      "manual": "この返信はキャンセルされました。",
+      "fallback": "問題が発生し、エージェントは返信を完了できませんでした。もう一度お試しください。"
+    },
     "tools_other": "ツール {{count}}個",
     "tool_result_named": "{{tool}} の結果: ",
     "tool_result_unnamed": "結果: ",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -18,7 +18,15 @@
     "show_details": "세부 정보 보기",
     "replied_in": "{{elapsed}} 만에 답변",
     "failed_after": "{{elapsed}} 후 실패",
-    "task_failed_fallback": "작업 실패",
+    "failure": {
+      "agent_error": "에이전트에 오류가 발생하여 답변을 완료하지 못했습니다. 다시 시도해 주세요.",
+      "timeout": "시간이 너무 오래 걸려 완료 전에 중단되었습니다. 다시 시도하거나 요청을 더 작게 나눠 보세요.",
+      "codex_semantic_inactivity": "에이전트가 응답하지 않아 완료 전에 중단되었습니다. 다시 시도해 주세요.",
+      "runtime_offline": "에이전트가 현재 오프라인 상태여서 답변할 수 없습니다. 다시 온라인이 되면 시도해 주세요.",
+      "runtime_recovery": "완료 전에 에이전트가 다시 시작되었습니다. 다시 시도해 주세요.",
+      "manual": "이 답변이 취소되었습니다.",
+      "fallback": "문제가 발생하여 에이전트가 답변을 완료하지 못했습니다. 다시 시도해 주세요."
+    },
     "tools_other": "도구 {{count}}개",
     "tool_result_named": "{{tool}} 결과: ",
     "tool_result_unnamed": "결과: ",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -18,7 +18,15 @@
     "show_details": "查看详情",
     "replied_in": "{{elapsed}} 内回复",
     "failed_after": "{{elapsed}} 后失败",
-    "task_failed_fallback": "task 失败",
+    "failure": {
+      "agent_error": "智能体运行时出错，没能完成回复。请重试。",
+      "timeout": "智能体处理超时，未能完成。可以重试，或把需求拆得更小一些。",
+      "codex_semantic_inactivity": "智能体长时间无响应，已停止。请重试。",
+      "runtime_offline": "智能体当前离线，暂时无法回复。等它恢复在线后再试。",
+      "runtime_recovery": "智能体在完成前重启了。请重试。",
+      "manual": "这次回复已取消。",
+      "fallback": "出了点问题，智能体未能完成回复。请重试。"
+    },
     "tools_other": "{{count}} 个工具",
     "tool_result_named": "{{tool}} 结果：",
     "tool_result_unnamed": "结果：",


### PR DESCRIPTION
## What

In Chat, when the backing agent runtime fails, the failure bubble led with a raw, technical error (e.g. `cursor-agent exited with error: exit status 1`) under a terse "Task failed" label. This replaces the lead line with friendly, plain-language copy per failure reason, each with a clear next step. The raw error stays available under the collapsed **Show details** for debugging.

Closes MUL-4249.

## Changes

- `packages/views/chat/components/chat-message-list.tsx`: `FailureBubble` now resolves chat-specific friendly copy per `TaskFailureReason` (with a generic fallback for unknown enums) instead of reusing the terse `failureReasonLabel` table (that table still powers the agent-detail / execution-log surfaces, which stay technical on purpose).
- `packages/views/locales/{en,zh-Hans,ja,ko}/chat.json`: added `message_list.failure.*` copy; removed the now-unused `task_failed_fallback` key.

## Copy (en)

| Reason | Message |
| --- | --- |
| agent_error | The agent ran into an error and couldn't finish replying. Please try again. |
| timeout | The agent took too long and stopped before finishing. Try again, or break your request into smaller steps. |
| codex_semantic_inactivity | The agent went idle and stopped before finishing. Please try again. |
| runtime_offline | The agent is offline right now, so it couldn't reply. Please try again once it's back online. |
| runtime_recovery | The agent restarted before it could finish. Please try again. |
| manual | This reply was cancelled. |
| fallback | Something went wrong and the agent couldn't finish replying. Please try again. |

zh-Hans / ja / ko translated to match, following the repo Chinese voice conventions (agent → 智能体, gentle-but-clear error tone).

## Verification

- `pnpm --filter @multica/views typecheck` — clean
- `pnpm --filter @multica/views exec vitest run chat/components/chat-message-list.test.tsx` — 2 passed
