### PR TITLE
fix(integrations): auto-recycle IM bot slots on owner delete + accurate conflict copy (#4810) MUL-3937

### DIFF
--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -760,6 +760,14 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to clean up agent invocation targets")
 		return
 	}
+	// Same app-layer cascade for channel_installation (no agent FK, MUL-3515 §4):
+	// drop the archived agents' IM bot installations so a hard-deleted agent never
+	// leaves an orphan row permanently holding the (channel_type, app_id) slot,
+	// which would block reconnecting that bot to any agent (#4810).
+	if err := qtx.DeleteChannelInstallationsByArchivedRuntimeAgents(r.Context(), rt.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to clean up channel installations")
+		return
+	}
 	if err := qtx.DeleteArchivedAgentsByRuntime(r.Context(), rt.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to clean up archived agents")
 		return
@@ -1002,6 +1010,14 @@ func (h *Handler) ArchiveAgentsAndDeleteRuntime(w http.ResponseWriter, r *http.R
 	//    (ON DELETE RESTRICT) no longer keeps the runtime alive.
 	if err := qtx.DeleteAgentInvocationTargetsByArchivedRuntimeAgents(r.Context(), rt.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to clean up agent invocation targets")
+		return
+	}
+	// Same app-layer cascade for channel_installation (no agent FK, MUL-3515 §4):
+	// drop the archived agents' IM bot installations so a hard-deleted agent never
+	// leaves an orphan row permanently holding the (channel_type, app_id) slot,
+	// which would block reconnecting that bot to any agent (#4810).
+	if err := qtx.DeleteChannelInstallationsByArchivedRuntimeAgents(r.Context(), rt.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to clean up channel installations")
 		return
 	}
 	if err := qtx.DeleteArchivedAgentsByRuntime(r.Context(), rt.ID); err != nil {

--- a/server/internal/handler/runtime_cascade_test.go
+++ b/server/internal/handler/runtime_cascade_test.go
@@ -272,6 +272,84 @@ func TestArchiveAgentsAndDeleteRuntime_HappyPath(t *testing.T) {
 	}
 }
 
+// TestArchiveAgentsAndDeleteRuntime_RemovesChannelInstallations pins the #4810
+// (MUL-3937) fix on the agent hard-delete path: channel_installation has no
+// agent FK (MUL-3515 §4), so tearing a runtime down must explicitly drop its
+// agents' IM bot installations. Otherwise a hard-deleted agent leaves an orphan
+// row holding the (channel_type, app_id) slot forever, and the bot can never be
+// reconnected. A control installation for an agent NOT on this runtime survives.
+func TestArchiveAgentsAndDeleteRuntime_RemovesChannelInstallations(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	const (
+		appID     = "cli_rt_delete_target"
+		ctrlAppID = "cli_rt_delete_control"
+		chatChat  = "oc_rt_del"
+	)
+	cleanup := func() {
+		testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE config->>'app_id' = ANY($1)`, []string{appID, ctrlAppID})
+		testPool.Exec(context.Background(), `DELETE FROM channel_chat_session_binding WHERE channel_chat_id = $1`, chatChat)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	runtimeID := createCascadeFixtureRuntime(t, ctx, "Cascade Channel Runtime")
+	agentID := createCascadeFixtureAgent(t, ctx, runtimeID, "Cascade Channel Agent")
+
+	var installID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', $3::text), $4, 'active')
+RETURNING id
+`, testWorkspaceID, agentID, appID, testUserID).Scan(&installID); err != nil {
+		t.Fatalf("insert channel installation: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+INSERT INTO channel_chat_session_binding (chat_session_id, installation_id, channel_type, channel_chat_id, chat_type)
+VALUES ($1, $2, 'feishu', $3, 'p2p')
+`, "9c000000-0000-4000-8000-0000000000e2", installID, chatChat); err != nil {
+		t.Fatalf("insert chat-session binding: %v", err)
+	}
+	// A control installation for an agent NOT on this runtime must survive.
+	var ctrlInstallID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, '9c000000-0000-4000-8000-0000000000eb', 'feishu', jsonb_build_object('app_id', $2::text), $3, 'active')
+RETURNING id
+`, testWorkspaceID, ctrlAppID, testUserID).Scan(&ctrlInstallID); err != nil {
+		t.Fatalf("insert control channel installation: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/runtimes/"+runtimeID+"/archive-agents-and-delete",
+		map[string]any{"expected_active_agent_ids": []string{agentID}})
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ArchiveAgentsAndDeleteRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	count := func(q string, args ...any) int {
+		var n int
+		if err := testPool.QueryRow(ctx, q, args...).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+	if n := count(`SELECT count(*) FROM channel_installation WHERE id = $1`, installID); n != 0 {
+		t.Fatalf("hard-deleted agent left an orphan channel_installation: %d rows (the bot could never rebind)", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_chat_session_binding WHERE installation_id = $1`, installID); n != 0 {
+		t.Fatalf("chat-session bindings not cleaned: %d dangling rows", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_installation WHERE id = $1`, ctrlInstallID); n != 1 {
+		t.Fatalf("a control installation for an agent on another runtime was wrongly deleted: %d rows remain", n)
+	}
+}
+
 func TestArchiveAgentsAndDeleteRuntime_CustomProfileInstanceRefusesDirectDelete(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/runtime_profile.go
+++ b/server/internal/handler/runtime_profile.go
@@ -458,6 +458,14 @@ func (h *Handler) DeleteRuntimeProfile(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to clean up agent invocation targets")
 			return
 		}
+		// Same app-layer cascade for channel_installation (no agent FK, MUL-3515
+		// §4): drop the archived agents' IM bot installations so a hard-deleted
+		// agent never leaves an orphan row holding the (channel_type, app_id)
+		// slot, which would block reconnecting that bot to any agent (#4810).
+		if err := qtx.DeleteChannelInstallationsByArchivedRuntimeAgents(r.Context(), rid); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to clean up channel installations")
+			return
+		}
 		if err := qtx.DeleteArchivedAgentsByRuntime(r.Context(), rid); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to clean up archived agents")
 			return

--- a/server/internal/handler/slack.go
+++ b/server/internal/handler/slack.go
@@ -145,6 +145,8 @@ func (h *Handler) RegisterSlackBYO(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, slack.ErrInvalidBotToken), errors.Is(err, slack.ErrInvalidAppToken), errors.Is(err, slack.ErrTokenAppMismatch):
 			writeError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, slack.ErrTeamOwnedByAnotherAgent):
+			writeError(w, http.StatusConflict, "this Slack app is already connected to another agent in this workspace; disconnect it from that agent first, then connect it here")
 		case errors.Is(err, slack.ErrTeamOwnedByAnotherWorkspace):
 			writeError(w, http.StatusConflict, "this Slack app is already connected to a different Multica workspace")
 		default:

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -236,6 +236,118 @@ VALUES ($1, 123456789, 'multica-ai', 'multica', 3366, 987654321, 'abc123', 15368
 	}
 }
 
+// TestDeleteWorkspace_RemovesChannelInstallations pins the #4810 (MUL-3937) fix:
+// channel_* has no FK to workspace (MUL-3515 §4), so deleting a workspace must
+// explicitly remove its channel installations and their app-layer dependents.
+// Otherwise the installation lingers, permanently holding the (channel_type,
+// app_id) unique slot, and the IM bot can never be reconnected to any agent.
+// A control installation in ANOTHER workspace must be left untouched.
+func TestDeleteWorkspace_RemovesChannelInstallations(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		slug        = "handler-tests-delete-channel"
+		ctrlSlug    = "handler-tests-delete-channel-ctrl"
+		appID       = "cli_ws_delete_target"
+		ctrlAppID   = "cli_ws_delete_control"
+		tokenHash   = "ws_delete_token_hash"
+		ctrlToken   = "ws_delete_ctrl_token"
+		auditEvent  = "ev_ws_delete_target"
+		userBinding = "ou_ws_delete_user"
+	)
+	member := "9c000000-0000-4000-8000-0000000000d1"
+	chatSess := "9c000000-0000-4000-8000-0000000000d2"
+	agentID := "9c000000-0000-4000-8000-0000000000da"
+	cleanup := func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_installation WHERE config->>'app_id' = ANY($1)`, []string{appID, ctrlAppID})
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_chat_session_binding WHERE chat_session_id = $1`, chatSess)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_user_binding WHERE multica_user_id = $1`, member)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_binding_token WHERE token_hash = ANY($1)`, []string{tokenHash, ctrlToken})
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM channel_inbound_audit WHERE channel_event_id = $1`, auditEvent)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE slug = ANY($1)`, []string{slug, ctrlSlug})
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	var wsID, ctrlWsID string
+	if err := testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug) VALUES ('WS Delete Channel', $1) RETURNING id`, slug).Scan(&wsID); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug) VALUES ('WS Delete Channel Ctrl', $1) RETURNING id`, ctrlSlug).Scan(&ctrlWsID); err != nil {
+		t.Fatalf("create control workspace: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'owner')`, wsID, testUserID); err != nil {
+		t.Fatalf("create owner member: %v", err)
+	}
+
+	// The target workspace's installation + its full spread of dependents.
+	var installID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', $3::text), $4, 'active')
+RETURNING id
+`, wsID, agentID, appID, testUserID).Scan(&installID); err != nil {
+		t.Fatalf("insert channel installation: %v", err)
+	}
+	seed := func(q string, args ...any) {
+		if _, err := testPool.Exec(ctx, q, args...); err != nil {
+			t.Fatalf("seed dependent: %v", err)
+		}
+	}
+	seed(`INSERT INTO channel_user_binding (workspace_id, multica_user_id, installation_id, channel_type, channel_user_id) VALUES ($1, $2, $3, 'feishu', $4)`, wsID, member, installID, userBinding)
+	seed(`INSERT INTO channel_chat_session_binding (chat_session_id, installation_id, channel_type, channel_chat_id, chat_type) VALUES ($1, $2, 'feishu', 'oc_ws_del', 'p2p')`, chatSess, installID)
+	seed(`INSERT INTO channel_binding_token (token_hash, workspace_id, installation_id, channel_type, channel_user_id, expires_at) VALUES ($1, $2, $3, 'feishu', $4, now() + interval '10 minutes')`, tokenHash, wsID, installID, userBinding)
+	seed(`INSERT INTO channel_inbound_audit (installation_id, channel_type, event_type, channel_event_id, drop_reason) VALUES ($1, 'feishu', 'im.message.receive_v1', $2, 'x')`, installID, auditEvent)
+
+	// A control installation owned by a DIFFERENT workspace must survive.
+	var ctrlInstallID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', $3::text), $4, 'active')
+RETURNING id
+`, ctrlWsID, agentID, ctrlAppID, testUserID).Scan(&ctrlInstallID); err != nil {
+		t.Fatalf("insert control channel installation: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+	req = withURLParam(req, "id", wsID)
+	testHandler.DeleteWorkspace(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 from DeleteWorkspace, got %d: %s", w.Code, w.Body.String())
+	}
+
+	count := func(q string, args ...any) int {
+		var n int
+		if err := testPool.QueryRow(ctx, q, args...).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+	if n := count(`SELECT count(*) FROM channel_installation WHERE id = $1`, installID); n != 0 {
+		t.Fatalf("deleted workspace left an orphan channel_installation: %d rows (the bot could never rebind)", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_user_binding WHERE installation_id = $1`, installID); n != 0 {
+		t.Fatalf("member links not cleaned: %d dangling rows", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_chat_session_binding WHERE installation_id = $1`, installID); n != 0 {
+		t.Fatalf("chat-session bindings not cleaned: %d dangling rows", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_binding_token WHERE installation_id = $1`, installID); n != 0 {
+		t.Fatalf("binding tokens not cleaned: %d dangling rows", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_inbound_audit WHERE installation_id = $1`, installID); n != 0 {
+		t.Fatalf("audit rows still reference the deleted installation: %d", n)
+	}
+	if n := count(`SELECT count(*) FROM channel_inbound_audit WHERE channel_event_id = $1 AND installation_id IS NULL`, auditEvent); n != 1 {
+		t.Fatalf("audit row should survive detached (installation_id NULL), got %d", n)
+	}
+	// The other workspace's installation is untouched.
+	if n := count(`SELECT count(*) FROM channel_installation WHERE id = $1`, ctrlInstallID); n != 1 {
+		t.Fatalf("a control installation in another workspace was wrongly deleted: %d rows remain", n)
+	}
+}
+
 // TestUpdateWorkspace_AvatarURL covers the avatar_url field added to
 // UpdateWorkspaceRequest: a PATCH with avatar_url is persisted and surfaced
 // back on the response, and partial updates leave other fields untouched.

--- a/server/internal/integrations/lark/channel_store.go
+++ b/server/internal/integrations/lark/channel_store.go
@@ -199,6 +199,25 @@ func (s *ChannelStore) RemoveRevokedInstallationByAppID(ctx context.Context, wor
 	return s.Queries.NullChannelInboundAuditInstallationID(ctx, installID)
 }
 
+// ReclaimOrphanedInstallationByAppID clears an installation that holds this
+// app's (channel_type, config->>'app_id') unique slot but whose owning workspace
+// or agent no longer exists — the "dead owner" self-heal for #4810 (MUL-3937).
+// channel_* has no FK/cascade (MUL-3515 §4), so deleting a workspace or hard-
+// deleting an agent leaves the row behind, and it then blocks re-installing the
+// same Feishu Bot against a new agent. Unlike RemoveRevokedInstallationByAppID
+// (which handles a still-live owner that merely disconnected), this targets a
+// genuinely gone owner; an ARCHIVED agent still exists and is left in place. The
+// underlying CTE cleans the reclaimed row's dependents in the same statement, so
+// this composes with the caller's transaction exactly like the revoked cleanup.
+func (s *ChannelStore) ReclaimOrphanedInstallationByAppID(ctx context.Context, workspaceID, agentID pgtype.UUID, appID string) error {
+	return s.Queries.ReclaimOrphanedChannelInstallationByAppID(ctx, db.ReclaimOrphanedChannelInstallationByAppIDParams{
+		ChannelType: channelTypeFeishu,
+		AppID:       appID,
+		WorkspaceID: workspaceID,
+		AgentID:     agentID,
+	})
+}
+
 func (s *ChannelStore) SetLarkInstallationStatus(ctx context.Context, arg SetInstallationStatusParams) error {
 	return s.Queries.SetChannelInstallationStatus(ctx, db.SetChannelInstallationStatusParams{
 		ID:     arg.ID,

--- a/server/internal/integrations/lark/channel_store_orphan_test.go
+++ b/server/internal/integrations/lark/channel_store_orphan_test.go
@@ -1,0 +1,198 @@
+package lark
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Orphan-reclaim fixtures (#4810 / MUL-3937). Namespaced away from the rebind /
+// scope tests so a shared test database never cross-contaminates. Unlike those
+// FK-free fixtures, this test DOES create real workspace / runtime / agent rows,
+// because the reclaim decision turns on whether the installation's owning
+// workspace or agent still EXISTS.
+const (
+	orWS           = "0f9a0000-0000-4000-8000-000000000001"
+	orRuntime      = "0f9a0000-0000-4000-8000-000000000002"
+	orLiveAgent    = "0f9a0000-0000-4000-8000-00000000000a"
+	orArchAgent    = "0f9a0000-0000-4000-8000-00000000000b"
+	orAbsentWS     = "0f9a0000-0000-4000-8000-0000000000f1"
+	orAbsentAgent  = "0f9a0000-0000-4000-8000-0000000000fa"
+	orCallerWS     = "0f9a0000-0000-4000-8000-0000000000c1"
+	orCallerAgent  = "0f9a0000-0000-4000-8000-0000000000ca"
+	orInstaller    = "0f9a0000-0000-4000-8000-000000000005"
+	orUser         = "0f9a0000-0000-4000-8000-000000000006"
+	orChatSess     = "0f9a0000-0000-4000-8000-000000000007"
+	orTokenHash    = "or_token_hash_cleanup"
+	orAuditEventID = "ev_or_cleanup"
+
+	orAppDead  = "cli_or_dead"  // ws + agent both gone      -> reclaim
+	orAppWS    = "cli_or_ws"    // ws gone, agent alive      -> reclaim
+	orAppAgent = "cli_or_agent" // ws alive, agent gone      -> reclaim
+	orAppLive  = "cli_or_live"  // ws + agent both alive     -> survive
+	orAppArch  = "cli_or_arch"  // agent archived (present)  -> survive
+	orAppOwn   = "cli_or_own"   // the caller's own row      -> survive
+	orAppDeps  = "cli_or_deps"  // orphan with dependents    -> reclaim + cleanup
+)
+
+// TestChannelStore_ReclaimOrphanedInstallationByAppID pins the dead-owner
+// self-heal: the reclaim removes an installation that holds the (channel_type,
+// app_id) slot only when its owning workspace or agent no longer exists, and
+// never touches a live owner (including an archived-but-present agent) or the
+// caller's own row.
+func TestChannelStore_ReclaimOrphanedInstallationByAppID(t *testing.T) {
+	pool := channelScopeTestDB(t)
+	ctx := context.Background()
+	store := NewChannelStore(db.New(pool))
+
+	apps := []string{orAppDead, orAppWS, orAppAgent, orAppLive, orAppArch, orAppOwn, orAppDeps}
+	clean := func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_installation WHERE config->>'app_id' = ANY($1)`, apps)
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_user_binding WHERE multica_user_id = $1`, orUser)
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_chat_session_binding WHERE chat_session_id = $1`, orChatSess)
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_binding_token WHERE token_hash = $1`, orTokenHash)
+		_, _ = pool.Exec(ctx, `DELETE FROM channel_inbound_audit WHERE channel_event_id = $1`, orAuditEventID)
+		// Deleting the workspace cascades the runtime + both agents (FK).
+		_, _ = pool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, orWS)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	exec := func(q string, args ...any) {
+		if _, err := pool.Exec(ctx, q, args...); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	// Real owner rows: one workspace, one runtime, a live agent and an archived agent.
+	exec(`INSERT INTO workspace (id, name, slug) VALUES ($1, 'orphan-reclaim-test', 'orphan-reclaim-test-ws')`, orWS)
+	exec(`INSERT INTO agent_runtime (id, workspace_id, name, runtime_mode, provider) VALUES ($1, $2, 'or-rt', 'local', 'local')`, orRuntime, orWS)
+	exec(`INSERT INTO agent (id, workspace_id, name, runtime_mode, runtime_id) VALUES ($1, $2, 'or-live', 'local', $3)`, orLiveAgent, orWS, orRuntime)
+	exec(`INSERT INTO agent (id, workspace_id, name, runtime_mode, runtime_id, archived_at) VALUES ($1, $2, 'or-arch', 'local', $3, now())`, orArchAgent, orWS, orRuntime)
+
+	insert := func(app, ws, agent string) pgtype.UUID {
+		var id string
+		if err := pool.QueryRow(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, $2, 'feishu', jsonb_build_object('app_id', $3::text), $4, 'active')
+RETURNING id
+`, ws, agent, app, orInstaller).Scan(&id); err != nil {
+			t.Fatalf("insert installation app=%s: %v", app, err)
+		}
+		return util.MustParseUUID(id)
+	}
+	exists := func(id pgtype.UUID) bool {
+		_, err := store.GetLarkInstallation(ctx, id)
+		if err == nil {
+			return true
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false
+		}
+		t.Fatalf("GetLarkInstallation: %v", err)
+		return false
+	}
+
+	callerWS := util.MustParseUUID(orCallerWS)
+	callerAgent := util.MustParseUUID(orCallerAgent)
+	reclaim := func(app string) {
+		if err := store.ReclaimOrphanedInstallationByAppID(ctx, callerWS, callerAgent, app); err != nil {
+			t.Fatalf("ReclaimOrphanedInstallationByAppID(%s): %v", app, err)
+		}
+	}
+
+	t.Run("workspace and agent both gone is reclaimed", func(t *testing.T) {
+		id := insert(orAppDead, orAbsentWS, orAbsentAgent)
+		reclaim(orAppDead)
+		if exists(id) {
+			t.Fatal("orphan row (workspace + agent both deleted) was not reclaimed; it keeps blocking the app_id slot")
+		}
+	})
+
+	t.Run("workspace gone (agent alive) is reclaimed", func(t *testing.T) {
+		id := insert(orAppWS, orAbsentWS, orLiveAgent)
+		reclaim(orAppWS)
+		if exists(id) {
+			t.Fatal("installation whose workspace was deleted was not reclaimed")
+		}
+	})
+
+	t.Run("agent gone (workspace alive) is reclaimed", func(t *testing.T) {
+		id := insert(orAppAgent, orWS, orAbsentAgent)
+		reclaim(orAppAgent)
+		if exists(id) {
+			t.Fatal("installation whose agent was hard-deleted was not reclaimed")
+		}
+	})
+
+	t.Run("live owner is never reclaimed", func(t *testing.T) {
+		id := insert(orAppLive, orWS, orLiveAgent)
+		reclaim(orAppLive)
+		if !exists(id) {
+			t.Fatal("a live owner's installation was reclaimed; only a dead owner may be reclaimed")
+		}
+	})
+
+	t.Run("archived agent counts as a live owner and survives", func(t *testing.T) {
+		id := insert(orAppArch, orWS, orArchAgent)
+		reclaim(orAppArch)
+		if !exists(id) {
+			t.Fatal("an archived-but-present agent's installation was reclaimed; archival is reversible and must stay a live-owner conflict")
+		}
+	})
+
+	t.Run("caller's own row is excluded even when orphaned", func(t *testing.T) {
+		// The caller's (workspace, agent) do not exist in this test, so ONLY the
+		// self-fence protects the row — the upsert reactivates it in place.
+		id := insert(orAppOwn, orCallerWS, orCallerAgent)
+		reclaim(orAppOwn)
+		if !exists(id) {
+			t.Fatal("the caller's own row was deleted; the upsert must be able to reactivate it in place")
+		}
+	})
+
+	t.Run("reclaimed orphan clears its dependent rows", func(t *testing.T) {
+		id := insert(orAppDeps, orAbsentWS, orAbsentAgent)
+		exec(`INSERT INTO channel_user_binding (workspace_id, multica_user_id, installation_id, channel_type, channel_user_id)
+VALUES ($1, $2, $3, 'feishu', 'ou_or_user')`, orAbsentWS, orUser, id)
+		exec(`INSERT INTO channel_chat_session_binding (chat_session_id, installation_id, channel_type, channel_chat_id, chat_type)
+VALUES ($1, $2, 'feishu', 'oc_or_chat', 'p2p')`, orChatSess, id)
+		exec(`INSERT INTO channel_binding_token (token_hash, workspace_id, installation_id, channel_type, channel_user_id, expires_at)
+VALUES ($1, $2, $3, 'feishu', 'ou_or_user', now() + interval '10 minutes')`, orTokenHash, orAbsentWS, id)
+		exec(`INSERT INTO channel_inbound_audit (installation_id, channel_type, event_type, channel_event_id, drop_reason)
+VALUES ($1, 'feishu', 'im.message.receive_v1', $2, 'orphaned_installation')`, id, orAuditEventID)
+
+		reclaim(orAppDeps)
+
+		count := func(q string, args ...any) int {
+			var n int
+			if err := pool.QueryRow(ctx, q, args...).Scan(&n); err != nil {
+				t.Fatalf("count: %v", err)
+			}
+			return n
+		}
+		if exists(id) {
+			t.Fatal("orphan installation with dependents was not reclaimed")
+		}
+		if n := count(`SELECT count(*) FROM channel_user_binding WHERE installation_id = $1`, id); n != 0 {
+			t.Fatalf("member links not cleaned: %d dangling rows", n)
+		}
+		if n := count(`SELECT count(*) FROM channel_chat_session_binding WHERE installation_id = $1`, id); n != 0 {
+			t.Fatalf("chat-session bindings not cleaned: %d dangling rows", n)
+		}
+		if n := count(`SELECT count(*) FROM channel_binding_token WHERE installation_id = $1`, id); n != 0 {
+			t.Fatalf("binding tokens not cleaned: %d dangling rows", n)
+		}
+		if n := count(`SELECT count(*) FROM channel_inbound_audit WHERE installation_id = $1`, id); n != 0 {
+			t.Fatalf("audit rows still reference the reclaimed installation: %d", n)
+		}
+		if n := count(`SELECT count(*) FROM channel_inbound_audit WHERE channel_event_id = $1 AND installation_id IS NULL`, orAuditEventID); n != 1 {
+			t.Fatalf("audit row should survive detached (installation_id NULL), got %d", n)
+		}
+	})
+}

--- a/server/internal/integrations/lark/registration_service.go
+++ b/server/internal/integrations/lark/registration_service.go
@@ -587,6 +587,19 @@ func (s *RegistrationService) finishSuccess(ctx context.Context, sess *registrat
 		return
 	}
 
+	// Also reclaim a "dead owner" placeholder: if the same Feishu app was bound
+	// to a workspace/agent that has since been deleted (channel_* has no FK
+	// cascade, MUL-3515 §4), its orphaned row still holds the (channel_type,
+	// app_id) unique slot and blocks the upsert below. Clearing it lets the bot
+	// reconnect to a new agent without a manual DB delete (#4810). An archived
+	// agent still exists and is left in place — that stays a live-owner conflict.
+	if err := qtx.ReclaimOrphanedInstallationByAppID(ctx, sess.workspaceID, sess.agentID, res.ClientID); err != nil {
+		s.cfg.Logger.Warn("lark registration: cleanup orphaned installation",
+			"session_id", sess.id, "err", err)
+		sess.markError(RegistrationReasonInternalError, err.Error(), s.gcDeadline())
+		return
+	}
+
 	inst, err := qtx.UpsertLarkInstallation(ctx, UpsertInstallationParams{
 		WorkspaceID:        sess.workspaceID,
 		AgentID:            sess.agentID,

--- a/server/internal/integrations/slack/byo_install.go
+++ b/server/internal/integrations/slack/byo_install.go
@@ -123,6 +123,7 @@ func (s *InstallService) RegisterBYO(ctx context.Context, p RegisterBYOParams) (
 		wsID:        p.WorkspaceID,
 		agentID:     p.AgentID,
 		installerID: p.InitiatorID,
+		appID:       appID,
 		configJSON:  cfgJSON,
 	})
 }

--- a/server/internal/integrations/slack/byo_install_test.go
+++ b/server/internal/integrations/slack/byo_install_test.go
@@ -215,6 +215,36 @@ func TestRegisterBYO_AppAlreadyConnected_Rejected(t *testing.T) {
 	)); err != ErrTeamOwnedByAnotherWorkspace {
 		t.Fatalf("app already connected = %v, want ErrTeamOwnedByAnotherWorkspace", err)
 	}
+	if !q.reclaimCalled {
+		t.Error("persistInstall must attempt the dead-owner reclaim before the upsert")
+	}
+}
+
+// TestRegisterBYO_AppOwnedBySameWorkspaceAgent_AccurateError pins the #4810 copy
+// fix: when the app_id slot is held by a DIFFERENT agent in the SAME workspace,
+// the conflict must be ErrTeamOwnedByAnotherAgent — not the old, misleading
+// "another workspace" error — so the user is told to disconnect it from that
+// agent rather than sent chasing a phantom other workspace.
+func TestRegisterBYO_AppOwnedBySameWorkspaceAgent_AccurateError(t *testing.T) {
+	srv := authTestServer(t, true)
+	defer srv.Close()
+	const callerWS = "11111111-1111-1111-1111-111111111111"
+	q := &fakeInstallQueries{
+		rowID:      mustUUID(t, "44444444-4444-4444-4444-444444444444"),
+		appIDTaken: true,
+		// The slot's live owner is another agent in the SAME workspace.
+		ownerWorkspaceID: mustUUID(t, callerWS),
+		ownerAgentID:     mustUUID(t, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+	}
+	svc := newTestInstallService(t, q)
+	svc.apiURL = srv.URL + "/"
+
+	if _, err := svc.RegisterBYO(context.Background(), byoParams(
+		callerWS,
+		"22222222-2222-2222-2222-222222222222",
+	)); err != ErrTeamOwnedByAnotherAgent {
+		t.Fatalf("same-workspace conflict = %v, want ErrTeamOwnedByAnotherAgent", err)
+	}
 }
 
 func TestRegisterBYO_ReconnectSameAgent_UpdatesRowInPlace(t *testing.T) {

--- a/server/internal/integrations/slack/install.go
+++ b/server/internal/integrations/slack/install.go
@@ -28,11 +28,18 @@ var (
 	// ErrInstallationNotFound surfaces "no row matches in this workspace".
 	ErrInstallationNotFound = errors.New("slack installation not found")
 	// ErrTeamOwnedByAnotherWorkspace is returned when the pasted Slack app is
-	// already connected to a DIFFERENT agent or Multica workspace — it would
+	// already connected to an agent in a DIFFERENT Multica workspace — it would
 	// collide with the (channel_type, app_id) routing index. A Slack app is one
 	// bot identity and maps to one agent; reusing it elsewhere requires
-	// disconnecting it there first.
-	ErrTeamOwnedByAnotherWorkspace = errors.New("slack: this Slack app is already connected to another agent or Multica workspace")
+	// disconnecting it there first. (#4810: this is now returned ONLY for a
+	// genuinely different workspace — a same-workspace conflict returns
+	// ErrTeamOwnedByAnotherAgent, and a dead-owner slot is reclaimed instead.)
+	ErrTeamOwnedByAnotherWorkspace = errors.New("slack: this Slack app is already connected to a different Multica workspace")
+	// ErrTeamOwnedByAnotherAgent is returned when the pasted Slack app is already
+	// connected to a DIFFERENT agent in the SAME workspace. The old text wrongly
+	// blamed "another workspace" (#4810); the accurate guidance is to disconnect
+	// it from that agent first.
+	ErrTeamOwnedByAnotherAgent = errors.New("slack: this Slack app is already connected to another agent in this workspace")
 )
 
 // installQueries is the slice of generated queries InstallService needs. WithTx
@@ -41,6 +48,8 @@ var (
 type installQueries interface {
 	WithTx(tx pgx.Tx) installQueries
 	UpsertChannelInstallation(ctx context.Context, arg db.UpsertChannelInstallationParams) (db.ChannelInstallation, error)
+	ReclaimOrphanedChannelInstallationByAppID(ctx context.Context, arg db.ReclaimOrphanedChannelInstallationByAppIDParams) error
+	GetChannelInstallationByAppID(ctx context.Context, arg db.GetChannelInstallationByAppIDParams) (db.ChannelInstallation, error)
 	ListChannelInstallationsByWorkspace(ctx context.Context, arg db.ListChannelInstallationsByWorkspaceParams) ([]db.ChannelInstallation, error)
 	GetChannelInstallationInWorkspace(ctx context.Context, arg db.GetChannelInstallationInWorkspaceParams) (db.ChannelInstallation, error)
 	SetChannelInstallationStatus(ctx context.Context, arg db.SetChannelInstallationStatusParams) error
@@ -115,6 +124,11 @@ type installPersist struct {
 	wsID        pgtype.UUID
 	agentID     pgtype.UUID
 	installerID pgtype.UUID
+	// appID is the real Slack app id (config->>'app_id'). It MUST equal the
+	// app_id inside configJSON; it is the (channel_type, app_id) routing key used
+	// to reclaim a dead-owner slot before the upsert and to resolve who currently
+	// owns the slot on a conflict (#4810).
+	appID string
 	// configJSON holds the Slack app id (config->>'app_id') used for inbound
 	// routing; the ROW itself is keyed by (workspace, agent) — one bot per agent.
 	configJSON []byte
@@ -142,6 +156,19 @@ func (s *InstallService) persistInstall(ctx context.Context, p installPersist) (
 	defer func() { _ = tx.Rollback(ctx) }()
 	qtx := s.q.WithTx(tx)
 
+	// Self-heal the "dead owner" case (#4810): if the (slack, app_id) slot is held
+	// by an installation whose workspace or agent has been deleted, reclaim it
+	// before the insert so the bot can reconnect to a new agent. A LIVE owner
+	// (active or archived) is left in place and surfaces as the conflict below.
+	if err := qtx.ReclaimOrphanedChannelInstallationByAppID(ctx, db.ReclaimOrphanedChannelInstallationByAppIDParams{
+		ChannelType: string(TypeSlack),
+		AppID:       p.appID,
+		WorkspaceID: p.wsID,
+		AgentID:     p.agentID,
+	}); err != nil {
+		return db.ChannelInstallation{}, fmt.Errorf("reclaim orphaned slack installation: %w", err)
+	}
+
 	inst, err := qtx.UpsertChannelInstallation(ctx, db.UpsertChannelInstallationParams{
 		WorkspaceID:     p.wsID,
 		AgentID:         p.agentID,
@@ -152,7 +179,7 @@ func (s *InstallService) persistInstall(ctx context.Context, p installPersist) (
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-			return db.ChannelInstallation{}, ErrTeamOwnedByAnotherWorkspace
+			return db.ChannelInstallation{}, s.ownershipConflict(ctx, p)
 		}
 		return db.ChannelInstallation{}, fmt.Errorf("upsert slack installation: %w", err)
 	}
@@ -160,6 +187,28 @@ func (s *InstallService) persistInstall(ctx context.Context, p installPersist) (
 		return db.ChannelInstallation{}, fmt.Errorf("commit slack install: %w", err)
 	}
 	return inst, nil
+}
+
+// ownershipConflict resolves an accurate error for a (channel_type, app_id)
+// routing-index violation on install: the slot is held by a live owner, and the
+// user needs to know WHICH — another agent in THIS workspace (disconnect it
+// there first) vs a genuinely different Multica workspace. Before #4810 both
+// collapsed into a single, often-wrong "different workspace" message. The lookup
+// runs on the pooled handle (s.q, not the now-aborted tx). If the owner has
+// since vanished (a concurrent delete freed the slot) we fall back to the
+// generic cross-workspace message rather than surfacing a 500 — a retry succeeds.
+func (s *InstallService) ownershipConflict(ctx context.Context, p installPersist) error {
+	owner, err := s.q.GetChannelInstallationByAppID(ctx, db.GetChannelInstallationByAppIDParams{
+		ChannelType: string(TypeSlack),
+		AppID:       p.appID,
+	})
+	if err != nil {
+		return ErrTeamOwnedByAnotherWorkspace
+	}
+	if owner.WorkspaceID == p.wsID {
+		return ErrTeamOwnedByAnotherAgent
+	}
+	return ErrTeamOwnedByAnotherWorkspace
 }
 
 // ListByWorkspace returns every Slack installation in the workspace (active and

--- a/server/internal/integrations/slack/install_test.go
+++ b/server/internal/integrations/slack/install_test.go
@@ -46,10 +46,43 @@ type fakeInstallQueries struct {
 	upsertParams db.UpsertChannelInstallationParams
 	upsertCalled bool
 	rowID        pgtype.UUID
+	// reclaimCalled records that persistInstall attempted the dead-owner reclaim
+	// before the upsert (#4810).
+	reclaimCalled bool
+	// ownerWorkspaceID is the workspace of the row that currently holds the
+	// app_id slot, returned by GetChannelInstallationByAppID on the conflict
+	// path. When unset it defaults to a distinct workspace, so an unconfigured
+	// conflict reads as cross-workspace (ErrTeamOwnedByAnotherWorkspace).
+	ownerWorkspaceID pgtype.UUID
+	ownerAgentID     pgtype.UUID
 }
 
 // WithTx returns the same fake — the fake tx is a no-op token.
 func (f *fakeInstallQueries) WithTx(_ pgx.Tx) installQueries { return f }
+
+// ReclaimOrphanedChannelInstallationByAppID is a no-op in the fake (no dead-owner
+// row to clear); it just records that persistInstall ran the reclaim step.
+func (f *fakeInstallQueries) ReclaimOrphanedChannelInstallationByAppID(_ context.Context, _ db.ReclaimOrphanedChannelInstallationByAppIDParams) error {
+	f.reclaimCalled = true
+	return nil
+}
+
+// GetChannelInstallationByAppID returns the current owner of the app_id slot so
+// persistInstall can tell "another agent in this workspace" from "another
+// workspace". Defaults to a distinct workspace when ownerWorkspaceID is unset.
+func (f *fakeInstallQueries) GetChannelInstallationByAppID(_ context.Context, _ db.GetChannelInstallationByAppIDParams) (db.ChannelInstallation, error) {
+	ws := f.ownerWorkspaceID
+	if !ws.Valid {
+		ws = staticUUID("99999999-9999-9999-9999-999999999999")
+	}
+	return db.ChannelInstallation{WorkspaceID: ws, AgentID: f.ownerAgentID, Status: "active"}, nil
+}
+
+// staticUUID parses a UUID for fixtures that cannot take a *testing.T.
+func staticUUID(s string) pgtype.UUID {
+	u, _ := util.ParseUUID(s)
+	return u
+}
 
 func (f *fakeInstallQueries) UpsertChannelInstallation(_ context.Context, arg db.UpsertChannelInstallationParams) (db.ChannelInstallation, error) {
 	f.upsertCalled = true

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -400,6 +400,47 @@ func (q *Queries) DeleteChannelChatSessionBindingsByInstallation(ctx context.Con
 	return err
 }
 
+const deleteChannelInstallationsByArchivedRuntimeAgents = `-- name: DeleteChannelInstallationsByArchivedRuntimeAgents :exec
+WITH target_installs AS MATERIALIZED (
+    SELECT ci.id
+    FROM channel_installation ci
+    WHERE ci.agent_id IN (
+        SELECT id FROM agent WHERE runtime_id = $1 AND archived_at IS NOT NULL
+    )
+),
+_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM target_installs)
+)
+DELETE FROM channel_installation
+WHERE id IN (SELECT id FROM target_installs)
+`
+
+// Application-layer replacement for the (deliberately absent, MUL-3515 §4)
+// channel_installation agent_id ON DELETE CASCADE: when a runtime teardown
+// hard-deletes its archived agents, remove those agents' channel installations
+// and their dependents too. Without this the installation row lingers forever,
+// holding the (channel_type, app_id) unique slot, so the bot can never be
+// reconnected to any agent (#4810). MUST run in the same tx as, and BEFORE,
+// DeleteArchivedAgentsByRuntime — mirrors that hard-delete's predicate exactly,
+// alongside DeleteAgentInvocationTargetsByArchivedRuntimeAgents.
+func (q *Queries) DeleteChannelInstallationsByArchivedRuntimeAgents(ctx context.Context, runtimeID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteChannelInstallationsByArchivedRuntimeAgents, runtimeID)
+	return err
+}
+
 const deleteChannelUserBindingsByInstallation = `-- name: DeleteChannelUserBindingsByInstallation :exec
 DELETE FROM channel_user_binding
 WHERE installation_id = $1
@@ -1028,6 +1069,81 @@ WHERE expires_at < $1
 
 func (q *Queries) PurgeExpiredChannelBindingTokens(ctx context.Context, expiresAt pgtype.Timestamptz) error {
 	_, err := q.db.Exec(ctx, purgeExpiredChannelBindingTokens, expiresAt)
+	return err
+}
+
+const reclaimOrphanedChannelInstallationByAppID = `-- name: ReclaimOrphanedChannelInstallationByAppID :exec
+WITH orphaned AS MATERIALIZED (
+    SELECT ci.id
+    FROM channel_installation ci
+    WHERE ci.channel_type = $1
+      AND ci.config ->> 'app_id' = $2::text
+      AND NOT (ci.workspace_id = $3
+               AND ci.agent_id = $4)
+      AND (
+            NOT EXISTS (SELECT 1 FROM workspace w WHERE w.id = ci.workspace_id)
+            OR NOT EXISTS (SELECT 1 FROM agent a WHERE a.id = ci.agent_id)
+      )
+),
+_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM orphaned)
+)
+DELETE FROM channel_installation
+WHERE id IN (SELECT id FROM orphaned)
+`
+
+type ReclaimOrphanedChannelInstallationByAppIDParams struct {
+	ChannelType string      `json:"channel_type"`
+	AppID       string      `json:"app_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	AgentID     pgtype.UUID `json:"agent_id"`
+}
+
+// Self-heal the "dead owner" case (#4810 / MUL-3937): reclaim the app_id slot
+// held by an installation whose owning workspace or agent no longer exists, so
+// the same IM bot can be reconnected to a NEW agent. channel_* has no FK/cascade
+// (MUL-3515 §4), so deleting a workspace or hard-deleting an agent leaves its
+// channel_installation row behind, permanently occupying the (channel_type,
+// config->>'app_id') unique slot. Without this the bot can never be re-bound —
+// the reporter's "无力回天" — and the only recovery is a manual DB delete.
+//
+// Reclaimed ONLY when the owner is genuinely gone:
+//   - workspace deleted  -> NOT EXISTS (workspace)
+//   - agent hard-deleted -> NOT EXISTS (agent)
+//
+// An ARCHIVED agent still EXISTS here (archived_at is set but the row is present),
+// so it is a LIVE owner and is NOT reclaimed — archival is reversible (unarchive
+// or Disconnect), matching ListActiveChannelInstallations' row-existence guard.
+// The revoked-but-live-owner case is handled by DeleteRevokedChannelInstallation-
+// ByAppID, not here. The caller's own (workspace, agent) row is excluded too:
+// a live installer's workspace + agent always exist (so the existence checks
+// already skip it), but the fence makes the invariant explicit and lets the
+// follow-up upsert reactivate that row in place via its ON CONFLICT.
+//
+// Cleanup mirrors DeleteRevokedChannelInstallationByAppID: dependent rows are
+// cleared and inbound-audit detached (installation_id -> NULL) in the same
+// statement so no dangling rows survive. Kept atomic in one CTE — the reclaim
+// and the dependent cleanup commit or roll back together with the caller's tx.
+func (q *Queries) ReclaimOrphanedChannelInstallationByAppID(ctx context.Context, arg ReclaimOrphanedChannelInstallationByAppIDParams) error {
+	_, err := q.db.Exec(ctx, reclaimOrphanedChannelInstallationByAppID,
+		arg.ChannelType,
+		arg.AppID,
+		arg.WorkspaceID,
+		arg.AgentID,
+	)
 	return err
 }
 

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -54,10 +54,40 @@ func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams
 const deleteWorkspace = `-- name: DeleteWorkspace :exec
 WITH deleted_pending_check_suites AS (
     DELETE FROM github_pending_check_suite WHERE workspace_id = $1
+),
+target_channel_installs AS MATERIALIZED (
+    SELECT channel_installation.id FROM channel_installation WHERE workspace_id = $1
+),
+_channel_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_installs AS (
+    DELETE FROM channel_installation WHERE workspace_id = $1
 )
-DELETE FROM workspace WHERE id = $1
+DELETE FROM workspace WHERE workspace.id = $1
 `
 
+// Most of the workspace's rows cascade away through their FK to workspace(id).
+// The channel_* tables deliberately have NO FK (MUL-3515 §4), so their rows do
+// NOT cascade — a plain workspace delete would leave each channel_installation
+// behind, permanently holding the (channel_type, app_id) unique slot, so the IM
+// bot could never be reconnected to any agent (#4810 / MUL-3937). Delete this
+// workspace's channel installations and their app-layer dependents explicitly,
+// in the same atomic statement as the workspace delete. github_pending_check_suite
+// is likewise cleaned here because it has no workspace FK cascade.
 func (q *Queries) DeleteWorkspace(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, deleteWorkspace, id)
 	return err

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -133,6 +133,97 @@ WHERE channel_type = sqlc.arg('channel_type')
   AND status = 'revoked'
 RETURNING id;
 
+-- name: ReclaimOrphanedChannelInstallationByAppID :exec
+-- Self-heal the "dead owner" case (#4810 / MUL-3937): reclaim the app_id slot
+-- held by an installation whose owning workspace or agent no longer exists, so
+-- the same IM bot can be reconnected to a NEW agent. channel_* has no FK/cascade
+-- (MUL-3515 §4), so deleting a workspace or hard-deleting an agent leaves its
+-- channel_installation row behind, permanently occupying the (channel_type,
+-- config->>'app_id') unique slot. Without this the bot can never be re-bound —
+-- the reporter's "无力回天" — and the only recovery is a manual DB delete.
+--
+-- Reclaimed ONLY when the owner is genuinely gone:
+--   - workspace deleted  -> NOT EXISTS (workspace)
+--   - agent hard-deleted -> NOT EXISTS (agent)
+-- An ARCHIVED agent still EXISTS here (archived_at is set but the row is present),
+-- so it is a LIVE owner and is NOT reclaimed — archival is reversible (unarchive
+-- or Disconnect), matching ListActiveChannelInstallations' row-existence guard.
+-- The revoked-but-live-owner case is handled by DeleteRevokedChannelInstallation-
+-- ByAppID, not here. The caller's own (workspace, agent) row is excluded too:
+-- a live installer's workspace + agent always exist (so the existence checks
+-- already skip it), but the fence makes the invariant explicit and lets the
+-- follow-up upsert reactivate that row in place via its ON CONFLICT.
+--
+-- Cleanup mirrors DeleteRevokedChannelInstallationByAppID: dependent rows are
+-- cleared and inbound-audit detached (installation_id -> NULL) in the same
+-- statement so no dangling rows survive. Kept atomic in one CTE — the reclaim
+-- and the dependent cleanup commit or roll back together with the caller's tx.
+WITH orphaned AS MATERIALIZED (
+    SELECT ci.id
+    FROM channel_installation ci
+    WHERE ci.channel_type = sqlc.arg('channel_type')
+      AND ci.config ->> 'app_id' = sqlc.arg('app_id')::text
+      AND NOT (ci.workspace_id = sqlc.arg('workspace_id')
+               AND ci.agent_id = sqlc.arg('agent_id'))
+      AND (
+            NOT EXISTS (SELECT 1 FROM workspace w WHERE w.id = ci.workspace_id)
+            OR NOT EXISTS (SELECT 1 FROM agent a WHERE a.id = ci.agent_id)
+      )
+),
+_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM orphaned)
+),
+_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM orphaned)
+)
+DELETE FROM channel_installation
+WHERE id IN (SELECT id FROM orphaned);
+
+-- name: DeleteChannelInstallationsByArchivedRuntimeAgents :exec
+-- Application-layer replacement for the (deliberately absent, MUL-3515 §4)
+-- channel_installation agent_id ON DELETE CASCADE: when a runtime teardown
+-- hard-deletes its archived agents, remove those agents' channel installations
+-- and their dependents too. Without this the installation row lingers forever,
+-- holding the (channel_type, app_id) unique slot, so the bot can never be
+-- reconnected to any agent (#4810). MUST run in the same tx as, and BEFORE,
+-- DeleteArchivedAgentsByRuntime — mirrors that hard-delete's predicate exactly,
+-- alongside DeleteAgentInvocationTargetsByArchivedRuntimeAgents.
+WITH target_installs AS MATERIALIZED (
+    SELECT ci.id
+    FROM channel_installation ci
+    WHERE ci.agent_id IN (
+        SELECT id FROM agent WHERE runtime_id = $1 AND archived_at IS NOT NULL
+    )
+),
+_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM target_installs)
+),
+_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM target_installs)
+)
+DELETE FROM channel_installation
+WHERE id IN (SELECT id FROM target_installs);
+
 -- name: ListChannelInstallationsByWorkspace :many
 -- Scoped by channel_type so a per-channel management surface (e.g. the Lark
 -- installation list) only ever sees its own platform's installations.

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -46,7 +46,37 @@ WHERE id = $1
 RETURNING issue_counter;
 
 -- name: DeleteWorkspace :exec
+-- Most of the workspace's rows cascade away through their FK to workspace(id).
+-- The channel_* tables deliberately have NO FK (MUL-3515 §4), so their rows do
+-- NOT cascade — a plain workspace delete would leave each channel_installation
+-- behind, permanently holding the (channel_type, app_id) unique slot, so the IM
+-- bot could never be reconnected to any agent (#4810 / MUL-3937). Delete this
+-- workspace's channel installations and their app-layer dependents explicitly,
+-- in the same atomic statement as the workspace delete. github_pending_check_suite
+-- is likewise cleaned here because it has no workspace FK cascade.
 WITH deleted_pending_check_suites AS (
     DELETE FROM github_pending_check_suite WHERE workspace_id = $1
+),
+target_channel_installs AS MATERIALIZED (
+    SELECT channel_installation.id FROM channel_installation WHERE workspace_id = $1
+),
+_channel_sess AS (
+    DELETE FROM channel_chat_session_binding
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_tok AS (
+    DELETE FROM channel_binding_token
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_usr AS (
+    DELETE FROM channel_user_binding
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_aud AS (
+    UPDATE channel_inbound_audit SET installation_id = NULL
+    WHERE installation_id IN (SELECT id FROM target_channel_installs)
+),
+_channel_installs AS (
+    DELETE FROM channel_installation WHERE workspace_id = $1
 )
-DELETE FROM workspace WHERE id = $1;
+DELETE FROM workspace WHERE workspace.id = $1;


### PR DESCRIPTION
## What & why

Fixes #4810 (MUL-3937): an IM bot could get permanently stuck — unable to reconnect to **any** agent — after its owner was deleted, and the conflict error text was misleading.

`channel_installation` has **no FK** to workspace/agent (MUL-3515 §4), so deleting a workspace or hard-deleting an agent left the row behind, permanently holding the `(channel_type, config->>'app_id')` unique slot. The bot then couldn't be re-bound anywhere, with the only recovery being a manual DB `DELETE` — the reporter's "无力回天". The 409 also always claimed the app was "connected to a different Multica workspace", even when the real owner was another agent in the *same* workspace (or a workspace the user had just deleted).

This implements the two things the finalized design calls for:

### 1. Owner deleted → auto-recycle
- **Prevent new orphans**: `DeleteWorkspace` now removes the workspace's channel installations + their app-layer dependents in the same atomic statement; the agent hard-delete path (runtime teardown — all three call sites) drops the archived agents' installations right beside the existing invocation-target cleanup.
- **Heal existing orphans**: the Slack and Lark install paths reclaim a pre-existing orphaned slot (owner workspace/agent no longer exists) before the upsert, so already-stuck bots self-heal on the next reconnect — no manual DB surgery.
- An **archived agent still exists**, so it stays a live-owner conflict (409) — archival is reversible (unarchive / Disconnect), matching the `ListActiveChannelInstallations` row-existence guard. Revoked-but-live owners keep their existing `DeleteRevokedChannelInstallationByAppID` path.

### 2. Live owner → accurate error text
A live-owner Slack conflict now distinguishes **another agent in this workspace** ("disconnect it from that agent first") from a genuinely **different Multica workspace**, instead of always blaming "another workspace".

## Relationship to #4820
Supersedes the community PR #4820 (which is unreviewed / stuck) and implements the design the issue thread converged on. Differences: #4820 *reclaimed* archived-agent slots (contradicting "archive = live owner, keep 409"), and did **not** cover `DeleteWorkspace` cascade cleanup nor the misleading `handler/slack.go` copy — both of which this PR handles.

## How it was verified
- `go build ./...`, `go vet`, `go test -race` for `internal/integrations/slack` and `internal/integrations/lark` — green.
- New DB-backed lark test `TestChannelStore_ReclaimOrphanedInstallationByAppID` covers every branch: workspace-gone, agent-gone, both-gone → reclaimed; live owner + **archived agent** + caller's own row → survive; dependent-row cleanup + audit detach.
- New handler test `TestDeleteWorkspace_RemovesChannelInstallations` (green) — installation + dependents removed on workspace delete, a control installation in another workspace untouched.
- New handler test `TestArchiveAgentsAndDeleteRuntime_RemovesChannelInstallations` for the runtime-teardown path; its `DeleteChannelInstallationsByArchivedRuntimeAgents` query was additionally proven in isolation (archived agent's install removed, an active agent's install on the same runtime survives).
- New Slack tests assert the same-workspace vs cross-workspace error split and that the dead-owner reclaim runs before the upsert.

Regenerated sqlc for the two changed query files only.
