### PR TITLE
fix(daemon): recover stale Claude resume sessions (MUL-4335)

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -240,13 +240,14 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// stderrBuf.Tail() is safe to sample now. Attach the tail to any
 		// non-empty failure message; callers upstream surface this as the
 		// task's error field, which is the only place users see it.
+		stderrTail := stderrBuf.Tail()
 		if finalError != "" {
-			finalError = withAgentStderr(finalError, "claude", stderrBuf.Tail())
+			finalError = withAgentStderr(finalError, "claude", stderrTail)
 		}
 
 		b.cfg.Logger.Info("claude finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
-		reportedSessionID := resolveSessionID(opts.ResumeSessionID, sessionID, finalStatus == "failed")
+		reportedSessionID := resolveSessionID(opts.ResumeSessionID, sessionID, finalStatus == "failed", stderrTail)
 		if reportedSessionID != sessionID {
 			b.cfg.Logger.Info("claude resume did not land; clearing fresh session id for daemon fallback",
 				"requested_resume", opts.ResumeSessionID,
@@ -637,16 +638,27 @@ func buildClaudeInput(prompt string) ([]byte, error) {
 
 // resolveSessionID decides which session id to report on the Result. When the
 // caller requested --resume but claude emitted a fresh, different session id
-// AND the run failed, the resume did not land (claude prints
-// "No conversation found with session ID: ..." to stderr, generates a fresh
-// session, and exits). Returning "" in that case keeps the daemon's
-// retry-with-fresh-session fallback able to trigger, instead of silently
-// persisting a brand-new id as if resume had succeeded.
-func resolveSessionID(requestedResume, emitted string, failed bool) string {
+// AND the run failed, the resume did not land. Claude can also report the
+// requested id while printing "No conversation found with session ID: ..." to
+// stderr. Returning "" in those cases keeps the daemon's retry-with-fresh-
+// session fallback able to trigger instead of persisting the dead resume id.
+func resolveSessionID(requestedResume, emitted string, failed bool, stderrTail ...string) string {
+	if failed && requestedResume != "" && claudeNoConversationFound(stderrTail...) {
+		return ""
+	}
 	if failed && requestedResume != "" && emitted != "" && emitted != requestedResume {
 		return ""
 	}
 	return emitted
+}
+
+func claudeNoConversationFound(stderrTail ...string) bool {
+	for _, tail := range stderrTail {
+		if strings.Contains(strings.ToLower(tail), "no conversation found") {
+			return true
+		}
+	}
+	return false
 }
 
 func buildEnv(extra map[string]string) []string {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -784,6 +784,7 @@ func TestResolveSessionID(t *testing.T) {
 		requested string
 		emitted   string
 		failed    bool
+		stderr    string
 		want      string
 	}{
 		{
@@ -791,6 +792,7 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "",
 			emitted:   "fresh-abc",
 			failed:    false,
+			stderr:    "",
 			want:      "fresh-abc",
 		},
 		{
@@ -798,6 +800,7 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "sess-old",
 			emitted:   "sess-old",
 			failed:    false,
+			stderr:    "",
 			want:      "sess-old",
 		},
 		{
@@ -805,6 +808,7 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "sess-old",
 			emitted:   "sess-old",
 			failed:    true,
+			stderr:    "",
 			want:      "sess-old",
 		},
 		{
@@ -812,6 +816,15 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "sess-dead",
 			emitted:   "fresh-new",
 			failed:    true,
+			stderr:    "",
+			want:      "",
+		},
+		{
+			name:      "resume not found stderr clears matching id so daemon fallback fires",
+			requested: "sess-dead",
+			emitted:   "sess-dead",
+			failed:    true,
+			stderr:    "No conversation found with session ID: sess-dead",
 			want:      "",
 		},
 		{
@@ -819,6 +832,7 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "sess-dead",
 			emitted:   "fresh-new",
 			failed:    false,
+			stderr:    "No conversation found with session ID: sess-dead",
 			want:      "fresh-new",
 		},
 		{
@@ -826,6 +840,7 @@ func TestResolveSessionID(t *testing.T) {
 			requested: "sess-old",
 			emitted:   "",
 			failed:    true,
+			stderr:    "",
 			want:      "",
 		},
 	}
@@ -834,10 +849,10 @@ func TestResolveSessionID(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := resolveSessionID(tc.requested, tc.emitted, tc.failed)
+			got := resolveSessionID(tc.requested, tc.emitted, tc.failed, tc.stderr)
 			if got != tc.want {
-				t.Fatalf("resolveSessionID(%q, %q, %v) = %q, want %q",
-					tc.requested, tc.emitted, tc.failed, got, tc.want)
+				t.Fatalf("resolveSessionID(%q, %q, %v, %q) = %q, want %q",
+					tc.requested, tc.emitted, tc.failed, tc.stderr, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes #5172.

When Claude reports `No conversation found` while the daemon is trying to resume a prior session, the Claude backend now treats that stderr message as a failed resume signal and returns an empty `SessionID`. That lets the daemon's existing retry-with-fresh-session fallback relaunch Claude without `--resume`, unblocking migrated/old chats instead of persisting the dead session pointer.

## Changes Made

- `server/pkg/agent/claude.go`
  - Sample stderr once after `cmd.Wait()` and pass the tail into `resolveSessionID`.
  - Clear the reported session id when a failed resumed run includes `No conversation found` in stderr.
  - Keep the existing different-fresh-session fallback behavior unchanged.
- `server/pkg/agent/claude_test.go`
  - Add regression coverage for the case where Claude emits the requested stale session id but stderr says no conversation was found.

## Verification

- Red test confirmed before implementation:
  - `go test ./pkg/agent -run TestResolveSessionID -count=1` failed to compile because the new regression called `resolveSessionID` with stderr context before production code supported it.
- After fix, using Go 1.26.1:
  - `go test ./pkg/agent -run TestResolveSessionID -count=1` → passed.
  - `go test ./pkg/agent -run 'TestResolveSessionID|TestClaudeExecuteSurfacesStderrWhenChildExitsEarly|TestClaudeExecuteRecordsResultModelUsage' -count=1` → passed.
  - `go test ./pkg/agent -count=1` → passed.
  - `git diff --check` → passed.
