### PR TITLE
feat(issues): make cancelled a default status, not filter-gated (MUL-4290)

### DIFF
--- a/packages/core/issues/config/index.ts
+++ b/packages/core/issues/config/index.ts
@@ -1,2 +1,2 @@
-export { STATUS_ORDER, ALL_STATUSES, BOARD_STATUSES, STATUS_CONFIG } from "./status";
+export { STATUS_ORDER, ALL_STATUSES, STATUS_CONFIG } from "./status";
 export { PRIORITY_ORDER, PRIORITY_CONFIG } from "./priority";

--- a/packages/core/issues/config/status.ts
+++ b/packages/core/issues/config/status.ts
@@ -20,16 +20,6 @@ export const ALL_STATUSES: IssueStatus[] = [
   "cancelled",
 ];
 
-/** Statuses shown as board columns (excludes cancelled). */
-export const BOARD_STATUSES: IssueStatus[] = [
-  "backlog",
-  "todo",
-  "in_progress",
-  "in_review",
-  "done",
-  "blocked",
-];
-
 export const STATUS_CONFIG: Record<
   IssueStatus,
   {

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -8,7 +8,7 @@ import type {
   ListIssuesParams,
   ListIssuesCache,
 } from "../types";
-import { BOARD_STATUSES } from "./config";
+import { ALL_STATUSES } from "./config";
 
 export interface IssueSortParam {
   sort_by?: ListIssuesParams["sort_by"];
@@ -132,17 +132,13 @@ export type AssigneeGroupedIssuesFilter = Omit<
 export const ISSUE_PAGE_SIZE = 50;
 
 /**
- * Statuses fetched and paginated into the list/board cache. `cancelled` is
- * included so cancelled issues always live in the cache (and rebucket
- * correctly when an issue is cancelled); the surface hides them by default and
- * only renders a Cancelled section when the status filter explicitly selects
- * it. `BOARD_STATUSES` stays the default *visible* column set — this constant
- * governs fetch/cache membership, not what the board shows.
+ * Statuses fetched and paginated into the list/board cache — every lifecycle
+ * status, `cancelled` included. `cancelled` is a first-class default status
+ * (MUL-4290), so it lives in the cache and renders like any other column;
+ * there is no separate "visible board" subset. This constant governs
+ * fetch/cache membership.
  */
-export const PAGINATED_STATUSES: readonly IssueStatus[] = [
-  ...BOARD_STATUSES,
-  "cancelled",
-];
+export const PAGINATED_STATUSES: readonly IssueStatus[] = ALL_STATUSES;
 
 /** Flatten a bucketed response to a single Issue[] for consumers that want the whole list. */
 export function flattenIssueBuckets(data: ListIssuesCache) {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -234,7 +234,6 @@ vi.mock("@multica/core/api", () => ({
 // Mock issue config
 vi.mock("@multica/core/issues/config", () => ({
   ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
-  BOARD_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
   STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
   STATUS_CONFIG: {
     backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -137,7 +137,6 @@ vi.mock("@multica/core/api", () => ({
 // Mock issue config
 vi.mock("@multica/core/issues/config", () => ({
   ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
-  BOARD_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
   STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
   STATUS_CONFIG: {
     backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
@@ -554,7 +553,7 @@ describe("IssuesPage (shared)", () => {
         group_by: "assignee",
         limit: 50,
         offset: 0,
-        statuses: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
+        statuses: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
       }),
     );
     expect(mockListIssues).not.toHaveBeenCalled();

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -95,7 +95,6 @@ vi.mock("../../navigation", () => ({
 // Mock issue config
 vi.mock("@multica/core/issues/config", () => ({
   ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
-  BOARD_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
   STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
   STATUS_CONFIG: {
     backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
@@ -372,10 +371,10 @@ describe("SwimLaneView", () => {
     expect(screen.getByText("In Progress")).toBeInTheDocument();
   });
 
-  // MUL-4261: the swimlane re-imposed canonical order by intersecting with
-  // BOARD_STATUSES, which silently dropped a filter-selected `cancelled`
-  // column. Status columns must come from `visibleStatuses` (via ALL_STATUSES
-  // order), so cancelled survives when selected and stays out by default.
+  // MUL-4290: `cancelled` is a first-class default status. Status columns come
+  // from `visibleStatuses` in ALL_STATUSES order, so the Cancelled column
+  // renders by default (ordered last) and is only dropped when the status
+  // filter narrows to a subset that excludes it.
   const cancelledOrphan: Issue = {
     id: "cancelled-orphan",
     workspace_id: "ws-1",
@@ -400,7 +399,20 @@ describe("SwimLaneView", () => {
     updated_at: "2026-01-01T00:00:00Z",
   };
 
-  it("renders a Cancelled column and its cards when cancelled is visible", () => {
+  it("renders a Cancelled column and its cards by default", () => {
+    renderWithI18n(
+      // No visibleStatuses prop → default (ALL_STATUSES) includes cancelled.
+      <SwimLaneView
+        issues={[...mockIssues, cancelledOrphan]}
+        onMoveIssue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled Orphan")).toBeInTheDocument();
+  });
+
+  it("omits the Cancelled column when the status filter narrows to a subset without cancelled", () => {
     renderWithI18n(
       <SwimLaneView
         issues={[...mockIssues, cancelledOrphan]}
@@ -411,21 +423,7 @@ describe("SwimLaneView", () => {
           "in_review",
           "done",
           "blocked",
-          "cancelled",
         ]}
-        onMoveIssue={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Cancelled")).toBeInTheDocument();
-    expect(screen.getByText("Cancelled Orphan")).toBeInTheDocument();
-  });
-
-  it("omits the Cancelled column when cancelled is not in visibleStatuses", () => {
-    renderWithI18n(
-      // Default visibleStatuses = BOARD_STATUSES (no cancelled).
-      <SwimLaneView
-        issues={[...mockIssues, cancelledOrphan]}
         onMoveIssue={vi.fn()}
       />,
     );
@@ -569,7 +567,7 @@ describe("SwimLaneView", () => {
     // No parent + Parent Issue 1 each have one + per visible status column.
     // The Other parents lane must add zero.
     const realLaneCount = 2;
-    const visibleStatusCount = 6; // BOARD_STATUSES default
+    const visibleStatusCount = 7; // ALL_STATUSES default (cancelled included)
     expect(
       screen.getAllByRole("button", { name: /add issue/i }).length,
     ).toBe(realLaneCount * visibleStatusCount);

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -42,11 +42,7 @@ import {
   DropdownMenuItem,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { sortIssues } from "../utils/sort";
-import {
-  ALL_STATUSES,
-  BOARD_STATUSES,
-  STATUS_CONFIG,
-} from "@multica/core/issues/config";
+import { ALL_STATUSES, STATUS_CONFIG } from "@multica/core/issues/config";
 import { DraggableBoardCard, BoardCardContent } from "./board-card";
 import { StatusIcon } from "./status-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
@@ -449,7 +445,7 @@ export function SwimLaneView({
   issues,
   unfilteredIssues,
   activeFilters: activeFiltersProp,
-  visibleStatuses = BOARD_STATUSES,
+  visibleStatuses = ALL_STATUSES,
   hiddenStatuses = [],
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
@@ -556,10 +552,9 @@ export function SwimLaneView({
     [myIssuesScope, myIssuesFilter],
   );
 
-  // Re-impose canonical status order on whatever the controller marked
-  // visible. Filter against ALL_STATUSES (not BOARD_STATUSES) so a
-  // filter-selected `cancelled` column survives — BOARD_STATUSES omits
-  // cancelled and would silently drop it here (MUL-4261).
+  // Re-impose canonical status order (ALL_STATUSES) on whatever the controller
+  // marked visible, so columns — including `cancelled`, ordered last — render
+  // in lifecycle order.
   const sortedStatuses = useMemo(
     () => ALL_STATUSES.filter((s) => visibleStatuses.includes(s)),
     [visibleStatuses],

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -481,9 +481,10 @@ describe("useIssueSurfaceController", () => {
     expect(result.current.isEmpty).toBe(true);
   });
 
-  // --- cancelled visibility (MUL-4261) ---------------------------------
-  // Cancelled issues are always fetched into the cache, but the surface hides
-  // them unless the status filter explicitly selects "cancelled".
+  // --- cancelled as a default status (MUL-4290) ------------------------
+  // Cancelled is a first-class default lifecycle status: fetched into the
+  // cache, surfaced by default, narrowed (not unlocked) by the status filter,
+  // and hideable like any other status.
 
   function mockListByStatus(byStatus: Partial<Record<IssueStatus, Issue[]>>) {
     listIssues.mockImplementation((params?: ListIssuesParams) => {
@@ -493,7 +494,7 @@ describe("useIssueSurfaceController", () => {
     });
   }
 
-  it("always fetches the cancelled bucket even though it is hidden by default", async () => {
+  it("fetches and surfaces the cancelled bucket as a default status", async () => {
     const { result } = renderHook(
       () =>
         useIssueSurfaceController({
@@ -509,11 +510,12 @@ describe("useIssueSurfaceController", () => {
     expect(listIssues).toHaveBeenCalledWith(
       expect.objectContaining({ status: "cancelled", limit: 50, offset: 0 }),
     );
-    // …but with no status filter, cancelled is not a visible column.
-    expect(result.current.visibleStatuses).not.toContain("cancelled");
+    // …and with no status filter it is a visible column, ordered last.
+    expect(result.current.visibleStatuses).toContain("cancelled");
+    expect(result.current.visibleStatuses.at(-1)).toBe("cancelled");
   });
 
-  it("keeps cancelled issues out of the default surface and visible statuses", async () => {
+  it("includes cancelled issues in the default surface and visible statuses", async () => {
     mockListByStatus({
       todo: [makeIssue({ id: "todo-1", status: "todo" })],
       cancelled: [makeIssue({ id: "cancelled-1", status: "cancelled" })],
@@ -530,14 +532,43 @@ describe("useIssueSurfaceController", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.visibleStatuses).not.toContain("cancelled");
+    expect(result.current.visibleStatuses).toContain("cancelled");
     const surfaceIds = result.current.surfaceIssues.map((i) => i.id);
     expect(surfaceIds).toContain("todo-1");
-    expect(surfaceIds).not.toContain("cancelled-1");
-    expect(result.current.issues.map((i) => i.id)).not.toContain("cancelled-1");
+    expect(surfaceIds).toContain("cancelled-1");
+    expect(result.current.issues.map((i) => i.id)).toContain("cancelled-1");
   });
 
-  it("reveals cancelled issues only when the status filter selects cancelled", async () => {
+  it("narrows the visible set to the selected statuses, dropping cancelled when it is not selected", async () => {
+    mockListByStatus({
+      todo: [makeIssue({ id: "todo-1", status: "todo" })],
+      cancelled: [makeIssue({ id: "cancelled-1", status: "cancelled" })],
+    });
+
+    const store = getIssueSurfaceViewStore("project:p1");
+    act(() => store.getState().toggleStatusFilter("todo"));
+
+    const { result } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "project", projectId: "p1" },
+          modes: ["list"],
+        }),
+      { wrapper: makeWrapper(qc, "project:p1") },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The filter narrows the rendered columns and their contents — cancelled
+    // is a normal status the filter can exclude, not an unlockable bucket.
+    expect(result.current.visibleStatuses).toEqual(["todo"]);
+    expect(result.current.issues.map((i) => i.id)).toEqual(["todo-1"]);
+    // cancelled participates in show/hide like the rest — hidden here because
+    // the active filter excludes it.
+    expect(result.current.hiddenStatuses).toContain("cancelled");
+  });
+
+  it("treats a cancelled-only filter like any other narrowing status filter", async () => {
     mockListByStatus({
       todo: [makeIssue({ id: "todo-1", status: "todo" })],
       cancelled: [makeIssue({ id: "cancelled-1", status: "cancelled" })],
@@ -557,13 +588,11 @@ describe("useIssueSurfaceController", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // Cancelled becomes the sole visible column, sorted last in ALL_STATUSES.
+    // Cancelled becomes the sole visible column and the surface narrows to it.
     expect(result.current.visibleStatuses).toEqual(["cancelled"]);
     expect(result.current.issues.map((i) => i.id)).toEqual(["cancelled-1"]);
     expect(result.current.surfaceIssues.map((i) => i.id)).toContain(
       "cancelled-1",
     );
-    // cancelled is never offered as a hideable/persistent board column.
-    expect(result.current.hiddenStatuses).not.toContain("cancelled");
   });
 });

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useQuery, type QueryKey } from "@tanstack/react-query";
 import type { Issue, IssueAssigneeGroup, Project } from "@multica/core/types";
-import { ALL_STATUSES, BOARD_STATUSES } from "@multica/core/issues/config";
+import { ALL_STATUSES } from "@multica/core/issues/config";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
   childIssueProgressOptions,
@@ -108,7 +108,7 @@ export function useIssueSurfaceData({
   const assigneeGroupFilter = useMemo<AssigneeGroupedIssuesFilter>(
     () => ({
       ...queryPlan.groupedScopeFilter,
-      statuses: statusFilters.length > 0 ? statusFilters : [...BOARD_STATUSES],
+      statuses: statusFilters.length > 0 ? statusFilters : [...ALL_STATUSES],
       priorities: priorityFilters,
       assignee_filters: assigneeFilters,
       include_no_assignee: includeNoAssignee,
@@ -156,22 +156,13 @@ export function useIssueSurfaceData({
       : (statusIssuesQuery.data ?? EMPTY_ISSUES);
   }, [assigneeGroupsQuery.data?.groups, statusIssuesQuery.data, usesAssigneeBoard]);
 
-  // Cancelled issues are always fetched into the cache (PAGINATED_STATUSES),
-  // but stay hidden until the status filter explicitly selects "cancelled".
-  // Gating the flattened list here means every downstream consumer — list /
+  // `cancelled` is a first-class default status (MUL-4290): it is fetched into
+  // the cache like every other status and flows straight through to list /
   // board / swimlane columns, header facet counts, batch selection, and the
-  // isEmpty check — excludes cancelled by default with no per-view branching.
-  const showCancelled = statusFilters.includes("cancelled");
-  const visibleBucketedIssues = useMemo(
-    () =>
-      showCancelled
-        ? bucketedIssues
-        : bucketedIssues.filter((issue) => issue.status !== "cancelled"),
-    [bucketedIssues, showCancelled],
-  );
-
+  // isEmpty check. The status filter narrows this set like any other status —
+  // it no longer unlocks an otherwise-hidden bucket.
   const ganttIssues = ganttIssuesQuery.data ?? EMPTY_ISSUES;
-  const surfaceIssues = usesGantt ? ganttIssues : visibleBucketedIssues;
+  const surfaceIssues = usesGantt ? ganttIssues : bucketedIssues;
 
   const baseFilterState = useMemo<IssueFilterState>(
     () => ({
@@ -254,20 +245,20 @@ export function useIssueSurfaceData({
   );
 
   const visibleStatuses = useMemo<IssueStatus[]>(() => {
+    // Default view shows every lifecycle status, `cancelled` last (its
+    // canonical position in ALL_STATUSES). An active status filter narrows to
+    // the selected subset while preserving that order.
     if (statusFilters.length > 0) {
-      // ALL_STATUSES keeps canonical order and places `cancelled` last, so a
-      // Cancelled section appears (only) when the filter explicitly selects it.
       return ALL_STATUSES.filter((s) => statusFilters.includes(s));
     }
-    // Default view: the six board statuses, cancelled excluded.
-    return BOARD_STATUSES;
+    return ALL_STATUSES;
   }, [statusFilters]);
 
-  // Hidden columns come from the board set only, so `cancelled` is never
-  // offered as a hideable/always-on board column (it is filter-gated, not a
-  // persistent column).
+  // Hidden columns are the lifecycle statuses not currently visible, so
+  // `cancelled` participates in the board show/hide controls exactly like the
+  // rest of the statuses.
   const hiddenStatuses = useMemo<IssueStatus[]>(
-    () => BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s)),
+    () => ALL_STATUSES.filter((s) => !visibleStatuses.includes(s)),
     [visibleStatuses],
   );
 


### PR DESCRIPTION
## What

Makes `cancelled` a first-class default issue status across the shared Web/Desktop issue surface (Workspace / Project / My Issues; List / Board / Swimlane). Follow-up to MUL-4261 / #5099.

Before this change, MUL-4261 surfaced cancelled issues **only** when the status filter explicitly selected "Cancelled": a separate `BOARD_STATUSES` (six statuses, cancelled excluded) plus a runtime `showCancelled` gate hid cancelled from the default surface. That treated cancelled as a hidden/archive bucket rather than a lifecycle state on par with `todo` / `in_progress` / `done` / `blocked`.

## Changes

- **Removed `BOARD_STATUSES`.** Its only purpose was to exclude cancelled, which this change reverses. `PAGINATED_STATUSES` is now `ALL_STATUSES`; the surface's default `visibleStatuses` / `hiddenStatuses`, the assignee-grouped board's default status set, and the swimlane column fallback all use `ALL_STATUSES`.
- **Removed the `bucketedIssues.filter(status !== "cancelled")` gate** in the surface data layer. Cancelled flows through to list/board/swimlane columns, header facet counts, batch selection, and `isEmpty` like every other status.
- **`hiddenStatuses` now derives from `ALL_STATUSES`**, so cancelled participates in the board show/hide controls consistently (`hideStatus` already used `ALL_STATUSES`).

Behavior after this change:
- List / Board / Swimlane include a **Cancelled** column by default, ordered last (its canonical `ALL_STATUSES` position, i.e. after `blocked`).
- The status filter **narrows** the visible set instead of unlocking a hidden bucket.
- Cancelled can be hidden/shown from the board hidden-columns panel like any other status.
- Load-more pagination for the Cancelled column works out of the box (it already has a real cache bucket + server total).

Out of scope (unchanged): mobile keeps its own status mirror (`apps/mobile/lib/issue-status.ts`) and is untouched; member/agent archive surfaces; gantt "hide completed" behavior.

## Verification

- `pnpm --filter @multica/core --filter @multica/views typecheck` — pass
- `pnpm --filter @multica/core --filter @multica/views exec vitest run` — pass (core 780, views 1689)
- `eslint` on changed source files — clean

Regression tests updated: the surface controller now asserts cancelled is a default visible status and that the filter narrows (and can hide cancelled); the swimlane renders the Cancelled column by default and drops it only when the filter narrows past it; the assignee board fetches cancelled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
