### PR TITLE
fix(chat): always write assistant anchor row on task completion (#5013)

### DIFF
--- a/server/internal/handler/daemon_chat_prompt_test.go
+++ b/server/internal/handler/daemon_chat_prompt_test.go
@@ -76,6 +76,20 @@ func TestTrailingUserMessages(t *testing.T) {
 			in:   []db.ChatMessage{msg("user", "hi")},
 			want: []string{"hi"},
 		},
+		{
+			// Regression guard for GitHub #5013. A run that completes with empty
+			// output still writes an (empty) assistant anchor row — see
+			// CompleteTask in service/task.go. That advances the anchor so the
+			// next turn only delivers the genuinely new message. If the anchor
+			// row is skipped on empty output, this slice would wrongly include
+			// the already-answered "看上海天气" and re-deliver it to the agent.
+			name: "empty assistant reply still anchors the turn",
+			in: []db.ChatMessage{
+				msg("user", "看上海天气"), msg("assistant", ""),
+				msg("user", "还有青岛"),
+			},
+			want: []string{"还有青岛"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1762,25 +1762,34 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	if task.ChatSessionID.Valid {
 		var assistantMsg *db.ChatMessage
 		var payload protocol.TaskCompletedPayload
-		if err := json.Unmarshal(result, &payload); err == nil && payload.Output != "" {
-			// Same unescape as the issue-comment path above: literal `\n` from
-			// agent stdout becomes a real newline so the chat panel renders
-			// paragraph breaks instead of one wall of prose.
-			body := util.UnescapeBackslashEscapes(payload.Output)
-			row, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
-				ChatSessionID: task.ChatSessionID,
-				Role:          "assistant",
-				Content:       redact.Text(body),
-				TaskID:        task.ID,
-				ElapsedMs:     computeChatElapsedMs(task),
-			})
-			if err != nil {
-				slog.Error("failed to save assistant chat message", "task_id", util.UUIDToString(task.ID), "error", err)
-			} else {
-				assistantMsg = &row
-				// Unread is derived from the read cursor (chat_session.last_read_at)
-				// vs the assistant messages after it — no per-reply stamping needed.
-			}
+		_ = json.Unmarshal(result, &payload)
+		// Always write the assistant row on completion — even when the agent
+		// produced no textual output (tool-only turns, empty final message).
+		// trailingUserMessages (handler/daemon.go) anchors the "already
+		// replied" cursor on the last assistant row and relies on the
+		// invariant that every completed OR failed run writes one. FailTask
+		// already writes unconditionally; gating CompleteTask on a non-empty
+		// output broke the symmetry, so on an empty-output turn the anchor did
+		// not advance and the next run re-delivered the prior turn's user
+		// messages to the resumed session (GitHub #5013).
+		//
+		// Same unescape as the issue-comment path above: literal `\n` from
+		// agent stdout becomes a real newline so the chat panel renders
+		// paragraph breaks instead of one wall of prose.
+		body := util.UnescapeBackslashEscapes(payload.Output)
+		row, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
+			ChatSessionID: task.ChatSessionID,
+			Role:          "assistant",
+			Content:       redact.Text(body),
+			TaskID:        task.ID,
+			ElapsedMs:     computeChatElapsedMs(task),
+		})
+		if err != nil {
+			slog.Error("failed to save assistant chat message", "task_id", util.UUIDToString(task.ID), "error", err)
+		} else {
+			assistantMsg = &row
+			// Unread is derived from the read cursor (chat_session.last_read_at)
+			// vs the assistant messages after it — no per-reply stamping needed.
 		}
 		s.broadcastChatDone(ctx, task, assistantMsg)
 	}


### PR DESCRIPTION
## Summary

Fixes #5013 — the bottom-right chat loses context after a few turns.

## Root cause

`trailingUserMessages` (`server/internal/handler/daemon.go`) selects the user
messages the agent has not yet replied to by anchoring on the last assistant
row. Its contract is documented in the function comment: *every completed or
failed run writes an assistant row, so the anchor advances one turn at a time.*

`FailTask` writes that row unconditionally. `CompleteTask`
(`server/internal/service/task.go`) gated it on `payload.Output != ""`. On an
empty-output completion (a tool-only turn, or an empty final message) the
anchor row was skipped, so `trailingUserMessages` re-included the prior turn's
user messages on the next run and the resumed agent session saw duplicated
input.

## Fix

Write the assistant row unconditionally on completion, matching `FailTask`.

## Test

Added a regression case to `TestTrailingUserMessages` covering the
empty-output-anchors-the-turn invariant.

## Trade-off / alternative

The minimal fix writes an empty-content assistant row on empty-output turns,
which produces an empty assistant bubble. The frontend already tolerates
empty/placeholder content. If you'd rather avoid the empty bubble, the anchor
could instead be derived from `chat_message.task_id` rather than "last
assistant row" — a larger change, so I went with the minimal one.