### PR TITLE
MUL-4284: restore chat and inbox list gutters

### DIFF
--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -133,7 +133,7 @@ export function ChatPage() {
   );
 
   const listHeader = (
-    <PageHeader className="justify-between border-b-0">
+    <PageHeader className="justify-between">
       <div className="flex items-center gap-2">
         <h1 className="text-sm font-semibold">{t(($) => $.page.title)}</h1>
       </div>
@@ -142,7 +142,7 @@ export function ChatPage() {
   );
 
   const listBody = (
-    <div className="p-1">
+    <div className="px-2 py-1">
       <ChatThreadList
         sessions={c.sessions}
         agents={c.agents}

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -223,7 +223,7 @@ export function InboxPage() {
   // -- Shared sub-components --------------------------------------------------
 
   const listHeader = (
-    <PageHeader className="justify-between border-b-0">
+    <PageHeader className="justify-between">
       <div className="flex items-center gap-2">
         <h1 className="text-sm font-semibold">{t(($) => $.page.title)}</h1>
         {unreadCount > 0 && (
@@ -273,7 +273,7 @@ export function InboxPage() {
       <p className="text-sm">{t(($) => $.list.empty)}</p>
     </div>
   ) : (
-    <div className="p-1">
+    <div className="px-2 py-1">
       {items.map((item) => (
         <InboxListItem
           key={item.id}


### PR DESCRIPTION
## Summary

- Restore the chat and inbox list header divider by using the shared `PageHeader` default border.
- Increase horizontal gutters around both list bodies from `p-1` to `px-2 py-1`.

## Validation

- `pnpm --filter @multica/views typecheck`
- Captured runtime screenshots from local `make start-worktree`:
  - `/tmp/mul4284-chat-list.png`
  - `/tmp/mul4284-inbox-list.png`
