### PR TITLE
fix(server): keep originator on agent-created issues so A2A mentions stay authorized (MUL-4305)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2249,6 +2249,31 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 		originType = pgtype.Text{String: *req.OriginType, Valid: true}
 		originID = oid
+	} else if creatorType == "agent" {
+		// MUL-4305: an agent creating an issue via the ordinary create path
+		// carries no explicit origin, which historically left the new issue
+		// unattributed. Any run later derived from it (agent assignment,
+		// squad-leader trigger) then lost the top-of-chain human originator,
+		// so A2A @-mentions from those runs failed the canInvokeAgent gate
+		// against private agents. Stamp the acting task as the issue's origin
+		// so resolveOriginatorForIssueTask can inherit its originator — the
+		// same trick CreateComment uses with comment.source_task_id (MUL-4015).
+		//
+		// The task id is taken from the SERVER-trusted X-Task-ID: resolveActor
+		// only returns creatorType=="agent" when either X-Actor-Source=task_token
+		// (the auth middleware bound X-Agent-ID/X-Task-ID from the mat_ token and
+		// stripped any client value) or the X-Agent-ID/X-Task-ID pair was
+		// validated against the DB. A member-forged X-Task-ID never reaches here
+		// because it would have resolved to creatorType=="member". We still
+		// re-check the task belongs to the acting agent before trusting it.
+		if taskIDHeader := r.Header.Get("X-Task-ID"); taskIDHeader != "" {
+			if taskUUID, perr := util.ParseUUID(taskIDHeader); perr == nil {
+				if task, terr := h.Queries.GetAgentTask(r.Context(), taskUUID); terr == nil && uuidToString(task.AgentID) == actualCreatorID {
+					originType = pgtype.Text{String: "agent_create", Valid: true}
+					originID = taskUUID
+				}
+			}
+		}
 	}
 
 	// Prefix is workspace-level; pre-compute once so both the broadcast

