### PR TITLE
fix(issue): wake parent on child review handoff

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2643,12 +2643,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 	}
 
-	// Platform-driven parent notification: when this issue transitions into
-	// `done` and has a parent, post a top-level system comment on the parent
-	// (MUL-2538 — replaces the agent-prompt rule that caused self-mention
-	// loops in PR #2918). The helper guards on transition + parent state and
-	// fails best-effort.
+	// Platform-driven parent handoffs: child `in_review` wakes the parent for
+	// verification; child `done` wakes the parent when a stage barrier closes.
+	// Both helpers guard on transition + parent state and fail best-effort.
 	if statusChanged {
+		h.notifyParentOfChildReview(r.Context(), prevIssue, issue)
 		h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
 	}
 
@@ -3142,9 +3141,10 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 		}
 
-		// Platform-driven parent notification, mirrored from UpdateIssue
-		// (MUL-2538). Best-effort; failure does not abort the batch.
+		// Platform-driven parent handoffs, mirrored from UpdateIssue. Best-effort;
+		// failure does not abort the batch.
 		if statusChanged {
+			h.notifyParentOfChildReview(r.Context(), prevIssue, issue)
 			h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
 		}
 

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -193,6 +193,77 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
 }
 
+// notifyParentOfChildReview wakes the parent assignee when a child moves into
+// `in_review`. This is the pre-terminal review handoff for orchestrated
+// pipelines: the child has delivered, but the parent/orchestrator must verify
+// before marking it done and unblocking downstream stages. Unlike child-done,
+// this is deliberately NOT stage-barrier gated — every child entering review is
+// a unit of work for the parent assignee.
+//
+// Guards mirror notifyParentOfChildDone where applicable: only transition INTO
+// in_review, skip parked/closed parents, skip human parent assignees, and keep
+// failures best-effort so the status update itself is never rolled back.
+func (h *Handler) notifyParentOfChildReview(ctx context.Context, prev, issue db.Issue) {
+	if !issue.ParentIssueID.Valid {
+		return
+	}
+	if prev.Status == "in_review" || issue.Status != "in_review" {
+		return
+	}
+
+	parent, err := h.Queries.GetIssue(ctx, issue.ParentIssueID)
+	if err != nil {
+		slog.Warn("child review: failed to load parent",
+			"error", err,
+			"child_id", uuidToString(issue.ID),
+			"parent_id", uuidToString(issue.ParentIssueID))
+		return
+	}
+	if parent.Status == "done" || parent.Status == "cancelled" || parent.Status == "backlog" {
+		return
+	}
+	if parent.AssigneeType.Valid && parent.AssigneeType.String == "member" {
+		return
+	}
+
+	prefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
+	identifier := prefix + "-" + strconv.Itoa(int(issue.Number))
+	childID := uuidToString(issue.ID)
+	title := sanitizeChildTitleForSystemComment(issue.Title)
+	mentionPrefix := h.buildParentAssigneeMention(ctx, parent)
+	content := fmt.Sprintf(
+		"%sSub-issue [%s](mention://issue/%s) — \"%s\" — is ready for parent review. Review its output against the brief; if it passes, mark the sub-issue `done` and continue the staged workflow. If it misses criteria, send it back with the specific fixes required.",
+		mentionPrefix, identifier, childID, title,
+	)
+
+	comment, err := h.Queries.CreateComment(ctx, db.CreateCommentParams{
+		IssueID:     parent.ID,
+		WorkspaceID: parent.WorkspaceID,
+		AuthorType:  "system",
+		AuthorID:    pgtype.UUID{Valid: true},
+		Content:     content,
+		Type:        "system",
+		ParentID:    pgtype.UUID{Valid: false},
+	})
+	if err != nil {
+		slog.Warn("child review: create system comment failed",
+			"error", err,
+			"child_id", childID,
+			"parent_id", uuidToString(parent.ID))
+		return
+	}
+
+	h.publish(protocol.EventCommentCreated, uuidToString(parent.WorkspaceID), "system", "", map[string]any{
+		"comment":             commentToResponse(comment, nil, nil),
+		"issue_title":         parent.Title,
+		"issue_assignee_type": textToPtr(parent.AssigneeType),
+		"issue_assignee_id":   uuidToPtr(parent.AssigneeID),
+		"issue_status":        parent.Status,
+	})
+
+	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
+}
+
 // isTerminalChildStatus reports whether a child issue status counts as
 // "finished" for stage-barrier purposes. Cancelled counts as terminal: a
 // cancelled sibling will never complete, so it must not hold a stage open.

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -554,3 +554,84 @@ func TestChildDoneWakesLeaderWhenChildIsSameSquad(t *testing.T) {
 		t.Errorf("expected 1 pending leader task for same-squad child (MUL-3969), got %d", got)
 	}
 }
