### PR TITLE
fix(chat): rename + menu upload item to "Image or files" (MUL-4250)

### DIFF
--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -19,7 +19,7 @@
     "send_failed_toast": "Failed to send message",
     "attachment_bind_failed_toast": "Message sent, but files were not attached. Please try again in a moment.",
     "add_tooltip": "Add",
-    "upload_file": "Image"
+    "upload_file": "Image or files"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -18,7 +18,7 @@
     "send_failed_toast": "メッセージを送信できませんでした",
     "attachment_bind_failed_toast": "メッセージは送信されましたが、ファイルを添付できませんでした。しばらくしてからもう一度お試しください。",
     "add_tooltip": "追加",
-    "upload_file": "画像"
+    "upload_file": "画像・ファイル"
   },
   "message_list": {
     "show_details": "詳細を表示",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -18,7 +18,7 @@
     "send_failed_toast": "메시지를 보내지 못했습니다",
     "attachment_bind_failed_toast": "메시지는 보냈지만 파일이 첨부되지 않았습니다. 잠시 후 다시 시도해 주세요.",
     "add_tooltip": "추가",
-    "upload_file": "이미지"
+    "upload_file": "이미지 또는 파일"
   },
   "message_list": {
     "show_details": "세부 정보 보기",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -18,7 +18,7 @@
     "send_failed_toast": "发送消息失败",
     "attachment_bind_failed_toast": "消息已发送，但文件未能附加。请稍后重试。",
     "add_tooltip": "添加",
-    "upload_file": "图片"
+    "upload_file": "图片或文件"
   },
   "message_list": {
     "show_details": "查看详情",


### PR DESCRIPTION
## What

Follow-up to #5088: the `+` add-menu upload item was labelled **Image**, but it accepts any file type. Renamed it so the copy matches the behavior.

- `Image` → **`Image or files`** (en)
- zh-Hans `图片或文件`, ja `画像・ファイル`, ko `이미지 또는 파일`

Text-only i18n change (`chat.input.upload_file`), no logic touched.

Base: `agent/lambda/e5a4c3a5` (previous PR already merged)