--- a/server/internal/handler/issue_agent_create_e2e_test.go
+++ b/server/internal/handler/issue_agent_create_e2e_test.go
@@ -1,0 +1,254 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// createPrivateAgentOwnedBy inserts a private agent owned by ownerID and
+// returns its id. Mirrors privateAgentTestFixture's agent shape (visibility
+// 'private', no explicit permission_mode so it keeps the private default the
+// canInvokeAgent gate treats as owner-only), but lets a test stand up a SECOND
+// private agent under the same human so a leader and a worker can both be
+// private and owned by the same originator.
+func createPrivateAgentOwnedBy(t *testing.T, name, ownerID string) string {
+	t.Helper()
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb,
+		        $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, name, handlerTestRuntimeID(t), ownerID).Scan(&agentID); err != nil {
+		t.Fatalf("create private agent %q: %v", name, err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID) })
+	return agentID
+}
+
+// TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered walks
+// the exact line failure shape from MUL-4305 end to end, deliberately NOT
+// re-testing the resolver in isolation but locking the real wiring between the
+// handler create stamp, the create-time squad gate, the squad-leader task's
+// stored originator, the comment source-task stamp, and the private-worker
+// invocation gate:
+//
+//	human H triggers agent A → A creates an issue via the ordinary
+//	`issue create` path AND assigns it to a squad whose leader is a private
+//	agent owned by H → the leader's assignment run @-mentions a *second*
+//	private agent J (also owned by H) → J must be triggered.
+//
+// Pre-fix, A's create left the issue unattributed, the leader task stored a
+// NULL originator, and the leader's mention of J failed canInvokeAgent — J
+// silently got 0 tasks. This asserts the leader task carries H and that J ends
+// up with a queued task whose originator is the original human H.
+func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Private worker J and the human originator H (J's owner).
+	workerJID, ownerH, _ := privateAgentTestFixture(t)
+
+	// Private squad leader L, owned by the same human H.
+	leaderID := createPrivateAgentOwnedBy(t, "mul4305-e2e-private-leader", ownerH)
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, 'MUL-4305 E2E Squad', '', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+
+	// Creator agent A, running a task on behalf of the human H. resolveActor
+	// validates the (A, task) pair; the handler then trusts X-Task-ID as A's
+	// acting task and inherits H from it.
+	creatorAID := createHandlerTestAgent(t, "mul4305-e2e-creator-agent", nil)
+	var creatorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, originator_user_id)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), 'running', 0, $2)
+		RETURNING id
+	`, creatorAID, ownerH).Scan(&creatorTaskID); err != nil {
+		t.Fatalf("create A's acting task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID) })
+
+	// Step 1: agent A creates an issue through the ordinary create path and
+	// assigns it to the private-leader squad in the same call.
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "MUL-4305 E2E agent-created + squad-assigned",
+		"assignee_type": "squad",
+		"assignee_id":   squadID,
+	})
+	r.Header.Set("X-Agent-ID", creatorAID)
+	r.Header.Set("X-Task-ID", creatorTaskID)
+	testHandler.CreateIssue(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, created.ID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	// The create must have stamped the issue back to A's acting task.
+	var originType, originID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT COALESCE(origin_type, ''), COALESCE(origin_id::text, '') FROM issue WHERE id = $1`, created.ID,
+	).Scan(&originType, &originID); err != nil {
+		t.Fatalf("load issue origin: %v", err)
+	}
+	if originType != "agent_create" || originID != creatorTaskID {
+		t.Fatalf("issue origin = (%q,%q), want (agent_create,%s)", originType, originID, creatorTaskID)
+	}
+
+	// The squad-leader assignment task must have been enqueued carrying H.
+	var leaderTaskID, leaderOriginator string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id, COALESCE(originator_user_id::text, '')
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND is_leader_task
+		ORDER BY created_at DESC LIMIT 1
+	`, created.ID, leaderID).Scan(&leaderTaskID, &leaderOriginator); err != nil {
+		t.Fatalf("load squad-leader task (expected one enqueued on create): %v", err)
+	}
+	if leaderOriginator != ownerH {
+		t.Fatalf("squad-leader task originator = %q, want the original human H %q", leaderOriginator, ownerH)
+	}
+
+	// Step 2: the leader L, running its assignment task, posts a comment that
+	// @-mentions the private worker J. The comment stamps source_task_id = the
+	// leader task, so the originator chain resolves to H.
+	w = httptest.NewRecorder()
+	r = newRequest("POST", "/api/issues/"+created.ID+"/comments", map[string]any{
+		"content": "handing the private part to [@Worker](mention://agent/" + workerJID + ")",
+	})
+	r.Header.Set("X-Agent-ID", leaderID)
+	r.Header.Set("X-Task-ID", leaderTaskID)
+	r = withURLParam(r, "id", created.ID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment (leader mentions worker): expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Step 3: the private worker J must now have a queued task whose originator
+	// is the original human H — the whole point of the fix.
+	var queuedForHuman int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND originator_user_id = $3
+	`, created.ID, workerJID, ownerH).Scan(&queuedForHuman); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if queuedForHuman == 0 {
+		t.Fatalf("private worker got 0 queued tasks attributed to H; the A2A mention was denied (MUL-4305 regression)")
+	}
+}
+
+// TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLeader
+// locks the specific squad-leader GATE change in this PR, which the create path
+// above does not exercise (create routes through the ungated service enqueue).
+//
+// Agent A (running for human H) creates an UNASSIGNED issue via the ordinary
+// path, then assigns it to a private-leader squad via UpdateIssue. That assign
+// routes through the handler enqueueSquadLeaderTask gate. Pre-fix the gate saw
+// an empty originator for an agent actor and denied the private leader, so no
+// leader task was enqueued even though the HTTP assign returned 200. With the
+// agent_create stamp feeding the shared OriginatorForIssueTask, the gate now
+// resolves H and enqueues the leader task carrying H.
+func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLeader(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Reuse the private-agent fixture purely for a private agent + its human
+	// owner H; the fixture agent here plays the squad leader.
+	leaderID, ownerH, _ := privateAgentTestFixture(t)
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, 'MUL-4305 E2E Update-Assign Squad', '', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+
+	creatorAID := createHandlerTestAgent(t, "mul4305-e2e-update-creator", nil)
+	var creatorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, originator_user_id)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), 'running', 0, $2)
+		RETURNING id
+	`, creatorAID, ownerH).Scan(&creatorTaskID); err != nil {
+		t.Fatalf("create A's acting task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID) })
+
+	// Agent A creates an unassigned issue via the ordinary path.
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "MUL-4305 E2E unassigned then squad-assigned",
+	})
+	r.Header.Set("X-Agent-ID", creatorAID)
+	r.Header.Set("X-Task-ID", creatorTaskID)
+	testHandler.CreateIssue(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, created.ID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	// Agent A assigns the issue to the private-leader squad via UpdateIssue.
+	w = httptest.NewRecorder()
+	r = newRequest("PATCH", "/api/issues/"+created.ID, map[string]any{
+		"assignee_type": "squad",
+		"assignee_id":   squadID,
+	})
+	r.Header.Set("X-Agent-ID", creatorAID)
+	r.Header.Set("X-Task-ID", creatorTaskID)
+	r = withURLParam(r, "id", created.ID)
+	testHandler.UpdateIssue(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue (assign squad): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The gated handler path must have enqueued the private leader carrying H.
+	var leaderCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND is_leader_task AND originator_user_id = $3
+	`, created.ID, leaderID, ownerH).Scan(&leaderCount); err != nil {
+		t.Fatalf("count leader tasks: %v", err)
+	}
+	if leaderCount == 0 {
+		t.Fatalf("private squad leader got 0 tasks attributed to H after agent-triggered assign; the enqueue gate denied it (MUL-4305 gate regression)")
+	}
+}

