### PR TITLE
feat(agents): show runtime model + effort on agent hover card [MUL-4280]

### DIFF
--- a/packages/views/agents/components/agent-profile-card.test.tsx
+++ b/packages/views/agents/components/agent-profile-card.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    agentDetail: (id: string) => `/test/agents/${id}`,
+  }),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    getBaseUrl: () => "http://127.0.0.1:8080",
+  },
+}));
+
+// AppLink is just a plain anchor here — the "Detail →" link target is not
+// under test.
+vi.mock("../../navigation", () => ({
+  AppLink: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockAgents = vi.hoisted(() => ({ current: [] as unknown[] }));
+const mockMembers = vi.hoisted(() => ({ current: [] as unknown[] }));
+const mockRuntimes = vi.hoisted(() => ({ current: [] as unknown[] }));
+
+// Distinguish the three list queries the card spreads into useQuery by their
+// query-key shape:
+//   ["workspaces", wsId, "agents"]   — agent list
+//   ["workspaces", wsId, "members"]  — member list
+//   ["runtimes",   wsId, "list"]     — runtime list
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+  return {
+    ...actual,
+    useQuery: (opts: { queryKey: readonly unknown[] }) => {
+      const key = opts.queryKey;
+      if (key[0] === "workspaces" && key[2] === "agents") {
+        return { data: mockAgents.current, isLoading: false };
+      }
+      if (key[0] === "workspaces" && key[2] === "members") {
+        return { data: mockMembers.current, isLoading: false };
+      }
+      if (key[0] === "runtimes") {
+        return { data: mockRuntimes.current, isLoading: false };
+      }
+      return { data: undefined, isLoading: false };
+    },
+  };
+});
+
+vi.mock("@multica/core/agents", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/agents")>(
+      "@multica/core/agents",
+    );
+  return {
+    ...actual,
+    useAgentPresenceDetail: () => ({
+      availability: "online",
+      workload: "idle",
+      runningCount: 0,
+      queuedCount: 0,
+      capacity: 1,
+    }),
+  };
+});
+
+import { AgentProfileCard } from "./agent-profile-card";
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent-1",
+    workspace_id: "ws-1",
+    runtime_id: "rt-1",
+    name: "Lambda",
+    description: "A coding agent.",
+    instructions: "",
+    avatar_url: null,
+    // cloud so RuntimeRow reads "online" without a runtime fixture — the
+    // Model row is what these tests exercise.
+    runtime_mode: "cloud" as const,
+    runtime_config: {},
+    custom_args: [],
+    visibility: "workspace" as const,
+    permission_mode: "public_to" as const,
+    invocation_targets: [],
+    status: "idle" as const,
+    max_concurrent_tasks: 1,
+    model: "claude-opus-4-8",
+    thinking_level: "high",
+    owner_id: null,
+    skills: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    archived_at: null,
+    archived_by: null,
+    ...overrides,
+  };
+}
+
+function renderCard() {
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <AgentProfileCard agentId="agent-1" />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+  mockMembers.current = [];
+  mockRuntimes.current = [];
+  mockAgents.current = [makeAgent()];
+});
+
+describe("AgentProfileCard — Model row", () => {
+  it("shows the pinned model id and the effort badge", () => {
+    mockAgents.current = [makeAgent({ model: "claude-opus-4-8", thinking_level: "high" })];
+    renderCard();
+
+    expect(screen.getByText("claude-opus-4-8")).toBeInTheDocument();
+    expect(screen.getByText("high")).toBeInTheDocument();
+    expect(screen.queryByText(enAgents.profile_card.model_unset)).toBeNull();
+  });
+
+  // Regression (Emacs code review): an agent with no pinned model but a
+  // persisted thinking_level runs WITH that effort at run time. The badge
+  // must render even though the model cell reads "Runtime default" — gating
+  // it on `hasModel` hid legitimate runtime config.
+  it("shows the effort badge even when the model is unset (Runtime default)", () => {
+    mockAgents.current = [makeAgent({ model: "", thinking_level: "high" })];
+    renderCard();
+
+    expect(screen.getByText(enAgents.profile_card.model_unset)).toBeInTheDocument();
+    expect(screen.getByText("high")).toBeInTheDocument();
+  });
+
+  it("renders no effort badge when thinking_level is empty", () => {
+    mockAgents.current = [makeAgent({ model: "", thinking_level: "" })];
+    renderCard();
+
+    expect(screen.getByText(enAgents.profile_card.model_unset)).toBeInTheDocument();
+    // No effort token anywhere on the card.
+    expect(screen.queryByText("high")).toBeNull();
+    expect(screen.queryByText("medium")).toBeNull();
+  });
+});

--- a/packages/views/agents/components/agent-profile-card.tsx
+++ b/packages/views/agents/components/agent-profile-card.tsx
@@ -113,11 +113,13 @@ export function AgentProfileCard({ agentId }: AgentProfileCardProps) {
         </p>
       )}
 
-      {/* Meta rows — minimal set: runtime (where it lives), skills (what
-          it knows), owner (who manages it). Model is intentionally
-          omitted — power-user detail lives on the detail page. */}
+      {/* Meta rows — runtime (where it lives), model (what powers it),
+          skills (what it knows), owner (who manages it). Model + effort
+          are surfaced here so a quick hover answers "which model is this
+          agent running?" without opening the detail page. */}
       <div className="flex flex-col gap-1.5 text-xs">
         <RuntimeRow agent={agent} runtime={runtime} />
+        <ModelRow model={agent.model} thinkingLevel={agent.thinking_level} />
         {agent.skills.length > 0 && (
           <SkillsRow skills={agent.skills.map((s) => s.name)} />
         )}
