### PR TITLE
MUL-4264: continue mentioned squad coordination

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -998,11 +998,12 @@ type CommentTriggerAgentResponse struct {
 type commentAgentTriggerSource string
 
 const (
-	commentTriggerSourceIssueAssignee      commentAgentTriggerSource = "issue_assignee"
-	commentTriggerSourceMentionAgent       commentAgentTriggerSource = "mention_agent"
-	commentTriggerSourceMentionSquadLeader commentAgentTriggerSource = "mention_squad_leader"
-	commentTriggerSourceThreadParent       commentAgentTriggerSource = "thread_parent"
-	commentTriggerSourceConversation       commentAgentTriggerSource = "conversation_continuation"
+	commentTriggerSourceIssueAssignee           commentAgentTriggerSource = "issue_assignee"
+	commentTriggerSourceMentionAgent            commentAgentTriggerSource = "mention_agent"
+	commentTriggerSourceMentionSquadLeader      commentAgentTriggerSource = "mention_squad_leader"
+	commentTriggerSourceCoordinatingSquadLeader commentAgentTriggerSource = "coordinating_squad_leader"
+	commentTriggerSourceThreadParent            commentAgentTriggerSource = "thread_parent"
+	commentTriggerSourceConversation            commentAgentTriggerSource = "conversation_continuation"
 )
 
 const defaultCommentRoutingEscalationDelay = 5 * time.Minute
@@ -1057,6 +1058,8 @@ func commentAgentTriggerReason(trigger commentAgentTrigger) string {
 		return "This agent was mentioned in the comment."
 	case commentTriggerSourceMentionSquadLeader:
 		return "A mentioned squad will trigger its leader."
+	case commentTriggerSourceCoordinatingSquadLeader:
+		return "A coordinating squad will trigger its leader."
 	case commentTriggerSourceThreadParent:
 		return "This reply will trigger the parent comment's author."
 	case commentTriggerSourceConversation:
@@ -1514,15 +1517,19 @@ func (h *Handler) mergeCommentIntoPendingTask(ctx context.Context, issue db.Issu
 // (MUL-4195) can fall back to it when a pending task vanished mid-flight.
 func (h *Handler) enqueueSingleCommentTrigger(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, trigger commentAgentTrigger, getEscalationDelay func() time.Duration) {
 	switch trigger.Source {
-	case commentTriggerSourceIssueAssignee:
+	case commentTriggerSourceIssueAssignee, commentTriggerSourceCoordinatingSquadLeader:
 		if trigger.Squad != nil {
 			if _, err := h.TaskService.EnqueueTaskForSquadLeader(ctx, issue, trigger.Agent.ID, trigger.Squad.ID, triggerCommentID); err != nil {
 				slog.Warn("enqueue squad leader task failed",
 					"issue_id", uuidToString(issue.ID),
 					"squad_id", uuidToString(trigger.Squad.ID),
 					"leader_id", uuidToString(trigger.Agent.ID),
+					"source", trigger.Source,
 					"error", err)
 			}
+			return
+		}
+		if trigger.Source == commentTriggerSourceCoordinatingSquadLeader {
 			return
 		}
 		if _, err := h.TaskService.EnqueueTaskForIssue(ctx, issue, triggerCommentID); err != nil {
@@ -1607,6 +1614,10 @@ func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issu
 			if trigger, ok := h.routeAssignedSquadLeaderFallback(ctx, issue, actorType, actorID, opts); ok {
 				return []commentAgentTrigger{trigger}
 			}
+			return nil
+		}
+		if trigger, ok := h.routeCoordinatingSquadLeaderFallback(ctx, issue, actorType, actorID, opts); ok {
+			return []commentAgentTrigger{trigger}
 		}
 		return nil
 	}
@@ -1843,6 +1854,18 @@ func (h *Handler) routeAssignedSquadLeaderFallback(ctx context.Context, issue db
 	if err != nil {
 		return commentAgentTrigger{}, false
 	}
+	return h.routeSquadLeaderFallback(ctx, issue, squad, authorType, authorID, opts, commentTriggerSourceIssueAssignee)
+}
+
+func (h *Handler) routeCoordinatingSquadLeaderFallback(ctx context.Context, issue db.Issue, authorType, authorID string, opts commentTriggerComputeOptions) (commentAgentTrigger, bool) {
+	squad, ok := h.resolveCoordinatingSquadForIssue(ctx, issue)
+	if !ok {
+		return commentAgentTrigger{}, false
+	}
+	return h.routeSquadLeaderFallback(ctx, issue, squad, authorType, authorID, opts, commentTriggerSourceCoordinatingSquadLeader)
+}
+
+func (h *Handler) routeSquadLeaderFallback(ctx context.Context, issue db.Issue, squad db.Squad, authorType, authorID string, opts commentTriggerComputeOptions, source commentAgentTriggerSource) (commentAgentTrigger, bool) {
 	if authorType == "agent" && authorID == uuidToString(squad.LeaderID) &&
 		h.shouldSuppressSquadLeaderSelfTrigger(ctx, issue.ID, squad.LeaderID, squad.ID) {
 		return commentAgentTrigger{}, false
@@ -1861,7 +1884,7 @@ func (h *Handler) routeAssignedSquadLeaderFallback(ctx context.Context, issue db
 	if err != nil {
 		return commentAgentTrigger{}, false
 	}
-	return commentAgentTrigger{Agent: agent, Source: commentTriggerSourceIssueAssignee, Squad: &squad, AlreadyPending: hasPending}, true
+	return commentAgentTrigger{Agent: agent, Source: source, Squad: &squad, AlreadyPending: hasPending}, true
 }
 
 func (h *Handler) hasPendingTaskForIssueAndAgent(ctx context.Context, issueID, agentID pgtype.UUID, opts commentTriggerComputeOptions) (bool, error) {

--- a/server/internal/handler/coordinating_squad.go
+++ b/server/internal/handler/coordinating_squad.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"context"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// resolveCoordinatingSquadForIssue returns the temporary coordinating squad
+// derived from the issue's latest valid leader task. It never mutates issue
+// assignment and never falls back to older squads if the latest leader task no
+// longer points at a runnable squad.
+func (h *Handler) resolveCoordinatingSquadForIssue(ctx context.Context, issue db.Issue) (db.Squad, bool) {
+	squad, err := h.Queries.GetLatestCoordinatingSquadForIssue(ctx, db.GetLatestCoordinatingSquadForIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return db.Squad{}, false
+	}
+	return squad, true
+}

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -98,11 +98,23 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	if parent.Status == "backlog" {
 		return
 	}
+	var coordinatingSquad *db.Squad
+
 	// Human-assigned parents read their own timeline; an automated system
-	// comment is just noise and there is no agent task to trigger. Skip the
-	// whole notification (comment + mention + inbox row) — MUL-2538.
+	// comment is just noise and there is no agent task to trigger. A squad that
+	// was explicitly @mentioned can still be coordinating this parent; in that
+	// case the system comment drives the same leader continuation as a squad
+	// assignment without changing issue.assignee.
 	if parent.AssigneeType.Valid && parent.AssigneeType.String == "member" {
-		return
+		squad, ok := h.resolveCoordinatingSquadForIssue(ctx, parent)
+		if !ok {
+			return
+		}
+		coordinatingSquad = &squad
+	} else if !parent.AssigneeType.Valid || !parent.AssigneeID.Valid {
+		if squad, ok := h.resolveCoordinatingSquadForIssue(ctx, parent); ok {
+			coordinatingSquad = &squad
+		}
 	}
 
 	// Stage barrier (MUL-3508 / discussion #4320). The notification + assignee
@@ -134,8 +146,12 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 
 	// Build the parent-assignee mention prefix. Empty when the parent has no
 	// assignee or the assignee row is missing (deleted member, archived
-	// agent the workspace lost track of, etc.).
+	// agent the workspace lost track of, etc.). Coordinating-squad fallback
+	// names the leader agent directly because the squad is not the assignee.
 	mentionPrefix := h.buildParentAssigneeMention(ctx, parent)
+	if coordinatingSquad != nil {
+		mentionPrefix = h.buildCoordinatingSquadLeaderMention(ctx, parent.WorkspaceID, *coordinatingSquad)
+	}
 
 	var content string
 	// When the set is staged and the barrier closed, the completed child is
@@ -190,7 +206,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// author_type='system'); this keeps smuggled mentions from the child
 	// title inert and gives the platform a single place to apply the loop
 	// and idempotency guards.
-	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
+	h.dispatchParentAssigneeTrigger(ctx, parent, comment, coordinatingSquad)
 }
 
 // isTerminalChildStatus reports whether a child issue status counts as
@@ -349,6 +365,17 @@ func (h *Handler) buildParentAssigneeMention(ctx context.Context, parent db.Issu
 	return fmt.Sprintf("[@%s](mention://%s/%s) ", label, parent.AssigneeType.String, uuidToString(parent.AssigneeID))
 }
 
+func (h *Handler) buildCoordinatingSquadLeaderMention(ctx context.Context, workspaceID pgtype.UUID, squad db.Squad) string {
+	agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+		ID:          squad.LeaderID,
+		WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("[@%s](mention://agent/%s) ", sanitizeMentionLabel(agent.Name), uuidToString(squad.LeaderID))
+}
+
 // resolveAssigneeMentionLabel returns the label text to render inside the
 // mention link. The label is for human display only — the mention regex
 // keys off the URL path, not the label — but a sensible fallback keeps the
@@ -394,11 +421,12 @@ func sanitizeMentionLabel(name string) string {
 
 // dispatchParentAssigneeTrigger fires the explicit side effect that pairs
 // with the @mention link in the system comment body — an agent task for
-// agent or squad-leader assignees. Member assignees never reach this code
-// path; notifyParentOfChildDone skips them outright. The generic comment
-// listener is intentionally bypassed (it short-circuits on
-// author_type='system'), so this is the single place where the platform
-// applies the idempotency guard for the child-done notification.
+// agent or squad-leader assignees, or for the coordinating squad leader when
+// a parent has no runnable agent/squad assignee. Member assignees without a
+// coordinating squad never reach this code path; notifyParentOfChildDone skips
+// them outright. The generic comment listener is intentionally bypassed (it
+// short-circuits on author_type='system'), so this is the single place where
+// the platform applies the idempotency guard for the child-done notification.
 //
 // Side-effect semantics (intentionally narrower than a normal @mention):
 //   - agent parent: one EnqueueTaskForMention on the parent assignee, same
@@ -412,6 +440,10 @@ func sanitizeMentionLabel(name string) string {
 //     actor that closed the child is irrelevant to routing: the target is the
 //     parent's own leader, chosen (and permission-checked) at squad-assign
 //     time, so no actor identity is threaded in — see triggerChildDoneSquad.
+//   - coordinating squad fallback: when the parent is member-assigned or
+//     unassigned, the latest valid leader task can supply a temporary
+//     coordinating squad. That leader is woken with the same leader-only side
+//     effect as the assigned squad path, without mutating issue.assignee.
 //   - notification_preference is not consulted: this is a platform routing
 //     signal targeted at the assignee that already owns the parent, not a
 //     general notification. Per-user mute settings are evaluated by the
@@ -421,7 +453,7 @@ func sanitizeMentionLabel(name string) string {
 //     child title are inert — only the explicit dispatch below runs.
 //
 // Guards applied here:
-//   - No-op when the parent has no assignee row.
+//   - No-op when the parent has no assignee row and no coordinating squad.
 //   - NO self-trigger guard on either the agent OR the squad path. Waking the
 //     parent assignee when one of its children finishes is a serial sub-task
 //     handoff across two DIFFERENT issues, not a self-loop — legitimate per
@@ -442,16 +474,27 @@ func sanitizeMentionLabel(name string) string {
 //     itself push a child back into a terminal transition.
 //   - Readiness: archived agents / missing runtimes are silently skipped
 //     so a closed-out agent does not surface as a phantom assignee.
-func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.Issue, systemComment db.Comment) {
-	if !parent.AssigneeType.Valid || !parent.AssigneeID.Valid {
-		return
+func (h *Handler) dispatchParentAssigneeTrigger(ctx context.Context, parent db.Issue, systemComment db.Comment, coordinatingSquad *db.Squad) {
+	if parent.AssigneeType.Valid && parent.AssigneeID.Valid {
+		switch parent.AssigneeType.String {
+		case "agent":
+			h.triggerChildDoneAgent(ctx, parent, systemComment.ID)
+			return
+		case "squad":
+			squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+				ID:          parent.AssigneeID,
+				WorkspaceID: parent.WorkspaceID,
+			})
+			if err != nil {
+				return
+			}
+			h.triggerChildDoneSquad(ctx, parent, squad, systemComment.ID)
+			return
+		}
 	}
 
-	switch parent.AssigneeType.String {
-	case "agent":
-		h.triggerChildDoneAgent(ctx, parent, systemComment.ID)
-	case "squad":
-		h.triggerChildDoneSquad(ctx, parent, systemComment.ID)
+	if coordinatingSquad != nil {
+		h.triggerChildDoneSquad(ctx, parent, *coordinatingSquad, systemComment.ID)
 	}
 }
 
@@ -495,8 +538,9 @@ func (h *Handler) triggerChildDoneAgent(ctx context.Context, parent db.Issue, tr
 	}
 }
 
-// triggerChildDoneSquad enqueues a leader-role task for the parent's squad
-// assignee. It mirrors the agent path (see triggerChildDoneAgent) exactly:
+// triggerChildDoneSquad enqueues a leader-role task for a parent squad assignee
+// or coordinating squad. It mirrors the agent path (see triggerChildDoneAgent)
+// exactly:
 //
 //   - NO self-trigger guard: even when the finished child is owned by the same
 //     squad or by another squad sharing this leader, the leader must still be
@@ -520,16 +564,11 @@ func (h *Handler) triggerChildDoneAgent(ctx context.Context, parent db.Issue, tr
 //
 // Re-triggering is bounded by the HasPendingTaskForIssueAndAgent idempotency
 // check below, exactly as the agent path relies on it.
-func (h *Handler) triggerChildDoneSquad(ctx context.Context, parent db.Issue, triggerCommentID pgtype.UUID) {
-	squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
-		ID:          parent.AssigneeID,
+func (h *Handler) triggerChildDoneSquad(ctx context.Context, parent db.Issue, squad db.Squad, triggerCommentID pgtype.UUID) {
+	agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+		ID:          squad.LeaderID,
 		WorkspaceID: parent.WorkspaceID,
 	})
-	if err != nil {
-		return
-	}
-
-	agent, err := h.Queries.GetAgent(ctx, squad.LeaderID)
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
 		return
 	}

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -378,6 +378,110 @@ func TestChildDoneSkippedWhenParentMember(t *testing.T) {
 	}
 }
 
+func TestChildDoneCoordinatingSquadFallback_MemberParent(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	var userID string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT user_id FROM member WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&userID); err != nil {
+		t.Fatalf("locate workspace member: %v", err)
+	}
+	setIssueAssigneeDirect(t, fx.parent.ID, "member", userID)
+	insertSquadLeaderTaskForIssueForTest(t, fx.parent.ID, sq.LeaderID, sq.SquadID, "completed", -10)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "done")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "mention://agent/"+sq.LeaderID) {
+		t.Errorf("expected coordinating leader mention in system comment, got: %s", content)
+	}
+	if strings.Contains(content, "mention://squad/"+sq.SquadID) {
+		t.Errorf("coordinating squad is not the assignee; comment should mention leader agent, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Errorf("expected 1 pending leader task for coordinating squad, got %d", got)
+	}
+	if got := countInboxItems(t, userID, fx.parent.ID); got != 0 {
+		t.Errorf("coordinating fallback should not create member inbox rows, got %d", got)
+	}
+}
+
+func TestChildDoneCoordinatingSquadFallback_UnassignedParent(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	insertSquadLeaderTaskForIssueForTest(t, fx.parent.ID, sq.LeaderID, sq.SquadID, "completed", -10)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "done")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "mention://agent/"+sq.LeaderID) {
+		t.Errorf("expected coordinating leader mention in system comment, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Errorf("expected 1 pending leader task for coordinating squad, got %d", got)
+	}
+}
+
+func TestChildDoneCoordinatingSquadFallback_DoesNotDoubleSendWithAgentAssignee(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	setIssueAssigneeDirect(t, fx.parent.ID, "agent", sq.OtherID)
+	insertSquadLeaderTaskForIssueForTest(t, fx.parent.ID, sq.LeaderID, sq.SquadID, "completed", -10)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "done")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "mention://agent/"+sq.OtherID) {
+		t.Errorf("expected parent agent assignee mention in system comment, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.OtherID); got != 1 {
+		t.Errorf("expected 1 pending task for parent agent assignee, got %d", got)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 0 {
+		t.Errorf("coordinating leader should not be double-sent when parent has agent assignee, got %d tasks", got)
+	}
+}
+
+func TestChildDoneCoordinatingSquadFallback_ParentStatusGates(t *testing.T) {
+	for _, status := range []string{"backlog", "done", "cancelled"} {
+		t.Run(status, func(t *testing.T) {
+			fx := newChildDoneFixture(t, status)
+			sq := newSquadCommentTriggerFixture(t)
+			insertSquadLeaderTaskForIssueForTest(t, fx.parent.ID, sq.LeaderID, sq.SquadID, "completed", -10)
+			t.Cleanup(func() {
+				testPool.Exec(context.Background(),
+					`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+			})
+
+			updateChildStatus(t, fx.child.ID, "done")
+
+			if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+				t.Errorf("parent at %q should not receive coordinating child-done comment, got %d", status, got)
+			}
+			if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 0 {
+				t.Errorf("parent at %q should not enqueue coordinating leader, got %d tasks", status, got)
+			}
+		})
+	}
+}
+
 // TestChildDoneMentionsParentAssignee_Squad verifies the squad branch: the
 // system comment carries a `mention://squad/<id>` link and the squad
 // leader receives a leader-role task. Reuses the squad fixture helper from

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -71,6 +71,86 @@ type squadCommentTriggerFixture struct {
 	OtherID  string // second agent in workspace (with runtime), used as a non-leader @mention target
 }
 
+func createRoutingTestIssue(t *testing.T, title string) db.Issue {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  title,
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create routing issue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, resp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, resp.ID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, resp.ID)
+	})
+
+	issue, err := testHandler.Queries.GetIssue(context.Background(), util.MustParseUUID(resp.ID))
+	if err != nil {
+		t.Fatalf("load routing issue: %v", err)
+	}
+	return issue
+}
+
+func createTestSquadWithLeader(t *testing.T, name, leaderID string) string {
+	t.Helper()
+
+	var squadID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, name, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad %q: %v", name, err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+	return squadID
+}
+
+func insertAgentTaskForIssueForTest(t *testing.T, issueID, agentID, status string, isLeader bool, squadID, originatorUserID string, offsetSeconds int) string {
+	t.Helper()
+
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `SELECT runtime_id FROM agent WHERE id = $1`, agentID).Scan(&runtimeID); err != nil {
+		t.Fatalf("load runtime for agent %s: %v", agentID, err)
+	}
+	var squadArg any
+	if squadID != "" {
+		squadArg = squadID
+	}
+	var originatorArg any
+	if originatorUserID != "" {
+		originatorArg = originatorUserID
+	}
+	var taskID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, is_leader_task, squad_id,
+			originator_user_id, created_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, now() + ($8::int * interval '1 second'))
+		RETURNING id
+	`, agentID, runtimeID, issueID, status, isLeader, squadArg, originatorArg, offsetSeconds).Scan(&taskID); err != nil {
+		t.Fatalf("insert agent task: %v", err)
+	}
+	return taskID
+}
+
+func insertSquadLeaderTaskForIssueForTest(t *testing.T, issueID, leaderID, squadID, status string, offsetSeconds int) string {
+	t.Helper()
+	return insertAgentTaskForIssueForTest(t, issueID, leaderID, status, true, squadID, testUserID, offsetSeconds)
+}
+
 func newSquadCommentTriggerFixture(t *testing.T) squadCommentTriggerFixture {
 	t.Helper()
 	ctx := context.Background()
@@ -845,5 +925,300 @@ func TestCreateComment_SquadMentionTriggersLeader(t *testing.T) {
 	// The squad's leader should have a queued task.
 	if got := countQueued(leaderID); got != 1 {
 		t.Fatalf("after @squad mention: expected 1 leader task, got %d", got)
+	}
+}
+
+func TestCreateComment_CoordinatingSquadWorkerCommentWakesMentionedLeader(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	issue := createRoutingTestIssue(t, "coordinating squad worker result")
+	issueID := uuidToString(issue.ID)
+	var leaderID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1
+	`, testWorkspaceID).Scan(&leaderID); err != nil {
+		t.Fatalf("load leader agent: %v", err)
+	}
+	workerID := createHandlerTestAgent(t, "Coordinating Squad Worker", nil)
+	squadID := createTestSquadWithLeader(t, "Coordinating Mention Squad", leaderID)
+
+	countQueuedLeaderTasks := func() int {
+		var n int
+		if err := testPool.QueryRow(ctx, `
+			SELECT count(*) FROM agent_task_queue
+			WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = TRUE
+		`, issueID, leaderID).Scan(&n); err != nil {
+			t.Fatalf("count queued leader tasks: %v", err)
+		}
+		return n
+	}
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "[@Squad](mention://squad/" + squadID + ") please plan this",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("member @squad CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := countQueuedLeaderTasks(); got != 1 {
+		t.Fatalf("after @squad mention: expected 1 queued leader task, got %d", got)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'completed'
+		WHERE issue_id = $1 AND agent_id = $2 AND is_leader_task = TRUE
+	`, issueID, leaderID); err != nil {
+		t.Fatalf("complete initial leader task: %v", err)
+	}
+
+	workerTaskID := insertAgentTaskForIssueForTest(t, issueID, workerID, "running", false, squadID, testUserID, 1)
+	w = httptest.NewRecorder()
+	r = newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "done with the worker slice",
+	})
+	r.Header.Set("X-Agent-ID", workerID)
+	r.Header.Set("X-Task-ID", workerTaskID)
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("worker result CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := countQueuedLeaderTasks(); got != 1 {
+		t.Fatalf("after worker result: expected 1 fresh queued leader task, got %d", got)
+	}
+}
+
+func TestResolveCoordinatingSquadForIssue_SelectionRules(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	newIssueAndSquads := func(t *testing.T, name string) (db.Issue, string, string, string, string) {
+		t.Helper()
+		issue := createRoutingTestIssue(t, "coordinating squad selection "+name)
+		leaderA := createHandlerTestAgent(t, "Coordinating Leader A "+name, nil)
+		leaderB := createHandlerTestAgent(t, "Coordinating Leader B "+name, nil)
+		squadA := createTestSquadWithLeader(t, "Coordinating Squad A "+name, leaderA)
+		squadB := createTestSquadWithLeader(t, "Coordinating Squad B "+name, leaderB)
+		return issue, leaderA, squadA, leaderB, squadB
+	}
+
+	t.Run("latest leader task wins", func(t *testing.T) {
+		issue, leaderA, squadA, leaderB, squadB := newIssueAndSquads(t, "latest")
+		issueID := uuidToString(issue.ID)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderA, squadA, "completed", -10)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderB, squadB, "completed", 0)
+
+		got, ok := testHandler.resolveCoordinatingSquadForIssue(ctx, issue)
+		if !ok {
+			t.Fatal("expected coordinating squad")
+		}
+		if uuidToString(got.ID) != squadB {
+			t.Fatalf("coordinating squad = %s, want latest %s", uuidToString(got.ID), squadB)
+		}
+	})
+
+	t.Run("cancelled latest leader task does not fall back", func(t *testing.T) {
+		issue, leaderA, squadA, leaderB, squadB := newIssueAndSquads(t, "cancelled")
+		issueID := uuidToString(issue.ID)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderA, squadA, "completed", -10)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderB, squadB, "cancelled", 0)
+
+		if _, ok := testHandler.resolveCoordinatingSquadForIssue(ctx, issue); ok {
+			t.Fatal("expected no coordinating squad when latest leader task is cancelled")
+		}
+	})
+
+	t.Run("archived latest squad does not fall back", func(t *testing.T) {
+		issue, leaderA, squadA, leaderB, squadB := newIssueAndSquads(t, "archived")
+		issueID := uuidToString(issue.ID)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderA, squadA, "completed", -10)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderB, squadB, "completed", 0)
+		if _, err := testPool.Exec(ctx, `UPDATE squad SET archived_at = now(), archived_by = $1 WHERE id = $2`, testUserID, squadB); err != nil {
+			t.Fatalf("archive latest squad: %v", err)
+		}
+
+		if _, ok := testHandler.resolveCoordinatingSquadForIssue(ctx, issue); ok {
+			t.Fatal("expected no coordinating squad when latest squad is archived")
+		}
+	})
+
+	t.Run("dangling latest squad does not fall back", func(t *testing.T) {
+		issue, leaderA, squadA, leaderB, squadB := newIssueAndSquads(t, "dangling")
+		issueID := uuidToString(issue.ID)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderA, squadA, "completed", -10)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderB, squadB, "completed", 0)
+		if _, err := testPool.Exec(ctx, `DELETE FROM squad WHERE id = $1`, squadB); err != nil {
+			t.Fatalf("delete latest squad: %v", err)
+		}
+
+		if _, ok := testHandler.resolveCoordinatingSquadForIssue(ctx, issue); ok {
+			t.Fatal("expected no coordinating squad when latest squad is dangling")
+		}
+	})
+}
+
+func TestComputeCommentAgentTriggers_CoordinatingSquadUsesSharedGates(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	issue := createRoutingTestIssue(t, "coordinating squad gate coverage")
+	issueID := uuidToString(issue.ID)
+	leaderID := createHandlerTestAgent(t, "Coordinating Gate Leader", nil)
+	workerID := createHandlerTestAgent(t, "Coordinating Gate Worker", nil)
+	squadID := createTestSquadWithLeader(t, "Coordinating Gate Squad", leaderID)
+
+	clearTasks := func() {
+		if _, err := testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID); err != nil {
+			t.Fatalf("clear tasks: %v", err)
+		}
+	}
+	coordinatingTrigger := func(authorID string) (commentAgentTrigger, bool) {
+		triggers := testHandler.computeCommentAgentTriggers(ctx, issue, "worker result", nil, "agent", authorID, commentTriggerComputeOptions{})
+		if len(triggers) == 0 {
+			return commentAgentTrigger{}, false
+		}
+		if len(triggers) != 1 {
+			t.Fatalf("got %d triggers, want 1", len(triggers))
+		}
+		return triggers[0], true
+	}
+
+	t.Run("worker result uses coordinating source", func(t *testing.T) {
+		clearTasks()
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+		trigger, ok := coordinatingTrigger(workerID)
+		if !ok {
+			t.Fatal("expected coordinating leader trigger")
+		}
+		if trigger.Source != commentTriggerSourceCoordinatingSquadLeader {
+			t.Fatalf("source = %q, want %q", trigger.Source, commentTriggerSourceCoordinatingSquadLeader)
+		}
+		if trigger.Squad == nil || uuidToString(trigger.Squad.ID) != squadID {
+			t.Fatalf("trigger squad = %+v, want %s", trigger.Squad, squadID)
+		}
+	})
+
+	t.Run("pending dedup is reused", func(t *testing.T) {
+		clearTasks()
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "queued", 0)
+		trigger, ok := coordinatingTrigger(workerID)
+		if !ok {
+			t.Fatal("expected coordinating leader trigger")
+		}
+		if !trigger.AlreadyPending {
+			t.Fatal("expected coordinating trigger to report AlreadyPending")
+		}
+	})
+
+	t.Run("leader self-trigger is suppressed", func(t *testing.T) {
+		clearTasks()
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+		if _, ok := coordinatingTrigger(leaderID); ok {
+			t.Fatal("expected latest leader task to suppress leader self-trigger")
+		}
+	})
+
+	t.Run("dual-role leader worker comment wakes leader", func(t *testing.T) {
+		clearTasks()
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+		insertAgentTaskForIssueForTest(t, issueID, leaderID, "completed", false, squadID, testUserID, 0)
+		if _, ok := coordinatingTrigger(leaderID); !ok {
+			t.Fatal("expected same-squad worker-role leader comment to wake leader")
+		}
+	})
+
+	t.Run("explicit mention still short-circuits fallback", func(t *testing.T) {
+		clearTasks()
+		insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+		content := "handing to [@Worker](mention://agent/" + workerID + ")"
+		triggers := testHandler.computeCommentAgentTriggers(ctx, issue, content, nil, "agent", workerID, commentTriggerComputeOptions{})
+		for _, trigger := range triggers {
+			if trigger.Source == commentTriggerSourceCoordinatingSquadLeader {
+				t.Fatal("explicit mention unexpectedly also triggered coordinating squad leader")
+			}
+		}
+	})
+}
+
+func TestCreateComment_CoordinatingSquadPrivateLeaderRequiresOriginator(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	privateAgent := func(name string) string {
+		t.Helper()
+		var agentID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent (
+				workspace_id, name, description, runtime_mode, runtime_config,
+				runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
+				instructions, custom_env, custom_args, mcp_config
+			)
+			VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+			RETURNING id
+		`, testWorkspaceID, name, handlerTestRuntimeID(t), testUserID).Scan(&agentID); err != nil {
+			t.Fatalf("create private agent %q: %v", name, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+		})
+		return agentID
+	}
+
+	issue := createRoutingTestIssue(t, "coordinating private leader originator")
+	issueID := uuidToString(issue.ID)
+	leaderID := privateAgent("Coordinating Private Leader")
+	workerID := privateAgent("Coordinating Private Worker")
+	squadID := createTestSquadWithLeader(t, "Coordinating Private Squad", leaderID)
+	insertSquadLeaderTaskForIssueForTest(t, issueID, leaderID, squadID, "completed", -10)
+
+	countQueuedLeaderTasks := func() int {
+		var n int
+		if err := testPool.QueryRow(ctx, `
+			SELECT count(*) FROM agent_task_queue
+			WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = TRUE
+		`, issueID, leaderID).Scan(&n); err != nil {
+			t.Fatalf("count queued leader tasks: %v", err)
+		}
+		return n
+	}
+	postWorkerResult := func(taskID string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+			"content": "worker done",
+		})
+		r.Header.Set("X-Agent-ID", workerID)
+		r.Header.Set("X-Task-ID", taskID)
+		r = withURLParam(r, "id", issueID)
+		testHandler.CreateComment(w, r)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("worker result CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	noOriginatorTaskID := insertAgentTaskForIssueForTest(t, issueID, workerID, "running", false, squadID, "", 0)
+	postWorkerResult(noOriginatorTaskID)
+	if got := countQueuedLeaderTasks(); got != 0 {
+		t.Fatalf("private leader woke with no originator: got %d queued tasks, want 0", got)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET status = 'completed' WHERE id = $1`, noOriginatorTaskID); err != nil {
+		t.Fatalf("complete no-originator task: %v", err)
+	}
+
+	ownerOriginatorTaskID := insertAgentTaskForIssueForTest(t, issueID, workerID, "running", false, squadID, testUserID, 1)
+	postWorkerResult(ownerOriginatorTaskID)
+	if got := countQueuedLeaderTasks(); got != 1 {
+		t.Fatalf("private leader with owner originator: got %d queued tasks, want 1", got)
 	}
 }

--- a/server/pkg/db/generated/squad.sql.go
+++ b/server/pkg/db/generated/squad.sql.go
@@ -127,6 +127,56 @@ func (q *Queries) CreateSquad(ctx context.Context, arg CreateSquadParams) (Squad
 	return i, err
 }
 
+const getLatestCoordinatingSquadForIssue = `-- name: GetLatestCoordinatingSquadForIssue :one
+WITH latest_leader_task AS (
+    SELECT squad_id, status
+    FROM agent_task_queue
+    WHERE issue_id = $1
+      AND is_leader_task = TRUE
+      AND squad_id IS NOT NULL
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+)
+SELECT s.id, s.workspace_id, s.name, s.description, s.leader_id, s.creator_id, s.created_at, s.updated_at, s.archived_at, s.archived_by, s.avatar_url, s.instructions
+FROM latest_leader_task lt
+JOIN squad s ON s.id = lt.squad_id
+JOIN agent a ON a.id = s.leader_id
+WHERE lt.status <> 'cancelled'
+  AND s.workspace_id = $2
+  AND s.archived_at IS NULL
+  AND a.workspace_id = $2
+  AND a.archived_at IS NULL
+  AND a.runtime_id IS NOT NULL
+`
+
+type GetLatestCoordinatingSquadForIssueParams struct {
+	IssueID     pgtype.UUID `json:"issue_id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// The coordinating squad is the exact squad on the latest leader task for
+// this issue. Validate that row's squad and leader, but do not fall back to an
+// older squad when the latest leader task is cancelled, archived, or dangling.
+func (q *Queries) GetLatestCoordinatingSquadForIssue(ctx context.Context, arg GetLatestCoordinatingSquadForIssueParams) (Squad, error) {
+	row := q.db.QueryRow(ctx, getLatestCoordinatingSquadForIssue, arg.IssueID, arg.WorkspaceID)
+	var i Squad
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Description,
+		&i.LeaderID,
+		&i.CreatorID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.AvatarUrl,
+		&i.Instructions,
+	)
+	return i, err
+}
+
 const getSquad = `-- name: GetSquad :one
 SELECT id, workspace_id, name, description, leader_id, creator_id, created_at, updated_at, archived_at, archived_by, avatar_url, instructions FROM squad WHERE id = $1
 `

--- a/server/pkg/db/queries/squad.sql
+++ b/server/pkg/db/queries/squad.sql
@@ -91,6 +91,30 @@ SELECT count(*) FROM squad_member WHERE squad_id = $1;
 -- Look up the squad when an issue is assigned to a squad.
 SELECT s.* FROM squad s WHERE s.id = $1 AND s.workspace_id = $2;
 
+-- name: GetLatestCoordinatingSquadForIssue :one
+-- The coordinating squad is the exact squad on the latest leader task for
+-- this issue. Validate that row's squad and leader, but do not fall back to an
+-- older squad when the latest leader task is cancelled, archived, or dangling.
+WITH latest_leader_task AS (
+    SELECT squad_id, status
+    FROM agent_task_queue
+    WHERE issue_id = $1
+      AND is_leader_task = TRUE
+      AND squad_id IS NOT NULL
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+)
+SELECT s.*
+FROM latest_leader_task lt
+JOIN squad s ON s.id = lt.squad_id
+JOIN agent a ON a.id = s.leader_id
+WHERE lt.status <> 'cancelled'
+  AND s.workspace_id = $2
+  AND s.archived_at IS NULL
+  AND a.workspace_id = $2
+  AND a.archived_at IS NULL
+  AND a.runtime_id IS NOT NULL;
+
 -- name: ListSquadsByMember :many
 -- Find all squads a given entity belongs to in a workspace.
 SELECT s.* FROM squad s


### PR DESCRIPTION
## Summary

- Add a coordinating-squad lookup based on the latest leader task for an issue, validating the exact squad and leader without mutating `issue.assignee` or falling back to stale squads.
- Refactor squad leader comment fallback through a shared `routeSquadLeaderFallback`, then route worker-agent result comments to a coordinating squad leader with a distinct `coordinating_squad_leader` source.
- Extend child-done routing so member-assigned and unassigned parents can wake the coordinating squad leader, while assigned agent/squad owners keep priority and no owner+coordinator double-send occurs.

## Tests

- `go test ./internal/handler -run 'Test.*Squad|Test.*ChildDone.*Squad' -count=1`
- `go test ./internal/handler -count=1`

Closes MUL-4264