--- a/server/internal/handler/issue_agent_create_origin_test.go
+++ b/server/internal/handler/issue_agent_create_origin_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCreateIssue_AgentCreate_StampsActingTaskOrigin locks the MUL-4305 fix at
+// the HTTP boundary: when an agent creates an issue through the ordinary POST
+// /api/issues path (no explicit origin, not quick_create), the handler stamps
+// origin_type='agent_create' + origin_id=<acting task>, resolved from the
+// SERVER-trusted X-Task-ID (resolveActor only grants "agent" once the
+// agent/task pair is validated). That link is what lets
+// resolveOriginatorForIssueTask recover the top-of-chain human for any
+// downstream assignment / squad-leader run and keep A2A mentions authorized.
+func TestCreateIssue_AgentCreate_StampsActingTaskOrigin(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("find test agent: %v", err)
+	}
+
+	// Acting task carrying the human originator (testUserID). resolveActor
+	// validates this (agent, task) pair before the handler trusts X-Task-ID.
+	var taskID string
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, originator_user_id)
+		 VALUES ($1, $2, 'running', 0, $3) RETURNING id`,
+		agentID, runtimeID, testUserID,
+	).Scan(&taskID); err != nil {
+		t.Fatalf("seed acting task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Agent-created via normal create (MUL-4305)",
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup := withURLParam(newRequest("DELETE", "/api/issues/"+created.ID, nil), "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanup)
+	})
+
+	var originType, originID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT COALESCE(origin_type, ''), COALESCE(origin_id::text, '') FROM issue WHERE id = $1`, created.ID,
+	).Scan(&originType, &originID); err != nil {
+		t.Fatalf("load issue origin: %v", err)
+	}
+	if originType != "agent_create" {
+		t.Fatalf("origin_type = %q, want agent_create", originType)
+	}
+	if originID != taskID {
+		t.Fatalf("origin_id = %q, want acting task %q", originID, taskID)
+	}
+}
+
+// TestCreateIssue_NoAgentCreateStampForMemberOrForgedAgent is the security
+// regression for MUL-4305: the agent_create stamp must only ride a genuine
+// agent actor. A plain member create carries no origin, and a member who
+// forges X-Agent-ID without a valid X-Task-ID is demoted to "member" by
+// resolveActor — so it must NOT smuggle an agent_create origin (which would
+// later let a downstream run inherit a human identity the caller never had).
+func TestCreateIssue_NoAgentCreateStampForMemberOrForgedAgent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID); err != nil {
+		t.Fatalf("find test agent: %v", err)
+	}
+
+	assertNoAgentOrigin := func(t *testing.T, mutate func(*http.Request)) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+			"title": "No agent_create stamp expected (MUL-4305)",
+		})
+		if mutate != nil {
+			mutate(req)
+		}
+		testHandler.CreateIssue(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+			t.Fatalf("decode issue: %v", err)
+		}
+		t.Cleanup(func() {
+			cleanup := withURLParam(newRequest("DELETE", "/api/issues/"+created.ID, nil), "id", created.ID)
+			testHandler.DeleteIssue(httptest.NewRecorder(), cleanup)
+		})
+		var originType string
+		if err := testPool.QueryRow(ctx,
+			`SELECT COALESCE(origin_type, '') FROM issue WHERE id = $1`, created.ID,
+		).Scan(&originType); err != nil {
+			t.Fatalf("load issue origin: %v", err)
+		}
+		if originType != "" {
+			t.Fatalf("origin_type = %q, want empty (no agent_create stamp)", originType)
+		}
+	}
+
+	t.Run("plain member create", func(t *testing.T) {
+		assertNoAgentOrigin(t, nil)
+	})
+
+	t.Run("forged X-Agent-ID without X-Task-ID", func(t *testing.T) {
+		// resolveActor refuses to trust X-Agent-ID without a paired, valid
+		// X-Task-ID, so this stays a member create and gets no origin stamp.
+		assertNoAgentOrigin(t, func(req *http.Request) {
+			req.Header.Set("X-Agent-ID", agentID)
+		})
+	})
+}

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -1039,13 +1039,21 @@ func (h *Handler) enqueueSquadLeaderTask(ctx context.Context, issue db.Issue, tr
 		return false
 	}
 
