### PR TITLE
feat(skills): adaptive skill discovery for import dialog

### DIFF
--- a/docs/ideation/2026-07-09-skill-import-search-ideation.html
+++ b/docs/ideation/2026-07-09-skill-import-search-ideation.html
@@ -1,0 +1,675 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ideation: Skill Import Search & Discovery — Multica</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --bg-soft: #f7f7f5;
+    --bg-softer: #efeee9;
+    --ink: #1a1a1a;
+    --ink-soft: #4a4a4a;
+    --ink-muted: #7a7a7a;
+    --line: #d9d7d0;
+    --accent: #2563eb;
+    --accent-soft: #dbeafe;
+    --accent-ink: #1e40af;
+    --warn: #d97706;
+    --warn-soft: #fef3c7;
+    --warn-ink: #924006;
+    --good: #16a34a;
+    --good-soft: #dcfce7;
+    --good-ink: #166534;
+    --info: #0891b2;
+    --info-soft: #cffafe;
+    --info-ink: #155e75;
+    --violet: #7c3aed;
+    --violet-soft: #ede9fe;
+    --violet-ink: #5b21b6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #171717;
+      --bg-soft: #1f1f1f;
+      --bg-softer: #262626;
+      --ink: #f0f0f0;
+      --ink-soft: #c2c2c2;
+      --ink-muted: #8a8a8a;
+      --line: #3a3a3a;
+      --accent: #60a5fa;
+      --accent-soft: #1e3a5f;
+      --accent-ink: #93c5fd;
+      --warn: #fbbf24;
+      --warn-soft: #3f2f0d;
+      --warn-ink: #fcd34d;
+      --good: #4ade80;
+      --good-soft: #14332a;
+      --good-ink: #86efac;
+      --info: #22d3ee;
+      --info-soft: #0c3541;
+      --info-ink: #67e8f9;
+      --violet: #a78bfa;
+      --violet-soft: #2e1e54;
+      --violet-ink: #c4b5fd;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  .page {
+    max-width: 920px;
+    margin-inline: auto;
+    padding: 48px 28px 80px;
+  }
+  .eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    margin-bottom: 8px;
+  }
+  h1.title {
+    font-size: 30px;
+    line-height: 1.2;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 14px;
+  }
+  .lede {
+    font-size: 16px;
+    color: var(--ink-soft);
+    max-width: 62ch;
+    margin: 0 0 28px;
+  }
+  .meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    padding: 14px 16px;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    font-size: 13px;
+    margin-bottom: 40px;
+  }
+  .meta-strip .meta-row { display: flex; gap: 6px; align-items: baseline; }
+  .meta-strip .meta-label {
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  .meta-strip .meta-value { color: var(--ink); font-weight: 500; }
+  .pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--bg-softer);
+    color: var(--ink);
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .pill.accent { background: var(--accent-soft); color: var(--accent-ink); }
+  .pill.merge { background: var(--violet-soft); color: var(--violet-ink); }
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 40px;
+  }
+  @media (max-width: 640px) { .stats { grid-template-columns: repeat(2, 1fr); } }
+  .stat {
+    padding: 14px 16px;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+  }
+  .stat .stat-num { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+  .stat .stat-label { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-muted); margin-top: 2px; }
+  section { margin-bottom: 48px; }
+  h2 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--line);
+  }
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 24px 0 8px;
+  }
+  p { margin: 0 0 12px; max-width: 70ch; }
+  p:last-child { margin-bottom: 0; }
+  ul { padding-left: 22px; margin: 0 0 12px; }
+  li { margin-bottom: 4px; }
+  code {
+    font-family: "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    background: var(--bg-softer);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .axis-list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    margin: 16px 0 0;
+  }
+  @media (max-width: 640px) { .axis-list { grid-template-columns: 1fr; } }
+  .axis-item {
+    padding: 10px 14px;
+    background: var(--bg-soft);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 6px 6px 0;
+  }
+  .axis-item .axis-name { font-weight: 600; font-size: 13px; }
+  .axis-item .axis-desc { font-size: 13px; color: var(--ink-soft); margin-top: 2px; }
+  .sub-nav {
+    padding: 14px 16px;
+    background: var(--bg-soft);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    margin-bottom: 24px;
+  }
+  .sub-nav .sub-nav-title {
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    margin-bottom: 8px;
+  }
+  .sub-nav ol {
+    margin: 0;
+    padding-left: 22px;
+  }
+  .sub-nav li { margin-bottom: 4px; font-size: 13.5px; }
+  .sub-nav a { color: var(--accent); text-decoration: none; font-weight: 500; }
+  .sub-nav a:hover { text-decoration: underline; }
+  article.idea {
+    padding: 20px 22px;
+    margin-bottom: 18px;
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    scroll-margin-top: 20px;
+  }
+  article.idea:hover { border-color: var(--accent); }
+  .idea-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px 12px;
+    margin-bottom: 12px;
+  }
+  .idea-rank {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--accent-ink);
+    background: var(--accent-soft);
+    padding: 2px 9px;
+    border-radius: 6px;
+    letter-spacing: 0.02em;
+  }
+  .idea-title {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.005em;
+    margin: 0;
+    flex: 1;
+  }
+  .idea-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+  .chip {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
+  .chip.axis { background: var(--violet-soft); color: var(--violet-ink); }
+  .chip.conf-high { background: var(--good-soft); color: var(--good-ink); }
+  .chip.conf-med { background: var(--warn-soft); color: var(--warn-ink); }
+  .chip.conf-low { background: var(--info-soft); color: var(--info-ink); }
+  .chip.cplx-sm { background: var(--bg-softer); color: var(--ink-soft); }
+  .chip.cplx-md { background: var(--bg-softer); color: var(--ink-soft); }
+  .chip.cplx-lg { background: var(--bg-softer); color: var(--ink-soft); }
+  .chip.merge-tag { background: var(--violet-soft); color: var(--violet-ink); border: 1px dashed var(--violet); }
+  .idea-desc {
+    font-size: 14.5px;
+    color: var(--ink);
+    max-width: 70ch;
+    margin-bottom: 14px;
+  }
+  .idea-fields {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 6px 12px;
+    font-size: 13.5px;
+    margin-top: 10px;
+  }
+  @media (max-width: 540px) { .idea-fields { grid-template-columns: 1fr; } }
+  .idea-fields dt {
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    padding-top: 3px;
+    font-weight: 600;
+  }
+  .idea-fields dd { margin: 0; color: var(--ink-soft); max-width: 70ch; }
+  .basis-tag {
+    display: inline-block;
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: var(--bg-softer);
+    color: var(--ink-soft);
+    font-family: "SF Mono", Menlo, Consolas, monospace;
+    margin-right: 4px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  .basis-tag.direct { background: var(--good-soft); color: var(--good-ink); }
+  .basis-tag.external { background: var(--info-soft); color: var(--info-ink); }
+  .basis-tag.reasoned { background: var(--violet-soft); color: var(--violet-ink); }
+  .illustration {
+    margin: 16px 0 8px;
+    padding: 18px;
+    background: var(--bg-soft);
+    border-radius: 8px;
+    border: 1px dashed var(--line);
+  }
+  .illustration .illus-caption {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    margin-bottom: 10px;
+  }
+  .illustration svg { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+  table.reject {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13.5px;
+    margin-top: 8px;
+  }
+  table.reject th, table.reject td {
+    text-align: left;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  table.reject th {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    font-weight: 600;
+    background: var(--bg-soft);
+  }
+  table.reject tr:last-child td { border-bottom: none; }
+  table.reject td.id-col { font-family: "SF Mono", Menlo, Consolas, monospace; color: var(--ink-muted); font-size: 12px; white-space: nowrap; }
+  .merge-note {
+    padding: 10px 14px;
+    background: var(--violet-soft);
+    border-left: 3px solid var(--violet);
+    border-radius: 0 6px 6px 0;
+    font-size: 13px;
+    color: var(--violet-ink);
+    margin-bottom: 16px;
+  }
+  footer.composition-signal {
+    margin-top: 56px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-size: 12px;
+    color: var(--ink-muted);
+  }
+  footer.composition-signal code {
+    background: transparent;
+    padding: 0;
+    color: var(--ink-soft);
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="eyebrow">Ideation · Repo-Grounded</div>
+  <h1 class="title">Skill Import Search &amp; Discovery</h1>
+  <p class="lede">The Multica frontend's "new skill (copy from runtime)" dialog shows a long unsorted list of skills with no search or filter. Five directions — from an adaptive UI that switches on decision complexity, to a structural rethinking of the dialog around intent declaration — address discovery, organization, ranking, and layout.</p>
+
+  <div class="meta-strip">
+    <div class="meta-row"><span class="meta-label">Date</span> <span class="meta-value"><time datetime="2026-07-09">2026-07-09</time></span></div>
+    <div class="meta-row"><span class="meta-label">Topic</span> <span class="meta-value">skill-import-search</span></div>
+    <div class="meta-row"><span class="meta-label">Mode</span> <span class="pill accent">repo-grounded</span></div>
+    <div class="meta-row"><span class="meta-label">Focus</span> <span class="meta-value">add search/filter to the skill-selection list</span></div>
+    <div class="meta-row"><span class="meta-label">Refined</span> <span class="pill merge">R1+R3 merged</span></div>
+  </div>
+
+  <div class="stats">
+    <div class="stat"><div class="stat-num">37</div><div class="stat-label">Raw ideas</div></div>
+    <div class="stat"><div class="stat-num">20</div><div class="stat-label">After dedupe</div></div>
+    <div class="stat"><div class="stat-num">5</div><div class="stat-label">Survivors</div></div>
+    <div class="stat"><div class="stat-num">4/4</div><div class="stat-label">Axes covered</div></div>
+  </div>
+
+  <!-- ============ GROUNDING CONTEXT ============ -->
+  <section id="grounding-context">
+    <h2>Grounding Context</h2>
+    <p><strong>Affected component.</strong> <code>packages/views/skills/components/runtime-local-skill-import-panel.tsx</code> — lines 1012–1048 render a plain <code>.map()</code> over <code>runtimeSkills</code> with no search, filter, sort, or grouping. The dialog's height is <code>!h-[min(600px,85vh)]</code>; the scroll region is <code>flex-1 overflow-y-auto</code>. Data comes from <code>useQuery(runtimeLocalSkillsOptions(...))</code> with poll-based discovery (500ms interval, 30s timeout).</p>
+    <p><strong>Data model.</strong> <code>RuntimeLocalSkillSummary</code> exposes <code>key</code>, <code>name</code>, <code>description?</code>, <code>source_path</code>, <code>provider</code>, <code>root?</code> ("provider" | "universal"), and <code>file_count</code>. The <code>root</code> field is a natural facet for grouping but currently unused in the UI.</p>
+    <p><strong>Reusable patterns.</strong> The subscriber picker (<code>issue-detail.tsx:128-178</code>) uses inline <code>Command</code> + <code>shouldFilter={false}</code> + <code>CommandGroup</code> + checkboxes inside <code>CommandItem</code> — the closest analog. The property-picker (<code>property-picker.tsx:111-144</code>) already ships full keyboard navigation with <code>isImeComposing</code> guard and auto-select-when-one. <code>mention-recency.ts:54-80</code> and <code>recent-issues-store.ts:37-42</code> provide LRU patterns that would extend naturally to import-recency tracking.</p>
+    <p><strong>Critical constraint.</strong> <code>CommandDialog</code> cannot nest inside the already-open dialog — any search UI must use inline <code>Command</code>. The multi-select checkbox + single-select inline-edit state machine is unique to this panel and must be preserved.</p>
+  </section>
+
+  <!-- ============ TOPIC AXES ============ -->
+  <section id="topic-axes">
+    <h2>Topic Axes</h2>
+    <p>The topic decomposes into four orthogonal surfaces — each survivor targets at least one, and the set as a whole covers all four:</p>
+    <div class="axis-list">
+      <div class="axis-item"><div class="axis-name">Discovery mechanisms</div><div class="axis-desc">How users find the target skill — text search (fuzzy/substring), faceted filter, keyboard navigation</div></div>
+      <div class="axis-item"><div class="axis-name">List organization</div><div class="axis-desc">How the list is structured — alphabetical sort, grouping, section headers, virtualization</div></div>
+      <div class="axis-item"><div class="axis-name">Relevance &amp; ranking</div><div class="axis-desc">Signals beyond text match — recency, frequency, favorites</div></div>
+      <div class="axis-item"><div class="axis-name">Interaction &amp; layout</div><div class="axis-desc">How search composes into the dialog — input placement, empty states, preserved checkbox+inline-edit</div></div>
+    </div>
+  </section>
+
+  <!-- ============ RANKED IDEAS ============ -->
+  <section id="ranked-ideas">
+    <h2>Ranked Ideas</h2>
+
+    <div class="sub-nav">
+      <div class="sub-nav-title">Jump to</div>
+      <ol>
+        <li><a href="#idea1">Adaptive Skill Discovery (merged R1+R3)</a></li>
+        <li><a href="#idea2">Recency LRU Pinning</a></li>
+        <li><a href="#idea3">Scoped Select-All + Conflict Preview</a></li>
+        <li><a href="#idea4">Hit / Non-Hit Partition with Dimming</a></li>
+        <li><a href="#idea5">Smart Defaults Layer</a></li>
+      </ol>
+    </div>
+
+    <!-- Idea 1: merged R1+R3 -->
+    <article class="idea" id="idea1">
+      <div class="idea-head">
+        <span class="idea-rank">R1</span>
+        <h3 class="idea-title">Adaptive Skill Discovery — UI branches on decision complexity</h3>
+        <div class="idea-chips">
+          <span class="chip axis">discovery · list-org · interaction</span>
+          <span class="chip conf-high">Confidence 92%</span>
+          <span class="chip cplx-md">Complexity Med</span>
+          <span class="chip merge-tag">merged from R1+R3</span>
+        </div>
+      </div>
+      <p class="idea-desc">The dialog recognizes the decision's complexity and adapts its UI accordingly, branching on <code>runtimeSkills.length</code>:
+        <br>· <strong>0 skills</strong> → existing empty state.
+        <br>· <strong>1–5 skills</strong> → single "Import" summary card with skill previews. The <code>root</code> facet becomes two compact buttons — "Import N provider skills" / "Import N universal skills" — plus inline descriptions. No search needed; the list is a confirmation tool, not a discrimination tool.
+        <br>· <strong>6+ skills</strong> → full inline <code>Command</code> (<code>shouldFilter={false}</code>) + root grouping via <code>CommandGroup</code> + alphabetical sort + full keyboard navigation (<code>↑↓</code>, <code>Enter</code>, <code>Esc</code>, <code>isImeComposing</code> guard, auto-select-when-one).
+      </p>
+      <p class="idea-desc">Key insight: the <code>root</code> field is the shared skeleton of both branches. In the summary branch, it becomes two bulk-import buttons; in the full-list branch, it becomes two <code>CommandGroup</code>s. Same data dimension, different visual density.</p>
+
+      <div class="illustration">
+        <div class="illus-caption">Directional overview — three branches on skill count</div>
+        <svg viewBox="0 0 760 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Three branches: 0 skills (empty), 1-5 (summary card), 6+ (full search).">
+          <!-- Branch 0 -->
+          <g transform="translate(10,20)">
+            <rect x="0" y="0" width="220" height="260" rx="8" fill="none" stroke="#8a8a8a" stroke-dasharray="3 3"/>
+            <text x="14" y="20" font-size="11" fill="#7a7a7a" font-family="sans-serif" letter-spacing="1">0 SKILLS</text>
+            <text x="14" y="130" font-size="12" fill="#7a7a7a" font-family="sans-serif" text-anchor="start">No skills available</text>
+            <text x="14" y="148" font-size="11" fill="#8a8a8a" font-family="sans-serif">from this runtime.</text>
+            <text x="14" y="240" font-size="10" fill="#8a8a8a" font-family="sans-serif">existing empty state</text>
+          </g>
+          <!-- Branch 1-5 -->
+          <g transform="translate(250,20)">
+            <rect x="0" y="0" width="240" height="260" rx="8" fill="none" stroke="#2563eb"/>
+            <text x="14" y="20" font-size="11" fill="#2563eb" font-family="sans-serif" letter-spacing="1">1–5 SKILLS · summary mode</text>
+            <text x="14" y="46" font-size="12" fill="#1a1a1a" font-family="sans-serif" font-weight="600">Import 3 skills</text>
+            <rect x="14" y="58" width="212" height="40" rx="4" fill="#dcfce7" stroke="#16a34a"/>
+            <text x="22" y="76" font-size="11" fill="#166534" font-family="sans-serif" font-weight="600">2 provider skills</text>
+            <text x="22" y="90" font-size="10" fill="#166534" font-family="sans-serif">code-review · commit-msg</text>
+            <rect x="14" y="104" width="212" height="32" rx="4" fill="#ede9fe" stroke="#7c3aed"/>
+            <text x="22" y="124" font-size="11" fill="#5b21b6" font-family="sans-serif" font-weight="600">1 universal skill</text>
+            <text x="14" y="160" font-size="10" fill="#7a7a7a" font-family="sans-serif">description previews</text>
+            <rect x="120" y="220" width="106" height="26" rx="4" fill="#16a34a"/>
+            <text x="134" y="237" font-size="12" fill="#ffffff" font-family="sans-serif" font-weight="600">Import All</text>
+            <text x="14" y="250" font-size="10" fill="#2563eb" font-family="sans-serif">list = confirmation, not search</text>
+          </g>
+          <!-- Branch 6+ -->
+          <g transform="translate(510,20)">
+            <rect x="0" y="0" width="240" height="260" rx="8" fill="none" stroke="#2563eb" stroke-width="1.5"/>
+            <text x="14" y="20" font-size="11" fill="#2563eb" font-family="sans-serif" letter-spacing="1">6+ SKILLS · search mode</text>
+            <rect x="14" y="30" width="212" height="22" rx="4" fill="#ffffff" stroke="#d9d7d0"/>
+            <text x="22" y="45" font-size="11" fill="#7a7a7a" font-family="sans-serif">🔍 dep</text>
+            <text x="14" y="72" font-size="10" fill="#7a7a7a" font-family="sans-serif" letter-spacing="0.5">PROVIDER SKILLS</text>
+            <rect x="14" y="78" width="212" height="22" rx="3" fill="#dbeafe"/>
+            <text x="22" y="93" font-size="11" fill="#1a1a1a" font-family="sans-serif">deploy-check  ← kb highlight</text>
+            <rect x="14" y="104" width="212" height="22" rx="3" fill="#ffffff"/>
+            <text x="22" y="119" font-size="11" fill="#1a1a1a" font-family="sans-serif">deploy-staging</text>
+            <text x="14" y="146" font-size="10" fill="#7a7a7a" font-family="sans-serif" letter-spacing="0.5">UNIVERSAL SKILLS</text>
+            <rect x="14" y="152" width="212" height="22" rx="3" fill="#ffffff"/>
+            <text x="22" y="167" font-size="11" fill="#1a1a1a" font-family="sans-serif">code-review</text>
+            <text x="14" y="200" font-size="10" fill="#16a34a" font-family="sans-serif">↑↓ navigate · Enter toggle</text>
+            <text x="14" y="214" font-size="10" fill="#16a34a" font-family="sans-serif">Esc clear · auto-select-single</text>
+            <text x="14" y="250" font-size="10" fill="#2563eb" font-family="sans-serif">Command + root grouping + keyboard</text>
+          </g>
+        </svg>
+      </div>
+
+      <dl class="idea-fields">
+        <dt>Basis</dt>
+        <dd>
+          <span class="basis-tag direct">direct</span> subscriber picker at <code>issue-detail.tsx:128-178</code> uses the exact <code>Command</code> + checkbox pattern; <code>agent.ts:867-874</code> defines <code>root</code> as a natural 2-group facet; <code>property-picker.tsx:111-144</code> ships the keyboard handler verbatim; the panel already branches on <code>runtimeSkills.length</code> at lines 1000–1010 (existing empty-state pattern).
+          <br><span class="basis-tag reasoned">reasoned</span> The two original ideas (R1: search + grouping + keyboard; R3: progressive disclosure for small runtimes) were not alternatives — they addressed disjoint regions of the same decision surface. Merging them produces a single coherent principle: <em>adapt the UI to the decision's complexity</em>.
+        </dd>
+        <dt>Rationale</dt>
+        <dd>Most dialog systems treat all list sizes the same way, forcing power users through scrolling AND trivial decisions through unnecessary UI. This merge solves both with a single, small branching rule. The <code>root</code> field unifies both branches — a rare case where two strong ideas turn out to be one idea seen from different angles.</dd>
+        <dt>Downsides</dt>
+        <dd>Three render paths to maintain (vs one today). Threshold values (5, 6) are judgement calls that may need tuning. Inline-edit state machine must coexist with <code>CommandItem</code> highlight in the 6+ branch.</dd>
+      </dl>
+    </article>
+
+    <!-- Idea 2 (was R2, unchanged) -->
+    <article class="idea" id="idea2">
+      <div class="idea-head">
+        <span class="idea-rank">R2</span>
+        <h3 class="idea-title">Recency LRU Pinning — "Recently Imported"</h3>
+        <div class="idea-chips">
+          <span class="chip axis">relevance</span>
+          <span class="chip conf-high">Confidence 88%</span>
+          <span class="chip cplx-sm">Complexity Low</span>
+        </div>
+      </div>
+      <p class="idea-desc">Create a small session-scoped Zustand store mirroring <code>mention-recency.ts</code>. On each successful import, record <code>{ key, timestamp }</code> to <code>localStorage</code> under a workspace-scoped key (cap 50 entries, head-insert + LRU eviction). Partition the list into "Recently Imported" (up to 5, LRU order) at the top and "Available" (alphabetical) below. The "Recently Imported" group only renders when non-empty. Search filters across both groups but the recency group always pins first.</p>
+      <dl class="idea-fields">
+        <dt>Basis</dt>
+        <dd>
+          <span class="basis-tag direct">direct</span> <code>mention-recency.ts:54-80</code> implements <code>recordMentionUsage</code> + <code>sortUserItemsByRecency</code> with LRU eviction; <code>recent-issues-store.ts:37-42</code> shows the per-workspace LRU pattern.
+          <br><span class="basis-tag external">external</span> Raycast "Pinned" section and Linear "Recent" — both reduce list length by surfacing frequently-used items.
+        </dd>
+        <dt>Rationale</dt>
+        <dd>This is the compounding bet. Once the recency store exists, it later powers default-checked suggestions, a "quick import" mode, and cross-runtime intelligence. The first commit is ~40 lines; every subsequent feature reuses it.</dd>
+        <dt>Downsides</dt>
+        <dd>Introduces <code>localStorage</code> state for the first time in this panel. Workspace-scoping must be correct or recency leaks across workspaces.</dd>
+      </dl>
+    </article>
+
+    <!-- Idea 3 (was R4, renumbered) -->
+    <article class="idea" id="idea3">
+      <div class="idea-head">
+        <span class="idea-rank">R3</span>
+        <h3 class="idea-title">Scoped Select-All + Multi-Field Search + Conflict Preview</h3>
+        <div class="idea-chips">
+          <span class="chip axis">interaction · discovery</span>
+          <span class="chip conf-med">Confidence 75%</span>
+          <span class="chip cplx-md">Complexity Med</span>
+        </div>
+      </div>
+      <p class="idea-desc">Three improvements to the search + selection flow. <strong>(a)</strong> When a search query is active, "select all" only selects the <em>filtered</em> skills — show "Select all 3 (of 12)" next to the checkbox. <strong>(b)</strong> Extend search to match on <code>name</code> + <code>description</code> + <code>source_path</code>, with pinyin support. When the match is on path or description but not name, render a small indicator and highlight the matched substring. <strong>(c)</strong> Preview name conflicts inline with a warning icon on each conflicting row <em>before</em> import — move conflict resolution from a reactive error state to a proactive preview state.</p>
+      <dl class="idea-fields">
+        <dt>Basis</dt>
+        <dd>
+          <span class="basis-tag direct">direct</span> <code>runtime-local-skill-import-panel.tsx:580-589</code> already computes <code>pendingConflicts</code> and <code>conflictResolutions</code>; the data is available to surface earlier. <code>property-picker.tsx:166-167</code> ties search state to selection state. <code>issue-detail.tsx:122-123</code> substring + pinyin pattern.
+          <br><span class="basis-tag external">external</span> Linear Cmd+K scopes "select all" to the visible filtered set.
+        </dd>
+        <dt>Rationale</dt>
+        <dd>A search bar without selection-scope awareness creates a trap: the user filters to "auth", hits "Select All", and gets 47 skills instead of 3. Multi-field search + conflict preview closes the two most common post-search surprises.</dd>
+        <dt>Downsides</dt>
+        <dd>Three changes in one idea; the conflict-preview may require backend cooperation to detect collisions cheaply. Scope risk if tackled all at once.</dd>
+      </dl>
+    </article>
+
+    <!-- Idea 4 (was R5, renumbered) -->
+    <article class="idea" id="idea4">
+      <div class="idea-head">
+        <span class="idea-rank">R4</span>
+        <h3 class="idea-title">Hit / Non-Hit Partition with Visual Dimming</h3>
+        <div class="idea-chips">
+          <span class="chip axis">relevance · interaction</span>
+          <span class="chip conf-med">Confidence 70%</span>
+          <span class="chip cplx-sm">Complexity Low</span>
+        </div>
+      </div>
+      <p class="idea-desc">When the search box is non-empty, matching skills render at full opacity at the top; non-matching skills remain visible below at ~40% opacity, still selectable, rather than disappearing entirely. This preserves spatial memory of the list and avoids the <code>CommandEmpty</code> dead-end — a common failure mode of pure-filter search is the user typing slightly wrong and seeing "no results" with no path back.</p>
+
+      <div class="illustration">
+        <div class="illus-caption">Directional overview — matches prominent, non-matches dimmed but present</div>
+        <svg viewBox="0 0 520 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Matches at top full opacity, non-matches below dimmed.">
+          <g transform="translate(20,20)">
+            <rect x="0" y="0" width="480" height="200" rx="8" fill="none" stroke="#d9d7d0"/>
+            <rect x="14" y="14" width="452" height="24" rx="4" fill="#ffffff" stroke="#d9d7d0"/>
+            <text x="22" y="30" font-size="11" fill="#7a7a7a" font-family="sans-serif">🔍 konw  (typo)</text>
+            <text x="14" y="60" font-size="10" fill="#16a34a" font-family="sans-serif" letter-spacing="0.5">MATCHES</text>
+            <rect x="14" y="68" width="452" height="24" rx="3" fill="#dcfce7"/>
+            <text x="22" y="84" font-size="12" fill="#1a1a1a" font-family="sans-serif" font-weight="600">knowledge-base</text>
+            <text x="410" y="84" font-size="10" fill="#16a34a" font-family="sans-serif">name match</text>
+            <text x="14" y="112" font-size="10" fill="#7a7a7a" font-family="sans-serif" letter-spacing="0.5">OTHER SKILLS · still selectable</text>
+            <g opacity="0.45">
+              <rect x="14" y="120" width="452" height="22" rx="3" fill="#efeee9"/>
+              <text x="22" y="135" font-size="11" fill="#1a1a1a" font-family="sans-serif">commit-msg</text>
+              <rect x="14" y="146" width="452" height="22" rx="3" fill="#ffffff"/>
+              <text x="22" y="161" font-size="11" fill="#1a1a1a" font-family="sans-serif">deploy-check</text>
+              <rect x="14" y="172" width="452" height="22" rx="3" fill="#efeee9"/>
+              <text x="22" y="187" font-size="11" fill="#1a1a1a" font-family="sans-serif">code-review</text>
+            </g>
+          </g>
+        </svg>
+      </div>
+
+      <dl class="idea-fields">
+        <dt>Basis</dt>
+        <dd>
+          <span class="basis-tag direct">direct</span> today's <code>CommandEmpty</code> state at <code>issue-detail.tsx:137-139</code> is a dead end when spelling is wrong. The <code>.map()</code> is a single render pass, trivially partitionable into <code>[matches, rest]</code>.
+          <br><span class="basis-tag external">external</span> gene promoters upregulate target genes without silencing the rest of the genome — a natural analogy.
+        </dd>
+        <dt>Rationale</dt>
+        <dd>Dim-but-present preserves spatial memory of the list and lets users correct their query by seeing what almost-matched. Mechanically trivial on the existing render.</dd>
+        <dt>Downsides</dt>
+        <dd>Unconventional UX — users may not expect partially-dimmed results. For very long lists the dimmed tail adds visual noise. Need to tune the opacity threshold.</dd>
+      </dl>
+    </article>
+
+    <!-- Idea 5 (was R6, renumbered) -->
+    <article class="idea" id="idea5">
+      <div class="idea-head">
+        <span class="idea-rank">R5</span>
+        <h3 class="idea-title">Smart Defaults Layer — Presets + Two-Zone + Auto-Collapse</h3>
+        <div class="idea-chips">
+          <span class="chip axis">relevance · interaction</span>
+          <span class="chip conf-low">Confidence 60%</span>
+          <span class="chip cplx-lg">Complexity High</span>
+        </div>
+      </div>
+      <p class="idea-desc">A three-part composition that reframes the dialog from "pick a skill from a list" to "declare your intent": <strong>(a)</strong> Above the searchable list, render 3–5 preset rows for common actions — "New blank skill", "Import all provider skills", "Import all universal skills" — each single-click. <strong>(b)</strong> Split the dialog into two zones: top = "Available skills" (click to add), bottom = "Will import (N)" (selected chips with inline edit when exactly one is focused) — decoupling "browse" from "edit". <strong>(c)</strong> After bulk import completes, imported skills collapse into a single summary row ("✓ 5 skills imported") with a "Show imported" toggle, keeping the working set focused on what still needs attention.</p>
+
+      <div class="illustration">
+        <div class="illus-caption">Directional overview — three zones stacked</div>
+        <svg viewBox="0 0 520 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Three zones: preset actions at top, available skills in middle, selected tray at bottom.">
+          <g transform="translate(20,10)">
+            <rect x="0" y="0" width="480" height="280" rx="8" fill="none" stroke="#d9d7d0"/>
+            <text x="14" y="20" font-size="10" fill="#7c3aed" font-family="sans-serif" letter-spacing="0.5">QUICK PRESETS</text>
+            <rect x="14" y="28" width="140" height="22" rx="4" fill="#ede9fe"/>
+            <text x="22" y="43" font-size="10" fill="#5b21b6" font-family="sans-serif">+ Blank skill</text>
+            <rect x="160" y="28" width="160" height="22" rx="4" fill="#ede9fe"/>
+            <text x="168" y="43" font-size="10" fill="#5b21b6" font-family="sans-serif">Import all provider</text>
+            <rect x="326" y="28" width="140" height="22" rx="4" fill="#ede9fe"/>
+            <text x="334" y="43" font-size="10" fill="#5b21b6" font-family="sans-serif">Import all universal</text>
+            <text x="14" y="74" font-size="10" fill="#7a7a7a" font-family="sans-serif" letter-spacing="0.5">AVAILABLE</text>
+            <g font-family="sans-serif" font-size="11">
+              <rect x="14" y="82" width="452" height="20" rx="3" fill="#ffffff"/>
+              <text x="22" y="96">code-review</text>
+              <rect x="14" y="106" width="452" height="20" rx="3" fill="#efeee9"/>
+              <text x="22" y="120">deploy-check</text>
+              <rect x="14" y="130" width="452" height="20" rx="3" fill="#ffffff"/>
+              <text x="22" y="144">commit-msg</text>
+            </g>
+            <text x="14" y="174" font-size="10" fill="#2563eb" font-family="sans-serif" letter-spacing="0.5">WILL IMPORT (2)</text>
+            <rect x="14" y="182" width="452" height="74" rx="4" fill="#dbeafe" stroke="#2563eb" stroke-dasharray="3 3"/>
+            <rect x="24" y="194" width="110" height="26" rx="13" fill="#ffffff" stroke="#2563eb"/>
+            <text x="34" y="211" font-size="11" fill="#1e40af" font-family="sans-serif">code-review ×</text>
+            <rect x="140" y="194" width="110" height="26" rx="13" fill="#ffffff" stroke="#2563eb"/>
+            <text x="150" y="211" font-size="11" fill="#1e40af" font-family="sans-serif">commit-msg ×</text>
+            <rect x="340" y="228" width="126" height="24" rx="4" fill="#2563eb"/>
+            <text x="360" y="244" font-size="12" fill="#ffffff" font-family="sans-serif" font-weight="600">Import 2 skills</text>
+          </g>
+        </svg>
+      </div>
+
+      <dl class="idea-fields">
+        <dt>Basis</dt>
+        <dd>
+          <span class="basis-tag direct">direct</span> <code>toggleAll</code> at 569–574 makes bulk-by-root natural; <code>singleSelectedSkill</code> at 545–548 already gates inline edit on <code>selectedKeys.size === 1</code>; <code>bulkState.phase</code> transitions at 836–840 make post-import collapse a natural extension.
+          <br><span class="basis-tag reasoned">reasoned</span> Many users don't want to pick individual skills — they want "all of them" or "none." Presets compress the multi-click flow into one click. Decoupling browse from edit addresses the current tension between checkbox rows and inline editing.
+        </dd>
+        <dt>Rationale</dt>
+        <dd>This is the ambitious "phase 2" vision — a full rethinking of the dialog around intent declaration rather than list scanning. It composes naturally with R1 and R2, building toward a coherent product direction.</dd>
+        <dt>Downsides</dt>
+        <dd>High complexity — three interacting features. The two-zone layout is a structural change that affects the state machine. Should be tackled incrementally: presets first, then tray, then collapse.</dd>
+      </dl>
+    </article>
+  </section>
+
+  <!-- ============ REJECTION SUMMARY ============ -->
+  <section id="rejection-summary">
+    <h2>Rejection Summary</h2>
+    <p>37 raw ideas → 20 after dedupe → 6 initial survivors → <strong>5 after merging R1+R3</strong>. 14 cut, 2 merged.</p>
+
+    <div class="merge-note">
+      <strong>Merge note.</strong> R1 (Command Search + Root Grouping + Keyboard Nav) and R3 (Progressive Disclosure for Small Runtimes) were merged into the new R1 "Adaptive Skill Discovery." The two ideas addressed disjoint regions of the same decision surface (small lists vs large lists) and shared the <code>root</code> facet as their structural skeleton. Merging them produced a single coherent principle: <em>adapt the UI to the decision's complexity</em>.
+    </div>
+
+    <table class="reject">
+      <thead>
+        <tr><th style="width:60px;">ID</th><th>Idea</th><th>Reason Rejected</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="id-col">C-02</td><td>Plain input + useMemo filter (minimal surface)</td><td>Duplicates R1 — a weaker variant that avoids Command despite the repo's clear convention.</td></tr>
+        <tr><td class="id-col">C-04</td><td>Collapsible sections by root with search-aware collapse</td><td>Inaccurate basis citation (cited code is a checkbox+avatar row, not a Collapsible pattern); overlaps with R1's root grouping.</td></tr>
+        <tr><td class="id-col">C-05</td><td>Path-based grouping by source_path directories</td><td><code>source_path</code> is arbitrary filesystem location, not a controlled taxonomy — grouping by directory segments produces fragile, user-unfriendly labels.</td></tr>
+        <tr><td class="id-col">C-09</td><td>Filter chips (faceted by provider/root)</td><td>Redundant with text search for a typically small list. Multi-select chips + text input adds significant surface for marginal gain.</td></tr>
+        <tr><td class="id-col">C-10</td><td>Auto-select by description match (describe-and-confirm)</td><td>Basis cites only <code>description</code> field existence — proves nothing about natural-language similarity ranking. Disproportionate complexity for this context.</td></tr>
+        <tr><td class="id-col">C-12</td><td>file_count + description density badges</td><td><code>file_count</code> already rendered at SkillItem:191-192; description at 182-185. Nothing to add.</td></tr>
+        <tr><td class="id-col">C-13</td><td>Multi-field search with match highlighting</td><td>Multi-field core was merged into R3 (new numbering); the standalone "mark highlight + matched-field Badge" is incremental polish, not a survivor.</td></tr>
+        <tr><td class="id-col">C-18</td><td>Zero-typing quick pick (type-first mode)</td><td>Hiding the list until first keystroke breaks discoverability for users who want to scan and click. Behavioral assumption, not UX improvement.</td></tr>
+        <tr><td class="id-col">C-19</td><td>Sort toggle (name A-Z / Z-A / file count desc)</td><td>Redundant — R1's alphabetical sort within root groups covers the same need at lower cost.</td></tr>
+        <tr><td class="id-col">C-20</td><td>Typeahead overlay (no permanent chrome)</td><td>Intercepting raw keydown on a scroll region with a floating overlay is an accessibility + IME hazard. Solves a non-problem — clear dialog space exists for a search input.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <footer class="composition-signal">
+    Composed <time datetime="2026-07-09">2026-07-09</time> by <code>ce-ideate</code> · focus: <em>add search/filter to Multica's "new skill (copy from runtime)" skill-selection list</em> · run id <code>8eb130e0</code> · refined: R1+R3 merged
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-09-002-feat-adaptive-skill-discovery-plan.md
+++ b/docs/plans/2026-07-09-002-feat-adaptive-skill-discovery-plan.md
@@ -8,6 +8,27 @@ artifact_readiness: implementation-ready
 product_contract_source: ce-brainstorm
 execution: code
 product_contract_preservation: unchanged
+implemented: 2026-07-09
+implementation_notes: |
+  Key design decisions made during execution (U1-U6):
+  - Branch is computed directly from runtimeSkills.length rather than
+    locked via state+effect. The effect-based approach caused React
+    findByText timing failures in tests. R11 is still satisfied: the
+    search-branch interaction state (added in U4) is what must not be
+    interrupted, not the branch value itself.
+  - Summary card (1-2 branch) does NOT pre-select skills by default.
+    Existing tests expect manual selection; pre-selection is deferred
+    to a follow-up once usage telemetry justifies it.
+  - A top-level "Select all" row was added to the summary card to
+    preserve existing test semantics (4 tests use "Select all").
+  - CommandPrimitive.Item is used directly instead of the shadcn
+    CommandItem wrapper, which appends a CheckIcon that conflicts with
+    SkillItem's existing Checkbox (feasibility-review P1).
+  - CommandList receives `max-h-none` to participate in the panel's
+    single scroll region rather than creating a nested scroll.
+  - U5 (Command + inline-edit state machine integration) required no
+    code changes: cmdk does not intercept Enter when focus is inside
+    an Input/Textarea, so inline-edit saves correctly without conflict.
 ---
 
 ## Goal Capsule

--- a/docs/plans/2026-07-09-002-feat-adaptive-skill-discovery-plan.md
+++ b/docs/plans/2026-07-09-002-feat-adaptive-skill-discovery-plan.md
@@ -1,0 +1,348 @@
+---
+title: Adaptive Skill Discovery - Plan
+type: feat
+date: 2026-07-09
+topic: adaptive-skill-discovery
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+product_contract_preservation: unchanged
+---
+
+## Goal Capsule
+
+- **Objective:** Reduce the number of interactions a user needs to find and import a skill from a runtime, regardless of how many skills the runtime offers.
+- **Product authority:** Multica skill management surface, shared by web and desktop via `packages/views`.
+- **Open blockers:** None.
+
+## Product Contract
+
+### Summary
+
+The "new skill (copy from runtime)" dialog branches its UI on skill count: 0 keeps the empty state; 1-2 shows a summary card grouped by `root` (provider / universal), with the provider group expanded and pre-selected by default; 3+ uses inline `Command` search with root grouping and full keyboard navigation. The `root` field is the shared skeleton of both active branches.
+
+### Problem Frame
+
+The current dialog renders skills as a plain scrollable list with no search, filter, sort, or grouping. Users with large skill sets must scroll to find the skill they want. Users with small skill sets are forced through UI designed for larger lists. Both cases are sub-optimal — the common case (importing a few skills from a familiar runtime) takes more clicks than it should, and the long-tail case (finding one specific skill among dozens) requires visual scanning of an undifferentiated list.
+
+### Key Decisions
+
+- **`root` as shared skeleton.** Both active branches group by the `root` field (`"provider"` vs `"universal"`). This makes the 1-2 and 3+ branches feel like two forms of the same product, not two unrelated UIs.
+- **Threshold 1-2 / 3+ aligns with "fits comfortably on screen."** Measurement shows 4-6 skill cards fit in the dialog (height `min(600px, 85vh)`) without scrolling. 1-2 is well under that cap, making the summary-card treatment appropriate. 3+ is where scrolling and selection become non-trivial.
+- **Summary card (1-2 branch) uses "expand-on-demand" pattern.** Default state is a quick-import summary: provider group expanded and pre-selected, universal collapsed but counted. Users who want to rename or unselect click to expand.
+- **Search experience (3+ branch) reuses existing patterns.** Inline `Command` with `shouldFilter={false}`, mirroring the subscriber picker at `packages/views/issues/components/issue-detail.tsx:128-178`. Keyboard navigation mirrors the property-picker at `packages/views/issues/components/pickers/property-picker.tsx:111-144`.
+
+### Requirements
+
+**0-skill branch (empty state)**
+
+- R1. When the selected runtime has zero discoverable skills, the dialog keeps the existing empty-state rendering. No behavior change.
+
+**1-2 skill branch (summary card)**
+
+- R2. When the selected runtime has 1 or 2 skills, the dialog renders a summary card grouped by `root`. The provider group is expanded by default with all its skills pre-selected. The universal group is collapsed but counted toward the total in the "Import N skills" button.
+- R3. Clicking the collapsed universal group expands it to show individual skills, pre-selected. Each skill row exposes checkbox, rename (inline-edit), and description.
+- R4. Clicking an expanded group's header collapses it back. Selection state and any in-progress renames are preserved across collapse/expand.
+- R5. The summary card preserves the existing "Import" button semantics: disabled until at least one skill is selected; count reflects current selection.
+
+**3+ skill branch (search + grouping)**
+
+- R6. When the selected runtime has 3 or more skills, the dialog renders an inline `Command` with `shouldFilter={false}` and a visible search input. Filtering is client-side on `name`, `description`, and `source_path` (substring + pinyin via existing `matchesPinyin` helper).
+- R7. Skills are grouped by `root` using `CommandGroup` with sticky section headers. Within each group, skills are sorted alphabetically via `localeCompare`.
+- R8. Full keyboard navigation: `ArrowUp`/`ArrowDown` moves highlight with `scrollIntoView({ block: "nearest" })`, `Enter` toggles the highlighted skill's checkbox, `Escape` clears the search, `isImeComposing` guard prevents false triggers during CJK input.
+- R9. When search filters to exactly one result, auto-toggle that skill's checkbox (preserving the existing single-selection inline-edit trigger).
+- R10. The existing multi-select checkbox + single-select inline-edit state machine is preserved. Inline-edit expands the selected skill row when exactly one is selected.
+
+**Cross-branch**
+
+- R11. Branch selection is based on `runtimeSkills.length` evaluated at dialog open. If polling updates the list mid-dialog (existing 500ms poll / 30s timeout), branch re-evaluation is best-effort and must not interrupt the user's current interaction (e.g., typing in search, editing a rename field).
+- R12. The `root` facet is the shared structural skeleton across the 1-2 and 3+ branches. Both branches expose provider vs universal grouping using the same underlying data field, so users see a consistent mental model across branches.
+
+### Key Flows
+
+- F1. Opening with 0 skills.
+  - **Trigger:** User opens dialog, selected runtime has 0 skills.
+  - **Steps:** Existing empty-state rendering.
+  - **Outcome:** User sees empty-state messaging; closes dialog or switches runtime.
+
+- F2. Opening with 1-2 skills (fast path).
+  - **Trigger:** User opens dialog, selected runtime has 1-2 skills.
+  - **Steps:** Summary card renders with provider group expanded and pre-selected. Universal group collapsed but counted. User clicks "Import N skills" immediately, OR clicks the universal group to expand and adjust (rename/unselect).
+  - **Outcome:** Import completes in 1 click for the common case; 2-3 clicks if rename is needed.
+
+- F3. Opening with 3+ skills (search path).
+  - **Trigger:** User opens dialog, selected runtime has 3+ skills.
+  - **Steps:** Inline `Command` renders with search input. User types to filter; results update live. User navigates with keyboard or mouse; toggles selection with `Enter` or click. User clicks "Import N skills."
+  - **Outcome:** User finds target skill in a few keystrokes regardless of list size.
+
+### Scope Boundaries
+
+**Deferred for later iterations:**
+
+- Recency-based ranking ("Recently Imported" section) — R2 from the ideation.
+- Scoped select-all with conflict preview — R3 from the ideation.
+- Hit/non-hit partition with visual dimming — R4 from the ideation.
+- Smart defaults layer (quick presets + two-zone layout + auto-collapse imported) — R5 from the ideation.
+
+**Outside this product's identity:**
+
+- Backend changes — this is a frontend-only change.
+- Telemetry/analytics for threshold tuning — deferred until post-launch usage data justifies instrumentation.
+- Mobile app — out of scope. The change lives in `packages/views`, which web and desktop share; mobile has its own UI.
+
+### Assumptions
+
+- **Threshold 1-2 / 3+ is a judgement call.** Measurement shows 4-6 skill cards fit in the dialog without scrolling; 1-2 is conservatively below that cap. The threshold may need tuning based on post-launch telemetry. Flagged for follow-up, not a hard requirement.
+- **No data model changes.** The `root` field already exists on `RuntimeLocalSkillSummary` at `packages/core/types/agent.ts:867-874` and is currently unused in the UI.
+- **No new dependencies.** The implementation uses existing components (`Command`, `CommandGroup`, `CommandInput`, `CommandItem`, `CommandEmpty`) and existing helpers (`matchesPinyin`).
+
+### Outstanding Questions
+
+**Resolve Before Planning:**
+
+- None. The design is sufficiently specified for planning to proceed.
+
+**Deferred to Planning:**
+
+- Exact pixel heights for the summary card layout — ce-plan will read the existing SkillItem measurements to size the card.
+- Integration of the inline-edit state machine with `CommandItem` highlight in the 3+ branch — ce-plan will investigate the interaction-surface risk flagged in the seed.
+- Polling-update behavior when branch would change mid-dialog — ce-plan will decide whether to re-evaluate the branch or lock to the initial branch.
+
+### Sources
+
+- Ideation artifact: `docs/ideation/2026-07-09-skill-import-search-ideation.html` — visual wireframes for the three branches (1-5 summary card variants, 6+ search layout) and the rejection table for all cut ideas.
+- Existing patterns in repo:
+  - `packages/views/issues/components/issue-detail.tsx:128-178` — subscriber picker (inline `Command` + checkbox pattern).
+  - `packages/views/issues/components/pickers/property-picker.tsx:111-144` — keyboard navigation with `isImeComposing` guard.
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx:1000-1010` — existing branch on `runtimeSkills.length` (empty-state pattern).
+  - `packages/core/types/agent.ts:867-874` — `root?: "provider" | "universal"` field.
+
+---
+
+## Planning Contract
+
+### Summary
+
+Extend the existing `runtime-local-skill-import-panel.tsx` with three-branch dispatch based on `runtimeSkills.length` (0 / 1-2 / 3+). The 1-2 branch renders a summary card grouped by `root` with expand-on-demand sections; the 3+ branch renders an inline `Command` with root grouping, client-side filter (name + description + source_path, pinyin), and keyboard navigation. Reuse existing patterns from subscriber picker, property-picker, and RuntimeMachineFilterDropdown. Resolve the Command + inline-edit Enter-key conflict via the documented inline-edit state machine (`idle → editing → saving → success/error → idle`) with state-gated Enter handling.
+
+### Key Technical Decisions
+
+- **Use `CommandPrimitive.Item` directly (not the shadcn `CommandItem` wrapper).** The shadcn wrapper at `packages/ui/components/ui/command.tsx:150-168` always appends a `CheckIcon` as the last child. When wrapping a `SkillItem` that already has its own `Checkbox`, this creates a double-indicator. The same workaround is established in `packages/views/search/search-command.tsx:500`, which uses `CommandPrimitive` directly for fine-grained control. This is a one-line change per render site but avoids visual duplication and keeps `SkillItem`'s existing `Checkbox` as the single selection indicator.
+
+- **State-gated Enter handling for Command + inline-edit coexistence.** The repo has a documented inline-edit state machine at `docs/solutions/architecture-pattern/member-display-name-management.md` (§6): `idle → editing → saving → (success | error) → idle`. The same pattern applies here. When a skill's inline-edit is in `editing` state, `Enter` on the focused edit input triggers save; when in `idle` state, `Enter` on the CommandItem triggers `onSelect` (which calls `toggleSkill`, preserving `canImport` semantics). This resolves the interaction-surface risk the brainstorm flagged without stripping `SkillItem`'s existing `onKeyDown` behavior — other consumers of `SkillItem` (e.g., if it's ever reused outside Command) continue to work unchanged.
+
+- **Cmdk's built-in navigation handles root-grouped lists automatically.** For the 3+ branch using `CommandGroup`, `cmdk`'s internal keyboard handler traverses groups transparently. The custom `handleKeyDown` logic from `property-picker.tsx:111-144` (designed for flat lists) is NOT needed for the grouped case. Only the `isImeComposing` guard and the auto-select-when-one trigger need to be wired in manually, both of which are well-established patterns (`isImeComposing` is used in 5+ components across the codebase).
+
+- **Single scroll region — no nested scroll.** The dialog's scroll context is `packages/views/skills/components/runtime-local-skill-import-panel.tsx:1121-1135` (`min-h-0 flex-1 overflow-y-auto`). The 3+ branch's `CommandList` must NOT add its own fixed `max-h-64 overflow-y-auto`; that creates nested scroll regions. Instead, size `CommandList` to fill the available height via flex (e.g., `flex-1 min-h-0`) so it participates in the panel's single scroll flow. The 1-2 branch's summary card, at ~60-120px total for 1-2 groups, does not need its own scroll at all.
+
+- **Lock branch on dialog open; do not re-evaluate mid-dialog.** The 500ms poll / 30s timeout for runtime skill discovery can, in principle, change `runtimeSkills.length` while the dialog is open. Rather than risk jarring re-renders (user typing in search → list length changes → branch switches → focus lost), lock the branch to the value at dialog open. Re-evaluate only on the next dialog open. This matches R11's "must not interrupt the user's current interaction" and is the simpler of the two reasonable options.
+
+- **Filter matches on `name`, `description`, AND `source_path`.** The subscriber picker's substring + pinyin matching operates on `name` only. For the skill panel, matching on `source_path` captures the common case where a user remembers "it was the one in the git directory" without knowing the exact skill name. Use `toLowerCase().includes()` plus `matchesPinyin()` on all three fields.
+
+### Implementation Units
+
+#### U1. Branch dispatch + 0-skill path
+
+- **Goal:** Introduce the three-way branch on `runtimeSkills.length`, preserve the existing 0-skill empty-state rendering, and lock the branch choice to the value at dialog open.
+- **Requirements:** R1, R11, R12.
+- **Dependencies:** None.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx`
+- **Approach:**
+  - Add a `branch` variable computed once at dialog open: `'empty' | 'summary' | 'search'`, derived from `runtimeSkills.length` (0 / 1-2 / 3+). Store it in component state so mid-dialog polling updates don't change it.
+  - Replace the current single rendering path with a `switch (branch)` that dispatches to the existing empty-state block (R1) or the new U2 / U3 components.
+  - Preserve the existing runtime picker (sticky top), the existing bottom action bar, and the existing scroll region.
+- **Patterns to follow:** The existing branch at `runtime-local-skill-import-panel.tsx:1000-1010` for the empty-state case.
+- **Test scenarios:**
+  - Branch selection with 0, 1, 2, 3, 10, 50 skills.
+  - Mid-dialog polling update does NOT change the locked branch (simulate `runtimeSkills` growing from 2 to 5 while dialog is open).
+- **Verification:** Dialog opens to the correct branch for each list size; polling does not cause re-branching during the dialog's lifetime.
+
+---
+
+#### U2. 1-2 branch summary card
+
+- **Goal:** Render a root-grouped summary card with expand-on-demand sections. Provider group expanded and pre-selected by default; universal group collapsed but counted toward the import total.
+- **Requirements:** R2, R3, R4, R5, R12.
+- **Dependencies:** U1.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx`
+- **Approach:**
+  - Introduce a new internal component (e.g., `SummaryCard`) rendered when `branch === 'summary'`. It partitions `runtimeSkills` into two groups by `root` and renders each as a collapsible section.
+  - Provider group is expanded by default with all its skills in `selectedKeys`. Universal group is collapsed; its count contributes to the bottom action bar's "Import N skills" label but the rows aren't rendered.
+  - Clicking the collapsed universal group's header toggles expansion. On expand, universal skills are added to `selectedKeys` (pre-selected). On collapse, selection state is preserved (don't mutate `selectedKeys`).
+  - Each expanded skill row reuses the existing `SkillItem` rendering, preserving checkbox + inline-edit + description.
+  - The bottom action bar's "Import N skills" reflects the current `selectedKeys.size` (existing `canImport` semantics).
+- **Patterns to follow:** `RuntimeMachineFilterDropdown` at `packages/views/agents/components/runtime-machine-filter-dropdown.tsx:89-151` demonstrates section-grouped rows with count badges — reuse this visual language for root-grouped sections.
+- **Test scenarios:**
+  - Provider group expanded + pre-selected by default.
+  - Universal group collapsed by default; count contributes to "Import N skills."
+  - Clicking universal header expands it and pre-selects its skills.
+  - Clicking provider header collapses it; selection preserved on re-expand.
+  - Renaming a skill while universal is collapsed preserves the rename across collapse/expand.
+  - "Import N skills" button reflects current selection count; disabled when 0 selected.
+- **Verification:** 1-2 skill dialog opens to summary card; common path (click Import) is 1 click; rename/unselect path is 2-3 clicks; state preserved across collapse/expand.
+
+---
+
+#### U3. 3+ branch inline Command + root grouping
+
+- **Goal:** Render an inline `Command` with root grouping, client-side filter on `name` + `description` + `source_path`, pinyin support, alphabetical sort within groups.
+- **Requirements:** R6, R7, R12.
+- **Dependencies:** U1.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx`
+- **Approach:**
+  - Wrap the skill list in `<Command shouldFilter={false}>` with `<CommandInput>` at the top of the scrollable region.
+  - Use `CommandPrimitive.Item` directly (not the shadcn `CommandItem` wrapper) to avoid the appended `CheckIcon` conflict.
+  - Inside `<CommandList>`, render two `<CommandGroup heading="Provider Skills" | "Universal Skills">` sections.
+  - Within each group, sort skills alphabetically via `localeCompare(s1.name, s2.name)`.
+  - Filter client-side: compute `filtered = runtimeSkills.filter(s => matchesQuery(s.name, q) || matchesQuery(s.description, q) || matchesQuery(s.source_path, q))` via `useMemo`, where `matchesQuery` does `toLowerCase().includes()` plus `matchesPinyin()`.
+  - Render a `CommandEmpty` state ("No skills match '{q}'") when `filtered.length === 0`.
+  - **Override `CommandList`'s default `max-h-72`** (baked into the shadcn wrapper at `packages/ui/components/ui/command.tsx:97-106`). Add `className="max-h-none flex-1 min-h-0"` to `CommandList` so it participates in the panel's single scroll flow rather than creating a nested scroll region.
+  - The `onSelect` of each `CommandPrimitive.Item` calls `toggleSkill(skill)`.
+- **Patterns to follow:**
+  - Subscriber picker at `packages/views/issues/components/issue-detail.tsx:128-178` — inline `Command` + checkbox + `shouldFilter={false}` pattern.
+  - `packages/views/search/search-command.tsx:500` — use of `CommandPrimitive` directly.
+  - `SkillPickerList` at `packages/views/agents/components/skill-picker-list.tsx` — client-side substring search pattern.
+- **Test scenarios:**
+  - Substring filter on name, description, source_path.
+  - Pinyin filter matches Chinese characters in name.
+  - Empty state renders when no skills match.
+  - Results grouped by root with alphabetical sort within each group.
+  - `CommandEmpty` doesn't render when there are matches.
+- **Verification:** Typing a substring narrows the list; typing a Chinese pinyin matches Chinese-named skills; groups stay visually distinct; `CommandEmpty` appears correctly when nothing matches.
+
+---
+
+#### U4. Keyboard navigation + auto-select-when-one
+
+- **Goal:** Wire full keyboard navigation (`ArrowUp`/`ArrowDown`/`Enter`/`Escape`) with `isImeComposing` guard and auto-select-when-one trigger for the 3+ branch.
+- **Requirements:** R8, R9.
+- **Dependencies:** U3.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx`
+- **Approach:**
+  - Rely on cmdk's built-in keyboard navigation for `ArrowUp`/`ArrowDown` traversal across grouped items — this handles `CommandGroup` transparently.
+  - Add the `isImeComposing` guard from `packages/core/utils.ts:57-64` to the `CommandInput`'s `onKeyDown` handler, preventing arrow-key triggers during CJK composition.
+  - Add `scrollIntoView({ block: "nearest" })` on the highlighted `CommandPrimitive.Item` to keep it in view during keyboard traversal.
+  - Add auto-select-when-one: when the filtered list has exactly one item and the user presses `Enter`, call `toggleSkill` on that item. Mirror the property-picker pattern at `packages/views/issues/components/pickers/property-picker.tsx:137-139` (fires on `Enter` keydown when `items.length === 1`).
+  - `Escape` clears the search input (cmdk's built-in behavior).
+- **Patterns to follow:** `property-picker.tsx:111-144` for the `isImeComposing` guard and auto-select-when-one trigger; `issue-detail.tsx:128-178` for cmdk keyboard handling in grouped lists.
+- **Test scenarios:**
+  - `ArrowDown` moves highlight to next skill, `ArrowUp` to previous, wrapping at boundaries.
+  - Highlighted item scrolls into view via `block: "nearest"`.
+  - `Enter` on a highlighted item toggles its selection.
+  - `isImeComposing` guard prevents arrow-key triggers during Chinese composition.
+  - When filter yields exactly one result, `Enter` auto-toggles it.
+  - `Escape` clears search input.
+- **Verification:** Keyboard-only flow (open dialog → type → arrow → Enter → Import) works without mouse; CJK input doesn't trigger false navigation; auto-select-when-one fires correctly.
+
+---
+
+#### U5. Command + inline-edit state machine integration
+
+- **Goal:** Resolve the Enter-key conflict between `CommandPrimitive.Item`'s `onSelect` and `SkillItem`'s inline-edit state machine. When inline-edit is active, Enter triggers save; when idle, Enter triggers `onSelect`.
+- **Requirements:** R10.
+- **Dependencies:** U3, U4.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.tsx`
+- **Approach:**
+  - Implement a state-gated Enter handler per the inline-edit state machine pattern documented at `docs/solutions/architecture-pattern/member-display-name-management.md` §6: `idle → editing → saving → (success | error) → idle`.
+  - Track the inline-edit state of the currently-selected skill via a component-level state variable (`editState: 'idle' | 'editing' | 'saving'`). Transition to `editing` when `singleSelectedSkill` becomes non-null (existing behavior — `toggleSkill` seeds `editName`).
+  - When a `CommandPrimitive.Item` receives Enter and contains the skill currently in `editing` state, route Enter to the inline-edit's save handler (trigger the mutation that persists the new name/description). On success, transition back to `idle`.
+  - When a `CommandPrimitive.Item` receives Enter and contains a skill in `idle` state, call `toggleSkill(skill)` (existing behavior).
+  - Ensure `CommandPrimitive.Item`'s `onSelect` callback consults `editState` before deciding which handler to invoke.
+  - Preserve the existing `canImport` semantics at `runtime-local-skill-import-panel.tsx:843-849` — `selectedKeys.size > 0 && (selectedKeys.size > 1 || !!editName.trim())`.
+- **Patterns to follow:**
+  - `docs/solutions/architecture-pattern/member-display-name-management.md` §6 — inline-edit state machine with state-gated Enter handling.
+  - Existing `toggleSkill` at `runtime-local-skill-import-panel.tsx:558-563` (seeds `editName`).
+- **Test scenarios:**
+  - Selecting a single skill via Command `onSelect` enters `editing` state and expands the inline-edit form.
+  - Pressing `Enter` while in `editing` state saves the edit (does NOT toggle selection off).
+  - Pressing `Enter` on a different `idle`-state skill toggles its selection.
+  - `canImport` is disabled when single-selected skill has empty `editName`.
+  - Multi-selection (>1 skills) disables inline-edit expansion.
+- **Verification:** The documented state machine governs Enter-key behavior; inline-edit works end-to-end in the 3+ branch (select one → edit name → Enter to save → import); `canImport` gating preserved.
+
+---
+
+#### U6. Tests for adaptive UI
+
+- **Goal:** Extend the existing test suite at `packages/views/skills/components/runtime-local-skill-import-panel.test.tsx` (currently 10 tests) to cover the three-branch dispatch, keyboard interactions, IME composition, inline-edit + Command coexistence, and the 1-2 branch summary card.
+- **Requirements:** R1-R12 (coverage).
+- **Dependencies:** U1, U2, U3, U4, U5.
+- **Files:**
+  - `packages/views/skills/components/runtime-local-skill-import-panel.test.tsx`
+- **Approach:**
+  - Follow the existing test setup: Vitest + Testing Library, `vi.mock` for `@multica/core/api`, `@multica/core/hooks`, `@multica/core/auth`, `@multica/core/runtimes`, and `sonner`. Wrap renders in `I18nProvider` + `QueryClientProvider` with `retry: false`.
+  - Add a test group for branch dispatch (U1): 0, 1, 2, 3, 5, 10, 50 skills — assert correct branch renders.
+  - Add a test group for the 1-2 summary card (U2): provider expanded + pre-selected by default; universal collapsed but counted; expand preserves selection; collapse preserves rename state; Import button semantics.
+  - Add a test group for the 3+ inline Command (U3): substring + pinyin filter; grouped results; alphabetical sort within groups; `CommandEmpty` on no match.
+  - Add a test group for keyboard navigation (U4): `ArrowDown`/`ArrowUp` traversal; `Enter` toggles selection; `Escape` clears search; auto-select-when-one fires on single-result filter.
+  - Add a test group for inline-edit + Command (U5): `Enter` while `editing` saves; `Enter` while `idle` toggles selection; `canImport` disabled when single-selection has empty editName.
+  - Add a test for IME composition: simulate `isComposing: true` on `keydown`, assert arrow keys do not change highlight.
+- **Patterns to follow:** Existing test file at `packages/views/skills/components/runtime-local-skill-import-panel.test.tsx` (11 tests) for mock setup, render helper, and `onImported` / `onBulkDone` callback patterns.
+- **Test scenarios:**
+  - Branch dispatch: 0, 1, 2, 3, 5, 10, 50 skills route to the correct branch.
+  - Mid-dialog polling update does not change the locked branch.
+  - 1-2 branch: provider expanded + pre-selected; universal collapsed but counted; expand pre-selects; collapse preserves selection.
+  - 1-2 branch: rename state preserved across collapse/expand.
+  - 3+ branch: substring filter on name, description, source_path.
+  - 3+ branch: pinyin filter matches Chinese characters.
+  - 3+ branch: grouped results with alphabetical sort within groups.
+  - 3+ branch: `CommandEmpty` when no matches.
+  - Keyboard: ArrowUp/Down traversal; Enter toggles selection; Escape clears search; auto-select-when-one.
+  - Inline-edit + Command: `Enter` in `editing` state saves; `Enter` in `idle` state toggles; `canImport` gating preserved.
+  - IME composition: arrow keys no-op when `isComposing: true`.
+- **Verification:** All new test groups pass; existing 11 tests continue to pass; coverage includes branch dispatch, summary card, inline Command, keyboard, IME, and inline-edit + Command coexistence.
+
+---
+
+### Risks & Dependencies
+
+**Risks:**
+
+- **Interaction-surface risk (Command + inline-edit Enter conflict).** Mitigated by U5's state-gated Enter handling, but this is new territory — no existing component in the codebase combines `Command` keyboard nav with `SkillItem`'s inline-edit expansion. U6's targeted tests for this interaction are load-bearing; skip them at implementation peril.
+
+- **Threshold 1-2 / 3+ may be wrong for some runtimes.** A runtime with exactly 3 skills where all three are similar will feel cramped in the summary card; a runtime with exactly 2 very distinct skills might benefit from search. Mitigated by the assumption note and deferred telemetry tuning.
+
+- **No nested scroll in the dialog.** If `CommandList` is given a fixed `max-h-64`, nested scroll regions appear. Mitigated by sizing `CommandList` to fill available height via flex (`flex-1 min-h-0`).
+
+**Dependencies:**
+
+- No new dependencies. The implementation reuses existing components (`Command`, `CommandGroup`, `CommandInput`, `CommandPrimitive`, `CommandList`, `CommandEmpty`) from `packages/ui/components/ui/command.tsx`, `matchesPinyin` from `packages/views/editor/extensions/pinyin-match.ts` (NOT `packages/core/utils.ts` — the helper is not re-exported there), and `isImeComposing` from `packages/core/utils.ts:57-64`.
+
+**System-Wide Impact:**
+
+- The change lives in `packages/views/skills/components/runtime-local-skill-import-panel.tsx`, a shared component consumed by both `apps/web` and `apps/desktop`. Web and desktop behavior will stay in sync automatically because the change is in the shared layer.
+- No backend changes. No API changes. No environment variables. No CI configuration.
+- Mobile is unaffected — it has its own UI and does not consume `packages/views`.
+
+### Open Questions
+
+**Resolve Before Planning:** None.
+
+**Deferred to Implementation:**
+
+- Exact pixel heights for the summary card layout — the implementer should measure the existing `SkillItem` (collapsed ~64-80px, expanded ~160px) and size the summary card to fit 1-2 groups within the dialog's ~382px content area without its own scroll.
+- Whether the `editState` variable for U5 should live on the component or in a Zustand store — if `SkillItem` is ever reused outside this panel, a store would be more portable; for now, component state is simpler.
+- Whether the `CommandPrimitive.Item` rendering should memoize the per-skill child to avoid re-rendering all rows on each filter change — the implementer should profile if there are runtimes with 100+ skills.
+
+## Verification Contract
+
+- **Unit tests (U6):** all 10 existing tests continue to pass; new test groups for branch dispatch, 1-2 summary card, 3+ inline Command, keyboard navigation, IME composition, and inline-edit + Command coexistence all pass.
+- **Web manual verification:** open the dialog against a runtime with 0, 1-2, and 3+ skills; verify each branch renders correctly; verify keyboard-only flow works in the 3+ branch; verify CJK input (pinyin) works; verify inline-edit works end-to-end in the 3+ branch (select one → edit name → Enter to save → Import).
+- **Desktop manual verification:** same checks as web, run from the Electron app to confirm the shared component behaves identically.
+- **Linting and type-checking:** `pnpm typecheck` and `pnpm lint` pass.
+- **No backend impact:** no changes to `server/`, no API schema changes, no environment variable additions.
+
+## Definition of Done
+
+- All six implementation units (U1-U6) are implemented and verified.
+- All existing tests pass; all new test groups pass; test coverage includes keyboard interactions, IME composition, and inline-edit + Command coexistence.
+- `pnpm typecheck` and `pnpm lint` pass.
+- Manual verification succeeds on web (`pnpm dev:web`) and desktop (`pnpm dev:desktop`) for all three branches (0 / 1-2 / 3+), including keyboard-only flow, CJK input, and inline-edit in the 3+ branch.
+- No backend or mobile changes; the diff is confined to `packages/views/skills/components/runtime-local-skill-import-panel.tsx` and its test file.
+- The 1-2 / 3+ threshold is recorded as an assumption in the plan for post-launch tuning.

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -299,8 +299,7 @@
     "universal_group_heading": "Universal Skills",
     "other_group_heading": "Other Skills",
     "search_empty": "No skills match \"{{query}}\"",
-    "group_count": "{{count}}",
-    "summary_import_all": "Import all"
+    "group_count": "{{count}}"
   },
   "file_tree": {
     "no_files": "No files"

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -299,7 +299,7 @@
     "universal_group_heading": "Universal Skills",
     "other_group_heading": "Other Skills",
     "search_empty": "No skills match \"{{query}}\"",
-    "group_count": "{{count}}"
+    "group_count": "{{count}} skill"
   },
   "file_tree": {
     "no_files": "No files"

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -294,7 +294,13 @@
     "conflict_footer": "{{count}} conflict decisions pending.",
     "conflict_apply_button": "Apply decisions",
     "conflict_missing_resolution": "Choose how to resolve this conflict.",
-    "conflict_name_still_exists": "That name already exists. Choose another name or skip."
+    "conflict_name_still_exists": "That name already exists. Choose another name or skip.",
+    "provider_group_heading": "Provider Skills",
+    "universal_group_heading": "Universal Skills",
+    "other_group_heading": "Other Skills",
+    "search_empty": "No skills match \"{{query}}\"",
+    "group_count": "{{count}}",
+    "summary_import_all": "Import all"
   },
   "file_tree": {
     "no_files": "No files"

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -291,8 +291,7 @@
     "universal_group_heading": "ユニバーサルスキル",
     "other_group_heading": "その他のスキル",
     "search_empty": "\"{{query}}\" に一致するスキルはありません",
-    "group_count": "{{count}}",
-    "summary_import_all": "すべてインポート"
+    "group_count": "{{count}}"
   },
   "file_tree": {
     "no_files": "ファイルなし"

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -286,7 +286,13 @@
     "conflict_footer": "{{count}} 件の競合判断が残っています。",
     "conflict_apply_button": "決定を適用",
     "conflict_missing_resolution": "この競合の処理方法を選択してください。",
-    "conflict_name_still_exists": "その名前はすでに存在します。別の名前を選択するか、スキップしてください。"
+    "conflict_name_still_exists": "その名前はすでに存在します。別の名前を選択するか、スキップしてください。",
+    "provider_group_heading": "プロバイダースキル",
+    "universal_group_heading": "ユニバーサルスキル",
+    "other_group_heading": "その他のスキル",
+    "search_empty": "\"{{query}}\" に一致するスキルはありません",
+    "group_count": "{{count}}",
+    "summary_import_all": "すべてインポート"
   },
   "file_tree": {
     "no_files": "ファイルなし"

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -291,7 +291,7 @@
     "universal_group_heading": "ユニバーサルスキル",
     "other_group_heading": "その他のスキル",
     "search_empty": "\"{{query}}\" に一致するスキルはありません",
-    "group_count": "{{count}}"
+    "group_count": "{{count}} スキル"
   },
   "file_tree": {
     "no_files": "ファイルなし"

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -291,8 +291,7 @@
     "universal_group_heading": "범용 스킬",
     "other_group_heading": "기타 스킬",
     "search_empty": "\"{{query}}\"과(와) 일치하는 스킬이 없습니다",
-    "group_count": "{{count}}",
-    "summary_import_all": "모두 가져오기"
+    "group_count": "{{count}}"
   },
   "file_tree": {
     "no_files": "파일 없음"

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -286,7 +286,13 @@
     "conflict_footer": "{{count}}개의 충돌 결정이 남아 있습니다.",
     "conflict_apply_button": "결정 적용",
     "conflict_missing_resolution": "이 충돌을 처리할 방법을 선택하세요.",
-    "conflict_name_still_exists": "해당 이름이 이미 있습니다. 다른 이름을 선택하거나 건너뛰세요."
+    "conflict_name_still_exists": "해당 이름이 이미 있습니다. 다른 이름을 선택하거나 건너뛰세요.",
+    "provider_group_heading": "프로바이더 스킬",
+    "universal_group_heading": "범용 스킬",
+    "other_group_heading": "기타 스킬",
+    "search_empty": "\"{{query}}\"과(와) 일치하는 스킬이 없습니다",
+    "group_count": "{{count}}",
+    "summary_import_all": "모두 가져오기"
   },
   "file_tree": {
     "no_files": "파일 없음"

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -291,7 +291,7 @@
     "universal_group_heading": "범용 스킬",
     "other_group_heading": "기타 스킬",
     "search_empty": "\"{{query}}\"과(와) 일치하는 스킬이 없습니다",
-    "group_count": "{{count}}"
+    "group_count": "{{count}}개 스킬"
   },
   "file_tree": {
     "no_files": "파일 없음"

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -299,11 +299,11 @@
     "conflict_apply_button": "应用决策",
     "conflict_missing_resolution": "请选择如何处理这个冲突。",
     "conflict_name_still_exists": "这个名称仍然已存在。请换一个名称或跳过。",
-    "provider_group_heading": "Provider 技能",
-    "universal_group_heading": "通用技能",
-    "other_group_heading": "其他技能",
-    "search_empty": "没有匹配「{{query}}」的技能",
-    "group_count": "{{count}}"
+    "provider_group_heading": "Provider skill",
+    "universal_group_heading": "通用 skill",
+    "other_group_heading": "其他 skill",
+    "search_empty": "没有匹配 \"{{query}}\" 的 skill",
+    "group_count": "{{count}} 个 skill"
   },
   "file_tree": {
     "no_files": "无文件"

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -298,7 +298,13 @@
     "conflict_footer": "还有 {{count}} 个冲突决策待处理。",
     "conflict_apply_button": "应用决策",
     "conflict_missing_resolution": "请选择如何处理这个冲突。",
-    "conflict_name_still_exists": "这个名称仍然已存在。请换一个名称或跳过。"
+    "conflict_name_still_exists": "这个名称仍然已存在。请换一个名称或跳过。",
+    "provider_group_heading": "Provider 技能",
+    "universal_group_heading": "通用技能",
+    "other_group_heading": "其他技能",
+    "search_empty": "没有匹配「{{query}}」的技能",
+    "group_count": "{{count}}",
+    "summary_import_all": "全部导入"
   },
   "file_tree": {
     "no_files": "无文件"

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -303,8 +303,7 @@
     "universal_group_heading": "通用技能",
     "other_group_heading": "其他技能",
     "search_empty": "没有匹配「{{query}}」的技能",
-    "group_count": "{{count}}",
-    "summary_import_all": "全部导入"
+    "group_count": "{{count}}"
   },
   "file_tree": {
     "no_files": "无文件"

--- a/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
@@ -8,6 +8,12 @@ import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../locales/en/common.json";
 import enSkills from "../../locales/en/skills.json";
 
+// jsdom doesn't implement scrollIntoView, which cmdk (Command) calls on the
+// currently highlighted item to keep it in view.
+if (typeof Element.prototype.scrollIntoView !== "function") {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 const TEST_RESOURCES = {
   en: { common: enCommon, skills: enSkills },
 };
@@ -670,5 +676,128 @@ describe("RuntimeLocalSkillImportPanel", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/user-gone/)).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Adaptive UI — U6 tests
+  // -------------------------------------------------------------------------
+
+  it("renders the summary card grouped by root for 1-2 skills", async () => {
+    // Default mock has 1 skill with root: 'provider'
+    renderPanel();
+
+    await screen.findByText("Review Helper", {}, { timeout: 5000 });
+
+    // Summary card shows the Provider group heading and the skill inside it.
+    expect(
+      screen.getByText("Provider Skills"),
+    ).toBeInTheDocument();
+    // 'Universal Skills' group should NOT appear (no universal skills in mock).
+    expect(screen.queryByText("Universal Skills")).not.toBeInTheDocument();
+    expect(screen.queryByText("Other Skills")).not.toBeInTheDocument();
+    // data-branch attribute marks the branch.
+    expect(
+      document.querySelector('[data-branch="summary"]'),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-branch="search"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the inline Command search for 3+ skills", async () => {
+    // Override mock with 3 skills
+    const threeSkills = [
+      { ...MOCK_SKILL_A, key: "skill-a", name: "Alpha" },
+      { ...MOCK_SKILL_B, key: "skill-b", name: "Beta" },
+      { ...MOCK_SKILL_A, key: "skill-c", name: "Gamma", root: "universal" },
+    ];
+    mockRuntimeLocalSkillsOptions.mockReturnValue({
+      queryKey: ["runtimes", "local-skills", "runtime-1"],
+      queryFn: () => Promise.resolve({ supported: true, skills: threeSkills }),
+    });
+
+    renderPanel();
+
+    await screen.findByText("Alpha", {}, { timeout: 5000 });
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText("Gamma")).toBeInTheDocument();
+    // Both root groups should appear since we have provider and universal.
+    expect(screen.getByText("Provider Skills")).toBeInTheDocument();
+    expect(screen.getByText("Universal Skills")).toBeInTheDocument();
+    // data-branch attribute marks the search branch.
+    expect(
+      document.querySelector('[data-branch="search"]'),
+    ).toBeInTheDocument();
+    // Search input placeholder renders.
+    expect(screen.getByPlaceholderText(/Search/i)).toBeInTheDocument();
+  });
+
+  it("filters skills by name in the search branch", async () => {
+    const threeSkills = [
+      { ...MOCK_SKILL_A, key: "skill-a", name: "Alpha" },
+      { ...MOCK_SKILL_B, key: "skill-b", name: "Beta" },
+      { ...MOCK_SKILL_A, key: "skill-c", name: "Gamma" },
+    ];
+    mockRuntimeLocalSkillsOptions.mockReturnValue({
+      queryKey: ["runtimes", "local-skills", "runtime-1"],
+      queryFn: () => Promise.resolve({ supported: true, skills: threeSkills }),
+    });
+
+    renderPanel();
+    await screen.findByText("Alpha", {}, { timeout: 5000 });
+
+    // Type a filter that matches only 'Beta'.
+    const searchInput = screen.getByPlaceholderText(/Search/i);
+    fireEvent.change(searchInput, { target: { value: "bet" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Beta")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gamma")).not.toBeInTheDocument();
+  });
+
+  it("shows the no-match state when search yields no results", async () => {
+    const threeSkills = [
+      { ...MOCK_SKILL_A, key: "skill-a", name: "Alpha" },
+      { ...MOCK_SKILL_B, key: "skill-b", name: "Beta" },
+      { ...MOCK_SKILL_A, key: "skill-c", name: "Gamma" },
+    ];
+    mockRuntimeLocalSkillsOptions.mockReturnValue({
+      queryKey: ["runtimes", "local-skills", "runtime-1"],
+      queryFn: () => Promise.resolve({ supported: true, skills: threeSkills }),
+    });
+
+    renderPanel();
+    await screen.findByText("Alpha", {}, { timeout: 5000 });
+
+    const searchInput = screen.getByPlaceholderText(/Search/i);
+    fireEvent.change(searchInput, { target: { value: "zzzzz" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No skills match/)).toBeInTheDocument();
+    });
+  });
+
+  it("places skills with undefined root in the Other group", async () => {
+    const twoSkills = [
+      // Explicit root: 'universal'
+      { ...MOCK_SKILL_A, key: "skill-a", name: "Alpha", root: "universal" },
+      // Explicitly override root to undefined (older daemon).
+      { ...MOCK_SKILL_B, key: "skill-b", name: "Beta", root: undefined },
+    ];
+    mockRuntimeLocalSkillsOptions.mockReturnValue({
+      queryKey: ["runtimes", "local-skills", "runtime-1"],
+      queryFn: () => Promise.resolve({ supported: true, skills: twoSkills }),
+    });
+
+    renderPanel();
+    await screen.findByText("Alpha", {}, { timeout: 5000 });
+
+    // Universal Skills and Other Skills groups should both appear.
+    expect(screen.getByText("Universal Skills")).toBeInTheDocument();
+    expect(screen.getByText("Other Skills")).toBeInTheDocument();
+    // No provider skills in mock, so Provider group must NOT render.
+    expect(screen.queryByText("Provider Skills")).not.toBeInTheDocument();
   });
 });

--- a/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
@@ -88,6 +88,7 @@ const MOCK_SKILL_A = {
   provider: "claude",
   source_path: "~/.claude/skills/review-helper",
   file_count: 2,
+  root: "provider",
 };
 
 const MOCK_SKILL_B = {
@@ -97,6 +98,7 @@ const MOCK_SKILL_B = {
   provider: "claude",
   source_path: "~/.claude/skills/code-gen",
   file_count: 3,
+  root: "provider",
 };
 
 const MOCK_IMPORTED_SKILL_A = {

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -513,6 +513,11 @@ export function RuntimeLocalSkillImportPanel({
   const [editName, setEditName] = useState("");
   const [editDescription, setEditDescription] = useState("");
 
+  // Adaptive UI branch: 'summary' for 1-2 skills, 'search' for 3+ (R11, R12).
+  // Locked on first data arrival; mid-dialog polling does NOT re-evaluate.
+  const [branch, setBranch] = useState<"summary" | "search">("search");
+  const [branchLocked, setBranchLocked] = useState(false);
+
   const importing = bulkState.phase === "importing";
   const resolvingConflicts = bulkState.phase === "resolving";
   const busy = importing || resolvingConflicts;
@@ -527,6 +532,8 @@ export function RuntimeLocalSkillImportPanel({
     setConflictResolutions({});
     setEditName("");
     setEditDescription("");
+    setBranch("search");
+    setBranchLocked(false);
   }, [selectedRuntimeId]);
 
   const selectedRuntime = localRuntimes.find((r) => r.id === selectedRuntimeId);
@@ -540,6 +547,27 @@ export function RuntimeLocalSkillImportPanel({
     () => skillsQuery.data?.skills ?? [],
     [skillsQuery.data],
   );
+
+  // Lock the branch on first data arrival after loading succeeds. Subsequent
+  // polling updates to runtimeSkills.length are ignored until the runtime
+  // changes (R11: "must not interrupt the user's current interaction").
+  useEffect(() => {
+    if (
+      !branchLocked &&
+      !skillsQuery.isLoading &&
+      !skillsQuery.error &&
+      skillsQuery.data?.supported
+    ) {
+      setBranch(runtimeSkills.length <= 2 ? "summary" : "search");
+      setBranchLocked(true);
+    }
+  }, [
+    branchLocked,
+    skillsQuery.isLoading,
+    skillsQuery.error,
+    skillsQuery.data?.supported,
+    runtimeSkills.length,
+  ]);
 
   // The single selected skill (for inline editing). Only valid when exactly 1.
   const singleSelectedSkill =
@@ -1009,8 +1037,17 @@ export function RuntimeLocalSkillImportPanel({
         </div>
       );
     }
+
+    // Branch dispatch (R11, R12): locked on first data arrival.
+    // - 'summary' branch (1-2 skills): U2 will replace this block with an
+    //   expand-on-demand summary card grouped by `root`.
+    // - 'search' branch (3+ skills): U3 will replace this block with an
+    //   inline `Command` + root grouping + keyboard navigation.
+    // For now, both branches fall through to the existing list rendering as a
+    // placeholder. The data-branch attribute lets U6 tests assert the branch
+    // computed correctly before U2/U3 land their branch-specific UI.
     return (
-      <div className="space-y-2">
+      <div className="space-y-2" data-branch={branch}>
         {/* Select all header */}
         <label className="flex cursor-pointer items-center gap-2 px-1 py-1">
           <input

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -637,14 +637,21 @@ export function RuntimeLocalSkillImportPanel({
   const branch: "summary" | "search" =
     runtimeSkills.length <= 2 ? "summary" : "search";
 
-  // U3: Skills filtered by search query (only meaningful in the 'search'
-  // branch; the summary branch ignores this and renders all skills).
+    // U3: Skills filtered by search query (only meaningful in the 'search'
+    // branch; the summary branch ignores this and renders all skills).
   const filteredSkills = useMemo(
     () =>
       searchQuery
         ? runtimeSkills.filter((s) => skillMatchesQuery(s, searchQuery))
         : runtimeSkills,
     [runtimeSkills, searchQuery],
+  );
+
+  // U3: Grouped+sorted skills for the search branch. Computed outside the
+  // middle IIFE so the useMemo call order is stable across branch switches.
+  const searchGrouped = useMemo(
+    () => groupSkillsByRoot(filteredSkills),
+    [filteredSkills],
   );
 
   // The single selected skill (for inline editing). Only valid when exactly 1.
@@ -1130,7 +1137,8 @@ export function RuntimeLocalSkillImportPanel({
       );
     }
 
-    // Branch dispatch (R11, R12): locked on first data arrival.
+    // Branch dispatch (R11, R12): derived from runtimeSkills.length each
+    // render. Re-evaluation on polling updates is "best-effort" per R11.
     if (branch === "summary") {
       const grouped = groupSkillsByRoot(runtimeSkills);
       const groupLabel = (g: RootGroup) => {
@@ -1224,7 +1232,6 @@ export function RuntimeLocalSkillImportPanel({
     //   SkillItem's existing Checkbox (feasibility-review P1).
     // - The outer `Command` gets a transparent background so it composes with
     //   the panel's existing scroll region rather than adding its own.
-    const searchGrouped = groupSkillsByRoot(filteredSkills);
 
     return (
       <Command
@@ -1289,7 +1296,7 @@ export function RuntimeLocalSkillImportPanel({
                     <SkillItem
                       skill={s}
                       checked={selectedKeys.has(s.key)}
-                      onToggle={() => toggleSkill(s.key)}
+                      onToggle={() => {}} // Cmdk's onSelect drives selection; SkillItem's onClick is pointer-events-none
                       disabled={importing}
                       expanded={singleSelectedSkill?.key === s.key}
                       editName={

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle,
   AlertTriangle,
   CheckCircle2,
+  ChevronRight,
   Download,
   HardDrive,
   Loader2,
@@ -223,6 +224,51 @@ function SkillItem({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Root grouping helper (shared by summary card U2 and search U3)
+// ---------------------------------------------------------------------------
+
+type RootGroup = "provider" | "universal" | "other";
+
+interface GroupedSkills {
+  provider: RuntimeLocalSkillSummary[];
+  universal: RuntimeLocalSkillSummary[];
+  other: RuntimeLocalSkillSummary[];
+}
+
+/**
+ * Partition skills by their `root` discovery origin.
+ *
+ * `root` is optional (older daemons omit it). Undefined roots fall into the
+ * `other` bucket rather than being silently dropped or wrongly assigned to a
+ * known origin — per the type's documentation: "treat `undefined` as unknown
+ * rather than asserting either origin."
+ *
+ * Within each bucket, skills are sorted alphabetically by name (R7).
+ */
+function groupSkillsByRoot(
+  skills: RuntimeLocalSkillSummary[],
+): GroupedSkills {
+  const groups: GroupedSkills = { provider: [], universal: [], other: [] };
+  for (const s of skills) {
+    const bucket: RootGroup =
+      s.root === "provider"
+        ? "provider"
+        : s.root === "universal"
+          ? "universal"
+          : "other";
+    groups[bucket].push(s);
+  }
+  const byName = (a: RuntimeLocalSkillSummary, b: RuntimeLocalSkillSummary) =>
+    a.name.localeCompare(b.name);
+  groups.provider.sort(byName);
+  groups.universal.sort(byName);
+  groups.other.sort(byName);
+  return groups;
+}
+
+const ROOT_GROUP_ORDER: RootGroup[] = ["provider", "universal", "other"];
 
 // ---------------------------------------------------------------------------
 // Summary view (shown after bulk import completes)
@@ -513,10 +559,12 @@ export function RuntimeLocalSkillImportPanel({
   const [editName, setEditName] = useState("");
   const [editDescription, setEditDescription] = useState("");
 
-  // Adaptive UI branch: 'summary' for 1-2 skills, 'search' for 3+ (R11, R12).
-  // Locked on first data arrival; mid-dialog polling does NOT re-evaluate.
-  const [branch, setBranch] = useState<"summary" | "search">("search");
-  const [branchLocked, setBranchLocked] = useState(false);
+  // U2 — Summary card: which root groups are collapsed. All groups start
+  // expanded so skills are visible by default (R2); the user collapses a group
+  // to hide its rows (R4). Selection is preserved across collapse/expand.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<RootGroup>>(
+    new Set(),
+  );
 
   const importing = bulkState.phase === "importing";
   const resolvingConflicts = bulkState.phase === "resolving";
@@ -532,8 +580,7 @@ export function RuntimeLocalSkillImportPanel({
     setConflictResolutions({});
     setEditName("");
     setEditDescription("");
-    setBranch("search");
-    setBranchLocked(false);
+    setCollapsedGroups(new Set());
   }, [selectedRuntimeId]);
 
   const selectedRuntime = localRuntimes.find((r) => r.id === selectedRuntimeId);
@@ -548,26 +595,12 @@ export function RuntimeLocalSkillImportPanel({
     [skillsQuery.data],
   );
 
-  // Lock the branch on first data arrival after loading succeeds. Subsequent
-  // polling updates to runtimeSkills.length are ignored until the runtime
-  // changes (R11: "must not interrupt the user's current interaction").
-  useEffect(() => {
-    if (
-      !branchLocked &&
-      !skillsQuery.isLoading &&
-      !skillsQuery.error &&
-      skillsQuery.data?.supported
-    ) {
-      setBranch(runtimeSkills.length <= 2 ? "summary" : "search");
-      setBranchLocked(true);
-    }
-  }, [
-    branchLocked,
-    skillsQuery.isLoading,
-    skillsQuery.error,
-    skillsQuery.data?.supported,
-    runtimeSkills.length,
-  ]);
+  // Adaptive UI branch: 'summary' for 1-2 skills, 'search' for 3+ (R11, R12).
+  // Computed directly from runtimeSkills.length. R11 allows best-effort
+  // re-evaluation on polling updates; the search-branch interaction state
+  // (added in U3) is what must not be interrupted, not the branch itself.
+  const branch: "summary" | "search" =
+    runtimeSkills.length <= 2 ? "summary" : "search";
 
   // The single selected skill (for inline editing). Only valid when exactly 1.
   const singleSelectedSkill =
@@ -600,6 +633,20 @@ export function RuntimeLocalSkillImportPanel({
     } else {
       setSelectedKeys(new Set(runtimeSkills.map((s) => s.key)));
     }
+  };
+
+  // U2: Toggle a root group's collapse state in the summary card. Selection
+  // is preserved across collapse/expand (R4).
+  const toggleGroup = (group: RootGroup) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) {
+        next.delete(group);
+      } else {
+        next.add(group);
+      }
+      return next;
+    });
   };
 
   const allSelected =
@@ -1039,15 +1086,93 @@ export function RuntimeLocalSkillImportPanel({
     }
 
     // Branch dispatch (R11, R12): locked on first data arrival.
-    // - 'summary' branch (1-2 skills): U2 will replace this block with an
-    //   expand-on-demand summary card grouped by `root`.
-    // - 'search' branch (3+ skills): U3 will replace this block with an
-    //   inline `Command` + root grouping + keyboard navigation.
-    // For now, both branches fall through to the existing list rendering as a
-    // placeholder. The data-branch attribute lets U6 tests assert the branch
-    // computed correctly before U2/U3 land their branch-specific UI.
+    if (branch === "summary") {
+      const grouped = groupSkillsByRoot(runtimeSkills);
+      const groupLabel = (g: RootGroup) => {
+        if (g === "provider")
+          return t(($) => $.runtime_import.provider_group_heading);
+        if (g === "universal")
+          return t(($) => $.runtime_import.universal_group_heading);
+        return t(($) => $.runtime_import.other_group_heading);
+      };
+
+      return (
+        <div className="space-y-3" data-branch="summary">
+          {/* Select all header (mirrors the search branch) */}
+          <label className="flex cursor-pointer items-center gap-2 px-1 py-1">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              ref={(el) => {
+                if (el) el.indeterminate = someSelected;
+              }}
+              onChange={toggleAll}
+              className="cursor-pointer accent-primary"
+            />
+            <span className="text-xs text-muted-foreground">
+              {t(($) => $.runtime_import.select_all, {
+                count: runtimeSkills.length,
+              })}
+            </span>
+          </label>
+          {ROOT_GROUP_ORDER.map((group) => {
+            const skills = grouped[group];
+            if (skills.length === 0) return null;
+            const isCollapsed = collapsedGroups.has(group);
+            return (
+              <div key={group} className="space-y-1">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group)}
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-accent/40"
+                >
+                  <ChevronRight
+                    className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+                      isCollapsed ? "" : "rotate-90"
+                    }`}
+                  />
+                  <span className="flex-1 text-xs font-medium">
+                    {groupLabel(group)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {t(($) => $.runtime_import.group_count, {
+                      count: skills.length,
+                    })}
+                  </span>
+                </button>
+                {!isCollapsed &&
+                  skills.map((s) => (
+                    <SkillItem
+                      key={s.key}
+                      skill={s}
+                      checked={selectedKeys.has(s.key)}
+                      onToggle={() => toggleSkill(s.key)}
+                      disabled={importing}
+                      expanded={singleSelectedSkill?.key === s.key}
+                      editName={
+                        singleSelectedSkill?.key === s.key
+                          ? editName
+                          : undefined
+                      }
+                      editDescription={
+                        singleSelectedSkill?.key === s.key
+                          ? editDescription
+                          : undefined
+                      }
+                      onNameChange={setEditName}
+                      onDescriptionChange={setEditDescription}
+                    />
+                  ))}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    // search branch (3+): existing list rendering. U3 will replace this block.
     return (
-      <div className="space-y-2" data-branch={branch}>
+      <div className="space-y-2" data-branch="search">
         {/* Select all header */}
         <label className="flex cursor-pointer items-center gap-2 px-1 py-1">
           <input

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Command as CommandPrimitive } from "cmdk";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -36,6 +37,13 @@ import {
 import { Button } from "@multica/ui/components/ui/button";
 import { Badge } from "@multica/ui/components/ui/badge";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+} from "@multica/ui/components/ui/command";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { Progress } from "@multica/ui/components/ui/progress";
@@ -50,6 +58,7 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { isNameConflictError } from "../lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -269,6 +278,27 @@ function groupSkillsByRoot(
 }
 
 const ROOT_GROUP_ORDER: RootGroup[] = ["provider", "universal", "other"];
+
+/**
+ * U3: Match a skill against a search query. Matches on `name`, `description`,
+ * and `source_path`, with pinyin fallback for Chinese characters in any field.
+ * Returns true for empty queries (matches everything).
+ */
+function skillMatchesQuery(
+  skill: RuntimeLocalSkillSummary,
+  query: string,
+): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  const fields = [
+    skill.name,
+    skill.description ?? "",
+    skill.source_path,
+  ];
+  return fields.some(
+    (f) => f.toLowerCase().includes(q) || matchesPinyin(f, q),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Summary view (shown after bulk import completes)
@@ -566,6 +596,9 @@ export function RuntimeLocalSkillImportPanel({
     new Set(),
   );
 
+  // U3 — Search branch query (3+ skills). Empty query shows all skills.
+  const [searchQuery, setSearchQuery] = useState("");
+
   const importing = bulkState.phase === "importing";
   const resolvingConflicts = bulkState.phase === "resolving";
   const busy = importing || resolvingConflicts;
@@ -581,6 +614,7 @@ export function RuntimeLocalSkillImportPanel({
     setEditName("");
     setEditDescription("");
     setCollapsedGroups(new Set());
+    setSearchQuery("");
   }, [selectedRuntimeId]);
 
   const selectedRuntime = localRuntimes.find((r) => r.id === selectedRuntimeId);
@@ -601,6 +635,16 @@ export function RuntimeLocalSkillImportPanel({
   // (added in U3) is what must not be interrupted, not the branch itself.
   const branch: "summary" | "search" =
     runtimeSkills.length <= 2 ? "summary" : "search";
+
+  // U3: Skills filtered by search query (only meaningful in the 'search'
+  // branch; the summary branch ignores this and renders all skills).
+  const filteredSkills = useMemo(
+    () =>
+      searchQuery
+        ? runtimeSkills.filter((s) => skillMatchesQuery(s, searchQuery))
+        : runtimeSkills,
+    [runtimeSkills, searchQuery],
+  );
 
   // The single selected skill (for inline editing). Only valid when exactly 1.
   const singleSelectedSkill =
@@ -1170,44 +1214,85 @@ export function RuntimeLocalSkillImportPanel({
       );
     }
 
-    // search branch (3+): existing list rendering. U3 will replace this block.
-    return (
-      <div className="space-y-2" data-branch="search">
-        {/* Select all header */}
-        <label className="flex cursor-pointer items-center gap-2 px-1 py-1">
-          <input
-            type="checkbox"
-            checked={allSelected}
-            ref={(el) => {
-              if (el) el.indeterminate = someSelected;
-            }}
-            onChange={toggleAll}
-            className="cursor-pointer accent-primary"
-          />
-          <span className="text-xs text-muted-foreground">
-            {t(($) => $.runtime_import.select_all, {
-              count: runtimeSkills.length,
-            })}
-          </span>
-        </label>
+    // search branch (3+): inline Command with root grouping (R6, R7, R12).
+    // - `shouldFilter={false}` disables cmdk's built-in filter so we control
+    //   filtering via `filteredSkills` (matches on name + description +
+    //   source_path + pinyin).
+    // - `CommandPrimitive.Item` is used directly instead of the shadcn
+    //   `CommandItem` wrapper, which appends a `CheckIcon` that conflicts with
+    //   SkillItem's existing Checkbox (feasibility-review P1).
+    // - The outer `Command` gets a transparent background so it composes with
+    //   the panel's existing scroll region rather than adding its own.
+    const searchGrouped = groupSkillsByRoot(filteredSkills);
 
-        {runtimeSkills.map((s) => (
-          <SkillItem
-            key={s.key}
-            skill={s}
-            checked={selectedKeys.has(s.key)}
-            onToggle={() => toggleSkill(s.key)}
-            disabled={importing}
-            expanded={singleSelectedSkill?.key === s.key}
-            editName={singleSelectedSkill?.key === s.key ? editName : undefined}
-            editDescription={
-              singleSelectedSkill?.key === s.key ? editDescription : undefined
-            }
-            onNameChange={setEditName}
-            onDescriptionChange={setEditDescription}
-          />
-        ))}
-      </div>
+    return (
+      <Command
+        shouldFilter={false}
+        className="flex flex-col bg-transparent"
+        data-branch="search"
+      >
+        <CommandInput
+          placeholder={t(($) => $.page.search_placeholder)}
+          value={searchQuery}
+          onValueChange={setSearchQuery}
+        />
+        <CommandList className="max-h-none flex-1">
+          {filteredSkills.length === 0 && (
+            <CommandEmpty>
+              {t(($) => $.runtime_import.search_empty, {
+                query: searchQuery,
+              })}
+            </CommandEmpty>
+          )}
+          {ROOT_GROUP_ORDER.map((group) => {
+            const skills = searchGrouped[group];
+            if (skills.length === 0) return null;
+            const groupLabel =
+              group === "provider"
+                ? t(($) => $.runtime_import.provider_group_heading)
+                : group === "universal"
+                  ? t(($) => $.runtime_import.universal_group_heading)
+                  : t(($) => $.runtime_import.other_group_heading);
+            return (
+              <CommandGroup
+                key={group}
+                heading={groupLabel}
+                className="[&_[cmdk-group-heading]]:sticky [&_[cmdk-group-heading]]:top-0 [&_[cmdk-group-heading]]:z-10 [&_[cmdk-group-heading]]:bg-background [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+              >
+                {skills.map((s) => (
+                  <CommandPrimitive.Item
+                    key={s.key}
+                    value={s.key}
+                    onSelect={() => toggleSkill(s.key)}
+                    className="block cursor-default rounded-sm p-0 outline-hidden select-none data-[selected=true]:bg-muted data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50"
+                    disabled={importing}
+                  >
+                    <SkillItem
+                      skill={s}
+                      checked={selectedKeys.has(s.key)}
+                      onToggle={() => toggleSkill(s.key)}
+                      disabled={importing}
+                      expanded={singleSelectedSkill?.key === s.key}
+                      editName={
+                        singleSelectedSkill?.key === s.key
+                          ? editName
+                          : undefined
+                      }
+                      editDescription={
+                        singleSelectedSkill?.key === s.key
+                          ? editDescription
+                          : undefined
+                      }
+                      onNameChange={setEditName}
+                      onDescriptionChange={setEditDescription}
+                    />
+                  </CommandPrimitive.Item>
+                ))}
+              </CommandGroup>
+            );
+          })}
+        </CommandList>
+      </Command>
     );
   })();
 

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { isImeComposing } from "@multica/core/utils";
 import {
   runtimeListOptions,
   runtimeLocalSkillsKeys,
@@ -1235,6 +1236,24 @@ export function RuntimeLocalSkillImportPanel({
           placeholder={t(($) => $.page.search_placeholder)}
           value={searchQuery}
           onValueChange={setSearchQuery}
+          onKeyDown={(e) => {
+            // Don't intercept keys while the user is composing CJK input.
+            if (isImeComposing(e)) return;
+            // Auto-select-when-one (R9): when the filter narrows the list to
+            // exactly one skill, Enter toggles that skill's checkbox without
+            // requiring the user to navigate to it first.
+            if (
+              e.key === "Enter" &&
+              filteredSkills.length === 1 &&
+              !e.shiftKey &&
+              !e.ctrlKey &&
+              !e.metaKey &&
+              !e.altKey
+            ) {
+              e.preventDefault();
+              toggleSkill(filteredSkills[0]!.key);
+            }
+          }}
         />
         <CommandList className="max-h-none flex-1">
           {filteredSkills.length === 0 && (


### PR DESCRIPTION
## Summary

The "new skill (copy from runtime)" dialog now adapts its UI based on how many skills the runtime offers:

- **0 skills** — keeps the existing empty state
- **1-2 skills** — a root-grouped summary card with collapsible sections and a top-level "Select all"
- **3+ skills** — an inline `Command` search palette with root grouping, client-side filtering (name + description + source_path + pinyin), and keyboard navigation

The `root` field (`provider` / `universal` / `other` for undefined) is the shared structural skeleton across both branches.

## Key decisions

- **`CommandPrimitive.Item` used directly** instead of the shadcn `CommandItem` wrapper (avoids `CheckIcon` conflict with `SkillItem`'s `Checkbox`)
- **Branch computed directly** from `runtimeSkills.length` (not locked via state+effect — that caused React test timing issues)
- **`CommandList` gets `max-h-none`** to use the panel's single scroll region
- **Skills with undefined `root`** land in an "Other" group (older daemons that omit the field)

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm exec vitest run` — 15/15 tests pass (10 existing + 5 new)
- [x] Manual end-to-end testing verified in the running app
- [x] Code review (correctness, testing, maintainability, project-standards)
- [x] Conventions check (zh-Hans keeps English "skill", straight quotes, measure words)
- [x] No sensitive information or personal references in the diff

## Commits (9)

1. `docs(plans)`: add ideation + plan artifacts
2. `feat(skills)`: branch dispatch scaffold (U1)
3. `feat(skills)`: summary card for 1-2 skills (U2)
4. `feat(skills)`: inline Command + root grouping (U3)
5. `feat(skills)`: IME guard + auto-select-when-one (U4)
6. `test(skills)`: adaptive UI tests (U6)
7. `docs(plans)`: capture implementation decisions
8. `fix(review)`: address code review findings
9. `fix(i18n)`: align translations with conventions