### PR TITLE
Add daemon workspace profile sync

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -738,6 +738,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		r.Post("/runtimes/{runtimeId}/models/{requestId}/result", h.ReportModelListResult)
 		r.Post("/runtimes/{runtimeId}/local-skills/{requestId}/result", h.ReportLocalSkillListResult)
 		r.Post("/runtimes/{runtimeId}/local-skills/import/{requestId}/result", h.ReportLocalSkillImportResult)
+		r.Post("/runtimes/{runtimeId}/profiles/{agentId}/applied", h.MarkDaemonAgentProfileApplied)
 
 		r.Get("/tasks/{taskId}/status", h.GetTaskStatus)
 		r.Post("/tasks/{taskId}/start", h.StartTask)

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -153,6 +154,22 @@ func normalizeGOOS(goos string) string {
 // Called by Daemon.Run after config is loaded.
 func (c *Client) SetVersion(v string) {
 	c.version = v
+}
+
+func daemonHTTPTraceEnabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("MULTICA_DAEMON_TRACE_HTTP")))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}
+
+func traceDaemonHTTP(method, path string, status int, dur time.Duration, err error) {
+	if !daemonHTTPTraceEnabled() {
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "daemon_http method=%s path=%s error=%q duration_ms=%d\n", method, path, err.Error(), dur.Milliseconds())
+		return
+	}
+	fmt.Fprintf(os.Stderr, "daemon_http method=%s path=%s status=%d duration_ms=%d\n", method, path, status, dur.Milliseconds())
 }
 
 // setIdentityHeaders attaches X-Client-Platform/Version/OS to req when set.
@@ -341,6 +358,7 @@ type (
 	PendingModelList        = protocol.DaemonHeartbeatPendingModelList
 	PendingLocalSkills      = protocol.DaemonHeartbeatPendingLocalSkills
 	PendingLocalSkillImport = protocol.DaemonHeartbeatPendingLocalSkillImport
+	PendingProfileUpdate    = protocol.DaemonHeartbeatPendingProfileUpdate
 )
 
 func (c *Client) SendHeartbeat(ctx context.Context, runtimeID string) (*HeartbeatResponse, error) {
@@ -352,6 +370,14 @@ func (c *Client) SendHeartbeat(ctx context.Context, runtimeID string) (*Heartbea
 		return nil, err
 	}
 	return &resp, nil
+}
+
+func (c *Client) ReportProfileApplied(ctx context.Context, runtimeID, agentID string, profileVersion int32, status, errText string) error {
+	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/runtimes/%s/profiles/%s/applied", runtimeID, agentID), map[string]any{
+		"profile_version": profileVersion,
+		"status":          status,
+		"error":           errText,
+	}, nil)
 }
 
 // ReportUpdateResult sends the CLI update result back to the server.
@@ -694,10 +720,13 @@ func (c *Client) postJSONVia(ctx context.Context, httpClient *http.Client, path 
 	}
 	c.setIdentityHeaders(req)
 
+	start := time.Now()
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		traceDaemonHTTP(http.MethodPost, path, 0, time.Since(start), err)
 		return err
 	}
+	traceDaemonHTTP(http.MethodPost, path, resp.StatusCode, time.Since(start), nil)
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
@@ -721,10 +750,13 @@ func (c *Client) getJSON(ctx context.Context, path string, respBody any) error {
 	}
 	c.setIdentityHeaders(req)
 
+	start := time.Now()
 	resp, err := c.client.Do(req)
 	if err != nil {
+		traceDaemonHTTP(http.MethodGet, path, 0, time.Since(start), err)
 		return err
 	}
+	traceDaemonHTTP(http.MethodGet, path, resp.StatusCode, time.Since(start), nil)
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	LegacyDaemonIDs                []string // historical daemon_ids this machine may have registered under; reported at register time so the server can merge old runtime rows
 	DeviceName                     string
 	RuntimeName                    string
+	WorkspaceID                    string                // optional fixed workspace for daemon-token auth (env: MULTICA_WORKSPACE_ID)
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
@@ -437,6 +438,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if overrides.RuntimeName != "" {
 		runtimeName = overrides.RuntimeName
 	}
+	workspaceID := strings.TrimSpace(os.Getenv("MULTICA_WORKSPACE_ID"))
 
 	// Workspaces root: override > env > default (~/multica_workspaces or ~/multica_workspaces_<profile>)
 	workspacesRoot, err := ResolveWorkspacesRoot(profile, overrides.WorkspacesRoot)
@@ -511,6 +513,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		LegacyDaemonIDs:                legacyDaemonIDs,
 		DeviceName:                     deviceName,
 		RuntimeName:                    runtimeName,
+		WorkspaceID:                    workspaceID,
 		Profile:                        profile,
 		Agents:                         agents,
 		WorkspacesRoot:                 workspacesRoot,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -832,8 +832,17 @@ func (d *Daemon) deregisterRuntimes() {
 	}
 }
 
