### PR TITLE
refactor(cli): make `issue reorder` require exactly one target flag via a cobra flag group [MUL-4222]

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -419,11 +419,7 @@ func init() {
 	issueStatusCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// issue reorder
-	issueReorderCmd.Flags().String("before", "", "Place the issue directly above this issue (same column)")
-	issueReorderCmd.Flags().String("after", "", "Place the issue directly below this issue (same column)")
-	issueReorderCmd.Flags().Bool("top", false, "Move the issue to the top of its status column")
-	issueReorderCmd.Flags().Bool("bottom", false, "Move the issue to the bottom of its status column")
-	issueReorderCmd.Flags().String("output", "json", "Output format: table or json")
+	registerIssueReorderFlags(issueReorderCmd)
 
 	// issue assign
 	issueAssignCmd.Flags().String("to", "", "Assignee name (member, agent, or squad; fuzzy match)")
@@ -1332,6 +1328,24 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 // Reorder command
 // ---------------------------------------------------------------------------
 
+// registerIssueReorderFlags wires the reorder command's flags and declares its
+// target selector as a cobra flag group: mutually exclusive so at most one of
+// --before/--after/--top/--bottom is accepted, and one-required so at least one
+// must be given. Declaring the rule (instead of counting the flags by hand in
+// runIssueReorder) lets cobra reject zero-target and multi-target invocations
+// before RunE with a canonical message, and makes shell completion group-aware
+// — it hides the sibling target flags once one of them is set. It is shared with
+// the command's tests so they exercise the exact flag-group wiring that ships.
+func registerIssueReorderFlags(cmd *cobra.Command) {
+	cmd.Flags().String("before", "", "Place the issue directly above this issue (same column)")
+	cmd.Flags().String("after", "", "Place the issue directly below this issue (same column)")
+	cmd.Flags().Bool("top", false, "Move the issue to the top of its status column")
+	cmd.Flags().Bool("bottom", false, "Move the issue to the bottom of its status column")
+	cmd.Flags().String("output", "json", "Output format: table or json")
+	cmd.MarkFlagsMutuallyExclusive("before", "after", "top", "bottom")
+	cmd.MarkFlagsOneRequired("before", "after", "top", "bottom")
+}
+
 // runIssueReorder repositions an issue inside its current status column. The
 // new position is computed client-side by computeReorderPosition, which mirrors
 // the board/list drag-and-drop math (computePosition in
@@ -1345,14 +1359,26 @@ func runIssueReorder(cmd *cobra.Command, args []string) error {
 	top, _ := cmd.Flags().GetBool("top")
 	bottom, _ := cmd.Flags().GetBool("bottom")
 
-	modes := 0
-	for _, set := range []bool{before != "", after != "", top, bottom} {
-		if set {
-			modes++
-		}
+	// "Exactly one of --before/--after/--top/--bottom" is enforced declaratively
+	// by the command's mutually-exclusive, one-required flag group (see
+	// registerIssueReorderFlags), so cobra rejects zero-target and multi-target
+	// invocations before RunE runs. Cobra keys off flag *presence* (Changed),
+	// not value, so guard the cases it cannot see: a --before/--after passed
+	// empty (e.g. an unset shell variable), or a --top/--bottom explicitly set
+	// to false (e.g. `--top=false` from a generated command). Each counts as
+	// "set" for the group yet selects no real target, and would otherwise fall
+	// through to a confusing "not found in column" error.
+	if cmd.Flags().Changed("before") && before == "" {
+		return fmt.Errorf("--before requires an issue ID or key")
 	}
-	if modes != 1 {
-		return fmt.Errorf("exactly one of --before, --after, --top, or --bottom is required")
+	if cmd.Flags().Changed("after") && after == "" {
+		return fmt.Errorf("--after requires an issue ID or key")
+	}
+	if cmd.Flags().Changed("top") && !top {
+		return fmt.Errorf("--top cannot be set to false; pass it on its own to move the issue to the top of its column")
+	}
+	if cmd.Flags().Changed("bottom") && !bottom {
+		return fmt.Errorf("--bottom cannot be set to false; pass it on its own to move the issue to the bottom of its column")
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2518,11 +2518,7 @@ func newIssueListTestCmd() *cobra.Command {
 
 func newIssueReorderTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "reorder"}
-	cmd.Flags().String("before", "", "")
-	cmd.Flags().String("after", "", "")
-	cmd.Flags().Bool("top", false, "")
-	cmd.Flags().Bool("bottom", false, "")
-	cmd.Flags().String("output", "json", "")
+	registerIssueReorderFlags(cmd)
 	return cmd
 }
 
@@ -2677,21 +2673,89 @@ func TestComputeReorderPosition(t *testing.T) {
 	}
 }
 
-func TestRunIssueReorderRejectsModeCount(t *testing.T) {
-	t.Run("zero modes", func(t *testing.T) {
+// TestIssueReorderTargetFlagGroup drives the command through Execute so the real
+// cobra flag group (registerIssueReorderFlags) validates the "exactly one
+// target" rule — zero targets, two bool targets, and --before+--after are all
+// rejected before RunE. A stub RunE that errors proves validation happens first.
+// The assertions match on cobra's canonical flag-group error strings, so they
+// are coupled to cobra's wording (pinned at v1.10.2 in server/go.mod).
+func TestIssueReorderTargetFlagGroup(t *testing.T) {
+	newCmd := func() *cobra.Command {
 		cmd := newIssueReorderTestCmd()
-		if err := runIssueReorder(cmd, []string{"MUL-1"}); err == nil {
-			t.Fatal("expected error when no mode flag is set")
+		cmd.Args = exactArgs(1)
+		cmd.RunE = func(*cobra.Command, []string) error {
+			return fmt.Errorf("RunE ran despite an invalid target flag group")
+		}
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		return cmd
+	}
+
+	t.Run("no target flag", func(t *testing.T) {
+		cmd := newCmd()
+		cmd.SetArgs([]string{"MUL-1"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected an error when no target flag is set")
+		}
+		if !strings.Contains(err.Error(), "at least one of the flags in the group") {
+			t.Fatalf("want cobra one-required error, got: %v", err)
 		}
 	})
-	t.Run("two modes", func(t *testing.T) {
-		cmd := newIssueReorderTestCmd()
-		_ = cmd.Flags().Set("top", "true")
-		_ = cmd.Flags().Set("bottom", "true")
-		if err := runIssueReorder(cmd, []string{"MUL-1"}); err == nil {
-			t.Fatal("expected error when two mode flags are set")
+
+	t.Run("two bool targets", func(t *testing.T) {
+		cmd := newCmd()
+		cmd.SetArgs([]string{"MUL-1", "--top", "--bottom"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected an error when --top and --bottom are combined")
+		}
+		if !strings.Contains(err.Error(), "none of the others can be") {
+			t.Fatalf("want cobra mutually-exclusive error, got: %v", err)
 		}
 	})
+
+	t.Run("before and after together", func(t *testing.T) {
+		cmd := newCmd()
+		cmd.SetArgs([]string{"MUL-1", "--before", "MUL-2", "--after", "MUL-3"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected an error when --before and --after are combined")
+		}
+		if !strings.Contains(err.Error(), "none of the others can be") {
+			t.Fatalf("want cobra mutually-exclusive error, got: %v", err)
+		}
+	})
+}
+
+// TestRunIssueReorderRejectsNoOpTargetValues covers the cases the flag group
+// cannot: cobra keys off flag presence (Changed), not value, so an
+// explicitly-passed but empty --before/--after or an explicit --top=false /
+// --bottom=false satisfies the group yet selects no real target. runIssueReorder
+// rejects each up front rather than falling through to a confusing downstream
+// error.
+func TestRunIssueReorderRejectsNoOpTargetValues(t *testing.T) {
+	cases := []struct{ flag, value string }{
+		{"before", ""},
+		{"after", ""},
+		{"top", "false"},
+		{"bottom", "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := newIssueReorderTestCmd()
+			if err := cmd.Flags().Set(tc.flag, tc.value); err != nil {
+				t.Fatalf("set --%s=%q: %v", tc.flag, tc.value, err)
+			}
+			err := runIssueReorder(cmd, []string{"MUL-1"})
+			if err == nil {
+				t.Fatalf("expected an error when --%s is passed %q", tc.flag, tc.value)
+			}
+			if !strings.Contains(err.Error(), "--"+tc.flag) {
+				t.Fatalf("want error naming --%s, got: %v", tc.flag, err)
+			}
+		})
+	}
 }
 
 // reorderTestServer serves a fixed three-issue "todo" column (positions


### PR DESCRIPTION
## What does this PR do?

Follow-up to #4110 (CLI issue ordering). When that PR merged, @Bohan-J left two small, non-blocking polish items. The first — rejecting `issue list --direction` on the default `position` sort — was already handled in #5072. This PR does the second one.

`issue reorder` accepts exactly one target: `--top`, `--bottom`, `--before <id>`, or `--after <id>`. Until now that "exactly one" rule was enforced by hand inside `runIssueReorder` (a small loop counting how many were set). That works, but the constraint is invisible to `--help` and to shell completion, and it re-implements something Cobra already models.

This declares the rule with Cobra's flag groups instead:

- `MarkFlagsMutuallyExclusive("before", "after", "top", "bottom")` — at most one target.
- `MarkFlagsOneRequired("before", "after", "top", "bottom")` — at least one target.

Cobra now rejects zero-target and multi-target invocations during flag validation (before `RunE`), with its canonical error messages, and — the concrete win — shell completion becomes group-aware: once one target flag is present it stops suggesting its siblings. The hand-rolled count is removed so there is a single source of truth.

One thing Cobra's group check cannot cover: it keys off flag *presence* (`Changed`), not value. So a target that is technically "set" but selects nothing — an empty `--before ""` / `--after ""` (e.g. an unset shell variable in a script), or an explicit `--top=false` / `--bottom=false` — would satisfy the group yet fall through to a confusing "not found in column" error. `runIssueReorder` keeps a small explicit guard that rejects each of those no-op target values up front, preserving the clean rejection the old hand-rolled count gave — the same footgun-avoidance spirit as #5072.

The command's contract is unchanged (still exactly one target, still same flags), so the docs in `CLI_AND_DAEMON.md` (which already say "Pick exactly one of …") need no change. No backend change.

## Related Issue

Follow-up to #4110 (CLI issue ordering); addresses the second review item from @Bohan-J's merge comment. Tracks Multica MUL-4222. No separate GitHub issue — the original feature issue #4109 was closed by #4110.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/cmd/multica/cmd_issue.go`:
  - New `registerIssueReorderFlags(cmd)` helper: registers the four target flags plus `--output` and declares the mutually-exclusive + one-required flag group. `init()` now calls it, and it is shared with the tests so they exercise the exact wiring that ships.
  - `runIssueReorder`: removed the runtime `modes != 1` count (now handled by Cobra); added an explicit guard rejecting a no-op target value — empty `--before` / `--after`, or `--top=false` / `--bottom=false`.
- `server/cmd/multica/cmd_issue_test.go`:
  - `newIssueReorderTestCmd` now uses the shared `registerIssueReorderFlags`.
  - Replaced `TestRunIssueReorderRejectsModeCount` with `TestIssueReorderTargetFlagGroup`, which drives the command through `Execute` so Cobra's real flag-group validation runs, asserting that zero targets, two bool targets, and `--before` + `--after` are each rejected with Cobra's canonical messages before `RunE`.
  - Added `TestRunIssueReorderRejectsNoOpTargetValues`, covering all four no-op target values (empty `--before`/`--after`, `--top=false`, `--bottom=false`).

## How to Test

1. `cd server && go test ./cmd/multica/...`
2. Against a running workspace:
   - `multica issue reorder <id>` → clear "at least one of the flags in the group …" error.
   - `multica issue reorder <id> --top --bottom` → "… none of the others can be" error.
   - `multica issue reorder <id> --before <other>` still works; `--before ""` errors with `--before requires an issue ID or key`, and `--top=false` errors instead of silently doing nothing.
   - In a shell with completion installed, after typing `--top ` the sibling target flags are no longer suggested.

## Checklist

- [x] I have included a thinking path that traces from project context to this change (see "What does this PR do?")
- [ ] I have run tests locally and they pass <!-- Go toolchain unavailable in my environment; relying on CI. See note below. -->
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (CLI only, n/a)
- [x] I have updated relevant documentation to reflect my changes (no doc change needed — contract unchanged; `CLI_AND_DAEMON.md` already documents "pick exactly one")
- [ ] If I added a new runtime / coding tool / UI tab, I synced landing copy + docs (n/a)
- [ ] If this PR touches Chinese product copy (n/a)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

> Note: I don't have a Go toolchain in my environment, so I could not run `go test` locally — I've leaned on a careful review and CI to compile and run the suite. Happy to iterate if CI surfaces anything.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Started from @Bohan-J's merge comment on #4110, confirmed item 1 was already shipped in #5072, and implemented item 2. I read the Cobra v1.10.2 source (`flag_groups.go`, `completions.go`) to confirm the exact validation error strings and that `enforceFlagGroupsForCompletion` genuinely drives group-aware completion, then verified the one gap (Cobra checks flag presence, not value) and kept a targeted empty-value guard for it. Reviewed with a 3-way pass (Antigravity/Gemini 3.1 Pro, Codex, and a second Claude session) before opening.
