### PR TITLE
Retry transient CLI assignee lookup GET failures

### DIFF
--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -95,6 +95,13 @@ func newHTTPError(method, path string, resp *http.Response) *HTTPError {
 // opaque "context deadline exceeded" to users.
 const defaultHTTPTimeout = 30 * time.Second
 
+const getJSONMaxAttempts = 3
+
+var getJSONRetryBackoffs = []time.Duration{
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+}
+
 // httpTimeout returns the HTTP client timeout, honoring MULTICA_HTTP_TIMEOUT.
 // The value may be a Go duration string ("45s", "2m") or a plain integer
 // number of seconds ("45"). Invalid or non-positive values fall back to the
@@ -198,6 +205,35 @@ func (c *APIClient) setHeaders(req *http.Request) {
 	}
 }
 
+func (c *APIClient) doGETWithRetry(req *http.Request) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt < getJSONMaxAttempts; attempt++ {
+		attemptReq := req
+		if attempt > 0 {
+			attemptReq = req.Clone(req.Context())
+		}
+
+		resp, err := c.HTTPClient.Do(attemptReq)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if attempt == getJSONMaxAttempts-1 || !isTransientGETTransportError(err) {
+			return nil, wrapTransport(attemptReq, err)
+		}
+
+		backoff := getJSONRetryBackoffs[attempt]
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, wrapTransport(attemptReq, req.Context().Err())
+		}
+	}
+	return nil, wrapTransport(req, lastErr)
+}
+
 // GetJSON performs a GET request and decodes the JSON response.
 //
 // On an HTTP error response (status >= 400) the returned error is a
@@ -212,8 +248,7 @@ func (c *APIClient) GetJSON(ctx context.Context, path string, out any) error {
 	}
 	c.setHeaders(req)
 
-	resp, err := c.HTTPClient.Do(req)
-	err = wrapTransport(req, err)
+	resp, err := c.doGETWithRetry(req)
 	if err != nil {
 		return err
 	}
@@ -238,8 +273,7 @@ func (c *APIClient) GetJSONWithHeaders(ctx context.Context, path string, out any
 	}
 	c.setHeaders(req)
 
