### PR TITLE
MUL-4282: use short task temp dirs for agent env

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3630,10 +3630,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		d.markActiveEnvRoot(env.RootDir)
 		defer d.unmarkActiveEnvRoot(env.RootDir)
 	}
-	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.ID)
+	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.WorkspaceID, task.ID)
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)
 	}
+	defer func() {
+		if cerr := os.RemoveAll(taskTempDir); cerr != nil {
+			taskLog.Warn("task temp dir cleanup failed", "path", taskTempDir, "error", cerr)
+		}
+	}()
 
 	// Issue #3999 race A: now that env.WorkDir is on disk, transition the
 	// server-side state machine dispatched (or waiting_local_directory) →
@@ -4644,13 +4649,21 @@ func composeOpenclawIncludeRoots(addRoot, userValue string) (string, bool) {
 	return strings.Join(parts, string(os.PathListSeparator)), true
 }
 
-func ensureTaskTempDir(envRoot string, taskID string) (string, error) {
+func ensureTaskTempDir(envRoot string, workspaceID string, taskID string) (string, error) {
 	envRoot = strings.TrimSpace(envRoot)
 	if envRoot == "" {
 		return "", errors.New("env root is empty")
 	}
-	dir := filepath.Join(envRoot, "tmp", safeTempPathComponent(taskID))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return "", errors.New("workspace id is empty")
+	}
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return "", errors.New("task id is empty")
+	}
+	dir, err := os.MkdirTemp(socketSafeTempBaseDir(), "multica-task-")
+	if err != nil {
 		return "", err
 	}
 	if err := os.Chmod(dir, 0o700); err != nil {
@@ -4659,13 +4672,13 @@ func ensureTaskTempDir(envRoot string, taskID string) (string, error) {
 	return dir, nil
 }
 
-func safeTempPathComponent(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "task"
+func socketSafeTempBaseDir() string {
+	if os.PathSeparator == '/' {
+		if info, err := os.Stat("/tmp"); err == nil && info.IsDir() {
+			return "/tmp"
+		}
 	}
-	replacer := strings.NewReplacer("/", "_", "\\", "_", ":", "_")
-	return replacer.Replace(value)
+	return os.TempDir()
 }
 
 // isBlockedEnvKey returns true if the key must not be overridden by user-

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -163,15 +163,20 @@ func TestRunTask_InjectsPrivateTaskTempDir(t *testing.T) {
 		t.Skip("shell-script agent fixture is POSIX-only")
 	}
 
-	workspacesRoot := t.TempDir()
+	workspacesRoot := filepath.Join(t.TempDir(), strings.Repeat("long-workspaces-root-", 3))
 	workspaceID := "ws-private-temp"
-	taskID := "task-private-temp"
-	expectedTempDir := filepath.Join(execenv.PredictRootDir(workspacesRoot, workspaceID, taskID), "tmp", taskID)
+	taskID := "task-private-temp-with-long-id-that-would-overflow-socket-paths"
+	envRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
 
 	captureFile := filepath.Join(t.TempDir(), "agent-env.txt")
 	fakeBin := filepath.Join(t.TempDir(), "claude")
 	script := `#!/bin/sh
-printf 'TMPDIR=%s\nTMP=%s\nTEMP=%s\n' "$TMPDIR" "$TMP" "$TEMP" > "$CAPTURE_FILE"
+if [ -d "$TMPDIR" ]; then
+  tmpdir_exists=yes
+else
+  tmpdir_exists=no
+fi
+printf 'TMPDIR=%s\nTMP=%s\nTEMP=%s\nTMPDIR_EXISTS=%s\n' "$TMPDIR" "$TMP" "$TEMP" "$tmpdir_exists" > "$CAPTURE_FILE"
 IFS= read -r _
 printf '%s\n' '{"type":"system","session_id":"sess-private-temp"}'
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-private-temp","result":"done"}'
@@ -231,14 +236,6 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 		t.Fatalf("runTask status = %q, want completed (comment=%q)", result.Status, result.Comment)
 	}
 
-	info, err := os.Stat(expectedTempDir)
-	if err != nil {
-		t.Fatalf("expected task temp dir %q to exist: %v", expectedTempDir, err)
-	}
-	if !info.IsDir() {
-		t.Fatalf("expected task temp path %q to be a directory", expectedTempDir)
-	}
-
 	raw, err := os.ReadFile(captureFile)
 	if err != nil {
 		t.Fatalf("read captured agent env: %v", err)
@@ -252,9 +249,25 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 		got[key] = value
 	}
 	for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
-		if got[key] != expectedTempDir {
-			t.Fatalf("%s = %q, want private task temp dir %q", key, got[key], expectedTempDir)
+		if got[key] == "" {
+			t.Fatalf("%s was not captured", key)
 		}
+		if got[key] != got["TMPDIR"] {
+			t.Fatalf("%s = %q, want same private task temp dir %q", key, got[key], got["TMPDIR"])
+		}
+	}
+	if got["TMPDIR_EXISTS"] != "yes" {
+		t.Fatalf("fake agent saw TMPDIR_EXISTS=%q, want yes", got["TMPDIR_EXISTS"])
+	}
+	taskTempDir := got["TMPDIR"]
+	if strings.HasPrefix(taskTempDir, envRoot) {
+		t.Fatalf("task temp dir %q must not live under long env root %q", taskTempDir, envRoot)
+	}
+	if len(taskTempDir) > 80 {
+		t.Fatalf("task temp dir %q length = %d, want <= 80 for Unix-socket headroom", taskTempDir, len(taskTempDir))
+	}
+	if _, err := os.Stat(taskTempDir); !os.IsNotExist(err) {
+		t.Fatalf("expected task temp dir %q to be cleaned after run, stat err=%v", taskTempDir, err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Move daemon-injected TMPDIR/TMP/TEMP to a short private task temp dir created under /tmp on Unix-like hosts.
- Clean the private temp dir after the task finishes.
- Extend the regression test to cover long env roots, custom_env override blocking, socket-path headroom, in-run existence, and cleanup.

Tests:
- go test ./internal/daemon