### PR TITLE
feat(issues): surface cancelled issues via status filter (MUL-4261)

### DIFF
--- a/packages/core/issues/cache-helpers.test.ts
+++ b/packages/core/issues/cache-helpers.test.ts
@@ -94,6 +94,24 @@ describe("patchIssueInBuckets — cross-status move", () => {
     expect(next.byStatus.todo?.total).toBe(0);
     expect(next.byStatus.in_progress?.total).toBe(2);
   });
+
+  // MUL-4261: `cancelled` is now a first-class paginated bucket, so cancelling
+  // an issue rebuckets it into `cancelled` (instead of dropping it) and the
+  // rebucketed card stays locatable for later patches.
+  it("rebuckets a cancelled issue and keeps it locatable", () => {
+    const c0 = cache({
+      todo: { issues: [mk("a", "todo", 1)], total: 1 },
+      cancelled: { issues: [], total: 0 },
+    });
+    const cancelled = patchIssueInBuckets(c0, "a", { status: "cancelled" });
+    expect(ids(cancelled, "todo")).toEqual([]);
+    expect(ids(cancelled, "cancelled")).toEqual(["a"]);
+    expect(cancelled.byStatus.cancelled?.total).toBe(1);
+
+    // A follow-up edit still finds the card in the cancelled bucket.
+    const renamed = patchIssueInBuckets(cancelled, "a", { title: "renamed" });
+    expect(renamed.byStatus.cancelled?.issues[0]?.title).toBe("renamed");
+  });
 });
 
 describe("patchIssueInBuckets — same status", () => {

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -131,8 +131,18 @@ export type AssigneeGroupedIssuesFilter = Omit<
 /** Page size per status column. */
 export const ISSUE_PAGE_SIZE = 50;
 
-/** Statuses the issues/my-issues pages paginate. Cancelled is intentionally excluded — it has never been surfaced in the list/board views. */
-export const PAGINATED_STATUSES: readonly IssueStatus[] = BOARD_STATUSES;
+/**
+ * Statuses fetched and paginated into the list/board cache. `cancelled` is
+ * included so cancelled issues always live in the cache (and rebucket
+ * correctly when an issue is cancelled); the surface hides them by default and
+ * only renders a Cancelled section when the status filter explicitly selects
+ * it. `BOARD_STATUSES` stays the default *visible* column set — this constant
+ * governs fetch/cache membership, not what the board shows.
+ */
+export const PAGINATED_STATUSES: readonly IssueStatus[] = [
+  ...BOARD_STATUSES,
+  "cancelled",
+];
 
 /** Flatten a bucketed response to a single Issue[] for consumers that want the whole list. */
 export function flattenIssueBuckets(data: ListIssuesCache) {

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -372,6 +372,68 @@ describe("SwimLaneView", () => {
     expect(screen.getByText("In Progress")).toBeInTheDocument();
   });
 
+  // MUL-4261: the swimlane re-imposed canonical order by intersecting with
+  // BOARD_STATUSES, which silently dropped a filter-selected `cancelled`
+  // column. Status columns must come from `visibleStatuses` (via ALL_STATUSES
+  // order), so cancelled survives when selected and stays out by default.
+  const cancelledOrphan: Issue = {
+    id: "cancelled-orphan",
+    workspace_id: "ws-1",
+    number: 9,
+    identifier: "PROJ-9",
+    title: "Cancelled Orphan",
+    description: "A cancelled orphan",
+    status: "cancelled",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 400,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+
+  it("renders a Cancelled column and its cards when cancelled is visible", () => {
+    renderWithI18n(
+      <SwimLaneView
+        issues={[...mockIssues, cancelledOrphan]}
+        visibleStatuses={[
+          "backlog",
+          "todo",
+          "in_progress",
+          "in_review",
+          "done",
+          "blocked",
+          "cancelled",
+        ]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled Orphan")).toBeInTheDocument();
+  });
+
+  it("omits the Cancelled column when cancelled is not in visibleStatuses", () => {
+    renderWithI18n(
+      // Default visibleStatuses = BOARD_STATUSES (no cancelled).
+      <SwimLaneView
+        issues={[...mockIssues, cancelledOrphan]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Cancelled")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cancelled Orphan")).not.toBeInTheDocument();
+  });
+
   it("renders parent swimlanes and orphans section", () => {
     renderWithI18n(
       <SwimLaneView

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -42,7 +42,11 @@ import {
   DropdownMenuItem,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { sortIssues } from "../utils/sort";
-import { BOARD_STATUSES, STATUS_CONFIG } from "@multica/core/issues/config";
+import {
+  ALL_STATUSES,
+  BOARD_STATUSES,
+  STATUS_CONFIG,
+} from "@multica/core/issues/config";
 import { DraggableBoardCard, BoardCardContent } from "./board-card";
 import { StatusIcon } from "./status-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
@@ -552,8 +556,12 @@ export function SwimLaneView({
     [myIssuesScope, myIssuesFilter],
   );
 
+  // Re-impose canonical status order on whatever the controller marked
+  // visible. Filter against ALL_STATUSES (not BOARD_STATUSES) so a
+  // filter-selected `cancelled` column survives — BOARD_STATUSES omits
+  // cancelled and would silently drop it here (MUL-4261).
   const sortedStatuses = useMemo(
-    () => BOARD_STATUSES.filter((s) => visibleStatuses.includes(s)),
+    () => ALL_STATUSES.filter((s) => visibleStatuses.includes(s)),
     [visibleStatuses],
   );
 

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -15,10 +15,39 @@ import {
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import type {
   AgentTask,
+  Issue,
+  IssueStatus,
   ListIssuesParams,
   ListIssuesResponse,
 } from "@multica/core/types";
 import { useIssueSurfaceController } from "./use-issue-surface-controller";
+
+function makeIssue(
+  overrides: Partial<Issue> & Pick<Issue, "id" | "status">,
+): Issue {
+  return {
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: overrides.id,
+    description: null,
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: "p1",
+    position: 1,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    metadata: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
 
 const updateIssueMutate = vi.hoisted(() => vi.fn());
 const batchUpdateMutateAsync = vi.hoisted(() => vi.fn());
@@ -450,5 +479,89 @@ describe("useIssueSurfaceController", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isEmpty).toBe(true);
+  });
+
+  // --- cancelled visibility (MUL-4261) ---------------------------------
+  // Cancelled issues are always fetched into the cache, but the surface hides
+  // them unless the status filter explicitly selects "cancelled".
+
+  function mockListByStatus(byStatus: Partial<Record<IssueStatus, Issue[]>>) {
+    listIssues.mockImplementation((params?: ListIssuesParams) => {
+      const status = params?.status as IssueStatus | undefined;
+      const issues = (status && byStatus[status]) ?? [];
+      return Promise.resolve({ issues, total: issues.length });
+    });
+  }
+
+  it("always fetches the cancelled bucket even though it is hidden by default", async () => {
+    const { result } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "workspace", actorKind: "all" },
+          modes: ["list"],
+        }),
+      { wrapper: makeWrapper(qc, "workspace:all") },
+    );
+
+    await waitFor(() => expect(listIssues).toHaveBeenCalled());
+
+    // The fetch layer requests the cancelled status page like any other.
+    expect(listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "cancelled", limit: 50, offset: 0 }),
+    );
+    // …but with no status filter, cancelled is not a visible column.
+    expect(result.current.visibleStatuses).not.toContain("cancelled");
+  });
+
+  it("keeps cancelled issues out of the default surface and visible statuses", async () => {
+    mockListByStatus({
+      todo: [makeIssue({ id: "todo-1", status: "todo" })],
+      cancelled: [makeIssue({ id: "cancelled-1", status: "cancelled" })],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "project", projectId: "p1" },
+          modes: ["list"],
+        }),
+      { wrapper: makeWrapper(qc, "project:p1") },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.visibleStatuses).not.toContain("cancelled");
+    const surfaceIds = result.current.surfaceIssues.map((i) => i.id);
+    expect(surfaceIds).toContain("todo-1");
+    expect(surfaceIds).not.toContain("cancelled-1");
+    expect(result.current.issues.map((i) => i.id)).not.toContain("cancelled-1");
+  });
+
+  it("reveals cancelled issues only when the status filter selects cancelled", async () => {
+    mockListByStatus({
+      todo: [makeIssue({ id: "todo-1", status: "todo" })],
+      cancelled: [makeIssue({ id: "cancelled-1", status: "cancelled" })],
+    });
+
+    const store = getIssueSurfaceViewStore("project:p1");
+    act(() => store.getState().toggleStatusFilter("cancelled"));
+
+    const { result } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "project", projectId: "p1" },
+          modes: ["list"],
+        }),
+      { wrapper: makeWrapper(qc, "project:p1") },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Cancelled becomes the sole visible column, sorted last in ALL_STATUSES.
+    expect(result.current.visibleStatuses).toEqual(["cancelled"]);
+    expect(result.current.issues.map((i) => i.id)).toEqual(["cancelled-1"]);
+    expect(result.current.surfaceIssues.map((i) => i.id)).toContain(
+      "cancelled-1",
+    );
   });
 });

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -563,5 +563,7 @@ describe("useIssueSurfaceController", () => {
     expect(result.current.surfaceIssues.map((i) => i.id)).toContain(
       "cancelled-1",
     );
+    // cancelled is never offered as a hideable/persistent board column.
+    expect(result.current.hiddenStatuses).not.toContain("cancelled");
   });
 });

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -2,9 +2,13 @@
 
 import { useEffect, useMemo } from "react";
 import type { QueryKey } from "@tanstack/react-query";
