### PR TITLE
fix(i18n): translate Chat sidebar nav to zh-Hans (MUL-4322)

### DIFF
--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -1,6 +1,6 @@
 {
   "page": {
-    "title": "Chat",
+    "title": "聊天",
     "select_prompt": "选择一个对话，或点 + 新建"
   },
   "fab": {

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -1,7 +1,7 @@
 {
   "nav": {
     "inbox": "收件箱",
-    "chat": "Chat",
+    "chat": "聊天",
     "my_issues": "我的 issue",
     "issues": "Issues",
     "projects": "项目",


### PR DESCRIPTION
## What

Sidebar 的 `Chat` 导航项在中文界面下没有翻译（`nav.chat` 在 `zh-Hans/layout.json` 里还是英文 `"Chat"`）。ja / ko 早已翻译（`チャット` / `채팅`），只有 zh-Hans 漏了。

按 `conventions.zh.mdx` 术语表，`Chat` 属于「概念词」（与 `Inbox → 收件箱` 同类，不是 `issue`/`skill` 那种保留英文的实体词），应完整翻译。

## Changes

- `zh-Hans/layout.json` → `nav.chat`: `Chat` → `聊天`（sidebar 导航项，本 issue 直接报告的问题）
- `zh-Hans/chat.json` → `page.title`: `Chat` → `聊天`（sidebar 点进去的页面标题，保持一致）

仅改动 value，未增删 key，locale parity 不受影响。

Closes MUL-4322