@@ -189,6 +191,49 @@ function RuntimeRow({
   );
 }
 
+// Model row — the runtime-native model id the agent runs (`agent.model`),
+// with the reasoning/effort token appended as a small badge whenever the
+// agent pins one. An empty model means "no override": the runtime CLI's own
+// default decides at run time, so we render a "Runtime default" placeholder
+// rather than a bare dash. The model id is mono so provider-slug ids like
+// `claude-opus-4-8` stay legible. The effort badge is gated on `effort`
+// alone (NOT on `hasModel`): a `Runtime default` agent can still persist a
+// `thinking_level` override that applies at run time against the runtime's
+// default model, and the whole point of this row is to surface that runtime
+// info at a glance — hiding it would misreport the agent's real config.
+function ModelRow({
+  model,
+  thinkingLevel,
+}: {
+  model: string;
+  thinkingLevel?: string;
+}) {
+  const { t } = useT("agents");
+  const hasModel = model.trim().length > 0;
+  const effort = thinkingLevel?.trim();
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-12 shrink-0 text-muted-foreground">
+        {t(($) => $.profile_card.model_label)}
+      </span>
+      {hasModel ? (
+        <span className="min-w-0 truncate font-mono text-[11px]" title={model}>
+          {model}
+        </span>
+      ) : (
+        <span className="min-w-0 truncate text-muted-foreground">
+          {t(($) => $.profile_card.model_unset)}
+        </span>
+      )}
+      {effort && (
+        <span className="shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          {effort}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function MetaRow({
   label,
   value,
@@ -213,19 +258,26 @@ function SkillsRow({ skills }: { skills: string[] }) {
   const visible = skills.slice(0, 3);
   const overflow = skills.length - visible.length;
   return (
-    <div className="flex items-center gap-1.5">
-      <span className="w-12 shrink-0 text-muted-foreground">{t(($) => $.profile_card.skills_label)}</span>
+    // `items-start` (not center): skill chips wrap to multiple lines, and a
+    // vertically-centred label would drift down next to the middle chip —
+    // making the first chip look like it belongs to the row above. Pin the
+    // label to the first chip row; `pt-0.5` lines its text up with the chip
+    // text (chips carry `py-0.5`). Each chip truncates so one long skill name
+    // can't blow out the card width.
+    <div className="flex items-start gap-1.5">
+      <span className="w-12 shrink-0 pt-0.5 text-muted-foreground">{t(($) => $.profile_card.skills_label)}</span>
       <div className="flex min-w-0 flex-wrap gap-1">
         {visible.map((s) => (
           <span
             key={s}
-            className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+            className="max-w-full truncate rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+            title={s}
           >
             {s}
           </span>
         ))}
         {overflow > 0 && (
-          <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          <span className="shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
             +{overflow}
           </span>
         )}

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -491,7 +491,9 @@
     "runtime_label": "Runtime",
     "skills_label": "Skills",
     "owner_label": "Owner",
-    "unknown_runtime": "Unknown runtime"
+    "unknown_runtime": "Unknown runtime",
+    "model_label": "Model",
+    "model_unset": "Runtime default"
   },
   "live_peek": {
     "current_issue_label": "Now on",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -470,7 +470,9 @@
     "runtime_label": "ランタイム",
     "skills_label": "スキル",
     "owner_label": "オーナー",
-    "unknown_runtime": "不明なランタイム"
+    "unknown_runtime": "不明なランタイム",
+    "model_label": "モデル",
+    "model_unset": "ランタイム既定"
   },
   "live_peek": {
     "current_issue_label": "現在の作業",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -478,7 +478,9 @@
     "runtime_label": "런타임",
     "skills_label": "스킬",
     "owner_label": "소유자",
-    "unknown_runtime": "알 수 없는 런타임"
+    "unknown_runtime": "알 수 없는 런타임",
+    "model_label": "모델",
+    "model_unset": "런타임 기본값"
   },
   "live_peek": {
     "current_issue_label": "현재 작업",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -478,7 +478,9 @@
     "runtime_label": "运行时",
     "skills_label": "Skills",
     "owner_label": "所有者",
-    "unknown_runtime": "未知运行时"
+    "unknown_runtime": "未知运行时",
+    "model_label": "模型",
+    "model_unset": "运行时默认"
   },
   "live_peek": {
     "current_issue_label": "正在处理",


### PR DESCRIPTION
## Summary

Agent profile hover card (`AgentProfileCard`) now surfaces runtime info at a glance — closes MUL-4280.

- **Model row (new):** shows the runtime-native model id (mono, e.g. `claude-opus-4-8`) with the reasoning/effort token as a badge. Empty model → `Runtime default` placeholder.
- **Skills row alignment fix:** chips wrap to multiple lines, so the vertically-centered label used to drift to the middle chip. It now pins to the first chip row (`items-start` + `pt`), and each chip truncates so a long skill name can't blow out the card width.
- **Effort badge gating:** gated on `effort` alone (not `hasModel`) — an agent with no pinned model can still persist a `thinking_level` override that applies at run time; hiding it would misreport config.
- **i18n:** new `profile_card.model_label` / `model_unset` in en/zh-Hans/ja/ko.

## Tests

New `agent-profile-card.test.tsx` (3 cases) covering model/effort render states, including the `model:"" / thinking_level:"high"` regression flagged in code review.

## Verification

- `pnpm --filter @multica/views typecheck` ✅
- `pnpm --filter @multica/views test agent-profile-card` ✅ (3 passed)
- i18n parity test ✅