-	resp, err := c.HTTPClient.Do(req)
-	err = wrapTransport(req, err)
+	resp, err := c.doGETWithRetry(req)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestPostJSON(t *testing.T) {
 	type reqBody struct {
 		Name string `json:"name"`
@@ -164,6 +170,127 @@ func TestPostJSON(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestGetJSONRetriesTransientTransportErrors(t *testing.T) {
+	attempts := 0
+	client := NewAPIClient("https://example.test", "ws-1", "test-token")
+	client.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		switch attempts {
+		case 1:
+			return nil, io.ErrUnexpectedEOF
+		case 2:
+			return nil, errors.New("http2: client connection lost")
+		default:
+			if req.Method != http.MethodGet {
+				t.Errorf("method = %s, want GET", req.Method)
+			}
+			if req.URL.Path != "/api/workspaces/ws-1/members" {
+				t.Errorf("path = %s, want /api/workspaces/ws-1/members", req.URL.Path)
+			}
+			if auth := req.Header.Get("Authorization"); auth != "Bearer test-token" {
+				t.Errorf("authorization = %q, want bearer token", auth)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}
+	})}
+
+	var out map[string]bool
+	if err := client.GetJSON(context.Background(), "/api/workspaces/ws-1/members", &out); err != nil {
+		t.Fatalf("GetJSON returned error after transient retries: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if !out["ok"] {
+		t.Fatalf("decoded response = %+v, want ok=true", out)
+	}
+}
+
+func TestGetJSONWithHeadersRetriesTransientTransportErrors(t *testing.T) {
+	attempts := 0
+	client := NewAPIClient("https://example.test", "", "")
+	client.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.New("read tcp 127.0.0.1:1234->127.0.0.1:443: connection reset by peer")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Total-Count": []string{"1"}},
+			Body:       io.NopCloser(strings.NewReader(`[{"id":"issue-1"}]`)),
+			Request:    req,
+		}, nil
+	})}
+
+	var out []map[string]string
+	headers, err := client.GetJSONWithHeaders(context.Background(), "/api/issues", &out)
+	if err != nil {
+		t.Fatalf("GetJSONWithHeaders returned error after transient retry: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if got := headers.Get("X-Total-Count"); got != "1" {
+		t.Errorf("X-Total-Count = %q, want 1", got)
+	}
+	if len(out) != 1 || out[0]["id"] != "issue-1" {
+		t.Fatalf("decoded response = %+v, want issue-1", out)
+	}
+}
+
+func TestGetJSONRetryExhaustionPreservesNetworkError(t *testing.T) {
+	attempts := 0
+	client := NewAPIClient("https://example.test", "", "")
+	client.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, io.ErrUnexpectedEOF
+	})}
+
+	err := client.GetJSON(context.Background(), "/api/issues", nil)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if attempts != getJSONMaxAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, getJSONMaxAttempts)
+	}
+	var netErr *NetworkError
+	if !errors.As(err, &netErr) {
+		t.Fatalf("error type = %T, want *NetworkError", err)
+	}
+	if netErr.Op != "GET /api/issues" {
+		t.Errorf("network op = %q, want GET /api/issues", netErr.Op)
+	}
+	if !errors.Is(netErr.Err, io.ErrUnexpectedEOF) {
+		t.Errorf("network cause = %v, want unexpected EOF", netErr.Err)
+	}
+}
+
+func TestPostJSONDoesNotRetryTransientTransportErrors(t *testing.T) {
+	attempts := 0
+	client := NewAPIClient("https://example.test", "", "")
+	client.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, io.ErrUnexpectedEOF
+	})}
+
+	err := client.PostJSON(context.Background(), "/api/issues", map[string]string{"title": "x"}, nil)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	var netErr *NetworkError
+	if !errors.As(err, &netErr) {
+		t.Fatalf("error type = %T, want *NetworkError", err)
+	}
 }
 
 func TestDeleteJSONResponse(t *testing.T) {

--- a/server/internal/cli/errors.go
+++ b/server/internal/cli/errors.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -252,6 +253,28 @@ func wrapTransport(req *http.Request, err error) error {
 		op = req.Method + " " + req.URL.Path
 	}
 	return &NetworkError{Kind: classifyNetworkError(err), Op: op, Err: err}
+}
+
+func isTransientGETTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "eof") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "http2: client connection lost") ||
+		strings.Contains(msg, "http2: server sent goaway") ||
+		strings.Contains(msg, "stream error")
 }
 
 // Language is the language FormatError renders messages in.


### PR DESCRIPTION
## What does this PR do?

Retries transient transport failures for the CLI's idempotent JSON GET helpers. This covers assignee-resolution lookup requests for workspace members, agents, and squads, so brief EOF-style HTTPS failures do not immediately fail commands such as issue create/update/list.

The retry policy is intentionally limited to GET helpers; write helpers still return transport failures after one attempt.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5075

Multica issue: ZIC-59

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added bounded retry handling for transient GET transport errors in `server/internal/cli/client.go`.
- Added transient classifier coverage for EOF, unexpected EOF, connection reset/abort, and common HTTP/2 connection-loss strings.
- Added tests proving GET retry success, exhausted retry error shape, header-preserving GET retry behavior, and no retry for POST writes.

## How to Test

1. `cd server && go test ./internal/cli`
2. `cd server && go test ./cmd/multica`
3. `make check-worktree`

Note: `make check-worktree` exited 0 locally, but printed that Docker was unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented from Multica issue ZIC-59 / GitHub #5075. I traced assignee resolution through the shared CLI JSON GET helpers, added the retry at the idempotent client layer, and covered retry/no-retry behavior with focused Go tests.

## Screenshots (optional)

N/A