-import type { Issue, IssueAssigneeGroup, Project } from "@multica/core/types";
+import type {
+  Issue,
+  IssueAssigneeGroup,
+  IssueStatus,
+  Project,
+} from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { dateOnlyToLocalDate } from "@multica/core/issues/date";
 import type {
   AssigneeGroupedIssuesFilter,
@@ -59,8 +63,8 @@ export interface IssueSurfaceController {
   loadMoreFilter?: MyIssuesFilter;
   sort: IssueSortParam;
   ganttIssues: Issue[];
-  visibleStatuses: typeof BOARD_STATUSES;
-  hiddenStatuses: typeof BOARD_STATUSES;
+  visibleStatuses: IssueStatus[];
+  hiddenStatuses: IssueStatus[];
   activeFilters: Omit<IssueFilters, "statusFilters" | "runningIssueIds">;
   activity: IssueSurfaceActivity;
   actions: IssueSurfaceActions;

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useQuery, type QueryKey } from "@tanstack/react-query";
 import type { Issue, IssueAssigneeGroup, Project } from "@multica/core/types";
-import { BOARD_STATUSES } from "@multica/core/issues/config";
+import { ALL_STATUSES, BOARD_STATUSES } from "@multica/core/issues/config";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
   childIssueProgressOptions,
@@ -47,8 +47,8 @@ export interface IssueSurfaceData {
   loadMoreScope?: string;
   loadMoreFilter?: MyIssuesFilter;
   ganttIssues: Issue[];
-  visibleStatuses: typeof BOARD_STATUSES;
-  hiddenStatuses: typeof BOARD_STATUSES;
+  visibleStatuses: IssueStatus[];
+  hiddenStatuses: IssueStatus[];
   activeFilters: Omit<IssueFilters, "statusFilters" | "runningIssueIds">;
   activity: IssueSurfaceActivity;
   childProgressMap: Map<string, ChildProgress>;
@@ -156,8 +156,22 @@ export function useIssueSurfaceData({
       : (statusIssuesQuery.data ?? EMPTY_ISSUES);
   }, [assigneeGroupsQuery.data?.groups, statusIssuesQuery.data, usesAssigneeBoard]);
 
+  // Cancelled issues are always fetched into the cache (PAGINATED_STATUSES),
+  // but stay hidden until the status filter explicitly selects "cancelled".
+  // Gating the flattened list here means every downstream consumer — list /
+  // board / swimlane columns, header facet counts, batch selection, and the
+  // isEmpty check — excludes cancelled by default with no per-view branching.
+  const showCancelled = statusFilters.includes("cancelled");
+  const visibleBucketedIssues = useMemo(
+    () =>
+      showCancelled
+        ? bucketedIssues
+        : bucketedIssues.filter((issue) => issue.status !== "cancelled"),
+    [bucketedIssues, showCancelled],
+  );
+
   const ganttIssues = ganttIssuesQuery.data ?? EMPTY_ISSUES;
-  const surfaceIssues = usesGantt ? ganttIssues : bucketedIssues;
+  const surfaceIssues = usesGantt ? ganttIssues : visibleBucketedIssues;
 
   const baseFilterState = useMemo<IssueFilterState>(
     () => ({
@@ -239,14 +253,20 @@ export function useIssueSurfaceData({
     [projects],
   );
 
-  const visibleStatuses = useMemo(() => {
+  const visibleStatuses = useMemo<IssueStatus[]>(() => {
     if (statusFilters.length > 0) {
-      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+      // ALL_STATUSES keeps canonical order and places `cancelled` last, so a
+      // Cancelled section appears (only) when the filter explicitly selects it.
+      return ALL_STATUSES.filter((s) => statusFilters.includes(s));
     }
+    // Default view: the six board statuses, cancelled excluded.
     return BOARD_STATUSES;
   }, [statusFilters]);
 
-  const hiddenStatuses = useMemo(
+  // Hidden columns come from the board set only, so `cancelled` is never
+  // offered as a hideable/always-on board column (it is filter-gated, not a
+  // persistent column).
+  const hiddenStatuses = useMemo<IssueStatus[]>(
     () => BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s)),
     [visibleStatuses],
   );


### PR DESCRIPTION
## Problem

Cancelled issues (`status = cancelled`) were never visible in the web/desktop issue surface. The list/board/swimlane fetch and render statuses from `BOARD_STATUSES`, which excludes `cancelled`, so:

- the flat list fetched one page per board status only — cancelled issues never entered the cache;
- there was no cancelled column/section to render them into; and
- the status filter *offered* a "Cancelled" checkbox (`ALL_STATUSES`) that, when selected, resolved to an empty list — a dead-end control.

The backend already supports `status=cancelled`; this was purely a frontend gap. It has been this way since `packages/core` was extracted, so it's a missing feature, not a regression.

## Approach — plan A: fetch always, hide by default

**Fetch/cache (`packages/core/issues/queries.ts`)**
`PAGINATED_STATUSES` now includes `cancelled`, so cancelled issues are always fetched into the `byStatus` cache. This also makes the `cancelled` bucket first-class in `cache-helpers`: cancelling an issue now rebuckets it into `cancelled` (and keeps it locatable) instead of dropping the card. `BOARD_STATUSES` stays the default *visible* column set.

**Display gate (`use-issue-surface-data.ts`)**
The flattened list is gated on the status filter: cancelled issues are excluded from `surfaceIssues` — and therefore from list/board/swimlane columns, header facet counts, batch selection, and the `isEmpty` check — unless the filter explicitly selects `cancelled`. When it does, `visibleStatuses` includes `cancelled` (sorted last via `ALL_STATUSES`) and a Cancelled section renders. `hiddenStatuses` stays board-only, so cancelled is never offered as a hideable/persistent board column. `visibleStatuses`/`hiddenStatuses` types widened from `typeof BOARD_STATUSES` to `IssueStatus[]`.

## Drag-and-drop

No new entry point or copy was added. When the Cancelled column is visible (filter selected), the existing generic column DnD naturally supports dropping a card into it, which sets `status=cancelled` through the normal move path. Preserved as-is.

## Non-goals (unchanged)

Mobile, member/agent archive surfaces, and an always-on cancelled column are out of scope. Mobile still mirrors `BOARD_STATUSES` and is untouched.

## Minor side effect

`flattenIssueBuckets` also backs the `@`-mention issue autocomplete; cancelled issues can now appear there. This is intended (you can reference a cancelled issue).

## Tests

- `use-issue-surface-controller.test.tsx`: cancelled is always fetched but hidden by default; excluded from `surfaceIssues`/`visibleStatuses` with no filter; revealed as the sole visible column when the filter selects it.
- `cache-helpers.test.ts`: cancelling an issue rebuckets it into `cancelled` and it stays locatable for follow-up patches.

## Verification

- `pnpm --filter @multica/core typecheck` ✅ · `pnpm --filter @multica/views typecheck` ✅
- `vitest run issues` — core 149 ✅ · views 281 ✅
- eslint on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
