### PR TITLE
fix(agent): cap hung OpenCode runs

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -170,7 +170,7 @@ Daemon behavior is configured via flags or environment variables:
 |---------|------|--------------|---------|
 | Poll interval | `--poll-interval` | `MULTICA_DAEMON_POLL_INTERVAL` | `3s` |
 | Heartbeat interval | `--heartbeat-interval` | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` |
-| Agent timeout | `--agent-timeout` | `MULTICA_AGENT_TIMEOUT` | `0` (no cap; bounded by the watchdogs) |
+| Agent timeout | `--agent-timeout` | `MULTICA_AGENT_TIMEOUT` | `0` (no global cap; bounded by watchdogs and provider-specific caps) |
 | Codex semantic inactivity timeout | `--codex-semantic-inactivity-timeout` | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` |
 | Max concurrent tasks | `--max-concurrent-tasks` | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` |
 | Daemon ID | `--daemon-id` | `MULTICA_DAEMON_ID` | hostname |
@@ -208,6 +208,7 @@ Agent-specific overrides:
 | `MULTICA_COPILOT_MODEL` | Override the Copilot model used (note: GitHub Copilot routes models through your account entitlement, so this may not be honoured) |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
+| `MULTICA_OPENCODE_RUN_TIMEOUT` | OpenCode-specific run timeout when `MULTICA_AGENT_TIMEOUT` is unset (default `30m`; set `0` to disable) |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -24,11 +24,41 @@ import (
 // precede closing the stdout pipe (#4533).
 var opencodeTerminateGraceNanos atomic.Int64
 
+const (
+	defaultOpencodeRunTimeout = 30 * time.Minute
+	opencodeRunTimeoutEnv     = "MULTICA_OPENCODE_RUN_TIMEOUT"
+)
+
 func opencodeTerminateGrace() time.Duration {
 	if n := opencodeTerminateGraceNanos.Load(); n > 0 {
 		return time.Duration(n)
 	}
 	return 5 * time.Second
+}
+
+func (b *opencodeBackend) runTimeout(explicit time.Duration) time.Duration {
+	if explicit > 0 {
+		return explicit
+	}
+
+	raw := strings.TrimSpace(b.cfg.Env[opencodeRunTimeoutEnv])
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv(opencodeRunTimeoutEnv))
+	}
+	if raw == "" {
+		return defaultOpencodeRunTimeout
+	}
+	if raw == "0" {
+		return 0
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout < 0 {
+		if b.cfg.Logger != nil {
+			b.cfg.Logger.Warn("invalid opencode run timeout; using default", "env", opencodeRunTimeoutEnv, "value", raw, "default", defaultOpencodeRunTimeout.String())
+		}
+		return defaultOpencodeRunTimeout
+	}
+	return timeout
 }
 
 // opencodeBlockedArgs are flags hardcoded by the daemon that must not be
@@ -63,7 +93,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	execPath = resolved
 
-	timeout := opts.Timeout
+	timeout := b.runTimeout(opts.Timeout)
 	runCtx, cancel := runContext(ctx, timeout)
 
 	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
@@ -169,7 +199,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
 
-	b.cfg.Logger.Info("opencode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+	b.cfg.Logger.Info("opencode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model, "timeout", timeout)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)

--- a/server/pkg/agent/opencode_cancel_unix_test.go
+++ b/server/pkg/agent/opencode_cancel_unix_test.go
@@ -60,6 +60,60 @@ func TestOpencodeCancellationEscalatesToSIGKILL(t *testing.T) {
 	runOpencodeCancellationTest(t, opencodeCancelFakeScript(true))
 }
 
+// TestOpencodeRunTimeoutTerminatesProcessGroup verifies the #4551 safety net:
+// when the daemon leaves the global agent timeout unset, OpenCode still gets a
+// provider-level wall-clock cap so a CLI process that keeps stdout open forever
+// cannot leave the task stuck in progress.
+func TestOpencodeRunTimeoutTerminatesProcessGroup(t *testing.T) {
+	tempDir := t.TempDir()
+	pidFile := filepath.Join(tempDir, "pids")
+	fakePath := filepath.Join(tempDir, "opencode")
+	writeTestExecutable(t, fakePath, []byte(opencodeCancelFakeScript(false)))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"OPENCODE_PID_FILE":   pidFile,
+			opencodeRunTimeoutEnv: "1s",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Cwd: tempDir})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	pids := waitForPids(t, pidFile)
+
+	select {
+	case res := <-session.Result:
+		if res.Status != "timeout" {
+			t.Fatalf("status = %q, error = %q; want timeout", res.Status, res.Error)
+		}
+		if !strings.Contains(res.Error, "1s") {
+			t.Fatalf("timeout error = %q, want configured timeout", res.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return after provider run timeout")
+	}
+
+	for _, pid := range pids {
+		waitProcessGone(t, pid)
+	}
+}
+
 func runOpencodeCancellationTest(t *testing.T, script string) {
 	t.Helper()
 

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -24,6 +24,59 @@ func TestNewReturnsOpencodeBackend(t *testing.T) {
 	}
 }
 
+func TestOpencodeRunTimeoutResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		env      string
+		explicit time.Duration
+		want     time.Duration
+	}{
+		{
+			name:     "explicit global timeout wins",
+			env:      "45m",
+			explicit: 2 * time.Minute,
+			want:     2 * time.Minute,
+		},
+		{
+			name: "opencode env override",
+			env:  "45m",
+			want: 45 * time.Minute,
+		},
+		{
+			name: "zero disables opencode cap",
+			env:  "0",
+			want: 0,
+		},
+		{
+			name: "zero duration disables opencode cap",
+			env:  "0s",
+			want: 0,
+		},
+		{
+			name: "invalid env falls back to default",
+			env:  "-1s",
+			want: defaultOpencodeRunTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &opencodeBackend{cfg: Config{
+				Env:    map[string]string{opencodeRunTimeoutEnv: tt.env},
+				Logger: slog.Default(),
+			}}
+
+			if got := b.runTimeout(tt.explicit); got != tt.want {
+				t.Fatalf("runTimeout() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 // ── Text event tests ──
 
 func TestOpencodeHandleTextEvent(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds an OpenCode-specific run timeout so a hung `opencode run` process cannot leave a Multica task stuck in progress when the global agent timeout is unset.

The daemon still lets operators use `MULTICA_AGENT_TIMEOUT` as the global cap. When that is `0`, OpenCode now defaults to a 30 minute provider-level cap, with `MULTICA_OPENCODE_RUN_TIMEOUT` available to override it or set `0` to disable the OpenCode-specific cap.

## Related Issue

Closes #4551

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/opencode.go`: resolve an OpenCode run timeout from the global timeout, `MULTICA_OPENCODE_RUN_TIMEOUT`, or the 30 minute default.
- `server/pkg/agent/opencode_cancel_unix_test.go`: cover timeout-driven termination of a hung OpenCode process group.
- `server/pkg/agent/opencode_test.go`: cover timeout resolution, overrides, and invalid values.
- `CLI_AND_DAEMON.md`: document the new OpenCode-specific timeout setting.

## How to Test

1. `cd server && go test ./pkg/agent -run 'TestOpencodeRunTimeout|TestOpencodeCancellation' -count=1`
2. `cd server && go test ./pkg/agent -run 'TestOpencode|TestOpenCode' -count=1`
3. `cd server && go test ./pkg/agent -count=1`
4. `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used Codex to inspect the issue context, implement the targeted OpenCode timeout guard, and run the local Go checks listed above. I reviewed the final diff before opening this PR.

## Screenshots (optional)

N/A.
