### PR TITLE
fix(chat): refresh Chat V2 input placeholder without remount (MUL-4276)

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -113,10 +113,12 @@ export function ChatInput({
   // mid-compose gives each agent its own draft. This is a STORAGE key, not
   // a React identity.
   //
-  // `editorKey` — React `key` on the ContentEditor. Used to force a
-  // remount when the user explicitly switches agent (so Tiptap's
-  // Placeholder, which only reads on mount, refreshes to "Tell {agent}…").
-  // A cancelled-run draft restore does NOT bump this key: it just writes
+  // `editorKey` — React `key` on the ContentEditor. Forces a fresh editor
+  // instance when the user explicitly switches agent. Placeholder text itself
+  // no longer depends on this: ContentEditor's placeholder-sync effect
+  // refreshes it live (e.g. across archived ↔ active sessions of the SAME
+  // agent, where this key does not change). A cancelled-run draft restore
+  // does NOT bump this key either: it just writes
   // the restored text into `inputDraft`, and the editor's own
   // defaultValue-sync effect (content-editor.tsx) pushes it into the live
   // instance. There is no second copy of the draft to drift or resurface.

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -7,6 +7,14 @@ import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 const mockFocus = vi.hoisted(() => vi.fn());
 const mockSetContent = vi.hoisted(() => vi.fn());
 const mockSetTextSelection = vi.hoisted(() => vi.fn());
+const mockDispatch = vi.hoisted(() => vi.fn());
+const emptyTr = vi.hoisted(() => ({ __emptyTransaction: true }));
+// Captures the options ContentEditor hands to createEditorExtensions on its
+// most recent render — lets the placeholder tests assert the getter it wires
+// into the Placeholder extension reads the live value.
+const capturedExtOptions = vi.hoisted<{
+  current: { placeholder?: string | (() => string) } | undefined;
+}>(() => ({ current: undefined }));
 const editorState = vi.hoisted(() => ({
   isFocused: false,
   isDestroyed: false,
@@ -31,7 +39,12 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 vi.mock("./extensions", () => ({
-  createEditorExtensions: () => [],
+  createEditorExtensions: (options: {
+    placeholder?: string | (() => string);
+  }) => {
+    capturedExtOptions.current = options;
+    return [];
+  },
 }));
 
 vi.mock("./extensions/file-upload", () => ({
@@ -93,7 +106,11 @@ vi.mock("@tiptap/react", () => ({
           setTextSelection: mockSetTextSelection,
         },
         getMarkdown: () => editorState.markdown,
+        view: { dispatch: mockDispatch },
         state: {
+          get tr() {
+            return emptyTr;
+          },
           doc: {
             content: { size: 0 },
             descendants: (cb: (node: { attrs: { uploading?: boolean } }) => boolean | void) => {
@@ -132,6 +149,7 @@ describe("ContentEditor", () => {
     onCreateFired.value = false;
     latestEditorOptions.current = undefined;
     providerProps.attachments = undefined;
+    capturedExtOptions.current = undefined;
   });
 
   afterEach(() => {
@@ -367,6 +385,41 @@ describe("ContentEditor", () => {
     unmount();
 
     expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the live placeholder getter and repaints when the placeholder prop changes", () => {
+    // Repro for MUL-4276: Tiptap's Placeholder snapshots a *string* option at
+    // mount, so switching between an archived and an active chat session under
+    // the SAME agent (no editor remount) left the input frozen on the archived
+    // copy. The fix wires a *getter* over a live ref into the extension and, on
+    // change, dispatches an empty transaction to force a decoration recompute.
+    const { rerender } = render(
+      <ContentEditor placeholder="This session is archived" />,
+    );
+    // What reaches the Placeholder extension is a getter, not a static string.
+    const getter = capturedExtOptions.current?.placeholder;
+    expect(typeof getter).toBe("function");
+    expect((getter as () => string)()).toBe("This session is archived");
+
+    mockDispatch.mockClear();
+
+    rerender(<ContentEditor placeholder="Message agent…" />);
+
+    // Same getter identity now returns the new text (reads the live ref)…
+    expect((getter as () => string)()).toBe("Message agent…");
+    // …and a repaint was nudged so the mounted decoration re-reads it.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(emptyTr);
+  });
+
+  it("does not repaint when the placeholder prop is unchanged", () => {
+    const { rerender } = render(<ContentEditor placeholder="Message agent…" />);
+
+    mockDispatch.mockClear();
+
+    rerender(<ContentEditor placeholder="Message agent…" />);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -220,6 +220,12 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     >(undefined);
     const mentionContextItemsRef = useRef<MentionItem[]>(mentionContextItems ?? []);
     const lastEmittedRef = useRef<string | null>(null);
+    // Live placeholder text. Passed into the Placeholder extension as a getter
+    // (not a static string) so the plugin re-reads it on every decoration pass —
+    // the sync effect below updates this ref and nudges a repaint. Tiptap
+    // snapshots a *string* placeholder at mount, so a getter is what lets it
+    // change without remounting the editor.
+    const placeholderRef = useRef(placeholderText);
 
     // In-session record of attachments freshly uploaded through this editor.
     // Surfaces (like the quick-create modal) that don't have a server-supplied
@@ -339,7 +345,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
           ? "markdown"
           : undefined,
       extensions: createEditorExtensions({
-        placeholder: placeholderText,
+        placeholder: () => placeholderRef.current,
         queryClient,
         onSubmitRef,
         onUploadFileRef,
@@ -486,6 +492,24 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
 
       lastEmittedRef.current = normalizeEditorMarkdown(editor);
     }, [defaultValue, editor]);
+
+    // Sync external `placeholder` changes into the mounted editor.
+    // The Placeholder extension is configured with a getter over `placeholderRef`
+    // (see createEditorExtensions above), which the plugin re-invokes every time
+    // it recomputes its decorations. Update the ref, then dispatch an empty
+    // transaction to force that recompute — the placeholder refreshes without a
+    // remount. Without this, it stays frozen at its mount value: switching
+    // between an archived and an active chat session under the same agent (no
+    // editor remount) leaves the input stuck on "This session is archived" even
+    // though it is usable.
+    useEffect(() => {
+      if (placeholderRef.current === placeholderText) return;
+      placeholderRef.current = placeholderText;
+      if (!editor || editor.isDestroyed) return;
+      // `docChanged` is false on an empty transaction, so onUpdate never fires
+      // and no self-write loop is triggered.
+      editor.view.dispatch(editor.state.tr);
+    }, [editor, placeholderText]);
 
     useImperativeHandle(ref, () => ({
       // Intentionally NOT routed through `normalizeMarkdown` — this refactor

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -117,7 +117,14 @@ export const ImageExtension = Image.extend({
 });
 
 export interface EditorExtensionsOptions {
-  placeholder?: string;
+  /**
+   * Placeholder text, or a getter for it. Prefer a getter when the value can
+   * change over the editor's lifetime: Tiptap's Placeholder snapshots a string
+   * option at mount, but re-invokes a function every time it recomputes its
+   * decorations — so a getter (paired with an empty-transaction nudge) lets the
+   * placeholder update live without remounting the editor. See ContentEditor.
+   */
+  placeholder?: string | (() => string);
   queryClient?: import("@tanstack/react-query").QueryClient;
   onSubmitRef?: RefObject<(() => void) | undefined>;
   onUploadFileRef?: RefObject<


### PR DESCRIPTION
## Problem

Chat V2 (IM-style Chat tab, #5076) input placeholder stays stuck on "This session is archived" (`placeholder_archived`) even on a normal, active, usable session.

## Root cause

The placeholder computation itself is correct. The real issue is that Tiptap's Placeholder only reads its text **at mount**:

- `content-editor.tsx` had a `defaultValue`-sync effect but **no placeholder-sync effect**, so the placeholder never refreshed after mount.
- The editor only remounts when `editorKey = selectedAgentId` changes (agent switch). Switching between sessions **of the same agent** does not remount, so the placeholder freezes on whatever value was set when it last mounted (e.g. the archived copy after visiting an archived session).

Because most users chat mostly with the same agent, once it sticks it stays stuck — hence "always archived".

## Fix

An important gotcha: mutating the extension's **string** option at runtime does **not** repaint — Tiptap snapshots a string placeholder at mount. A **function** placeholder, however, is re-invoked on every decoration pass. So:

- `editor/extensions/index.ts` — `placeholder` option now accepts `string | (() => string)`.
- `editor/content-editor.tsx` — pass a getter `() => placeholderRef.current` to the Placeholder extension; a new placeholder-sync effect (symmetric with the `defaultValue`-sync effect) updates the ref and dispatches an empty transaction (`docChanged=false` → no `onUpdate` loop) to force a decoration recompute. No remount needed. This also fixes placeholder staleness when the session/agent archive state changes live.
- `chat/components/chat-input.tsx` — updated the `editorKey` comment (placeholder no longer relies on the agent-switch remount).

## Tests

- Added unit tests: the getter wired into the extension reads the live value and a single repaint is nudged on change; no repaint when the placeholder prop is unchanged.

## Verification

- `pnpm --filter @multica/views typecheck` ✅
- `editor/` suite: 520 tests passed ✅
- eslint clean ✅
- Built the **real Tiptap (3.27)** into headless Chromium and confirmed the before/after: with a static string the placeholder stays "This session is archived"; with the getter + empty-transaction nudge it correctly updates to "Message {agent}…" — same editor instance, no remount.

Closes MUL-4276.
