### PR TITLE
Fix Hermes TMPDIR Unix socket path overflow

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3634,6 +3634,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)
 	}
+	defer func() {
+		if cerr := os.RemoveAll(taskTempDir); cerr != nil {
+			taskLog.Warn("task temp dir cleanup failed", "path", taskTempDir, "error", cerr)
+		}
+	}()
 
 	// Issue #3999 race A: now that env.WorkDir is on disk, transition the
 	// server-side state machine dispatched (or waiting_local_directory) →
@@ -4649,7 +4654,14 @@ func ensureTaskTempDir(envRoot string, taskID string) (string, error) {
 	if envRoot == "" {
 		return "", errors.New("env root is empty")
 	}
-	dir := filepath.Join(envRoot, "tmp", safeTempPathComponent(taskID))
+	root := shortTaskTempRoot()
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return "", err
+	}
+	dir := taskTempDirPath(envRoot, taskID)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
@@ -4659,13 +4671,23 @@ func ensureTaskTempDir(envRoot string, taskID string) (string, error) {
 	return dir, nil
 }
 
-func safeTempPathComponent(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "task"
+func shortTaskTempRoot() string {
+	if os.PathSeparator == '/' {
+		return filepath.Join("/tmp", "multica-"+strconv.Itoa(os.Getuid()))
 	}
-	replacer := strings.NewReplacer("/", "_", "\\", "_", ":", "_")
-	return replacer.Replace(value)
+	return filepath.Join(os.TempDir(), "multica")
+}
+
+func taskTempDirPath(envRoot string, taskID string) string {
+	return filepath.Join(shortTaskTempRoot(), taskTempDirName(envRoot, taskID))
+}
+
+func taskTempDirName(envRoot string, taskID string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(strings.TrimSpace(envRoot)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(strings.TrimSpace(taskID)))
+	return fmt.Sprintf("task-%016x", h.Sum64())
 }
 
 // isBlockedEnvKey returns true if the key must not be overridden by user-

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -166,12 +166,14 @@ func TestRunTask_InjectsPrivateTaskTempDir(t *testing.T) {
 	workspacesRoot := t.TempDir()
 	workspaceID := "ws-private-temp"
 	taskID := "task-private-temp"
-	expectedTempDir := filepath.Join(execenv.PredictRootDir(workspacesRoot, workspaceID, taskID), "tmp", taskID)
+	envRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+	expectedTempDir := taskTempDirPath(envRoot, taskID)
 
 	captureFile := filepath.Join(t.TempDir(), "agent-env.txt")
 	fakeBin := filepath.Join(t.TempDir(), "claude")
 	script := `#!/bin/sh
-printf 'TMPDIR=%s\nTMP=%s\nTEMP=%s\n' "$TMPDIR" "$TMP" "$TEMP" > "$CAPTURE_FILE"
+if [ -d "$TMPDIR" ]; then tmpdir_exists=1; else tmpdir_exists=0; fi
+printf 'TMPDIR=%s\nTMP=%s\nTEMP=%s\nTMPDIR_EXISTS=%s\n' "$TMPDIR" "$TMP" "$TEMP" "$tmpdir_exists" > "$CAPTURE_FILE"
 IFS= read -r _
 printf '%s\n' '{"type":"system","session_id":"sess-private-temp"}'
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-private-temp","result":"done"}'
@@ -231,14 +233,6 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 		t.Fatalf("runTask status = %q, want completed (comment=%q)", result.Status, result.Comment)
 	}
 
-	info, err := os.Stat(expectedTempDir)
-	if err != nil {
-		t.Fatalf("expected task temp dir %q to exist: %v", expectedTempDir, err)
-	}
-	if !info.IsDir() {
-		t.Fatalf("expected task temp path %q to be a directory", expectedTempDir)
-	}
-
 	raw, err := os.ReadFile(captureFile)
 	if err != nil {
 		t.Fatalf("read captured agent env: %v", err)
@@ -255,6 +249,15 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 		if got[key] != expectedTempDir {
 			t.Fatalf("%s = %q, want private task temp dir %q", key, got[key], expectedTempDir)
 		}
+	}
+	if got["TMPDIR_EXISTS"] != "1" {
+		t.Fatalf("agent did not see task temp dir on disk: captured env %v", got)
+	}
+	if strings.Contains(expectedTempDir, envRoot) {
+		t.Fatalf("task temp dir must not live under long env root %q: got %q", envRoot, expectedTempDir)
+	}
+	if os.PathSeparator == '/' && len(expectedTempDir) >= 64 {
+		t.Fatalf("task temp dir must stay short for Unix-domain sockets: len(%q) = %d", expectedTempDir, len(expectedTempDir))
 	}
 }
 

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1674,6 +1674,11 @@ var acpErrorHeaderRe = regexp.MustCompile(`(?:⚠️|❌|\[ERROR\]).*(?:BadReque
 // "Details:" tag actually spells out what happened).
 var acpErrorDetailRe = regexp.MustCompile(`(?:Error:|detail:|Details:)\s*(.+)`)
 
+// acpUnixSocketPathErrorRe catches Hermes/Python AF_UNIX socket failures,
+// which otherwise look like a generic provider failure even though the
+// actionable cause is an overlong TMPDIR-derived socket path.
+var acpUnixSocketPathErrorRe = regexp.MustCompile(`(?i)(AF_UNIX|Unix(?:-domain)? socket|sun_path).*(path too long)|path too long.*(AF_UNIX|Unix(?:-domain)? socket|sun_path)`)
+
 // acpTerminalErrorRe matches markers that only appear when the
 // adapter has *given up* on the upstream call — either after
 // exhausting retries ("after N retries"), or because the error is
@@ -1722,10 +1727,10 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line)) {
+		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line) || acpUnixSocketPathErrorRe.MatchString(line)) {
 			continue
 		}
