### PR TITLE
Fix skill import oversized binary assets (ZIC-61)

### DIFF
--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -31,7 +31,7 @@ Workspace skills come from four sources:
 - **From ClawHub** — search and import from the [ClawHub](https://clawhub.io) public marketplace, with version selection
 - **From local** — the daemon scans skill directories on your machine, and you pick which to bring into the workspace
 
-Both individual files and whole skill packs have size caps (single-file cap around 1 MB when importing from GitHub). The exact rules appear in the import dialog — exceeding them returns an error.
+Text files and whole skill packs have size caps (single-file cap around 1 MiB when importing from GitHub). Binary supporting assets such as images, fonts, archives, PDFs, and Office files are skipped during import because workspace skills store text content; oversized text-like files return an error that names the file and cap.
 
 ## Attaching to an agent
 

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -574,8 +574,8 @@ func validImportOnConflict(strategy string) bool {
 
 // Per-import bundle limits. These mirror the local-runtime importer so that
 // URL imports cannot smuggle in payloads that the rest of the stack would
-// reject. fetchRawFile enforces the per-file cap; importedSkill.addFile
-// enforces the bundle-wide caps.
+// reject. fetchRawFile enforces the per-file cap for text-like files;
+// importedSkill.addFile enforces the bundle-wide caps.
 const (
 	maxImportFileSize  = 1 << 20 // 1 MiB per file
 	maxImportTotalSize = 8 << 20 // 8 MiB per import bundle (sum of supporting files)
@@ -611,13 +611,12 @@ func isCapError(err error) bool {
 // returns an error when either the file count or aggregate byte budget would
 // be exceeded so the caller fails the import instead of silently truncating.
 //
-// Binary files (images, fonts, archives) are silently skipped: their bytes
-// can't survive a PG TEXT column (SQLSTATE 22021), and they're reference
-// assets the agent never reads as text anyway. Logging the skip leaves a
-// breadcrumb if a user expected one of these to import.
+// Binary files (images, fonts, archives) are skipped: their bytes can't survive
+// a PG TEXT column (SQLSTATE 22021), and they're reference assets the agent
+// never reads as text anyway. URL importers also call skipBinaryImportFile
+// before downloading so oversized binary assets do not trip the text-file cap.
 func (s *importedSkill) addFile(path, content string) error {
-	if isLikelyBinaryFilePath(path) {
-		slog.Info("skill import: skipping binary file", "path", path, "size", len(content))
+	if skipBinaryImportFile(path, len(content)) {
 		return nil
 	}
 	if len(s.files) >= maxImportFileCount {
@@ -629,6 +628,18 @@ func (s *importedSkill) addFile(path, content string) error {
 	s.bundleSize += len(content)
 	s.files = append(s.files, importedFile{path: path, content: content})
 	return nil
+}
+
+func skipBinaryImportFile(path string, size int) bool {
+	if !isLikelyBinaryFilePath(path) {
+		return false
+	}
+	attrs := []any{"path", path}
+	if size >= 0 {
+		attrs = append(attrs, "size", size)
+	}
+	slog.Info("skill import: skipping binary file", attrs...)
+	return true
 }
 
 // isLikelyBinaryFilePath reports whether the file's extension indicates a
@@ -968,11 +979,14 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 		if latestVersion != "" {
 			fileURL += "&version=" + url.QueryEscape(latestVersion)
 		}
+		if fp != "SKILL.md" && skipBinaryImportFile(fp, -1) {
+			continue
+		}
 		body, err := fetchRawFile(httpClient, fileURL)
 		if err != nil {
-			// Cap violations must abort: silently dropping a file would
-			// produce an incomplete bundle that looks valid. SKILL.md is
-			// load-bearing, so any failure on it is fatal too.
+			// Cap violations on text-like files must abort: silently dropping
+			// them would produce an incomplete bundle that looks valid. SKILL.md
+			// is load-bearing, so any failure on it is fatal too.
 			if isCapError(err) || fp == "SKILL.md" {
 				return nil, fmt.Errorf("clawhub import: %s: %w", fp, err)
 			}
@@ -1117,6 +1131,10 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		if entry.DownloadURL == "" {
 			continue
 		}
+		relPath := strings.TrimPrefix(entry.Path, basePath)
+		if skipBinaryImportFile(relPath, -1) {
+			continue
+		}
 		body, err := fetchRawFile(httpClient, entry.DownloadURL)
 		if err != nil {
 			if isCapError(err) {
@@ -1125,8 +1143,6 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 			slog.Warn("github import: file download failed", "path", entry.Path, "error", err)
 			continue
 		}
-		// Convert absolute GitHub path to relative path within skill
-		relPath := strings.TrimPrefix(entry.Path, basePath)
 		if err := result.addFile(relPath, string(body)); err != nil {
 			return nil, err
 		}
@@ -1679,6 +1695,10 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 		if entry.DownloadURL == "" {
 			continue
 		}
+		relPath := strings.TrimPrefix(entry.Path, basePath)
+		if skipBinaryImportFile(relPath, -1) {
+			continue
+		}
 		body, err := fetchRawFile(httpClient, entry.DownloadURL)
 		if err != nil {
 			if isCapError(err) {
@@ -1687,7 +1707,6 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 			slog.Warn("github import: file download failed", "path", entry.Path, "error", err)
 			continue
 		}
-		relPath := strings.TrimPrefix(entry.Path, basePath)
 		if err := result.addFile(relPath, string(body)); err != nil {
 			return nil, err
 		}
@@ -1725,7 +1744,7 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 		return nil, err
 	}
 	if len(body) > maxImportFileSize {
-		return nil, fmt.Errorf("%w: file exceeds %d byte limit", errImportCapExceeded, maxImportFileSize)
+		return nil, fmt.Errorf("%w: file exceeds 1 MiB per-file import limit (%d bytes)", errImportCapExceeded, maxImportFileSize)
 	}
 	return body, nil
 }

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -899,8 +899,8 @@ func TestFetchRawFile_ReturnsErrorOnOversizedFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for oversized file, got nil")
 	}
-	if !strings.Contains(err.Error(), "byte limit") {
-		t.Fatalf("error = %q, want byte limit message", err.Error())
+	if !strings.Contains(err.Error(), "per-file import limit") {
+		t.Fatalf("error = %q, want per-file import limit message", err.Error())
 	}
 	if !isCapError(err) {
 		t.Fatalf("error %q must be classified as a cap error so callers fail-fast", err.Error())
@@ -979,7 +979,7 @@ func TestFetchFromGitHub_OversizedSupportingFileFailsImport(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected oversized supporting file to fail the whole import")
 	}
-	if !strings.Contains(err.Error(), "huge.bin") || !strings.Contains(err.Error(), "byte limit") {
+	if !strings.Contains(err.Error(), "huge.bin") || !strings.Contains(err.Error(), "per-file import limit") {
 		t.Fatalf("error %q should name the file and the cap", err.Error())
 	}
 }

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -1027,6 +1027,116 @@ func TestFetchFromSkillsSh_OversizedSupportingFileFailsImport(t *testing.T) {
 	}
 }
 
+func TestFetchFromGitHub_SkipsOversizedBinaryAsset(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills/commits/main":
+				w.Write([]byte("deadbeef"))
+			case "/repos/acme/skills/contents/foo":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "theme-style-grid.png",
+						Path:        "foo/assets/skill/theme-style-grid.png",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/foo/assets/skill/theme-style-grid.png",
+					},
+					{
+						Name:        "notes.md",
+						Path:        "foo/references/notes.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/foo/references/notes.md",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			case "/acme/skills/main/foo/references/notes.md":
+				w.Write([]byte("notes"))
+			case "/acme/skills/main/foo/assets/skill/theme-style-grid.png":
+				t.Fatalf("binary asset should be skipped before raw download")
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromGitHub(client, "https://github.com/acme/skills/tree/main/foo")
+	if err != nil {
+		t.Fatalf("fetchFromGitHub: %v", err)
+	}
+	if got := importedFilePaths(result.files); !equalStrings(got, []string{"references/notes.md"}) {
+		t.Fatalf("files = %v, want only text support file", got)
+	}
+	for _, request := range *requests {
+		if strings.Contains(request, "theme-style-grid.png") && strings.HasPrefix(request, "raw.githubusercontent.com ") {
+			t.Fatalf("binary asset should not be fetched: %v", *requests)
+		}
+	}
+}
+
+func TestFetchFromSkillsSh_SkipsOversizedBinaryAsset(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/contents/skills/foo":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "theme-style-grid.png",
+						Path:        "skills/foo/assets/skill/theme-style-grid.png",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/foo/assets/skill/theme-style-grid.png",
+					},
+					{
+						Name:        "notes.md",
+						Path:        "skills/foo/references/notes.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/foo/references/notes.md",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			case "/acme/skills/main/skills/foo/references/notes.md":
+				w.Write([]byte("notes"))
+			case "/acme/skills/main/skills/foo/assets/skill/theme-style-grid.png":
+				t.Fatalf("binary asset should be skipped before raw download")
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/foo")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+	if got := importedFilePaths(result.files); !equalStrings(got, []string{"references/notes.md"}) {
+		t.Fatalf("files = %v, want only text support file", got)
+	}
+	for _, request := range *requests {
+		if strings.Contains(request, "theme-style-grid.png") && strings.HasPrefix(request, "raw.githubusercontent.com ") {
+			t.Fatalf("binary asset should not be fetched: %v", *requests)
+		}
+	}
+}
+
 // Slash-bearing refs (e.g. release/v2) are now resolved against the API
 // instead of being silently parsed as ref="release", path="v2/...". The
 // resolver must walk longest→shortest and pick the prefix the API


### PR DESCRIPTION
## What does this PR do?

Fixes URL skill imports that currently fail when a supporting binary asset, such as a PNG under `assets/`, exceeds the 1 MiB raw-file cap.

The importer now skips known binary supporting files before downloading them, while keeping the existing caps for `SKILL.md` and text-like supporting files. This preserves usable text skill content without trying to store binary assets in workspace skill text rows.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5134

Multica issue: ZIC-61

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/skill.go`: skip likely binary supporting files before raw download for GitHub, skills.sh, and ClawHub imports; keep text-file cap failures fatal and improve the cap message.
- `server/internal/handler/skill_test.go`: add regressions proving oversized PNG assets are skipped and not fetched while text support files still import.
- `apps/docs/content/docs/skills.mdx`: document that URL imports store text content, skip binary support assets, and still reject oversized text-like files.

Local `.Agents/skills` auto-loading is not changed here; existing local skill import/discovery remains the documented fallback, and this PR keeps the GitHub URL import fix narrowly scoped.

## How to Test

1. `cd server && go test ./internal/handler -run 'TestFetchFrom(GitHub|SkillsSh)|TestFetchRawFile|TestImportedSkill'`
2. `cd server && go test ./internal/handler`
3. `make check-worktree`

Note: `make check-worktree` exited 0 locally but reported Docker was unavailable while checking PostgreSQL, so the focused Go tests above are the meaningful verification from this run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the URL skill import path from the reported oversized PNG failure, kept the fix limited to binary supporting assets, added regression coverage for GitHub and skills.sh imports, and documented the import behavior.

## Screenshots (optional)

N/A
