### PR TITLE
feat(chat): default floating chat window to on (MUL-4281)

### DIFF
--- a/packages/core/chat/store.test.ts
+++ b/packages/core/chat/store.test.ts
@@ -97,8 +97,15 @@ describe("chat store — draft attachments", () => {
 });
 
 describe("chat store — floating window preference", () => {
-  it("defaults OFF when no preference is stored (opt-in)", () => {
+  it("defaults ON when no preference is stored", () => {
     const store = createChatStore({ storage: memStorage() });
+    expect(store.getState().floatingChatEnabled).toBe(true);
+  });
+
+  it("honours an explicit stored 'false' preference (opt-out)", () => {
+    const storage = memStorage();
+    storage.setItem("multica:chat:floatingChatEnabled", "false");
+    const store = createChatStore({ storage });
     expect(store.getState().floatingChatEnabled).toBe(false);
   });
 

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -40,8 +40,8 @@ const OPEN_KEY = "multica:chat:isOpen";
  * Whether the floating chat window (FAB + overlay) is available at all,
  * persisted globally like OPEN_KEY. This is the Settings → Chat preference:
  * when off, the FAB/overlay never mount and Chat lives only in its tab.
- * Missing key = default OFF — the floating window is opt-in, enabled from
- * the Settings → Chat tab.
+ * Missing key = default ON — the floating window is on by default and can
+ * be turned off from the Settings → Chat tab.
  */
 const FLOATING_KEY = "multica:chat:floatingChatEnabled";
 
@@ -179,9 +179,10 @@ export function createChatStore(options: ChatStoreOptions) {
   const storedOpen = storage.getItem(OPEN_KEY);
   const initialIsOpen = storedOpen === "true";
 
-  // Default OFF: the floating window is opt-in — only an explicit "true"
-  // (set from the Settings → Chat tab) enables it.
-  const initialFloatingEnabled = storage.getItem(FLOATING_KEY) === "true";
+  // Default ON: the floating window is enabled unless the user explicitly
+  // turned it off ("false") from the Settings → Chat tab. A missing key
+  // (new user) resolves to enabled.
+  const initialFloatingEnabled = storage.getItem(FLOATING_KEY) !== "false";
 
   const store = create<ChatState>((set, get) => ({
     isOpen: initialIsOpen,

--- a/packages/views/settings/components/chat-tab.tsx
+++ b/packages/views/settings/components/chat-tab.tsx
@@ -6,8 +6,8 @@ import { useT } from "../../i18n";
 
 /**
  * Chat settings — its own tab under "My Account". Currently just the
- * floating-window toggle: when off (the default), the FAB / overlay never
- * mount and Chat is reachable only from its dedicated tab. The preference is
+ * floating-window toggle: when off, the FAB / overlay never mount and Chat
+ * is reachable only from its dedicated tab. It is on by default. The preference is
  * a persisted client setting (`floatingChatEnabled`), so it applies
  * immediately without a round-trip.
  */


### PR DESCRIPTION
## What

将 chat 悬浮窗（floating chat window / FAB + overlay）的默认设置从**关闭**改为**打开**。

Closes MUL-4281.

## Change

`packages/core/chat/store.ts` 的初始化逻辑：

```diff
-const initialFloatingEnabled = storage.getItem(FLOATING_KEY) === "true";
+const initialFloatingEnabled = storage.getItem(FLOATING_KEY) !== "false";
```

三态语义：

- 未设置过 / 新用户 → **默认开启**（此前默认关闭）
- 显式存过 `"false"`（用户手动关过）→ 保持关闭
- 显式存过 `"true"`（用户手动开过）→ 保持开启

同时同步了 `packages/core/chat/store.ts` 与 `packages/views/settings/components/chat-tab.tsx` 的说明注释，并更新/新增了 store 单测覆盖「默认 ON」与「显式 false 保持关闭」。

## Verification

- `pnpm --filter @multica/core test` — 10 passed
- `pnpm --filter @multica/core typecheck` — pass