-		if acpTerminalErrorRe.MatchString(line) {
+		if acpTerminalErrorRe.MatchString(line) || acpUnixSocketPathErrorRe.MatchString(line) {
 			s.terminal = true
 		}
 		if s.seen[line] {
@@ -1776,6 +1781,11 @@ func (s *acpProviderErrorSniffer) terminalMessage() string {
 // and terminalMessage(). Caller must hold s.mu.
 func (s *acpProviderErrorSniffer) messageLocked() string {
 	prefix := s.provider + " provider error: "
+	for _, line := range s.lines {
+		if acpUnixSocketPathErrorRe.MatchString(line) {
+			return prefix + "Unix socket path too long; TMPDIR-derived socket path exceeded the platform limit"
+		}
+	}
 	for _, line := range s.lines {
 		if m := acpErrorDetailRe.FindStringSubmatch(line); m != nil {
 			detail := strings.TrimSpace(m[1])

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1490,6 +1490,21 @@ func TestHermesProviderErrorSnifferTerminalNonRetryable(t *testing.T) {
 	}
 }
 
+func TestHermesProviderErrorSnifferUnixSocketPathTooLong(t *testing.T) {
+	t.Parallel()
+
+	s := newACPProviderErrorSniffer("hermes")
+	s.Write([]byte("OSError: AF_UNIX path too long\n"))
+
+	msg := s.terminalMessage()
+	if msg == "" {
+		t.Fatal("expected AF_UNIX path error to be classified as terminal")
+	}
+	if !strings.Contains(msg, "Unix socket path too long") || !strings.Contains(msg, "TMPDIR") {
+		t.Fatalf("expected clear TMPDIR/socket message, got %q", msg)
+	}
+}
+
 // TestHermesBackendPromotesProviderErrorWithNonEmptyOutput pins the
 // fix for GitHub multica#1952: a hermes run that hits a 429 (or any
 // upstream provider error) must surface as Status=failed even though


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes Hermes-backed tasks on Linux where the daemon-injected per-task `TMPDIR` could be long enough for Hermes' derived AF_UNIX RPC socket path to exceed the platform `sun_path` limit.

The daemon now gives spawned agents a short per-task temp directory under `/tmp/multica-<uid>/task-<hash>` on Unix, while still blocking user custom env from overriding `TMPDIR` / `TMP` / `TEMP`. Hermes provider stderr also classifies residual AF_UNIX path-length failures into a clear task error.

## Related Issue

Closes #5112

Multica issue: ZIC-58

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: move task temp dirs out of long env roots and into a short hashed `/tmp` path, then clean them up after the task.
- `server/internal/daemon/workdir_race_test.go`: assert spawned agents receive the short private temp dir and custom TMP overrides remain blocked.
- `server/pkg/agent/hermes.go`: classify AF_UNIX/socket path-length stderr as a terminal provider error with a clear TMPDIR message.
- `server/pkg/agent/hermes_test.go`: add coverage for the AF_UNIX path-length classifier.

## How to Test

1. `go test ./server/internal/daemon -run 'TestRunTask_InjectsPrivateTaskTempDir|TestIsBlockedEnvKey'`
2. `go test ./server/pkg/agent -run 'TestHermesProviderErrorSnifferUnixSocketPathTooLong|TestHermesProviderErrorSnifferTerminalNonRetryable'`
3. From `server/`: `go test ./internal/daemon ./pkg/agent`
4. `make check-worktree` (exited 0 locally; Docker daemon was not reachable while the target checked PostgreSQL)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced daemon task environment construction and Hermes provider error handling from GitHub #5112. Implemented the smallest daemon/runtime change that preserves private task temp dirs while avoiding long Unix socket paths, then added focused regression coverage.

## Screenshots (optional)

N/A
