### PR TITLE
fix(ui): unify chat list & inbox list avatar size to 32px [MUL-4283]

### DIFF
--- a/packages/views/chat/components/chat-thread-list.tsx
+++ b/packages/views/chat/components/chat-thread-list.tsx
@@ -259,9 +259,9 @@ export function ChatThreadList({
         {/* Thin ring keeps photo + fallback avatars reading as the same circle
             (the fallback's faint bg otherwise looks smaller). */}
         {agent ? (
-          <ActorAvatar actorType="agent" actorId={agent.id} size={36} enableHoverCard className="ring-1 ring-inset ring-border" />
+          <ActorAvatar actorType="agent" actorId={agent.id} size={32} enableHoverCard className="ring-1 ring-inset ring-border" />
         ) : (
-          <span className="size-9 shrink-0" />
+          <span className="size-8 shrink-0" />
         )}
 
         <div className="min-w-0 flex-1">

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -51,7 +51,7 @@ export function InboxListItem({
       <ActorAvatar
         actorType={item.actor_type ?? item.recipient_type}
         actorId={item.actor_id ?? item.recipient_id}
-        size={28}
+        size={32}
         enableHoverCard
       />
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## What

Unify the avatar size in **chat list** and **inbox list** to **32px**.

- Chat list (`chat-thread-list.tsx`): `size={36}` → `32` (fallback placeholder `size-9` → `size-8`)
- Inbox list (`inbox-list-item.tsx`): `size={28}` → `32`

## Why

The two surfaces were inconsistent — chat list at 36px read too large ("头重脚轻"), inbox list at 28px too small. 32px is the common list-row avatar size already used across settings/members surfaces, and sits comfortably against the row height and text.

## Verification

Ran the web app locally and captured the real chat list before/after; measured the live DOM to confirm the rendered avatar is 32px (down from 36px). Chat list ring border and `h-14` row remain centered with ample padding.

MUL-4283
