### PR TITLE
fix(inbox): match chat list selected-item style (MUL-4253)

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -44,7 +44,7 @@ export function InboxListItem({
     <button
       type="button"
       onClick={onClick}
-      className={`group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+      className={`group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors ${
         isSelected ? "bg-accent" : "hover:bg-accent/50"
       }`}
     >

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -273,7 +273,7 @@ export function InboxPage() {
       <p className="text-sm">{t(($) => $.list.empty)}</p>
     </div>
   ) : (
-    <div>
+    <div className="p-1">
       {items.map((item) => (
         <InboxListItem
           key={item.id}


### PR DESCRIPTION
Makes the inbox selected-item highlight match the chat list: wrap the list in `p-1` and give each row `rounded-md px-3` so the selected `bg-accent` reads as an inset rounded card instead of a full-bleed sharp-cornered strip. Content stays 16px-inset (p-1 + px-3 == old px-4).

Base: #5076 (Chat V2)

Fixes MUL-4253.