### PR TITLE
Fix integration restore after runtime restart (ZIC-55)

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1617,14 +1617,26 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		if agent.McpConfig != nil {
 			mcpConfig = json.RawMessage(agent.McpConfig)
 		}
-		// Layer the per-task overlay (set at enqueue from the initiator
-		// user's active integrations — currently Composio) on top of the
-		// agent's saved mcp_config. Overlay wins on server-name collisions
-		// because it carries the live user-scoped session URL. Errors are
-		// logged but never fail the claim: a broken overlay must not prevent
-		// the agent from running with its base config.
-		if composioMCPEnabled && len(task.RuntimeMcpOverlay) > 0 {
-			if merged, err := mergeMCPOverlay(mcpConfig, json.RawMessage(task.RuntimeMcpOverlay)); err != nil {
+		runtimeMCPOverlay := json.RawMessage(task.RuntimeMcpOverlay)
+		if composioMCPEnabled {
+			// Rehydrate the Composio MCP overlay at claim time from durable
+			// connection rows. Enqueue-time overlays are retained as a fallback,
+			// but fresh claim-time sessions keep daemon/runtime restarts from
+			// handing the agent an old short-lived session URL.
+			freshOverlay := h.TaskService.BuildRuntimeMCPOverlay(r.Context(), task.OriginatorUserID, agent)
+			if len(freshOverlay.Overlay) > 0 {
+				runtimeMCPOverlay = freshOverlay.Overlay
+				resp.ConnectedApps = parseRuntimeConnectedAppsForClaim(freshOverlay.ConnectedApps, task.ID)
+			}
+		}
+		// Layer the per-task overlay (freshly rehydrated at claim when possible,
+		// otherwise the enqueue-time fallback) on top of the agent's saved
+		// mcp_config. Overlay wins on server-name collisions because it carries
+		// the live user-scoped session URL. Errors are logged but never fail the
+		// claim: a broken overlay must not prevent the agent from running with
+		// its base config.
+		if composioMCPEnabled && len(runtimeMCPOverlay) > 0 {
+			if merged, err := mergeMCPOverlay(mcpConfig, runtimeMCPOverlay); err != nil {
 				slog.Warn("daemon claim: merge runtime_mcp_overlay failed; falling back to agent mcp_config", "task_id", uuidToString(task.ID), "error", err)
 			} else {
 				mcpConfig = merged

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -16,11 +16,15 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
+	"github.com/multica-ai/multica/server/internal/featureflags"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/runtimeapps"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/featureflag"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -88,6 +92,26 @@ type popRecordingLocalSkillImportStore struct {
 func (s *popRecordingLocalSkillImportStore) PopPending(ctx context.Context, runtimeID string) (*RuntimeLocalSkillImportRequest, error) {
 	s.popCalls++
 	return s.LocalSkillImportStore.PopPending(ctx, runtimeID)
+}
+
+type claimOverlayBuilder struct {
+	calls int
+	resp  json.RawMessage
+	apps  []runtimeapps.ConnectedApp
+}
+
+func (b *claimOverlayBuilder) BuildTaskOverlay(context.Context, pgtype.UUID, db.Agent) (runtimeapps.MCPOverlayResult, error) {
+	b.calls++
+	return runtimeapps.MCPOverlayResult{
+		MCPOverlay:    b.resp,
+		ConnectedApps: b.apps,
+	}, nil
+}
+
+func composioClaimTestFlags(enabled bool) *featureflag.Service {
+	provider := featureflag.NewStaticProvider()
+	provider.Set(featureflags.ComposioMCPApps, featureflag.Rule{Default: enabled})
+	return featureflag.NewService(provider)
 }
 
 func setHandlerTestWorkspaceRepos(t *testing.T, repos []map[string]string) {
@@ -603,6 +627,93 @@ func TestClaimTaskByRuntime_DoesNotReclaimDifferentRuntimeTask(t *testing.T) {
 	}
 	if runtimeID != owningRuntimeID {
 		t.Fatalf("task runtime_id = %s, want %s", runtimeID, owningRuntimeID)
+	}
+}
+
+func TestClaimTaskByRuntime_RehydratesRuntimeMCPOverlayAtClaim(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	runtimeID := createClaimReclaimRuntime(t, ctx, "Runtime MCP overlay claim runtime")
+	agentID, issueID := createClaimReclaimAgentAndIssue(t, ctx, runtimeID, "Runtime MCP overlay claim agent")
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent
+		SET composio_toolkit_allowlist = ARRAY['notion']
+		WHERE id = $1
+	`, agentID); err != nil {
+		t.Fatalf("setup: update agent allowlist: %v", err)
+	}
+
+	staleOverlay := []byte(`{"mcpServers":{"composio":{"type":"http","url":"https://mcp.example/session/stale"}}}`)
+	staleApps := []byte(`[{"provider":"composio","server_name":"composio","toolkit_slug":"old","toolkit_name":"Old"}]`)
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			originator_user_id, runtime_mcp_overlay, runtime_connected_apps
+		)
+		VALUES ($1, $2, $3, 'queued', 0, $4, $5::jsonb, $6::jsonb)
+		RETURNING id
+	`, agentID, runtimeID, issueID, testUserID, staleOverlay, staleApps).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create queued task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	builder := &claimOverlayBuilder{
+		resp: json.RawMessage(`{"mcpServers":{"composio":{"type":"http","url":"https://mcp.example/session/fresh"}}}`),
+		apps: []runtimeapps.ConnectedApp{{
+			Provider:    "composio",
+			ServerName:  "composio",
+			ToolkitSlug: "notion",
+			ToolkitName: "Notion",
+		}},
+	}
+	origComposio := testHandler.TaskService.Composio
+	origFlags := testHandler.TaskService.FeatureFlags
+	testHandler.TaskService.Composio = builder
+	testHandler.TaskService.FeatureFlags = composioClaimTestFlags(true)
+	t.Cleanup(func() {
+		testHandler.TaskService.Composio = origComposio
+		testHandler.TaskService.FeatureFlags = origFlags
+	})
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil, testWorkspaceID, "runtime-mcp-overlay-claim")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if builder.calls != 1 {
+		t.Fatalf("BuildTaskOverlay calls = %d, want 1", builder.calls)
+	}
+
+	var resp struct {
+		Task *struct {
+			Agent *struct {
+				McpConfig json.RawMessage `json:"mcp_config"`
+			} `json:"agent"`
+			ConnectedApps []runtimeapps.ConnectedApp `json:"connected_apps"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode claim response: %v", err)
+	}
+	if resp.Task == nil || resp.Task.Agent == nil {
+		t.Fatalf("expected claimed task with agent data, got %s", w.Body.String())
+	}
+	var cfg map[string]map[string]map[string]any
+	if err := json.Unmarshal(resp.Task.Agent.McpConfig, &cfg); err != nil {
+		t.Fatalf("unmarshal mcp_config: %v (%s)", err, string(resp.Task.Agent.McpConfig))
+	}
+	gotURL, _ := cfg["mcpServers"]["composio"]["url"].(string)
+	if gotURL != "https://mcp.example/session/fresh" {
+		t.Fatalf("composio URL = %q, want fresh claim-time URL", gotURL)
+	}
+	if len(resp.Task.ConnectedApps) != 1 || resp.Task.ConnectedApps[0].ToolkitSlug != "notion" {
+		t.Fatalf("connected_apps = %+v, want fresh notion metadata", resp.Task.ConnectedApps)
 	}
 }
 

--- a/server/internal/integrations/channel/channel.go
+++ b/server/internal/integrations/channel/channel.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"encoding/json"
+	"errors"
 )
 
 // Type identifies an inbound channel platform — the discriminator the
@@ -18,6 +19,12 @@ const (
 	// not a separate Type.
 	TypeFeishu Type = "feishu"
 )
+
+// ErrNeedsReauth marks an installation credential/config problem that cannot
+// be fixed by reconnect backoff. Supervisors persist the installation as
+// "needs_reauth" so operators see a clear recovery state instead of a row that
+// stays "active" while every reconnect attempt fails.
+var ErrNeedsReauth = errors.New("channel: installation needs re-auth")
 
 // Channel is the platform-agnostic contract every IM integration
 // implements. An adapter keeps ALL platform specifics behind these five

--- a/server/internal/integrations/channel/engine/supervisor.go
+++ b/server/internal/integrations/channel/engine/supervisor.go
@@ -89,6 +89,11 @@ type InstallationStore interface {
 
 	// ReleaseWSLease releases a lease the caller holds (token-fenced).
 	ReleaseWSLease(ctx context.Context, arg ReleaseLeaseParams) error
+
+	// MarkNeedsReauth persists that an active installation cannot be restored
+	// without fresh credentials. Implementations should also clear any held
+	// lease so this process stops retrying until the user re-installs.
+	MarkNeedsReauth(ctx context.Context, id pgtype.UUID) error
 }
 
 // Config tunes the Supervisor's lifecycle loops. All fields have sensible
@@ -486,6 +491,10 @@ func (s *Supervisor) supervise(ctx context.Context, inst Installation, id string
 		})
 		if err != nil {
 			log.Error("channel engine: build channel failed", "error", err)
+			if errors.Is(err, channel.ErrNeedsReauth) {
+				s.markNeedsReauth(inst.ID, id, log)
+				return
+			}
 			s.releaseLease(inst.ID, leaseTok)
 			if sleep(ctx, backoff) {
 				return
@@ -510,6 +519,10 @@ func (s *Supervisor) supervise(ctx context.Context, inst Installation, id string
 		runCancel()
 		<-renewDone
 		s.disconnect(ch, id, log)
+		if errors.Is(runErr, channel.ErrNeedsReauth) {
+			s.markNeedsReauth(inst.ID, id, log)
+			return
+		}
 		s.releaseLease(inst.ID, leaseTok)
 
 		if ctx.Err() != nil {
@@ -532,6 +545,16 @@ func (s *Supervisor) supervise(ctx context.Context, inst Installation, id string
 		}
 		backoff = nextBackoff(backoff, s.cfg.MaxBackoff)
 	}
+}
+
+func (s *Supervisor) markNeedsReauth(instID pgtype.UUID, id string, log *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.cfg.LeaseReleaseTimeout)
+	defer cancel()
+	if err := s.store.MarkNeedsReauth(ctx, instID); err != nil {
+		log.Warn("channel engine: mark installation needs re-auth failed", "installation_id", id, "error", err)
+		return
+	}
+	log.Warn("channel engine: installation marked needs re-auth", "installation_id", id)
 }
 
 // acquireLease tries to claim or renew the WS lease. Returns (true, nil)

--- a/server/internal/integrations/channel/engine/supervisor_test.go
+++ b/server/internal/integrations/channel/engine/supervisor_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -24,8 +25,10 @@ type fakeStore struct {
 	listErr        error
 	leaseOwner     map[string]string    // installation_id -> lease token
 	leaseExpiresAt map[string]time.Time // installation_id -> expiry
+	status         map[string]string
 	acquireErr     error
 	releaseErr     error
+	markErr        error
 	now            func() time.Time
 	acquireCount   int32
 
@@ -40,6 +43,7 @@ func newFakeStore() *fakeStore {
 	return &fakeStore{
 		leaseOwner:     make(map[string]string),
 		leaseExpiresAt: make(map[string]time.Time),
+		status:         make(map[string]string),
 		now:            time.Now,
 	}
 }
@@ -102,6 +106,19 @@ func (f *fakeStore) ReleaseWSLease(ctx context.Context, arg ReleaseLeaseParams) 
 	return nil
 }
 
+func (f *fakeStore) MarkNeedsReauth(ctx context.Context, id pgtype.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.markErr != nil {
+		return f.markErr
+	}
+	key := uuidString(id)
+	f.status[key] = "needs_reauth"
+	delete(f.leaseOwner, key)
+	delete(f.leaseExpiresAt, key)
+	return nil
+}
+
 func (f *fakeStore) presetLease(id pgtype.UUID, token string, expires time.Time) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -114,6 +131,12 @@ func (f *fakeStore) leaseHolder(id pgtype.UUID) (string, bool) {
 	defer f.mu.Unlock()
 	owner, ok := f.leaseOwner[uuidString(id)]
 	return owner, ok
+}
+
+func (f *fakeStore) installationStatus(id pgtype.UUID) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.status[uuidString(id)]
 }
 
 // fakeChannel is a channel.Channel whose Connect behaves per a script
@@ -482,6 +505,60 @@ func TestSupervisorBacksOffOnBuildError(t *testing.T) {
 	}
 	if fc.Connects() != 0 {
 		t.Fatalf("channel should never connect when build fails; connects=%d", fc.Connects())
+	}
+}
+
+func TestSupervisorMarksNeedsReauthOnBuildCredentialError(t *testing.T) {
+	q := newFakeStore()
+	instID := uuidFromString(t, "7a777777-7777-7777-7777-777777777777")
+	q.installations = []Installation{activeInst(instID, "fp1")}
+
+	fc := &fakeChannel{typ: channel.TypeFeishu}
+	var builds int32
+	reg := fakeRegistry(fc, &builds, fmt.Errorf("%w: decrypt app token", channel.ErrNeedsReauth))
+
+	sup := NewSupervisor(q, reg, nil, fastConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	if !waitFor(300*time.Millisecond, func() bool { return q.installationStatus(instID) == "needs_reauth" }) {
+		t.Fatalf("expected installation to be marked needs_reauth, status=%q", q.installationStatus(instID))
+	}
+	if owner, ok := q.leaseHolder(instID); ok {
+		t.Fatalf("needs_reauth path must clear lease, got owner %q", owner)
+	}
+	if fc.Connects() != 0 {
+		t.Fatalf("channel should not connect when build needs reauth; connects=%d", fc.Connects())
+	}
+}
+
+func TestSupervisorMarksNeedsReauthOnConnectCredentialError(t *testing.T) {
+	q := newFakeStore()
+	instID := uuidFromString(t, "7b777777-7777-7777-7777-777777777777")
+	q.installations = []Installation{activeInst(instID, "fp1")}
+
+	fc := &fakeChannel{
+		typ: channel.TypeFeishu,
+		script: []func(ctx context.Context) error{
+			func(ctx context.Context) error {
+				return fmt.Errorf("%w: decrypt app_secret", channel.ErrNeedsReauth)
+			},
+		},
+	}
+	var builds int32
+	reg := fakeRegistry(fc, &builds, nil)
+
+	sup := NewSupervisor(q, reg, nil, fastConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.Run(ctx)
+
+	if !waitFor(300*time.Millisecond, func() bool { return q.installationStatus(instID) == "needs_reauth" }) {
+		t.Fatalf("expected installation to be marked needs_reauth, status=%q", q.installationStatus(instID))
+	}
+	if owner, ok := q.leaseHolder(instID); ok {
+		t.Fatalf("needs_reauth path must clear lease, got owner %q", owner)
 	}
 }
 

--- a/server/internal/integrations/lark/feishu_channel.go
+++ b/server/internal/integrations/lark/feishu_channel.go
@@ -103,7 +103,7 @@ func (c *feishuChannel) installationCredentials() (InstallationCredentials, erro
 	}
 	secret, err := c.creds.DecryptAppSecret(c.inst)
 	if err != nil {
-		return InstallationCredentials{}, fmt.Errorf("decrypt app_secret: %w", err)
+		return InstallationCredentials{}, fmt.Errorf("%w: decrypt app_secret: %w", channel.ErrNeedsReauth, err)
 	}
 	creds := InstallationCredentials{
 		AppID:     c.inst.AppID,
@@ -278,6 +278,10 @@ func (s *channelInstallationStore) ReleaseWSLease(ctx context.Context, arg engin
 		ID:           arg.ID,
 		CurrentToken: pgtype.Text{String: arg.Token, Valid: true},
 	})
+}
+
+func (s *channelInstallationStore) MarkNeedsReauth(ctx context.Context, id pgtype.UUID) error {
+	return s.q.MarkChannelInstallationNeedsReauth(ctx, id)
 }
 
 // rowFingerprint condenses the credential-bearing config of a

--- a/server/internal/integrations/slack/slack_channel.go
+++ b/server/internal/integrations/slack/slack_channel.go
@@ -242,14 +242,14 @@ func newSlackFactory(deps ChannelDeps) channel.Factory {
 		}
 		appToken, err := decryptToken(ic.AppTokenEncrypted, deps.Decrypt)
 		if err != nil {
-			return nil, fmt.Errorf("slack: decrypt app token: %w", err)
+			return nil, fmt.Errorf("%w: slack: decrypt app token: %w", channel.ErrNeedsReauth, err)
 		}
 		if appToken == "" {
-			return nil, errors.New("slack: installation has no app-level token")
+			return nil, fmt.Errorf("%w: slack: installation has no app-level token", channel.ErrNeedsReauth)
 		}
 		botToken, err := decryptToken(ic.BotTokenEncrypted, deps.Decrypt)
 		if err != nil {
-			return nil, fmt.Errorf("slack: decrypt bot token: %w", err)
+			return nil, fmt.Errorf("%w: slack: decrypt bot token: %w", channel.ErrNeedsReauth, err)
 		}
 		return &slackChannel{
 			appID:     ic.AppID,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -270,10 +270,12 @@ func (s *TaskService) captureTaskQueued(ctx context.Context, task db.AgentTaskQu
 	}
 }
 
-type runtimeMCPOverlayData struct {
+type RuntimeMCPOverlayData struct {
 	Overlay       json.RawMessage
 	ConnectedApps json.RawMessage
 }
+
+type runtimeMCPOverlayData = RuntimeMCPOverlayData
 
 // buildRuntimeMCPOverlay computes the optional per-task Composio MCP overlay.
 // Enqueue paths call this BEFORE inserting the queued row so the daemon cannot
@@ -315,6 +317,14 @@ func (s *TaskService) buildRuntimeMCPOverlay(ctx context.Context, originatorUser
 		data.ConnectedApps = raw
 	}
 	return data
+}
+
+// BuildRuntimeMCPOverlay recomputes the optional Composio MCP overlay from the
+// durable agent allowlist + owner connection rows. Daemon claim uses this to
+// hand the runtime a fresh MCP session after daemon/runtime restarts instead of
+// relying on an older enqueue-time session URL.
+func (s *TaskService) BuildRuntimeMCPOverlay(ctx context.Context, originatorUserID pgtype.UUID, agent db.Agent) RuntimeMCPOverlayData {
+	return s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 }
 
 // resolveOriginatorFromTriggerComment returns the top-of-chain HUMAN user

--- a/server/migrations/157_channel_installation_needs_reauth.down.sql
+++ b/server/migrations/157_channel_installation_needs_reauth.down.sql
@@ -1,0 +1,8 @@
+UPDATE channel_installation
+SET status = 'revoked'
+WHERE status = 'needs_reauth';
+
+ALTER TABLE channel_installation
+    DROP CONSTRAINT IF EXISTS channel_installation_status_check,
+    ADD CONSTRAINT channel_installation_status_check
+        CHECK (status IN ('active', 'revoked'));

--- a/server/migrations/157_channel_installation_needs_reauth.up.sql
+++ b/server/migrations/157_channel_installation_needs_reauth.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE channel_installation
+    DROP CONSTRAINT IF EXISTS channel_installation_status_check,
+    ADD CONSTRAINT channel_installation_status_check
+        CHECK (status IN ('active', 'revoked', 'needs_reauth'));
+
+COMMENT ON COLUMN channel_installation.status IS
+    'active = supervised normally; revoked = user disconnected; needs_reauth = stored integration credentials could not be used after restart and must be refreshed.';

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -1270,6 +1270,25 @@ func (q *Queries) ReleaseChannelWSLease(ctx context.Context, arg ReleaseChannelW
 	return err
 }
 
+const markChannelInstallationNeedsReauth = `-- name: MarkChannelInstallationNeedsReauth :exec
+UPDATE channel_installation
+SET status = 'needs_reauth',
+    ws_lease_token = NULL,
+    ws_lease_expires_at = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND status = 'active'
+`
+
+// Supervisor fail-closed path: when a channel adapter cannot use the persisted
+// credentials after process restart (bad/missing master key, corrupt ciphertext,
+// expired non-refreshable credential), stop supervising the row and surface a
+// durable "needs re-auth" state. Re-install/upsert flips it back to 'active'.
+func (q *Queries) MarkChannelInstallationNeedsReauth(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, markChannelInstallationNeedsReauth, id)
+	return err
+}
+
 const setChannelInstallationConfig = `-- name: SetChannelInstallationConfig :exec
 UPDATE channel_installation
 SET config = $2, updated_at = now()

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -287,6 +287,19 @@ UPDATE channel_installation
 SET status = $2, updated_at = now()
 WHERE id = $1;
 
+-- name: MarkChannelInstallationNeedsReauth :exec
+-- Supervisor fail-closed path: when a channel adapter cannot use the persisted
+-- credentials after process restart (bad/missing master key, corrupt ciphertext,
+-- expired non-refreshable credential), stop supervising the row and surface a
+-- durable "needs re-auth" state. Re-install/upsert flips it back to 'active'.
+UPDATE channel_installation
+SET status = 'needs_reauth',
+    ws_lease_token = NULL,
+    ws_lease_expires_at = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND status = 'active';
+
 -- name: SetChannelInstallationConfig :exec
 -- Replaces the whole config blob for one installation. Used by the
 -- operator backfills (e.g. setting a freshly-fetched bot_union_id) that


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes integration restoration after runtime/daemon restarts by refreshing runtime MCP overlays at daemon claim time and surfacing channel credentials that cannot be restored as a durable `needs_reauth` state.

Root cause: Composio MCP session overlays were captured at enqueue time, so daemon/runtime restarts could hand agents stale short-lived session URLs; channel credential restoration failures were only retried/logged while the installation still appeared `active`.

## Related Issue

Closes #4874

Multica issue: ZIC-55

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Rehydrate Composio runtime MCP overlays from durable user connection rows when the daemon claims a task, using the enqueue-time overlay only as a fallback.
- Add `channel_installation.status = 'needs_reauth'` for integrations whose persisted credentials cannot be used after restart.
- Mark Feishu/Lark and Slack installations as `needs_reauth` when credential decrypt/config restoration fails, clearing the WS lease so the supervisor stops hidden retries.
- Add supervisor and daemon claim tests for restart rehydration and `needs_reauth` transitions.

## How to Test

1. `go test ./internal/integrations/channel/... ./internal/integrations/lark ./internal/integrations/slack ./internal/handler ./internal/service`
2. `go test ./...`

`go test ./...` currently fails only in `server/cmd/multica` because this Multica agent workspace contains `.multica/daemon_task_context.json`, causing CLI tests to enter agent-task auth mode. Other server packages pass.

`make check-worktree` returned exit 0 but printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`, so it was not treated as a clean full check.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass where the local environment permits
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the runtime integration restore path from daemon task claim through channel installation supervision, preserved existing branch work, and added the smallest backend changes plus regression tests for durable rehydration and explicit re-auth state.

## Screenshots (optional)

Not applicable.
