### PR TITLE
feat(issues): push priority filter into ListIssues server list membership (MUL-4289)

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -734,4 +734,46 @@ describe("ApiClient", () => {
       expect(JSON.parse(fetchMock.mock.calls[1]![1]?.body as string)).toEqual({ content: "again" });
     });
   });
+
+  describe("listIssues priority serialization", () => {
+    function stubOkList() {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ issues: [], total: 0 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    it("serializes multi-select priorities as a comma-joined param", async () => {
+      const fetchMock = stubOkList();
+      const client = new ApiClient("https://api.example.test");
+      await client.listIssues({ status: "todo", priorities: ["high", "urgent"] });
+
+      const url = new URL(fetchMock.mock.calls[0]![0] as string);
+      expect(url.searchParams.get("priorities")).toBe("high,urgent");
+      expect(url.searchParams.get("status")).toBe("todo");
+    });
+
+    it("omits priorities entirely when the list is empty (byte-consistent default)", async () => {
+      const fetchMock = stubOkList();
+      const client = new ApiClient("https://api.example.test");
+      await client.listIssues({ status: "todo", priorities: [] });
+
+      const url = new URL(fetchMock.mock.calls[0]![0] as string);
+      expect(url.searchParams.has("priorities")).toBe(false);
+    });
+
+    it("still serializes the legacy single priority param", async () => {
+      const fetchMock = stubOkList();
+      const client = new ApiClient("https://api.example.test");
+      await client.listIssues({ priority: "high" });
+
+      const url = new URL(fetchMock.mock.calls[0]![0] as string);
+      expect(url.searchParams.get("priority")).toBe("high");
+      expect(url.searchParams.has("priorities")).toBe(false);
+    });
+  });
 });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -505,6 +505,7 @@ export class ApiClient {
     if (params?.workspace_id) search.set("workspace_id", params.workspace_id);
     if (params?.status) search.set("status", params.status);
     if (params?.priority) search.set("priority", params.priority);
+    if (params?.priorities?.length) search.set("priorities", params.priorities.join(","));
     if (params?.assignee_id) search.set("assignee_id", params.assignee_id);
     if (params?.assignee_ids?.length) search.set("assignee_ids", params.assignee_ids.join(","));
     if (params?.assignee_types?.length) search.set("assignee_types", params.assignee_types.join(","));

--- a/packages/core/issues/cache-coordinator.test.ts
+++ b/packages/core/issues/cache-coordinator.test.ts
@@ -12,7 +12,7 @@ import type { InboxItem, Issue, ListIssuesCache } from "../types";
 const WS_ID = "ws-1";
 const sort: IssueSortParam = { sort_by: "position", sort_direction: undefined };
 
-const wsKey = issueKeys.listSorted(WS_ID, sort);
+const wsKey = issueKeys.listSorted(WS_ID, {}, sort);
 const myAssignedKey = issueKeys.myListSorted(WS_ID, "assigned", { assignee_id: "me" }, sort);
 const myAllKey = issueKeys.myListSorted(WS_ID, "all", {}, sort);
 const involvedKey = issueKeys.myListSorted(WS_ID, "agents", { involves_user_id: "me" }, sort);
@@ -359,5 +359,72 @@ describe("applyIssueChange", () => {
 
     expect(qc.getQueryData(groupedKey)).toBe(grouped);
     expect(result.staleKeys.map(hashKey)).not.toContain(hashKey(groupedKey));
+  });
+});
+
+describe("applyIssueChange — priority membership", () => {
+  let qc: QueryClient;
+  const wsHighKey = issueKeys.listSorted(WS_ID, { priorities: ["high"] }, sort);
+  const wsLowKey = issueKeys.listSorted(WS_ID, { priorities: ["low"] }, sort);
+  const highIssue = () => makeIssue(1, { priority: "high" });
+  const priorityPatch = { priority: "low" as const };
+  const priorityChanged = () =>
+    issueChangedDims(priorityPatch, highIssue());
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+  afterEach(() => qc.clear());
+
+  it("removes a loaded card that no longer matches the priority filter", () => {
+    qc.setQueryData<ListIssuesCache>(wsHighKey, bucketed([highIssue()]));
+
+    applyIssueChange(qc, WS_ID, "issue-1", priorityPatch, {
+      changed: priorityChanged(),
+      baseIssue: highIssue(),
+    });
+
+    expect(ids(qc, wsHighKey, "todo")).toEqual([]);
+    expect(total(qc, wsHighKey, "todo")).toBe(0);
+  });
+
+  it("decrements the bucket total for an off-screen high→low member", () => {
+    // Off-screen: counted in `total` but not in the loaded window.
+    qc.setQueryData<ListIssuesCache>(wsHighKey, bucketed([], 1));
+
+    applyIssueChange(qc, WS_ID, "issue-1", priorityPatch, {
+      changed: priorityChanged(),
+      baseIssue: highIssue(),
+    });
+
+    expect(total(qc, wsHighKey, "todo")).toBe(0);
+  });
+
+  it("marks the low-filtered list stale when an issue may have entered it", () => {
+    qc.setQueryData<ListIssuesCache>(wsLowKey, bucketed([], 0));
+
+    const result = applyIssueChange(qc, WS_ID, "issue-1", priorityPatch, {
+      changed: priorityChanged(),
+      baseIssue: highIssue(),
+    });
+
+    expect(result.staleKeys.map(hashKey)).toContain(hashKey(wsLowKey));
+  });
+
+  it("leaves an unfiltered workspace list in place on a priority change", () => {
+    qc.setQueryData<ListIssuesCache>(wsKey, bucketed([highIssue()]));
+
+    const result = applyIssueChange(qc, WS_ID, "issue-1", priorityPatch, {
+      changed: priorityChanged(),
+      baseIssue: highIssue(),
+    });
+
+    // Still present (patched in place), no stale key — priority isn't a
+    // membership dimension for a list without a priority facet.
+    expect(ids(qc, wsKey, "todo")).toEqual(["issue-1"]);
+    expect(qc.getQueryData<ListIssuesCache>(wsKey)?.byStatus.todo?.issues[0]?.priority).toBe(
+      "low",
+    );
+    expect(result.staleKeys.map(hashKey)).not.toContain(hashKey(wsKey));
   });
 });

--- a/packages/core/issues/cache-coordinator.ts
+++ b/packages/core/issues/cache-coordinator.ts
@@ -14,6 +14,7 @@ import {
   issueMatchesListFilter,
   listFilterDependsOn,
   type IssueChangedDims,
+  type IssueMembership,
 } from "./surface/membership";
 import type { InboxItem, Issue, ListIssuesCache } from "../types";
 
@@ -75,10 +76,12 @@ export interface IssueCacheChangeResult {
   prevIssue: Issue | undefined;
 }
 
-/** The server contract a bucketed list key encodes. `myListSorted` keys are
- *  `["issues", wsId, "my", scope, filter, sort]`; the workspace list carries
- *  no filter. The `byStatus` shape check upstream keeps grouped/flat caches
- *  under the same prefixes out of this path. */
+/** The server contract a bucketed list key encodes. Both key shapes carry a
+ *  filter segment: `myListSorted` is `["issues", wsId, "my", scope, filter,
+ *  sort]` and the workspace `listSorted` is `["issues", wsId, "list", filter,
+ *  sort]` (the filter holds the priority membership contract, empty for the
+ *  default board). The `byStatus` shape check upstream keeps grouped/flat
+ *  caches under the same prefixes out of this path. */
 function listContractFromKey(
   key: QueryKey,
 ): { scope: string | undefined; filter: MyIssuesFilter } {
@@ -88,7 +91,22 @@ function listContractFromKey(
       filter: (key[4] ?? {}) as MyIssuesFilter,
     };
   }
