### PR TITLE
feat(chat): round send button, file upload into + menu (MUL-4250)

### DIFF
--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { ArrowUp, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -15,6 +16,12 @@ interface SubmitButtonProps {
   loading?: boolean;
   running?: boolean;
   onStop?: () => void;
+  /**
+   * Button silhouette. `"rounded"` (default) keeps the rounded-square used by
+   * issue comment composers; `"circle"` makes it a fully-round pill — the
+   * Chat V2 look. Opt-in so shared callers keep their existing shape.
+   */
+  shape?: "rounded" | "circle";
   /**
    * Tooltip shown over the send button when idle. Pass a string or a node
    * (e.g. `Send · ⌘↵`). Omit to render no tooltip.
@@ -34,10 +41,12 @@ function SubmitButton({
   onStop,
   tooltip,
   stopTooltip,
+  shape = "rounded",
 }: SubmitButtonProps) {
+  const shapeClass = shape === "circle" ? "rounded-full" : undefined;
   if (running) {
     const stopButton = (
-      <Button size="icon-sm" onClick={onStop}>
+      <Button size="icon-sm" className={cn(shapeClass)} onClick={onStop}>
         <Square className="fill-current" />
       </Button>
     );
@@ -51,7 +60,12 @@ function SubmitButton({
   }
 
   const submitButton = (
-    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
+    <Button
+      size="icon-sm"
+      className={cn(shapeClass)}
+      disabled={disabled || loading}
+      onClick={onClick}
+    >
       {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
     </Button>
   );

--- a/packages/views/chat/components/chat-add-menu.tsx
+++ b/packages/views/chat/components/chat-add-menu.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useRef } from "react";
+import { Plus, Image as ImageIcon } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@multica/ui/components/ui/dropdown-menu";
+import { useT } from "../../i18n";
+
+interface ChatAddMenuProps {
+  /** Called with each selected file — the caller routes it through the
+   *  editor's upload extension, same path as paste / drag-drop. */
+  onSelectFile: (file: File) => void;
+  disabled?: boolean;
+}
+
+/**
+ * The "+" affordance at the bottom-left of the chat composer. Replaces the
+ * standalone paperclip button: file upload now lives here as a submenu entry,
+ * leaving room for future add-actions (agents, skills, tools) under one entry
+ * point without crowding the input bar.
+ */
+export function ChatAddMenu({ onSelectFile, disabled }: ChatAddMenuProps) {
+  const { t } = useT("chat");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
+    e.target.value = "";
+    for (const file of files) onSelectFile(file);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={disabled}
+              aria-label={t(($) => $.input.add_tooltip)}
+              title={t(($) => $.input.add_tooltip)}
+              className="rounded-full text-muted-foreground"
+            >
+              <Plus />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="start" side="top" sideOffset={6}>
+          <DropdownMenuItem onClick={() => inputRef.current?.click()}>
+            <ImageIcon />
+            {t(($) => $.input.upload_file)}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleChange}
+      />
+    </>
+  );
+}

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -248,7 +248,8 @@ describe("ChatInput attachment wiring", () => {
 
     // Wait for the submit button to become enabled (onUpdate has fired and
     // React has re-rendered). SubmitButton has no aria-label, so we pick
-    // the last action button on the bar (FileUploadButton, SubmitButton).
+    // the last action button on the bar (ChatAddMenu "+" is on the left,
+    // SubmitButton is last).
     let sendButton: HTMLElement;
     await waitFor(() => {
       const buttons = screen.getAllByRole("button");
@@ -363,10 +364,10 @@ describe("ChatInput attachment wiring", () => {
 
   it("does not render the file upload button when onUploadFile is omitted", () => {
     renderInput({ onUploadFile: undefined });
-    // FileUploadButton renders an icon button labelled by its tooltip — when
-    // upload wiring is absent the chat input falls back to "submit + extras"
-    // only. Probe by counting buttons: with no upload, only the submit
-    // button is in the action row.
+    // The ChatAddMenu "+" (which hosts file upload) only mounts when upload
+    // wiring is present — without it the chat input falls back to "submit +
+    // extras" only. Probe by counting buttons: with no upload, only the
+    // submit button is in the action row.
     const buttons = screen.getAllByRole("button");
     // The agent picker may render zero buttons
     // in this test (no leftAdornment passed). So a single button = submit.

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -9,8 +9,8 @@ import {
   useFileDropZone,
   FileDropOverlay,
 } from "../../editor";
-import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
+import { ChatAddMenu } from "./chat-add-menu";
 import { useChatStore, newSessionDraftKey } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
 import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
@@ -389,20 +389,19 @@ export function ChatInput({
             // continues a bullet list, leaving users stuck after one item.
           />
         </div>
-        {leftAdornment && (
-          <div className="absolute bottom-1.5 left-2 flex items-center">
+        {(uploadEnabled || leftAdornment) && (
+          <div className="absolute bottom-1.5 left-1.5 flex items-center gap-1">
+            {uploadEnabled && (
+              <ChatAddMenu
+                onSelectFile={(file) => editorRef.current?.uploadFile(file)}
+              />
+            )}
             {leftAdornment}
           </div>
         )}
         <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
-          {uploadEnabled && (
-            <FileUploadButton
-              size="sm"
-              multiple
-              onSelect={(file) => editorRef.current?.uploadFile(file)}
-            />
-          )}
           <SubmitButton
+            shape="circle"
             onClick={handleSend}
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             loading={isSubmitting}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -17,7 +17,9 @@
     "send_tooltip": "Send",
     "stop_tooltip": "Stop",
     "send_failed_toast": "Failed to send message",
-    "attachment_bind_failed_toast": "Message sent, but files were not attached. Please try again in a moment."
+    "attachment_bind_failed_toast": "Message sent, but files were not attached. Please try again in a moment.",
+    "add_tooltip": "Add",
+    "upload_file": "Image"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -16,7 +16,9 @@
     "send_tooltip": "送信",
     "stop_tooltip": "停止",
     "send_failed_toast": "メッセージを送信できませんでした",
-    "attachment_bind_failed_toast": "メッセージは送信されましたが、ファイルを添付できませんでした。しばらくしてからもう一度お試しください。"
+    "attachment_bind_failed_toast": "メッセージは送信されましたが、ファイルを添付できませんでした。しばらくしてからもう一度お試しください。",
+    "add_tooltip": "追加",
+    "upload_file": "画像"
   },
   "message_list": {
     "show_details": "詳細を表示",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -16,7 +16,9 @@
     "send_tooltip": "보내기",
     "stop_tooltip": "중지",
     "send_failed_toast": "메시지를 보내지 못했습니다",
-    "attachment_bind_failed_toast": "메시지는 보냈지만 파일이 첨부되지 않았습니다. 잠시 후 다시 시도해 주세요."
+    "attachment_bind_failed_toast": "메시지는 보냈지만 파일이 첨부되지 않았습니다. 잠시 후 다시 시도해 주세요.",
+    "add_tooltip": "추가",
+    "upload_file": "이미지"
   },
   "message_list": {
     "show_details": "세부 정보 보기",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -16,7 +16,9 @@
     "send_tooltip": "发送",
     "stop_tooltip": "停止",
     "send_failed_toast": "发送消息失败",
-    "attachment_bind_failed_toast": "消息已发送，但文件未能附加。请稍后重试。"
+    "attachment_bind_failed_toast": "消息已发送，但文件未能附加。请稍后重试。",
+    "add_tooltip": "添加",
+    "upload_file": "图片"
   },
   "message_list": {
     "show_details": "查看详情",


### PR DESCRIPTION
## What

Redesigns the Chat V2 composer per the attached mocks:

- **Round send button** — the send/stop button is now a full circle (`rounded-full`) instead of a rounded square.
- **File upload → `+` menu** — the standalone paperclip is gone; a new `+` "add" menu at the bottom-left hosts file upload as an **Image** item (submenu entry).

## Scope (is this global?)

- `ChatInput` (`packages/views/chat/components/chat-input.tsx`) is **shared by web + desktop** chat (Chat tab + floating window), so the redesign lands on both.
- `SubmitButton` and `FileUploadButton` are shared UI primitives used elsewhere (issue comments, modals). To avoid regressing those surfaces, the round shape is an **opt-in** `shape="circle"` prop used only by chat, and the paperclip primitive is untouched — I only swapped its *usage* in the chat composer for the new `ChatAddMenu`.

## Out of scope

The mocks also show a mic button and richer `+` items (Plan/Debug/Multitask/Ask/Skills/MCP). Those need agent-mode / skills / MCP wiring that doesn't exist yet, so this PR ships only the two requested changes.

## Test

- `packages/views` chat-input suite: 15/15 pass.
- typecheck/lint clean on changed files (pre-existing `chat-window.tsx` EmptyState error is unrelated).

Base: #5076