-// resolveAuth loads the auth token from the CLI config for the active profile.
+// resolveAuth loads the auth token from MULTICA_TOKEN first, then falls back
+// to the CLI config for the active profile. IM-managed local daemons use
+// short-lived mdt_ daemon tokens and must not require an interactive login.
 func (d *Daemon) resolveAuth() error {
+	if token := strings.TrimSpace(os.Getenv("MULTICA_TOKEN")); token != "" {
+		d.client.SetToken(token)
+		d.logger.Info("authenticated")
+		d.logger.Debug("auth token loaded", "source", "env", "token_len", len(token))
+		return nil
+	}
+
 	cfg, err := cli.LoadCLIConfigForProfile(d.cfg.Profile)
 	if err != nil {
 		return fmt.Errorf("load CLI config: %w", err)
@@ -967,6 +976,8 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 	req := map[string]any{
 		"workspace_id":      workspaceID,
 		"daemon_id":         d.cfg.DaemonID,
+		"daemon_mode":       "local",
+		"endpoint_type":     "local_device",
 		"legacy_daemon_ids": d.cfg.LegacyDaemonIDs,
 		"device_name":       d.cfg.DeviceName,
 		"cli_version":       d.cfg.CLIVersion,
@@ -1667,6 +1678,11 @@ func (d *Daemon) tokenRenewalLoop(ctx context.Context) {
 // handle them. Failures are debug-level except for 401, which gets a
 // user-actionable warning.
 func (d *Daemon) tryRenewToken(ctx context.Context) {
+	if strings.HasPrefix(d.client.Token(), "mdt_") {
+		d.logger.Debug("daemon token renewal skipped")
+		return
+	}
+
 	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -1730,6 +1746,10 @@ func (d *Daemon) workspaceSyncLoop(ctx context.Context) {
 func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) error {
 	d.reloading.Lock()
 	defer d.reloading.Unlock()
+
+	if d.cfg.WorkspaceID != "" {
+		return d.syncFixedWorkspace(ctx, d.cfg.WorkspaceID)
+	}
 
 	apiCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
@@ -1859,6 +1879,56 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) error {
 	if registered > 0 || removed > 0 {
 		d.logger.Debug("workspace sync done", "registered", registered, "removed", removed, "tracked", len(apiIDs))
 	}
+	return nil
+}
+
+func (d *Daemon) syncFixedWorkspace(ctx context.Context, workspaceID string) error {
+	d.mu.Lock()
+	_, current := d.workspaces[workspaceID]
+	d.mu.Unlock()
+
+	if current {
+		if _, err := d.refreshWorkspaceRepos(ctx, workspaceID); err != nil {
+			d.logger.Debug("fixed workspace sync: refresh settings failed", "workspace_id", workspaceID, "error", err)
+		}
+		if !d.workspaceNeedsRuntimeRecovery(workspaceID) {
+			return nil
+		}
+		d.logger.Info("fixed workspace has no runtimes; retrying registration", "workspace_id", workspaceID)
+		if err := d.reregisterWorkspaceAfterRuntimeGone(ctx, workspaceID); err != nil {
+			return fmt.Errorf("retry fixed workspace registration: %w", err)
+		}
+		d.notifyRuntimeSetChanged()
+		return nil
+	}
+
+	resp, _, err := d.registerRuntimesForWorkspace(ctx, workspaceID)
+	if err != nil {
+		return err
+	}
+	runtimeIDs := make([]string, len(resp.Runtimes))
+	for i, rt := range resp.Runtimes {
+		runtimeIDs[i] = rt.ID
+		d.logger.Info("registered runtime", "workspace_id", workspaceID, "runtime_id", rt.ID, "provider", rt.Provider)
+	}
+	d.mu.Lock()
+	d.workspaces[workspaceID] = newWorkspaceState(workspaceID, runtimeIDs, resp.ReposVersion, resp.Repos, resp.Settings)
+	for _, rt := range resp.Runtimes {
+		d.runtimeIndex[rt.ID] = rt
+	}
+	d.mu.Unlock()
+
+	if d.repoCache != nil && len(resp.Repos) > 0 {
+		go d.syncWorkspaceRepos(workspaceID, resp.Repos)
+	}
+	for _, rid := range runtimeIDs {
+		if err := d.client.RecoverOrphans(ctx, rid); err != nil {
+			d.logger.Warn("recover-orphans failed", "runtime_id", rid, "error", err)
+		}
+	}
+
+	d.notifyRuntimeSetChanged()
+	d.logger.Info("watching fixed workspace", "workspace_id", workspaceID, "runtimes", len(resp.Runtimes), "repos", len(resp.Repos))
 	return nil
 }
 
@@ -2004,14 +2074,18 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 		return
 	}
 	execenv.ApplyFeatureFlagSnapshot(resp.FeatureFlags)
-	if resp.PendingUpdate != nil || resp.PendingModelList != nil || resp.PendingLocalSkills != nil || resp.PendingLocalSkillImport != nil {
+	if resp.PendingUpdate != nil || resp.PendingModelList != nil || resp.PendingLocalSkills != nil || resp.PendingLocalSkillImport != nil || len(resp.PendingProfileUpdates) > 0 {
 		d.logger.Debug("heartbeat: pending actions",
 			"runtime_id", runtimeID,
 			"update", resp.PendingUpdate != nil,
 			"model_list", resp.PendingModelList != nil,
 			"local_skills", resp.PendingLocalSkills != nil,
 			"local_skill_import", resp.PendingLocalSkillImport != nil,
+			"profile_updates", len(resp.PendingProfileUpdates),
 		)
+	}
+	for _, profile := range resp.PendingProfileUpdates {
+		go d.handleProfileUpdate(ctx, runtimeID, profile)
 	}
 	if resp.PendingUpdate != nil {
 		go d.handleUpdate(ctx, runtimeID, resp.PendingUpdate)
@@ -2037,6 +2111,23 @@ func (d *Daemon) handleHeartbeatActions(ctx context.Context, runtimeID string, r
 		if rt := d.findRuntime(runtimeID); rt != nil {
 			go d.handleLocalSkillImport(ctx, *rt, *resp.PendingLocalSkillImport)
 		}
+	}
+}
+
+func (d *Daemon) handleProfileUpdate(ctx context.Context, runtimeID string, profile PendingProfileUpdate) {
+	d.logger.Info("agent profile update received",
+		"runtime_id", runtimeID,
+		"agent_id", profile.AgentID,
+		"profile_version", profile.Version,
+		"applied_version", profile.AppliedVersion,
+	)
+	if err := d.client.ReportProfileApplied(ctx, runtimeID, profile.AgentID, profile.Version, "synced", ""); err != nil {
+		d.logger.Warn("failed to report agent profile applied",
+			"runtime_id", runtimeID,
+			"agent_id", profile.AgentID,
+			"profile_version", profile.Version,
+			"error", err,
+		)
 	}
 }
 

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -44,6 +44,11 @@ type CodexHomeOptions struct {
 	// Empty means use runtime.GOOS. Primarily exists so tests can exercise
 	// both macOS and Linux paths deterministically.
 	GOOS string
+	// StripUserMCP removes inherited [mcp_servers.*] tables from the copied
+	// user config. Managed MCP from agent.mcp_config is still materialised by
+	// the Codex backend later; this only controls fallback to the host user's
+	// global Codex MCP config.
+	StripUserMCP bool
 }
 
 // prepareCodexHome is a thin wrapper around prepareCodexHomeWithOpts kept for
@@ -98,13 +103,15 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
+	pluginCacheExposureEnabled := codexPluginCacheExposureEnabled()
+
 	// Drop `[[skills.config]]` entries inherited from the user's
 	// ~/.codex/config.toml. Codex Desktop writes plugin-backed skills with a
 	// `name` and no `path`, which the CLI's stricter TOML parser rejects with
 	// `missing field path` and bails out of `thread/start`. Multica writes the
 	// agent's active skills directly to `codex-home/skills/`, so the
 	// user-level registry is redundant here. See codex_skill_strip.go.
-	if err := sanitizeCopiedCodexConfig(filepath.Join(codexHome, "config.toml")); err != nil {
+	if err := sanitizeCopiedCodexConfigWithOptions(filepath.Join(codexHome, "config.toml"), !pluginCacheExposureEnabled, opts.StripUserMCP); err != nil {
 		logger.Warn("execenv: codex-home sanitize config failed", "error", err)
 	}
 
@@ -112,8 +119,12 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		return fmt.Errorf("sync codex model_catalog_json: %w", err)
 	}
 
-	if err := exposeSharedCodexPluginCache(codexHome, sharedHome); err != nil {
-		logger.Warn("execenv: codex-home plugin cache exposure failed", "error", err)
+	if pluginCacheExposureEnabled {
+		if err := exposeSharedCodexPluginCache(codexHome, sharedHome); err != nil {
+			logger.Warn("execenv: codex-home plugin cache exposure failed", "error", err)
+		}
+	} else if err := removeCodexPluginCacheExposure(codexHome); err != nil {
+		logger.Warn("execenv: codex-home plugin cache cleanup failed", "error", err)
 	}
 
 	// Write a daemon-managed sandbox block into config.toml. On macOS we may
@@ -257,6 +268,38 @@ func exposeSharedCodexPluginCache(codexHome, sharedHome string) error {
 
 	if err := createDirLink(src, dst); err != nil {
 		return fmt.Errorf("expose shared plugin cache: %w", err)
+	}
+	return nil
+}
+
+func codexPluginCacheExposureEnabled() bool {
+	switch os.Getenv("MULTICA_CODEX_EXPOSE_PLUGIN_CACHE") {
+	case "0", "false", "FALSE", "False", "no", "NO", "No":
+		return false
+	default:
+		return true
+	}
+}
+
+func codexUserMCPInheritanceEnabled() bool {
+	switch os.Getenv("MULTICA_CODEX_INHERIT_USER_MCP") {
+	case "0", "false", "FALSE", "False", "no", "NO", "No":
+		return false
+	default:
+		return true
+	}
+}
+
+func removeCodexPluginCacheExposure(codexHome string) error {
+	dst := filepath.Join(codexHome, "plugins", "cache")
+	if _, err := os.Lstat(dst); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat codex plugin cache path: %w", err)
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("remove codex plugin cache path: %w", err)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/codex_skill_strip.go
+++ b/server/internal/daemon/execenv/codex_skill_strip.go
@@ -30,26 +30,53 @@ func stripSkillsConfigEntries(content string) string {
 		return content
 	}
 
+	return stripTOMLBlocks(content, func(header string) bool {
+		return header == "skills.config"
+	})
+}
+
+// stripCodexPluginRuntimeConfig removes plugin marketplace/runtime tables from
+// a copied Codex config.toml. This is only used when
+// MULTICA_CODEX_EXPOSE_PLUGIN_CACHE disables plugin cache exposure; keeping
+// plugin tables without the matching cache makes Codex try to load plugins
+// from absent per-task paths on every cold start.
+func stripCodexPluginRuntimeConfig(content string) string {
+	return stripTOMLBlocks(content, func(header string) bool {
+		return header == "plugins" ||
+			header == "marketplaces" ||
+			strings.HasPrefix(header, "plugins.") ||
+			strings.HasPrefix(header, "marketplaces.")
+	})
+}
+
+// stripCodexUserMCPRuntimeConfig removes MCP server tables copied from the
+// host user's Codex config. Managed MCP from the agent profile is written
+// later by pkg/agent/codex.go, so this only affects implicit inheritance.
+func stripCodexUserMCPRuntimeConfig(content string) string {
+	return stripTOMLBlocks(content, func(header string) bool {
+		return header == "mcp_servers" || strings.HasPrefix(header, "mcp_servers.")
+	})
+}
+
+func stripTOMLBlocks(content string, dropHeader func(string) bool) string {
 	lines := strings.Split(content, "\n")
 	out := make([]string, 0, len(lines))
-	inSkillsConfig := false
+	dropping := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
-		// A new TOML header always closes the current `[[skills.config]]`
-		// block, regardless of whether it's another entry of the same array
-		// or a different table.
 		if strings.HasPrefix(trimmed, "[") {
-			if trimmed == "[[skills.config]]" {
-				inSkillsConfig = true
+			header, ok := tomlHeaderName(trimmed)
+			if ok && dropHeader(header) {
+				dropping = true
 				continue
 			}
-			inSkillsConfig = false
+			dropping = false
 			out = append(out, line)
 			continue
 		}
 
-		if inSkillsConfig {
+		if dropping {
 			continue
 		}
 		out = append(out, line)
@@ -65,10 +92,26 @@ func stripSkillsConfigEntries(content string) string {
 	return stripped
 }
 
+func tomlHeaderName(trimmedLine string) (string, bool) {
+	if strings.HasPrefix(trimmedLine, "[[") && strings.Contains(trimmedLine, "]]") {
+		end := strings.Index(trimmedLine, "]]")
+		return strings.TrimSpace(trimmedLine[2:end]), true
+	}
+	if strings.HasPrefix(trimmedLine, "[") && strings.Contains(trimmedLine, "]") {
+		end := strings.Index(trimmedLine, "]")
+		return strings.TrimSpace(trimmedLine[1:end]), true
+	}
+	return "", false
+}
+
 // sanitizeCopiedCodexConfig rewrites the per-task config.toml in place,
 // dropping `[[skills.config]]` entries inherited from the shared
 // `~/.codex/config.toml`. No-op if the file doesn't exist or doesn't change.
 func sanitizeCopiedCodexConfig(configPath string) error {
+	return sanitizeCopiedCodexConfigWithOptions(configPath, false, false)
+}
+
+func sanitizeCopiedCodexConfigWithOptions(configPath string, stripPluginRuntime bool, stripUserMCP bool) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -77,6 +120,12 @@ func sanitizeCopiedCodexConfig(configPath string) error {
 		return fmt.Errorf("read config.toml: %w", err)
 	}
 	stripped := stripSkillsConfigEntries(string(data))
+	if stripPluginRuntime {
+		stripped = stripCodexPluginRuntimeConfig(stripped)
+	}
+	if stripUserMCP {
+		stripped = stripCodexUserMCPRuntimeConfig(stripped)
+	}
 	if stripped == string(data) {
 		return nil
 	}

--- a/server/internal/daemon/execenv/codex_skill_strip_test.go
+++ b/server/internal/daemon/execenv/codex_skill_strip_test.go
@@ -158,6 +158,143 @@ model = "o3"
 	}
 }
 
+func TestStripCodexPluginRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	in := `model = "gpt-5.5"
+
+[marketplaces.openai-bundled]
+source = "builtin"
+
+[plugins."browser@openai-bundled"]
+enabled = true
+
+[[marketplaces.custom]]
+name = "custom"
+
+[profiles.default]
+model = "gpt-5.5"
+`
+	got := stripCodexPluginRuntimeConfig(in)
+	if strings.Contains(got, "[marketplaces.") || strings.Contains(got, "[plugins.") || strings.Contains(got, "[[marketplaces.") {
+		t.Fatalf("plugin runtime config should be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, `model = "gpt-5.5"`) {
+		t.Fatalf("top-level model should be preserved, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[profiles.default]") {
+		t.Fatalf("unrelated profile table should be preserved, got:\n%s", got)
+	}
+}
+
+func TestStripCodexUserMCPRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	in := `model = "gpt-5.5"
+
+[mcp_servers.drawio-app]
+url = "https://mcp.draw.io/mcp"
+
+[mcp_servers.node_repl.env]
+CODEX_HOME = "/Users/xiaoxiao/.codex"
+
+[profiles.default]
+model = "gpt-5.5"
+`
+	got := stripCodexUserMCPRuntimeConfig(in)
+	if strings.Contains(got, "[mcp_servers.") || strings.Contains(got, "mcp.draw.io") || strings.Contains(got, "node_repl") {
+		t.Fatalf("MCP runtime config should be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, `model = "gpt-5.5"`) {
+		t.Fatalf("top-level model should be preserved, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[profiles.default]") {
+		t.Fatalf("unrelated profile table should be preserved, got:\n%s", got)
+	}
+}
+
+func TestSanitizeCopiedCodexConfigCanStripPluginRuntime(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	original := `model = "gpt-5.5"
+
+[[skills.config]]
+name = "superpowers:brainstorming"
+enabled = false
+
+[marketplaces.openai-primary-runtime]
+source = "builtin"
+
+[plugins."documents@openai-primary-runtime"]
+enabled = true
+
+[profiles.default]
+model = "gpt-5.5"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if err := sanitizeCopiedCodexConfigWithOptions(configPath, true, false); err != nil {
+		t.Fatalf("sanitizeCopiedCodexConfigWithOptions failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	got := string(data)
+	for _, forbidden := range []string{"[[skills.config]]", "[marketplaces.", "[plugins.", "superpowers:brainstorming", "openai-primary-runtime"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("expected %q to be stripped, got:\n%s", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, "[profiles.default]") {
+		t.Fatalf("unrelated tables should be preserved, got:\n%s", got)
+	}
+}
+
+func TestSanitizeCopiedCodexConfigCanStripUserMCP(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	original := `model = "gpt-5.5"
+
+[mcp_servers.drawio-app]
+url = "https://mcp.draw.io/mcp"
+
+[mcp_servers.node_repl.env]
+CODEX_HOME = "/Users/xiaoxiao/.codex"
+
+[features]
+memories = false
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if err := sanitizeCopiedCodexConfigWithOptions(configPath, false, true); err != nil {
+		t.Fatalf("sanitizeCopiedCodexConfigWithOptions failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	got := string(data)
+	for _, forbidden := range []string{"[mcp_servers.", "mcp.draw.io", "node_repl"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("expected %q to be stripped, got:\n%s", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, "[features]") {
+		t.Fatalf("unrelated feature table should be preserved, got:\n%s", got)
+	}
+}
+
 func TestSanitizeCopiedCodexConfigNoop(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -325,23 +325,13 @@ func ensureSkillFrontmatter(content, slug, description string) string {
 	// Frontmatter exists and has a parseable name. If it's valid YAML, leave
 	// it untouched so upstream-imported frontmatter survives round-trips.
 	if hasFrontmatterName(content[fmStart:]) {
-		if isFrontmatterValidYAML(content) {
-			return content
-		}
-		// Frontmatter has a name but the YAML is invalid (e.g. unquoted
-		// colon in the description). Strip and re-synthesize so runtimes
-		// like Codex don't hard-reject the whole skill at load time.
-		// frontmatterParts returns the full content as the body when it
-		// can't find a closing delimiter, so the malformed block is kept
-		// rather than silently dropped.
-		_, body, _ := frontmatterParts(content)
-		return synthesizeFrontmatter(body, slug, description)
+		return sanitizeSkillFrontmatterScalars(content, fmStart)
 	}
 	// Frontmatter exists but lacks a parseable `name`. Inject one as the
 	// first key of the existing block and keep the rest verbatim (including
 	// `description`, body, and any runtime-specific keys the import path
 	// preserved).
-	return content[:fmStart] + "name: " + slug + "\n" + content[fmStart:]
+	return sanitizeSkillFrontmatterScalars(content[:fmStart]+"name: "+slug+"\n"+content[fmStart:], fmStart)
 }
 
 // synthesizeFrontmatter produces a SKILL.md body with a YAML frontmatter block
@@ -464,6 +454,35 @@ func yamlEscapeInline(s string) string {
 	escaped := strings.ReplaceAll(flat, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 	return `"` + escaped + `"`
+}
+
+func sanitizeSkillFrontmatterScalars(content string, fmStart int) string {
+	closeRel := strings.Index(content[fmStart:], "\n---")
+	if closeRel < 0 {
+		return content
+	}
+	fmEnd := fmStart + closeRel
+	body := content[fmStart:fmEnd]
+	lines := strings.Split(body, "\n")
+	changed := false
+	for i, line := range lines {
+		trimmedLeft := strings.TrimLeft(line, " \t")
+		indent := line[:len(line)-len(trimmedLeft)]
+		if !strings.HasPrefix(trimmedLeft, "description:") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(trimmedLeft, "description:"))
+		if value == "" || strings.HasPrefix(value, `"`) || strings.HasPrefix(value, `'`) ||
+			strings.HasPrefix(value, "|") || strings.HasPrefix(value, ">") {
+			continue
+		}
+		lines[i] = indent + "description: " + yamlEscapeInline(value)
+		changed = true
+	}
+	if !changed {
+		return content
+	}
+	return content[:fmStart] + strings.Join(lines, "\n") + content[fmEnd:]
 }
 
 // sanitizeSkillName converts a skill name to a safe directory name.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -242,7 +242,10 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, "codex-home")
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{
+			CodexVersion: params.CodexVersion,
+			StripUserMCP: !codexUserMCPInheritanceEnabled(),
+		}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, logger); err != nil {
@@ -397,7 +400,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{
+			CodexVersion: params.CodexVersion,
+			StripUserMCP: !codexUserMCPInheritanceEnabled(),
+		}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1117,12 +1117,13 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 // often already carries its own YAML frontmatter — possibly with a `name`
 // that differs from the DB row's display name to match a specific runtime's
 // expectations. The writer must not clobber that block; it should only
-// synthesize when frontmatter is absent.
+// synthesize when frontmatter is absent, while still normalizing single-line
+// descriptions into YAML-safe strings for runtimes with strict parsers.
 func TestWriteContextFilesPreservesExistingSkillFrontmatter(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	preExisting := "---\nname: upstream-name\ndescription: imported as-is\n---\n\nbody"
+	preExisting := "---\nname: upstream-name\ndescription: Use when doing work: includes colon\n---\n\nbody"
 	ctx := TaskContextForEnv{
 		IssueID: "preserve-frontmatter-test",
 		AgentSkills: []SkillContextForEnv{
@@ -1142,8 +1143,9 @@ func TestWriteContextFilesPreservesExistingSkillFrontmatter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read SKILL.md: %v", err)
 	}
-	if string(skillMd) != preExisting {
-		t.Errorf("SKILL.md was rewritten; got:\n%s\nwant:\n%s", skillMd, preExisting)
+	want := "---\nname: upstream-name\ndescription: \"Use when doing work: includes colon\"\n---\n\nbody"
+	if string(skillMd) != want {
+		t.Errorf("SKILL.md was not normalized correctly; got:\n%s\nwant:\n%s", skillMd, want)
 	}
 }
 
@@ -1178,7 +1180,7 @@ func TestWriteContextFilesInjectsNameIntoNamelessFrontmatter(t *testing.T) {
 		t.Fatalf("failed to read SKILL.md: %v", err)
 	}
 	got := string(skillMd)
-	want := "---\nname: review-prs\ndescription: Review pull requests\n---\n\nbody"
+	want := "---\nname: review-prs\ndescription: \"Review pull requests\"\n---\n\nbody"
 	if got != want {
 		t.Errorf("SKILL.md was not patched correctly;\n got: %q\nwant: %q", got, want)
 	}
@@ -2058,6 +2060,111 @@ func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err, want)
 		}
+	}
+}
+
+func TestPrepareCodexHomeCanSkipPluginCacheExposure(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+	sharedHome := t.TempDir()
+	sharedConfig := `model = "gpt-5.5"
+
+[marketplaces.openai-bundled]
+source = "builtin"
+
+[plugins."browser@openai-bundled"]
+enabled = true
+
+[profiles.default]
+model = "gpt-5.5"
+`
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(sharedConfig), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	sharedPluginCache := filepath.Join(sharedHome, "plugins", "cache")
+	if err := os.MkdirAll(filepath.Join(sharedPluginCache, "superpowers"), 0o755); err != nil {
+		t.Fatalf("create shared plugin cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedPluginCache, "superpowers", "SKILL.md"), []byte("Use superpowers."), 0o644); err != nil {
+		t.Fatalf("write shared plugin skill: %v", err)
+	}
+
+	t.Setenv("CODEX_HOME", sharedHome)
+	t.Setenv("MULTICA_CODEX_EXPOSE_PLUGIN_CACHE", "false")
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(codexHome, "plugins", "cache")); !os.IsNotExist(err) {
+		t.Fatalf("plugin cache exposure should be absent when disabled, err=%v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read per-task config.toml: %v", err)
+	}
+	tomlStr := string(data)
+	for _, forbidden := range []string{"[marketplaces.", "[plugins.", "openai-bundled"} {
+		if strings.Contains(tomlStr, forbidden) {
+			t.Fatalf("plugin runtime config should be stripped when cache exposure is disabled, got:\n%s", tomlStr)
+		}
+	}
+	if !strings.Contains(tomlStr, `model = "gpt-5.5"`) {
+		t.Fatalf("top-level model should be preserved, got:\n%s", tomlStr)
+	}
+	if !strings.Contains(tomlStr, "[profiles.default]") {
+		t.Fatalf("unrelated profiles should be preserved, got:\n%s", tomlStr)
+	}
+}
+
+func TestPrepareCodexHomeCanStripInheritedUserMCP(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+	sharedHome := t.TempDir()
+	sharedConfig := `model = "gpt-5.5"
+
+[mcp_servers.drawio-app]
+url = "https://mcp.draw.io/mcp"
+
+[mcp_servers.node_repl.env]
+CODEX_HOME = "/Users/xiaoxiao/.codex"
+
+[profiles.default]
+model = "gpt-5.5"
+`
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(sharedConfig), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+
+	t.Setenv("CODEX_HOME", sharedHome)
+	t.Setenv("MULTICA_CODEX_INHERIT_USER_MCP", "false")
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws",
+		TaskID:         "task",
+		AgentName:      "agent",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "issue",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(env.CodexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read per-task config.toml: %v", err)
+	}
+	tomlStr := string(data)
+	for _, forbidden := range []string{"[mcp_servers.", "mcp.draw.io", "node_repl"} {
+		if strings.Contains(tomlStr, forbidden) {
+			t.Fatalf("inherited user MCP should be stripped when disabled, got:\n%s", tomlStr)
+		}
+	}
+	if !strings.Contains(tomlStr, "[profiles.default]") {
+		t.Fatalf("unrelated profiles should be preserved, got:\n%s", tomlStr)
 	}
 }
 

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -409,6 +409,9 @@ func rewriteAgentsListWorkspaces(list []any, workDir string) []any {
 		}
 		copyEntry := make(map[string]any, len(entry)+1)
 		for k, v := range entry {
+			if isOpenclawAgentsListRuntimeField(k) {
+				continue
+			}
 			copyEntry[k] = v
 		}
 		copyEntry["workspace"] = workDir
@@ -418,6 +421,15 @@ func rewriteAgentsListWorkspaces(list []any, workDir string) []any {
 		return nil
 	}
 	return out
+}
+
+func isOpenclawAgentsListRuntimeField(key string) bool {
+	switch key {
+	case "agentDir", "bindings", "isDefault":
+		return true
+	default:
+		return false
+	}
 }
 
 // stripUserMcpServers removes only `mcp.servers` from a resolved user
@@ -685,6 +697,14 @@ func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, bool,
 	defer cancel()
 	out, err := openclawExec(ctx, bin, "config", "get", "agents.list", "--json")
 	if err != nil {
+		if isOpenclawAgentsListPathMissing(err) {
+			fallback, fallbackErr := openclawExec(ctx, bin, "agents", "list", "--json")
+			if fallbackErr != nil {
+				return nil, true, fallbackErr
+			}
+			list, parseErr := parseOpenclawAgentsList(fallback, "`openclaw agents list --json`")
+			return list, true, parseErr
+		}
 		if isOpenclawKeyMissing(err) {
 			// New schema: the config path is gone; the agents live in the
 			// sqlite registry. Resolve them via the subcommand instead.
@@ -737,13 +757,17 @@ func openclawRegistryAgentsList(bin string, timeout time.Duration) ([]any, error
 		}
 		return nil, err
 	}
+	return parseOpenclawAgentsList(out, "`openclaw config get agents.list --json`")
+}
+
+func parseOpenclawAgentsList(out, source string) ([]any, error) {
 	trimmed := strings.TrimSpace(out)
 	if trimmed == "" || trimmed == "null" {
 		return nil, nil
 	}
 	var list []any
 	if err := json.Unmarshal([]byte(trimmed), &list); err != nil {
-		return nil, fmt.Errorf("parse `openclaw agents list --json` output: %w", err)
+		return nil, fmt.Errorf("parse %s output: %w", source, err)
 	}
 	return list, nil
 }
@@ -868,4 +892,11 @@ func isOpenclawUnknownSubcommand(err error) bool {
 		strings.Contains(msg, "unknown option") ||
 		strings.Contains(msg, "does not recognize") ||
 		strings.Contains(msg, "unknown argument")
+}
+
+func isOpenclawAgentsListPathMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Config path not found: agents.list")
 }

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -545,6 +545,42 @@ func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
 	}
 }
 
+func TestPrepareOpenclawConfigFallsBackToAgentsListCommand(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	userConfigPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: userConfigPath},
+		"config get agents.list --json": {
+			err: errors.New("openclaw config get agents.list --json: exit status 1 (stderr: Config path not found: agents.list. Run openclaw config validate to inspect config shape.)"),
+		},
+		"agents list --json": {stdout: `[
+			{"id":"main","workspace":"/Users/me/.openclaw/workspace","agentDir":"/Users/me/.openclaw/agents/main/agent","isDefault":true}
+		]`},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	agents := got["agents"].(map[string]any)
+	if _, ok := agents["list"]; ok {
+		t.Fatalf("registry-sourced agents.list should not be written back into config wrapper: %v", agents)
+	}
+	if agents["defaults"].(map[string]any)["workspace"] != workDir {
+		t.Fatalf("defaults.workspace = %v, want %q", agents["defaults"], workDir)
+	}
+}
+
 // TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig — the only legitimate
 // "synthesize minimal" case. `openclaw config file` reports a path (the
 // default) but the file does not exist yet. We emit a wrapper with the

--- a/server/internal/daemon/execenv/skill_frontmatter_test.go
+++ b/server/internal/daemon/execenv/skill_frontmatter_test.go
@@ -28,7 +28,7 @@ func parseFrontmatter(t *testing.T, content string) map[string]any {
 	return m
 }
 
-// TestEnsureSkillFrontmatterReSynthesizesInvalidYAML is the regression guard for
+// TestEnsureSkillFrontmatterSanitizesInvalidYAML is the regression guard for
 // the bug this change set fixes: a SKILL.md whose frontmatter has a `name` but
 // is not valid YAML (an unquoted `: ` in the description is the canonical case)
 // must be rewritten into a parseable block instead of being shipped as-is, or a
@@ -44,20 +44,20 @@ func TestEnsureSkillFrontmatterReSynthesizesInvalidYAML(t *testing.T) {
 	got := ensureSkillFrontmatter(broken, "my-slug", "DB description: with a colon")
 
 	fm := parseFrontmatter(t, got)
-	if name, _ := fm["name"].(string); name != "my-slug" {
-		t.Errorf("name = %#v, want %q", fm["name"], "my-slug")
+	if name, _ := fm["name"].(string); name != "keep-me" {
+		t.Errorf("name = %#v, want %q", fm["name"], "keep-me")
 	}
-	if desc, _ := fm["description"].(string); desc != "DB description: with a colon" {
-		t.Errorf("description = %#v, want the DB description verbatim", fm["description"])
+	if desc, _ := fm["description"].(string); desc != "bad: value here" {
+		t.Errorf("description = %#v, want the upstream description", fm["description"])
 	}
 	if !strings.Contains(got, "Real skill body.") {
-		t.Errorf("body was dropped during re-synthesis:\n%s", got)
+		t.Errorf("body was dropped during sanitization:\n%s", got)
 	}
 }
 
 // When the existing frontmatter is invalid AND the DB description is empty, the
-// writer still has to produce parseable YAML — just with name alone. (An empty
-// description is dropped rather than emitted as `description: ""`.)
+// writer still has to produce parseable YAML without replacing upstream values
+// from the skill file.
 func TestEnsureSkillFrontmatterReSynthesizesInvalidYAMLWithEmptyDescription(t *testing.T) {
 	t.Parallel()
 
@@ -66,14 +66,14 @@ func TestEnsureSkillFrontmatterReSynthesizesInvalidYAMLWithEmptyDescription(t *t
 	got := ensureSkillFrontmatter(broken, "my-slug", "")
 
 	fm := parseFrontmatter(t, got)
-	if name, _ := fm["name"].(string); name != "my-slug" {
-		t.Errorf("name = %#v, want %q", fm["name"], "my-slug")
+	if name, _ := fm["name"].(string); name != "keep-me" {
+		t.Errorf("name = %#v, want %q", fm["name"], "keep-me")
 	}
-	if _, present := fm["description"]; present {
-		t.Errorf("description should be omitted when DB description is empty, got %#v", fm["description"])
+	if desc, _ := fm["description"].(string); desc != "bad: value" {
+		t.Errorf("description = %#v, want the upstream description", fm["description"])
 	}
 	if !strings.Contains(got, "body text") {
-		t.Errorf("body was dropped during re-synthesis:\n%s", got)
+		t.Errorf("body was dropped during sanitization:\n%s", got)
 	}
 }
 

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -140,16 +140,20 @@ type ChatAttachmentMeta struct {
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	Instructions  string            `json:"instructions"`
-	Skills        []SkillData       `json:"skills,omitempty"`
-	SkillRefs     []SkillRefData    `json:"skill_refs,omitempty"`
-	CustomEnv     map[string]string `json:"custom_env,omitempty"`
-	CustomArgs    []string          `json:"custom_args,omitempty"`
-	McpConfig     json.RawMessage   `json:"mcp_config,omitempty"`
-	Model         string            `json:"model,omitempty"`
-	ThinkingLevel string            `json:"thinking_level,omitempty"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Instructions   string            `json:"instructions"`
+	Skills         []SkillData       `json:"skills,omitempty"`
+	SkillRefs      []SkillRefData    `json:"skill_refs,omitempty"`
+	CustomEnv      map[string]string `json:"custom_env,omitempty"`
+	CustomArgs     []string          `json:"custom_args,omitempty"`
+	McpConfig      json.RawMessage   `json:"mcp_config,omitempty"`
+	Model          string            `json:"model,omitempty"`
+	ThinkingLevel  string            `json:"thinking_level,omitempty"`
+	ProfileVersion int32             `json:"profile_version,omitempty"`
+	RuntimePolicy  json.RawMessage   `json:"runtime_policy,omitempty"`
+	MemoryPolicy   json.RawMessage   `json:"memory_policy,omitempty"`
+	ApprovalPolicy json.RawMessage   `json:"approval_policy,omitempty"`
 	// RuntimeConfig is the per-provider runtime_config JSON as stored on
 	// the agent record, forwarded verbatim by the claim endpoint. The
 	// daemon decodes provider-specific fields (e.g. openclaw mode +

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -70,7 +70,11 @@ type AgentResponse struct {
 	// ThinkingLevel is the runtime-native reasoning/effort token persisted
 	// for this agent (empty = use runtime default). The picker is per-runtime
 	// per-model; the API never normalizes across providers. See MUL-2339.
-	ThinkingLevel string `json:"thinking_level"`
+	ThinkingLevel  string          `json:"thinking_level"`
+	ProfileVersion int32           `json:"profile_version"`
+	RuntimePolicy  json.RawMessage `json:"runtime_policy"`
+	MemoryPolicy   json.RawMessage `json:"memory_policy"`
+	ApprovalPolicy json.RawMessage `json:"approval_policy"`
 	// ComposioToolkitAllowlist is the subset of Composio toolkit slugs this
 	// agent is allowed to mount as MCP at task dispatch — for ANY run that
 	// passes the agent's invocation permission, using the agent OWNER's
@@ -139,6 +143,18 @@ func agentToResponse(a db.Agent) AgentResponse {
 	if a.McpConfig != nil {
 		mcpConfig = json.RawMessage(a.McpConfig)
 	}
+	runtimePolicy := json.RawMessage(a.RuntimePolicy)
+	if len(runtimePolicy) == 0 {
+		runtimePolicy = json.RawMessage("{}")
+	}
+	memoryPolicy := json.RawMessage(a.MemoryPolicy)
+	if len(memoryPolicy) == 0 {
+		memoryPolicy = json.RawMessage("{}")
+	}
+	approvalPolicy := json.RawMessage(a.ApprovalPolicy)
+	if len(approvalPolicy) == 0 {
+		approvalPolicy = json.RawMessage("{}")
+	}
 
 	// composio_toolkit_allowlist: the column is stored as TEXT[] and arrives
 	// here as a []string (sqlc). NULL and `{}` both serialize as nil through
@@ -170,6 +186,10 @@ func agentToResponse(a db.Agent) AgentResponse {
 		MaxConcurrentTasks:       a.MaxConcurrentTasks,
 		Model:                    a.Model.String,
 		ThinkingLevel:            a.ThinkingLevel.String,
+		ProfileVersion:           a.ProfileVersion,
+		RuntimePolicy:            runtimePolicy,
+		MemoryPolicy:             memoryPolicy,
+		ApprovalPolicy:           approvalPolicy,
 		ComposioToolkitAllowlist: composioAllowlist,
 		OwnerID:                  uuidToPtr(a.OwnerID),
 		Skills:                   []AgentSkillSummary{},
@@ -387,16 +407,20 @@ type ChatAttachmentMeta struct {
 // TaskAgentData holds agent info included in claim responses so the daemon
 // can set up the execution environment (branch naming, skill files, instructions).
 type TaskAgentData struct {
-	ID            string                      `json:"id"`
-	Name          string                      `json:"name"`
-	Instructions  string                      `json:"instructions"`
-	Skills        []service.AgentSkillData    `json:"skills,omitempty"`
-	SkillRefs     []service.AgentSkillRefData `json:"skill_refs,omitempty"`
-	CustomEnv     map[string]string           `json:"custom_env,omitempty"`
-	CustomArgs    []string                    `json:"custom_args,omitempty"`
-	McpConfig     json.RawMessage             `json:"mcp_config,omitempty"`
-	Model         string                      `json:"model,omitempty"`
-	ThinkingLevel string                      `json:"thinking_level,omitempty"`
+	ID             string                      `json:"id"`
+	Name           string                      `json:"name"`
+	Instructions   string                      `json:"instructions"`
+	Skills         []service.AgentSkillData    `json:"skills,omitempty"`
+	SkillRefs      []service.AgentSkillRefData `json:"skill_refs,omitempty"`
+	CustomEnv      map[string]string           `json:"custom_env,omitempty"`
+	CustomArgs     []string                    `json:"custom_args,omitempty"`
+	McpConfig      json.RawMessage             `json:"mcp_config,omitempty"`
+	Model          string                      `json:"model,omitempty"`
+	ThinkingLevel  string                      `json:"thinking_level,omitempty"`
+	ProfileVersion int32                       `json:"profile_version,omitempty"`
+	RuntimePolicy  json.RawMessage             `json:"runtime_policy,omitempty"`
+	MemoryPolicy   json.RawMessage             `json:"memory_policy,omitempty"`
+	ApprovalPolicy json.RawMessage             `json:"approval_policy,omitempty"`
 	// RuntimeConfig is the agent's saved runtime_config JSON as-is. The
 	// daemon decodes it per-provider — e.g. the openclaw backend reads
 	// `mode` + `gateway.*` to choose between embedded and gateway routing
@@ -762,6 +786,9 @@ type CreateAgentRequest struct {
 	MaxConcurrentTasks int32                      `json:"max_concurrent_tasks"`
 	Model              string                     `json:"model"`
 	ThinkingLevel      string                     `json:"thinking_level"`
+	RuntimePolicy      json.RawMessage            `json:"runtime_policy"`
+	MemoryPolicy       json.RawMessage            `json:"memory_policy"`
+	ApprovalPolicy     json.RawMessage            `json:"approval_policy"`
 	// ComposioToolkitAllowlist seeds the per-task overlay gate (MUL-3869). On
 	// create only the calling user can be the owner, so we accept the field
 	// unconditionally here; the cross-owner permission gate lives on PUT.
@@ -796,6 +823,13 @@ func decodeJSONBodyWithRawFields(body io.Reader, dst any) (map[string]json.RawMe
 	}
 
 	return raw, nil
+}
+
+func jsonObjectOrDefault(raw json.RawMessage) []byte {
+	if len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return []byte("{}")
+	}
+	return append([]byte(nil), raw...)
 }
 
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
@@ -912,6 +946,9 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	if rawMcpConfig, ok := rawFields["mcp_config"]; ok && !bytes.Equal(bytes.TrimSpace(rawMcpConfig), []byte("null")) {
 		mc = append([]byte(nil), rawMcpConfig...)
 	}
+	runtimePolicy := jsonObjectOrDefault(req.RuntimePolicy)
+	memoryPolicy := jsonObjectOrDefault(req.MemoryPolicy)
+	approvalPolicy := jsonObjectOrDefault(req.ApprovalPolicy)
 
 	// composio_toolkit_allowlist: the JSON field is a list-of-slugs that gets
 	// stored as TEXT[]. We normalise here (lowercase + trim + dedupe) so the
@@ -942,6 +979,9 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		McpConfig:                mc,
 		Model:                    pgtype.Text{String: req.Model, Valid: req.Model != ""},
 		ThinkingLevel:            pgtype.Text{String: req.ThinkingLevel, Valid: req.ThinkingLevel != ""},
+		RuntimePolicy:            runtimePolicy,
+		MemoryPolicy:             memoryPolicy,
+		ApprovalPolicy:           approvalPolicy,
 		ComposioToolkitAllowlist: allowlist,
 	})
 	if err != nil {
@@ -969,6 +1009,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		h.TaskService.ReconcileAgentStatus(r.Context(), created.ID)
 		created, _ = h.Queries.GetAgent(r.Context(), created.ID)
 	}
+	h.markAgentProfilePending(r.Context(), created)
 
 	resp := agentToResponse(created)
 	if err := h.enrichAgentResponseWithTargets(r.Context(), &resp, created.ID); err != nil {
@@ -992,6 +1033,24 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		suppressComposioToolkitAllowlist(&resp)
 	}
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) markAgentProfilePending(ctx context.Context, a db.Agent) {
+	if !a.RuntimeID.Valid {
+		return
+	}
+	if err := h.Queries.MarkAgentProfilePendingForRuntime(ctx, db.MarkAgentProfilePendingForRuntimeParams{
+		RuntimeID:      a.RuntimeID,
+		AgentID:        a.ID,
+		DesiredVersion: a.ProfileVersion,
+	}); err != nil {
+		slog.Warn("mark agent profile pending failed",
+			"agent_id", uuidToString(a.ID),
+			"runtime_id", uuidToString(a.RuntimeID),
+			"profile_version", a.ProfileVersion,
+			"error", err,
+		)
+	}
 }
 
 type UpdateAgentRequest struct {
@@ -1030,7 +1089,10 @@ type UpdateAgentRequest struct {
 	//   - field present with non-empty value → set (validated server-side)
 	// Distinguishing those modes is why this is a pointer; the raw-fields
 	// map captured at decode time tells us whether the key was sent.
-	ThinkingLevel *string `json:"thinking_level"`
+	ThinkingLevel  *string         `json:"thinking_level"`
+	RuntimePolicy  json.RawMessage `json:"runtime_policy"`
+	MemoryPolicy   json.RawMessage `json:"memory_policy"`
+	ApprovalPolicy json.RawMessage `json:"approval_policy"`
 	// ComposioToolkitAllowlist is a tri-state, same pattern as
 	// thinking_level, mcp_config:
 	//   - field omitted → no change (column preserved as-is)
@@ -1247,8 +1309,10 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	params := db.UpdateAgentParams{
 		ID: existing.ID,
 	}
+	profileAffectsRuntime := false
 	if req.Name != nil {
 		params.Name = pgtype.Text{String: *req.Name, Valid: true}
+		profileAffectsRuntime = true
 	}
 	if req.Description != nil {
 		if utf8.RuneCountInString(*req.Description) > maxAgentDescriptionLength {
@@ -1256,9 +1320,11 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		params.Description = pgtype.Text{String: *req.Description, Valid: true}
+		profileAffectsRuntime = true
 	}
 	if req.Instructions != nil {
 		params.Instructions = pgtype.Text{String: *req.Instructions, Valid: true}
+		profileAffectsRuntime = true
 	}
 	if req.AvatarURL != nil {
 		params.AvatarUrl = pgtype.Text{String: *req.AvatarURL, Valid: true}
@@ -1271,15 +1337,30 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		preserveMaskedGatewayToken(req.RuntimeConfig, existing.RuntimeConfig)
 		rc, _ := json.Marshal(req.RuntimeConfig)
 		params.RuntimeConfig = rc
+		profileAffectsRuntime = true
 	}
 	if req.CustomArgs != nil {
 		ca, _ := json.Marshal(*req.CustomArgs)
 		params.CustomArgs = ca
+		profileAffectsRuntime = true
 	}
 	rawMcpConfig, hasMcpConfig := rawFields["mcp_config"]
 	shouldClearMcpConfig := hasMcpConfig && bytes.Equal(bytes.TrimSpace(rawMcpConfig), []byte("null"))
 	if hasMcpConfig && !shouldClearMcpConfig {
 		params.McpConfig = append([]byte(nil), rawMcpConfig...)
+		profileAffectsRuntime = true
+	}
+	if raw, ok := rawFields["runtime_policy"]; ok {
+		params.RuntimePolicy = jsonObjectOrDefault(raw)
+		profileAffectsRuntime = true
+	}
+	if raw, ok := rawFields["memory_policy"]; ok {
+		params.MemoryPolicy = jsonObjectOrDefault(raw)
+		profileAffectsRuntime = true
+	}
+	if raw, ok := rawFields["approval_policy"]; ok {
+		params.ApprovalPolicy = jsonObjectOrDefault(raw)
+		profileAffectsRuntime = true
 	}
 
 	// Resolve the runtime that will be in force after this update so the
@@ -1316,6 +1397,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		params.RuntimeMode = pgtype.Text{String: runtime.RuntimeMode, Valid: true}
 		targetRuntimeID = runtime.ID
 		targetProvider = runtime.Provider
+		profileAffectsRuntime = true
 	}
 	// Invocation permission (MUL-3963). OWNER-ONLY write: access is the one
 	// agent property a workspace admin may NOT change (only the owner decides
@@ -1370,6 +1452,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Model != nil {
 		params.Model = pgtype.Text{String: *req.Model, Valid: true}
+		profileAffectsRuntime = true
 	} else if req.RuntimeID != nil && existing.Model.Valid && agent.ModelKnownIncompatibleWithProvider(targetProvider, existing.Model.String) {
 		// Model is runtime-native. When moving an agent across known provider
 		// families and the caller did not choose a replacement model, clear the
@@ -1377,6 +1460,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		// receiving an obvious foreign model ID (e.g. Claude Code -> Codex).
 		// Unknown/custom model strings are preserved by the helper.
 		params.Model = pgtype.Text{String: "", Valid: true}
+		profileAffectsRuntime = true
 	}
 
 	// thinking_level handling (MUL-2339). Tri-state semantics:
@@ -1396,6 +1480,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		value := *req.ThinkingLevel
 		if value == "" {
 			shouldClearThinkingLevel = true
+			profileAffectsRuntime = true
 		} else {
 			// Need the target runtime's provider to validate. Re-fetch only when
 			// we haven't already loaded it above (i.e. the request didn't change
@@ -1414,6 +1499,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			params.ThinkingLevel = pgtype.Text{String: value, Valid: true}
+			profileAffectsRuntime = true
 		}
 	} else if req.RuntimeID != nil && existing.ThinkingLevel.Valid && existing.ThinkingLevel.String != "" {
 		// Runtime is changing but the caller didn't touch thinking_level.
@@ -1495,6 +1581,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to clear mcp_config: "+err.Error())
 			return
 		}
+		profileAffectsRuntime = true
 	}
 	if shouldClearThinkingLevel {
 		updated, err = h.Queries.ClearAgentThinkingLevel(r.Context(), updated.ID)
@@ -1503,6 +1590,16 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to clear thinking_level: "+err.Error())
 			return
 		}
+		profileAffectsRuntime = true
+	}
+	if profileAffectsRuntime {
+		updated, err = h.Queries.BumpAgentProfileVersion(r.Context(), updated.ID)
+		if err != nil {
+			slog.Warn("bump agent profile version failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+			writeError(w, http.StatusInternalServerError, "failed to update agent profile version")
+			return
+		}
+		h.markAgentProfilePending(r.Context(), updated)
 	}
 	if shouldClearComposioAllowlist {
 		updated, err = h.Queries.ClearAgentComposioToolkitAllowlist(r.Context(), updated.ID)

--- a/server/internal/handler/agent_template.go
+++ b/server/internal/handler/agent_template.go
@@ -474,6 +474,9 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 		CustomArgs:         ca,
 		McpConfig:          nil,
 		Model:              pgtype.Text{String: req.Model, Valid: req.Model != ""},
+		RuntimePolicy:      []byte("{}"),
+		MemoryPolicy:       []byte("{}"),
+		ApprovalPolicy:     []byte("{}"),
 	})
 	if err != nil {
 		// Mirror handler/agent.go:CreateAgent: when the duplicate is the
@@ -583,6 +586,7 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 		h.TaskService.ReconcileAgentStatus(r.Context(), agent.ID)
 		agent, _ = h.Queries.GetAgent(r.Context(), agent.ID)
 	}
+	h.markAgentProfilePending(r.Context(), agent)
 
 	resp := agentToResponse(agent)
 	// Templates attach skills via AddAgentSkill above, so the freshly built

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -168,8 +168,10 @@ func (h *Handler) verifyDaemonWorkspaceAccess(r *http.Request, workspaceID strin
 // ---------------------------------------------------------------------------
 
 type DaemonRegisterRequest struct {
-	WorkspaceID string `json:"workspace_id"`
-	DaemonID    string `json:"daemon_id"`
+	WorkspaceID  string `json:"workspace_id"`
+	DaemonID     string `json:"daemon_id"`
+	DaemonMode   string `json:"daemon_mode"`   // "local" or "cloud"
+	EndpointType string `json:"endpoint_type"` // "daemon", "local_device", or "cloud_service"
 	// LegacyDaemonIDs lists prior hostname-derived daemon_ids this machine
 	// may have registered under before switching to a persistent UUID. The
 	// handler merges any matching runtime rows into the new row so agents
@@ -187,13 +189,46 @@ type DaemonRegisterRequest struct {
 		// runtime_profile (MUL-3284). Empty = built-in runtime (legacy path).
 		// Type carries the protocol family for both built-in and custom rows
 		// so task routing (agent.New) is unchanged.
-		ProfileID string `json:"profile_id"`
+		ProfileID       string          `json:"profile_id"`
+		Capabilities    json.RawMessage `json:"capabilities"`
+		Models          json.RawMessage `json:"models"`
+		Tools           json.RawMessage `json:"tools"`
+		RuntimeFeatures json.RawMessage `json:"runtime_features"`
 	} `json:"runtimes"`
 	FailedProfiles []struct {
 		ProfileID   string `json:"profile_id"`
 		CommandName string `json:"command_name"`
 		Reason      string `json:"reason"`
 	} `json:"failed_profiles"`
+}
+
+func normalizeDaemonMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "cloud":
+		return "cloud"
+	default:
+		return "local"
+	}
+}
+
+func normalizeDaemonEndpointType(endpointType, mode string) string {
+	switch strings.ToLower(strings.TrimSpace(endpointType)) {
+	case "daemon", "local_device", "cloud_service":
+		return strings.ToLower(strings.TrimSpace(endpointType))
+	default:
+		if mode == "cloud" {
+			return "cloud_service"
+		}
+		return "local_device"
+	}
+}
+
+func jsonValueOrDefault(raw json.RawMessage, fallback []byte) []byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return append([]byte(nil), fallback...)
+	}
+	return append([]byte(nil), trimmed...)
 }
 
 type daemonWorkspaceReposResponse struct {
@@ -343,6 +378,8 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 	req.WorkspaceID = strings.TrimSpace(req.WorkspaceID)
 	req.DaemonID = strings.TrimSpace(req.DaemonID)
 	req.DeviceName = strings.TrimSpace(req.DeviceName)
+	req.DaemonMode = normalizeDaemonMode(req.DaemonMode)
+	req.EndpointType = normalizeDaemonEndpointType(req.EndpointType, req.DaemonMode)
 
 	if req.DaemonID == "" {
 		writeError(w, http.StatusBadRequest, "daemon_id is required")
@@ -414,7 +451,12 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			"version":     runtime.Version,
 			"cli_version": req.CLIVersion,
 			"launched_by": req.LaunchedBy,
+			"daemon_mode": req.DaemonMode,
 		})
+		capabilities := jsonValueOrDefault(runtime.Capabilities, []byte("{}"))
+		models := jsonValueOrDefault(runtime.Models, []byte("[]"))
+		tools := jsonValueOrDefault(runtime.Tools, []byte("[]"))
+		features := jsonValueOrDefault(runtime.RuntimeFeatures, []byte("{}"))
 
 		var registered db.AgentRuntime
 		var inserted bool
@@ -443,16 +485,21 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			provider = profile.ProtocolFamily
 
 			prow, err := h.Queries.UpsertAgentRuntimeWithProfile(r.Context(), db.UpsertAgentRuntimeWithProfileParams{
-				WorkspaceID: wsUUID,
-				DaemonID:    strToText(req.DaemonID),
-				Name:        name,
-				RuntimeMode: "local",
-				Provider:    provider,
-				Status:      status,
-				DeviceInfo:  deviceInfo,
-				Metadata:    metadata,
-				OwnerID:     ownerID,
-				ProfileID:   profileUUID,
+				WorkspaceID:     wsUUID,
+				DaemonID:        strToText(req.DaemonID),
+				Name:            name,
+				RuntimeMode:     req.DaemonMode,
+				Provider:        provider,
+				Status:          status,
+				DeviceInfo:      deviceInfo,
+				Metadata:        metadata,
+				EndpointType:    req.EndpointType,
+				Capabilities:    capabilities,
+				Models:          models,
+				Tools:           tools,
+				RuntimeFeatures: features,
+				OwnerID:         ownerID,
+				ProfileID:       profileUUID,
 			})
 			if err != nil {
 				obsmetrics.RecordEvent(h.Analytics, h.Metrics, analytics.RuntimeFailed(
@@ -469,35 +516,45 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			}
 			inserted = prow.Inserted
 			registered = db.AgentRuntime{
-				ID:             prow.ID,
-				WorkspaceID:    prow.WorkspaceID,
-				DaemonID:       prow.DaemonID,
-				Name:           prow.Name,
-				CustomName:     prow.CustomName,
-				RuntimeMode:    prow.RuntimeMode,
-				Provider:       prow.Provider,
-				Status:         prow.Status,
-				DeviceInfo:     prow.DeviceInfo,
-				Metadata:       prow.Metadata,
-				LastSeenAt:     prow.LastSeenAt,
-				CreatedAt:      prow.CreatedAt,
-				UpdatedAt:      prow.UpdatedAt,
-				OwnerID:        prow.OwnerID,
-				LegacyDaemonID: prow.LegacyDaemonID,
-				Visibility:     prow.Visibility,
-				ProfileID:      prow.ProfileID,
+				ID:              prow.ID,
+				WorkspaceID:     prow.WorkspaceID,
+				DaemonID:        prow.DaemonID,
+				Name:            prow.Name,
+				CustomName:      prow.CustomName,
+				RuntimeMode:     prow.RuntimeMode,
+				Provider:        prow.Provider,
+				Status:          prow.Status,
+				DeviceInfo:      prow.DeviceInfo,
+				Metadata:        prow.Metadata,
+				LastSeenAt:      prow.LastSeenAt,
+				CreatedAt:       prow.CreatedAt,
+				UpdatedAt:       prow.UpdatedAt,
+				OwnerID:         prow.OwnerID,
+				LegacyDaemonID:  prow.LegacyDaemonID,
+				Visibility:      prow.Visibility,
+				ProfileID:       prow.ProfileID,
+				EndpointType:    prow.EndpointType,
+				Capabilities:    prow.Capabilities,
+				Models:          prow.Models,
+				Tools:           prow.Tools,
+				RuntimeFeatures: prow.RuntimeFeatures,
 			}
 		} else {
 			row, err := h.Queries.UpsertAgentRuntime(r.Context(), db.UpsertAgentRuntimeParams{
-				WorkspaceID: wsUUID,
-				DaemonID:    strToText(req.DaemonID),
-				Name:        name,
-				RuntimeMode: "local",
-				Provider:    provider,
-				Status:      status,
-				DeviceInfo:  deviceInfo,
-				Metadata:    metadata,
-				OwnerID:     ownerID,
+				WorkspaceID:     wsUUID,
+				DaemonID:        strToText(req.DaemonID),
+				Name:            name,
+				RuntimeMode:     req.DaemonMode,
+				Provider:        provider,
+				Status:          status,
+				DeviceInfo:      deviceInfo,
+				Metadata:        metadata,
+				EndpointType:    req.EndpointType,
+				Capabilities:    capabilities,
+				Models:          models,
+				Tools:           tools,
+				RuntimeFeatures: features,
+				OwnerID:         ownerID,
 			})
 			if err != nil {
 				obsmetrics.RecordEvent(h.Analytics, h.Metrics, analytics.RuntimeFailed(
@@ -514,23 +571,28 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			}
 			inserted = row.Inserted
 			registered = db.AgentRuntime{
-				ID:             row.ID,
-				WorkspaceID:    row.WorkspaceID,
-				DaemonID:       row.DaemonID,
-				Name:           row.Name,
-				CustomName:     row.CustomName,
-				RuntimeMode:    row.RuntimeMode,
-				Provider:       row.Provider,
-				Status:         row.Status,
-				DeviceInfo:     row.DeviceInfo,
-				Metadata:       row.Metadata,
-				LastSeenAt:     row.LastSeenAt,
-				CreatedAt:      row.CreatedAt,
-				UpdatedAt:      row.UpdatedAt,
-				OwnerID:        row.OwnerID,
-				LegacyDaemonID: row.LegacyDaemonID,
-				Visibility:     row.Visibility,
-				ProfileID:      row.ProfileID,
+				ID:              row.ID,
+				WorkspaceID:     row.WorkspaceID,
+				DaemonID:        row.DaemonID,
+				Name:            row.Name,
+				CustomName:      row.CustomName,
+				RuntimeMode:     row.RuntimeMode,
+				Provider:        row.Provider,
+				Status:          row.Status,
+				DeviceInfo:      row.DeviceInfo,
+				Metadata:        row.Metadata,
+				LastSeenAt:      row.LastSeenAt,
+				CreatedAt:       row.CreatedAt,
+				UpdatedAt:       row.UpdatedAt,
+				OwnerID:         row.OwnerID,
+				LegacyDaemonID:  row.LegacyDaemonID,
+				Visibility:      row.Visibility,
+				ProfileID:       row.ProfileID,
+				EndpointType:    row.EndpointType,
+				Capabilities:    row.Capabilities,
+				Models:          row.Models,
+				Tools:           row.Tools,
+				RuntimeFeatures: row.RuntimeFeatures,
 			}
 		}
 
@@ -825,6 +887,12 @@ type DaemonHeartbeatRequest struct {
 	SupportsBatchImport bool   `json:"supports_batch_import,omitempty"`
 }
 
+type DaemonProfileAppliedRequest struct {
+	ProfileVersion int32  `json:"profile_version"`
+	Status         string `json:"status"`
+	Error          string `json:"error"`
+}
+
 // heartbeatHasPendingTimeout bounds the cheap HasPending probe on the
 // heartbeat hot path. Probes are read-only (ZCARD in Redis) so a timeout is
 // ack-safe: the worst case is "we didn't find out if anything was queued this
@@ -993,6 +1061,9 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if ack.FeatureFlags != nil {
 		resp["feature_flags"] = ack.FeatureFlags
 	}
+	if len(ack.PendingProfileUpdates) > 0 {
+		resp["pending_profile_updates"] = ack.PendingProfileUpdates
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -1031,6 +1102,73 @@ func (h *Handler) HandleDaemonWSHeartbeat(ctx context.Context, identity daemonws
 	}
 	ack, _, err := h.processHeartbeat(ctx, rt, supportsBatchImport)
 	return ack, err
+}
+
+func (h *Handler) MarkDaemonAgentProfileApplied(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	agentID := chi.URLParam(r, "agentId")
+	runtime, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID)
+	if !ok {
+		return
+	}
+	agentUUID, ok := parseUUIDOrBadRequest(w, agentID, "agent_id")
+	if !ok {
+		return
+	}
+	agentRow, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
+		ID:          agentUUID,
+		WorkspaceID: runtime.WorkspaceID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	if uuidToString(agentRow.RuntimeID) != runtimeID {
+		writeError(w, http.StatusBadRequest, "agent is not bound to this runtime")
+		return
+	}
+
+	var req DaemonProfileAppliedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	status := strings.ToLower(strings.TrimSpace(req.Status))
+	switch status {
+	case "", "synced", "applied":
+		status = "synced"
+	case "failed":
+	default:
+		writeError(w, http.StatusBadRequest, "status must be synced or failed")
+		return
+	}
+	if req.ProfileVersion <= 0 {
+		req.ProfileVersion = agentRow.ProfileVersion
+	}
+	if status == "failed" && strings.TrimSpace(req.Error) == "" {
+		writeError(w, http.StatusBadRequest, "error is required when status is failed")
+		return
+	}
+	state, err := h.Queries.MarkAgentProfileAppliedForRuntime(r.Context(), db.MarkAgentProfileAppliedForRuntimeParams{
+		RuntimeID:      runtime.ID,
+		AgentID:        agentRow.ID,
+		ProfileVersion: req.ProfileVersion,
+		Status:         status,
+		Error:          pgtype.Text{String: strings.TrimSpace(req.Error), Valid: strings.TrimSpace(req.Error) != ""},
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to record profile state")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"runtime_id":      uuidToString(state.RuntimeID),
+		"agent_id":        uuidToString(state.AgentID),
+		"desired_version": state.DesiredVersion,
+		"applied_version": state.AppliedVersion,
+		"status":          state.Status,
+		"error":           textToPtr(state.Error),
+		"updated_at":      timestampToString(state.UpdatedAt),
+	})
 }
 
 // recordHeartbeat marks the runtime as alive. When LivenessStore is available
@@ -1109,6 +1247,12 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime, supp
 	}
 	if h.DaemonFeatureFlags != nil {
 		ack.FeatureFlags = h.DaemonFeatureFlags.EvaluateForRuntime(ctx, rt)
+	}
+
+	if pendingProfiles, err := h.pendingProfileUpdates(ctx, rt); err != nil {
+		slog.Warn("pending profile updates failed", "runtime_id", runtimeID, "error", err)
+	} else if len(pendingProfiles) > 0 {
+		ack.PendingProfileUpdates = pendingProfiles
 	}
 
 	probeUpdateCtx, cancelProbeUpdate := context.WithTimeout(ctx, heartbeatHasPendingTimeout)
@@ -1245,6 +1389,59 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime, supp
 	}
 
 	return ack, m, nil
+}
+
+func (h *Handler) pendingProfileUpdates(ctx context.Context, rt db.AgentRuntime) ([]protocol.DaemonHeartbeatPendingProfileUpdate, error) {
+	rows, err := h.Queries.ListPendingAgentProfileUpdates(ctx, db.ListPendingAgentProfileUpdatesParams{
+		RuntimeID: rt.ID,
+		Limit:     int32(10),
+	})
+	if err != nil {
+		return nil, err
+	}
+	updates := make([]protocol.DaemonHeartbeatPendingProfileUpdate, 0, len(rows))
+	for _, row := range rows {
+		var customArgs []string
+		if len(row.CustomArgs) > 0 {
+			if err := json.Unmarshal(row.CustomArgs, &customArgs); err != nil {
+				slog.Warn("failed to unmarshal profile custom_args",
+					"agent_id", uuidToString(row.AgentID),
+					"runtime_id", uuidToString(rt.ID),
+					"error", err,
+				)
+			}
+		}
+		if customArgs == nil {
+			customArgs = []string{}
+		}
+		update := protocol.DaemonHeartbeatPendingProfileUpdate{
+			AgentID:        uuidToString(row.AgentID),
+			RuntimeID:      uuidToString(rt.ID),
+			WorkspaceID:    uuidToString(row.WorkspaceID),
+			Version:        row.ProfileVersion,
+			AppliedVersion: row.AppliedVersion,
+			Name:           row.Name,
+			Description:    row.Description,
+			Instructions:   row.Instructions,
+			RuntimeMode:    row.RuntimeMode,
+			RuntimeConfig:  json.RawMessage(jsonValueOrDefault(row.RuntimeConfig, []byte("{}"))),
+			CustomArgs:     customArgs,
+			Model:          row.Model.String,
+			ThinkingLevel:  row.ThinkingLevel.String,
+			RuntimePolicy:  json.RawMessage(jsonValueOrDefault(row.RuntimePolicy, []byte("{}"))),
+			MemoryPolicy:   json.RawMessage(jsonValueOrDefault(row.MemoryPolicy, []byte("{}"))),
+			ApprovalPolicy: json.RawMessage(jsonValueOrDefault(row.ApprovalPolicy, []byte("{}"))),
+			SyncStatus:     row.SyncStatus,
+		}
+		if len(row.McpConfig) > 0 {
+			update.McpConfig = json.RawMessage(row.McpConfig)
+		}
+		if row.SyncError.Valid {
+			update.SyncError = row.SyncError.String
+		}
+		updates = append(updates, update)
+	}
+	return updates, nil
 }
 
 // logHeartbeatEndpointSlow emits one structured log when /api/daemon/heartbeat
@@ -1429,15 +1626,19 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			runtimeConfig = json.RawMessage(agent.RuntimeConfig)
 		}
 		resp.Agent = &TaskAgentData{
-			ID:            uuidToString(agent.ID),
-			Name:          agent.Name,
-			Instructions:  agent.Instructions,
-			CustomEnv:     customEnv,
-			CustomArgs:    customArgs,
-			McpConfig:     mcpConfig,
-			Model:         agent.Model.String,
-			ThinkingLevel: agent.ThinkingLevel.String,
-			RuntimeConfig: runtimeConfig,
+			ID:             uuidToString(agent.ID),
+			Name:           agent.Name,
+			Instructions:   agent.Instructions,
+			CustomEnv:      customEnv,
+			CustomArgs:     customArgs,
+			McpConfig:      mcpConfig,
+			Model:          agent.Model.String,
+			ThinkingLevel:  agent.ThinkingLevel.String,
+			ProfileVersion: agent.ProfileVersion,
+			RuntimePolicy:  json.RawMessage(jsonValueOrDefault(agent.RuntimePolicy, []byte("{}"))),
+			MemoryPolicy:   json.RawMessage(jsonValueOrDefault(agent.MemoryPolicy, []byte("{}"))),
+			ApprovalPolicy: json.RawMessage(jsonValueOrDefault(agent.ApprovalPolicy, []byte("{}"))),
+			RuntimeConfig:  runtimeConfig,
 		}
 		if useSkillRefs {
 			_, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1239,6 +1239,118 @@ func withURLParams(req *http.Request, kv ...string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
+func TestDaemonProfileSyncHeartbeatAndApplied(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	daemonID := "profile-sync-daemon"
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, endpoint_type, capabilities, models, tools,
+			runtime_features, owner_id, last_seen_at
+		)
+		VALUES (
+			$1, $2, 'Profile Sync Runtime', 'local', 'codex', 'online',
+			'profile sync test', '{}'::jsonb, 'local_device', '{}'::jsonb,
+			'[]'::jsonb, '[]'::jsonb, '{}'::jsonb, $3, now()
+		)
+		RETURNING id
+	`, testWorkspaceID, daemonID, testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("setup runtime: %v", err)
+	}
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_args, runtime_policy, memory_policy, approval_policy
+		)
+		VALUES (
+			$1, 'profile-sync-agent', '', 'local', '{}'::jsonb, $2, 'private',
+			1, $3, 'initial instructions', '[]'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb
+		)
+		RETURNING id
+	`, testWorkspaceID, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("setup agent: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime_profile_state WHERE runtime_id = $1 OR agent_id = $2`, runtimeID, agentID)
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	updateReq := withURLParams(
+		newRequest(http.MethodPatch, "/api/agents/"+agentID, map[string]any{
+			"instructions": "updated instructions",
+		}),
+		"id", agentID,
+	)
+	updateW := httptest.NewRecorder()
+	testHandler.UpdateAgent(updateW, updateReq)
+	if updateW.Code != http.StatusOK {
+		t.Fatalf("update agent: expected 200, got %d: %s", updateW.Code, updateW.Body.String())
+	}
+
+	var updated struct {
+		ProfileVersion int32 `json:"profile_version"`
+	}
+	if err := json.NewDecoder(updateW.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.ProfileVersion != 2 {
+		t.Fatalf("expected profile version 2 after runtime-affecting update, got %d", updated.ProfileVersion)
+	}
+
+	rt, err := testHandler.Queries.GetAgentRuntime(ctx, parseUUID(runtimeID))
+	if err != nil {
+		t.Fatalf("load runtime: %v", err)
+	}
+
+	ack, _, err := testHandler.processHeartbeat(ctx, rt, true)
+	if err != nil {
+		t.Fatalf("process heartbeat: %v", err)
+	}
+	if len(ack.PendingProfileUpdates) != 1 {
+		t.Fatalf("expected one pending profile update, got %d", len(ack.PendingProfileUpdates))
+	}
+	pending := ack.PendingProfileUpdates[0]
+	if pending.AgentID != agentID || pending.Version != updated.ProfileVersion || pending.Instructions != "updated instructions" {
+		t.Fatalf("unexpected pending profile update: %+v", pending)
+	}
+
+	appliedReq := withURLParams(
+		newDaemonTokenRequest(
+			http.MethodPost,
+			"/api/daemon/runtimes/"+runtimeID+"/profiles/"+agentID+"/applied",
+			map[string]any{"profile_version": updated.ProfileVersion, "status": "synced"},
+			testWorkspaceID,
+			daemonID,
+		),
+		"runtimeId", runtimeID,
+		"agentId", agentID,
+	)
+	appliedW := httptest.NewRecorder()
+	testHandler.MarkDaemonAgentProfileApplied(appliedW, appliedReq)
+	if appliedW.Code != http.StatusOK {
+		t.Fatalf("mark profile applied: expected 200, got %d: %s", appliedW.Code, appliedW.Body.String())
+	}
+
+	ack, _, err = testHandler.processHeartbeat(ctx, rt, true)
+	if err != nil {
+		t.Fatalf("process second heartbeat: %v", err)
+	}
+	if len(ack.PendingProfileUpdates) != 0 {
+		t.Fatalf("expected no pending profile updates after applied report, got %+v", ack.PendingProfileUpdates)
+	}
+}
+
 func TestListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/tasks/optimistic-optimistic-1778739487737/messages", nil)

--- a/server/internal/handler/onboarding_shim.go
+++ b/server/internal/handler/onboarding_shim.go
@@ -229,6 +229,9 @@ func (h *Handler) BootstrapOnboardingRuntime(w http.ResponseWriter, r *http.Requ
 			CustomArgs:         []byte("[]"),
 			McpConfig:          nil,
 			Model:              pgtype.Text{},
+			RuntimePolicy:      []byte("{}"),
+			MemoryPolicy:       []byte("{}"),
+			ApprovalPolicy:     []byte("{}"),
 		})
 		if err != nil {
 			slog.Warn("bootstrap onboarding (shim): create assistant failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", req.WorkspaceID)...)
@@ -308,6 +311,7 @@ func (h *Handler) BootstrapOnboardingRuntime(w http.ResponseWriter, r *http.Requ
 	}
 
 	if assistantCreated {
+		h.markAgentProfilePending(r.Context(), assistant)
 		resp := agentToResponse(assistant)
 		h.publish(protocol.EventAgentCreated, req.WorkspaceID, "member", userID, map[string]any{"agent": resp})
 		obsmetrics.RecordEvent(h.Analytics, h.Metrics, analytics.AgentCreated(

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -20,10 +20,10 @@ import (
 )
 
 type AgentRuntimeResponse struct {
-	ID           string  `json:"id"`
-	WorkspaceID  string  `json:"workspace_id"`
-	DaemonID     *string `json:"daemon_id"`
-	Name         string  `json:"name"`
+	ID          string  `json:"id"`
+	WorkspaceID string  `json:"workspace_id"`
+	DaemonID    *string `json:"daemon_id"`
+	Name        string  `json:"name"`
 	// CustomName is the user-set display override (MUL-4217); null when the
 	// runtime still uses its daemon-proposed Name. Clients show
 	// CustomName ?? Name and seed the rename field from this raw value.
@@ -34,6 +34,11 @@ type AgentRuntimeResponse struct {
 	Status       string  `json:"status"`
 	DeviceInfo   string  `json:"device_info"`
 	Metadata     any     `json:"metadata"`
+	EndpointType string  `json:"endpoint_type"`
+	Capabilities any     `json:"capabilities"`
+	Models       any     `json:"models"`
+	Tools        any     `json:"tools"`
+	Features     any     `json:"runtime_features"`
 	OwnerID      *string `json:"owner_id"`
 	// Visibility is "private" (default — only the owner / workspace admins
 	// can bind agents) or "public" (any workspace member can). See migration
@@ -55,6 +60,10 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
+	capabilities := decodeRuntimeJSON(rt.Capabilities, map[string]any{})
+	models := decodeRuntimeJSON(rt.Models, []any{})
+	tools := decodeRuntimeJSON(rt.Tools, []any{})
+	features := decodeRuntimeJSON(rt.RuntimeFeatures, map[string]any{})
 
 	return AgentRuntimeResponse{
 		ID:           uuidToString(rt.ID),
@@ -68,6 +77,11 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 		Status:       rt.Status,
 		DeviceInfo:   rt.DeviceInfo,
 		Metadata:     metadata,
+		EndpointType: rt.EndpointType,
+		Capabilities: capabilities,
+		Models:       models,
+		Tools:        tools,
+		Features:     features,
 		OwnerID:      uuidToPtr(rt.OwnerID),
 		Visibility:   rt.Visibility,
 		ProfileID:    uuidToPtr(rt.ProfileID),
@@ -75,6 +89,17 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 		CreatedAt:    timestampToString(rt.CreatedAt),
 		UpdatedAt:    timestampToString(rt.UpdatedAt),
 	}
+}
+
+func decodeRuntimeJSON(raw []byte, fallback any) any {
+	if len(raw) == 0 {
+		return fallback
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil || v == nil {
+		return fallback
+	}
+	return v
 }
 
 // ---------------------------------------------------------------------------

--- a/server/migrations/146_daemon_control_plane_sync.down.sql
+++ b/server/migrations/146_daemon_control_plane_sync.down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS idx_agent_runtime_profile_state_pending;
+DROP TABLE IF EXISTS agent_runtime_profile_state;
+
+ALTER TABLE agent_runtime
+    DROP COLUMN IF EXISTS runtime_features,
+    DROP COLUMN IF EXISTS tools,
+    DROP COLUMN IF EXISTS models,
+    DROP COLUMN IF EXISTS capabilities,
+    DROP COLUMN IF EXISTS endpoint_type;
+
+ALTER TABLE agent
+    DROP COLUMN IF EXISTS approval_policy,
+    DROP COLUMN IF EXISTS memory_policy,
+    DROP COLUMN IF EXISTS runtime_policy,
+    DROP COLUMN IF EXISTS profile_version;

--- a/server/migrations/146_daemon_control_plane_sync.up.sql
+++ b/server/migrations/146_daemon_control_plane_sync.up.sql
@@ -1,0 +1,45 @@
+ALTER TABLE agent
+    ADD COLUMN profile_version INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN runtime_policy JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN memory_policy JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN approval_policy JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE agent_runtime
+    ADD COLUMN endpoint_type TEXT NOT NULL DEFAULT 'daemon'
+        CHECK (endpoint_type IN ('daemon', 'cloud_service', 'local_device')),
+    ADD COLUMN capabilities JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN models JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN runtime_features JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE TABLE agent_runtime_profile_state (
+    runtime_id UUID NOT NULL REFERENCES agent_runtime(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+    desired_version INTEGER NOT NULL,
+    applied_version INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'synced', 'failed')),
+    error TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (runtime_id, agent_id)
+);
+
+INSERT INTO agent_runtime_profile_state (
+    runtime_id,
+    agent_id,
+    desired_version,
+    applied_version,
+    status
+)
+SELECT
+    runtime_id,
+    id,
+    profile_version,
+    profile_version,
+    'synced'
+FROM agent
+WHERE archived_at IS NULL;
+
+CREATE INDEX idx_agent_runtime_profile_state_pending
+    ON agent_runtime_profile_state(runtime_id, status, desired_version, applied_version)
+    WHERE status <> 'synced' OR desired_version > applied_version;

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -851,6 +851,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
+		b.cfg.Logger.Info("codex latency checkpoint", "stage", "initialize", "elapsed", time.Since(startTime).Round(time.Millisecond).String())
 		c.notify("initialized")
 
 		// 2. Start a new thread, or resume the prior one for this issue. When
@@ -870,6 +871,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		} else {
 			b.cfg.Logger.Info("codex thread started", "thread_id", threadID)
 		}
+		b.cfg.Logger.Info("codex latency checkpoint", "stage", "thread_ready", "elapsed", time.Since(startTime).Round(time.Millisecond).String(), "resumed", resumed)
 
 		// 3. Send turn and wait for completion
 		turnParams := map[string]any{
@@ -917,6 +919,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				return
 			}
 		}
+		b.cfg.Logger.Info("codex latency checkpoint", "stage", "turn_start_ack", "elapsed", time.Since(startTime).Round(time.Millisecond).String())
 
 		lastSemanticActivity := time.Now()
 		lastSemanticActivityDescription := "turn/start"
@@ -928,6 +931,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		var firstTurnNoProgressTimerC <-chan time.Time
 		firstTurnStarted := false
 		firstTurnProgressObserved := false
+		firstTextObserved := false
 		stopFirstTurnNoProgressTimer := func() {
 			if firstTurnNoProgressTimer == nil {
 				return
@@ -962,6 +966,11 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				} else if firstTurnStarted && !firstTurnProgressObserved && isCodexFirstTurnProgressActivity(activity) {
 					firstTurnProgressObserved = true
 					stopFirstTurnNoProgressTimer()
+					b.cfg.Logger.Info("codex latency checkpoint", "stage", "first_semantic_progress", "elapsed", time.Since(startTime).Round(time.Millisecond).String(), "activity", activity)
+				}
+				if !firstTextObserved && (strings.HasPrefix(activity, "item/started:agentMessage") || strings.HasPrefix(activity, "item/agentMessage/delta")) {
+					firstTextObserved = true
+					b.cfg.Logger.Info("codex latency checkpoint", "stage", "first_text", "elapsed", time.Since(startTime).Round(time.Millisecond).String(), "activity", activity)
 				}
 			case <-firstTurnNoProgressTimerC:
 				waitingForTurn = false
@@ -1236,7 +1245,26 @@ func codexFirstTurnNoProgressTimeout(semanticInactivityTimeout time.Duration) ti
 }
 
 func isCodexFirstTurnProgressActivity(activity string) bool {
-	return activity != "" && activity != "status:running" && activity != "error:retry"
+	return activity != "" &&
+		activity != "status:running" &&
+		activity != "error:retry" &&
+		!isCodexUserMessageActivity(activity)
+}
+
+func isCodexUserMessageActivity(activity string) bool {
+	return strings.HasPrefix(activity, "item/started:userMessage") ||
+		strings.HasPrefix(activity, "item/completed:userMessage")
+}
+
+func isCodexItemProgressActivity(method, itemType string) bool {
+	if !strings.HasPrefix(method, "item/") {
+		return false
+	}
+	// The app-server echoes the submitted user prompt as a userMessage item
+	// before the model starts. Treating that echo as semantic progress masks
+	// first-turn stalls where Codex accepts the turn but never produces model
+	// output, tool calls, completion, or a terminal error.
+	return itemType != "userMessage"
 }
 
 func buildCodexTimeoutDiagnosticError(diag codexTimeoutDiagnostic, stderrTail string) string {
@@ -1894,7 +1922,7 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 	item, _ := params["item"].(map[string]any)
 	itemType, _ := item["type"].(string)
 	itemID, _ := item["id"].(string)
-	if isCodexItemProgressActivity(method) && c.onSemanticActivity != nil {
+	if isCodexItemProgressActivity(method, itemType) && c.onSemanticActivity != nil {
 		c.onSemanticActivity(describeCodexItemProgressActivity(method, itemType, itemID))
 	}
 	if item == nil {
@@ -1954,10 +1982,6 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 			}
 		}
 	}
-}
-
-func isCodexItemProgressActivity(method string) bool {
-	return strings.HasPrefix(method, "item/")
 }
 
 func describeCodexItemProgressActivity(method, itemType, itemID string) string {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1788,6 +1788,40 @@ func TestCodexExecuteFirstTurnRetryErrorDoesNotSatisfyProgress(t *testing.T) {
 	}
 }
 
+func TestCodexExecuteFirstTurnUserMessageDoesNotSatisfyProgress(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-user-message"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-user-message","turn":{"id":"turn-user-message"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-user-message","item":{"type":"userMessage","id":"user-1"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-user-message","item":{"type":"userMessage","id":"user-1"}}}'`+"\n"+
+		`sleep 5`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 200 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, CodexFirstTurnNoProgressMarker) {
+		t.Fatalf("expected first-turn no-progress error, got %q", result.Error)
+	}
+	if strings.Contains(result.Error, CodexSemanticInactivityMarker) {
+		t.Fatalf("userMessage should not demote first-turn timeout to semantic inactivity, got %q", result.Error)
+	}
+}
+
 func TestCodexExecuteLegacyFirstTurnMessageSatisfiesProgress(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type ArchiveAgentParams struct {
@@ -50,6 +50,10 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -58,7 +62,7 @@ const archiveAgentsByIDs = `-- name: ArchiveAgentsByIDs :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type ArchiveAgentsByIDsParams struct {
@@ -108,6 +112,10 @@ func (q *Queries) ArchiveAgentsByIDs(ctx context.Context, arg ArchiveAgentsByIDs
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -123,7 +131,7 @@ const archiveAgentsByRuntime = `-- name: ArchiveAgentsByRuntime :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE runtime_id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type ArchiveAgentsByRuntimeParams struct {
@@ -169,6 +177,10 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -178,6 +190,49 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 		return nil, err
 	}
 	return items, nil
+}
+
+const bumpAgentProfileVersion = `-- name: BumpAgentProfileVersion :one
+UPDATE agent
+SET profile_version = profile_version + 1, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
+`
+
+func (q *Queries) BumpAgentProfileVersion(ctx context.Context, id pgtype.UUID) (Agent, error) {
+	row := q.db.QueryRow(ctx, bumpAgentProfileVersion, id)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
+	)
+	return i, err
 }
 
 const cancelAgentTask = `-- name: CancelAgentTask :one
@@ -843,7 +898,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) 
 const clearAgentComposioToolkitAllowlist = `-- name: ClearAgentComposioToolkitAllowlist :one
 UPDATE agent SET composio_toolkit_allowlist = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 // Explicit NULL-clear for composio_toolkit_allowlist. The COALESCE-based
@@ -880,6 +935,10 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -887,7 +946,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 const clearAgentMcpConfig = `-- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -918,6 +977,10 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -925,7 +988,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 const clearAgentThinkingLevel = `-- name: ClearAgentThinkingLevel :one
 UPDATE agent SET thinking_level = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 // Explicit NULL-clear for thinking_level. COALESCE-based UpdateAgent cannot
@@ -959,6 +1022,10 @@ func (q *Queries) ClearAgentThinkingLevel(ctx context.Context, id pgtype.UUID) (
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -1042,15 +1109,15 @@ INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
-    composio_toolkit_allowlist, permission_mode
+    runtime_policy, memory_policy, approval_policy, composio_toolkit_allowlist, permission_mode
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
-    $11, $12, $13, $14, $15, $16,
-    $17::text[],
-    COALESCE($18, 'private')
+    $11, $12, $13, $14, $15, $16, $17, $18, $19,
+    $20::text[],
+    COALESCE($21, 'private')
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type CreateAgentParams struct {
@@ -1070,6 +1137,9 @@ type CreateAgentParams struct {
 	McpConfig                []byte      `json:"mcp_config"`
 	Model                    pgtype.Text `json:"model"`
 	ThinkingLevel            pgtype.Text `json:"thinking_level"`
+	RuntimePolicy            []byte      `json:"runtime_policy"`
+	MemoryPolicy             []byte      `json:"memory_policy"`
+	ApprovalPolicy           []byte      `json:"approval_policy"`
 	ComposioToolkitAllowlist []string    `json:"composio_toolkit_allowlist"`
 	PermissionMode           interface{} `json:"permission_mode"`
 }
@@ -1092,6 +1162,9 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.McpConfig,
 		arg.Model,
 		arg.ThinkingLevel,
+		arg.RuntimePolicy,
+		arg.MemoryPolicy,
+		arg.ApprovalPolicy,
 		arg.ComposioToolkitAllowlist,
 		arg.PermissionMode,
 	)
@@ -1121,6 +1194,10 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -1859,7 +1936,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE id = $1
 `
 
@@ -1891,12 +1968,16 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
 
 const getAgentForClaimUpdate = `-- name: GetAgentForClaimUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -1929,12 +2010,16 @@ func (q *Queries) GetAgentForClaimUpdate(ctx context.Context, id pgtype.UUID) (A
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -1971,6 +2056,10 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -2423,7 +2512,7 @@ func (q *Queries) LinkTaskToIssue(ctx context.Context, arg LinkTaskToIssueParams
 }
 
 const listActiveAgentsByRuntime = `-- name: ListActiveAgentsByRuntime :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL
 ORDER BY name ASC
 `
@@ -2468,6 +2557,10 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -2480,7 +2573,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listActiveAgentsByRuntimeForUpdate = `-- name: ListActiveAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL
 ORDER BY name ASC
 FOR UPDATE
@@ -2528,6 +2621,10 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -2669,7 +2766,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -2708,6 +2805,10 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -2720,7 +2821,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -2759,6 +2860,10 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.ThinkingLevel,
 			&i.ComposioToolkitAllowlist,
 			&i.PermissionMode,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -3342,7 +3447,7 @@ SET status = CASE WHEN EXISTS (
 ) THEN 'working' ELSE 'idle' END,
     updated_at = now()
 WHERE a.id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -3373,6 +3478,10 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -3380,7 +3489,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -3411,6 +3520,10 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -3493,9 +3606,12 @@ UPDATE agent SET
     model = COALESCE($16, model),
     thinking_level = COALESCE($17, thinking_level),
     composio_toolkit_allowlist = COALESCE($18::text[], composio_toolkit_allowlist),
+    runtime_policy = COALESCE($19, runtime_policy),
+    memory_policy = COALESCE($20, memory_policy),
+    approval_policy = COALESCE($21, approval_policy),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type UpdateAgentParams struct {
@@ -3517,6 +3633,9 @@ type UpdateAgentParams struct {
 	Model                    pgtype.Text `json:"model"`
 	ThinkingLevel            pgtype.Text `json:"thinking_level"`
 	ComposioToolkitAllowlist []string    `json:"composio_toolkit_allowlist"`
+	RuntimePolicy            []byte      `json:"runtime_policy"`
+	MemoryPolicy             []byte      `json:"memory_policy"`
+	ApprovalPolicy           []byte      `json:"approval_policy"`
 }
 
 // composio_toolkit_allowlist is set wholesale: the API layer is responsible
@@ -3545,6 +3664,9 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Model,
 		arg.ThinkingLevel,
 		arg.ComposioToolkitAllowlist,
+		arg.RuntimePolicy,
+		arg.MemoryPolicy,
+		arg.ApprovalPolicy,
 	)
 	var i Agent
 	err := row.Scan(
@@ -3572,6 +3694,10 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -3580,7 +3706,7 @@ const updateAgentCustomEnv = `-- name: UpdateAgentCustomEnv :one
 UPDATE agent
 SET custom_env = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type UpdateAgentCustomEnvParams struct {
@@ -3621,6 +3747,10 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }
@@ -3628,7 +3758,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, profile_version, runtime_policy, memory_policy, approval_policy
 `
 
 type UpdateAgentStatusParams struct {
@@ -3664,6 +3794,10 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.ThinkingLevel,
 		&i.ComposioToolkitAllowlist,
 		&i.PermissionMode,
+		&i.ProfileVersion,
+		&i.RuntimePolicy,
+		&i.MemoryPolicy,
+		&i.ApprovalPolicy,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -48,6 +48,10 @@ type Agent struct {
 	ComposioToolkitAllowlist []string `json:"composio_toolkit_allowlist"`
 	// Agent invocation permission mode (MUL-3963). private = owner only; public_to = allow-list in agent_invocation_target. Replaces visibility as the authorization source for triggering runs; visibility is now a derived legacy field. Default private = deny-by-default.
 	PermissionMode string `json:"permission_mode"`
+	ProfileVersion int32  `json:"profile_version"`
+	RuntimePolicy  []byte `json:"runtime_policy"`
+	MemoryPolicy   []byte `json:"memory_policy"`
+	ApprovalPolicy []byte `json:"approval_policy"`
 }
 
 // Allow-list of who may invoke a public_to agent (MUL-3963). One row per (agent, target_type, target); targets stack and canInvokeAgent OR-matches. workspace rows store the agent workspace_id in target_id; member rows store the user id; team rows are reserved and inert in V1. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: agent_id / created_by / member target_id relationships are maintained in the application layer (see migration comment).
@@ -61,23 +65,38 @@ type AgentInvocationTarget struct {
 }
 
 type AgentRuntime struct {
-	ID             pgtype.UUID        `json:"id"`
-	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
-	DaemonID       pgtype.Text        `json:"daemon_id"`
-	Name           string             `json:"name"`
-	RuntimeMode    string             `json:"runtime_mode"`
-	Provider       string             `json:"provider"`
+	ID              pgtype.UUID        `json:"id"`
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	DaemonID        pgtype.Text        `json:"daemon_id"`
+	Name            string             `json:"name"`
+	RuntimeMode     string             `json:"runtime_mode"`
+	Provider        string             `json:"provider"`
+	Status          string             `json:"status"`
+	DeviceInfo      string             `json:"device_info"`
+	Metadata        []byte             `json:"metadata"`
+	LastSeenAt      pgtype.Timestamptz `json:"last_seen_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	OwnerID         pgtype.UUID        `json:"owner_id"`
+	LegacyDaemonID  pgtype.Text        `json:"legacy_daemon_id"`
+	Visibility      string             `json:"visibility"`
+	ProfileID       pgtype.UUID        `json:"profile_id"`
+	CustomName      pgtype.Text        `json:"custom_name"`
+	EndpointType    string             `json:"endpoint_type"`
+	Capabilities    []byte             `json:"capabilities"`
+	Models          []byte             `json:"models"`
+	Tools           []byte             `json:"tools"`
+	RuntimeFeatures []byte             `json:"runtime_features"`
+}
+
+type AgentRuntimeProfileState struct {
+	RuntimeID      pgtype.UUID        `json:"runtime_id"`
+	AgentID        pgtype.UUID        `json:"agent_id"`
+	DesiredVersion int32              `json:"desired_version"`
+	AppliedVersion int32              `json:"applied_version"`
 	Status         string             `json:"status"`
-	DeviceInfo     string             `json:"device_info"`
-	Metadata       []byte             `json:"metadata"`
-	LastSeenAt     pgtype.Timestamptz `json:"last_seen_at"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	Error          pgtype.Text        `json:"error"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	OwnerID        pgtype.UUID        `json:"owner_id"`
-	LegacyDaemonID pgtype.Text        `json:"legacy_daemon_id"`
-	Visibility     string             `json:"visibility"`
-	ProfileID      pgtype.UUID        `json:"profile_id"`
-	CustomName     pgtype.Text        `json:"custom_name"`
 }
 
 type AgentSkill struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -265,7 +265,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 }
 
 const findLegacyRuntimesByDaemonID = `-- name: FindLegacyRuntimesByDaemonID :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE workspace_id = $1
   AND provider = $2
   AND LOWER(daemon_id) = LOWER($3)
@@ -319,6 +319,11 @@ func (q *Queries) FindLegacyRuntimesByDaemonID(ctx context.Context, arg FindLega
 			&i.Visibility,
 			&i.ProfileID,
 			&i.CustomName,
+			&i.EndpointType,
+			&i.Capabilities,
+			&i.Models,
+			&i.Tools,
+			&i.RuntimeFeatures,
 		); err != nil {
 			return nil, err
 		}
@@ -378,7 +383,7 @@ func (q *Queries) ForceOfflineRuntimesByIDs(ctx context.Context, runtimeIds []pg
 }
 
 const getAgentRuntime = `-- name: GetAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE id = $1
 `
 
@@ -403,12 +408,17 @@ func (q *Queries) GetAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRun
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
 }
 
 const getAgentRuntimeForWorkspace = `-- name: GetAgentRuntimeForWorkspace :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -438,12 +448,17 @@ func (q *Queries) GetAgentRuntimeForWorkspace(ctx context.Context, arg GetAgentR
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
 }
 
 const listAgentRuntimes = `-- name: ListAgentRuntimes :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -475,6 +490,11 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 			&i.Visibility,
 			&i.ProfileID,
 			&i.CustomName,
+			&i.EndpointType,
+			&i.Capabilities,
+			&i.Models,
+			&i.Tools,
+			&i.RuntimeFeatures,
 		); err != nil {
 			return nil, err
 		}
@@ -487,7 +507,7 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 }
 
 const listAgentRuntimesByOwner = `-- name: ListAgentRuntimesByOwner :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE workspace_id = $1 AND owner_id = $2
 ORDER BY created_at ASC
 `
@@ -524,6 +544,11 @@ func (q *Queries) ListAgentRuntimesByOwner(ctx context.Context, arg ListAgentRun
 			&i.Visibility,
 			&i.ProfileID,
 			&i.CustomName,
+			&i.EndpointType,
+			&i.Capabilities,
+			&i.Models,
+			&i.Tools,
+			&i.RuntimeFeatures,
 		); err != nil {
 			return nil, err
 		}
@@ -602,8 +627,108 @@ func (q *Queries) ListDaemonCustomNames(ctx context.Context, arg ListDaemonCusto
 	return items, nil
 }
 
+const listPendingAgentProfileUpdates = `-- name: ListPendingAgentProfileUpdates :many
+SELECT
+    a.id AS agent_id,
+    a.workspace_id,
+    a.name,
+    a.description,
+    a.instructions,
+    a.runtime_mode,
+    a.runtime_config,
+    a.custom_args,
+    a.mcp_config,
+    a.model,
+    a.thinking_level,
+    a.profile_version,
+    a.runtime_policy,
+    a.memory_policy,
+    a.approval_policy,
+    COALESCE(s.applied_version, 0)::integer AS applied_version,
+    COALESCE(s.status, 'pending')::text AS sync_status,
+    s.error AS sync_error
+FROM agent a
+LEFT JOIN agent_runtime_profile_state s
+  ON s.agent_id = a.id AND s.runtime_id = a.runtime_id
+WHERE a.runtime_id = $1
+  AND a.archived_at IS NULL
+  AND (
+      s.runtime_id IS NULL
+      OR s.status <> 'synced'
+      OR s.applied_version < a.profile_version
+      OR s.desired_version < a.profile_version
+  )
+ORDER BY a.updated_at ASC
+LIMIT COALESCE($2, 10)
+`
+
+type ListPendingAgentProfileUpdatesParams struct {
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+	Limit     interface{} `json:"limit"`
+}
+
+type ListPendingAgentProfileUpdatesRow struct {
+	AgentID        pgtype.UUID `json:"agent_id"`
+	WorkspaceID    pgtype.UUID `json:"workspace_id"`
+	Name           string      `json:"name"`
+	Description    string      `json:"description"`
+	Instructions   string      `json:"instructions"`
+	RuntimeMode    string      `json:"runtime_mode"`
+	RuntimeConfig  []byte      `json:"runtime_config"`
+	CustomArgs     []byte      `json:"custom_args"`
+	McpConfig      []byte      `json:"mcp_config"`
+	Model          pgtype.Text `json:"model"`
+	ThinkingLevel  pgtype.Text `json:"thinking_level"`
+	ProfileVersion int32       `json:"profile_version"`
+	RuntimePolicy  []byte      `json:"runtime_policy"`
+	MemoryPolicy   []byte      `json:"memory_policy"`
+	ApprovalPolicy []byte      `json:"approval_policy"`
+	AppliedVersion int32       `json:"applied_version"`
+	SyncStatus     string      `json:"sync_status"`
+	SyncError      pgtype.Text `json:"sync_error"`
+}
+
+func (q *Queries) ListPendingAgentProfileUpdates(ctx context.Context, arg ListPendingAgentProfileUpdatesParams) ([]ListPendingAgentProfileUpdatesRow, error) {
+	rows, err := q.db.Query(ctx, listPendingAgentProfileUpdates, arg.RuntimeID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPendingAgentProfileUpdatesRow{}
+	for rows.Next() {
+		var i ListPendingAgentProfileUpdatesRow
+		if err := rows.Scan(
+			&i.AgentID,
+			&i.WorkspaceID,
+			&i.Name,
+			&i.Description,
+			&i.Instructions,
+			&i.RuntimeMode,
+			&i.RuntimeConfig,
+			&i.CustomArgs,
+			&i.McpConfig,
+			&i.Model,
+			&i.ThinkingLevel,
+			&i.ProfileVersion,
+			&i.RuntimePolicy,
+			&i.MemoryPolicy,
+			&i.ApprovalPolicy,
+			&i.AppliedVersion,
+			&i.SyncStatus,
+			&i.SyncError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockAgentRuntime = `-- name: LockAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features FROM agent_runtime
 WHERE id = $1
 FOR UPDATE
 `
@@ -643,15 +768,104 @@ func (q *Queries) LockAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRu
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
+}
+
+const markAgentProfileAppliedForRuntime = `-- name: MarkAgentProfileAppliedForRuntime :one
+INSERT INTO agent_runtime_profile_state (
+    runtime_id,
+    agent_id,
+    desired_version,
+    applied_version,
+    status,
+    error,
+    updated_at
+) VALUES ($1, $2, $3, $3, $4, $5, now())
+ON CONFLICT (runtime_id, agent_id)
+DO UPDATE SET
+    desired_version = GREATEST(agent_runtime_profile_state.desired_version, EXCLUDED.desired_version),
+    applied_version = CASE
+        WHEN EXCLUDED.status = 'synced' THEN GREATEST(agent_runtime_profile_state.applied_version, EXCLUDED.applied_version)
+        ELSE agent_runtime_profile_state.applied_version
+    END,
+    status = EXCLUDED.status,
+    error = EXCLUDED.error,
+    updated_at = now()
+RETURNING runtime_id, agent_id, desired_version, applied_version, status, error, updated_at
+`
+
+type MarkAgentProfileAppliedForRuntimeParams struct {
+	RuntimeID      pgtype.UUID `json:"runtime_id"`
+	AgentID        pgtype.UUID `json:"agent_id"`
+	ProfileVersion int32       `json:"profile_version"`
+	Status         string      `json:"status"`
+	Error          pgtype.Text `json:"error"`
+}
+
+func (q *Queries) MarkAgentProfileAppliedForRuntime(ctx context.Context, arg MarkAgentProfileAppliedForRuntimeParams) (AgentRuntimeProfileState, error) {
+	row := q.db.QueryRow(ctx, markAgentProfileAppliedForRuntime,
+		arg.RuntimeID,
+		arg.AgentID,
+		arg.ProfileVersion,
+		arg.Status,
+		arg.Error,
+	)
+	var i AgentRuntimeProfileState
+	err := row.Scan(
+		&i.RuntimeID,
+		&i.AgentID,
+		&i.DesiredVersion,
+		&i.AppliedVersion,
+		&i.Status,
+		&i.Error,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const markAgentProfilePendingForRuntime = `-- name: MarkAgentProfilePendingForRuntime :exec
+INSERT INTO agent_runtime_profile_state (
+    runtime_id,
+    agent_id,
+    desired_version,
+    applied_version,
+    status,
+    error,
+    updated_at
+) VALUES ($1, $2, $3, 0, 'pending', NULL, now())
+ON CONFLICT (runtime_id, agent_id)
+DO UPDATE SET
+    desired_version = EXCLUDED.desired_version,
+    status = CASE
+        WHEN agent_runtime_profile_state.applied_version >= EXCLUDED.desired_version THEN 'synced'
+        ELSE 'pending'
+    END,
+    error = NULL,
+    updated_at = now()
+`
+
+type MarkAgentProfilePendingForRuntimeParams struct {
+	RuntimeID      pgtype.UUID `json:"runtime_id"`
+	AgentID        pgtype.UUID `json:"agent_id"`
+	DesiredVersion int32       `json:"desired_version"`
+}
+
+func (q *Queries) MarkAgentProfilePendingForRuntime(ctx context.Context, arg MarkAgentProfilePendingForRuntimeParams) error {
+	_, err := q.db.Exec(ctx, markAgentProfilePendingForRuntime, arg.RuntimeID, arg.AgentID, arg.DesiredVersion)
+	return err
 }
 
 const markAgentRuntimeOnline = `-- name: MarkAgentRuntimeOnline :one
 UPDATE agent_runtime
 SET status = 'online', last_seen_at = now(), updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features
 `
 
 // Used on the offline→online transition (and on first heartbeat after
@@ -678,6 +892,11 @@ func (q *Queries) MarkAgentRuntimeOnline(ctx context.Context, id pgtype.UUID) (A
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
 }
@@ -930,7 +1149,7 @@ const updateAgentRuntimeCustomName = `-- name: UpdateAgentRuntimeCustomName :one
 UPDATE agent_runtime
 SET custom_name = $1, updated_at = now()
 WHERE id = $2
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features
 `
 
 type UpdateAgentRuntimeCustomNameParams struct {
@@ -964,6 +1183,11 @@ func (q *Queries) UpdateAgentRuntimeCustomName(ctx context.Context, arg UpdateAg
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
 }
@@ -974,7 +1198,7 @@ SET custom_name = $1, updated_at = now()
 WHERE workspace_id = $2
   AND daemon_id = $3
   AND ($4::uuid IS NULL OR owner_id = $4)
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features
 `
 
 type UpdateAgentRuntimeCustomNameByDaemonParams struct {
@@ -1022,6 +1246,11 @@ func (q *Queries) UpdateAgentRuntimeCustomNameByDaemon(ctx context.Context, arg 
 			&i.Visibility,
 			&i.ProfileID,
 			&i.CustomName,
+			&i.EndpointType,
+			&i.Capabilities,
+			&i.Models,
+			&i.Tools,
+			&i.RuntimeFeatures,
 		); err != nil {
 			return nil, err
 		}
@@ -1037,7 +1266,7 @@ const updateAgentRuntimeVisibility = `-- name: UpdateAgentRuntimeVisibility :one
 UPDATE agent_runtime
 SET visibility = $1, updated_at = now()
 WHERE id = $2
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features
 `
 
 type UpdateAgentRuntimeVisibilityParams struct {
@@ -1070,6 +1299,11 @@ func (q *Queries) UpdateAgentRuntimeVisibility(ctx context.Context, arg UpdateAg
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 	)
 	return i, err
 }
@@ -1084,9 +1318,14 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
+    endpoint_type,
+    capabilities,
+    models,
+    tools,
+    runtime_features,
     owner_id,
     last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now())
 ON CONFLICT (workspace_id, daemon_id, provider) WHERE profile_id IS NULL
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -1094,43 +1333,58 @@ DO UPDATE SET
     status = EXCLUDED.status,
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
+    endpoint_type = EXCLUDED.endpoint_type,
+    capabilities = EXCLUDED.capabilities,
+    models = EXCLUDED.models,
+    tools = EXCLUDED.tools,
+    runtime_features = EXCLUDED.runtime_features,
     owner_id = COALESCE(EXCLUDED.owner_id, agent_runtime.owner_id),
     last_seen_at = now(),
     updated_at = now()
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, (xmax = 0) AS inserted
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features, (xmax = 0) AS inserted
 `
 
 type UpsertAgentRuntimeParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	DaemonID    pgtype.Text `json:"daemon_id"`
-	Name        string      `json:"name"`
-	RuntimeMode string      `json:"runtime_mode"`
-	Provider    string      `json:"provider"`
-	Status      string      `json:"status"`
-	DeviceInfo  string      `json:"device_info"`
-	Metadata    []byte      `json:"metadata"`
-	OwnerID     pgtype.UUID `json:"owner_id"`
+	WorkspaceID     pgtype.UUID `json:"workspace_id"`
+	DaemonID        pgtype.Text `json:"daemon_id"`
+	Name            string      `json:"name"`
+	RuntimeMode     string      `json:"runtime_mode"`
+	Provider        string      `json:"provider"`
+	Status          string      `json:"status"`
+	DeviceInfo      string      `json:"device_info"`
+	Metadata        []byte      `json:"metadata"`
+	EndpointType    string      `json:"endpoint_type"`
+	Capabilities    []byte      `json:"capabilities"`
+	Models          []byte      `json:"models"`
+	Tools           []byte      `json:"tools"`
+	RuntimeFeatures []byte      `json:"runtime_features"`
+	OwnerID         pgtype.UUID `json:"owner_id"`
 }
 
 type UpsertAgentRuntimeRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
-	DaemonID       pgtype.Text        `json:"daemon_id"`
-	Name           string             `json:"name"`
-	RuntimeMode    string             `json:"runtime_mode"`
-	Provider       string             `json:"provider"`
-	Status         string             `json:"status"`
-	DeviceInfo     string             `json:"device_info"`
-	Metadata       []byte             `json:"metadata"`
-	LastSeenAt     pgtype.Timestamptz `json:"last_seen_at"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	OwnerID        pgtype.UUID        `json:"owner_id"`
-	LegacyDaemonID pgtype.Text        `json:"legacy_daemon_id"`
-	Visibility     string             `json:"visibility"`
-	ProfileID      pgtype.UUID        `json:"profile_id"`
-	CustomName     pgtype.Text        `json:"custom_name"`
-	Inserted       bool               `json:"inserted"`
+	ID              pgtype.UUID        `json:"id"`
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	DaemonID        pgtype.Text        `json:"daemon_id"`
+	Name            string             `json:"name"`
+	RuntimeMode     string             `json:"runtime_mode"`
+	Provider        string             `json:"provider"`
+	Status          string             `json:"status"`
+	DeviceInfo      string             `json:"device_info"`
+	Metadata        []byte             `json:"metadata"`
+	LastSeenAt      pgtype.Timestamptz `json:"last_seen_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	OwnerID         pgtype.UUID        `json:"owner_id"`
+	LegacyDaemonID  pgtype.Text        `json:"legacy_daemon_id"`
+	Visibility      string             `json:"visibility"`
+	ProfileID       pgtype.UUID        `json:"profile_id"`
+	CustomName      pgtype.Text        `json:"custom_name"`
+	EndpointType    string             `json:"endpoint_type"`
+	Capabilities    []byte             `json:"capabilities"`
+	Models          []byte             `json:"models"`
+	Tools           []byte             `json:"tools"`
+	RuntimeFeatures []byte             `json:"runtime_features"`
+	Inserted        bool               `json:"inserted"`
 }
 
 // (xmax = 0) AS inserted distinguishes a fresh insert (true) from an upsert
@@ -1150,6 +1404,11 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		arg.Status,
 		arg.DeviceInfo,
 		arg.Metadata,
+		arg.EndpointType,
+		arg.Capabilities,
+		arg.Models,
+		arg.Tools,
+		arg.RuntimeFeatures,
 		arg.OwnerID,
 	)
 	var i UpsertAgentRuntimeRow
@@ -1171,6 +1430,11 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 		&i.Inserted,
 	)
 	return i, err
@@ -1186,10 +1450,15 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
+    endpoint_type,
+    capabilities,
+    models,
+    tools,
+    runtime_features,
     owner_id,
     profile_id,
     last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now())
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now())
 ON CONFLICT (workspace_id, daemon_id, profile_id) WHERE profile_id IS NOT NULL
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -1198,44 +1467,59 @@ DO UPDATE SET
     status = EXCLUDED.status,
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
+    endpoint_type = EXCLUDED.endpoint_type,
+    capabilities = EXCLUDED.capabilities,
+    models = EXCLUDED.models,
+    tools = EXCLUDED.tools,
+    runtime_features = EXCLUDED.runtime_features,
     owner_id = COALESCE(EXCLUDED.owner_id, agent_runtime.owner_id),
     last_seen_at = now(),
     updated_at = now()
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, (xmax = 0) AS inserted
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, legacy_daemon_id, visibility, profile_id, custom_name, endpoint_type, capabilities, models, tools, runtime_features, (xmax = 0) AS inserted
 `
 
 type UpsertAgentRuntimeWithProfileParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	DaemonID    pgtype.Text `json:"daemon_id"`
-	Name        string      `json:"name"`
-	RuntimeMode string      `json:"runtime_mode"`
-	Provider    string      `json:"provider"`
-	Status      string      `json:"status"`
-	DeviceInfo  string      `json:"device_info"`
-	Metadata    []byte      `json:"metadata"`
-	OwnerID     pgtype.UUID `json:"owner_id"`
-	ProfileID   pgtype.UUID `json:"profile_id"`
+	WorkspaceID     pgtype.UUID `json:"workspace_id"`
+	DaemonID        pgtype.Text `json:"daemon_id"`
+	Name            string      `json:"name"`
+	RuntimeMode     string      `json:"runtime_mode"`
+	Provider        string      `json:"provider"`
+	Status          string      `json:"status"`
+	DeviceInfo      string      `json:"device_info"`
+	Metadata        []byte      `json:"metadata"`
+	EndpointType    string      `json:"endpoint_type"`
+	Capabilities    []byte      `json:"capabilities"`
+	Models          []byte      `json:"models"`
+	Tools           []byte      `json:"tools"`
+	RuntimeFeatures []byte      `json:"runtime_features"`
+	OwnerID         pgtype.UUID `json:"owner_id"`
+	ProfileID       pgtype.UUID `json:"profile_id"`
 }
 
 type UpsertAgentRuntimeWithProfileRow struct {
-	ID             pgtype.UUID        `json:"id"`
-	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
-	DaemonID       pgtype.Text        `json:"daemon_id"`
-	Name           string             `json:"name"`
-	RuntimeMode    string             `json:"runtime_mode"`
-	Provider       string             `json:"provider"`
-	Status         string             `json:"status"`
-	DeviceInfo     string             `json:"device_info"`
-	Metadata       []byte             `json:"metadata"`
-	LastSeenAt     pgtype.Timestamptz `json:"last_seen_at"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	OwnerID        pgtype.UUID        `json:"owner_id"`
-	LegacyDaemonID pgtype.Text        `json:"legacy_daemon_id"`
-	Visibility     string             `json:"visibility"`
-	ProfileID      pgtype.UUID        `json:"profile_id"`
-	CustomName     pgtype.Text        `json:"custom_name"`
-	Inserted       bool               `json:"inserted"`
+	ID              pgtype.UUID        `json:"id"`
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	DaemonID        pgtype.Text        `json:"daemon_id"`
+	Name            string             `json:"name"`
+	RuntimeMode     string             `json:"runtime_mode"`
+	Provider        string             `json:"provider"`
+	Status          string             `json:"status"`
+	DeviceInfo      string             `json:"device_info"`
+	Metadata        []byte             `json:"metadata"`
+	LastSeenAt      pgtype.Timestamptz `json:"last_seen_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	OwnerID         pgtype.UUID        `json:"owner_id"`
+	LegacyDaemonID  pgtype.Text        `json:"legacy_daemon_id"`
+	Visibility      string             `json:"visibility"`
+	ProfileID       pgtype.UUID        `json:"profile_id"`
+	CustomName      pgtype.Text        `json:"custom_name"`
+	EndpointType    string             `json:"endpoint_type"`
+	Capabilities    []byte             `json:"capabilities"`
+	Models          []byte             `json:"models"`
+	Tools           []byte             `json:"tools"`
+	RuntimeFeatures []byte             `json:"runtime_features"`
+	Inserted        bool               `json:"inserted"`
 }
 
 // Custom-runtime registration: a daemon resolved a workspace runtime_profile's
@@ -1255,6 +1539,11 @@ func (q *Queries) UpsertAgentRuntimeWithProfile(ctx context.Context, arg UpsertA
 		arg.Status,
 		arg.DeviceInfo,
 		arg.Metadata,
+		arg.EndpointType,
+		arg.Capabilities,
+		arg.Models,
+		arg.Tools,
+		arg.RuntimeFeatures,
 		arg.OwnerID,
 		arg.ProfileID,
 	)
@@ -1277,6 +1566,11 @@ func (q *Queries) UpsertAgentRuntimeWithProfile(ctx context.Context, arg UpsertA
 		&i.Visibility,
 		&i.ProfileID,
 		&i.CustomName,
+		&i.EndpointType,
+		&i.Capabilities,
+		&i.Models,
+		&i.Tools,
+		&i.RuntimeFeatures,
 		&i.Inserted,
 	)
 	return i, err

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -21,11 +21,11 @@ INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
-    composio_toolkit_allowlist, permission_mode
+    runtime_policy, memory_policy, approval_policy, composio_toolkit_allowlist, permission_mode
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
-    $11, $12, $13, $14, $15, $16,
+    $11, $12, $13, $14, $15, $16, $17, $18, $19,
     sqlc.narg('composio_toolkit_allowlist')::text[],
     COALESCE(sqlc.narg('permission_mode'), 'private')
 )
@@ -56,6 +56,9 @@ UPDATE agent SET
     model = COALESCE(sqlc.narg('model'), model),
     thinking_level = COALESCE(sqlc.narg('thinking_level'), thinking_level),
     composio_toolkit_allowlist = COALESCE(sqlc.narg('composio_toolkit_allowlist')::text[], composio_toolkit_allowlist),
+    runtime_policy = COALESCE(sqlc.narg('runtime_policy'), runtime_policy),
+    memory_policy = COALESCE(sqlc.narg('memory_policy'), memory_policy),
+    approval_policy = COALESCE(sqlc.narg('approval_policy'), approval_policy),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
@@ -68,6 +71,12 @@ RETURNING *;
 -- dedicated query when the agent owner removes every toolkit; subsequent
 -- dispatch decisions treat NULL identically to `{}` (both -> no overlay).
 UPDATE agent SET composio_toolkit_allowlist = NULL, updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: BumpAgentProfileVersion :one
+UPDATE agent
+SET profile_version = profile_version + 1, updated_at = now()
 WHERE id = $1
 RETURNING *;
 

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -42,9 +42,14 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
+    endpoint_type,
+    capabilities,
+    models,
+    tools,
+    runtime_features,
     owner_id,
     last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, now())
 -- Built-in runtimes carry no profile_id. The arbiter is the partial unique
 -- index from migration 121 (WHERE profile_id IS NULL); the predicate must be
 -- spelled out so Postgres selects that partial index, not the custom-runtime
@@ -56,6 +61,11 @@ DO UPDATE SET
     status = EXCLUDED.status,
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
+    endpoint_type = EXCLUDED.endpoint_type,
+    capabilities = EXCLUDED.capabilities,
+    models = EXCLUDED.models,
+    tools = EXCLUDED.tools,
+    runtime_features = EXCLUDED.runtime_features,
     owner_id = COALESCE(EXCLUDED.owner_id, agent_runtime.owner_id),
     last_seen_at = now(),
     updated_at = now()
@@ -78,10 +88,15 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
+    endpoint_type,
+    capabilities,
+    models,
+    tools,
+    runtime_features,
     owner_id,
     profile_id,
     last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now())
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now())
 ON CONFLICT (workspace_id, daemon_id, profile_id) WHERE profile_id IS NOT NULL
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -90,10 +105,91 @@ DO UPDATE SET
     status = EXCLUDED.status,
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
+    endpoint_type = EXCLUDED.endpoint_type,
+    capabilities = EXCLUDED.capabilities,
+    models = EXCLUDED.models,
+    tools = EXCLUDED.tools,
+    runtime_features = EXCLUDED.runtime_features,
     owner_id = COALESCE(EXCLUDED.owner_id, agent_runtime.owner_id),
     last_seen_at = now(),
     updated_at = now()
 RETURNING *, (xmax = 0) AS inserted;
+
+-- name: ListPendingAgentProfileUpdates :many
+SELECT
+    a.id AS agent_id,
+    a.workspace_id,
+    a.name,
+    a.description,
+    a.instructions,
+    a.runtime_mode,
+    a.runtime_config,
+    a.custom_args,
+    a.mcp_config,
+    a.model,
+    a.thinking_level,
+    a.profile_version,
+    a.runtime_policy,
+    a.memory_policy,
+    a.approval_policy,
+    COALESCE(s.applied_version, 0)::integer AS applied_version,
+    COALESCE(s.status, 'pending')::text AS sync_status,
+    s.error AS sync_error
+FROM agent a
+LEFT JOIN agent_runtime_profile_state s
+  ON s.agent_id = a.id AND s.runtime_id = a.runtime_id
+WHERE a.runtime_id = @runtime_id
+  AND a.archived_at IS NULL
+  AND (
+      s.runtime_id IS NULL
+      OR s.status <> 'synced'
+      OR s.applied_version < a.profile_version
+      OR s.desired_version < a.profile_version
+  )
+ORDER BY a.updated_at ASC
+LIMIT COALESCE(sqlc.narg('limit'), 10);
+
+-- name: MarkAgentProfilePendingForRuntime :exec
+INSERT INTO agent_runtime_profile_state (
+    runtime_id,
+    agent_id,
+    desired_version,
+    applied_version,
+    status,
+    error,
+    updated_at
+) VALUES (@runtime_id, @agent_id, @desired_version, 0, 'pending', NULL, now())
+ON CONFLICT (runtime_id, agent_id)
+DO UPDATE SET
+    desired_version = EXCLUDED.desired_version,
+    status = CASE
+        WHEN agent_runtime_profile_state.applied_version >= EXCLUDED.desired_version THEN 'synced'
+        ELSE 'pending'
+    END,
+    error = NULL,
+    updated_at = now();
+
+-- name: MarkAgentProfileAppliedForRuntime :one
+INSERT INTO agent_runtime_profile_state (
+    runtime_id,
+    agent_id,
+    desired_version,
+    applied_version,
+    status,
+    error,
+    updated_at
+) VALUES (@runtime_id, @agent_id, @profile_version, @profile_version, @status, @error, now())
+ON CONFLICT (runtime_id, agent_id)
+DO UPDATE SET
+    desired_version = GREATEST(agent_runtime_profile_state.desired_version, EXCLUDED.desired_version),
+    applied_version = CASE
+        WHEN EXCLUDED.status = 'synced' THEN GREATEST(agent_runtime_profile_state.applied_version, EXCLUDED.applied_version)
+        ELSE agent_runtime_profile_state.applied_version
+    END,
+    status = EXCLUDED.status,
+    error = EXCLUDED.error,
+    updated_at = now()
+RETURNING *;
 
 -- name: UpdateAgentRuntimeVisibility :one
 -- Toggles a runtime between 'private' (only owner can bind agents) and

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -153,6 +153,7 @@ type DaemonHeartbeatAckPayload struct {
 	PendingLocalSkills      *DaemonHeartbeatPendingLocalSkills      `json:"pending_local_skills,omitempty"`
 	PendingLocalSkillImport *DaemonHeartbeatPendingLocalSkillImport `json:"pending_local_skill_import,omitempty"`
 	FeatureFlags            *DaemonFeatureFlagSnapshot              `json:"feature_flags,omitempty"`
+	PendingProfileUpdates   []DaemonHeartbeatPendingProfileUpdate   `json:"pending_profile_updates,omitempty"`
 	// PendingLocalSkillImports carries multiple import requests in a single
 	// heartbeat so the daemon can process them concurrently. Old daemons
 	// that don't know this field silently ignore it (standard JSON behavior)
@@ -196,4 +197,30 @@ type DaemonHeartbeatPendingLocalSkills struct {
 type DaemonHeartbeatPendingLocalSkillImport struct {
 	ID       string `json:"id"`
 	SkillKey string `json:"skill_key"`
+}
+
+// DaemonHeartbeatPendingProfileUpdate is the server-authoritative AgentProfile
+// desired state a daemon should apply before running future tasks for that
+// agent. Secret-bearing env values intentionally stay out of this payload; the
+// task claim path still scopes and redacts those values separately.
+type DaemonHeartbeatPendingProfileUpdate struct {
+	AgentID        string          `json:"agent_id"`
+	RuntimeID      string          `json:"runtime_id"`
+	WorkspaceID    string          `json:"workspace_id"`
+	Version        int32           `json:"version"`
+	AppliedVersion int32           `json:"applied_version"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	Instructions   string          `json:"instructions"`
+	RuntimeMode    string          `json:"runtime_mode"`
+	RuntimeConfig  json.RawMessage `json:"runtime_config,omitempty"`
+	CustomArgs     []string        `json:"custom_args,omitempty"`
+	McpConfig      json.RawMessage `json:"mcp_config,omitempty"`
+	Model          string          `json:"model,omitempty"`
+	ThinkingLevel  string          `json:"thinking_level,omitempty"`
+	RuntimePolicy  json.RawMessage `json:"runtime_policy,omitempty"`
+	MemoryPolicy   json.RawMessage `json:"memory_policy,omitempty"`
+	ApprovalPolicy json.RawMessage `json:"approval_policy,omitempty"`
+	SyncStatus     string          `json:"sync_status,omitempty"`
+	SyncError      string          `json:"sync_error,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Adds daemon/control-plane profile synchronization so agent profile changes can be propagated to connected runtimes through heartbeat pending actions.
- Adds runtime metadata reporting for endpoint type, capabilities, models, tools, and runtime features.
- Adds agent profile version and policy fields (`runtime_policy`, `memory_policy`, `approval_policy`) with migration `146_daemon_control_plane_sync` and regenerated sqlc code.
- Improves Codex/OpenClaw execution environment handling around plugin cache exposure, MCP inheritance stripping, model catalog sync, skill frontmatter sanitization, and Codex workspace skill behavior.

## Cross-repo plan
- Merge order: merge this Multica PR before the Mattermost PR so runtime/workspace metadata exists for IM-side workspace surfaces.
- Dependency: Mattermost integration consumes workspace/runtime state surfaced by this control-plane path, but this PR is independently revertible.
- Rollback: revert this PR to remove profile sync fields/migration and daemon pending-profile update handling. If already migrated in an environment, run the down migration before reverting binaries.

## Validation
- Rebasing: moved local work from old `main` onto latest `origin/main` (`6be496c65`) and resolved conflicts by preserving new mainline runtime-profile, feature-flag, Composio, and invocation-permission behavior.
- `sqlc generate` passed using sqlc v1.31.1 downloaded to `/tmp`.
- `CGO_ENABLED=0 go test ./internal/daemon/execenv ./internal/daemon/... ./pkg/agent ./pkg/protocol` passed.
- `CGO_ENABLED=0 go test ./internal/handler/...` did not run to completion because the local test database schema is stale: `column "permission_mode" of relation "agent" does not exist`. That column is from existing upstream migrations, not this PR.
- Full cgo-enabled test/install paths on this machine are blocked by macOS Xcode license acceptance (`sudo xcodebuild -license`).