-  return { scope: undefined, filter: {} };
+  return { scope: undefined, filter: (key[3] ?? {}) as MyIssuesFilter };
+}
+
+/**
+ * Judge a created / updated issue against the list contract a bucketed cache
+ * key encodes. Create paths use this to skip inserting an issue into a
+ * filtered cache it does not belong to (e.g. a `priorities:["high"]` list must
+ * not gain a freshly-created `low` issue). `false` → skip, `true` → insert,
+ * `"unknown"` → let the caller refetch that key.
+ */
+export function issueMatchesListKey(
+  key: QueryKey,
+  issue: Partial<Issue>,
+): IssueMembership {
+  const { scope, filter } = listContractFromKey(key);
+  return issueMatchesListFilter(issue, scope, filter);
 }
 
 function bucketedListEntries(

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -114,7 +114,7 @@ describe("useLoadMoreByStatus", () => {
 
   it("targets the sorted cache key and forwards sort to the API", async () => {
     const sort: IssueSortParam = { sort_by: "priority", sort_direction: "desc" };
-    const activeKey = issueKeys.listSorted(WS_ID, sort);
+    const activeKey = issueKeys.listSorted(WS_ID, {}, sort);
     const seed: ListIssuesCache = {
       byStatus: {
         todo: { issues: [makeIssue(1)], total: 3 },
@@ -128,7 +128,7 @@ describe("useLoadMoreByStatus", () => {
     });
 
     const { result } = renderHook(
-      () => useLoadMoreByStatus("todo", undefined, sort),
+      () => useLoadMoreByStatus("todo", { filter: {} }, sort),
       { wrapper: createWrapper(qc) },
     );
 
@@ -159,13 +159,13 @@ describe("useLoadMoreByStatus", () => {
   it("ignores a stale cache entry under a different sort", async () => {
     // Stale entry from a previous sort lingers (kept by gcTime / keepPreviousData).
     const staleSort: IssueSortParam = { sort_by: "priority", sort_direction: "desc" };
-    qc.setQueryData<ListIssuesCache>(issueKeys.listSorted(WS_ID, staleSort), {
+    qc.setQueryData<ListIssuesCache>(issueKeys.listSorted(WS_ID, {}, staleSort), {
       byStatus: { todo: { issues: [makeIssue(99)], total: 99 } },
     });
 
     // The active sort cache has its own bucket — load-more must target THIS one.
     const activeSort: IssueSortParam = { sort_by: "position", sort_direction: undefined };
-    const activeKey = issueKeys.listSorted(WS_ID, activeSort);
+    const activeKey = issueKeys.listSorted(WS_ID, {}, activeSort);
     qc.setQueryData<ListIssuesCache>(activeKey, {
       byStatus: { todo: { issues: [makeIssue(1)], total: 2 } },
     });
@@ -176,7 +176,7 @@ describe("useLoadMoreByStatus", () => {
     });
 
     const { result } = renderHook(
-      () => useLoadMoreByStatus("todo", undefined, activeSort),
+      () => useLoadMoreByStatus("todo", { filter: {} }, activeSort),
       { wrapper: createWrapper(qc) },
     );
 
@@ -198,7 +198,7 @@ describe("useLoadMoreByStatus", () => {
     ]);
 
     // Stale cache is untouched.
-    const stale = qc.getQueryData<ListIssuesCache>(issueKeys.listSorted(WS_ID, staleSort));
+    const stale = qc.getQueryData<ListIssuesCache>(issueKeys.listSorted(WS_ID, {}, staleSort));
     expect(stale?.byStatus.todo?.issues.map((i) => i.id)).toEqual(["issue-99"]);
   });
 
@@ -393,7 +393,7 @@ describe("useUpdateIssue — optimistic move keeps every bucketed board in sync"
   const myFilter = { assignee_id: "user-1" };
   const projectScope = "project:p1";
   const projectFilter = { project_id: "p1" };
-  const wsKey = issueKeys.listSorted(WS_ID, sort);
+  const wsKey = issueKeys.listSorted(WS_ID, {}, sort);
   const inboxKey = inboxKeys.list(WS_ID);
   // My-Issues AND the Project board both ride this myList cache; a move that
   // only patched the workspace cache snaps back on those boards.
@@ -706,7 +706,7 @@ describe("useBatchUpdateIssues — optimistic patch covers filtered boards too",
   const sort: IssueSortParam = { sort_by: "position", sort_direction: undefined };
   const myScope = "assigned";
   const myFilter = { assignee_id: "user-1" };
-  const wsKey = issueKeys.listSorted(WS_ID, sort);
+  const wsKey = issueKeys.listSorted(WS_ID, {}, sort);
   const myKey = issueKeys.myListSorted(WS_ID, myScope, myFilter, sort);
 
   let qc: QueryClient;

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -14,6 +14,7 @@ import {
   applyIssueChange,
   invalidateIssueDerivatives,
   invalidateStaleListKeys,
+  issueMatchesListKey,
   rollbackIssueChange,
 } from "./cache-coordinator";
 import { issueChangedDims } from "./surface/membership";
@@ -65,27 +66,33 @@ export type ToggleIssueReactionVars = {
 
 /**
  * Paginate one status column into the cache. Works for both the workspace
- * issue list and per-scope My Issues lists (pass `myIssues` to target the
- * latter).
+ * issue list (`opts.scope === undefined` → `listSorted`) and per-scope My
+ * Issues lists (`opts.scope` set → `myListSorted`).
  *
- * `sort` must match the sort the consuming `useQuery` was called with —
- * the query key embeds it (see `listSorted` / `myListSorted`), so a load-more
- * with the wrong sort would patch a stale cache entry that nobody is
- * subscribed to. It is also threaded into the API request so the appended
- * page lines up with the server-side ordering of the existing items.
+ * `opts.filter` is the membership filter that keyed the surface query —
+ * scope fields plus the normalized `priorities` — so `activeKey` and the
+ * appended page's request are byte-consistent with the surface query. Passing
+ * a filter whose shape differs from the surface's would patch a cache entry
+ * nobody is subscribed to.
+ *
+ * `sort` must likewise match the sort the consuming `useQuery` was called
+ * with — the query key embeds it (see `listSorted` / `myListSorted`). It is
+ * also threaded into the API request so the appended page lines up with the
+ * server-side ordering of the existing items.
  */
 export function useLoadMoreByStatus(
   status: IssueStatus,
-  myIssues?: { scope: string; filter: MyIssuesFilter },
+  opts: { scope?: string; filter: MyIssuesFilter },
   sort?: IssueSortParam,
 ) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   const [isLoading, setIsLoading] = useState(false);
 
-  const activeKey = myIssues
-    ? issueKeys.myListSorted(wsId, myIssues.scope, myIssues.filter, sort)
-    : issueKeys.listSorted(wsId, sort);
+  const activeKey =
+    opts.scope !== undefined
+      ? issueKeys.myListSorted(wsId, opts.scope, opts.filter, sort)
+      : issueKeys.listSorted(wsId, opts.filter, sort);
   const cache = qc.getQueryData<ListIssuesCache>(activeKey);
   const bucket = cache?.byStatus[status];
   const loaded = bucket?.issues.length ?? 0;
@@ -101,7 +108,7 @@ export function useLoadMoreByStatus(
         limit: ISSUE_PAGE_SIZE,
         offset: loaded,
         ...sort,
-        ...myIssues?.filter,
+        ...opts.filter,
       });
       qc.setQueryData<ListIssuesCache>(activeKey, (old) => {
         if (!old) return old;
@@ -116,7 +123,7 @@ export function useLoadMoreByStatus(
     } finally {
       setIsLoading(false);
     }
-  }, [qc, activeKey, status, loaded, hasMore, isLoading, myIssues?.filter, sort]);
+  }, [qc, activeKey, status, loaded, hasMore, isLoading, opts.filter, sort]);
 
   return { loadMore, hasMore, isLoading, total };
 }
@@ -193,7 +200,17 @@ export function useCreateIssue() {
     mutationFn: (data: CreateIssueRequest) => api.createIssue(data),
     onSuccess: (newIssue) => {
       for (const [key, data] of qc.getQueriesData<ListIssuesCache>({ queryKey: issueKeys.list(wsId) })) {
-        if (data) qc.setQueryData<ListIssuesCache>(key, addIssueToBuckets(data, newIssue));
+        if (!data) continue;
+        // Don't optimistically insert into a filtered cache the new issue
+        // doesn't match (e.g. a priorities:["high"] board getting a `low`
+        // issue) — that would flash a wrong card before onSettled refetches.
+        const membership = issueMatchesListKey(key, newIssue);
+        if (membership === false) continue;
+        if (membership === "unknown") {
+          qc.invalidateQueries({ queryKey: key, exact: true });
+          continue;
+        }
+        qc.setQueryData<ListIssuesCache>(key, addIssueToBuckets(data, newIssue));
       }
       // Surface the just-created issue in cmd+k's Recent list without
       // requiring the user to open it first.

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -4,13 +4,18 @@ import { QueryClient } from "@tanstack/react-query";
 import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import type { Issue, ListIssuesParams, ListIssuesResponse } from "../types";
+import { hashKey } from "@tanstack/react-query";
 import {
   CHILDREN_BY_PARENTS_CHUNK_SIZE,
   PROJECT_GANTT_MAX_ISSUES,
   PROJECT_GANTT_PAGE_LIMIT,
   childrenByParentsOptions,
   issueKeys,
+  issueListOptions,
+  myIssueListOptions,
+  normalizePriorities,
   projectGanttIssuesOptions,
+  withPriorityFilter,
 } from "./queries";
 
 const WS_ID = "ws-1";
@@ -212,5 +217,83 @@ describe("childrenByParentsOptions chunking", () => {
 
     expect(grouped.get("p-0")).toHaveLength(1);
     expect(grouped.get(lastId)).toHaveLength(1);
+  });
+});
+
+describe("priority filter wiring", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizePriorities drops an empty selection to undefined", () => {
+    expect(normalizePriorities([])).toBeUndefined();
+    expect(normalizePriorities(undefined)).toBeUndefined();
+    expect(normalizePriorities(["high"])).toEqual(["high"]);
+  });
+
+  it("normalizePriorities dedupes and stably sorts so the SET keys once", () => {
+    // Same set, different click orders → identical normalized result.
+    expect(normalizePriorities(["urgent", "high"])).toEqual(["high", "urgent"]);
+    expect(normalizePriorities(["high", "urgent"])).toEqual(["high", "urgent"]);
+    // Duplicates collapse.
+    expect(normalizePriorities(["high", "high", "low"])).toEqual(["high", "low"]);
+  });
+
+  it("withPriorityFilter returns the base unchanged when nothing is selected", () => {
+    const base = { assignee_id: "me" };
+    expect(withPriorityFilter(base, [])).toBe(base);
+    expect(withPriorityFilter(base, ["high"])).toEqual({
+      assignee_id: "me",
+      priorities: ["high"],
+    });
+  });
+
+  it("keys the default board identically whether priorities are empty or absent", () => {
+    // JSON.stringify drops undefined props, so an empty selection must hash to
+    // the same key as the unfiltered default — no cache fragmentation.
+    const sort = { sort_by: "position" as const, sort_direction: undefined };
+    const withEmpty = issueListOptions(WS_ID, withPriorityFilter({}, []), sort).queryKey;
+    const bare = issueListOptions(WS_ID, {}, sort).queryKey;
+    expect(hashKey(withEmpty)).toBe(hashKey(bare));
+  });
+
+  it("surface list key and load-more activeKey stay byte-consistent", () => {
+    // The surface query and useLoadMoreByStatus both build their key from the
+    // same `listFilter`, so identical inputs must hash identically. This guards
+    // the one invariant that would silently break pagination.
+    const sort = { sort_by: "position" as const, sort_direction: undefined };
+    const filter = withPriorityFilter({}, ["high", "urgent"]);
+    const surfaceKey = issueListOptions(WS_ID, filter, sort).queryKey;
+    const loadMoreKey = issueKeys.listSorted(WS_ID, filter, sort);
+    expect(hashKey(surfaceKey)).toBe(hashKey(loadMoreKey));
+
+    const scopedFilter = withPriorityFilter({ assignee_id: "me" }, ["high"]);
+    const scopedSurface = myIssueListOptions(
+      WS_ID,
+      "assigned",
+      scopedFilter,
+      undefined,
+      sort,
+    ).queryKey;
+    const scopedLoadMore = issueKeys.myListSorted(WS_ID, "assigned", scopedFilter, sort);
+    expect(hashKey(scopedSurface)).toBe(hashKey(scopedLoadMore));
+  });
+
+  it("forwards priorities to every per-status first-page request", async () => {
+    const listIssues = vi
+      .fn<(p?: ListIssuesParams) => Promise<ListIssuesResponse>>()
+      .mockResolvedValue({ issues: [], total: 0 });
+    installFakeApi(listIssues);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await qc.fetchQuery(
+      issueListOptions(WS_ID, withPriorityFilter({}, ["high", "urgent"])),
+    );
+
+    expect(listIssues).toHaveBeenCalled();
+    for (const call of listIssues.mock.calls) {
+      expect(call[0]).toMatchObject({ priorities: ["high", "urgent"] });
+    }
+    qc.clear();
   });
 });

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -3,6 +3,7 @@ import { api } from "../api";
 import type {
   GroupedIssuesResponse,
   Issue,
+  IssuePriority,
   IssueStatus,
   ListGroupedIssuesParams,
   ListIssuesParams,
@@ -20,11 +21,15 @@ export interface IssueSortParam {
 
 export const issueKeys = {
   all: (wsId: string) => ["issues", wsId] as const,
-  /** PREFIX for invalidation — no sort. */
+  /** PREFIX for invalidation — no filter, no sort. */
   list: (wsId: string) => [...issueKeys.all(wsId), "list"] as const,
-  /** FULL KEY for queryOptions — includes sort. */
-  listSorted: (wsId: string, sort?: IssueSortParam) =>
-    [...issueKeys.list(wsId), sort ?? {}] as const,
+  /** FULL KEY for queryOptions — includes the membership filter (priorities)
+   *  and sort. The filter segment mirrors `myListSorted` so the cache
+   *  coordinator can recover the workspace list's priority contract from its
+   *  key (see `listContractFromKey`). An empty filter hashes identically to
+   *  the unfiltered default (`JSON.stringify` drops `undefined`). */
+  listSorted: (wsId: string, filter?: MyIssuesFilter, sort?: IssueSortParam) =>
+    [...issueKeys.list(wsId), filter ?? {}, sort ?? {}] as const,
   assigneeGroupsAll: (wsId: string) =>
     [...issueKeys.all(wsId), "assignee-groups"] as const,
   assigneeGroups: (wsId: string, filter: AssigneeGroupedIssuesFilter) =>
@@ -121,7 +126,42 @@ export type MyIssuesFilter = Pick<
   | "creator_id"
   | "project_id"
   | "involves_user_id"
+  // Priority is a membership dimension of the server list (not a scope), but
+  // it rides in the same key-encoded filter object so the cache coordinator
+  // and load-more reconstruct one contract. Normalized empty → omitted.
+  | "priorities"
 >;
+
+/**
+ * Normalize the view store's priority selection into the list filter's
+ * `priorities` field. An empty selection becomes `undefined` so the query key
+ * and request are byte-identical to the unfiltered default (`JSON.stringify`
+ * drops `undefined` object props). The result is deduped and stably sorted so
+ * the same selected SET yields one cache key regardless of the toggle order
+ * that built it — otherwise `["high","urgent"]` and `["urgent","high"]` would
+ * hash to two distinct-but-equivalent query keys and each refetch its own page.
+ */
+export function normalizePriorities(
+  priorities: readonly IssuePriority[] | undefined,
+): IssuePriority[] | undefined {
+  if (!priorities || priorities.length === 0) return undefined;
+  return [...new Set(priorities)].sort();
+}
+
+/**
+ * Merge a priority selection into a base list filter. THE single source of
+ * truth for the filter that keys BOTH the first-page query and the load-more
+ * request, so the surface query key and `useLoadMoreByStatus`'s `activeKey`
+ * stay byte-consistent. Returns `base` unchanged (same reference) when no
+ * priority is selected.
+ */
+export function withPriorityFilter(
+  base: MyIssuesFilter,
+  priorities: readonly IssuePriority[] | undefined,
+): MyIssuesFilter {
+  const normalized = normalizePriorities(priorities);
+  return normalized ? { ...base, priorities: normalized } : base;
+}
 
 export type AssigneeGroupedIssuesFilter = Omit<
   ListGroupedIssuesParams,
@@ -187,11 +227,15 @@ async function fetchFirstPages(filter: MyIssuesFilter = {}, sort?: IssueSortPara
  * total — pagination on the "All" scope is out of scope; the first
  * 50-per-status × 3 widening (deduped) is what the page renders.
  */
-async function fetchAllMyFirstPages(userId: string, sort?: IssueSortParam): Promise<ListIssuesCache> {
+async function fetchAllMyFirstPages(
+  userId: string,
+  sort?: IssueSortParam,
+  priorities?: IssuePriority[],
+): Promise<ListIssuesCache> {
   const [byAssignee, byCreator, byInvolves] = await Promise.all([
-    fetchFirstPages({ assignee_id: userId }, sort),
-    fetchFirstPages({ creator_id: userId }, sort),
-    fetchFirstPages({ involves_user_id: userId }, sort),
+    fetchFirstPages({ assignee_id: userId, priorities }, sort),
+    fetchFirstPages({ creator_id: userId, priorities }, sort),
+    fetchFirstPages({ involves_user_id: userId, priorities }, sort),
   ]);
   const byStatus: ListIssuesCache["byStatus"] = {};
   for (const status of PAGINATED_STATUSES) {
@@ -275,10 +319,14 @@ async function fetchAllMyAssigneeGroups(
  * Fetches the first page of each paginated status in parallel. Use
  * {@link useLoadMoreByStatus} to paginate a specific status into the cache.
  */
-export function issueListOptions(wsId: string, sort?: IssueSortParam) {
+export function issueListOptions(
+  wsId: string,
+  filter: MyIssuesFilter = {},
+  sort?: IssueSortParam,
+) {
   return queryOptions({
-    queryKey: issueKeys.listSorted(wsId, sort),
-    queryFn: () => fetchFirstPages({}, sort),
+    queryKey: issueKeys.listSorted(wsId, filter, sort),
+    queryFn: () => fetchFirstPages(filter, sort),
     select: flattenIssueBuckets,
     placeholderData: keepPreviousData,
   });
@@ -322,7 +370,7 @@ export function myIssueListOptions(
     queryKey: issueKeys.myListSorted(wsId, scope, filter, sort),
     queryFn: () =>
       scope === "all" && userId
-        ? fetchAllMyFirstPages(userId, sort)
+        ? fetchAllMyFirstPages(userId, sort, filter.priorities)
         : fetchFirstPages(filter, sort),
     select: flattenIssueBuckets,
     placeholderData: keepPreviousData,

--- a/packages/core/issues/surface/membership.test.ts
+++ b/packages/core/issues/surface/membership.test.ts
@@ -110,11 +110,13 @@ describe("issueChangedDims", () => {
       assignee: true,
       project: false,
       status: false,
+      priority: false,
     });
     expect(issueChangedDims({ project_id: null })).toEqual({
       assignee: false,
       project: true,
       status: false,
+      priority: false,
     });
   });
 
@@ -124,10 +126,15 @@ describe("issueChangedDims", () => {
       assignee: false,
       project: false,
       status: false,
+      priority: false,
     });
     expect(issueChangedDims({ status: "todo" }, base).status).toBe(false);
     expect(issueChangedDims({ status: "done" }, base).status).toBe(true);
     expect(issueChangedDims({ project_id: "p2" }, base).project).toBe(true);
+    expect(issueChangedDims({ priority: "none" }, base).priority).toBe(false);
+    expect(issueChangedDims({ priority: "high" }, base).priority).toBe(true);
+    // Without a base, any written priority counts as changed.
+    expect(issueChangedDims({ priority: "high" }).priority).toBe(true);
   });
 
   it("ignores non-membership fields", () => {
@@ -135,12 +142,13 @@ describe("issueChangedDims", () => {
       assignee: false,
       project: false,
       status: false,
+      priority: false,
     });
   });
 });
 
 describe("listFilterDependsOn", () => {
-  const none = { assignee: false, project: false, status: false };
+  const none = { assignee: false, project: false, status: false, priority: false };
 
   it("my:all reacts to assignee changes only", () => {
     expect(listFilterDependsOn("all", {}, { ...none, assignee: true })).toBe(true);
@@ -180,14 +188,75 @@ describe("listFilterDependsOn", () => {
       listFilterDependsOn(
         "created",
         { creator_id: "me" },
-        { assignee: true, project: true, status: true },
+        { assignee: true, project: true, status: true, priority: false },
       ),
     ).toBe(false);
   });
 
   it("the unfiltered workspace list never reacts", () => {
     expect(
-      listFilterDependsOn(undefined, {}, { assignee: true, project: true, status: true }),
+      listFilterDependsOn(undefined, {}, {
+        assignee: true,
+        project: true,
+        status: true,
+        priority: false,
+      }),
     ).toBe(false);
+  });
+
+  it("priority-filtered lists react to priority changes (workspace + my:all)", () => {
+    // Workspace list with a priority facet: a priority change moves membership.
+    expect(
+      listFilterDependsOn(undefined, { priorities: ["high"] }, { ...none, priority: true }),
+    ).toBe(true);
+    // No priority facet → a priority change is a no-op for the workspace list.
+    expect(
+      listFilterDependsOn(undefined, {}, { ...none, priority: true }),
+    ).toBe(false);
+    // my:all is normally assignee-only, but a priority facet layered on top
+    // makes it react to priority changes too (the all-scope shortcut must not
+    // swallow the priority dimension).
+    expect(
+      listFilterDependsOn("all", { priorities: ["high"] }, { ...none, priority: true }),
+    ).toBe(true);
+    expect(listFilterDependsOn("all", {}, { ...none, priority: true })).toBe(false);
+  });
+});
+
+describe("issueMatchesListFilter — priorities", () => {
+  it("judges priority membership definitively from the entity", () => {
+    expect(
+      issueMatchesListFilter(makeIssue({ priority: "high" }), undefined, {
+        priorities: ["high", "urgent"],
+      }),
+    ).toBe(true);
+    expect(
+      issueMatchesListFilter(makeIssue({ priority: "low" }), undefined, {
+        priorities: ["high", "urgent"],
+      }),
+    ).toBe(false);
+  });
+
+  it("a priority miss is a definitive non-member even for the my:all union", () => {
+    // The all-scope early return must NOT bypass the priority check: a low
+    // issue can never belong to a priorities:["high"] all-list, regardless of
+    // the server-only union membership.
+    expect(
+      issueMatchesListFilter(makeIssue({ priority: "low" }), "all", {
+        priorities: ["high"],
+      }),
+    ).toBe(false);
+    // A priority match still leaves the union itself undecidable.
+    expect(
+      issueMatchesListFilter(makeIssue({ priority: "high" }), "all", {
+        priorities: ["high"],
+      }),
+    ).toBe("unknown");
+  });
+
+  it("degrades to unknown when a partial entity is missing priority", () => {
+    expect(
+      issueMatchesListFilter({ title: "partial" }, undefined, { priorities: ["high"] }),
+    ).toBe("unknown");
   });
 });

--- a/packages/core/issues/surface/membership.ts
+++ b/packages/core/issues/surface/membership.ts
@@ -15,13 +15,14 @@ export type IssueMembership = true | false | "unknown";
 
 /**
  * The field groups a write can touch that move an issue in or out of a
- * filtered list (assignee / project) or shift per-status bucket totals
- * (status). Creator is not here: it is immutable after create.
+ * filtered list (assignee / project / priority) or shift per-status bucket
+ * totals (status). Creator is not here: it is immutable after create.
  */
 export interface IssueChangedDims {
   assignee: boolean;
   project: boolean;
   status: boolean;
+  priority: boolean;
 }
 
 /**
@@ -44,6 +45,8 @@ export function issueChangedDims(
       (has("assignee_type") && (!base || base.assignee_type !== p.assignee_type)),
     project: has("project_id") && (!base || base.project_id !== p.project_id),
     status: has("status") && p.status !== undefined && (!base || base.status !== p.status),
+    priority:
+      has("priority") && p.priority !== undefined && (!base || base.priority !== p.priority),
   };
 }
 
@@ -59,9 +62,13 @@ export function listFilterDependsOn(
   filter: MyIssuesFilter,
   changed: IssueChangedDims,
 ): boolean {
+  // Priority is an AND filter layered on every scope, so a priority change can
+  // move an issue in/out of any priority-filtered list — including my:all.
+  const priorityTouched =
+    changed.priority && (filter.priorities?.length ?? 0) > 0;
   // my:all is the union of assigned / created / involved — the assigned and
   // involved legs key on the assignee.
-  if (scope === "all") return changed.assignee;
+  if (scope === "all") return changed.assignee || priorityTouched;
   if (
     changed.assignee &&
     (filter.assignee_id !== undefined ||
@@ -72,6 +79,7 @@ export function listFilterDependsOn(
     return true;
   }
   if (changed.project && filter.project_id !== undefined) return true;
+  if (priorityTouched) return true;
   // creator_id filters never react to updates — creator is immutable.
   return false;
 }
@@ -87,11 +95,23 @@ export function issueMatchesListFilter(
   scope: string | undefined,
   filter: MyIssuesFilter,
 ): IssueMembership {
-  // my:all — union across relations; the involved leg needs the server's
-  // agent-ownership graph, so membership is never decidable client-side.
-  if (scope === "all") return "unknown";
-
   let unknown = false;
+
+  // Priority is a hard AND filter, decidable from the entity's own field.
+  // It runs BEFORE every scope branch — including the scope==="all" union
+  // whose own membership is server-only — so a priority miss is a definitive
+  // non-member even there (the all-scope early return must NOT bypass it). A
+  // field missing on a partial entity degrades to "unknown" instead of a guess.
+  if (filter.priorities !== undefined) {
+    if (issue.priority === undefined) unknown = true;
+    else if (!filter.priorities.includes(issue.priority)) return false;
+  }
+
+  // my:all — union across relations; the involved leg needs the server's
+  // agent-ownership graph, so scope membership is never decidable client-side.
+  // A confirmed priority miss already returned above; here membership stays
+  // uncertain.
+  if (scope === "all") return "unknown";
 
   if (filter.assignee_id !== undefined) {
     if (issue.assignee_id === undefined) unknown = true;

--- a/packages/core/issues/surface/repository.ts
+++ b/packages/core/issues/surface/repository.ts
@@ -7,6 +7,7 @@ import {
   projectGanttIssuesOptions,
   type AssigneeGroupedIssuesFilter,
   type IssueSortParam,
+  type MyIssuesFilter,
 } from "../queries";
 import type {
   GroupedIssuesResponse,
@@ -31,12 +32,15 @@ import type { IssueSurfaceQueryPlan } from "./query-plan";
 export function issueSurfaceListOptions(
   wsId: string,
   plan: IssueSurfaceQueryPlan,
+  // The membership filter (scope fields + normalized priorities), merged by
+  // the caller so the surface query key matches load-more's `activeKey`.
+  filter: MyIssuesFilter,
   sort?: IssueSortParam,
 ): UseQueryOptions<ListIssuesCache, Error, Issue[]> {
   return (
     plan.kind === "workspace"
-      ? issueListOptions(wsId, sort)
-      : myIssueListOptions(wsId, plan.queryScope, plan.queryFilter, plan.userId, sort)
+      ? issueListOptions(wsId, filter, sort)
+      : myIssueListOptions(wsId, plan.queryScope, filter, plan.userId, sort)
   ) as UseQueryOptions<ListIssuesCache, Error, Issue[]>;
 }
 

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -803,3 +803,89 @@ describe("project gantt cache invalidation", () => {
     expectInvalidated(qc, issueKeys.projectGantt(WS_ID, PROJECT_ID));
   });
 });
+
+describe("onIssueUpdated — priority_changed reconciles priority-filtered lists", () => {
+  let qc: QueryClient;
+  const highKey = issueKeys.listSorted(WS_ID, { priorities: ["high"] });
+  const lowKey = issueKeys.listSorted(WS_ID, { priorities: ["low"] });
+  const highIssue: Issue = { ...baseIssue, priority: "high" };
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("removes a loaded issue from a high-filtered list and marks the low list stale", () => {
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), highIssue);
+    qc.setQueryData<ListIssuesCache>(highKey, makeListCache(highIssue));
+    qc.setQueryData<ListIssuesCache>(lowKey, {
+      byStatus: { todo: { issues: [], total: 0 } },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { ...highIssue, priority: "low" },
+      { priorityChanged: true },
+    );
+
+    // Left the high list surgically.
+    const high = qc.getQueryData<ListIssuesCache>(highKey);
+    expect(high?.byStatus.todo?.issues.map((i) => i.id)).toEqual([]);
+    expect(high?.byStatus.todo?.total).toBe(0);
+    // May have entered the low list — refetch is the only channel that can
+    // place the row into its server-ordered slot.
+    expectInvalidated(qc, lowKey);
+  });
+
+  it("decrements an off-screen high→low member's bucket total", () => {
+    const offScreen: Issue = { ...highIssue, id: "off-screen" };
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, "off-screen"), offScreen);
+    qc.setQueryData<ListIssuesCache>(highKey, {
+      byStatus: { todo: { issues: [], total: 1 } },
+    });
+
+    onIssueUpdated(
+      qc,
+      WS_ID,
+      { ...offScreen, priority: "low" },
+      { priorityChanged: true },
+    );
+
+    expect(qc.getQueryData<ListIssuesCache>(highKey)?.byStatus.todo?.total).toBe(0);
+  });
+});
+
+describe("onIssueCreated — respects priority-filtered workspace caches", () => {
+  let qc: QueryClient;
+  const highKey = issueKeys.listSorted(WS_ID, { priorities: ["high"] });
+  const defaultKey = issueKeys.listSorted(WS_ID, {});
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("does not insert a non-matching new issue into a priority-filtered cache", () => {
+    qc.setQueryData<ListIssuesCache>(highKey, { byStatus: { todo: { issues: [], total: 0 } } });
+    qc.setQueryData<ListIssuesCache>(defaultKey, { byStatus: { todo: { issues: [], total: 0 } } });
+
+    onIssueCreated(qc, WS_ID, { ...baseIssue, priority: "low", status: "todo" });
+
+    // High-only cache is untouched; the unfiltered default cache gains the row.
+    expect(qc.getQueryData<ListIssuesCache>(highKey)?.byStatus.todo?.issues).toEqual([]);
+    expect(qc.getQueryData<ListIssuesCache>(highKey)?.byStatus.todo?.total).toBe(0);
+    expect(
+      qc.getQueryData<ListIssuesCache>(defaultKey)?.byStatus.todo?.issues.map((i) => i.id),
+    ).toEqual([ISSUE_ID]);
+  });
+
+  it("inserts a matching new issue into a priority-filtered cache", () => {
+    qc.setQueryData<ListIssuesCache>(highKey, { byStatus: { todo: { issues: [], total: 0 } } });
+
+    onIssueCreated(qc, WS_ID, { ...baseIssue, priority: "high", status: "todo" });
+
+    expect(
+      qc.getQueryData<ListIssuesCache>(highKey)?.byStatus.todo?.issues.map((i) => i.id),
+    ).toEqual([ISSUE_ID]);
+    expect(qc.getQueryData<ListIssuesCache>(highKey)?.byStatus.todo?.total).toBe(1);
+  });
+});

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -6,6 +6,7 @@ import {
   applyIssueChange,
   invalidateIssueDerivatives,
   invalidateStaleListKeys,
+  issueMatchesListKey,
 } from "./cache-coordinator";
 import {
   addIssueToBuckets,
@@ -22,7 +23,18 @@ export function onIssueCreated(
   issue: Issue,
 ) {
   for (const [key, data] of qc.getQueriesData<ListIssuesCache>({ queryKey: issueKeys.list(wsId) })) {
-    if (data) qc.setQueryData<ListIssuesCache>(key, addIssueToBuckets(data, issue));
+    if (!data) continue;
+    // A filtered workspace list (e.g. priorities:["high"]) must not gain an
+    // issue that doesn't match its contract. Membership is client-decidable
+    // from the full created entity, so this is true/false in practice; keep
+    // the "unknown" → refetch branch for safety.
+    const membership = issueMatchesListKey(key, issue);
+    if (membership === false) continue;
+    if (membership === "unknown") {
+      qc.invalidateQueries({ queryKey: key, exact: true });
+      continue;
+    }
+    qc.setQueryData<ListIssuesCache>(key, addIssueToBuckets(data, issue));
   }
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
@@ -45,15 +57,17 @@ export function onIssueUpdated(
   qc: QueryClient,
   wsId: string,
   issue: Partial<Issue> & { id: string },
-  // assigneeChanged / statusChanged / projectChanged come from the server's
-  // issue:updated flags — authoritative "did this write move a membership
-  // dimension" signals. They feed the coordinator's changed-dims input so a
-  // non-membership change (title / position / priority / label) keeps every
-  // loaded list in place instead of refetching.
+  // assigneeChanged / statusChanged / projectChanged / priorityChanged come
+  // from the server's issue:updated flags — authoritative "did this write move
+  // a membership dimension" signals. They feed the coordinator's changed-dims
+  // input so a non-membership change (title / position / label) keeps every
+  // loaded list in place instead of refetching, while a priority change
+  // reconciles priority-filtered lists.
   meta: {
     assigneeChanged?: boolean;
     statusChanged?: boolean;
     projectChanged?: boolean;
+    priorityChanged?: boolean;
   } = {},
 ) {
   // Look up the OLD parent + cached entity before mutating cache state, so we
@@ -96,6 +110,11 @@ export function onIssueUpdated(
       (cachedIssue !== undefined &&
         issue.status !== undefined &&
         issue.status !== cachedIssue.status),
+    priority:
+      meta.priorityChanged ??
+      (cachedIssue !== undefined &&
+        issue.priority !== undefined &&
+        issue.priority !== cachedIssue.priority),
   };
 
   // The coordinator applies the same rules table the local mutations use:

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -638,6 +638,7 @@ export function useRealtimeSync(
           assigneeChanged: payload.assignee_changed,
           statusChanged: payload.status_changed,
           projectChanged: payload.project_changed,
+          priorityChanged: payload.priority_changed,
         });
         if (issue.status) {
           onInboxIssueStatusChanged(qc, wsId, issue.id, issue.status);

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -79,6 +79,13 @@ export interface ListIssuesParams {
   workspace_id?: string;
   status?: IssueStatus;
   priority?: IssuePriority;
+  /**
+   * Multi-select priority filter. Serialized as `priorities=high,urgent`.
+   * The status board pushes its priority facet here so per-status `total`
+   * reflects the filter. `priority` (singular) stays for older clients; the
+   * server reads `priorities` first and falls back to `priority`.
+   */
+  priorities?: IssuePriority[];
   assignee_id?: string;
   assignee_ids?: string[];
   /**

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -101,11 +101,13 @@ export interface IssueUpdatedPayload {
   // counts when a status change lands on an off-screen (unloaded) issue;
   // project_changed lets it drop a moved issue from the old project's filtered
   // list (the client-side cache diff is unreliable after an optimistic local
-  // move — MUL-3669 / #4548). Other change flags are present on the wire too and
-  // can be surfaced here when needed.
+  // move — MUL-3669 / #4548); priority_changed does the same for
+  // priority-filtered status boards (MUL-4289). Other change flags are present
+  // on the wire too and can be surfaced here when needed.
   assignee_changed?: boolean;
   status_changed?: boolean;
   project_changed?: boolean;
+  priority_changed?: boolean;
 }
 
 export interface IssueDeletedPayload {

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -158,9 +158,9 @@ export function BoardView({
     ? t(($) => $.board.ordered_by, { field: t(($) => $.display[`sort_${sortFieldKey}` as keyof typeof $.display]) })
     : null;
   const { getActorName } = useActorName();
-  const myIssuesOpts = myIssuesScope
-    ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
-    : undefined;
+  // Always defined so the workspace list (no scope) still carries its priority
+  // filter into load-more; `scope` undefined keys off `listSorted`.
+  const myIssuesOpts = { scope: myIssuesScope, filter: myIssuesFilter ?? {} };
   const groupedIssues = useMemo(
     () =>
       grouping === "assignee" && assigneeGroups
@@ -569,7 +569,7 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
   projectMap?: Map<string, Project>;
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   sort?: IssueSortParam;
   projectId?: string;
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
@@ -577,7 +577,7 @@ const PaginatedBoardColumn = memo(function PaginatedBoardColumn({
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     group.status,
-    myIssuesOpts,
+    myIssuesOpts ?? { filter: {} },
     sort,
   );
   return (
@@ -613,10 +613,10 @@ function BoardHiddenColumnRow({
   sort,
 }: {
   status: IssueStatus;
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   sort?: IssueSortParam;
 }) {
-  const { total } = useLoadMoreByStatus(status, myIssuesOpts, sort);
+  const { total } = useLoadMoreByStatus(status, myIssuesOpts ?? { filter: {} }, sort);
   return <HiddenColumnRow status={status} total={total} />;
 }
 
@@ -626,7 +626,7 @@ function BoardHiddenColumnsPanel({
   sort,
 }: {
   hiddenStatuses: IssueStatus[];
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   sort?: IssueSortParam;
 }) {
   return (

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -98,9 +98,10 @@ export function ListView({
     [visibleStatuses, listCollapsedStatuses]
   );
 
-  const myIssuesOpts = myIssuesScope
-    ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
-    : undefined;
+  // Always defined: the workspace list (no scope) still needs its filter to
+  // carry the priority selection into load-more. `scope` is undefined for the
+  // workspace list, which keys off `listSorted` instead of `myListSorted`.
+  const myIssuesOpts = { scope: myIssuesScope, filter: myIssuesFilter ?? {} };
 
   const dragEnabled = !!onMoveIssue;
 
@@ -384,7 +385,7 @@ function StatusAccordionItem({
   issueMap: Map<string, Issue>;
   childProgressMap: Map<string, ChildProgress>;
   projectMap?: Map<string, Project>;
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   projectId?: string;
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
   dragEnabled: boolean;
@@ -399,7 +400,7 @@ function StatusAccordionItem({
   const deselect = selection.deselect;
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     status,
-    myIssuesOpts,
+    myIssuesOpts ?? { filter: {} },
     sort,
   );
 

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -548,11 +548,10 @@ export function SwimLaneView({
 
   const laneSourceIssues = unfilteredIssues ?? issues;
 
+  // Always defined so the workspace list (no scope) still carries its priority
+  // filter into load-more; `scope` undefined keys off `listSorted`.
   const myIssuesOpts = useMemo(
-    () =>
-      myIssuesScope
-        ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
-        : undefined,
+    () => ({ scope: myIssuesScope, filter: myIssuesFilter ?? {} }),
     [myIssuesScope, myIssuesFilter],
   );
 
@@ -1559,7 +1558,7 @@ function SwimLaneLoadMoreRow({
 }: {
   sortedStatuses: IssueStatus[];
   gridStyle: React.CSSProperties;
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   sort?: IssueSortParam;
 }) {
   return (
@@ -1582,10 +1581,10 @@ function SwimLaneLoadMoreCell({
   sort,
 }: {
   status: IssueStatus;
-  myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  myIssuesOpts?: { scope?: string; filter: MyIssuesFilter };
   sort?: IssueSortParam;
 }) {
-  const { loadMore, hasMore, isLoading } = useLoadMoreByStatus(status, myIssuesOpts, sort);
+  const { loadMore, hasMore, isLoading } = useLoadMoreByStatus(status, myIssuesOpts ?? { filter: {} }, sort);
   if (!hasMore) return <div />;
   return <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />;
 }

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -182,13 +182,19 @@ describe("useIssueSurfaceController", () => {
     expect(result.current.scopeKey).toBe("workspace:all");
     expect(result.current.filter).toEqual({});
     expect(result.current.loadMoreScope).toBeUndefined();
-    expect(result.current.loadMoreFilter).toBeUndefined();
+    // loadMoreFilter is now always the merged membership filter — empty for the
+    // default workspace board (no priority selected), not undefined.
+    expect(result.current.loadMoreFilter).toEqual({});
     expect(
       qc.getQueryCache().find({
-        queryKey: issueKeys.listSorted("ws-1", {
-          sort_by: "position",
-          sort_direction: undefined,
-        }),
+        queryKey: issueKeys.listSorted(
+          "ws-1",
+          {},
+          {
+            sort_by: "position",
+            sort_direction: undefined,
+          },
+        ),
         exact: true,
       }),
     ).toBeDefined();

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -7,6 +7,7 @@ import { ALL_STATUSES, BOARD_STATUSES } from "@multica/core/issues/config";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
   childIssueProgressOptions,
+  withPriorityFilter,
   type AssigneeGroupedIssuesFilter,
   type IssueSortParam,
   type MyIssuesFilter,
@@ -137,8 +138,17 @@ export function useIssueSurfaceData({
     sort,
   );
 
+  // The membership filter for the bucketed status list: the plan's scope
+  // fields plus the normalized priority selection. Built once here (the single
+  // source of truth) and threaded to BOTH the surface query key and the
+  // load-more `activeKey` (via loadMoreFilter) so they hash identically.
+  const listFilter = useMemo<MyIssuesFilter>(
+    () => withPriorityFilter(queryPlan.queryFilter, priorityFilters),
+    [queryPlan.queryFilter, priorityFilters],
+  );
+
   const statusIssuesQuery = useQuery({
-    ...issueSurfaceListOptions(wsId, queryPlan, sort),
+    ...issueSurfaceListOptions(wsId, queryPlan, listFilter, sort),
     enabled: !usesAssigneeBoard && !usesGantt,
   });
   const assigneeGroupsQuery = useQuery({
@@ -324,7 +334,10 @@ export function useIssueSurfaceData({
     assigneeGroupFilter: usesAssigneeBoard ? assigneeGroupFilter : undefined,
     filter: queryPlan.queryFilter,
     loadMoreScope: queryPlan.loadMoreScope,
-    loadMoreFilter: queryPlan.loadMoreFilter,
+    // Always the merged filter (scope + priorities), even for the workspace
+    // list whose plan carries no loadMoreFilter — the load-more hook keys off
+    // this, so it must match the surface query's `listFilter` byte-for-byte.
+    loadMoreFilter: listFilter,
     ganttIssues,
     visibleStatuses,
     hiddenStatuses,

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -759,9 +759,12 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	// Parse optional filter params. Malformed UUIDs in filters return 400 —
 	// silently coercing them to a zero UUID would mask a client bug and let
 	// the query return an empty result set (or worse, match a NULL row).
-	var priorityFilter pgtype.Text
-	if p := r.URL.Query().Get("priority"); p != "" {
-		priorityFilter = pgtype.Text{String: p, Valid: true}
+	// Multi-select priorities with single-`priority` back-compat (mirrors
+	// ListGroupedIssues): new clients send priorities=high,urgent; older
+	// clients keep sending priority=high.
+	priorities := splitCommaParam(r.URL.Query().Get("priorities"))
+	if len(priorities) == 0 {
+		priorities = splitCommaParam(r.URL.Query().Get("priority"))
 	}
 	var assigneeFilter pgtype.UUID
 	if a := r.URL.Query().Get("assignee_id"); a != "" {
@@ -824,6 +827,13 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 
 	// open_only=true returns all non-done/cancelled issues (no limit).
 	if r.URL.Query().Get("open_only") == "true" {
+		// open_only keeps its original single-`priority` contract (no frontend
+		// caller; intentionally not widened to the multi-select `priorities`
+		// the paginated path uses, to avoid expanding the sqlc query).
+		var priorityFilter pgtype.Text
+		if p := r.URL.Query().Get("priority"); p != "" {
+			priorityFilter = pgtype.Text{String: p, Valid: true}
+		}
 		issues, err := h.Queries.ListOpenIssues(ctx, db.ListOpenIssuesParams{
 			WorkspaceID:    wsUUID,
 			Priority:       priorityFilter,
@@ -945,8 +955,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	if statusFilter.Valid {
 		where = append(where, fmt.Sprintf("i.status = %s", addArg(statusFilter.String)))
 	}
-	if priorityFilter.Valid {
-		where = append(where, fmt.Sprintf("i.priority = %s", addArg(priorityFilter.String)))
+	if len(priorities) > 0 {
+		where = append(where, fmt.Sprintf("i.priority = ANY(%s::text[])", addArg(priorities)))
 	}
 	if assigneeFilter.Valid {
 		where = append(where, fmt.Sprintf("i.assignee_id = %s::uuid", addArg(assigneeFilter)))

--- a/server/internal/handler/issue_priorities_test.go
+++ b/server/internal/handler/issue_priorities_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ListIssues gained a multi-select `priorities` filter so the status board can
+// push priority server-side and get per-status totals that reflect the filter.
+// The single `priority` param must keep working for older clients. Both filter
+// the returned rows AND the `total` count.
+func TestListIssues_PrioritiesFilter(t *testing.T) {
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	// Dedicated project so parallel tests' issues don't pollute the counts.
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Priorities %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
+	insertIssue := func(title, priority string) string {
+		var number int
+		if err := testPool.QueryRow(ctx, `
+			UPDATE workspace
+			SET issue_counter = GREATEST(issue_counter, (SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)) + 1
+			WHERE id = $1 RETURNING issue_counter
+		`, testWorkspaceID).Scan(&number); err != nil {
+			t.Fatalf("next issue number: %v", err)
+		}
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number, project_id)
+			VALUES ($1, $2, 'todo', $3, 'member', $4, 0, $5, $6) RETURNING id
+		`, testWorkspaceID, title, priority, testUserID, number, projectID).Scan(&id); err != nil {
+			t.Fatalf("create issue %q: %v", title, err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, id) })
+		return id
+	}
+
+	urgentID := insertIssue(fmt.Sprintf("urgent-%d", suffix), "urgent")
+	highID := insertIssue(fmt.Sprintf("high-%d", suffix), "high")
+	lowID := insertIssue(fmt.Sprintf("low-%d", suffix), "low")
+
+	list := func(query string) (ids []string, total int64) {
+		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500%s",
+			testWorkspaceID, projectID, query)
+		w := httptest.NewRecorder()
+		testHandler.ListIssues(w, newRequest("GET", path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Issues []IssueResponse `json:"issues"`
+			Total  int64           `json:"total"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode list response: %v", err)
+		}
+		for _, iss := range resp.Issues {
+			ids = append(ids, iss.ID)
+		}
+		return ids, resp.Total
+	}
+
+	// Baseline: no priority filter returns all three.
+	allIDs, allTotal := list("")
+	for _, want := range []string{urgentID, highID, lowID} {
+		if !containsIssueID(allIDs, want) {
+			t.Fatalf("baseline list missing %s — all=%v", want, allIDs)
+		}
+	}
+	if allTotal != 3 {
+		t.Fatalf("baseline total: want 3, got %d", allTotal)
+	}
+
+	// Multi-select: priorities=high,urgent narrows rows AND total, drops low.
+	multiIDs, multiTotal := list("&priorities=high,urgent")
+	for _, want := range []string{urgentID, highID} {
+		if !containsIssueID(multiIDs, want) {
+			t.Fatalf("priorities filter missing %s — got %v", want, multiIDs)
+		}
+	}
+	if containsIssueID(multiIDs, lowID) {
+		t.Fatalf("priorities filter unexpectedly includes low issue %s", lowID)
+	}
+	if multiTotal != 2 {
+		t.Fatalf("priorities total: want 2, got %d", multiTotal)
+	}
+
+	// Back-compat: old single `priority=high` still filters rows AND total.
+	singleIDs, singleTotal := list("&priority=high")
+	if !containsIssueID(singleIDs, highID) {
+		t.Fatalf("single priority filter missing %s — got %v", highID, singleIDs)
+	}
+	for _, unwanted := range []string{urgentID, lowID} {
+		if containsIssueID(singleIDs, unwanted) {
+			t.Fatalf("single priority filter unexpectedly includes %s — got %v", unwanted, singleIDs)
+		}
+	}
+	if singleTotal != 1 {
+		t.Fatalf("single priority total: want 1, got %d", singleTotal)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes MUL-4289: on the status board / list view, selecting a priority filter left each status's header total unchanged and could hide matches beyond the first loaded page. Priority was applied only client-side over the loaded page, while the header total came from the server's *unfiltered* per-status count.

This makes priority a **server list membership dimension** — the same system-level equality the assignee-grouped board already upholds:

> `API query params = TanStack query key = cache membership predicate = realtime/mutation reconciliation predicate`

No UI/copy change, no DB migration, no wire-shape change. Old clients that send singular `priority` keep working.

## What changed

**Backend** (`server/internal/handler/issue.go`)
- `ListIssues` accepts a multi-select `priorities` (comma param), reusing the `ListGroupedIssues` pattern (`priorities` first, fallback to singular `priority`). `total` is `COUNT(*)` over the same `where`, so it narrows with the filter automatically. `open_only` keeps its original single-`priority` contract (not widened).

**Core**
- `ListIssuesParams.priorities` + client serialization (`priorities=high,urgent`).
- `MyIssuesFilter.priorities`; one shared `normalizePriorities` / `withPriorityFilter` helper — empty → omitted, deduped, stably sorted — so the surface query key and `useLoadMoreByStatus` `activeKey` are byte-consistent and the same selected set keys once regardless of click order.
- Workspace `listSorted` key gains a filter segment; `fetchFirstPages` / `fetchAllMyFirstPages` / `useLoadMoreByStatus` all forward `priorities`.
- Cache coordinator: priority is a fourth `IssueChangedDims` dimension and a membership predicate. The priority check runs **before** the `scope === "all"` early return, so a priority miss is a definitive non-member even for the my:all union. Create paths (`onIssueCreated`, `useCreateIssue.onSuccess`) no longer blind-insert into a filtered cache.
- Realtime: the server's existing `priority_changed` flag is now declared on `IssueUpdatedPayload` and routed through `onIssueUpdated` into the coordinator.

**Views**
- `use-issue-surface-data` builds the merged `listFilter` once and threads it to both the surface query and load-more. `list-view` / `board-view` / `swimlane-view` carry the priority filter into load-more even for the workspace list (no scope).

## Verification

- **Go handler** (run against a clean DB migrated to this checkout — the shared dev DB had unrelated `space_id` drift): `TestListIssues_PrioritiesFilter` — `priorities=high,urgent&status=todo` narrows rows **and** `total`; legacy `priority=high` still works; unfiltered returns all. Full `TestListIssues*` suite green. `gofmt`/`go vet` clean.
- **Core** (`pnpm --filter @multica/core test`): 800 passed. New tests: client serialization (multi/empty/legacy), query-key + first-page + load-more, **surface key === loadMore activeKey** byte-consistency, `normalizePriorities` dedup/sort, membership priority (incl. the scope==="all" case), coordinator (loaded high→low removed, off-screen high→low decrements total, low-list marked stale), realtime `priority_changed`, and create-path guard.
- **Views** (`pnpm --filter @multica/views test`): 1688 passed.
- **Typecheck**: full monorepo `pnpm typecheck` green (6/6 projects).

## Residual risk

- One-time cache-key change: the workspace list key gains a filter segment, so existing entries invalidate once on deploy (fresh fetch, no data risk).
- Known naming debt (out of scope): `MyIssuesFilter` is now effectively the bucketed-list server contract, not just "My Issues". If assignee/creator/project/label facets are later pushed server-side too, consider renaming to `IssueListFilter`. This PR deliberately does not touch those facets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