+
+// TestChildReviewMentionsParentAssignee_Agent verifies the review handoff path:
+// when a child moves into in_review, the parent agent is woken immediately to
+// verify the child output before the child is marked done and before downstream
+// stages advance.
+func TestChildReviewMentionsParentAssignee_Agent(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	var agentID string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID); err != nil {
+		t.Fatalf("locate test agent: %v", err)
+	}
+	setIssueAssigneeDirect(t, fx.parent.ID, "agent", agentID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "ready for parent review") {
+		t.Errorf("expected review handoff wording, got: %s", content)
+	}
+	if !strings.Contains(content, "mention://issue/"+fx.child.ID) {
+		t.Errorf("expected issue mention in review handoff, got: %s", content)
+	}
+	if !strings.Contains(content, "mention://agent/"+agentID) {
+		t.Errorf("expected parent-agent mention in review handoff, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, agentID); got != 1 {
+		t.Errorf("expected 1 pending task for parent agent review handoff, got %d", got)
+	}
+}
+
+// TestChildReviewNotificationIsIdempotent ensures re-saving an already
+// in_review child does not create another parent handoff comment.
+func TestChildReviewNotificationIsIdempotent(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("after first in_review: expected 1 comment, got %d", got)
+	}
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("after second in_review: expected still 1 comment (idempotent), got %d", got)
+	}
+}
+
+// TestChildReviewSkippedWhenParentMember mirrors child-done: human parent
+// assignees should not get platform-generated review handoff noise.
+func TestChildReviewSkippedWhenParentMember(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	var userID string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT user_id FROM member WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&userID); err != nil {
+		t.Fatalf("locate workspace member: %v", err)
+	}
+	setIssueAssigneeDirect(t, fx.parent.ID, "member", userID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM inbox_item WHERE issue_id = $1`, fx.parent.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+		t.Errorf("parent with member assignee should not receive review handoff, got %d comments", got)
+	}
+	if got := countInboxItems(t, userID, fx.parent.ID); got != 0 {
+		t.Errorf("parent with member assignee should not receive an inbox row, got %d", got)
+	}
+}

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -154,9 +154,12 @@ on it. These are the contracts, not advice:
 - **`backlog`** parks an agent-assigned issue: the assignee is set but no task
   fires. Moving `backlog → todo` (or any non-done/non-cancelled status) enqueues
   the assigned agent then.
-- **`in_review`** is an accepted issue status. Some workflows use it while a PR
-  is open and awaiting review; moving to it is an explicit mutation.
-- **`done`** on a child issue posts a system comment on its parent. If a PR
+- **`in_review`** is an accepted issue status. On a child issue, moving into
+  `in_review` posts a parent review-handoff system comment and wakes the parent
+  assignee so the orchestrator can verify the child output before marking it
+  done.
+- **`done`** on a child issue posts a system comment on its parent when the
+  relevant stage barrier closes. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
 - **`cancelled`** stops outstanding work; treat it as a user-driven decision.
@@ -185,12 +188,13 @@ Creating every serial step as `todo` enqueues the whole chain at once.
 ### Stages: order sub-issues into barrier groups
 
 `--stage <N>` (N ≥ 1) groups sub-issues under the same parent into ordered
-stages. The parent assignee is woken **once, when a whole stage finishes** —
-i.e. every sub-issue in the lowest unfinished stage has reached a terminal
-status (`done`/`cancelled`). A completion that does not close a stage is silent
-(no comment, no wake). A sibling set with **no** stages is one implicit stage,
-so the parent is woken once when the *last* sub-issue finishes — not on every
-child.
+stages. The parent assignee is woken for **review** whenever a child enters
+`in_review`, because that is an orchestrator handoff. Separately, the parent is
+woken **once, when a whole stage finishes** — i.e. every sub-issue in the lowest
+unfinished stage has reached a terminal status (`done`/`cancelled`). A completion
+that does not close a stage is silent (no stage-complete comment, no stage wake).
+A sibling set with **no** stages is one implicit stage, so the parent gets the
+stage-complete wake once when the *last* sub-issue finishes — not on every child.
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -119,12 +119,14 @@ and is hidden from the PR list.
 | `shouldEnqueueAgentTask` returns false for `backlog` (parking lot) | `server/internal/handler/issue.go:2644-2648` | new citation |
 | Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
 | Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
-| Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
+| Child → `in_review` notifies + wakes the parent for review | `server/internal/handler/issue_child_done.go` (`notifyParentOfChildReview`) | new citation |
+| Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go` (`notifyParentOfChildDone`; barrier gate in `stageBarrierClosed`) | func def `:51` |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee
-set but no trigger. Promoting `backlog → todo` later fires it then (update path,
-line 2537).
+set but no trigger. Promoting `backlog → todo` later fires it then. A child
+transition into `in_review` is a parent review handoff and wakes the parent
+assignee before the child is marked `done`.
 
 ## Sub-issue stages (barrier wake)
 
@@ -163,5 +165,5 @@ grep -n 'func issuePullRequestRowToResponse\|type GitHubPullRequestResponse stru
 grep -n 'extractIdentifiers(\|extractClosingIdentifiers(\|derivePRState(' internal/handler/github.go
 grep -n 'qualifyingIdents\|reference_only\|ReferenceOnly' internal/handler/github.go pkg/db/queries/github.sql
 grep -n 'prevIssue.Status == "backlog"\|func (h \*Handler) shouldEnqueueAgentTask' internal/handler/issue.go
-grep -n 'func notifyParentOfChildDone'       internal/handler/issue_child_done.go
+grep -n 'func notifyParentOfChildReview\|func notifyParentOfChildDone' internal/handler/issue_child_done.go
 ```


### PR DESCRIPTION
## Summary
- Wake the parent assignee when a child issue transitions into `in_review`, so orchestrators are automatically brought back for review before a child is marked done.
- Keep the existing stage-complete wake for `done` transitions, but document the distinction between review handoffs and stage-barrier completion.
- Add regression coverage for parent-agent review handoff, idempotent repeated `in_review`, and human parent-assignee skip behavior.
- Update the built-in Multica working-on-issues skill/source map so future agents know the permanent contract.

## Test Plan
- `go test ./internal/handler -run 'TestChildReview|TestChildDone' -count=1`
- `go test ./internal/handler ./internal/service -count=1`
- `git diff --check`

## Notes
- `make test` was attempted after `make worktree-env`, but full local verification is blocked because Docker/Colima is not running: `Cannot connect to the Docker daemon at unix:///Users/paglabhoot/.colima/default/docker.sock`.
