### PR TITLE
fix(i18n): use absolute Chinese time labels

### DIFF
--- a/packages/views/i18n/use-time-ago.test.tsx
+++ b/packages/views/i18n/use-time-ago.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RESOURCES } from "../locales";
+import { useTimeAgo } from "./use-time-ago";
+import type { SupportedLocale } from "@multica/core/i18n";
+
+function wrapperFor(locale: SupportedLocale) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nProvider locale={locale} resources={RESOURCES}>
+        {children}
+      </I18nProvider>
+    );
+  };
+}
+
+describe("useTimeAgo", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps relative timestamps for English", () => {
+    vi.setSystemTime(new Date("2026-05-19T16:30:00"));
+
+    const { result } = renderHook(() => useTimeAgo(), { wrapper: wrapperFor("en") });
+
+    expect(result.current("2026-05-19T14:30:00")).toBe("2h ago");
+  });
+
+  it("uses absolute Chinese date-time labels for Simplified Chinese", () => {
+    vi.setSystemTime(new Date("2026-05-19T16:30:00"));
+
+    const { result } = renderHook(() => useTimeAgo(), {
+      wrapper: wrapperFor("zh-Hans"),
+    });
+
+    expect(result.current("2026-05-19T14:30:00")).toBe("2026年5月19日 14:30");
+  });
+});

--- a/packages/views/i18n/use-time-ago.ts
+++ b/packages/views/i18n/use-time-ago.ts
@@ -1,10 +1,24 @@
 import { useT } from "./use-t";
 
+function formatZhDateTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}年${month}月${day}日 ${hours}:${minutes}`;
+}
+
 // Localized relative-time formatter. Returns a function so call-site usage
 // stays terse: `const timeAgo = useTimeAgo(); ...timeAgo(dateStr)`.
 export function useTimeAgo() {
-  const { t } = useT("common");
+  const { t, i18n } = useT("common");
   return (dateStr: string): string => {
+    if (i18n.language === "zh-Hans") {
+      return formatZhDateTime(dateStr);
+    }
+
     const diff = Date.now() - new Date(dateStr).getTime();
     const minutes = Math.floor(diff / 60000);
     if (minutes < 1) return t(($) => $.time.just_now);


### PR DESCRIPTION
## Summary
- format shared web time labels as absolute yyyy年M月d日 HH:mm values for zh-Hans
- keep existing relative time labels for English and other locales
- add hook coverage for both English and Simplified Chinese behavior

Fixes #5020

## Tests
- pnpm --filter @multica/views exec vitest run i18n/use-time-ago.test.tsx
- pnpm --filter @multica/views exec vitest run i18n/use-time-ago.test.tsx locales/parity.test.ts
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views test
- pnpm --filter @multica/views lint