-	// Member authors are their own originator; agent-authored triggers have no
-	// request context here, so the originator is left empty (canInvokeAgent
-	// then fails closed for member/team targets — a workspace target still
-	// admits the agent as a workspace principal).
+	// The gate must judge the SAME top-of-chain human the enqueue path will
+	// persist on the leader task row, or it drifts: an agent-created issue that
+	// correctly inherits its originator (MUL-4305) would still be denied here
+	// if the gate used an empty originator. Member authors are their own
+	// originator; for agent/system-triggered assigns we resolve the originator
+	// exactly like EnqueueTaskForSquadLeader* does (via the issue's origin
+	// link). triggerCommentID is always empty on the assign/promote path, so we
+	// pass an invalid UUID to match. A still-unresolved originator leaves
+	// leaderOriginator empty, which correctly fails closed for member/team
+	// targets while a workspace target still admits the agent principal.
 	leaderOriginator := ""
 	if authorType == "member" {
 		leaderOriginator = authorID
+	} else {
+		leaderOriginator = uuidToString(h.TaskService.OriginatorForIssueTask(ctx, issue, pgtype.UUID{}))
 	}
 	if !h.canEnqueueSquadLeader(ctx, squad.LeaderID, authorType, authorID, leaderOriginator, uuidToString(issue.WorkspaceID)) {
 		return false

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -372,7 +372,10 @@ func classifyOrigin(issue db.Issue, opts IssueCreateOpts) (source, taskID, autop
 	}
 	originID := util.UUIDToString(issue.OriginID)
 	switch issue.OriginType.String {
-	case "quick_create":
+	case "quick_create", "agent_create":
+		// Both link the issue back to the agent_task_queue row that created it
+		// (agent_create is the ordinary agent `issue create` path, MUL-4305);
+		// surface that task id and keep the manual source label.
 		return analytics.SourceManual, originID, ""
 	case "autopilot":
 		return analytics.SourceAutopilot, "", originID

--- a/server/internal/service/resolve_originator_test.go
+++ b/server/internal/service/resolve_originator_test.go
@@ -308,6 +308,58 @@ func TestResolveOriginatorForIssueTask_QuickCreateIssueInheritsParentTask(t *tes
 	}
 }
 
+// TestResolveOriginatorForIssueTask_AgentCreateIssueInheritsParentTask covers
+// the MUL-4305 fix: an agent that creates an issue through the ordinary
+// `issue create` path gets origin_type='agent_create' + origin_id=<acting
+// task>. The issue creator is the agent, but the top-of-chain human lives on
+// that acting task and must be inherited so downstream assignment /
+// squad-leader runs (and the A2A mentions they emit) keep the originator.
+func TestResolveOriginatorForIssueTask_AgentCreateIssueInheritsParentTask(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	_, _, parentTaskID, userID := seedOriginatorFanout(t, pool)
+	svc := &TaskService{Queries: db.New(pool)}
+	issue := db.Issue{
+		CreatorType: "agent",
+		OriginType:  pgtype.Text{String: "agent_create", Valid: true},
+		OriginID:    parentTaskID,
+	}
+
+	got := svc.resolveOriginatorForIssueTask(context.Background(), issue, pgtype.UUID{})
+	if !got.Valid {
+		t.Fatalf("expected agent_create issue to inherit originator, got invalid")
+	}
+	if got.Bytes != userID.Bytes {
+		t.Errorf("originator = %s, want %s", util.UUIDToString(got), util.UUIDToString(userID))
+	}
+}
+
+// TestOriginatorForIssueTask_MatchesResolverForAgentCreate pins the gate/enqueue
+// consistency guarantee from MUL-4305: the exported OriginatorForIssueTask
+// (used by the squad-leader access gate) must return the SAME human the
+// unexported resolver persists on the task row. If these drift, an
+// agent-created issue could be attributed correctly on the task row yet denied
+// by a gate that computed a different (empty) originator.
+func TestOriginatorForIssueTask_MatchesResolverForAgentCreate(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	_, _, parentTaskID, userID := seedOriginatorFanout(t, pool)
+	svc := &TaskService{Queries: db.New(pool)}
+	issue := db.Issue{
+		CreatorType: "agent",
+		OriginType:  pgtype.Text{String: "agent_create", Valid: true},
+		OriginID:    parentTaskID,
+	}
+
+	gate := svc.OriginatorForIssueTask(context.Background(), issue, pgtype.UUID{})
+	write := svc.resolveOriginatorForIssueTask(context.Background(), issue, pgtype.UUID{})
+	if gate.Bytes != write.Bytes || gate.Valid != write.Valid {
+		t.Fatalf("gate originator %s != write originator %s",
+			util.UUIDToString(gate), util.UUIDToString(write))
+	}
+	if !gate.Valid || gate.Bytes != userID.Bytes {
+		t.Errorf("gate originator = %s, want %s", util.UUIDToString(gate), util.UUIDToString(userID))
+	}
+}
+
 // TestEnqueueTaskForIssueStoresRuntimeMCPOverlayInQueuedRow guards the race
 // where the daemon could poll-claim a newly inserted queued task while the old
 // post-insert overlay updater was still making the outbound Composio session

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -306,8 +306,10 @@ func (s *TaskService) resolveOriginatorFromTriggerComment(ctx context.Context, c
 // resolveOriginatorForIssueTask returns the top-of-chain human for issue-backed
 // dispatches. Comment-triggered runs keep the existing comment-chain semantics;
 // direct issue assignment/creation falls back to the issue's member creator.
-// Agent-created quick-create issues have an explicit origin link back to the
-// quick-create task, so they can inherit that task's originator safely. Other
+// Agent-created issues that carry an explicit task-origin link — quick_create
+// (daemon quick-create flow) or agent_create (an agent's ordinary `issue
+// create`, MUL-4305) — inherit that origin task's originator, since origin_id
+// points at the agent_task_queue row that created the issue. Other
 // agent/system origins, including autopilot, deliberately remain unattributed.
 func (s *TaskService) resolveOriginatorForIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID) pgtype.UUID {
 	if triggerCommentID.Valid {
@@ -320,7 +322,9 @@ func (s *TaskService) resolveOriginatorForIssueTask(ctx context.Context, issue d
 		return pgtype.UUID{}
 	}
 	switch issue.OriginType.String {
-	case "quick_create":
+	case "quick_create", "agent_create":
+		// Both stamp origin_id with the agent_task_queue row that created the
+		// issue, so the top-of-chain human is that task's originator_user_id.
 		task, err := s.Queries.GetAgentTask(ctx, issue.OriginID)
 		if err != nil {
 			return pgtype.UUID{}
@@ -329,6 +333,17 @@ func (s *TaskService) resolveOriginatorForIssueTask(ctx context.Context, issue d
 	default:
 		return pgtype.UUID{}
 	}
+}
+
+// OriginatorForIssueTask exposes resolveOriginatorForIssueTask to callers
+// outside the service package (the squad-leader access gate in the handler
+// layer) so the gate judges the top-of-chain human with the exact same
+// resolution the enqueue path persists on the task row. Without a shared entry
+// point the gate saw an empty originator for agent-triggered assigns and denied
+// private leaders that the write path would have attributed correctly
+// (MUL-4305).
+func (s *TaskService) OriginatorForIssueTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID) pgtype.UUID {
+	return s.resolveOriginatorForIssueTask(ctx, issue, triggerCommentID)
 }
 
 func (s *TaskService) captureTaskDispatched(ctx context.Context, task db.AgentTaskQueue) {

--- a/server/migrations/149_issue_origin_agent_create.down.sql
+++ b/server/migrations/149_issue_origin_agent_create.down.sql
@@ -1,0 +1,8 @@
+-- Revert to the pre-agent_create issue_origin_type_check list. Any existing rows
+-- with origin_type='agent_create' would violate the rolled-back constraint; the
+-- down migration assumes the operator has already deleted or relabeled those
+-- rows. Kept strict (no DROP NOT VALID dance) to preserve the schema invariant
+-- downstream code relies on. Mirrors 131 (slack_chat).
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_origin_type_check;
+ALTER TABLE issue ADD CONSTRAINT issue_origin_type_check
+    CHECK (origin_type IN ('autopilot', 'quick_create', 'lark_chat', 'slack_chat'));

--- a/server/migrations/149_issue_origin_agent_create.up.sql
+++ b/server/migrations/149_issue_origin_agent_create.up.sql
@@ -1,0 +1,13 @@
+-- Extend issue.origin_type to allow an agent's ordinary `issue create` to stamp
+-- the new issue with origin_type='agent_create' + origin_id=<agent_task_queue.id>
+-- (the acting task that created it). This is the load-bearing link that lets
+-- resolveOriginatorForIssueTask inherit the top-of-chain human originator for
+-- any run derived from the new issue (assignment / squad-leader). Without it an
+-- agent-created issue was left unattributed, so downstream A2A mentions from
+-- those runs failed the canInvokeAgent gate against private agents (MUL-4305).
+-- Mirrors the quick_create link (060) — same origin_id semantics (an
+-- agent_task_queue row), different label because this is the normal create path
+-- rather than the daemon quick-create flow.
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_origin_type_check;
+ALTER TABLE issue ADD CONSTRAINT issue_origin_type_check
+    CHECK (origin_type IN ('autopilot', 'quick_create', 'lark_chat', 'slack_chat', 'agent_create'));


### PR DESCRIPTION
## Background

Fixes MUL-4305. After MUL-3963 gated A2A invocation on the top-of-chain **human originator**, a latent gap started biting: when an agent creates an issue through the ordinary `multica issue create` path (not `quick_create`), the new issue was left with **no origin link**. `resolveOriginatorForIssueTask` therefore could not recover the originator, so any assignment / squad-leader run derived from that issue ran with `originator_user_id = NULL`. When such a run @-mentioned a **private** agent, `canInvokeAgent` fell back to an empty effective user and denied the invocation — the mentioned agent was never triggered.

The comment-write path already solved the identical problem (MUL-4015) by stamping `comment.source_task_id`; the issue-create path just never caught up. This PR closes that gap.

## Core logic

- **`CreateIssue` handler** — when the creator is an agent and no explicit origin was supplied, stamp `origin_type='agent_create'` + `origin_id=<acting task id>`. The task id comes from the **server-trusted `X-Task-ID`** (`resolveActor` only returns `agent` once the agent/task pair is validated or a `task_token` was used), never a client-reported field. We re-check the task belongs to the acting agent before trusting it.
- **`resolveOriginatorForIssueTask`** — inherit the origin task's `originator_user_id` for `agent_create` exactly as for `quick_create` (both point `origin_id` at the creating `agent_task_queue` row).
- **Squad-leader gate drift** — `enqueueSquadLeaderTask` computed `leaderOriginator` only for member authors, leaving it empty for agent-triggered assigns even after the task row itself would be attributed correctly. It now resolves the originator via the new exported `TaskService.OriginatorForIssueTask`, so the gate and the persisted task row agree.
- **Migration 149** — adds `agent_create` to `issue_origin_type_check`.
- **Analytics** — classify `agent_create` (surfacing the creating task id) so it no longer logs an "unknown issue origin type" warning.

## Security

The stamp only rides a genuine agent actor. A plain member create carries no origin, and a member who forges `X-Agent-ID` without a valid `X-Task-ID` is demoted to `member` by `resolveActor` and gets no stamp — so no caller can smuggle a human identity onto the issue origin. Cross-owner mentions still fail closed in `canInvokeAgent`.

## Tests

- `TestResolveOriginatorForIssueTask_AgentCreateIssueInheritsParentTask` — attribution layer inherits the human for an `agent_create` issue.
- `TestOriginatorForIssueTask_MatchesResolverForAgentCreate` — gate and enqueue resolution agree.
- `TestCreateIssue_AgentCreate_StampsActingTaskOrigin` — HTTP boundary stamps `agent_create` + acting task id from the trusted `X-Task-ID`.
- `TestCreateIssue_NoAgentCreateStampForMemberOrForgedAgent` — security regression: member create and forged `X-Agent-ID` get no origin stamp.

`go build ./...`, `go vet`, and the full `internal/handler` + `internal/service` packages pass locally (migration 149 applied to the test DB first).

## Out of scope (per issue)

The "same-owner shortcut" is a MUL-3963 product decision, not this bug — with correct originator propagation the same-owner case now flows through the owner branch naturally. The stale `agent→agent always passes` comment cleanup is left for a separate change.
